### PR TITLE
test: harden remote MCP attachment flow

### DIFF
--- a/.changeset/calm-public-attachments.md
+++ b/.changeset/calm-public-attachments.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Warn in CLI and agent tool help that uploads and predictable PR/issue attachment keys remain public for private and internal repositories.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,6 @@ jobs:
 
       - name: Verify npm package
         run: pnpm --filter @buildinternet/uploads run build && pnpm --filter @buildinternet/uploads run pack:check
+
+      - name: Bundle remote MCP Worker
+        run: pnpm --filter @uploads/mcp run bundle:check

--- a/.github/workflows/remote-mcp-smoke.yml
+++ b/.github/workflows/remote-mcp-smoke.yml
@@ -1,0 +1,40 @@
+name: Remote MCP smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      workspace:
+        description: Existing disposable workspace to test
+        required: true
+        default: smoke
+
+concurrency:
+  group: remote-mcp-smoke
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  lifecycle:
+    name: Enrollment and MCP lifecycle
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: remote-mcp-smoke
+    env:
+      ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+      UPLOADS_API_URL: ${{ vars.UPLOADS_API_URL }}
+      UPLOADS_MCP_URL: ${{ vars.UPLOADS_MCP_URL }}
+      UPLOADS_WORKSPACE: ${{ inputs.workspace }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Exercise remote MCP with an ephemeral scoped token
+        run: node scripts/smoke-remote-mcp.mjs

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ uploads attach ./before.png ./after.png
 For a one-off or pinned run without a global install:
 
 ```bash
-npx @buildinternet/uploads@0.3.0 login
-npx @buildinternet/uploads@0.3.0 attach ./before.png ./after.png
+npx @buildinternet/uploads@0.4.0 login
+npx @buildinternet/uploads@0.4.0 attach ./before.png ./after.png
 ```
 
 `attach` detects the GitHub repository and current PR through `gh`, uploads all

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ uploads login
 uploads attach ./before.png ./after.png
 ```
 
-For a one-off or pinned run without a global install:
+For a one-off run without a global install:
 
 ```bash
-npx @buildinternet/uploads@0.4.0 login
-npx @buildinternet/uploads@0.4.0 attach ./before.png ./after.png
+npx @buildinternet/uploads login
+npx @buildinternet/uploads attach ./before.png ./after.png
 ```
 
 `attach` detects the GitHub repository and current PR through `gh`, uploads all

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -67,6 +67,9 @@ function env(
             }
             return null;
           },
+          async run() {
+            return { success: true, meta: { changes: 1 }, results: [] };
+          },
         };
       },
     },
@@ -95,6 +98,43 @@ describe("auth routes", () => {
     );
     expect(response.status).toBe(400);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("allows delete scope when explicitly requested for an enrollment", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          label: "remote-mcp-smoke",
+          scopes: ["files:read", "files:write", "files:delete"],
+        }),
+      },
+      env(),
+    );
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      label: "remote-mcp-smoke",
+      scopes: ["files:read", "files:write", "files:delete"],
+    });
+  });
+
+  it("keeps enrollment scopes read/write by default", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({ label: "routine-agent" }),
+      },
+      env(),
+    );
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({
+      label: "routine-agent",
+      scopes: ["files:read", "files:write"],
+    });
   });
 
   it("uses one uniform, non-cacheable public exchange error", async () => {

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -8,6 +8,7 @@
     "dev": "wrangler dev",
     "predeploy": "pnpm --filter @buildinternet/uploads run build",
     "deploy": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
+    "bundle:check": "wrangler deploy --dry-run --outdir .wrangler/bundle-check",
     "types": "wrangler types",
     "typecheck": "wrangler types && tsc --noEmit",
     "pretest": "pnpm --filter @buildinternet/uploads run build",

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -57,7 +57,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "put",
       description:
-        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
+        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead. Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
       inputSchema: {
         type: "object",
         properties: {

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,7 +27,7 @@ the public CDN response body). Clients may send:
 
 ```http
 X-Uploads-Meta-client: uploads-cli
-X-Uploads-Meta-client-version: 0.3.0
+X-Uploads-Meta-client-version: 0.4.0
 X-Uploads-Meta-source-name: shot.png
 X-Uploads-Meta-optimized: 1
 X-Uploads-Meta-frame: phone

--- a/docs/contract-testing.md
+++ b/docs/contract-testing.md
@@ -57,6 +57,24 @@ as repository secrets, limit their scopes, use a single disposable repository,
 and serialize runs to prevent comment races. Keep that job separate from pull
 request CI so untrusted changes never receive the secrets.
 
+## Remote MCP lifecycle
+
+The manual **Remote MCP smoke** workflow exercises the deployed enrollment and
+stateless MCP boundary. Protect its `remote-mcp-smoke` GitHub Environment with
+required reviewers and restrict its deployment branches/tags to `main`. Store
+`ADMIN_TOKEN` only as an environment secret, and configure `UPLOADS_API_URL` and
+`UPLOADS_MCP_URL` as environment variables. Run it only against an existing
+disposable workspace. The job also rejects non-`main` workflow refs before loading
+the protected environment.
+
+The test creates a five-minute, single-use enrollment and exchanges it for a
+15-minute read/write/delete token. It then runs `initialize`, `tools/list`, put,
+list, and delete before revoking the token and confirming it receives 401. Generated
+credentials are masked immediately; response bodies, tokens, and public object URLs
+are never printed. Object cleanup and token revocation run in `finally` blocks.
+The workflow is manual-only and never exposes its administrator credential to pull
+request code or routine agents.
+
 ## Release gate
 
 A release is ready for the agent workflow when a clean environment can:

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -15,10 +15,10 @@ uploads login
 uploads doctor
 ```
 
-Or use a pinned package without a global install:
+Or run it once without a global install:
 
 ```bash
-npx @buildinternet/uploads@0.4.0 login
+npx @buildinternet/uploads login
 ```
 
 Interactive login prompts without echoing the enrollment code. For automation, use an

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -18,7 +18,7 @@ uploads doctor
 Or use a pinned package without a global install:
 
 ```bash
-npx @buildinternet/uploads@0.1.0 login
+npx @buildinternet/uploads@0.4.0 login
 ```
 
 Interactive login prompts without echoing the enrollment code. For automation, use an
@@ -61,6 +61,11 @@ belongs in routine-agent configuration.
 The response shows the enrollment code once. Transfer only that code to the routine
 agent. It expires after 10 minutes and is consumed by a successful exchange. Invalid,
 expired, and consumed codes receive the same public error shape.
+
+Enrollment creation accepts `files:delete` only when the administrator explicitly
+includes it in `scopes`. Keep the default read/write scopes for routine agents;
+reserve delete for short-lived maintenance or smoke-test credentials that clean up
+their own objects.
 
 ## Token policy
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing `@buildinternet/uploads`
 
 The CLI/client package is published with **changesets** + npm **trusted
-publishing** (OIDC — no long-lived `NPM_TOKEN`). Version `0.1.1` is already on
-npm; later versions are cut by the **Release** workflow on `main`.
+publishing** (OIDC — no long-lived `NPM_TOKEN`). Published versions are cut by
+the **Release** workflow on `main`.
 
 ## Trusted-publishing configuration
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -8,7 +8,7 @@ Binary: **`uploads`**. Install globally (or use a pinned `npx` one-shot):
 
 ```bash
 npm install --global @buildinternet/uploads
-npx @buildinternet/uploads@0.1.0 --help
+npx @buildinternet/uploads@0.4.0 --help
 ```
 
 ```bash

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -4,11 +4,11 @@ CLI and client for **uploads.sh** — upload files, get public URLs, and produce
 
 ## CLI
 
-Binary: **`uploads`**. Install globally (or use a pinned `npx` one-shot):
+Binary: **`uploads`**. Install globally (or use an `npx` one-shot):
 
 ```bash
 npm install --global @buildinternet/uploads
-npx @buildinternet/uploads@0.4.0 --help
+npx @buildinternet/uploads --help
 ```
 
 ```bash

--- a/packages/uploads/src/agent.ts
+++ b/packages/uploads/src/agent.ts
@@ -23,7 +23,7 @@ export function createUploadsWorkerFileTools(
     overrides: {
       uploadFile: {
         description:
-          "Upload a file for public hosting (e.g. GitHub embeds). Prefer keys under screenshots/.",
+          "Upload a non-sensitive file for public hosting (e.g. GitHub embeds). GitHub repository visibility does not restrict access; prefer keys under screenshots/.",
       },
       ...overrides,
     },

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -65,6 +65,10 @@ upload as-is, or --keep-exif when image metadata matters for the discussion.
 Optional --frame wraps the image in a device/browser chrome before optimize
 (default off). See: uploads put --help frames
 
+Uploads are public. --pr/--issue keys include the repo, number, and filename and
+remain public even for private/internal GitHub repositories. Upload only media
+that is safe at a predictable public URL.
+
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
   --destination <id>    Typed root: screenshots | gh | f (sets --prefix)
@@ -249,6 +253,10 @@ const ATTACH_HELP = `uploads attach <file...> [options]
 
 Upload one or more stable PR/issue attachments and maintain a single GitHub
 comment. With no target, uses the pull request for the current branch.
+
+Attachments are public and their repo/number/filename keys are predictable.
+Private/internal GitHub repository visibility does not restrict access; upload
+only media that is safe at a public URL.
 
 Still images are optimized to WebP by default (same as put). Use --no-optimize
 to upload originals. Optional --frame wraps images in device/browser chrome.

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -179,7 +179,7 @@ export function createUploadsMcpTools(opts: {
     {
       name: "put",
       description:
-        "Upload a file to uploads.sh and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Pass `file` (a local path) or `contentBase64` + `filename` for in-memory content; with `pr`/`issue` the key is stable (same filename → same URL) and `comment` syncs the managed attachments comment.",
+        "Upload a file to uploads.sh and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Pass `file` (a local path) or `contentBase64` + `filename` for in-memory content; with `pr`/`issue` the key is stable (same filename → same URL) and `comment` syncs the managed attachments comment. All uploads are public; pr/issue keys are predictable and remain public for private/internal GitHub repositories, so upload only non-sensitive media.",
       inputSchema: {
         type: "object",
         properties: {
@@ -351,7 +351,7 @@ export function createUploadsMcpTools(opts: {
     {
       name: "attach",
       description:
-        "Upload one or more files as stable PR/issue attachments and maintain a single managed GitHub comment listing them (each upload's `markdown` is ready to paste into GitHub). With no pr/issue, targets the pull request for the current branch.",
+        "Upload one or more files as stable PR/issue attachments and maintain a single managed GitHub comment listing them (each upload's `markdown` is ready to paste into GitHub). With no pr/issue, targets the pull request for the current branch. Attachments are public and their repo/number/filename keys are predictable even for private/internal GitHub repositories; upload only non-sensitive media.",
       inputSchema: {
         type: "object",
         properties: {

--- a/scripts/smoke-remote-mcp.mjs
+++ b/scripts/smoke-remote-mcp.mjs
@@ -1,0 +1,163 @@
+import { randomUUID } from "node:crypto";
+
+const required = ["UPLOADS_API_URL", "UPLOADS_MCP_URL", "UPLOADS_WORKSPACE", "ADMIN_TOKEN"];
+for (const name of required) {
+  if (!process.env[name]) throw new Error(`missing required environment variable: ${name}`);
+}
+
+const apiUrl = process.env.UPLOADS_API_URL.replace(/\/$/, "");
+const mcpUrl = process.env.UPLOADS_MCP_URL.replace(/\/$/, "");
+const workspace = process.env.UPLOADS_WORKSPACE;
+const adminToken = process.env.ADMIN_TOKEN;
+const runId = randomUUID();
+const label = `remote-mcp-smoke-${runId}`;
+const key = `f/mcp-smoke/${runId}.png`;
+const pngBase64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+XDRZ4wAAAABJRU5ErkJggg==";
+
+let rpcId = 0;
+let scopedToken;
+let putAttempted = false;
+let exchanged = false;
+
+function mask(value) {
+  if (process.env.GITHUB_ACTIONS === "true") process.stdout.write(`::add-mask::${value}\n`);
+}
+
+function ok(step) {
+  process.stdout.write(`ok ${step}\n`);
+}
+
+async function jsonRequest(url, options, expected = [200]) {
+  const response = await fetch(url, options);
+  if (!expected.includes(response.status)) {
+    throw new Error(
+      `${options.method ?? "GET"} request expected ${expected.join("/")}, got ${response.status}`,
+    );
+  }
+  try {
+    return { status: response.status, body: await response.json() };
+  } catch {
+    throw new Error(
+      `${options.method ?? "GET"} request returned non-JSON status ${response.status}`,
+    );
+  }
+}
+
+function headers(token) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function mcp(method, params, expected = [200]) {
+  return jsonRequest(
+    mcpUrl,
+    {
+      method: "POST",
+      headers: headers(scopedToken),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: ++rpcId,
+        method,
+        ...(params ? { params } : {}),
+      }),
+    },
+    expected,
+  );
+}
+
+async function tool(name, args) {
+  const { body } = await mcp("tools/call", { name, arguments: args });
+  if (body.error || body.result?.isError) throw new Error(`MCP tool failed: ${name}`);
+  return body.result?.structuredContent;
+}
+
+async function revoke() {
+  await jsonRequest(
+    `${apiUrl}/admin/tokens`,
+    {
+      method: "DELETE",
+      headers: headers(adminToken),
+      body: JSON.stringify({ workspace, label }),
+    },
+    [200],
+  );
+}
+
+try {
+  const enrollment = await jsonRequest(
+    `${apiUrl}/admin/enrollments`,
+    {
+      method: "POST",
+      headers: headers(adminToken),
+      body: JSON.stringify({
+        workspace,
+        label,
+        enrollmentSeconds: 300,
+        tokenExpiresInSeconds: 900,
+        scopes: ["files:read", "files:write", "files:delete"],
+      }),
+    },
+    [201],
+  );
+  const code = enrollment.body.code;
+  if (typeof code !== "string") throw new Error("enrollment response missing code");
+  mask(code);
+  ok("enrollment");
+
+  const exchange = await jsonRequest(
+    `${apiUrl}/auth/enrollments/exchange`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    },
+    [201],
+  );
+  if (exchange.body.workspace !== workspace || typeof exchange.body.token !== "string") {
+    throw new Error("enrollment exchange returned invalid credentials");
+  }
+  scopedToken = exchange.body.token;
+  exchanged = true;
+  mask(scopedToken);
+  ok("exchange");
+
+  const initialized = await mcp("initialize", { protocolVersion: "2025-06-18" });
+  if (initialized.body.result?.protocolVersion !== "2025-06-18") {
+    throw new Error("MCP initialize returned unexpected protocol version");
+  }
+  ok("initialize");
+
+  const listedTools = await mcp("tools/list");
+  const toolNames = new Set(listedTools.body.result?.tools?.map((item) => item.name));
+  for (const name of ["put", "list", "delete"]) {
+    if (!toolNames.has(name)) throw new Error(`MCP tools/list missing required tool: ${name}`);
+  }
+  ok("tools/list");
+
+  putAttempted = true;
+  const put = await tool("put", { contentBase64: pngBase64, filename: "smoke.png", key });
+  if (put?.key !== key) throw new Error("MCP put returned unexpected key");
+  ok("put");
+
+  const list = await tool("list", { prefix: key });
+  if (!list?.items?.some((item) => item.key === key)) {
+    throw new Error("MCP list did not return uploaded key");
+  }
+  ok("list");
+} finally {
+  try {
+    if (putAttempted && scopedToken) {
+      await tool("delete", { key });
+      ok("cleanup");
+    }
+  } finally {
+    if (exchanged) {
+      await revoke();
+      ok("revoke");
+    }
+  }
+}
+
+const rejected = await mcp("tools/list", undefined, [401]);
+if (rejected.body.error !== "unauthorized") throw new Error("revoked token was not rejected");
+ok("revoked token");

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -52,7 +52,7 @@ propagate within ~a minute).
 - **The CLI.** Install globally for repeated agent use, or run a pinned version:
   ```bash
   npm install --global @buildinternet/uploads
-  npx @buildinternet/uploads@0.1.0 --help
+  npx @buildinternet/uploads@0.4.0 --help
   ```
   Every example in this skill uses the **global** `uploads …` binary (as after
   install). Inside the uploads monorepo only, `pnpm uploads …` builds from
@@ -192,6 +192,12 @@ uploads put ./after.png --pr 123 --alt "Dashboard after"
 from `--repo` or the git remote. `--pr`/`--issue` can't be combined with `--key`,
 `--ref`, or `--prefix` (the key layout is fixed), and are mutually exclusive.
 
+These keys are deliberately predictable: they include the owner, repository, PR or
+issue number, and filename. uploads.sh does not check GitHub visibility, so a private
+or internal repository does **not** make the uploaded file private. Before using this
+mode, confirm the media is safe for a public, guessable URL; otherwise redact it or do
+not upload it.
+
 Then reference the URL in the PR/issue markdown you write with `gh`:
 
 ```markdown
@@ -280,9 +286,11 @@ uploads --api-url http://localhost:8787 doctor
 
 ## Notes and cautions
 
-- **Uploads are public and effectively permanent** until deleted. Never upload
-  secrets, tokens, internal dashboards with sensitive data, or customer PII visible in
-  a shot — crop/redact first.
+- **Uploads are public and effectively permanent** until deleted. GitHub repository
+  visibility is not an access control: private/internal PR and issue attachments remain
+  public, and `gh/<owner>/<repo>/pull|issues/<num>/<filename>` keys are predictable.
+  Never upload secrets, tokens, internal dashboards with sensitive data, or customer
+  PII visible in a shot — crop/redact first.
 - **Edge cache:** responses carry `Cache-Control: max-age=60`, so an overwrite or a
   delete can keep serving the old bytes from the edge for up to ~a minute. The object
   in storage changes immediately.

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -49,10 +49,10 @@ propagate within ~a minute).
 ## Prerequisites
 
 - **Node.js ≥ 22.**
-- **The CLI.** Install globally for repeated agent use, or run a pinned version:
+- **The CLI.** Install globally for repeated agent use, or run it once with `npx`:
   ```bash
   npm install --global @buildinternet/uploads
-  npx @buildinternet/uploads@0.4.0 --help
+  npx @buildinternet/uploads --help
   ```
   Every example in this skill uses the **global** `uploads …` binary (as after
   install). Inside the uploads monorepo only, `pnpm uploads …` builds from


### PR DESCRIPTION
The existing agent attachment workflow now has a safer deployed-path smoke test, a real Worker bundle check in CI, current installation examples, and clearer warnings around predictable public attachment URLs. This hardens the boundaries that recently caused friction without adding a new auth system or changing attachment key semantics.

## What it does

- removes unnecessary public `npx` version pins so examples resolve the current release and do not go stale
- adds a manual, protected remote MCP lifecycle test covering enrollment, scoped token exchange, MCP initialization and discovery, upload/list/delete cleanup, revocation, and rejected-token verification
- keeps routine enrollment defaults read/write while testing the explicitly authorized delete scope used by cleanup credentials
- makes CI perform a credential-free Wrangler dry-run bundle of `apps/mcp`
- strengthens CLI, MCP, Worker-tool, and agent-skill warnings that private/internal repository attachments still use predictable public URLs
- adds the required patch changeset for the public CLI/help changes

This does not restore the PR-title Action, redesign public keys, deploy anything, add Better Auth, or introduce private-media access control.

## Operational notes

The remote smoke workflow is manual-only, restricted to a `main` workflow ref, and uses a protected `remote-mcp-smoke` GitHub Environment. That environment should require reviewers, restrict deployments to `main`, store `ADMIN_TOKEN` as an environment secret, and provide the API/MCP URLs as environment variables. Generated enrollment and workspace tokens are immediately masked; response bodies, tokens, and public object URLs are not logged.

## Follow-ups

Separate design work should cover:

- a noindex uploads.sh file-view page for media, safe metadata, and optional PR/issue context
- simplifying the root README in favor of focused documents under `docs/`
- publishing an explainer/documentation surface at `uploads.sh/docs`

## Test plan

- [x] `git diff --check`
- [x] Oxfmt check over all changed files
- [x] Node syntax check for `scripts/smoke-remote-mcp.mjs`
- [x] API tests: 96 passed
- [x] Credential-pattern scan; no credentials added
- [ ] Full CLI package tests locally — dependency linking on the Windows-mounted checkout did not complete; 55 tests passed before missing `sharp` stopped dependent suites
- [ ] Local Wrangler bundle — the incomplete local dependency tree could not resolve workspace packages/`sharp`; the new CI job runs this from a frozen install
- [ ] Protected remote smoke — intentionally not run without explicit production credential approval
