### PR TITLE
Add list and revoke endpoints to admin token API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,27 @@ curl -XPOST https://api.uploads.sh/admin/tokens \
 
 The token is shown once. Minting appends — a workspace can hold several valid
 tokens. The workspace must already exist (`pnpm workspace:add …`); this endpoint
-issues tokens, it does not create workspaces. There is no revoke endpoint yet —
-remove a token by editing its `ws:<name>` record in KV.
+issues tokens, it does not create workspaces.
+
+List a workspace's tokens (the raw token and full hash are never returned — only
+an 8-char `hashPrefix`, which is the handle for revoke):
+
+```bash
+curl https://api.uploads.sh/admin/tokens?workspace=default \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+# → { "workspace": "default", "tokens": [ { "label": "ci", "createdAt": "…", "hashPrefix": "a1b2c3d4" } ] }
+```
+
+Revoke a token by `hashPrefix` or `label`. A selector that matches no token is
+`404`; one that matches more than one is `409` (pick a longer `hashPrefix`):
+
+```bash
+curl -XDELETE https://api.uploads.sh/admin/tokens \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workspace":"default","hashPrefix":"a1b2c3d4"}'
+# or: -d '{"workspace":"default","label":"ci"}'
+```
 
 ## API
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3,6 +3,12 @@ import { adminAuth } from "../admin";
 import { sha256Hex, type WorkspaceRecord } from "../workspace";
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
+const HASH_PREFIX_LEN = 8;
+
+/** Token list for a record, migrating a legacy `tokenHash`-only record into the list shape. */
+function migrateTokens(record: WorkspaceRecord): { hash: string; label?: string; createdAt: string }[] {
+  return record.tokens ?? (record.tokenHash ? [{ hash: record.tokenHash, createdAt: new Date(0).toISOString() }] : []);
+}
 
 export const admin = new Hono<{ Bindings: Env }>()
   .use("/*", adminAuth)
@@ -24,10 +30,62 @@ export const admin = new Hono<{ Bindings: Env }>()
       .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")}`;
     const entry = { hash: await sha256Hex(token), label, createdAt: new Date().toISOString() };
 
-    const tokens = record.tokens ?? (record.tokenHash ? [{ hash: record.tokenHash, createdAt: entry.createdAt }] : []);
+    const tokens = migrateTokens(record);
     tokens.push(entry);
     const { tokenHash: _drop, ...rest } = record;
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify({ ...rest, tokens }));
 
     return c.json({ workspace: name, token, label: label ?? null }, 201);
+  })
+
+  // List a workspace's tokens (defaults to "default"). Never returns the full
+  // hash or raw token — only the 8-char hashPrefix, which is the revoke handle.
+  .get("/tokens", async (c) => {
+    const name = c.req.query("workspace")?.trim() || "default";
+    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
+
+    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json" });
+    if (!record) return c.json({ error: "workspace not found" }, 404);
+
+    const tokens = migrateTokens(record).map((t) => ({
+      label: t.label ?? null,
+      createdAt: t.createdAt,
+      hashPrefix: t.hash.slice(0, HASH_PREFIX_LEN),
+    }));
+    return c.json({ workspace: name, tokens });
+  })
+
+  // Revoke a token by { hashPrefix } or { label }. Migrates a legacy
+  // tokenHash-only record into tokens[] first, then removes the match.
+  // 404 when nothing matches, 409 when the selector is ambiguous.
+  .delete("/tokens", async (c) => {
+    const body = await c.req
+      .json<{ workspace?: string; hashPrefix?: string; label?: string }>()
+      .catch(() => ({}) as { workspace?: string; hashPrefix?: string; label?: string });
+    const name = body.workspace?.trim() || "default";
+    const hashPrefix = body.hashPrefix?.trim();
+    const label = body.label?.trim();
+    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
+    if (!hashPrefix && !label) return c.json({ error: "hashPrefix or label required" }, 400);
+
+    // Read-modify-write, no locking: a concurrent mint/revoke on the same workspace can race (last put wins). Acceptable for this admin-only PoC endpoint.
+    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json" });
+    if (!record) return c.json({ error: "workspace not found" }, 404);
+
+    const tokens = migrateTokens(record);
+    const matches = tokens.filter((t) =>
+      hashPrefix ? t.hash.startsWith(hashPrefix) : t.label === label,
+    );
+    if (matches.length === 0) return c.json({ error: "no matching token" }, 404);
+    if (matches.length > 1) return c.json({ error: "selector matches multiple tokens" }, 409);
+
+    const revoked = matches[0];
+    const remaining = tokens.filter((t) => t !== revoked);
+    const { tokenHash: _drop, ...rest } = record;
+    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify({ ...rest, tokens: remaining }));
+
+    return c.json({
+      workspace: name,
+      revoked: { label: revoked.label ?? null, hashPrefix: revoked.hash.slice(0, HASH_PREFIX_LEN) },
+    });
   });


### PR DESCRIPTION
Adds token listing and revocation to the `/admin/tokens` API, alongside the existing mint endpoint. Gated by the same `ADMIN_TOKEN`-backed `adminAuth`.

## What's new

**`GET /admin/tokens?workspace=<name>`** (default `default`) — lists a workspace's tokens as `{ label, createdAt, hashPrefix }`. Returns only the first 8 hex chars of each hash — never the full hash or raw token. The prefix is the handle used for revoke.

**`DELETE /admin/tokens`** with body `{ workspace?, hashPrefix }` or `{ label }` — removes the matching entry via read-modify-write:
- `404` when the selector matches no token
- `409` when it matches more than one (use a longer `hashPrefix`)
- Legacy `tokenHash`-only records are migrated into `tokens[]` before removal, matching the mint path.

The legacy-migration logic is factored into a shared `migrateTokens` helper used by mint, list, and revoke.

## Notes / tradeoffs

- **Unlocked read-modify-write** — mint and revoke both do get→modify→put with no locking, so concurrent admin calls on the same workspace can drop a change (last put wins). Same low-traffic, admin-only-PoC tradeoff already documented on mint; commented in `routes/admin.ts`.
- **Timing**: revoke only shrinks the token list, so it adds no new per-request timing exposure to `workspaceAuth`.

## Verification

- `pnpm --filter @uploads/api typecheck` — passes.
- Drove every path against `wrangler dev` + curl with a seeded local KV: list (incl. null label, no hash leak), unknown-workspace 404, legacy-record listing, delete by `hashPrefix`, delete by `label`, no-match 404, ambiguous 409 (record left unchanged), legacy migrate-then-remove (`tokenHash` dropped, `tokens: []`), missing-selector 400, and bad-admin-token 401.

## Cleanup done alongside

- Revoked the live `prod-smoke-test` token on the prod `default` workspace (direct KV edit, since prod runs the pre-DELETE code).
- Confirmed there is **no** stale `ADMIN_SECRET` secret in production — only `ADMIN_TOKEN` exists.
- Updated the README "Minting tokens" section to document the new list/revoke endpoints (replacing the "no revoke endpoint yet" note).

## Out of scope

Token expiry, per-token scopes, and admin-endpoint rate-limiting — those belong to the real auth system (Better Auth) that will replace this layer.