### PR TITLE
feat: leaner image uploads for GitHub embeds

### DIFF
--- a/.changeset/cli-image-optimize.md
+++ b/.changeset/cli-image-optimize.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Optimize still images to WebP on `put`/`attach` (and MCP) by default for leaner GitHub embeds, with `--no-optimize` / `UPLOADS_NO_OPTIMIZE` escape hatch.

--- a/.changeset/cli-image-optimize.md
+++ b/.changeset/cli-image-optimize.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": minor
 ---
 
-Optimize still images to WebP on `put`/`attach` (and MCP) by default for leaner GitHub embeds, with `--no-optimize` / `UPLOADS_NO_OPTIMIZE` escape hatch.
+Optimize still images to WebP on `put`/`attach` (and MCP) by default for leaner GitHub embeds (EXIF stripped unless `--keep-exif`), with `--no-optimize` / `UPLOADS_NO_OPTIMIZE` escape hatch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,21 @@ pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
 pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] \
   [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
   [--clear-max-storage] [--clear-allowed-prefixes] […]
-pnpm uploads put <file> --env-file .env   # CLI (builds package first)
-pnpm uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
+pnpm uploads put <file> --env-file .env   # monorepo only: builds package first
+pnpm uploads put <file> --pr <num> --comment
 ```
+
+**CLI examples — installed binary vs monorepo:** product-facing examples
+(PR “how to try it”, skill docs, issue comments, user-facing README snippets)
+use the global binary as someone who already installed the CLI would:
+
+```bash
+uploads put ./shot.png
+uploads put ./after.png --pr 123 --comment
+```
+
+Reserve `pnpm uploads …` for **in-repo** development (build-from-source via the
+root script). Do not assume readers have the monorepo checked out.
 
 Use `pnpm run deploy` (not bare `pnpm deploy` — that's pnpm's built-in).
 `deploy:api` applies pending D1 migrations (`migrate:d1`) before
@@ -136,10 +148,14 @@ know the code. Prefer plain language over dense bullet dumps of identifiers.
    type names, or flag lists.
 2. **What it does / what it is not** — a few concrete bullets; call out
    opt-in vs breaking, and anything deliberately deferred.
-3. **How to try it** — only when useful (commands, operator flags).
+3. **How to try it** — only when useful. Show the **installed** CLI
+   (`uploads …`), not `pnpm uploads …`, unless the step is explicitly
+   monorepo-only (e.g. running package tests). Same for issue comments and
+   other post-merge “once this ships” examples.
 4. **Technical notes** — optional short section for implementers (modules,
    error codes, test commands). Keep it secondary to the plain summary.
-5. **Test plan** — checkboxes for what was run / what remains.
+5. **Test plan** — checkboxes for what was run / what remains. Filter-style
+   `pnpm --filter … test` is fine here (repo CI context).
 
 **Titles:** conventional-commit type prefix + plain-language subject, e.g.
 `feat: organize upload paths (typed destinations + optional folder rules)`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,14 +66,16 @@ curl -X PUT https://api.uploads.sh/v1/default/files/screenshots/myapp/42/shot.pn
 
 ## CLI
 
-The `@buildinternet/uploads` package wraps the API for GitHub image embeds:
+The `@buildinternet/uploads` package wraps the API for GitHub image embeds.
+Examples assume the CLI is installed globally (`uploads`); use
+`pnpm uploads …` only when developing inside this monorepo.
 
 ```bash
-pnpm uploads put <file> --env-file .env
-pnpm uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
-pnpm uploads usage --env-file .env
-pnpm uploads reconcile --env-file .env
-pnpm uploads purge-expired --env-file .env
+uploads put <file>
+uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
+uploads usage
+uploads reconcile
+uploads purge-expired
 ```
 
 See `skills/uploads-cli/SKILL.md` for agent-oriented usage.

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -39,8 +39,9 @@ use `gh/…`. Workspaces may restrict put/sign to those roots via
 `allowedKeyPrefixes` (see [workspaces](../../docs/workspaces.md)).
 
 **Image optimization:** by default, still images are re-encoded to WebP (long edge
-capped, high quality) before upload so GitHub embeds stay small. Pass `--no-optimize`
-or set `UPLOADS_NO_OPTIMIZE=1` to upload originals.
+capped, high quality) before upload so GitHub embeds stay small, and **EXIF is
+stripped**. Pass `--keep-exif` / `UPLOADS_KEEP_EXIF=1` to preserve image metadata, or
+`--no-optimize` / `UPLOADS_NO_OPTIMIZE=1` to upload originals unchanged.
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -18,6 +18,7 @@ pnpm uploads setup --env-file .env
 pnpm uploads attach ./before.png ./after.png --env-file .env
 pnpm uploads put ./shot.png --env-file .env
 pnpm uploads put ./shot.png --destination screenshots --env-file .env
+pnpm uploads put ./shot.png --no-optimize --env-file .env
 pnpm uploads put ./after.png --pr 123 --comment --env-file .env
 pnpm uploads doctor --env-file .env
 ```
@@ -34,6 +35,10 @@ the target explicitly, or `--no-comment` to upload without changing GitHub comme
 (`--destination screenshots|gh|f`, MCP `destination`) set the root; `--pr`/`--issue`
 use `gh/…`. Workspaces may restrict put/sign to those roots via
 `allowedKeyPrefixes` (see [workspaces](../../docs/workspaces.md)).
+
+**Image optimization:** by default, still images are re-encoded to WebP (long edge
+capped, high quality) before upload so GitHub embeds stay small. Pass `--no-optimize`
+or set `UPLOADS_NO_OPTIMIZE=1` to upload originals.
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -4,9 +4,7 @@ CLI and client for **uploads.sh** — upload files, get public URLs, and produce
 
 ## CLI
 
-Binary: `uploads` (also `pnpm uploads` from repo root after `pnpm install`).
-
-Install globally or run a pinned version without installing:
+Binary: **`uploads`**. Install globally (or use a pinned `npx` one-shot):
 
 ```bash
 npm install --global @buildinternet/uploads
@@ -14,14 +12,18 @@ npx @buildinternet/uploads@0.1.0 --help
 ```
 
 ```bash
-pnpm uploads setup --env-file .env
-pnpm uploads attach ./before.png ./after.png --env-file .env
-pnpm uploads put ./shot.png --env-file .env
-pnpm uploads put ./shot.png --destination screenshots --env-file .env
-pnpm uploads put ./shot.png --no-optimize --env-file .env
-pnpm uploads put ./after.png --pr 123 --comment --env-file .env
-pnpm uploads doctor --env-file .env
+uploads setup
+uploads attach ./before.png ./after.png
+uploads put ./shot.png
+uploads put ./shot.png --destination screenshots
+uploads put ./shot.png --no-optimize
+uploads put ./after.png --pr 123 --comment
+uploads doctor
 ```
+
+Inside this monorepo only, `pnpm uploads …` builds the package first so you pick
+up local source; product docs and PR “how to try it” examples should use the
+global `uploads` form above.
 
 Commands: `attach`, `put`, `comment`, `list`, `delete`, `usage`, `reconcile`,
 `purge-expired`, `setup`, `install`, `config`, `doctor`, `health`, `mcp`.

--- a/packages/uploads/config.example
+++ b/packages/uploads/config.example
@@ -41,3 +41,7 @@ UPLOADS_DEFAULT_PREFIX=screenshots
 # Default markdown width and git behavior.
 # UPLOADS_DEFAULT_WIDTH=700
 # UPLOADS_NO_GIT=1
+
+# Skip client-side image optimization on put/attach (default: optimize still
+# images to WebP for leaner GitHub embeds).
+# UPLOADS_NO_OPTIMIZE=1

--- a/packages/uploads/config.example
+++ b/packages/uploads/config.example
@@ -45,3 +45,7 @@ UPLOADS_DEFAULT_PREFIX=screenshots
 # Skip client-side image optimization on put/attach (default: optimize still
 # images to WebP for leaner GitHub embeds).
 # UPLOADS_NO_OPTIMIZE=1
+
+# Keep EXIF/XMP/ICC when optimizing (default: strip for privacy on public URLs).
+# Prefer for discussion-critical photo metadata; otherwise leave unset.
+# UPLOADS_KEEP_EXIF=1

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -60,5 +60,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "dependencies": {
+    "sharp": "^0.35.3"
   }
 }

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -33,6 +33,13 @@ import {
   type CommandRunner,
 } from "./github-gh.js";
 import { resolvePutPrefix } from "./destinations.js";
