### PR TITLE
feat: Make GitHub media uploads agent-friendly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,6 @@ jobs:
 
       - name: Run tests
         run: pnpm --filter @uploads/storage test && pnpm --filter @buildinternet/uploads test
+
+      - name: Verify npm package
+        run: pnpm --filter @buildinternet/uploads run build && pnpm --filter @buildinternet/uploads run pack:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release npm package
+
+on:
+  push:
+    tags:
+      - "uploads-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @buildinternet/uploads
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+      - name: Install trusted-publishing npm version
+        run: npm install --global npm@11.18.0
+      - name: Verify npm version
+        run: test "$(npm --version)" = "11.18.0"
+      - run: pnpm install --frozen-lockfile
+      - name: Check tag matches package version
+        shell: bash
+        run: test "${GITHUB_REF_NAME}" = "uploads-v$(node -p \"require('./packages/uploads/package.json').version\")"
+      - name: Test and verify package
+        run: pnpm --filter @buildinternet/uploads test && pnpm --filter @buildinternet/uploads run build && pnpm --filter @buildinternet/uploads run pack:check
+      - name: Publish to npm with provenance
+        working-directory: packages/uploads
+        run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -9,7 +9,34 @@ Lightweight file-hosting backend on Cloudflare Workers, built on
 > the open and its APIs (including auth) will change without notice. Don't rely
 > on it for anything you can't afford to lose or re-key.
 
