### PR TITLE
fix: tree-shake sharp out of the MCP worker bundle

### DIFF
--- a/.changeset/mcp-worker-tree-shake-sharp.md
+++ b/.changeset/mcp-worker-tree-shake-sharp.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Mark the package `sideEffects: false` so Workers that import helpers from the main entry (e.g. the remote MCP worker) can tree-shake Node-only image code (`sharp` / optimize / frame) and deploy cleanly.

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "CLI and client for uploads.sh — workspace-scoped image hosting for GitHub embeds",
   "type": "module",
+  "sideEffects": false,
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/uploads/scripts/check-pack.mjs
+++ b/packages/uploads/scripts/check-pack.mjs
@@ -44,6 +44,14 @@ try {
   );
   assert.equal(manifest.private, undefined, "package must not be marked private");
   assert.equal(manifest.publishConfig?.access, "public");
+  // Workers (apps/mcp) import helpers from the main entry; without this, esbuild
+  // keeps the optimize/frame re-exports and bundles native `sharp`, which fails
+  // Cloudflare startup validation (createRequire / path undefined).
+  assert.equal(
+    manifest.sideEffects,
+    false,
+    "package must set sideEffects: false for Worker tree-shaking",
+  );
   assert.equal(
     manifest.bin?.uploads?.replace(/^\.\//, ""),
     "bin/uploads.js",


### PR DESCRIPTION
## In plain terms

The remote MCP worker (`uploads-mcp`) failed to deploy because the bundle
included native `sharp` image code. Cloudflare then rejected the script at
startup. This marks the published package as free of side effects so Workers
can tree-shake that Node-only path and deploy cleanly.

## What it does

- Sets `"sideEffects": false` on `@buildinternet/uploads`
- Asserts that flag in `pack:check` so it can’t regress silently
- Adds a patch changeset for the published package

## What it is not

- No CLI/API behavior change for optimize/frame (still available when imported)
- Not a Cloudflare config change on the MCP worker itself

## How to try it

Already confirmed manually:

```text
pnpm --filter @uploads/mcp run deploy
# Uploaded uploads-mcp — Worker Startup Time: 12 ms
# agents.uploads.sh / mcp.uploads.sh both return {"ok":true}
```

## Technical notes

`apps/mcp` imports only `buildMarkdown` / `buildScreenshotKey` from the main
entry. After optimize/frame landed on that barrel (with a top-level `sharp`
import), esbuild kept those re-exports unless `sideEffects` is false. That
pulled in `createRequire` and failed Workers validation (error 10021).

## Test plan

- [x] `pnpm --filter @uploads/mcp run deploy` (success; startup 12 ms)
- [x] `GET https://agents.uploads.sh/health` → `{"ok":true}`
- [x] `GET https://mcp.uploads.sh/health` → `{"ok":true}`
- [x] `pnpm --filter @uploads/mcp test` (20 passed)
- [x] `pnpm --filter @buildinternet/uploads run pack:check`
- [x] wrangler dry-run bundle contains no `sharp` / `createRequire`