+import {
+  optimizeImageForUpload,
+  rewriteKeyExtension,
+  type OptimizeImageOptions,
+  type OptimizeImageResult,
+} from "./optimize.js";
+import type { PutDefaults } from "./config-file.js";
 
 export interface CliContext {
   config: ResolvedConfig;
@@ -48,6 +55,10 @@ const PUT_HELP = `uploads put <file> [options]
 
 Upload an image for GitHub embeds. Use "-" for stdin.
 
+Still images (PNG/JPEG/…) are optimized to WebP by default (long edge capped,
+high quality) so GitHub embeds stay lean. Original bytes are kept when they are
+already smaller, animated, or not an image. Use --no-optimize to upload as-is.
+
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
   --destination <id>    Typed root: screenshots | gh | f (sets --prefix)
@@ -56,7 +67,10 @@ Options:
   --ref <id>            PR/issue/branch segment (default: today, or UPLOADS_DEFAULT_REF)
   --alt <text>          Alt text (default: filename)
   --width <px>          <img width=…> markdown (or UPLOADS_DEFAULT_WIDTH)
-  --content-type <mime> Override Content-Type
+  --content-type <mime> Override Content-Type (ignored when optimize rewrites the body)
+  --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
+  --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
+  --optimize-quality <1-100>  WebP quality (default: 85)
   --no-git              Don't derive --repo from git (or UPLOADS_NO_GIT=1)
   --workspace, -w <name>  Override workspace (wins over UPLOADS_WORKSPACE and token inference)
   --format human|url|markdown|json
@@ -67,6 +81,7 @@ Options:
 Examples:
   uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
   uploads put ./shot.png --destination screenshots
+  uploads put ./shot.png --no-optimize
   uploads --env-file .env put ./shot.png
   uploads --env-file .env put ./after.png --pr 123 --comment
 `;
@@ -99,6 +114,35 @@ function ghTargetFromFlags(flags: CommandFlags["flags"], run: CommandRunner): Gh
   );
 }
 