-## Quick start
+## Agent quick start
+
+Install/run the CLI, save a workspace token once, then attach media from a
+checked-out PR branch:
+
+```bash
+npx @buildinternet/uploads setup --token up_<workspace>_...
+npx @buildinternet/uploads doctor
+npx @buildinternet/uploads attach ./before.png ./after.png
+```
+
+`attach` detects the GitHub repository and current PR through `gh`, uploads all
+files, and creates or updates one managed attachments comment. Use
+`--pr <number>` or `--issue <number>` when inference is not possible, and
+`--no-comment` when only the public URLs and Markdown are wanted.
+
+An uploads.sh administrator must mint the workspace token. See
+[admin tokens](docs/admin-tokens.md); agents never need the admin credential.
+Hosted files are public, including media attached to private repositories. Do
+not upload secrets or sensitive UI.
+
+For agent runtimes, install the checked-in skill as well:
+
+```bash
+npx skills add buildinternet/uploads --skill uploads-cli
+```
+
+## Local development quick start
 
 ```bash
 pnpm install
@@ -101,12 +128,13 @@ plus peer deps, no API changes.
 
 ## Docs
 
-| Doc                                  | Contents                                     |
-| ------------------------------------ | -------------------------------------------- |
-| [workspaces](docs/workspaces.md)     | Multi-tenant model, registration, BYO-bucket |
-| [admin-tokens](docs/admin-tokens.md) | Minting, listing, and revoking upload tokens |
-| [api](docs/api.md)                   | REST routes and CLI usage                    |
-| [deploy](docs/deploy.md)             | Cloudflare setup and production deploy       |
-| [roadmap](docs/roadmap.md)           | Planned features                             |
+| Doc                                          | Contents                                     |
+| -------------------------------------------- | -------------------------------------------- |
+| [workspaces](docs/workspaces.md)             | Multi-tenant model, registration, BYO-bucket |
+| [admin-tokens](docs/admin-tokens.md)         | Minting, listing, and revoking upload tokens |
+| [api](docs/api.md)                           | REST routes and CLI usage                    |
+| [deploy](docs/deploy.md)                     | Cloudflare setup and production deploy       |
+| [contract testing](docs/contract-testing.md) | Deployed smoke checks and release gate       |
+| [roadmap](docs/roadmap.md)                   | Planned features                             |
 
 Agent and contributor conventions live in [AGENTS.md](AGENTS.md).

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -1,0 +1,71 @@
+# Contract testing
+
+The product promise crosses the CLI, API, object storage, public CDN, and
+GitHub. Unit tests cover local behavior; use these smoke checks to verify the
+deployed boundaries without committing credentials.
+
+## Read-only check
+
+This is safe to run against production and requires no secret:
+
+```bash
+node scripts/smoke-contract.mjs
+```
+
+It verifies that the API is reachable and that `GET /health` still returns the
+documented contract.
+
+## Upload lifecycle
+
+The lifecycle check creates a uniquely named text object, verifies the upload
+response, metadata, listing, public URL bytes and content type, then deletes the
+object. Cleanup runs even if an intermediate assertion fails.
+
+```bash
+UPLOADS_API_URL=https://api.uploads.sh \
+UPLOADS_WORKSPACE=default \
+UPLOADS_TOKEN=up_default_... \
+node scripts/smoke-contract.mjs --lifecycle
+```
+
+Use a dedicated, revocable smoke-test token. Pass it through the environment,
+not a command-line flag, and never commit it. The script prints no token or
+public object URL.
+
+## Full GitHub acceptance test
+
+Run this manually in a disposable public repository before a CLI release. It
+mutates a real PR and therefore is intentionally not part of the API script.
+
+1. Install the exact package artifact or version being released.
+2. Authenticate `gh` and create a disposable branch and PR.
+3. Run `uploads setup --token <dedicated-token>` and `uploads doctor`.
+4. Run `uploads attach before.png after.png` from the PR branch.
+5. Confirm one managed comment contains both rendered images.
+6. Replace `after.png`, rerun `uploads attach after.png`, and confirm the same
+   comment and URL are updated rather than duplicated.
+7. Confirm `uploads attach after.png --no-comment` uploads without changing the
+   managed comment.
+8. Repeat once with explicit `--pr <number>` and once with `--issue <number>`.
+9. Verify a failed `gh` invocation does not lose the uploaded URL/Markdown and
+   returns actionable machine-readable output with `--json`.
+10. Delete the disposable attachments, close the PR/issue, and revoke the test
+    token.
+
+For a scheduled CI job, store only the dedicated upload token and GitHub token
+as repository secrets, limit their scopes, use a single disposable repository,
+and serialize runs to prevent comment races. Keep that job separate from pull
+request CI so untrusted changes never receive the secrets.
+
+## Release gate
+
+A release is ready for the agent workflow when a clean environment can:
+
+```bash
+npx @buildinternet/uploads setup --token <token>
+npx @buildinternet/uploads attach screenshot.png
+```
+
+Success means repository and current PR inference work, the public media
+renders in one managed comment, reruns update rather than duplicate it, and all
+failure modes retain the uploaded URL in structured output.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,19 @@
+# Releasing `@buildinternet/uploads`
+
+The CLI is published from `.github/workflows/release.yml` using npm trusted publishing, without a long-lived npm token.
+
+## One-time npm setup
+
+1. Create or claim the `@buildinternet` npm organization and ensure the maintainer can publish `@buildinternet/uploads`.
+2. In npm package settings, add a GitHub Actions trusted publisher for organization `buildinternet`, repository `uploads`, workflow `release.yml`, with no environment. Select `npm publish` as the allowed action.
+3. Keep maintainer 2FA enabled. No `NPM_TOKEN` GitHub secret is needed. The workflow pins npm 11.18.0 because trusted publishing requires npm 11.5.1 or newer and Node 22.14 or newer.
+
+A first publication may need to be manual before npm allows configuring the trusted publisher. Run the build and `pack:check`, publish once from `packages/uploads` with a maintainer account, then configure trusted publishing immediately.
+
+## Release
+
+1. Update `packages/uploads/package.json` to the intended semver version and merge to `main`.
+2. Push a matching tag, such as `uploads-v0.2.0` for package version `0.2.0`.
+3. Confirm the **Release npm package** workflow succeeds and verify npm.
+
+The workflow rejects a tag that does not exactly match the package version. Provenance is enabled in the manifest and publish command.

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -6,14 +6,27 @@ CLI and client for **uploads.sh** — upload files, get public URLs, and produce
 
 Binary: `uploads` (also `pnpm uploads` from repo root after `pnpm install`).
 
+Install globally or run a pinned version without installing:
+
+```bash
+npm install --global @buildinternet/uploads
+npx @buildinternet/uploads@0.1.0 --help
+```
+
 ```bash
 pnpm uploads setup --env-file .env
