### PR TITLE
feat: standardize API errors with nested envelope

### DIFF
--- a/.changeset/standardized-errors.md
+++ b/.changeset/standardized-errors.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Parse the nested API error envelope (`error.code` / `error.message`) while still accepting the legacy flat `{ error: string }` shape.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ scripts in `buildinternet-skills/github-screenshots`.
 apps/api            Hono worker — REST API, deploys to api.uploads.sh
 apps/mcp            Hono worker — remote MCP server, deploys to agents.uploads.sh (alt: mcp.uploads.sh)
 apps/web            Astro placeholder — future browse/manage UI (separate deploy)
+packages/errors     @uploads/errors — typed AppError hierarchy + nested wire envelope
 packages/storage    @uploads/storage — files-sdk adapter factory
 packages/uploads    @buildinternet/uploads — CLI + client for GitHub image embeds
                     (also ships `uploads mcp`, a stdio MCP server mirroring the CLI commands)
@@ -123,6 +124,10 @@ records; any future global secrets go through `wrangler secret put` (prod) or
 - Auth is per-workspace bearer tokens, hashed + timing-safe compare, with
   uniform 401s so workspace names can't be enumerated — see
   `apps/api/src/workspace.ts`.
+- HTTP errors: throw `AppError` subclasses from `@uploads/errors` and let
+  `respondError` / Hono `onError` serialize the nested envelope
+  `{ error: { code, type, message, details? } }`. Never hand-roll
+  `c.json({ error: "…" })`. Status is derived from `type` via `STATUS_BY_TYPE`.
 - Object keys are validated (`badKey` in `routes/files.ts`); URL parsing
   normalizes dot segments before handlers run.
 - Upload guardrails live in `apps/api/src/guards.ts`: a byte cap (default 25 MiB)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",
     "hono": "^4.12.28"
   },

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 import { hexToBytes, sha256Hex } from "./workspace";
 
@@ -17,6 +18,6 @@ export const adminAuth: MiddlewareHandler<{ Bindings: Env }> = async (c, next) =
     token.length > 0 &&
     crypto.subtle.timingSafeEqual(hexToBytes(providedHash), hexToBytes(expectedHash));
 
