### PR TITLE
feat(mcp): agents.uploads.sh primary domain, token-inferred /mcp endpoint, uploads install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ scripts in `buildinternet-skills/github-screenshots`.
 
 ```
 apps/api            Hono worker — REST API, deploys to api.uploads.sh
-apps/mcp            Hono worker — remote MCP server, deploys to mcp.uploads.sh
+apps/mcp            Hono worker — remote MCP server, deploys to agents.uploads.sh (alt: mcp.uploads.sh)
 apps/web            Astro placeholder — future browse/manage UI (separate deploy)
 packages/storage    @uploads/storage — files-sdk adapter factory
 packages/uploads    @buildinternet/uploads — CLI + client for GitHub image embeds

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -79,11 +79,11 @@ export function workspaceNameFromToken(token: string): string | undefined {
  * without a workspace segment (the remote MCP worker's `/mcp`).
  */
 function workspaceAuthWith(
-  nameOf: (c: Parameters<MiddlewareHandler<WorkspaceVars>>[0]) => string | undefined,
+  nameOf: (c: Parameters<MiddlewareHandler<WorkspaceVars>>[0], token: string) => string | undefined,
 ): MiddlewareHandler<WorkspaceVars> {
   return async (c, next) => {
-    const name = nameOf(c);
     const token = bearerToken(c.req.header("Authorization"));
+    const name = nameOf(c, token);
 
     const record =
       name && WS_NAME_RE.test(name)
@@ -102,8 +102,15 @@ function workspaceAuthWith(
       if (crypto.subtle.timingSafeEqual(providedBytes, hexToBytes(hash))) matched = true;
     }
     const legacyOk = record !== null && token.length > 0 && candidates.length > 0 && matched;
-    const d1Token = record && name && token ? await findActiveToken(c.env.DB, name, token) : null;
-    const ok = legacyOk || d1Token !== null;
+    // Always pay the D1 round-trip, with dummy inputs when the workspace is
+    // unknown or the token empty, so response latency doesn't reveal whether
+    // a workspace name exists (uniform-401 guarantee above).
+    const d1Token = await findActiveToken(
+      c.env.DB,
+      record && name ? name : "__unknown__",
+      token || "__unknown__",
+    );
+    const ok = legacyOk || (record !== null && d1Token !== null);
 
     if (!ok || !record || !name) return c.json({ error: "unauthorized" }, 401);
 
@@ -119,9 +126,7 @@ function workspaceAuthWith(
 export const workspaceAuth = workspaceAuthWith((c) => c.req.param("workspace"));
 
 /** Resolves the workspace from the bearer token itself (`up_<name>_…`). */
-export const tokenWorkspaceAuth = workspaceAuthWith((c) =>
-  workspaceNameFromToken(bearerToken(c.req.header("Authorization"))),
-);
+export const tokenWorkspaceAuth = workspaceAuthWith((_c, token) => workspaceNameFromToken(token));
 
 export function requireScope(scope: FileScope): MiddlewareHandler<WorkspaceVars> {
   return async (c, next) => {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -60,45 +60,68 @@ export function workspaceTokenHashes(record: WorkspaceRecord): string[] {
   return record.tokens?.map((t) => t.hash) ?? (record.tokenHash ? [record.tokenHash] : []);
 }
 
+function bearerToken(header: string | undefined): string {
+  return header?.startsWith("Bearer ") ? header.slice(7) : "";
+}
+
+/** Workspace name encoded in a bearer token (`up_<name>_…`), if well-formed. */
+export function workspaceNameFromToken(token: string): string | undefined {
+  const match = /^up_([a-z0-9][a-z0-9-]{1,62})_./.exec(token);
+  return match?.[1];
+}
+
 /**
- * Resolves `:workspace` from the path, verifies the bearer token against the
- * workspace's stored token hash, and puts the record on the context.
- * 404 for unknown workspaces only after the token check, so probing for
- * workspace names requires no fewer requests than probing tokens.
+ * Verifies the bearer token against the named workspace's stored token
+ * hashes and puts the record on the context. 401 for unknown workspaces only
+ * after the token check, so probing for workspace names requires no fewer
+ * requests than probing tokens. `nameOf` supplies the workspace name —
+ * from the path for the REST API, or from the token itself for endpoints
+ * without a workspace segment (the remote MCP worker's `/mcp`).
  */
-export const workspaceAuth: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
-  const name = c.req.param("workspace");
-  const header = c.req.header("Authorization") ?? "";
-  const token = header.startsWith("Bearer ") ? header.slice(7) : "";
+function workspaceAuthWith(
+  nameOf: (c: Parameters<MiddlewareHandler<WorkspaceVars>>[0]) => string | undefined,
+): MiddlewareHandler<WorkspaceVars> {
+  return async (c, next) => {
+    const name = nameOf(c);
+    const token = bearerToken(c.req.header("Authorization"));
 
-  const record =
-    name && WS_NAME_RE.test(name)
-      ? await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json", cacheTtl: 60 })
-      : null;
+    const record =
+      name && WS_NAME_RE.test(name)
+        ? await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json", cacheTtl: 60 })
+        : null;
 
-  const providedHash = await sha256Hex(token);
-  const providedBytes = hexToBytes(providedHash);
-  const candidates = record ? workspaceTokenHashes(record) : [];
-  // Compare against every candidate hash (no early break) so match position isn't timing-visible.
-  // Note: total work scales with token count — acceptable for this throwaway PoC; a leaked
-  // token-count signal goes away with the real auth system.
-  const toCheck = candidates.length > 0 ? candidates : [providedHash.replace(/./g, "0")];
-  let matched = false;
-  for (const hash of toCheck) {
-    if (crypto.subtle.timingSafeEqual(providedBytes, hexToBytes(hash))) matched = true;
-  }
-  const legacyOk = record !== null && token.length > 0 && candidates.length > 0 && matched;
-  const d1Token = record && name && token ? await findActiveToken(c.env.DB, name, token) : null;
-  const ok = legacyOk || d1Token !== null;
+    const providedHash = await sha256Hex(token);
+    const providedBytes = hexToBytes(providedHash);
+    const candidates = record ? workspaceTokenHashes(record) : [];
+    // Compare against every candidate hash (no early break) so match position isn't timing-visible.
+    // Note: total work scales with token count — acceptable for this throwaway PoC; a leaked
+    // token-count signal goes away with the real auth system.
+    const toCheck = candidates.length > 0 ? candidates : [providedHash.replace(/./g, "0")];
+    let matched = false;
+    for (const hash of toCheck) {
+      if (crypto.subtle.timingSafeEqual(providedBytes, hexToBytes(hash))) matched = true;
+    }
+    const legacyOk = record !== null && token.length > 0 && candidates.length > 0 && matched;
+    const d1Token = record && name && token ? await findActiveToken(c.env.DB, name, token) : null;
+    const ok = legacyOk || d1Token !== null;
 
-  if (!ok || !record || !name) return c.json({ error: "unauthorized" }, 401);
+    if (!ok || !record || !name) return c.json({ error: "unauthorized" }, 401);
 
-  c.set("workspace", record);
-  c.set("workspaceName", name);
-  c.set("authScopes", d1Token ? parseScopes(d1Token.scopes) : [...FILE_SCOPES]);
-  c.set("authSource", d1Token ? "d1" : "legacy");
-  await next();
-};
+    c.set("workspace", record);
+    c.set("workspaceName", name);
+    c.set("authScopes", d1Token ? parseScopes(d1Token.scopes) : [...FILE_SCOPES]);
+    c.set("authSource", d1Token ? "d1" : "legacy");
+    await next();
+  };
+}
+
+/** Resolves `:workspace` from the path (the REST API's routes). */
+export const workspaceAuth = workspaceAuthWith((c) => c.req.param("workspace"));
+
+/** Resolves the workspace from the bearer token itself (`up_<name>_…`). */
+export const tokenWorkspaceAuth = workspaceAuthWith((c) =>
+  workspaceNameFromToken(bearerToken(c.req.header("Authorization"))),
+);
 
 export function requireScope(scope: FileScope): MiddlewareHandler<WorkspaceVars> {
   return async (c, next) => {

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -19,14 +19,18 @@ are rate limited per workspace.
 ## Endpoint
 
 ```