+pnpm uploads attach ./before.png ./after.png --env-file .env
 pnpm uploads put ./shot.png --env-file .env
 pnpm uploads put ./after.png --pr 123 --comment --env-file .env
 pnpm uploads doctor --env-file .env
 ```
 
-Commands: `put`, `comment`, `list`, `delete`, `setup`, `config`, `doctor`, `health`.
+Commands: `attach`, `put`, `comment`, `list`, `delete`, `setup`, `config`, `doctor`, `health`.
+
+`attach` is the agent-friendly default for GitHub media. It accepts one or more files,
+infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
+or updates one managed attachments comment. Use `--pr`, `--issue`, and `--repo` to select
+the target explicitly, or `--no-comment` to upload without changing GitHub comments.
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 
@@ -43,6 +56,9 @@ bin/uploads.js      Bin shim
 pnpm build        # tsc → dist/
 pnpm typecheck
 pnpm test
+pnpm pack:check   # verify the npm tarball contents
 ```
+
+Maintainer release instructions: [`docs/releasing.md`](../../docs/releasing.md).
 
 Agent-oriented usage: [`skills/uploads-cli/SKILL.md`](../../skills/uploads-cli/SKILL.md). REST details: [`docs/api.md`](../../docs/api.md).

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@buildinternet/uploads",
   "version": "0.1.0",
-  "private": true,
   "description": "CLI and client for uploads.sh — workspace-scoped image hosting for GitHub embeds",
   "type": "module",
   "license": "MIT",
