### PR TITLE
feat(web): landing refresh — CLI-first demo, copy panel, favicon

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,6 +1,10 @@
 ---
-// uploads.sh — placeholder landing. One terminal, one story: what the API does.
+// uploads.sh — landing. Three beats: the two-command demo, the GitHub comment
+// it produces, and copyable setup rows for the CLI / skill / MCP server.
 const REPO = "https://github.com/buildinternet/uploads";
+// Stacked up-chevrons, fading as they rise — inline so the page stays a single request.
+const FAVICON =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23120d1e'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
 ---
 
 <html lang="en">
@@ -8,41 +12,58 @@ const REPO = "https://github.com/buildinternet/uploads";
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>uploads.sh</title>
-    <meta name="description" content="Workspace-scoped file hosting API on Cloudflare Workers." />
+    <meta
+      name="description"
+      content="File hosting for agents & humans — CLI, agent skill, and MCP server on Cloudflare Workers."
+    />
+    <link rel="icon" href={FAVICON} />
     <style>
       :root {
-        --bg: #0c0a08;
-        --screen: #14100b;
-        --bezel: #241d14;
-        --amber: #ffb454;
-        --amber-dim: #b87e3c;
-        --amber-faint: #6e4f28;
+        --bg: #0b0813;
+        --screen: #120d1e;
+        --bezel: #251a3d;
+        --fg: #e6dff5;
+        --purple: #b794ff;
+        --purple-dim: #8262c9;
+        --purple-faint: #53407e;
+        --neutral: #726d8c;
+        --cyan: #7dcfff;
         --green-ok: #9ece6a;
         --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       }
       * { box-sizing: border-box; }
-      html, body { height: 100%; }
       body {
         margin: 0;
+        min-height: 100dvh;
         background:
-          radial-gradient(120% 90% at 50% 0%, #171208 0%, var(--bg) 60%),
+          radial-gradient(120% 90% at 50% 0%, #150e24 0%, var(--bg) 60%),
           var(--bg);
-        color: var(--amber);
+        color: var(--fg);
         font: 15px/1.65 var(--mono);
         display: grid;
         place-items: center;
-        padding: 24px;
+        padding: 40px 24px 56px;
+      }
+      main {
+        width: min(680px, 100%);
+        display: grid;
+        gap: 18px;
+      }
+      .hidden { visibility: hidden; }
+      @media (prefers-reduced-motion: reduce) {
+        .hidden { visibility: visible; }
       }
 
+      /* ---------- terminal ---------- */
       .terminal {
-        width: min(720px, 100%);
         background: var(--screen);
         border: 1px solid var(--bezel);
         border-radius: 10px;
         box-shadow:
           0 0 0 1px #000,
           0 24px 80px rgba(0, 0, 0, 0.6),
-          0 0 120px rgba(255, 180, 84, 0.07);
+          0 0 120px rgba(183, 148, 255, 0.08);
         overflow: hidden;
         position: relative;
       }
@@ -61,97 +82,343 @@ const REPO = "https://github.com/buildinternet/uploads";
         );
         mix-blend-mode: overlay;
       }
-
       .titlebar {
         display: flex;
         align-items: center;
         gap: 8px;
         padding: 10px 14px;
         background: var(--bezel);
-        color: var(--amber-dim);
+        color: var(--purple-dim);
         font-size: 12px;
         letter-spacing: 0.08em;
       }