-  if (!ok) return c.json({ error: "unauthorized" }, 401);
+  if (!ok) throw new UnauthorizedError();
   await next();
 };

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -61,7 +61,6 @@ export function checkPutBudget(
         status: 429,
         message: `upload budget exceeded (${usage.uploadsInPeriod}/${maxUploadsPerPeriod} this period)`,
         detail: {
-          code: "upload_budget_exceeded",
           uploadsInPeriod: usage.uploadsInPeriod,
           maxUploadsPerPeriod,
           periodStart: usage.periodStart,
@@ -78,7 +77,6 @@ export function checkPutBudget(
         status: 507,
         message: `storage quota exceeded (${usage.bytes} + ${delta.bytes} > ${maxStorageBytes} bytes)`,
         detail: {
-          code: "storage_quota_exceeded",
           bytes: usage.bytes,
           deltaBytes: delta.bytes,
           maxStorageBytes,

--- a/apps/api/src/error-response.ts
+++ b/apps/api/src/error-response.ts
@@ -1,0 +1,29 @@
+/**
+ * Single boundary serializer for HTTP error responses. Routes and middleware
+ * throw `AppError` subclasses (or plain values that `AppError.from` wraps);
+ * this turns them into the nested wire envelope.
+ */
+import { AppError, isAppError } from "@uploads/errors";
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+export function respondError(c: Context, err: unknown): Response {
+  const appErr = isAppError(err) ? err : AppError.from(err);
+  if (!appErr.expose || appErr.type === "internal") {
+    const cause = appErr.cause;
+    console.error(
+      JSON.stringify({
+        message: appErr.message,
+        code: appErr.code,
+        type: appErr.type,
+        stack: appErr.stack,
+        ...(cause instanceof Error
+          ? { cause: cause.message, causeStack: cause.stack }
+          : cause !== undefined
+            ? { cause: String(cause) }
+            : {}),
+      }),
+    );
+  }
+  return c.json(appErr.toWire(), appErr.status as ContentfulStatusCode);
+}

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -1,9 +1,11 @@
 /**
  * Workspace file operations shared by the REST routes (routes/files.ts) and
  * the remote MCP worker (apps/mcp) — one code path for key/body validation,
- * storage I/O, and result shapes. Validation failures throw FileOpError;
- * each surface maps it (HTTP 400 / MCP tool error).
+ * storage I/O, and result shapes. Validation failures throw AppError subclasses
+ * from `@uploads/errors`; REST serializes via `respondError`, MCP surfaces
+ * `message` in the tool error.
  */
+import { InsufficientStorageError, RateLimitedError, ValidationError } from "@uploads/errors";
 import type { Files } from "@uploads/storage";
 import { checkPutBudget } from "./budget";
 import { inspectUpload, resolveUploadPolicy } from "./guards";
@@ -71,35 +73,14 @@ export type KeyPolicyRecord = Pick<
  */
 export function finalizeUploadKey(key: string, ws: KeyPolicyRecord): string {
   const finalKey = governUploadKey(key, ws.autoPrefixBareKeys !== false);
-  if (badKey(finalKey)) throw new FileOpError("invalid key");
+  if (badKey(finalKey)) throw new ValidationError("invalid key", { code: "invalid_key" });
 
   const violation = checkKeyPolicy(finalKey, resolveKeyPolicy(ws));
   if (violation) {
     const { message, code, ...extra } = violation;
-    throw new FileOpError(message, 400, { code, ...extra });
+    throw new ValidationError(message, { code, details: extra });
   }
   return finalKey;
-}
-
-/**
- * Rejected input to a file operation (always a caller error, never a storage
- * failure). Carries the REST status and error body so both surfaces report the
- * same policy: HTTP responds with them; MCP renders `message` in the tool error.
- */
-export class FileOpError extends Error {
-  readonly status: 400 | 413 | 415 | 429 | 507;
-  readonly body: Record<string, unknown>;
-
-  constructor(
-    message: string,
-    status: 400 | 413 | 415 | 429 | 507 = 400,
-    extra?: Record<string, unknown>,
-  ) {
-    super(message);
-    this.name = "FileOpError";
-    this.status = status;
-    this.body = { error: message, ...extra };
-  }
 }
 
 /** Size of an existing object, or `null` if missing / unreadable (metering may drift). */
@@ -135,13 +116,10 @@ export async function putObject(
   metadata?: ProvenanceMap;
 }> {
   const finalKey = finalizeUploadKey(key, ws);
-  if (bytes.byteLength === 0) throw new FileOpError("empty body");
+  if (bytes.byteLength === 0) throw new ValidationError("empty body", { code: "empty_body" });
 
   const inspection = inspectUpload(bytes, resolveUploadPolicy(ws));
-  if (!inspection.ok) {
-    const { error, ...extra } = inspection.body as { error: string } & Record<string, unknown>;
-    throw new FileOpError(error, inspection.status, extra);
-  }
+  if (!inspection.ok) throw inspection.error;
 
   const store = await storage(env, ws);
   const prev = await existingSize(store, finalKey);
@@ -150,7 +128,18 @@ export async function putObject(
 
   const usage = await getWorkspaceUsage(env.DB, workspaceName);
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
-  if (denial) throw new FileOpError(denial.message, denial.status, denial.detail);
+  if (denial) {
+    if (denial.status === 507) {
+      throw new InsufficientStorageError(denial.message, {
+        code: denial.code,
+        details: denial.detail,
+      });
+    }
+    throw new RateLimitedError(denial.message, {
+      code: denial.code,
+      details: denial.detail,
+    });
+  }
 
   // Client headers first; always attach content-sha256 of the final stored body
   // (never trust a client-supplied hash).
@@ -227,7 +216,7 @@ export async function deleteObject(
   key: string,
   workspaceName: string,
 ): Promise<{ key: string; deleted: true }> {
-  if (badKey(key)) throw new FileOpError("invalid key");
+  if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
 
   const store = await storage(env, ws);
   const prev = await existingSize(store, key);

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -1,3 +1,9 @@
+import {
+  PayloadTooLargeError,
+  RateLimitedError,
+  UnsupportedMediaTypeError,
+  type AppError,
+} from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 import type { WorkspaceVars } from "./workspace";
 
@@ -108,7 +114,11 @@ export function detectContentType(bytes: Uint8Array): string | null {
   return null;
 }
 
-export type UploadRejection = { ok: false; status: 413 | 415; body: Record<string, unknown> };
+export type UploadRejection = {
+  ok: false;
+  status: 413 | 415;
+  error: AppError;
+};
 export type UploadInspection = { ok: true; contentType: string } | UploadRejection;
 
 /** The shared 413 rejection for both the pre-buffer and post-buffer size checks. */
@@ -119,12 +129,10 @@ function tooLarge(
   return {
     ok: false,
     status: 413,
-    body: {
-      error: "payload too large",
+    error: new PayloadTooLargeError("payload too large", {
       code: "upload_too_large",
-      maxBytes,
-      ...extra,
-    },
+      details: { maxBytes, ...extra },
+    }),
   };
 }
 
@@ -153,7 +161,9 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
     return {
       ok: false,
       status: 415,
-      body: { error: "unsupported media type", allowed: [...policy.allowed] },
+      error: new UnsupportedMediaTypeError("unsupported media type", {
+        details: { allowed: [...policy.allowed] },
+      }),
     };
   }
   const maxBytes = maxBytesForContentType(policy, detected);
@@ -173,7 +183,7 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
  */
 export const writeRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
   if (!(await allowWrite(c.env, c.get("workspaceName")))) {
-    return c.json({ error: "rate limit exceeded" }, 429);
+    throw new RateLimitedError("rate limit exceeded");
   }
   await next();
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,6 @@
+import { AppError, NotFoundError } from "@uploads/errors";
 import { Hono } from "hono";
+import { respondError } from "./error-response";
 import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
 import { usage } from "./routes/usage";
@@ -14,11 +16,8 @@ export const app = new Hono<WorkspaceVars>()
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/files", files)
   .route("/v1/:workspace/usage", usage)
-  .onError((err, c) => {
-    console.error(JSON.stringify({ message: err.message, stack: err.stack }));
-    return c.json({ error: "internal error" }, 500);
-  })
-  .notFound((c) => c.json({ error: "not found" }, 404));
+  .onError((err, c) => respondError(c, err))
+  .notFound((c) => respondError(c, new NotFoundError()));
 
 /** Worker entry: fetch + daily retention cron. */
 export default {
@@ -26,10 +25,12 @@ export default {
   async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
     ctx.waitUntil(
       runRetentionSweep(env).catch((err) => {
+        const appErr = AppError.from(err);
         console.error(
           JSON.stringify({
             message: "retention_sweep_failed",
-            error: err instanceof Error ? err.message : String(err),
+            error: appErr.message,
+            code: appErr.code,
           }),
         );
       }),

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,3 +1,4 @@
+import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { adminAuth } from "../admin";
 import {
@@ -49,6 +50,20 @@ function labelValue(value: unknown): string | undefined | null {
   return label.length >= 1 && label.length <= 100 ? label : null;
 }
 
+function requireWorkspaceName(name: string): void {
+  if (!WS_NAME_RE.test(name)) {
+    throw new ValidationError("invalid workspace", { code: "invalid_workspace" });
+  }
+}
+
+function requireLabel(label: string | undefined | null): asserts label is string | undefined {
+  if (label === null) {
+    throw new ValidationError("label must be between 1 and 100 characters", {
+      code: "invalid_label",
+    });
+  }
+}
+
 export const admin = new Hono<{ Bindings: Env }>()
   .use("/*", adminAuth)
 
@@ -73,19 +88,21 @@ export const admin = new Hono<{ Bindings: Env }>()
       );
     const name = body.workspace?.trim() || "default";
     const label = labelValue(body.label);
-    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
-    if (label === null) return c.json({ error: "label must be between 1 and 100 characters" }, 400);
-    if (!(await workspace(c, name))) return c.json({ error: "workspace not found" }, 404);
+    requireWorkspaceName(name);
+    requireLabel(label);
+    if (!(await workspace(c, name))) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
 
     const scopes = validateScopes(body.scopes, [...FILE_SCOPES]);
-    if (!scopes) return c.json({ error: "invalid scopes" }, 400);
+    if (!scopes) throw new ValidationError("invalid scopes", { code: "invalid_scopes" });
     if (
       body.expiresInDays !== undefined &&
       !validInteger(body.expiresInDays, 1, MAX_TOKEN_SECONDS / SECONDS_PER_DAY)
     ) {
-      return c.json(
-        { error: `expiresInDays must be between 1 and ${MAX_TOKEN_SECONDS / SECONDS_PER_DAY}` },
-        400,
+      throw new ValidationError(
+        `expiresInDays must be between 1 and ${MAX_TOKEN_SECONDS / SECONDS_PER_DAY}`,
+        { code: "invalid_expires" },
       );
     }
 
@@ -134,28 +151,30 @@ export const admin = new Hono<{ Bindings: Env }>()
       );
     const name = body.workspace?.trim() || "default";
     const label = labelValue(body.label);
-    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
-    if (label === null) return c.json({ error: "label must be between 1 and 100 characters" }, 400);
-    if (!(await workspace(c, name))) return c.json({ error: "workspace not found" }, 404);
+    requireWorkspaceName(name);
+    requireLabel(label);
+    if (!(await workspace(c, name))) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
 
     const scopes = validateScopes(body.scopes, ["files:read", "files:write"]);
-    if (!scopes) return c.json({ error: "invalid scopes" }, 400);
+    if (!scopes) throw new ValidationError("invalid scopes", { code: "invalid_scopes" });
     if (
       body.enrollmentSeconds !== undefined &&
       !validInteger(body.enrollmentSeconds, 60, MAX_ENROLLMENT_SECONDS)
     ) {
-      return c.json(
-        { error: `enrollmentSeconds must be between 60 and ${MAX_ENROLLMENT_SECONDS}` },
-        400,
+      throw new ValidationError(
+        `enrollmentSeconds must be between 60 and ${MAX_ENROLLMENT_SECONDS}`,
+        { code: "invalid_expires" },
       );
     }
     if (
       body.tokenExpiresInSeconds !== undefined &&
       !validInteger(body.tokenExpiresInSeconds, 60, MAX_TOKEN_SECONDS)
     ) {
-      return c.json(
-        { error: `tokenExpiresInSeconds must be between 60 and ${MAX_TOKEN_SECONDS}` },
-        400,
+      throw new ValidationError(
+        `tokenExpiresInSeconds must be between 60 and ${MAX_TOKEN_SECONDS}`,
+        { code: "invalid_expires" },
       );
     }
 
@@ -172,9 +191,11 @@ export const admin = new Hono<{ Bindings: Env }>()
   // Lists D1 credentials and legacy KV credentials without exposing secrets.
   .get("/tokens", async (c) => {
     const name = c.req.query("workspace")?.trim() || "default";
-    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
+    requireWorkspaceName(name);
     const record = await workspace(c, name);
-    if (!record) return c.json({ error: "workspace not found" }, 404);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
 
     const d1 = (await listTokens(c.env.DB, name)).map((token) => ({
       label: token.label,
@@ -205,11 +226,17 @@ export const admin = new Hono<{ Bindings: Env }>()
     const name = body.workspace?.trim() || "default";
     const hashPrefix = body.hashPrefix?.trim();
     const label = body.label?.trim();
-    if (!WS_NAME_RE.test(name)) return c.json({ error: "invalid workspace" }, 400);
-    if (!hashPrefix && !label) return c.json({ error: "hashPrefix or label required" }, 400);
+    requireWorkspaceName(name);
+    if (!hashPrefix && !label) {
+      throw new ValidationError("hashPrefix or label required", {
+        code: "hash_prefix_or_label_required",
+      });
+    }
 
     const record = await workspace(c, name);
-    if (!record) return c.json({ error: "workspace not found" }, 404);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
     const kv = legacyTokens(record);
     const kvMatches = kv.filter((token) =>
       hashPrefix ? token.hash.startsWith(hashPrefix) : token.label === label,
@@ -220,12 +247,12 @@ export const admin = new Hono<{ Bindings: Env }>()
         (hashPrefix ? token.token_hash.startsWith(hashPrefix) : token.label === label),
     );
     const count = kvMatches.length + activeD1.length;
-    if (count === 0) return c.json({ error: "no matching token" }, 404);
-    if (count > 1) return c.json({ error: "selector matches multiple tokens" }, 409);
+    if (count === 0) throw new NotFoundError("no matching token");
+    if (count > 1) throw new ConflictError("selector matches multiple tokens");
 
     if (activeD1.length === 1) {
       const result = await revokeToken(c.env.DB, name, { hashPrefix, label });
-      if (!result.match) return c.json({ error: "no matching token" }, 404);
+      if (!result.match) throw new NotFoundError("no matching token");
       return c.json({
         workspace: name,
         revoked: {
@@ -261,6 +288,6 @@ export const admin = new Hono<{ Bindings: Env }>()
       return c.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return c.json({ error: message }, 400);
+      throw new ValidationError(message, { cause: err });
     }
   });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,22 +1,24 @@
+import { ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { exchangeEnrollment } from "../auth-db";
 
-const INVALID_ENROLLMENT = { error: "invalid or expired enrollment code" } as const;
+const INVALID_ENROLLMENT = () =>
+  new ValidationError("invalid or expired enrollment code", { code: "invalid_enrollment" });
 const MAX_EXCHANGE_BODY_BYTES = 1024;
 
 export const auth = new Hono<{ Bindings: Env }>().post("/enrollments/exchange", async (c) => {
   c.header("Cache-Control", "no-store");
   const contentLength = Number(c.req.header("Content-Length") ?? 0);
-  if (contentLength > MAX_EXCHANGE_BODY_BYTES) return c.json(INVALID_ENROLLMENT, 400);
+  if (contentLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
   const body = await c.req
     .json<Record<string, unknown>>()
     .catch(() => ({}) as Record<string, unknown>);
   if (Object.keys(body).length !== 1 || typeof body.code !== "string") {
-    return c.json(INVALID_ENROLLMENT, 400);
+    throw INVALID_ENROLLMENT();
   }
   const code = body.code?.trim() ?? "";
-  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) return c.json(INVALID_ENROLLMENT, 400);
+  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
   const result = await exchangeEnrollment(c.env.DB, code);
-  if (!result) return c.json(INVALID_ENROLLMENT, 400);
+  if (!result) throw INVALID_ENROLLMENT();
   return c.json(result, 201);
 });

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,6 +1,6 @@
-import { Hono, type Context } from "hono";
+import { NotFoundError, ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
 import {
-  FileOpError,
   badKey,
   deleteObject,
   finalizeUploadKey,
@@ -12,14 +12,6 @@ import { provenanceFromHeaders } from "../provenance";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../guards";
-
-/** Maps a core validation failure to the REST error shape; rethrows anything else. */
-function mapFileOpError(c: Context, err: unknown): Response {
-  if (err instanceof FileOpError) {
-    return c.json(err.body, err.status as 400 | 413 | 415 | 429 | 507);
-  }
-  throw err;
-}
 
 export const files = new Hono<WorkspaceVars>()
 
@@ -43,15 +35,10 @@ export const files = new Hono<WorkspaceVars>()
       );
 
     const rawKey = typeof body.key === "string" ? body.key : "";
-    if (!rawKey) return c.json({ error: "invalid key" }, 400);
+    if (!rawKey) throw new ValidationError("invalid key", { code: "invalid_key" });
 
     const ws = c.get("workspace");
-    let key: string;
-    try {
-      key = finalizeUploadKey(rawKey, ws);
-    } catch (err) {
-      return mapFileOpError(c, err);
-    }
+    const key = finalizeUploadKey(rawKey, ws);
 
     const policy = resolveUploadPolicy(ws);
     const ceiling = Math.max(policy.maxBytes, policy.maxVideoBytes);
@@ -83,13 +70,9 @@ export const files = new Hono<WorkspaceVars>()
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(JSON.stringify({ message: "presign failed", error: message }));
-      return c.json(
-        {
-          error:
-            "presign unavailable for this workspace (needs S3 HTTP credentials; binding-only cannot sign)",
-          detail: message,
-        },
-        400,
+      throw new ValidationError(
+        "presign unavailable for this workspace (needs S3 HTTP credentials; binding-only cannot sign)",
+        { code: "presign_unavailable", details: { detail: message }, cause: err },
       );
     }
   })
@@ -99,25 +82,21 @@ export const files = new Hono<WorkspaceVars>()
   // files-core's putObject (shared with the MCP worker); see guards.ts.
   .put("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
     const key = c.req.param("key");
-    if (badKey(key)) return c.json({ error: "invalid key" }, 400);
+    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
     const policy = resolveUploadPolicy(c.get("workspace"));
     const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
-    if (declared) return c.json(declared.body, declared.status);
+    if (declared) throw declared.error;
 
     const body = await c.req.arrayBuffer();
-    try {
-      const result = await putObject(
-        c.env,
-        c.get("workspace"),
-        key,
-        new Uint8Array(body),
-        c.get("workspaceName"),
-        { provenance: provenanceFromHeaders((n) => c.req.header(n)) },
-      );
-      return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
-    } catch (err) {
-      return mapFileOpError(c, err);
-    }
+    const result = await putObject(
+      c.env,
+      c.get("workspace"),
+      key,
+      new Uint8Array(body),
+      c.get("workspaceName"),
+      { provenance: provenanceFromHeaders((n) => c.req.header(n)) },
+    );
+    return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
   })
 
   .get("/", requireScope("files:read"), async (c) => {
@@ -128,20 +107,16 @@ export const files = new Hono<WorkspaceVars>()
 
   .get("/:key{.+}", requireScope("files:read"), async (c) => {
     const key = c.req.param("key");
-    if (badKey(key)) return c.json({ error: "invalid key" }, 400);
+    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
     const ws = c.get("workspace");
     const store = await storage(c.env, ws);
-    if (!(await store.exists(key))) return c.json({ error: "not found" }, 404);
+    if (!(await store.exists(key))) throw new NotFoundError();
     const meta = await store.head(key);
     return c.json(headObjectJson(key, meta, publicUrl(await storageConfig(c.env, ws), key)));
   })
 
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {
-    try {
-      return c.json(
-        await deleteObject(c.env, c.get("workspace"), c.req.param("key"), c.get("workspaceName")),
-      );
-    } catch (err) {
-      return mapFileOpError(c, err);
-    }
+    return c.json(
+      await deleteObject(c.env, c.get("workspace"), c.req.param("key"), c.get("workspaceName")),
+    );
   });

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -1,3 +1,4 @@
+import { InsufficientScopeError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 import type { StorageProvider } from "@uploads/storage";
 import { FILE_SCOPES, findActiveToken, parseScopes, type FileScope } from "./auth-db";
@@ -146,7 +147,7 @@ function workspaceAuthWith(
     );
     const ok = legacyOk || (record !== null && d1Token !== null);
 
-    if (!ok || !record || !name) return c.json({ error: "unauthorized" }, 401);
+    if (!ok || !record || !name) throw new UnauthorizedError();
 
     c.set("workspace", record);
     c.set("workspaceName", name);
@@ -164,7 +165,9 @@ export const tokenWorkspaceAuth = workspaceAuthWith((_c, token) => workspaceName
 
 export function requireScope(scope: FileScope): MiddlewareHandler<WorkspaceVars> {
   return async (c, next) => {
-    if (!c.get("authScopes").includes(scope)) return c.json({ error: "forbidden" }, 403);
+    if (!c.get("authScopes").includes(scope)) {
+      throw new InsufficientScopeError(scope, "forbidden");
+    }
     await next();
   };
 }

--- a/apps/api/test/guards-video.test.ts
+++ b/apps/api/test/guards-video.test.ts
@@ -17,9 +17,8 @@ describe("per-type upload size", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(413);
-      expect(result.body.code).toBe("upload_too_large");
-      expect(result.body.kind).toBe("video");
-      expect(result.body.maxBytes).toBe(4);
+      expect(result.error.code).toBe("upload_too_large");
+      expect(result.error.details).toMatchObject({ kind: "video", maxBytes: 4 });
     }
   });
 

--- a/apps/api/test/key-policy.test.ts
+++ b/apps/api/test/key-policy.test.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "@uploads/errors";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_ALLOWED_PREFIXES,
@@ -6,7 +7,7 @@ import {
   normalizeKeyPrefix,
   resolveKeyPolicy,
 } from "../src/key-policy";
-import { finalizeUploadKey, FileOpError, governUploadKey } from "../src/files-core";
+import { finalizeUploadKey, governUploadKey } from "../src/files-core";
 
 describe("normalizeKeyPrefix", () => {
   it("normalizes roots with or without trailing slash", () => {
@@ -73,13 +74,13 @@ describe("finalizeUploadKey", () => {
 
   it("enforces allowed prefixes after governance", () => {
     expect(() => finalizeUploadKey("tmp/x.png", { allowedKeyPrefixes: ["screenshots"] })).toThrow(
-      FileOpError,
+      ValidationError,
     );
     try {
       finalizeUploadKey("tmp/x.png", { allowedKeyPrefixes: ["screenshots"] });
     } catch (err) {
-      expect(err).toBeInstanceOf(FileOpError);
-      expect((err as FileOpError).body.code).toBe("key_prefix_not_allowed");
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).code).toBe("key_prefix_not_allowed");
     }
   });
 

--- a/apps/api/test/routes-budget.test.ts
+++ b/apps/api/test/routes-budget.test.ts
@@ -64,9 +64,12 @@ describe("workspace budget enforcement", () => {
     const { env } = await makeEnv({ maxStorageBytes: PNG.byteLength - 1 });
     const res = await put(env);
     expect(res.status).toBe(507);
-    const body = (await res.json()) as { code: string; maxStorageBytes: number };
-    expect(body.code).toBe("storage_quota_exceeded");
-    expect(body.maxStorageBytes).toBe(PNG.byteLength - 1);
+    const body = (await res.json()) as {
+      error: { code: string; type: string; message: string; details: { maxStorageBytes: number } };
+    };
+    expect(body.error.code).toBe("storage_quota_exceeded");
+    expect(body.error.type).toBe("insufficient_storage");
+    expect(body.error.details.maxStorageBytes).toBe(PNG.byteLength - 1);
   });
 
   it("returns 429 when monthly upload budget is spent", async () => {
@@ -76,8 +79,9 @@ describe("workspace budget enforcement", () => {
 
     const res = await put(env, "b.png");
     expect(res.status).toBe(429);
-    const body = (await res.json()) as { code: string };
-    expect(body.code).toBe("upload_budget_exceeded");
+    const body = (await res.json()) as { error: { code: string; type: string } };
+    expect(body.error.code).toBe("upload_budget_exceeded");
+    expect(body.error.type).toBe("rate_limited");
   });
 
   it("surfaces limits on GET /usage", async () => {

--- a/apps/api/test/routes-key-policy.test.ts
+++ b/apps/api/test/routes-key-policy.test.ts
@@ -73,9 +73,11 @@ describe("PUT key policy", () => {
     const { env } = await makeEnv({ allowedKeyPrefixes: ["screenshots", "gh"] });
     const res = await putKey(env, "tmp/shot.png");
     expect(res.status).toBe(400);
-    const json = (await res.json()) as { code: string; allowedKeyPrefixes: string[] };
-    expect(json.code).toBe("key_prefix_not_allowed");
-    expect(json.allowedKeyPrefixes).toContain("screenshots/");
+    const json = (await res.json()) as {
+      error: { code: string; details: { allowedKeyPrefixes: string[] } };
+    };
+    expect(json.error.code).toBe("key_prefix_not_allowed");
+    expect(json.error.details.allowedKeyPrefixes).toContain("screenshots/");
   });
 
   it("allows keys under an allowed destination", async () => {
@@ -89,9 +91,11 @@ describe("PUT key policy", () => {
     const { env } = await makeEnv({ maxKeyDepth: 2 });
     const res = await putKey(env, "screenshots/a/b/shot.png");
     expect(res.status).toBe(400);
-    const json = (await res.json()) as { code: string; maxKeyDepth: number };
-    expect(json.code).toBe("key_too_deep");
-    expect(json.maxKeyDepth).toBe(2);
+    const json = (await res.json()) as {
+      error: { code: string; details: { maxKeyDepth: number } };
+    };
+    expect(json.error.code).toBe("key_too_deep");
+    expect(json.error.details.maxKeyDepth).toBe(2);
   });
 
   it("auto-prefix bare keys still works with f/ allowlist", async () => {

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@buildinternet/uploads": "workspace:^",
     "@uploads/api": "workspace:^",
+    "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",
     "hono": "^4.12.28"
   },

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -9,8 +9,10 @@
  * `createMcpServer`, shared verbatim.
  */
 import { createMcpServer } from "@buildinternet/uploads/mcp";
+import { AppError, isAppError, MethodNotAllowedError, NotFoundError } from "@uploads/errors";
 import { tokenWorkspaceAuth, workspaceAuth, type WorkspaceVars } from "@uploads/api/workspace";
 import { Hono, type Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import pkg from "../package.json";
 import { createRemoteTools } from "./tools";
 
@@ -31,8 +33,24 @@ async function handleMcp(c: Context<WorkspaceVars>): Promise<Response> {
   return c.body(result, 200, { "Content-Type": "application/json" });
 }
 
-const methodNotAllowed = (c: Context<WorkspaceVars>) =>
-  c.json({ error: "method not allowed" }, 405);
+function respondError(c: Context, err: unknown): Response {
+  const appErr = isAppError(err) ? err : AppError.from(err);
+  if (!appErr.expose || appErr.type === "internal") {
+    console.error(
+      JSON.stringify({
+        message: appErr.message,
+        code: appErr.code,
+        type: appErr.type,
+        stack: appErr.stack,
+      }),
+    );
+  }
+  return c.json(appErr.toWire(), appErr.status as ContentfulStatusCode);
+}
+
+const methodNotAllowed = (_c: Context<WorkspaceVars>) => {
+  throw new MethodNotAllowedError();
+};
 
 const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
@@ -44,10 +62,7 @@ const app = new Hono<WorkspaceVars>()
   .use("/:workspace/*", workspaceAuth)
   .post("/:workspace/mcp", handleMcp)
   .on(["GET", "DELETE"], "/:workspace/mcp", methodNotAllowed)
-  .onError((err, c) => {
-    console.error(JSON.stringify({ message: err.message, stack: err.stack }));
-    return c.json({ error: "internal error" }, 500);
-  })
-  .notFound((c) => c.json({ error: "not found" }, 404));
+  .onError((err, c) => respondError(c, err))
+  .notFound((c) => respondError(c, new NotFoundError()));
 
 export default app;

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -128,7 +128,13 @@ describe("mcp worker", () => {
     const { env } = await makeEnv();
     const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, "wrong");
     expect(response.status).toBe(401);
-    expect(await response.json()).toEqual({ error: "unauthorized" });
+    expect(await response.json()).toEqual({
+      error: {
+        code: "unauthorized",
+        type: "unauthorized",
+        message: "Authentication required.",
+      },
+    });
   });
 
   it("answers the initialize handshake", async () => {
@@ -293,7 +299,13 @@ describe("mcp worker", () => {
     for (const path of ["/default/mcp", "/other-ws/mcp"]) {
       const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, TOKEN, path);
       expect(response.status).toBe(401);
-      expect(await response.json()).toEqual({ error: "unauthorized" });
+      expect(await response.json()).toEqual({
+        error: {
+          code: "unauthorized",
+          type: "unauthorized",
+          message: "Authentication required.",
+        },
+      });
     }
   });
 
@@ -319,7 +331,13 @@ describe("mcp worker", () => {
         env,
       );
       expect(response.status).toBe(405);
-      expect(await response.json()).toEqual({ error: "method not allowed" });
+      expect(await response.json()).toEqual({
+        error: {
+          code: "method_not_allowed",
+          type: "method_not_allowed",
+          message: "Method not allowed.",
+        },
+      });
     }
   });
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,6 +3,31 @@
 All `/v1` routes require the workspace's `Authorization: Bearer <token>`.
 Unknown workspaces and bad tokens are indistinguishable (both 401).
 
+## Errors
+
+Every non-2xx response uses one nested envelope (same shape as either/releases):
+
+```json
+{
+  "error": {
+    "code": "storage_quota_exceeded",
+    "type": "insufficient_storage",
+    "message": "storage quota exceeded (…)",
+    "details": { "maxStorageBytes": 1000 }
+  }
+}
+```
+
+| Field     | Role                                                                         |
+| --------- | ---------------------------------------------------------------------------- |
+| `type`    | Coarse category; pins HTTP status (`validation` → 400, `not_found` → 404, …) |
+| `code`    | Stable machine string clients branch on                                      |
+| `message` | Human-readable; may change; never parse this                                 |
+| `details` | Optional structured context for select codes                                 |
+
+Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
+`onError` serializes them. See `packages/errors`.
+
 ## Routes
 
 | Route                                             | Description                                                                                      |
@@ -54,14 +79,14 @@ size delta; deletes free bytes/objects but not the monthly upload count.
 
 When the workspace record sets budgets (`maxStorageBytes`,
 `maxUploadsPerPeriod`), the response also includes those caps and remaining
-headroom. Puts that would exceed them fail with:
+headroom. Puts that would exceed them fail with (fields on `error`):
 
-| HTTP | `code`                   | Meaning                                              |
-| ---- | ------------------------ | ---------------------------------------------------- |
-| 507  | `storage_quota_exceeded` | Net stored bytes would exceed `maxStorageBytes`      |
-| 429  | `upload_budget_exceeded` | Monthly put count would exceed `maxUploadsPerPeriod` |
-| 400  | `key_prefix_not_allowed` | Key not under `allowedKeyPrefixes` (put/sign)        |
-| 400  | `key_too_deep`           | Key path segments exceed `maxKeyDepth`               |
+| HTTP | `type`                 | `code`                   | Meaning                                              |
+| ---- | ---------------------- | ------------------------ | ---------------------------------------------------- |
+| 507  | `insufficient_storage` | `storage_quota_exceeded` | Net stored bytes would exceed `maxStorageBytes`      |
+| 429  | `rate_limited`         | `upload_budget_exceeded` | Monthly put count would exceed `maxUploadsPerPeriod` |
+| 400  | `validation`           | `key_prefix_not_allowed` | Key not under `allowedKeyPrefixes` (put/sign)        |
+| 400  | `validation`           | `key_too_deep`           | Key path segments exceed `maxKeyDepth`               |
 
 Configure limits with `pnpm workspace:limits <name> …` (see
 [workspaces](workspaces.md)). Bare keys are rewritten to `f/<id>/<name>` before

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,7 +4,12 @@ Shared libraries consumed by `apps/api` and published/used from the CLI.
 
 | Directory  | Package                  | Role                                                               |
 | ---------- | ------------------------ | ------------------------------------------------------------------ |
+| `errors/`  | `@uploads/errors`        | Shared error taxonomy + wire envelope (`AppError`, codes, types)   |
 | `storage/` | `@uploads/storage`       | files-sdk adapter factory — single entry point for all storage I/O |
 | `uploads/` | `@buildinternet/uploads` | CLI (`uploads` bin) + programmatic client for GitHub image embeds  |
 
 Rule: route code never imports files-sdk adapters or touches R2 bindings directly — always go through `createStorage()` in `@uploads/storage`.
+
+HTTP errors use the nested envelope from `@uploads/errors` — throw an `AppError`
+subclass and let `respondError` / `onError` serialize it. Never hand-roll
+`c.json({ error: "…" })`.

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@uploads/errors",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/errors/src/base.ts
+++ b/packages/errors/src/base.ts
@@ -1,0 +1,67 @@
+import { type ErrorCodeInput } from "./codes";
+import { statusForType, type ErrorType } from "./types";
+import { type ErrorEnvelope } from "./wire";
+
+export const GENERIC_MESSAGE = "Something went wrong.";
+
+export interface AppErrorInit {
+  code: ErrorCodeInput;
+  message: string;
+  type: ErrorType;
+  /**
+   * Defaults to the HTTP status for `type`. Overrides the derived status for
+   * the in-process throw/response only. NOT carried on the wire — a client
+   * decoding via `fromWire` always recomputes status from `type`.
+   */
+  status?: number;
+  details?: unknown;
+  /** When false, `toWire` hides the real message. Defaults to true. */
+  expose?: boolean;
+  cause?: unknown;
+}
+
+/** Base class for all typed application errors. */
+export class AppError extends Error {
+  readonly code: ErrorCodeInput;
+  readonly type: ErrorType;
+  readonly status: number;
+  readonly details?: unknown;
+  readonly expose: boolean;
+
+  constructor(init: AppErrorInit) {
+    super(init.message, init.cause !== undefined ? { cause: init.cause } : undefined);
+    this.name = new.target.name;
+    this.code = init.code;
+    this.type = init.type;
+    this.status = init.status ?? statusForType(init.type);
+    this.details = init.details;
+    this.expose = init.expose ?? true;
+  }
+
+  toWire(): ErrorEnvelope {
+    return {
+      error: {
+        code: this.code,
+        type: this.type,
+        message: this.expose ? this.message : GENERIC_MESSAGE,
+        ...(this.details !== undefined ? { details: this.details } : {}),
+      },
+    };
+  }
+
+  /** Coerce any thrown value into an AppError (for the API onError boundary). */
+  static from(err: unknown): AppError {
+    if (err instanceof AppError) return err;
+    return new AppError({
+      code: "internal_error",
+      type: "internal",
+      message: err instanceof Error ? err.message : String(err),
+      expose: false,
+      cause: err,
+    });
+  }
+}
+
+export function isAppError(err: unknown): err is AppError {
+  return err instanceof AppError;
+}

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -1,0 +1,60 @@
+/**
+ * Registry of well-known application error codes. The wire schema keeps `code`
+ * an open string (forward-compat), but producers reference this registry so
+ * typos are compile errors.
+ *
+ * `ErrorCodeInput` (`ErrorCode | (string & {})`) preserves autocomplete while
+ * still admitting codes outside the registry.
+ *
+ * Grouped by domain. New codes should follow `«domain»_«failure»` so the code
+ * alone names both the feature and the failure.
+ */
+export const ERROR_CODES = [
+  // Generic — subclass defaults
+  "validation_error",
+  "unauthorized",
+  "forbidden",
+  "insufficient_scope",
+  "not_found",
+  "method_not_allowed",
+  "conflict",
+  "payload_too_large",
+  "unsupported_media_type",
+  "rate_limited",
+  "insufficient_storage",
+  "service_unavailable",
+  "internal_error",
+  "malformed_error_response",
+
+  // Files / keys
+  "invalid_key",
+  "empty_body",
+  "upload_too_large",
+  "key_prefix_not_allowed",
+  "key_too_deep",
+  "presign_unavailable",
+
+  // Budgets
+  "storage_quota_exceeded",
+  "upload_budget_exceeded",
+
+  // Auth / enrollment
+  "invalid_enrollment",
+
+  // Admin
+  "invalid_workspace",
+  "workspace_not_found",
+  "invalid_scopes",
+  "invalid_label",
+  "invalid_expires",
+  "hash_prefix_or_label_required",
+] as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[number];
+
+/** A known code with autocomplete, or any other string (open wire contract). */
+export type ErrorCodeInput = ErrorCode | (string & {});
+
+export function isKnownErrorCode(code: string): code is ErrorCode {
+  return (ERROR_CODES as readonly string[]).includes(code);
+}

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1,0 +1,174 @@
+import { AppError } from "./base";
+import { type ErrorCodeInput } from "./codes";
+
+interface SubclassOpts {
+  code?: ErrorCodeInput;
+  details?: unknown;
+  cause?: unknown;
+}
+
+export class ValidationError extends AppError {
+  constructor(message = "Invalid request.", opts: SubclassOpts = {}) {
+    super({
+      type: "validation",
+      code: opts.code ?? "validation_error",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = "Authentication required.", opts: SubclassOpts = {}) {
+    super({
+      type: "unauthorized",
+      code: opts.code ?? "unauthorized",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = "Forbidden.", opts: SubclassOpts = {}) {
+    super({
+      type: "forbidden",
+      code: opts.code ?? "forbidden",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+/** Missing OAuth/API scope — fixed code + `{ required_scope }` details. */
+export class InsufficientScopeError extends AppError {
+  constructor(requiredScope: string, message = "Insufficient scope.") {
+    super({
+      type: "insufficient_scope",
+      code: "insufficient_scope",
+      message,
+      details: { required_scope: requiredScope },
+    });
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Not found.", opts: SubclassOpts = {}) {
+    super({
+      type: "not_found",
+      code: opts.code ?? "not_found",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class MethodNotAllowedError extends AppError {
+  constructor(message = "Method not allowed.", opts: SubclassOpts = {}) {
+    super({
+      type: "method_not_allowed",
+      code: opts.code ?? "method_not_allowed",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message = "Conflict.", opts: SubclassOpts = {}) {
+    super({
+      type: "conflict",
+      code: opts.code ?? "conflict",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class PayloadTooLargeError extends AppError {
+  constructor(message = "Payload too large.", opts: SubclassOpts = {}) {
+    super({
+      type: "payload_too_large",
+      code: opts.code ?? "payload_too_large",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class UnsupportedMediaTypeError extends AppError {
+  constructor(message = "Unsupported media type.", opts: SubclassOpts = {}) {
+    super({
+      type: "unsupported_media_type",
+      code: opts.code ?? "unsupported_media_type",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class RateLimitedError extends AppError {
+  readonly retryAfterSeconds?: number;
+  constructor(
+    message = "Too many requests.",
+    opts: SubclassOpts & { retryAfterSeconds?: number } = {},
+  ) {
+    super({
+      type: "rate_limited",
+      code: opts.code ?? "rate_limited",
+      message,
+      details:
+        opts.retryAfterSeconds !== undefined
+          ? { ...(opts.details as object | undefined), retry_after: opts.retryAfterSeconds }
+          : opts.details,
+      cause: opts.cause,
+    });
+    this.retryAfterSeconds = opts.retryAfterSeconds;
+  }
+}
+
+/** Storage budget exceeded (HTTP 507). */
+export class InsufficientStorageError extends AppError {
+  constructor(message = "Insufficient storage.", opts: SubclassOpts = {}) {
+    super({
+      type: "insufficient_storage",
+      code: opts.code ?? "insufficient_storage",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class ServiceUnavailableError extends AppError {
+  constructor(message = "Service unavailable.", opts: SubclassOpts = {}) {
+    super({
+      type: "unavailable",
+      code: opts.code ?? "service_unavailable",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+    });
+  }
+}
+
+export class InternalError extends AppError {
+  constructor(message = "Internal error.", opts: SubclassOpts = {}) {
+    super({
+      type: "internal",
+      code: opts.code ?? "internal_error",
+      message,
+      details: opts.details,
+      cause: opts.cause,
+      expose: false,
+    });
+  }
+}

--- a/packages/errors/src/from-wire.ts
+++ b/packages/errors/src/from-wire.ts
@@ -1,0 +1,21 @@
+import { AppError } from "./base";
+import { isErrorEnvelope } from "./wire";
+
+/**
+ * Decode an API error body into an AppError. Reconstructs a generic AppError
+ * carrying the wire `code`/`type` (not a specific subclass), so a server `code`
+ * the client does not recognize still decodes cleanly. Never throws: a malformed
+ * body becomes a non-exposed internal error.
+ */
+export function fromWire(body: unknown): AppError {
+  if (!isErrorEnvelope(body)) {
+    return new AppError({
+      code: "malformed_error_response",
+      type: "internal",
+      message: "The server returned an unrecognized error response.",
+      expose: false,
+    });
+  }
+  const { code, type, message, details } = body.error;
+  return new AppError({ code, type, message, details });
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+export * from "./codes";
+export * from "./wire";
+export * from "./base";
+export * from "./errors";
+export * from "./from-wire";

--- a/packages/errors/src/types.ts
+++ b/packages/errors/src/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Coarse error categories. Each maps to an HTTP status via {@link STATUS_BY_TYPE}.
+ * Clients switch on `type` for branching; `code` is the specific discriminant.
+ */
+export const ERROR_TYPES = [
+  "validation",
+  "unauthorized",
+  "forbidden",
+  "insufficient_scope",
+  "not_found",
+  "method_not_allowed",
+  "conflict",
+  "payload_too_large",
+  "unsupported_media_type",
+  "rate_limited",
+  "insufficient_storage",
+  "unavailable",
+  "internal",
+] as const;
+
+export type ErrorType = (typeof ERROR_TYPES)[number];
+
+/** category → HTTP status. Status is derived from `type`, never hand-picked on the wire. */
+export const STATUS_BY_TYPE: Record<ErrorType, number> = {
+  validation: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  insufficient_scope: 403,
+  not_found: 404,
+  method_not_allowed: 405,
+  conflict: 409,
+  payload_too_large: 413,
+  unsupported_media_type: 415,
+  rate_limited: 429,
+  insufficient_storage: 507,
+  unavailable: 503,
+  internal: 500,
+};
+
+export function statusForType(type: ErrorType): number {
+  return STATUS_BY_TYPE[type];
+}
+
+/**
+ * Reverse of {@link STATUS_BY_TYPE}. Shared statuses resolve to the earlier
+ * (primary) type in {@link ERROR_TYPES} — 403 → `forbidden`, not `insufficient_scope`.
+ */
+export const TYPE_BY_STATUS: Record<number, ErrorType> = (() => {
+  const map: Record<number, ErrorType> = {};
+  for (const type of ERROR_TYPES) {
+    const status = STATUS_BY_TYPE[type];
+    if (map[status] === undefined) map[status] = type;
+  }
+  return map;
+})();
+
+export function typeForStatus(status: number): ErrorType {
+  return TYPE_BY_STATUS[status] ?? "internal";
+}
+
+/** Types where retrying the same request later can plausibly succeed. */
+const RETRYABLE_TYPES: ReadonlySet<ErrorType> = new Set(["rate_limited", "unavailable"]);
+
+export function isRetryableType(type: ErrorType): boolean {
+  return RETRYABLE_TYPES.has(type);
+}

--- a/packages/errors/src/wire.ts
+++ b/packages/errors/src/wire.ts
@@ -1,0 +1,27 @@
+import { ERROR_TYPES, type ErrorType } from "./types";
+
+/**
+ * The single on-the-wire error shape (nested `error`, Stripe-style).
+ * `type` is a constrained enum; `code` is an open string for forward-compat.
+ */
+export type ErrorEnvelope = {
+  error: {
+    code: string;
+    type: ErrorType;
+    message: string;
+    details?: unknown;
+  };
+};
+
+export function isErrorType(value: unknown): value is ErrorType {
+  return typeof value === "string" && (ERROR_TYPES as readonly string[]).includes(value);
+}
+
+/** Structural check for a nested error envelope (no zod — Workers-friendly). */
+export function isErrorEnvelope(body: unknown): body is ErrorEnvelope {
+  if (typeof body !== "object" || body === null || !("error" in body)) return false;
+  const err = (body as { error: unknown }).error;
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as Record<string, unknown>;
+  return typeof e.code === "string" && isErrorType(e.type) && typeof e.message === "string";
+}

--- a/packages/errors/test/errors.test.ts
+++ b/packages/errors/test/errors.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  AppError,
+  ERROR_CODES,
+  ERROR_TYPES,
+  fromWire,
+  isAppError,
+  isErrorEnvelope,
+  isKnownErrorCode,
+  InsufficientStorageError,
+  InternalError,
+  NotFoundError,
+  RateLimitedError,
+  STATUS_BY_TYPE,
+  ValidationError,
+  statusForType,
+} from "../src/index";
+
+describe("AppError", () => {
+  it("derives status from type by default", () => {
+    const err = new AppError({ code: "invalid_key", type: "validation", message: "bad key" });
+    expect(err.status).toBe(400);
+  });
+
+  it("allows an explicit status override", () => {
+    const err = new AppError({
+      code: "x",
+      type: "internal",
+      message: "x",
+      status: 418,
+    });
+    expect(err.status).toBe(418);
+  });
+
+  it("toWire emits the nested envelope with details", () => {
+    const err = new ValidationError("invalid key", {
+      code: "invalid_key",
+      details: { key: ".." },
+    });
+    expect(err.toWire()).toEqual({
+      error: {
+        code: "invalid_key",
+        type: "validation",
+        message: "invalid key",
+        details: { key: ".." },
+      },
+    });
+  });
+
+  it("toWire omits details when absent", () => {
+    const err = new NotFoundError();
+    expect(err.toWire()).toEqual({
+      error: { code: "not_found", type: "not_found", message: "Not found." },
+    });
+  });
+
+  it("toWire hides the real message when expose is false", () => {
+    const err = new InternalError("secret db dsn");
+    expect(err.toWire().error.message).toBe("Something went wrong.");
+  });
+
+  it("isAppError is a working guard", () => {
+    expect(isAppError(new ValidationError())).toBe(true);
+    expect(isAppError(new Error("plain"))).toBe(false);
+  });
+
+  it("from() returns AppError instances unchanged", () => {
+    const original = new NotFoundError("gone");
+    expect(AppError.from(original)).toBe(original);
+  });
+
+  it("from() wraps a plain Error as a non-exposed internal error", () => {
+    const wrapped = AppError.from(new Error("boom"));
+    expect(wrapped.type).toBe("internal");
+    expect(wrapped.code).toBe("internal_error");
+    expect(wrapped.status).toBe(500);
+    expect(wrapped.expose).toBe(false);
+    expect(wrapped.toWire().error.message).toBe("Something went wrong.");
+  });
+});
+
+describe("subclasses", () => {
+  it("RateLimitedError carries retry_after in details", () => {
+    const err = new RateLimitedError("slow down", { retryAfterSeconds: 30 });
+    expect(err.status).toBe(429);
+    expect(err.toWire().error.details).toEqual({ retry_after: 30 });
+  });
+
+  it("InsufficientStorageError maps to 507", () => {
+    const err = new InsufficientStorageError("quota", {
+      code: "storage_quota_exceeded",
+      details: { maxStorageBytes: 100 },
+    });
+    expect(err.status).toBe(507);
+    expect(err.type).toBe("insufficient_storage");
+    expect(err.code).toBe("storage_quota_exceeded");
+  });
+});
+
+describe("fromWire", () => {
+  it("round-trips through toWire", () => {
+    const original = new ValidationError("invalid key", {
+      code: "invalid_key",
+      details: { allowedKeyPrefixes: ["f/"] },
+    });
+    const decoded = fromWire(original.toWire());
+    expect(decoded.code).toBe("invalid_key");
+    expect(decoded.type).toBe("validation");
+    expect(decoded.status).toBe(400);
+    expect(decoded.message).toBe("invalid key");
+    expect(decoded.details).toEqual({ allowedKeyPrefixes: ["f/"] });
+  });
+
+  it("never throws on malformed bodies", () => {
+    const decoded = fromWire({ error: "flat legacy" });
+    expect(decoded.code).toBe("malformed_error_response");
+    expect(decoded.expose).toBe(false);
+  });
+});
+
+describe("registry", () => {
+  it("every ERROR_TYPE has a status mapping", () => {
+    for (const type of ERROR_TYPES) {
+      expect(typeof STATUS_BY_TYPE[type]).toBe("number");
+      expect(statusForType(type)).toBe(STATUS_BY_TYPE[type]);
+    }
+  });
+
+  it("isKnownErrorCode matches the registry", () => {
+    expect(isKnownErrorCode("invalid_key")).toBe(true);
+    expect(isKnownErrorCode("not_a_real_code")).toBe(false);
+    expect(ERROR_CODES).toContain("storage_quota_exceeded");
+  });
+
+  it("isErrorEnvelope validates structure", () => {
+    expect(
+      isErrorEnvelope({
+        error: { code: "x", type: "validation", message: "y" },
+      }),
+    ).toBe(true);
+    expect(isErrorEnvelope({ error: "flat" })).toBe(false);
+    expect(isErrorEnvelope(null)).toBe(false);
+  });
+});

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": []
+  },
+  "include": ["src", "test"]
+}

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -175,19 +175,19 @@ function usageBase(config: UploadsClientConfig): string {
 
 function mapApiError(status: number, error: string, code?: string): UploadsError {
   const normalized = error.toLowerCase();
-  if (status === 401 || normalized === "unauthorized") {
+  if (status === 401 || code === "unauthorized" || normalized === "unauthorized") {
     return new UploadsError(error, "UNAUTHORIZED", status);
   }
-  if (status === 404 || normalized === "not found") {
+  if (status === 404 || code === "not_found" || normalized === "not found") {
     return new UploadsError(error, "NOT_FOUND", status);
   }
-  if (status === 400 && normalized === "invalid key") {
+  if (code === "invalid_key" || (status === 400 && normalized === "invalid key")) {
     return new UploadsError(error, "INVALID_KEY", status);
   }
   if (code === "key_prefix_not_allowed" || code === "key_too_deep") {
     return new UploadsError(error, "KEY_POLICY", status);
   }
-  // Prefer stable body.code — bare 429 is also used for write rate limits.
+  // Prefer stable body code — bare 429 is also used for write rate limits.
   if (status === 507 || code === "storage_quota_exceeded") {
     return new UploadsError(error, "STORAGE_QUOTA", status);
   }
@@ -197,17 +197,36 @@ function mapApiError(status: number, error: string, code?: string): UploadsError
   return new UploadsError(error, "API_ERROR", status);
 }
 
+/**
+ * Parse API error bodies. Prefers the nested envelope
+ * `{ error: { code, type, message, details? } }`; still accepts the legacy
+ * flat `{ error: string, code?: string }` shape.
+ */
+function extractErrorFields(body: unknown): { message: string; code?: string } {
+  if (typeof body === "object" && body && "error" in body) {
+    const err = (body as { error: unknown }).error;
+    if (typeof err === "object" && err && "message" in err) {
+      const nested = err as { message?: unknown; code?: unknown };
+      return {
+        message: typeof nested.message === "string" ? nested.message : "request failed",
+        code: typeof nested.code === "string" ? nested.code : undefined,
+      };
+    }
+    if (typeof err === "string") {
+      const code =
+        "code" in body && typeof (body as { code: unknown }).code === "string"
+          ? (body as { code: string }).code
+          : undefined;
+      return { message: err, code };
+    }
+  }
+  return { message: "request failed" };
+}
+
 async function parseErrorResponse(res: Response): Promise<UploadsError> {
   const body = await res.json().catch(() => ({}));
-  const message =
-    typeof body === "object" && body && "error" in body && typeof body.error === "string"
-      ? body.error
-      : res.statusText || "request failed";
-  const code =
-    typeof body === "object" && body && "code" in body && typeof body.code === "string"
-      ? body.code
-      : undefined;
-  return mapApiError(res.status, message, code);
+  const { message, code } = extractErrorFields(body);
+  return mapApiError(res.status, message || res.statusText || "request failed", code);
 }
 
 export function createUploadsClient(config: UploadsClientConfig) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@uploads/errors':
+        specifier: workspace:^
+        version: link:../../packages/errors
       '@uploads/storage':
         specifier: workspace:^
         version: link:../../packages/storage
@@ -66,6 +69,9 @@ importers:
       '@uploads/api':
         specifier: workspace:^
         version: link:../api
+      '@uploads/errors':
+        specifier: workspace:^
+        version: link:../../packages/errors
       '@uploads/storage':
         specifier: workspace:^
         version: link:../../packages/storage
@@ -101,6 +107,15 @@ importers:
       wrangler:
         specifier: ^4.107.0
         version: 4.107.0
+
+  packages/errors:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/storage:
     dependencies:


### PR DESCRIPTION
## In plain terms

Error responses were a mix of flat `{ error: "…" }` strings, optional top-level `code` fields, and a file-only `FileOpError`. This adds a shared `@uploads/errors` package (same idea as either’s `packages/errors` and releases’ nested envelope) so every non-2xx response uses one stable shape that clients can branch on.

## What it does

- New private package `@uploads/errors`: `AppError` hierarchy, `ERROR_TYPES` / `ERROR_CODES`, nested wire envelope `{ error: { code, type, message, details? } }`
- API and MCP: throw typed errors; `onError` / `respondError` serialize (no more hand-rolled `c.json({ error })` on the migrated routes)
- Replaces `FileOpError` with `ValidationError` / budget / media-type subclasses
- CLI client parses the nested envelope (still accepts legacy flat shape)
- Docs + changeset for `@buildinternet/uploads` (minor)

## What it is not

- Not a full `packages/api-types` / domain-types package — not needed yet at this surface size
- Does not auto-request CodeRabbit

## How to try it

```bash
# After deploy, a bad key looks like:
curl -s -o /dev/null -w "%{http_code}" -X PUT \
  -H "Authorization: Bearer $UPLOADS_TOKEN" \
  "$UPLOADS_API_URL/v1/$UPLOADS_WORKSPACE/files/.."
# → 400 with body:
# { "error": { "code": "invalid_key", "type": "validation", "message": "invalid key" } }
```

## Technical notes

- Status is derived from `type` via `STATUS_BY_TYPE` (includes `insufficient_storage` → 507)
- Internal/5xx messages are genericized (`expose: false`)
- Worktree: `.worktrees/standardized-errors`

## Test plan

- [x] `pnpm --filter @uploads/errors test`
- [x] `pnpm --filter @uploads/api test`
- [x] `pnpm --filter @uploads/mcp test`
- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm check` (lint + format)
- [ ] CI on the PR