+/** Shared put/attach optimize flags + UPLOADS_NO_OPTIMIZE default. */
+export function optimizeOptionsFromFlags(
+  flags: CommandFlags["flags"],
+  defaults: PutDefaults,
+): OptimizeImageOptions {
+  if (flags.has("--no-optimize") && typeof flags.get("--no-optimize") === "string") {
+    throw new UsageError("--no-optimize takes no value");
+  }
+  const quality = flagInt(flags, "--optimize-quality", "--optimize-quality");
+  if (quality !== undefined && quality > 100) {
+    throw new UsageError("invalid --optimize-quality: must be 1–100");
+  }
+  return {
+    enabled: !(flagBool(flags, "--no-optimize") || defaults.noOptimize === true),
+    maxEdge: flagInt(flags, "--optimize-max-edge", "--optimize-max-edge"),
+    quality,
+  };
+}
+
+function formatOptimizeNote(opt: OptimizeImageResult): string | undefined {
+  if (opt.optimized) {
+    return `optimized ${opt.originalBytes} → ${opt.outputBytes} bytes (${opt.filename})`;
+  }
+  if (opt.skippedReason && opt.skippedReason !== "disabled") {
+    return `optimize skipped (${opt.skippedReason})`;
+  }
+  return undefined;
+}
+
 /**
  * List every attachment under the target's prefix and create/update the
  * managed comment. Throws on gh failure — callers decide whether that is
@@ -127,12 +171,18 @@ const ATTACH_HELP = `uploads attach <file...> [options]
 Upload one or more stable PR/issue attachments and maintain a single GitHub
 comment. With no target, uses the pull request for the current branch.
 
+Still images are optimized to WebP by default (same as put). Use --no-optimize
+to upload originals.
+
 Options:
   --pr <num>            Attach to this pull request
   --issue <num>         Attach to this issue
   --repo <owner/repo>   Repository (default: gh/git inference)
   --no-comment          Upload only; don't create/update the managed comment
-  --content-type <mime> Override Content-Type (applied to every file)
+  --content-type <mime> Override Content-Type (applied to every file; ignored when optimize rewrites)
+  --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
+  --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
+  --optimize-quality <1-100>  WebP quality (default: 85)
   --workspace, -w <name>  Override workspace
 
 Examples:
@@ -164,18 +214,38 @@ export async function runAttach(
   const target =
     explicitTarget ??
     resolveCurrentPullRequest(resolveRepo(flagString(parsed.flags, "--repo"), run), run);
+  const defaults = resolvePutDefaults({ envFile: ctx.envFile });
+  const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, defaults);
+  const contentTypeOverride = flagString(parsed.flags, "--content-type");
   const results = [];
   for (const file of parsed.positionals) {
     if (file === "-")
       throw new UsageError("attach does not support stdin; pass one or more file paths");
-    const filename = basename(file);
+    const sourceName = basename(file);
     if (!ctx.quiet && !ctx.json) process.stderr.write(`>> uploading ${file}\n`);
-    const result = await ctx.client.put(new Uint8Array(readFileSync(file)), {
-      filename,
-      key: ghAttachmentKey(target, filename),
-      contentType: flagString(parsed.flags, "--content-type"),
+    const prepared = await optimizeImageForUpload(
+      new Uint8Array(readFileSync(file)),
+      sourceName,
+      optimizeOpts,
+    );
+    const note = formatOptimizeNote(prepared);
+    if (note && !ctx.quiet && !ctx.json) process.stderr.write(`>> ${note}\n`);
+    const result = await ctx.client.put(prepared.bytes, {
+      filename: prepared.filename,
+      key: ghAttachmentKey(target, prepared.filename),
+      contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
     });
-    results.push({ ...result, markdown: buildMarkdown(result.url, { alt: filename }) });
+    results.push({
+      ...result,
+      markdown: buildMarkdown(result.url, { alt: sourceName }),
+      optimize: {
+        optimized: prepared.optimized,
+        skippedReason: prepared.skippedReason,
+        originalBytes: prepared.originalBytes,
+        outputBytes: prepared.outputBytes,
+        filename: prepared.filename,
+      },
+    });
   }
 
   let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
@@ -253,7 +323,7 @@ export async function runPut(
   }
   const bytes =
     fileArg === "-" ? new Uint8Array(readFileSync(0)) : new Uint8Array(readFileSync(fileArg));
-  const filename =
+  const sourceName =
     fileArg === "-" ? (keyHint ? basename(keyHint) : "stdin.bin") : basename(fileArg);
 
   const format = ctx.json
@@ -266,7 +336,11 @@ export async function runPut(
       })();
 
   const defaults = resolvePutDefaults({ envFile: ctx.envFile });
-  const alt = flagString(parsed.flags, "--alt") ?? basename(filename);
+  const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, defaults);
+  const prepared = await optimizeImageForUpload(bytes, sourceName, optimizeOpts);
+  const filename = prepared.filename;
+  const contentTypeOverride = flagString(parsed.flags, "--content-type");
+  const alt = flagString(parsed.flags, "--alt") ?? basename(sourceName);
   const widthRaw = flagString(parsed.flags, "--width");
   const width =
     widthRaw && /^\d+$/.test(widthRaw) && Number(widthRaw) > 0
@@ -279,20 +353,31 @@ export async function runPut(
 
   if (!ctx.quiet && format === "human") {
     process.stderr.write(`>> uploading ${fileArg === "-" ? "stdin" : fileArg}\n`);
+    const note = formatOptimizeNote(prepared);
+    if (note) process.stderr.write(`>> ${note}\n`);
   }
 
   const noGit = flagBool(parsed.flags, "--no-git") || defaults.noGit === true;
-  const result = await ctx.client.put(bytes, {
+  let key = ghTarget ? ghAttachmentKey(ghTarget, filename) : keyHint;
+  if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
+  const result = await ctx.client.put(prepared.bytes, {
     filename,
-    key: ghTarget ? ghAttachmentKey(ghTarget, filename) : keyHint,
+    key,
     prefix: resolvedPrefix ?? defaults.prefix,
     repo: flagString(parsed.flags, "--repo") ?? defaults.repo,
     ref: flagString(parsed.flags, "--ref") ?? defaults.ref,
-    contentType: flagString(parsed.flags, "--content-type"),
+    contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
     deriveRepoFromGit: !noGit,
   });
 
   const markdown = buildMarkdown(result.url, { alt, width });
+  const optimizeMeta = {
+    optimized: prepared.optimized,
+    skippedReason: prepared.skippedReason,
+    originalBytes: prepared.originalBytes,
+    outputBytes: prepared.outputBytes,
+    filename: prepared.filename,
+  };
 
   if (!ctx.quiet && format === "human") {
     process.stderr.write(`>> key: ${result.key}\n\n`);
@@ -300,7 +385,7 @@ export async function runPut(
 
   switch (format) {
     case "json":
-      await writeJson({ ...result, markdown });
+      await writeJson({ ...result, markdown, optimize: optimizeMeta });
       break;
     case "url":
       await writeStdout(`${result.url}\n`);

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -56,8 +56,9 @@ const PUT_HELP = `uploads put <file> [options]
 Upload an image for GitHub embeds. Use "-" for stdin.
 
 Still images (PNG/JPEG/…) are optimized to WebP by default (long edge capped,
-high quality) so GitHub embeds stay lean. Original bytes are kept when they are
-already smaller, animated, or not an image. Use --no-optimize to upload as-is.
+high quality; EXIF stripped) so GitHub embeds stay lean. Original bytes are kept
+when they are already smaller, animated, or not an image. Use --no-optimize to
+upload as-is, or --keep-exif when image metadata matters for the discussion.
 
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
@@ -71,6 +72,7 @@ Options:
   --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
   --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
   --optimize-quality <1-100>  WebP quality (default: 85)
+  --keep-exif           Keep EXIF/XMP/ICC when optimizing (default: strip for privacy)
   --no-git              Don't derive --repo from git (or UPLOADS_NO_GIT=1)
   --workspace, -w <name>  Override workspace (wins over UPLOADS_WORKSPACE and token inference)
   --format human|url|markdown|json
@@ -122,6 +124,9 @@ export function optimizeOptionsFromFlags(
   if (flags.has("--no-optimize") && typeof flags.get("--no-optimize") === "string") {
     throw new UsageError("--no-optimize takes no value");
   }
+  if (flags.has("--keep-exif") && typeof flags.get("--keep-exif") === "string") {
+    throw new UsageError("--keep-exif takes no value");
+  }
   const quality = flagInt(flags, "--optimize-quality", "--optimize-quality");
   if (quality !== undefined && quality > 100) {
     throw new UsageError("invalid --optimize-quality: must be 1–100");
@@ -130,6 +135,7 @@ export function optimizeOptionsFromFlags(
     enabled: !(flagBool(flags, "--no-optimize") || defaults.noOptimize === true),
     maxEdge: flagInt(flags, "--optimize-max-edge", "--optimize-max-edge"),
     quality,
+    keepExif: flagBool(flags, "--keep-exif") || defaults.keepExif === true,
   };
 }
 
@@ -183,6 +189,7 @@ Options:
   --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
   --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
   --optimize-quality <1-100>  WebP quality (default: 85)
+  --keep-exif           Keep EXIF/XMP/ICC when optimizing (default: strip for privacy)
   --workspace, -w <name>  Override workspace
 
 Examples:

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -13,6 +13,7 @@ export const UPLOADS_CONFIG_KEYS = [
   "UPLOADS_DEFAULT_WIDTH",
   "UPLOADS_NO_GIT",
   "UPLOADS_NO_OPTIMIZE",
+  "UPLOADS_KEEP_EXIF",
 ] as const;
 
 export type UploadsConfigKey = (typeof UPLOADS_CONFIG_KEYS)[number];
@@ -27,6 +28,8 @@ export interface PutDefaults {
   noGit?: boolean;
   /** When true, put/attach skip client-side image optimization. */
   noOptimize?: boolean;
+  /** When true, optimize keeps EXIF/XMP/ICC (default strips). */
+  keepExif?: boolean;
 }
 
 const PUT_DEFAULT_KEY_MAP: Record<keyof PutDefaults, UploadsConfigKey> = {
@@ -36,6 +39,7 @@ const PUT_DEFAULT_KEY_MAP: Record<keyof PutDefaults, UploadsConfigKey> = {
   width: "UPLOADS_DEFAULT_WIDTH",
   noGit: "UPLOADS_NO_GIT",
   noOptimize: "UPLOADS_NO_OPTIMIZE",
+  keepExif: "UPLOADS_KEEP_EXIF",
 };
 
 function isTruthyConfigFlag(value: string | undefined): boolean {
@@ -52,6 +56,7 @@ export function putDefaultsToConfigValues(defaults: PutDefaults): UploadsConfigV
   if (defaults.width != null) out.UPLOADS_DEFAULT_WIDTH = String(defaults.width);
   if (defaults.noGit) out.UPLOADS_NO_GIT = "1";
   if (defaults.noOptimize) out.UPLOADS_NO_OPTIMIZE = "1";
+  if (defaults.keepExif) out.UPLOADS_KEEP_EXIF = "1";
   return out;
 }
 
@@ -66,6 +71,7 @@ function parsePutDefaultsFromRaw(raw: UploadsConfigValues): PutDefaults {
   }
   if (isTruthyConfigFlag(raw.UPLOADS_NO_GIT)) out.noGit = true;
   if (isTruthyConfigFlag(raw.UPLOADS_NO_OPTIMIZE)) out.noOptimize = true;
+  if (isTruthyConfigFlag(raw.UPLOADS_KEEP_EXIF)) out.keepExif = true;
   return out;
 }
 
@@ -79,6 +85,7 @@ function parsePutDefaultsFromEnv(): PutDefaults {
     raw.UPLOADS_DEFAULT_WIDTH = process.env.UPLOADS_DEFAULT_WIDTH;
   if (process.env.UPLOADS_NO_GIT) raw.UPLOADS_NO_GIT = process.env.UPLOADS_NO_GIT;
   if (process.env.UPLOADS_NO_OPTIMIZE) raw.UPLOADS_NO_OPTIMIZE = process.env.UPLOADS_NO_OPTIMIZE;
+  if (process.env.UPLOADS_KEEP_EXIF) raw.UPLOADS_KEEP_EXIF = process.env.UPLOADS_KEEP_EXIF;
   return parsePutDefaultsFromRaw(raw);
 }
 
