### PR TITLE
Add uploads-cli agent skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,13 @@ apps/api            Hono worker — REST API, deploys to api.uploads.sh
 apps/web            Astro placeholder — future browse/manage UI (separate deploy)
 packages/storage    @uploads/storage — files-sdk adapter factory
 packages/uploads    @buildinternet/uploads — CLI + client for GitHub image embeds
+skills/uploads-cli  Agent skill for driving the CLI (host a file → embed in a PR/issue)
 ```
+
+The `uploads-cli` skill in `skills/uploads-cli/SKILL.md` is checked in at the repo
+root so it's installable via the `npx skills add` convention (`--skill uploads-cli`),
+and is the API-backed successor to the `github-screenshots` skill's bundled R2
+scripts. Keep it in sync when the CLI's commands or flags change.
 
 Keep API and web separate deployables. All storage access goes through
 `createStorage()` in `packages/storage` — never import files-sdk adapters or

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -105,18 +105,18 @@ capture them. Use `-` as the file to read from stdin.
 
 Key options (`uploads put --help` for all):
 
-| Flag | Purpose |
-|---|---|
-| `--alt <text>` | Alt text for the markdown (default: filename). Always write meaningful alt text. |
-| `--width <px>` | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images). |
-| `--repo <owner/repo>` | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`). |
-| `--ref <id>` | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`). |
-| `--prefix <path>` | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`). |
-| `--key <key>` | Set the object key explicitly; skips the auto-naming below. |
-| `--content-type <mime>` | Override the content type (else inferred from extension). |
-| `--no-git` | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`). |
-| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json. |
-| `-w, --workspace <name>` | Override workspace (wins over env and token inference). |
+| Flag                                  | Purpose                                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------- |
+| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text. |
+| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images). |
+| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).   |
+| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).         |
+| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                |
+| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                      |
+| `--content-type <mime>`               | Override the content type (else inferred from extension).                        |
+| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).               |
+| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                   |
+| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                          |
 
 **Auto key naming** (when you don't pass `--key`):
 `<prefix>/<repo-name>/<ref-or-date>/<basename>-<shorthash>.<ext>`. The short hash keeps
@@ -180,12 +180,12 @@ uploads comment --issue 45 --repo buildinternet/uploads
 - **Constrain width** on large shots with `--width` so they don't dominate the page.
 - **Before/after reads best side by side** in a table:
   ```markdown
-  | Before | After |
-  |---|---|
+  | Before                               | After                               |
+  | ------------------------------------ | ----------------------------------- |
   | <img width="380" src="…/before.png"> | <img width="380" src="…/after.png"> |
   ```
 - Prefer writing the body to a file and using `gh pr edit --body-file` / `gh issue
