### PR TITLE
feat: organize upload paths (typed destinations + optional folder rules)

### DIFF
--- a/.changeset/key-destinations-policy.md
+++ b/.changeset/key-destinations-policy.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add typed destinations (`--destination screenshots|gh|f` / MCP `destination`) and map API key-policy denials (`key_prefix_not_allowed`, `key_too_deep`) to a dedicated CLI error with an actionable hint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,9 @@ pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # all workers; or deploy:api / deploy:web / deploy:mcp
 pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
   [--max-storage 25GB] [--max-uploads-per-month N] [--max-upload-bytes 25MB]
-pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] [--clear-max-storage] […]
+pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] \
+  [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
+  [--clear-max-storage] [--clear-allowed-prefixes] […]
 pnpm uploads put <file> --env-file .env   # CLI (builds package first)
 pnpm uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
 ```
@@ -136,10 +138,10 @@ records; any future global secrets go through `wrangler secret put` (prod) or
 ## Roadmap (see docs/roadmap.md for detail)
 
 MCP server for agent access (primary users are agents); key/path governance
-(auto-prefix bare filenames, typed destinations like `screenshots`,
-per-workspace key policy — arbitrary paths are an internal-audience allowance,
-not the end state); encrypt BYO-bucket S3 credentials in KV records before
-external tenants; presigned upload URLs (`POST /v1/sign`); web UI on
+(auto-prefix bare filenames; typed destinations `screenshots`/`gh`/`f` and
+optional `allowedKeyPrefixes`/`maxKeyDepth` — arbitrary paths remain an
+internal/BYO allowance when policy is unset); encrypt BYO-bucket S3 credentials
+in KV records before external tenants; presigned upload URLs (`POST /v1/sign`); web UI on
 files-sdk's `createFilesRouter` + browser client rather than more hand-rolled
 REST; more providers in `packages/storage`; point the `github-screenshots`
 skill at this API.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,28 @@ records; any future global secrets go through `wrangler secret put` (prod) or
 - Follow Cloudflare Workers best practices: no floating promises, no
   module-level request state, secrets never in config or source.
 
+## Pull requests
+
+Write PR descriptions for humans first, not only for reviewers who already
+know the code. Prefer plain language over dense bullet dumps of identifiers.
+
+**Shape (compact):**
+
+1. **In plain terms** — one short paragraph: what this changes and why anyone
+   should care (the problem, the outcome). Avoid leading with file paths,
+   type names, or flag lists.
+2. **What it does / what it is not** — a few concrete bullets; call out
+   opt-in vs breaking, and anything deliberately deferred.
+3. **How to try it** — only when useful (commands, operator flags).
+4. **Technical notes** — optional short section for implementers (modules,
+   error codes, test commands). Keep it secondary to the plain summary.
+5. **Test plan** — checkboxes for what was run / what remains.
+
+Do **not** auto-request CodeRabbit on every PR (org policy: on-demand only).
+Do **not** invent conventional-commit title rules; keep titles short and
+descriptive. User-visible `@buildinternet/uploads` changes still need a
+changeset; do not merge “version packages” PRs unless shipping is intentional.
+
 ## Environment files
 
 - `.env.example` (repo root) — client vars (`UPLOADS_API_URL`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,10 +141,13 @@ know the code. Prefer plain language over dense bullet dumps of identifiers.
    error codes, test commands). Keep it secondary to the plain summary.
 5. **Test plan** — checkboxes for what was run / what remains.
 
-Do **not** auto-request CodeRabbit on every PR (org policy: on-demand only).
-Do **not** invent conventional-commit title rules; keep titles short and
-descriptive. User-visible `@buildinternet/uploads` changes still need a
-changeset; do not merge “version packages” PRs unless shipping is intentional.
+**Titles:** conventional-commit type prefix + plain-language subject, e.g.
+`feat: organize upload paths (typed destinations + optional folder rules)`.
+Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`. Keep the
+subject readable (outcome first); avoid stuffing every flag/module into the
+title. Do **not** auto-request CodeRabbit on every PR (org policy: on-demand
+only). User-visible `@buildinternet/uploads` changes still need a changeset;
+do not merge “version packages” PRs unless shipping is intentional.
 
 ## Environment files
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ pnpm uploads put ./shot.png --env-file .env
 # stdout: public URL + ready-to-paste markdown; stderr: human summary
 ```
 
-**How keys work:** default `put` is the fast path — run it with no flags and you get
-a unique public URL (`screenshots/<repo>/<date>/<name>-<hash>.<ext>`). Use `--pr` or
-`--issue` when you need a stable, hash-free filename for a GitHub embed. Use `--key`
-only when you want an exact path.
+**How keys work:** default `put` lands under `screenshots/…`. Prefer
+`--destination screenshots` (or `gh` with `--pr`/`--issue`) over inventing roots —
+workspaces may allowlist only those destinations. Use `--pr`/`--issue` for stable,
+hash-free GitHub keys; use `--key` only for an exact path under an allowed root.
 
 More output control:
 
@@ -135,14 +135,15 @@ plus peer deps, no API changes.
 
 ## Docs
 
-| Doc                                          | Contents                                     |
-| -------------------------------------------- | -------------------------------------------- |
-| [workspaces](docs/workspaces.md)             | Multi-tenant model, registration, BYO-bucket |
-| [enrollment](docs/enrollment.md)             | Agent login, scopes, expiry, and migration   |
-| [admin-tokens](docs/admin-tokens.md)         | Minting, listing, and revoking upload tokens |
-| [api](docs/api.md)                           | REST routes and CLI usage                    |
-| [deploy](docs/deploy.md)                     | Cloudflare setup and production deploy       |
-| [contract testing](docs/contract-testing.md) | Deployed smoke checks and release gate       |
-| [roadmap](docs/roadmap.md)                   | Planned features                             |
+| Doc                                          | Contents                                            |
+| -------------------------------------------- | --------------------------------------------------- |
+| [workspaces](docs/workspaces.md)             | Multi-tenant model, budgets, key policy, BYO-bucket |
+| [ops](docs/ops.md)                           | Operator runbook (limits, retention, secrets)       |
+| [enrollment](docs/enrollment.md)             | Agent login, scopes, expiry, and migration          |
+| [admin-tokens](docs/admin-tokens.md)         | Minting, listing, and revoking upload tokens        |
+| [api](docs/api.md)                           | REST routes and CLI usage                           |
+| [deploy](docs/deploy.md)                     | Cloudflare setup and production deploy              |
+| [contract testing](docs/contract-testing.md) | Deployed smoke checks and release gate              |
+| [roadmap](docs/roadmap.md)                   | Planned features                                    |
 
 Agent and contributor conventions live in [AGENTS.md](AGENTS.md).

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,34 +4,38 @@ Hono worker — workspace-scoped REST API for file I/O. Deploys to **api.uploads
 
 ## Routes
 
-| Path                     | Auth             | Purpose                           |
-| ------------------------ | ---------------- | --------------------------------- |
-| `GET /health`            | —                | Liveness                          |
-| `/admin/*`               | admin token      | Mint/list/revoke workspace tokens |
-| `/v1/:workspace/files/*` | workspace bearer | Put, get, head, list, delete      |
+| Path                     | Auth             | Purpose                                       |
+| ------------------------ | ---------------- | --------------------------------------------- |
+| `GET /health`            | —                | Liveness                                      |
+| `/admin/*`               | admin token      | Mint/list/revoke tokens; credential reencrypt |
+| `/v1/:workspace/files/*` | workspace bearer | Put, sign, get, list, delete                  |
+| `/v1/:workspace/usage/*` | workspace bearer | Usage, reconcile, purge-expired               |
 
-Workspaces are tenant records in the `REGISTRY` KV namespace. Auth and storage wiring live in `src/workspace.ts` and `src/storage.ts`; all object I/O goes through `@uploads/storage`.
+Workspaces are tenant records in the `REGISTRY` KV namespace. Auth and storage wiring live in `src/workspace.ts` and `src/storage.ts`; all object I/O goes through `@uploads/storage`. Put/sign share `files-core` (guards, budgets, key policy).
 
 ## Layout
 
 ```
 src/
-  index.ts          Hono app + route mounting
+  index.ts          Hono app + scheduled retention
   workspace.ts      KV lookup, bearer auth, WorkspaceRecord
-  storage.ts        createStorage() bridge from workspace → @uploads/storage
-  routes/files.ts   File CRUD handlers
-  routes/admin.ts   Token minting
+  files-core.ts     Shared put/list/delete + key governance
+  key-policy.ts     allowedKeyPrefixes / maxKeyDepth
+  storage.ts        createStorage() bridge → @uploads/storage
+  routes/           files, usage, auth, admin
 scripts/
-  add-workspace.mjs Register a workspace (prod or --local KV)
+  add-workspace.mjs           Register a workspace (prod or --local KV)
+  set-workspace-limits.mjs    Budgets, retention, key policy
 ```
 
 ## Commands
 
 ```bash
 pnpm dev                              # wrangler dev (:8787)
-pnpm run deploy                       # production deploy
+pnpm run deploy                       # D1 migrate + production deploy
 pnpm types                            # regenerate worker-configuration.d.ts
 pnpm workspace:add <name> --local     # dev KV registration
+pnpm workspace:limits <name> --allowed-prefixes default --max-key-depth 8
 ```
 
 After editing `wrangler.jsonc`, run `pnpm types` — `Env` is generated, never hand-written.
@@ -39,6 +43,7 @@ After editing `wrangler.jsonc`, run `pnpm types` — `Env` is generated, never h
 ## Docs
 
 - [API reference](../../docs/api.md)
-- [Workspaces](../../docs/workspaces.md)
+- [Workspaces](../../docs/workspaces.md) (budgets + key destinations)
+- [Operator runbook](../../docs/ops.md)
 - [Admin tokens](../../docs/admin-tokens.md)
 - [Deploy](../../docs/deploy.md)

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -9,10 +9,11 @@
  *     [--binding UPLOADS] [--public-base-url https://media.example.com] \
  *     [--account-id ...] [--access-key-id ...] [--secret-access-key ...] \
  *     [--max-storage 25GB] [--max-uploads-per-month 10000] [--max-upload-bytes 25MB] \
+ *     [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
  *     [--local]             # write to wrangler dev's local KV instead of prod
  *
- * Limit flags are optional (omit = unlimited). Change later with
- * scripts/set-workspace-limits.mjs without re-minting tokens.
+ * Limit flags are optional (omit = unlimited / unrestricted keys). Change later
+ * with scripts/set-workspace-limits.mjs without re-minting tokens.
  *
  * Default (no --bucket): the workspace is a "<name>/" prefix in the shared
  * uploads-default bucket, served at https://storage.uploads.sh/<name>/...
@@ -95,6 +96,41 @@ function parseCount(raw, label) {
   return n;
 }
 
+function parseDepth(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  const n = Number(s);
+  if (!Number.isInteger(n) || n < 1 || n > 64) {
+    fail(`invalid ${label}: ${JSON.stringify(raw)} (use 1–64)`);
+  }
+  return n;
+}
+
+function parseAllowedPrefixes(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  const parts = s
+    .split(/[,;\s]+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length === 0) fail(`invalid ${label}: empty list`);
+  const out = [];
+  for (const part of parts) {
+    if (/^default$/i.test(part)) {
+      out.push("f", "screenshots", "gh");
+      continue;
+    }
+    const cleaned = part.replace(/^\/+/, "").replace(/\/+$/, "");
+    if (!cleaned || cleaned.includes("..") || !/^[\w.!-]+(?:\/[\w.!-]+)*$/.test(cleaned)) {
+      fail(`invalid ${label} entry: ${JSON.stringify(part)}`);
+    }
+    out.push(cleaned);
+  }
+  return [...new Set(out)];
+}
+
 if (!name || !/^[a-z0-9][a-z0-9-]{1,62}$/.test(name)) {
   fail("workspace name must be lowercase alphanumeric/hyphens, 2-63 chars");
 }
@@ -144,10 +180,14 @@ const maxStorageBytes = parseBytes(opts["max-storage"], "max-storage");
 const maxUploadsPerPeriod = parseCount(opts["max-uploads-per-month"], "max-uploads-per-month");
 const maxUploadBytes = parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
 const maxVideoUploadBytes = parseBytes(opts["max-video-bytes"], "max-video-bytes");
+const allowedKeyPrefixes = parseAllowedPrefixes(opts["allowed-prefixes"], "allowed-prefixes");
+const maxKeyDepth = parseDepth(opts["max-key-depth"], "max-key-depth");
 if (maxStorageBytes !== undefined) record.maxStorageBytes = maxStorageBytes;
 if (maxUploadsPerPeriod !== undefined) record.maxUploadsPerPeriod = maxUploadsPerPeriod;
 if (maxUploadBytes !== undefined) record.maxUploadBytes = maxUploadBytes;
 if (maxVideoUploadBytes !== undefined) record.maxVideoUploadBytes = maxVideoUploadBytes;
+if (allowedKeyPrefixes !== undefined) record.allowedKeyPrefixes = allowedKeyPrefixes;
+if (maxKeyDepth !== undefined) record.maxKeyDepth = maxKeyDepth;
 
 const master = process.env.WORKSPACE_SECRETS_KEY;
 if (master && (record.accessKeyId || record.secretAccessKey)) {

--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Patch budget / upload limits on an existing workspace registry record.
- * Does not re-mint tokens — only updates limit fields on the KV record.
+ * Patch budget / upload / key-policy limits on an existing workspace registry
+ * record. Does not re-mint tokens — only updates limit fields on the KV record.
  *
  * Usage (from apps/api):
  *   node --env-file=../../.env scripts/set-workspace-limits.mjs <name> \
@@ -9,13 +9,19 @@
  *     [--max-uploads-per-month 10000] \
  *     [--max-upload-bytes 25MB] \
  *     [--retention-days 90] \
+ *     [--allowed-prefixes default|f,screenshots,gh] \
+ *     [--max-key-depth 8] \
  *     [--clear-max-storage] [--clear-max-uploads-per-month] [--clear-max-upload-bytes] \
- *     [--clear-retention-days] \
+ *     [--clear-retention-days] [--clear-allowed-prefixes] [--clear-max-key-depth] \
  *     [--local]
  *
  * Units: bare number = bytes (or count for uploads). Also accepts KB/MB/GB
  * and KiB/MiB/GiB (e.g. 1GB, 25MiB). Use 0 or "unlimited" with a --clear-*
  * flag to remove a cap.
+ *
+ * Key policy: --allowed-prefixes restricts put/sign roots (comma-separated).
+ * The sentinel "default" expands to f/, screenshots/, gh/ (CLI layouts).
+ * --max-key-depth caps path segments after bare-key governance.
  *
  * Show current limits only:
  *   node scripts/set-workspace-limits.mjs <name> [--local]
@@ -89,6 +95,46 @@ function parseCount(raw, label) {
   return n === 0 ? null : n;
 }
 
+/** Parse depth: positive integer, or null for unlimited. */
+function parseDepth(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
+  const n = Number(s);
+  if (!Number.isInteger(n) || n < 1 || n > 64) {
+    fail(`invalid ${label}: ${JSON.stringify(raw)} (use 1–64 or unlimited)`);
+  }
+  return n;
+}
+
+/**
+ * Parse allowed key prefixes. Comma-separated list; "default" → f,screenshots,gh.
+ * Returns string[] or null (clear).
+ */
+function parseAllowedPrefixes(raw, label) {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const s = String(raw).trim();
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
+  const parts = s
+    .split(/[,;\s]+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length === 0) fail(`invalid ${label}: empty list`);
+  const out = [];
+  for (const part of parts) {
+    if (/^default$/i.test(part)) {
+      out.push("f", "screenshots", "gh");
+      continue;
+    }
+    const cleaned = part.replace(/^\/+/, "").replace(/\/+$/, "");
+    if (!cleaned || cleaned.includes("..") || !/^[\w.!-]+(?:\/[\w.!-]+)*$/.test(cleaned)) {
+      fail(`invalid ${label} entry: ${JSON.stringify(part)}`);
+    }
+    out.push(cleaned);
+  }
+  return [...new Set(out)];
+}
+
 function wranglerKv(args) {
   return execFileSync(
     "pnpm",
@@ -127,6 +173,8 @@ const before = {
   maxUploadBytes: record.maxUploadBytes,
   maxVideoUploadBytes: record.maxVideoUploadBytes,
   retentionDays: record.retentionDays,
+  allowedKeyPrefixes: record.allowedKeyPrefixes,
+  maxKeyDepth: record.maxKeyDepth,
 };
 
 const patch = {};
@@ -158,6 +206,16 @@ if (clears.has("retention-days") || opts["retention-days"] !== undefined) {
     : parseCount(opts["retention-days"], "retention-days");
   patch.retentionDays = v;
 }
+if (clears.has("allowed-prefixes") || opts["allowed-prefixes"] !== undefined) {
+  const v = clears.has("allowed-prefixes")
+    ? null
+    : parseAllowedPrefixes(opts["allowed-prefixes"], "allowed-prefixes");
+  patch.allowedKeyPrefixes = v;
+}
+if (clears.has("max-key-depth") || opts["max-key-depth"] !== undefined) {
+  const v = clears.has("max-key-depth") ? null : parseDepth(opts["max-key-depth"], "max-key-depth");
+  patch.maxKeyDepth = v;
+}
 
 const changing = Object.keys(patch).length > 0;
 if (!changing) {
@@ -166,6 +224,9 @@ if (!changing) {
   console.log("\nNo flags — nothing updated. Examples:");
   console.log(
     `  node scripts/set-workspace-limits.mjs ${name} --max-storage 25GB --max-uploads-per-month 10000`,
+  );
+  console.log(
+    `  node scripts/set-workspace-limits.mjs ${name} --allowed-prefixes default --max-key-depth 8`,
   );
   console.log(`  node scripts/set-workspace-limits.mjs ${name} --clear-max-storage`);
   process.exit(0);
@@ -184,6 +245,8 @@ const after = {
   maxUploadBytes: record.maxUploadBytes,
   maxVideoUploadBytes: record.maxVideoUploadBytes,
   retentionDays: record.retentionDays,
+  allowedKeyPrefixes: record.allowedKeyPrefixes,
+  maxKeyDepth: record.maxKeyDepth,
 };
 
 console.log(`workspace : ${name} (${opts.local ? "local" : "remote"})`);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -7,6 +7,7 @@
 import type { Files } from "@uploads/storage";
 import { checkPutBudget } from "./budget";
 import { inspectUpload, resolveUploadPolicy } from "./guards";
+import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
 import { publicUrl, storage, storageConfig } from "./storage";
 import { getWorkspaceUsage, recordUsageSafe } from "./usage";
 import type { WorkspaceRecord } from "./workspace";
@@ -50,6 +51,28 @@ export function shortUploadId(bytes = 9): string {
 export function governUploadKey(key: string, autoPrefix = true): string {
   if (!autoPrefix || key.includes("/")) return key;
   return `f/${shortUploadId()}/${sanitizeKeyBasename(key)}`;
+}
+
+/** Workspace fields that affect key governance and prefix/depth policy. */
+export type KeyPolicyRecord = Pick<
+  WorkspaceRecord,
+  "autoPrefixBareKeys" | "allowedKeyPrefixes" | "maxKeyDepth"
+>;
+
+/**
+ * Bare-key governance + per-workspace prefix/depth policy. Shared by put and
+ * presign so both surfaces reject the same keys.
+ */
+export function finalizeUploadKey(key: string, ws: KeyPolicyRecord): string {
+  const finalKey = governUploadKey(key, ws.autoPrefixBareKeys !== false);
+  if (badKey(finalKey)) throw new FileOpError("invalid key");
+
+  const violation = checkKeyPolicy(finalKey, resolveKeyPolicy(ws));
+  if (violation) {
+    const { message, code, ...extra } = violation;
+    throw new FileOpError(message, 400, { code, ...extra });
+  }
+  return finalKey;
 }
 
 /**
@@ -98,8 +121,7 @@ export async function putObject(
   bytes: Uint8Array,
   workspaceName: string,
 ): Promise<{ key: string; url: string | null; size: number; contentType: string }> {
-  const finalKey = governUploadKey(key, ws.autoPrefixBareKeys !== false);
-  if (badKey(finalKey)) throw new FileOpError("invalid key");
+  const finalKey = finalizeUploadKey(key, ws);
   if (bytes.byteLength === 0) throw new FileOpError("empty body");
 
   const inspection = inspectUpload(bytes, resolveUploadPolicy(ws));

--- a/apps/api/src/key-policy.ts
+++ b/apps/api/src/key-policy.ts
@@ -1,0 +1,119 @@
+/**
+ * Opt-in object-key policy for put/sign. When unset, any nested path is allowed
+ * (internal/BYO). Shared agent workspaces typically set
+ * `allowedKeyPrefixes: ["f","screenshots","gh"]` (or the operator sentinel
+ * `default`) and `maxKeyDepth: 8`.
+ */
+import type { WorkspaceRecord } from "./workspace";
+
+/** Built-in roots used by the CLI (`--destination`) and recommended allowlist. */
+export const BUILTIN_DESTINATIONS = {
+  f: "f",
+  screenshots: "screenshots",
+  gh: "gh",
+} as const;
+
+export type BuiltinDestinationId = keyof typeof BUILTIN_DESTINATIONS;
+
+/** `default` operator sentinel expands to these roots (with trailing `/`). */
+export const DEFAULT_ALLOWED_PREFIXES: readonly string[] = [
+  `${BUILTIN_DESTINATIONS.f}/`,
+  `${BUILTIN_DESTINATIONS.screenshots}/`,
+  `${BUILTIN_DESTINATIONS.gh}/`,
+];
+
+export type KeyPolicy = {
+  /** Normalized roots ending with `/`, or null when unrestricted. */
+  allowedKeyPrefixes: string[] | null;
+  /** Max `/`-separated segments, or null when unrestricted. */
+  maxKeyDepth: number | null;
+};
+
+const ROOT_SEG_RE = /^[a-zA-Z0-9][\w.-]{0,62}$/;
+
+/** Normalize a prefix entry to `root/` form, or null if invalid. */
+export function normalizeKeyPrefix(raw: string): string | null {
+  const trimmed = raw.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!trimmed) return null;
+  const segs = trimmed.split("/");
+  if (segs.some((s) => !s || s === "." || s === ".." || !ROOT_SEG_RE.test(s))) return null;
+  return `${trimmed}/`;
+}
+
+/**
+ * Parse allowed prefixes. Accepts `f`, `f/`, nested roots, and `default`
+ * (→ f + screenshots + gh). Invalid entries are skipped.
+ */
+export function normalizeAllowedKeyPrefixes(list: unknown): string[] {
+  if (!Array.isArray(list)) return [];
+  const out = new Set<string>();
+  for (const item of list) {
+    if (typeof item !== "string") continue;
+    const raw = item.trim();
+    if (!raw) continue;
+    if (/^default$/i.test(raw)) {
+      for (const p of DEFAULT_ALLOWED_PREFIXES) out.add(p);
+      continue;
+    }
+    const normalized = normalizeKeyPrefix(raw);
+    if (normalized) out.add(normalized);
+  }
+  return [...out].sort();
+}
+
+export function resolveKeyPolicy(
+  record: Pick<WorkspaceRecord, "allowedKeyPrefixes" | "maxKeyDepth">,
+): KeyPolicy {
+  const prefixes = normalizeAllowedKeyPrefixes(record.allowedKeyPrefixes);
+  const depth =
+    typeof record.maxKeyDepth === "number" &&
+    Number.isInteger(record.maxKeyDepth) &&
+    record.maxKeyDepth >= 1
+      ? Math.min(record.maxKeyDepth, 64)
+      : null;
+  return {
+    allowedKeyPrefixes: prefixes.length > 0 ? prefixes : null,
+    maxKeyDepth: depth,
+  };
+}
+
+export type KeyPolicyViolation =
+  | {
+      code: "key_prefix_not_allowed";
+      message: string;
+      allowedKeyPrefixes: string[];
+    }
+  | {
+      code: "key_too_deep";
+      message: string;
+      maxKeyDepth: number;
+      depth: number;
+    };
+
+/** Structured violation when `key` fails the workspace policy, else null. */
+export function checkKeyPolicy(key: string, policy: KeyPolicy): KeyPolicyViolation | null {
+  if (policy.maxKeyDepth !== null) {
+    const depth = key.split("/").length;
+    if (depth > policy.maxKeyDepth) {
+      return {
+        code: "key_too_deep",
+        message: `key exceeds max depth (${depth} > ${policy.maxKeyDepth} segments)`,
+        maxKeyDepth: policy.maxKeyDepth,
+        depth,
+      };
+    }
+  }
+
+  if (policy.allowedKeyPrefixes !== null) {
+    const allowed = policy.allowedKeyPrefixes;
+    if (!allowed.some((prefix) => key.startsWith(prefix))) {
+      return {
+        code: "key_prefix_not_allowed",
+        message: `key prefix not allowed (must start with one of: ${allowed.join(", ")})`,
+        allowedKeyPrefixes: allowed,
+      };
+    }
+  }
+
+  return null;
+}

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,5 +1,12 @@
 import { Hono, type Context } from "hono";
-import { FileOpError, badKey, deleteObject, listObjects, putObject } from "../files-core";
+import {
+  FileOpError,
+  badKey,
+  deleteObject,
+  finalizeUploadKey,
+  listObjects,
+  putObject,
+} from "../files-core";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../guards";
@@ -33,10 +40,17 @@ export const files = new Hono<WorkspaceVars>()
           },
       );
 
-    const key = typeof body.key === "string" ? body.key : "";
-    if (!key || badKey(key)) return c.json({ error: "invalid key" }, 400);
+    const rawKey = typeof body.key === "string" ? body.key : "";
+    if (!rawKey) return c.json({ error: "invalid key" }, 400);
 
     const ws = c.get("workspace");
+    let key: string;
+    try {
+      key = finalizeUploadKey(rawKey, ws);
+    } catch (err) {
+      return mapFileOpError(c, err);
+    }
+
     const policy = resolveUploadPolicy(ws);
     const ceiling = Math.max(policy.maxBytes, policy.maxVideoBytes);
     const maxSize =

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -53,6 +53,17 @@ export interface WorkspaceRecord {
    * to allow root basenames (not recommended on shared buckets).
    */
   autoPrefixBareKeys?: boolean;
+  /**
+   * When set (non-empty), put/sign keys must start with one of these prefixes
+   * after bare-key governance. Entries may omit the trailing `/`. Operator
+   * tooling accepts `"default"` → `f/`, `screenshots/`, `gh/`. Omit = any path.
+   */
+  allowedKeyPrefixes?: string[];
+  /**
+   * Max `/`-separated path segments on put/sign after governance (e.g. 8).
+   * Omit = only structural key validation (`badKey`).
+   */
+  maxKeyDepth?: number;
 }
 
 export type WorkspaceVars = {

--- a/apps/api/test/key-policy.test.ts
+++ b/apps/api/test/key-policy.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ALLOWED_PREFIXES,
+  checkKeyPolicy,
+  normalizeAllowedKeyPrefixes,
+  normalizeKeyPrefix,
+  resolveKeyPolicy,
+} from "../src/key-policy";
+import { finalizeUploadKey, FileOpError, governUploadKey } from "../src/files-core";
+
+describe("normalizeKeyPrefix", () => {
+  it("normalizes roots with or without trailing slash", () => {
+    expect(normalizeKeyPrefix("screenshots")).toBe("screenshots/");
+    expect(normalizeKeyPrefix("screenshots/")).toBe("screenshots/");
+    expect(normalizeKeyPrefix("/gh/")).toBe("gh/");
+  });
+
+  it("rejects empty and path-escape segments", () => {
+    expect(normalizeKeyPrefix("")).toBeNull();
+    expect(normalizeKeyPrefix("..")).toBeNull();
+    expect(normalizeKeyPrefix("a/../b")).toBeNull();
+  });
+});
+
+describe("normalizeAllowedKeyPrefixes", () => {
+  it("expands default sentinel to built-in destinations", () => {
+    expect(normalizeAllowedKeyPrefixes(["default"])).toEqual([...DEFAULT_ALLOWED_PREFIXES].sort());
+  });
+
+  it("dedupes and sorts", () => {
+    expect(normalizeAllowedKeyPrefixes(["gh", "f/", "f", "screenshots"])).toEqual([
+      "f/",
+      "gh/",
+      "screenshots/",
+    ]);
+  });
+});
+
+describe("checkKeyPolicy", () => {
+  const policy = resolveKeyPolicy({
+    allowedKeyPrefixes: ["f", "screenshots", "gh"],
+    maxKeyDepth: 6,
+  });
+
+  it("allows keys under permitted roots", () => {
+    expect(checkKeyPolicy("screenshots/app/1/shot.png", policy)).toBeNull();
+    expect(checkKeyPolicy("f/abc/shot.png", policy)).toBeNull();
+    expect(checkKeyPolicy("gh/o/r/pull/1/a.png", policy)).toBeNull();
+  });
+
+  it("rejects disallowed roots", () => {
+    expect(checkKeyPolicy("tmp/secret.png", policy)?.code).toBe("key_prefix_not_allowed");
+  });
+
+  it("rejects deep paths", () => {
+    const v = checkKeyPolicy("screenshots/a/b/c/d/e/f.png", policy);
+    expect(v?.code).toBe("key_too_deep");
+    if (v?.code === "key_too_deep") {
+      expect(v.depth).toBe(7);
+      expect(v.maxKeyDepth).toBe(6);
+    }
+  });
+
+  it("is a no-op when policy fields are unset", () => {
+    expect(checkKeyPolicy("anything/goes/here.png", resolveKeyPolicy({}))).toBeNull();
+  });
+});
+
+describe("finalizeUploadKey", () => {
+  it("auto-prefixes bare keys under f/", () => {
+    expect(finalizeUploadKey("shot.png", {})).toMatch(/^f\/[A-Za-z0-9_-]+\/shot\.png$/);
+  });
+
+  it("enforces allowed prefixes after governance", () => {
+    expect(() => finalizeUploadKey("tmp/x.png", { allowedKeyPrefixes: ["screenshots"] })).toThrow(
+      FileOpError,
+    );
+    try {
+      finalizeUploadKey("tmp/x.png", { allowedKeyPrefixes: ["screenshots"] });
+    } catch (err) {
+      expect(err).toBeInstanceOf(FileOpError);
+      expect((err as FileOpError).body.code).toBe("key_prefix_not_allowed");
+    }
+  });
+
+  it("allows bare keys when f/ is in the allowlist", () => {
+    expect(
+      finalizeUploadKey("shot.png", { allowedKeyPrefixes: ["default"] }).startsWith("f/"),
+    ).toBe(true);
+  });
+
+  it("leaves nested keys intact when under allowlist", () => {
+    expect(
+      finalizeUploadKey("screenshots/app/shot.png", { allowedKeyPrefixes: ["screenshots"] }),
+    ).toBe("screenshots/app/shot.png");
+  });
+});
+
+describe("governUploadKey (regression)", () => {
+  it("still prefixes bare basenames", () => {
+    expect(governUploadKey("shot.png")).toMatch(/^f\//);
+  });
+});

--- a/apps/api/test/routes-key-policy.test.ts
+++ b/apps/api/test/routes-key-policy.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+
+const TOKEN = "secret-token";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+async function makeEnv(overrides: Partial<WorkspaceRecord> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...overrides,
+  };
+  const bucket = new FakeR2Bucket();
+  const env = {
+    REGISTRY: { get: async () => record, put: async () => undefined },
+    DB: {
+      prepare: () => ({
+        bind() {
+          return this;
+        },
+        async first() {
+          return null;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+      }),
+      async batch(stmts: { run: () => Promise<unknown> }[]) {
+        return Promise.all(stmts.map((s) => s.run()));
+      },
+    },
+    UPLOADS_DEFAULT: bucket,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+  };
+  return { env, bucket };
+}
+
+function putKey(env: Parameters<typeof app.request>[2], key: string) {
+  return app.request(
+    `/v1/default/files/${key}`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+      body: PNG,
+    },
+    env,
+  );
+}
+
+describe("PUT key policy", () => {
+  it("rejects keys outside allowedKeyPrefixes with 400", async () => {
+    const { env } = await makeEnv({ allowedKeyPrefixes: ["screenshots", "gh"] });
+    const res = await putKey(env, "tmp/shot.png");
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string; allowedKeyPrefixes: string[] };
+    expect(json.code).toBe("key_prefix_not_allowed");
+    expect(json.allowedKeyPrefixes).toContain("screenshots/");
+  });
+
+  it("allows keys under an allowed destination", async () => {
+    const { env, bucket } = await makeEnv({ allowedKeyPrefixes: ["default"] });
+    const res = await putKey(env, "screenshots/shot.png");
+    expect(res.status).toBe(201);
+    expect(bucket.store.has("default/screenshots/shot.png")).toBe(true);
+  });
+
+  it("rejects keys that exceed maxKeyDepth", async () => {
+    const { env } = await makeEnv({ maxKeyDepth: 2 });
+    const res = await putKey(env, "screenshots/a/b/shot.png");
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string; maxKeyDepth: number };
+    expect(json.code).toBe("key_too_deep");
+    expect(json.maxKeyDepth).toBe(2);
+  });
+
+  it("auto-prefix bare keys still works with f/ allowlist", async () => {
+    const { env } = await makeEnv({ allowedKeyPrefixes: ["f"] });
+    const res = await putKey(env, "shot.png");
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { key: string };
+    expect(json.key).toMatch(/^f\/.+\/shot\.png$/);
+  });
+});

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -11,10 +11,9 @@ public URL + GitHub-ready markdown), `list`, `delete`, `health`. Filesystem/
 `gh`-dependent tools (attach, comment, doctor) live only in the stdio server
 (`uploads mcp`).
 
