### PR TITLE
Shared-bucket workspace prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ pnpm dev                 # API on :8787 (local R2 + KV simulation)
 pnpm dev:web             # Astro site
 pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # both workers; or deploy:api / deploy:web
-pnpm workspace:add <name> --bucket <bucket> [--binding X] [--local]
+pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local]
 pnpm uploads put <file> --env-file .env   # CLI (builds package first)
 ```
 
@@ -47,6 +47,17 @@ bucket, optional R2 binding name, optional `publicBaseUrl`, optional S3
 credentials, and the SHA-256 hash of its bearer token. Register workspaces
 with `apps/api/scripts/add-workspace.mjs` (`--local` for dev KV). Never treat
 any workspace as special in code — even `default` is just a registered tenant.
+
+By default a workspace is a **`<name>/` prefix in the shared `uploads-default`
+bucket** (binding `UPLOADS_DEFAULT`, public at `https://storage.uploads.sh`):
+the record carries `prefix: "<name>/"` and creating one is a pure KV write.
+The prefix is applied in exactly one place — `createStorage()` in
+`packages/storage` (files-sdk instance prefix) — so route code and clients
+never see it; public URLs are `https://storage.uploads.sh/<name>/<key>`.
+Bring-your-own-bucket is the advanced case: register with `--bucket` and the
+record points at a dedicated bucket (own binding or S3 credentials, own
+`publicBaseUrl`, no prefix) — `buildinternet` on `buildinternet-dev` is the
+reference example.
 
 R2 workspaces have **two credential paths on the same bucket**:
 

--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ the `routes` block to serve from your `workers.dev` subdomain.
    default binding expects `uploads-default`), or create one with
    `wrangler r2 bucket create`. Same-account buckets get binding-mode I/O;
    workspaces can instead carry their own S3 credentials for HTTP mode.
-3. Register the workspace: `pnpm workspace:add default
-   [--bucket uploads-default] [--binding UPLOADS_DEFAULT] --public-base-url
-   https://storage.uploads.sh`.
+3. Register the workspace: `pnpm workspace:add default` — with no flags it
+   lands in the shared `uploads-default` bucket under a `default/` prefix,
+   served at `https://storage.uploads.sh`. Pass `--bucket` (and optionally
+   `--binding` / `--public-base-url`) for a dedicated bucket instead.
 4. `pnpm run deploy` — ships both workers (`deploy:api` → `api.uploads.sh`,
    `deploy:web` → the `uploads.sh` apex). Note `pnpm run deploy`, not
    `pnpm deploy` — the bare form is pnpm's own command. In CI, Workers Builds

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ curl -X PUT https://api.uploads.sh/v1/default/files/screenshots/myapp/42/shot.pn
 ```bash
 pnpm install
 cp apps/api/.dev.vars.example apps/api/.dev.vars
-pnpm workspace:add default [--bucket uploads-default] [--binding UPLOADS_DEFAULT] --local
+pnpm workspace:add default --local
 pnpm dev            # API on :8787 (local R2 + KV simulation); pnpm dev:web for the site
 pnpm typecheck
 ```

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ peer deps — no API changes.
 
 ## Workspaces
 
-Every request is scoped to a **workspace** — a tenant with its own bucket,
-credentials, and bearer token. Nothing in the code treats any workspace as
-special; landing in a particular bucket is always an intentional choice of
-workspace. The default workspace ships ready to use:
+Every request is scoped to a **workspace** — a tenant with its own credentials
+and bearer token. By default, a workspace is a `<name>/` prefix in the shared
+`uploads-default` bucket (binding `UPLOADS_DEFAULT`, public at
+`https://storage.uploads.sh`); the record carries `prefix: "<name>/"` and
+creating one is a pure KV write. Bring-your-own-bucket is the advanced case:
+register with `--bucket` and the record points at a dedicated bucket (own
+binding or S3 credentials). Nothing in the code treats any workspace as special.
+The default workspace ships ready to use:
 
 | Workspace | Bucket | Public base URL |
 |---|---|---|
@@ -41,8 +45,8 @@ another with:
 
 ```bash
 pnpm workspace:add my-workspace \
-  --bucket my-bucket --binding UPLOADS \
-  --public-base-url https://media.example.com   # add --local for dev
+  [--bucket my-bucket] [--binding UPLOADS] \
+  [--public-base-url https://media.example.com]   # add --local for dev
 ```
 
 It prints the bearer token once.
@@ -124,7 +128,7 @@ curl -X PUT https://api.uploads.sh/v1/default/files/screenshots/myapp/42/shot.pn
 ```bash
 pnpm install
 cp apps/api/.dev.vars.example apps/api/.dev.vars
-pnpm workspace:add default --bucket uploads-default --binding UPLOADS_DEFAULT --local
+pnpm workspace:add default [--bucket uploads-default] [--binding UPLOADS_DEFAULT] --local
 pnpm dev            # API on :8787 (local R2 + KV simulation); pnpm dev:web for the site
 pnpm typecheck
 ```
@@ -145,7 +149,7 @@ the `routes` block to serve from your `workers.dev` subdomain.
    `wrangler r2 bucket create`. Same-account buckets get binding-mode I/O;
    workspaces can instead carry their own S3 credentials for HTTP mode.
 3. Register the workspace: `pnpm workspace:add default
-   --bucket uploads-default --binding UPLOADS_DEFAULT --public-base-url
+   [--bucket uploads-default] [--binding UPLOADS_DEFAULT] --public-base-url
    https://storage.uploads.sh`.
 4. `pnpm run deploy` — ships both workers (`deploy:api` → `api.uploads.sh`,
    `deploy:web` → the `uploads.sh` apex). Note `pnpm run deploy`, not

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -4,15 +4,23 @@
  * The token is printed once; only its SHA-256 hash is stored.
  *
  * Usage (from apps/api):
