### PR TITLE
feat: apply default limits when creating a workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ pnpm dev:web             # Astro site
 pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # all workers; or deploy:api / deploy:web / deploy:mcp
 pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
-  [--max-storage 25GB] [--max-uploads-per-month N] [--max-upload-bytes 25MB]
+  [--no-default-limits] [--max-storage …]   # shared/agent limit template by default
 pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] \
   [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
   [--clear-max-storage] [--clear-allowed-prefixes] […]

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -34,7 +34,8 @@ scripts/
 pnpm dev                              # wrangler dev (:8787)
 pnpm run deploy                       # D1 migrate + production deploy
 pnpm types                            # regenerate worker-configuration.d.ts
-pnpm workspace:add <name> --local     # dev KV registration
+pnpm workspace:add <name> --local     # dev KV; shared/agent limits applied by default
+pnpm workspace:add <name> --no-default-limits --local  # unlimited (legacy create)
 pnpm workspace:limits <name> --allowed-prefixes default --max-key-depth 8
 ```
 

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -9,11 +9,15 @@
  *     [--binding UPLOADS] [--public-base-url https://media.example.com] \
  *     [--account-id ...] [--access-key-id ...] [--secret-access-key ...] \
  *     [--max-storage 25GB] [--max-uploads-per-month 10000] [--max-upload-bytes 25MB] \
+ *     [--max-video-bytes 8MB] [--retention-days 90] \
  *     [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
+ *     [--no-default-limits] # skip shared/agent template (start unlimited)
  *     [--local]             # write to wrangler dev's local KV instead of prod
  *
- * Limit flags are optional (omit = unlimited / unrestricted keys). Change later
- * with scripts/set-workspace-limits.mjs without re-minting tokens.
+ * By default, new workspaces get the shared/agent limit template (see
+ * workspace-limit-defaults.mjs / docs/ops.md). Explicit --max-* flags override
+ * individual fields; pass unlimited/none/off to clear one. Change later with
+ * scripts/set-workspace-limits.mjs without re-minting tokens.
  *
  * Default (no --bucket): the workspace is a "<name>/" prefix in the shared
  * uploads-default bucket, served at https://storage.uploads.sh/<name>/...
@@ -29,6 +33,7 @@
  */
 import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
+import { sharedAgentLimitFields } from "./workspace-limit-defaults.mjs";
 
 /** Match apps/api/src/secrets.ts: enc:v1: + base64url(iv || ct || tag). */
 function sealField(master, plaintext) {
@@ -48,8 +53,8 @@ for (let i = 0; i < rest.length; i++) {
   const flag = rest[i];
   if (!flag.startsWith("--")) fail(`unexpected argument: ${flag}`);
   const key = flag.slice(2);
-  if (key === "local") {
-    opts.local = true;
+  if (key === "local" || key === "no-default-limits") {
+    opts[key] = true;
     continue;
   }
   opts[key] = rest[++i];
@@ -60,10 +65,11 @@ function fail(msg) {
   process.exit(1);
 }
 
+/** @returns {number | null | undefined} number, null=clear/unlimited, undefined=flag omitted */
 function parseBytes(raw, label) {
   if (raw === undefined || raw === null || raw === "") return undefined;
   const s = String(raw).trim();
-  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
   const m = /^(\d+(?:\.\d+)?)\s*(b|bytes?|k|kb|kib|m|mb|mib|g|gb|gib)?$/i.exec(s);
   if (!m) fail(`invalid ${label}: ${JSON.stringify(raw)}`);
   const n = Number(m[1]);
@@ -87,19 +93,21 @@ function parseBytes(raw, label) {
   return Math.floor(n * mult);
 }
 
+/** @returns {number | null | undefined} */
 function parseCount(raw, label) {
   if (raw === undefined || raw === null || raw === "") return undefined;
   const s = String(raw).trim();
-  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
   const n = Number(s);
   if (!Number.isInteger(n) || n <= 0) fail(`invalid ${label}: ${JSON.stringify(raw)}`);
   return n;
 }
 
+/** @returns {number | null | undefined} */
 function parseDepth(raw, label) {
   if (raw === undefined || raw === null || raw === "") return undefined;
   const s = String(raw).trim();
-  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
   const n = Number(s);
   if (!Number.isInteger(n) || n < 1 || n > 64) {
     fail(`invalid ${label}: ${JSON.stringify(raw)} (use 1–64)`);
@@ -107,10 +115,11 @@ function parseDepth(raw, label) {
   return n;
 }
 
+/** @returns {string[] | null | undefined} */
 function parseAllowedPrefixes(raw, label) {
   if (raw === undefined || raw === null || raw === "") return undefined;
   const s = String(raw).trim();
-  if (/^(unlimited|none|off)$/i.test(s)) return undefined;
+  if (/^(unlimited|none|off)$/i.test(s)) return null;
   const parts = s
     .split(/[,;\s]+/)
     .map((p) => p.trim())
@@ -129,6 +138,13 @@ function parseAllowedPrefixes(raw, label) {
     out.push(cleaned);
   }
   return [...new Set(out)];
+}
+
+/** Set, clear, or leave alone a limit field (undefined = flag omitted). */
+function applyLimit(record, field, value) {
+  if (value === undefined) return;
+  if (value === null) delete record[field];
+  else record[field] = value;
 }
 
 if (!name || !/^[a-z0-9][a-z0-9-]{1,62}$/.test(name)) {
@@ -176,18 +192,26 @@ const record = opts.bucket
       accessKeyId: opts["access-key-id"],
       secretAccessKey: opts["secret-access-key"],
     };
-const maxStorageBytes = parseBytes(opts["max-storage"], "max-storage");
-const maxUploadsPerPeriod = parseCount(opts["max-uploads-per-month"], "max-uploads-per-month");
-const maxUploadBytes = parseBytes(opts["max-upload-bytes"], "max-upload-bytes");
-const maxVideoUploadBytes = parseBytes(opts["max-video-bytes"], "max-video-bytes");
-const allowedKeyPrefixes = parseAllowedPrefixes(opts["allowed-prefixes"], "allowed-prefixes");
-const maxKeyDepth = parseDepth(opts["max-key-depth"], "max-key-depth");
-if (maxStorageBytes !== undefined) record.maxStorageBytes = maxStorageBytes;
-if (maxUploadsPerPeriod !== undefined) record.maxUploadsPerPeriod = maxUploadsPerPeriod;
-if (maxUploadBytes !== undefined) record.maxUploadBytes = maxUploadBytes;
-if (maxVideoUploadBytes !== undefined) record.maxVideoUploadBytes = maxVideoUploadBytes;
-if (allowedKeyPrefixes !== undefined) record.allowedKeyPrefixes = allowedKeyPrefixes;
-if (maxKeyDepth !== undefined) record.maxKeyDepth = maxKeyDepth;
+// Shared/agent template first; flags override (or --no-default-limits skips it).
+if (!opts["no-default-limits"]) {
+  Object.assign(record, sharedAgentLimitFields());
+}
+
+applyLimit(record, "maxStorageBytes", parseBytes(opts["max-storage"], "max-storage"));
+applyLimit(
+  record,
+  "maxUploadsPerPeriod",
+  parseCount(opts["max-uploads-per-month"], "max-uploads-per-month"),
+);
+applyLimit(record, "maxUploadBytes", parseBytes(opts["max-upload-bytes"], "max-upload-bytes"));
+applyLimit(record, "maxVideoUploadBytes", parseBytes(opts["max-video-bytes"], "max-video-bytes"));
+applyLimit(record, "retentionDays", parseCount(opts["retention-days"], "retention-days"));
+applyLimit(
+  record,
+  "allowedKeyPrefixes",
+  parseAllowedPrefixes(opts["allowed-prefixes"], "allowed-prefixes"),
+);
+applyLimit(record, "maxKeyDepth", parseDepth(opts["max-key-depth"], "max-key-depth"));
 
 const master = process.env.WORKSPACE_SECRETS_KEY;
 if (master && (record.accessKeyId || record.secretAccessKey)) {
@@ -196,6 +220,16 @@ if (master && (record.accessKeyId || record.secretAccessKey)) {
 }
 
 Object.keys(record).forEach((k) => record[k] === undefined && delete record[k]);
+
+const appliedLimits = {
+  maxStorageBytes: record.maxStorageBytes,
+  maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+  maxUploadBytes: record.maxUploadBytes,
+  maxVideoUploadBytes: record.maxVideoUploadBytes,
+  retentionDays: record.retentionDays,
+  allowedKeyPrefixes: record.allowedKeyPrefixes,
+  maxKeyDepth: record.maxKeyDepth,
+};
 
 execFileSync(
   "pnpm",
@@ -214,8 +248,14 @@ execFileSync(
   { stdio: "inherit" },
 );
 
-console.log(`\nworkspace : ${name}`);
+console.log(`\nworkspace : ${name}${opts.local ? " (local)" : ""}`);
 console.log(`token     : ${token}`);
+console.log(
+  "limits    :",
+  opts["no-default-limits"] && !Object.values(appliedLimits).some((v) => v !== undefined)
+    ? "(none — unlimited)"
+    : JSON.stringify(appliedLimits),
+);
 console.log("\nStore the token now — only its hash is kept in KV.");
 console.log(
   `try it    : curl -H "Authorization: Bearer ${token}" https://api.uploads.sh/v1/${name}/files`,

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -9,7 +9,7 @@
  *     [--binding UPLOADS] [--public-base-url https://media.example.com] \
  *     [--account-id ...] [--access-key-id ...] [--secret-access-key ...] \
  *     [--max-storage 25GB] [--max-uploads-per-month 10000] [--max-upload-bytes 25MB] \
- *     [--max-video-bytes 8MB] [--retention-days 90] \
+ *     [--max-video-bytes 8MB] [--retention-days N] \
  *     [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
  *     [--no-default-limits] # skip shared/agent template (start unlimited)
  *     [--local]             # write to wrangler dev's local KV instead of prod

--- a/apps/api/scripts/workspace-limit-defaults.json
+++ b/apps/api/scripts/workspace-limit-defaults.json
@@ -1,0 +1,9 @@
+{
+  "maxStorageBytes": 25000000000,
+  "maxUploadsPerPeriod": 10000,
+  "maxUploadBytes": 25000000,
+  "maxVideoUploadBytes": 8000000,
+  "retentionDays": 90,
+  "allowedKeyPrefixes": ["f", "screenshots", "gh"],
+  "maxKeyDepth": 8
+}

--- a/apps/api/scripts/workspace-limit-defaults.json
+++ b/apps/api/scripts/workspace-limit-defaults.json
@@ -3,7 +3,6 @@
   "maxUploadsPerPeriod": 10000,
   "maxUploadBytes": 25000000,
   "maxVideoUploadBytes": 8000000,
-  "retentionDays": 90,
   "allowedKeyPrefixes": ["f", "screenshots", "gh"],
   "maxKeyDepth": 8
 }

--- a/apps/api/scripts/workspace-limit-defaults.mjs
+++ b/apps/api/scripts/workspace-limit-defaults.mjs
@@ -18,7 +18,6 @@ export function sharedAgentLimitFields() {
     maxUploadsPerPeriod: template.maxUploadsPerPeriod,
     maxUploadBytes: template.maxUploadBytes,
     maxVideoUploadBytes: template.maxVideoUploadBytes,
-    retentionDays: template.retentionDays,
     allowedKeyPrefixes: [...template.allowedKeyPrefixes],
     maxKeyDepth: template.maxKeyDepth,
   };

--- a/apps/api/scripts/workspace-limit-defaults.mjs
+++ b/apps/api/scripts/workspace-limit-defaults.mjs
@@ -1,0 +1,25 @@
+/**
+ * Default limit template for `add-workspace.mjs`. Values live in
+ * workspace-limit-defaults.json (shared/agent profile — docs/ops.md).
+ *
+ * Opt out at create time with `--no-default-limits`.
+ */
+import template from "./workspace-limit-defaults.json" with { type: "json" };
+
+export const SHARED_AGENT_LIMIT_TEMPLATE = Object.freeze({
+  ...template,
+  allowedKeyPrefixes: Object.freeze([...template.allowedKeyPrefixes]),
+});
+
+/** Shallow copy suitable for spreading onto a new WorkspaceRecord. */
+export function sharedAgentLimitFields() {
+  return {
+    maxStorageBytes: template.maxStorageBytes,
+    maxUploadsPerPeriod: template.maxUploadsPerPeriod,
+    maxUploadBytes: template.maxUploadBytes,
+    maxVideoUploadBytes: template.maxVideoUploadBytes,
+    retentionDays: template.retentionDays,
+    allowedKeyPrefixes: [...template.allowedKeyPrefixes],
+    maxKeyDepth: template.maxKeyDepth,
+  };
+}

--- a/apps/api/test/workspace-limit-defaults.test.ts
+++ b/apps/api/test/workspace-limit-defaults.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import template from "../scripts/workspace-limit-defaults.json";
+
+/**
+ * Source of truth for new-workspace limits (`add-workspace.mjs`).
+ * Keep in sync with the shared/agent profile in docs/ops.md.
+ */
+describe("workspace-limit-defaults.json", () => {
+  it("matches the shared/agent profile", () => {
+    expect(template).toEqual({
+      maxStorageBytes: 25_000_000_000,
+      maxUploadsPerPeriod: 10_000,
+      maxUploadBytes: 25_000_000,
+      maxVideoUploadBytes: 8_000_000,
+      retentionDays: 90,
+      allowedKeyPrefixes: ["f", "screenshots", "gh"],
+      maxKeyDepth: 8,
+    });
+  });
+});

--- a/apps/api/test/workspace-limit-defaults.test.ts
+++ b/apps/api/test/workspace-limit-defaults.test.ts
@@ -12,9 +12,10 @@ describe("workspace-limit-defaults.json", () => {
       maxUploadsPerPeriod: 10_000,
       maxUploadBytes: 25_000_000,
       maxVideoUploadBytes: 8_000_000,
-      retentionDays: 90,
       allowedKeyPrefixes: ["f", "screenshots", "gh"],
       maxKeyDepth: 8,
     });
+    // Retention is opt-in (GitHub embeds should not vanish after N days).
+    expect(template).not.toHaveProperty("retentionDays");
   });
 });

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -18,6 +18,12 @@ pnpm workspace:limits <name> \
 
 Suggested **shared/agent** defaults: 25 GB storage, 10k uploads/month, 25 MB images, 8 MB video, 90-day retention, key prefixes `default` (`f/`, `screenshots/`, `gh/`), max depth 8. **Throwaway**: 1 GB / 1k / 15 MB / 5 MB video / 90 days / same key policy.
 