@@ -142,6 +149,7 @@ export function mergePutDefaults(...layers: PutDefaults[]): PutDefaults {
     if (layer.width != null) out.width = layer.width;
     if (layer.noGit != null) out.noGit = layer.noGit;
     if (layer.noOptimize != null) out.noOptimize = layer.noOptimize;
+    if (layer.keepExif != null) out.keepExif = layer.keepExif;
   }
   return out;
 }

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -12,6 +12,7 @@ export const UPLOADS_CONFIG_KEYS = [
   "UPLOADS_DEFAULT_REF",
   "UPLOADS_DEFAULT_WIDTH",
   "UPLOADS_NO_GIT",
+  "UPLOADS_NO_OPTIMIZE",
 ] as const;
 
 export type UploadsConfigKey = (typeof UPLOADS_CONFIG_KEYS)[number];
@@ -24,6 +25,8 @@ export interface PutDefaults {
   ref?: string;
   width?: number;
   noGit?: boolean;
+  /** When true, put/attach skip client-side image optimization. */
+  noOptimize?: boolean;
 }
 
 const PUT_DEFAULT_KEY_MAP: Record<keyof PutDefaults, UploadsConfigKey> = {
@@ -32,7 +35,14 @@ const PUT_DEFAULT_KEY_MAP: Record<keyof PutDefaults, UploadsConfigKey> = {
   ref: "UPLOADS_DEFAULT_REF",
   width: "UPLOADS_DEFAULT_WIDTH",
   noGit: "UPLOADS_NO_GIT",
+  noOptimize: "UPLOADS_NO_OPTIMIZE",
 };
+
+function isTruthyConfigFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const v = value.toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
 
 export function putDefaultsToConfigValues(defaults: PutDefaults): UploadsConfigValues {
   const out: UploadsConfigValues = {};
@@ -41,6 +51,7 @@ export function putDefaultsToConfigValues(defaults: PutDefaults): UploadsConfigV
   if (defaults.ref) out.UPLOADS_DEFAULT_REF = defaults.ref;
   if (defaults.width != null) out.UPLOADS_DEFAULT_WIDTH = String(defaults.width);
   if (defaults.noGit) out.UPLOADS_NO_GIT = "1";
+  if (defaults.noOptimize) out.UPLOADS_NO_OPTIMIZE = "1";
   return out;
 }
 
@@ -53,9 +64,8 @@ function parsePutDefaultsFromRaw(raw: UploadsConfigValues): PutDefaults {
     const n = Number.parseInt(raw.UPLOADS_DEFAULT_WIDTH, 10);
     if (Number.isFinite(n) && n > 0) out.width = n;
   }
-  if (raw.UPLOADS_NO_GIT === "1" || raw.UPLOADS_NO_GIT?.toLowerCase() === "true") {
-    out.noGit = true;
-  }
+  if (isTruthyConfigFlag(raw.UPLOADS_NO_GIT)) out.noGit = true;
+  if (isTruthyConfigFlag(raw.UPLOADS_NO_OPTIMIZE)) out.noOptimize = true;
   return out;
 }
 
@@ -68,6 +78,7 @@ function parsePutDefaultsFromEnv(): PutDefaults {
   if (process.env.UPLOADS_DEFAULT_WIDTH)
     raw.UPLOADS_DEFAULT_WIDTH = process.env.UPLOADS_DEFAULT_WIDTH;
   if (process.env.UPLOADS_NO_GIT) raw.UPLOADS_NO_GIT = process.env.UPLOADS_NO_GIT;
+  if (process.env.UPLOADS_NO_OPTIMIZE) raw.UPLOADS_NO_OPTIMIZE = process.env.UPLOADS_NO_OPTIMIZE;
   return parsePutDefaultsFromRaw(raw);
 }
 
