### PR TITLE
feat(api): reconcile usage + retention purge

### DIFF
--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -8,7 +8,9 @@
  *     [--max-storage 25GB] \
  *     [--max-uploads-per-month 10000] \
  *     [--max-upload-bytes 25MB] \
+ *     [--retention-days 90] \
  *     [--clear-max-storage] [--clear-max-uploads-per-month] [--clear-max-upload-bytes] \
+ *     [--clear-retention-days] \
  *     [--local]
  *
  * Units: bare number = bytes (or count for uploads). Also accepts KB/MB/GB
@@ -123,6 +125,7 @@ const before = {
   maxStorageBytes: record.maxStorageBytes,
   maxUploadsPerPeriod: record.maxUploadsPerPeriod,
   maxUploadBytes: record.maxUploadBytes,
+  retentionDays: record.retentionDays,
 };
 
 const patch = {};
@@ -141,6 +144,12 @@ if (clears.has("max-upload-bytes") || opts["max-upload-bytes"] !== undefined) {
     ? null
     : parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
   patch.maxUploadBytes = v;
+}
+if (clears.has("retention-days") || opts["retention-days"] !== undefined) {
+  const v = clears.has("retention-days")
+    ? null
+    : parseCount(opts["retention-days"], "retention-days");
+  patch.retentionDays = v;
 }
 
 const changing = Object.keys(patch).length > 0;
@@ -166,6 +175,7 @@ const after = {
   maxStorageBytes: record.maxStorageBytes,
   maxUploadsPerPeriod: record.maxUploadsPerPeriod,
   maxUploadBytes: record.maxUploadBytes,
+  retentionDays: record.retentionDays,
 };
 
 console.log(`workspace : ${name} (${opts.local ? "local" : "remote"})`);

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -1,0 +1,48 @@
+/**
+ * Rebuild workspace storage totals from the object store (source of truth).
+ * Fixes ledger drift from failed metering, external deletes, or races.
+ * Does not change monthly `uploadsInPeriod`.
+ */
+import { storage } from "./storage";
+import { getWorkspaceUsage, setUsageTotals, type WorkspaceUsage } from "./usage";
+import type { WorkspaceRecord } from "./workspace";
+
+export interface ReconcileResult {
+  workspace: string;
+  /** Totals scanned from storage. */
+  bytes: number;
+  objects: number;
+  /** Ledger before the write. */
+  previous: { bytes: number; objects: number };
+  /** True when bytes or objects changed. */
+  changed: boolean;
+  usage: WorkspaceUsage;
+}
+
+/** Walk every object under the workspace prefix and replace ledger bytes/objects. */
+export async function reconcileWorkspaceUsage(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  now = new Date(),
+): Promise<ReconcileResult> {
+  const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
+  const store = storage(env, ws);
+
+  let bytes = 0;
+  let objects = 0;
+  for await (const item of store.listAll()) {
+    bytes += item.size ?? 0;
+    objects += 1;
+  }
+
+  const usage = await setUsageTotals(env.DB, workspaceName, { bytes, objects }, now);
+  return {
+    workspace: workspaceName,
+    bytes,
+    objects,
+    previous: { bytes: previous.bytes, objects: previous.objects },
+    changed: previous.bytes !== bytes || previous.objects !== objects,
+    usage,
+  };
+}

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -2,6 +2,12 @@
  * Rebuild workspace storage totals from the object store (source of truth).
  * Fixes ledger drift from failed metering, external deletes, or races.
  * Does not change monthly `uploadsInPeriod`.
+ *
+ * files-sdk: uses `listAll()` on the workspace-scoped `Files` instance
+ * (`createStorage` already applies `prefix`). Listing returns `size` on the
+ * metadata without fetching bodies — do not call body accessors during the walk.
+ * The in-memory `files-sdk/usage` plugin is not used: it does not survive
+ * across Worker isolates and does not track net storage after deletes.
  */
 import { storage } from "./storage";
 import { getWorkspaceUsage, setUsageTotals, type WorkspaceUsage } from "./usage";