-POST https://agents.uploads.sh/<workspace>/mcp   # alternate: mcp.uploads.sh
+POST https://agents.uploads.sh/mcp
 Authorization: Bearer up_<workspace>_…
 ```
 
-Claude Code:
+The workspace is inferred from the bearer token, so clients only need the URL
+and the token. `https://agents.uploads.sh/<workspace>/mcp` remains as a
+workspace-prefixed alternate, and `mcp.uploads.sh` as an alternate hostname.
+
+Claude Code (or run `uploads install` to do this for you):
 
 ```bash
-claude mcp add --transport http uploads https://agents.uploads.sh/<ws>/mcp \
+claude mcp add --transport http uploads https://agents.uploads.sh/mcp \
   --header "Authorization: Bearer <token>"
 ```
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,7 +1,7 @@
 # @uploads/mcp
 
 Remote MCP server for uploads.sh — a standalone Hono worker on
-`mcp.uploads.sh`, sibling to `apps/api`. It shares the API's bindings
+`agents.uploads.sh` (with `mcp.uploads.sh` as an alternate), sibling to `apps/api`. It shares the API's bindings
 (registry KV, D1, R2 buckets) and its per-workspace bearer auth, and reuses
 the CLI package's transport-agnostic MCP core (`@buildinternet/uploads/mcp`).
 
