### PR TITLE
feat: wrap screenshots in device or browser frames

### DIFF
--- a/.changeset/cli-device-frames.md
+++ b/.changeset/cli-device-frames.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add optional `--frame` device/browser chrome on put/attach (and MCP) before image optimize — procedural phone/browser plus remote community device frames.

--- a/.changeset/cli-device-frames.md
+++ b/.changeset/cli-device-frames.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": minor
 ---
 
-Add optional `--frame` device/browser chrome on put/attach (and MCP) before image optimize — procedural phone/browser plus remote community device frames.
+Add optional `--frame` (phone/browser/iphone-16-pro) on put/attach before optimize, and link uploads.sh in the managed GitHub attachments comment footer.

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -17,6 +17,8 @@ uploads attach ./before.png ./after.png
 uploads put ./shot.png
 uploads put ./shot.png --destination screenshots
 uploads put ./shot.png --no-optimize
+uploads put ./mobile.png --frame phone
+uploads put ./ui.png --frame browser --frame-url "https://app.example"
 uploads put ./after.png --pr 123 --comment
 uploads doctor
 ```
@@ -42,6 +44,12 @@ use `gh/…`. Workspaces may restrict put/sign to those roots via
 capped, high quality) before upload so GitHub embeds stay small, and **EXIF is
 stripped**. Pass `--keep-exif` / `UPLOADS_KEEP_EXIF=1` to preserve image metadata, or
 `--no-optimize` / `UPLOADS_NO_OPTIMIZE=1` to upload originals unchanged.
+
+**Frames (opt-in):** `--frame phone|browser|iphone-16-pro|…` composites device or
+browser chrome **before** optimize. Procedural frames need no download; named
+devices fetch PNGs from
+[device-frames-media](https://github.com/jonnyjackson26/device-frames-media) into
+`~/.cache/uploads/frames` (not shipped in the npm package).
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -45,11 +45,10 @@ capped, high quality) before upload so GitHub embeds stay small, and **EXIF is
 stripped**. Pass `--keep-exif` / `UPLOADS_KEEP_EXIF=1` to preserve image metadata, or
 `--no-optimize` / `UPLOADS_NO_OPTIMIZE=1` to upload originals unchanged.
 
-**Frames (opt-in):** `--frame phone|browser|iphone-16-pro|…` composites device or
-browser chrome **before** optimize. Procedural frames need no download; named
-devices fetch PNGs from
-[device-frames-media](https://github.com/jonnyjackson26/device-frames-media) into
-`~/.cache/uploads/frames` (not shipped in the npm package).
+**Frames (opt-in):** `--frame phone|browser|iphone-16-pro` composites chrome
+**before** optimize. `phone`/`browser` are procedural; `iphone-16-pro` fetches
+community art from [device-frames-media](https://github.com/jonnyjackson26/device-frames-media)
+into `~/.cache/uploads/frames` (not bundled).
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -39,6 +39,7 @@ import {
   type OptimizeImageOptions,
   type OptimizeImageResult,
 } from "./optimize.js";
+import { applyFrame, listFramePresets, resolveFrameId, type FrameResult } from "./frame.js";
 import type { PutDefaults } from "./config-file.js";
 
 export interface CliContext {
@@ -60,6 +61,9 @@ high quality; EXIF stripped) so GitHub embeds stay lean. Original bytes are kept
 when they are already smaller, animated, or not an image. Use --no-optimize to
 upload as-is, or --keep-exif when image metadata matters for the discussion.
 
+Optional --frame wraps the image in a device/browser chrome before optimize
+(default off). See: uploads put --help frames
+
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
   --destination <id>    Typed root: screenshots | gh | f (sets --prefix)
@@ -69,6 +73,9 @@ Options:
   --alt <text>          Alt text (default: filename)
   --width <px>          <img width=…> markdown (or UPLOADS_DEFAULT_WIDTH)
   --content-type <mime> Override Content-Type (ignored when optimize rewrites the body)
+  --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro|…)
+  --frame-url <url>     Address shown in procedural browser chrome (with --frame browser)
+  --frame-fit cover|contain  How the screenshot fills the screen (default: cover)
   --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
   --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
   --optimize-quality <1-100>  WebP quality (default: 85)
@@ -82,10 +89,21 @@ Options:
 
 Examples:
   uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
+  uploads put ./mobile.png --frame phone
+  uploads put ./ui.png --frame browser --frame-url "https://app.example/settings"
+  uploads put ./mobile.png --frame iphone-16-pro
   uploads put ./shot.png --destination screenshots
   uploads put ./shot.png --no-optimize
-  uploads --env-file .env put ./shot.png
-  uploads --env-file .env put ./after.png --pr 123 --comment
+`;
+
+const FRAMES_HELP = `Built-in --frame ids:
+
+${listFramePresets()
+  .map((p) => `  ${p.id.padEnd(18)} ${p.label} (${p.kind})`)
+  .join("\n")}
+
+Procedural frames need no download. Device frames are fetched once from
+device-frames-media and cached under ~/.cache/uploads/frames (not bundled).
 `;
 
 /**
@@ -149,6 +167,75 @@ function formatOptimizeNote(opt: OptimizeImageResult): string | undefined {
   return undefined;
 }
 
+export type PreparedUpload = OptimizeImageResult & {
+  frame?: Pick<FrameResult, "framed" | "frameId" | "skippedReason">;
+};
+
+/** Frame (optional) then optimize — shared by put/attach/MCP. */
+export async function prepareImageForUpload(
+  bytes: Uint8Array,
+  filename: string,
+  opts: {
+    frameId?: string;
+    frameUrl?: string;
+    frameFit?: "cover" | "contain";
+    optimize: OptimizeImageOptions;
+  },
+): Promise<PreparedUpload> {
+  let currentBytes = bytes;
+  let currentName = filename;
+  let frameMeta: PreparedUpload["frame"];
+
+  if (opts.frameId) {
+    const framed = await applyFrame(currentBytes, currentName, {
+      id: opts.frameId,
+      browserUrl: opts.frameUrl,
+      fit: opts.frameFit,
+    });
+    frameMeta = {
+      framed: framed.framed,
+      frameId: framed.frameId,
+      skippedReason: framed.skippedReason,
+    };
+    if (framed.framed) {
+      currentBytes = framed.bytes;
+      currentName = framed.filename;
+    }
+  }
+
+  const optimized = await optimizeImageForUpload(currentBytes, currentName, opts.optimize);
+  return { ...optimized, frame: frameMeta };
+}
+
+function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
+  frameId?: string;
+  frameUrl?: string;
+  frameFit?: "cover" | "contain";
+} {
+  const raw = flagString(flags, "--frame");
+  let frameId: string | undefined;
+  try {
+    frameId = resolveFrameId(raw);
+  } catch (err) {
+    throw new UsageError(err instanceof Error ? err.message : String(err));
+  }
+  const fitRaw = flagString(flags, "--frame-fit");
+  let frameFit: "cover" | "contain" | undefined;
+  if (fitRaw) {
+    if (fitRaw !== "cover" && fitRaw !== "contain") {
+      throw new UsageError(`invalid --frame-fit: ${fitRaw} (use cover or contain)`);
+    }
+    frameFit = fitRaw;
+  }
+  if (frameFit && !frameId) throw new UsageError("--frame-fit requires --frame");
+  const frameUrl = flagString(flags, "--frame-url");
+  if (frameUrl && frameId !== "browser") {
+    // Allow anyway for future chrome frames; warn via usage only if no frame.
+    if (!frameId) throw new UsageError("--frame-url requires --frame browser");
+  }
+  return { frameId, frameUrl, frameFit };
+}
+
 /**
  * List every attachment under the target's prefix and create/update the
  * managed comment. Throws on gh failure — callers decide whether that is
@@ -178,7 +265,7 @@ Upload one or more stable PR/issue attachments and maintain a single GitHub
 comment. With no target, uses the pull request for the current branch.
 
 Still images are optimized to WebP by default (same as put). Use --no-optimize
-to upload originals.
+to upload originals. Optional --frame wraps images in device/browser chrome.
 
 Options:
   --pr <num>            Attach to this pull request
@@ -186,6 +273,9 @@ Options:
   --repo <owner/repo>   Repository (default: gh/git inference)
   --no-comment          Upload only; don't create/update the managed comment
   --content-type <mime> Override Content-Type (applied to every file; ignored when optimize rewrites)
+  --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro|…)
+  --frame-url <url>     Address shown in procedural browser chrome
+  --frame-fit cover|contain  Screenshot fit inside the frame (default: cover)
   --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
   --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
   --optimize-quality <1-100>  WebP quality (default: 85)
@@ -194,6 +284,7 @@ Options:
 
 Examples:
   uploads attach ./before.png ./after.png
+  uploads attach ./mobile.png --frame phone
   uploads attach ./shot.png --pr 123 --repo myorg/myapp
   uploads attach ./artifact.zip --issue 45 --no-comment
 `;
@@ -223,6 +314,7 @@ export async function runAttach(
     resolveCurrentPullRequest(resolveRepo(flagString(parsed.flags, "--repo"), run), run);
   const defaults = resolvePutDefaults({ envFile: ctx.envFile });
   const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, defaults);
+  const frameOpts = frameOptionsFromFlags(parsed.flags);
   const contentTypeOverride = flagString(parsed.flags, "--content-type");
   const results = [];
   for (const file of parsed.positionals) {
@@ -230,11 +322,13 @@ export async function runAttach(
       throw new UsageError("attach does not support stdin; pass one or more file paths");
     const sourceName = basename(file);
     if (!ctx.quiet && !ctx.json) process.stderr.write(`>> uploading ${file}\n`);
-    const prepared = await optimizeImageForUpload(
-      new Uint8Array(readFileSync(file)),
-      sourceName,
-      optimizeOpts,
-    );
+    const prepared = await prepareImageForUpload(new Uint8Array(readFileSync(file)), sourceName, {
+      ...frameOpts,
+      optimize: optimizeOpts,
+    });
+    if (prepared.frame?.framed && !ctx.quiet && !ctx.json) {
+      process.stderr.write(`>> framed with ${prepared.frame.frameId}\n`);
+    }
     const note = formatOptimizeNote(prepared);
     if (note && !ctx.quiet && !ctx.json) process.stderr.write(`>> ${note}\n`);
     const result = await ctx.client.put(prepared.bytes, {
@@ -252,6 +346,7 @@ export async function runAttach(
         outputBytes: prepared.outputBytes,
         filename: prepared.filename,
       },
+      frame: prepared.frame,
     });
   }
 
@@ -287,11 +382,13 @@ export async function runPut(
 ): Promise<number> {
   if (help) {
     process.stderr.write(PUT_HELP);
+    process.stderr.write(`\n${FRAMES_HELP}`);
     return 0;
   }
   const parsed = parseCommandArgs(args);
   if (parsed.help) {
     process.stderr.write(PUT_HELP);
+    process.stderr.write(`\n${FRAMES_HELP}`);
     return 0;
   }
 
@@ -344,7 +441,11 @@ export async function runPut(
 
   const defaults = resolvePutDefaults({ envFile: ctx.envFile });
   const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, defaults);
-  const prepared = await optimizeImageForUpload(bytes, sourceName, optimizeOpts);
+  const frameOpts = frameOptionsFromFlags(parsed.flags);
+  const prepared = await prepareImageForUpload(bytes, sourceName, {
+    ...frameOpts,
+    optimize: optimizeOpts,
+  });
   const filename = prepared.filename;
   const contentTypeOverride = flagString(parsed.flags, "--content-type");
   const alt = flagString(parsed.flags, "--alt") ?? basename(sourceName);
@@ -360,6 +461,7 @@ export async function runPut(
 
   if (!ctx.quiet && format === "human") {
     process.stderr.write(`>> uploading ${fileArg === "-" ? "stdin" : fileArg}\n`);
+    if (prepared.frame?.framed) process.stderr.write(`>> framed with ${prepared.frame.frameId}\n`);
     const note = formatOptimizeNote(prepared);
     if (note) process.stderr.write(`>> ${note}\n`);
   }
@@ -392,7 +494,7 @@ export async function runPut(
 
   switch (format) {
     case "json":
-      await writeJson({ ...result, markdown, optimize: optimizeMeta });
+      await writeJson({ ...result, markdown, optimize: optimizeMeta, frame: prepared.frame });
       break;
     case "url":
       await writeStdout(`${result.url}\n`);

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -39,7 +39,7 @@ import {
   type OptimizeImageOptions,
   type OptimizeImageResult,
 } from "./optimize.js";
-import { applyFrame, listFramePresets, resolveFrameId, type FrameResult } from "./frame.js";
+import { applyFrame, resolveFrameId, type FrameResult } from "./frame.js";
 import type { PutDefaults } from "./config-file.js";
 
 export interface CliContext {
@@ -73,9 +73,9 @@ Options:
   --alt <text>          Alt text (default: filename)
   --width <px>          <img width=…> markdown (or UPLOADS_DEFAULT_WIDTH)
   --content-type <mime> Override Content-Type (ignored when optimize rewrites the body)
-  --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro|…)
-  --frame-url <url>     Address shown in procedural browser chrome (with --frame browser)
-  --frame-fit cover|contain  How the screenshot fills the screen (default: cover)
+  --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro)
+  --frame-url <url>     Address bar text for --frame browser
+  --frame-fit cover|contain  How the shot fills the screen (default: cover)
   --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
   --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
   --optimize-quality <1-100>  WebP quality (default: 85)
@@ -91,19 +91,7 @@ Examples:
   uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
   uploads put ./mobile.png --frame phone
   uploads put ./ui.png --frame browser --frame-url "https://app.example/settings"
-  uploads put ./mobile.png --frame iphone-16-pro
   uploads put ./shot.png --destination screenshots
-  uploads put ./shot.png --no-optimize
-`;
-
-const FRAMES_HELP = `Built-in --frame ids:
-
-${listFramePresets()
-  .map((p) => `  ${p.id.padEnd(18)} ${p.label} (${p.kind})`)
-  .join("\n")}
-
-Procedural frames need no download. Device frames are fetched once from
-device-frames-media and cached under ~/.cache/uploads/frames (not bundled).
 `;
 
 /**
@@ -229,10 +217,7 @@ function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
   }
   if (frameFit && !frameId) throw new UsageError("--frame-fit requires --frame");
   const frameUrl = flagString(flags, "--frame-url");
-  if (frameUrl && frameId !== "browser") {
-    // Allow anyway for future chrome frames; warn via usage only if no frame.
-    if (!frameId) throw new UsageError("--frame-url requires --frame browser");
-  }
+  if (frameUrl && !frameId) throw new UsageError("--frame-url requires --frame");
   return { frameId, frameUrl, frameFit };
 }
 
@@ -273,9 +258,9 @@ Options:
   --repo <owner/repo>   Repository (default: gh/git inference)
   --no-comment          Upload only; don't create/update the managed comment
   --content-type <mime> Override Content-Type (applied to every file; ignored when optimize rewrites)
-  --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro|…)
-  --frame-url <url>     Address shown in procedural browser chrome
-  --frame-fit cover|contain  Screenshot fit inside the frame (default: cover)
+  --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro)
+  --frame-url <url>     Address bar text for --frame browser
+  --frame-fit cover|contain  How the shot fills the screen (default: cover)
   --no-optimize         Skip client-side image optimization (or UPLOADS_NO_OPTIMIZE=1)
   --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
   --optimize-quality <1-100>  WebP quality (default: 85)
@@ -382,13 +367,11 @@ export async function runPut(
 ): Promise<number> {
   if (help) {
     process.stderr.write(PUT_HELP);
-    process.stderr.write(`\n${FRAMES_HELP}`);
     return 0;
   }
   const parsed = parseCommandArgs(args);
   if (parsed.help) {
     process.stderr.write(PUT_HELP);
-    process.stderr.write(`\n${FRAMES_HELP}`);
     return 0;
   }
 

--- a/packages/uploads/src/frame.ts
+++ b/packages/uploads/src/frame.ts
@@ -1,11 +1,11 @@
 /**
- * Optional device/browser frames for put/attach.
+ * Optional device/browser frames for put/attach (default off).
  *
- * Default off. Procedural `phone` / `browser` ship with no third-party assets.
- * Named device presets fetch frame+mask from the open
- * [device-frames-media](https://github.com/jonnyjackson26/device-frames-media)
- * set (cached under the user cache dir) — not redistributed in the npm tarball
- * until license redistributability is clearer.
+ * - `phone` / `browser` — procedural (no third-party assets)
+ * - `iphone-16-pro` — fetches frame+mask from device-frames-media once,
+ *   cached under ~/.cache/uploads/frames (not bundled in the npm package)
+ *
+ * @see https://github.com/jonnyjackson26/device-frames-media
  */
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -16,14 +16,11 @@ import sharp from "sharp";
 export type FrameFit = "cover" | "contain";
 
 export interface FrameOptions {
-  /** Preset id: phone | browser | iphone-16-pro | … */
   id: string;
   fit?: FrameFit;
-  /** Optional URL shown in the procedural browser chrome. */
+  /** Address bar text for procedural `browser`. */
   browserUrl?: string;
-  /** Injected for tests (skip network). */
   fetchImpl?: typeof fetch;
-  /** Override cache root (tests). */
   cacheDir?: string;
 }
 
