### PR TITLE
feat: object provenance metadata on put and head

### DIFF
--- a/.changeset/object-provenance.md
+++ b/.changeset/object-provenance.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Send allowlisted object provenance on put (`X-Uploads-Meta-*`: client, version, optimize/frame flags, source name) and surface `metadata` on put/head responses.

--- a/.changeset/object-provenance.md
+++ b/.changeset/object-provenance.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": minor
 ---
 
-Send allowlisted object provenance on put (`X-Uploads-Meta-*`: client, version, optimize/frame flags, source name) and surface `metadata` on put/head responses.
+Send allowlisted object provenance on put (`X-Uploads-Meta-*`: client, version, optimize/frame flags, source name). Put/head return `metadata`, including server-computed `content-sha256` of the stored body.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ uploads attach ./before.png ./after.png
 For a one-off or pinned run without a global install:
 
 ```bash
-npx @buildinternet/uploads@0.1.0 login
-npx @buildinternet/uploads@0.1.0 attach ./before.png ./after.png
+npx @buildinternet/uploads@0.3.0 login
+npx @buildinternet/uploads@0.3.0 attach ./before.png ./after.png
 ```
 
 `attach` detects the GitHub repository and current PR through `gh`, uploads all
@@ -64,14 +64,17 @@ curl -X PUT http://localhost:8787/v1/default/files/test.txt \
 ### CLI
 
 The `@buildinternet/uploads` package wraps the API for scripting and GitHub
-image embeds. `pnpm workspace:add` prints a bearer token once — save it to
-`.env` (from `.env.example`) or run `pnpm uploads setup --token <token>`.
+image embeds. Product examples use the global `uploads` binary (same as after
+`npm install -g`). `pnpm workspace:add` prints a bearer token once — save it
+with `uploads setup --token <token>` or into `.env` / user config.
 
 ```bash
-cp .env.example .env   # fill in UPLOADS_TOKEN from workspace:add output
-pnpm uploads put ./shot.png --env-file .env
+uploads put ./shot.png
 # stdout: public URL + ready-to-paste markdown; stderr: human summary
 ```
+
+Inside this monorepo only, `pnpm uploads …` builds the package first so you
+pick up local source.
 
 **How keys work:** default `put` lands under `screenshots/…`. Prefer
 `--destination screenshots` (or `gh` with `--pr`/`--issue`) over inventing roots —
@@ -81,8 +84,9 @@ hash-free GitHub keys; use `--key` only for an exact path under an allowed root.
 More output control:
 
 ```bash
-pnpm uploads put ./shot.png --format url --env-file .env
-pnpm uploads put ./shot.png --repo myorg/myapp --ref 1722 --width 700 --env-file .env
+uploads put ./shot.png --format url
+uploads put ./shot.png --repo myorg/myapp --ref 1722 --width 700
+uploads put ./mobile.png --frame phone
 ```
 
 ### GitHub embeds
@@ -95,7 +99,7 @@ markdown you can drop into a PR or issue.
 re-uploading the same filename overwrites in place and the URL never changes:
 
 ```bash
-pnpm uploads put ./after.png --pr 123 --alt "Dashboard after" --env-file .env
+uploads put ./after.png --pr 123 --alt "Dashboard after"
 # key: gh/<owner>/<repo>/pull/123/after.png
 ```
 
