### PR TITLE
Fix R2 file list reporting octet-stream for every object

### DIFF
--- a/patches/files-sdk@2.1.0.patch
+++ b/patches/files-sdk@2.1.0.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/r2/index.js b/dist/r2/index.js
+index 291ca05dee674c7845e5e18868d481a3e4168b10..237e9726bd3e49ea5246cdf50acf62f37a54b035 100644
+--- a/dist/r2/index.js
++++ b/dist/r2/index.js
+@@ -231,7 +231,11 @@ var r2FromBinding = (opts) => {
+           ...options?.prefix && { prefix: options.prefix },
+           ...options?.limit !== undefined && { limit: options.limit },
+           ...options?.cursor && { cursor: options.cursor },
+-          ...options?.delimiter && { delimiter: options.delimiter }
++          ...options?.delimiter && { delimiter: options.delimiter },
++          // Patched: R2 list() omits httpMetadata/customMetadata unless explicitly
++          // requested, so item.type would always default to application/octet-stream.
++          // Requesting them makes list() report the stored content type like head().
++          include: ["httpMetadata", "customMetadata"]
+         });
+       } catch (error) {
+         throw mapR2Error(error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  files-sdk@2.1.0: 9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2
+
 importers:
 
   .: {}
@@ -56,7 +59,7 @@ importers:
         version: 3.1080.0
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(h3@1.15.11)(hono@4.12.27)(zod@4.4.3)
+        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(h3@1.15.11)(hono@4.12.27)(zod@4.4.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260706.1
@@ -4148,7 +4151,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  files-sdk@2.1.0(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(h3@1.15.11)(hono@4.12.27)(zod@4.4.3):
+  files-sdk@2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(h3@1.15.11)(hono@4.12.27)(zod@4.4.3):
     dependencies:
       commander: 15.0.0
       picomatch: 4.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,5 @@ minimumReleaseAgeExclude:
   - '@cloudflare/workers-types@5.20260706.1'
   - files-sdk@2.1.0
   - hono@4.12.28
+patchedDependencies:
+  files-sdk@2.1.0: patches/files-sdk@2.1.0.patch


### PR DESCRIPTION
## Problem

`GET /v1/:workspace/files` reported every item's `type` as `application/octet-stream`, even for objects stored with a correct content type. Confirmed in prod: uploading a PNG then hitting the metadata endpoint (`GET .../files/:key`) and the public URL both correctly returned `image/png`, but the list response showed `application/octet-stream` for the same object.

## Root cause

The list `type` is populated by the `files-sdk` R2 adapter, which calls Cloudflare R2's `bucket.list()` **without** `include: ["httpMetadata"]`. R2 omits `httpMetadata` (and thus `contentType`) from list results unless explicitly requested, so the adapter's `obj.httpMetadata?.contentType` was always `undefined` and fell back to `application/octet-stream`. `head()` was unaffected because `bucket.head()` returns full metadata natively — hence the asymmetry.

Our own code (`@uploads/storage`, `apps/api/src/routes/files.ts`) only delegates to `files-sdk`, and the adapter exposes no passthrough to request `include`, so the fix is a pinned patch of the dependency.

## Fix

`pnpm patch files-sdk@2.1.0` adding `include: ["httpMetadata", "customMetadata"]` to the R2 adapter's `list()` call. The adapter already paginates via `truncated`/`cursor` rather than counting against `limit`, so the smaller per-page result count that `include` can trigger doesn't affect correctness. The worker's `compatibility_date` (2026-07-06) satisfies R2's ≥2022-08-04 requirement for `include` to be honored.

The **S3/HTTP provider is intentionally left unchanged**: its `ListObjectsV2` API doesn't return content types at all (files-sdk hardcodes octet-stream there), a separate, inherent limitation that `include` cannot address.

## Verification

- `pnpm --filter @uploads/api typecheck` → passes
- `wrangler dev` + curl round-trip against a local R2 binding:

| key | uploaded Content-Type | `list` now reports |
|---|---|---|
| sample.png | image/png | image/png |
| notes.txt | text/plain | text/plain |
| blob.bin | (curl default) x-www-form-urlencoded | x-www-form-urlencoded |

List now matches `head()` for every object.