@@ -19,14 +19,14 @@ are rate limited per workspace.
 ## Endpoint
 
 ```
-POST https://mcp.uploads.sh/<workspace>/mcp
+POST https://agents.uploads.sh/<workspace>/mcp   # alternate: mcp.uploads.sh
 Authorization: Bearer up_<workspace>_…
 ```
 
 Claude Code:
 
 ```bash
-claude mcp add --transport http uploads https://mcp.uploads.sh/<ws>/mcp \
+claude mcp add --transport http uploads https://agents.uploads.sh/<ws>/mcp \
   --header "Authorization: Bearer <token>"
 ```
 
@@ -36,7 +36,5 @@ claude mcp add --transport http uploads https://mcp.uploads.sh/<ws>/mcp \
 pnpm deploy:mcp   # from the repo root
 ```
 
-The custom domain and the first deploy need one-time Cloudflare setup —
-Workers Builds currently only auto-deploys `uploads-api` and `uploads-web`.
-The bindings in `wrangler.jsonc` are shared with `uploads-api`; keep the ids
+Workers Builds also auto-deploys this worker on pushes to `main`. The bindings in `wrangler.jsonc` are shared with `uploads-api`; keep the ids
 in sync.

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -9,31 +9,41 @@
  * `createMcpServer`, shared verbatim.
  */
 import { createMcpServer } from "@buildinternet/uploads/mcp";
-import { workspaceAuth, type WorkspaceVars } from "@uploads/api/workspace";
-import { Hono } from "hono";
+import { tokenWorkspaceAuth, workspaceAuth, type WorkspaceVars } from "@uploads/api/workspace";
+import { Hono, type Context } from "hono";
 import pkg from "../package.json";
 import { createRemoteTools } from "./tools";
 
+async function handleMcp(c: Context<WorkspaceVars>): Promise<Response> {
+  const body = await c.req.text();
+  const server = createMcpServer({
+    serverInfo: { name: "uploads-mcp", version: pkg.version },
+    tools: createRemoteTools({
+      env: c.env,
+      workspace: c.get("workspace"),
+      workspaceName: c.get("workspaceName"),
+      authScopes: c.get("authScopes"),
+    }),
+  });
+  const result = await server.handleLine(body);
+  // Notifications and client responses get no JSON-RPC reply: 202, empty.
+  if (result === undefined) return c.body(null, 202);
+  return c.body(result, 200, { "Content-Type": "application/json" });
+}
+
+const methodNotAllowed = (c: Context<WorkspaceVars>) =>
+  c.json({ error: "method not allowed" }, 405);
+
 const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
+  // Primary endpoint: the workspace is inferred from the bearer token
+  // (up_<workspace>_…), so clients only need the URL and the token.
+  .post("/mcp", tokenWorkspaceAuth, handleMcp)
+  .on(["GET", "DELETE"], "/mcp", methodNotAllowed)
+  // Workspace-prefixed alternate, kept for existing clients.
   .use("/:workspace/*", workspaceAuth)
-  .post("/:workspace/mcp", async (c) => {
-    const body = await c.req.text();
-    const server = createMcpServer({
-      serverInfo: { name: "uploads-mcp", version: pkg.version },
-      tools: createRemoteTools({
-        env: c.env,
-        workspace: c.get("workspace"),
-        workspaceName: c.get("workspaceName"),
-        authScopes: c.get("authScopes"),
-      }),
-    });
-    const result = await server.handleLine(body);
-    // Notifications and client responses get no JSON-RPC reply: 202, empty.
-    if (result === undefined) return c.body(null, 202);
-    return c.body(result, 200, { "Content-Type": "application/json" });
-  })
-  .on(["GET", "DELETE"], "/:workspace/mcp", (c) => c.json({ error: "method not allowed" }, 405))
+  .post("/:workspace/mcp", handleMcp)
+  .on(["GET", "DELETE"], "/:workspace/mcp", methodNotAllowed)
   .onError((err, c) => {
     console.error(JSON.stringify({ message: err.message, stack: err.stack }));
     return c.json({ error: "internal error" }, 500);

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Remote MCP server for uploads.sh — a standalone worker on mcp.uploads.sh.
+ * Remote MCP server for uploads.sh — a standalone worker on agents.uploads.sh (alternate: mcp.uploads.sh).
  *
  * Stateless MCP Streamable HTTP: each POST carries one JSON-RPC message and
  * gets its response (or 202 for notifications) in the same HTTP exchange. No

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -321,3 +321,71 @@ describe("mcp worker", () => {
     expect(body.error.code).toBe(-32600);
   });
 });
+
+describe("token-inferred /mcp endpoint", () => {
+  it("serves tool calls at /mcp with the workspace inferred from the token", async () => {
+    const { env, bucket } = await makeEnv();
+    const result = await (async () => {
+      const response = await rpc(
+        env,
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "put",
+            arguments: { contentBase64: PNG_B64, filename: "shot.png", key: "shots/shot.png" },
+          },
+        },
+        TOKEN,
+        "/mcp",
+      );
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        result: { isError: boolean; structuredContent?: Record<string, unknown> };
+      };
+    })();
+    expect(result.result.isError).toBe(false);
+    expect(result.result.structuredContent).toMatchObject({
+      workspace: "test-ws",
+      key: "shots/shot.png",
+    });
+    expect(bucket.store.has("shots/shot.png")).toBe(true);
+  });
+
+  it("rejects /mcp with a token for an unknown workspace", async () => {
+    const { env } = await makeEnv();
+    const response = await rpc(
+      env,
+      { jsonrpc: "2.0", id: 1, method: "initialize" },
+      "up_other-ws_nope",
+      "/mcp",
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects /mcp with a malformed token (no workspace to infer)", async () => {
+    const { env } = await makeEnv();
+    for (const token of ["", "not-a-token", "up_", "up_test-ws"]) {
+      const response = await rpc(
+        env,
+        { jsonrpc: "2.0", id: 1, method: "initialize" },
+        token,
+        "/mcp",
+      );
+      expect(response.status).toBe(401);
+    }
+  });
+
+  it("rejects GET and DELETE on /mcp", async () => {
+    const { env } = await makeEnv();
+    for (const method of ["GET", "DELETE"]) {
+      const response = await app.request(
+        "/mcp",
+        { method, headers: { Authorization: `Bearer ${TOKEN}` } },
+        env,
+      );
+      expect(response.status).toBe(405);
+    }
+  });
+});

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -5,6 +5,11 @@
   "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat"],
   "routes": [
+    // Primary domain; mcp.uploads.sh is kept as a working alternate.
+    {
+      "pattern": "agents.uploads.sh",
+      "custom_domain": true,
+    },
     {
       "pattern": "mcp.uploads.sh",
       "custom_domain": true,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 - **MCP server** — shipped in both variants: a local stdio server in the CLI
   (`uploads mcp`, tools mirror the CLI commands) and a remote worker on
-  `mcp.uploads.sh` (`apps/mcp`, standalone worker, per-workspace bearer auth
+  `agents.uploads.sh` (alt `mcp.uploads.sh`) (`apps/mcp`, standalone worker, per-workspace bearer auth
   like REST, put/list/delete/health).
 - **Presigned upload URLs** (`POST /v1/sign`) via files-sdk `signedUploadUrl()`
   — needs the hybrid-mode HTTP credentials above; lets clients PUT large files

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -40,7 +40,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 
 Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
 
-For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/<workspace>/mcp` (alternate: `mcp.uploads.sh`) (put/list/delete/health, same bearer tokens as the REST API — see `apps/mcp` in the repo). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
+For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: put/list/delete/health, same bearer tokens as the REST API — see `apps/mcp` in the repo. `uploads install` registers it with Claude Code (and installs the agent skill) in one step. Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 
 ## Programmatic use
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -40,7 +40,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 
 Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
 
