### PR TITLE
feat(api): workspace usage ledger (observe-first)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,10 @@ R2_PUBLIC_BASE_URL=
 #
 # Wrangler reads these two natively; `pnpm deploy` loads this file first, so
 # no `wrangler login` is required. Create the token from the "Edit Cloudflare
-# Workers" template and add Workers KV Storage:Edit + Workers R2 Storage:Edit.
-# (Interactive alternative: skip these and run `wrangler login` once.)
+# Workers" template and add Workers KV Storage:Edit + Workers R2 Storage:Edit
+# + D1:Edit (needed for `d1 migrations apply` in deploy and the D1 Migrations
+# GitHub Action). Interactive alternative: skip these and `wrangler login` once.
+# Mirror the same two names as repo secrets for CI.
 CLOUDFLARE_ACCOUNT_ID=
 CLOUDFLARE_API_TOKEN=
 

--- a/.github/workflows/d1-migrations.yml
+++ b/.github/workflows/d1-migrations.yml
@@ -1,0 +1,58 @@
+# Apply pending D1 migrations to production on merge to main.
+#
+# Prior art: releases (deploy-workers applies migrations before deploy) and
+# room-configurator (deploy scripts run `d1 migrations apply` first).
+# Uploads ships API code via Workers Builds; this workflow is the explicit
+# CI guarantee that schema lands when migration files merge. Replay-safe:
+# wrangler skips rows already recorded in d1_migrations.
+#
+# Secrets (same as headless deploy): CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID.
+# Token needs D1 edit in addition to Workers (Edit Cloudflare Workers template
+# alone is not always enough — add D1 write if apply fails with auth errors).
+
+name: D1 Migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/migrations/**"
+      - "apps/api/wrangler.jsonc"
+      - ".github/workflows/d1-migrations.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: d1-migrations-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    name: Apply D1 migrations (production)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      # Workspace install so apps/api resolves its wrangler devDependency.
+      - run: pnpm install --frozen-lockfile
+
+      # Binding name `DB` (see apps/api/wrangler.jsonc). Non-interactive CI skips
+      # the confirmation prompt; already-applied migrations are no-ops.
+      - name: Apply D1 migrations
+        working-directory: apps/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 migrations apply DB --remote

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 .DS_Store
 worker-configuration.d.ts
 .impeccable/
+# Local agent notes, private plans, pricing scratch (not for the public repo)
+.context/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,11 @@ pnpm uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub 
 ```
 
 Use `pnpm run deploy` (not bare `pnpm deploy` — that's pnpm's built-in).
-Production deploys normally happen via Workers Builds on push to main.
+`deploy:api` applies pending D1 migrations (`migrate:d1`) before
+`wrangler deploy`. On merge to main, `.github/workflows/d1-migrations.yml`
+also applies remote migrations when `apps/api/migrations/**` changes
+(secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`). Production
+worker deploys normally happen via Workers Builds on push to main.
 
 Run `wrangler types` (or `pnpm --filter @uploads/api types`) after any
 `wrangler.jsonc` change — `Env` is generated into `worker-configuration.d.ts`,

--- a/apps/api/migrations/20260710140000_workspace_usage.sql
+++ b/apps/api/migrations/20260710140000_workspace_usage.sql
@@ -1,0 +1,13 @@
+-- Per-workspace storage ledger (observe first; enforce budgets later).
+-- Primary unit is the workspace/tenant — not the API token.
+-- bytes/objects are net stored size under the workspace prefix;
+-- uploads_in_period is a monthly upload counter (UTC calendar month).
+
+CREATE TABLE workspace_usage (
+  workspace TEXT PRIMARY KEY,
+  bytes INTEGER NOT NULL DEFAULT 0,
+  objects INTEGER NOT NULL DEFAULT 0,
+  uploads_in_period INTEGER NOT NULL DEFAULT 0,
+  period_start TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
+    "migrate:d1": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js d1 migrations apply DB --remote",
+    "deploy": "pnpm run migrate:d1 && node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
     "types": "wrangler types",
     "workspace:add": "node --env-file-if-exists=../../.env scripts/add-workspace.mjs",
     "typecheck": "wrangler types && tsc --noEmit",

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -4,8 +4,10 @@
  * storage I/O, and result shapes. Validation failures throw FileOpError;
  * each surface maps it (HTTP 400 / MCP tool error).
  */
