### PR TITLE
feat(auth): add D1-backed uploads login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 #
 # For personal CLI defaults, prefer the shared buildinternet config instead:
 #   ~/.config/buildinternet/config   (see packages/uploads/config.example)
-#   uploads config init --token <token>
+#   uploads login
 #
 # The worker itself does not read this file — its local config is
 # apps/api/.dev.vars (see apps/api/.dev.vars.example) and its per-workspace
@@ -27,14 +27,18 @@ UPLOADS_WORKSPACE=default
 # Local vs prod: tokens minted with --local only work against localhost; prod tokens
 # need UPLOADS_API_URL=https://api.uploads.sh (the default in this file).
 
-# Bearer token for that workspace. Two ways to get one:
-#   - create a workspace (mints its first token, shown once):
-#       cd apps/api && node scripts/add-workspace.mjs <workspace> --bucket <bucket> --binding <BINDING>
-#   - mint an additional token for an existing workspace via the admin endpoint:
-#       curl -XPOST $UPLOADS_API_URL/admin/tokens -H "Authorization: Bearer $ADMIN_TOKEN"
+# Bearer token for that workspace. For routine agent setup, ask an administrator for
+# a short-lived enrollment code and run `uploads login`; the CLI saves this value.
+# Never give ADMIN_TOKEN to a routine agent. Direct token minting is reserved for CI,
+# migration, and break-glass administration.
 # Local dev (--local) tokens are a separate store from production — they only
 # work against localhost.
 UPLOADS_TOKEN=
+
+# Optional one-command, non-interactive login. Enrollment codes expire quickly and
+# should be supplied only for the `uploads login` process, not kept in a persistent
+# .env file. Prefer: UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login
+# UPLOADS_ENROLLMENT_CODE=
 
 # ---------------------------------------------------------------------------
 # Optional: real Cloudflare/R2 credentials for development.
@@ -69,4 +73,5 @@ CLOUDFLARE_API_TOKEN=
 #   routes[0].pattern   your API domain (or delete the routes block to serve
 #                       from the workers.dev subdomain)
 #   kv_namespaces[0].id output of `wrangler kv namespace create REGISTRY`
+#   d1_databases[0]      application DB from `wrangler d1 create uploads-production`
 #   r2_buckets[0]       your bucket name/binding

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+# Preserve binary assets byte-for-byte.
+*.gif binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.png binary
+*.webp binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: pnpm types
 
       - name: Run tests
-        run: pnpm --filter @uploads/storage test && pnpm --filter @buildinternet/uploads test
+        run: pnpm --filter @uploads/api test && pnpm --filter @uploads/storage test && pnpm --filter @buildinternet/uploads test
 
       - name: Verify npm package
         run: pnpm --filter @buildinternet/uploads run build && pnpm --filter @buildinternet/uploads run pack:check

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ Lightweight file-hosting backend on Cloudflare Workers, built on
 
 ## Agent quick start
 
-Install/run the CLI, save a workspace token once, then attach media from a
-checked-out PR branch:
+Install the CLI, enroll once, then attach media from a checked-out PR branch:
 
 ```bash
-npx @buildinternet/uploads setup --token up_<workspace>_...
-npx @buildinternet/uploads doctor
-npx @buildinternet/uploads attach ./before.png ./after.png
+npm install --global @buildinternet/uploads
+uploads login
+uploads attach ./before.png ./after.png
+```
+
+For a one-off or pinned run without a global install:
+
+```bash
+npx @buildinternet/uploads@0.1.0 login
+npx @buildinternet/uploads@0.1.0 attach ./before.png ./after.png
 ```
 
 `attach` detects the GitHub repository and current PR through `gh`, uploads all
@@ -25,8 +31,9 @@ files, and creates or updates one managed attachments comment. Use
 `--pr <number>` or `--issue <number>` when inference is not possible, and
 `--no-comment` when only the public URLs and Markdown are wanted.
 
-An uploads.sh administrator must mint the workspace token. See
-[admin tokens](docs/admin-tokens.md); agents never need the admin credential.
+An uploads.sh administrator creates a short-lived, single-use enrollment code;
+`uploads login` exchanges it and saves the resulting workspace token. Routine
+agents never receive or need `ADMIN_TOKEN`. See [enrollment](docs/enrollment.md).
 Hosted files are public, including media attached to private repositories. Do
 not upload secrets or sensitive UI.
 
@@ -131,6 +138,7 @@ plus peer deps, no API changes.
 | Doc                                          | Contents                                     |
 | -------------------------------------------- | -------------------------------------------- |
 | [workspaces](docs/workspaces.md)             | Multi-tenant model, registration, BYO-bucket |
+| [enrollment](docs/enrollment.md)             | Agent login, scopes, expiry, and migration   |
 | [admin-tokens](docs/admin-tokens.md)         | Minting, listing, and revoking upload tokens |
 | [api](docs/api.md)                           | REST routes and CLI usage                    |
 | [deploy](docs/deploy.md)                     | Cloudflare setup and production deploy       |