-  comment --body-file` over inline HEREDOCs.
+comment --body-file` over inline HEREDOCs.
 - The host is agnostic — the same URLs work in issues, PR comments, discussions, and
   plain markdown docs.
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: uploads-cli
+description: >-
+  Host a file on uploads.sh (Cloudflare R2 behind an API) and get a stable, public
+  URL — then embed it in a GitHub PR or issue. Use this whenever you want to put a
+  screenshot, diagram, before/after image, GIF, or any binary into a PR description,
+  issue body, or PR/issue comment, or whenever you just need a durable public link to
+  a local file. Triggers include "upload this", "host this image", "attach a
+  screenshot to the PR", "add a before/after to the issue", "give me a public URL for
+  this file", "put this in the PR comment", or having just built/changed something
+  visual that a shot would make clearer. Reach for this instead of drag-and-drop or
+  the GitHub API (an agent can't upload to github.com/user-attachments) and instead of
+  hand-rolling R2/SigV4 uploads. This is the API-backed successor to the
+  github-screenshots skill's bundled R2 scripts.
+---
+
+# Uploading files to uploads.sh and embedding in GitHub
+
+## What this does and why
+
+GitHub's native image hosting (`github.com/user-attachments/…`) is only reachable
+through an authenticated **browser session** — there is no `gh` CLI or REST endpoint
+for it. So any image URL you put in a PR/issue body written with `gh … --body-file`
+must already point at something publicly hosted.
+
+This skill solves that with the **`uploads` CLI**: it PUTs a local file to the
+uploads.sh API (Cloudflare R2 behind a Hono Worker), which returns a stable
+`https://storage.uploads.sh/<key>` URL you can drop straight into markdown. No
+browser, no repo bloat, no SigV4 by hand. For PRs and issues it can also create and
+maintain a single "attachments" comment for you via your local `gh` auth.
+
+The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
+(`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
+in place and the URL never changes — you can update a screenshot after review and the
+PR keeps rendering the new one (the API sets `Cache-Control: max-age=60`, so edits
+propagate within ~a minute).
+
+## Prerequisites
+
+- **Node.js ≥ 22.**
+- **The CLI.** Inside this repo, run it via pnpm — the root `uploads` script builds
+  the package first, so it always reflects local source:
+  ```bash
+  pnpm uploads <command> [args]        # from the repo root
+  ```
+  If `@buildinternet/uploads` is installed/linked elsewhere, the binary is just
+  `uploads`. Every example below uses `uploads …`; prefix with `pnpm ` in-repo.
+- **A configured token** (one-time — see below). Check with `uploads doctor`.
+- **`gh` CLI, authenticated** — only for the `--comment` / `comment` features that
+  write to a PR/issue. Plain uploads don't need it.
+
+## One-time setup
+
+Config lives in a shared, user-owned file so it survives skill reinstalls and is
+shared with `github-screenshots` and other buildinternet skills (each reads only its
+own prefixed keys):
+
+```
+~/.config/buildinternet/config        # or $XDG_CONFIG_HOME/buildinternet/config
+```
+
+Resolution is **per key, first match wins**: CLI flags (`--api-url`, `--token`,
+`--workspace`) → `UPLOADS_*` environment vars → `--env-file <path>` →
+`$BUILDINTERNET_CONFIG` → the shared config file. For a one-off against a different
+API or workspace, just export the var or pass `--env-file`.
+
+The fastest path is the guided wizard, which prints exactly what's missing and how to
+fix it:
+
+```bash
+uploads setup          # shows status + next steps; run it again anytime
+```
+
+You need a **bearer token** for a workspace. Tokens are minted by an admin endpoint
+guarded by `ADMIN_TOKEN` (ask the uploads.sh admin, or set it locally in
+`apps/api/.dev.vars`). Mint one (defaults to the `default` workspace):
+
+```bash
+curl -XPOST https://api.uploads.sh/admin/tokens \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+# → { "workspace": "default", "token": "up_default_…", … }   (shown once)
+```
+
+Then save it and verify:
+
+```bash
+uploads setup --token up_default_… --check     # writes config, runs doctor
+uploads doctor                                 # health + auth + workspace checks
+```
+
+Tokens encode their workspace (`up_<workspace>_…`), so the CLI infers `--workspace`
+from the token when you don't set it. See "Config commands" for setting put defaults
+(default repo, prefix, image width) once instead of per-command.
+
+## Core workflow: `uploads put`
+
+Upload a file and get back a URL plus ready-to-paste markdown:
+
+```bash
+uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New live feed cards" --width 700
+```
+
+Human output goes to stderr; the URL and markdown to stdout, so you can pipe or
+capture them. Use `-` as the file to read from stdin.
+
+Key options (`uploads put --help` for all):
+
+| Flag | Purpose |
+|---|---|
+| `--alt <text>` | Alt text for the markdown (default: filename). Always write meaningful alt text. |
+| `--width <px>` | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images). |
+| `--repo <owner/repo>` | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`). |
+| `--ref <id>` | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`). |
+| `--prefix <path>` | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`). |
+| `--key <key>` | Set the object key explicitly; skips the auto-naming below. |
+| `--content-type <mime>` | Override the content type (else inferred from extension). |
+| `--no-git` | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`). |
+| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json. |
+| `-w, --workspace <name>` | Override workspace (wins over env and token inference). |
+
+**Auto key naming** (when you don't pass `--key`):
+`<prefix>/<repo-name>/<ref-or-date>/<basename>-<shorthash>.<ext>`. The short hash keeps
+repeated uploads from colliding. Override with `--key` only when you have a reason.
+
+**Output formats** — pick what you'll consume:
+
+```bash
+uploads put ./shot.png --format url        # just the URL, for scripting
+uploads put ./shot.png --format markdown   # just the ![]()/<img> snippet
+uploads put ./shot.png --json              # {workspace,key,url,size,markdown}
+```
+
+## Embedding in a GitHub PR or issue
+
+Two ways, depending on whether you want a durable URL, a managed comment, or both.
+
+### Option A — stable attachment URL (`--pr` / `--issue`)
+
+Gives the file a **hash-free, stable key** so re-uploads overwrite in place and the
+URL is safe to hard-code in a PR body you'll edit later:
+
+```bash
+uploads put ./after.png --pr 123 --alt "Dashboard after"
+# key: gh/<owner>/<repo>/pull/123/after.png  → stable public URL
+```
+
+`--issue <num>` does the same under `.../issues/<num>/`. The `<owner>/<repo>` comes
+from `--repo` or the git remote. `--pr`/`--issue` can't be combined with `--key`,
+`--ref`, or `--prefix` (the key layout is fixed), and are mutually exclusive.
+
+Then reference the URL in the PR/issue markdown you write with `gh`:
+
+```markdown
+<img width="700" alt="Dashboard after" src="https://storage.uploads.sh/gh/myorg/myapp/pull/123/after.png">
+```
+
+### Option B — managed attachments comment (`--comment` / `comment`)
+
+Add `--comment` to upload **and** create/update a single comment on the PR/issue that
+lists every file uploaded for it. It finds its own prior comment via a hidden marker
+and edits it in place — it never touches the description or other comments:
+
+```bash
+uploads put ./after.png --pr 123 --comment
+```
+
+The upload is authoritative; the comment is best-effort — if `gh` is missing or
+unauthenticated, the upload still succeeds and you get a warning. To (re)sync the
+comment without uploading anything (e.g. after several `--pr` uploads), use the
+standalone command:
+
+```bash
+uploads comment --pr 123
+uploads comment --issue 45 --repo buildinternet/uploads
+```
+
+### Embedding best practices
+
+- **Meaningful alt text**, always — it's what readers with images off and search see.
+- **Constrain width** on large shots with `--width` so they don't dominate the page.
+- **Before/after reads best side by side** in a table:
+  ```markdown
+  | Before | After |
+  |---|---|
+  | <img width="380" src="…/before.png"> | <img width="380" src="…/after.png"> |
+  ```
+- Prefer writing the body to a file and using `gh pr edit --body-file` / `gh issue
+  comment --body-file` over inline HEREDOCs.
+- The host is agnostic — the same URLs work in issues, PR comments, discussions, and
+  plain markdown docs.
+
+## Managing uploads
+
+```bash
+uploads list --prefix screenshots/        # list objects (key + url)
+uploads list --pr 123                      # everything attached to a PR
+uploads list --all --json                  # paginate fully, machine-readable
+uploads delete <key>                       # remove an object
+uploads delete <key> --dry-run             # show what would be deleted
+uploads health                             # API liveness (no auth)
+uploads doctor                             # health + auth + workspace alignment
+```
+
+`doctor` is the first thing to run when something's off — it distinguishes a down
+API, a bad/missing token, a workspace/token mismatch, and a local-vs-prod URL
+mismatch, and prints targeted hints.
+
+## Config commands
+
+Set shared defaults once instead of passing flags every time:
+
+```bash
+uploads config show                              # effective settings (token redacted)
+uploads config path                              # resolved config file path
+uploads config set UPLOADS_DEFAULT_REPO myorg/myapp
+uploads config set UPLOADS_DEFAULT_WIDTH 700
+uploads config init --api-url http://localhost:8787 --workspace default --token up_default_…
+```
+
+Recognized keys: `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, `UPLOADS_TOKEN`,
+`UPLOADS_DEFAULT_PREFIX`, `UPLOADS_DEFAULT_REPO`, `UPLOADS_DEFAULT_REF`,
+`UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`.
+
+## Local development
+
+Point at a locally running API (`pnpm dev` serves it on `:8787`). Tokens minted with
+`workspace:add --local` only work against localhost; prod tokens need
+`UPLOADS_API_URL=https://api.uploads.sh`. `doctor` flags this mismatch for you.
+
+```bash
+uploads --api-url http://localhost:8787 doctor
+```
+
+## Notes and cautions
+
+- **Uploads are public and effectively permanent** until deleted. Never upload
+  secrets, tokens, internal dashboards with sensitive data, or customer PII visible in
+  a shot — crop/redact first.
+- **Edge cache:** responses carry `Cache-Control: max-age=60`, so an overwrite or a
+  delete can keep serving the old bytes from the edge for up to ~a minute. The object
+  in R2 changes immediately.
+- **Exit codes** (useful in scripts): `2` usage/missing-token, `3` unauthorized or
+  not-found, `4` network, `1` other. `--json` also emits `{error,code,status}`.
+- **Agents on the Worker side:** the package also exports
+  `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing
+  upload/list/delete as AI-SDK tools inside the Worker — separate from this CLI, and
+  only relevant if you're building the agent tooling itself, not embedding images.


### PR DESCRIPTION
Adds a repo-shipped agent skill documenting the `@buildinternet/uploads` CLI, so agents working in this repo pick it up automatically and it's installable elsewhere via `npx skills add buildinternet/uploads --skill uploads-cli`.

## What's here

- **`skills/uploads-cli/SKILL.md`** — covers the full CLI surface:
  - Setup: shared `~/.config/buildinternet/config`, per-key resolution order, `uploads setup` / `doctor`, token minting via the admin endpoint.
  - `put`: flags, auto key naming (`<prefix>/<repo>/<ref>/<name>-<hash>.<ext>`), and the `human`/`url`/`markdown`/`json` output formats.
  - GitHub embedding — the two intended paths: `--pr`/`--issue` for hash-free **stable URLs** (re-upload overwrites in place), and `--comment` / `comment` for the managed attachments comment via local `gh` auth.
  - `list` / `delete` / `health` / `doctor`, config commands, local dev, exit codes, and the public/permanent + `max-age=60` cache cautions.
- **`AGENTS.md`** — points at the skill and the `--skill uploads-cli` install flag.

## Notes

- Slug is `uploads-cli` (the skills CLI requires lowercase-hyphen names — no dots/spaces); the "uploads.sh CLI" framing lives in the title and description.
- Positioned as the API-backed successor to the `github-screenshots` skill's bundled R2 scripts, per the roadmap.
- Claims were verified against CLI source and a local build (`--help`, key-layout in `github.ts`); no `skills.sh.json` display manifest included for now.