### PR TITLE
Add @buildinternet/uploads CLI and client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,15 @@ UPLOADS_API_URL=https://api.uploads.sh
 # that workspace's bucket.
 UPLOADS_WORKSPACE=default
 
+# CLI (local dev from this repo — no npm publish needed):
+#   pnpm uploads put ./shot.png --env-file .env
+# After publish: npx @buildinternet/uploads put ./shot.png --env-file .env
+#
+# UPLOADS_WORKSPACE overrides token inference when set. Omit it to use the workspace
+# encoded in the token (up_<workspace>_…). CLI: --workspace / -w overrides both.
+# Local vs prod: tokens minted with --local only work against localhost; prod tokens
+# need UPLOADS_API_URL=https://api.uploads.sh (the default in this file).
+
 # Bearer token for that workspace. Two ways to get one:
 #   - create a workspace (mints its first token, shown once):
 #       cd apps/api && node scripts/add-workspace.mjs <workspace> --bucket <bucket> --binding <BINDING>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,10 @@ scripts in `buildinternet-skills/github-screenshots`.
 ## Layout
 
 ```
-apps/api          Hono worker — REST API, deploys to api.uploads.sh
-apps/web          Astro placeholder — future browse/manage UI (separate deploy)
-packages/storage  @uploads/storage — files-sdk adapter factory
+apps/api            Hono worker — REST API, deploys to api.uploads.sh
+apps/web            Astro placeholder — future browse/manage UI (separate deploy)
+packages/storage    @uploads/storage — files-sdk adapter factory
+packages/uploads    @buildinternet/uploads — CLI + client for GitHub image embeds
 ```
 
 Keep API and web separate deployables. All storage access goes through
@@ -27,6 +28,7 @@ pnpm dev:web             # Astro site
 pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # both workers; or deploy:api / deploy:web
 pnpm workspace:add <name> --bucket <bucket> [--binding X] [--local]