--- a/apps/api/migrations/20260710120000_auth.sql
+++ b/apps/api/migrations/20260710120000_auth.sql
@@ -1,0 +1,27 @@
+CREATE TABLE auth_tokens (
+  id TEXT PRIMARY KEY,
+  workspace TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  label TEXT,
+  scopes TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE INDEX auth_tokens_workspace_idx ON auth_tokens (workspace, created_at);
+CREATE INDEX auth_tokens_active_hash_idx ON auth_tokens (token_hash, revoked_at, expires_at);
+
+CREATE TABLE auth_enrollments (
+  id TEXT PRIMARY KEY,
+  workspace TEXT NOT NULL,
+  code_hash TEXT NOT NULL UNIQUE,
+  label TEXT,
+  scopes TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  token_expires_at TEXT NOT NULL,
+  used_at TEXT
+);
+
+CREATE INDEX auth_enrollments_code_idx ON auth_enrollments (code_hash, used_at, expires_at);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
     "deploy": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
     "types": "wrangler types",
     "workspace:add": "node --env-file-if-exists=../../.env scripts/add-workspace.mjs",
-    "typecheck": "wrangler types && tsc --noEmit"
+    "typecheck": "wrangler types && tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@uploads/storage": "workspace:^",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "@types/node": "^26.1.0",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.10",
     "wrangler": "^4.107.0"
   }
 }

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -1,0 +1,249 @@
+import { sha256Hex } from "./workspace";
+
+export const FILE_SCOPES = ["files:read", "files:write", "files:delete"] as const;
+export type FileScope = (typeof FILE_SCOPES)[number];
+
+export const DEFAULT_ENROLLMENT_SECONDS = 10 * 60;
+export const DEFAULT_TOKEN_SECONDS = 90 * 24 * 60 * 60;
+export const MAX_TOKEN_SECONDS = 365 * 24 * 60 * 60;
+
+export interface AuthTokenRecord {
+  id: string;
+  workspace: string;
+  token_hash: string;
+  label: string | null;
+  scopes: string;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+}
+
+interface EnrollmentRecord {
+  id: string;
+  workspace: string;
+  code_hash: string;
+  label: string | null;
+  scopes: string;
+  created_at: string;
+  expires_at: string;
+  token_expires_at: string;
+  used_at: string | null;
+}
+
+export function parseScopes(value: string): FileScope[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed) || parsed.length === 0 || !parsed.every(isFileScope)) return [];
+    return [...new Set(parsed)];
+  } catch {
+    return [];
+  }
+}
+
+export function isFileScope(value: unknown): value is FileScope {
+  return typeof value === "string" && FILE_SCOPES.includes(value as FileScope);
+}
+
+export function validateScopes(value: unknown, defaults: FileScope[]): FileScope[] | null {
+  if (value === undefined) return defaults;
+  if (!Array.isArray(value) || value.length === 0 || !value.every(isFileScope)) return null;
+  return [...new Set(value)];
+}
+
+function randomSecret(prefix: string, bytes = 24): string {
+  return `${prefix}${btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(bytes))))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")}`;
+}
+
+function id(): string {
+  return crypto.randomUUID();
+}
+
+export async function findActiveToken(
+  db: D1Database,
+  workspace: string,
+  rawToken: string,
+  now = new Date(),
+): Promise<AuthTokenRecord | null> {
+  if (!rawToken) return null;
+  const hash = await sha256Hex(rawToken);
+  return db
+    .prepare(
+      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at
+       FROM auth_tokens
+       WHERE workspace = ? AND token_hash = ? AND revoked_at IS NULL
+         AND (expires_at IS NULL OR expires_at > ?)
+       LIMIT 1`,
+    )
+    .bind(workspace, hash, now.toISOString())
+    .first<AuthTokenRecord>();
+}
+
+export async function createToken(
+  db: D1Database,
+  input: {
+    workspace: string;
+    label?: string;
+    scopes: FileScope[];
+    expiresAt?: Date;
+    now?: Date;
+  },
+): Promise<{ token: string; record: AuthTokenRecord }> {
+  const token = randomSecret(`up_${input.workspace}_`);
+  const now = input.now ?? new Date();
+  const record: AuthTokenRecord = {
+    id: id(),
+    workspace: input.workspace,
+    token_hash: await sha256Hex(token),
+    label: input.label ?? null,
+    scopes: JSON.stringify(input.scopes),
+    created_at: now.toISOString(),
+    expires_at: input.expiresAt?.toISOString() ?? null,
+    revoked_at: null,
+  };
+  await db
+    .prepare(
+      `INSERT INTO auth_tokens
+       (id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
+    )
+    .bind(
+      record.id,
+      record.workspace,
+      record.token_hash,
+      record.label,
+      record.scopes,
+      record.created_at,
+      record.expires_at,
+    )
+    .run();
+  return { token, record };
+}
+
+export async function createEnrollment(
+  db: D1Database,
+  input: {
+    workspace: string;
+    label?: string;
+    scopes: FileScope[];
+    enrollmentSeconds?: number;
+    tokenSeconds?: number;
+    now?: Date;
+  },
+): Promise<{ code: string; expiresAt: string; tokenExpiresAt: string }> {
+  const now = input.now ?? new Date();
+  const expiresAt = new Date(
+    now.getTime() + (input.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS) * 1000,
+  );
+  const tokenExpiresAt = new Date(
+    now.getTime() + (input.tokenSeconds ?? DEFAULT_TOKEN_SECONDS) * 1000,
+  );
+  const code = randomSecret("upe_", 18);
+  await db
+    .prepare(
+      `INSERT INTO auth_enrollments
+       (id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+    )
+    .bind(
+      id(),
+      input.workspace,
+      await sha256Hex(code),
+      input.label ?? null,
+      JSON.stringify(input.scopes),
+      now.toISOString(),
+      expiresAt.toISOString(),
+      tokenExpiresAt.toISOString(),
+    )
+    .run();
+  return { code, expiresAt: expiresAt.toISOString(), tokenExpiresAt: tokenExpiresAt.toISOString() };
+}
+
+export async function exchangeEnrollment(
+  db: D1Database,
+  code: string,
+  now = new Date(),
+): Promise<{ workspace: string; token: string; scopes: FileScope[]; expiresAt: string } | null> {
+  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) return null;
+  const nowIso = now.toISOString();
+  const codeHash = await sha256Hex(code);
+  const enrollment = await db
+    .prepare(
+      `SELECT id, workspace, code_hash, label, scopes, created_at, expires_at,
+              token_expires_at, used_at
+       FROM auth_enrollments
+       WHERE code_hash = ? AND used_at IS NULL AND expires_at > ?
+       LIMIT 1`,
+    )
+    .bind(codeHash, nowIso)
+    .first<EnrollmentRecord>();
+  if (!enrollment) return null;
+
+  const scopes = parseScopes(enrollment.scopes);
+  if (scopes.length === 0) return null;
+  const token = randomSecret(`up_${enrollment.workspace}_`);
+  const tokenId = id();
+  const tokenHash = await sha256Hex(token);
+  // D1 batch statements execute as one transaction. The INSERT reads directly
+  // from the still-active enrollment, then the UPDATE consumes it. A replay or
+  // concurrent loser changes zero rows and receives no token; any statement
+  // error rolls back both operations.
+  const [inserted, consumed] = await db.batch([
+    db
+      .prepare(
+        `INSERT INTO auth_tokens
+         (id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at)
+         SELECT ?, workspace, ?, label, scopes, ?, token_expires_at, NULL
+         FROM auth_enrollments
+         WHERE id = ? AND code_hash = ? AND used_at IS NULL AND expires_at > ?`,
+      )
+      .bind(tokenId, tokenHash, nowIso, enrollment.id, codeHash, nowIso),
+    db
+      .prepare(
+        `UPDATE auth_enrollments SET used_at = ?
+         WHERE id = ? AND code_hash = ? AND used_at IS NULL AND expires_at > ?`,
+      )
+      .bind(nowIso, enrollment.id, codeHash, nowIso),
+  ]);
+  if (inserted.meta.changes !== 1 || consumed.meta.changes !== 1) return null;
+  return {
+    workspace: enrollment.workspace,
+    token,
+    scopes,
+    expiresAt: enrollment.token_expires_at,
+  };
+}
+
+export async function listTokens(db: D1Database, workspace: string): Promise<AuthTokenRecord[]> {
+  const result = await db
+    .prepare(
+      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at
+       FROM auth_tokens WHERE workspace = ? ORDER BY created_at ASC`,
+    )
+    .bind(workspace)
+    .all<AuthTokenRecord>();
+  return result.results;
+}
+
+export async function revokeToken(
+  db: D1Database,
+  workspace: string,
+  selector: { hashPrefix?: string; label?: string },
+  now = new Date(),
+): Promise<{ match: AuthTokenRecord | null; ambiguous: boolean }> {
+  const tokens = (await listTokens(db, workspace)).filter((token) => token.revoked_at === null);
+  const matches = tokens.filter((token) =>
+    selector.hashPrefix
+      ? token.token_hash.startsWith(selector.hashPrefix)
+      : token.label === selector.label,
+  );
+  if (matches.length !== 1) return { match: null, ambiguous: matches.length > 1 };
+  const match = matches[0];
+  await db
+    .prepare(`UPDATE auth_tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`)
+    .bind(now.toISOString(), match.id)
+    .run();
+  return { match, ambiguous: false };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,10 +2,12 @@ import { Hono } from "hono";
 import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
 import { admin } from "./routes/admin";
+import { auth } from "./routes/auth";
 
 const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
   .route("/admin", admin)
+  .route("/auth", auth)
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/files", files)
   .onError((err, c) => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,72 +1,202 @@
 import { Hono } from "hono";
 import { adminAuth } from "../admin";
-import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import {
+  DEFAULT_ENROLLMENT_SECONDS,
+  DEFAULT_TOKEN_SECONDS,
+  FILE_SCOPES,
+  MAX_TOKEN_SECONDS,
+  createEnrollment,
+  createToken,
+  listTokens,
+  parseScopes,
+  revokeToken,
+  validateScopes,
+} from "../auth-db";
+import type { WorkspaceRecord } from "../workspace";
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 const HASH_PREFIX_LEN = 8;
+const MAX_ENROLLMENT_SECONDS = 60 * 60;
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+interface LegacyToken {
+  hash: string;
+  label?: string;
+  createdAt: string;
+}
 
 /** Token list for a record, migrating a legacy `tokenHash`-only record into the list shape. */
-function migrateTokens(
-  record: WorkspaceRecord,
-): { hash: string; label?: string; createdAt: string }[] {
+function legacyTokens(record: WorkspaceRecord): LegacyToken[] {
   return (
     record.tokens ??
     (record.tokenHash ? [{ hash: record.tokenHash, createdAt: new Date(0).toISOString() }] : [])
   );
 }
 
+async function workspace(c: { env: Env }, name: string): Promise<WorkspaceRecord | null> {
+  return c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json" });
+}
+
+function validInteger(value: unknown, min: number, max: number): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= min && value <= max;
+}
+
+function labelValue(value: unknown): string | undefined | null {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") return null;
+  const label = value.trim();
+  return label.length >= 1 && label.length <= 100 ? label : null;
+}
+
 export const admin = new Hono<{ Bindings: Env }>()
   .use("/*", adminAuth)
 
-  // Mint a bearer token for an existing workspace (defaults to "default").
+  // Mint a scoped bearer token for an existing workspace (defaults to "default").
+  // New credentials live in D1; legacy KV credentials remain readable/revocable.
   .post("/tokens", async (c) => {
     const body = await c.req
-      .json<{ workspace?: string; label?: string }>()
-      .catch(() => ({}) as { workspace?: string; label?: string });
+      .json<{
+        workspace?: string;
+        label?: string;
+        scopes?: unknown;
+        expiresInDays?: number;
+      }>()
+      .catch(
+        () =>
+          ({}) as {
+            workspace?: string;
+            label?: string;
+            scopes?: unknown;
+            expiresInDays?: number;
+          },
+      );
     const name = body.workspace?.trim() || "default";
-    const label = body.label?.trim() || undefined;
+    const label = labelValue(body.label);
     if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
+    if (label === null) return c.json({ error: "label must be between 1 and 100 characters" }, 400);
+    if (!(await workspace(c, name))) return c.json({ error: "workspace not found" }, 404);
 
-    // Read-modify-write, no locking: concurrent mints for the same workspace can race (last put wins, dropping a token). Acceptable for this admin-only PoC endpoint.
-    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json" });
-    if (!record) return c.json({ error: "workspace not found" }, 404);
+    const scopes = validateScopes(body.scopes, [...FILE_SCOPES]);
+    if (!scopes) return c.json({ error: "invalid scopes" }, 400);
+    if (
+      body.expiresInDays !== undefined &&
+      !validInteger(body.expiresInDays, 1, MAX_TOKEN_SECONDS / SECONDS_PER_DAY)
+    ) {
+      return c.json(
+        { error: `expiresInDays must be between 1 and ${MAX_TOKEN_SECONDS / SECONDS_PER_DAY}` },
+        400,
+      );
+    }
 
-    const token = `up_${name}_${btoa(
-      String.fromCharCode(...crypto.getRandomValues(new Uint8Array(24))),
-    )
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=+$/, "")}`;
-    const entry = { hash: await sha256Hex(token), label, createdAt: new Date().toISOString() };
-
-    const tokens = migrateTokens(record);
-    tokens.push(entry);
-    const { tokenHash: _drop, ...rest } = record;
-    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify({ ...rest, tokens }));
-
-    return c.json({ workspace: name, token, label: label ?? null }, 201);
+    const expiresAt = body.expiresInDays
+      ? new Date(Date.now() + body.expiresInDays * 24 * 60 * 60 * 1000)
+      : undefined;
+    const created = await createToken(c.env.DB, {
+      workspace: name,
+      label,
+      scopes,
+      expiresAt,
+    });
+    return c.json(
+      {
+        workspace: name,
+        token: created.token,
+        label: label ?? null,
+        scopes,
+        expiresAt: created.record.expires_at,
+      },
+      201,
+    );
   })
 
-  // List a workspace's tokens (defaults to "default"). Never returns the full
-  // hash or raw token — only the 8-char hashPrefix, which is the revoke handle.
+  // Create a one-time login code. The code itself is returned once and only its
+  // hash is persisted. Exchanged tokens default to 90 days and read/write.
+  .post("/enrollments", async (c) => {
+    c.header("Cache-Control", "no-store");
+    const body = await c.req
+      .json<{
+        workspace?: string;
+        label?: string;
+        scopes?: unknown;
+        enrollmentSeconds?: number;
+        tokenExpiresInSeconds?: number;
+      }>()
+      .catch(
+        () =>
+          ({}) as {
+            workspace?: string;
+            label?: string;
+            scopes?: unknown;
+            enrollmentSeconds?: number;
+            tokenExpiresInSeconds?: number;
+          },
+      );
+    const name = body.workspace?.trim() || "default";
+    const label = labelValue(body.label);
+    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
+    if (label === null) return c.json({ error: "label must be between 1 and 100 characters" }, 400);
+    if (!(await workspace(c, name))) return c.json({ error: "workspace not found" }, 404);
+
+    const scopes = validateScopes(body.scopes, ["files:read", "files:write"]);
+    if (!scopes) return c.json({ error: "invalid scopes" }, 400);
+    if (
+      body.enrollmentSeconds !== undefined &&
+      !validInteger(body.enrollmentSeconds, 60, MAX_ENROLLMENT_SECONDS)
+    ) {
+      return c.json(
+        { error: `enrollmentSeconds must be between 60 and ${MAX_ENROLLMENT_SECONDS}` },
+        400,
+      );
+    }
+    if (
+      body.tokenExpiresInSeconds !== undefined &&
+      !validInteger(body.tokenExpiresInSeconds, 60, MAX_TOKEN_SECONDS)
+    ) {
+      return c.json(
+        { error: `tokenExpiresInSeconds must be between 60 and ${MAX_TOKEN_SECONDS}` },
+        400,
+      );
+    }
+
+    const enrollment = await createEnrollment(c.env.DB, {
+      workspace: name,
+      label,
+      scopes,
+      enrollmentSeconds: body.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS,
+      tokenSeconds: body.tokenExpiresInSeconds ?? DEFAULT_TOKEN_SECONDS,
+    });
+    return c.json({ workspace: name, label: label ?? null, scopes, ...enrollment }, 201);
+  })
+
+  // Lists D1 credentials and legacy KV credentials without exposing secrets.
   .get("/tokens", async (c) => {
     const name = c.req.query("workspace")?.trim() || "default";
     if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
-
-    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json" });
+    const record = await workspace(c, name);
     if (!record) return c.json({ error: "workspace not found" }, 404);
 
-    const tokens = migrateTokens(record).map((t) => ({
-      label: t.label ?? null,
-      createdAt: t.createdAt,
-      hashPrefix: t.hash.slice(0, HASH_PREFIX_LEN),
+    const d1 = (await listTokens(c.env.DB, name)).map((token) => ({
+      label: token.label,
+      createdAt: token.created_at,
+      hashPrefix: token.token_hash.slice(0, HASH_PREFIX_LEN),
+      scopes: parseScopes(token.scopes),
+      expiresAt: token.expires_at,
+      revokedAt: token.revoked_at,
+      source: "d1" as const,
     }));
-    return c.json({ workspace: name, tokens });
+    const legacy = legacyTokens(record).map((token) => ({
+      label: token.label ?? null,
+      createdAt: token.createdAt,
+      hashPrefix: token.hash.slice(0, HASH_PREFIX_LEN),
+      scopes: [...FILE_SCOPES],
+      expiresAt: null,
+      revokedAt: null,
+      source: "legacy" as const,
+    }));
+    return c.json({ workspace: name, tokens: [...legacy, ...d1] });
   })
 
-  // Revoke a token by { hashPrefix } or { label }. Migrates a legacy
-  // tokenHash-only record into tokens[] first, then removes the match.
-  // 404 when nothing matches, 409 when the selector is ambiguous.
+  // Revoke an active D1 or legacy KV token by hash prefix or label.
   .delete("/tokens", async (c) => {
     const body = await c.req
       .json<{ workspace?: string; hashPrefix?: string; label?: string }>()
@@ -77,22 +207,37 @@ export const admin = new Hono<{ Bindings: Env }>()
     if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
     if (!hashPrefix && !label) return c.json({ error: "hashPrefix or label required" }, 400);
 
-    // Read-modify-write, no locking: a concurrent mint/revoke on the same workspace can race (last put wins). Acceptable for this admin-only PoC endpoint.
-    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json" });
+    const record = await workspace(c, name);
     if (!record) return c.json({ error: "workspace not found" }, 404);
-
-    const tokens = migrateTokens(record);
-    const matches = tokens.filter((t) =>
-      hashPrefix ? t.hash.startsWith(hashPrefix) : t.label === label,
+    const kv = legacyTokens(record);
+    const kvMatches = kv.filter((token) =>
+      hashPrefix ? token.hash.startsWith(hashPrefix) : token.label === label,
     );
-    if (matches.length === 0) return c.json({ error: "no matching token" }, 404);
-    if (matches.length > 1) return c.json({ error: "selector matches multiple tokens" }, 409);
+    const activeD1 = (await listTokens(c.env.DB, name)).filter(
+      (token) =>
+        token.revoked_at === null &&
+        (hashPrefix ? token.token_hash.startsWith(hashPrefix) : token.label === label),
+    );
+    const count = kvMatches.length + activeD1.length;
+    if (count === 0) return c.json({ error: "no matching token" }, 404);
+    if (count > 1) return c.json({ error: "selector matches multiple tokens" }, 409);
 
-    const revoked = matches[0];
-    const remaining = tokens.filter((t) => t !== revoked);
+    if (activeD1.length === 1) {
+      const result = await revokeToken(c.env.DB, name, { hashPrefix, label });
+      if (!result.match) return c.json({ error: "no matching token" }, 404);
+      return c.json({
+        workspace: name,
+        revoked: {
+          label: result.match.label,
+          hashPrefix: result.match.token_hash.slice(0, HASH_PREFIX_LEN),
+        },
+      });
+    }
+
+    const revoked = kvMatches[0];
+    const remaining = kv.filter((token) => token !== revoked);
     const { tokenHash: _drop, ...rest } = record;
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify({ ...rest, tokens: remaining }));
-
     return c.json({
       workspace: name,
       revoked: { label: revoked.label ?? null, hashPrefix: revoked.hash.slice(0, HASH_PREFIX_LEN) },

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono";
+import { exchangeEnrollment } from "../auth-db";
+
+const INVALID_ENROLLMENT = { error: "invalid or expired enrollment code" } as const;
+const MAX_EXCHANGE_BODY_BYTES = 1024;
+
+export const auth = new Hono<{ Bindings: Env }>().post("/enrollments/exchange", async (c) => {
+  c.header("Cache-Control", "no-store");
+  const contentLength = Number(c.req.header("Content-Length") ?? 0);
+  if (contentLength > MAX_EXCHANGE_BODY_BYTES) return c.json(INVALID_ENROLLMENT, 400);
+  const body = await c.req
+    .json<Record<string, unknown>>()
+    .catch(() => ({}) as Record<string, unknown>);
+  if (Object.keys(body).length !== 1 || typeof body.code !== "string") {
+    return c.json(INVALID_ENROLLMENT, 400);
+  }
+  const code = body.code?.trim() ?? "";
+  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) return c.json(INVALID_ENROLLMENT, 400);
+  const result = await exchangeEnrollment(c.env.DB, code);
+  if (!result) return c.json(INVALID_ENROLLMENT, 400);
+  return c.json(result, 201);
+});

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { publicUrl, storage, storageConfig } from "../storage";
-import type { WorkspaceVars } from "../workspace";
+import { requireScope, type WorkspaceVars } from "../workspace";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
 // for GitHub embeds: they're proxied through GitHub's Camo/Fastly cache, and
@@ -22,7 +22,7 @@ function badKey(key: string): boolean {
 export const files = new Hono<WorkspaceVars>()
 
   // Upload: raw body PUT. Content-Type header becomes the stored content type.
-  .put("/:key{.+}", async (c) => {
+  .put("/:key{.+}", requireScope("files:write"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
     const body = await c.req.arrayBuffer();
@@ -43,7 +43,7 @@ export const files = new Hono<WorkspaceVars>()
   })
 
   // List
-  .get("/", async (c) => {
+  .get("/", requireScope("files:read"), async (c) => {
     const { prefix, cursor } = c.req.query();
     const limit = Math.min(Number(c.req.query("limit") ?? 100) || 100, 1000);
     const ws = c.get("workspace");
@@ -59,7 +59,7 @@ export const files = new Hono<WorkspaceVars>()
   })
 
   // Metadata
-  .get("/:key{.+}", async (c) => {
+  .get("/:key{.+}", requireScope("files:read"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
     const ws = c.get("workspace");
@@ -70,7 +70,7 @@ export const files = new Hono<WorkspaceVars>()
   })
 
   // Delete
-  .delete("/:key{.+}", async (c) => {
+  .delete("/:key{.+}", requireScope("files:delete"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
     await storage(c.env, c.get("workspace")).delete(key);

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import type { StorageProvider } from "@uploads/storage";
+import { FILE_SCOPES, findActiveToken, parseScopes, type FileScope } from "./auth-db";
 
 /**
  * A workspace is a tenant: its own bucket, credentials, and auth token.
@@ -26,7 +27,12 @@ export interface WorkspaceRecord {
 }
 
 export type WorkspaceVars = {
-  Variables: { workspace: WorkspaceRecord; workspaceName: string };
+  Variables: {
+    workspace: WorkspaceRecord;
+    workspaceName: string;
+    authScopes: FileScope[];
+    authSource: "d1" | "legacy";
+  };
   Bindings: Env;
 };
 
@@ -75,11 +81,22 @@ export const workspaceAuth: MiddlewareHandler<WorkspaceVars> = async (c, next) =
   for (const hash of toCheck) {
     if (crypto.subtle.timingSafeEqual(providedBytes, hexToBytes(hash))) matched = true;
   }
-  const ok = record !== null && token.length > 0 && candidates.length > 0 && matched;
+  const legacyOk = record !== null && token.length > 0 && candidates.length > 0 && matched;
+  const d1Token = record && name && token ? await findActiveToken(c.env.DB, name, token) : null;
+  const ok = legacyOk || d1Token !== null;
 
   if (!ok || !record || !name) return c.json({ error: "unauthorized" }, 401);
 
   c.set("workspace", record);
   c.set("workspaceName", name);
+  c.set("authScopes", d1Token ? parseScopes(d1Token.scopes) : [...FILE_SCOPES]);
+  c.set("authSource", d1Token ? "d1" : "legacy");
   await next();
 };
+
+export function requireScope(scope: FileScope): MiddlewareHandler<WorkspaceVars> {
+  return async (c, next) => {
+    if (!c.get("authScopes").includes(scope)) return c.json({ error: "forbidden" }, 403);
+    await next();
+  };
+}

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ENROLLMENT_SECONDS,
+  DEFAULT_TOKEN_SECONDS,
+  createEnrollment,
+  exchangeEnrollment,
+  findActiveToken,
+  parseScopes,
+} from "../src/auth-db";
+
+type Row = Record<string, unknown>;
+
+class FakeStatement {
+  values: unknown[] = [];
+
+  constructor(
+    readonly db: FakeD1,
+    readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]): FakeStatement {
+    this.values = values;
+    return this;
+  }
+
+  first<T>(): Promise<T | null> {
+    return Promise.resolve(this.db.first(this) as T | null);
+  }
+
+  run(): Promise<D1Result> {
+    return Promise.resolve(this.db.run(this) as unknown as D1Result);
+  }
+}
+
+class FakeD1 {
+  enrollments: Row[] = [];
+  tokens: Row[] = [];
+  failBatchAt: number | null = null;
+
+  prepare(sql: string): FakeStatement {
+    return new FakeStatement(this, sql.replace(/\s+/g, " ").trim());
+  }
+
+  first(statement: FakeStatement): Row | null {
+    const { sql, values } = statement;
+    if (sql.startsWith("SELECT id, workspace, code_hash")) {
+      const [hash, now] = values as string[];
+      return (
+        this.enrollments.find(
+          (row) =>
+            row.code_hash === hash && row.used_at === null && (row.expires_at as string) > now,
+        ) ?? null
+      );
+    }
+    if (sql.startsWith("SELECT id, workspace, token_hash")) {
+      const [workspace, hash, now] = values as string[];
+      return (
+        this.tokens.find(
+          (row) =>
+            row.workspace === workspace &&
+            row.token_hash === hash &&
+            row.revoked_at === null &&
+            (row.expires_at === null || (row.expires_at as string) > now),
+        ) ?? null
+      );
+    }
+    throw new Error(`unsupported first: ${sql}`);
+  }
+
+  run(statement: FakeStatement): { meta: { changes: number }; success: true; results: never[] } {
+    const { sql, values } = statement;
+    if (sql.startsWith("INSERT INTO auth_enrollments")) {
+      const [id, workspace, codeHash, label, scopes, createdAt, expiresAt, tokenExpiresAt] = values;
+      this.enrollments.push({
+        id,
+        workspace,
+        code_hash: codeHash,
+        label,
+        scopes,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        token_expires_at: tokenExpiresAt,
+        used_at: null,
+      });
+      return result(1);
+    }
+    if (sql.startsWith("INSERT INTO auth_tokens") && sql.includes("SELECT ?")) {
+      const [id, tokenHash, createdAt, enrollmentId, codeHash, now] = values;
+      const enrollment = this.enrollments.find(
+        (row) =>
+          row.id === enrollmentId &&
+          row.code_hash === codeHash &&
+          row.used_at === null &&
+          (row.expires_at as string) > (now as string),
+      );
+      if (!enrollment) return result(0);
+      this.tokens.push({
+        id,
+        workspace: enrollment.workspace,
+        token_hash: tokenHash,
+        label: enrollment.label,
+        scopes: enrollment.scopes,
+        created_at: createdAt,
+        expires_at: enrollment.token_expires_at,
+        revoked_at: null,
+      });
+      return result(1);
+    }
+    if (sql.startsWith("UPDATE auth_enrollments SET used_at")) {
+      const [usedAt, enrollmentId, codeHash, now] = values;
+      const enrollment = this.enrollments.find(
+        (row) =>
+          row.id === enrollmentId &&
+          row.code_hash === codeHash &&
+          row.used_at === null &&
+          (row.expires_at as string) > (now as string),
+      );
+      if (!enrollment) return result(0);
+      enrollment.used_at = usedAt;
+      return result(1);
+    }
+    throw new Error(`unsupported run: ${sql}`);
+  }
+
+  async batch(statements: FakeStatement[]): Promise<D1Result[]> {
+    const enrollmentSnapshot = structuredClone(this.enrollments);
+    const tokenSnapshot = structuredClone(this.tokens);
+    try {
+      return statements.map((statement, index) => {
+        if (this.failBatchAt === index) throw new Error("injected batch failure");
+        return this.run(statement) as unknown as D1Result;
+      });
+    } catch (error) {
+      this.enrollments = enrollmentSnapshot;
+      this.tokens = tokenSnapshot;
+      throw error;
+    }
+  }
+}
+
+function result(changes: number) {
+  return { meta: { changes }, success: true as const, results: [] as never[] };
+}
+
+function database(fake: FakeD1): D1Database {
+  return fake as unknown as D1Database;
+}
+
+describe("D1 enrollment exchange", () => {
+  it("stores only a hash and applies the 10 minute / 90 day defaults", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "default",
+      scopes: ["files:read", "files:write"],
+      now,
+    });
+
+    expect(enrollment.code).toMatch(/^upe_/);
+    expect(JSON.stringify(fake.enrollments)).not.toContain(enrollment.code);
+    expect(Date.parse(enrollment.expiresAt) - now.getTime()).toBe(
+      DEFAULT_ENROLLMENT_SECONDS * 1000,
+    );
+    expect(Date.parse(enrollment.tokenExpiresAt) - now.getTime()).toBe(
+      DEFAULT_TOKEN_SECONDS * 1000,
+    );
+  });
+
+  it("atomically exchanges once and creates a scoped, expiring token", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "default",
+      label: "codex",
+      scopes: ["files:read", "files:write"],
+      now,
+    });
+
+    const [first, replay] = await Promise.all([
+      exchangeEnrollment(database(fake), enrollment.code, now),
+      exchangeEnrollment(database(fake), enrollment.code, now),
+    ]);
+    const successes = [first, replay].filter((value) => value !== null);
+    expect(successes).toHaveLength(1);
+    expect(fake.tokens).toHaveLength(1);
+    expect(JSON.stringify(fake.tokens)).not.toContain(successes[0]?.token);
+    expect(successes[0]?.scopes).toEqual(["files:read", "files:write"]);
+
+    const active = await findActiveToken(database(fake), "default", successes[0]?.token ?? "", now);
+    expect(parseScopes(active?.scopes ?? "[]")).toEqual(["files:read", "files:write"]);
+  });
+
+  it("rolls back consumption when the transactional batch fails", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "default",
+      scopes: ["files:read", "files:write"],
+      now,
+    });
+    fake.failBatchAt = 1;
+
+    await expect(exchangeEnrollment(database(fake), enrollment.code, now)).rejects.toThrow(
+      "injected batch failure",
+    );
+    expect(fake.enrollments[0].used_at).toBeNull();
+    expect(fake.tokens).toHaveLength(0);
+
+    fake.failBatchAt = null;
+    await expect(exchangeEnrollment(database(fake), enrollment.code, now)).resolves.not.toBeNull();
+  });
+
+  it("rejects expired and unknown codes identically", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "default",
+      scopes: ["files:read", "files:write"],
+      enrollmentSeconds: 60,
+      now,
+    });
+    const later = new Date(now.getTime() + 61_000);
+
+    expect(await exchangeEnrollment(database(fake), enrollment.code, later)).toBeNull();
+    expect(await exchangeEnrollment(database(fake), "upe_unknown", later)).toBeNull();
+  });
+});

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -1,0 +1,174 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+
+const workspace: WorkspaceRecord = { provider: "r2", bucket: "test" };
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+function env(
+  options: {
+    legacyHash?: string;
+    d1?: {
+      tokenHash: string;
+      scopes: string;
+      expiresAt?: string | null;
+      revokedAt?: string | null;
+    };
+  } = {},
+) {
+  const record = options.legacyHash ? { ...workspace, tokenHash: options.legacyHash } : workspace;
+  return {
+    ADMIN_TOKEN: "admin-secret",
+    REGISTRY: {
+      get: async () => record,
+      put: async () => undefined,
+    },
+    DB: {
+      prepare: () => {
+        let values: unknown[] = [];
+        return {
+          bind(...next: unknown[]) {
+            values = next;
+            return this;
+          },
+          async first() {
+            const [, hash, now] = values as string[];
+            const token = options.d1;
+            if (
+              token &&
+              token.tokenHash === hash &&
+              token.revokedAt == null &&
+              (token.expiresAt == null || token.expiresAt > now)
+            ) {
+              return {
+                id: "token-id",
+                workspace: "default",
+                token_hash: token.tokenHash,
+                label: null,
+                scopes: token.scopes,
+                created_at: "2026-07-10T00:00:00.000Z",
+                expires_at: token.expiresAt ?? null,
+                revoked_at: token.revokedAt ?? null,
+              };
+            }
+            return null;
+          },
+        };
+      },
+    },
+  } as unknown as Env;
+}
+
+describe("auth routes", () => {
+  it("requires administrator authentication for enrollment creation", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      { method: "POST", body: JSON.stringify({}) },
+      env(),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("validates enrollment input and marks every response no-store", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({ label: "x".repeat(101) }),
+      },
+      env(),
+    );
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("uses one uniform, non-cacheable public exchange error", async () => {
+    const responses = await Promise.all([
+      app.request("/auth/enrollments/exchange", { method: "POST", body: "{}" }, env()),
+      app.request(
+        "/auth/enrollments/exchange",
+        { method: "POST", body: JSON.stringify({ code: "upe_bad" }) },
+        env(),
+      ),
+      app.request(
+        "/auth/enrollments/exchange",
+        {
+          method: "POST",
+          body: JSON.stringify({ code: `upe_${"a".repeat(24)}`, extra: true }),
+        },
+        env(),
+      ),
+    ]);
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+    expect(responses.map((response) => response.status)).toEqual([400, 400, 400]);
+    expect(
+      responses.every((response) => response.headers.get("Cache-Control") === "no-store"),
+    ).toBe(true);
+    expect(new Set(bodies.map((body) => JSON.stringify(body))).size).toBe(1);
+  });
+
+  it("keeps legacy KV credentials fully scoped", async () => {
+    const token = "legacy-token";
+    const response = await app.request(
+      "/v1/default/files/bad%20key",
+      { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+      env({ legacyHash: await sha256Hex(token) }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("allows D1 read/write credentials but denies delete", async () => {
+    const token = "up_default_scoped-token-value";
+    const bindings = env({
+      d1: {
+        tokenHash: await sha256Hex(token),
+        scopes: JSON.stringify(["files:read", "files:write"]),
+      },
+    });
+    const read = await app.request(
+      "/v1/default/files/bad%20key",
+      { headers: { Authorization: `Bearer ${token}` } },
+      bindings,
+    );
+    const remove = await app.request(
+      "/v1/default/files/bad%20key",
+      { method: "DELETE", headers: { Authorization: `Bearer ${token}` } },
+      bindings,
+    );
+    expect(read.status).toBe(400);
+    expect(remove.status).toBe(403);
+  });
+
+  it("rejects expired and revoked D1 credentials", async () => {
+    const token = "up_default_expired-token-value";
+    const tokenHash = await sha256Hex(token);
+    const [expired, revoked] = await Promise.all([
+      app.request(
+        "/v1/default/files/bad%20key",
+        { headers: { Authorization: `Bearer ${token}` } },
+        env({ d1: { tokenHash, scopes: JSON.stringify(["files:read"]), expiresAt: "2000-01-01" } }),
+      ),
+      app.request(
+        "/v1/default/files/bad%20key",
+        { headers: { Authorization: `Bearer ${token}` } },
+        env({ d1: { tokenHash, scopes: JSON.stringify(["files:read"]), revokedAt: "2026-01-01" } }),
+      ),
+    ]);
+    expect([expired.status, revoked.status]).toEqual([401, 401]);
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "types": ["./worker-configuration.d.ts"]
   },
-  "include": ["src", "worker-configuration.d.ts"]
+  "include": ["src", "test", "worker-configuration.d.ts"]
 }

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -24,6 +24,14 @@
       "id": "808bc1c3a86a4675b134e11b6dca303d",
     },
   ],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "uploads-production",
+      "database_id": "5f73946b-edd5-414c-856c-8f9bd3c644ba",
+      "migrations_dir": "migrations",
+    },
+  ],
   // One binding per same-account bucket a workspace wants binding-mode I/O on.
   // Workspaces reference these by name; workspaces without a binding fall back
   // to their S3 credentials over HTTP.

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -1,8 +1,9 @@
 # Admin tokens
 
-Upload tokens are minted by an admin endpoint guarded by the `ADMIN_TOKEN`
-secret. The workspace must already exist (`pnpm workspace:add …`); this
-endpoint issues tokens, it does not create workspaces.
+`ADMIN_TOKEN` is a server-administration credential. Routine agents must never
+receive it. The normal onboarding path is for an administrator to create a
+short-lived enrollment code and for the agent to exchange it with `uploads login`.
+The workspace must already exist (`pnpm workspace:add …`).
 
 ## Setup
 
@@ -14,7 +15,14 @@ Set `ADMIN_TOKEN` once per environment:
 cd apps/api && pnpm exec wrangler secret put ADMIN_TOKEN
 ```
 
+The admin CLI reads `ADMIN_TOKEN` as its primary environment variable;
+`UPLOADS_ADMIN_TOKEN` may be accepted as a compatibility alias. Do not place either
+value in routine-agent configuration.
+
 ## Mint a token
+
+Direct minting is retained for CI, migration, and break-glass use. Interactive and
+routine agent setup should use [enrollment](enrollment.md) instead.
 
 Defaults to the `default` workspace:
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,16 +13,40 @@ subdomain.
 
 1. Create the registry: `wrangler kv namespace create REGISTRY`, paste the id
    into `apps/api/wrangler.jsonc`.
-2. Point `bucket_name` in `apps/api/wrangler.jsonc` at your bucket (the
+2. Create the enrollment database and add the emitted binding to
+   `apps/api/wrangler.jsonc` as `DB`:
+   ```bash
+   cd apps/api
+   pnpm exec wrangler d1 create uploads-production
+   ```
+3. Apply enrollment migrations locally during development:
+   ```bash
+   pnpm exec wrangler d1 migrations apply uploads-production --local
+   ```
+4. Point `bucket_name` in `apps/api/wrangler.jsonc` at your bucket (the
    default binding expects `uploads-default`), or create one with
    `wrangler r2 bucket create`. Same-account buckets get binding-mode I/O;
    workspaces can instead carry their own S3 credentials for HTTP mode.
-3. Register the workspace: `pnpm workspace:add default` — with no flags it
+5. Register the workspace: `pnpm workspace:add default` — with no flags it
    lands in the shared `uploads-default` bucket under a `default/` prefix,
    served at `https://storage.uploads.sh`. Pass `--bucket` (and optionally
    `--binding` / `--public-base-url`) for a dedicated bucket instead.
-4. `pnpm run deploy` — ships both workers (`deploy:api` → `api.uploads.sh`,
+6. Apply D1 migrations remotely **before** deploying API code that depends on
+   them, then deploy:
+   ```bash
+   cd apps/api
+   pnpm exec wrangler d1 migrations apply uploads-production --remote
+   cd ../..
+   pnpm run deploy
+   ```
+   This ships both workers (`deploy:api` → `api.uploads.sh`,
    `deploy:web` → the `uploads.sh` apex).
+
+D1 owns short-lived enrollment state, redemption, and all new scoped/expiring tokens.
+KV remains the source of truth for workspace storage configuration and legacy tokens.
+Never deploy a Worker that reads a new D1 schema before the corresponding remote
+migration succeeds. Check in every migration and test both `--local` and `--remote`
+ordering in staging.
 
 Use `pnpm run deploy`, not `pnpm deploy` — the bare form is pnpm's own
 command. In CI, Workers Builds deploys each app from its own directory on

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -1,0 +1,108 @@
+# Agent enrollment and `uploads login`
+
+Routine agents authenticate through short-lived enrollment codes. They never receive
+the API's `ADMIN_TOKEN`. An administrator authorizes an existing workspace, shares the
+single-use code, and the agent runs `uploads login` to exchange it for a scoped,
+expiring workspace token.
+
+## Agent login
+
+Install once for repeated use:
+
+```bash
+npm install --global @buildinternet/uploads
+uploads login
+uploads doctor
+```
+
+Or use a pinned package without a global install:
+
+```bash
+npx @buildinternet/uploads@0.1.0 login
+```
+
+Interactive login prompts without echoing the enrollment code. For automation, use an
+ephemeral environment value rather than putting the code in shell history or the
+process list:
+
+```bash
+UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login
+```
+
+On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
+`UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never prints
+the raw workspace token. Use `--force` only when intentionally replacing an existing
+configured token.
+
+## Administrator: create an enrollment
+
+Enrollment creation remains behind `ADMIN_TOKEN`; only an administrator runs this
+request. Do not paste the admin credential into agent prompts, configuration, issues,
+or shell commands shared with an agent.
+
+```bash
+curl -X POST https://api.uploads.sh/admin/enrollments \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"workspace":"default","label":"codex-cli","enrollmentSeconds":600,"tokenExpiresInSeconds":7776000,"scopes":["files:read","files:write"]}'
+```
+
+The admin CLI provides the same operation:
+
+```bash
+ADMIN_TOKEN=<admin-credential> uploads admin enrollment create \
+  --workspace default --label codex-cli
+```
+
+`ADMIN_TOKEN` is the primary environment name used by the existing API and admin
+workflow. `UPLOADS_ADMIN_TOKEN` may be accepted as a compatibility alias. Neither
+belongs in routine-agent configuration.
+
+The response shows the enrollment code once. Transfer only that code to the routine
+agent. It expires after 10 minutes and is consumed by a successful exchange. Invalid,
+expired, and consumed codes receive the same public error shape.
+
+## Token policy
+
+Enrollment-issued tokens default to:
+
+- 90-day lifetime;
+- `files:read` for list and metadata operations;
+- `files:write` for uploads;
+- no `files:delete` unless explicitly authorized.
+
+The API stores token hashes, scopes, labels, creation time, and expiry—not raw tokens.
+Revocation continues to use the admin token-list and revoke endpoints. Existing tokens
+without scopes or expiry remain valid with their legacy access until deliberately
+rotated or revoked.
+
+## D1 state and deployment
+
+D1 stores enrollment requests and every new scoped/expiring token, and guarantees
+atomic single-use redemption. `REGISTRY` KV retains workspace storage configuration
+and legacy tokens. Create and migrate the database before deploying enrollment-aware
+API code:
+
+```bash
+cd apps/api
+pnpm exec wrangler d1 create uploads-production
+pnpm exec wrangler d1 migrations apply uploads-production --local
+pnpm exec wrangler d1 migrations apply uploads-production --remote
+```
+
+Bind the database as `DB` in `apps/api/wrangler.jsonc`. Commit migrations, apply
+the remote migration first, and deploy the API only after it succeeds. See
+[deploy](deploy.md) for the complete ordering.
+
+## Migration and future auth
+
+Enrollment is additive: existing direct-minted and workspace-bootstrap tokens continue
+to authenticate. New installations should use `uploads login`; direct token minting is
+reserved for CI and break-glass administration. Rotate legacy routine-agent tokens to
+scoped enrollment tokens gradually, then revoke the old hashes.
+
+Better Auth with D1 and its API Key and Device Authorization plugins remains a later
+migration path when uploads.sh has human accounts, organization membership, and an
+authenticated browser approval UI. The current D1 schema and explicit workspace/token
+boundary keep that migration possible without coupling storage configuration to an
+identity framework today.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -4,9 +4,16 @@ Every request is scoped to a **workspace** — a tenant with its own credentials
 and bearer token. Workspace records live in the `REGISTRY` KV namespace
 (`ws:<name>`). Each record carries the storage provider, bucket, optional R2
 binding name, optional public base URL, S3-style credentials if needed, and the
-SHA-256 hash of the workspace's token (the token itself is never stored).
+SHA-256 hashes and metadata for the workspace's tokens (raw tokens are never stored).
 
 Nothing in the code treats any workspace as special.
+
+New enrollment-issued tokens are stored in D1 and carry an expiry and explicit scopes.
+Workspace configuration and legacy tokens remain in `REGISTRY` KV. The routine-agent
+default is `files:read` plus `files:write`, which is sufficient for upload, listing,
+metadata, and managed attachment comments. Deletion requires `files:delete`. Existing
+tokens without scope or expiry metadata retain their legacy full-access behavior so
+deployment does not invalidate installed clients.
 
 ## Default model
 

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -20,6 +20,8 @@ import {
 } from "./commands.js";
 import { runConfig } from "./commands/config.js";
 import { runSetup } from "./commands/setup.js";
+import { runLogin } from "./commands/login.js";
+import { runAdmin } from "./commands/admin-enrollment.js";
 
 const ROOT_HELP = `uploads — CLI for uploads.sh (GitHub image embeds)
 
@@ -51,7 +53,9 @@ Commands:
   comment             Create/update a PR/issue attachments comment (via gh)
   list                List objects
   delete <key>        Delete object
-  setup               Guided config + token minting steps
+  setup               Inspect/configure advanced CLI settings
+  login               Exchange an enrollment code and configure credentials
+  admin               Admin enrollment management
   config              Show path, init, or set shared config
   doctor              Health + auth + workspace checks
   health              API liveness (no auth)
@@ -146,6 +150,10 @@ export async function runCli(argv: string[]): Promise<number> {
         return runConfig(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
       case "setup":
         return runSetup(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
+      case "login":
+        return runLogin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+      case "admin":
+        return runAdmin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
       case "attach":
       case "put":
       case "list":

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -55,6 +55,63 @@ export interface HealthResult {
   ok: boolean;
 }
 
+export interface EnrollmentExchangeResult {
+  apiUrl?: string;
+  workspace: string;
+  token: string;
+  scopes?: Array<"files:read" | "files:write" | "files:delete">;
+  expiresAt?: string;
+}
+
+export interface EnrollmentCreateResult {
+  code: string;
+  expiresAt: string;
+  tokenExpiresAt: string;
+}
+
+async function jsonRequest<T>(url: string, init: RequestInit): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (err) {
+    throw new UploadsError(
+      err instanceof Error ? err.message : "network request failed",
+      "NETWORK",
+    );
+  }
+  if (!res.ok) throw await parseErrorResponse(res);
+  return (await res.json()) as T;
+}
+
+export function exchangeEnrollment(
+  apiUrl: string,
+  code: string,
+): Promise<EnrollmentExchangeResult> {
+  return jsonRequest(`${apiUrl.replace(/\/$/, "")}/auth/enrollments/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code }),
+  });
+}
+
+export function createEnrollment(
+  apiUrl: string,
+  adminToken: string,
+  input: {
+    workspace?: string;
+    label?: string;
+    enrollmentSeconds?: number;
+    tokenExpiresInSeconds?: number;
+    scopes?: Array<"files:read" | "files:write" | "files:delete">;
+  },
+): Promise<EnrollmentCreateResult> {
+  return jsonRequest(`${apiUrl.replace(/\/$/, "")}/admin/enrollments`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${adminToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
 function encodeKeyPath(key: string): string {
   return key.split("/").map(encodeURIComponent).join("/");
 }

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -1,0 +1,72 @@
+import { createEnrollment } from "../client.js";
+import { flagInt, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+
+const HELP = `uploads admin enrollment create [options]
+
+Admin-only: create a short-lived, one-time enrollment code.
+
+Options:
+  --admin-token <token>  Or ADMIN_TOKEN (UPLOADS_ADMIN_TOKEN is a legacy alias)
+  --workspace <name>     Default: default
+  --label <label>
+  --expires-in <seconds> Default: server policy
+  --token-expires-in <seconds>  Upload token lifetime (default: server policy)
+  --scopes <list>        Comma-separated files:read,files:write,files:delete
+  --api-url <url>        Default: https://api.uploads.sh
+`;
+
+type FileScope = "files:read" | "files:write" | "files:delete";
+const FILE_SCOPES = new Set<FileScope>(["files:read", "files:write", "files:delete"]);
+
+export function parseScopes(raw: string | undefined): FileScope[] | undefined {
+  if (raw === undefined) return undefined;
+  const scopes = raw
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+  if (scopes.length === 0) throw new UsageError("--scopes must contain at least one scope");
+  const invalid = scopes.find((scope) => !FILE_SCOPES.has(scope as FileScope));
+  if (invalid)
+    throw new UsageError(
+      `invalid scope: ${invalid} (expected files:read, files:write, or files:delete)`,
+    );
+  return [...new Set(scopes)] as FileScope[];
+}
+
+export async function runAdmin(
+  args: string[],
+  opts: { json?: boolean; apiUrl?: string },
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(HELP);
+    return 0;
+  }
+  if (parsed.positionals[0] !== "enrollment" || parsed.positionals[1] !== "create")
+    throw new UsageError("expected: uploads admin enrollment create");
+  const adminToken =
+    flagString(parsed.flags, "--admin-token") ??
+    process.env.ADMIN_TOKEN ??
+    process.env.UPLOADS_ADMIN_TOKEN;
+  if (!adminToken) throw new UsageError("ADMIN_TOKEN is required for admin enrollment creation");
+  const apiUrl = flagString(parsed.flags, "--api-url") ?? opts.apiUrl ?? "https://api.uploads.sh";
+  const workspace = flagString(parsed.flags, "--workspace") ?? "default";
+  const label = flagString(parsed.flags, "--label");
+  const result = await createEnrollment(apiUrl, adminToken, {
+    workspace,
+    label,
+    enrollmentSeconds: flagInt(parsed.flags, "--expires-in", "--expires-in"),
+    tokenExpiresInSeconds: flagInt(parsed.flags, "--token-expires-in", "--token-expires-in"),
+    scopes: parseScopes(flagString(parsed.flags, "--scopes")),
+  });
+  if (opts.json)
+    process.stdout.write(
+      JSON.stringify({ workspace, label: label ?? null, ...result }, null, 2) + "\n",
+    );
+  else
+    process.stdout.write(
+      `Enrollment code (share once): ${result.code}\nworkspace: ${workspace}\nexpires: ${result.expiresAt}\n`,
+    );
+  return 0;
+}

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -1,0 +1,174 @@
+import { stdin, stdout } from "node:process";
+import {
+  loadConfigFile,
+  redactToken,
+  resolveConfigPath,
+  writeConfigKeys,
+  workspaceFromToken,
+} from "../config.js";
+import { exchangeEnrollment, createUploadsClient } from "../client.js";
+import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+
+const HELP = `uploads login [options]
+
+Exchange a one-time enrollment code for workspace credentials, save them, and
+verify access. Ask your uploads.sh administrator for an enrollment code.
+
+Options:
+  --code <code>       Code in argv (may be visible in shell history/process lists)
+  --code-stdin        Read one line from stdin
+  --non-interactive   Never prompt
+  --api-url <url>     API base (default: https://api.uploads.sh)
+  --path <file>       Config destination
+  --force             Replace existing saved credentials
+  --no-check          Skip doctor verification
+`;
+
+export function validateEnrollmentCode(raw: string): string {
+  const code = raw.trim();
+  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw new UsageError("invalid enrollment code");
+  return code;
+}
+
+async function readLine(): Promise<string> {
+  let out = "";
+  for await (const chunk of stdin) {
+    out += String(chunk);
+    if (out.includes("\n")) break;
+  }
+  return out.split(/\r?\n/, 1)[0] ?? "";
+}
+
+async function hiddenPrompt(): Promise<string> {
+  if (!stdin.isTTY || typeof stdin.setRawMode !== "function") return readLine();
+  stdout.write("Enrollment code: ");
+  stdin.setRawMode(true);
+  stdin.resume();
+  return new Promise((resolve, reject) => {
+    let value = "";
+    let settled = false;
+    const done = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      stdin.off("data", onData);
+      stdin.off("error", onError);
+      try {
+        stdin.setRawMode(false);
+      } finally {
+        stdin.pause();
+        stdout.write("\n");
+      }
+      if (err) reject(err);
+      else resolve(value);
+    };
+    const onData = (chunk: Buffer) => {
+      for (const char of chunk.toString("utf8")) {
+        if (char === "\r" || char === "\n") return done();
+        if (char === "\u0003") return done(new UsageError("login cancelled"));
+        if (char === "\u007f") value = value.slice(0, -1);
+        else value += char;
+      }
+    };
+    const onError = (err: Error) => done(err);
+    stdin.on("data", onData);
+    stdin.on("error", onError);
+  });
+}
+
+export async function resolveEnrollmentCode(
+  parsed: ReturnType<typeof parseCommandArgs>,
+  io: { isTTY: boolean; readLine: () => Promise<string>; hiddenPrompt: () => Promise<string> } = {
+    isTTY: Boolean(stdin.isTTY),
+    readLine,
+    hiddenPrompt,
+  },
+): Promise<string> {
+  const direct = flagString(parsed.flags, "--code");
+  const env = process.env.UPLOADS_ENROLLMENT_CODE;
+  const fromStdin = flagBool(parsed.flags, "--code-stdin");
+  const sources = [Boolean(direct), Boolean(env), fromStdin].filter(Boolean).length;
+  if (sources > 1) throw new UsageError("provide enrollment code through only one source");
+  if (direct) return validateEnrollmentCode(direct);
+  if (env) return validateEnrollmentCode(env);
+  if (fromStdin) return validateEnrollmentCode(await io.readLine());
+  if (flagBool(parsed.flags, "--non-interactive"))
+    throw new UsageError("enrollment code required in non-interactive mode");
+  if (!io.isTTY) return validateEnrollmentCode(await io.readLine());
+  return validateEnrollmentCode(await io.hiddenPrompt());
+}
+
+export async function runLogin(
+  args: string[],
+  opts: { json?: boolean; apiUrl?: string },
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(HELP);
+    return 0;
+  }
+  const apiUrl = flagString(parsed.flags, "--api-url") ?? opts.apiUrl ?? "https://api.uploads.sh";
+  const path = flagString(parsed.flags, "--path") ?? resolveConfigPath();
+  const force = flagBool(parsed.flags, "--force");
+  const existing = loadConfigFile(path);
+  if (existing.UPLOADS_TOKEN && !force)
+    throw new UsageError(`credentials already exist in ${path}; use --force to replace them`);
+  if (process.env.UPLOADS_TOKEN && !force)
+    throw new UsageError(
+      "UPLOADS_TOKEN is already set in the environment; unset it or use --force",
+    );
+  const code = await resolveEnrollmentCode(parsed);
+  const result = await exchangeEnrollment(apiUrl, code);
+  const encoded = workspaceFromToken(result.token);
+  if (!encoded || encoded !== result.workspace || /[\r\n]/.test(result.token))
+    throw new UsageError("enrollment returned invalid credentials");
+  const savedApiUrl = result.apiUrl ?? apiUrl;
+  const write = writeConfigKeys(
+    path,
+    {
+      UPLOADS_API_URL: savedApiUrl,
+      UPLOADS_WORKSPACE: result.workspace,
+      UPLOADS_TOKEN: result.token,
+    },
+    { force },
+  );
+  if (
+    !["UPLOADS_API_URL", "UPLOADS_WORKSPACE", "UPLOADS_TOKEN"].every((key) =>
+      write.updated.includes(key),
+    )
+  )
+    throw new UsageError("credentials were not fully written; retry with --force");
+  const checked = !flagBool(parsed.flags, "--no-check");
+  let doctor = { ok: true, error: undefined as string | undefined };
+  if (checked) {
+    try {
+      const client = createUploadsClient({
+        apiUrl: savedApiUrl,
+        workspace: result.workspace,
+        token: result.token,
+      });
+      const health = await client.health();
+      if (!health.ok) throw new Error("API unhealthy");
+      await client.list({ limit: 1 });
+    } catch (err) {
+      doctor = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+  const payload = {
+    ok: doctor.ok,
+    configPath: path,
+    workspace: result.workspace,
+    token: redactToken(result.token),
+    doctor: checked ? doctor : { skipped: true },
+  };
+  if (opts.json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  else {
+    process.stdout.write(
+      `saved credentials to ${path}\nworkspace: ${result.workspace}\ntoken: ${redactToken(result.token)}\n`,
+    );
+    process[doctor.ok ? "stdout" : "stderr"].write(
+      `doctor: ${checked ? (doctor.ok ? "ok" : `failed — ${doctor.error}`) : "skipped"}\n`,
+    );
+  }
+  return doctor.ok ? 0 : 1;
+}

--- a/packages/uploads/src/commands/setup.ts
+++ b/packages/uploads/src/commands/setup.ts
@@ -27,7 +27,7 @@ With flags: saves provided values, then optionally verifies with doctor.
 Options:
   --api-url <url>       API base (default: ${DEFAULT_API_URL})
   --workspace, -w <name>
-  --token <token>       Bearer token (mint via admin endpoint — see below)
+  --token <token>       Existing bearer token (or use uploads login)
   --prefix <path>       Default key prefix for put/list (default: screenshots)
   --repo <owner/repo>   Default repo segment for put
   --ref <id>            Default ref segment for put (PR/issue/branch/date)
@@ -66,17 +66,6 @@ function buildStatus(envFile?: string): SetupStatus {
   };
 }
 
-function mintTokenCommand(apiUrl: string, workspace?: string): string {
-  const body =
-    workspace && workspace !== DEFAULT_WORKSPACE
-      ? ` \\\n  -H "Content-Type: application/json" \\\n  -d '{"workspace":"${workspace}","label":"cli"}'`
-      : "";
-  return [
-    `curl -XPOST ${apiUrl}/admin/tokens \\`,
-    `  -H "Authorization: Bearer $ADMIN_TOKEN"${body}`,
-  ].join("\n");
-}
-
 function formatWizard(status: SetupStatus): string {
   const lines: string[] = ["uploads setup", ""];
 
@@ -97,13 +86,10 @@ function formatWizard(status: SetupStatus): string {
   lines.push("");
 
   if (!status.token) {
-    lines.push("Step 1 — Mint a token");
-    lines.push(
-      "  You need ADMIN_TOKEN for the API (ask your uploads.sh admin, or set it locally in apps/api/.dev.vars).",
-    );
-    lines.push("  Mint:");
-    lines.push(`    ${mintTokenCommand(status.apiUrl, status.workspace)}`);
-    lines.push("  Save:");
+    lines.push("Step 1 — Sign in");
+    lines.push("  Ask your uploads.sh administrator for a one-time enrollment code, then run:");
+    lines.push("    uploads login");
+    lines.push("  If you already have a bearer token:");
     lines.push("    uploads setup --token up_<workspace>_…");
     lines.push("");
   } else {
@@ -267,7 +253,7 @@ export async function runSetup(
   } else if (token || checkExplicit) {
     process.stderr.write("hint: run uploads doctor to verify\n");
   } else {
-    process.stderr.write("hint: run uploads setup to see minting instructions\n");
+    process.stderr.write("hint: run uploads login with an admin-provided enrollment code\n");
   }
 
   return doctorOk === false ? 1 : 0;

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
 import type { UploadsClientConfig } from "./config.js";
@@ -171,6 +171,9 @@ export function writeConfigKeys(
   opts?: { force?: boolean },
 ): { path: string; created: boolean; updated: string[] } {
   const entries = Object.entries(keys).filter(([, v]) => v !== undefined && v !== "");
+  for (const [key, value] of entries) {
+    if (/[\r\n]/.test(value!)) throw new Error(`invalid newline in ${key}`);
+  }
   if (entries.length === 0) {
     throw new Error("no config values to write");
   }
@@ -198,7 +201,14 @@ export function writeConfigKeys(
     }
   }
 
-  writeFileSync(path, lines.join("\n").replace(/\n*$/, "\n"), "utf8");
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, lines.join("\n").replace(/\n*$/, "\n"), { encoding: "utf8", mode: 0o600 });
+  renameSync(tmp, path);
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    /* Windows/filesystems may not support modes. */
+  }
   return { path, created: !existed, updated };
 }
 

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -186,6 +186,7 @@ export function resolveConfig(
 function missingTokenMessage(configPath: string): string {
   return [
     "UPLOADS_TOKEN is required.",
+    "  uploads login                         # exchange an admin-provided enrollment code",
     `  uploads setup --token <token>         # guided setup → ${configPath}`,
     `  uploads config init --token <token>   # writes ${configPath}`,
     "  or set UPLOADS_TOKEN in env, pass --token, or use --env-file",

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -1,0 +1,231 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveEnrollmentCode, runLogin, validateEnrollmentCode } from "../src/commands/login.js";
+import { parseScopes, runAdmin } from "../src/commands/admin-enrollment.js";
+import { parseCommandArgs } from "../src/cli-args.js";
+import { loadConfigFile, writeConfigKeys } from "../src/config-file.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const key of [
+    "UPLOADS_ENROLLMENT_CODE",
+    "UPLOADS_TOKEN",
+    "ADMIN_TOKEN",
+    "UPLOADS_ADMIN_TOKEN",
+  ])
+    delete process.env[key];
+});
+
+const response = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+function captureOutput() {
+  let out = "";
+  let err = "";
+  vi.spyOn(process.stdout, "write").mockImplementation(((value: string | Uint8Array) => {
+    out += String(value);
+    return true;
+  }) as typeof process.stdout.write);
+  vi.spyOn(process.stderr, "write").mockImplementation(((value: string | Uint8Array) => {
+    err += String(value);
+    return true;
+  }) as typeof process.stderr.write);
+  return { out: () => out, err: () => err };
+}
+
+describe("login enrollment input", () => {
+  it("accepts and trims a high-entropy enrollment code", () => {
+    const code = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    expect(validateEnrollmentCode(`  ${code}\n`)).toBe(code);
+  });
+
+  it.each(["", "123456", "upe_short", "upe_has whitespace 12345678901234567890"])(
+    "rejects malformed code %j",
+    (code) => expect(() => validateEnrollmentCode(code)).toThrow("invalid enrollment code"),
+  );
+
+  it("allows explicit stdin with --non-interactive", async () => {
+    const code = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    await expect(
+      resolveEnrollmentCode(parseCommandArgs(["--code-stdin", "--non-interactive"]), {
+        isTTY: false,
+        readLine: async () => code,
+        hiddenPrompt: async () => "unused",
+      }),
+    ).resolves.toBe(code);
+  });
+
+  it("uses UPLOADS_ENROLLMENT_CODE without stdin", async () => {
+    process.env.UPLOADS_ENROLLMENT_CODE = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    const readLine = vi.fn(async () => "unused");
+    await expect(
+      resolveEnrollmentCode(parseCommandArgs(["--non-interactive"]), {
+        isTTY: false,
+        readLine,
+        hiddenPrompt: async () => "unused",
+      }),
+    ).resolves.toBe(process.env.UPLOADS_ENROLLMENT_CODE);
+    expect(readLine).not.toHaveBeenCalled();
+  });
+});
+
+describe("runLogin", () => {
+  it("exchanges, writes, verifies, and redacts the raw token", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const token = "up_default_abcdefghijklmnopqrstuvwxyz";
+    process.env.UPLOADS_ENROLLMENT_CODE = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(response({ workspace: "default", token }, 201))
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockResolvedValueOnce(response({ items: [], cursor: null }));
+    const output = captureOutput();
+    expect(await runLogin(["--non-interactive", "--path", path], { json: true })).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(loadConfigFile(path).UPLOADS_TOKEN).toBe(token);
+    expect(output.out() + output.err()).not.toContain(token);
+    expect(output.out()).toContain("set (up_default_");
+  });
+
+  it("preflights existing config before exchange", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    writeConfigKeys(path, { UPLOADS_TOKEN: "up_default_existingexistingexisting" });
+    process.env.UPLOADS_ENROLLMENT_CODE = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(runLogin(["--non-interactive", "--path", path], {})).rejects.toThrow(
+      "credentials already exist",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("supports --no-check", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    process.env.UPLOADS_ENROLLMENT_CODE = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        response({ workspace: "default", token: "up_default_abcdefghijklmnopqrstuvwxyz" }, 201),
+      );
+    captureOutput();
+    expect(
+      await runLogin(["--non-interactive", "--no-check", "--path", path], { json: true }),
+    ).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a malformed exchange response", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    process.env.UPLOADS_ENROLLMENT_CODE = "upe_abcdefghijklmnopqrstuvwxyz012345";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response({ workspace: "other", token: "up_default_abcdefghijklmnopqrstuvwxyz" }, 201),
+    );
+    await expect(runLogin(["--non-interactive", "--path", path], {})).rejects.toThrow(
+      "invalid credentials",
+    );
+  });
+});
+
+describe("admin enrollment", () => {
+  it("uses ADMIN_TOKEN and sends explicit lifetime and scopes", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response(
+        {
+          code: "upe_abcdefghijklmnopqrstuvwxyz012345",
+          expiresAt: "2030-01-01T00:00:00Z",
+          tokenExpiresAt: "2030-02-01T00:00:00Z",
+        },
+        201,
+      ),
+    );
+    captureOutput();
+    expect(
+      await runAdmin(
+        [
+          "enrollment",
+          "create",
+          "--workspace",
+          "default",
+          "--expires-in",
+          "600",
+          "--token-expires-in",
+          "86400",
+          "--scopes",
+          "files:read,files:write",
+        ],
+        { json: true },
+      ),
+    ).toBe(0);
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer admin-secret");
+    expect(JSON.parse(String(init.body))).toEqual({
+      workspace: "default",
+      enrollmentSeconds: 600,
+      tokenExpiresInSeconds: 86400,
+      scopes: ["files:read", "files:write"],
+    });
+    expect(process.env.UPLOADS_TOKEN).toBeUndefined();
+  });
+
+  it("omits optional policy fields when flags are absent", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response(
+        {
+          code: "upe_abcdefghijklmnopqrstuvwxyz012345",
+          expiresAt: "2030-01-01T00:00:00Z",
+          tokenExpiresAt: "2030-02-01T00:00:00Z",
+        },
+        201,
+      ),
+    );
+    captureOutput();
+    await runAdmin(["enrollment", "create"], { json: true });
+    expect(JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body))).toEqual({
+      workspace: "default",
+    });
+  });
+
+  it("validates scopes locally", () => {
+    expect(parseScopes("files:read, files:delete,files:read")).toEqual([
+      "files:read",
+      "files:delete",
+    ]);
+    expect(() => parseScopes("")).toThrow("at least one scope");
+    expect(() => parseScopes("files:admin")).toThrow("invalid scope");
+  });
+});
+
+describe("credential config writes", () => {
+  it("writes all credentials and preserves unrelated keys", () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    writeConfigKeys(path, { UPLOADS_DEFAULT_WIDTH: "700" });
+    const result = writeConfigKeys(
+      path,
+      {
+        UPLOADS_API_URL: "https://api.uploads.sh",
+        UPLOADS_WORKSPACE: "buildinternet",
+        UPLOADS_TOKEN: "up_buildinternet_abcdefghijklmnopqrstuvwxyz",
+      },
+      { force: true },
+    );
+    expect(result.updated).toEqual(["UPLOADS_API_URL", "UPLOADS_WORKSPACE", "UPLOADS_TOKEN"]);
+    expect(loadConfigFile(path)).toMatchObject({
+      UPLOADS_DEFAULT_WIDTH: "700",
+      UPLOADS_WORKSPACE: "buildinternet",
+      UPLOADS_TOKEN: "up_buildinternet_abcdefghijklmnopqrstuvwxyz",
+    });
+  });
+
+  it("rejects newline injection without modifying the file", () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    writeConfigKeys(path, { UPLOADS_WORKSPACE: "default" });
+    const before = readFileSync(path, "utf8");
+    expect(() =>
+      writeConfigKeys(path, { UPLOADS_TOKEN: "valid\nINJECTED=yes" }, { force: true }),
+    ).toThrow("invalid newline");
+    expect(readFileSync(path, "utf8")).toBe(before);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
       wrangler:
         specifier: ^4.107.0
         version: 4.107.0

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -49,7 +49,12 @@ propagate within ~a minute).
 ## Prerequisites
 
 - **Node.js ≥ 22.**
-- **The CLI.** Inside this repo, run it via pnpm — the root `uploads` script builds
+- **The CLI.** Install globally for repeated agent use, or run a pinned version:
+  ```bash
+  npm install --global @buildinternet/uploads
+  npx @buildinternet/uploads@0.1.0 --help
+  ```
+  Inside this repo, run it via pnpm — the root `uploads` script builds
   the package first, so it always reflects local source:
   ```bash
   pnpm uploads <command> [args]        # from the repo root
@@ -75,32 +80,33 @@ Resolution is **per key, first match wins**: CLI flags (`--api-url`, `--token`,
 `$BUILDINTERNET_CONFIG` → the shared config file. For a one-off against a different
 API or workspace, just export the var or pass `--env-file`.
 
-The fastest path is the guided wizard, which prints exactly what's missing and how to
-fix it:
+The fastest path is enrollment. Ask an uploads.sh administrator for a short-lived
+enrollment code, then run:
 
 ```bash
-uploads setup          # shows status + next steps; run it again anytime
+uploads login          # prompts without echoing the code, saves config, runs doctor
 ```
 
-You need a **bearer token** for a workspace. Tokens are minted by an admin endpoint
-guarded by `ADMIN_TOKEN` (ask the uploads.sh admin, or set it locally in
-`apps/api/.dev.vars`). Mint one (defaults to the `default` workspace):
+For a non-interactive agent, pass the short-lived code through the environment rather
+than a process-list-visible command argument:
 
 ```bash
-curl -XPOST https://api.uploads.sh/admin/tokens \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-# → { "workspace": "default", "token": "up_default_…", … }   (shown once)
+UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login
 ```
 
-Then save it and verify:
+Routine agents never need `ADMIN_TOKEN`. Enrollment codes expire after 10 minutes and
+can be redeemed once. The resulting token defaults to 90 days and `files:read` plus
+`files:write`; it cannot delete files unless an administrator explicitly grants
+`files:delete`. Verify or inspect setup at any time:
 
 ```bash
-uploads setup --token up_default_… --check     # writes config, runs doctor
+uploads setup                                  # shows effective configuration
 uploads doctor                                 # health + auth + workspace checks
 ```
 
 Tokens encode their workspace (`up_<workspace>_…`), so the CLI infers `--workspace`
-from the token when you don't set it. See "Config commands" for setting put defaults
+when you don't set it. Legacy administrator-minted tokens remain valid. See "Config
+commands" for setting put defaults
 (default repo, prefix, image width) once instead of per-command.
 
 ## Core workflow: `uploads put`


### PR DESCRIPTION
## What changed

- add one-time enrollment codes and `uploads login` for agent-friendly onboarding
- store new scoped, expiring credentials in D1 while retaining legacy KV token compatibility
- enforce read, write, and delete scopes across file routes
- add administrator enrollment management, CLI configuration safety, and login verification
- configure the general-purpose `uploads-production` D1 database through the `DB` binding
- adopt LF normalization and timestamp-prefixed D1 migrations

## Why

Agents need a safe way to acquire narrowly scoped uploads credentials without receiving the administrator secret or requiring a manually copied long-lived bearer token. The generic database name also leaves room for future file-directory metadata and other relational product data while R2 continues to hold file bytes.

## Validation

- `pnpm run types`
- `pnpm run check`
- `pnpm run typecheck`
- API tests: 10 passed
- CLI tests: 52 passed
- storage tests: 19 passed
- `pnpm --filter @buildinternet/uploads pack:check`
- `wrangler d1 migrations apply uploads-production --local`

## Rollout

The empty `uploads-production` D1 database has been created, but its remote migration has not been applied and the Worker has not been deployed. After merge, apply the remote migration before deploying the API, then mint an enrollment and dogfood `uploads login` before publishing the next CLI version.