@@ -27,13 +26,14 @@
   "files": [
     "bin",
     "dist",
-    "src"
+    "README.md"
   ],
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "build": "tsc",
-    "prepublishOnly": "pnpm run build"
+    "pack:check": "node ./scripts/check-pack.mjs",
+    "prepublishOnly": "npm run build"
   },
   "engines": {
     "node": ">=22"
@@ -54,6 +54,7 @@
     "vitest": "^4.1.10"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/uploads/scripts/check-pack.mjs
+++ b/packages/uploads/scripts/check-pack.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+const packageRoot = new URL("..", import.meta.url);
+const outputDirectory = mkdtempSync(join(tmpdir(), "uploads-pack-"));
+const packArguments = ["pack", "--json", "--pack-destination", outputDirectory];
+const packageManager = process.env.npm_execpath
+  ? { command: process.execPath, arguments: [process.env.npm_execpath, ...packArguments] }
+  : { command: "pnpm", arguments: packArguments };
+try {
+  const result = JSON.parse(
+    execFileSync(packageManager.command, packageManager.arguments, {
+      cwd: packageRoot,
+      encoding: "utf8",
+    }),
+  );
+  const packed = Array.isArray(result) ? result[0] : result;
+  const files = new Set(packed.files.map(({ path }) => path));
+  for (const required of [
+    "README.md",
+    "bin/uploads.js",
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/agent.js",
+    "dist/agent.d.ts",
+    "dist/cli.js",
+  ]) {
+    assert(files.has(required), `packed artifact is missing ${required}`);
+  }
+  assert(
+    [...files].every((path) => !path.startsWith("src/")),
+    "packed artifact must not contain TypeScript source files",
+  );
+  const tarballPath = join(outputDirectory, basename(packed.filename));
+  const manifest = JSON.parse(
+    execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], {
+      encoding: "utf8",
+    }),
+  );
+  assert.equal(manifest.private, undefined, "package must not be marked private");
+  assert.equal(manifest.publishConfig?.access, "public");
+  assert.equal(
+    manifest.bin?.uploads?.replace(/^\.\//, ""),
+    "bin/uploads.js",
+    "packed manifest must retain the uploads executable",
+  );
+  console.log(`Verified ${packed.filename} (${packed.files.length} files)`);
+} finally {
+  rmSync(outputDirectory, { recursive: true, force: true });
+}

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -10,6 +10,7 @@ import {
 } from "./cli-args.js";
 import {
   runPut,
+  runAttach,
   runList,
   runDelete,
   runHealth,
@@ -45,6 +46,7 @@ Other globals (before command):
   --quiet
 
 Commands:
+  attach <file...>     Attach media to the current PR (stable URLs + managed comment)
   put <file>          Upload (+ URL + markdown for GitHub)
   comment             Create/update a PR/issue attachments comment (via gh)
   list                List objects
@@ -61,6 +63,7 @@ Put/list defaults (config file or env):
 Examples:
   uploads setup
   uploads setup --token up_default_… --repo myorg/myapp
+  uploads attach ./before.png ./after.png
   uploads put ./shot.png --ref 42
   uploads doctor
 
@@ -143,6 +146,7 @@ export async function runCli(argv: string[]): Promise<number> {
         return runConfig(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
       case "setup":
         return runSetup(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
+      case "attach":
       case "put":
       case "list":
       case "delete":
@@ -150,6 +154,8 @@ export async function runCli(argv: string[]): Promise<number> {
       case "comment": {
         const ctx = createContext(parsed.globals, !showHelp, cmdArgs);
         switch (parsed.command) {
+          case "attach":
+            return runAttach(ctx, cmdArgs, showHelp);
           case "put":
             return runPut(ctx, cmdArgs, showHelp);
           case "comment":

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -26,6 +26,7 @@ import {
 } from "./github.js";
 import {
   resolveRepo,
+  resolveCurrentPullRequest,
   execRunner,
   upsertAttachmentsComment,
   type CommandRunner,
@@ -111,6 +112,88 @@ async function syncAttachmentsComment(
   const body = attachmentsCommentBody(items);
   const { created } = upsertAttachmentsComment(target, body, run);
   return { action: created ? "created" : "updated", count: items.length };
+}
+
+// --- attach ---
+
+const ATTACH_HELP = `uploads attach <file...> [options]
+
+Upload one or more stable PR/issue attachments and maintain a single GitHub
+comment. With no target, uses the pull request for the current branch.
+
+Options:
+  --pr <num>            Attach to this pull request
+  --issue <num>         Attach to this issue
+  --repo <owner/repo>   Repository (default: gh/git inference)
+  --no-comment          Upload only; don't create/update the managed comment
+  --content-type <mime> Override Content-Type (applied to every file)
+  --workspace, -w <name>  Override workspace
+
+Examples:
+  uploads attach ./before.png ./after.png
+  uploads attach ./shot.png --pr 123 --repo myorg/myapp
+  uploads attach ./artifact.zip --issue 45 --no-comment
+`;
+
+export async function runAttach(
+  ctx: CliContext,
+  args: string[],
+  help = false,
+  run: CommandRunner = execRunner,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(ATTACH_HELP);
+    return 0;
+  }
+  if (parsed.positionals.length === 0) {
+    process.stderr.write(ATTACH_HELP);
+    return 2;
+  }
+  if (parsed.flags.has("--no-comment") && typeof parsed.flags.get("--no-comment") === "string") {
+    throw new UsageError("--no-comment takes no value — place it after the file arguments");
+  }
+
+  const explicitTarget = ghTargetFromFlags(parsed.flags, run);
+  const target =
+    explicitTarget ??
+    resolveCurrentPullRequest(resolveRepo(flagString(parsed.flags, "--repo"), run), run);
+  const results = [];
+  for (const file of parsed.positionals) {
+    if (file === "-")
+      throw new UsageError("attach does not support stdin; pass one or more file paths");
+    const filename = basename(file);
+    if (!ctx.quiet && !ctx.json) process.stderr.write(`>> uploading ${file}\n`);
+    const result = await ctx.client.put(new Uint8Array(readFileSync(file)), {
+      filename,
+      key: ghAttachmentKey(target, filename),
+      contentType: flagString(parsed.flags, "--content-type"),
+    });
+    results.push({ ...result, markdown: buildMarkdown(result.url, { alt: filename }) });
+  }
+
+  let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+  let commentError: string | undefined;
+  if (!parsed.flags.has("--no-comment")) {
+    try {
+      comment = await syncAttachmentsComment(ctx, target, run);
+    } catch (err) {
+      commentError = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `warning: uploads succeeded but the GitHub comment failed (is gh installed and authenticated?): ${commentError}\n`,
+      );
+    }
+  }
+
+  if (ctx.json) {
+    await writeJson({ target, uploads: results, comment, commentError });
+  } else {
+    for (const result of results) {
+      await writeStdout(`URL: ${result.url}\nMARKDOWN: ${result.markdown}\n`);
+    }
+    if (!ctx.quiet && comment) process.stderr.write(`>> attachments comment ${comment.action}\n`);
+  }
+  return 0;
 }
 
 export async function runPut(

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -47,6 +47,30 @@ export function resolveRepo(explicit: string | undefined, run: CommandRunner = e
   throw new UsageError("could not infer repository from git — pass --repo owner/name");
 }
 
+/** Resolve the pull request associated with the current branch. */
+export function resolveCurrentPullRequest(repo: string, run: CommandRunner = execRunner): GhTarget {
+  try {
+    const out = run("gh", [
+      "pr",
+      "view",
+      "--repo",
+      repo,
+      "--json",
+      "number",
+      "--jq",
+      ".number",
+    ]).trim();
+    if (/^\d+$/.test(out) && Number(out) > 0) {
+      return { repo, kind: "pull", num: Number.parseInt(out, 10) };
+    }
+  } catch {
+    // Normalize gh's varying errors into a stable, actionable CLI message.
+  }
+  throw new UsageError(
+    "could not infer a pull request for the current branch — pass --pr <num> or --issue <num>",
+  );
+}
+
 interface GhComment {
   id: number;
   body: string;

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { UsageError } from "../src/cli-args.js";
+import type { UploadsClient } from "../src/client.js";
+import { runAttach, type CliContext } from "../src/commands.js";
+import type { CommandRunner } from "../src/github-gh.js";
+
+function files(...names: string[]): string[] {
+  const dir = mkdtempSync(join(tmpdir(), "uploads-attach-test-"));
+  return names.map((name) => {
+    const path = join(dir, name);
+    writeFileSync(path, name);
+    return path;
+  });
+}
+
+function fakeClient() {
+  const puts: string[] = [];
+  const client = {
+    put: async (_body: Uint8Array, opts: { key: string }) => {
+      puts.push(opts.key);
+      return {
+        workspace: "test",
+        key: opts.key,
+        url: `https://x.test/${opts.key}`,
+        size: 3,
+        contentType: "image/png",
+      };
+    },
+    list: async ({ prefix }: { prefix?: string }) => ({
+      items: puts
+        .filter((key) => key.startsWith(prefix ?? ""))
+        .map((key) => ({ key, url: `https://x.test/${key}` })),
+      cursor: null,
+    }),
+  } as unknown as UploadsClient;
+  return { client, puts };
+}
+
+function ctxWith(client: UploadsClient): CliContext {
+  return {
+    config: {
+      apiUrl: "https://x.test",
+      workspace: "test",
+      token: "up_test_x",
+      workspaceSource: "override",
+      configPath: "/tmp/uploads-test-config",
+      configExists: false,
+    },
+    client,
+    json: false,
+    quiet: true,
+  };
+}
+
+function ghRunner() {
+  const calls: string[][] = [];
+  const run: CommandRunner = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    if (args[0] === "repo") return "buildinternet/uploads\n";
+    if (args[0] === "pr" && args[1] === "view") return "123\n";
+    if (args[1]?.includes("per_page=100")) return "[]";
+    return JSON.stringify({ id: 9 });
+  };
+  return { run, calls };
+}
+
+const noPullRequestRunner: CommandRunner = (_cmd, args) => {
+  if (args[0] === "repo") return "o/r";
+  throw new Error("no pull request");
+};
+
+describe("runAttach", () => {
+  it("infers the current PR, uploads multiple stable keys, and creates a comment", async () => {
+    const { client, puts } = fakeClient();
+    const { run, calls } = ghRunner();
+    expect(await runAttach(ctxWith(client), files("before.png", "after.png"), false, run)).toBe(0);
+    expect(puts).toEqual([
+      "gh/buildinternet/uploads/pull/123/before.png",
+      "gh/buildinternet/uploads/pull/123/after.png",
+    ]);
+    expect(calls.some((call) => call[1] === "pr" && call[2] === "view")).toBe(true);
+    expect(
+      calls.some((call) => call.includes("repos/buildinternet/uploads/issues/123/comments")),
+    ).toBe(true);
+  });
+
+  it("supports an explicit issue and skips the managed comment with --no-comment", async () => {
+    const { client, puts } = fakeClient();
+    const { run, calls } = ghRunner();
+    await runAttach(
+      ctxWith(client),
+      [...files("artifact.zip"), "--issue", "45", "--repo", "o/r", "--no-comment"],
+      false,
+      run,
+    );
+    expect(puts).toEqual(["gh/o/r/issues/45/artifact.zip"]);
+    expect(calls).toEqual([]);
+  });
+
+  it("requires an inferable current PR when no target is supplied", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runAttach(ctxWith(client), files("shot.png"), false, noPullRequestRunner),
+    ).rejects.toThrow(UsageError);
+  });
+});

--- a/scripts/smoke-contract.mjs
+++ b/scripts/smoke-contract.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+
+const args = new Set(process.argv.slice(2));
+const lifecycle = args.has("--lifecycle");
+const apiUrl = (process.env.UPLOADS_API_URL ?? "https://api.uploads.sh").replace(/\/$/, "");
+const workspace = process.env.UPLOADS_WORKSPACE ?? "default";
+const token = process.env.UPLOADS_TOKEN;
+
+if (args.has("--help")) {
+  process.stdout.write(`uploads API contract smoke test
+
+Usage:
+  node scripts/smoke-contract.mjs
+  UPLOADS_TOKEN=... node scripts/smoke-contract.mjs --lifecycle
+
+Environment:
+  UPLOADS_API_URL    API base (default: https://api.uploads.sh)
+  UPLOADS_WORKSPACE  workspace (default: default)
+  UPLOADS_TOKEN      required only for --lifecycle
+
+The default check is read-only. --lifecycle uploads a unique test object,
+verifies metadata/listing/public bytes, and deletes it in a finally block.
+The token is read only from the environment so it does not appear in argv.
+`);
+  process.exit(0);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function request(path, init, expected) {
+  const response = await fetch(`${apiUrl}${path}`, init);
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    throw new Error(`${init?.method ?? "GET"} ${path}: expected JSON, got ${text.slice(0, 120)}`);
+  }
+  if (!expected.includes(response.status)) {
+    throw new Error(
+      `${init?.method ?? "GET"} ${path}: expected ${expected.join("/")}, got ${response.status}: ${text}`,
+    );
+  }
+  return { body };
+}
+
+const health = await request("/health", undefined, [200]);
+assert(health.body?.ok === true, "GET /health did not return { ok: true }");
+process.stdout.write(`ok health ${apiUrl}\n`);
+
+if (!lifecycle) {
+  process.stdout.write("ok read-only contract (use --lifecycle for upload verification)\n");
+  process.exit(0);
+}
+
+assert(token, "UPLOADS_TOKEN is required with --lifecycle");
+
+const key = `contract-smoke/${new Date().toISOString().slice(0, 10)}/${randomUUID()}.txt`;
+const filePath = `/v1/${encodeURIComponent(workspace)}/files/${key}`;
+const bytes = new TextEncoder().encode(`uploads contract smoke ${randomUUID()}\n`);
+const auth = { Authorization: `Bearer ${token}` };
+let uploaded = false;
+
+try {
+  const put = await request(
+    filePath,
+    {
+      method: "PUT",
+      headers: { ...auth, "Content-Type": "text/plain; charset=utf-8" },
+      body: bytes,
+    },
+    [201],
+  );
+  uploaded = true;
+  assert(put.body?.workspace === workspace, "upload returned the wrong workspace");
+  assert(put.body?.key === key, "upload returned the wrong key");
+  assert(put.body?.size === bytes.byteLength, "upload returned the wrong size");
+  assert(
+    typeof put.body?.url === "string" && put.body.url.length > 0,
+    "upload returned no public URL",
+  );
+  process.stdout.write("ok upload\n");
+
+  const metadata = await request(filePath, { headers: auth }, [200]);
+  assert(metadata.body?.url === put.body.url, "metadata URL differs from upload URL");
+  process.stdout.write("ok metadata\n");
+
+  const list = await request(
+    `/v1/${encodeURIComponent(workspace)}/files?prefix=${encodeURIComponent(key)}&limit=10`,
+    { headers: auth },
+    [200],
+  );
+  assert(Array.isArray(list.body?.items), "list response has no items array");
+  assert(
+    list.body.items.some((item) => item.key === key),
+    "uploaded key is absent from list",
+  );
+  process.stdout.write("ok list\n");
+
+  const publicResponse = await fetch(put.body.url, { cache: "no-store" });
+  assert(publicResponse.ok, `public URL returned ${publicResponse.status}`);
+  const publicBytes = new Uint8Array(await publicResponse.arrayBuffer());
+  assert(
+    Buffer.from(publicBytes).equals(Buffer.from(bytes)),
+    "public URL bytes differ from upload",
+  );
+  assert(
+    publicResponse.headers.get("content-type")?.startsWith("text/plain"),
+    "public URL has the wrong Content-Type",
+  );
+  process.stdout.write("ok public bytes\n");
+} finally {
+  if (uploaded) {
+    await request(filePath, { method: "DELETE", headers: auth }, [200]);
+    await request(filePath, { headers: auth }, [404]);
+    process.stdout.write("ok delete\n");
+  }
+}
+
+process.stdout.write("ok lifecycle contract\n");

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -29,6 +29,17 @@ uploads.sh API (Cloudflare R2 behind a Hono Worker), which returns a stable
 browser, no repo bloat, no SigV4 by hand. For PRs and issues it can also create and
 maintain a single "attachments" comment for you via your local `gh` auth.
 
+For the common case, use `uploads attach <file...>`. It infers the current branch's PR,
+uploads every file under stable attachment keys, and maintains the comment by default:
+
+```bash
+uploads attach ./before.png ./after.png
+uploads attach ./shot.png --issue 45 --repo buildinternet/uploads
+```
+
+Pass `--no-comment` when only stable URLs are wanted. Use `put` for lower-level naming
+and output control.
+
 The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
 in place and the URL never changes — you can update a screenshot after review and the


### PR DESCRIPTION
## Summary

- add `uploads attach <file...>` with current-PR inference, multi-file uploads, stable attachment keys, and managed comments by default
- make `@buildinternet/uploads` publishable and add verified npm packaging plus a trusted-publishing release workflow
- add agent-first onboarding, release guidance, and safe API contract smoke testing

## Why

Agents currently have the low-level upload primitives, but installing the CLI, targeting the current PR, attaching multiple files, and publishing the package still require too much manual assembly. This milestone makes the common GitHub media workflow one command and prepares the package for a reviewed npm bootstrap release.

## User impact

From any configured repository, an agent can run:

```bash
uploads attach before.png after.png
```

The CLI infers the current PR, uploads stable URLs, and creates or updates one managed attachments comment. Explicit `--pr`, `--issue`, `--repo`, `--no-comment`, and aggregate `--json` flows remain available.

## Validation

- lint and format checks passed
- all workspace typechecks passed
- storage tests: 19 passed
- uploads CLI tests: 36 passed
- npm tarball verified with expected CLI bin and 34 files
- live read-only `https://api.uploads.sh/health` contract passed
- npm 11 publish dry-run passed

## Follow-up after merge

Bootstrap-publish `@buildinternet/uploads@0.1.0` from a clean `main`, configure npm trusted publishing for `release.yml`, then use `uploads-v*` tags for later releases.