-For HTTP clients there's also a hosted variant at `https://mcp.uploads.sh/<workspace>/mcp` (put/list/delete/health, same bearer tokens as the REST API — see `apps/mcp` in the repo). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
+For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/<workspace>/mcp` (alternate: `mcp.uploads.sh`) (put/list/delete/health, same bearer tokens as the REST API — see `apps/mcp` in the repo). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 
 ## Programmatic use
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -21,7 +21,7 @@ pnpm uploads put ./after.png --pr 123 --comment --env-file .env
 pnpm uploads doctor --env-file .env
 ```
 
-Commands: `attach`, `put`, `comment`, `list`, `delete`, `setup`, `config`, `doctor`, `health`, `mcp`.
+Commands: `attach`, `put`, `comment`, `list`, `delete`, `setup`, `install`, `config`, `doctor`, `health`, `mcp`.
 
 `attach` is the agent-friendly default for GitHub media. It accepts one or more files,
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -23,6 +23,7 @@ import { runSetup } from "./commands/setup.js";
 import { runLogin } from "./commands/login.js";
 import { runAdmin } from "./commands/admin-enrollment.js";
 import { runMcp } from "./commands/mcp.js";
+import { runInstall } from "./commands/install.js";
 
 const ROOT_HELP = `uploads — CLI for uploads.sh (GitHub image embeds)
 
@@ -55,6 +56,7 @@ Commands:
   list                List objects
   delete <key>        Delete object
   setup               Inspect/configure advanced CLI settings
+  install             Install the agent skill + register the remote MCP server
   login               Exchange an enrollment code and configure credentials
   admin               Admin enrollment management
   config              Show path, init, or set shared config
@@ -73,7 +75,9 @@ Examples:
   uploads put ./shot.png --ref 42
   uploads doctor
 
-Agent/MCP: run \`uploads mcp\` for local stdio, or use createUploadsWorkerFileTools()
+Agent/MCP: \`uploads install\` sets up the agent skill and the hosted MCP server
+(https://agents.uploads.sh/mcp, workspace inferred from the token). Run
+\`uploads mcp\` for local stdio, or use createUploadsWorkerFileTools()
 from @buildinternet/uploads/agent on the Worker.
 `;
 
