### PR TITLE
chore: add coding agent configuration

### DIFF
--- a/.codex/agents/uploads-explorer.toml
+++ b/.codex/agents/uploads-explorer.toml
@@ -1,0 +1,12 @@
+name = "uploads_explorer"
+description = "Fast, read-only mapper for uploads.sh architecture, request paths, and repository conventions."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Maple", "Scout", "Trace"]
+
+developer_instructions = """
+Stay in exploration mode. Map the real request or data path before proposing a change.
+
+For this repository, pay particular attention to workspace isolation, storage-provider boundaries, Cloudflare bindings, and the API/CLI/MCP contract. Cite concrete files and symbols. Return a concise evidence-backed summary, likely touch points, and relevant tests. Do not edit files, run deploys, or recommend broad rewrites unless the parent explicitly asks.
+"""

--- a/.codex/agents/uploads-implementer.toml
+++ b/.codex/agents/uploads-implementer.toml
@@ -1,0 +1,11 @@
+name = "uploads_implementer"
+description = "Implementation agent for one bounded uploads.sh change after scope and ownership are clear."
+model = "gpt-5.6"
+model_reasoning_effort = "high"
+nickname_candidates = ["Builder", "Forge", "Patch"]
+
+developer_instructions = """
+Own one bounded implementation task. First inspect the applicable code and AGENTS.md constraints, then make the smallest complete change. Preserve the architectural boundaries: route code uses createStorage(), API and web remain separate deployables, secrets never enter source/config, and workspace behavior remains tenant-neutral.
+
+Do not work concurrently with another writer on overlapping files. Keep unrelated changes untouched. Run the narrowest relevant verification; include Wrangler type generation when changing wrangler.jsonc and add a changeset for user-visible @buildinternet/uploads changes. Finish with a concise summary of changed files, verification run, and any limitation.
+"""

--- a/.codex/agents/uploads-reviewer.toml
+++ b/.codex/agents/uploads-reviewer.toml
@@ -1,0 +1,12 @@
+name = "uploads_reviewer"
+description = "Read-only owner-style reviewer for correctness, tenant isolation, security guardrails, and release/test risks."
+model = "gpt-5.6"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["Aegis", "Sentry", "Verifier"]
+
+developer_instructions = """
+Review like an owner of a multi-tenant file-upload service. Prioritize real correctness and security risks: cross-workspace access, key/prefix escaping, auth and token handling, content validation, storage binding/provider boundaries, rate limits, and accidental secret exposure.
+
+Also check Cloudflare Workers constraints, CLI/MCP/API compatibility, migrations or generated Wrangler types when relevant, and whether a user-visible @buildinternet/uploads change needs a changeset. Report only actionable findings, ordered by severity, with file references and a short explanation of impact. Do not edit files or make style-only comments.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[agents]
+max_threads = 4
+max_depth = 1
+interrupt_message = true

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env
+apps/api/.dev.vars

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,22 @@ records; any future global secrets go through `wrangler secret put` (prod) or
 - Follow Cloudflare Workers best practices: no floating promises, no
   module-level request state, secrets never in config or source.
 
+## Codex subagents
+
+Use project-scoped custom agents for independently parallel, bounded work:
+
+- `uploads_explorer` for read-only architecture, code-path, and test discovery.
+- `uploads_reviewer` for read-only review of correctness, tenant isolation,
+  upload security, and release risks.
+- `uploads_implementer` for one isolated code change after the scope is clear.
+
+For investigations and reviews, split independent questions between the
+explorer and reviewer, wait for both, then consolidate their evidence before
+changing code. Do not delegate routine small edits. Do not run concurrent
+implementers against the same area; use a single implementer or partition
+non-overlapping files explicitly. The root agent remains responsible for final
+integration, tests, and user-facing decisions.
+
 ## Pull requests
 
 Write PR descriptions for humans first, not only for reviewers who already


### PR DESCRIPTION
## In plain terms

This adds shared coding-agent guidance for the repository: specialized Codex subagents for exploration, review, and bounded implementation, plus Claude worktree setup that carries the ignored local configuration files developers need.

## What it does

- Adds project-scoped Codex agent definitions and a conservative four-thread, one-level delegation policy.
- Documents when to use each agent and how to avoid overlapping writers.
- Adds Claude's `.worktreeinclude` for `.env` and `apps/api/.dev.vars` only.
- Does not change the upload service, runtime behavior, or release artifacts.

## Technical notes

The read-only agents focus on tenant isolation, storage boundaries, upload guardrails, and API/CLI/MCP compatibility. The implementer remains responsible for a single bounded change at a time.

## Test plan

- [x] `git diff --check`
- [ ] `pnpm check` — blocked locally: the pnpm shim cannot locate its configured 11.10.0 binary (`ENOENT`).