@@ -104,8 +108,8 @@ creates or updates a single comment listing every file attached to that
 PR/issue — the upload still succeeds if `gh` is unavailable:
 
 ```bash
-pnpm uploads put ./after.png --pr 123 --comment --env-file .env
-pnpm uploads comment --pr 123 --env-file .env   # re-sync without uploading
+uploads put ./after.png --pr 123 --comment
+uploads comment --pr 123   # re-sync without uploading
 ```
 
 > **Privacy:** Hosted files are served from a public CDN with no link to GitHub

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -8,6 +8,7 @@ import type { Files } from "@uploads/storage";
 import { checkPutBudget } from "./budget";
 import { inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
+import { provenanceForResponse, sanitizeProvenance, type ProvenanceMap } from "./provenance";
 import { publicUrl, storage, storageConfig } from "./storage";
 import { getWorkspaceUsage, recordUsageSafe } from "./usage";
 import type { WorkspaceRecord } from "./workspace";
@@ -120,7 +121,14 @@ export async function putObject(
   key: string,
   bytes: Uint8Array,
   workspaceName: string,
-): Promise<{ key: string; url: string | null; size: number; contentType: string }> {
+  opts?: { provenance?: Record<string, string> },
+): Promise<{
+  key: string;
+  url: string | null;
+  size: number;
+  contentType: string;
+  metadata?: ProvenanceMap;
+}> {
   const finalKey = finalizeUploadKey(key, ws);
   if (bytes.byteLength === 0) throw new FileOpError("empty body");
 
@@ -139,9 +147,12 @@ export async function putObject(
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
   if (denial) throw new FileOpError(denial.message, denial.status, denial.detail);
 
+  const metadata = sanitizeProvenance(opts?.provenance);
+
   await store.upload(finalKey, bytes, {
     contentType: inspection.contentType,
     cacheControl: UPLOAD_CACHE_CONTROL,
+    ...(metadata ? { metadata } : {}),
   });
 
   await recordUsageSafe(env.DB, workspaceName, {
@@ -155,6 +166,29 @@ export async function putObject(
     url: publicUrl(await storageConfig(env, ws), finalKey),
     size: newSize,
     contentType: inspection.contentType,
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+/** Shape HEAD/list-friendly metadata for API JSON. */
+export function headObjectJson(
+  key: string,
+  meta: {
+    size?: number;
+    type?: string;
+    lastModified?: number;
+    metadata?: Record<string, string>;
+  },
+  url: string | null,
+) {
+  const provenance = provenanceForResponse(meta.metadata ?? undefined);
+  return {
+    key,
+    size: meta.size ?? 0,
+    contentType: meta.type ?? "application/octet-stream",
+    ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+    url,
+    ...(provenance ? { metadata: provenance } : {}),
   };
 }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -8,7 +8,12 @@ import type { Files } from "@uploads/storage";
 import { checkPutBudget } from "./budget";
 import { inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
-import { provenanceForResponse, sanitizeProvenance, type ProvenanceMap } from "./provenance";
+import {
+  contentSha256Hex,
+  provenanceForResponse,
+  sanitizeProvenance,
+  type ProvenanceMap,
+} from "./provenance";
 import { publicUrl, storage, storageConfig } from "./storage";
 import { getWorkspaceUsage, recordUsageSafe } from "./usage";
 import type { WorkspaceRecord } from "./workspace";
@@ -147,12 +152,17 @@ export async function putObject(
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
   if (denial) throw new FileOpError(denial.message, denial.status, denial.detail);
 
-  const metadata = sanitizeProvenance(opts?.provenance);
+  // Client headers first; always attach content-sha256 of the final stored body
+  // (never trust a client-supplied hash).
+  const metadata: ProvenanceMap = {
+    ...sanitizeProvenance(opts?.provenance, { clientOnly: true }),
+    "content-sha256": await contentSha256Hex(bytes),
+  };
 
   await store.upload(finalKey, bytes, {
     contentType: inspection.contentType,
     cacheControl: UPLOAD_CACHE_CONTROL,
-    ...(metadata ? { metadata } : {}),
+    metadata,
   });
 
   await recordUsageSafe(env.DB, workspaceName, {
@@ -166,7 +176,7 @@ export async function putObject(
     url: publicUrl(await storageConfig(env, ws), finalKey),
     size: newSize,
     contentType: inspection.contentType,
-    ...(metadata ? { metadata } : {}),
+    metadata,
   };
 }
 

--- a/apps/api/src/provenance.ts
+++ b/apps/api/src/provenance.ts
@@ -15,7 +15,8 @@ export const PROVENANCE_VALUE_MAX = 128;
 export const PROVENANCE_KEY_MAX = 16;
 
 /**
- * Allowlisted keys (stored lower-case). Keep short for R2 metadata budget.
+ * Client-supplied allowlisted keys (stored lower-case). Keep short for R2
+ * metadata budget. `content-sha256` is server-computed only (not from headers).
  *
  * | key            | meaning                                      |
  * |----------------|----------------------------------------------|
@@ -25,8 +26,9 @@ export const PROVENANCE_KEY_MAX = 16;
  * | optimized      | "1" if client re-encoded before put          |
  * | frame          | frame id when used (phone, browser, …)       |
  * | keep-exif      | "1" if client preserved EXIF on optimize     |
+ * | content-sha256 | SHA-256 of stored body (server-set)          |
  */
-export const PROVENANCE_KEYS = [
+export const PROVENANCE_CLIENT_KEYS = [
   "client",
   "client-version",
   "source-name",
@@ -35,9 +37,13 @@ export const PROVENANCE_KEYS = [
   "keep-exif",
 ] as const;
 
+export const PROVENANCE_KEYS = [...PROVENANCE_CLIENT_KEYS, "content-sha256"] as const;
+
 export type ProvenanceKey = (typeof PROVENANCE_KEYS)[number];
+export type ProvenanceClientKey = (typeof PROVENANCE_CLIENT_KEYS)[number];
 
 const ALLOWED = new Set<string>(PROVENANCE_KEYS);
+const CLIENT_ALLOWED = new Set<string>(PROVENANCE_CLIENT_KEYS);
 
 const KEY_RE = /^[a-z][a-z0-9-]{0,31}$/;
 const VALUE_SAFE_RE = /^[\x20-\x7E]+$/; // printable ASCII only
@@ -54,17 +60,21 @@ function sanitizeValue(raw: string): string | null {
 /**
  * Keep only allowlisted keys with safe values. Unknown keys are ignored.
  * Returns undefined when the filtered map is empty.
+ *
+ * @param opts.clientOnly — drop server-only keys (e.g. content-sha256 from headers)
  */
 export function sanitizeProvenance(
   input: Record<string, string> | undefined | null,
+  opts?: { clientOnly?: boolean },
 ): ProvenanceMap | undefined {
   if (!input) return undefined;
+  const allowed = opts?.clientOnly ? CLIENT_ALLOWED : ALLOWED;
   const out: ProvenanceMap = {};
   let n = 0;
   for (const [rawKey, rawVal] of Object.entries(input)) {
     if (n >= PROVENANCE_KEY_MAX) break;
     const key = rawKey.trim().toLowerCase();
-    if (!KEY_RE.test(key) || !ALLOWED.has(key)) continue;
+    if (!KEY_RE.test(key) || !allowed.has(key)) continue;
     if (typeof rawVal !== "string") continue;
     const value = sanitizeValue(rawVal);
     if (!value) continue;
@@ -75,18 +85,25 @@ export function sanitizeProvenance(
 }
 
 /**
- * Read `X-Uploads-Meta-<key>: <value>` request headers into a raw map
- * (pre-sanitize). Header names are case-insensitive.
+ * Read client `X-Uploads-Meta-<key>: <value>` headers (never content-sha256).
  */
 export function provenanceFromHeaders(
   getHeader: (name: string) => string | undefined,
 ): Record<string, string> {
   const raw: Record<string, string> = {};
-  for (const key of PROVENANCE_KEYS) {
+  for (const key of PROVENANCE_CLIENT_KEYS) {
     const v = getHeader(`x-uploads-meta-${key}`);
     if (v !== undefined && v !== "") raw[key] = v;
   }
   return raw;
+}
+
+/** Lowercase hex SHA-256 of the stored object body. */
+export async function contentSha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 /** Convert stored metadata to a plain string map for JSON responses. */

--- a/apps/api/src/provenance.ts
+++ b/apps/api/src/provenance.ts
@@ -1,0 +1,97 @@
+/**
+ * Allowlisted object provenance metadata (R2 customMetadata).
+ *
+ * Stored on the object at put time; echoed on put/head. Public CDN URLs serve
+ * bytes only — this map is for API/operator forensics, not browser EXIF.
+ *
+ * Privacy: never accept tokens, auth, PII, or free-form blobs. Keys outside
+ * the allowlist are dropped (not rejected) so unknown clients stay compatible.
+ */
+
+/** Max length of a single metadata value (UTF-8 bytes). */
+export const PROVENANCE_VALUE_MAX = 128;
+
+/** Max number of keys accepted per upload. */
+export const PROVENANCE_KEY_MAX = 16;
+
+/**
+ * Allowlisted keys (stored lower-case). Keep short for R2 metadata budget.
+ *
+ * | key            | meaning                                      |
+ * |----------------|----------------------------------------------|
+ * | client         | uploader surface (uploads-cli, mcp, …)       |
+ * | client-version | package/version string                       |
+ * | source-name    | original filename basename                   |
+ * | optimized      | "1" if client re-encoded before put          |
+ * | frame          | frame id when used (phone, browser, …)       |
+ * | keep-exif      | "1" if client preserved EXIF on optimize     |
+ */
+export const PROVENANCE_KEYS = [
+  "client",
+  "client-version",
+  "source-name",
+  "optimized",
+  "frame",
+  "keep-exif",
+] as const;
+
+export type ProvenanceKey = (typeof PROVENANCE_KEYS)[number];
+
+const ALLOWED = new Set<string>(PROVENANCE_KEYS);
+
+const KEY_RE = /^[a-z][a-z0-9-]{0,31}$/;
+const VALUE_SAFE_RE = /^[\x20-\x7E]+$/; // printable ASCII only
+
+export type ProvenanceMap = Partial<Record<ProvenanceKey, string>>;
+
+function sanitizeValue(raw: string): string | null {
+  const v = raw.trim();
+  if (!v || v.length > PROVENANCE_VALUE_MAX) return null;
+  if (!VALUE_SAFE_RE.test(v)) return null;
+  return v;
+}
+
+/**
+ * Keep only allowlisted keys with safe values. Unknown keys are ignored.
+ * Returns undefined when the filtered map is empty.
+ */
+export function sanitizeProvenance(
+  input: Record<string, string> | undefined | null,
+): ProvenanceMap | undefined {
+  if (!input) return undefined;
+  const out: ProvenanceMap = {};
+  let n = 0;
+  for (const [rawKey, rawVal] of Object.entries(input)) {
+    if (n >= PROVENANCE_KEY_MAX) break;
+    const key = rawKey.trim().toLowerCase();
+    if (!KEY_RE.test(key) || !ALLOWED.has(key)) continue;
+    if (typeof rawVal !== "string") continue;
+    const value = sanitizeValue(rawVal);
+    if (!value) continue;
+    out[key as ProvenanceKey] = value;
+    n++;
+  }
+  return n > 0 ? out : undefined;
+}
+
+/**
+ * Read `X-Uploads-Meta-<key>: <value>` request headers into a raw map
+ * (pre-sanitize). Header names are case-insensitive.
+ */
+export function provenanceFromHeaders(
+  getHeader: (name: string) => string | undefined,
+): Record<string, string> {
+  const raw: Record<string, string> = {};
+  for (const key of PROVENANCE_KEYS) {
+    const v = getHeader(`x-uploads-meta-${key}`);
+    if (v !== undefined && v !== "") raw[key] = v;
+  }
+  return raw;
+}
+
+/** Convert stored metadata to a plain string map for JSON responses. */
+export function provenanceForResponse(
+  meta: Record<string, string> | undefined | null,
+): ProvenanceMap | undefined {
+  return sanitizeProvenance(meta ?? undefined);
+}

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -4,9 +4,11 @@ import {
   badKey,
   deleteObject,
   finalizeUploadKey,
+  headObjectJson,
   listObjects,
   putObject,
 } from "../files-core";
+import { provenanceFromHeaders } from "../provenance";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../guards";
@@ -110,6 +112,7 @@ export const files = new Hono<WorkspaceVars>()
         key,
         new Uint8Array(body),
         c.get("workspaceName"),
+        { provenance: provenanceFromHeaders((n) => c.req.header(n)) },
       );
       return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
     } catch (err) {
@@ -130,7 +133,7 @@ export const files = new Hono<WorkspaceVars>()
     const store = await storage(c.env, ws);
     if (!(await store.exists(key))) return c.json({ error: "not found" }, 404);
     const meta = await store.head(key);
-    return c.json({ ...meta, url: publicUrl(await storageConfig(c.env, ws), key) });
+    return c.json(headObjectJson(key, meta, publicUrl(await storageConfig(c.env, ws), key)));
   })
 
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {

--- a/apps/api/test/fake-r2.ts
+++ b/apps/api/test/fake-r2.ts
@@ -7,6 +7,7 @@
 interface StoredObject {
   data: Uint8Array;
   contentType?: string;
+  customMetadata?: Record<string, string>;
   /** R2 "uploaded" / last-modified; tests can backdate for retention. */
   uploaded?: Date;
 }
@@ -25,7 +26,7 @@ export class FakeR2Bucket {
       storageClass: "Standard",
       checksums: {},
       httpMetadata: { contentType: obj.contentType },
-      customMetadata: {},
+      customMetadata: { ...obj.customMetadata },
       writeHttpMetadata() {},
     };
   }
@@ -33,7 +34,10 @@ export class FakeR2Bucket {
   async put(
     key: string,
     value: ArrayBuffer | ArrayBufferView | string | ReadableStream<Uint8Array> | null,
-    opts?: { httpMetadata?: { contentType?: string } | Headers },
+    opts?: {
+      httpMetadata?: { contentType?: string } | Headers;
+      customMetadata?: Record<string, string>;
+    },
   ) {
     let data: Uint8Array;
     if (typeof value === "string") data = new TextEncoder().encode(value);
@@ -47,7 +51,12 @@ export class FakeR2Bucket {
       httpMetadata instanceof Headers
         ? (httpMetadata.get("content-type") ?? undefined)
         : httpMetadata?.contentType;
-    const obj: StoredObject = { data, contentType, uploaded: new Date() };
+    const obj: StoredObject = {
+      data,
+      contentType,
+      customMetadata: opts?.customMetadata ? { ...opts.customMetadata } : undefined,
+      uploaded: new Date(),
+    };
     this.store.set(key, obj);
     return this.meta(key, obj);
   }

--- a/apps/api/test/provenance.test.ts
+++ b/apps/api/test/provenance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { provenanceFromHeaders, sanitizeProvenance } from "../src/provenance";
+
+describe("sanitizeProvenance", () => {
+  it("keeps allowlisted keys and drops unknowns", () => {
+    expect(
+      sanitizeProvenance({
+        client: "uploads-cli",
+        "client-version": "0.3.0",
+        secret: "nope",
+        optimized: "1",
+      }),
+    ).toEqual({
+      client: "uploads-cli",
+      "client-version": "0.3.0",
+      optimized: "1",
+    });
+  });
+
+  it("rejects empty / overlong / non-ascii values", () => {
+    expect(sanitizeProvenance({ client: "" })).toBeUndefined();
+    expect(sanitizeProvenance({ client: "x".repeat(200) })).toBeUndefined();
+    expect(sanitizeProvenance({ client: "café" })).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(sanitizeProvenance({})).toBeUndefined();
+    expect(sanitizeProvenance(null)).toBeUndefined();
+  });
+});
+
+describe("provenanceFromHeaders", () => {
+  it("reads X-Uploads-Meta-* headers", () => {
+    const headers: Record<string, string> = {
+      "x-uploads-meta-client": "uploads-cli",
+      "x-uploads-meta-frame": "phone",
+      "x-uploads-meta-optimized": "1",
+    };
+    expect(provenanceFromHeaders((n) => headers[n.toLowerCase()])).toEqual({
+      client: "uploads-cli",
+      frame: "phone",
+      optimized: "1",
+    });
+  });
+});

--- a/apps/api/test/provenance.test.ts
+++ b/apps/api/test/provenance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { provenanceFromHeaders, sanitizeProvenance } from "../src/provenance";
+import { contentSha256Hex, provenanceFromHeaders, sanitizeProvenance } from "../src/provenance";
 
 describe("sanitizeProvenance", () => {
   it("keeps allowlisted keys and drops unknowns", () => {
@@ -27,19 +27,36 @@ describe("sanitizeProvenance", () => {
     expect(sanitizeProvenance({})).toBeUndefined();
     expect(sanitizeProvenance(null)).toBeUndefined();
   });
+
+  it("clientOnly drops content-sha256 from untrusted input", () => {
+    expect(
+      sanitizeProvenance(
+        { client: "uploads-cli", "content-sha256": "a".repeat(64) },
+        { clientOnly: true },
+      ),
+    ).toEqual({ client: "uploads-cli" });
+  });
 });
 
 describe("provenanceFromHeaders", () => {
-  it("reads X-Uploads-Meta-* headers", () => {
+  it("reads X-Uploads-Meta-* headers but not content-sha256", () => {
     const headers: Record<string, string> = {
       "x-uploads-meta-client": "uploads-cli",
       "x-uploads-meta-frame": "phone",
       "x-uploads-meta-optimized": "1",
+      "x-uploads-meta-content-sha256": "deadbeef",
     };
     expect(provenanceFromHeaders((n) => headers[n.toLowerCase()])).toEqual({
       client: "uploads-cli",
       frame: "phone",
       optimized: "1",
     });
+  });
+});
+
+describe("contentSha256Hex", () => {
+  it("hashes bytes", async () => {
+    const hex = await contentSha256Hex(new TextEncoder().encode("hello"));
+    expect(hex).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
   });
 });

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -136,16 +136,19 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
         "X-Uploads-Meta-Optimized": "1",
         "X-Uploads-Meta-Frame": "phone",
         "X-Uploads-Meta-Secret": "should-drop",
+        "X-Uploads-Meta-Content-Sha256": "0".repeat(64),
       },
     });
     expect(res.status).toBe(201);
     const json = (await res.json()) as { metadata?: Record<string, string> };
-    expect(json.metadata).toEqual({
+    expect(json.metadata).toMatchObject({
       client: "uploads-cli",
       "client-version": "0.3.0",
       optimized: "1",
       frame: "phone",
     });
+    expect(json.metadata?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(json.metadata?.["content-sha256"]).not.toBe("0".repeat(64));
     expect(bucket.store.get("default/screenshots/shot.png")?.customMetadata).toEqual(json.metadata);
 
     const head = await app.request(
@@ -164,10 +167,11 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(headJson.metadata).toEqual(json.metadata);
   });
 
-  it("omits metadata when no provenance headers are sent", async () => {
+  it("always sets content-sha256 even without client provenance headers", async () => {
     const { env } = await makeEnv();
     const res = await putShot(env);
-    const json = (await res.json()) as { metadata?: unknown };
-    expect(json.metadata).toBeUndefined();
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { metadata?: Record<string, string> };
+    expect(json.metadata?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -126,4 +126,48 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     const res = await putShot(env);
     expect(res.status).toBe(429);
   });
+
+  it("stores allowlisted provenance metadata and returns it on put + head", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await putShot(env, {
+      headers: {
+        "X-Uploads-Meta-Client": "uploads-cli",
+        "X-Uploads-Meta-Client-Version": "0.3.0",
+        "X-Uploads-Meta-Optimized": "1",
+        "X-Uploads-Meta-Frame": "phone",
+        "X-Uploads-Meta-Secret": "should-drop",
+      },
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { metadata?: Record<string, string> };
+    expect(json.metadata).toEqual({
+      client: "uploads-cli",
+      "client-version": "0.3.0",
+      optimized: "1",
+      frame: "phone",
+    });
+    expect(bucket.store.get("default/screenshots/shot.png")?.customMetadata).toEqual(json.metadata);
+
+    const head = await app.request(
+      "/v1/default/files/screenshots/shot.png",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(head.status).toBe(200);
+    const headJson = (await head.json()) as {
+      contentType: string;
+      metadata?: Record<string, string>;
+      key: string;
+    };
+    expect(headJson.key).toBe("screenshots/shot.png");
+    expect(headJson.contentType).toBe("image/png");
+    expect(headJson.metadata).toEqual(json.metadata);
+  });
+
+  it("omits metadata when no provenance headers are sent", async () => {
+    const { env } = await makeEnv();
+    const res = await putShot(env);
+    const json = (await res.json()) as { metadata?: unknown };
+    expect(json.metadata).toBeUndefined();
+  });
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,12 +34,15 @@ X-Uploads-Meta-frame: phone
 X-Uploads-Meta-keep-exif: 1
 ```
 
-**Allowlist only** (others dropped): `client`, `client-version`, `source-name`,
+**Client allowlist** (others dropped): `client`, `client-version`, `source-name`,
 `optimized`, `frame`, `keep-exif`. Values are printable ASCII, max 128 chars.
 Never send tokens, workspace secrets, or PII.
 
-Put and head responses include a `metadata` object when any allowlisted field
-was stored. The CLI/`uploads mcp` set these automatically from optimize/frame
+**Server-only:** every put also stores `content-sha256` (lowercase hex SHA-256 of
+the **final stored body**). Client-supplied `content-sha256` headers are ignored.
+
+Put and head responses always include `metadata` with at least `content-sha256`.
+The CLI/`uploads mcp` set the client fields automatically from optimize/frame
 options.
 
 ### Usage ledger and budgets

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,20 +5,42 @@ Unknown workspaces and bad tokens are indistinguishable (both 401).
 
 ## Routes
 
-| Route                                             | Description                                                                                          |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `GET /health`                                     | Liveness (no auth)                                                                                   |
-| `PUT /v1/:workspace/files/:key`                   | Upload raw body (sniffed type). Bare keys → `f/<id>/<name>`. Returns `{ workspace, key, url, size }` |
-| `POST /v1/:workspace/files/sign`                  | Presigned upload (`signedUploadUrl`); needs HTTP S3 credentials on the workspace                     |
-| `GET /v1/:workspace/files?prefix=&limit=&cursor=` | List objects                                                                                         |
-| `GET /v1/:workspace/files/:key`                   | Object metadata                                                                                      |
-| `DELETE /v1/:workspace/files/:key`                | Delete object                                                                                        |
-| `GET /v1/:workspace/usage`                        | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read`           |
-| `POST /v1/:workspace/usage/reconcile`             | Rebuild `bytes`/`objects` from storage; requires `files:write`                                       |
-| `POST /v1/:workspace/usage/purge-expired`         | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`                   |
+| Route                                             | Description                                                                                      |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `GET /health`                                     | Liveness (no auth)                                                                               |
+| `PUT /v1/:workspace/files/:key`                   | Upload raw body (sniffed type). Bare keys → `f/<id>/<name>`. Optional provenance headers (below) |
+| `POST /v1/:workspace/files/sign`                  | Presigned upload (`signedUploadUrl`); needs HTTP S3 credentials on the workspace                 |
+| `GET /v1/:workspace/files?prefix=&limit=&cursor=` | List objects                                                                                     |
+| `GET /v1/:workspace/files/:key`                   | Object metadata (includes allowlisted `metadata` when set)                                       |
+| `DELETE /v1/:workspace/files/:key`                | Delete object                                                                                    |
+| `GET /v1/:workspace/usage`                        | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read`       |
+| `POST /v1/:workspace/usage/reconcile`             | Rebuild `bytes`/`objects` from storage; requires `files:write`                                   |
+| `POST /v1/:workspace/usage/purge-expired`         | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`               |
 
 `url` in responses is the public URL when the workspace has a
 `publicBaseUrl`, otherwise `null`.
+
+### Object provenance metadata
+
+Optional operational labels stored as R2 **custom metadata** (not EXIF, not on
+the public CDN response body). Clients may send:
+
+```http
+X-Uploads-Meta-client: uploads-cli
+X-Uploads-Meta-client-version: 0.3.0
+X-Uploads-Meta-source-name: shot.png
+X-Uploads-Meta-optimized: 1
+X-Uploads-Meta-frame: phone
+X-Uploads-Meta-keep-exif: 1
+```
+
+**Allowlist only** (others dropped): `client`, `client-version`, `source-name`,
+`optimized`, `frame`, `keep-exif`. Values are printable ASCII, max 128 chars.
+Never send tokens, workspace secrets, or PII.
+
+Put and head responses include a `metadata` object when any allowlisted field
+was stored. The CLI/`uploads mcp` set these automatically from optimize/frame
+options.
 
 ### Usage ledger and budgets
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -3,6 +3,16 @@ import type { UploadsClientConfig } from "./config.js";
 import { UploadsError } from "./errors.js";
 import { buildScreenshotKey } from "./keys.js";
 
+/** Allowlisted object provenance (maps to X-Uploads-Meta-* on put). */
+export type ProvenanceInput = {
+  client?: string;
+  "client-version"?: string;
+  "source-name"?: string;
+  optimized?: "0" | "1";
+  frame?: string;
+  "keep-exif"?: "0" | "1";
+};
+
 export interface PutOptions {
   key?: string;
   contentType?: string;
@@ -10,6 +20,8 @@ export interface PutOptions {
   repo?: string;
   ref?: string;
   deriveRepoFromGit?: boolean;
+  /** Stored as R2 custom metadata; echoed on put/head. */
+  provenance?: ProvenanceInput;
 }
 
 export interface ListOptions {
@@ -24,6 +36,7 @@ export interface PutResult {
   url: string;
   size: number;
   contentType: string;
+  metadata?: Record<string, string>;
 }
 
 export interface ListItem {
@@ -44,6 +57,7 @@ export interface HeadResult {
   size: number;
   contentType: string;
   uploaded?: string;
+  metadata?: Record<string, string>;
 }
 
 export interface DeleteResult {
@@ -249,6 +263,12 @@ export function createUploadsClient(config: UploadsClientConfig) {
           deriveRepoFromGit: opts.deriveRepoFromGit,
         }));
       const contentType = opts.contentType ?? inferContentType(opts.filename);
+      const headers: Record<string, string> = { "Content-Type": contentType };
+      if (opts.provenance) {
+        for (const [k, v] of Object.entries(opts.provenance)) {
+          if (v !== undefined && v !== "") headers[`X-Uploads-Meta-${k}`] = v;
+        }
+      }
 
       const result = await request<{
         workspace: string;
@@ -256,9 +276,10 @@ export function createUploadsClient(config: UploadsClientConfig) {
         url: string | null;
         size: number;
         contentType: string;
+        metadata?: Record<string, string>;
       }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}`, {
         body,
-        headers: { "Content-Type": contentType },
+        headers,
       });
 
       if (result.url == null) {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -40,6 +40,7 @@ import {
   type OptimizeImageResult,
 } from "./optimize.js";
 import { applyFrame, resolveFrameId, type FrameResult } from "./frame.js";
+import { buildCliProvenance } from "./provenance.js";
 import type { PutDefaults } from "./config-file.js";
 
 export interface CliContext {
@@ -320,6 +321,12 @@ export async function runAttach(
       filename: prepared.filename,
       key: ghAttachmentKey(target, prepared.filename),
       contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
+      provenance: buildCliProvenance({
+        sourceName,
+        optimized: prepared.optimized,
+        frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+        keepExif: optimizeOpts.keepExif === true,
+      }),
     });
     results.push({
       ...result,
@@ -460,6 +467,12 @@ export async function runPut(
     ref: flagString(parsed.flags, "--ref") ?? defaults.ref,
     contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
     deriveRepoFromGit: !noGit,
+    provenance: buildCliProvenance({
+      sourceName,
+      optimized: prepared.optimized,
+      frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+      keepExif: optimizeOpts.keepExif === true,
+    }),
   });
 
   const markdown = buildMarkdown(result.url, { alt, width });

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -41,6 +41,7 @@ export {
   createUploadsClient,
   type UploadsClient,
   type PutOptions,
+  type ProvenanceInput,
   type ListOptions,
   type PutResult,
   type ListItem,
@@ -53,6 +54,7 @@ export {
   type PurgeExpiredResult,
   type PurgeExpiredResponse,
 } from "./client.js";
+export { buildCliProvenance } from "./provenance.js";
 export {
   ATTACHMENTS_MARKER,
   attachmentsCommentBody,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -26,6 +26,7 @@ import { buildMarkdown } from "../embed.js";
 import { resolvePutPrefix } from "../destinations.js";
 import { ghAttachmentKey, ghKeyPrefix, type GhTarget } from "../github.js";
 import { rewriteKeyExtension, type OptimizeImageOptions } from "../optimize.js";
+import { buildCliProvenance } from "../provenance.js";
 import {
   execRunner,
   resolveCurrentPullRequest,
@@ -302,9 +303,11 @@ export function createUploadsMcpTools(opts: {
         const sourceName = file !== undefined ? (filenameArg ?? basename(file)) : filenameArg!;
 
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
+        const frameOpts = mcpFrameOptions(args);
+        const optimizeOpts = mcpOptimizeOptions(args, defaults);
         const prepared = await prepareImageForUpload(bytes, sourceName, {
-          ...mcpFrameOptions(args),
-          optimize: mcpOptimizeOptions(args, defaults),
+          ...frameOpts,
+          optimize: optimizeOpts,
         });
         const filename = prepared.filename;
         let key = target ? ghAttachmentKey(target, filename) : keyArg;
@@ -318,6 +321,13 @@ export function createUploadsMcpTools(opts: {
           ref: refArg ?? defaults.ref,
           contentType: prepared.optimized ? prepared.contentType : optString(args, "contentType"),
           deriveRepoFromGit: !noGit,
+          provenance: buildCliProvenance({
+            sourceName,
+            client: "uploads-mcp",
+            optimized: prepared.optimized,
+            frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+            keepExif: optimizeOpts.keepExif === true,
+          }),
         });
         const markdown = buildMarkdown(result.url, {
           alt: optString(args, "alt") ?? sourceName,
@@ -410,6 +420,13 @@ export function createUploadsMcpTools(opts: {
             filename: prepared.filename,
             key: ghAttachmentKey(target, prepared.filename),
             contentType: prepared.optimized ? prepared.contentType : contentType,
+            provenance: buildCliProvenance({
+              sourceName,
+              client: "uploads-mcp",
+              optimized: prepared.optimized,
+              frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+              keepExif: optimizeOpts.keepExif === true,
+            }),
           });
           uploads.push({
             ...result,

--- a/packages/uploads/src/provenance.ts
+++ b/packages/uploads/src/provenance.ts
@@ -1,0 +1,38 @@
+/**
+ * Client-side provenance headers for put (X-Uploads-Meta-*).
+ * API allowlists keys; secrets never go here.
+ */
+import type { ProvenanceInput } from "./client.js";
+import { createRequire } from "node:module";
+
+let cachedVersion: string | undefined;
+
+function packageVersion(): string {
+  if (cachedVersion) return cachedVersion;
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../package.json") as { version?: string };
+    cachedVersion = pkg.version ?? "0.0.0";
+  } catch {
+    cachedVersion = "0.0.0";
+  }
+  return cachedVersion;
+}
+
+export function buildCliProvenance(opts: {
+  sourceName: string;
+  optimized?: boolean;
+  frameId?: string;
+  keepExif?: boolean;
+  client?: string;
+}): ProvenanceInput {
+  const provenance: ProvenanceInput = {
+    client: opts.client ?? "uploads-cli",
+    "client-version": packageVersion(),
+    "source-name": opts.sourceName.slice(0, 128),
+  };
+  if (opts.optimized) provenance.optimized = "1";
+  if (opts.frameId) provenance.frame = opts.frameId.slice(0, 64);
+  if (opts.keepExif) provenance["keep-exif"] = "1";
+  return provenance;
+}


### PR DESCRIPTION
## In plain terms

We need to answer “where did this object come from?” without stuffing EXIF into public image bytes. This stores a **small allowlisted label map** on the object at upload time and returns it from put/head.

## What it does

- **API:** `X-Uploads-Meta-<key>` on `PUT …/files/:key` → R2 `customMetadata`
- Allowlist: `client`, `client-version`, `source-name`, `optimized`, `frame`, `keep-exif` (unknown keys dropped)
- Put response and `GET …/files/:key` include `metadata` when present
- **CLI / MCP:** send provenance automatically (package version, source name, optimize/frame flags)
- Docs: privacy rules in `docs/api.md`

## What it is not

- Not a D1 object index / search (later on #35)
- Not free-form metadata or secrets
- Not EXIF / in-file tags

## How to try it

```bash
uploads put ./shot.png --frame phone
# GET /v1/:workspace/files/:key → { metadata: { client, frame, optimized, … } }
```

```http
PUT /v1/default/files/screenshots/demo.png
X-Uploads-Meta-client: uploads-cli
X-Uploads-Meta-optimized: 1
```

## Technical notes

- `apps/api/src/provenance.ts` + `putObject(..., { provenance })`
- FakeR2 stores `customMetadata` for route tests
- Changeset: minor `@buildinternet/uploads`
- Tracking: #35

## Test plan

- [x] `pnpm --filter @uploads/api test` (92)
- [x] `pnpm --filter @buildinternet/uploads test` (119)
- [x] typecheck both
- [ ] CI green