### PR TITLE
chore: ignore Claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ worker-configuration.d.ts
 .impeccable/
 # Local agent notes, private plans, pricing scratch (not for the public repo)
 .context/
+.claude/worktrees/


### PR DESCRIPTION
## In plain terms

This prevents Claude Code's default in-repository worktrees from showing up as untracked files in the main checkout.

## What it does

- Ignores `.claude/worktrees/`, where Claude creates its default worktrees.
- Does not affect tracked source files, configured agent definitions, or runtime behavior.

## Test plan

- [x] `git diff --check`
- [x] `pnpm types && pnpm check`
