### PR TITLE
feat(api): add upload guardrails for the hosted API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,14 @@ records; any future global secrets go through `wrangler secret put` (prod) or
   `apps/api/src/workspace.ts`.
 - Object keys are validated (`badKey` in `routes/files.ts`); URL parsing
   normalizes dot segments before handlers run.
+- Upload guardrails live in `apps/api/src/guards.ts`: a byte cap (default 25 MiB)
+  enforced on `Content-Length` and post-buffer, and a content-type allowlist
+  (images + mp4/webm, no SVG) verified by magic-byte sniffing — the stored
+  content type comes from the bytes, never the client header. Defaults are
+  overridable per workspace via `maxUploadBytes` / `allowedContentTypes` on the
+  record. Mutating routes carry the `writeRateLimit` middleware, keyed by
+  workspace against the `WRITE_LIMITER` Rate Limiting binding (`unsafe.bindings`
+  in `wrangler.jsonc`); it no-ops when the binding is absent.
 - Follow Cloudflare Workers best practices: no floating promises, no
   module-level request state, secrets never in config or source.
 

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -1,0 +1,151 @@
+import type { MiddlewareHandler } from "hono";
+import type { WorkspaceVars } from "./workspace";
+
+/**
+ * Upload guardrails for the hosted API: a byte cap and a content-type
+ * allowlist backed by magic-byte sniffing, plus a per-workspace write rate
+ * limit. Defaults live here; per-workspace overrides ride on the
+ * `WorkspaceRecord` (`maxUploadBytes` / `allowedContentTypes`) and are merged
+ * in `resolveUploadPolicy`.
+ */
+
+/** Default ceiling on a single upload. Covers screenshots and short clips. */
+export const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25 MiB
+
+/**
+ * Intended payloads: static images plus the short gif/video clips embedded in
+ * GitHub repos. Deliberately excludes `image/svg+xml` — an SVG served inline
+ * from storage.uploads.sh can carry script (stored XSS on our own origin).
+ */
+export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "video/mp4",
+  "video/webm",
+];
+
+export interface UploadPolicy {
+  maxBytes: number;
+  allowed: Set<string>;
+}
+
+/** Fields a workspace record may carry to override the default upload policy. */
+export interface UploadPolicyOverrides {
+  maxUploadBytes?: number;
+  allowedContentTypes?: string[];
+}
+
+export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy {
+  const maxBytes =
+    typeof record.maxUploadBytes === "number" && record.maxUploadBytes > 0
+      ? record.maxUploadBytes
+      : DEFAULT_MAX_UPLOAD_BYTES;
+  const allowed =
+    record.allowedContentTypes && record.allowedContentTypes.length > 0
+      ? record.allowedContentTypes
+      : DEFAULT_ALLOWED_CONTENT_TYPES;
+  return { maxBytes, allowed: new Set(allowed) };
+}
+
+/** Strip parameters (`; charset=…`) and normalize case for header comparison. */
+export function normalizeContentType(value: string | undefined): string {
+  return (value ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+function matches(bytes: Uint8Array, signature: number[], offset = 0): boolean {
+  if (bytes.length < offset + signature.length) return false;
+  for (let i = 0; i < signature.length; i++) {
+    if (bytes[offset + i] !== signature[i]) return false;
+  }
+  return true;
+}
+
+function asciiAt(bytes: Uint8Array, offset: number, length: number): string {
+  if (bytes.length < offset + length) return "";
+  return String.fromCharCode(...bytes.subarray(offset, offset + length));
+}
+
+/**
+ * Identify a payload from its leading bytes, returning the canonical MIME type
+ * we recognize or `null`. This is what actually stops "a zip renamed to .png":
+ * the stored content type comes from the bytes, never from the client header.
+ */
+export function detectContentType(bytes: Uint8Array): string | null {
+  // PNG: \x89PNG\r\n\x1a\n
+  if (matches(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  // JPEG: FF D8 FF
+  if (matches(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  // GIF87a / GIF89a
+  if (matches(bytes, [0x47, 0x49, 0x46, 0x38])) return "image/gif";
+  // RIFF....WEBP
+  if (matches(bytes, [0x52, 0x49, 0x46, 0x46]) && matches(bytes, [0x57, 0x45, 0x42, 0x50], 8)) {
+    return "image/webp";
+  }
+  // WebM / Matroska (EBML header). We only serve webm; an .mkv would be
+  // labeled webm, which is close enough for a guardrail.
+  if (matches(bytes, [0x1a, 0x45, 0xdf, 0xa3])) return "video/webm";
+  // ISO base media (ftyp box at offset 4) — AVIF and MP4 share the container,
+  // so split on the major brand at offset 8.
+  if (matches(bytes, [0x66, 0x74, 0x79, 0x70], 4)) {
+    const brand = asciiAt(bytes, 8, 4);
+    if (brand === "avif" || brand === "avis") return "image/avif";
+    return "video/mp4";
+  }
+  return null;
+}
+
+export type UploadInspection =
+  | { ok: true; contentType: string }
+  | { ok: false; status: 413 | 415; body: Record<string, unknown> };
+
+/**
+ * Validate a fully-buffered upload body against the policy. Size is checked
+ * again here (the pre-buffer Content-Length check can be absent or lying), then
+ * the sniffed type must be on the allowlist.
+ */
+export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadInspection {
+  if (bytes.byteLength > policy.maxBytes) {
+    return {
+      ok: false,
+      status: 413,
+      body: { error: "payload too large", maxBytes: policy.maxBytes },
+    };
+  }
+  const detected = detectContentType(bytes);
+  if (detected === null || !policy.allowed.has(detected)) {
+    return {
+      ok: false,
+      status: 415,
+      body: { error: "unsupported media type", allowed: [...policy.allowed] },
+    };
+  }
+  return { ok: true, contentType: detected };
+}
+
+/**
+ * The Rate Limiting API binding (configured under `unsafe.bindings` in
+ * wrangler.jsonc). Unsafe bindings aren't emitted by `wrangler types`, so we
+ * describe the shape locally and read it off `env` defensively — when the
+ * binding is absent (some local/dev setups, tests) the middleware no-ops.
+ */
+interface RateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+/**
+ * Per-workspace rate limit for mutating requests. Keyed by workspace name so
+ * one tenant's traffic can't exhaust another's budget. The window and quota
+ * are fixed in wrangler.jsonc (the binding is a fixed sliding window); it's
+ * per-colo rather than globally exact — enough to blunt abuse, not billing.
+ */
+export const writeRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
+  const limiter = (c.env as { WRITE_LIMITER?: RateLimiter }).WRITE_LIMITER;
+  if (limiter) {
+    const { success } = await limiter.limit({ key: c.get("workspaceName") });
+    if (!success) return c.json({ error: "rate limit exceeded" }, 429);
+  }
+  await next();
+};

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -27,6 +27,8 @@ export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
   "video/webm",
 ];
 
+const DEFAULT_ALLOWED_SET = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
+
 export interface UploadPolicy {
   maxBytes: number;
   allowed: Set<string>;
@@ -45,14 +47,9 @@ export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy
       : DEFAULT_MAX_UPLOAD_BYTES;
   const allowed =
     record.allowedContentTypes && record.allowedContentTypes.length > 0
-      ? record.allowedContentTypes
-      : DEFAULT_ALLOWED_CONTENT_TYPES;
-  return { maxBytes, allowed: new Set(allowed) };
-}
-
-/** Strip parameters (`; charset=…`) and normalize case for header comparison. */
-export function normalizeContentType(value: string | undefined): string {
-  return (value ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+      ? new Set(record.allowedContentTypes)
+      : DEFAULT_ALLOWED_SET;
+  return { maxBytes, allowed };
 }
 
 function matches(bytes: Uint8Array, signature: number[], offset = 0): boolean {
@@ -97,23 +94,34 @@ export function detectContentType(bytes: Uint8Array): string | null {
   return null;
 }
 
-export type UploadInspection =
-  | { ok: true; contentType: string }
-  | { ok: false; status: 413 | 415; body: Record<string, unknown> };
+export type UploadRejection = { ok: false; status: 413 | 415; body: Record<string, unknown> };
+export type UploadInspection = { ok: true; contentType: string } | UploadRejection;
+
+function tooLarge(maxBytes: number): UploadRejection {
+  return { ok: false, status: 413, body: { error: "payload too large", maxBytes } };
+}
 
 /**
- * Validate a fully-buffered upload body against the policy. Size is checked
- * again here (the pre-buffer Content-Length check can be absent or lying), then
- * the sniffed type must be on the allowlist.
+ * Pre-buffer size gate: reject on a declared `Content-Length` over the cap
+ * before the body is read into isolate memory. Returns `null` when the header
+ * is absent or within range — `inspectUpload` is the authoritative backstop for
+ * missing or dishonest lengths.
+ */
+export function checkDeclaredLength(
+  contentLength: string | undefined,
+  policy: UploadPolicy,
+): UploadRejection | null {
+  const declared = Number(contentLength);
+  if (Number.isFinite(declared) && declared > policy.maxBytes) return tooLarge(policy.maxBytes);
+  return null;
+}
+
+/**
+ * Validate a fully-buffered upload body against the policy: size (the
+ * authoritative check) then the sniffed type against the allowlist.
  */
 export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadInspection {
-  if (bytes.byteLength > policy.maxBytes) {
-    return {
-      ok: false,
-      status: 413,
-      body: { error: "payload too large", maxBytes: policy.maxBytes },
-    };
-  }
+  if (bytes.byteLength > policy.maxBytes) return tooLarge(policy.maxBytes);
   const detected = detectContentType(bytes);
   if (detected === null || !policy.allowed.has(detected)) {
     return {
@@ -126,23 +134,14 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
 }
 
 /**
- * The Rate Limiting API binding (configured under `unsafe.bindings` in
- * wrangler.jsonc). Unsafe bindings aren't emitted by `wrangler types`, so we
- * describe the shape locally and read it off `env` defensively — when the
- * binding is absent (some local/dev setups, tests) the middleware no-ops.
- */
-interface RateLimiter {
-  limit(options: { key: string }): Promise<{ success: boolean }>;
-}
-
-/**
  * Per-workspace rate limit for mutating requests. Keyed by workspace name so
- * one tenant's traffic can't exhaust another's budget. The window and quota
- * are fixed in wrangler.jsonc (the binding is a fixed sliding window); it's
+ * one tenant's traffic can't exhaust another's budget. The window and quota are
+ * fixed in wrangler.jsonc (`WRITE_LIMITER`, a fixed sliding window); it's
  * per-colo rather than globally exact — enough to blunt abuse, not billing.
+ * Fails open when the binding is absent (some local/dev setups, tests).
  */
 export const writeRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
-  const limiter = (c.env as { WRITE_LIMITER?: RateLimiter }).WRITE_LIMITER;
+  const limiter = c.env.WRITE_LIMITER;
   if (limiter) {
     const { success } = await limiter.limit({ key: c.get("workspaceName") });
     if (!success) return c.json({ error: "rate limit exceeded" }, 429);

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -52,6 +52,7 @@ export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy
   return { maxBytes, allowed };
 }
 
+/** True when `bytes` contains `signature` at `offset` (bounds-checked). */
 function matches(bytes: Uint8Array, signature: number[], offset = 0): boolean {
   if (bytes.length < offset + signature.length) return false;
   for (let i = 0; i < signature.length; i++) {
@@ -60,6 +61,7 @@ function matches(bytes: Uint8Array, signature: number[], offset = 0): boolean {
   return true;
 }
 
+/** Decode `length` bytes at `offset` as ASCII (empty string if out of range). */
 function asciiAt(bytes: Uint8Array, offset: number, length: number): string {
   if (bytes.length < offset + length) return "";
   return String.fromCharCode(...bytes.subarray(offset, offset + length));
@@ -97,6 +99,7 @@ export function detectContentType(bytes: Uint8Array): string | null {
 export type UploadRejection = { ok: false; status: 413 | 415; body: Record<string, unknown> };
 export type UploadInspection = { ok: true; contentType: string } | UploadRejection;
 
+/** The shared 413 rejection for both the pre-buffer and post-buffer size checks. */
 function tooLarge(maxBytes: number): UploadRejection {
   return { ok: false, status: 413, body: { error: "payload too large", maxBytes } };
 }

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
+import { inspectUpload, resolveUploadPolicy, writeRateLimit } from "../guards";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
 // for GitHub embeds: they're proxied through GitHub's Camo/Fastly cache, and
@@ -21,16 +22,32 @@ function badKey(key: string): boolean {
 
 export const files = new Hono<WorkspaceVars>()
 
-  // Upload: raw body PUT. Content-Type header becomes the stored content type.
-  .put("/:key{.+}", requireScope("files:write"), async (c) => {
+  // Upload: raw body PUT. The stored content type is sniffed from the bytes,
+  // not taken from the client header — see guards.ts.
+  .put("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
+
+    const policy = resolveUploadPolicy(c.get("workspace"));
+
+    // Reject oversized uploads on the declared length before buffering the
+    // body into isolate memory. The post-buffer check in inspectUpload is the
+    // authoritative backstop for missing or dishonest Content-Length headers.
+    const declaredLength = Number(c.req.header("Content-Length"));
+    if (Number.isFinite(declaredLength) && declaredLength > policy.maxBytes) {
+      return c.json({ error: "payload too large", maxBytes: policy.maxBytes }, 413);
+    }
+
     const body = await c.req.arrayBuffer();
     if (body.byteLength === 0) return c.json({ error: "empty body" }, 400);
 
+    const bytes = new Uint8Array(body);
+    const inspection = inspectUpload(bytes, policy);
+    if (!inspection.ok) return c.json(inspection.body, inspection.status);
+
     const ws = c.get("workspace");
-    const contentType = c.req.header("Content-Type") ?? "application/octet-stream";
-    await storage(c.env, ws).upload(key, new Uint8Array(body), {
+    const contentType = inspection.contentType;
+    await storage(c.env, ws).upload(key, bytes, {
       contentType,
       cacheControl: UPLOAD_CACHE_CONTROL,
     });
@@ -70,7 +87,7 @@ export const files = new Hono<WorkspaceVars>()
   })
 
   // Delete
-  .delete("/:key{.+}", requireScope("files:delete"), async (c) => {
+  .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
     await storage(c.env, c.get("workspace")).delete(key);

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
-import { inspectUpload, resolveUploadPolicy, writeRateLimit } from "../guards";
+import { checkDeclaredLength, inspectUpload, resolveUploadPolicy, writeRateLimit } from "../guards";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
 // for GitHub embeds: they're proxied through GitHub's Camo/Fastly cache, and
@@ -30,13 +30,10 @@ export const files = new Hono<WorkspaceVars>()
 
     const policy = resolveUploadPolicy(c.get("workspace"));
 
-    // Reject oversized uploads on the declared length before buffering the
-    // body into isolate memory. The post-buffer check in inspectUpload is the
-    // authoritative backstop for missing or dishonest Content-Length headers.
-    const declaredLength = Number(c.req.header("Content-Length"));
-    if (Number.isFinite(declaredLength) && declaredLength > policy.maxBytes) {
-      return c.json({ error: "payload too large", maxBytes: policy.maxBytes }, 413);
-    }
+    // Reject oversized uploads on the declared length before buffering the body
+    // into isolate memory; inspectUpload re-checks the actual size below.
+    const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
+    if (declared) return c.json(declared.body, declared.status);
 
     const body = await c.req.arrayBuffer();
     if (body.byteLength === 0) return c.json({ error: "empty body" }, 400);

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -24,6 +24,10 @@ export interface WorkspaceRecord {
   accountId?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
+  /** Max bytes for a single upload. Falls back to DEFAULT_MAX_UPLOAD_BYTES. */
+  maxUploadBytes?: number;
+  /** Allowed (sniffed) content types. Falls back to DEFAULT_ALLOWED_CONTENT_TYPES. */
+  allowedContentTypes?: string[];
 }
 
 export type WorkspaceVars = {

--- a/apps/api/test/fake-r2.ts
+++ b/apps/api/test/fake-r2.ts
@@ -1,0 +1,96 @@
+/**
+ * Minimal in-memory R2 binding stand-in for the route tests — just the surface
+ * the files-sdk r2 adapter touches. A local copy (rather than importing the
+ * storage package's fixture) keeps it inside the API's DOM-free lib, where
+ * `BlobPart` and friends don't exist. `store` exposes the raw written keys.
+ */
+interface StoredObject {
+  data: Uint8Array;
+  contentType?: string;
+}
+
+export class FakeR2Bucket {
+  store = new Map<string, StoredObject>();
+
+  private meta(key: string, obj: StoredObject) {
+    return {
+      key,
+      size: obj.data.byteLength,
+      etag: "fake-etag",
+      httpEtag: '"fake-etag"',
+      uploaded: new Date(0),
+      version: "1",
+      storageClass: "Standard",
+      checksums: {},
+      httpMetadata: { contentType: obj.contentType },
+      customMetadata: {},
+      writeHttpMetadata() {},
+    };
+  }
+
+  async put(
+    key: string,
+    value: ArrayBuffer | ArrayBufferView | string | ReadableStream<Uint8Array> | null,
+    opts?: { httpMetadata?: { contentType?: string } | Headers },
+  ) {
+    let data: Uint8Array;
+    if (typeof value === "string") data = new TextEncoder().encode(value);
+    else if (value instanceof ArrayBuffer) data = new Uint8Array(value);
+    else if (value && ArrayBuffer.isView(value))
+      data = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    else data = new Uint8Array(0);
+
+    const httpMetadata = opts?.httpMetadata;
+    const contentType =
+      httpMetadata instanceof Headers
+        ? (httpMetadata.get("content-type") ?? undefined)
+        : httpMetadata?.contentType;
+    const obj = { data, contentType };
+    this.store.set(key, obj);
+    return this.meta(key, obj);
+  }
+
+  async get(key: string) {
+    const obj = this.store.get(key);
+    if (!obj) return null;
+    const data = obj.data;
+    return {
+      ...this.meta(key, obj),
+      bodyUsed: false,
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      }),
+      async arrayBuffer() {
+        return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+      },
+      async bytes() {
+        return data;
+      },
+      async text() {
+        return new TextDecoder().decode(data);
+      },
+    };
+  }
+
+  async head(key: string) {
+    const obj = this.store.get(key);
+    return obj ? this.meta(key, obj) : null;
+  }
+
+  async delete(keys: string | string[]) {
+    for (const k of Array.isArray(keys) ? keys : [keys]) this.store.delete(k);
+  }
+
+  async list(opts?: { prefix?: string }) {
+    const prefix = opts?.prefix ?? "";
+    const keys = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
+    return {
+      objects: keys.map((k) => this.meta(k, this.store.get(k)!)),
+      truncated: false as const,
+      delimitedPrefixes: [] as string[],
+    };
+  }
+}

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ALLOWED_CONTENT_TYPES,
+  DEFAULT_MAX_UPLOAD_BYTES,
+  detectContentType,
+  inspectUpload,
+  normalizeContentType,
+  resolveUploadPolicy,
+} from "../src/guards";
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+const JPEG = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0]);
+const GIF = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+const WEBP = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0, 0]);
+const ftyp = (brand: string) =>
+  new Uint8Array([
+    0,
+    0,
+    0,
+    0x18,
+    0x66,
+    0x74,
+    0x79,
+    0x70,
+    ...[...brand].map((ch) => ch.charCodeAt(0)),
+  ]);
+
+describe("detectContentType", () => {
+  it("recognizes each intended type from its magic bytes", () => {
+    expect(detectContentType(PNG)).toBe("image/png");
+    expect(detectContentType(JPEG)).toBe("image/jpeg");
+    expect(detectContentType(GIF)).toBe("image/gif");
+    expect(detectContentType(WEBP)).toBe("image/webp");
+    expect(detectContentType(WEBM)).toBe("video/webm");
+    expect(detectContentType(ftyp("avif"))).toBe("image/avif");
+    expect(detectContentType(ftyp("isom"))).toBe("video/mp4");
+    expect(detectContentType(ftyp("mp42"))).toBe("video/mp4");
+  });
+
+  it("returns null for unrecognized or truncated payloads", () => {
+    expect(detectContentType(new Uint8Array([0x50, 0x4b, 0x03, 0x04]))).toBeNull(); // zip
+    expect(detectContentType(new TextEncoder().encode("<svg></svg>"))).toBeNull();
+    expect(detectContentType(new Uint8Array([0x89]))).toBeNull();
+    expect(detectContentType(new Uint8Array(0))).toBeNull();
+  });
+});
+
+describe("normalizeContentType", () => {
+  it("strips parameters and lowercases", () => {
+    expect(normalizeContentType("Image/PNG; charset=binary")).toBe("image/png");
+    expect(normalizeContentType(undefined)).toBe("");
+  });
+});
+
+describe("resolveUploadPolicy", () => {
+  it("uses defaults when the record omits overrides", () => {
+    const policy = resolveUploadPolicy({});
+    expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
+    expect([...policy.allowed].sort()).toEqual([...DEFAULT_ALLOWED_CONTENT_TYPES].sort());
+  });
+
+  it("applies per-workspace overrides", () => {
+    const policy = resolveUploadPolicy({
+      maxUploadBytes: 1000,
+      allowedContentTypes: ["image/png"],
+    });
+    expect(policy.maxBytes).toBe(1000);
+    expect([...policy.allowed]).toEqual(["image/png"]);
+  });
+
+  it("ignores empty or non-positive overrides and falls back", () => {
+    const policy = resolveUploadPolicy({ maxUploadBytes: 0, allowedContentTypes: [] });
+    expect(policy.maxBytes).toBe(DEFAULT_MAX_UPLOAD_BYTES);
+    expect(policy.allowed.size).toBe(DEFAULT_ALLOWED_CONTENT_TYPES.length);
+  });
+});
+
+describe("inspectUpload", () => {
+  const policy = resolveUploadPolicy({});
+
+  it("accepts an allowed type and returns the sniffed content type", () => {
+    const result = inspectUpload(PNG, policy);
+    expect(result).toEqual({ ok: true, contentType: "image/png" });
+  });
+
+  it("rejects payloads over the size cap with 413", () => {
+    const small = resolveUploadPolicy({ maxUploadBytes: 4 });
+    const result = inspectUpload(PNG, small);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(413);
+  });
+
+  it("rejects a disallowed sniffed type with 415", () => {
+    const result = inspectUpload(new Uint8Array([0x50, 0x4b, 0x03, 0x04]), policy);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  });
+
+  it("rejects a real image whose type is excluded by policy with 415", () => {
+    const gifOnly = resolveUploadPolicy({ allowedContentTypes: ["image/gif"] });
+    const result = inspectUpload(PNG, gifOnly);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(415);
+  });
+});

--- a/apps/api/test/guards.test.ts
+++ b/apps/api/test/guards.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  checkDeclaredLength,
   DEFAULT_ALLOWED_CONTENT_TYPES,
   DEFAULT_MAX_UPLOAD_BYTES,
   detectContentType,
   inspectUpload,
-  normalizeContentType,
   resolveUploadPolicy,
 } from "../src/guards";
 
@@ -48,10 +48,17 @@ describe("detectContentType", () => {
   });
 });
 
-describe("normalizeContentType", () => {
-  it("strips parameters and lowercases", () => {
-    expect(normalizeContentType("Image/PNG; charset=binary")).toBe("image/png");
-    expect(normalizeContentType(undefined)).toBe("");
+describe("checkDeclaredLength", () => {
+  const policy = resolveUploadPolicy({ maxUploadBytes: 100 });
+
+  it("rejects a Content-Length over the cap with 413", () => {
+    expect(checkDeclaredLength("999", policy)?.status).toBe(413);
+  });
+
+  it("passes (null) when the header is within range, absent, or unparseable", () => {
+    expect(checkDeclaredLength("50", policy)).toBeNull();
+    expect(checkDeclaredLength(undefined, policy)).toBeNull();
+    expect(checkDeclaredLength("not-a-number", policy)).toBeNull();
   });
 });
 

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -1,0 +1,165 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+
+const TOKEN = "secret-token";
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+async function makeEnv(
+  overrides: Partial<WorkspaceRecord> = {},
+  opts: { rateLimitOk?: boolean } = {},
+) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...overrides,
+  };
+  const bucket = new FakeR2Bucket();
+  const env = {
+    REGISTRY: { get: async () => record, put: async () => undefined },
+    // No D1 token: force the legacy token path.
+    DB: {
+      prepare: () => ({
+        bind() {
+          return this;
+        },
+        async first() {
+          return null;
+        },
+      }),
+    },
+    UPLOADS_DEFAULT: bucket,
+    WRITE_LIMITER: { limit: async () => ({ success: opts.rateLimitOk ?? true }) },
+  };
+  return { env, bucket };
+}
+
+describe("PUT /v1/:workspace/files upload guardrails", () => {
+  it("stores a valid image with the sniffed content type", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { contentType: string; url: string };
+    expect(json.contentType).toBe("image/png");
+    expect(json.url).toBe("https://storage.uploads.sh/default/shot.png");
+    expect(bucket.store.has("default/shot.png")).toBe(true);
+  });
+
+  it("overrides a lying Content-Type header with the sniffed type", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/svg+xml" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(bucket.store.get("default/shot.png")?.contentType).toBe("image/png");
+  });
+
+  it("rejects a non-image payload with 415", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00]), // zip
+      },
+      env,
+    );
+    expect(res.status).toBe(415);
+  });
+
+  it("rejects an oversized body with 413", async () => {
+    const { env } = await makeEnv({ maxUploadBytes: 4 });
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects on an oversized Content-Length before buffering", async () => {
+    const { env } = await makeEnv({ maxUploadBytes: 4 });
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          "Content-Type": "image/png",
+          "Content-Length": "999999",
+        },
+        body: PNG,
+      },
+      env,
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects an empty body with 400", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: new Uint8Array(0),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when the write rate limit is exceeded", async () => {
+    const { env } = await makeEnv({}, { rateLimitOk: false });
+    const res = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -55,18 +55,26 @@ async function makeEnv(
   return { env, bucket };
 }
 
+/** PUT the standard test key with auth, letting each test vary body/headers/env. */
+function putShot(
+  env: Parameters<typeof app.request>[2],
+  { body = PNG as BodyInit, headers = {} as Record<string, string> } = {},
+) {
+  return app.request(
+    "/v1/default/files/shot.png",
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png", ...headers },
+      body,
+    },
+    env,
+  );
+}
+
 describe("PUT /v1/:workspace/files upload guardrails", () => {
   it("stores a valid image with the sniffed content type", async () => {
     const { env, bucket } = await makeEnv();
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
-        body: PNG,
-      },
-      env,
-    );
+    const res = await putShot(env);
     expect(res.status).toBe(201);
     const json = (await res.json()) as { contentType: string; url: string };
     expect(json.contentType).toBe("image/png");
@@ -76,90 +84,38 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
 
   it("overrides a lying Content-Type header with the sniffed type", async () => {
     const { env, bucket } = await makeEnv();
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/svg+xml" },
-        body: PNG,
-      },
-      env,
-    );
+    const res = await putShot(env, { headers: { "Content-Type": "image/svg+xml" } });
     expect(res.status).toBe(201);
     expect(bucket.store.get("default/shot.png")?.contentType).toBe("image/png");
   });
 
   it("rejects a non-image payload with 415", async () => {
     const { env } = await makeEnv();
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
-        body: new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00]), // zip
-      },
-      env,
-    );
+    const res = await putShot(env, { body: new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x00]) }); // zip
     expect(res.status).toBe(415);
   });
 
   it("rejects an oversized body with 413", async () => {
     const { env } = await makeEnv({ maxUploadBytes: 4 });
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
-        body: PNG,
-      },
-      env,
-    );
+    const res = await putShot(env);
     expect(res.status).toBe(413);
   });
 
   it("rejects on an oversized Content-Length before buffering", async () => {
     const { env } = await makeEnv({ maxUploadBytes: 4 });
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${TOKEN}`,
-          "Content-Type": "image/png",
-          "Content-Length": "999999",
-        },
-        body: PNG,
-      },
-      env,
-    );
+    const res = await putShot(env, { headers: { "Content-Length": "999999" } });
     expect(res.status).toBe(413);
   });
 
   it("rejects an empty body with 400", async () => {
     const { env } = await makeEnv();
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
-        body: new Uint8Array(0),
-      },
-      env,
-    );
+    const res = await putShot(env, { body: new Uint8Array(0) });
     expect(res.status).toBe(400);
   });
 
   it("returns 429 when the write rate limit is exceeded", async () => {
     const { env } = await makeEnv({}, { rateLimitOk: false });
-    const res = await app.request(
-      "/v1/default/files/shot.png",
-      {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
-        body: PNG,
-      },
-      env,
-    );
+    const res = await putShot(env);
     expect(res.status).toBe(429);
   });
 });

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -32,6 +32,24 @@
       "migrations_dir": "migrations",
     },
   ],
+  // Per-workspace write rate limit (uploads + deletes). The Rate Limiting API
+  // is an `unsafe` binding: not typed by `wrangler types`, read defensively in
+  // guards.ts (writeRateLimit). Keyed by workspace name; `period` must be 10 or
+  // 60. 60 writes/min/workspace is generous for legit screenshot flows and
+  // blunts a runaway client. Per-colo, not globally exact.
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "WRITE_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": {
+          "limit": 60,
+          "period": 60,
+        },
+      },
+    ],
+  },
   // One binding per same-account bucket a workspace wants binding-mode I/O on.
   // Workspaces reference these by name; workspaces without a binding fall back
   // to their S3 credentials over HTTP.

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -32,11 +32,12 @@
       "migrations_dir": "migrations",
     },
   ],
-  // Per-workspace write rate limit (uploads + deletes). The Rate Limiting API
-  // is an `unsafe` binding: not typed by `wrangler types`, read defensively in
-  // guards.ts (writeRateLimit). Keyed by workspace name; `period` must be 10 or
-  // 60. 60 writes/min/workspace is generous for legit screenshot flows and
-  // blunts a runaway client. Per-colo, not globally exact.
+  // Per-workspace write rate limit (uploads + deletes), enforced by the
+  // writeRateLimit middleware in guards.ts. The Rate Limiting API is an
+  // `unsafe` binding but `wrangler types` still emits it as `WRITE_LIMITER:
+  // RateLimit`. Keyed by workspace name; `period` must be 10 or 60. 60
+  // writes/min/workspace is generous for legit screenshot flows and blunts a
+  // runaway client. Per-colo, not globally exact.
   "unsafe": {
     "bindings": [
       {


### PR DESCRIPTION
Basic abuse controls for the public `api.uploads.sh` surface: a size cap, a content-type allowlist, and a per-workspace write rate limit. Policy lives in a new `apps/api/src/guards.ts` with defaults overridable on the `WorkspaceRecord`.

## What & why

The upload handler previously buffered any body up to the Workers 100 MB ceiling, stored the client's `Content-Type` header verbatim, and had no rate limiting. This closes those three doors.

**1. Size cap (413)**
- Rejects on the `Content-Length` header *before* buffering the body into isolate memory, with a post-buffer `byteLength` backstop for missing/dishonest headers.
- Default 25 MiB (`DEFAULT_MAX_UPLOAD_BYTES`), overridable per workspace via `maxUploadBytes`.

**2. Content-type allowlist + magic-byte sniffing (415)**
- The stored content type is derived from the file's leading bytes, **not** the client header — so a payload mislabeled `image/png` is rejected.
- Allowlist: `png`, `jpeg`, `gif`, `webp`, `avif`, `mp4`, `webm`. `image/svg+xml` is deliberately excluded — an SVG served inline from `storage.uploads.sh` can carry script (stored XSS on our own origin).
- Overridable per workspace via `allowedContentTypes`.

**3. Per-workspace write rate limit (429)**
- `writeRateLimit` middleware on the mutating routes (`PUT`, `DELETE`), keyed by workspace name against the `WRITE_LIMITER` Cloudflare Rate Limiting binding (`unsafe.bindings` in `wrangler.jsonc`, 60 writes/min). Fails open when the binding is absent (local/dev, tests). Per-colo, not a globally exact quota.

## Notes for the reviewer

- **`namespace_id` is a placeholder (`1001`)** — pick real, distinct IDs before relying on it in production.
- **Per-IP protection for the unauthenticated surface** (`/auth/enrollments/exchange`, `/health`) is intentionally out of scope here — that's a zone-level WAF Rate Limiting Rule in the Cloudflare dashboard, not repo config.
- Reads (`GET` list/metadata) are deliberately left unlimited and uncapped; they're cheap and CDN-fronted.

## Tests

New `guards.test.ts` (magic-byte detection, policy resolution, size gate, inspection) and `routes-files.test.ts` (end-to-end PUT: valid image, lying header override, 415/413/400/429 paths). Full suite: 28 passing, typecheck and lint/format gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHuJzbKy61ce3W7iwqLR1B

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHuJzbKy61ce3W7iwqLR1B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upload size limits and supported media-type validation.
  * Uploads are verified by their actual file contents, rather than declared headers.
  * Added configurable per-workspace upload policies.
  * Added rate limiting for file uploads and deletions, returning an error when limits are exceeded.

* **Bug Fixes**
  * Prevented empty, oversized, unsupported, or misleadingly labeled files from being stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->