-The REST API's upload guardrails apply: the stored content type is sniffed
-server-side from the bytes (no caller override) and checked against the
-workspace's allowlist, uploads are size-capped, and writes (`put`/`delete`)
-are rate limited per workspace.
+The REST API's upload guardrails apply: content type is sniffed server-side,
+size-capped, budget-checked, and subject to optional key policy
+(`allowedKeyPrefixes` / `maxKeyDepth`). Writes are rate limited per workspace.
 
 ## Endpoint
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,9 +35,12 @@ headroom. Puts that would exceed them fail with:
 | ---- | ------------------------ | ---------------------------------------------------- |
 | 507  | `storage_quota_exceeded` | Net stored bytes would exceed `maxStorageBytes`      |
 | 429  | `upload_budget_exceeded` | Monthly put count would exceed `maxUploadsPerPeriod` |
+| 400  | `key_prefix_not_allowed` | Key not under `allowedKeyPrefixes` (put/sign)        |
+| 400  | `key_too_deep`           | Key path segments exceed `maxKeyDepth`               |
 
 Configure limits with `pnpm workspace:limits <name> …` (see
-[workspaces](workspaces.md)).
+[workspaces](workspaces.md)). Bare keys are rewritten to `f/<id>/<name>` before
+policy checks; presign uses the same finalization as put.
 
 **Reconcile** scans every object under the workspace prefix and replaces ledger
 `bytes`/`objects` (monthly upload count is preserved). Use after external

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -11,10 +11,14 @@ pnpm workspace:limits <name> \
   --max-uploads-per-month 10000 \
   --max-upload-bytes 25MB \
   --max-video-bytes 8MB \