-      .titlebar .dot { width: 10px; height: 10px; border-radius: 50%; background: #3a2f20; }
+      .titlebar .dot { width: 10px; height: 10px; border-radius: 50%; background: #382a58; }
       .titlebar .label { margin-left: auto; margin-right: auto; }
-
       .screen {
         padding: 22px 22px 26px;
-        min-height: 380px;
-        text-shadow: 0 0 6px rgba(255, 180, 84, 0.28);
+        text-shadow: 0 0 6px rgba(183, 148, 255, 0.18);
       }
-
       .line { white-space: pre-wrap; word-break: break-word; margin: 0; }
-      .line.hidden { visibility: hidden; }
-      .prompt { color: var(--amber-dim); user-select: none; }
-      .cmd { color: var(--amber); }
-      .out { color: var(--amber-dim); }
-      .out .k { color: var(--amber-faint); }
-      .out .v { color: var(--amber); }
+      .prompt { color: var(--purple); user-select: none; }
+      .cmd { color: var(--fg); }
+      .out { color: var(--neutral); }
+      .out .v { color: var(--cyan); }
       .ok { color: var(--green-ok); }
-      .comment { color: var(--amber-faint); font-style: italic; }
       .gap { height: 0.9em; }
-
-      a {
-        color: var(--amber);
-        text-decoration: underline;
-        text-decoration-color: var(--amber-faint);
-        text-underline-offset: 3px;
-      }
-      a:hover, a:focus-visible { background: rgba(255, 180, 84, 0.12); outline: none; }
-
       .cursor {
         display: inline-block;
         width: 0.6em;
         height: 1.1em;
-        background: var(--amber);
+        background: var(--purple);
         vertical-align: text-bottom;
         animation: blink 1.1s steps(1) infinite;
       }
       @keyframes blink { 50% { opacity: 0; } }
       @media (prefers-reduced-motion: reduce) {
         .cursor { animation: none; }
-        .line.hidden { visibility: visible; }
+      }
+
+      /* ---------- connector ---------- */
+      .flow-note {
+        font-size: 12px;
+        color: var(--neutral);
+        padding-left: 22px;
+        margin: -6px 0;
+      }
+      .flow-note .arrow { color: var(--purple); }
+
+      /* ---------- wireframe github comment ---------- */
+      .ghc {
+        display: grid;
+        grid-template-columns: 40px 1fr;
+        gap: 12px;
+        font: 13px/1.5 var(--sans);
+      }
+      .ghc .avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: #21262e;
+        border: 1px solid #30363d;
+      }
+      .ghc .bubble {
+        background: #161b22;
+        border: 1px solid #30363d;
+        border-radius: 8px;
+        overflow: hidden;
+        position: relative;
+      }
+      .ghc .bubble::before {
+        content: "";
+        position: absolute;
+        left: -6px;
+        top: 14px;
+        width: 10px;
+        height: 10px;
+        background: #1c2129;
+        border-left: 1px solid #30363d;
+        border-bottom: 1px solid #30363d;
+        transform: rotate(45deg);
+      }
+      .ghc .head {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        background: #1c2129;
+        border-bottom: 1px solid #30363d;
+        padding: 8px 14px;
+        color: #8b949e;
+      }
+      .ghc .head .user { color: #e6edf3; font-weight: 600; }
+      .ghc .head .badge {
+        font: 11px var(--mono);
+        color: #8b949e;
+        border: 1px solid #30363d;
+        border-radius: 999px;
+        padding: 1px 8px;
+        margin-left: auto;
+      }
+      .ghc .body { padding: 14px; }
+      .ghc .md-title { color: #e6edf3; font-weight: 600; margin: 0 0 10px; }
+      .ghc .imgs {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+        margin-bottom: 12px;
+      }
+      .ghc figure { margin: 0; }
+      .ghc .ph {
+        aspect-ratio: 16 / 10;
+        border: 1.5px dashed #444c56;
+        border-radius: 6px;
+        background: linear-gradient(135deg, rgba(139, 148, 158, 0.06) 0%, rgba(139, 148, 158, 0.02) 100%);
+        display: grid;
+        place-items: center;
+        color: #545d68;
+      }
+      .ghc .ph svg { width: 42px; height: 42px; }
+      .ghc figcaption {
+        font: 11px var(--mono);
+        color: #8b949e;
+        margin-top: 6px;
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+      }
+      .ghc figcaption .host { color: #58a6ff; }
+      .skel { height: 8px; border-radius: 4px; background: #2d333b; margin: 8px 0; }
+      .skel.w70 { width: 70%; }
+      .skel.w45 { width: 45%; }
+      @media (max-width: 560px) {
+        .ghc .imgs { grid-template-columns: 1fr; }
+      }
+
+      /* ---------- install panel ---------- */
+      .install { font-size: 13px; margin-top: 6px; }
+      .install .head {
+        color: var(--purple-dim);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin: 0 0 10px 2px;
+      }
+      .install .rows { display: grid; gap: 8px; }
+      .cmdrow {
+        display: grid;
+        grid-template-columns: 74px 1fr auto;
+        align-items: center;
+        gap: 12px;
+        background: var(--screen);
+        border: 1px solid var(--bezel);
+        border-radius: 8px;
+        padding: 10px 12px;
+      }
+      .cmdrow .tag {
+        color: var(--purple-dim);
+        font-size: 10.5px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      .cmdrow .cmdtext {
+        color: var(--fg);
+        overflow-x: auto;
+        white-space: nowrap;
+        scrollbar-width: none;
+      }
+      .cmdrow .cmdtext::before { content: "$ "; color: var(--purple); }
+      .cmdrow .cmdtext .url { color: var(--cyan); }
+      .cmdrow button {
+        font: 11px var(--mono);
+        letter-spacing: 0.06em;
+        color: var(--purple);
+        background: rgba(183, 148, 255, 0.08);
+        border: 1px solid #38295c;
+        border-radius: 6px;
+        padding: 5px 10px;
+        cursor: pointer;
+      }
+      .cmdrow button:hover,
+      .cmdrow button:focus-visible {
+        background: rgba(183, 148, 255, 0.18);
+        outline: none;
+        border-color: var(--purple-faint);
+      }
+      .cmdrow button.done { color: var(--green-ok); border-color: #3c4a2e; }
+      .install .foot { color: var(--neutral); margin: 10px 2px 0; font-size: 12px; }
+      .install .foot a { color: var(--cyan); }
+      a {
+        color: var(--cyan);
+        text-decoration: underline;
+        text-decoration-color: var(--purple-faint);
+        text-underline-offset: 3px;
+      }
+      a:hover,
+      a:focus-visible { background: rgba(125, 207, 255, 0.12); outline: none; }
+      @media (max-width: 560px) {
+        .cmdrow { grid-template-columns: 1fr auto; }
+        .cmdrow .tag { grid-column: 1 / -1; }
       }
     </style>
   </head>
   <body>
-    <main class="terminal" aria-label="uploads.sh terminal">
-      <div class="titlebar" aria-hidden="true">
-        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-        <span class="label">uploads.sh — bash</span>
-      </div>
-      <div class="screen" id="screen">
-        <p class="line"><span class="prompt">$</span> <span class="cmd">whatis uploads.sh</span></p>
-        <p class="line out hidden">uploads.sh (1)      - workspace-scoped file hosting for agents &amp; humans</p>
-        <div class="gap"></div>
-        <p class="line hidden"><span class="prompt">$</span> <span class="cmd">curl -X PUT https://api.uploads.sh/v1/default/files/shot.png \</span></p>
-        <p class="line hidden"><span class="cmd">    -H "Authorization: Bearer $UPLOADS_TOKEN" --data-binary @shot.png</span></p>
-        <p class="line out hidden">&#123; <span class="k">"workspace"</span>: <span class="v">"default"</span>, <span class="k">"url"</span>: <span class="v">"https://storage.uploads.sh/f/x7q2/shot.png"</span> &#125;</p>
-        <div class="gap"></div>
-        <p class="line hidden"><span class="prompt">$</span> <span class="cmd">systemctl status uploads-api</span></p>
-        <p class="line out hidden"><span class="ok">●</span> active (running) since 2026-07-06; cloudflare workers · r2 · files-sdk</p>
-        <p class="line out hidden">  public access: <span class="ok">by invitation</span> (internal tooling, for now)</p>
-        <div class="gap"></div>
-        <p class="line hidden"><span class="prompt">$</span> <span class="cmd">cat /etc/motd</span></p>
-        <p class="line out hidden">source &amp; roadmap → <a href={REPO}>github.com/buildinternet/uploads</a></p>
-        <div class="gap"></div>
-        <p class="line hidden" id="last"><span class="prompt">$</span> <span class="cursor" aria-hidden="true"></span></p>
-      </div>
+    <main>
+      <section class="terminal" aria-label="uploads.sh terminal">
+        <div class="titlebar" aria-hidden="true">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="label">uploads.sh — bash</span>
+        </div>
+        <div class="screen">
+          <p class="line"><span class="prompt">$</span> <span class="cmd">whatis uploads.sh</span></p>
+          <p class="line out hidden">uploads.sh (1)      - file hosting for agents &amp; humans</p>
+          <div class="gap"></div>
+          <p class="line hidden"><span class="prompt">$</span> <span class="cmd">uploads attach ./before.png ./after.png</span></p>
+          <p class="line out hidden"><span class="ok">✓</span> uploaded 2 files → <span class="v">https://storage.uploads.sh/…</span></p>
+          <p class="line out hidden"><span class="ok">✓</span> attachments comment updated on PR #123</p>
+          <div class="gap"></div>
+          <p class="line hidden"><span class="prompt">$</span> <span class="cursor" aria-hidden="true"></span></p>
+        </div>
+      </section>
+
+      <p class="flow-note hidden"><span class="arrow">└─▶</span> which lands on your pull request as:</p>
+
+      <section
+        class="ghc hidden"
+        role="img"
+        aria-label="Wireframe of the managed GitHub attachments comment with two inline images"
+      >
+        <div class="avatar"></div>
+        <div class="bubble">
+          <div class="head">
+            <span class="user">you</span>
+            <span>commented just now</span>
+            <span class="badge">managed by uploads</span>
+          </div>
+          <div class="body">
+            <p class="md-title">Attachments</p>
+            <div class="imgs">
+              <figure>
+                <div class="ph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4">
+                    <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+                    <circle cx="9" cy="10" r="1.8"></circle>
+                    <path d="M3 17 L9.5 12.5 L13.5 15.5 L17 13 L21 16"></path>
+                  </svg>
+                </div>
+                <figcaption><span>before.png</span><span class="host">storage.uploads.sh</span></figcaption>
+              </figure>
+              <figure>
+                <div class="ph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4">
+                    <rect x="3" y="4" width="18" height="16" rx="2"></rect>
+                    <circle cx="9" cy="10" r="1.8"></circle>
+                    <path d="M3 17 L9.5 12.5 L13.5 15.5 L17 13 L21 16"></path>
+                  </svg>
+                </div>
+                <figcaption><span>after.png</span><span class="host">storage.uploads.sh</span></figcaption>
+              </figure>
+            </div>
+            <div class="skel w70"></div>
+            <div class="skel w45"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="install hidden" aria-label="Install commands">
+        <p class="head"># get set up — click to copy</p>
+        <div class="rows">
+          <div class="cmdrow">
+            <span class="tag">cli</span>
+            <span class="cmdtext">npm install -g @buildinternet/uploads &amp;&amp; uploads login</span>
+            <button type="button" data-copy="npm install -g @buildinternet/uploads && uploads login">copy</button>
+          </div>
+          <div class="cmdrow">
+            <span class="tag">agents</span>
+            <span class="cmdtext">uploads install</span>
+            <button type="button" data-copy="uploads install">copy</button>
+          </div>
+          <div class="cmdrow">
+            <span class="tag">skill</span>
+            <span class="cmdtext">npx skills add buildinternet/uploads --skill uploads-cli</span>
+            <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli">copy</button>
+          </div>
+          <div class="cmdrow">
+            <span class="tag">mcp</span>
+            <span class="cmdtext">claude mcp add --transport http uploads <span class="url">https://agents.uploads.sh/mcp</span></span>
+            <button type="button" data-copy="claude mcp add --transport http uploads https://agents.uploads.sh/mcp">copy</button>
+          </div>
+        </div>
+        <p class="foot">
+          access by invitation · `uploads install` covers the skill + mcp rows ·
+          <a href={REPO}>source &amp; roadmap</a>
+        </p>
+      </section>
     </main>
+
     <script>
-      // Reveal lines like a session replaying; no typing per-char to keep it calm.
+      // Reveal like a session replaying; no per-char typing to keep it calm.
       const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      const lines = document.querySelectorAll(".line.hidden");
+      const hidden = document.querySelectorAll(".hidden");
       if (!reduced) {
         let t = 350;
-        for (const el of lines) {
-          const isCmd = el.querySelector(".cmd") !== null;
+        for (const el of hidden) {
+          const isCmd = el.matches(".line") && el.querySelector(".cmd") !== null;
+          const isBlock = !el.matches(".line");
           setTimeout(() => el.classList.remove("hidden"), t);
-          t += isCmd ? 620 : 240;
+          t += isBlock ? 420 : isCmd ? 620 : 240;
         }
       } else {
-        lines.forEach((el) => el.classList.remove("hidden"));
+        hidden.forEach((el) => el.classList.remove("hidden"));
+      }
+
+      for (const btn of document.querySelectorAll(".cmdrow button")) {
+        btn.addEventListener("click", async () => {
+          const text = btn.getAttribute("data-copy") ?? "";
+          let ok = false;
+          try {
+            await navigator.clipboard.writeText(text);
+            ok = true;
+          } catch {
+            const ta = document.createElement("textarea");
+            ta.value = text;
+            ta.style.position = "fixed";
+            ta.style.opacity = "0";
+            document.body.appendChild(ta);
+            ta.select();
+            try {
+              ok = document.execCommand("copy");
+            } catch {
+              ok = false;
+            }
+            ta.remove();
+          }
+          btn.textContent = ok ? "copied ✓" : "copy failed";
+          btn.classList.toggle("done", ok);
+          setTimeout(() => {
+            btn.textContent = "copy";
+            btn.classList.remove("done");
+          }, 1500);
+        });
       }
     </script>
   </body>


### PR DESCRIPTION
Refreshes the `apps/web` landing page to match what uploads.sh actually ships today, replacing the amber curl-focused placeholder.

## What changed

- **Two-command demo.** The terminal session is cut down to `whatis uploads.sh` and `uploads attach ./before.png ./after.png` — the systemctl/motd/curl blocks are gone. The point is that using this is dead simple.
- **Wireframe GitHub comment.** Between the terminal and the setup rows, a GitHub-styled comment mock (avatar, "managed by uploads" badge, two dashed image placeholders captioned `before.png` / `after.png` @ storage.uploads.sh) shows exactly what `attach` produces on a PR. Pure CSS/inline SVG, joins the same staggered reveal.
- **Click-to-copy setup panel.** Four rows: CLI install + login, `uploads install` (one-shot skill + MCP registration), `npx skills add buildinternet/uploads --skill uploads-cli`, and `claude mcp add --transport http uploads https://agents.uploads.sh/mcp` (short form — `uploads login` has already saved the token). Footnote carries the by-invitation note and repo link.
- **Royal purple phosphor with hierarchy.** Purple is the accent (prompt, cursor, buttons), commands are near-white, URLs cyan, success green, and the GitHub mock keeps GitHub's own dark neutrals so it reads as a separate surface.
- **Favicon.** Inline SVG data URI: three stacked up-chevrons, each layer progressively lower opacity as they rise. Meta description updated to mention the CLI and MCP server.

## Verified

- `pnpm check` and `astro check` pass.
- Rendered via `pnpm dev:web`: reveal animation, reduced-motion fallback, and the copy buttons (real-click test shows "copied ✓" then resets; `execCommand` fallback covers clipboard-API failures).

## Screenshot

![New uploads.sh landing page](https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/21/landing-refresh.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