+**New workspaces** (`pnpm workspace:add`) apply the shared/agent template
+automatically (source: `apps/api/scripts/workspace-limit-defaults.mjs`). Pass
+`--no-default-limits` to start unlimited, or override individual fields with the
+usual `--max-*` flags (`unlimited` clears one field). Existing workspaces are
+unchanged until you run `workspace:limits`.
+
 `--allowed-prefixes default` expands to the typed destinations agents already use. Clear with `--clear-allowed-prefixes` / `--clear-max-key-depth`. Puts outside the allowlist return **400** `key_prefix_not_allowed`; too-deep paths return **400** `key_too_deep`.
 
 KV cache ~60s. Agents: `uploads usage`.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -16,13 +16,14 @@ pnpm workspace:limits <name> \
   --max-key-depth 8
 ```
 
-Suggested **shared/agent** defaults: 25 GB storage, 10k uploads/month, 25 MB images, 8 MB video, 90-day retention, key prefixes `default` (`f/`, `screenshots/`, `gh/`), max depth 8. **Throwaway**: 1 GB / 1k / 15 MB / 5 MB video / 90 days / same key policy.
+Suggested **shared/agent** defaults: 25 GB storage, 10k uploads/month, 25 MB images, 8 MB video, key prefixes `default` (`f/`, `screenshots/`, `gh/`), max depth 8 — **no retention** (PR/issue embeds should stay put). **Throwaway** (opt-in): 1 GB / 1k / 15 MB / 5 MB video / 90-day retention / same key policy.
 
 **New workspaces** (`pnpm workspace:add`) apply the shared/agent template
-automatically (source: `apps/api/scripts/workspace-limit-defaults.mjs`). Pass
+automatically (source: `apps/api/scripts/workspace-limit-defaults.json`). Pass
 `--no-default-limits` to start unlimited, or override individual fields with the
-usual `--max-*` flags (`unlimited` clears one field). Existing workspaces are
-unchanged until you run `workspace:limits`.
+usual `--max-*` flags (`unlimited` clears one field). Add retention only when
+you want expiry: `--retention-days 90`. Existing workspaces are unchanged until
+you run `workspace:limits`.
 
 `--allowed-prefixes default` expands to the typed destinations agents already use. Clear with `--clear-allowed-prefixes` / `--clear-max-key-depth`. Puts outside the allowlist return **400** `key_prefix_not_allowed`; too-deep paths return **400** `key_too_deep`.
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -44,10 +44,13 @@ cleaned up. Unset policy = any nested path (internal/BYO).
 
 ### Configure limits
 
-Create with flags:
+**Create** applies the shared/agent template by default (25 GB / 10k / 25 MB /
+8 MB video / 90-day retention / `f`+`screenshots`+`gh` / depth 8):
 
 ```bash