-  --retention-days 90
+  --retention-days 90 \
+  --allowed-prefixes default \
+  --max-key-depth 8
 ```
 
-Suggested **shared/agent** defaults: 25 GB storage, 10k uploads/month, 25 MB images, 8 MB video, 90-day retention. **Throwaway**: 1 GB / 1k / 15 MB / 5 MB video / 90 days.
+Suggested **shared/agent** defaults: 25 GB storage, 10k uploads/month, 25 MB images, 8 MB video, 90-day retention, key prefixes `default` (`f/`, `screenshots/`, `gh/`), max depth 8. **Throwaway**: 1 GB / 1k / 15 MB / 5 MB video / 90 days / same key policy.
+
+`--allowed-prefixes default` expands to the typed destinations agents already use. Clear with `--clear-allowed-prefixes` / `--clear-max-key-depth`. Puts outside the allowlist return **400** `key_prefix_not_allowed`; too-deep paths return **400** `key_too_deep`.
 
 KV cache ~60s. Agents: `uploads usage`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,10 +8,10 @@
   (files-sdk `signedUploadUrl()`; needs HTTP S3 credentials on the workspace).
 - **Web UI** — lightweight browser console at `/console` on the Astro site;
   longer-term: files-sdk `createFilesRouter` + browser client for full browse/manage.
-- **Key/path governance** — bare filenames auto-prefix to `f/<shortid>/<name>`
-  (opt out with `autoPrefixBareKeys: false`). Still open:
-  - Typed destinations (`screenshots/…`) as first-class policy
-  - Per-workspace allowed prefixes / max depth / reserved roots
+- **Key/path governance** — bare keys → `f/<shortid>/<name>`; typed destinations
+  (`screenshots` / `gh` / `f`); optional `allowedKeyPrefixes` + `maxKeyDepth` on
+  put/sign. Remaining ideas: destination-specific size rules; expose policy on
+  `usage`/`doctor`.
 - **Encrypt BYO-bucket credentials at rest** — shipped when
   `WORKSPACE_SECRETS_KEY` is set (`enc:v1:…` AES-GCM on access/secret keys).
   Re-write existing plaintext records to encrypt; rotate key carefully.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -25,11 +25,22 @@ Optional **budgets** live on the workspace registry record (KV), same as
 | `maxVideoUploadBytes` | Cap on video/mp4\|webm (default: same as images) |
 | `retentionDays`       | Age (days) for purge-expired + daily worker cron |
 | `autoPrefixBareKeys`  | Default true: bare keys become `f/<id>/<name>`   |
+| `allowedKeyPrefixes`  | Put/sign must start with one of these roots      |
+| `maxKeyDepth`         | Max `/`-separated segments after governance      |
 
-Omit a field for unlimited (or no retention). Puts that would exceed storage
-return **507** with `code: "storage_quota_exceeded"`; monthly upload budget
-returns **429** with `code: "upload_budget_exceeded"`. `GET …/usage` includes
-the caps and remaining when set.
+Omit a field for unlimited (or no retention / unrestricted keys). Puts that
+would exceed storage return **507** with `code: "storage_quota_exceeded"`;
+monthly upload budget returns **429** with `code: "upload_budget_exceeded"`.
+Key policy denials return **400** with `code: "key_prefix_not_allowed"` or
+`key_too_deep`. `GET …/usage` includes the caps and remaining when set.
+
+### Key destinations
+
+CLI/MCP typed destinations map to fixed roots: **`screenshots`**, **`gh`**,
+**`f`** (bare-key auto-prefix). Operators can lock a workspace to those roots
+with `--allowed-prefixes default` (plus optional `--max-key-depth 8`). Put and
+presign enforce the allowlist; list/delete do not, so orphans can still be
+cleaned up. Unset policy = any nested path (internal/BYO).
 
 ### Configure limits
 
@@ -48,6 +59,8 @@ pnpm workspace:limits my-ws --max-uploads-per-month 20000
 pnpm workspace:limits my-ws --clear-max-storage      # back to unlimited
 pnpm workspace:limits my-ws --retention-days 90
 pnpm workspace:limits my-ws --clear-retention-days
+pnpm workspace:limits my-ws --allowed-prefixes default --max-key-depth 8
+pnpm workspace:limits my-ws --clear-allowed-prefixes --clear-max-key-depth
 pnpm workspace:limits my-ws --local                  # local KV for wrangler dev
 ```
 