@@ -159,6 +163,8 @@ export async function runCli(argv: string[]): Promise<number> {
         return runAdmin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
       case "mcp":
         return runMcp(cmdArgs, { globals: parsed.globals }, showHelp);
+      case "install":
+        return runInstall(cmdArgs, { globals: parsed.globals, json }, showHelp);
       case "attach":
       case "put":
       case "list":

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -1,0 +1,139 @@
+import {
+  flagBool,
+  flagString,
+  parseCommandArgs,
+  UsageError,
+  type GlobalFlags,
+} from "../cli-args.js";
+import { resolveConfig } from "../config.js";
+import { execRunner, type CommandRunner } from "../github-gh.js";
+
+export const DEFAULT_MCP_URL = "https://agents.uploads.sh/mcp";
+const SKILL_SOURCE = "buildinternet/uploads";
+const SKILL_NAME = "uploads-cli";
+
+const INSTALL_HELP = `uploads install — set up agent integrations (skill + remote MCP)
+
+Installs the uploads-cli agent skill and registers the hosted MCP server
+with Claude Code. The remote MCP endpoint infers your workspace from the
+bearer token, so only the token is needed.
+
+Usage:
+  uploads install [skill|mcp|all]     (default: all)
+
+What runs:
+  skill   npx -y skills add ${SKILL_SOURCE} --skill ${SKILL_NAME}
+  mcp     claude mcp add --transport http uploads ${DEFAULT_MCP_URL} \\
+            --header "Authorization: Bearer <token>"
+
+Options:
+  --url <endpoint>    Remote MCP endpoint (default: ${DEFAULT_MCP_URL})
+  --name <name>       MCP server name in the client (default: uploads)
+  --dry-run           Print the commands without running them
+
+Examples:
+  uploads install
+  uploads install skill
+  uploads install mcp --dry-run
+`;
+
+interface StepResult {
+  command: string[];
+  ok: boolean;
+  skipped?: string;
+  error?: string;
+  output?: string;
+}
+
+function runStep(run: CommandRunner, command: string[]): StepResult {
+  try {
+    const output = run(command[0], command.slice(1)).trim();
+    return { command, ok: true, output: output || undefined };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // execFileSync's ENOENT means the binary itself is missing.
+    const hint =
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+        ? `${command[0]} not found on PATH — run manually: ${command.join(" ")}`
+        : message;
+    return { command, ok: false, error: hint };
+  }
+}
+
+export async function runInstall(
+  args: string[],
+  opts: { globals: GlobalFlags; json?: boolean; runner?: CommandRunner },
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(INSTALL_HELP);
+    return 0;
+  }
+
+  const target = parsed.positionals[0] ?? "all";
+  if (!["skill", "mcp", "all"].includes(target)) {
+    throw new UsageError(`unknown install target: ${target} (expected skill, mcp, or all)`);
+  }
+  const url = flagString(parsed.flags, "--url") ?? DEFAULT_MCP_URL;
+  const name = flagString(parsed.flags, "--name") ?? "uploads";
+  const dryRun = flagBool(parsed.flags, "--dry-run");
+  const run = opts.runner ?? execRunner;
+
+  const results: Record<string, StepResult> = {};
+
+  if (target === "skill" || target === "all") {
+    const command = ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", SKILL_NAME];
+    results.skill = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
+  }
+
+  if (target === "mcp" || target === "all") {
+    const config = resolveConfig({
+      apiUrl: opts.globals.apiUrl,
+      workspace: opts.globals.workspace,
+      token: opts.globals.token,
+      envFile: opts.globals.envFile,
+      requireToken: !dryRun,
+    });
+    const bearer = config.token || "<token>";
+    const command = [
+      "claude",
+      "mcp",
+      "add",
+      "--transport",
+      "http",
+      name,
+      url,
+      "--header",
+      `Authorization: Bearer ${bearer}`,
+    ];
+    results.mcp = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
+  }
+
+  const failed = Object.values(results).some((r) => !r.ok);
+
+  if (opts.json) {
+    // Never echo the token in structured output.
+    const redacted = Object.fromEntries(
+      Object.entries(results).map(([key, r]) => [
+        key,
+        { ...r, command: r.command.map((part) => part.replace(/Bearer up_\S+/, "Bearer ***")) },
+      ]),
+    );
+    process.stdout.write(JSON.stringify({ ok: !failed, steps: redacted }, null, 2) + "\n");
+    return failed ? 1 : 0;
+  }
+
+  for (const [step, r] of Object.entries(results)) {
+    const shown = r.command.map((part) => part.replace(/Bearer up_\S+/, "Bearer ***")).join(" ");
+    if (r.skipped) process.stdout.write(`${step}: would run — ${shown}\n`);
+    else if (r.ok) {
+      process.stdout.write(`${step}: ok — ${shown}\n`);
+      if (r.output) process.stdout.write(`  ${r.output.split("\n").join("\n  ")}\n`);
+    } else process.stderr.write(`${step}: failed — ${r.error}\n`);
+  }
+  if (!failed && !dryRun) {
+    process.stderr.write("hint: restart your agent session to pick up the new skill/server\n");
+  }
+  return failed ? 1 : 0;
+}

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -45,6 +45,19 @@ interface StepResult {
   output?: string;
 }
 