@@ -31,6 +37,7 @@ export async function reconcileWorkspaceUsage(
 
   let bytes = 0;
   let objects = 0;
+  // listAll follows list() cursors; each item is a StoredFile with size metadata.
   for await (const item of store.listAll()) {
     bytes += item.size ?? 0;
     objects += 1;

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -2,6 +2,15 @@
  * App-driven retention: delete objects older than `retentionDays` on the
  * workspace record. Uses object `lastModified` from the store (R2 upload time).
  * After purge, call reconcile so the ledger matches storage.
+ *
+ * files-sdk notes:
+ * - Walk with `listAll()` (same as reconcile) — cursor pagination, prefix-scoped.
+ * - Expire with bulk `delete(keys[])` so R2/S3 use native multi-object delete
+ *   instead of one request per key (see files-sdk delete bulk form).
+ * - `softDelete` plugin is a recycle bin (move to `.trash`), not TTL — skip.
+ * - R2 lifecycle rules via `files.raw` are bucket-wide, not per-workspace —
+ *   multi-tenant prefixes need this app-level pass until we own the bucket
+ *   lifecycle policy per prefix.
  */
 import { positiveLimit } from "./budget";
 import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
@@ -11,6 +20,11 @@ import type { WorkspaceRecord } from "./workspace";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** Cap listed deleted keys in the response so agents don't get huge payloads. */
 const MAX_KEYS_IN_RESPONSE = 100;
+/**
+ * Batch size for files-sdk bulk delete. S3/R2 DeleteObjects allows 1000;
+ * stay under that and keep isolate memory bounded while listing.
+ */
+const DELETE_BATCH = 500;
 
 export interface PurgeExpiredResult {
   workspace: string;
@@ -28,10 +42,15 @@ export function retentionCutoff(retentionDays: number, now = new Date()): Date {
   return new Date(now.getTime() - retentionDays * MS_PER_DAY);
 }
 
+function isExpired(lastModified: Date | number | undefined, cutoff: Date): boolean {
+  if (lastModified === undefined) return false;
+  const modified = lastModified instanceof Date ? lastModified : new Date(lastModified);
+  return !Number.isNaN(modified.getTime()) && modified < cutoff;
+}
+
 /**
  * Delete objects last-modified before the retention window. No-ops when
- * `retentionDays` is unset. Always re-reconciles when anything was deleted
- * (and still reconciles when nothing matched so operators can chain safely).
+ * `retentionDays` is unset. Always re-reconciles so the ledger matches storage.
  */
 export async function purgeExpiredObjects(
   env: Env,
@@ -46,21 +65,31 @@ export async function purgeExpiredObjects(
 
   const cutoff = retentionCutoff(days, now);
   const store = storage(env, ws);
-  const keys: string[] = [];
+  const sampleKeys: string[] = [];
   let deleted = 0;
   let freedBytes = 0;
   let keysTruncated = false;
+  let batch: string[] = [];
+
+  async function flush() {
+    if (batch.length === 0) return;
+    // Bulk form: native multi-delete on R2/S3 when available.
+    await store.delete(batch);
+    batch = [];
+  }
 
   for await (const item of store.listAll()) {
-    const modified = item.lastModified ? new Date(item.lastModified) : null;
-    if (!modified || Number.isNaN(modified.getTime()) || modified >= cutoff) continue;
+    if (!isExpired(item.lastModified, cutoff)) continue;
 
-    await store.delete(item.key);
+    batch.push(item.key);
     deleted += 1;
     freedBytes += item.size ?? 0;
-    if (keys.length < MAX_KEYS_IN_RESPONSE) keys.push(item.key);
+    if (sampleKeys.length < MAX_KEYS_IN_RESPONSE) sampleKeys.push(item.key);
     else keysTruncated = true;
+
+    if (batch.length >= DELETE_BATCH) await flush();
   }
+  await flush();
 
   const reconcile = await reconcileWorkspaceUsage(env, ws, workspaceName, now);
   return {
@@ -69,7 +98,7 @@ export async function purgeExpiredObjects(
     cutoff: cutoff.toISOString(),
     deleted,
     freedBytes,
-    keys,
+    keys: sampleKeys,
     keysTruncated,
     reconcile,
   };

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -1,0 +1,76 @@
+/**
+ * App-driven retention: delete objects older than `retentionDays` on the
+ * workspace record. Uses object `lastModified` from the store (R2 upload time).
+ * After purge, call reconcile so the ledger matches storage.
+ */
+import { positiveLimit } from "./budget";
+import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
+import { storage } from "./storage";
+import type { WorkspaceRecord } from "./workspace";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+/** Cap listed deleted keys in the response so agents don't get huge payloads. */
+const MAX_KEYS_IN_RESPONSE = 100;
+
+export interface PurgeExpiredResult {
+  workspace: string;
+  retentionDays: number;
+  cutoff: string;
+  deleted: number;
+  freedBytes: number;
+  /** Sample of deleted keys (capped). */
+  keys: string[];
+  keysTruncated: boolean;
+  reconcile: ReconcileResult;
+}
+
+export function retentionCutoff(retentionDays: number, now = new Date()): Date {
+  return new Date(now.getTime() - retentionDays * MS_PER_DAY);
+}
+
+/**
+ * Delete objects last-modified before the retention window. No-ops when
+ * `retentionDays` is unset. Always re-reconciles when anything was deleted
+ * (and still reconciles when nothing matched so operators can chain safely).
+ */
+export async function purgeExpiredObjects(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  now = new Date(),
+): Promise<PurgeExpiredResult | { skipped: true; reason: string }> {
+  const days = positiveLimit(ws.retentionDays);
+  if (days === undefined) {
+    return { skipped: true, reason: "retentionDays not set on workspace" };
+  }
+
+  const cutoff = retentionCutoff(days, now);
+  const store = storage(env, ws);
+  const keys: string[] = [];
+  let deleted = 0;
+  let freedBytes = 0;
+  let keysTruncated = false;
+
+  for await (const item of store.listAll()) {
+    const modified = item.lastModified ? new Date(item.lastModified) : null;
+    if (!modified || Number.isNaN(modified.getTime()) || modified >= cutoff) continue;
+
+    await store.delete(item.key);
+    deleted += 1;
+    freedBytes += item.size ?? 0;
+    if (keys.length < MAX_KEYS_IN_RESPONSE) keys.push(item.key);
+    else keysTruncated = true;
+  }
+
+  const reconcile = await reconcileWorkspaceUsage(env, ws, workspaceName, now);
+  return {
+    workspace: workspaceName,
+    retentionDays: days,
+    cutoff: cutoff.toISOString(),
+    deleted,
+    freedBytes,
+    keys,
+    keysTruncated,
+    reconcile,
+  };
+}

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -1,10 +1,40 @@
 import { Hono } from "hono";
 import { usageWithLimits } from "../budget";
+import { reconcileWorkspaceUsage } from "../reconcile";
+import { purgeExpiredObjects } from "../retention";
 import { getWorkspaceUsage } from "../usage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 
-/** Read-only workspace usage (+ configured limits when set). Auth + `files:read`. */
-export const usage = new Hono<WorkspaceVars>().get("/", requireScope("files:read"), async (c) => {
-  const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
-  return c.json(usageWithLimits(snapshot, c.get("workspace")));
-});
+/**
+ * Usage snapshot + maintenance:
+ * - GET  /           read counters (+ limits)
+ * - POST /reconcile  rebuild bytes/objects from storage
+ * - POST /purge-expired  delete past retentionDays, then reconcile
+ */
+export const usage = new Hono<WorkspaceVars>()
+  .get("/", requireScope("files:read"), async (c) => {
+    const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
+    return c.json(usageWithLimits(snapshot, c.get("workspace")));
+  })
+
+  .post("/reconcile", requireScope("files:write"), async (c) => {
+    const result = await reconcileWorkspaceUsage(c.env, c.get("workspace"), c.get("workspaceName"));
+    return c.json({
+      ...result,
+      usage: usageWithLimits(result.usage, c.get("workspace")),
+    });
+  })
+
+  .post("/purge-expired", requireScope("files:delete"), async (c) => {
+    const result = await purgeExpiredObjects(c.env, c.get("workspace"), c.get("workspaceName"));
+    if ("skipped" in result) {
+      return c.json(result, 200);
+    }
+    return c.json({
+      ...result,
+      reconcile: {
+        ...result.reconcile,
+        usage: usageWithLimits(result.reconcile.usage, c.get("workspace")),
+      },
+    });
+  });

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -146,3 +146,40 @@ export async function recordUsageSafe(
     );
   }
 }
+
+/**
+ * Replace absolute bytes/objects from a storage scan (reconcile).
+ * Preserves uploads_in_period for the current period when the row exists.
+ */
+export async function setUsageTotals(
+  db: D1Database,
+  workspace: string,
+  totals: { bytes: number; objects: number },
+  now = new Date(),
+): Promise<WorkspaceUsage> {
+  const period = usagePeriodStart(now);
+  const updatedAt = now.toISOString();
+  const bytes = Math.max(0, Math.floor(totals.bytes));
+  const objects = Math.max(0, Math.floor(totals.objects));
+
+  await db.batch([
+    db
+      .prepare(
+        `INSERT OR IGNORE INTO workspace_usage
+           (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+         VALUES (?, ?, ?, 0, ?, ?)`,
+      )
+      .bind(workspace, bytes, objects, period, updatedAt),
+    db
+      .prepare(
+        `UPDATE workspace_usage SET
+           bytes = ?,
+           objects = ?,
+           updated_at = ?
+         WHERE workspace = ?`,
+      )
+      .bind(bytes, objects, updatedAt, workspace),
+  ]);
+
+  return getWorkspaceUsage(db, workspace, now);
+}

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -39,6 +39,11 @@ export interface WorkspaceRecord {
    * Cap on successful puts in the current UTC calendar month. Omit for unlimited.
    */
   maxUploadsPerPeriod?: number;
+  /**
+   * Delete objects whose last-modified is older than this many days when
+   * purge-expired runs. Omit to skip retention. Configure via workspace:limits.
+   */
+  retentionDays?: number;
 }
 
 export type WorkspaceVars = {

--- a/apps/api/test/fake-r2.ts
+++ b/apps/api/test/fake-r2.ts
@@ -7,6 +7,8 @@
 interface StoredObject {
   data: Uint8Array;
   contentType?: string;
+  /** R2 "uploaded" / last-modified; tests can backdate for retention. */
+  uploaded?: Date;
 }
 
 export class FakeR2Bucket {
@@ -18,7 +20,7 @@ export class FakeR2Bucket {
       size: obj.data.byteLength,
       etag: "fake-etag",
       httpEtag: '"fake-etag"',
-      uploaded: new Date(0),
+      uploaded: obj.uploaded ?? new Date(),
       version: "1",
       storageClass: "Standard",
       checksums: {},
@@ -45,9 +47,15 @@ export class FakeR2Bucket {
       httpMetadata instanceof Headers
         ? (httpMetadata.get("content-type") ?? undefined)
         : httpMetadata?.contentType;
-    const obj = { data, contentType };
+    const obj: StoredObject = { data, contentType, uploaded: new Date() };
     this.store.set(key, obj);
     return this.meta(key, obj);
+  }
+
+  /** Test helper: set last-modified for retention purge scenarios. */
+  setUploaded(key: string, uploaded: Date) {
+    const obj = this.store.get(key);
+    if (obj) obj.uploaded = uploaded;
   }
 
   async get(key: string) {

--- a/apps/api/test/reconcile-retention.test.ts
+++ b/apps/api/test/reconcile-retention.test.ts
@@ -1,0 +1,135 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const TOKEN = "secret-token";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+async function makeEnv(overrides: Partial<WorkspaceRecord> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...overrides,
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  return {
+    env: {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: db,
+      UPLOADS_DEFAULT: bucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    },
+    bucket,
+    db,
+  };
+}
+
+const auth = { Authorization: `Bearer ${TOKEN}` };
+
+describe("POST /usage/reconcile", () => {
+  it("rebuilds ledger totals from storage when metering drifted", async () => {
+    const { env, bucket, db } = await makeEnv();
+    // Object in R2 without going through put metering
+    await bucket.put("default/orphan.png", PNG, { httpMetadata: { contentType: "image/png" } });
+    db.usage.set("default", {
+      workspace: "default",
+      bytes: 9999,
+      objects: 99,
+      uploads_in_period: 7,
+      period_start: "2026-07",
+      updated_at: "2026-07-01T00:00:00.000Z",
+    });
+
+    const res = await app.request(
+      "/v1/default/usage/reconcile",
+      { method: "POST", headers: auth },
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      bytes: number;
+      objects: number;
+      previous: { bytes: number; objects: number };
+      changed: boolean;
+      usage: { uploadsInPeriod: number; bytes: number };
+    };
+    expect(body.previous).toEqual({ bytes: 9999, objects: 99 });
+    expect(body.bytes).toBe(PNG.byteLength);
+    expect(body.objects).toBe(1);
+    expect(body.changed).toBe(true);
+    // Monthly upload counter preserved
+    expect(body.usage.uploadsInPeriod).toBe(7);
+    expect(body.usage.bytes).toBe(PNG.byteLength);
+  });
+
+  it("requires files:write", async () => {
+    const { env } = await makeEnv();
+    // No auth
+    expect(
+      (await app.request("/v1/default/usage/reconcile", { method: "POST" }, env as never)).status,
+    ).toBe(401);
+  });
+});
+
+describe("POST /usage/purge-expired", () => {
+  it("skips when retentionDays is unset", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/usage/purge-expired",
+      { method: "POST", headers: auth },
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ skipped: true });
+  });
+
+  it("deletes old objects and reconciles", async () => {
+    const { env, bucket } = await makeEnv({ retentionDays: 30 });
+    await bucket.put("default/old.png", PNG, { httpMetadata: { contentType: "image/png" } });
+    await bucket.put("default/new.png", PNG, { httpMetadata: { contentType: "image/png" } });
+    bucket.setUploaded("default/old.png", new Date("2020-01-01T00:00:00Z"));
+    bucket.setUploaded("default/new.png", new Date());
+
+    const res = await app.request(
+      "/v1/default/usage/purge-expired",
+      { method: "POST", headers: auth },
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      deleted: number;
+      freedBytes: number;
+      keys: string[];
+      reconcile: { objects: number; bytes: number };
+    };
+    expect(body.deleted).toBe(1);
+    expect(body.freedBytes).toBe(PNG.byteLength);
+    expect(body.keys).toContain("old.png");
+    expect(bucket.store.has("default/old.png")).toBe(false);
+    expect(bucket.store.has("default/new.png")).toBe(true);
+    expect(body.reconcile.objects).toBe(1);
+    expect(body.reconcile.bytes).toBe(PNG.byteLength);
+  });
+});

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -33,20 +33,65 @@ export class UsageFakeD1 {
       },
       run: async () => {
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
-          const [workspace, period, updatedAt] = values as [string, string, string];
-          if (!this.usage.has(workspace)) {
-            this.usage.set(workspace, {
-              workspace,
-              bytes: 0,
-              objects: 0,
-              uploads_in_period: 0,
-              period_start: period,
-              updated_at: updatedAt,
-            });
+          // applyUsageDelta: (ws, period, updatedAt) with zeros
+          // setUsageTotals: (ws, bytes, objects, period, updatedAt)
+          if (values.length === 3) {
+            const [workspace, period, updatedAt] = values as [string, string, string];
+            if (!this.usage.has(workspace)) {
+              this.usage.set(workspace, {
+                workspace,
+                bytes: 0,
+                objects: 0,
+                uploads_in_period: 0,
+                period_start: period,
+                updated_at: updatedAt,
+              });
+            }
+          } else {
+            const [workspace, bytes, objects, period, updatedAt] = values as [
+              string,
+              number,
+              number,
+              string,
+              string,
+            ];
+            if (!this.usage.has(workspace)) {
+              this.usage.set(workspace, {
+                workspace,
+                bytes,
+                objects,
+                uploads_in_period: 0,
+                period_start: period,
+                updated_at: updatedAt,
+              });
+            }
           }
           return { success: true as const, meta: { changes: 1 }, results: [] };
         }
         if (normalized.startsWith("UPDATE workspace_usage SET")) {
+          // Absolute totals from setUsageTotals: bytes, objects, updated_at, workspace
+          if (
+            normalized.includes("bytes = ?") &&
+            normalized.includes("objects = ?") &&
+            !normalized.includes("bytes +")
+          ) {
+            const [bytes, objects, updatedAt, workspace] = values as [
+              number,
+              number,
+              string,
+              string,
+            ];
+            const row = this.usage.get(workspace);
+            if (!row) throw new Error(`update before insert for ${workspace}`);
+            this.usage.set(workspace, {
+              ...row,
+              bytes,
+              objects,
+              updated_at: updatedAt,
+            });
+            return { success: true as const, meta: { changes: 1 }, results: [] };
+          }
+          // Delta apply from applyUsageDelta
           const [
             dBytes,
             dObjects,

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,8 @@ Unknown workspaces and bad tokens are indistinguishable (both 401).
 | `GET /v1/:workspace/files/:key`                   | Object metadata                                                                            |
 | `DELETE /v1/:workspace/files/:key`                | Delete object                                                                              |
 | `GET /v1/:workspace/usage`                        | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read` |
+| `POST /v1/:workspace/usage/reconcile`             | Rebuild `bytes`/`objects` from storage; requires `files:write`                             |
+| `POST /v1/:workspace/usage/purge-expired`         | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`         |
 
 `url` in responses is the public URL when the workspace has a
 `publicBaseUrl`, otherwise `null`.
@@ -35,6 +37,19 @@ headroom. Puts that would exceed them fail with:
 
 Configure limits with `pnpm workspace:limits <name> …` (see
 [workspaces](workspaces.md)).
+
+**Reconcile** scans every object under the workspace prefix and replaces ledger
+`bytes`/`objects` (monthly upload count is preserved). Use after external
+deletes or if counters look wrong:
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  https://api.uploads.sh/v1/$WS/usage/reconcile
+```
+
+**Purge expired** deletes objects whose store last-modified is older than
+`retentionDays` on the workspace record, then reconciles. Skips with
+`{ "skipped": true }` when retention is unset.
 
 ## Example
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -17,16 +17,17 @@ D1 table `workspace_usage` tracks net `bytes` / `objects` and monthly
 Optional **budgets** live on the workspace registry record (KV), same as
 `maxUploadBytes`:
 
-| Field                 | Meaning                                       |
-| --------------------- | --------------------------------------------- |
-| `maxStorageBytes`     | Cap on net stored bytes                       |
-| `maxUploadsPerPeriod` | Cap on puts in the current UTC calendar month |
-| `maxUploadBytes`      | Cap on a single object (default 25 MiB)       |
+| Field                 | Meaning                                         |
+| --------------------- | ----------------------------------------------- |
+| `maxStorageBytes`     | Cap on net stored bytes                         |
+| `maxUploadsPerPeriod` | Cap on puts in the current UTC calendar month   |
+| `maxUploadBytes`      | Cap on a single object (default 25 MiB)         |
+| `retentionDays`       | Age (days) after which purge-expired may delete |
 
-Omit a field for unlimited. Puts that would exceed storage return **507** with
-`code: "storage_quota_exceeded"`; monthly upload budget returns **429** with
-`code: "upload_budget_exceeded"`. `GET …/usage` includes the caps and remaining
-when set.
+Omit a field for unlimited (or no retention). Puts that would exceed storage
+return **507** with `code: "storage_quota_exceeded"`; monthly upload budget
+returns **429** with `code: "upload_budget_exceeded"`. `GET …/usage` includes
+the caps and remaining when set.
 
 ### Configure limits
 
@@ -43,11 +44,22 @@ pnpm workspace:limits my-ws                          # show current
 pnpm workspace:limits my-ws --max-storage 50GB
 pnpm workspace:limits my-ws --max-uploads-per-month 20000
 pnpm workspace:limits my-ws --clear-max-storage      # back to unlimited
+pnpm workspace:limits my-ws --retention-days 90
+pnpm workspace:limits my-ws --clear-retention-days
 pnpm workspace:limits my-ws --local                  # local KV for wrangler dev
 ```
 
 Sizes accept `25MB`, `1GiB`, or raw byte counts. KV is cached ~60s on the
 Worker — new limits apply on the next request after that.
+
+### Reconcile and retention
+
+- `POST /v1/:ws/usage/reconcile` — re-scan storage, fix ledger drift (`files:write`).
+- `POST /v1/:ws/usage/purge-expired` — delete objects older than `retentionDays`
+  (`files:delete`), then reconcile. No-op skip if retention is unset.
+
+There is no automatic cron yet — run purge from ops/CI when you want expiry.
+Retention uses object last-modified from the store (R2 upload time).
 
 New enrollment-issued tokens are stored in D1 and carry an expiry and explicit scopes.
 Workspace configuration and legacy tokens remain in `REGISTRY` KV. The routine-agent

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -61,6 +61,13 @@ Worker — new limits apply on the next request after that.
 There is no automatic cron yet — run purge from ops/CI when you want expiry.
 Retention uses object last-modified from the store (R2 upload time).
 
+**files-sdk:** reconcile/purge walk with `listAll()` on the workspace-prefixed
+`Files` instance (metadata only — no body reads). Purge uses bulk
+`delete(keys[])` so R2 can multi-delete. We do **not** use the in-memory
+`usage()` plugin (not durable across Workers), nor the `softDelete` plugin
+(recycle bin, not TTL). Bucket lifecycle via `files.raw` is bucket-wide and
+doesn’t express per-workspace `retentionDays` on a shared bucket.
+
 New enrollment-issued tokens are stored in D1 and carry an expiry and explicit scopes.
 Workspace configuration and legacy tokens remain in `REGISTRY` KV. The routine-agent
 default is `files:read` plus `files:write`, which is sufficient for upload, listing,


### PR DESCRIPTION
## Summary

High-value follow-ups before Durable Objects (#24):

1. **Reconcile** — `POST /v1/:workspace/usage/reconcile` (`files:write`) walks storage via files-sdk `listAll`, replaces ledger `bytes`/`objects`, **keeps** `uploadsInPeriod`.
2. **Retention** — optional `retentionDays` on the workspace KV record; `POST /v1/:workspace/usage/purge-expired` (`files:delete`) deletes objects older than that window (by last-modified), then reconciles. Skips cleanly when unset.
3. **Config** — `pnpm workspace:limits <ws> --retention-days 90` / `--clear-retention-days`.

No automatic cron yet — ops/CI can call purge when desired.

Relates to #22. Deliberately not #24 (DO).

## Test plan

- [x] API unit/route tests (drift fix, purge old/keep new, skip without retention)
- [x] Full API + MCP suites green
- [ ] After merge: reconcile a prod workspace; optionally set retention and dry-run logic via purge on a test prefix