### PR TITLE
feat: ops foundations (cron, encrypt, presign, keys, video caps)

### DIFF
--- a/.changeset/ops-foundations-cli-hints.md
+++ b/.changeset/ops-foundations-cli-hints.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Print actionable stderr hints on storage/upload budget and payload-too-large failures (point at `uploads usage` and size policy flags).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # all workers; or deploy:api / deploy:web / deploy:mcp
 pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
   [--max-storage 25GB] [--max-uploads-per-month N] [--max-upload-bytes 25MB]
-pnpm workspace:limits <name> [--max-storage …] [--clear-max-storage] […]
+pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] [--clear-max-storage] […]
 pnpm uploads put <file> --env-file .env   # CLI (builds package first)
 pnpm uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
 ```
@@ -48,6 +48,9 @@ Use `pnpm run deploy` (not bare `pnpm deploy` — that's pnpm's built-in).
 also applies remote migrations when `apps/api/migrations/**` changes
 (secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`). Production
 worker deploys normally happen via Workers Builds on push to main.
+
+Operator runbook: [docs/ops.md](docs/ops.md). Daily retention cron on the API
+worker; BYO secrets use `WORKSPACE_SECRETS_KEY`; bare upload keys get `f/<id>/…`.
 
 ### Releasing `@buildinternet/uploads` (changesets)
 

--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -12,3 +12,5 @@ ADMIN_TOKEN=
 # Optional: encrypt BYO S3 keys in REGISTRY KV (openssl rand -base64 32).
 # Production: wrangler secret put WORKSPACE_SECRETS_KEY
 WORKSPACE_SECRETS_KEY=
+# During rotation only: old key while re-encrypting (then remove).
+# WORKSPACE_SECRETS_KEY_PREVIOUS=

--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -8,3 +8,7 @@
 #   cd apps/api && pnpm exec wrangler secret put ADMIN_TOKEN
 # If unset, /admin/* rejects every request (fails closed).
 ADMIN_TOKEN=
+
+# Optional: encrypt BYO S3 keys in REGISTRY KV (openssl rand -base64 32).
+# Production: wrangler secret put WORKSPACE_SECRETS_KEY
+WORKSPACE_SECRETS_KEY=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "types": "wrangler types",
     "workspace:add": "node --env-file-if-exists=../../.env scripts/add-workspace.mjs",
     "workspace:limits": "node --env-file-if-exists=../../.env scripts/set-workspace-limits.mjs",
+    "workspace:reencrypt-secrets": "node --env-file-if-exists=../../.env scripts/reencrypt-workspace-secrets.mjs",
     "typecheck": "wrangler types && tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -29,6 +29,18 @@
 import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 
+/** Match apps/api/src/secrets.ts: enc:v1: + base64url(iv || ct || tag). */
+function sealField(master, plaintext) {
+  if (!master || !plaintext || String(plaintext).startsWith("enc:v1:")) return plaintext;
+  if (master.length < 16) fail("WORKSPACE_SECRETS_KEY must be at least 16 characters");
+  const key = crypto.createHash("sha256").update(master).digest();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const enc = Buffer.concat([cipher.update(String(plaintext), "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `enc:v1:${Buffer.concat([iv, enc, tag]).toString("base64url")}`;
+}
+
 const [name, ...rest] = process.argv.slice(2);
 const opts = {};
 for (let i = 0; i < rest.length; i++) {
@@ -131,9 +143,17 @@ const record = opts.bucket
 const maxStorageBytes = parseBytes(opts["max-storage"], "max-storage");
 const maxUploadsPerPeriod = parseCount(opts["max-uploads-per-month"], "max-uploads-per-month");
 const maxUploadBytes = parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
+const maxVideoUploadBytes = parseBytes(opts["max-video-bytes"], "max-video-bytes");
 if (maxStorageBytes !== undefined) record.maxStorageBytes = maxStorageBytes;
 if (maxUploadsPerPeriod !== undefined) record.maxUploadsPerPeriod = maxUploadsPerPeriod;
 if (maxUploadBytes !== undefined) record.maxUploadBytes = maxUploadBytes;
+if (maxVideoUploadBytes !== undefined) record.maxVideoUploadBytes = maxVideoUploadBytes;
+
+const master = process.env.WORKSPACE_SECRETS_KEY;
+if (master && (record.accessKeyId || record.secretAccessKey)) {
+  if (record.accessKeyId) record.accessKeyId = sealField(master, record.accessKeyId);
+  if (record.secretAccessKey) record.secretAccessKey = sealField(master, record.secretAccessKey);
+}
 
 Object.keys(record).forEach((k) => record[k] === undefined && delete record[k]);
 

--- a/apps/api/scripts/reencrypt-workspace-secrets.mjs
+++ b/apps/api/scripts/reencrypt-workspace-secrets.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Re-seal BYO credentials under the current WORKSPACE_SECRETS_KEY.
+ *
+ * Rotation procedure (see docs/ops.md):
+ *   1. openssl rand -base64 32  → NEW
+ *   2. wrangler secret put WORKSPACE_SECRETS_KEY_PREVIOUS  # paste OLD
+ *   3. wrangler secret put WORKSPACE_SECRETS_KEY            # paste NEW
+ *   4. WORKSPACE_SECRETS_KEY=NEW WORKSPACE_SECRETS_KEY_PREVIOUS=OLD \
+ *        node scripts/reencrypt-workspace-secrets.mjs [--local] [--dry-run]
+ *   5. Verify BYO workspaces; remove WORKSPACE_SECRETS_KEY_PREVIOUS
+ *
+ * Decrypt tries PREVIOUS then CURRENT; encrypt uses CURRENT only.
+ */
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+
+const args = process.argv.slice(2);
+const local = args.includes("--local");
+const dryRun = args.includes("--dry-run");
+
+const PREFIX = "enc:v1:";
+const current = process.env.WORKSPACE_SECRETS_KEY ?? "";
+const previous = process.env.WORKSPACE_SECRETS_KEY_PREVIOUS ?? "";
+
+function fail(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+if (current.length < 16) {
+  fail("WORKSPACE_SECRETS_KEY (current) must be set and ≥ 16 characters");
+}
+
+function aesKey(secret) {
+  return crypto.createHash("sha256").update(secret).digest();
+}
+
+function encrypt(master, plaintext) {
+  const key = aesKey(master);
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const enc = Buffer.concat([cipher.update(String(plaintext), "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return PREFIX + Buffer.concat([iv, enc, tag]).toString("base64url");
+}
+
+function decryptOne(master, value) {
+  const packed = Buffer.from(value.slice(PREFIX.length), "base64url");
+  if (packed.length < 13) throw new Error("invalid ciphertext");
+  const iv = packed.subarray(0, 12);
+  const tag = packed.subarray(packed.length - 16);
+  const data = packed.subarray(12, packed.length - 16);
+  const decipher = crypto.createDecipheriv("aes-256-gcm", aesKey(master), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
+}
+
+function decrypt(value) {
+  if (!value || !String(value).startsWith(PREFIX)) return { plain: value, usedPrevious: false };
+  const masters = [current, previous].filter(
+    (s, i, a) => s && s.length >= 16 && a.indexOf(s) === i,
+  );
+  let last;
+  for (let i = 0; i < masters.length; i++) {
+    try {
+      return {
+        plain: decryptOne(masters[i], value),
+        usedPrevious: i > 0 || masters[i] === previous,
+      };
+    } catch (e) {
+      last = e;
+    }
+  }
+  throw last ?? new Error("decrypt failed");
+}
+
+function wrangler(args) {
+  return execFileSync(
+    "pnpm",
+    ["exec", "wrangler", ...args, "--binding", "REGISTRY", local ? "--local" : "--remote"],
+    {
+      encoding: "utf8",
+    },
+  );
+}
+
+function listKeys() {
+  // wrangler kv key list --prefix ws:
+  const out = wrangler(["kv", "key", "list", "--prefix", "ws:"]);
+  const parsed = JSON.parse(out);
+  return parsed.map((k) => k.name).filter((n) => typeof n === "string" && n.startsWith("ws:"));
+}
+
+function getRecord(key) {
+  const raw = wrangler(["kv", "key", "get", key]);
+  return JSON.parse(raw);
+}
+
+function putRecord(key, record) {
+  wrangler(["kv", "key", "put", key, JSON.stringify(record)]);
+}
+
+const keys = listKeys();
+let scanned = 0;
+let updated = 0;
+let skipped = 0;
+let errors = 0;
+
+console.log(
+  `reencrypt: ${keys.length} registry keys (${local ? "local" : "remote"})${dryRun ? " dry-run" : ""}`,
+);
+
+for (const key of keys) {
+  scanned += 1;
+  let record;
+  try {
+    record = getRecord(key);
+  } catch (e) {
+    console.error(`  ${key}: get failed — ${e.message ?? e}`);
+    errors += 1;
+    continue;
+  }
+
+  const hasCreds = record.accessKeyId || record.secretAccessKey;
+  if (!hasCreds) {
+    skipped += 1;
+    continue;
+  }
+
+  try {
+    const ak = record.accessKeyId ? decrypt(record.accessKeyId) : { plain: undefined };
+    const sk = record.secretAccessKey ? decrypt(record.secretAccessKey) : { plain: undefined };
+    const next = { ...record };
+    if (ak.plain !== undefined) next.accessKeyId = encrypt(current, ak.plain);
+    if (sk.plain !== undefined) next.secretAccessKey = encrypt(current, sk.plain);
+
+    const changed =
+      next.accessKeyId !== record.accessKeyId || next.secretAccessKey !== record.secretAccessKey;
+    if (!changed) {
+      skipped += 1;
+      continue;
+    }
+    if (dryRun) {
+      console.log(`  ${key}: would re-seal (usedPrevious=${ak.usedPrevious || sk.usedPrevious})`);
+      updated += 1;
+    } else {
+      putRecord(key, next);
+      console.log(`  ${key}: re-sealed under current key`);
+      updated += 1;
+    }
+  } catch (e) {
+    console.error(`  ${key}: ${e.message ?? e}`);
+    errors += 1;
+  }
+}
+
+console.log(`\ndone: scanned=${scanned} updated=${updated} skipped=${skipped} errors=${errors}`);
+if (errors > 0) process.exit(1);
+console.log("After verifying BYO workspaces, remove WORKSPACE_SECRETS_KEY_PREVIOUS.");

--- a/apps/api/scripts/reencrypt-workspace-secrets.mjs
+++ b/apps/api/scripts/reencrypt-workspace-secrets.mjs
@@ -1,160 +1,46 @@
 #!/usr/bin/env node
 /**
- * Re-seal BYO credentials under the current WORKSPACE_SECRETS_KEY.
+ * Thin client for POST /admin/credentials/reencrypt.
  *
- * Rotation procedure (see docs/ops.md):
- *   1. openssl rand -base64 32  → NEW
- *   2. wrangler secret put WORKSPACE_SECRETS_KEY_PREVIOUS  # paste OLD
- *   3. wrangler secret put WORKSPACE_SECRETS_KEY            # paste NEW
- *   4. WORKSPACE_SECRETS_KEY=NEW WORKSPACE_SECRETS_KEY_PREVIOUS=OLD \
- *        node scripts/reencrypt-workspace-secrets.mjs [--local] [--dry-run]
- *   5. Verify BYO workspaces; remove WORKSPACE_SECRETS_KEY_PREVIOUS
+ * Prefer the admin API so WORKSPACE_SECRETS_KEY never leaves the worker.
+ * Secret rotation (putting NEW / PREVIOUS) still uses wrangler secret put.
  *
- * Decrypt tries PREVIOUS then CURRENT; encrypt uses CURRENT only.
+ * Usage:
+ *   UPLOADS_API_URL=https://api.uploads.sh ADMIN_TOKEN=… \
+ *     node scripts/reencrypt-workspace-secrets.mjs [--dry-run]
+ *
+ * Or from monorepo root after setting ADMIN_TOKEN in .env:
+ *   pnpm workspace:reencrypt-secrets --dry-run
  */
-import { execFileSync } from "node:child_process";
-import crypto from "node:crypto";
+const dryRun = process.argv.includes("--dry-run");
+const api = (process.env.UPLOADS_API_URL ?? "https://api.uploads.sh").replace(/\/$/, "");
+const token = process.env.ADMIN_TOKEN ?? process.env.UPLOADS_ADMIN_TOKEN ?? "";
 
-const args = process.argv.slice(2);
-const local = args.includes("--local");
-const dryRun = args.includes("--dry-run");
-
-const PREFIX = "enc:v1:";
-const current = process.env.WORKSPACE_SECRETS_KEY ?? "";
-const previous = process.env.WORKSPACE_SECRETS_KEY_PREVIOUS ?? "";
-
-function fail(msg) {
-  console.error(`error: ${msg}`);
+if (!token) {
+  console.error("error: ADMIN_TOKEN (or UPLOADS_ADMIN_TOKEN) is required");
   process.exit(1);
 }
 
-if (current.length < 16) {
-  fail("WORKSPACE_SECRETS_KEY (current) must be set and ≥ 16 characters");
+const url = `${api}/admin/credentials/reencrypt${dryRun ? "?dryRun=1" : ""}`;
+const res = await fetch(url, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${token}` },
+});
+const text = await res.text();
+let body;
+try {
+  body = JSON.parse(text);
+} catch {
+  body = text;
 }
-
-function aesKey(secret) {
-  return crypto.createHash("sha256").update(secret).digest();
+if (!res.ok) {
+  console.error(`HTTP ${res.status}`, body);
+  process.exit(1);
 }
-
-function encrypt(master, plaintext) {
-  const key = aesKey(master);
-  const iv = crypto.randomBytes(12);
-  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
-  const enc = Buffer.concat([cipher.update(String(plaintext), "utf8"), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  return PREFIX + Buffer.concat([iv, enc, tag]).toString("base64url");
-}
-
-function decryptOne(master, value) {
-  const packed = Buffer.from(value.slice(PREFIX.length), "base64url");
-  if (packed.length < 13) throw new Error("invalid ciphertext");
-  const iv = packed.subarray(0, 12);
-  const tag = packed.subarray(packed.length - 16);
-  const data = packed.subarray(12, packed.length - 16);
-  const decipher = crypto.createDecipheriv("aes-256-gcm", aesKey(master), iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
-}
-
-function decrypt(value) {
-  if (!value || !String(value).startsWith(PREFIX)) return { plain: value, usedPrevious: false };
-  const masters = [current, previous].filter(
-    (s, i, a) => s && s.length >= 16 && a.indexOf(s) === i,
-  );
-  let last;
-  for (let i = 0; i < masters.length; i++) {
-    try {
-      return {
-        plain: decryptOne(masters[i], value),
-        usedPrevious: i > 0 || masters[i] === previous,
-      };
-    } catch (e) {
-      last = e;
-    }
-  }
-  throw last ?? new Error("decrypt failed");
-}
-
-function wrangler(args) {
-  return execFileSync(
-    "pnpm",
-    ["exec", "wrangler", ...args, "--binding", "REGISTRY", local ? "--local" : "--remote"],
-    {
-      encoding: "utf8",
-    },
-  );
-}
-
-function listKeys() {
-  // wrangler kv key list --prefix ws:
-  const out = wrangler(["kv", "key", "list", "--prefix", "ws:"]);
-  const parsed = JSON.parse(out);
-  return parsed.map((k) => k.name).filter((n) => typeof n === "string" && n.startsWith("ws:"));
-}
-
-function getRecord(key) {
-  const raw = wrangler(["kv", "key", "get", key]);
-  return JSON.parse(raw);
-}
-
-function putRecord(key, record) {
-  wrangler(["kv", "key", "put", key, JSON.stringify(record)]);
-}
-
-const keys = listKeys();
-let scanned = 0;
-let updated = 0;
-let skipped = 0;
-let errors = 0;
-
+console.log(JSON.stringify(body, null, 2));
+if (body.errors?.length) process.exit(1);
 console.log(
-  `reencrypt: ${keys.length} registry keys (${local ? "local" : "remote"})${dryRun ? " dry-run" : ""}`,
+  dryRun
+    ? "\nDry-run only. Re-run without --dry-run, then remove WORKSPACE_SECRETS_KEY_PREVIOUS."
+    : "\nDone. After verifying BYO workspaces, remove WORKSPACE_SECRETS_KEY_PREVIOUS.",
 );
-
-for (const key of keys) {
-  scanned += 1;
-  let record;
-  try {
-    record = getRecord(key);
-  } catch (e) {
-    console.error(`  ${key}: get failed — ${e.message ?? e}`);
-    errors += 1;
-    continue;
-  }
-
-  const hasCreds = record.accessKeyId || record.secretAccessKey;
-  if (!hasCreds) {
-    skipped += 1;
-    continue;
-  }
-
-  try {
-    const ak = record.accessKeyId ? decrypt(record.accessKeyId) : { plain: undefined };
-    const sk = record.secretAccessKey ? decrypt(record.secretAccessKey) : { plain: undefined };
-    const next = { ...record };
-    if (ak.plain !== undefined) next.accessKeyId = encrypt(current, ak.plain);
-    if (sk.plain !== undefined) next.secretAccessKey = encrypt(current, sk.plain);
-
-    const changed =
-      next.accessKeyId !== record.accessKeyId || next.secretAccessKey !== record.secretAccessKey;
-    if (!changed) {
-      skipped += 1;
-      continue;
-    }
-    if (dryRun) {
-      console.log(`  ${key}: would re-seal (usedPrevious=${ak.usedPrevious || sk.usedPrevious})`);
-      updated += 1;
-    } else {
-      putRecord(key, next);
-      console.log(`  ${key}: re-sealed under current key`);
-      updated += 1;
-    }
-  } catch (e) {
-    console.error(`  ${key}: ${e.message ?? e}`);
-    errors += 1;
-  }
-}
-
-console.log(`\ndone: scanned=${scanned} updated=${updated} skipped=${skipped} errors=${errors}`);
-if (errors > 0) process.exit(1);
-console.log("After verifying BYO workspaces, remove WORKSPACE_SECRETS_KEY_PREVIOUS.");

--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -125,6 +125,7 @@ const before = {
   maxStorageBytes: record.maxStorageBytes,
   maxUploadsPerPeriod: record.maxUploadsPerPeriod,
   maxUploadBytes: record.maxUploadBytes,
+  maxVideoUploadBytes: record.maxVideoUploadBytes,
   retentionDays: record.retentionDays,
 };
 
@@ -144,6 +145,12 @@ if (clears.has("max-upload-bytes") || opts["max-upload-bytes"] !== undefined) {
     ? null
     : parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
   patch.maxUploadBytes = v;
+}
+if (clears.has("max-video-bytes") || opts["max-video-bytes"] !== undefined) {
+  const v = clears.has("max-video-bytes")
+    ? null
+    : parseBytes(opts["max-video-bytes"], "max-video-bytes");
+  patch.maxVideoUploadBytes = v;
 }
 if (clears.has("retention-days") || opts["retention-days"] !== undefined) {
   const v = clears.has("retention-days")
@@ -175,6 +182,7 @@ const after = {
   maxStorageBytes: record.maxStorageBytes,
   maxUploadsPerPeriod: record.maxUploadsPerPeriod,
   maxUploadBytes: record.maxUploadBytes,
+  maxVideoUploadBytes: record.maxVideoUploadBytes,
   retentionDays: record.retentionDays,
 };
 

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -1,5 +1,7 @@
-// ADMIN_TOKEN is a runtime Worker secret (see .dev.vars.example), not declared
-// in wrangler.jsonc, so `wrangler types` does not generate it. Augment Env here.
+// Runtime Worker secrets (see .dev.vars.example), not declared in wrangler.jsonc,
+// so `wrangler types` does not generate them. Augment Env here.
 interface Env {
   ADMIN_TOKEN?: string;
+  /** AES master for BYO accessKeyId/secretAccessKey at rest in KV (optional). */
+  WORKSPACE_SECRETS_KEY?: string;
 }

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -2,6 +2,11 @@
 // so `wrangler types` does not generate them. Augment Env here.
 interface Env {
   ADMIN_TOKEN?: string;
-  /** AES master for BYO accessKeyId/secretAccessKey at rest in KV (optional). */
+  /** Current AES master for BYO credentials at rest in KV (optional). */
   WORKSPACE_SECRETS_KEY?: string;
+  /**
+   * Previous master during rotation. Decrypt tries current, then previous.
+   * Remove after reencrypt-workspace-secrets.mjs completes.
+   */
+  WORKSPACE_SECRETS_KEY_PREVIOUS?: string;
 }

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -28,6 +28,30 @@ export function badKey(key: string): boolean {
   );
 }
 
+/** Sanitize a bare basename for object keys. */
+export function sanitizeKeyBasename(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "file";
+}
+
+/** Short url-safe id for auto-prefix paths (`f/<id>/…`). */
+export function shortUploadId(bytes = 9): string {
+  return btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(bytes))))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Bare filenames (no `/`) get `f/<shortid>/<name>` so the workspace root doesn't
+ * accumulate loose objects. Nested keys (`screenshots/…`, `gh/…`) pass through.
+ * Default ON; opt out with `WorkspaceRecord.autoPrefixBareKeys === false`.
+ */
+export function governUploadKey(key: string, autoPrefix = true): string {
+  if (!autoPrefix || key.includes("/")) return key;
+  return `f/${shortUploadId()}/${sanitizeKeyBasename(key)}`;
+}
+
 /**
  * Rejected input to a file operation (always a caller error, never a storage
  * failure). Carries the REST status and error body so both surfaces report the
@@ -74,7 +98,8 @@ export async function putObject(
   bytes: Uint8Array,
   workspaceName: string,
 ): Promise<{ key: string; url: string | null; size: number; contentType: string }> {
-  if (badKey(key)) throw new FileOpError("invalid key");
+  const finalKey = governUploadKey(key, ws.autoPrefixBareKeys !== false);
+  if (badKey(finalKey)) throw new FileOpError("invalid key");
   if (bytes.byteLength === 0) throw new FileOpError("empty body");
 
   const inspection = inspectUpload(bytes, resolveUploadPolicy(ws));
@@ -83,17 +108,16 @@ export async function putObject(
     throw new FileOpError(error, inspection.status, extra);
   }
 
-  const store = storage(env, ws);
-  const prev = await existingSize(store, key);
+  const store = await storage(env, ws);
+  const prev = await existingSize(store, finalKey);
   const newSize = bytes.byteLength;
   const deltaBytes = prev === null ? newSize : newSize - prev;
 
-  // Enforce workspace budgets before writing (omit limits on the record = unlimited).
   const usage = await getWorkspaceUsage(env.DB, workspaceName);
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
   if (denial) throw new FileOpError(denial.message, denial.status, denial.detail);
 
-  await store.upload(key, bytes, {
+  await store.upload(finalKey, bytes, {
     contentType: inspection.contentType,
     cacheControl: UPLOAD_CACHE_CONTROL,
   });
@@ -105,8 +129,8 @@ export async function putObject(
   });
 
   return {
-    key,
-    url: publicUrl(storageConfig(env, ws), key),
+    key: finalKey,
+    url: publicUrl(await storageConfig(env, ws), finalKey),
     size: newSize,
     contentType: inspection.contentType,
   };
@@ -118,8 +142,9 @@ export async function listObjects(
   opts: { prefix?: string; limit?: number; cursor?: string } = {},
 ) {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 1000);
-  const result = await storage(env, ws).list({ prefix: opts.prefix, limit, cursor: opts.cursor });
-  const cfg = storageConfig(env, ws);
+  const store = await storage(env, ws);
+  const result = await store.list({ prefix: opts.prefix, limit, cursor: opts.cursor });
+  const cfg = await storageConfig(env, ws);
   return {
     items: result.items.map((item: { key: string }) => ({
       ...item,
@@ -138,7 +163,7 @@ export async function deleteObject(
 ): Promise<{ key: string; deleted: true }> {
   if (badKey(key)) throw new FileOpError("invalid key");
 
-  const store = storage(env, ws);
+  const store = await storage(env, ws);
   const prev = await existingSize(store, key);
 
   await store.delete(key);

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -2,11 +2,10 @@ import type { MiddlewareHandler } from "hono";
 import type { WorkspaceVars } from "./workspace";
 
 /**
- * Upload guardrails for the hosted API: a byte cap and a content-type
+ * Upload guardrails for the hosted API: byte caps and a content-type
  * allowlist backed by magic-byte sniffing, plus a per-workspace write rate
  * limit. Defaults live here; per-workspace overrides ride on the
- * `WorkspaceRecord` (`maxUploadBytes` / `allowedContentTypes`) and are merged
- * in `resolveUploadPolicy`.
+ * `WorkspaceRecord` and are merged in `resolveUploadPolicy`.
  */
 
 /** Default ceiling on a single upload. Covers screenshots and short clips. */
@@ -29,27 +28,40 @@ export const DEFAULT_ALLOWED_CONTENT_TYPES: readonly string[] = [
 
 const DEFAULT_ALLOWED_SET = new Set(DEFAULT_ALLOWED_CONTENT_TYPES);
 
+const VIDEO_TYPES = new Set(["video/mp4", "video/webm"]);
+
 export interface UploadPolicy {
+  /** Max for images (and as fallback when maxVideoBytes is unset). */
   maxBytes: number;
+  /** Max for video/* when set; otherwise maxBytes. */
+  maxVideoBytes: number;
   allowed: Set<string>;
 }
 
 /** Fields a workspace record may carry to override the default upload policy. */
 export interface UploadPolicyOverrides {
   maxUploadBytes?: number;
+  /** Cap for video/mp4 and video/webm. When unset, videos use maxUploadBytes. */
+  maxVideoUploadBytes?: number;
   allowedContentTypes?: string[];
 }
 
+function positiveBytes(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
 export function resolveUploadPolicy(record: UploadPolicyOverrides): UploadPolicy {
-  const maxBytes =
-    typeof record.maxUploadBytes === "number" && record.maxUploadBytes > 0
-      ? record.maxUploadBytes
-      : DEFAULT_MAX_UPLOAD_BYTES;
+  const maxBytes = positiveBytes(record.maxUploadBytes) ?? DEFAULT_MAX_UPLOAD_BYTES;
+  const maxVideoBytes = positiveBytes(record.maxVideoUploadBytes) ?? maxBytes;
   const allowed =
     record.allowedContentTypes && record.allowedContentTypes.length > 0
       ? new Set(record.allowedContentTypes)
       : DEFAULT_ALLOWED_SET;
-  return { maxBytes, allowed };
+  return { maxBytes, maxVideoBytes, allowed };
+}
+
+export function maxBytesForContentType(policy: UploadPolicy, contentType: string): number {
+  return VIDEO_TYPES.has(contentType) ? policy.maxVideoBytes : policy.maxBytes;
 }
 
 /** True when `bytes` contains `signature` at `offset` (bounds-checked). */
@@ -100,31 +112,42 @@ export type UploadRejection = { ok: false; status: 413 | 415; body: Record<strin
 export type UploadInspection = { ok: true; contentType: string } | UploadRejection;
 
 /** The shared 413 rejection for both the pre-buffer and post-buffer size checks. */
-function tooLarge(maxBytes: number): UploadRejection {
-  return { ok: false, status: 413, body: { error: "payload too large", maxBytes } };
+function tooLarge(
+  maxBytes: number,
+  extra?: { contentType?: string; kind?: "image" | "video" },
+): UploadRejection {
+  return {
+    ok: false,
+    status: 413,
+    body: {
+      error: "payload too large",
+      code: "upload_too_large",
+      maxBytes,
+      ...extra,
+    },
+  };
 }
 
 /**
- * Pre-buffer size gate: reject on a declared `Content-Length` over the cap
- * before the body is read into isolate memory. Returns `null` when the header
- * is absent or within range — `inspectUpload` is the authoritative backstop for
- * missing or dishonest lengths.
+ * Pre-buffer size gate: reject on a declared `Content-Length` over the larger
+ * of image/video caps before the body is read into isolate memory.
+ * `inspectUpload` is the authoritative backstop for type-specific limits.
  */
 export function checkDeclaredLength(
   contentLength: string | undefined,
   policy: UploadPolicy,
 ): UploadRejection | null {
   const declared = Number(contentLength);
-  if (Number.isFinite(declared) && declared > policy.maxBytes) return tooLarge(policy.maxBytes);
+  const ceiling = Math.max(policy.maxBytes, policy.maxVideoBytes);
+  if (Number.isFinite(declared) && declared > ceiling) return tooLarge(ceiling);
   return null;
 }
 
 /**
- * Validate a fully-buffered upload body against the policy: size (the
- * authoritative check) then the sniffed type against the allowlist.
+ * Validate a fully-buffered upload body against the policy: sniffed type
+ * against the allowlist, then the type-specific size cap.
  */
 export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadInspection {
-  if (bytes.byteLength > policy.maxBytes) return tooLarge(policy.maxBytes);
   const detected = detectContentType(bytes);
   if (detected === null || !policy.allowed.has(detected)) {
     return {
@@ -132,6 +155,11 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
       status: 415,
       body: { error: "unsupported media type", allowed: [...policy.allowed] },
     };
+  }
+  const maxBytes = maxBytesForContentType(policy, detected);
+  const kind = VIDEO_TYPES.has(detected) ? ("video" as const) : ("image" as const);
+  if (bytes.byteLength > maxBytes) {
+    return tooLarge(maxBytes, { contentType: detected, kind });
   }
   return { ok: true, contentType: detected };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,8 +4,10 @@ import { files } from "./routes/files";
 import { usage } from "./routes/usage";
 import { admin } from "./routes/admin";
 import { auth } from "./routes/auth";
+import { runRetentionSweep } from "./retention-sweep";
 
-const app = new Hono<WorkspaceVars>()
+/** Hono app — also re-exported for vitest (`app.request`). */
+export const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
   .route("/admin", admin)
   .route("/auth", auth)
@@ -18,4 +20,19 @@ const app = new Hono<WorkspaceVars>()
   })
   .notFound((c) => c.json({ error: "not found" }, 404));
 
-export default app;
+/** Worker entry: fetch + daily retention cron. */
+export default {
+  fetch: app.fetch.bind(app),
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+    ctx.waitUntil(
+      runRetentionSweep(env).catch((err) => {
+        console.error(
+          JSON.stringify({
+            message: "retention_sweep_failed",
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }),
+    );
+  },
+};

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -33,7 +33,7 @@ export async function reconcileWorkspaceUsage(
   now = new Date(),
 ): Promise<ReconcileResult> {
   const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
-  const store = storage(env, ws);
+  const store = await storage(env, ws);
 
   let bytes = 0;
   let objects = 0;

--- a/apps/api/src/reencrypt-registry.ts
+++ b/apps/api/src/reencrypt-registry.ts
@@ -1,0 +1,113 @@
+/**
+ * Re-seal BYO credentials in REGISTRY under the current WORKSPACE_SECRETS_KEY.
+ * Decrypt uses current + previous; encrypt uses current only.
+ * Intended for POST /admin/credentials/reencrypt (admin-gated) — not a laptop
+ * script holding the KEK in the shell.
+ */
+import { resealCredentialFields, secretsKeyRingFromEnv, type SecretsKeyRing } from "./secrets";
+import type { WorkspaceRecord } from "./workspace";
+
+export interface ReencryptResult {
+  dryRun: boolean;
+  scanned: number;
+  updated: number;
+  skipped: number;
+  errors: Array<{ workspace: string; error: string }>;
+  workspaces: Array<{
+    workspace: string;
+    action: "updated" | "would_update" | "skipped";
+    reason?: string;
+  }>;
+}
+
+export async function reencryptRegistryCredentials(
+  env: Env,
+  opts: { dryRun?: boolean } = {},
+): Promise<ReencryptResult> {
+  const dryRun = opts.dryRun === true;
+  const ring: SecretsKeyRing = secretsKeyRingFromEnv(env);
+  if (!ring.current || ring.current.length < 16) {
+    throw new Error("WORKSPACE_SECRETS_KEY must be configured on the worker");
+  }
+
+  let cursor: string | undefined;
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+  const errors: ReencryptResult["errors"] = [];
+  const workspaces: ReencryptResult["workspaces"] = [];
+
+  do {
+    const page = await env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
+    for (const entry of page.keys) {
+      scanned += 1;
+      const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
+      if (!name) continue;
+
+      let record: WorkspaceRecord | null;
+      try {
+        record = await env.REGISTRY.get<WorkspaceRecord>(entry.name, "json");
+      } catch (err) {
+        errors.push({
+          workspace: name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+      if (!record) {
+        skipped += 1;
+        workspaces.push({ workspace: name, action: "skipped", reason: "missing" });
+        continue;
+      }
+      if (!record.accessKeyId && !record.secretAccessKey) {
+        skipped += 1;
+        workspaces.push({ workspace: name, action: "skipped", reason: "no_credentials" });
+        continue;
+      }
+
+      try {
+        const resealed = await resealCredentialFields(ring, {
+          accessKeyId: record.accessKeyId,
+          secretAccessKey: record.secretAccessKey,
+        });
+        if (!resealed.changed) {
+          skipped += 1;
+          workspaces.push({ workspace: name, action: "skipped", reason: "already_current" });
+          continue;
+        }
+        if (!dryRun) {
+          const next: WorkspaceRecord = {
+            ...record,
+            accessKeyId: resealed.accessKeyId,
+            secretAccessKey: resealed.secretAccessKey,
+          };
+          await env.REGISTRY.put(entry.name, JSON.stringify(next));
+        }
+        updated += 1;
+        workspaces.push({
+          workspace: name,
+          action: dryRun ? "would_update" : "updated",
+        });
+      } catch (err) {
+        errors.push({
+          workspace: name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+
+  console.log(
+    JSON.stringify({
+      message: "credentials_reencrypt",
+      dryRun,
+      scanned,
+      updated,
+      skipped,
+      errorCount: errors.length,
+    }),
+  );
+
+  return { dryRun, scanned, updated, skipped, errors, workspaces };
+}

--- a/apps/api/src/retention-sweep.ts
+++ b/apps/api/src/retention-sweep.ts
@@ -1,0 +1,81 @@
+/**
+ * Daily retention sweep: every REGISTRY workspace with retentionDays set runs
+ * purgeExpiredObjects. Invoked from the Worker scheduled handler.
+ */
+import { purgeExpiredObjects } from "./retention";
+import type { WorkspaceRecord } from "./workspace";
+
+export interface SweepResult {
+  workspacesScanned: number;
+  workspacesWithRetention: number;
+  purged: Array<{
+    workspace: string;
+    deleted: number;
+    freedBytes: number;
+    skipped?: boolean;
+    error?: string;
+  }>;
+}
+
+export async function runRetentionSweep(env: Env): Promise<SweepResult> {
+  let cursor: string | undefined;
+  let workspacesScanned = 0;
+  let workspacesWithRetention = 0;
+  const purged: SweepResult["purged"] = [];
+
+  do {
+    const page = await env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
+    for (const entry of page.keys) {
+      workspacesScanned += 1;
+      const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
+      if (!name) continue;
+
+      let record: WorkspaceRecord | null = null;
+      try {
+        record = await env.REGISTRY.get<WorkspaceRecord>(entry.name, "json");
+      } catch (err) {
+        purged.push({
+          workspace: name,
+          deleted: 0,
+          freedBytes: 0,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+      if (!record) continue;
+      if (typeof record.retentionDays !== "number" || record.retentionDays <= 0) continue;
+
+      workspacesWithRetention += 1;
+      try {
+        const result = await purgeExpiredObjects(env, record, name);
+        if ("skipped" in result) {
+          purged.push({ workspace: name, deleted: 0, freedBytes: 0, skipped: true });
+        } else {
+          purged.push({
+            workspace: name,
+            deleted: result.deleted,
+            freedBytes: result.freedBytes,
+          });
+        }
+      } catch (err) {
+        purged.push({
+          workspace: name,
+          deleted: 0,
+          freedBytes: 0,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+
+  console.log(
+    JSON.stringify({
+      message: "retention_sweep",
+      workspacesScanned,
+      workspacesWithRetention,
+      purged,
+    }),
+  );
+  return { workspacesScanned, workspacesWithRetention, purged };
+}

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -64,7 +64,7 @@ export async function purgeExpiredObjects(
   }
 
   const cutoff = retentionCutoff(days, now);
-  const store = storage(env, ws);
+  const store = await storage(env, ws);
   const sampleKeys: string[] = [];
   let deleted = 0;
   let freedBytes = 0;

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,6 +12,7 @@ import {
   revokeToken,
   validateScopes,
 } from "../auth-db";
+import { reencryptRegistryCredentials } from "../reencrypt-registry";
 import type { WorkspaceRecord } from "../workspace";
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
@@ -242,4 +243,24 @@ export const admin = new Hono<{ Bindings: Env }>()
       workspace: name,
       revoked: { label: revoked.label ?? null, hashPrefix: revoked.hash.slice(0, HASH_PREFIX_LEN) },
     });
+  })
+
+  /**
+   * Re-seal BYO S3 credentials under WORKSPACE_SECRETS_KEY (current).
+   * Decrypt tries current then WORKSPACE_SECRETS_KEY_PREVIOUS.
+   * Prefer this over a laptop script so the KEK never leaves the worker.
+   * Query: ?dryRun=1
+   */
+  .post("/credentials/reencrypt", async (c) => {
+    const dryRun =
+      c.req.query("dryRun") === "1" ||
+      c.req.query("dryRun") === "true" ||
+      c.req.query("dry_run") === "1";
+    try {
+      const result = await reencryptRegistryCredentials(c.env, { dryRun });
+      return c.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 400);
+    }
   });

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -14,12 +14,74 @@ function mapFileOpError(c: Context, err: unknown): Response {
 
 export const files = new Hono<WorkspaceVars>()
 
+  // Presigned direct-to-bucket upload (workspace needs S3 HTTP credentials).
+  .post("/sign", writeRateLimit, requireScope("files:write"), async (c) => {
+    const body = await c.req
+      .json<{
+        key?: string;
+        contentType?: string;
+        maxSize?: number;
+        expiresIn?: number;
+      }>()
+      .catch(
+        () =>
+          ({}) as {
+            key?: string;
+            contentType?: string;
+            maxSize?: number;
+            expiresIn?: number;
+          },
+      );
+
+    const key = typeof body.key === "string" ? body.key : "";
+    if (!key || badKey(key)) return c.json({ error: "invalid key" }, 400);
+
+    const ws = c.get("workspace");
+    const policy = resolveUploadPolicy(ws);
+    const ceiling = Math.max(policy.maxBytes, policy.maxVideoBytes);
+    const maxSize =
+      typeof body.maxSize === "number" && body.maxSize > 0
+        ? Math.min(body.maxSize, ceiling)
+        : ceiling;
+    const expiresIn =
+      typeof body.expiresIn === "number" && body.expiresIn > 0 && body.expiresIn <= 86400
+        ? Math.floor(body.expiresIn)
+        : 3600;
+
+    try {
+      const store = await storage(c.env, ws);
+      const upload = await store.signedUploadUrl(key, {
+        expiresIn,
+        contentType: body.contentType,
+        maxSize,
+      });
+      const cfg = await storageConfig(c.env, ws);
+      return c.json({
+        workspace: c.get("workspaceName"),
+        key,
+        maxSize,
+        expiresIn,
+        publicUrl: publicUrl(cfg, key),
+        upload,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(JSON.stringify({ message: "presign failed", error: message }));
+      return c.json(
+        {
+          error:
+            "presign unavailable for this workspace (needs S3 HTTP credentials; binding-only cannot sign)",
+          detail: message,
+        },
+        400,
+      );
+    }
+  })
+
   // Upload: raw body PUT. The stored content type is sniffed from the bytes,
   // not taken from the client header — size/type policy is enforced in
   // files-core's putObject (shared with the MCP worker); see guards.ts.
   .put("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
-    // Fail fast on a bad key and on an oversized declared length before
-    // buffering the body into isolate memory; putObject re-checks both.
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
     const policy = resolveUploadPolicy(c.get("workspace"));
@@ -41,25 +103,22 @@ export const files = new Hono<WorkspaceVars>()
     }
   })
 
-  // List
   .get("/", requireScope("files:read"), async (c) => {
     const { prefix, cursor } = c.req.query();
     const limit = Number(c.req.query("limit") ?? 100) || 100;
     return c.json(await listObjects(c.env, c.get("workspace"), { prefix, limit, cursor }));
   })
 
-  // Metadata
   .get("/:key{.+}", requireScope("files:read"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) return c.json({ error: "invalid key" }, 400);
     const ws = c.get("workspace");
-    const store = storage(c.env, ws);
+    const store = await storage(c.env, ws);
     if (!(await store.exists(key))) return c.json({ error: "not found" }, 404);
     const meta = await store.head(key);
-    return c.json({ ...meta, url: publicUrl(storageConfig(c.env, ws), key) });
+    return c.json({ ...meta, url: publicUrl(await storageConfig(c.env, ws), key) });
   })
 
-  // Delete
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {
     try {
       return c.json(

--- a/apps/api/src/secrets.ts
+++ b/apps/api/src/secrets.ts
@@ -1,10 +1,34 @@
 /**
  * Encrypt workspace BYO credentials at rest in KV.
- * Form: `enc:v1:<base64url(iv || ciphertext)>` (AES-GCM-256).
- * Plaintext (no prefix) still accepted for migration. Master: WORKSPACE_SECRETS_KEY.
+ *
+ * Form: `enc:v1:<base64url(iv || ciphertext||tag)>` (AES-GCM-256).
+ * Plaintext (no prefix) still accepted for migration.
+ *
+ * Key ring (good practice for rotation):
+ * - WORKSPACE_SECRETS_KEY — current KEK; all new seals use this
+ * - WORKSPACE_SECRETS_KEY_PREVIOUS — optional; decrypt tries current then previous
+ *
+ * Rotate: put old → PREVIOUS, put new → KEY, run reencrypt-workspace-secrets.mjs,
+ * then remove PREVIOUS after verification.
  */
 
 const PREFIX = "enc:v1:";
+
+/** Current + optional previous master secrets for decrypt during rotation. */
+export type SecretsKeyRing = {
+  current?: string;
+  previous?: string;
+};
+
+export function secretsKeyRingFromEnv(env: {
+  WORKSPACE_SECRETS_KEY?: string;
+  WORKSPACE_SECRETS_KEY_PREVIOUS?: string;
+}): SecretsKeyRing {
+  return {
+    current: env.WORKSPACE_SECRETS_KEY,
+    previous: env.WORKSPACE_SECRETS_KEY_PREVIOUS,
+  };
+}
 
 function b64urlEncode(buf: ArrayBuffer | Uint8Array): string {
   const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
@@ -27,14 +51,19 @@ async function aesKey(secret: string): Promise<CryptoKey> {
   return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
 }
 
+function assertMaster(secret: string, label: string): void {
+  if (secret.length < 16) {
+    throw new Error(`${label} must be at least 16 characters`);
+  }
+}
+
 export function isEncryptedSecret(value: string): boolean {
   return value.startsWith(PREFIX);
 }
 
+/** Encrypt with the **current** master only. */
 export async function encryptSecret(masterSecret: string, plaintext: string): Promise<string> {
-  if (masterSecret.length < 16) {
-    throw new Error("WORKSPACE_SECRETS_KEY must be at least 16 characters");
-  }
+  assertMaster(masterSecret, "WORKSPACE_SECRETS_KEY");
   const key = await aesKey(masterSecret);
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ct = await crypto.subtle.encrypt(
@@ -48,23 +77,56 @@ export async function encryptSecret(masterSecret: string, plaintext: string): Pr
   return PREFIX + b64urlEncode(packed);
 }
 
+/**
+ * Decrypt a single secret value.
+ * - Plaintext: returned as-is
+ * - Encrypted: try ring.current, then ring.previous
+ * @returns plaintext and whether the previous key was required
+ */
 export async function decryptSecret(
-  masterSecret: string | undefined,
+  ring: SecretsKeyRing | string | undefined,
   value: string,
-): Promise<string> {
-  if (!isEncryptedSecret(value)) return value;
-  if (!masterSecret || masterSecret.length < 16) {
+): Promise<{ plaintext: string; usedPrevious: boolean }> {
+  if (!isEncryptedSecret(value)) {
+    return { plaintext: value, usedPrevious: false };
+  }
+
+  const candidates: { secret: string; previous: boolean }[] = [];
+  if (typeof ring === "string") {
+    if (ring) candidates.push({ secret: ring, previous: false });
+  } else if (ring) {
+    if (ring.current) candidates.push({ secret: ring.current, previous: false });
+    if (ring.previous && ring.previous !== ring.current) {
+      candidates.push({ secret: ring.previous, previous: true });
+    }
+  }
+
+  if (candidates.length === 0) {
     throw new Error("encrypted credential requires WORKSPACE_SECRETS_KEY");
   }
+
   const packed = b64urlDecode(value.slice(PREFIX.length));
   if (packed.length < 13) throw new Error("invalid encrypted credential");
   const iv = packed.subarray(0, 12);
   const data = packed.subarray(12);
-  const key = await aesKey(masterSecret);
-  const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, data);
-  return new TextDecoder().decode(pt);
+
+  let lastErr: unknown;
+  for (const { secret, previous } of candidates) {
+    try {
+      assertMaster(secret, previous ? "WORKSPACE_SECRETS_KEY_PREVIOUS" : "WORKSPACE_SECRETS_KEY");
+      const key = await aesKey(secret);
+      const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, data);
+      return { plaintext: new TextDecoder().decode(pt), usedPrevious: previous };
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr instanceof Error
+    ? lastErr
+    : new Error("failed to decrypt credential with current or previous key");
 }
 
+/** Seal plaintext fields with the **current** master. Already-encrypted values left as-is. */
 export async function sealCredentialFields(
   masterSecret: string | undefined,
   fields: { accessKeyId?: string; secretAccessKey?: string },
@@ -80,16 +142,56 @@ export async function sealCredentialFields(
   return out;
 }
 
+/**
+ * Decrypt fields with the key ring. `usedPrevious` is true if either field
+ * needed the previous master (caller may re-seal with current).
+ */
 export async function openCredentialFields(
-  masterSecret: string | undefined,
+  ring: SecretsKeyRing | string | undefined,
   fields: { accessKeyId?: string; secretAccessKey?: string },
-): Promise<{ accessKeyId?: string; secretAccessKey?: string }> {
-  return {
-    accessKeyId: fields.accessKeyId
-      ? await decryptSecret(masterSecret, fields.accessKeyId)
-      : undefined,
-    secretAccessKey: fields.secretAccessKey
-      ? await decryptSecret(masterSecret, fields.secretAccessKey)
-      : undefined,
-  };
+): Promise<{
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  usedPrevious: boolean;
+}> {
+  let usedPrevious = false;
+  let accessKeyId: string | undefined;
+  let secretAccessKey: string | undefined;
+
+  if (fields.accessKeyId) {
+    const r = await decryptSecret(ring, fields.accessKeyId);
+    accessKeyId = r.plaintext;
+    if (r.usedPrevious) usedPrevious = true;
+  }
+  if (fields.secretAccessKey) {
+    const r = await decryptSecret(ring, fields.secretAccessKey);
+    secretAccessKey = r.plaintext;
+    if (r.usedPrevious) usedPrevious = true;
+  }
+
+  return { accessKeyId, secretAccessKey, usedPrevious };
+}
+
+/**
+ * Decrypt with ring (current + previous), then seal with **current** only.
+ * Use after rotation to rewrite KV under the new KEK.
+ */
+export async function resealCredentialFields(
+  ring: SecretsKeyRing,
+  fields: { accessKeyId?: string; secretAccessKey?: string },
+): Promise<{ accessKeyId?: string; secretAccessKey?: string; changed: boolean }> {
+  if (!ring.current) {
+    throw new Error("reseal requires WORKSPACE_SECRETS_KEY (current)");
+  }
+  const opened = await openCredentialFields(ring, fields);
+  const out: { accessKeyId?: string; secretAccessKey?: string } = {};
+  if (opened.accessKeyId !== undefined) {
+    out.accessKeyId = await encryptSecret(ring.current, opened.accessKeyId);
+  }
+  if (opened.secretAccessKey !== undefined) {
+    out.secretAccessKey = await encryptSecret(ring.current, opened.secretAccessKey);
+  }
+  const changed =
+    out.accessKeyId !== fields.accessKeyId || out.secretAccessKey !== fields.secretAccessKey;
+  return { ...out, changed };
 }

--- a/apps/api/src/secrets.ts
+++ b/apps/api/src/secrets.ts
@@ -1,0 +1,95 @@
+/**
+ * Encrypt workspace BYO credentials at rest in KV.
+ * Form: `enc:v1:<base64url(iv || ciphertext)>` (AES-GCM-256).
+ * Plaintext (no prefix) still accepted for migration. Master: WORKSPACE_SECRETS_KEY.
+ */
+
+const PREFIX = "enc:v1:";
+
+function b64urlEncode(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function aesKey(secret: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+export function isEncryptedSecret(value: string): boolean {
+  return value.startsWith(PREFIX);
+}
+
+export async function encryptSecret(masterSecret: string, plaintext: string): Promise<string> {
+  if (masterSecret.length < 16) {
+    throw new Error("WORKSPACE_SECRETS_KEY must be at least 16 characters");
+  }
+  const key = await aesKey(masterSecret);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  const packed = new Uint8Array(iv.length + ct.byteLength);
+  packed.set(iv, 0);
+  packed.set(new Uint8Array(ct), iv.length);
+  return PREFIX + b64urlEncode(packed);
+}
+
+export async function decryptSecret(
+  masterSecret: string | undefined,
+  value: string,
+): Promise<string> {
+  if (!isEncryptedSecret(value)) return value;
+  if (!masterSecret || masterSecret.length < 16) {
+    throw new Error("encrypted credential requires WORKSPACE_SECRETS_KEY");
+  }
+  const packed = b64urlDecode(value.slice(PREFIX.length));
+  if (packed.length < 13) throw new Error("invalid encrypted credential");
+  const iv = packed.subarray(0, 12);
+  const data = packed.subarray(12);
+  const key = await aesKey(masterSecret);
+  const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, data);
+  return new TextDecoder().decode(pt);
+}
+
+export async function sealCredentialFields(
+  masterSecret: string | undefined,
+  fields: { accessKeyId?: string; secretAccessKey?: string },
+): Promise<{ accessKeyId?: string; secretAccessKey?: string }> {
+  if (!masterSecret) return fields;
+  const out = { ...fields };
+  if (fields.accessKeyId && !isEncryptedSecret(fields.accessKeyId)) {
+    out.accessKeyId = await encryptSecret(masterSecret, fields.accessKeyId);
+  }
+  if (fields.secretAccessKey && !isEncryptedSecret(fields.secretAccessKey)) {
+    out.secretAccessKey = await encryptSecret(masterSecret, fields.secretAccessKey);
+  }
+  return out;
+}
+
+export async function openCredentialFields(
+  masterSecret: string | undefined,
+  fields: { accessKeyId?: string; secretAccessKey?: string },
+): Promise<{ accessKeyId?: string; secretAccessKey?: string }> {
+  return {
+    accessKeyId: fields.accessKeyId
+      ? await decryptSecret(masterSecret, fields.accessKeyId)
+      : undefined,
+    secretAccessKey: fields.secretAccessKey
+      ? await decryptSecret(masterSecret, fields.secretAccessKey)
+      : undefined,
+  };
+}

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -1,5 +1,5 @@
 import { createStorage, publicUrl, type StorageConfig } from "@uploads/storage";
-import { openCredentialFields } from "./secrets";
+import { openCredentialFields, secretsKeyRingFromEnv } from "./secrets";
 import type { WorkspaceRecord } from "./workspace";
 
 export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<StorageConfig> {
@@ -11,10 +11,20 @@ export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<Stor
     }
     binding = candidate as R2Bucket;
   }
-  const opened = await openCredentialFields(env.WORKSPACE_SECRETS_KEY, {
+  const ring = secretsKeyRingFromEnv(env);
+  const opened = await openCredentialFields(ring, {
     accessKeyId: ws.accessKeyId,
     secretAccessKey: ws.secretAccessKey,
   });
+  // During rotation, previous-key decrypts still work; re-seal offline with the script.
+  if (opened.usedPrevious) {
+    console.log(
+      JSON.stringify({
+        message: "credential_decrypted_with_previous_key",
+        hint: "run scripts/reencrypt-workspace-secrets.mjs then remove WORKSPACE_SECRETS_KEY_PREVIOUS",
+      }),
+    );
+  }
   return {
     provider: ws.provider,
     bucket: ws.bucket,

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -1,7 +1,8 @@
 import { createStorage, publicUrl, type StorageConfig } from "@uploads/storage";
+import { openCredentialFields } from "./secrets";
 import type { WorkspaceRecord } from "./workspace";
 
-export function storageConfig(env: Env, ws: WorkspaceRecord): StorageConfig {
+export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<StorageConfig> {
   let binding: R2Bucket | undefined;
   if (ws.binding) {
     const candidate: unknown = Reflect.get(env, ws.binding);
@@ -10,6 +11,10 @@ export function storageConfig(env: Env, ws: WorkspaceRecord): StorageConfig {
     }
     binding = candidate as R2Bucket;
   }
+  const opened = await openCredentialFields(env.WORKSPACE_SECRETS_KEY, {
+    accessKeyId: ws.accessKeyId,
+    secretAccessKey: ws.secretAccessKey,
+  });
   return {
     provider: ws.provider,
     bucket: ws.bucket,
@@ -17,13 +22,13 @@ export function storageConfig(env: Env, ws: WorkspaceRecord): StorageConfig {
     publicBaseUrl: ws.publicBaseUrl,
     r2Binding: binding,
     accountId: ws.accountId,
-    accessKeyId: ws.accessKeyId,
-    secretAccessKey: ws.secretAccessKey,
+    accessKeyId: opened.accessKeyId,
+    secretAccessKey: opened.secretAccessKey,
   };
 }
 
-export function storage(env: Env, ws: WorkspaceRecord) {
-  return createStorage(storageConfig(env, ws));
+export async function storage(env: Env, ws: WorkspaceRecord) {
+  return createStorage(await storageConfig(env, ws));
 }
 
 export { publicUrl };

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -26,8 +26,12 @@ export interface WorkspaceRecord {
   accountId?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
-  /** Max bytes for a single upload. Falls back to DEFAULT_MAX_UPLOAD_BYTES. */
+  /** Max bytes for a single image upload. Falls back to DEFAULT_MAX_UPLOAD_BYTES. */
   maxUploadBytes?: number;
+  /**
+   * Max bytes for video/mp4 and video/webm. When unset, videos use maxUploadBytes.
+   */
+  maxVideoUploadBytes?: number;
   /** Allowed (sniffed) content types. Falls back to DEFAULT_ALLOWED_CONTENT_TYPES. */
   allowedContentTypes?: string[];
   /**
@@ -44,6 +48,11 @@ export interface WorkspaceRecord {
    * purge-expired runs. Omit to skip retention. Configure via workspace:limits.
    */
   retentionDays?: number;
+  /**
+   * When true/undefined, bare keys (no `/`) become `f/<id>/<name>`. Set false
+   * to allow root basenames (not recommended on shared buckets).
+   */
+  autoPrefixBareKeys?: boolean;
 }
 
 export type WorkspaceVars = {

--- a/apps/api/test/files-core-keys.test.ts
+++ b/apps/api/test/files-core-keys.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { governUploadKey, sanitizeKeyBasename } from "../src/files-core";
+
+describe("governUploadKey", () => {
+  it("prefixes bare basenames", () => {
+    const key = governUploadKey("shot.png");
+    expect(key).toMatch(/^f\/[A-Za-z0-9_-]+\/shot\.png$/);
+  });
+
+  it("leaves nested keys unchanged", () => {
+    expect(governUploadKey("screenshots/app/1/shot.png")).toBe("screenshots/app/1/shot.png");
+    expect(governUploadKey("gh/o/r/pull/1/a.png")).toBe("gh/o/r/pull/1/a.png");
+  });
+
+  it("can disable auto-prefix", () => {
+    expect(governUploadKey("shot.png", false)).toBe("shot.png");
+  });
+
+  it("sanitizes basename characters", () => {
+    expect(sanitizeKeyBasename("my shot!!.png")).toBe("my-shot-.png");
+  });
+});

--- a/apps/api/test/guards-video.test.ts
+++ b/apps/api/test/guards-video.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { inspectUpload, resolveUploadPolicy } from "../src/guards";
+
+// Minimal valid-looking WebM (EBML) and PNG headers for sniffing.
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+describe("per-type upload size", () => {
+  it("allows a small image under maxUploadBytes", () => {
+    const policy = resolveUploadPolicy({ maxUploadBytes: 100, maxVideoUploadBytes: 4 });
+    expect(inspectUpload(PNG, policy).ok).toBe(true);
+  });
+
+  it("rejects video over maxVideoUploadBytes even if maxUploadBytes is higher", () => {
+    const policy = resolveUploadPolicy({ maxUploadBytes: 1000, maxVideoUploadBytes: 4 });
+    const result = inspectUpload(WEBM, policy);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(413);
+      expect(result.body.code).toBe("upload_too_large");
+      expect(result.body.kind).toBe("video");
+      expect(result.body.maxBytes).toBe(4);
+    }
+  });
+
+  it("uses maxUploadBytes for video when maxVideoUploadBytes is unset", () => {
+    const policy = resolveUploadPolicy({ maxUploadBytes: 100 });
+    expect(policy.maxVideoBytes).toBe(100);
+    expect(inspectUpload(WEBM, policy).ok).toBe(true);
+  });
+});

--- a/apps/api/test/reconcile-retention.test.ts
+++ b/apps/api/test/reconcile-retention.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
-import app from "../src/index";
+import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 import { UsageFakeD1 } from "./usage-fake-d1";
 

--- a/apps/api/test/reencrypt-registry.test.ts
+++ b/apps/api/test/reencrypt-registry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { encryptSecret } from "../src/secrets";
+import { reencryptRegistryCredentials } from "../src/reencrypt-registry";
+import type { WorkspaceRecord } from "../src/workspace";
+
+const CURRENT = "current-master-secret!!";
+const PREVIOUS = "previous-master-secret!";
+
+describe("reencryptRegistryCredentials", () => {
+  it("rewrites credentials sealed with the previous key", async () => {
+    const sealedAk = await encryptSecret(PREVIOUS, "AKIA");
+    const sealedSk = await encryptSecret(PREVIOUS, "secret");
+    const store = new Map<string, string>([
+      [
+        "ws:byo",
+        JSON.stringify({
+          provider: "r2",
+          bucket: "other",
+          accessKeyId: sealedAk,
+          secretAccessKey: sealedSk,
+        } satisfies WorkspaceRecord),
+      ],
+      [
+        "ws:shared",
+        JSON.stringify({
+          provider: "r2",
+          bucket: "uploads-default",
+          prefix: "shared/",
+        } satisfies WorkspaceRecord),
+      ],
+    ]);
+
+    const env = {
+      WORKSPACE_SECRETS_KEY: CURRENT,
+      WORKSPACE_SECRETS_KEY_PREVIOUS: PREVIOUS,
+      REGISTRY: {
+        list: async () => ({
+          keys: [...store.keys()].map((name) => ({ name })),
+          list_complete: true as const,
+          cursor: undefined,
+        }),
+        get: async (key: string) => {
+          const raw = store.get(key);
+          return raw ? (JSON.parse(raw) as WorkspaceRecord) : null;
+        },
+        put: async (key: string, value: string) => {
+          store.set(key, value);
+        },
+      },
+    } as unknown as Env;
+
+    const dry = await reencryptRegistryCredentials(env, { dryRun: true });
+    expect(dry.updated).toBe(1);
+    expect(dry.workspaces.find((w) => w.workspace === "byo")?.action).toBe("would_update");
+    // dry-run must not write
+    expect(JSON.parse(store.get("ws:byo")!).accessKeyId).toBe(sealedAk);
+
+    const live = await reencryptRegistryCredentials(env, { dryRun: false });
+    expect(live.updated).toBe(1);
+    const next = JSON.parse(store.get("ws:byo")!) as WorkspaceRecord;
+    expect(next.accessKeyId).not.toBe(sealedAk);
+    // Decrypt with current alone
+    const { openCredentialFields } = await import("../src/secrets");
+    const opened = await openCredentialFields(CURRENT, next);
+    expect(opened.accessKeyId).toBe("AKIA");
+    expect(opened.secretAccessKey).toBe("secret");
+    expect(opened.usedPrevious).toBe(false);
+  });
+});

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import app from "../src/index";
+import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 
 const workspace: WorkspaceRecord = { provider: "r2", bucket: "test" };

--- a/apps/api/test/routes-budget.test.ts
+++ b/apps/api/test/routes-budget.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
-import app from "../src/index";
+import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 import { UsageFakeD1 } from "./usage-fake-d1";
 

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
-import app from "../src/index";
+import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 
 const TOKEN = "secret-token";
@@ -66,8 +66,9 @@ function putShot(
   env: Parameters<typeof app.request>[2],
   { body = PNG as BodyInit, headers = {} as Record<string, string> } = {},
 ) {
+  // Nested key so auto-prefix of bare basenames does not rewrite the path.
   return app.request(
-    "/v1/default/files/shot.png",
+    "/v1/default/files/screenshots/shot.png",
     {
       method: "PUT",
       headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png", ...headers },
@@ -82,17 +83,18 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     const { env, bucket } = await makeEnv();
     const res = await putShot(env);
     expect(res.status).toBe(201);
-    const json = (await res.json()) as { contentType: string; url: string };
+    const json = (await res.json()) as { contentType: string; url: string; key: string };
     expect(json.contentType).toBe("image/png");
-    expect(json.url).toBe("https://storage.uploads.sh/default/shot.png");
-    expect(bucket.store.has("default/shot.png")).toBe(true);
+    expect(json.key).toBe("screenshots/shot.png");
+    expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+    expect(bucket.store.has("default/screenshots/shot.png")).toBe(true);
   });
 
   it("overrides a lying Content-Type header with the sniffed type", async () => {
     const { env, bucket } = await makeEnv();
     const res = await putShot(env, { headers: { "Content-Type": "image/svg+xml" } });
     expect(res.status).toBe(201);
-    expect(bucket.store.get("default/shot.png")?.contentType).toBe("image/png");
+    expect(bucket.store.get("default/screenshots/shot.png")?.contentType).toBe("image/png");
   });
 
   it("rejects a non-image payload with 415", async () => {

--- a/apps/api/test/routes-usage.test.ts
+++ b/apps/api/test/routes-usage.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
-import app from "../src/index";
+import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 import { usagePeriodStart } from "../src/usage";
 import { UsageFakeD1 } from "./usage-fake-d1";
@@ -65,7 +65,7 @@ describe("GET /v1/:workspace/usage + put/delete metering", () => {
     const { env } = await makeEnv();
 
     const put = await app.request(
-      "/v1/default/files/shot.png",
+      "/v1/default/files/screenshots/shot.png",
       {
         method: "PUT",
         headers: { ...auth, "Content-Type": "image/png" },
@@ -74,6 +74,7 @@ describe("GET /v1/:workspace/usage + put/delete metering", () => {
       env,
     );
     expect(put.status).toBe(201);
+    const putBody = (await put.json()) as { key: string };
 
     let usage = await (await app.request("/v1/default/usage", { headers: auth }, env)).json();
     expect(usage).toMatchObject({
@@ -83,7 +84,7 @@ describe("GET /v1/:workspace/usage + put/delete metering", () => {
     });
 
     const del = await app.request(
-      "/v1/default/files/shot.png",
+      `/v1/default/files/${putBody.key}`,
       { method: "DELETE", headers: auth },
       env,
     );

--- a/apps/api/test/secrets.test.ts
+++ b/apps/api/test/secrets.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  decryptSecret,
+  encryptSecret,
+  isEncryptedSecret,
+  openCredentialFields,
+  sealCredentialFields,
+} from "../src/secrets";
+
+const MASTER = "test-master-secret-key!!";
+
+describe("workspace secret encryption", () => {
+  it("round-trips AES-GCM", async () => {
+    const enc = await encryptSecret(MASTER, "s3-secret-value");
+    expect(isEncryptedSecret(enc)).toBe(true);
+    expect(await decryptSecret(MASTER, enc)).toBe("s3-secret-value");
+  });
+
+  it("passes through plaintext when not encrypted", async () => {
+    expect(await decryptSecret(MASTER, "plain")).toBe("plain");
+    expect(await decryptSecret(undefined, "plain")).toBe("plain");
+  });
+
+  it("seals and opens credential fields", async () => {
+    const sealed = await sealCredentialFields(MASTER, {
+      accessKeyId: "AKIA",
+      secretAccessKey: "secret",
+    });
+    expect(isEncryptedSecret(sealed.accessKeyId!)).toBe(true);
+    expect(isEncryptedSecret(sealed.secretAccessKey!)).toBe(true);
+    const opened = await openCredentialFields(MASTER, sealed);
+    expect(opened).toEqual({ accessKeyId: "AKIA", secretAccessKey: "secret" });
+  });
+
+  it("leaves fields alone without master secret", async () => {
+    const fields = { accessKeyId: "AKIA", secretAccessKey: "secret" };
+    expect(await sealCredentialFields(undefined, fields)).toEqual(fields);
+  });
+});

--- a/apps/api/test/secrets.test.ts
+++ b/apps/api/test/secrets.test.ts
@@ -4,32 +4,85 @@ import {
   encryptSecret,
   isEncryptedSecret,
   openCredentialFields,
+  resealCredentialFields,
   sealCredentialFields,
+  secretsKeyRingFromEnv,
 } from "../src/secrets";
 
-const MASTER = "test-master-secret-key!!";
+const CURRENT = "test-master-secret-key!!";
+const PREVIOUS = "previous-master-secret!!";
 
 describe("workspace secret encryption", () => {
   it("round-trips AES-GCM", async () => {
-    const enc = await encryptSecret(MASTER, "s3-secret-value");
+    const enc = await encryptSecret(CURRENT, "s3-secret-value");
     expect(isEncryptedSecret(enc)).toBe(true);
-    expect(await decryptSecret(MASTER, enc)).toBe("s3-secret-value");
+    expect((await decryptSecret(CURRENT, enc)).plaintext).toBe("s3-secret-value");
   });
 
   it("passes through plaintext when not encrypted", async () => {
-    expect(await decryptSecret(MASTER, "plain")).toBe("plain");
-    expect(await decryptSecret(undefined, "plain")).toBe("plain");
+    expect((await decryptSecret(CURRENT, "plain")).plaintext).toBe("plain");
+    expect((await decryptSecret(undefined, "plain")).plaintext).toBe("plain");
   });
 
-  it("seals and opens credential fields", async () => {
-    const sealed = await sealCredentialFields(MASTER, {
+  it("decrypts with previous key during rotation", async () => {
+    const enc = await encryptSecret(PREVIOUS, "legacy-secret");
+    const ring = { current: CURRENT, previous: PREVIOUS };
+    const r = await decryptSecret(ring, enc);
+    expect(r.plaintext).toBe("legacy-secret");
+    expect(r.usedPrevious).toBe(true);
+  });
+
+  it("prefers current over previous", async () => {
+    const enc = await encryptSecret(CURRENT, "new-secret");
+    const ring = { current: CURRENT, previous: PREVIOUS };
+    const r = await decryptSecret(ring, enc);
+    expect(r.plaintext).toBe("new-secret");
+    expect(r.usedPrevious).toBe(false);
+  });
+
+  it("openCredentialFields sets usedPrevious when needed", async () => {
+    const sealed = await sealCredentialFields(PREVIOUS, {
       accessKeyId: "AKIA",
       secretAccessKey: "secret",
     });
-    expect(isEncryptedSecret(sealed.accessKeyId!)).toBe(true);
-    expect(isEncryptedSecret(sealed.secretAccessKey!)).toBe(true);
-    const opened = await openCredentialFields(MASTER, sealed);
-    expect(opened).toEqual({ accessKeyId: "AKIA", secretAccessKey: "secret" });
+    const opened = await openCredentialFields({ current: CURRENT, previous: PREVIOUS }, sealed);
+    expect(opened).toMatchObject({
+      accessKeyId: "AKIA",
+      secretAccessKey: "secret",
+      usedPrevious: true,
+    });
+  });
+
+  it("reseal rewrites ciphertext under current key", async () => {
+    const sealedOld = await sealCredentialFields(PREVIOUS, {
+      accessKeyId: "AKIA",
+      secretAccessKey: "secret",
+    });
+    const resealed = await resealCredentialFields(
+      { current: CURRENT, previous: PREVIOUS },
+      sealedOld,
+    );
+    expect(resealed.changed).toBe(true);
+    // Must decrypt with current alone (no previous).
+    const opened = await openCredentialFields(CURRENT, {
+      accessKeyId: resealed.accessKeyId,
+      secretAccessKey: resealed.secretAccessKey,
+    });
+    expect(opened.accessKeyId).toBe("AKIA");
+    expect(opened.secretAccessKey).toBe("secret");
+    expect(opened.usedPrevious).toBe(false);
+  });
+
+  it("secretsKeyRingFromEnv maps both secrets", () => {
+    expect(
+      secretsKeyRingFromEnv({
+        WORKSPACE_SECRETS_KEY: "a".repeat(16),
+        WORKSPACE_SECRETS_KEY_PREVIOUS: "b".repeat(16),
+      }),
+    ).toEqual({
+      current: "a".repeat(16),
+      previous: "b".repeat(16),
+    });
   });
 
   it("leaves fields alone without master secret", async () => {

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -14,6 +14,10 @@
     "enabled": true,
     "head_sampling_rate": 1,
   },
+  // Daily retention sweep (purgeExpired for workspaces with retentionDays).
+  "triggers": {
+    "crons": ["0 6 * * *"],
+  },
   // Workspace registry: `ws:<name>` → WorkspaceRecord (see src/workspace.ts).
   // Create with `wrangler kv namespace create <title>` and paste the id here.
   // The account-level namespace title (ours: UPLOADS_REGISTRY) is independent

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -1,0 +1,133 @@
+---
+// Minimal operator console: paste a bearer token, list usage + files via the public API.
+// No server-side secrets — token stays in the browser. Scaffold toward a fuller files-sdk UI.
+const API_DEFAULT = "https://api.uploads.sh";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>uploads.sh console</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0813;
+        --panel: #120d1e;
+        --fg: #e6dff5;
+        --muted: #8a84a8;
+        --accent: #b794ff;
+        --border: #2a2240;
+        --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background: var(--bg);
+        color: var(--fg);
+        font: 14px/1.5 var(--mono);
+        padding: 32px 20px 48px;
+      }
+      main { max-width: 720px; margin: 0 auto; display: grid; gap: 16px; }
+      h1 { font-size: 1.15rem; font-weight: 600; margin: 0; }
+      p.muted { color: var(--muted); margin: 0; font-size: 0.9rem; }
+      label { display: grid; gap: 6px; color: var(--muted); font-size: 0.8rem; }
+      input {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--fg);
+        padding: 10px 12px;
+        font: inherit;
+      }
+      .row { display: flex; flex-wrap: wrap; gap: 10px; }
+      button {
+        background: var(--accent);
+        color: #120d1e;
+        border: 0;
+        border-radius: 8px;
+        padding: 10px 14px;
+        font: inherit;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      button.secondary { background: transparent; color: var(--accent); border: 1px solid var(--border); }
+      pre {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px;
+        overflow: auto;
+        max-height: 50vh;
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      a { color: var(--accent); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>uploads console</h1>
+      <p class="muted">
+        Browser-only scaffold. Token never leaves your machine. Prefer
+        <code>uploads usage</code> / CLI for production ops. See
+        <a href="https://github.com/buildinternet/uploads/blob/main/docs/ops.md">ops runbook</a>.
+      </p>
+      <label>
+        API base
+        <input id="api" type="url" value={API_DEFAULT} autocomplete="off" />
+      </label>
+      <label>
+        Workspace
+        <input id="ws" type="text" value="default" autocomplete="off" />
+      </label>
+      <label>
+        Bearer token
+        <input id="token" type="password" placeholder="up_…" autocomplete="off" />
+      </label>
+      <div class="row">
+        <button type="button" id="btn-usage">GET usage</button>
+        <button type="button" id="btn-list" class="secondary">List files</button>
+        <button type="button" id="btn-reconcile" class="secondary">Reconcile</button>
+      </div>
+      <pre id="out">Ready.</pre>
+    </main>
+    <script>
+      const out = document.getElementById("out");
+      function cfg() {
+        return {
+          api: document.getElementById("api").value.replace(/\/$/, ""),
+          ws: document.getElementById("ws").value.trim(),
+          token: document.getElementById("token").value.trim(),
+        };
+      }
+      async function call(path, method = "GET") {
+        const { api, ws, token } = cfg();
+        if (!token) {
+          out.textContent = "Paste a bearer token first.";
+          return;
+        }
+        out.textContent = "…";
+        try {
+          const res = await fetch(`${api}/v1/${encodeURIComponent(ws)}${path}`, {
+            method,
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          const text = await res.text();
+          let body = text;
+          try {
+            body = JSON.stringify(JSON.parse(text), null, 2);
+          } catch {}
+          out.textContent = `HTTP ${res.status}\n${body}`;
+        } catch (e) {
+          out.textContent = String(e);
+        }
+      }
+      document.getElementById("btn-usage").onclick = () => call("/usage");
+      document.getElementById("btn-list").onclick = () => call("/files?limit=50");
+      document.getElementById("btn-reconcile").onclick = () => call("/usage/reconcile", "POST");
+    </script>
+  </body>
+</html>

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,16 +5,17 @@ Unknown workspaces and bad tokens are indistinguishable (both 401).
 
 ## Routes
 
-| Route                                             | Description                                                                                |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `GET /health`                                     | Liveness (no auth)                                                                         |
-| `PUT /v1/:workspace/files/:key`                   | Upload raw body; `Content-Type` header is stored. Returns `{ workspace, key, url, size }`  |
-| `GET /v1/:workspace/files?prefix=&limit=&cursor=` | List objects                                                                               |
-| `GET /v1/:workspace/files/:key`                   | Object metadata                                                                            |
-| `DELETE /v1/:workspace/files/:key`                | Delete object                                                                              |
-| `GET /v1/:workspace/usage`                        | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read` |
-| `POST /v1/:workspace/usage/reconcile`             | Rebuild `bytes`/`objects` from storage; requires `files:write`                             |
-| `POST /v1/:workspace/usage/purge-expired`         | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`         |
+| Route                                             | Description                                                                                          |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `GET /health`                                     | Liveness (no auth)                                                                                   |
+| `PUT /v1/:workspace/files/:key`                   | Upload raw body (sniffed type). Bare keys → `f/<id>/<name>`. Returns `{ workspace, key, url, size }` |
+| `POST /v1/:workspace/files/sign`                  | Presigned upload (`signedUploadUrl`); needs HTTP S3 credentials on the workspace                     |
+| `GET /v1/:workspace/files?prefix=&limit=&cursor=` | List objects                                                                                         |
+| `GET /v1/:workspace/files/:key`                   | Object metadata                                                                                      |
+| `DELETE /v1/:workspace/files/:key`                | Delete object                                                                                        |
+| `GET /v1/:workspace/usage`                        | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read`           |
+| `POST /v1/:workspace/usage/reconcile`             | Rebuild `bytes`/`objects` from storage; requires `files:write`                                       |
+| `POST /v1/:workspace/usage/purge-expired`         | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`                   |
 
 `url` in responses is the public URL when the workspace has a
 `publicBaseUrl`, otherwise `null`.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -48,27 +48,33 @@ pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY
 
 ### Rotating `WORKSPACE_SECRETS_KEY`
 
-1. Generate a new key: `openssl rand -base64 32` → keep both OLD and NEW.
-2. Set previous = old (while the worker still has the old value as current):
+**Putting secrets** is always `wrangler secret put` (the Worker config).
+**Re-sealing records** is an **admin API** so the KEK stays on the worker (not in shell history).
+
+1. Generate a new key: `openssl rand -base64 32` → keep OLD and NEW.
+2. Install both on the worker (from `apps/api`):
    ```bash
    pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY_PREVIOUS   # paste OLD
    pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY            # paste NEW
    ```
-3. Re-seal every registry record that has BYO credentials under the **new** key:
+3. Re-seal registry credentials under the **current** key:
    ```bash
-   WORKSPACE_SECRETS_KEY='<NEW>' WORKSPACE_SECRETS_KEY_PREVIOUS='<OLD>' \
-     pnpm exec node scripts/reencrypt-workspace-secrets.mjs --dry-run
-   WORKSPACE_SECRETS_KEY='<NEW>' WORKSPACE_SECRETS_KEY_PREVIOUS='<OLD>' \
-     pnpm exec node scripts/reencrypt-workspace-secrets.mjs
+   # dry-run
+   curl -XPOST -H "Authorization: Bearer $ADMIN_TOKEN" \
+     'https://api.uploads.sh/admin/credentials/reencrypt?dryRun=1'
+   # live
+   curl -XPOST -H "Authorization: Bearer $ADMIN_TOKEN" \
+     https://api.uploads.sh/admin/credentials/reencrypt
+   # or: pnpm workspace:reencrypt-secrets --dry-run
    ```
-4. Verify BYO workspaces (presign / put). Logs may show
-   `credential_decrypted_with_previous_key` until re-seal finishes.
-5. Remove the previous secret so only the new KEK remains:
+4. Verify BYO / presign. Logs may show `credential_decrypted_with_previous_key`
+   until re-seal finishes.
+5. Drop the previous secret:
    ```bash
    pnpm exec wrangler secret delete WORKSPACE_SECRETS_KEY_PREVIOUS
    ```
 
-Do **not** delete PREVIOUS before re-encrypt completes, or ciphertext sealed only with OLD becomes unreadable.
+Do **not** delete PREVIOUS before re-encrypt completes.
 
 ## Presign
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -30,16 +30,45 @@ The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every wo
 
 ## Secrets
 
-| Secret                  | Purpose                                                          |
-| ----------------------- | ---------------------------------------------------------------- |
-| `ADMIN_TOKEN`           | `/admin/*`                                                       |
-| `WORKSPACE_SECRETS_KEY` | Encrypt BYO `accessKeyId` / `secretAccessKey` in KV (`enc:v1:…`) |
+| Secret                           | Purpose                                                               |
+| -------------------------------- | --------------------------------------------------------------------- |
+| `ADMIN_TOKEN`                    | `/admin/*`                                                            |
+| `WORKSPACE_SECRETS_KEY`          | **Current** KEK for BYO credentials in KV (`enc:v1:…`)                |
+| `WORKSPACE_SECRETS_KEY_PREVIOUS` | **Previous** KEK during rotation only (decrypt fallback, then remove) |
 
 ```bash
-openssl rand -base64 32 | wrangler secret put WORKSPACE_SECRETS_KEY
+# Generate
+openssl rand -base64 32
+
+# First-time install (production, from apps/api)
+pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY
 ```
 
-`workspace:add --bucket …` encrypts keys when `WORKSPACE_SECRETS_KEY` is in the env. Plaintext legacy values still work until re-written.
+`workspace:add --bucket …` encrypts keys when `WORKSPACE_SECRETS_KEY` is in the env. Plaintext legacy values still work until re-written. Decrypt tries **current**, then **previous**, so rotation does not brick BYO workspaces mid-cutover.
+
+### Rotating `WORKSPACE_SECRETS_KEY`
+
+1. Generate a new key: `openssl rand -base64 32` → keep both OLD and NEW.
+2. Set previous = old (while the worker still has the old value as current):
+   ```bash
+   pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY_PREVIOUS   # paste OLD
+   pnpm exec wrangler secret put WORKSPACE_SECRETS_KEY            # paste NEW
+   ```
+3. Re-seal every registry record that has BYO credentials under the **new** key:
+   ```bash
+   WORKSPACE_SECRETS_KEY='<NEW>' WORKSPACE_SECRETS_KEY_PREVIOUS='<OLD>' \
+     pnpm exec node scripts/reencrypt-workspace-secrets.mjs --dry-run
+   WORKSPACE_SECRETS_KEY='<NEW>' WORKSPACE_SECRETS_KEY_PREVIOUS='<OLD>' \
+     pnpm exec node scripts/reencrypt-workspace-secrets.mjs
+   ```
+4. Verify BYO workspaces (presign / put). Logs may show
+   `credential_decrypted_with_previous_key` until re-seal finishes.
+5. Remove the previous secret so only the new KEK remains:
+   ```bash
+   pnpm exec wrangler secret delete WORKSPACE_SECRETS_KEY_PREVIOUS
+   ```
+
+Do **not** delete PREVIOUS before re-encrypt completes, or ciphertext sealed only with OLD becomes unreadable.
 
 ## Presign
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,0 +1,52 @@
+# Operator runbook
+
+Day-to-day ops for **uploads.sh**. Secrets stay out of git.
+
+## Workspace limits
+
+```bash
+pnpm workspace:limits <name>
+pnpm workspace:limits <name> \
+  --max-storage 25GB \
+  --max-uploads-per-month 10000 \
+  --max-upload-bytes 25MB \
+  --max-video-bytes 8MB \
+  --retention-days 90
+```
+
+Suggested **shared/agent** defaults: 25 GB storage, 10k uploads/month, 25 MB images, 8 MB video, 90-day retention. **Throwaway**: 1 GB / 1k / 15 MB / 5 MB video / 90 days.
+
+KV cache ~60s. Agents: `uploads usage`.
+
+## Ledger + retention
+
+```bash
+uploads usage
+uploads reconcile          # storage is truth
+uploads purge-expired      # needs retentionDays
+```
+
+The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every workspace with `retentionDays` set. Logs: `retention_sweep` JSON.
+
+## Secrets
+
+| Secret                  | Purpose                                                          |
+| ----------------------- | ---------------------------------------------------------------- |
+| `ADMIN_TOKEN`           | `/admin/*`                                                       |
+| `WORKSPACE_SECRETS_KEY` | Encrypt BYO `accessKeyId` / `secretAccessKey` in KV (`enc:v1:…`) |
+
+```bash
+openssl rand -base64 32 | wrangler secret put WORKSPACE_SECRETS_KEY
+```
+
+`workspace:add --bucket …` encrypts keys when `WORKSPACE_SECRETS_KEY` is in the env. Plaintext legacy values still work until re-written.
+
+## Presign
+
+`POST /v1/:ws/files/sign` — workspace needs HTTP S3 credentials (not binding-only).
+
+## Deploys
+
+Code via Workers Builds / `pnpm run deploy`. D1 migrations on merge. npm CLI via changesets.
+
+See also [workspaces.md](workspaces.md), [deploy.md](deploy.md), [releasing.md](releasing.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,28 +4,18 @@
   (`uploads mcp`, tools mirror the CLI commands) and a remote worker on
   `agents.uploads.sh` (alt `mcp.uploads.sh`) (`apps/mcp`, standalone worker, per-workspace bearer auth
   like REST, put/list/delete/health).
-- **Presigned upload URLs** (`POST /v1/sign`) via files-sdk `signedUploadUrl()`
-  — needs the hybrid-mode HTTP credentials above; lets clients PUT large files
-  straight to the bucket.
-- **Web UI**: files-sdk ships `createFilesRouter` + a browser client
-  (`files-sdk/client`, `files-sdk/hono`) — mount it in the worker and the Astro
-  app gets list/upload/download against the same bucket with per-operation
-  authorization, without hand-rolling more REST.
-- **Key/path governance** — today any authenticated client can write to any
-  key in its workspace's bucket, which is fine for an internal audience but
-  not long-term (especially in `uploads-default`). Future passes:
-  - Bare filenames (no `/`) get an auto-generated unique prefix (e.g.
-    `f/<shortid>/shot.png`) instead of landing in the bucket root — the root
-    should never accumulate a million loose objects.
-  - Typed destinations: a category like `screenshots` routes to its own
-    prefix convention automatically (what the github-screenshots skill does
-    by hand today with `screenshots/<repo>/<ref>/…`).
-  - Per-workspace key policy in the registry record (allowed prefixes,
-    max depth, reserved roots) enforced at upload time.
-- **Encrypt BYO-bucket credentials at rest** — workspace records for external
-  buckets carry S3 keys in KV; before opening to outside tenants, wrap those
-  fields with an encryption key held as a Worker secret so KV read access
-  alone doesn't yield credentials.
+- **Presigned upload URLs** — shipped as `POST /v1/:workspace/files/sign`
+  (files-sdk `signedUploadUrl()`; needs HTTP S3 credentials on the workspace).
+- **Web UI** — lightweight browser console at `/console` on the Astro site;
+  longer-term: files-sdk `createFilesRouter` + browser client for full browse/manage.
+- **Key/path governance** — bare filenames auto-prefix to `f/<shortid>/<name>`
+  (opt out with `autoPrefixBareKeys: false`). Still open:
+  - Typed destinations (`screenshots/…`) as first-class policy
+  - Per-workspace allowed prefixes / max depth / reserved roots
+- **Encrypt BYO-bucket credentials at rest** — shipped when
+  `WORKSPACE_SECRETS_KEY` is set (`enc:v1:…` AES-GCM on access/secret keys).
+  Re-write existing plaintext records to encrypt; rotate key carefully.
+- **Retention cron** — daily Worker cron sweeps workspaces with `retentionDays`.
 - **More providers**: add cases to `packages/storage` (`s3`, `gcs`, …).
 - **Point `github-screenshots` at this API** — replaces its bundled SigV4
   script with one authenticated PUT.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -17,12 +17,14 @@ D1 table `workspace_usage` tracks net `bytes` / `objects` and monthly
 Optional **budgets** live on the workspace registry record (KV), same as
 `maxUploadBytes`:
 
-| Field                 | Meaning                                         |
-| --------------------- | ----------------------------------------------- |
-| `maxStorageBytes`     | Cap on net stored bytes                         |
-| `maxUploadsPerPeriod` | Cap on puts in the current UTC calendar month   |
-| `maxUploadBytes`      | Cap on a single object (default 25 MiB)         |
-| `retentionDays`       | Age (days) after which purge-expired may delete |
+| Field                 | Meaning                                          |
+| --------------------- | ------------------------------------------------ |
+| `maxStorageBytes`     | Cap on net stored bytes                          |
+| `maxUploadsPerPeriod` | Cap on puts in the current UTC calendar month    |
+| `maxUploadBytes`      | Cap on a single image (default 25 MiB)           |
+| `maxVideoUploadBytes` | Cap on video/mp4\|webm (default: same as images) |
+| `retentionDays`       | Age (days) for purge-expired + daily worker cron |
+| `autoPrefixBareKeys`  | Default true: bare keys become `f/<id>/<name>`   |
 
 Omit a field for unlimited (or no retention). Puts that would exceed storage
 return **507** with `code: "storage_quota_exceeded"`; monthly upload budget

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typecheck": "pnpm --filter @buildinternet/uploads run build && pnpm -r typecheck",
     "workspace:add": "pnpm --filter @uploads/api run workspace:add",
     "workspace:limits": "pnpm --filter @uploads/api run workspace:limits",
+    "workspace:reencrypt-secrets": "pnpm --filter @uploads/api run workspace:reencrypt-secrets",
     "preuploads": "pnpm --filter @buildinternet/uploads run build",
     "uploads": "pnpm exec uploads",
     "changeset": "changeset",

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -142,6 +142,17 @@ function errorOut(err: unknown, json: boolean): void {
     const msg = payload.error;
     if (msg.includes("\n")) process.stderr.write(`${msg}\n`);
     else process.stderr.write(`error: ${msg}\n`);
+    if (err instanceof UploadsError) {
+      if (err.code === "STORAGE_QUOTA" || err.code === "UPLOAD_BUDGET") {
+        process.stderr.write(
+          "hint: run `uploads usage` then delete objects or raise limits (`pnpm workspace:limits`)\n",
+        );
+      } else if (err.status === 413 || err.message.toLowerCase().includes("too large")) {
+        process.stderr.write(
+          "hint: file exceeds workspace size policy (images vs video may differ); compress or raise --max-upload-bytes / --max-video-bytes\n",
+        );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Single PR covering the non-DO “do them all” list (subagents raced the tree earlier; this is a clean integrated branch).

| Item | Implementation |
| --- | --- |
| **Ops runbook** | `docs/ops.md` — limits, reconcile, secrets, presign, deploys |
| **Scheduled purge** | Worker `scheduled` + `triggers.crons: 0 6 * * *` → `runRetentionSweep` |
| **Per-type size** | `maxVideoUploadBytes`; 413 `code: upload_too_large` + `kind` |
| **Key governance** | Bare keys → `f/<shortid>/<name>` (`autoPrefixBareKeys` default on) |
| **Encrypt BYO** | `WORKSPACE_SECRETS_KEY` + `enc:v1:…` AES-GCM; seal on `workspace:add` |
| **Presign** | `POST /v1/:ws/files/sign` (files-sdk `signedUploadUrl`) |
| **Web scaffold** | `apps/web` `/console` — browser-only token usage/list/reconcile |
| **CLI UX** | Hints on STORAGE_QUOTA / UPLOAD_BUDGET / 413 |

**Not in this PR:** Durable Objects (#24).

### Deploy notes

1. Optional: `wrangler secret put WORKSPACE_SECRETS_KEY` (and local `.dev.vars`)
2. Cron activates on next API deploy
3. Set real workspace limits via `pnpm workspace:limits …` (see ops.md)

## Test plan

- [x] `@uploads/api` tests (63)
- [x] MCP + uploads package tests
- [ ] After merge: confirm cron in wrangler dashboard; optional secret put; `/console` on web deploy