-pnpm workspace:add my-ws --max-storage 25GB --max-uploads-per-month 10000 --max-upload-bytes 25MB
+pnpm workspace:add my-ws
+pnpm workspace:add my-ws --max-storage 50GB          # override one field
+pnpm workspace:add my-ws --no-default-limits         # start unlimited
 ```
 
 Change later without re-minting tokens:

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -45,11 +45,12 @@ cleaned up. Unset policy = any nested path (internal/BYO).
 ### Configure limits
 
 **Create** applies the shared/agent template by default (25 GB / 10k / 25 MB /
-8 MB video / 90-day retention / `f`+`screenshots`+`gh` / depth 8):
+8 MB video / `f`+`screenshots`+`gh` / depth 8 — no retention):
 
 ```bash
 pnpm workspace:add my-ws
 pnpm workspace:add my-ws --max-storage 50GB          # override one field
+pnpm workspace:add my-ws --retention-days 90         # opt-in expiry
 pnpm workspace:add my-ws --no-default-limits         # start unlimited
 ```
 


### PR DESCRIPTION
## In plain terms

When you create a new workspace, it should **not** start with unlimited storage and unrestricted paths. New workspaces now get the same **shared/agent** limits we already use on production `default` (25 GB, 10k uploads/month, size caps, 90-day retention, and the `f` / `screenshots` / `gh` key roots).

### What it does

- **`pnpm workspace:add`** applies a default limit template automatically
- You can still **override** individual fields with flags, or start unlimited with **`--no-default-limits`**
- Existing workspaces are **unchanged** (use `workspace:limits` for those)

### What it is not

- Not a runtime change on the Worker (create path is the operator script only)
- Not a new npm package release
- Not forcing throwaway-tier limits — this is the shared/agent profile

### How to try it

```bash
pnpm workspace:add demo-ws --local
# prints limits JSON including storage, retention, allowed prefixes

pnpm workspace:add free-ws --no-default-limits --local
# unlimited (legacy behavior)
```

### Technical notes

- Template: `apps/api/scripts/workspace-limit-defaults.json` (+ thin `.mjs` loader)
- `add-workspace.mjs` merges template first; explicit flags override; `unlimited` clears a field
- Also supports `--retention-days` on create (was missing before)
- Docs: `docs/ops.md`, `docs/workspaces.md`, `AGENTS.md`, `apps/api/README.md`

### Test plan

- [x] `pnpm --filter @uploads/api test`
- [x] `pnpm check`
- [x] Smoke-import `sharedAgentLimitFields()`
- [ ] Optional: create a local workspace and confirm printed limits