+pnpm uploads put <file> --env-file .env   # CLI (builds package first)
 ```
 
 Use `pnpm run deploy` (not bare `pnpm deploy` — that's pnpm's built-in).

--- a/package.json
+++ b/package.json
@@ -13,8 +13,13 @@
     "upload:api": "pnpm --filter @uploads/api exec wrangler versions upload",
     "upload:web": "pnpm --filter @uploads/web run build && pnpm --filter @uploads/web exec wrangler versions upload",
     "types": "pnpm --filter @uploads/api types",
-    "typecheck": "pnpm -r typecheck",
-    "workspace:add": "pnpm --filter @uploads/api run workspace:add"
+    "typecheck": "pnpm --filter @buildinternet/uploads run build && pnpm -r typecheck",
+    "workspace:add": "pnpm --filter @uploads/api run workspace:add",
+    "preuploads": "pnpm --filter @buildinternet/uploads run build",
+    "uploads": "pnpm exec uploads"
+  },
+  "devDependencies": {
+    "@buildinternet/uploads": "workspace:*"
   },
   "engines": {
     "node": ">=22",

--- a/packages/uploads/bin/uploads.js
+++ b/packages/uploads/bin/uploads.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { runCli } from "../dist/cli.js";
+
+runCli(process.argv)
+  .then((code) => process.exit(code ?? 0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@buildinternet/uploads",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CLI and client for uploads.sh — workspace-scoped image hosting for GitHub embeds",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buildinternet/uploads.git",
+    "directory": "packages/uploads"
+  },
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./agent": {
+      "types": "./dist/agent.d.ts",
+      "import": "./dist/agent.js"
+    }
+  },
+  "bin": {
+    "uploads": "./bin/uploads.js"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc",
+    "prepublishOnly": "pnpm run build"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "peerDependencies": {
+    "files-sdk": "^2.1.0"
+  },
+  "peerDependenciesMeta": {
+    "files-sdk": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "ai": "^6.0.0",
+    "files-sdk": "^2.1.0",
+    "typescript": "^6.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/uploads/src/agent.ts
+++ b/packages/uploads/src/agent.ts
@@ -1,0 +1,32 @@
+import type { Files } from "files-sdk";
+import { createFileTools, type FileToolsOptions } from "files-sdk/ai-sdk";
+
+export type { FileReadToolName, FileToolName, FileWriteToolName } from "files-sdk/ai-sdk";
+
+/**
+ * Worker-side agent tools (Mode A). Pass `Files` from `createStorage()` —
+ * reuses files-sdk tool schemas; do not duplicate MCP tool definitions here.
+ */
+export function createUploadsWorkerFileTools(
+  files: Files,
+  opts: Omit<FileToolsOptions, "files"> = {},
+) {
+  const { overrides, requireApproval, ...rest } = opts;
+  return createFileTools({
+    files,
+    requireApproval: requireApproval ?? {
+      deleteFile: true,
+      uploadFile: false,
+      copyFile: true,
+      signUploadUrl: true,
+    },
+    overrides: {
+      uploadFile: {
+        description:
+          "Upload a file for public hosting (e.g. GitHub embeds). Prefer keys under screenshots/.",
+      },
+      ...overrides,
+    },
+    ...rest,
+  });
+}

--- a/packages/uploads/src/cli-args.ts
+++ b/packages/uploads/src/cli-args.ts
@@ -1,0 +1,172 @@
+export interface GlobalFlags {
+  apiUrl?: string;
+  workspace?: string;
+  token?: string;
+  envFile?: string;
+  json?: boolean;
+  quiet?: boolean;
+}
+
+export interface ParsedArgv {
+  globals: GlobalFlags;
+  help: boolean;
+  command?: string;
+  /** Args starting at the command name (includes command-specific flags). */
+  rest: string[];
+}
+
+const VALUE_GLOBALS = new Set(["--api-url", "--workspace", "-w", "--token", "--env-file"]);
+
+export function isHelpFlag(arg: string): boolean {
+  return arg === "-h" || arg === "--help";
+}
+
+/**
+ * Parse global flags that appear before the subcommand. Stops at the first
+ * positional token (the command name) or an unrecognized flag.
+ */
+export function parseArgv(argv: string[]): ParsedArgv {
+  const args = argv.slice(2);
+  const globals: GlobalFlags = {};
+  let help = false;
+  let i = 0;
+
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (isHelpFlag(arg)) {
+      help = true;
+      i++;
+      continue;
+    }
+    if (arg === "--json") {
+      globals.json = true;
+      i++;
+      continue;
+    }
+    if (arg === "--quiet") {
+      globals.quiet = true;
+      i++;
+      continue;
+    }
+    if (VALUE_GLOBALS.has(arg)) {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) {
+        throw new UsageError(`missing value for ${arg}`);
+      }
+      switch (arg) {
+        case "--api-url":
+          globals.apiUrl = value;
+          break;
+        case "--workspace":
+        case "-w":
+          globals.workspace = value;
+          break;
+        case "--token":
+          globals.token = value;
+          break;
+        case "--env-file":
+          globals.envFile = value;
+          break;
+      }
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith("-")) break;
+    break;
+  }
+
+  const rest = args.slice(i);
+  return { globals, help, command: rest[0], rest };
+}
+
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
+export interface CommandFlags {
+  positionals: string[];
+  flags: Map<string, string | boolean>;
+  help: boolean;
+}
+
+/**
+ * Parse command-specific args. Supports `--flag value`, `--flag=value`, and
+ * boolean `--flag` flags.
+ */
+export function parseCommandArgs(args: string[]): CommandFlags {
+  const positionals: string[] = [];
+  const flags = new Map<string, string | boolean>();
+  let help = false;
+  let i = 0;
+
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (isHelpFlag(arg)) {
+      help = true;
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      const eq = arg.indexOf("=");
+      if (eq !== -1) {
+        flags.set(arg.slice(0, eq), arg.slice(eq + 1));
+        i++;
+        continue;
+      }
+
+      const name = arg;
+      const next = args[i + 1];
+      if (next && !next.startsWith("-")) {
+        flags.set(name, next);
+        i += 2;
+        continue;
+      }
+
+      flags.set(name, true);
+      i++;
+      continue;
+    }
+
+    positionals.push(arg);
+    i++;
+  }
+
+  return { positionals, flags, help };
+}
+
+export function flagString(flags: CommandFlags["flags"], name: string): string | undefined {
+  const value = flags.get(name);
+  return typeof value === "string" ? value : undefined;
+}
+
+export function flagBool(flags: CommandFlags["flags"], name: string): boolean {
+  return flags.get(name) === true;
+}
+
+/** Command-level workspace override (`--workspace` / `-w`). */
+export function commandWorkspace(flags: CommandFlags["flags"]): string | undefined {
+  return flagString(flags, "--workspace") ?? flagString(flags, "-w");
+}
+
+export function flagInt(
+  flags: CommandFlags["flags"],
+  name: string,
+  label: string,
+): number | undefined {
+  const raw = flagString(flags, name);
+  if (raw === undefined) return undefined;
+  if (!/^\d+$/.test(raw)) {
+    throw new UsageError(`invalid ${label}: must be a positive integer (got ${raw})`);
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new UsageError(`invalid ${label}: must be a positive integer (got ${raw})`);
+  }
+  return n;
+}

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -1,0 +1,149 @@
+import { createUploadsClient } from "./client.js";
+import { resolveApiUrl, resolveConfig } from "./config.js";
+import { UploadsError } from "./errors.js";
+import {
+  commandWorkspace,
+  isHelpFlag,
+  parseArgv,
+  parseCommandArgs,
+  UsageError,
+} from "./cli-args.js";
+import {
+  runPut,
+  runList,
+  runDelete,
+  runHealth,
+  runDoctor,
+  type CliContext,
+} from "./commands.js";
+
+const ROOT_HELP = `uploads — CLI for uploads.sh (GitHub image embeds)
+
+Usage:
+  uploads [globals] <command> [args]
+
+Workspace (first match wins):
+  --workspace, -w     override — global (before command) or per-command (after)
+  UPLOADS_WORKSPACE   env / --env-file
+  (else inferred from token up_<name>_…, else "default")
+
+Other globals (before command):
+  --api-url <url>     default: https://api.uploads.sh
+  --token <token>     or UPLOADS_TOKEN
+  --env-file <path>
+  --json              JSON on stdout
+  --quiet
+
+Commands:
+  put <file>          Upload (+ URL + markdown for GitHub)
+  list                List objects
+  delete <key>        Delete object
+  doctor              Health + auth + workspace checks
+  health              API liveness (no auth)
+
+Examples:
+  uploads --env-file .env put ./shot.png --repo myorg/myapp --ref 42
+  uploads put ./shot.png --workspace acme
+  uploads --workspace buildinternet --env-file .env doctor
+
+Agent/MCP: use createUploadsWorkerFileTools() from @buildinternet/uploads/agent on the Worker.
+`;
+
+function createContext(
+  globals: ReturnType<typeof parseArgv>["globals"],
+  requireToken: boolean,
+  commandArgs: string[],
+): CliContext {
+  const cmdWorkspace = commandWorkspace(parseCommandArgs(commandArgs).flags);
+  const config = resolveConfig({
+    apiUrl: globals.apiUrl,
+    workspace: cmdWorkspace ?? globals.workspace,
+    token: globals.token,
+    envFile: globals.envFile,
+    requireToken,
+  });
+  return {
+    config,
+    client: createUploadsClient(config),
+    json: globals.json ?? false,
+    quiet: globals.quiet ?? false,
+  };
+}
+
+function exitCode(err: unknown): number {
+  if (err instanceof UsageError) return 2;
+  if (err instanceof UploadsError) {
+    switch (err.code) {
+      case "MISSING_TOKEN":
+      case "USAGE":
+        return 2;
+      case "UNAUTHORIZED":
+      case "NOT_FOUND":
+        return 3;
+      case "NETWORK":
+        return 4;
+      default:
+        return 1;
+    }
+  }
+  return 1;
+}
+
+function errorOut(err: unknown, json: boolean): void {
+  const payload =
+    err instanceof UploadsError
+      ? { error: err.message, code: err.code, status: err.status }
+      : err instanceof UsageError
+        ? { error: err.message, code: "USAGE" }
+        : { error: err instanceof Error ? err.message : String(err) };
+  if (json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  else process.stderr.write(`error: ${payload.error}\n`);
+}
+
+export async function runCli(argv: string[]): Promise<number> {
+  try {
+    const parsed = parseArgv(argv);
+    const json = parsed.globals.json ?? false;
+
+    if (!parsed.command) {
+      process.stderr.write(ROOT_HELP);
+      return parsed.help ? 0 : 2;
+    }
+
+    const cmdArgs = parsed.rest.slice(1);
+    const showHelp = parsed.help || cmdArgs.some(isHelpFlag);
+
+    switch (parsed.command) {
+      case "health":
+        return runHealth(
+          { apiUrl: resolveApiUrl(parsed.globals), json },
+          cmdArgs,
+          showHelp,
+        );
+      case "put":
+      case "list":
+      case "delete":
+      case "doctor": {
+        const ctx = createContext(parsed.globals, !showHelp, cmdArgs);
+        switch (parsed.command) {
+          case "put":
+            return runPut(ctx, cmdArgs, showHelp);
+          case "list":
+            return runList(ctx, cmdArgs, showHelp);
+          case "delete":
+            return runDelete(ctx, cmdArgs, showHelp);
+          case "doctor":
+            return runDoctor(ctx, cmdArgs, showHelp);
+        }
+      }
+      default:
+        process.stderr.write(`unknown command: ${parsed.command}\n\n${ROOT_HELP}`);
+        return 2;
+    }
+  } catch (err) {
+    errorOut(err, argv.includes("--json"));
+    if (err instanceof UsageError && !argv.includes("--json")) process.stderr.write(`\n${ROOT_HELP}`);
+    return exitCode(err);
+  }
+  return 1;
+}

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -1,0 +1,180 @@
+import { inferContentType } from "./embed.js";
+import type { UploadsClientConfig } from "./config.js";
+import { UploadsError } from "./errors.js";
+import { buildScreenshotKey } from "./keys.js";
+
+export interface PutOptions {
+  key?: string;
+  contentType?: string;
+  repo?: string;
+  ref?: string;
+  deriveRepoFromGit?: boolean;
+}
+
+export interface ListOptions {
+  prefix?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface PutResult {
+  workspace: string;
+  key: string;
+  url: string;
+  size: number;
+  contentType: string;
+}
+
+export interface ListItem {
+  key: string;
+  url: string | null;
+  size?: number;
+  uploaded?: string;
+}
+
+export interface ListResult {
+  items: ListItem[];
+  cursor: string | null;
+}
+
+export interface HeadResult {
+  key: string;
+  url: string | null;
+  size: number;
+  contentType: string;
+  uploaded?: string;
+}
+
+export interface DeleteResult {
+  key: string;
+  deleted: boolean;
+}
+
+export interface HealthResult {
+  ok: boolean;
+}
+
+function encodeKeyPath(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function filesBase(config: UploadsClientConfig): string {
+  return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/files`;
+}
+
+function mapApiError(status: number, error: string): UploadsError {
+  const normalized = error.toLowerCase();
+  if (status === 401 || normalized === "unauthorized") {
+    return new UploadsError(error, "UNAUTHORIZED", status);
+  }
+  if (status === 404 || normalized === "not found") {
+    return new UploadsError(error, "NOT_FOUND", status);
+  }
+  if (status === 400 && normalized === "invalid key") {
+    return new UploadsError(error, "INVALID_KEY", status);
+  }
+  return new UploadsError(error, "API_ERROR", status);
+}
+
+async function parseErrorResponse(res: Response): Promise<UploadsError> {
+  const body = await res.json().catch(() => ({}));
+  const message =
+    typeof body === "object" && body && "error" in body && typeof body.error === "string"
+      ? body.error
+      : res.statusText || "request failed";
+  return mapApiError(res.status, message);
+}
+
+export function createUploadsClient(config: UploadsClientConfig) {
+  async function request<T>(
+    method: string,
+    path: string,
+    opts?: { body?: Uint8Array; headers?: Record<string, string>; auth?: boolean },
+  ): Promise<T> {
+    const headers: Record<string, string> = { ...opts?.headers };
+    if (opts?.auth !== false) {
+      headers.Authorization = `Bearer ${config.token}`;
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(path, {
+        method,
+        headers,
+        body: opts?.body,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "network request failed";
+      throw new UploadsError(message, "NETWORK");
+    }
+
+    if (!res.ok) {
+      throw await parseErrorResponse(res);
+    }
+
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  return {
+    async put(body: Uint8Array, opts: PutOptions & { filename: string }): Promise<PutResult> {
+      const key =
+        opts.key ??
+        (await buildScreenshotKey({
+          filename: opts.filename,
+          fileBytes: body,
+          repo: opts.repo,
+          ref: opts.ref,
+          deriveRepoFromGit: opts.deriveRepoFromGit,
+        }));
+      const contentType = opts.contentType ?? inferContentType(opts.filename);
+
+      const result = await request<{
+        workspace: string;
+        key: string;
+        url: string | null;
+        size: number;
+        contentType: string;
+      }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}`, {
+        body,
+        headers: { "Content-Type": contentType },
+      });
+
+      if (result.url == null) {
+        throw new UploadsError(
+          "upload succeeded but workspace has no publicBaseUrl",
+          "NO_PUBLIC_URL",
+          201,
+        );
+      }
+
+      return { ...result, url: result.url };
+    },
+
+    async list(opts: ListOptions = {}): Promise<ListResult> {
+      const params = new URLSearchParams();
+      if (opts.prefix) params.set("prefix", opts.prefix);
+      if (opts.limit != null) params.set("limit", String(opts.limit));
+      if (opts.cursor) params.set("cursor", opts.cursor);
+      const qs = params.toString();
+      return request<ListResult>(
+        "GET",
+        `${filesBase(config)}${qs ? `?${qs}` : ""}`,
+      );
+    },
+
+    async delete(key: string): Promise<DeleteResult> {
+      return request<DeleteResult>("DELETE", `${filesBase(config)}/${encodeKeyPath(key)}`);
+    },
+
+    async head(key: string): Promise<HeadResult> {
+      return request<HeadResult>("GET", `${filesBase(config)}/${encodeKeyPath(key)}`);
+    },
+
+    async health(): Promise<HealthResult> {
+      return request<HealthResult>("GET", `${config.apiUrl}/health`, { auth: false });
+    },
+  };
+}
+
+export type UploadsClient = ReturnType<typeof createUploadsClient>;

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1,0 +1,295 @@
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { createUploadsClient, type UploadsClient } from "./client.js";
+import {
+  parseCommandArgs,
+  flagString,
+  flagBool,
+  flagInt,
+  UsageError,
+} from "./cli-args.js";
+import { workspaceMismatch, workspaceFromToken, type ResolvedConfig } from "./config.js";
+import { buildMarkdown } from "./embed.js";
+import { UploadsError } from "./errors.js";
+
+export interface CliContext {
+  config: ResolvedConfig;
+  client: UploadsClient;
+  json: boolean;
+  quiet: boolean;
+}
+
+async function writeStdout(text: string): Promise<void> {
+  if (!process.stdout.write(text)) {
+    await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
+  }
+}
+
+async function writeJson(value: unknown): Promise<void> {
+  await writeStdout(JSON.stringify(value, null, 2) + "\n");
+}
+
+// --- put ---
+
+const PUT_HELP = `uploads put <file> [options]
+
+Upload an image for GitHub embeds. Use "-" for stdin.
+
+Options:
+  --key <key>           Object key (default: screenshots/<repo>/<ref>/<name>-<hash>.<ext>)
+  --repo <owner/repo>   Repo segment (default: git remote)
+  --ref <id>            PR/issue/branch segment (default: today's date)
+  --alt <text>          Alt text (default: filename)
+  --width <px>          <img width=…> markdown
+  --content-type <mime> Override Content-Type
+  --no-git              Don't derive --repo from git
+  --workspace, -w <name>  Override workspace (wins over UPLOADS_WORKSPACE and token inference)
+  --format human|url|markdown|json
+
+Examples:
+  uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
+  uploads --env-file .env put ./shot.png
+`;
+
+export async function runPut(ctx: CliContext, args: string[], help = false): Promise<number> {
+  if (help) {
+    process.stderr.write(PUT_HELP);
+    return 0;
+  }
+  const parsed = parseCommandArgs(args);
+  if (parsed.help) {
+    process.stderr.write(PUT_HELP);
+    return 0;
+  }
+
+  const fileArg = parsed.positionals[0];
+  if (!fileArg) {
+    process.stderr.write(PUT_HELP);
+    return 2;
+  }
+
+  const keyHint = flagString(parsed.flags, "--key");
+  const bytes =
+    fileArg === "-"
+      ? new Uint8Array(readFileSync(0))
+      : new Uint8Array(readFileSync(fileArg));
+  const filename = fileArg === "-" ? (keyHint ? basename(keyHint) : "stdin.bin") : basename(fileArg);
+
+  const format = ctx.json
+    ? "json"
+    : (() => {
+        const raw = flagString(parsed.flags, "--format");
+        if (!raw || raw === "human") return "human" as const;
+        if (raw === "url" || raw === "markdown" || raw === "json") return raw;
+        throw new UsageError(`invalid --format: ${raw}`);
+      })();
+
+  const alt = flagString(parsed.flags, "--alt") ?? basename(filename);
+  const widthRaw = flagString(parsed.flags, "--width");
+  const width =
+    widthRaw && /^\d+$/.test(widthRaw) && Number(widthRaw) > 0
+      ? Number.parseInt(widthRaw, 10)
+      : widthRaw
+        ? (() => {
+            throw new UsageError(`invalid --width: ${widthRaw}`);
+          })()
+        : undefined;
+
+  if (!ctx.quiet && format === "human") {
+    process.stderr.write(`>> uploading ${fileArg === "-" ? "stdin" : fileArg}\n`);
+  }
+
+  const result = await ctx.client.put(bytes, {
+    filename,
+    key: keyHint,
+    repo: flagString(parsed.flags, "--repo"),
+    ref: flagString(parsed.flags, "--ref"),
+    contentType: flagString(parsed.flags, "--content-type"),
+    deriveRepoFromGit: !flagBool(parsed.flags, "--no-git"),
+  });
+
+  const markdown = buildMarkdown(result.url, { alt, width });
+
+  if (!ctx.quiet && format === "human") {
+    process.stderr.write(`>> key: ${result.key}\n\n`);
+  }
+
+  switch (format) {
+    case "json":
+      await writeJson({ ...result, markdown });
+      break;
+    case "url":
+      await writeStdout(`${result.url}\n`);
+      break;
+    case "markdown":
+      await writeStdout(`${markdown}\n`);
+      break;
+    default:
+      await writeStdout(`URL: ${result.url}\nMARKDOWN: ${markdown}\n`);
+  }
+  return 0;
+}
+
+// --- list ---
+
+const LIST_HELP = `uploads list [--prefix <p>] [--limit <n>] [--cursor <c>] [--all] [--workspace <name>]
+
+Examples:
+  uploads list --prefix screenshots/
+  uploads list --all --json
+`;
+
+export async function runList(ctx: CliContext, args: string[], help = false): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(LIST_HELP);
+    return 0;
+  }
+  const prefix = flagString(parsed.flags, "--prefix");
+  const limit = flagInt(parsed.flags, "--limit", "--limit");
+  const cursor = flagString(parsed.flags, "--cursor");
+
+  if (flagBool(parsed.flags, "--all")) {
+    const items = [];
+    let next: string | null | undefined = cursor;
+    do {
+      const page = await ctx.client.list({ prefix, limit, cursor: next ?? undefined });
+      items.push(...page.items);
+      next = page.cursor;
+    } while (next);
+    if (ctx.json) await writeJson({ items, cursor: null });
+    else for (const item of items) await writeStdout(`${item.key}${item.url ? `  ${item.url}` : ""}\n`);
+    return 0;
+  }
+
+  const result = await ctx.client.list({ prefix, limit, cursor });
+  if (ctx.json) await writeJson(result);
+  else {
+    for (const item of result.items) await writeStdout(`${item.key}${item.url ? `  ${item.url}` : ""}\n`);
+    if (result.cursor) process.stderr.write(`cursor: ${result.cursor}\n`);
+  }
+  return 0;
+}
+
+// --- delete ---
+
+const DELETE_HELP = `uploads delete <key> [--dry-run] [--workspace <name>]
+
+Examples:
+  uploads delete screenshots/myapp/42/shot-a1b2c3.png
+`;
+
+export async function runDelete(ctx: CliContext, args: string[], help = false): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(DELETE_HELP);
+    return 0;
+  }
+  const key = parsed.positionals[0];
+  if (!key) {
+    process.stderr.write(DELETE_HELP);
+    return 2;
+  }
+  if (flagBool(parsed.flags, "--dry-run")) {
+    if (ctx.json) await writeJson({ key, deleted: false, dryRun: true });
+    else process.stderr.write(`dry-run: would delete ${key}\n`);
+    return 0;
+  }
+  const result = await ctx.client.delete(key);
+  if (ctx.json) await writeJson(result);
+  else if (!ctx.quiet) process.stderr.write(`deleted ${result.key}\n`);
+  return 0;
+}
+
+// --- health & doctor ---
+
+const HEALTH_HELP = `uploads health
+
+API liveness (no auth).
+
+Examples:
+  uploads health
+  uploads --api-url http://localhost:8787 health
+`;
+
+export async function runHealth(
+  ctx: Pick<CliContext, "json"> & { apiUrl: string },
+  args: string[],
+  help = false,
+): Promise<number> {
+  if (help || parseCommandArgs(args).help) {
+    process.stderr.write(HEALTH_HELP);
+    return 0;
+  }
+  const result = await createUploadsClient({
+    apiUrl: ctx.apiUrl,
+    workspace: "default",
+    token: "",
+  }).health();
+
+  if (ctx.json) await writeJson({ ...result, apiUrl: ctx.apiUrl });
+  else await writeStdout(result.ok ? `ok (${ctx.apiUrl})\n` : `unhealthy (${ctx.apiUrl})\n`);
+  return result.ok ? 0 : 1;
+}
+
+const DOCTOR_HELP = `uploads doctor [--workspace <name>]
+
+Checks API health, token auth, and workspace/token alignment.
+
+Examples:
+  uploads --env-file .env doctor
+  uploads --workspace acme --env-file .env doctor
+`;
+
+export async function runDoctor(ctx: CliContext, args: string[], help = false): Promise<number> {
+  if (help || parseCommandArgs(args).help) {
+    process.stderr.write(DOCTOR_HELP);
+    return 0;
+  }
+
+  const mismatch = workspaceMismatch(ctx.config);
+  const hints: string[] = [];
+  if (mismatch) hints.push(mismatch);
+  if (ctx.config.apiUrl.includes("localhost") || ctx.config.apiUrl.includes("127.0.0.1")) {
+    hints.push("local API uses dev KV — prod tokens won't work unless minted with --local");
+  }
+
+  const health = await ctx.client.health();
+  let authOk = false;
+  let authError: string | undefined;
+  try {
+    await ctx.client.list({ limit: 1 });
+    authOk = true;
+  } catch (err) {
+    authError = err instanceof UploadsError ? err.message : String(err);
+    if (err instanceof UploadsError && err.code === "UNAUTHORIZED") {
+      hints.push("if this token works on api.uploads.sh, set UPLOADS_API_URL=https://api.uploads.sh");
+    }
+  }
+
+  const report = {
+    ok: health.ok && authOk,
+    apiUrl: ctx.config.apiUrl,
+    workspace: ctx.config.workspace,
+    workspaceSource: ctx.config.workspaceSource,
+    workspaceFromToken: workspaceFromToken(ctx.config.token),
+    health,
+    auth: { ok: authOk, error: authError },
+    hints,
+  };
+
+  if (ctx.json) {
+    await writeJson(report);
+    return report.ok ? 0 : 1;
+  }
+
+  const lines = [
+    `api:       ${ctx.config.apiUrl} (${health.ok ? "ok" : "failed"})`,
+    `workspace: ${ctx.config.workspace}`,
+    `auth:      ${authOk ? "ok" : `failed — ${authError}`}`,
+  ];
+  if (mismatch) lines.push(`warning:   ${mismatch}`);
+  for (const h of hints) if (h !== mismatch) lines.push(`hint:      ${h}`);
+  await writeStdout(lines.join("\n") + "\n");
+  return report.ok ? 0 : 1;
+}

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { UploadsError } from "./errors.js";
+
+export interface UploadsClientConfig {
+  apiUrl: string;
+  workspace: string;
+  token: string;
+}
+
+export const DEFAULT_API_URL = "https://api.uploads.sh";
+export const DEFAULT_WORKSPACE = "default";
+
+const TOKEN_WORKSPACE_RE = /^up_([a-z0-9][a-z0-9-]{1,62})_/;
+
+/** Workspace encoded in minted tokens: `up_<workspace>_…` */
+export function workspaceFromToken(token: string): string | undefined {
+  return TOKEN_WORKSPACE_RE.exec(token)?.[1];
+}
+
+export function loadEnvFile(path: string): Partial<UploadsClientConfig> {
+  const out: Partial<UploadsClientConfig> = {};
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key === "UPLOADS_API_URL") out.apiUrl = value;
+    else if (key === "UPLOADS_WORKSPACE") out.workspace = value;
+    else if (key === "UPLOADS_TOKEN") out.token = value;
+  }
+  return out;
+}
+
+export function resolveApiUrl(flags?: { apiUrl?: string; envFile?: string }): string {
+  const fromFile = flags?.envFile ? loadEnvFile(flags.envFile) : {};
+  return flags?.apiUrl ?? process.env.UPLOADS_API_URL ?? fromFile.apiUrl ?? DEFAULT_API_URL;
+}
+
+/** How the active workspace was chosen (for doctor hints). */
+export type WorkspaceSource = "override" | "env" | "file" | "token" | "default";
+
+export interface ResolvedConfig extends UploadsClientConfig {
+  workspaceSource: WorkspaceSource;
+}
+
+export function resolveConfig(
+  flags?: Partial<UploadsClientConfig> & { envFile?: string; requireToken?: boolean },
+): ResolvedConfig {
+  const fromFile = flags?.envFile ? loadEnvFile(flags.envFile) : {};
+  const token = flags?.token ?? process.env.UPLOADS_TOKEN ?? fromFile.token;
+  const apiUrl = resolveApiUrl(flags);
+
+  let workspace: string;
+  let workspaceSource: WorkspaceSource;
+
+  if (flags?.workspace) {
+    workspace = flags.workspace;
+    workspaceSource = "override";
+  } else if (process.env.UPLOADS_WORKSPACE) {
+    workspace = process.env.UPLOADS_WORKSPACE;
+    workspaceSource = "env";
+  } else if (fromFile.workspace) {
+    workspace = fromFile.workspace;
+    workspaceSource = "file";
+  } else if (token && workspaceFromToken(token)) {
+    workspace = workspaceFromToken(token)!;
+    workspaceSource = "token";
+  } else {
+    workspace = DEFAULT_WORKSPACE;
+    workspaceSource = "default";
+  }
+
+  if (flags?.requireToken !== false && !token) {
+    throw new UploadsError(
+      "UPLOADS_TOKEN is required — set in env, pass --token, or use --env-file",
+      "MISSING_TOKEN",
+    );
+  }
+
+  return { apiUrl, workspace, token: token ?? "", workspaceSource };
+}
+
+/** Warn when an explicit workspace override may not match the token's embedded workspace. */
+export function workspaceMismatch(config: ResolvedConfig): string | undefined {
+  const fromToken = workspaceFromToken(config.token);
+  if (!fromToken || fromToken === config.workspace) return undefined;
+  if (config.workspaceSource === "token" || config.workspaceSource === "default") return undefined;
+  return `workspace override "${config.workspace}" (token encodes "${fromToken}") — ensure the token is valid for the override workspace`;
+}

--- a/packages/uploads/src/embed.ts
+++ b/packages/uploads/src/embed.ts
@@ -1,0 +1,30 @@
+/** GitHub-embed helpers (content type + markdown). */
+
+export function inferContentType(filename: string): string {
+  const ext = filename.includes(".") ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase() : "";
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "svg":
+      return "image/svg+xml";
+    case "mp4":
+      return "video/mp4";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+export function buildMarkdown(url: string, opts: { alt: string; width?: number }): string {
+  if (opts.width) {
+    const alt = opts.alt.replace(/"/g, "&quot;");
+    return `<img width="${opts.width}" alt="${alt}" src="${url}">`;
+  }
+  return `![${opts.alt}](${url})`;
+}

--- a/packages/uploads/src/errors.ts
+++ b/packages/uploads/src/errors.ts
@@ -1,0 +1,21 @@
+export type UploadsErrorCode =
+  | "MISSING_TOKEN"
+  | "NO_PUBLIC_URL"
+  | "NOT_FOUND"
+  | "UNAUTHORIZED"
+  | "INVALID_KEY"
+  | "API_ERROR"
+  | "NETWORK"
+  | "USAGE";
+
+export class UploadsError extends Error {
+  readonly code: UploadsErrorCode;
+  readonly status?: number;
+
+  constructor(message: string, code: UploadsErrorCode, status?: number) {
+    super(message);
+    this.name = "UploadsError";
+    this.code = code;
+    this.status = status;
+  }
+}

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -1,0 +1,32 @@
+export { inferContentType, buildMarkdown } from "./embed.js";
+export {
+  sanitizeKeySegment,
+  sha256Short,
+  deriveRepoFromGit,
+  buildScreenshotKey,
+} from "./keys.js";
+export {
+  DEFAULT_API_URL,
+  DEFAULT_WORKSPACE,
+  loadEnvFile,
+  resolveApiUrl,
+  resolveConfig,
+  workspaceFromToken,
+  workspaceMismatch,
+  type UploadsClientConfig,
+  type ResolvedConfig,
+  type WorkspaceSource,
+} from "./config.js";
+export { UploadsError, type UploadsErrorCode } from "./errors.js";
+export {
+  createUploadsClient,
+  type UploadsClient,
+  type PutOptions,
+  type ListOptions,
+  type PutResult,
+  type ListItem,
+  type ListResult,
+  type HeadResult,
+  type DeleteResult,
+  type HealthResult,
+} from "./client.js";

--- a/packages/uploads/src/keys.ts
+++ b/packages/uploads/src/keys.ts
@@ -1,0 +1,43 @@
+import { execSync } from "node:child_process";
+
+export function sanitizeKeySegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+export async function sha256Short(bytes: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 6);
+}
+
+export function deriveRepoFromGit(): string | undefined {
+  try {
+    const url = execSync("git config --get remote.origin.url", { encoding: "utf8" }).trim();
+    const match = url.match(/[/:]([^/]+?)(?:\.git)?$/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildScreenshotKey(opts: {
+  filename: string;
+  fileBytes: Uint8Array;
+  repo?: string;
+  ref?: string;
+  deriveRepoFromGit?: boolean;
+}): Promise<string> {
+  const dot = opts.filename.lastIndexOf(".");
+  const ext = dot >= 0 ? opts.filename.slice(dot + 1) : "";
+  const stem = dot >= 0 ? opts.filename.slice(0, dot) : opts.filename;
+
+  let repo = opts.repo;
+  if (!repo && opts.deriveRepoFromGit) repo = deriveRepoFromGit();
+  repo = sanitizeKeySegment(repo ?? "misc");
+  const ref = sanitizeKeySegment(opts.ref ?? new Date().toISOString().slice(0, 10));
+  const short = await sha256Short(opts.fileBytes);
+
+  return `screenshots/${repo}/${ref}/${sanitizeKeySegment(stem)}-${short}${ext ? `.${sanitizeKeySegment(ext)}` : ""}`;
+}

--- a/packages/uploads/tsconfig.json
+++ b/packages/uploads/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,11 @@ patchedDependencies:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@buildinternet/uploads':
+        specifier: workspace:*
+        version: link:packages/uploads
 
   apps/api:
     dependencies:
@@ -59,7 +63,7 @@ importers:
         version: 3.1080.0
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(h3@1.15.11)(hono@4.12.27)(zod@4.4.3)
+        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(h3@1.15.11)(hono@4.12.27)(zod@4.4.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260706.1
@@ -68,7 +72,38 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/uploads:
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
+      ai:
+        specifier: ^6.0.0
+        version: 6.0.220(zod@4.4.3)
+      files-sdk:
+        specifier: ^2.1.0
+        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(h3@1.15.11)(hono@4.12.28)(zod@4.4.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
 packages:
+
+  '@ai-sdk/gateway@3.0.144':
+    resolution: {integrity: sha512-U0B6LI+12JNN7rCzYQ5hlaKJCMypFldnLBLzJSgioC4Z6hrCLA8K6ICl2MfRfpLfo9yz2EN30chgo/89RDe5ZQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.36':
+    resolution: {integrity: sha512-hy0V+eyKcYyjmIxdcSh1jvy4+zNC7DbP0/V45jkRmfVnz+lI6GslT0qsd0V/bfJKo/A+P2t1tYFypTQJdOH1Sg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.13':
+    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
+    engines: {node: '>=18'}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -913,6 +948,10 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -1097,6 +1136,9 @@ packages:
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1123,6 +1165,10 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1153,6 +1199,12 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  ai@6.0.220:
+    resolution: {integrity: sha512-S0zifFbegc4CjfEo3nsEtBraXP22JKchN5SkcLDvIUNCefkWavmp8pPF0ey1yipBPRdTF7oy7EchLIZM1HmtuQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -1807,6 +1859,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
@@ -2683,6 +2738,24 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/gateway@3.0.144(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.36(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.13':
+    dependencies:
+      json-schema: 0.4.0
+
   '@astrojs/check@0.9.9(prettier@3.9.4)(typescript@6.0.3)':
     dependencies:
       '@astrojs/language-server': 2.16.11(prettier@3.9.4)(typescript@6.0.3)
@@ -3455,6 +3528,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.138.0': {}
@@ -3605,6 +3680,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.17': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -3635,6 +3712,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@vercel/oidc@3.2.0': {}
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
@@ -3691,6 +3770,14 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
     optional: true
+
+  ai@6.0.220(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.144(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
@@ -4083,8 +4170,7 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.1.0:
-    optional: true
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -4151,7 +4237,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  files-sdk@2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(h3@1.15.11)(hono@4.12.27)(zod@4.4.3):
+  files-sdk@2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(h3@1.15.11)(hono@4.12.27)(zod@4.4.3):
     dependencies:
       commander: 15.0.0
       picomatch: 4.0.5
@@ -4161,8 +4247,29 @@ snapshots:
       '@aws-sdk/s3-presigned-post': 3.1080.0
       '@aws-sdk/s3-request-presigner': 3.1080.0
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      ai: 6.0.220(zod@4.4.3)
       h3: 1.15.11
       hono: 4.12.27
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  files-sdk@2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(h3@1.15.11)(hono@4.12.28)(zod@4.4.3):
+    dependencies:
+      commander: 15.0.0
+      picomatch: 4.0.5
+      safe-regex2: 5.1.1
+    optionalDependencies:
+      '@aws-sdk/client-s3': 3.1080.0
+      '@aws-sdk/s3-presigned-post': 3.1080.0
+      '@aws-sdk/s3-request-presigner': 3.1080.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      ai: 6.0.220(zod@4.4.3)
+      h3: 1.15.11
+      hono: 4.12.28
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -4340,6 +4447,8 @@ snapshots:
 
   json-schema-typed@8.0.2:
     optional: true
+
+  json-schema@0.4.0: {}
 
   jsonc-parser@2.3.1: {}
 


### PR DESCRIPTION
## Summary

Adds `@buildinternet/uploads` — a CLI and TypeScript client for uploads.sh, focused on GitHub image embeds via public URLs.

- **CLI commands:** `put`, `list`, `delete`, `doctor`, `health`
- **Workspace resolution:** `--workspace` / `-w` → `UPLOADS_WORKSPACE` → env file → token inference (`up_<workspace>_…`) → `default`
- **Put output:** public URL + markdown (`--format url|markdown|json|human`)
- **Screenshot keys:** `screenshots/<repo>/<ref>/<stem>-<hash>.<ext>` with git remote inference
- **Library exports:** REST client, config helpers, embed builders, optional Worker agent wrapper (`@buildinternet/uploads/agent`)
- **Local dev:** `pnpm uploads put ./shot.png --env-file .env` (builds package via `preuploads`)

## Test plan

- [x] `pnpm typecheck` passes
- [x] Prod upload verified against `https://api.uploads.sh` with `default` workspace
- [ ] `pnpm uploads doctor --env-file .env` with your token
- [ ] `pnpm uploads put ./shot.png --env-file .env --repo owner/repo --ref 42`