+import type { Files } from "@uploads/storage";
 import { inspectUpload, resolveUploadPolicy } from "./guards";
 import { publicUrl, storage, storageConfig } from "./storage";
+import { recordUsageSafe } from "./usage";
 import type { WorkspaceRecord } from "./workspace";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
@@ -42,16 +44,30 @@ export class FileOpError extends Error {
   }
 }
 
+/** Size of an existing object, or `null` if missing / unreadable (metering may drift). */
+async function existingSize(store: Files, key: string): Promise<number | null> {
+  try {
+    const meta = await store.head(key);
+    return meta.size ?? 0;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Upload with the workspace's guardrails applied: size cap and content-type
  * allowlist, the stored content type sniffed from the bytes rather than taken
  * from the caller — see guards.ts.
+ *
+ * After a successful write, updates the workspace usage ledger (overwrite-aware).
+ * Metering is best-effort and never fails the upload.
  */
 export async function putObject(
   env: Env,
   ws: WorkspaceRecord,
   key: string,
   bytes: Uint8Array,
+  workspaceName: string,
 ): Promise<{ key: string; url: string | null; size: number; contentType: string }> {
   if (badKey(key)) throw new FileOpError("invalid key");
   if (bytes.byteLength === 0) throw new FileOpError("empty body");
@@ -62,14 +78,25 @@ export async function putObject(
     throw new FileOpError(error, inspection.status, extra);
   }
 
-  await storage(env, ws).upload(key, bytes, {
+  const store = storage(env, ws);
+  const prev = await existingSize(store, key);
+  const newSize = bytes.byteLength;
+
+  await store.upload(key, bytes, {
     contentType: inspection.contentType,
     cacheControl: UPLOAD_CACHE_CONTROL,
   });
+
+  await recordUsageSafe(env.DB, workspaceName, {
+    bytes: prev === null ? newSize : newSize - prev,
+    objects: prev === null ? 1 : 0,
+    uploads: 1,
+  });
+
   return {
     key,
     url: publicUrl(storageConfig(env, ws), key),
-    size: bytes.byteLength,
+    size: newSize,
     contentType: inspection.contentType,
   };
 }
@@ -91,12 +118,27 @@ export async function listObjects(
   };
 }
 
+/** Delete an object and decrement the workspace ledger when size was known. */
 export async function deleteObject(
   env: Env,
   ws: WorkspaceRecord,
   key: string,
+  workspaceName: string,
 ): Promise<{ key: string; deleted: true }> {
   if (badKey(key)) throw new FileOpError("invalid key");
-  await storage(env, ws).delete(key);
+
+  const store = storage(env, ws);
+  const prev = await existingSize(store, key);
+
+  await store.delete(key);
+
+  if (prev !== null) {
+    await recordUsageSafe(env.DB, workspaceName, {
+      bytes: -prev,
+      objects: -1,
+      uploads: 0,
+    });
+  }
+
   return { key, deleted: true };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
+import { usage } from "./routes/usage";
 import { admin } from "./routes/admin";
 import { auth } from "./routes/auth";
 
@@ -10,6 +11,7 @@ const app = new Hono<WorkspaceVars>()
   .route("/auth", auth)
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/files", files)
+  .route("/v1/:workspace/usage", usage)
   .onError((err, c) => {
     console.error(JSON.stringify({ message: err.message, stack: err.stack }));
     return c.json({ error: "internal error" }, 500);

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -26,7 +26,13 @@ export const files = new Hono<WorkspaceVars>()
 
     const body = await c.req.arrayBuffer();
     try {
-      const result = await putObject(c.env, c.get("workspace"), key, new Uint8Array(body));
+      const result = await putObject(
+        c.env,
+        c.get("workspace"),
+        key,
+        new Uint8Array(body),
+        c.get("workspaceName"),
+      );
       return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
     } catch (err) {
       return mapFileOpError(c, err);
@@ -54,7 +60,9 @@ export const files = new Hono<WorkspaceVars>()
   // Delete
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {
     try {
-      return c.json(await deleteObject(c.env, c.get("workspace"), c.req.param("key")));
+      return c.json(
+        await deleteObject(c.env, c.get("workspace"), c.req.param("key"), c.get("workspaceName")),
+      );
     } catch (err) {
       return mapFileOpError(c, err);
     }

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -1,0 +1,8 @@
+import { Hono } from "hono";
+import { getWorkspaceUsage } from "../usage";
+import { requireScope, type WorkspaceVars } from "../workspace";
+
+/** Read-only workspace usage snapshot. Auth + `files:read`. */
+export const usage = new Hono<WorkspaceVars>().get("/", requireScope("files:read"), async (c) =>
+  c.json(await getWorkspaceUsage(c.env.DB, c.get("workspaceName"))),
+);

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -1,0 +1,147 @@
+/**
+ * Workspace usage ledger — durable D1 counters for multi-tenant quotas.
+ *
+ * files-sdk's in-memory `usage()` plugin does not survive across Worker
+ * requests and does not track net stored size after deletes. This ledger is
+ * keyed by workspace (not API token): multiple tokens share one prefix.
+ *
+ * Observe-first: record failures never fail the storage op. Enforce budgets later.
+ */
+
+export interface WorkspaceUsage {
+  workspace: string;
+  /** Net stored bytes under the workspace (after overwrites/deletes). */
+  bytes: number;
+  /** Net object count under the workspace. */
+  objects: number;
+  /** Successful puts in the current UTC calendar month. */
+  uploadsInPeriod: number;
+  /** Period key `YYYY-MM` (UTC). */
+  periodStart: string;
+  updatedAt: string;
+}
+
+interface UsageRow {
+  workspace: string;
+  bytes: number;
+  objects: number;
+  uploads_in_period: number;
+  period_start: string;
+  updated_at: string;
+}
+
+export type UsageDelta = { bytes: number; objects: number; uploads: number };
+
+/** UTC calendar month as `YYYY-MM` — the upload-budget window. */
+export function usagePeriodStart(now = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+function toUsage(row: UsageRow): WorkspaceUsage {
+  return {
+    workspace: row.workspace,
+    bytes: row.bytes,
+    objects: row.objects,
+    uploadsInPeriod: row.uploads_in_period,
+    periodStart: row.period_start,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function emptyUsage(workspace: string, now = new Date()): WorkspaceUsage {
+  return {
+    workspace,
+    bytes: 0,
+    objects: 0,
+    uploadsInPeriod: 0,
+    periodStart: usagePeriodStart(now),
+    updatedAt: now.toISOString(),
+  };
+}
+
+export async function getWorkspaceUsage(
+  db: D1Database,
+  workspace: string,
+  now = new Date(),
+): Promise<WorkspaceUsage> {
+  const row = await db
+    .prepare(
+      `SELECT workspace, bytes, objects, uploads_in_period, period_start, updated_at
+       FROM workspace_usage WHERE workspace = ? LIMIT 1`,
+    )
+    .bind(workspace)
+    .first<UsageRow>();
+
+  if (!row) return emptyUsage(workspace, now);
+
+  const period = usagePeriodStart(now);
+  if (row.period_start === period) return toUsage(row);
+  // New month: surface zero uploads without waiting for a put.
+  return { ...toUsage(row), uploadsInPeriod: 0, periodStart: period };
+}
+
+/** Apply a delta. `bytes`/`objects` may be negative; `uploads` only on puts. */
+export async function applyUsageDelta(
+  db: D1Database,
+  workspace: string,
+  delta: UsageDelta,
+  now = new Date(),
+): Promise<void> {
+  if (delta.bytes === 0 && delta.objects === 0 && delta.uploads === 0) return;
+
+  const period = usagePeriodStart(now);
+  const updatedAt = now.toISOString();
+
+  // Ensure row, then update — clearer than a 13-bind upsert, same effect.
+  await db.batch([
+    db
+      .prepare(
+        `INSERT OR IGNORE INTO workspace_usage
+           (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+         VALUES (?, 0, 0, 0, ?, ?)`,
+      )
+      .bind(workspace, period, updatedAt),
+    db
+      .prepare(
+        `UPDATE workspace_usage SET
+           bytes = MAX(0, bytes + ?),
+           objects = MAX(0, objects + ?),
+           uploads_in_period = CASE
+             WHEN period_start = ? THEN uploads_in_period + ?
+             ELSE MAX(0, ?)
+           END,
+           period_start = ?,
+           updated_at = ?
+         WHERE workspace = ?`,
+      )
+      .bind(
+        delta.bytes,
+        delta.objects,
+        period,
+        delta.uploads,
+        delta.uploads,
+        period,
+        updatedAt,
+        workspace,
+      ),
+  ]);
+}
+
+/** Best-effort metering: log and continue if D1 fails. */
+export async function recordUsageSafe(
+  db: D1Database,
+  workspace: string,
+  delta: UsageDelta,
+  now = new Date(),
+): Promise<void> {
+  try {
+    await applyUsageDelta(db, workspace, delta, now);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({ message: "usage ledger update failed", workspace, delta, error: message }),
+    );
+  }
+}

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -38,7 +38,7 @@ async function makeEnv(
   const bucket = new FakeR2Bucket();
   const env = {
     REGISTRY: { get: async () => record, put: async () => undefined },
-    // No D1 token: force the legacy token path.
+    // No D1 token: force the legacy token path. run/batch no-op for usage metering.
     DB: {
       prepare: () => ({
         bind() {
@@ -47,7 +47,13 @@ async function makeEnv(
         async first() {
           return null;
         },
+        async run() {
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
       }),
+      async batch(stmts: { run: () => Promise<unknown> }[]) {
+        return Promise.all(stmts.map((s) => s.run()));
+      },
     },
     UPLOADS_DEFAULT: bucket,
     WRITE_LIMITER: { limit: async () => ({ success: opts.rateLimitOk ?? true }) },

--- a/apps/api/test/routes-usage.test.ts
+++ b/apps/api/test/routes-usage.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { usagePeriodStart } from "../src/usage";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const TOKEN = "secret-token";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+async function makeEnv() {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  return {
+    env: {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: db,
+      UPLOADS_DEFAULT: bucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    },
+    db,
+  };
+}
+
+const auth = { Authorization: `Bearer ${TOKEN}` };
+
+describe("GET /v1/:workspace/usage + put/delete metering", () => {
+  it("returns zeros before any uploads", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/v1/default/usage", { headers: auth }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      workspace: "default",
+      bytes: 0,
+      objects: 0,
+      uploadsInPeriod: 0,
+      periodStart: usagePeriodStart(),
+    });
+  });
+
+  it("tracks put then delete against the ledger", async () => {
+    const { env } = await makeEnv();
+
+    const put = await app.request(
+      "/v1/default/files/shot.png",
+      {
+        method: "PUT",
+        headers: { ...auth, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(put.status).toBe(201);
+
+    let usage = await (await app.request("/v1/default/usage", { headers: auth }, env)).json();
+    expect(usage).toMatchObject({
+      bytes: PNG.byteLength,
+      objects: 1,
+      uploadsInPeriod: 1,
+    });
+
+    const del = await app.request(
+      "/v1/default/files/shot.png",
+      { method: "DELETE", headers: auth },
+      env,
+    );
+    expect(del.status).toBe(200);
+
+    usage = await (await app.request("/v1/default/usage", { headers: auth }, env)).json();
+    expect(usage).toMatchObject({ bytes: 0, objects: 0, uploadsInPeriod: 1 });
+  });
+
+  it("requires auth", async () => {
+    const { env } = await makeEnv();
+    expect((await app.request("/v1/default/usage", {}, env)).status).toBe(401);
+  });
+});

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared D1 stand-in for workspace_usage (INSERT OR IGNORE + UPDATE batch)
+ * and optional no-op auth_tokens lookups for route tests.
+ */
+
+export type UsageRow = {
+  workspace: string;
+  bytes: number;
+  objects: number;
+  uploads_in_period: number;
+  period_start: string;
+  updated_at: string;
+};
+
+export class UsageFakeD1 {
+  usage = new Map<string, UsageRow>();
+
+  prepare = (sql: string) => {
+    const normalized = sql.replace(/\s+/g, " ").trim();
+    let values: unknown[] = [];
+
+    const stmt = {
+      bind: (...v: unknown[]) => {
+        values = v;
+        return stmt;
+      },
+      first: async () => {
+        if (normalized.includes("FROM auth_tokens")) return null;
+        if (normalized.includes("FROM workspace_usage")) {
+          return this.usage.get(values[0] as string) ?? null;
+        }
+        throw new Error(`unsupported first: ${normalized}`);
+      },
+      run: async () => {
+        if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
+          const [workspace, period, updatedAt] = values as [string, string, string];
+          if (!this.usage.has(workspace)) {
+            this.usage.set(workspace, {
+              workspace,
+              bytes: 0,
+              objects: 0,
+              uploads_in_period: 0,
+              period_start: period,
+              updated_at: updatedAt,
+            });
+          }
+          return { success: true as const, meta: { changes: 1 }, results: [] };
+        }
+        if (normalized.startsWith("UPDATE workspace_usage SET")) {
+          const [
+            dBytes,
+            dObjects,
+            period,
+            dUploadsAdd,
+            dUploadsNew,
+            periodSet,
+            updatedAt,
+            workspace,
+          ] = values as [number, number, string, number, number, string, string, string];
+          const row = this.usage.get(workspace);
+          if (!row) throw new Error(`update before insert for ${workspace}`);
+          const samePeriod = row.period_start === period;
+          this.usage.set(workspace, {
+            workspace,
+            bytes: Math.max(0, row.bytes + dBytes),
+            objects: Math.max(0, row.objects + dObjects),
+            uploads_in_period: samePeriod
+              ? row.uploads_in_period + dUploadsAdd
+              : Math.max(0, dUploadsNew),
+            period_start: periodSet,
+            updated_at: updatedAt,
+          });
+          return { success: true as const, meta: { changes: 1 }, results: [] };
+        }
+        throw new Error(`unsupported run: ${normalized}`);
+      },
+    };
+    return stmt;
+  };
+
+  batch = async (statements: { run: () => Promise<unknown> }[]) => {
+    const results = [];
+    for (const stmt of statements) results.push(await stmt.run());
+    return results;
+  };
+}

--- a/apps/api/test/usage.test.ts
+++ b/apps/api/test/usage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { applyUsageDelta, emptyUsage, getWorkspaceUsage, usagePeriodStart } from "../src/usage";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+describe("usagePeriodStart", () => {
+  it("formats UTC calendar month as YYYY-MM", () => {
+    expect(usagePeriodStart(new Date("2026-07-10T12:00:00Z"))).toBe("2026-07");
+  });
+});
+
+describe("workspace usage ledger", () => {
+  it("returns empty usage when no row exists", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const now = new Date("2026-07-10T00:00:00Z");
+    expect(await getWorkspaceUsage(db, "acme", now)).toEqual(emptyUsage("acme", now));
+  });
+
+  it("increments on put and decrements on delete", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const now = new Date("2026-07-10T00:00:00Z");
+
+    await applyUsageDelta(db, "acme", { bytes: 1200, objects: 1, uploads: 1 }, now);
+    await applyUsageDelta(db, "acme", { bytes: 800, objects: 1, uploads: 1 }, now);
+    let snap = await getWorkspaceUsage(db, "acme", now);
+    expect(snap).toMatchObject({ bytes: 2000, objects: 2, uploadsInPeriod: 2 });
+
+    await applyUsageDelta(db, "acme", { bytes: -1200, objects: -1, uploads: 0 }, now);
+    snap = await getWorkspaceUsage(db, "acme", now);
+    expect(snap).toMatchObject({ bytes: 800, objects: 1, uploadsInPeriod: 2 });
+  });
+
+  it("adjusts net bytes on overwrite (delta only)", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const now = new Date("2026-07-10T00:00:00Z");
+    await applyUsageDelta(db, "acme", { bytes: 1000, objects: 1, uploads: 1 }, now);
+    await applyUsageDelta(db, "acme", { bytes: -400, objects: 0, uploads: 1 }, now);
+    expect(await getWorkspaceUsage(db, "acme", now)).toMatchObject({
+      bytes: 600,
+      objects: 1,
+      uploadsInPeriod: 2,
+    });
+  });
+
+  it("resets uploads_in_period on a new calendar month", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    await applyUsageDelta(
+      db,
+      "acme",
+      { bytes: 100, objects: 1, uploads: 5 },
+      new Date("2026-07-10T00:00:00Z"),
+    );
+    expect(await getWorkspaceUsage(db, "acme", new Date("2026-08-01T00:00:00Z"))).toMatchObject({
+      bytes: 100,
+      uploadsInPeriod: 0,
+      periodStart: "2026-08",
+    });
+
+    await applyUsageDelta(
+      db,
+      "acme",
+      { bytes: 50, objects: 1, uploads: 1 },
+      new Date("2026-08-02T00:00:00Z"),
+    );
+    expect(await getWorkspaceUsage(db, "acme", new Date("2026-08-02T00:00:00Z"))).toMatchObject({
+      bytes: 150,
+      uploadsInPeriod: 1,
+      periodStart: "2026-08",
+    });
+  });
+
+  it("isolates workspaces and clamps at zero", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const now = new Date("2026-07-10T00:00:00Z");
+    await applyUsageDelta(db, "acme", { bytes: 100, objects: 1, uploads: 1 }, now);
+    await applyUsageDelta(db, "globex", { bytes: 999, objects: 3, uploads: 2 }, now);
+    expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(100);
+    expect((await getWorkspaceUsage(db, "globex", now)).bytes).toBe(999);
+
+    await applyUsageDelta(db, "acme", { bytes: -999, objects: -5, uploads: 0 }, now);
+    expect(await getWorkspaceUsage(db, "acme", now)).toMatchObject({ bytes: 0, objects: 0 });
+  });
+});

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -123,7 +123,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
 
         // Key/body validation and the size/type guardrails live in putObject,
         // shared with the REST API — the stored content type is sniffed there.
-        const result = await putObject(env, workspace, key, bytes);
+        const result = await putObject(env, workspace, key, bytes, workspaceName);
         const markdown =
           result.url === null
             ? undefined
@@ -172,7 +172,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         await requireWriteBudget();
         const key = optString(args, "key");
         if (!key) usage("key is required");
-        return deleteObject(env, workspace, key);
+        return deleteObject(env, workspace, key, workspaceName);
       },
     },
     {

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -46,6 +46,7 @@ async function makeEnv(
       put: async () => undefined,
     },
     DB: {
+      // run() no-op for workspace_usage metering after put/delete.
       prepare: () => {
         let values: unknown[] = [];
         return {
@@ -70,7 +71,13 @@ async function makeEnv(
             }
             return null;
           },
+          async run() {
+            return { success: true, meta: { changes: 0 }, results: [] };
+          },
         };
+      },
+      async batch(stmts: { run: () => Promise<unknown> }[]) {
+        return Promise.all(stmts.map((s) => s.run()));
       },
     },
     UPLOADS: bucket,

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,16 +5,25 @@ Unknown workspaces and bad tokens are indistinguishable (both 401).
 
 ## Routes
 
-| Route                                             | Description                                                                               |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `GET /health`                                     | Liveness (no auth)                                                                        |
-| `PUT /v1/:workspace/files/:key`                   | Upload raw body; `Content-Type` header is stored. Returns `{ workspace, key, url, size }` |
-| `GET /v1/:workspace/files?prefix=&limit=&cursor=` | List objects                                                                              |
-| `GET /v1/:workspace/files/:key`                   | Object metadata                                                                           |
-| `DELETE /v1/:workspace/files/:key`                | Delete object                                                                             |
+| Route                                             | Description                                                                                |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `GET /health`                                     | Liveness (no auth)                                                                         |
+| `PUT /v1/:workspace/files/:key`                   | Upload raw body; `Content-Type` header is stored. Returns `{ workspace, key, url, size }`  |
+| `GET /v1/:workspace/files?prefix=&limit=&cursor=` | List objects                                                                               |
+| `GET /v1/:workspace/files/:key`                   | Object metadata                                                                            |
+| `DELETE /v1/:workspace/files/:key`                | Delete object                                                                              |
+| `GET /v1/:workspace/usage`                        | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read` |
 
 `url` in responses is the public URL when the workspace has a
 `publicBaseUrl`, otherwise `null`.
+
+### Usage ledger
+
+`GET /v1/:workspace/usage` returns durable workspace counters (`bytes`,
+`objects`, `uploadsInPeriod` for the UTC calendar month), updated best-effort
+after put/delete. Observe-first — not enforced yet. Keyed by workspace, not
+token. Overwrites adjust `bytes` by size delta; deletes free bytes/objects but
+not the monthly upload count.
 
 ## Example
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -34,23 +34,38 @@ subdomain.
 6. Apply D1 migrations remotely **before** deploying API code that depends on
    them, then deploy:
    ```bash
-   cd apps/api
-   pnpm exec wrangler d1 migrations apply uploads-production --remote
-   cd ../..
+   pnpm run deploy:api   # runs migrate:d1 then wrangler deploy
+   # or both workers:
    pnpm run deploy
    ```
-   This ships both workers (`deploy:api` → `api.uploads.sh`,
-   `deploy:web` → the `uploads.sh` apex).
+   `deploy:api` always applies pending migrations first (binding `DB`,
+   database `uploads-production`) so schema lands before new code. Manual-only:
+   `pnpm --filter @uploads/api run migrate:d1`.
 
-D1 owns short-lived enrollment state, redemption, and all new scoped/expiring tokens.
-KV remains the source of truth for workspace storage configuration and legacy tokens.
-Never deploy a Worker that reads a new D1 schema before the corresponding remote
-migration succeeds. Check in every migration and test both `--local` and `--remote`
-ordering in staging.
+D1 owns short-lived enrollment state, redemption, scoped/expiring tokens, and
+the workspace usage ledger. KV remains the source of truth for workspace
+storage configuration and legacy tokens. Never deploy a Worker that reads a
+new D1 schema before the corresponding remote migration succeeds. Check in
+every migration under `apps/api/migrations/`.
+
+### CI: migrations on merge
+
+On push to `main` that touches `apps/api/migrations/**` (or the workflow /
+API wrangler config), the **D1 Migrations** GitHub Actions workflow
+(`.github/workflows/d1-migrations.yml`) runs
+`wrangler d1 migrations apply DB --remote`. It needs repository secrets
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (same as headless deploy;
+token must be allowed to edit D1). Apply is replay-safe. You can also run the
+workflow manually via **Actions → D1 Migrations → Run workflow**.
+
+Workers Builds still deploys each app from its directory on push to main; if
+the API build command is `pnpm run deploy` / `deploy:api`, migrations run in
+that path too. Prefer **additive** migrations so “migrate then deploy” stays
+safe; destructive changes need a deliberate reverse order and should not rely
+on the default pipeline.
 
 Use `pnpm run deploy`, not `pnpm deploy` — the bare form is pnpm's own
-command. In CI, Workers Builds deploys each app from its own directory on
-push to main.
+command.
 
 ## After wrangler.jsonc changes
 

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -86,13 +86,14 @@ API code:
 ```bash
 cd apps/api
 pnpm exec wrangler d1 create uploads-production
-pnpm exec wrangler d1 migrations apply uploads-production --local
-pnpm exec wrangler d1 migrations apply uploads-production --remote
+pnpm exec wrangler d1 migrations apply DB --local
+pnpm exec wrangler d1 migrations apply DB --remote
+# or: pnpm --filter @uploads/api run migrate:d1
 ```
 
-Bind the database as `DB` in `apps/api/wrangler.jsonc`. Commit migrations, apply
-the remote migration first, and deploy the API only after it succeeds. See
-[deploy](deploy.md) for the complete ordering.
+Bind the database as `DB` in `apps/api/wrangler.jsonc`. Commit migrations under
+`apps/api/migrations/`; remote apply runs via `deploy:api`, the **D1 Migrations**
+GitHub Action on merge to main, or `migrate:d1` manually. See [deploy](deploy.md).
 
 ## Migration and future auth
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -8,6 +8,13 @@ SHA-256 hashes and metadata for the workspace's tokens (raw tokens are never sto
 
 Nothing in the code treats any workspace as special.
 
+## Usage accounting
+
+D1 table `workspace_usage` tracks net `bytes` / `objects` and monthly
+`uploads_in_period` per workspace (not per token). Updated best-effort from
+`files-core` put/delete; read via `GET /v1/:workspace/usage` (`files:read`).
+Observe-first — no budget enforcement yet.
+
 New enrollment-issued tokens are stored in D1 and carry an expiry and explicit scopes.
 Workspace configuration and legacy tokens remain in `REGISTRY` KV. The routine-agent
 default is `files:read` plus `files:write`, which is sufficient for upload, listing,


### PR DESCRIPTION
## Summary

- Add a durable **workspace-scoped** usage ledger in D1 (`workspace_usage`): net `bytes` / `objects`, plus `uploadsInPeriod` for the UTC calendar month.
- Meter successful put/delete on the shared `files-core` path (REST + remote MCP), overwrite-aware via a single `head` before write.
- Expose **`GET /v1/:workspace/usage`** (`files:read`) for read-only snapshots.
- Best-effort metering: D1 failures are logged and never fail the storage op (observe-first; enforce budgets later).
- Gitignore `.context/` for private local notes.

Relates to #22 (storage quotas / retention foundations). No commercial packaging in this PR.

### files-sdk note

We evaluated `files-sdk/usage` (in-memory per `Files` instance) and `audit()` sinks. Neither provides durable **net storage** across Worker requests; this ledger is app-owned. `listAll` remains the path for a future reconcile job.

### Deploy note

Apply D1 migration `20260710140000_workspace_usage.sql` before relying on counters in production. Until then, metering fails soft.

## Test plan

- [x] `pnpm --filter @uploads/api test` (ledger unit + route integration)
- [x] `pnpm --filter @uploads/mcp test`
- [x] `pnpm --filter @uploads/api typecheck`
- [ ] Apply migration on prod D1 and smoke `GET /v1/<ws>/usage` after a put/delete