@@ -60,8 +73,9 @@ Worker — new limits apply on the next request after that.
 - `POST /v1/:ws/usage/purge-expired` — delete objects older than `retentionDays`
   (`files:delete`), then reconcile. No-op skip if retention is unset.
 
-There is no automatic cron yet — run purge from ops/CI when you want expiry.
-Retention uses object last-modified from the store (R2 upload time).
+The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every
+workspace with `retentionDays` set. Retention uses object last-modified from
+the store (R2 upload time).
 
 **files-sdk:** reconcile/purge walk with `listAll()` on the workspace-prefixed
 `Files` instance (metadata only — no body reads). Purge uses bulk

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -17,6 +17,7 @@ npx @buildinternet/uploads@0.1.0 --help
 pnpm uploads setup --env-file .env
 pnpm uploads attach ./before.png ./after.png --env-file .env
 pnpm uploads put ./shot.png --env-file .env
+pnpm uploads put ./shot.png --destination screenshots --env-file .env
 pnpm uploads put ./after.png --pr 123 --comment --env-file .env
 pnpm uploads doctor --env-file .env
 ```
@@ -28,6 +29,11 @@ Commands: `attach`, `put`, `comment`, `list`, `delete`, `usage`, `reconcile`,
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
 or updates one managed attachments comment. Use `--pr`, `--issue`, and `--repo` to select
 the target explicitly, or `--no-comment` to upload without changing GitHub comments.
+
+**Keys / destinations:** default put uses the `screenshots` layout. Typed destinations
+(`--destination screenshots|gh|f`, MCP `destination`) set the root; `--pr`/`--issue`
+use `gh/…`. Workspaces may restrict put/sign to those roots via
+`allowedKeyPrefixes` (see [workspaces](../../docs/workspaces.md)).
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -118,6 +118,7 @@ function exitCode(err: unknown): number {
         return 2;
       case "UNAUTHORIZED":
       case "NOT_FOUND":
+      case "KEY_POLICY":
       case "STORAGE_QUOTA":
       case "UPLOAD_BUDGET":
         return 3;
@@ -146,6 +147,10 @@ function errorOut(err: unknown, json: boolean): void {
       if (err.code === "STORAGE_QUOTA" || err.code === "UPLOAD_BUDGET") {
         process.stderr.write(
           "hint: run `uploads usage` then delete objects or raise limits (`pnpm workspace:limits`)\n",
+        );
+      } else if (err.code === "KEY_POLICY") {
+        process.stderr.write(
+          "hint: use a typed destination (`--destination screenshots|gh`) or an allowed prefix; operators set allowlists with `pnpm workspace:limits --allowed-prefixes`\n",
         );
       } else if (err.status === 413 || err.message.toLowerCase().includes("too large")) {
         process.stderr.write(

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -170,6 +170,9 @@ function mapApiError(status: number, error: string, code?: string): UploadsError
   if (status === 400 && normalized === "invalid key") {
     return new UploadsError(error, "INVALID_KEY", status);
   }
+  if (code === "key_prefix_not_allowed" || code === "key_too_deep") {
+    return new UploadsError(error, "KEY_POLICY", status);
+  }
   // Prefer stable body.code — bare 429 is also used for write rate limits.
   if (status === 507 || code === "storage_quota_exceeded") {
     return new UploadsError(error, "STORAGE_QUOTA", status);

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -32,6 +32,7 @@ import {
   upsertAttachmentsComment,
   type CommandRunner,
 } from "./github-gh.js";
+import { resolvePutPrefix } from "./destinations.js";
 
 export interface CliContext {
   config: ResolvedConfig;
@@ -49,6 +50,7 @@ Upload an image for GitHub embeds. Use "-" for stdin.
 
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
+  --destination <id>    Typed root: screenshots | gh | f (sets --prefix)
   --prefix <path>       Key prefix (default: screenshots, or UPLOADS_DEFAULT_PREFIX)
   --repo <owner/repo>   Repo segment (default: git remote, or UPLOADS_DEFAULT_REPO)
   --ref <id>            PR/issue/branch segment (default: today, or UPLOADS_DEFAULT_REF)
@@ -64,6 +66,7 @@ Options:
 
 Examples:
   uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
+  uploads put ./shot.png --destination screenshots
   uploads --env-file .env put ./shot.png
   uploads --env-file .env put ./after.png --pr 123 --comment
 `;