- *   node scripts/add-workspace.mjs <name> --bucket <bucket> \
+ *   node scripts/add-workspace.mjs <name> \
+ *     [--bucket <bucket>]   # omit for shared-bucket mode (uploads-default + "<name>/" prefix)
  *     [--binding UPLOADS] [--public-base-url https://media.example.com] \
  *     [--account-id ...] [--access-key-id ...] [--secret-access-key ...] \
- *     [--local]            # write to wrangler dev's local KV instead of prod
+ *     [--local]             # write to wrangler dev's local KV instead of prod
  *
- * Credential flags fall back to R2_ACCOUNT_ID / R2_ACCESS_KEY_ID /
- * R2_SECRET_ACCESS_KEY, and --public-base-url to R2_PUBLIC_BASE_URL, so you
- * can keep them in the repo-root .env and run:
+ * Default (no --bucket): the workspace is a "<name>/" prefix in the shared
+ * uploads-default bucket, served at https://storage.uploads.sh/<name>/...
+ * Creating one is a pure KV write — no bucket, binding, or deploy needed.
+ *
+ * BYO mode (--bucket): dedicated bucket, today's behavior. Credential flags
+ * fall back to R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY, and
+ * --public-base-url to R2_PUBLIC_BASE_URL, so you can keep them in the
+ * repo-root .env and run:
  *   node --env-file=../../.env scripts/add-workspace.mjs <name> --bucket <bucket>
+ * Env fallbacks apply ONLY in BYO mode — shared-mode records never inherit
+ * BYO-bucket credentials from the environment.
  */
 import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
@@ -32,23 +40,46 @@ function fail(msg) { console.error(`error: ${msg}`); process.exit(1); }
 if (!name || !/^[a-z0-9][a-z0-9-]{1,62}$/.test(name)) {
   fail("workspace name must be lowercase alphanumeric/hyphens, 2-63 chars");
 }
-if (!opts.bucket) fail("--bucket is required");
-
 const token = `up_${name}_${crypto.randomBytes(24).toString("base64url")}`;
-const record = {
-  provider: "r2",
-  bucket: opts.bucket,
-  binding: opts.binding,
-  publicBaseUrl: opts["public-base-url"] ?? process.env.R2_PUBLIC_BASE_URL,
-  tokens: [{
-    hash: crypto.createHash("sha256").update(token).digest("hex"),
-    label: "initial",
-    createdAt: new Date().toISOString(),
-  }],
-  accountId: opts["account-id"] ?? process.env.R2_ACCOUNT_ID,
-  accessKeyId: opts["access-key-id"] ?? process.env.R2_ACCESS_KEY_ID,
-  secretAccessKey: opts["secret-access-key"] ?? process.env.R2_SECRET_ACCESS_KEY,
+
+const SHARED = {
+  bucket: "uploads-default",
+  binding: "UPLOADS_DEFAULT",
+  publicBaseUrl: "https://storage.uploads.sh",
 };
+
+const tokens = [{
+  hash: crypto.createHash("sha256").update(token).digest("hex"),
+  label: "initial",
+  createdAt: new Date().toISOString(),
+}];
+
+const record = opts.bucket
+  ? {
+      // BYO mode: dedicated bucket, credentials from flags or .env.
+      provider: "r2",
+      bucket: opts.bucket,
+      binding: opts.binding,
+      publicBaseUrl: opts["public-base-url"] ?? process.env.R2_PUBLIC_BASE_URL,
+      tokens,
+      accountId: opts["account-id"] ?? process.env.R2_ACCOUNT_ID,
+      accessKeyId: opts["access-key-id"] ?? process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: opts["secret-access-key"] ?? process.env.R2_SECRET_ACCESS_KEY,
+    }
+  : {
+      // Shared mode: a "<name>/" prefix in the shared bucket. No env credential
+      // fallback — R2_* env keys are scoped to BYO buckets, and presigning
+      // against the shared bucket is deferred (see the design spec).
+      provider: "r2",
+      bucket: SHARED.bucket,
+      binding: opts.binding ?? SHARED.binding,
+      prefix: `${name}/`,
+      publicBaseUrl: opts["public-base-url"] ?? SHARED.publicBaseUrl,
+      tokens,
+      accountId: opts["account-id"],
+      accessKeyId: opts["access-key-id"],
+      secretAccessKey: opts["secret-access-key"],
+    };
 Object.keys(record).forEach((k) => record[k] === undefined && delete record[k]);
 
 execFileSync(

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -13,6 +13,7 @@ export function storageConfig(env: Env, ws: WorkspaceRecord): StorageConfig {
   return {
     provider: ws.provider,
     bucket: ws.bucket,
+    prefix: ws.prefix,
     publicBaseUrl: ws.publicBaseUrl,
     r2Binding: binding,
     accountId: ws.accountId,

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -11,6 +11,8 @@ export interface WorkspaceRecord {
   bucket: string;
   /** Name of an R2 binding declared in wrangler.jsonc (e.g. "UPLOADS"). When set, I/O uses the binding. */
   binding?: string;
+  /** Key prefix inside the bucket (e.g. "myws/"). Set for shared-bucket workspaces; all I/O is confined under it. */
+  prefix?: string;
   /** Public custom domain for this workspace's bucket. */
   publicBaseUrl?: string;
   /** Bearer tokens valid for this workspace. */

--- a/docs/superpowers/plans/2026-07-07-shared-bucket-workspace-prefixes.md
+++ b/docs/superpowers/plans/2026-07-07-shared-bucket-workspace-prefixes.md
@@ -1,0 +1,665 @@
+# Shared-Bucket Workspace Prefixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Default workspaces become per-workspace key prefixes inside the shared `uploads-default` R2 bucket, so creating a workspace is a pure KV write; dedicated-bucket (BYO) workspaces keep working unchanged.
+
+**Architecture:** `WorkspaceRecord` gains an optional `prefix` field. The prefix is applied in exactly one place — `createStorage()` in `packages/storage` — using files-sdk's native instance-level `prefix` option (`new Files({ adapter, prefix })`), which prepends on every operation and strips prefixes from list results. Route code in `apps/api/src/routes/files.ts` is untouched. `add-workspace.mjs` flips its default: no `--bucket` flag now means shared-bucket mode.
+
+**Tech Stack:** TypeScript (strict, ESM), Hono on Cloudflare Workers, files-sdk 2.1.0 (pnpm-patched), Wrangler, pnpm workspaces, vitest (new, added by this plan).
+
+**Spec:** `docs/superpowers/specs/2026-07-07-shared-bucket-workspace-prefixes-design.md`
+
+## Global Constraints
+
+- TypeScript strict, ESM only, `lib: ["ES2022"]` — no DOM types (Workers types own globals).
+- All storage access goes through `createStorage()` in `packages/storage`; never import files-sdk adapters or touch R2 bindings from route code.
+- Secrets never go in `wrangler.jsonc` or source files.
+- Never edit `.env` files — if a `.env` value must change, tell the user and stop.
+- No workspace is special-cased in code; `default` is just a registered tenant.
+- Shared-bucket constants (exact values): bucket `uploads-default`, binding `UPLOADS_DEFAULT`, public base URL `https://storage.uploads.sh`.
+- Prefix convention: `<workspace-name>/` — must end with `/`.
+- Run all commands from the repo root unless a task says otherwise. Use `pnpm`, never `npm`/`yarn`.
+- `apps/api/wrangler.jsonc` is NOT modified by this plan (both bindings already exist). If you think you need to change it, stop and re-read the task.
+- Commit after every task with the exact message given. Do not push.
+
+---
+
+### Task 1: Prefix plumbing in `@uploads/storage` (config, validation, publicUrl) + vitest setup
+
+**Files:**
+- Modify: `packages/storage/src/index.ts`
+- Modify: `packages/storage/package.json`
+- Create: `packages/storage/test/index.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `StorageConfig.prefix?: string` (optional, must match `/^([a-z0-9][a-z0-9._-]*\/)+$/`); `createStorage(config)` returns a `Files` instance whose operations are confined under `config.prefix`; `publicUrl(config, key)` returns `<base>/<prefix><key>` (segments URI-encoded). Task 2 tests behavior; Task 3 passes `prefix` from the workspace record.
+
+- [ ] **Step 1: Add vitest to the storage package**
+
+Run:
+```bash
+pnpm --filter @uploads/storage add -D vitest
+```
+
+Then in `packages/storage/package.json`, add a `test` script alongside the existing `typecheck` script:
+
+```json
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+```
+
+No vitest config file is needed — defaults pick up `test/**/*.test.ts`. Note: `packages/storage/tsconfig.json` has `"include": ["src"]`, so test files are deliberately outside the typecheck surface; vitest transpiles them itself.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `packages/storage/test/index.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createStorage, publicUrl, type StorageConfig } from "../src/index.js";
+
+const base: StorageConfig = {
+  provider: "r2",
+  bucket: "shared",
+  accountId: "acct",
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+};
+
+describe("createStorage prefix", () => {
+  it("applies the prefix to the Files instance (normalized, no trailing slash)", () => {
+    const files = createStorage({ ...base, prefix: "myws/" });
+    expect(files.prefix).toBe("myws");
+  });
+
+  it("has no prefix when the config omits it (BYO mode)", () => {
+    const files = createStorage(base);
+    expect(files.prefix).toBe("");
+  });
+
+  it.each(["/myws/", "myws", "a//b/", "../x/", "./", "MyWS/", " /"])(
+    "rejects invalid prefix %j",
+    (prefix) => {
+      expect(() => createStorage({ ...base, prefix })).toThrow(/invalid storage prefix/);
+    },
+  );
+
+  it("accepts multi-segment prefixes", () => {
+    const files = createStorage({ ...base, prefix: "team/myws/" });
+    expect(files.prefix).toBe("team/myws");
+  });
+});
+
+describe("publicUrl", () => {
+  const cfg: StorageConfig = { ...base, publicBaseUrl: "https://storage.uploads.sh" };
+
+  it("includes the prefix in the public URL", () => {
+    expect(publicUrl({ ...cfg, prefix: "myws/" }, "dir/a.png")).toBe(
+      "https://storage.uploads.sh/myws/dir/a.png",
+    );
+  });
+
+  it("omits the prefix when not configured (BYO mode)", () => {
+    expect(publicUrl(cfg, "dir/a.png")).toBe("https://storage.uploads.sh/dir/a.png");
+  });
+
+  it("URI-encodes key segments but not the slashes", () => {
+    expect(publicUrl({ ...cfg, prefix: "myws/" }, "dir/a b.png")).toBe(
+      "https://storage.uploads.sh/myws/dir/a%20b.png",
+    );
+  });
+
+  it("returns null without a publicBaseUrl", () => {
+    expect(publicUrl({ ...base, prefix: "myws/" }, "a.png")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/storage test`
+Expected: FAIL on assertions (vitest strips types, so no compile error): `files.prefix` is `""` instead of `"myws"`, the invalid-prefix cases don't throw, and `publicUrl` omits the prefix.
+
+- [ ] **Step 4: Implement prefix support in `packages/storage/src/index.ts`**
+
+Apply these three edits:
+
+(a) Add the field to `StorageConfig` (after the `publicBaseUrl` field):
+
+```ts
+  /**
+   * Key prefix all operations are confined under (e.g. "myws/"). Must end
+   * with "/". Applied via files-sdk's instance prefix; clients never see it.
+   */
+  prefix?: string;
+```
+
+(b) At the top of `createStorage`, before the `switch`, validate and thread the prefix through. Replace the current `return new Files({ adapter });` line — the full function becomes:
+
+```ts
+/** Segments of lowercase alphanumerics/._- each ending in "/"; first char alphanumeric (so "." and ".." are impossible). */
+const PREFIX_RE = /^([a-z0-9][a-z0-9._-]*\/)+$/;
+
+export function createStorage(config: StorageConfig): Files {
+  if (config.prefix !== undefined && !PREFIX_RE.test(config.prefix)) {
+    throw new Error(`invalid storage prefix: ${JSON.stringify(config.prefix)}`);
+  }
+  switch (config.provider) {
+    case "r2": {
+      const shared = {
+        accountId: config.accountId,
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+        publicBaseUrl: config.publicBaseUrl,
+      };
+      // Binding mode (hybrid when HTTP creds are also set) vs pure HTTP mode.
+      const adapter = config.r2Binding
+        ? r2({ binding: config.r2Binding, bucket: config.bucket, ...shared })
+        : r2({ bucket: config.bucket, ...shared });
+      return new Files({ adapter, prefix: config.prefix });
+    }
+    default:
+      throw new Error(`Unsupported storage provider: ${config.provider satisfies never}`);
+  }
+}
+```
+
+(c) Include the prefix in `publicUrl` — the full function becomes:
+
+```ts
+/** Public URL for a key when the bucket is fronted by a custom domain. Includes the workspace prefix. */
+export function publicUrl(config: StorageConfig, key: string): string | null {
+  if (!config.publicBaseUrl) return null;
+  const base = config.publicBaseUrl.replace(/\/$/, "");
+  const fullKey = `${config.prefix ?? ""}${key}`;
+  return `${base}/${fullKey.split("/").map(encodeURIComponent).join("/")}`;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/storage test`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @uploads/storage typecheck`
+Expected: exit 0, no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/storage pnpm-lock.yaml
+git commit -m "feat(storage): confine operations under an optional key prefix"
+```
+
+---
+
+### Task 2: Behavioral prefix-confinement tests (fake R2 binding)
+
+**Files:**
+- Create: `packages/storage/test/fake-r2.ts`
+- Create: `packages/storage/test/prefix-confinement.test.ts`
+
+**Interfaces:**
+- Consumes: `createStorage` with `prefix` from Task 1.
+- Produces: `FakeR2Bucket` (in-memory stand-in for a Workers `R2Bucket` binding, exposing its raw `store: Map<string, ...>` for assertions). Test-only; nothing else depends on it.
+
+These tests prove the spec's isolation guarantee: a workspace cannot read, write, delete, or list outside its prefix, and listed keys come back with the prefix stripped. They exercise our real `createStorage` + files-sdk r2 binding adapter against an in-memory fake binding.
+
+- [ ] **Step 1: Write the fake R2 binding**
+
+Create `packages/storage/test/fake-r2.ts`:
+
+```ts
+/**
+ * Minimal in-memory stand-in for a Workers R2Bucket binding — just enough
+ * surface for the files-sdk r2 adapter's binding-mode I/O. `store` is exposed
+ * so tests can assert on the RAW keys actually written to the bucket.
+ */
+interface StoredObject {
+  data: Uint8Array;
+  contentType?: string;
+}
+
+export class FakeR2Bucket {
+  store = new Map<string, StoredObject>();
+
+  private meta(key: string, obj: StoredObject) {
+    return {
+      key,
+      size: obj.data.byteLength,
+      etag: "fake-etag",
+      httpEtag: '"fake-etag"',
+      uploaded: new Date(0),
+      version: "1",
+      storageClass: "Standard",
+      checksums: {},
+      httpMetadata: { contentType: obj.contentType },
+      customMetadata: {},
+      writeHttpMetadata() {},
+    };
+  }
+
+  async put(
+    key: string,
+    value: ArrayBuffer | ArrayBufferView | string | ReadableStream<Uint8Array> | null,
+    opts?: { httpMetadata?: { contentType?: string } | Headers },
+  ) {
+    let data: Uint8Array;
+    if (typeof value === "string") data = new TextEncoder().encode(value);
+    else if (value instanceof ArrayBuffer) data = new Uint8Array(value);
+    else if (value && ArrayBuffer.isView(value))
+      data = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    else if (value) {
+      const chunks: Uint8Array[] = [];
+      const reader = value.getReader();
+      for (;;) {
+        const { done, value: chunk } = await reader.read();
+        if (done) break;
+        chunks.push(chunk);
+      }
+      data = new Uint8Array(chunks.reduce((n, c) => n + c.byteLength, 0));
+      let offset = 0;
+      for (const c of chunks) {
+        data.set(c, offset);
+        offset += c.byteLength;
+      }
+    } else data = new Uint8Array(0);
+
+    const httpMetadata = opts?.httpMetadata;
+    const contentType =
+      httpMetadata instanceof Headers
+        ? (httpMetadata.get("content-type") ?? undefined)
+        : httpMetadata?.contentType;
+    const obj = { data, contentType };
+    this.store.set(key, obj);
+    return this.meta(key, obj);
+  }
+
+  async get(key: string) {
+    const obj = this.store.get(key);
+    if (!obj) return null;
+    const data = obj.data;
+    return {
+      ...this.meta(key, obj),
+      bodyUsed: false,
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      }),
+      async arrayBuffer() {
+        return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+      },
+      async bytes() {
+        return data;
+      },
+      async text() {
+        return new TextDecoder().decode(data);
+      },
+      async json() {
+        return JSON.parse(new TextDecoder().decode(data));
+      },
+      async blob() {
+        return new Blob([data as BlobPart]);
+      },
+    };
+  }
+
+  async head(key: string) {
+    const obj = this.store.get(key);
+    return obj ? this.meta(key, obj) : null;
+  }
+
+  async delete(keys: string | string[]) {
+    for (const k of Array.isArray(keys) ? keys : [keys]) this.store.delete(k);
+  }
+
+  async list(opts?: { prefix?: string; limit?: number; cursor?: string; delimiter?: string }) {
+    const prefix = opts?.prefix ?? "";
+    const keys = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
+    return {
+      objects: keys.map((k) => this.meta(k, this.store.get(k)!)),
+      truncated: false as const,
+      delimitedPrefixes: [] as string[],
+    };
+  }
+}
+```
+
+If a test in Step 2 fails with a `TypeError` saying some method is not a function, the files-sdk adapter needs a binding method the fake lacks — add that method to `FakeR2Bucket` following the real `R2Bucket` signature (see `@cloudflare/workers-types`) rather than changing the test.
+
+- [ ] **Step 2: Write the failing confinement tests**
+
+Create `packages/storage/test/prefix-confinement.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { R2Bucket } from "@cloudflare/workers-types";
+import { createStorage } from "../src/index.js";
+import { FakeR2Bucket } from "./fake-r2.js";
+
+/** Two workspaces sharing one bucket, like default-mode tenants in uploads-default. */
+function tenant(bucket: FakeR2Bucket, prefix: string) {
+  return createStorage({
+    provider: "r2",
+    bucket: "uploads-default",
+    prefix,
+    r2Binding: bucket as unknown as R2Bucket,
+  });
+}
+
+const body = (s: string) => new TextEncoder().encode(s);
+
+describe("prefix confinement through createStorage", () => {
+  it("writes land under the workspace prefix in the raw bucket", async () => {
+    const bucket = new FakeR2Bucket();
+    await tenant(bucket, "alpha/").upload("dir/a.txt", body("hi"), {
+      contentType: "text/plain",
+    });
+    expect([...bucket.store.keys()]).toEqual(["alpha/dir/a.txt"]);
+  });
+
+  it("reads see only the workspace's own objects", async () => {
+    const bucket = new FakeR2Bucket();
+    const alpha = tenant(bucket, "alpha/");
+    const beta = tenant(bucket, "beta/");
+    await alpha.upload("secret.txt", body("alpha data"), { contentType: "text/plain" });
+
+    expect(await alpha.exists("secret.txt")).toBe(true);
+    expect(await beta.exists("secret.txt")).toBe(false);
+    // A tenant also can't reach another tenant's data by naming its prefix:
+    // that just becomes a key under its OWN prefix (beta/alpha/secret.txt).
+    expect(await beta.exists("alpha/secret.txt")).toBe(false);
+  });
+
+  it("list returns only own objects, with the prefix stripped", async () => {
+    const bucket = new FakeR2Bucket();
+    const alpha = tenant(bucket, "alpha/");
+    const beta = tenant(bucket, "beta/");
+    await alpha.upload("one.txt", body("1"), { contentType: "text/plain" });
+    await alpha.upload("dir/two.txt", body("2"), { contentType: "text/plain" });
+    await beta.upload("other.txt", body("3"), { contentType: "text/plain" });
+
+    const result = await alpha.list();
+    const keys = result.items.map((i: { key: string }) => i.key).sort();
+    expect(keys).toEqual(["dir/two.txt", "one.txt"]);
+  });
+
+  it("delete only touches the workspace's own prefix", async () => {
+    const bucket = new FakeR2Bucket();
+    const alpha = tenant(bucket, "alpha/");
+    const beta = tenant(bucket, "beta/");
+    await alpha.upload("same-name.txt", body("alpha"), { contentType: "text/plain" });
+    await beta.upload("same-name.txt", body("beta"), { contentType: "text/plain" });
+
+    await alpha.delete("same-name.txt");
+
+    expect(bucket.store.has("alpha/same-name.txt")).toBe(false);
+    expect(bucket.store.has("beta/same-name.txt")).toBe(true);
+  });
+
+  it("an unprefixed instance (BYO mode) sees the whole bucket", async () => {
+    const bucket = new FakeR2Bucket();
+    await tenant(bucket, "alpha/").upload("a.txt", body("a"), { contentType: "text/plain" });
+    const byo = createStorage({
+      provider: "r2",
+      bucket: "uploads-default",
+      r2Binding: bucket as unknown as R2Bucket,
+    });
+    expect(await byo.exists("alpha/a.txt")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `pnpm --filter @uploads/storage test`
+Expected: PASS. (Task 1 already implemented the behavior — these tests pin the guarantee. If any confinement test fails, that is a real defect in the prefix wiring or the fake: debug it, do not weaken assertions. If a `TypeError: ... is not a function` points at the fake, extend `FakeR2Bucket` per Step 1's note.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/storage/test
+git commit -m "test(storage): prove prefix confinement across shared-bucket tenants"
+```
+
+---
+
+### Task 3: Thread `prefix` through the API (workspace record → storage config)
+
+**Files:**
+- Modify: `apps/api/src/workspace.ts` (the `WorkspaceRecord` interface, around line 9-24)
+- Modify: `apps/api/src/storage.ts` (the `storageConfig` return object, around line 13-21)
+
+**Interfaces:**
+- Consumes: `StorageConfig.prefix` from Task 1.
+- Produces: `WorkspaceRecord.prefix?: string` — read by `storageConfig()`; Task 4 writes it when registering shared-bucket workspaces. Route code is NOT modified.
+
+- [ ] **Step 1: Add `prefix` to `WorkspaceRecord`**
+
+In `apps/api/src/workspace.ts`, add after the `binding` field (line 13):
+
+```ts
+  /** Key prefix inside the bucket (e.g. "myws/"). Set for shared-bucket workspaces; all I/O is confined under it. */
+  prefix?: string;
+```
+
+- [ ] **Step 2: Pass it through in `storageConfig`**
+
+In `apps/api/src/storage.ts`, add one line to the returned object, after `bucket: ws.bucket,`:
+
+```ts
+    prefix: ws.prefix,
+```
+
+- [ ] **Step 3: Typecheck the API workspace**
+
+Run: `pnpm --filter @uploads/api typecheck`
+Expected: exit 0. (This runs `wrangler types` first; that is expected and does not modify `wrangler.jsonc`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/workspace.ts apps/api/src/storage.ts
+git commit -m "feat(api): carry workspace key prefix into storage config"
+```
+
+---
+
+### Task 4: Flip `add-workspace.mjs` to shared-bucket defaults
+
+**Files:**
+- Modify: `apps/api/scripts/add-workspace.mjs`
+
+**Interfaces:**
+- Consumes: `WorkspaceRecord.prefix` shape from Task 3 (the script writes raw JSON to KV; it does not import the type).
+- Produces: registration behavior — no `--bucket` ⇒ shared-bucket record (`bucket: "uploads-default"`, `binding: "UPLOADS_DEFAULT"`, `prefix: "<name>/"`, `publicBaseUrl: "https://storage.uploads.sh"`); `--bucket <name>` ⇒ BYO record identical to today's output.
+
+Note: the spec mentions "setup wizard defaults" alongside this script. The CLI setup wizard (`packages/uploads/src/commands/config.ts`) configures client-side values only (API URL, workspace name, token) and has no bucket knowledge — there is nothing to change there. Do not modify `packages/uploads`.
+
+- [ ] **Step 1: Update the usage comment**
+
+Replace the usage block in the header comment (the lines starting `* Usage (from apps/api):` through the example command at the end of the comment) with:
+
+```js
+ * Usage (from apps/api):
+ *   node scripts/add-workspace.mjs <name> \
+ *     [--bucket <bucket>]   # omit for shared-bucket mode (uploads-default + "<name>/" prefix)
+ *     [--binding UPLOADS] [--public-base-url https://media.example.com] \
+ *     [--account-id ...] [--access-key-id ...] [--secret-access-key ...] \
+ *     [--local]             # write to wrangler dev's local KV instead of prod
+ *
+ * Default (no --bucket): the workspace is a "<name>/" prefix in the shared
+ * uploads-default bucket, served at https://storage.uploads.sh/<name>/...
+ * Creating one is a pure KV write — no bucket, binding, or deploy needed.
+ *
+ * BYO mode (--bucket): dedicated bucket, today's behavior. Credential flags
+ * fall back to R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY, and
+ * --public-base-url to R2_PUBLIC_BASE_URL, so you can keep them in the
+ * repo-root .env and run:
+ *   node --env-file=../../.env scripts/add-workspace.mjs <name> --bucket <bucket>
+ * Env fallbacks apply ONLY in BYO mode — shared-mode records never inherit
+ * BYO-bucket credentials from the environment.
+```
+
+- [ ] **Step 2: Replace the required-bucket check and record construction**
+
+Delete the line:
+
+```js
+if (!opts.bucket) fail("--bucket is required");
+```
+
+Replace the `const record = { ... }` block (from `const record =` through `Object.keys(record).forEach(...)`) with:
+
+```js
+const SHARED = {
+  bucket: "uploads-default",
+  binding: "UPLOADS_DEFAULT",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+const tokens = [{
+  hash: crypto.createHash("sha256").update(token).digest("hex"),
+  label: "initial",
+  createdAt: new Date().toISOString(),
+}];
+
+const record = opts.bucket
+  ? {
+      // BYO mode: dedicated bucket, credentials from flags or .env.
+      provider: "r2",
+      bucket: opts.bucket,
+      binding: opts.binding,
+      publicBaseUrl: opts["public-base-url"] ?? process.env.R2_PUBLIC_BASE_URL,
+      tokens,
+      accountId: opts["account-id"] ?? process.env.R2_ACCOUNT_ID,
+      accessKeyId: opts["access-key-id"] ?? process.env.R2_ACCESS_KEY_ID,
+      secretAccessKey: opts["secret-access-key"] ?? process.env.R2_SECRET_ACCESS_KEY,
+    }
+  : {
+      // Shared mode: a "<name>/" prefix in the shared bucket. No env credential
+      // fallback — R2_* env keys are scoped to BYO buckets, and presigning
+      // against the shared bucket is deferred (see the design spec).
+      provider: "r2",
+      bucket: SHARED.bucket,
+      binding: opts.binding ?? SHARED.binding,
+      prefix: `${name}/`,
+      publicBaseUrl: opts["public-base-url"] ?? SHARED.publicBaseUrl,
+      tokens,
+      accountId: opts["account-id"],
+      accessKeyId: opts["access-key-id"],
+      secretAccessKey: opts["secret-access-key"],
+    };
+Object.keys(record).forEach((k) => record[k] === undefined && delete record[k]);
+```
+
+- [ ] **Step 3: Verify shared mode against local KV**
+
+Run (from `apps/api`):
+```bash
+node scripts/add-workspace.mjs planck --local
+pnpm exec wrangler kv key get ws:planck --binding REGISTRY --local
+```
+Expected: the second command prints a JSON record with `"bucket": "uploads-default"`, `"binding": "UPLOADS_DEFAULT"`, `"prefix": "planck/"`, `"publicBaseUrl": "https://storage.uploads.sh"`, a `tokens` array, and NO `accountId`/`accessKeyId`/`secretAccessKey` keys.
+
+- [ ] **Step 4: Verify BYO mode against local KV**
+
+Run (from `apps/api`):
+```bash
+node scripts/add-workspace.mjs byocheck --bucket custom-bucket --binding UPLOADS --local
+pnpm exec wrangler kv key get ws:byocheck --binding REGISTRY --local
+```
+Expected: JSON with `"bucket": "custom-bucket"`, `"binding": "UPLOADS"`, and NO `prefix` key. (Run without `--env-file`, so no env credentials leak in.)
+
+- [ ] **Step 5: Clean up the local test records**
+
+Run (from `apps/api`):
+```bash
+pnpm exec wrangler kv key delete ws:planck --binding REGISTRY --local
+pnpm exec wrangler kv key delete ws:byocheck --binding REGISTRY --local
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/scripts/add-workspace.mjs
+git commit -m "feat(api): default new workspaces to shared-bucket prefix mode"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `AGENTS.md` (the "Workspaces (multi-tenant model)" section and the `workspace:add` line in "Commands")
+- Modify: `README.md` only if it mentions `--bucket` being required or describes the one-bucket-per-workspace model (check with `grep -n "bucket" README.md`); otherwise leave it.
+
+**Interfaces:**
+- Consumes: final behavior from Tasks 1-4.
+- Produces: docs matching reality. Nothing depends on this task.
+
+- [ ] **Step 1: Update the Commands section in AGENTS.md**
+
+Replace the line:
+
+```
+pnpm workspace:add <name> --bucket <bucket> [--binding X] [--local]
+```
+
+with:
+
+```
+pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local]
+```
+
+- [ ] **Step 2: Update the Workspaces section in AGENTS.md**
+
+In the "## Workspaces (multi-tenant model)" section, after the sentence ending "even `default` is just a registered tenant.", insert this paragraph:
+
+```markdown
+By default a workspace is a **`<name>/` prefix in the shared `uploads-default`
+bucket** (binding `UPLOADS_DEFAULT`, public at `https://storage.uploads.sh`):
+the record carries `prefix: "<name>/"` and creating one is a pure KV write.
+The prefix is applied in exactly one place — `createStorage()` in
+`packages/storage` (files-sdk instance prefix) — so route code and clients
+never see it; public URLs are `https://storage.uploads.sh/<name>/<key>`.
+Bring-your-own-bucket is the advanced case: register with `--bucket` and the
+record points at a dedicated bucket (own binding or S3 credentials, own
+`publicBaseUrl`, no prefix) — `buildinternet` on `buildinternet-dev` is the
+reference example.
+```
+
+- [ ] **Step 3: Check README**
+
+Run: `grep -n "bucket" README.md`
+If any line documents `--bucket` as required or one-bucket-per-workspace, update it to match the AGENTS.md wording above. If nothing matches, skip.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md README.md
+git commit -m "docs: describe shared-bucket prefix workspaces"
+```
+
+---
+
+## Post-merge production runbook (manual — NOT for implementation agents)
+
+For Zach / the main session after this branch merges and deploys. Do not execute as part of the plan; it touches production KV and re-mints a live token.
+
+1. Re-register `default` as a shared-bucket workspace (overwrites its record and mints a fresh token — the old token stops working):
+   ```bash
+   cd apps/api && node scripts/add-workspace.mjs default
+   ```
+2. Update `UPLOADS_TOKEN` in the main checkout's `.env` with the newly printed token (user edits `.env` by hand — agents must not).
+3. The old `screenshots/` objects at the root of `uploads-default` (~196 B) predate the prefix model. Either delete them in the dashboard or re-upload them through the API so they land under `default/`.
+4. Verify: `curl -H "Authorization: Bearer <token>" https://api.uploads.sh/v1/default/files` lists only prefixed content, and an uploaded file serves at `https://storage.uploads.sh/default/<key>`.
+5. `buildinternet` workspace: no action.

--- a/docs/superpowers/specs/2026-07-07-shared-bucket-workspace-prefixes-design.md
+++ b/docs/superpowers/specs/2026-07-07-shared-bucket-workspace-prefixes-design.md
@@ -1,0 +1,111 @@
+# Shared-bucket workspaces with per-workspace prefixes
+
+**Date:** 2026-07-07
+**Status:** Approved
+
+## Problem
+
+Today one workspace = one R2 bucket. On Workers that model doesn't scale:
+R2 bindings are declared statically in `wrangler.jsonc`, so every new
+bucket-backed workspace requires creating a bucket, adding a binding,
+regenerating types, and redeploying — or minting per-bucket S3 credentials
+for HTTP mode. Either way, workspace creation has infrastructure ceremony.
+
+## Decision
+
+Default workspaces become **prefixes in one shared bucket**
+(`uploads-default`, bound as `UPLOADS_DEFAULT`, public at
+`https://storage.uploads.sh`). Each workspace's objects live under
+`<workspace-name>/` in that bucket. Creating a default-mode workspace is a
+pure KV write — no infra side effects.
+
+Bring-your-own-bucket remains supported as the advanced case: a workspace
+record that points at a dedicated bucket (own binding or S3 credentials,
+own `publicBaseUrl`) with no prefix. `buildinternet` (bucket
+`buildinternet-dev`) stays exactly as it is and is the reference BYO case.
+
+No workspace is special-cased in code. "Default mode" vs "BYO mode" is only
+which fields the record carries.
+
+## Design
+
+### 1. Workspace record
+
+`WorkspaceRecord` (apps/api/src/workspace.ts) gains an optional field:
+
+```ts
+/** Key prefix inside the bucket (e.g. "myws/"). All I/O is confined under it; clients never see it. */
+prefix?: string;
+```
+
+- Must end with `/`; segments validated by the same rules as object keys
+  (no empty, `.`, or `..` segments).
+- Convention for shared-bucket workspaces: `prefix: "<name>/"`.
+- BYO records omit it (empty prefix = whole bucket, today's behavior).
+
+### 2. Storage layer
+
+Prefixing is applied in exactly one place — the storage layer behind
+`createStorage()` (`packages/storage`) — so route code in
+`apps/api/src/routes/files.ts` is untouched and clients never see the
+prefix.
+
+- `StorageConfig` gains `prefix?: string`; `storageConfig()` in
+  `apps/api/src/storage.ts` passes it through from the record.
+- Writes/reads/head/exists/delete prepend the prefix to the client key.
+- `list` uses the prefix as the base and strips it from returned keys.
+- `publicUrl()` includes the prefix, so shared-bucket objects serve at
+  `https://storage.uploads.sh/<workspace>/<key>`.
+- Implementation note: check whether files-sdk supports a key prefix
+  natively; if not, wrap the `Files` instance with a thin prefixing layer.
+
+Safety: `badKey` in `routes/files.ts` already rejects `..` and empty
+segments before keys reach storage, which is what makes blind prefix
+prepending safe. The prefix layer gets unit tests proving a workspace
+cannot read, write, delete, or list outside its prefix.
+
+### 3. Provisioning
+
+`apps/api/scripts/add-workspace.mjs` (and the setup wizard defaults) flip
+polarity:
+
+- **No `--bucket` flag (new default):** `bucket: uploads-default`,
+  `binding: UPLOADS_DEFAULT`, `prefix: "<name>/"`,
+  `publicBaseUrl: https://storage.uploads.sh`.
+- **`--bucket <name>` (BYO mode):** today's behavior — dedicated bucket,
+  optional `--binding`, credentials from flags/env, no prefix.
+
+Default-mode records may still carry the shared bucket's S3 credentials
+(from env, as today) — the binding handles I/O, credentials only enable
+presigning. Presigned URLs are bucket-scoped, not prefix-scoped, so
+presigning against the shared bucket is deferred until the prefix layer
+constrains it; nothing currently depends on it.
+
+### 4. Existing data / migration
+
+None needed. The `default` workspace has no user base; re-register it as a
+prefixed shared-bucket workspace. The existing `screenshots/` content in
+`uploads-default` (~196 B) is moved under `default/` by hand or dropped.
+`buildinternet` is unchanged.
+
+### 5. Future direction (acknowledged, not built)
+
+Per-workspace subdomains (`<name>.uploads.sh`) later: a small routing
+worker mapping host → `uploads-default/<name>/`. The prefix convention is
+exactly that mapping key, so nothing in this design needs undoing.
+
+## Trade-offs accepted
+
+- Isolation is logical (prefix) rather than physical (bucket); the prefix
+  layer's tests are the guardrail.
+- Per-workspace metrics/quotas aren't free; R2 lifecycle rules can still
+  scope to a prefix.
+- Shared-domain public URLs expose the workspace name in the path —
+  considered a feature (self-describing URLs).
+
+## Testing
+
+- Unit tests for the prefix layer: key mapping on all operations, list
+  stripping, no escape outside the prefix, `publicUrl` composition.
+- Existing route behavior unchanged for records without `prefix`
+  (BYO regression coverage).

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1080.0",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260706.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -19,9 +19,20 @@ export interface StorageConfig {
   accountId?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
+  /**
+   * Key prefix all operations are confined under (e.g. "myws/"). Must end
+   * with "/". Applied via files-sdk's instance prefix; clients never see it.
+   */
+  prefix?: string;
 }
 
+/** Segments of lowercase alphanumerics/._- each ending in "/"; first char alphanumeric (so "." and ".." are impossible). */
+const PREFIX_RE = /^([a-z0-9][a-z0-9._-]*\/)+$/;
+
 export function createStorage(config: StorageConfig): Files {
+  if (config.prefix !== undefined && !PREFIX_RE.test(config.prefix)) {
+    throw new Error(`invalid storage prefix: ${JSON.stringify(config.prefix)}`);
+  }
   switch (config.provider) {
     case "r2": {
       const shared = {
@@ -34,18 +45,19 @@ export function createStorage(config: StorageConfig): Files {
       const adapter = config.r2Binding
         ? r2({ binding: config.r2Binding, bucket: config.bucket, ...shared })
         : r2({ bucket: config.bucket, ...shared });
-      return new Files({ adapter });
+      return new Files({ adapter, prefix: config.prefix });
     }
     default:
       throw new Error(`Unsupported storage provider: ${config.provider satisfies never}`);
   }
 }
 
-/** Public URL for a key when the bucket is fronted by a custom domain. */
+/** Public URL for a key when the bucket is fronted by a custom domain. Includes the workspace prefix. */
 export function publicUrl(config: StorageConfig, key: string): string | null {
   if (!config.publicBaseUrl) return null;
   const base = config.publicBaseUrl.replace(/\/$/, "");
-  return `${base}/${key.split("/").map(encodeURIComponent).join("/")}`;
+  const fullKey = `${config.prefix ?? ""}${key}`;
+  return `${base}/${fullKey.split("/").map(encodeURIComponent).join("/")}`;
 }
 
 export type { Files };

--- a/packages/storage/test/fake-r2.ts
+++ b/packages/storage/test/fake-r2.ts
@@ -1,0 +1,115 @@
+/**
+ * Minimal in-memory stand-in for a Workers R2Bucket binding — just enough
+ * surface for the files-sdk r2 adapter's binding-mode I/O. `store` is exposed
+ * so tests can assert on the RAW keys actually written to the bucket.
+ */
+interface StoredObject {
+  data: Uint8Array;
+  contentType?: string;
+}
+
+export class FakeR2Bucket {
+  store = new Map<string, StoredObject>();
+
+  private meta(key: string, obj: StoredObject) {
+    return {
+      key,
+      size: obj.data.byteLength,
+      etag: "fake-etag",
+      httpEtag: '"fake-etag"',
+      uploaded: new Date(0),
+      version: "1",
+      storageClass: "Standard",
+      checksums: {},
+      httpMetadata: { contentType: obj.contentType },
+      customMetadata: {},
+      writeHttpMetadata() {},
+    };
+  }
+
+  async put(
+    key: string,
+    value: ArrayBuffer | ArrayBufferView | string | ReadableStream<Uint8Array> | null,
+    opts?: { httpMetadata?: { contentType?: string } | Headers },
+  ) {
+    let data: Uint8Array;
+    if (typeof value === "string") data = new TextEncoder().encode(value);
+    else if (value instanceof ArrayBuffer) data = new Uint8Array(value);
+    else if (value && ArrayBuffer.isView(value))
+      data = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    else if (value) {
+      const chunks: Uint8Array[] = [];
+      const reader = value.getReader();
+      for (;;) {
+        const { done, value: chunk } = await reader.read();
+        if (done) break;
+        chunks.push(chunk);
+      }
+      data = new Uint8Array(chunks.reduce((n, c) => n + c.byteLength, 0));
+      let offset = 0;
+      for (const c of chunks) {
+        data.set(c, offset);
+        offset += c.byteLength;
+      }
+    } else data = new Uint8Array(0);
+
+    const httpMetadata = opts?.httpMetadata;
+    const contentType =
+      httpMetadata instanceof Headers
+        ? (httpMetadata.get("content-type") ?? undefined)
+        : httpMetadata?.contentType;
+    const obj = { data, contentType };
+    this.store.set(key, obj);
+    return this.meta(key, obj);
+  }
+
+  async get(key: string) {
+    const obj = this.store.get(key);
+    if (!obj) return null;
+    const data = obj.data;
+    return {
+      ...this.meta(key, obj),
+      bodyUsed: false,
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      }),
+      async arrayBuffer() {
+        return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+      },
+      async bytes() {
+        return data;
+      },
+      async text() {
+        return new TextDecoder().decode(data);
+      },
+      async json() {
+        return JSON.parse(new TextDecoder().decode(data));
+      },
+      async blob() {
+        return new Blob([data as BlobPart]);
+      },
+    };
+  }
+
+  async head(key: string) {
+    const obj = this.store.get(key);
+    return obj ? this.meta(key, obj) : null;
+  }
+
+  async delete(keys: string | string[]) {
+    for (const k of Array.isArray(keys) ? keys : [keys]) this.store.delete(k);
+  }
+
+  async list(opts?: { prefix?: string; limit?: number; cursor?: string; delimiter?: string }) {
+    const prefix = opts?.prefix ?? "";
+    const keys = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
+    return {
+      objects: keys.map((k) => this.meta(k, this.store.get(k)!)),
+      truncated: false as const,
+      delimitedPrefixes: [] as string[],
+    };
+  }
+}

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { createStorage, publicUrl, type StorageConfig } from "../src/index.js";
+
+const base: StorageConfig = {
+  provider: "r2",
+  bucket: "shared",
+  accountId: "acct",
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+};
+
+describe("createStorage prefix", () => {
+  it("applies the prefix to the Files instance (normalized, no trailing slash)", () => {
+    const files = createStorage({ ...base, prefix: "myws/" });
+    expect(files.prefix).toBe("myws");
+  });
+
+  it("has no prefix when the config omits it (BYO mode)", () => {
+    const files = createStorage(base);
+    expect(files.prefix).toBe("");
+  });
+
+  it.each(["/myws/", "myws", "a//b/", "../x/", "./", "MyWS/", " /"])(
+    "rejects invalid prefix %j",
+    (prefix) => {
+      expect(() => createStorage({ ...base, prefix })).toThrow(/invalid storage prefix/);
+    },
+  );
+
+  it("accepts multi-segment prefixes", () => {
+    const files = createStorage({ ...base, prefix: "team/myws/" });
+    expect(files.prefix).toBe("team/myws");
+  });
+});
+
+describe("publicUrl", () => {
+  const cfg: StorageConfig = { ...base, publicBaseUrl: "https://storage.uploads.sh" };
+
+  it("includes the prefix in the public URL", () => {
+    expect(publicUrl({ ...cfg, prefix: "myws/" }, "dir/a.png")).toBe(
+      "https://storage.uploads.sh/myws/dir/a.png",
+    );
+  });
+
+  it("omits the prefix when not configured (BYO mode)", () => {
+    expect(publicUrl(cfg, "dir/a.png")).toBe("https://storage.uploads.sh/dir/a.png");
+  });
+
+  it("URI-encodes key segments but not the slashes", () => {
+    expect(publicUrl({ ...cfg, prefix: "myws/" }, "dir/a b.png")).toBe(
+      "https://storage.uploads.sh/myws/dir/a%20b.png",
+    );
+  });
+
+  it("returns null without a publicBaseUrl", () => {
+    expect(publicUrl({ ...base, prefix: "myws/" }, "a.png")).toBeNull();
+  });
+});

--- a/packages/storage/test/prefix-confinement.test.ts
+++ b/packages/storage/test/prefix-confinement.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { R2Bucket } from "@cloudflare/workers-types";
+import { createStorage } from "../src/index.js";
+import { FakeR2Bucket } from "./fake-r2.js";
+
+/** Two workspaces sharing one bucket, like default-mode tenants in uploads-default. */
+function tenant(bucket: FakeR2Bucket, prefix: string) {
+  return createStorage({
+    provider: "r2",
+    bucket: "uploads-default",
+    prefix,
+    r2Binding: bucket as unknown as R2Bucket,
+  });
+}
+
+const body = (s: string) => new TextEncoder().encode(s);
+
+describe("prefix confinement through createStorage", () => {
+  it("writes land under the workspace prefix in the raw bucket", async () => {
+    const bucket = new FakeR2Bucket();
+    await tenant(bucket, "alpha/").upload("dir/a.txt", body("hi"), {
+      contentType: "text/plain",
+    });
+    expect([...bucket.store.keys()]).toEqual(["alpha/dir/a.txt"]);
+  });
+
+  it("reads see only the workspace's own objects", async () => {
+    const bucket = new FakeR2Bucket();
+    const alpha = tenant(bucket, "alpha/");
+    const beta = tenant(bucket, "beta/");
+    await alpha.upload("secret.txt", body("alpha data"), { contentType: "text/plain" });
+
+    expect(await alpha.exists("secret.txt")).toBe(true);
+    expect(await beta.exists("secret.txt")).toBe(false);
+    // A tenant also can't reach another tenant's data by naming its prefix:
+    // that just becomes a key under its OWN prefix (beta/alpha/secret.txt).
+    expect(await beta.exists("alpha/secret.txt")).toBe(false);
+  });
+
+  it("list returns only own objects, with the prefix stripped", async () => {
+    const bucket = new FakeR2Bucket();
+    const alpha = tenant(bucket, "alpha/");
+    const beta = tenant(bucket, "beta/");
+    await alpha.upload("one.txt", body("1"), { contentType: "text/plain" });
+    await alpha.upload("dir/two.txt", body("2"), { contentType: "text/plain" });
+    await beta.upload("other.txt", body("3"), { contentType: "text/plain" });
+
+    const result = await alpha.list();
+    const keys = result.items.map((i: { key: string }) => i.key).sort();
+    expect(keys).toEqual(["dir/two.txt", "one.txt"]);
+  });
+
+  it("delete only touches the workspace's own prefix", async () => {
+    const bucket = new FakeR2Bucket();
+    const alpha = tenant(bucket, "alpha/");
+    const beta = tenant(bucket, "beta/");
+    await alpha.upload("same-name.txt", body("alpha"), { contentType: "text/plain" });
+    await beta.upload("same-name.txt", body("beta"), { contentType: "text/plain" });
+
+    await alpha.delete("same-name.txt");
+
+    expect(bucket.store.has("alpha/same-name.txt")).toBe(false);
+    expect(bucket.store.has("beta/same-name.txt")).toBe(true);
+  });
+
+  it("an unprefixed instance (BYO mode) sees the whole bucket", async () => {
+    const bucket = new FakeR2Bucket();
+    await tenant(bucket, "alpha/").upload("a.txt", body("a"), { contentType: "text/plain" });
+    const byo = createStorage({
+      provider: "r2",
+      bucket: "uploads-default",
+      r2Binding: bucket as unknown as R2Bucket,
+    });
+    expect(await byo.exists("alpha/a.txt")).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/uploads:
     devDependencies:
@@ -1142,6 +1145,12 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1169,6 +1178,35 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1253,6 +1291,10 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astro@7.0.6:
     resolution: {integrity: sha512-Myw0sFia+zs/Y0yqfZEsUYXfDPh3ELcLf1f0Q/qQzVXBh/af1qO62WNT+P89DCcfGVV51nMoQhEfkBYqJmoUOQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -1297,6 +1339,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1357,6 +1403,9 @@ packages:
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -1511,6 +1560,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1525,6 +1577,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -2289,6 +2345,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -2303,9 +2362,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2330,6 +2395,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -2341,6 +2409,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -2537,6 +2609,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.71:
     resolution: {integrity: sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==}
     peerDependencies:
@@ -2646,6 +2759,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workerd@1.20260701.1:
@@ -3687,6 +3805,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -3714,6 +3839,47 @@ snapshots:
   '@ungap/structured-clone@1.3.2': {}
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
@@ -3817,6 +3983,8 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
 
   astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(yaml@2.9.0):
     dependencies:
@@ -3952,6 +4120,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -3996,6 +4166,8 @@ snapshots:
 
   content-type@2.0.0:
     optional: true
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -4165,6 +4337,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   etag@1.8.1:
     optional: true
 
@@ -4176,6 +4352,8 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.0
     optional: true
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -4957,6 +5135,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
     optional: true
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
   smol-toml@1.7.0: {}
@@ -4965,8 +5145,12 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2:
     optional: true
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -4997,6 +5181,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.15: {}
 
   tinyexec@1.2.4: {}
@@ -5005,6 +5191,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1:
     optional: true
@@ -5127,6 +5315,34 @@ snapshots:
     optionalDependencies:
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.0
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.71(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
@@ -5239,6 +5455,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
     optional: true
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260701.1:
     optionalDependencies:


### PR DESCRIPTION
## Summary

Default workspaces are now **`<name>/` key prefixes inside the shared `uploads-default` bucket** instead of one R2 bucket per workspace. Creating a workspace becomes a pure KV write — no bucket creation, no `wrangler.jsonc` binding edit, no redeploy. Bring-your-own-bucket stays supported as the advanced case (`--bucket`), and the `buildinternet` workspace is untouched.

Spec and plan are committed under `docs/superpowers/`.

## Changes

- **`@uploads/storage`**: `StorageConfig.prefix` (validated, must end `/`) is passed to files-sdk's instance-level `prefix`, so every operation is confined under it and list results come back stripped; `publicUrl()` includes the prefix (`https://storage.uploads.sh/<name>/<key>`).
- **API**: `WorkspaceRecord.prefix` threaded into `storageConfig()`. Route code unchanged — clients never see the prefix.
- **`add-workspace.mjs`**: no `--bucket` now defaults to shared mode (`uploads-default` / `UPLOADS_DEFAULT` / `prefix: "<name>/"` / `storage.uploads.sh`). Env credential fallbacks apply only in BYO mode so BYO keys can't leak into shared records.
- **Tests**: vitest introduced in `packages/storage` — 19 tests, including behavioral prefix-confinement tests through `createStorage` against an in-memory fake R2 binding (writes land under the prefix, tenants can't see/list/delete each other's objects, BYO instances see the whole bucket).
- **Docs**: AGENTS.md / README updated to the new model.

## Post-merge (manual)

Re-register `default` (`node scripts/add-workspace.mjs default`) — this re-mints its token, so `UPLOADS_TOKEN` in the main checkout's `.env` needs updating by hand. The ~196 B of legacy root objects in `uploads-default` can be dropped or re-uploaded under `default/`.

## Testing

- `pnpm --filter @uploads/storage test` — 19/19 passing
- `pnpm typecheck` — clean across all workspaces
- Registration script verified in both modes against local KV