+/**
+ * Masks the configured token (and any Bearer credential) in text destined
+ * for stdout/stderr/JSON — command echoes, child-process output, and error
+ * messages can all embed it.
+ */
+function redactor(token: string | undefined): (text: string) => string {
+  return (text) => {
+    let out = text.replace(/Bearer \S+/g, "Bearer ***");
+    if (token) out = out.split(token).join("***");
+    return out;
+  };
+}
+
 function runStep(run: CommandRunner, command: string[]): StepResult {
   try {
     const output = run(command[0], command.slice(1)).trim();
@@ -81,6 +94,7 @@ export async function runInstall(
   const run = opts.runner ?? execRunner;
 
   const results: Record<string, StepResult> = {};
+  let redact = redactor(undefined);
 
   if (target === "skill" || target === "all") {
     const command = ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", SKILL_NAME];
@@ -96,6 +110,7 @@ export async function runInstall(
       requireToken: !dryRun,
     });
     const bearer = config.token || "<token>";
+    redact = redactor(config.token || undefined);
     const command = [
       "claude",
       "mcp",
@@ -113,11 +128,17 @@ export async function runInstall(
   const failed = Object.values(results).some((r) => !r.ok);
 
   if (opts.json) {
-    // Never echo the token in structured output.
+    // Never echo the token in structured output — commands, child output,
+    // and error text can all embed it.
     const redacted = Object.fromEntries(
       Object.entries(results).map(([key, r]) => [
         key,
-        { ...r, command: r.command.map((part) => part.replace(/Bearer up_\S+/, "Bearer ***")) },
+        {
+          ...r,
+          command: r.command.map(redact),
+          output: r.output === undefined ? undefined : redact(r.output),
+          error: r.error === undefined ? undefined : redact(r.error),
+        },
       ]),
     );
     process.stdout.write(JSON.stringify({ ok: !failed, steps: redacted }, null, 2) + "\n");
@@ -125,12 +146,12 @@ export async function runInstall(
   }
 
   for (const [step, r] of Object.entries(results)) {
-    const shown = r.command.map((part) => part.replace(/Bearer up_\S+/, "Bearer ***")).join(" ");
+    const shown = redact(r.command.join(" "));
     if (r.skipped) process.stdout.write(`${step}: would run — ${shown}\n`);
     else if (r.ok) {
       process.stdout.write(`${step}: ok — ${shown}\n`);
-      if (r.output) process.stdout.write(`  ${r.output.split("\n").join("\n  ")}\n`);
-    } else process.stderr.write(`${step}: failed — ${r.error}\n`);
+      if (r.output) process.stdout.write(`  ${redact(r.output).split("\n").join("\n  ")}\n`);
+    } else process.stderr.write(`${step}: failed — ${redact(r.error ?? "")}\n`);
   }
   if (!failed && !dryRun) {
     process.stderr.write("hint: restart your agent session to pick up the new skill/server\n");

--- a/packages/uploads/test/install.test.ts
+++ b/packages/uploads/test/install.test.ts
@@ -96,14 +96,24 @@ describe("uploads install", () => {
     ).rejects.toThrow(/UPLOADS_TOKEN|token/i);
   });
 
-  it("reports a missing binary with a manual-command hint and exits 1", async () => {
+  it("reports a missing binary with a manual-command hint, redacted, and exits 1", async () => {
     const enoent: CommandRunner = () => {
       const err = new Error("spawn claude ENOENT") as NodeJS.ErrnoException;
       err.code = "ENOENT";
       throw err;
     };
+    const errChunks: string[] = [];
+    vi.mocked(process.stderr.write).mockImplementation((chunk) => {
+      errChunks.push(String(chunk));
+      return true;
+    });
     const code = await runInstall(["mcp"], { globals: GLOBALS, runner: enoent });
     expect(code).toBe(1);
+    const printed = errChunks.join("");
+    // The manual-command hint embeds the full command — token must be masked.
+    expect(printed).toContain("claude not found on PATH");
+    expect(printed).not.toContain("up_acme_secret");
+    expect(printed).toContain("Bearer ***");
   });
 
   it("rejects unknown targets", async () => {

--- a/packages/uploads/test/install.test.ts
+++ b/packages/uploads/test/install.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandRunner } from "../src/github-gh.js";
+import { runInstall, DEFAULT_MCP_URL } from "../src/commands/install.js";
+
+function fakeRunner() {
+  const calls: string[][] = [];
+  const run: CommandRunner = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    return "installed\n";
+  };
+  return { run, calls };
+}
+
+function captureStdout() {
+  const chunks: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  return chunks;
+}
+
+const GLOBALS = { apiUrl: "https://x.test", token: "up_acme_secret" };
+
+beforeEach(() => {
+  vi.stubEnv("BUILDINTERNET_CONFIG", "/nonexistent/uploads-install-test-config");
+  vi.stubEnv("UPLOADS_TOKEN", "");
+  vi.stubEnv("UPLOADS_WORKSPACE", "");
+  captureStdout();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("uploads install", () => {
+  it("runs both steps by default: npx skills add and claude mcp add", async () => {
+    const { run, calls } = fakeRunner();
+    const code = await runInstall([], { globals: GLOBALS, runner: run });
+    expect(code).toBe(0);
+    expect(calls).toEqual([
+      ["npx", "-y", "skills", "add", "buildinternet/uploads", "--skill", "uploads-cli"],
+      [
+        "claude",
+        "mcp",
+        "add",
+        "--transport",
+        "http",
+        "uploads",
+        DEFAULT_MCP_URL,
+        "--header",
+        "Authorization: Bearer up_acme_secret",
+      ],
+    ]);
+  });
+
+  it("install skill runs only the skills step", async () => {
+    const { run, calls } = fakeRunner();
+    expect(await runInstall(["skill"], { globals: GLOBALS, runner: run })).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe("npx");
+  });
+
+  it("install mcp honors --url and --name", async () => {
+    const { run, calls } = fakeRunner();
+    const code = await runInstall(["mcp", "--url", "https://mcp.uploads.sh/mcp", "--name", "up"], {
+      globals: GLOBALS,
+      runner: run,
+    });
+    expect(code).toBe(0);
+    expect(calls[0]).toContain("https://mcp.uploads.sh/mcp");
+    expect(calls[0]).toContain("up");
+  });
+
+  it("--dry-run runs nothing and never prints the token", async () => {
+    const { run, calls } = fakeRunner();
+    const chunks: string[] = [];
+    vi.mocked(process.stdout.write).mockImplementation((chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+    const code = await runInstall(["--dry-run"], { globals: GLOBALS, json: true, runner: run });
+    expect(code).toBe(0);
+    expect(calls).toEqual([]);
+    const printed = chunks.join("");
+    expect(printed).not.toContain("up_acme_secret");
+    expect(printed).toContain("Bearer ***");
+  });
+
+  it("install mcp without a token is a tool error, not a crash", async () => {
+    const { run } = fakeRunner();
+    await expect(
+      runInstall(["mcp"], { globals: { apiUrl: "https://x.test" }, runner: run }),
+    ).rejects.toThrow(/UPLOADS_TOKEN|token/i);
+  });
+
+  it("reports a missing binary with a manual-command hint and exits 1", async () => {
+    const enoent: CommandRunner = () => {
+      const err = new Error("spawn claude ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    };
+    const code = await runInstall(["mcp"], { globals: GLOBALS, runner: enoent });
+    expect(code).toBe(1);
+  });
+
+  it("rejects unknown targets", async () => {
+    const { run } = fakeRunner();
+    await expect(runInstall(["nope"], { globals: GLOBALS, runner: run })).rejects.toThrow(
+      /unknown install target/,
+    );
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -274,6 +274,10 @@ uploads --api-url http://localhost:8787 doctor
   Every tool also accepts a per-call `workspace` argument to override the configured
   workspace (mirrors `--workspace`).
   E.g. `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
+  There is also a hosted MCP server at `https://agents.uploads.sh/mcp` (workspace
+  inferred from the bearer token; `mcp.uploads.sh` is an alternate hostname).
+  `uploads install` sets up both this skill (via `npx skills`) and the hosted MCP
+  server in Claude Code; `uploads install --dry-run` prints the commands instead.
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing
   upload/list/delete as AI-SDK tools inside the Worker — separate from this CLI, and


### PR DESCRIPTION
## What

### Domain
- `agents.uploads.sh` is the primary custom domain for the `uploads-mcp` worker; `mcp.uploads.sh` remains a working alternate. Both are in the checked-in routes config so Workers Builds deploys keep them.

### Endpoint
- **`POST https://agents.uploads.sh/mcp` is now the primary MCP endpoint.** The workspace is inferred from the bearer token (`up_<workspace>_…`) via a new `tokenWorkspaceAuth` middleware (a factory refactor of the existing `workspaceAuth` — same verification path, different name source). The workspace-prefixed `/:workspace/mcp` stays supported.
- New worker tests: token-inferred tool calls, unknown-workspace and malformed-token 401s, GET/DELETE 405.

### CLI
- New `uploads install [skill|mcp|all]` convenience command:
  - `skill` → `npx -y skills add buildinternet/uploads --skill uploads-cli`
  - `mcp` → `claude mcp add --transport http uploads https://agents.uploads.sh/mcp --header "Authorization: Bearer <token>"` using the resolved config token
  - `--url`/`--name` overrides, `--dry-run`, `--json`; bearer tokens are redacted in all output; missing binaries produce a manual-command hint instead of a crash.

### Docs
- Worker README, package README, and the uploads-cli SKILL.md now lead with the `/mcp` endpoint and mention `uploads install`; stale Workers-Builds note removed.

## Verification

- 131 tests pass across the CLI package, api, and mcp workers.
- Deployed and verified in production: `/mcp` serves tool calls with workspace inferred from the token on both hostnames; bad/malformed tokens 401; GET 405; legacy `/default/mcp` path unaffected.
- `uploads install --dry-run` exercised end-to-end via the built CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `uploads install` to configure the uploads skill and hosted MCP server, with support for custom names, URLs, dry runs, and JSON output.
  * Added the hosted MCP endpoint at `https://agents.uploads.sh/mcp`, with workspace inferred from the bearer token.
  * Retained `mcp.uploads.sh` as an alternate hostname.

* **Bug Fixes**
  * Improved authentication handling and validation for token-based MCP access.

* **Documentation**
  * Updated CLI, MCP, roadmap, and deployment documentation with the new endpoint and installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->