### PR TITLE
chore(release): harden publishing guardrails

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,24 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  conventional-commit:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Validate title
+        shell: bash
+        run: |
+          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9._/-]+\))?(!)?: .+'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "PR title must use Conventional Commit format, for example: feat(cli): add attach command" >&2
+            exit 1
+          fi

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,19 +1,29 @@
 # Releasing `@buildinternet/uploads`
 
-The CLI is published from `.github/workflows/release.yml` using npm trusted publishing, without a long-lived npm token.
+The CLI is published from `.github/workflows/release.yml` using npm trusted publishing, without a long-lived npm token. Version `0.1.0` is already published and the trusted publisher is configured; do not manually publish later releases.
 
-## One-time npm setup
+## Trusted-publishing configuration
 
-1. Create or claim the `@buildinternet` npm organization and ensure the maintainer can publish `@buildinternet/uploads`.
-2. In npm package settings, add a GitHub Actions trusted publisher for organization `buildinternet`, repository `uploads`, workflow `release.yml`, with no environment. Select `npm publish` as the allowed action.
-3. Keep maintainer 2FA enabled. No `NPM_TOKEN` GitHub secret is needed. The workflow pins npm 11.18.0 because trusted publishing requires npm 11.5.1 or newer and Node 22.14 or newer.
+The npm package is configured with a GitHub Actions trusted publisher for organization `buildinternet`, repository `uploads`, workflow `release.yml`, no environment, and allowed action `npm publish`. No `NPM_TOKEN` GitHub secret is needed.
 
-A first publication may need to be manual before npm allows configuring the trusted publisher. Run the build and `pack:check`, publish once from `packages/uploads` with a maintainer account, then configure trusted publishing immediately.
+Keep maintainer 2FA enabled. The workflow pins npm 11.18.0 because trusted publishing requires npm 11.5.1 or newer and Node 22.14 or newer.
 
 ## Release
 
-1. Update `packages/uploads/package.json` to the intended semver version and merge to `main`.
-2. Push a matching tag, such as `uploads-v0.2.0` for package version `0.2.0`.
-3. Confirm the **Release npm package** workflow succeeds and verify npm.
+1. From `packages/uploads`, choose the next semantic version and update the manifest without creating a tag:
 
-The workflow rejects a tag that does not exactly match the package version. Provenance is enabled in the manifest and publish command.
+   ```bash
+   npm version 0.2.0 --no-git-tag-version
+   ```
+
+2. Run the package tests and tarball check, then open a PR containing the version change. Merge it to `main` before tagging.
+3. Update local `main`, verify `packages/uploads/package.json` contains the intended version, and tag that exact merge commit:
+
+   ```bash
+   git tag uploads-v0.2.0
+   git push origin uploads-v0.2.0
+   ```
+
+4. Confirm the **Release npm package** workflow succeeds, then verify the new version and provenance on npm.
+
+The tag must be new and must exactly match the package version; never move or reuse a release tag. The workflow rejects mismatches and npm rejects versions that are already published.

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -21,7 +21,7 @@
     }
   },
   "bin": {
-    "uploads": "./bin/uploads.js"
+    "uploads": "bin/uploads.js"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary

- enforce Conventional Commit formatting for pull request titles without third-party actions or write permissions
- normalize the npm CLI bin path so future publishes avoid misleading package normalization warnings
- document the trusted-publishing release flow now that `0.1.0` is public

## Why

The initial package release exposed two maintenance gaps: PR title conventions were only conversational, and npm normalized the executable path during publishing. This makes both behaviors explicit and keeps future releases tied to reviewed, merged version changes.

## Validation

- changed-file formatting passed
- lint passed with zero warnings
- all workspace typechecks passed
- storage tests: 19 passed
- uploads CLI tests: 36 passed
- npm tarball verification passed with 34 files
- Conventional Commit title validator accepted valid examples and rejected invalid titles

## Local environment note

The Windows checkout stores unchanged files with CRLF, so the repository-wide local formatter reports pre-existing line-ending noise. All changed files pass formatting, and GitHub's Linux CI remains the authoritative full-tree format gate.