@@ -36,68 +33,30 @@ export interface FrameResult {
   skippedReason?: string;
 }
 
-interface ScreenRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
+type ScreenRect = { x: number; y: number; width: number; height: number };
+type Size = { width: number; height: number };
 
-interface RemoteDevicePreset {
-  kind: "remote";
-  label: string;
-  /** Directory URL (no trailing slash) hosting frame.png + mask.png */
-  assetBase: string;
-  screen: ScreenRect;
-  frameSize: { width: number; height: number };
-  attribution: string;
-}
+type FramePreset =
+  | { kind: "procedural"; label: string }
+  | {
+      kind: "remote";
+      label: string;
+      /** Directory URL with frame.png, mask.png, template.json */
+      assetBase: string;
+    };
 
-interface ProceduralPreset {
-  kind: "procedural";
-  label: string;
-}
+const DEVICE_FRAMES_BASE =
+  "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output";
 
-type FramePreset = ProceduralPreset | RemoteDevicePreset;
-
-/**
- * Built-in frame catalog. Remote presets use community PNGs at fetch time.
- * @see https://github.com/jonnyjackson26/device-frames-media
- */
 export const FRAME_PRESETS: Record<string, FramePreset> = {
-  phone: { kind: "procedural", label: "Generic phone bezel (procedural)" },
-  browser: { kind: "procedural", label: "Generic browser chrome (procedural)" },
+  phone: { kind: "procedural", label: "Generic phone bezel" },
+  browser: { kind: "procedural", label: "Generic browser chrome" },
   "iphone-16-pro": {
     kind: "remote",
-    label: "iPhone 16 Pro (Black Titanium)",
-    assetBase:
-      "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output/Apple%20iPhone/16%20Pro/Black%20Titanium",
-    screen: { x: 102, y: 100, width: 1206, height: 2622 },
-    frameSize: { width: 1406, height: 2822 },
-    attribution: "Frame art from jonnyjackson26/device-frames-media (fetched at use; not bundled).",
-  },
-  "iphone-15-pro-max": {
-    kind: "remote",
-    label: "iPhone 15 Pro Max (Black Titanium)",
-    assetBase:
-      "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output/Apple%20iPhone/15%20Pro%20Max/Black%20Titanium",
-    screen: { x: 100, y: 100, width: 1290, height: 2796 },
-    frameSize: { width: 1490, height: 2996 },
-    attribution: "Frame art from jonnyjackson26/device-frames-media (fetched at use; not bundled).",
-  },
-  "pixel-9-pro": {
-    kind: "remote",
-    label: "Pixel 9 Pro (Obsidian)",
-    assetBase:
-      "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output/Android%20Phone/Pixel%209%20Pro/Obsidian",
-    screen: { x: 170, y: 142, width: 1280, height: 2856 },
-    frameSize: { width: 1620, height: 3136 },
-    attribution: "Frame art from jonnyjackson26/device-frames-media (fetched at use; not bundled).",
+    label: "iPhone 16 Pro (community frame art)",
+    assetBase: `${DEVICE_FRAMES_BASE}/Apple%20iPhone/16%20Pro/Black%20Titanium`,
   },
 };