@@ -222,6 +225,8 @@ export async function runPut(
   }
 
   const keyHint = flagString(parsed.flags, "--key");
+  const destFlag = flagString(parsed.flags, "--destination");
+  const prefixFlag = flagString(parsed.flags, "--prefix");
   const ghTarget = ghTargetFromFlags(parsed.flags, run);
   const wantComment = parsed.flags.has("--comment");
   if (wantComment && typeof parsed.flags.get("--comment") === "string") {
@@ -233,9 +238,18 @@ export async function runPut(
     if (flagString(parsed.flags, "--ref")) {
       throw new UsageError("--ref cannot be combined with --pr/--issue");
     }
-    if (flagString(parsed.flags, "--prefix")) {
-      throw new UsageError("--prefix cannot be combined with --pr/--issue");
-    }
+    if (prefixFlag) throw new UsageError("--prefix cannot be combined with --pr/--issue");
+  }
+  let resolvedPrefix: string | undefined;
+  try {
+    resolvedPrefix = resolvePutPrefix({
+      destination: destFlag,
+      prefix: prefixFlag,
+      key: keyHint,
+      ghAttachment: Boolean(ghTarget),
+    });
+  } catch (err) {
+    throw new UsageError(err instanceof Error ? err.message : String(err));
   }
   const bytes =
     fileArg === "-" ? new Uint8Array(readFileSync(0)) : new Uint8Array(readFileSync(fileArg));
@@ -271,7 +285,7 @@ export async function runPut(
   const result = await ctx.client.put(bytes, {
     filename,
     key: ghTarget ? ghAttachmentKey(ghTarget, filename) : keyHint,
-    prefix: flagString(parsed.flags, "--prefix") ?? defaults.prefix,
+    prefix: resolvedPrefix ?? defaults.prefix,
     repo: flagString(parsed.flags, "--repo") ?? defaults.repo,
     ref: flagString(parsed.flags, "--ref") ?? defaults.ref,
     contentType: flagString(parsed.flags, "--content-type"),

--- a/packages/uploads/src/destinations.ts
+++ b/packages/uploads/src/destinations.ts
@@ -1,0 +1,60 @@
+/**
+ * Typed destination roots for put/attach. Matches the API allowlist defaults
+ * (`f/`, `screenshots/`, `gh/`) — see apps/api `key-policy.ts`.
+ */
+
+export const BUILTIN_DESTINATIONS = {
+  f: "f",
+  screenshots: "screenshots",
+  gh: "gh",
+} as const;
+
+export type BuiltinDestinationId = keyof typeof BUILTIN_DESTINATIONS;
+
+export function isBuiltinDestination(id: string): id is BuiltinDestinationId {
+  return Object.hasOwn(BUILTIN_DESTINATIONS, id);
+}
+
+/** Root segment for a known destination, or throws with a usage-friendly message. */
+export function resolveDestinationRoot(id: string): string {
+  if (!isBuiltinDestination(id)) {
+    const known = Object.keys(BUILTIN_DESTINATIONS).join(", ");
+    throw new Error(`unknown destination: ${id} (known: ${known})`);
+  }
+  return BUILTIN_DESTINATIONS[id];
+}
+
+/** True when `key` is under the destination root. */
+export function keyMatchesDestination(key: string, destinationId: string): boolean {
+  if (!isBuiltinDestination(destinationId)) return false;
+  const root = BUILTIN_DESTINATIONS[destinationId];
+  return key === root || key.startsWith(`${root}/`);
+}
+
+/**
+ * Resolve CLI/MCP destination flags into a put `prefix`. Throws plain Errors
+ * (callers wrap as UsageError / MCP usage errors).
+ */
+export function resolvePutPrefix(opts: {
+  destination?: string;
+  prefix?: string;
+  key?: string;
+  /** When true (PR/issue attach), destination must be `gh` or omitted. */
+  ghAttachment?: boolean;
+}): string | undefined {
+  const { destination, prefix, key, ghAttachment } = opts;
+  if (!destination) return prefix;
+
+  const root = resolveDestinationRoot(destination);
+
+  if (ghAttachment && destination !== "gh") {
+    throw new Error("destination with pr/issue must be gh (or omit it)");
+  }
+  if (key && !keyMatchesDestination(key, destination)) {
+    throw new Error(`key must start with destination root "${root}/"`);
+  }
+  if (prefix && prefix.replace(/\/+$/, "") !== root) {
+    throw new Error(`prefix (${prefix}) conflicts with destination ${destination} (root ${root})`);
+  }
+  return root;
+}

--- a/packages/uploads/src/errors.ts
+++ b/packages/uploads/src/errors.ts
@@ -4,6 +4,7 @@ export type UploadsErrorCode =
   | "NOT_FOUND"
   | "UNAUTHORIZED"
   | "INVALID_KEY"
+  | "KEY_POLICY"
   | "STORAGE_QUOTA"
   | "UPLOAD_BUDGET"
   | "API_ERROR"

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -1,6 +1,14 @@
 export { inferContentType, buildMarkdown } from "./embed.js";
 export { sanitizeKeySegment, sha256Short, deriveRepoFromGit, buildScreenshotKey } from "./keys.js";
 export {
+  BUILTIN_DESTINATIONS,
+  isBuiltinDestination,
+  keyMatchesDestination,
+  resolveDestinationRoot,
+  resolvePutPrefix,
+  type BuiltinDestinationId,
+} from "./destinations.js";
+export {
   DEFAULT_API_URL,
   DEFAULT_WORKSPACE,
   UPLOADS_CONFIG_KEYS,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -17,6 +17,7 @@ import {
   type UploadsClientConfig,
 } from "../config.js";
 import { buildMarkdown } from "../embed.js";
+import { resolvePutPrefix } from "../destinations.js";
 import { ghAttachmentKey, ghKeyPrefix, type GhTarget } from "../github.js";
 import {
   execRunner,
@@ -137,6 +138,11 @@ export function createUploadsMcpTools(opts: {
             description:
               "Explicit object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>). Cannot be combined with pr/issue.",
           },
+          destination: {
+            type: "string",
+            description:
+              "Typed destination root: screenshots | gh | f. Sets the key prefix; first-class alternative to prefix. With pr/issue must be gh or omitted.",
+          },
           prefix: {
             type: "string",
             description:
@@ -183,6 +189,7 @@ export function createUploadsMcpTools(opts: {
         const target = ghTargetFromArgs(args, run);
         const wantComment = optBool(args, "comment");
         const key = optString(args, "key");
+        const destArg = optString(args, "destination");
         const prefixArg = optString(args, "prefix");
         const refArg = optString(args, "ref");
         if (wantComment && !target) usage("comment requires pr or issue");
@@ -190,6 +197,17 @@ export function createUploadsMcpTools(opts: {
           if (key) usage("key cannot be combined with pr/issue");
           if (refArg) usage("ref cannot be combined with pr/issue");
           if (prefixArg) usage("prefix cannot be combined with pr/issue");
+        }
+        let resolvedPrefix: string | undefined;
+        try {
+          resolvedPrefix = resolvePutPrefix({
+            destination: destArg,
+            prefix: prefixArg,
+            key,
+            ghAttachment: Boolean(target),
+          });
+        } catch (err) {
+          usage(err instanceof Error ? err.message : String(err));
         }
 
         const { client } = clientFor(args);
@@ -204,7 +222,7 @@ export function createUploadsMcpTools(opts: {
         const result = await client.put(bytes, {
           filename,
           key: target ? ghAttachmentKey(target, filename) : key,
-          prefix: prefixArg ?? defaults.prefix,
+          prefix: resolvedPrefix ?? defaults.prefix,
           repo: optString(args, "repo") ?? defaults.repo,
           ref: refArg ?? defaults.ref,
           contentType: optString(args, "contentType"),

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -9,10 +9,10 @@ import { join } from "node:path";
 
 /** Fake client capturing put() calls; other methods throw if reached. */
 function fakeClient() {
-  const puts: { key?: string; filename: string }[] = [];
+  const puts: { key?: string; filename: string; prefix?: string }[] = [];
   const client = {
-    put: async (_body: Uint8Array, opts: { filename: string; key?: string }) => {
-      puts.push({ key: opts.key, filename: opts.filename });
+    put: async (_body: Uint8Array, opts: { filename: string; key?: string; prefix?: string }) => {
+      puts.push({ key: opts.key, filename: opts.filename, prefix: opts.prefix });
       return {
         workspace: "test",
         key: opts.key ?? "generated/key.png",
@@ -119,5 +119,72 @@ describe("runPut --pr/--issue", () => {
     const { client, puts } = fakeClient();
     await runPut(ctxWith(client), [tmpFile(), "--repo", "myapp", "--no-git"], false, noRun);
     expect(puts[0].key).toBeUndefined(); // client falls back to buildScreenshotKey
+  });
+});
+
+describe("runPut --destination", () => {
+  it("sets prefix from destination screenshots", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--destination", "screenshots", "--repo", "myapp", "--no-git"],
+      false,
+      noRun,
+    );
+    expect(puts[0].prefix).toBe("screenshots");
+  });
+
+  it("allows --destination gh with --pr", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "1", "--destination", "gh", "--repo", "o/r"],
+      false,
+      noRun,
+    );
+    expect(puts[0].key).toBe("gh/o/r/pull/1/shot.png");
+  });
+
+  it("rejects --destination screenshots with --pr", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(
+        ctxWith(client),
+        [tmpFile(), "--pr", "1", "--destination", "screenshots", "--repo", "o/r"],
+        false,
+        noRun,
+      ),
+    ).rejects.toThrow(/must be gh/);
+  });
+
+  it("rejects unknown destinations", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), [tmpFile(), "--destination", "tmp"], false, noRun),
+    ).rejects.toThrow(/unknown destination/);
+  });
+
+  it("rejects conflicting --prefix and --destination", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(
+        ctxWith(client),
+        [tmpFile(), "--destination", "screenshots", "--prefix", "other"],
+        false,
+        noRun,
+      ),
+    ).rejects.toThrow(/conflicts/);
+  });
+
+  it("rejects --key outside the destination root", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(
+        ctxWith(client),
+        [tmpFile(), "--destination", "screenshots", "--key", "tmp/a.png"],
+        false,
+        noRun,
+      ),
+    ).rejects.toThrow(/must start with destination root/);
   });
 });

--- a/packages/uploads/test/destinations.test.ts
+++ b/packages/uploads/test/destinations.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_DESTINATIONS,
+  keyMatchesDestination,
+  resolveDestinationRoot,
+  resolvePutPrefix,
+} from "../src/destinations.js";
+
+describe("resolveDestinationRoot", () => {
+  it("resolves built-ins", () => {
+    expect(resolveDestinationRoot("screenshots")).toBe(BUILTIN_DESTINATIONS.screenshots);
+    expect(resolveDestinationRoot("gh")).toBe("gh");
+    expect(resolveDestinationRoot("f")).toBe("f");
+  });
+
+  it("rejects unknown ids", () => {
+    expect(() => resolveDestinationRoot("tmp")).toThrow(/unknown destination/);
+  });
+});
+
+describe("keyMatchesDestination", () => {
+  it("matches root and nested keys", () => {
+    expect(keyMatchesDestination("screenshots/a.png", "screenshots")).toBe(true);
+    expect(keyMatchesDestination("gh/o/r/pull/1/a.png", "gh")).toBe(true);
+  });
+
+  it("rejects other roots", () => {
+    expect(keyMatchesDestination("tmp/a.png", "screenshots")).toBe(false);
+  });
+});
+
+describe("resolvePutPrefix", () => {
+  it("returns destination root", () => {
+    expect(resolvePutPrefix({ destination: "screenshots" })).toBe("screenshots");
+  });
+
+  it("passes through plain prefix when no destination", () => {
+    expect(resolvePutPrefix({ prefix: "custom" })).toBe("custom");
+  });
+
+  it("rejects destination other than gh for attachments", () => {
+    expect(() => resolvePutPrefix({ destination: "screenshots", ghAttachment: true })).toThrow(
+      /must be gh/,
+    );
+  });
+
+  it("rejects conflicting prefix", () => {
+    expect(() => resolvePutPrefix({ destination: "screenshots", prefix: "other" })).toThrow(
+      /conflicts/,
+    );
+  });
+
+  it("rejects key outside destination", () => {
+    expect(() => resolvePutPrefix({ destination: "screenshots", key: "tmp/a.png" })).toThrow(
+      /must start with destination root/,
+    );
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -128,6 +128,7 @@ Key options (`uploads put --help` for all):
 | `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images). |
 | `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).   |
 | `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).         |
+| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                      |
 | `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                |
 | `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                      |
 | `--content-type <mime>`               | Override the content type (else inferred from extension).                        |
@@ -137,17 +138,20 @@ Key options (`uploads put --help` for all):
 
 **How keys work** — three paths, no extra naming modes:
 
-| Intent                                | Command                                    |
-| ------------------------------------- | ------------------------------------------ |
-| Just upload it, give me a URL         | `uploads put ./file.png`                   |
-| Stable GitHub embed I might re-upload | `uploads put ./file.png --pr <num>`        |
-| I know exactly where it goes          | `uploads put ./file.png --key my/path.png` |
+| Intent                                | Command                                            |
+| ------------------------------------- | -------------------------------------------------- |
+| Just upload it, give me a URL         | `uploads put ./file.png`                           |
+| Explicit typed destination            | `uploads put ./file.png --destination screenshots` |
+| Stable GitHub embed I might re-upload | `uploads put ./file.png --pr <num>`                |
+| I know exactly where it goes          | `uploads put ./file.png --key screenshots/…/x.png` |
 
 Default `put` is the fast path; you don't need `--key`, `--prefix`, or `--repo`. Without
 `--key`, keys look like
 `<prefix>/<repo-name>/<ref-or-date>/<basename>-<shorthash>.<ext>` — the short hash
-prevents collisions without random names or a separate "preserve name" flag. Override
-with `--key` only when you have a reason.
+prevents collisions without random names or a separate "preserve name" flag. Prefer
+`--destination screenshots` (or `gh` with `--pr`/`--issue`) over inventing roots —
+workspaces may allowlist only those destinations. Override with `--key` only when you
+have a reason, and keep the key under an allowed root.
 
 **Output formats** — pick what you'll consume:
 


### PR DESCRIPTION
## In plain terms

This PR helps keep uploaded files **organized**, and lets operators *optionally* lock a workspace so uploads can only go into certain folders.

### The problem

Anyone with a token could put a file almost anywhere under a workspace. That’s flexible for internal use, but messy for agents and multi-tenant hosting — random roots, deep nested junk, harder to reason about.

### What this does

1. **Named “places” for files (destinations)**  
   Instead of inventing paths, agents can use typed roots:
   - **screenshots** — normal image uploads  
   - **gh** — PR/issue attachments  
   - **f** — auto-organized bare filenames  

   That’s what CLI `--destination` and MCP `destination` are for.

2. **Optional rules per workspace**  
   An operator can say: “this workspace only accepts those folders” and “paths can’t be deeper than N levels.”  
   Uploads that break the rules get a clear error.  
   If you don’t set rules, **nothing changes** — any path still works.

3. **Same rules on upload and presign**  
   So you can’t sneak around policy with a signed URL.

### What this is *not*

- Not billing  
- Not a new storage backend  
- Not forcing the new rules on existing workspaces (opt-in)  
- Not publishing a new npm version by itself (changeset only — leave the version packages PR alone until we intend to ship)

## Operator quick start (when you want it on)

```bash
pnpm workspace:limits <name> \
  --allowed-prefixes default \
  --max-key-depth 8
```

`default` expands to `f/`, `screenshots/`, and `gh/`.

## Technical notes (for reviewers)

- API: `allowedKeyPrefixes` + `maxKeyDepth` on put/sign via shared `finalizeUploadKey` (bare keys still rewrite to `f/<id>/…` first)
- Errors: `400` with `key_prefix_not_allowed` / `key_too_deep`; CLI maps these to `KEY_POLICY` + a hint
- Docs: root + package READMEs, ops/workspaces/api, agent skill
- Simplification: no custom `keyDestinations` map (builtins only on client; allowlist-only on server); shared `resolvePutPrefix` for CLI + MCP

## Test plan

- [x] `pnpm --filter @uploads/api test`
- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @uploads/mcp test`
- [x] `pnpm check`
- [ ] After merge: apply policy on a shared workspace when ready
- [ ] Do **not** merge version packages PR until intentionally releasing