### PR TITLE
chore(release): publish uploads v0.1.1

### DIFF
--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildinternet/uploads",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI and client for uploads.sh — workspace-scoped image hosting for GitHub embeds",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What changed

- bumps `@buildinternet/uploads` from `0.1.0` to `0.1.1`

## Why

This release publishes the merged D1-backed enrollment and `uploads login` flow for agent-friendly uploads access.

## Validation

- 52 CLI tests passed
- package contents verified with `pack:check`
- production enrollment/login smoke test passed; its test credential was revoked