-
-// Catalog screen/frameSize are fallbacks; resolveRemoteScreen() prefers
-// template.json from the asset base when download succeeds.
 
 export function listFramePresets(): Array<{ id: string; label: string; kind: string }> {
   return Object.entries(FRAME_PRESETS).map(([id, p]) => ({
@@ -108,67 +67,49 @@ export function listFramePresets(): Array<{ id: string; label: string; kind: str
 }
 
 export function resolveFrameId(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
+  if (!raw?.trim()) return undefined;
   const id = raw.trim().toLowerCase();
-  if (!id) return undefined;
   if (!(id in FRAME_PRESETS)) {
-    const known = Object.keys(FRAME_PRESETS).join(", ");
-    throw new Error(`unknown frame "${raw}" (known: ${known})`);
+    throw new Error(`unknown frame "${raw}" (known: ${Object.keys(FRAME_PRESETS).join(", ")})`);
   }
   return id;
 }
 
-function defaultCacheDir(): string {
-  const xdg = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache");
-  return join(xdg, "uploads", "frames");
+function cacheDirDefault(): string {
+  return join(process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache"), "uploads", "frames");
 }
 
-async function loadRemoteAsset(
+async function cachedFetch(
   url: string,
   cacheDir: string,
   fetchImpl: typeof fetch,
 ): Promise<Buffer> {
-  const hash = createHash("sha256").update(url).digest("hex").slice(0, 16);
-  const ext = url.includes("mask") ? "mask.png" : url.endsWith(".json") ? "json" : "frame.png";
-  const path = join(cacheDir, `${hash}-${ext}`);
+  const name = `${createHash("sha256").update(url).digest("hex").slice(0, 16)}-${url.split("/").pop() ?? "bin"}`;
+  const path = join(cacheDir, name);
   if (existsSync(path)) return readFileSync(path);
-
   mkdirSync(cacheDir, { recursive: true });
   const res = await fetchImpl(url);
-  if (!res.ok) {
-    throw new Error(`failed to download frame asset (${res.status}): ${url}`);
-  }
+  if (!res.ok) throw new Error(`frame download failed (${res.status}): ${url}`);
   const buf = Buffer.from(await res.arrayBuffer());
   writeFileSync(path, buf);
   return buf;
 }
 
-async function resolveRemoteScreen(
-  preset: RemoteDevicePreset,
-  cacheDir: string,
-  fetchImpl: typeof fetch,
-): Promise<{ screen: ScreenRect; frameSize: { width: number; height: number } }> {
-  try {
-    const tplBuf = await loadRemoteAsset(`${preset.assetBase}/template.json`, cacheDir, fetchImpl);
-    const tpl = JSON.parse(tplBuf.toString("utf8")) as {
-      screen?: ScreenRect;
-      frameSize?: { width: number; height: number };
-    };
-    if (tpl.screen && tpl.frameSize) {
-      return { screen: tpl.screen, frameSize: tpl.frameSize };
-    }
-  } catch {
-    /* fall back to catalog geometry */
-  }
-  return { screen: preset.screen, frameSize: preset.frameSize };
+function scaleRect(r: ScreenRect, s: number): ScreenRect {
+  return {
+    x: Math.round(r.x * s),
+    y: Math.round(r.y * s),
+    width: Math.round(r.width * s),
+    height: Math.round(r.height * s),
+  };
 }
 
-async function compositeWithDeviceFrame(
+async function compositeDevice(
   screenshot: Uint8Array,
   framePng: Buffer,
-  maskPng: Buffer | null,
+  maskPng: Buffer | undefined,
   screen: ScreenRect,
-  frameSize: { width: number; height: number },
+  frameSize: Size,
   fit: FrameFit,
 ): Promise<Buffer> {
   const fitted = await sharp(screenshot)
@@ -182,8 +123,7 @@ async function compositeWithDeviceFrame(
     .png()
     .toBuffer();
 
-  // Full-canvas screenshot layer (transparent outside the screen rect).
-  let screenLayer = await sharp({
+  let layer = await sharp({
     create: {
       width: frameSize.width,
       height: frameSize.height,
@@ -196,25 +136,14 @@ async function compositeWithDeviceFrame(
     .toBuffer();
 
   if (maskPng) {
-    // mask: white = screen. dest-in keeps screenshot only where mask is opaque.
-    screenLayer = await sharp(screenLayer)
+    layer = await sharp(layer)
       .composite([{ input: maskPng, blend: "dest-in" }])
       .png()
       .toBuffer();
   }
 
-  return sharp({
-    create: {
-      width: frameSize.width,
-      height: frameSize.height,
-      channels: 4,
-      background: { r: 0, g: 0, b: 0, alpha: 0 },
-    },
-  })
-    .composite([
-      { input: screenLayer, left: 0, top: 0 },
-      { input: framePng, left: 0, top: 0 },
-    ])
+  return sharp(layer)
+    .composite([{ input: framePng, left: 0, top: 0 }])
     .png()
     .toBuffer();
 }
@@ -223,11 +152,10 @@ async function proceduralPhone(screenshot: Uint8Array, fit: FrameFit): Promise<B
   const screenW = 390;
   const screenH = 844;
   const bezel = 14;
-  const topChrome = 36;
-  const bottomChrome = 18;
+  const top = 36;
+  const bottom = 18;
   const outerW = screenW + bezel * 2;
-  const outerH = screenH + topChrome + bottomChrome;
-  const radius = 48;
+  const outerH = screenH + top + bottom;
 
   const fitted = await sharp(screenshot)
     .rotate()
@@ -239,29 +167,34 @@ async function proceduralPhone(screenshot: Uint8Array, fit: FrameFit): Promise<B
     .png()
     .toBuffer();
 
-  // Rounded-rect mask for the screen
-  const maskSvg = Buffer.from(
-    `<svg width="${screenW}" height="${screenH}" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width="${screenW}" height="${screenH}" rx="36" ry="36" fill="white"/>
-    </svg>`,
-  );
-  const roundedScreen = await sharp(fitted)
-    .ensureAlpha()
-    .composite([{ input: await sharp(maskSvg).png().toBuffer(), blend: "dest-in" }])
+  const roundMask = await sharp(
+    Buffer.from(
+      `<svg width="${screenW}" height="${screenH}" xmlns="http://www.w3.org/2000/svg"><rect width="${screenW}" height="${screenH}" rx="36" fill="white"/></svg>`,
+    ),
+  )
     .png()
     .toBuffer();
 
-  const shellSvg = Buffer.from(
-    `<svg width="${outerW}" height="${outerH}" xmlns="http://www.w3.org/2000/svg">
-      <rect x="1" y="1" width="${outerW - 2}" height="${outerH - 2}" rx="${radius}" ry="${radius}"
-            fill="#1c1c1e" stroke="#3a3a3c" stroke-width="2"/>
-      <rect x="${bezel + 70}" y="12" width="${screenW - 140}" height="22" rx="11" ry="11" fill="#0a0a0a"/>
-      <circle cx="${outerW / 2}" cy="${outerH - 10}" r="4" fill="#3a3a3c"/>
-    </svg>`,
-  );
+  const screen = await sharp(fitted)
+    .ensureAlpha()
+    .composite([{ input: roundMask, blend: "dest-in" }])
+    .png()
+    .toBuffer();
 
-  return sharp(await sharp(shellSvg).png().toBuffer())
-    .composite([{ input: roundedScreen, left: bezel, top: topChrome }])
+  const shell = await sharp(
+    Buffer.from(
+      `<svg width="${outerW}" height="${outerH}" xmlns="http://www.w3.org/2000/svg">
+        <rect x="1" y="1" width="${outerW - 2}" height="${outerH - 2}" rx="48" fill="#1c1c1e" stroke="#3a3a3c" stroke-width="2"/>
+        <rect x="${bezel + 70}" y="12" width="${screenW - 140}" height="22" rx="11" fill="#0a0a0a"/>
+        <circle cx="${outerW / 2}" cy="${outerH - 10}" r="4" fill="#3a3a3c"/>
+      </svg>`,
+    ),
+  )
+    .png()
+    .toBuffer();
+
+  return sharp(shell)
+    .composite([{ input: screen, left: bezel, top }])
     .png()
     .toBuffer();
 }
@@ -273,13 +206,10 @@ async function proceduralBrowser(
 ): Promise<Buffer> {
   const chromeH = 72;
   const pad = 12;
-  const maxContentW = 1200;
-  const maxContentH = 800;
-
   const meta = await sharp(screenshot).rotate().metadata();
   const srcW = meta.width ?? 800;
   const srcH = meta.height ?? 600;
-  const scale = Math.min(1, maxContentW / srcW, maxContentH / srcH);
+  const scale = Math.min(1, 1200 / srcW, 800 / srcH);
   const contentW = Math.max(320, Math.round(srcW * scale));
   const contentH = Math.max(200, Math.round(srcH * scale));
   const outerW = contentW + pad * 2;
@@ -295,53 +225,52 @@ async function proceduralBrowser(
     .png()
     .toBuffer();
 
-  const safeUrl = escapeXml(url.slice(0, 80));
-  const chromeSvg = Buffer.from(
-    `<svg width="${outerW}" height="${outerH}" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stop-color="#f6f6f7"/>
-          <stop offset="100%" stop-color="#e8e8ea"/>
-        </linearGradient>
-      </defs>
-      <rect x="0.5" y="0.5" width="${outerW - 1}" height="${outerH - 1}" rx="12" ry="12"
-            fill="url(#g)" stroke="#c7c7cc" stroke-width="1"/>
-      <circle cx="22" cy="22" r="6" fill="#ff5f57"/>
-      <circle cx="42" cy="22" r="6" fill="#febc2e"/>
-      <circle cx="62" cy="22" r="6" fill="#28c840"/>
-      <rect x="84" y="12" width="${Math.max(120, outerW - 100)}" height="28" rx="8" ry="8"
-            fill="#ffffff" stroke="#d1d1d6" stroke-width="1"/>
-      <text x="96" y="31" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12"
-            fill="#6e6e73">${safeUrl}</text>
-      <rect x="${pad}" y="${chromeH}" width="${contentW}" height="${contentH}" fill="#ffffff"/>
-    </svg>`,
-  );
+  const safe = url
+    .slice(0, 80)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 
-  return sharp(await sharp(chromeSvg).png().toBuffer())
+  const chrome = await sharp(
+    Buffer.from(
+      `<svg width="${outerW}" height="${outerH}" xmlns="http://www.w3.org/2000/svg">
+        <rect x="0.5" y="0.5" width="${outerW - 1}" height="${outerH - 1}" rx="12" fill="#f0f0f2" stroke="#c7c7cc"/>
+        <circle cx="22" cy="22" r="6" fill="#ff5f57"/>
+        <circle cx="42" cy="22" r="6" fill="#febc2e"/>
+        <circle cx="62" cy="22" r="6" fill="#28c840"/>
+        <rect x="84" y="12" width="${Math.max(120, outerW - 100)}" height="28" rx="8" fill="#fff" stroke="#d1d1d6"/>
+        <text x="96" y="31" font-family="system-ui,sans-serif" font-size="12" fill="#6e6e73">${safe}</text>
+        <rect x="${pad}" y="${chromeH}" width="${contentW}" height="${contentH}" fill="#fff"/>
+      </svg>`,
+    ),
+  )
+    .png()
+    .toBuffer();
+
+  return sharp(chrome)
     .composite([{ input: fitted, left: pad, top: chromeH }])
     .png()
     .toBuffer();
 }
 
-function escapeXml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function withPngExtension(filename: string): string {
+function asPngName(filename: string): string {
   const base = filename.includes("/") ? filename.slice(filename.lastIndexOf("/") + 1) : filename;
   const dot = base.lastIndexOf(".");
-  const stem = dot >= 0 ? base.slice(0, dot) : base;
-  return `${stem}.png`;
+  return `${dot >= 0 ? base.slice(0, dot) : base}.png`;
 }
 
-/**
- * Apply a named frame. Non-images pass through unchanged.
- * Output is PNG; callers typically run optimizeImageForUpload next.
- */
+function skip(
+  bytes: Uint8Array,
+  filename: string,
+  frameId: string,
+  reason: string,
+  contentType = "application/octet-stream",
+): FrameResult {
+  return { bytes, filename, contentType, framed: false, frameId, skippedReason: reason };
+}
+
+/** Apply a named frame. Non-images pass through. Output PNG for the optimize step. */
 export async function applyFrame(
   bytes: Uint8Array,
   filename: string,
@@ -349,99 +278,71 @@ export async function applyFrame(
 ): Promise<FrameResult> {
   const id = opts.id.toLowerCase();
   const preset = FRAME_PRESETS[id];
-  if (!preset) {
-    throw new Error(`unknown frame "${opts.id}"`);
-  }
+  if (!preset) throw new Error(`unknown frame "${opts.id}"`);
 
-  // Quick reject for obvious non-images (optimize will also skip).
   try {
     const meta = await sharp(bytes, { failOn: "none" }).metadata();
-    if (!meta.format || meta.format === "svg") {
-      return {
-        bytes,
-        filename,
-        contentType: "application/octet-stream",
-        framed: false,
-        frameId: id,
-        skippedReason: "not_image",
-      };
-    }
+    if (!meta.format || meta.format === "svg") return skip(bytes, filename, id, "not_image");
     if ((meta.pages ?? 1) > 1) {
-      return {
+      return skip(
         bytes,
         filename,
-        contentType: meta.format === "gif" ? "image/gif" : "image/webp",
-        framed: false,
-        frameId: id,
-        skippedReason: "animated",
-      };
+        id,
+        "animated",
+        meta.format === "gif" ? "image/gif" : "image/webp",
+      );
     }
   } catch {
-    return {
-      bytes,
-      filename,
-      contentType: "application/octet-stream",
-      framed: false,
-      frameId: id,
-      skippedReason: "not_image",
-    };
+    return skip(bytes, filename, id, "not_image");
   }
 
   const fit: FrameFit = opts.fit ?? "cover";
   let out: Buffer;
 
   if (preset.kind === "procedural") {
-    if (id === "browser") {
-      out = await proceduralBrowser(bytes, fit, opts.browserUrl ?? "https://app.example");
-    } else {
-      out = await proceduralPhone(bytes, fit);
-    }
+    out =
+      id === "browser"
+        ? await proceduralBrowser(bytes, fit, opts.browserUrl ?? "https://app.example")
+        : await proceduralPhone(bytes, fit);
   } else {
     const fetchImpl = opts.fetchImpl ?? fetch;
-    const cacheDir = opts.cacheDir ?? defaultCacheDir();
-    const { screen, frameSize } = await resolveRemoteScreen(preset, cacheDir, fetchImpl);
-    const framePng = await loadRemoteAsset(`${preset.assetBase}/frame.png`, cacheDir, fetchImpl);
-    let maskPng: Buffer | null = null;
+    const cacheDir = opts.cacheDir ?? cacheDirDefault();
+    const tpl = JSON.parse(
+      (await cachedFetch(`${preset.assetBase}/template.json`, cacheDir, fetchImpl)).toString(
+        "utf8",
+      ),
+    ) as { screen: ScreenRect; frameSize: Size };
+    const framePng = await cachedFetch(`${preset.assetBase}/frame.png`, cacheDir, fetchImpl);
+    let maskPng: Buffer | undefined;
     try {
-      maskPng = await loadRemoteAsset(`${preset.assetBase}/mask.png`, cacheDir, fetchImpl);
+      maskPng = await cachedFetch(`${preset.assetBase}/mask.png`, cacheDir, fetchImpl);
     } catch {
-      maskPng = null;
+      /* optional */
     }
-    // Downscale huge device frames so WebP optimize stays snappy.
+
+    // Keep remote frames manageable before WebP optimize.
     const maxEdge = 1600;
-    const scale = Math.min(1, maxEdge / Math.max(frameSize.width, frameSize.height));
-    const scaledScreen: ScreenRect = {
-      x: Math.round(screen.x * scale),
-      y: Math.round(screen.y * scale),
-      width: Math.round(screen.width * scale),
-      height: Math.round(screen.height * scale),
+    const s = Math.min(1, maxEdge / Math.max(tpl.frameSize.width, tpl.frameSize.height));
+    const frameSize = {
+      width: Math.round(tpl.frameSize.width * s),
+      height: Math.round(tpl.frameSize.height * s),
     };
-    const scaledSize = {
-      width: Math.round(frameSize.width * scale),
-      height: Math.round(frameSize.height * scale),
-    };
-    const scaledFrame =
-      scale < 1
-        ? await sharp(framePng).resize(scaledSize.width, scaledSize.height).png().toBuffer()
+    const screen = scaleRect(tpl.screen, s);
+    const frame =
+      s < 1
+        ? await sharp(framePng).resize(frameSize.width, frameSize.height).png().toBuffer()
         : framePng;
-    const scaledMask =
-      maskPng && scale < 1
-        ? await sharp(maskPng).resize(scaledSize.width, scaledSize.height).png().toBuffer()
+    const mask =
+      maskPng && s < 1
+        ? await sharp(maskPng).resize(frameSize.width, frameSize.height).png().toBuffer()
         : maskPng;
 
-    out = await compositeWithDeviceFrame(
-      bytes,
-      scaledFrame,
-      scaledMask,
-      scaledScreen,
-      scaledSize,
-      fit,
-    );
+    out = await compositeDevice(bytes, frame, mask, screen, frameSize, fit);
   }
 
   return {
     bytes: new Uint8Array(out),
-    filename: withPngExtension(filename),
+    filename: asPngName(filename),
     contentType: "image/png",
     framed: true,
     frameId: id,

--- a/packages/uploads/src/frame.ts
+++ b/packages/uploads/src/frame.ts
@@ -320,8 +320,8 @@ export async function applyFrame(
       /* optional */
     }
 
-    // Keep remote frames manageable before WebP optimize.
-    const maxEdge = 1600;
+    // Keep remote frames light for PR embeds (display width is capped separately).
+    const maxEdge = 1000;
     const s = Math.min(1, maxEdge / Math.max(tpl.frameSize.width, tpl.frameSize.height));
     const frameSize = {
       width: Math.round(tpl.frameSize.width * s),

--- a/packages/uploads/src/frame.ts
+++ b/packages/uploads/src/frame.ts
@@ -1,0 +1,449 @@
+/**
+ * Optional device/browser frames for put/attach.
+ *
+ * Default off. Procedural `phone` / `browser` ship with no third-party assets.
+ * Named device presets fetch frame+mask from the open
+ * [device-frames-media](https://github.com/jonnyjackson26/device-frames-media)
+ * set (cached under the user cache dir) — not redistributed in the npm tarball
+ * until license redistributability is clearer.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+
+export type FrameFit = "cover" | "contain";
+
+export interface FrameOptions {
+  /** Preset id: phone | browser | iphone-16-pro | … */
+  id: string;
+  fit?: FrameFit;
+  /** Optional URL shown in the procedural browser chrome. */
+  browserUrl?: string;
+  /** Injected for tests (skip network). */
+  fetchImpl?: typeof fetch;
+  /** Override cache root (tests). */
+  cacheDir?: string;
+}
+
+export interface FrameResult {
+  bytes: Uint8Array;
+  filename: string;
+  contentType: string;
+  framed: boolean;
+  frameId: string;
+  skippedReason?: string;
+}
+
+interface ScreenRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface RemoteDevicePreset {
+  kind: "remote";
+  label: string;
+  /** Directory URL (no trailing slash) hosting frame.png + mask.png */
+  assetBase: string;
+  screen: ScreenRect;
+  frameSize: { width: number; height: number };
+  attribution: string;
+}
+
+interface ProceduralPreset {
+  kind: "procedural";
+  label: string;
+}
+
+type FramePreset = ProceduralPreset | RemoteDevicePreset;
+
+/**
+ * Built-in frame catalog. Remote presets use community PNGs at fetch time.
+ * @see https://github.com/jonnyjackson26/device-frames-media
+ */
+export const FRAME_PRESETS: Record<string, FramePreset> = {
+  phone: { kind: "procedural", label: "Generic phone bezel (procedural)" },
+  browser: { kind: "procedural", label: "Generic browser chrome (procedural)" },
+  "iphone-16-pro": {
+    kind: "remote",
+    label: "iPhone 16 Pro (Black Titanium)",
+    assetBase:
+      "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output/Apple%20iPhone/16%20Pro/Black%20Titanium",
+    screen: { x: 102, y: 100, width: 1206, height: 2622 },
+    frameSize: { width: 1406, height: 2822 },
+    attribution: "Frame art from jonnyjackson26/device-frames-media (fetched at use; not bundled).",
+  },
+  "iphone-15-pro-max": {
+    kind: "remote",
+    label: "iPhone 15 Pro Max (Black Titanium)",
+    assetBase:
+      "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output/Apple%20iPhone/15%20Pro%20Max/Black%20Titanium",
+    screen: { x: 100, y: 100, width: 1290, height: 2796 },
+    frameSize: { width: 1490, height: 2996 },
+    attribution: "Frame art from jonnyjackson26/device-frames-media (fetched at use; not bundled).",
+  },
+  "pixel-9-pro": {
+    kind: "remote",
+    label: "Pixel 9 Pro (Obsidian)",
+    assetBase:
+      "https://raw.githubusercontent.com/jonnyjackson26/device-frames-media/main/device-frames-output/Android%20Phone/Pixel%209%20Pro/Obsidian",
+    screen: { x: 170, y: 142, width: 1280, height: 2856 },
+    frameSize: { width: 1620, height: 3136 },
+    attribution: "Frame art from jonnyjackson26/device-frames-media (fetched at use; not bundled).",
+  },
+};
+
+// Catalog screen/frameSize are fallbacks; resolveRemoteScreen() prefers
+// template.json from the asset base when download succeeds.
+
+export function listFramePresets(): Array<{ id: string; label: string; kind: string }> {
+  return Object.entries(FRAME_PRESETS).map(([id, p]) => ({
+    id,
+    label: p.label,
+    kind: p.kind,
+  }));
+}
+
+export function resolveFrameId(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const id = raw.trim().toLowerCase();
+  if (!id) return undefined;
+  if (!(id in FRAME_PRESETS)) {
+    const known = Object.keys(FRAME_PRESETS).join(", ");
+    throw new Error(`unknown frame "${raw}" (known: ${known})`);
+  }
+  return id;
+}
+
+function defaultCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache");
+  return join(xdg, "uploads", "frames");
+}
+
+async function loadRemoteAsset(
+  url: string,
+  cacheDir: string,
+  fetchImpl: typeof fetch,
+): Promise<Buffer> {
+  const hash = createHash("sha256").update(url).digest("hex").slice(0, 16);
+  const ext = url.includes("mask") ? "mask.png" : url.endsWith(".json") ? "json" : "frame.png";
+  const path = join(cacheDir, `${hash}-${ext}`);
+  if (existsSync(path)) return readFileSync(path);
+
+  mkdirSync(cacheDir, { recursive: true });
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`failed to download frame asset (${res.status}): ${url}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  writeFileSync(path, buf);
+  return buf;
+}
+
+async function resolveRemoteScreen(
+  preset: RemoteDevicePreset,
+  cacheDir: string,
+  fetchImpl: typeof fetch,
+): Promise<{ screen: ScreenRect; frameSize: { width: number; height: number } }> {
+  try {
+    const tplBuf = await loadRemoteAsset(`${preset.assetBase}/template.json`, cacheDir, fetchImpl);
+    const tpl = JSON.parse(tplBuf.toString("utf8")) as {
+      screen?: ScreenRect;
+      frameSize?: { width: number; height: number };
+    };
+    if (tpl.screen && tpl.frameSize) {
+      return { screen: tpl.screen, frameSize: tpl.frameSize };
+    }
+  } catch {
+    /* fall back to catalog geometry */
+  }
+  return { screen: preset.screen, frameSize: preset.frameSize };
+}
+
+async function compositeWithDeviceFrame(
+  screenshot: Uint8Array,
+  framePng: Buffer,
+  maskPng: Buffer | null,
+  screen: ScreenRect,
+  frameSize: { width: number; height: number },
+  fit: FrameFit,
+): Promise<Buffer> {
+  const fitted = await sharp(screenshot)
+    .rotate()
+    .resize(screen.width, screen.height, {
+      fit,
+      position: "centre",
+      background: { r: 0, g: 0, b: 0, alpha: 1 },
+    })
+    .ensureAlpha()
+    .png()
+    .toBuffer();
+
+  // Full-canvas screenshot layer (transparent outside the screen rect).
+  let screenLayer = await sharp({
+    create: {
+      width: frameSize.width,
+      height: frameSize.height,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite([{ input: fitted, left: screen.x, top: screen.y }])
+    .png()
+    .toBuffer();
+
+  if (maskPng) {
+    // mask: white = screen. dest-in keeps screenshot only where mask is opaque.
+    screenLayer = await sharp(screenLayer)
+      .composite([{ input: maskPng, blend: "dest-in" }])
+      .png()
+      .toBuffer();
+  }
+
+  return sharp({
+    create: {
+      width: frameSize.width,
+      height: frameSize.height,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite([
+      { input: screenLayer, left: 0, top: 0 },
+      { input: framePng, left: 0, top: 0 },
+    ])
+    .png()
+    .toBuffer();
+}
+
+async function proceduralPhone(screenshot: Uint8Array, fit: FrameFit): Promise<Buffer> {
+  const screenW = 390;
+  const screenH = 844;
+  const bezel = 14;
+  const topChrome = 36;
+  const bottomChrome = 18;
+  const outerW = screenW + bezel * 2;
+  const outerH = screenH + topChrome + bottomChrome;
+  const radius = 48;
+
+  const fitted = await sharp(screenshot)
+    .rotate()
+    .resize(screenW, screenH, {
+      fit,
+      position: "centre",
+      background: { r: 0, g: 0, b: 0, alpha: 1 },
+    })
+    .png()
+    .toBuffer();
+
+  // Rounded-rect mask for the screen
+  const maskSvg = Buffer.from(
+    `<svg width="${screenW}" height="${screenH}" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" width="${screenW}" height="${screenH}" rx="36" ry="36" fill="white"/>
+    </svg>`,
+  );
+  const roundedScreen = await sharp(fitted)
+    .ensureAlpha()
+    .composite([{ input: await sharp(maskSvg).png().toBuffer(), blend: "dest-in" }])
+    .png()
+    .toBuffer();
+
+  const shellSvg = Buffer.from(
+    `<svg width="${outerW}" height="${outerH}" xmlns="http://www.w3.org/2000/svg">
+      <rect x="1" y="1" width="${outerW - 2}" height="${outerH - 2}" rx="${radius}" ry="${radius}"
+            fill="#1c1c1e" stroke="#3a3a3c" stroke-width="2"/>
+      <rect x="${bezel + 70}" y="12" width="${screenW - 140}" height="22" rx="11" ry="11" fill="#0a0a0a"/>
+      <circle cx="${outerW / 2}" cy="${outerH - 10}" r="4" fill="#3a3a3c"/>
+    </svg>`,
+  );
+
+  return sharp(await sharp(shellSvg).png().toBuffer())
+    .composite([{ input: roundedScreen, left: bezel, top: topChrome }])
+    .png()
+    .toBuffer();
+}
+
+async function proceduralBrowser(
+  screenshot: Uint8Array,
+  fit: FrameFit,
+  url: string,
+): Promise<Buffer> {
+  const chromeH = 72;
+  const pad = 12;
+  const maxContentW = 1200;
+  const maxContentH = 800;
+
+  const meta = await sharp(screenshot).rotate().metadata();
+  const srcW = meta.width ?? 800;
+  const srcH = meta.height ?? 600;
+  const scale = Math.min(1, maxContentW / srcW, maxContentH / srcH);
+  const contentW = Math.max(320, Math.round(srcW * scale));
+  const contentH = Math.max(200, Math.round(srcH * scale));
+  const outerW = contentW + pad * 2;
+  const outerH = contentH + chromeH + pad;
+
+  const fitted = await sharp(screenshot)
+    .rotate()
+    .resize(contentW, contentH, {
+      fit,
+      position: "centre",
+      background: { r: 255, g: 255, b: 255, alpha: 1 },
+    })
+    .png()
+    .toBuffer();
+
+  const safeUrl = escapeXml(url.slice(0, 80));
+  const chromeSvg = Buffer.from(
+    `<svg width="${outerW}" height="${outerH}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#f6f6f7"/>
+          <stop offset="100%" stop-color="#e8e8ea"/>
+        </linearGradient>
+      </defs>
+      <rect x="0.5" y="0.5" width="${outerW - 1}" height="${outerH - 1}" rx="12" ry="12"
+            fill="url(#g)" stroke="#c7c7cc" stroke-width="1"/>
+      <circle cx="22" cy="22" r="6" fill="#ff5f57"/>
+      <circle cx="42" cy="22" r="6" fill="#febc2e"/>
+      <circle cx="62" cy="22" r="6" fill="#28c840"/>
+      <rect x="84" y="12" width="${Math.max(120, outerW - 100)}" height="28" rx="8" ry="8"
+            fill="#ffffff" stroke="#d1d1d6" stroke-width="1"/>
+      <text x="96" y="31" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12"
+            fill="#6e6e73">${safeUrl}</text>
+      <rect x="${pad}" y="${chromeH}" width="${contentW}" height="${contentH}" fill="#ffffff"/>
+    </svg>`,
+  );
+
+  return sharp(await sharp(chromeSvg).png().toBuffer())
+    .composite([{ input: fitted, left: pad, top: chromeH }])
+    .png()
+    .toBuffer();
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function withPngExtension(filename: string): string {
+  const base = filename.includes("/") ? filename.slice(filename.lastIndexOf("/") + 1) : filename;
+  const dot = base.lastIndexOf(".");
+  const stem = dot >= 0 ? base.slice(0, dot) : base;
+  return `${stem}.png`;
+}
+
+/**
+ * Apply a named frame. Non-images pass through unchanged.
+ * Output is PNG; callers typically run optimizeImageForUpload next.
+ */
+export async function applyFrame(
+  bytes: Uint8Array,
+  filename: string,
+  opts: FrameOptions,
+): Promise<FrameResult> {
+  const id = opts.id.toLowerCase();
+  const preset = FRAME_PRESETS[id];
+  if (!preset) {
+    throw new Error(`unknown frame "${opts.id}"`);
+  }
+
+  // Quick reject for obvious non-images (optimize will also skip).
+  try {
+    const meta = await sharp(bytes, { failOn: "none" }).metadata();
+    if (!meta.format || meta.format === "svg") {
+      return {
+        bytes,
+        filename,
+        contentType: "application/octet-stream",
+        framed: false,
+        frameId: id,
+        skippedReason: "not_image",
+      };
+    }
+    if ((meta.pages ?? 1) > 1) {
+      return {
+        bytes,
+        filename,
+        contentType: meta.format === "gif" ? "image/gif" : "image/webp",
+        framed: false,
+        frameId: id,
+        skippedReason: "animated",
+      };
+    }
+  } catch {
+    return {
+      bytes,
+      filename,
+      contentType: "application/octet-stream",
+      framed: false,
+      frameId: id,
+      skippedReason: "not_image",
+    };
+  }
+
+  const fit: FrameFit = opts.fit ?? "cover";
+  let out: Buffer;
+
+  if (preset.kind === "procedural") {
+    if (id === "browser") {
+      out = await proceduralBrowser(bytes, fit, opts.browserUrl ?? "https://app.example");
+    } else {
+      out = await proceduralPhone(bytes, fit);
+    }
+  } else {
+    const fetchImpl = opts.fetchImpl ?? fetch;
+    const cacheDir = opts.cacheDir ?? defaultCacheDir();
+    const { screen, frameSize } = await resolveRemoteScreen(preset, cacheDir, fetchImpl);
+    const framePng = await loadRemoteAsset(`${preset.assetBase}/frame.png`, cacheDir, fetchImpl);
+    let maskPng: Buffer | null = null;
+    try {
+      maskPng = await loadRemoteAsset(`${preset.assetBase}/mask.png`, cacheDir, fetchImpl);
+    } catch {
+      maskPng = null;
+    }
+    // Downscale huge device frames so WebP optimize stays snappy.
+    const maxEdge = 1600;
+    const scale = Math.min(1, maxEdge / Math.max(frameSize.width, frameSize.height));
+    const scaledScreen: ScreenRect = {
+      x: Math.round(screen.x * scale),
+      y: Math.round(screen.y * scale),
+      width: Math.round(screen.width * scale),
+      height: Math.round(screen.height * scale),
+    };
+    const scaledSize = {
+      width: Math.round(frameSize.width * scale),
+      height: Math.round(frameSize.height * scale),
+    };
+    const scaledFrame =
+      scale < 1
+        ? await sharp(framePng).resize(scaledSize.width, scaledSize.height).png().toBuffer()
+        : framePng;
+    const scaledMask =
+      maskPng && scale < 1
+        ? await sharp(maskPng).resize(scaledSize.width, scaledSize.height).png().toBuffer()
+        : maskPng;
+
+    out = await compositeWithDeviceFrame(
+      bytes,
+      scaledFrame,
+      scaledMask,
+      scaledScreen,
+      scaledSize,
+      fit,
+    );
+  }
+
+  return {
+    bytes: new Uint8Array(out),
+    filename: withPngExtension(filename),
+    contentType: "image/png",
+    framed: true,
+    frameId: id,
+  };
+}

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -45,13 +45,46 @@ export interface AttachmentItem {
   url: string | null;
 }
 
+/** Default max width for images in the managed attachments comment (HTML img). */
+export const ATTACHMENT_IMAGE_WIDTH_DEFAULT = 400;
+/** Portrait / device mockups — keep phones readable, not full-column. */
+export const ATTACHMENT_IMAGE_WIDTH_PORTRAIT = 280;
+/** Wide UI / browser chrome. */
+export const ATTACHMENT_IMAGE_WIDTH_WIDE = 640;
+
+/**
+ * Pick a display width for GitHub comment embeds. Filenames are a weak but
+ * practical signal (we don't re-fetch dimensions when rebuilding the comment).
+ */
+export function attachmentImageWidth(filename: string): number {
+  const n = filename.toLowerCase();
+  if (/(?:^|[-_.])(browser|desktop|dashboard|wide)(?:[-_.]|$)/.test(n)) {
+    return ATTACHMENT_IMAGE_WIDTH_WIDE;
+  }
+  if (
+    /(?:^|[-_.])(phone|iphone|ipad|pixel|android|mobile|device)(?:[-_.]|$)/.test(n) ||
+    /iphone|pixel-?\d/.test(n)
+  ) {
+    return ATTACHMENT_IMAGE_WIDTH_PORTRAIT;
+  }
+  return ATTACHMENT_IMAGE_WIDTH_DEFAULT;
+}
+
+function escapeHtmlAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
 export function attachmentsCommentBody(items: AttachmentItem[]): string {
   const sorted = items.toSorted((a, b) => a.key.localeCompare(b.key));
   const lines: string[] = [ATTACHMENTS_MARKER, "### 📎 Attachments", ""];
   for (const item of sorted) {
     const name = item.key.slice(item.key.lastIndexOf("/") + 1);
     if (item.url && inferContentType(name).startsWith("image/")) {
-      lines.push(`![${name}](${item.url})`);
+      // Markdown ![]() has no width control — phone frames become full-column giants.
+      const w = attachmentImageWidth(name);
+      const alt = escapeHtmlAttr(name);
+      lines.push(`<img width="${w}" alt="${alt}" src="${item.url}">`);
+      lines.push("");
     } else if (item.url) {
       lines.push(`- [${name}](${item.url})`);
     } else {
@@ -59,7 +92,6 @@ export function attachmentsCommentBody(items: AttachmentItem[]): string {
     }
   }
   lines.push(
-    "",
     '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',
   );
   return lines.join("\n");

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -81,9 +81,11 @@ export function attachmentsCommentBody(items: AttachmentItem[]): string {
     const name = item.key.slice(item.key.lastIndexOf("/") + 1);
     if (item.url && inferContentType(name).startsWith("image/")) {
       // Markdown ![]() has no width control — phone frames become full-column giants.
+      // Link to the asset so a click opens the full image (no "open in new tab" hunt).
       const w = attachmentImageWidth(name);
       const alt = escapeHtmlAttr(name);
-      lines.push(`<img width="${w}" alt="${alt}" src="${item.url}">`);
+      const href = escapeHtmlAttr(item.url);
+      lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${href}"></a>`);
       lines.push("");
     } else if (item.url) {
       lines.push(`- [${name}](${item.url})`);

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -60,7 +60,7 @@ export function attachmentsCommentBody(items: AttachmentItem[]): string {
   }
   lines.push(
     "",
-    "<sub>Maintained by uploads.sh — re-uploading a file with the same name updates it everywhere it is embedded.</sub>",
+    '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',
   );
   return lines.join("\n");
 }

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -75,6 +75,15 @@ export {
   type OptimizeOutputFormat,
 } from "./optimize.js";
 export {
+  FRAME_PRESETS,
+  applyFrame,
+  listFramePresets,
+  resolveFrameId,
+  type FrameFit,
+  type FrameOptions,
+  type FrameResult,
+} from "./frame.js";
+export {
   execRunner,
   resolveRepo,
   upsertAttachmentsComment,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -9,7 +9,13 @@ import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import type { GlobalFlags } from "../cli-args.js";
 import { createUploadsClient, type UploadsClient } from "../client.js";
-import { buildDoctorReport, makeGhTarget, syncAttachmentsComment } from "../commands.js";
+import {
+  buildDoctorReport,
+  makeGhTarget,
+  prepareImageForUpload,
+  syncAttachmentsComment,
+} from "../commands.js";
+import { resolveFrameId } from "../frame.js";
 import {
   resolveConfig,
   resolvePutDefaults,
@@ -19,11 +25,7 @@ import {
 import { buildMarkdown } from "../embed.js";
 import { resolvePutPrefix } from "../destinations.js";
 import { ghAttachmentKey, ghKeyPrefix, type GhTarget } from "../github.js";
-import {
-  optimizeImageForUpload,
-  rewriteKeyExtension,
-  type OptimizeImageOptions,
-} from "../optimize.js";
+import { rewriteKeyExtension, type OptimizeImageOptions } from "../optimize.js";
 import {
   execRunner,
   resolveCurrentPullRequest,
@@ -62,6 +64,48 @@ function mcpOptimizeOptions(
     keepExif: optBool(args, "keepExif") || defaults.keepExif === true,
   };
 }
+
+function mcpFrameOptions(args: ToolArgs): {
+  frameId?: string;
+  frameUrl?: string;
+  frameFit?: "cover" | "contain";
+} {
+  const raw = optString(args, "frame");
+  let frameId: string | undefined;
+  try {
+    frameId = resolveFrameId(raw);
+  } catch (err) {
+    usage(err instanceof Error ? err.message : String(err));
+  }
+  const fitRaw = optString(args, "frameFit");
+  let frameFit: "cover" | "contain" | undefined;
+  if (fitRaw) {
+    if (fitRaw !== "cover" && fitRaw !== "contain") {
+      usage("frameFit must be cover or contain");
+    }
+    frameFit = fitRaw;
+  }
+  if (frameFit && !frameId) usage("frameFit requires frame");
+  const frameUrl = optString(args, "frameUrl");
+  if (frameUrl && !frameId) usage("frameUrl requires frame");
+  return { frameId, frameUrl, frameFit };
+}
+
+const frameProps = {
+  frame: {
+    type: "string",
+    description:
+      "Optional device/browser frame before optimize: phone | browser | iphone-16-pro | iphone-15-pro-max | pixel-9-pro.",
+  },
+  frameUrl: {
+    type: "string",
+    description: "URL shown in procedural browser chrome (with frame=browser).",
+  },
+  frameFit: {
+    type: "string",
+    description: "cover (default) or contain — how the screenshot fills the screen.",
+  },
+};
 
 /** Reads pr/issue (+ repo) into a GhTarget; undefined when neither is present. */
 function ghTargetFromArgs(args: ToolArgs, run: CommandRunner): GhTarget | undefined {
@@ -205,6 +249,7 @@ export function createUploadsMcpTools(opts: {
             description:
               "Keep EXIF/XMP/ICC when optimizing (default: strip for privacy on public embeds).",
           },
+          ...frameProps,
           noGit: { type: "boolean", description: "Don't derive the repo segment from git." },
           comment: {
             type: "boolean",
@@ -258,8 +303,10 @@ export function createUploadsMcpTools(opts: {
         const sourceName = file !== undefined ? (filenameArg ?? basename(file)) : filenameArg!;
 
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
-        const optimizeOpts = mcpOptimizeOptions(args, defaults);
-        const prepared = await optimizeImageForUpload(bytes, sourceName, optimizeOpts);
+        const prepared = await prepareImageForUpload(bytes, sourceName, {
+          ...mcpFrameOptions(args),
+          optimize: mcpOptimizeOptions(args, defaults),
+        });
         const filename = prepared.filename;
         let key = target ? ghAttachmentKey(target, filename) : keyArg;
         if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
@@ -287,9 +334,9 @@ export function createUploadsMcpTools(opts: {
 
         if (wantComment && target) {
           const { comment, commentError } = await syncComment(client, target);
-          return { ...result, markdown, optimize, comment, commentError };
+          return { ...result, markdown, optimize, frame: prepared.frame, comment, commentError };
         }
-        return { ...result, markdown, optimize };
+        return { ...result, markdown, optimize, frame: prepared.frame };
       },
     },
     {
@@ -332,6 +379,7 @@ export function createUploadsMcpTools(opts: {
             description:
               "Keep EXIF/XMP/ICC when optimizing (default: strip for privacy on public embeds).",
           },
+          ...frameProps,
           workspace: workspaceProp,
         },
         required: ["files"],
@@ -348,15 +396,16 @@ export function createUploadsMcpTools(opts: {
         const { client } = clientFor(args);
         const contentType = optString(args, "contentType");
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
+        const frameOpts = mcpFrameOptions(args);
         const optimizeOpts = mcpOptimizeOptions(args, defaults);
 
         const uploads = [];
         for (const file of files) {
           const sourceName = basename(file);
-          const prepared = await optimizeImageForUpload(
+          const prepared = await prepareImageForUpload(
             new Uint8Array(readFileSync(file)),
             sourceName,
-            optimizeOpts,
+            { ...frameOpts, optimize: optimizeOpts },
           );
           const result = await client.put(prepared.bytes, {
             filename: prepared.filename,
@@ -366,6 +415,7 @@ export function createUploadsMcpTools(opts: {
           uploads.push({
             ...result,
             markdown: buildMarkdown(result.url, { alt: sourceName }),
+            frame: prepared.frame,
             optimize: {
               optimized: prepared.optimized,
               skippedReason: prepared.skippedReason,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -94,16 +94,15 @@ function mcpFrameOptions(args: ToolArgs): {
 const frameProps = {
   frame: {
     type: "string",
-    description:
-      "Optional device/browser frame before optimize: phone | browser | iphone-16-pro | iphone-15-pro-max | pixel-9-pro.",
+    description: "Optional frame before optimize: phone | browser | iphone-16-pro.",
   },
   frameUrl: {
     type: "string",
-    description: "URL shown in procedural browser chrome (with frame=browser).",
+    description: "Address bar text for frame=browser.",
   },
   frameFit: {
     type: "string",
-    description: "cover (default) or contain — how the screenshot fills the screen.",
+    description: "cover (default) or contain.",
   },
 };
 

--- a/packages/uploads/test/frame.test.ts
+++ b/packages/uploads/test/frame.test.ts
@@ -19,9 +19,7 @@ async function solidPng(width: number, height: number): Promise<Uint8Array> {
 describe("resolveFrameId / listFramePresets", () => {
   it("lists built-in presets", () => {
     const ids = listFramePresets().map((p) => p.id);
-    expect(ids).toContain("phone");
-    expect(ids).toContain("browser");
-    expect(ids).toContain("iphone-16-pro");
+    expect(ids).toEqual(["phone", "browser", "iphone-16-pro"]);
   });
 
   it("normalizes ids and rejects unknown", () => {

--- a/packages/uploads/test/frame.test.ts
+++ b/packages/uploads/test/frame.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import sharp from "sharp";
+import { applyFrame, listFramePresets, resolveFrameId } from "../src/frame.js";
+
+async function solidPng(width: number, height: number): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 30, g: 120, b: 200 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return new Uint8Array(buf);
+}
+
+describe("resolveFrameId / listFramePresets", () => {
+  it("lists built-in presets", () => {
+    const ids = listFramePresets().map((p) => p.id);
+    expect(ids).toContain("phone");
+    expect(ids).toContain("browser");
+    expect(ids).toContain("iphone-16-pro");
+  });
+
+  it("normalizes ids and rejects unknown", () => {
+    expect(resolveFrameId("Phone")).toBe("phone");
+    expect(() => resolveFrameId("toaster")).toThrow(/unknown frame/);
+  });
+});
+
+describe("applyFrame (procedural)", () => {
+  it("wraps a screenshot in a phone bezel and returns PNG", async () => {
+    const shot = await solidPng(300, 600);
+    const result = await applyFrame(shot, "ui.png", { id: "phone" });
+    expect(result.framed).toBe(true);
+    expect(result.frameId).toBe("phone");
+    expect(result.filename).toBe("ui.png");
+    expect(result.contentType).toBe("image/png");
+    const meta = await sharp(result.bytes).metadata();
+    expect(meta.format).toBe("png");
+    // Bezel adds padding around the 390×844 design canvas (scaled from input).
+    expect((meta.width ?? 0) * (meta.height ?? 0)).toBeGreaterThan(300 * 600);
+  });
+
+  it("wraps a screenshot in browser chrome", async () => {
+    const shot = await solidPng(800, 500);
+    const result = await applyFrame(shot, "dash.png", {
+      id: "browser",
+      browserUrl: "https://app.example/home",
+    });
+    expect(result.framed).toBe(true);
+    expect(result.frameId).toBe("browser");
+    const meta = await sharp(result.bytes).metadata();
+    expect(meta.format).toBe("png");
+    expect(meta.height ?? 0).toBeGreaterThan(500);
+  });
+
+  it("skips non-images", async () => {
+    const bytes = new TextEncoder().encode("hello");
+    const result = await applyFrame(bytes, "notes.txt", { id: "phone" });
+    expect(result.framed).toBe(false);
+    expect(result.skippedReason).toBe("not_image");
+    expect(result.bytes).toBe(bytes);
+  });
+});

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -70,6 +70,7 @@ describe("attachmentsCommentBody", () => {
     expect(body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
     expect(body).toContain("![after.png](https://x.test/gh/o/r/pull/1/after.png)");
     expect(body).toContain("- [notes.txt](https://x.test/gh/o/r/pull/1/notes.txt)");
+    expect(body).toContain('<a href="https://uploads.sh">uploads.sh</a>');
   });
 
   it("sorts deterministically by key so repeated runs produce identical bodies", () => {

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -62,15 +62,35 @@ describe("ghKeyPrefix / ghAttachmentKey", () => {
 });
 
 describe("attachmentsCommentBody", () => {
-  it("starts with the marker and renders images inline, other files as links", () => {
+  it("starts with the marker and renders images with a width cap, other files as links", () => {
     const body = attachmentsCommentBody([
       { key: "gh/o/r/pull/1/notes.txt", url: "https://x.test/gh/o/r/pull/1/notes.txt" },
       { key: "gh/o/r/pull/1/after.png", url: "https://x.test/gh/o/r/pull/1/after.png" },
     ]);
     expect(body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
-    expect(body).toContain("![after.png](https://x.test/gh/o/r/pull/1/after.png)");
+    expect(body).toContain(
+      '<img width="400" alt="after.png" src="https://x.test/gh/o/r/pull/1/after.png">',
+    );
+    expect(body).not.toContain("![after.png]");
     expect(body).toContain("- [notes.txt](https://x.test/gh/o/r/pull/1/notes.txt)");
     expect(body).toContain('<a href="https://uploads.sh">uploads.sh</a>');
+  });
+
+  it("uses a narrower width for phone-like filenames", () => {
+    const body = attachmentsCommentBody([
+      {
+        key: "gh/o/r/pull/1/demo-mobile-iphone.webp",
+        url: "https://x.test/iphone.webp",
+      },
+    ]);
+    expect(body).toContain('<img width="280" alt="demo-mobile-iphone.webp"');
+  });
+
+  it("uses a wider width for browser-like filenames", () => {
+    const body = attachmentsCommentBody([
+      { key: "gh/o/r/pull/1/demo-web-browser.webp", url: "https://x.test/browser.webp" },
+    ]);
+    expect(body).toContain('<img width="640" alt="demo-web-browser.webp"');
   });
 
   it("sorts deterministically by key so repeated runs produce identical bodies", () => {

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -69,7 +69,7 @@ describe("attachmentsCommentBody", () => {
     ]);
     expect(body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
     expect(body).toContain(
-      '<img width="400" alt="after.png" src="https://x.test/gh/o/r/pull/1/after.png">',
+      '<a href="https://x.test/gh/o/r/pull/1/after.png"><img width="400" alt="after.png" src="https://x.test/gh/o/r/pull/1/after.png"></a>',
     );
     expect(body).not.toContain("![after.png]");
     expect(body).toContain("- [notes.txt](https://x.test/gh/o/r/pull/1/notes.txt)");
@@ -83,14 +83,18 @@ describe("attachmentsCommentBody", () => {
         url: "https://x.test/iphone.webp",
       },
     ]);
-    expect(body).toContain('<img width="280" alt="demo-mobile-iphone.webp"');
+    expect(body).toContain(
+      '<a href="https://x.test/iphone.webp"><img width="280" alt="demo-mobile-iphone.webp"',
+    );
   });
 
   it("uses a wider width for browser-like filenames", () => {
     const body = attachmentsCommentBody([
       { key: "gh/o/r/pull/1/demo-web-browser.webp", url: "https://x.test/browser.webp" },
     ]);
-    expect(body).toContain('<img width="640" alt="demo-web-browser.webp"');
+    expect(body).toContain(
+      '<a href="https://x.test/browser.webp"><img width="640" alt="demo-web-browser.webp"',
+    );
   });
 
   it("sorts deterministically by key so repeated runs produce identical bodies", () => {

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -128,6 +128,9 @@ Key options (`uploads put --help` for all):
 | `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                  |
 | `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                        |
 | `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body). |
+| `--frame <id>`                        | Opt-in device/browser chrome before optimize: `phone`, `browser`, `iphone-16-pro`, …               |
+| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                            |
+| `--frame-fit cover\|contain`          | How the screenshot fills the frame screen (default: `cover`).                                      |
 | `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.    |
 | `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                     |
 | `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                        |
@@ -143,6 +146,12 @@ lean. The object key/filename extension follows the output (e.g. `shot.png` →
 `--keep-exif` when the discussion needs the embedded image metadata. Animated GIF,
 SVG, video, and non-images are left alone; if the optimized payload is not smaller,
 the original is uploaded. Use `--no-optimize` when you need lossless originals.
+
+**Frames (opt-in):** pass `--frame phone` (generic bezel), `--frame browser`, or a
+named device (`iphone-16-pro`, `iphone-15-pro-max`, `pixel-9-pro`) to wrap a mobile
+or web screenshot before optimize. Named devices download frame art once from the
+open [device-frames-media](https://github.com/jonnyjackson26/device-frames-media)
+set into `~/.cache/uploads/frames`. Default is **no frame**.
 
 **How keys work** — three paths, no extra naming modes:
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -128,9 +128,9 @@ Key options (`uploads put --help` for all):
 | `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                  |
 | `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                        |
 | `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body). |
-| `--frame <id>`                        | Opt-in device/browser chrome before optimize: `phone`, `browser`, `iphone-16-pro`, …               |
+| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                |
 | `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                            |
-| `--frame-fit cover\|contain`          | How the screenshot fills the frame screen (default: `cover`).                                      |
+| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                  |
 | `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.    |
 | `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                     |
 | `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                        |
@@ -147,11 +147,9 @@ lean. The object key/filename extension follows the output (e.g. `shot.png` →
 SVG, video, and non-images are left alone; if the optimized payload is not smaller,
 the original is uploaded. Use `--no-optimize` when you need lossless originals.
 
-**Frames (opt-in):** pass `--frame phone` (generic bezel), `--frame browser`, or a
-named device (`iphone-16-pro`, `iphone-15-pro-max`, `pixel-9-pro`) to wrap a mobile
-or web screenshot before optimize. Named devices download frame art once from the
-open [device-frames-media](https://github.com/jonnyjackson26/device-frames-media)
-set into `~/.cache/uploads/frames`. Default is **no frame**.
+**Frames (opt-in):** `--frame phone` (generic bezel), `--frame browser`, or
+`--frame iphone-16-pro` (community device art, cached under
+`~/.cache/uploads/frames`). Default is **no frame**.
 
 **How keys work** — three paths, no extra naming modes:
 


### PR DESCRIPTION
## In plain terms

PR reviewers often see bare mobile screenshots with no context. This adds an **opt-in** `--frame` flag so agents can wrap a shot in phone or browser chrome **before** the usual WebP optimize, then upload one ready-to-embed image.

Also: the managed attachments comment footer now links **[uploads.sh](https://uploads.sh)**.

## Demo

Same fake mobile UI three ways (uploaded with this branch):

| Unframed | `--frame phone` | `--frame iphone-16-pro` |
| --- | --- | --- |
| <img width="180" alt="Bare mobile screenshot" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/39/demo-mobile-raw.png"> | <img width="180" alt="Procedural phone bezel" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/39/demo-mobile-phone.webp"> | <img width="180" alt="iPhone 16 Pro community frame" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/39/demo-mobile-iphone.webp"> |

Browser chrome:

<img width="700" alt="Dashboard in browser frame" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/39/demo-web-browser.webp">

```bash
uploads put ./mobile.png --frame phone
uploads put ./mobile.png --frame iphone-16-pro
uploads put ./web.png --frame browser --frame-url "https://app.example/dashboard"
```

## What it does

- Opt-in `--frame phone|browser|iphone-16-pro` on put/attach + MCP (default off)
- Procedural `phone` / `browser`; one community device frame fetched into `~/.cache/uploads/frames`
- Framing runs before WebP optimize / EXIF strip
- Attachments comment: “Maintained by [uploads.sh](https://uploads.sh) — …”

## What it is not

- Not on by default; not server-side framing (#38)
- Not a large device catalog (one remote preset for now)

## Tracking

#36 · #37

## Test plan

- [x] Package tests + typecheck
- [x] Live demos on this PR
- [ ] CI green