@@ -130,6 +141,7 @@ export function mergePutDefaults(...layers: PutDefaults[]): PutDefaults {
     if (layer.ref) out.ref = layer.ref;
     if (layer.width != null) out.width = layer.width;
     if (layer.noGit != null) out.noGit = layer.noGit;
+    if (layer.noOptimize != null) out.noOptimize = layer.noOptimize;
   }
   return out;
 }

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -65,6 +65,16 @@ export {
   type GhTargetKind,
 } from "./github.js";
 export {
+  DEFAULT_OPTIMIZE_MAX_EDGE,
+  DEFAULT_OPTIMIZE_QUALITY,
+  optimizeImageForUpload,
+  rewriteKeyExtension,
+  withImageExtension,
+  type OptimizeImageOptions,
+  type OptimizeImageResult,
+  type OptimizeOutputFormat,
+} from "./optimize.js";
+export {
   execRunner,
   resolveRepo,
   upsertAttachmentsComment,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -20,6 +20,11 @@ import { buildMarkdown } from "../embed.js";
 import { resolvePutPrefix } from "../destinations.js";
 import { ghAttachmentKey, ghKeyPrefix, type GhTarget } from "../github.js";
 import {
+  optimizeImageForUpload,
+  rewriteKeyExtension,
+  type OptimizeImageOptions,
+} from "../optimize.js";
+import {
   execRunner,
   resolveCurrentPullRequest,
   resolveRepo,
@@ -42,6 +47,19 @@ function optStringArray(args: ToolArgs, name: string): string[] | undefined {
     usage(`${name} must be an array of strings`);
   }
   return v as string[];
+}
+
+function mcpOptimizeOptions(
+  args: ToolArgs,
+  defaults: { noOptimize?: boolean },
+): OptimizeImageOptions {
+  const quality = optPosInt(args, "optimizeQuality");
+  if (quality !== undefined && quality > 100) usage("optimizeQuality must be 1–100");
+  return {
+    enabled: !(optBool(args, "noOptimize") || defaults.noOptimize === true),
+    maxEdge: optPosInt(args, "optimizeMaxEdge"),
+    quality,
+  };
 }
 
 /** Reads pr/issue (+ repo) into a GhTarget; undefined when neither is present. */
@@ -164,7 +182,23 @@ export function createUploadsMcpTools(opts: {
             type: "number",
             description: "Emit <img width=…> markdown instead of a plain image embed.",
           },
-          contentType: { type: "string", description: "Override the Content-Type." },
+          contentType: {
+            type: "string",
+            description: "Override the Content-Type (ignored when optimize rewrites the body).",
+          },
+          noOptimize: {
+            type: "boolean",
+            description:
+              "Skip client-side image optimization (default: optimize still images to WebP).",
+          },
+          optimizeMaxEdge: {
+            type: "number",
+            description: "Max long edge in pixels when optimizing (default: 2400).",
+          },
+          optimizeQuality: {
+            type: "number",
+            description: "WebP quality 1–100 when optimizing (default: 85).",
+          },
           noGit: { type: "boolean", description: "Don't derive the repo segment from git." },
           comment: {
             type: "boolean",
@@ -188,13 +222,13 @@ export function createUploadsMcpTools(opts: {
 
         const target = ghTargetFromArgs(args, run);
         const wantComment = optBool(args, "comment");
-        const key = optString(args, "key");
+        const keyArg = optString(args, "key");
         const destArg = optString(args, "destination");
         const prefixArg = optString(args, "prefix");
         const refArg = optString(args, "ref");
         if (wantComment && !target) usage("comment requires pr or issue");
         if (target) {
-          if (key) usage("key cannot be combined with pr/issue");
+          if (keyArg) usage("key cannot be combined with pr/issue");
           if (refArg) usage("ref cannot be combined with pr/issue");
           if (prefixArg) usage("prefix cannot be combined with pr/issue");
         }
@@ -203,7 +237,7 @@ export function createUploadsMcpTools(opts: {
           resolvedPrefix = resolvePutPrefix({
             destination: destArg,
             prefix: prefixArg,
-            key,
+            key: keyArg,
             ghAttachment: Boolean(target),
           });
         } catch (err) {
@@ -215,29 +249,41 @@ export function createUploadsMcpTools(opts: {
           file !== undefined
             ? new Uint8Array(readFileSync(file))
             : new Uint8Array(Buffer.from(contentBase64!, "base64"));
-        const filename = file !== undefined ? (filenameArg ?? basename(file)) : filenameArg!;
+        const sourceName = file !== undefined ? (filenameArg ?? basename(file)) : filenameArg!;
 
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
+        const optimizeOpts = mcpOptimizeOptions(args, defaults);
+        const prepared = await optimizeImageForUpload(bytes, sourceName, optimizeOpts);
+        const filename = prepared.filename;
+        let key = target ? ghAttachmentKey(target, filename) : keyArg;
+        if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
         const noGit = optBool(args, "noGit") || defaults.noGit === true;
-        const result = await client.put(bytes, {
+        const result = await client.put(prepared.bytes, {
           filename,
-          key: target ? ghAttachmentKey(target, filename) : key,
+          key,
           prefix: resolvedPrefix ?? defaults.prefix,
           repo: optString(args, "repo") ?? defaults.repo,
           ref: refArg ?? defaults.ref,
-          contentType: optString(args, "contentType"),
+          contentType: prepared.optimized ? prepared.contentType : optString(args, "contentType"),
           deriveRepoFromGit: !noGit,
         });
         const markdown = buildMarkdown(result.url, {
-          alt: optString(args, "alt") ?? filename,
+          alt: optString(args, "alt") ?? sourceName,
           width: optPosInt(args, "width") ?? defaults.width,
         });
+        const optimize = {
+          optimized: prepared.optimized,
+          skippedReason: prepared.skippedReason,
+          originalBytes: prepared.originalBytes,
+          outputBytes: prepared.outputBytes,
+          filename: prepared.filename,
+        };
 
         if (wantComment && target) {
           const { comment, commentError } = await syncComment(client, target);
-          return { ...result, markdown, comment, commentError };
+          return { ...result, markdown, optimize, comment, commentError };
         }
-        return { ...result, markdown };
+        return { ...result, markdown, optimize };
       },
     },
     {
@@ -259,7 +305,21 @@ export function createUploadsMcpTools(opts: {
           },
           contentType: {
             type: "string",
-            description: "Override the Content-Type (applied to every file).",
+            description:
+              "Override the Content-Type (applied to every file; ignored when optimize rewrites).",
+          },
+          noOptimize: {
+            type: "boolean",
+            description:
+              "Skip client-side image optimization (default: optimize still images to WebP).",
+          },
+          optimizeMaxEdge: {
+            type: "number",
+            description: "Max long edge in pixels when optimizing (default: 2400).",
+          },
+          optimizeQuality: {
+            type: "number",
+            description: "WebP quality 1–100 when optimizing (default: 85).",
           },
           workspace: workspaceProp,
         },
@@ -276,16 +336,33 @@ export function createUploadsMcpTools(opts: {
           resolveCurrentPullRequest(resolveRepo(optString(args, "repo"), run), run);
         const { client } = clientFor(args);
         const contentType = optString(args, "contentType");
+        const defaults = resolvePutDefaults({ envFile: globals.envFile });
+        const optimizeOpts = mcpOptimizeOptions(args, defaults);
 
         const uploads = [];
         for (const file of files) {
-          const filename = basename(file);
-          const result = await client.put(new Uint8Array(readFileSync(file)), {
-            filename,
-            key: ghAttachmentKey(target, filename),
-            contentType,
+          const sourceName = basename(file);
+          const prepared = await optimizeImageForUpload(
+            new Uint8Array(readFileSync(file)),
+            sourceName,
+            optimizeOpts,
+          );
+          const result = await client.put(prepared.bytes, {
+            filename: prepared.filename,
+            key: ghAttachmentKey(target, prepared.filename),
+            contentType: prepared.optimized ? prepared.contentType : contentType,
           });
-          uploads.push({ ...result, markdown: buildMarkdown(result.url, { alt: filename }) });
+          uploads.push({
+            ...result,
+            markdown: buildMarkdown(result.url, { alt: sourceName }),
+            optimize: {
+              optimized: prepared.optimized,
+              skippedReason: prepared.skippedReason,
+              originalBytes: prepared.originalBytes,
+              outputBytes: prepared.outputBytes,
+              filename: prepared.filename,
+            },
+          });
         }
 
         if (optBool(args, "noComment")) return { target, uploads };

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -51,7 +51,7 @@ function optStringArray(args: ToolArgs, name: string): string[] | undefined {
 
 function mcpOptimizeOptions(
   args: ToolArgs,
-  defaults: { noOptimize?: boolean },
+  defaults: { noOptimize?: boolean; keepExif?: boolean },
 ): OptimizeImageOptions {
   const quality = optPosInt(args, "optimizeQuality");
   if (quality !== undefined && quality > 100) usage("optimizeQuality must be 1–100");
@@ -59,6 +59,7 @@ function mcpOptimizeOptions(
     enabled: !(optBool(args, "noOptimize") || defaults.noOptimize === true),
     maxEdge: optPosInt(args, "optimizeMaxEdge"),
     quality,
+    keepExif: optBool(args, "keepExif") || defaults.keepExif === true,
   };
 }
 
@@ -199,6 +200,11 @@ export function createUploadsMcpTools(opts: {
             type: "number",
             description: "WebP quality 1–100 when optimizing (default: 85).",
           },
+          keepExif: {
+            type: "boolean",
+            description:
+              "Keep EXIF/XMP/ICC when optimizing (default: strip for privacy on public embeds).",
+          },
           noGit: { type: "boolean", description: "Don't derive the repo segment from git." },
           comment: {
             type: "boolean",
@@ -320,6 +326,11 @@ export function createUploadsMcpTools(opts: {
           optimizeQuality: {
             type: "number",
             description: "WebP quality 1–100 when optimizing (default: 85).",
+          },
+          keepExif: {
+            type: "boolean",
+            description:
+              "Keep EXIF/XMP/ICC when optimizing (default: strip for privacy on public embeds).",
           },
           workspace: workspaceProp,
         },

--- a/packages/uploads/src/optimize.ts
+++ b/packages/uploads/src/optimize.ts
@@ -21,6 +21,12 @@ export interface OptimizeImageOptions {
   format?: OptimizeOutputFormat;
   maxEdge?: number;
   quality?: number;
+  /**
+   * When true, preserve EXIF/XMP/ICC (and related) from the input via sharp
+   * `withMetadata()`. Default false — strip for privacy and smaller embeds.
+   * Orientation is still applied so pixels match what the user saw.
+   */
+  keepExif?: boolean;
 }
 
 export interface OptimizeImageResult {
@@ -169,6 +175,11 @@ export async function optimizeImageForUpload(
 
   // Apply EXIF orientation so stored pixels match what users saw.
   image = image.rotate();
+  // Default: strip metadata (privacy + size). Opt in to keep EXIF/etc. for
+  // cases where image metadata is part of the discussion (e.g. photo forensics).
+  if (opts.keepExif) {
+    image = image.withMetadata();
+  }
 
   let encoded: Buffer;
   try {

--- a/packages/uploads/src/optimize.ts
+++ b/packages/uploads/src/optimize.ts
@@ -1,0 +1,224 @@
+/**
+ * Client-side still-image optimization for put/attach.
+ *
+ * Default path for GitHub embeds: re-encode PNG/JPEG (and similar) to WebP,
+ * cap the long edge, keep the smaller of original vs optimized. Animated GIF,
+ * SVG, video, and non-images are left unchanged.
+ */
+import sharp from "sharp";
+
+/** Longest edge in pixels (screenshots beyond this rarely help PR review). */
+export const DEFAULT_OPTIMIZE_MAX_EDGE = 2400;
+
+/** WebP quality tuned for UI screenshots (text/chrome stay sharp enough). */
+export const DEFAULT_OPTIMIZE_QUALITY = 85;
+
+export type OptimizeOutputFormat = "webp" | "jpeg";
+
+export interface OptimizeImageOptions {
+  /** When false, returns the input unchanged. Default true. */
+  enabled?: boolean;
+  format?: OptimizeOutputFormat;
+  maxEdge?: number;
+  quality?: number;
+}
+
+export interface OptimizeImageResult {
+  bytes: Uint8Array;
+  filename: string;
+  /** Suggested Content-Type for the body (API still sniffs magic bytes). */
+  contentType: string;
+  optimized: boolean;
+  /** Why bytes were left as-is when optimized is false. */
+  skippedReason?: string;
+  originalBytes: number;
+  outputBytes: number;
+}
+
+const IMAGE_EXT = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "gif",
+  "tif",
+  "tiff",
+  "avif",
+  "heic",
+  "heif",
+]);
+
+function extensionOf(name: string): string {
+  const base = name.includes("/") ? name.slice(name.lastIndexOf("/") + 1) : name;
+  const dot = base.lastIndexOf(".");
+  return dot >= 0 ? base.slice(dot + 1).toLowerCase() : "";
+}
+
+/** Replace a trailing image-looking extension, or append when missing. */
+export function withImageExtension(name: string, ext: string): string {
+  const clean = ext.replace(/^\./, "").toLowerCase();
+  const slash = name.lastIndexOf("/");
+  const dir = slash >= 0 ? name.slice(0, slash + 1) : "";
+  const base = slash >= 0 ? name.slice(slash + 1) : name;
+  const dot = base.lastIndexOf(".");
+  if (dot >= 0 && IMAGE_EXT.has(base.slice(dot + 1).toLowerCase())) {
+    return `${dir}${base.slice(0, dot)}.${clean}`;
+  }
+  return `${dir}${base}.${clean}`;
+}
+
+function contentTypeForFormat(format: OptimizeOutputFormat): string {
+  return format === "jpeg" ? "image/jpeg" : "image/webp";
+}
+
+function looksLikeSvg(bytes: Uint8Array, filename: string): boolean {
+  if (extensionOf(filename) === "svg") return true;
+  const head = new TextDecoder("utf-8", { fatal: false })
+    .decode(bytes.subarray(0, Math.min(bytes.length, 256)))
+    .trimStart()
+    .toLowerCase();
+  return head.startsWith("<?xml") || head.startsWith("<svg");
+}
+
+function passthrough(
+  bytes: Uint8Array,
+  filename: string,
+  contentType: string,
+  skippedReason: string,
+): OptimizeImageResult {
+  return {
+    bytes,
+    filename,
+    contentType,
+    optimized: false,
+    skippedReason,
+    originalBytes: bytes.byteLength,
+    outputBytes: bytes.byteLength,
+  };
+}
+
+/**
+ * Optimize still images for public embeds. Safe to call on any payload:
+ * non-images and unsupported types pass through.
+ */
+export async function optimizeImageForUpload(
+  bytes: Uint8Array,
+  filename: string,
+  opts: OptimizeImageOptions = {},
+): Promise<OptimizeImageResult> {
+  const originalBytes = bytes.byteLength;
+  if (opts.enabled === false) {
+    return passthrough(bytes, filename, guessContentType(filename), "disabled");
+  }
+  if (originalBytes === 0) {
+    return passthrough(bytes, filename, guessContentType(filename), "empty");
+  }
+  if (looksLikeSvg(bytes, filename)) {
+    return passthrough(bytes, filename, "image/svg+xml", "svg");
+  }
+
+  const format: OptimizeOutputFormat = opts.format ?? "webp";
+  const maxEdge = opts.maxEdge ?? DEFAULT_OPTIMIZE_MAX_EDGE;
+  const quality = opts.quality ?? DEFAULT_OPTIMIZE_QUALITY;
+  if (!Number.isFinite(maxEdge) || maxEdge < 1) {
+    throw new Error(`optimize maxEdge must be a positive number (got ${maxEdge})`);
+  }
+  if (!Number.isFinite(quality) || quality < 1 || quality > 100) {
+    throw new Error(`optimize quality must be 1–100 (got ${quality})`);
+  }
+
+  let image = sharp(bytes, { animated: true, failOn: "none" });
+  let meta: Awaited<ReturnType<typeof image.metadata>>;
+  try {
+    meta = await image.metadata();
+  } catch {
+    return passthrough(bytes, filename, guessContentType(filename), "not_image");
+  }
+
+  if (!meta.format) {
+    return passthrough(bytes, filename, guessContentType(filename), "not_image");
+  }
+
+  // Animated GIF/WebP: keep as-is (re-encoding often breaks or balloons size).
+  if ((meta.pages ?? 1) > 1) {
+    return passthrough(
+      bytes,
+      filename,
+      meta.format === "gif" ? "image/gif" : guessContentType(filename),
+      "animated",
+    );
+  }
+
+  if (meta.format === "gif") {
+    // Single-frame GIF can convert; multi-page already returned above.
+  }
+
+  const width = meta.width ?? 0;
+  const height = meta.height ?? 0;
+  if (width > 0 && height > 0) {
+    const longEdge = Math.max(width, height);
+    if (longEdge > maxEdge) {
+      image = image.resize({
+        width: width >= height ? maxEdge : undefined,
+        height: height > width ? maxEdge : undefined,
+        fit: "inside",
+        withoutEnlargement: true,
+      });
+    }
+  }
+
+  // Apply EXIF orientation so stored pixels match what users saw.
+  image = image.rotate();
+
+  let encoded: Buffer;
+  try {
+    if (format === "jpeg") {
+      encoded = await image.jpeg({ quality, mozjpeg: true }).toBuffer();
+    } else {
+      encoded = await image.webp({ quality, effort: 4 }).toBuffer();
+    }
+  } catch {
+    return passthrough(bytes, filename, guessContentType(filename), "encode_failed");
+  }
+
+  if (encoded.byteLength >= originalBytes) {
+    return passthrough(bytes, filename, guessContentType(filename), "not_smaller");
+  }
+
+  const outFilename = withImageExtension(filename, format === "jpeg" ? "jpg" : "webp");
+  return {
+    bytes: new Uint8Array(encoded),
+    filename: outFilename,
+    contentType: contentTypeForFormat(format),
+    optimized: true,
+    originalBytes,
+    outputBytes: encoded.byteLength,
+  };
+}
+
+function guessContentType(filename: string): string {
+  switch (extensionOf(filename)) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "avif":
+      return "image/avif";
+    case "svg":
+      return "image/svg+xml";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/** Rewrite an object key's trailing image extension to match optimized output. */
+export function rewriteKeyExtension(key: string, filename: string): string {
+  const ext = extensionOf(filename);
+  if (!ext || !IMAGE_EXT.has(ext)) return key;
+  return withImageExtension(key, ext);
+}

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -9,15 +9,15 @@ import { join } from "node:path";
 
 /** Fake client capturing put() calls; other methods throw if reached. */
 function fakeClient() {
-  const puts: { key?: string; filename: string; prefix?: string }[] = [];
+  const puts: { key?: string; filename: string; prefix?: string; body: Uint8Array }[] = [];
   const client = {
-    put: async (_body: Uint8Array, opts: { filename: string; key?: string; prefix?: string }) => {
-      puts.push({ key: opts.key, filename: opts.filename, prefix: opts.prefix });
+    put: async (body: Uint8Array, opts: { filename: string; key?: string; prefix?: string }) => {
+      puts.push({ key: opts.key, filename: opts.filename, prefix: opts.prefix, body });
       return {
         workspace: "test",
         key: opts.key ?? "generated/key.png",
         url: `https://x.test/${opts.key ?? "generated/key.png"}`,
-        size: 3,
+        size: body.byteLength,
         contentType: "image/png",
       };
     },
@@ -119,6 +119,27 @@ describe("runPut --pr/--issue", () => {
     const { client, puts } = fakeClient();
     await runPut(ctxWith(client), [tmpFile(), "--repo", "myapp", "--no-git"], false, noRun);
     expect(puts[0].key).toBeUndefined(); // client falls back to buildScreenshotKey
+  });
+
+  it("uploads non-image bytes unchanged when optimize cannot help", async () => {
+    const { client, puts } = fakeClient();
+    // tmpFile writes the text "png" — not a real image; optimize passes through.
+    await runPut(ctxWith(client), [tmpFile(), "--pr", "9", "--repo", "o/r"], false, noRun);
+    expect(puts[0].filename).toBe("shot.png");
+    expect(puts[0].key).toBe("gh/o/r/pull/9/shot.png");
+    expect(new TextDecoder().decode(puts[0].body)).toBe("png");
+  });
+
+  it("honors --no-optimize", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "9", "--repo", "o/r", "--no-optimize"],
+      false,
+      noRun,
+    );
+    expect(puts[0].filename).toBe("shot.png");
+    expect(puts[0].key).toBe("gh/o/r/pull/9/shot.png");
   });
 });
 

--- a/packages/uploads/test/optimize.test.ts
+++ b/packages/uploads/test/optimize.test.ts
@@ -107,4 +107,40 @@ describe("optimizeImageForUpload", () => {
     expect(result.outputBytes).toBeLessThanOrEqual(result.originalBytes);
     if (!result.optimized) expect(result.skippedReason).toBe("not_smaller");
   });
+
+  it("strips EXIF by default and preserves it with keepExif", async () => {
+    const jpeg = new Uint8Array(
+      await sharp({
+        create: {
+          width: 400,
+          height: 300,
+          channels: 3,
+          background: { r: 90, g: 40, b: 20 },
+        },
+      })
+        .jpeg({ quality: 95 })
+        .withMetadata({
+          exif: {
+            IFD0: {
+              Copyright: "uploads-exif-fixture",
+              Software: "uploads-test",
+            },
+          },
+        })
+        .toBuffer(),
+    );
+    const withExif = await sharp(jpeg).metadata();
+    expect(withExif.exif).toBeTruthy();
+
+    const stripped = await optimizeImageForUpload(jpeg, "photo.jpg");
+    expect(stripped.optimized).toBe(true);
+    const strippedMeta = await sharp(stripped.bytes).metadata();
+    expect(strippedMeta.exif).toBeUndefined();
+
+    const kept = await optimizeImageForUpload(jpeg, "photo.jpg", { keepExif: true });
+    expect(kept.optimized).toBe(true);
+    const keptMeta = await sharp(kept.bytes).metadata();
+    expect(keptMeta.exif).toBeTruthy();
+    expect(Buffer.from(kept.bytes).includes(Buffer.from("uploads-exif-fixture"))).toBe(true);
+  });
 });

--- a/packages/uploads/test/optimize.test.ts
+++ b/packages/uploads/test/optimize.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import sharp from "sharp";
+import {
+  optimizeImageForUpload,
+  rewriteKeyExtension,
+  withImageExtension,
+} from "../src/optimize.js";
+
+async function solidPng(width: number, height: number): Promise<Uint8Array> {
+  // Compressible solid color — real screenshots shrink more; this still beats raw PNG size.
+  const buf = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 40, g: 80, b: 160 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return new Uint8Array(buf);
+}
+
+describe("withImageExtension / rewriteKeyExtension", () => {
+  it("rewrites a trailing image extension", () => {
+    expect(withImageExtension("shot.png", "webp")).toBe("shot.webp");
+    expect(withImageExtension("dir/shot.PNG", "webp")).toBe("dir/shot.webp");
+    expect(rewriteKeyExtension("gh/o/r/pull/1/shot.png", "shot.webp")).toBe(
+      "gh/o/r/pull/1/shot.webp",
+    );
+  });
+
+  it("appends when the name has no image extension", () => {
+    expect(withImageExtension("shot", "webp")).toBe("shot.webp");
+    expect(withImageExtension("archive.tar.gz", "webp")).toBe("archive.tar.gz.webp");
+  });
+});
+
+describe("optimizeImageForUpload", () => {
+  it("converts a large PNG to a smaller WebP and rewrites the filename", async () => {
+    const png = await solidPng(1200, 800);
+    const result = await optimizeImageForUpload(png, "dashboard.png");
+    expect(result.optimized).toBe(true);
+    expect(result.filename).toBe("dashboard.webp");
+    expect(result.contentType).toBe("image/webp");
+    expect(result.outputBytes).toBeLessThan(result.originalBytes);
+    expect(result.bytes.byteLength).toBe(result.outputBytes);
+    // RIFF....WEBP
+    expect(String.fromCharCode(...result.bytes.subarray(0, 4))).toBe("RIFF");
+  });
+
+  it("respects --no-optimize / enabled: false", async () => {
+    const png = await solidPng(400, 300);
+    const result = await optimizeImageForUpload(png, "shot.png", { enabled: false });
+    expect(result.optimized).toBe(false);
+    expect(result.skippedReason).toBe("disabled");
+    expect(result.filename).toBe("shot.png");
+    expect(result.bytes).toBe(png);
+  });
+
+  it("skips non-images", async () => {
+    const bytes = new TextEncoder().encode("not an image");
+    const result = await optimizeImageForUpload(bytes, "notes.txt");
+    expect(result.optimized).toBe(false);
+    expect(result.skippedReason).toBe("not_image");
+    expect(result.filename).toBe("notes.txt");
+  });
+
+  it("skips SVG", async () => {
+    const svg = new TextEncoder().encode(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>',
+    );
+    const result = await optimizeImageForUpload(svg, "icon.svg");
+    expect(result.optimized).toBe(false);
+    expect(result.skippedReason).toBe("svg");
+  });
+
+  it("caps the long edge when larger than maxEdge", async () => {
+    const png = await solidPng(4000, 2000);
+    const result = await optimizeImageForUpload(png, "wide.png", {
+      maxEdge: 1000,
+      quality: 80,
+    });
+    expect(result.optimized).toBe(true);
+    const meta = await sharp(result.bytes).metadata();
+    expect(meta.width).toBeLessThanOrEqual(1000);
+    expect(meta.height).toBeLessThanOrEqual(1000);
+    expect(Math.max(meta.width ?? 0, meta.height ?? 0)).toBe(1000);
+  });
+
+  it("keeps the original when the optimized payload is not smaller", async () => {
+    // Tiny already-efficient WebP often won't shrink further at high quality.
+    const webp = new Uint8Array(
+      await sharp({
+        create: {
+          width: 8,
+          height: 8,
+          channels: 3,
+          background: { r: 0, g: 0, b: 0 },
+        },
+      })
+        .webp({ quality: 80 })
+        .toBuffer(),
+    );
+    const result = await optimizeImageForUpload(webp, "tiny.webp", { quality: 90 });
+    // Either not_smaller or still optimized — must never grow the payload.
+    expect(result.outputBytes).toBeLessThanOrEqual(result.originalBytes);
+    if (!result.optimized) expect(result.skippedReason).toBe("not_smaller");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,10 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/uploads:
+    dependencies:
+      sharp:
+        specifier: ^0.35.3
+        version: 0.35.3(@types/node@26.1.0)
     devDependencies:
       '@types/node':
         specifier: ^26.1.0
@@ -6436,7 +6440,6 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 26.1.0
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -54,13 +54,9 @@ propagate within ~a minute).
   npm install --global @buildinternet/uploads
   npx @buildinternet/uploads@0.1.0 --help
   ```
-  Inside this repo, run it via pnpm — the root `uploads` script builds
-  the package first, so it always reflects local source:
-  ```bash
-  pnpm uploads <command> [args]        # from the repo root
-  ```
-  If `@buildinternet/uploads` is installed/linked elsewhere, the binary is just
-  `uploads`. Every example below uses `uploads …`; prefix with `pnpm ` in-repo.
+  Every example in this skill uses the **global** `uploads …` binary (as after
+  install). Inside the uploads monorepo only, `pnpm uploads …` builds from
+  local source first — do not write product/PR examples that way.
 - **A configured token** (one-time — see below). Check with `uploads doctor`.
 - **`gh` CLI, authenticated** — only for the `--comment` / `comment` features that
   write to a PR/issue. Plain uploads don't need it.

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -122,19 +122,29 @@ capture them. Use `-` as the file to read from stdin.
 
 Key options (`uploads put --help` for all):
 
-| Flag                                  | Purpose                                                                          |
-| ------------------------------------- | -------------------------------------------------------------------------------- |
-| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text. |
-| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images). |
-| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).   |
-| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).         |
-| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                      |
-| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                |
-| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                      |
-| `--content-type <mime>`               | Override the content type (else inferred from extension).                        |
-| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).               |
-| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                   |
-| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                          |
+| Flag                                  | Purpose                                                                                            |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                   |
+| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                   |
+| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                     |
+| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                           |
+| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                        |
+| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                  |
+| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                        |
+| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body). |
+| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.    |
+| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                     |
+| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                        |
+| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                 |
+| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                     |
+| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                            |
+
+**Image optimization (default on):** PNG/JPEG and similar still images are re-encoded to
+WebP (long edge capped at 2400px, quality 85) before upload so PR/issue embeds stay
+lean. The object key/filename extension follows the output (e.g. `shot.png` →
+`…/shot.webp`). Animated GIF, SVG, video, and non-images are left alone; if the
+optimized payload is not smaller, the original is uploaded. Use `--no-optimize` when
+you need lossless originals.
 
 **How keys work** — three paths, no extra naming modes:
 
@@ -253,7 +263,7 @@ uploads config init --api-url http://localhost:8787 --workspace default --token 
 
 Recognized keys: `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, `UPLOADS_TOKEN`,
 `UPLOADS_DEFAULT_PREFIX`, `UPLOADS_DEFAULT_REPO`, `UPLOADS_DEFAULT_REF`,
-`UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`.
+`UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`, `UPLOADS_NO_OPTIMIZE`.
 
 ## Local development
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -131,6 +131,7 @@ Key options (`uploads put --help` for all):
 | `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.    |
 | `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                     |
 | `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                        |
+| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.      |
 | `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                 |
 | `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                     |
 | `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                            |
@@ -138,9 +139,10 @@ Key options (`uploads put --help` for all):
 **Image optimization (default on):** PNG/JPEG and similar still images are re-encoded to
 WebP (long edge capped at 2400px, quality 85) before upload so PR/issue embeds stay
 lean. The object key/filename extension follows the output (e.g. `shot.png` →
-`…/shot.webp`). Animated GIF, SVG, video, and non-images are left alone; if the
-optimized payload is not smaller, the original is uploaded. Use `--no-optimize` when
-you need lossless originals.
+`…/shot.webp`). **EXIF/XMP is stripped by default** (public URLs + privacy); pass
+`--keep-exif` when the discussion needs the embedded image metadata. Animated GIF,
+SVG, video, and non-images are left alone; if the optimized payload is not smaller,
+the original is uploaded. Use `--no-optimize` when you need lossless originals.
 
 **How keys work** — three paths, no extra naming modes:
 
@@ -259,7 +261,7 @@ uploads config init --api-url http://localhost:8787 --workspace default --token 
 
 Recognized keys: `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, `UPLOADS_TOKEN`,
 `UPLOADS_DEFAULT_PREFIX`, `UPLOADS_DEFAULT_REPO`, `UPLOADS_DEFAULT_REF`,
-`UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`, `UPLOADS_NO_OPTIMIZE`.
+`UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`, `UPLOADS_NO_OPTIMIZE`, `UPLOADS_KEEP_EXIF`.
 
 ## Local development
 


### PR DESCRIPTION
## In plain terms

Agent screenshots often land in PR comments as large PNGs, which makes review pages heavy for no good reason. This change re-encodes still images to WebP **on the client before upload**, so the public URL you embed is already small—without standing up Cloudflare image transforms on every view.

## What it does

- Default **on** for `uploads put` / `uploads attach` and the matching MCP tools
- WebP re-encode with a long-edge cap (2400px) and high quality (85), tuned for UI screenshots
- **EXIF/XMP/ICC stripped by default** (public URLs + privacy); opt in with `--keep-exif` when the discussion needs embedded image metadata
- Leaves animated GIF, SVG, video, and non-images alone; keeps the original when optimize is not smaller
- Rewrites the object key/filename extension to match (e.g. `shot.png` → `…/shot.webp`) so stable PR keys stay consistent across re-uploads
- Escape hatches: `--no-optimize`, `UPLOADS_NO_OPTIMIZE=1`, `--keep-exif` / `UPLOADS_KEEP_EXIF=1`, optional quality / max-edge knobs
- Skill + README + help text updated so agents know the default

## What it is not

- **Not** Cloudflare live transforms / flows on `storage.uploads.sh` (that stays out of scope—see #33 Phase 2 for optional server-side ingest later)
- **Not** dual-store (original + optimized); one canonical object
- **Not** video re-encode
- **Not** rich provenance in a database / object custom metadata — tracked separately in #35
- Default is a behavior change for still images (extension may change; EXIF removed); use `--no-optimize` or `--keep-exif` when needed

## How to try it

After the package is published (or with a global install from this branch):

```bash
uploads put ./shot.png
# stderr may show: optimized N → M bytes (shot.webp); EXIF stripped

uploads put ./photo.jpg --keep-exif
uploads put ./shot.png --no-optimize
```

## Technical notes

- New module: `packages/uploads/src/optimize.ts` (`sharp`)
- Shared by CLI and stdio MCP; human stderr + JSON `optimize` metadata
- Changeset: **minor** `@buildinternet/uploads`
- Tracking: #33 (optimize), #35 (rich object/DB provenance later)

## Test plan

- [x] Package tests + typecheck (112 tests)
- [x] Rebased onto latest `main` (destinations #32) and resolved conflicts
- [ ] CI green on this PR