### PR TITLE
feat(api): configurable workspace storage and upload budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ pnpm dev                 # API on :8787 (local R2 + KV simulation)
 pnpm dev:web             # Astro site
 pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # all workers; or deploy:api / deploy:web / deploy:mcp
-pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local]
+pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
+  [--max-storage 25GB] [--max-uploads-per-month N] [--max-upload-bytes 25MB]
+pnpm workspace:limits <name> [--max-storage …] [--clear-max-storage] […]
 pnpm uploads put <file> --env-file .env   # CLI (builds package first)
 pnpm uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
 ```

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "deploy": "pnpm run migrate:d1 && node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
     "types": "wrangler types",
     "workspace:add": "node --env-file-if-exists=../../.env scripts/add-workspace.mjs",
+    "workspace:limits": "node --env-file-if-exists=../../.env scripts/set-workspace-limits.mjs",
     "typecheck": "wrangler types && tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -8,7 +8,11 @@
  *     [--bucket <bucket>]   # omit for shared-bucket mode (uploads-default + "<name>/" prefix)
  *     [--binding UPLOADS] [--public-base-url https://media.example.com] \
  *     [--account-id ...] [--access-key-id ...] [--secret-access-key ...] \
+ *     [--max-storage 25GB] [--max-uploads-per-month 10000] [--max-upload-bytes 25MB] \
  *     [--local]             # write to wrangler dev's local KV instead of prod
+ *
+ * Limit flags are optional (omit = unlimited). Change later with
+ * scripts/set-workspace-limits.mjs without re-minting tokens.
  *
  * Default (no --bucket): the workspace is a "<name>/" prefix in the shared
  * uploads-default bucket, served at https://storage.uploads.sh/<name>/...
@@ -41,6 +45,42 @@ for (let i = 0; i < rest.length; i++) {
 function fail(msg) {
   console.error(`error: ${msg}`);
   process.exit(1);
+}
+
+function parseBytes(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  const m = /^(\d+(?:\.\d+)?)\s*(b|bytes?|k|kb|kib|m|mb|mib|g|gb|gib)?$/i.exec(s);
+  if (!m) fail(`invalid ${label}: ${JSON.stringify(raw)}`);
+  const n = Number(m[1]);
+  const unit = (m[2] || "b").toLowerCase();
+  const mult =
+    unit === "b" || unit === "byte" || unit === "bytes"
+      ? 1
+      : unit === "k" || unit === "kb"
+        ? 1000
+        : unit === "kib"
+          ? 1024
+          : unit === "m" || unit === "mb"
+            ? 1000 ** 2
+            : unit === "mib"
+              ? 1024 ** 2
+              : unit === "g" || unit === "gb"
+                ? 1000 ** 3
+                : unit === "gib"
+                  ? 1024 ** 3
+                  : 1;
+  return Math.floor(n * mult);
+}
+
+function parseCount(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  const n = Number(s);
+  if (!Number.isInteger(n) || n <= 0) fail(`invalid ${label}: ${JSON.stringify(raw)}`);
+  return n;
 }
 
 if (!name || !/^[a-z0-9][a-z0-9-]{1,62}$/.test(name)) {
@@ -88,6 +128,13 @@ const record = opts.bucket
       accessKeyId: opts["access-key-id"],
       secretAccessKey: opts["secret-access-key"],
     };
+const maxStorageBytes = parseBytes(opts["max-storage"], "max-storage");
+const maxUploadsPerPeriod = parseCount(opts["max-uploads-per-month"], "max-uploads-per-month");
+const maxUploadBytes = parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
+if (maxStorageBytes !== undefined) record.maxStorageBytes = maxStorageBytes;
+if (maxUploadsPerPeriod !== undefined) record.maxUploadsPerPeriod = maxUploadsPerPeriod;
+if (maxUploadBytes !== undefined) record.maxUploadBytes = maxUploadBytes;
+
 Object.keys(record).forEach((k) => record[k] === undefined && delete record[k]);
 
 execFileSync(

--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Patch budget / upload limits on an existing workspace registry record.
+ * Does not re-mint tokens — only updates limit fields on the KV record.
+ *
+ * Usage (from apps/api):
+ *   node --env-file=../../.env scripts/set-workspace-limits.mjs <name> \
+ *     [--max-storage 25GB] \
+ *     [--max-uploads-per-month 10000] \
+ *     [--max-upload-bytes 25MB] \
+ *     [--clear-max-storage] [--clear-max-uploads-per-month] [--clear-max-upload-bytes] \
+ *     [--local]
+ *
+ * Units: bare number = bytes (or count for uploads). Also accepts KB/MB/GB
+ * and KiB/MiB/GiB (e.g. 1GB, 25MiB). Use 0 or "unlimited" with a --clear-*
+ * flag to remove a cap.
+ *
+ * Show current limits only:
+ *   node scripts/set-workspace-limits.mjs <name> [--local]
+ */
+import { execFileSync } from "node:child_process";
+
+const [name, ...rest] = process.argv.slice(2);
+const opts = { local: false };
+const clears = new Set();
+
+for (let i = 0; i < rest.length; i++) {
+  const flag = rest[i];
+  if (!flag.startsWith("--")) fail(`unexpected argument: ${flag}`);
+  const key = flag.slice(2);
+  if (key === "local") {
+    opts.local = true;
+    continue;
+  }
+  if (key.startsWith("clear-")) {
+    clears.add(key.slice("clear-".length));
+    continue;
+  }
+  opts[key] = rest[++i];
+}
+
+function fail(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+if (!name || !/^[a-z0-9][a-z0-9-]{1,62}$/.test(name)) {
+  fail("workspace name must be lowercase alphanumeric/hyphens, 2-63 chars");
+}
+
+/** Parse byte sizes: 123, 1KB, 25MiB, 2GB. Returns integer bytes or null (unlimited). */
+function parseBytes(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
+  const m = /^(\d+(?:\.\d+)?)\s*(b|bytes?|k|kb|kib|m|mb|mib|g|gb|gib)?$/i.exec(s);
+  if (!m) fail(`invalid ${label}: ${JSON.stringify(raw)} (try 25MB, 1GiB, or a byte count)`);
+  const n = Number(m[1]);
+  if (!Number.isFinite(n) || n < 0) fail(`invalid ${label}: ${JSON.stringify(raw)}`);
+  const unit = (m[2] || "b").toLowerCase();
+  const mult =
+    unit === "b" || unit === "byte" || unit === "bytes"
+      ? 1
+      : unit === "k" || unit === "kb"
+        ? 1000
+        : unit === "kib"
+          ? 1024
+          : unit === "m" || unit === "mb"
+            ? 1000 ** 2
+            : unit === "mib"
+              ? 1024 ** 2
+              : unit === "g" || unit === "gb"
+                ? 1000 ** 3
+                : unit === "gib"
+                  ? 1024 ** 3
+                  : 1;
+  return Math.floor(n * mult);
+}
+
+/** Parse a positive integer count (uploads per month). */
+function parseCount(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
+  const n = Number(s);
+  if (!Number.isInteger(n) || n < 0) fail(`invalid ${label}: ${JSON.stringify(raw)}`);
+  return n === 0 ? null : n;
+}
+
+function wranglerKv(args) {
+  return execFileSync(
+    "pnpm",
+    [
+      "exec",
+      "wrangler",
+      "kv",
+      "key",
+      ...args,
+      "--binding",
+      "REGISTRY",
+      opts.local ? "--local" : "--remote",
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+const key = `ws:${name}`;
+let raw;
+try {
+  raw = wranglerKv(["get", key]);
+} catch {
+  fail(`workspace not found in REGISTRY: ${key} (${opts.local ? "local" : "remote"})`);
+}
+
+let record;
+try {
+  record = JSON.parse(raw);
+} catch {
+  fail(`invalid JSON for ${key}`);
+}
+
+const before = {
+  maxStorageBytes: record.maxStorageBytes,
+  maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+  maxUploadBytes: record.maxUploadBytes,
+};
+
+const patch = {};
+if (clears.has("max-storage") || opts["max-storage"] !== undefined) {
+  const v = clears.has("max-storage") ? null : parseBytes(opts["max-storage"], "max-storage");
+  patch.maxStorageBytes = v;
+}
+if (clears.has("max-uploads-per-month") || opts["max-uploads-per-month"] !== undefined) {
+  const v = clears.has("max-uploads-per-month")
+    ? null
+    : parseCount(opts["max-uploads-per-month"], "max-uploads-per-month");
+  patch.maxUploadsPerPeriod = v;
+}
+if (clears.has("max-upload-bytes") || opts["max-upload-bytes"] !== undefined) {
+  const v = clears.has("max-upload-bytes")
+    ? null
+    : parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
+  patch.maxUploadBytes = v;
+}
+
+const changing = Object.keys(patch).length > 0;
+if (!changing) {
+  console.log(`workspace : ${name} (${opts.local ? "local" : "remote"})`);
+  console.log("limits    :", JSON.stringify(before, null, 2));
+  console.log("\nNo flags — nothing updated. Examples:");
+  console.log(
+    `  node scripts/set-workspace-limits.mjs ${name} --max-storage 25GB --max-uploads-per-month 10000`,
+  );
+  console.log(`  node scripts/set-workspace-limits.mjs ${name} --clear-max-storage`);
+  process.exit(0);
+}
+
+for (const [field, value] of Object.entries(patch)) {
+  if (value === null) delete record[field];
+  else record[field] = value;
+}
+
+wranglerKv(["put", key, JSON.stringify(record)]);
+
+const after = {
+  maxStorageBytes: record.maxStorageBytes,
+  maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+  maxUploadBytes: record.maxUploadBytes,
+};
+
+console.log(`workspace : ${name} (${opts.local ? "local" : "remote"})`);
+console.log("before    :", JSON.stringify(before));
+console.log("after     :", JSON.stringify(after));
+console.log("\nLimits apply on the next request (KV cacheTtl ≈ 60s).");

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -1,0 +1,116 @@
+/**
+ * Per-workspace cumulative budgets (storage + monthly uploads).
+ *
+ * Limits ride on `WorkspaceRecord` (KV) — same place as `maxUploadBytes` —
+ * so operators can change them with a KV put / set-workspace-limits script
+ * without redeploying. Omit a field (or set null via the script) for unlimited.
+ */
+
+import type { WorkspaceUsage } from "./usage";
+
+/** Cumulative caps from the workspace registry record. */
+export interface WorkspaceBudgetLimits {
+  /** Hard cap on net stored bytes. */
+  maxStorageBytes?: number;
+  /** Cap on successful puts in the current UTC calendar month. */
+  maxUploadsPerPeriod?: number;
+}
+
+export type BudgetDenialCode = "storage_quota_exceeded" | "upload_budget_exceeded";
+
+export interface BudgetDenial {
+  code: BudgetDenialCode;
+  message: string;
+  /** HTTP status: 507 storage, 429 monthly upload budget. */
+  status: 507 | 429;
+  /** Structured fields for agents / CLI. */
+  detail: Record<string, unknown>;
+}
+
+/** Positive finite number, else undefined (unlimited). */
+export function positiveLimit(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export function resolveBudgetLimits(record: WorkspaceBudgetLimits): {
+  maxStorageBytes?: number;
+  maxUploadsPerPeriod?: number;
+} {
+  return {
+    maxStorageBytes: positiveLimit(record.maxStorageBytes),
+    maxUploadsPerPeriod: positiveLimit(record.maxUploadsPerPeriod),
+  };
+}
+
+/**
+ * Whether a put that would apply `delta` is allowed under the workspace limits.
+ * `delta.bytes` is the net storage change (newSize − previousSize for overwrites).
+ * Overwrites that shrink storage never trip the storage cap.
+ */
+export function checkPutBudget(
+  usage: WorkspaceUsage,
+  limits: WorkspaceBudgetLimits,
+  delta: { bytes: number; uploads: number },
+): BudgetDenial | null {
+  const { maxStorageBytes, maxUploadsPerPeriod } = resolveBudgetLimits(limits);
+
+  if (maxUploadsPerPeriod !== undefined && delta.uploads > 0) {
+    if (usage.uploadsInPeriod + delta.uploads > maxUploadsPerPeriod) {
+      return {
+        code: "upload_budget_exceeded",
+        status: 429,
+        message: `upload budget exceeded (${usage.uploadsInPeriod}/${maxUploadsPerPeriod} this period)`,
+        detail: {
+          code: "upload_budget_exceeded",
+          uploadsInPeriod: usage.uploadsInPeriod,
+          maxUploadsPerPeriod,
+          periodStart: usage.periodStart,
+        },
+      };
+    }
+  }
+
+  if (maxStorageBytes !== undefined && delta.bytes > 0) {
+    const next = usage.bytes + delta.bytes;
+    if (next > maxStorageBytes) {
+      return {
+        code: "storage_quota_exceeded",
+        status: 507,
+        message: `storage quota exceeded (${usage.bytes} + ${delta.bytes} > ${maxStorageBytes} bytes)`,
+        detail: {
+          code: "storage_quota_exceeded",
+          bytes: usage.bytes,
+          deltaBytes: delta.bytes,
+          maxStorageBytes,
+          objects: usage.objects,
+        },
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Fields for GET /usage — limits + remaining when capped. */
+export function usageWithLimits(usage: WorkspaceUsage, limits: WorkspaceBudgetLimits) {
+  const resolved = resolveBudgetLimits(limits);
+  const out: Record<string, unknown> = {
+    workspace: usage.workspace,
+    bytes: usage.bytes,
+    objects: usage.objects,
+    uploadsInPeriod: usage.uploadsInPeriod,
+    periodStart: usage.periodStart,
+    updatedAt: usage.updatedAt,
+  };
+
+  if (resolved.maxStorageBytes !== undefined) {
+    out.maxStorageBytes = resolved.maxStorageBytes;
+    out.storageRemainingBytes = Math.max(0, resolved.maxStorageBytes - usage.bytes);
+  }
+  if (resolved.maxUploadsPerPeriod !== undefined) {
+    out.maxUploadsPerPeriod = resolved.maxUploadsPerPeriod;
+    out.uploadsRemaining = Math.max(0, resolved.maxUploadsPerPeriod - usage.uploadsInPeriod);
+  }
+
+  return out;
+}

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -5,9 +5,10 @@
  * each surface maps it (HTTP 400 / MCP tool error).
  */
 import type { Files } from "@uploads/storage";
+import { checkPutBudget } from "./budget";
 import { inspectUpload, resolveUploadPolicy } from "./guards";
 import { publicUrl, storage, storageConfig } from "./storage";
-import { recordUsageSafe } from "./usage";
+import { getWorkspaceUsage, recordUsageSafe } from "./usage";
 import type { WorkspaceRecord } from "./workspace";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
@@ -33,10 +34,14 @@ export function badKey(key: string): boolean {
  * same policy: HTTP responds with them; MCP renders `message` in the tool error.
  */
 export class FileOpError extends Error {
-  readonly status: 400 | 413 | 415;
+  readonly status: 400 | 413 | 415 | 429 | 507;
   readonly body: Record<string, unknown>;
 
-  constructor(message: string, status: 400 | 413 | 415 = 400, extra?: Record<string, unknown>) {
+  constructor(
+    message: string,
+    status: 400 | 413 | 415 | 429 | 507 = 400,
+    extra?: Record<string, unknown>,
+  ) {
     super(message);
     this.name = "FileOpError";
     this.status = status;
@@ -81,6 +86,12 @@ export async function putObject(
   const store = storage(env, ws);
   const prev = await existingSize(store, key);
   const newSize = bytes.byteLength;
+  const deltaBytes = prev === null ? newSize : newSize - prev;
+
+  // Enforce workspace budgets before writing (omit limits on the record = unlimited).
+  const usage = await getWorkspaceUsage(env.DB, workspaceName);
+  const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
+  if (denial) throw new FileOpError(denial.message, denial.status, denial.detail);
 
   await store.upload(key, bytes, {
     contentType: inspection.contentType,
@@ -88,7 +99,7 @@ export async function putObject(
   });
 
   await recordUsageSafe(env.DB, workspaceName, {
-    bytes: prev === null ? newSize : newSize - prev,
+    bytes: deltaBytes,
     objects: prev === null ? 1 : 0,
     uploads: 1,
   });

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -6,7 +6,9 @@ import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../gua
 
 /** Maps a core validation failure to the REST error shape; rethrows anything else. */
 function mapFileOpError(c: Context, err: unknown): Response {
-  if (err instanceof FileOpError) return c.json(err.body, err.status);
+  if (err instanceof FileOpError) {
+    return c.json(err.body, err.status as 400 | 413 | 415 | 429 | 507);
+  }
   throw err;
 }
 

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
+import { usageWithLimits } from "../budget";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 
-/** Read-only workspace usage snapshot. Auth + `files:read`. */
-export const usage = new Hono<WorkspaceVars>().get("/", requireScope("files:read"), async (c) =>
-  c.json(await getWorkspaceUsage(c.env.DB, c.get("workspaceName"))),
-);
+/** Read-only workspace usage (+ configured limits when set). Auth + `files:read`. */
+export const usage = new Hono<WorkspaceVars>().get("/", requireScope("files:read"), async (c) => {
+  const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
+  return c.json(usageWithLimits(snapshot, c.get("workspace")));
+});

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -5,7 +5,8 @@
  * requests and does not track net stored size after deletes. This ledger is
  * keyed by workspace (not API token): multiple tokens share one prefix.
  *
- * Observe-first: record failures never fail the storage op. Enforce budgets later.
+ * Metering write failures never fail the storage op. Budget checks read this
+ * ledger before put (see budget.ts) when the workspace record sets caps.
  */
 
 export interface WorkspaceUsage {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -30,6 +30,15 @@ export interface WorkspaceRecord {
   maxUploadBytes?: number;
   /** Allowed (sniffed) content types. Falls back to DEFAULT_ALLOWED_CONTENT_TYPES. */
   allowedContentTypes?: string[];
+  /**
+   * Cap on net stored bytes for this workspace. Omit for unlimited.
+   * Enforced on put against the usage ledger (see budget.ts / usage.ts).
+   */
+  maxStorageBytes?: number;
+  /**
+   * Cap on successful puts in the current UTC calendar month. Omit for unlimited.
+   */
+  maxUploadsPerPeriod?: number;
 }
 
 export type WorkspaceVars = {

--- a/apps/api/test/budget.test.ts
+++ b/apps/api/test/budget.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { checkPutBudget, resolveBudgetLimits, usageWithLimits } from "../src/budget";
+import type { WorkspaceUsage } from "../src/usage";
+
+const usage = (partial: Partial<WorkspaceUsage> = {}): WorkspaceUsage => ({
+  workspace: "acme",
+  bytes: 1000,
+  objects: 2,
+  uploadsInPeriod: 5,
+  periodStart: "2026-07",
+  updatedAt: "2026-07-11T00:00:00.000Z",
+  ...partial,
+});
+
+describe("resolveBudgetLimits", () => {
+  it("treats missing and non-positive as unlimited", () => {
+    expect(resolveBudgetLimits({})).toEqual({
+      maxStorageBytes: undefined,
+      maxUploadsPerPeriod: undefined,
+    });
+    expect(resolveBudgetLimits({ maxStorageBytes: 0, maxUploadsPerPeriod: -1 })).toEqual({
+      maxStorageBytes: undefined,
+      maxUploadsPerPeriod: undefined,
+    });
+  });
+});
+
+describe("checkPutBudget", () => {
+  it("allows puts when no limits are set", () => {
+    expect(checkPutBudget(usage(), {}, { bytes: 9e15, uploads: 1 })).toBeNull();
+  });
+
+  it("denies when storage would exceed the cap", () => {
+    const denial = checkPutBudget(
+      usage({ bytes: 900 }),
+      { maxStorageBytes: 1000 },
+      {
+        bytes: 200,
+        uploads: 1,
+      },
+    );
+    expect(denial?.code).toBe("storage_quota_exceeded");
+    expect(denial?.status).toBe(507);
+    expect(denial?.detail).toMatchObject({
+      bytes: 900,
+      deltaBytes: 200,
+      maxStorageBytes: 1000,
+    });
+  });
+
+  it("allows overwrites that shrink or stay under the cap", () => {
+    expect(
+      checkPutBudget(
+        usage({ bytes: 1000 }),
+        { maxStorageBytes: 1000 },
+        { bytes: -100, uploads: 1 },
+      ),
+    ).toBeNull();
+    expect(
+      checkPutBudget(usage({ bytes: 900 }), { maxStorageBytes: 1000 }, { bytes: 100, uploads: 1 }),
+    ).toBeNull();
+  });
+
+  it("denies when monthly upload budget is exhausted", () => {
+    const denial = checkPutBudget(
+      usage({ uploadsInPeriod: 10 }),
+      { maxUploadsPerPeriod: 10 },
+      { bytes: 1, uploads: 1 },
+    );
+    expect(denial?.code).toBe("upload_budget_exceeded");
+    expect(denial?.status).toBe(429);
+  });
+});
+
+describe("usageWithLimits", () => {
+  it("includes remaining when caps are set", () => {
+    expect(
+      usageWithLimits(usage({ bytes: 400, uploadsInPeriod: 3 }), {
+        maxStorageBytes: 1000,
+        maxUploadsPerPeriod: 10,
+      }),
+    ).toMatchObject({
+      bytes: 400,
+      maxStorageBytes: 1000,
+      storageRemainingBytes: 600,
+      uploadsInPeriod: 3,
+      maxUploadsPerPeriod: 10,
+      uploadsRemaining: 7,
+    });
+  });
+
+  it("omits limit fields when unlimited", () => {
+    const snap = usageWithLimits(usage(), {});
+    expect(snap).not.toHaveProperty("maxStorageBytes");
+    expect(snap).not.toHaveProperty("maxUploadsPerPeriod");
+  });
+});

--- a/apps/api/test/routes-budget.test.ts
+++ b/apps/api/test/routes-budget.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const TOKEN = "secret-token";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+async function makeEnv(overrides: Partial<WorkspaceRecord> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...overrides,
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  return {
+    env: {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: db,
+      UPLOADS_DEFAULT: bucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    },
+    db,
+  };
+}
+
+const auth = { Authorization: `Bearer ${TOKEN}` };
+
+function put(env: unknown, key = "shot.png") {
+  return app.request(
+    `/v1/default/files/${key}`,
+    {
+      method: "PUT",
+      headers: { ...auth, "Content-Type": "image/png" },
+      body: PNG,
+    },
+    env as never,
+  );
+}
+
+describe("workspace budget enforcement", () => {
+  it("returns 507 when a put would exceed maxStorageBytes", async () => {
+    const { env } = await makeEnv({ maxStorageBytes: PNG.byteLength - 1 });
+    const res = await put(env);
+    expect(res.status).toBe(507);
+    const body = (await res.json()) as { code: string; maxStorageBytes: number };
+    expect(body.code).toBe("storage_quota_exceeded");
+    expect(body.maxStorageBytes).toBe(PNG.byteLength - 1);
+  });
+
+  it("returns 429 when monthly upload budget is spent", async () => {
+    const { env, db } = await makeEnv({ maxUploadsPerPeriod: 1 });
+    expect((await put(env, "a.png")).status).toBe(201);
+    expect(db.usage.get("default")?.uploads_in_period).toBe(1);
+
+    const res = await put(env, "b.png");
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("upload_budget_exceeded");
+  });
+
+  it("surfaces limits on GET /usage", async () => {
+    const { env } = await makeEnv({
+      maxStorageBytes: 10_000,
+      maxUploadsPerPeriod: 50,
+    });
+    await put(env);
+    const res = await app.request("/v1/default/usage", { headers: auth }, env as never);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      bytes: PNG.byteLength,
+      maxStorageBytes: 10_000,
+      storageRemainingBytes: 10_000 - PNG.byteLength,
+      maxUploadsPerPeriod: 50,
+      uploadsRemaining: 49,
+    });
+  });
+
+  it("allows unlimited workspaces (no limit fields)", async () => {
+    const { env } = await makeEnv();
+    expect((await put(env)).status).toBe(201);
+  });
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,13 +17,24 @@ Unknown workspaces and bad tokens are indistinguishable (both 401).
 `url` in responses is the public URL when the workspace has a
 `publicBaseUrl`, otherwise `null`.
 
-### Usage ledger
+### Usage ledger and budgets
 
 `GET /v1/:workspace/usage` returns durable workspace counters (`bytes`,
 `objects`, `uploadsInPeriod` for the UTC calendar month), updated best-effort
-after put/delete. Observe-first — not enforced yet. Keyed by workspace, not
-token. Overwrites adjust `bytes` by size delta; deletes free bytes/objects but
-not the monthly upload count.
+after put/delete. Keyed by workspace, not token. Overwrites adjust `bytes` by
+size delta; deletes free bytes/objects but not the monthly upload count.
+
+When the workspace record sets budgets (`maxStorageBytes`,
+`maxUploadsPerPeriod`), the response also includes those caps and remaining
+headroom. Puts that would exceed them fail with:
+
+| HTTP | `code`                   | Meaning                                              |
+| ---- | ------------------------ | ---------------------------------------------------- |
+| 507  | `storage_quota_exceeded` | Net stored bytes would exceed `maxStorageBytes`      |
+| 429  | `upload_budget_exceeded` | Monthly put count would exceed `maxUploadsPerPeriod` |
+
+Configure limits with `pnpm workspace:limits <name> …` (see
+[workspaces](workspaces.md)).
 
 ## Example
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -8,12 +8,46 @@ SHA-256 hashes and metadata for the workspace's tokens (raw tokens are never sto
 
 Nothing in the code treats any workspace as special.
 
-## Usage accounting
+## Usage accounting and budgets
 
 D1 table `workspace_usage` tracks net `bytes` / `objects` and monthly
 `uploads_in_period` per workspace (not per token). Updated best-effort from
 `files-core` put/delete; read via `GET /v1/:workspace/usage` (`files:read`).
-Observe-first — no budget enforcement yet.
+
+Optional **budgets** live on the workspace registry record (KV), same as
+`maxUploadBytes`:
+
+| Field                 | Meaning                                       |
+| --------------------- | --------------------------------------------- |
+| `maxStorageBytes`     | Cap on net stored bytes                       |
+| `maxUploadsPerPeriod` | Cap on puts in the current UTC calendar month |
+| `maxUploadBytes`      | Cap on a single object (default 25 MiB)       |
+
+Omit a field for unlimited. Puts that would exceed storage return **507** with
+`code: "storage_quota_exceeded"`; monthly upload budget returns **429** with
+`code: "upload_budget_exceeded"`. `GET …/usage` includes the caps and remaining
+when set.
+
+### Configure limits
+
+Create with flags:
+
+```bash
+pnpm workspace:add my-ws --max-storage 25GB --max-uploads-per-month 10000 --max-upload-bytes 25MB
+```
+
+Change later without re-minting tokens:
+
+```bash
+pnpm workspace:limits my-ws                          # show current
+pnpm workspace:limits my-ws --max-storage 50GB
+pnpm workspace:limits my-ws --max-uploads-per-month 20000
+pnpm workspace:limits my-ws --clear-max-storage      # back to unlimited
+pnpm workspace:limits my-ws --local                  # local KV for wrangler dev
+```
+
+Sizes accept `25MB`, `1GiB`, or raw byte counts. KV is cached ~60s on the
+Worker — new limits apply on the next request after that.
 
 New enrollment-issued tokens are stored in D1 and carry an expiry and explicit scopes.
 Workspace configuration and legacy tokens remain in `REGISTRY` KV. The routine-agent

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check": "pnpm run lint && pnpm run format:check",
     "typecheck": "pnpm --filter @buildinternet/uploads run build && pnpm -r typecheck",
     "workspace:add": "pnpm --filter @uploads/api run workspace:add",
+    "workspace:limits": "pnpm --filter @uploads/api run workspace:limits",
     "preuploads": "pnpm --filter @buildinternet/uploads run build",
     "uploads": "pnpm exec uploads",
     "prepare": "husky"


### PR DESCRIPTION
## Summary

- Soft **workspace budgets** on the registry record: `maxStorageBytes`, `maxUploadsPerPeriod` (omit = unlimited).
- Enforced on put via the usage ledger: **507** `storage_quota_exceeded`, **429** `upload_budget_exceeded` (stable `code` for agents).
- `GET /v1/:workspace/usage` includes caps + remaining when set.
- **Easy config**: `pnpm workspace:limits <name> --max-storage 25GB …` (and create-time flags on `workspace:add`). No redeploy to change limits (KV ~60s cache).

### Prod smoke (done before this PR)

Against `api.uploads.sh` / `buildinternet`: usage went `0 → 67 bytes / 1 object / 1 upload` on put, then `0 bytes / 0 objects / 1 upload` after delete.

### Configure

```bash
pnpm workspace:limits my-ws --max-storage 25GB --max-uploads-per-month 10000
pnpm workspace:limits my-ws --clear-max-storage
pnpm workspace:limits my-ws   # show
```

Relates to #22.

## Test plan

- [x] Unit tests for `checkPutBudget` / `usageWithLimits`
- [x] Route tests: 507, 429, usage remaining, unlimited default
- [x] Full API + MCP test suites
- [ ] After merge: set a low limit on a test workspace, confirm put rejects, clear limit