### PR TITLE
feat: add secure invite onboarding

### DIFF
--- a/.changeset/safe-invite-pages.md
+++ b/.changeset/safe-invite-pages.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads admin invite create` as the user-facing invitation command and return a separate, non-secret onboarding page URL alongside the one-time login code. The previous `admin enrollment create` spelling remains supported.

--- a/.changeset/safe-invite-pages.md
+++ b/.changeset/safe-invite-pages.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": minor
 ---
 
-Add `uploads admin invite create` as the user-facing invitation command and return a separate, non-secret onboarding page URL alongside the one-time login code. The previous `admin enrollment create` spelling remains supported.
+Add `uploads admin invite create` as the user-facing invitation command and return a separate, non-secret onboarding page URL alongside the one-time login code. Alternate deployments can derive the page origin from `--api-url` or set it explicitly with `--web-url`; the previous `admin enrollment create` spelling remains supported.

--- a/apps/api/migrations/20260711120000_invite_pages.sql
+++ b/apps/api/migrations/20260711120000_invite_pages.sql
@@ -1,0 +1,4 @@
+ALTER TABLE auth_enrollments ADD COLUMN page_id TEXT;
+
+CREATE UNIQUE INDEX auth_enrollments_page_id_idx
+  ON auth_enrollments (page_id) WHERE page_id IS NOT NULL;

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -28,6 +28,7 @@ interface EnrollmentRecord {
   expires_at: string;
   token_expires_at: string;
   used_at: string | null;
+  page_id: string | null;
 }
 
 export function parseScopes(value: string): FileScope[] {
@@ -132,7 +133,7 @@ export async function createEnrollment(
     tokenSeconds?: number;
     now?: Date;
   },
-): Promise<{ code: string; expiresAt: string; tokenExpiresAt: string }> {
+): Promise<{ pageId: string; code: string; expiresAt: string; tokenExpiresAt: string }> {
   const now = input.now ?? new Date();
   const expiresAt = new Date(
     now.getTime() + (input.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS) * 1000,
@@ -141,11 +142,13 @@ export async function createEnrollment(
     now.getTime() + (input.tokenSeconds ?? DEFAULT_TOKEN_SECONDS) * 1000,
   );
   const code = randomSecret("upe_", 18);
+  const pageId = randomSecret("upi_", 12);
   await db
     .prepare(
       `INSERT INTO auth_enrollments
-       (id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+       (id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at,
+        page_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
     )
     .bind(
       id(),
@@ -156,9 +159,31 @@ export async function createEnrollment(
       now.toISOString(),
       expiresAt.toISOString(),
       tokenExpiresAt.toISOString(),
+      pageId,
     )
     .run();
-  return { code, expiresAt: expiresAt.toISOString(), tokenExpiresAt: tokenExpiresAt.toISOString() };
+  return {
+    pageId,
+    code,
+    expiresAt: expiresAt.toISOString(),
+    tokenExpiresAt: tokenExpiresAt.toISOString(),
+  };
+}
+
+export async function findEnrollmentPage(
+  db: D1Database,
+  pageId: string,
+  now = new Date(),
+): Promise<{ expiresAt: string; used: boolean } | null> {
+  if (!/^upi_[A-Za-z0-9_-]{16}$/.test(pageId)) return null;
+  const record = await db
+    .prepare(
+      `SELECT expires_at, used_at FROM auth_enrollments
+       WHERE page_id = ? AND expires_at > ? LIMIT 1`,
+    )
+    .bind(pageId, now.toISOString())
+    .first<Pick<EnrollmentRecord, "expires_at" | "used_at">>();
+  return record ? { expiresAt: record.expires_at, used: record.used_at !== null } : null;
 }
 
 export async function exchangeEnrollment(

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,24 +1,46 @@
-import { ValidationError } from "@uploads/errors";
+import { RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
-import { exchangeEnrollment } from "../auth-db";
+import { exchangeEnrollment, findEnrollmentPage } from "../auth-db";
 
 const INVALID_ENROLLMENT = () =>
   new ValidationError("invalid or expired enrollment code", { code: "invalid_enrollment" });
 const MAX_EXCHANGE_BODY_BYTES = 1024;
 
-export const auth = new Hono<{ Bindings: Env }>().post("/enrollments/exchange", async (c) => {
-  c.header("Cache-Control", "no-store");
-  const contentLength = Number(c.req.header("Content-Length") ?? 0);
-  if (contentLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
-  const body = await c.req
-    .json<Record<string, unknown>>()
-    .catch(() => ({}) as Record<string, unknown>);
-  if (Object.keys(body).length !== 1 || typeof body.code !== "string") {
-    throw INVALID_ENROLLMENT();
-  }
-  const code = body.code?.trim() ?? "";
-  if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
-  const result = await exchangeEnrollment(c.env.DB, code);
-  if (!result) throw INVALID_ENROLLMENT();
-  return c.json(result, 201);
-});
+export const auth = new Hono<{ Bindings: Env }>()
+  .use("/enrollments/*", async (c, next) => {
+    const limiter = c.env.INVITE_LIMITER;
+    if (limiter) {
+      const address = c.req.header("CF-Connecting-IP") ?? "unknown";
+      const { success } = await limiter.limit({ key: `invite:${address}` });
+      if (!success) throw new RateLimitedError("invitation rate limit exceeded");
+    }
+    await next();
+  })
+  .get("/enrollments/:pageId", async (c) => {
+    c.header("Cache-Control", "no-store");
+    c.header("Access-Control-Allow-Origin", "https://uploads.sh");
+    const result = await findEnrollmentPage(c.env.DB, c.req.param("pageId"));
+    if (!result) throw INVALID_ENROLLMENT();
+    return c.json(result);
+  })
+  .post("/enrollments/exchange", async (c) => {
+    c.header("Cache-Control", "no-store");
+    const contentLength = Number(c.req.header("Content-Length") ?? 0);
+    if (contentLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
+    const bytes = await c.req.arrayBuffer();
+    if (bytes.byteLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+    } catch {
+      throw INVALID_ENROLLMENT();
+    }
+    if (Object.keys(body).length !== 1 || typeof body.code !== "string") {
+      throw INVALID_ENROLLMENT();
+    }
+    const code = body.code.trim();
+    if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
+    const result = await exchangeEnrollment(c.env.DB, code);
+    if (!result) throw INVALID_ENROLLMENT();
+    return c.json(result, 201);
+  });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -11,7 +11,8 @@ export const auth = new Hono<{ Bindings: Env }>()
     const limiter = c.env.INVITE_LIMITER;
     if (limiter) {
       const address = c.req.header("CF-Connecting-IP") ?? "unknown";
-      const { success } = await limiter.limit({ key: `invite:${address}` });
+      const operation = c.req.path.endsWith("/exchange") ? "exchange" : "lookup";
+      const { success } = await limiter.limit({ key: `invite:${operation}:${address}` });
       if (!success) throw new RateLimitedError("invitation rate limit exceeded");
     }
     await next();
@@ -29,16 +30,23 @@ export const auth = new Hono<{ Bindings: Env }>()
     if (contentLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
     const bytes = await c.req.arrayBuffer();
     if (bytes.byteLength > MAX_EXCHANGE_BODY_BYTES) throw INVALID_ENROLLMENT();
-    let body: Record<string, unknown>;
+    let parsed: unknown;
     try {
-      body = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+      parsed = JSON.parse(new TextDecoder().decode(bytes));
     } catch {
       throw INVALID_ENROLLMENT();
     }
-    if (Object.keys(body).length !== 1 || typeof body.code !== "string") {
+    if (
+      parsed === null ||
+      Array.isArray(parsed) ||
+      typeof parsed !== "object" ||
+      !("code" in parsed) ||
+      Object.keys(parsed).length !== 1 ||
+      typeof parsed.code !== "string"
+    ) {
       throw INVALID_ENROLLMENT();
     }
-    const code = body.code.trim();
+    const code = parsed.code.trim();
     if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) throw INVALID_ENROLLMENT();
     const result = await exchangeEnrollment(c.env.DB, code);
     if (!result) throw INVALID_ENROLLMENT();

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -5,6 +5,7 @@ import {
   createEnrollment,
   exchangeEnrollment,
   findActiveToken,
+  findEnrollmentPage,
   parseScopes,
 } from "../src/auth-db";
 
@@ -43,6 +44,13 @@ class FakeD1 {
 
   first(statement: FakeStatement): Row | null {
     const { sql, values } = statement;
+    if (sql.startsWith("SELECT expires_at, used_at")) {
+      const [pageId, now] = values as string[];
+      const enrollment = this.enrollments.find(
+        (row) => row.page_id === pageId && (row.expires_at as string) > now,
+      );
+      return enrollment ? { expires_at: enrollment.expires_at, used_at: enrollment.used_at } : null;
+    }
     if (sql.startsWith("SELECT id, workspace, code_hash")) {
       const [hash, now] = values as string[];
       return (
@@ -70,7 +78,8 @@ class FakeD1 {
   run(statement: FakeStatement): { meta: { changes: number }; success: true; results: never[] } {
     const { sql, values } = statement;
     if (sql.startsWith("INSERT INTO auth_enrollments")) {
-      const [id, workspace, codeHash, label, scopes, createdAt, expiresAt, tokenExpiresAt] = values;
+      const [id, workspace, codeHash, label, scopes, createdAt, expiresAt, tokenExpiresAt, pageId] =
+        values;
       this.enrollments.push({
         id,
         workspace,
@@ -81,6 +90,7 @@ class FakeD1 {
         expires_at: expiresAt,
         token_expires_at: tokenExpiresAt,
         used_at: null,
+        page_id: pageId,
       });
       return result(1);
     }
@@ -157,6 +167,8 @@ describe("D1 enrollment exchange", () => {
     });
 
     expect(enrollment.code).toMatch(/^upe_/);
+    expect(enrollment.pageId).toMatch(/^upi_[A-Za-z0-9_-]{16}$/);
+    expect(fake.enrollments[0]?.page_id).toBe(enrollment.pageId);
     expect(JSON.stringify(fake.enrollments)).not.toContain(enrollment.code);
     expect(Date.parse(enrollment.expiresAt) - now.getTime()).toBe(
       DEFAULT_ENROLLMENT_SECONDS * 1000,
@@ -164,6 +176,22 @@ describe("D1 enrollment exchange", () => {
     expect(Date.parse(enrollment.tokenExpiresAt) - now.getTime()).toBe(
       DEFAULT_TOKEN_SECONDS * 1000,
     );
+  });
+
+  it("looks up only safe page status by its non-secret identifier", async () => {
+    const fake = new FakeD1();
+    const now = new Date("2026-07-10T12:00:00.000Z");
+    const enrollment = await createEnrollment(database(fake), {
+      workspace: "default",
+      scopes: ["files:read", "files:write"],
+      now,
+    });
+
+    await expect(findEnrollmentPage(database(fake), enrollment.pageId, now)).resolves.toEqual({
+      expiresAt: enrollment.expiresAt,
+      used: false,
+    });
+    await expect(findEnrollmentPage(database(fake), "upi_invalid", now)).resolves.toBeNull();
   });
 
   it("atomically exchanges once and creates a scoped, expiring token", async () => {

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -23,6 +23,7 @@ function env(
   options: {
     legacyHash?: string;
     inviteAllowed?: boolean;
+    inviteKeys?: string[];
     d1?: {
       tokenHash: string;
       scopes: string;
@@ -37,7 +38,12 @@ function env(
     INVITE_LIMITER:
       options.inviteAllowed === undefined
         ? undefined
-        : { limit: async () => ({ success: options.inviteAllowed }) },
+        : {
+            limit: async ({ key }: { key: string }) => {
+              options.inviteKeys?.push(key);
+              return { success: options.inviteAllowed };
+            },
+          },
     REGISTRY: {
       get: async () => record,
       put: async () => undefined,
@@ -145,6 +151,7 @@ describe("auth routes", () => {
   it("uses one uniform, non-cacheable public exchange error", async () => {
     const responses = await Promise.all([
       app.request("/auth/enrollments/exchange", { method: "POST", body: "{}" }, env()),
+      app.request("/auth/enrollments/exchange", { method: "POST", body: "null" }, env()),
       app.request(
         "/auth/enrollments/exchange",
         { method: "POST", body: JSON.stringify({ code: "upe_bad" }) },
@@ -160,11 +167,26 @@ describe("auth routes", () => {
       ),
     ]);
     const bodies = await Promise.all(responses.map((response) => response.json()));
-    expect(responses.map((response) => response.status)).toEqual([400, 400, 400]);
+    expect(responses.map((response) => response.status)).toEqual([400, 400, 400, 400]);
     expect(
       responses.every((response) => response.headers.get("Cache-Control") === "no-store"),
     ).toBe(true);
     expect(new Set(bodies.map((body) => JSON.stringify(body))).size).toBe(1);
+  });
+
+  it("uses separate address-scoped quotas for lookup and exchange", async () => {
+    const keys: string[] = [];
+    const bindings = env({ inviteAllowed: true, inviteKeys: keys });
+    const headers = { "CF-Connecting-IP": "203.0.113.7" };
+
+    await app.request("/auth/enrollments/upi_abcdefghijklmnop", { headers }, bindings);
+    await app.request(
+      "/auth/enrollments/exchange",
+      { method: "POST", headers, body: "{}" },
+      bindings,
+    );
+
+    expect(keys).toEqual(["invite:lookup:203.0.113.7", "invite:exchange:203.0.113.7"]);
   });
 
   it("rate limits public invitation routes independently", async () => {

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -22,6 +22,7 @@ beforeAll(() => {
 function env(
   options: {
     legacyHash?: string;
+    inviteAllowed?: boolean;
     d1?: {
       tokenHash: string;
       scopes: string;
@@ -33,6 +34,10 @@ function env(
   const record = options.legacyHash ? { ...workspace, tokenHash: options.legacyHash } : workspace;
   return {
     ADMIN_TOKEN: "admin-secret",
+    INVITE_LIMITER:
+      options.inviteAllowed === undefined
+        ? undefined
+        : { limit: async () => ({ success: options.inviteAllowed }) },
     REGISTRY: {
       get: async () => record,
       put: async () => undefined,
@@ -160,6 +165,17 @@ describe("auth routes", () => {
       responses.every((response) => response.headers.get("Cache-Control") === "no-store"),
     ).toBe(true);
     expect(new Set(bodies.map((body) => JSON.stringify(body))).size).toBe(1);
+  });
+
+  it("rate limits public invitation routes independently", async () => {
+    const response = await app.request(
+      "/auth/enrollments/exchange",
+      { method: "POST", body: JSON.stringify({ code: `upe_${"a".repeat(24)}` }) },
+      env({ inviteAllowed: false }),
+    );
+    expect(response.status).toBe(429);
+    const body = (await response.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("rate_limited");
   });
 
   it("keeps legacy KV credentials fully scoped", async () => {

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -36,20 +36,27 @@
       "migrations_dir": "migrations",
     },
   ],
-  // Per-workspace write rate limit (uploads + deletes), enforced by the
-  // writeRateLimit middleware in guards.ts. The Rate Limiting API is an
-  // `unsafe` binding but `wrangler types` still emits it as `WRITE_LIMITER:
-  // RateLimit`. Keyed by workspace name; `period` must be 10 or 60. 60
-  // writes/min/workspace is generous for legit screenshot flows and blunts a
-  // runaway client. Per-colo, not globally exact.
+  // Rate limits use separate namespaces so public invite traffic cannot consume
+  // a workspace's write quota. Both are per-colo rather than globally exact.
   "unsafe": {
     "bindings": [
       {
+        // Authenticated uploads + deletes, keyed by workspace.
         "name": "WRITE_LIMITER",
         "type": "ratelimit",
         "namespace_id": "1001",
         "simple": {
           "limit": 60,
+          "period": 60,
+        },
+      },
+      {
+        // Public invite status + exchange, keyed by Cloudflare client IP.
+        "name": "INVITE_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1002",
+        "simple": {
+          "limit": 30,
           "period": 60,
         },
       },

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,7 @@
+/invite*
+  Cache-Control: no-store
+  Referrer-Policy: no-referrer
+  X-Robots-Tag: noindex, nofollow, noarchive
+  X-Content-Type-Options: nosniff
+  Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+  Permissions-Policy: camera=(), microphone=(), geolocation=()

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -22,7 +22,7 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
   <section id="instructions" hidden>
     <ol>
       <li>Install the CLI.<div class="command"><code>npm install --global @buildinternet/uploads</code><button data-copy="npm install --global @buildinternet/uploads">copy</button></div></li>
-      <li>Start login, then paste the separate one-time code from your invitation email.<div class="command"><code>uploads login</code><button data-copy="uploads login">copy</button></div></li>
+      <li>Start login, then paste the separately shared one-time code.<div class="command"><code>uploads login</code><button data-copy="uploads login">copy</button></div></li>
       <li>Confirm the CLI reports that credentials were saved and the doctor check passed.</li>
     </ol>
   </section>

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -1,0 +1,61 @@
+---
+const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23120d1e'/%3E%3Cpath d='M8 19 L16 11 L24 19' fill='none' stroke='%23b794ff' stroke-width='3.2'/%3E%3C/svg%3E";
+---
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow, noarchive" />
+  <meta name="referrer" content="no-referrer" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://api.uploads.sh; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'" />
+  <title>Your uploads.sh invitation</title>
+  <link rel="icon" href={FAVICON} />
+  <style>
+    :root{color-scheme:dark;--bg:#0b0813;--panel:#120d1e;--line:#2b1f46;--fg:#e6dff5;--muted:#8e86a5;--purple:#b794ff;--green:#9ece6a;--red:#f7768e}*{box-sizing:border-box}body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:radial-gradient(100% 80% at 50% 0%,#19102b,var(--bg) 62%);color:var(--fg);font:15px/1.6 ui-monospace,"SFMono-Regular",Consolas,monospace}main{width:min(680px,100%);background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:clamp(24px,6vw,44px);box-shadow:0 24px 90px #0009}h1{margin:0 0 8px;font-size:clamp(24px,5vw,34px)}p{color:var(--muted)}.status{border-left:3px solid var(--purple);padding:10px 14px;margin:24px 0;background:#0d0a16}.status[data-state=ready]{border-color:var(--green);color:var(--green)}.status[data-state=closed]{border-color:var(--red);color:var(--red)}li{margin:18px 0}.command{display:flex;gap:12px;align-items:center;padding:13px 14px;border:1px solid var(--line);border-radius:8px;background:#09070f;overflow:auto}.command code{flex:1;white-space:nowrap}button{border:1px solid #553c88;border-radius:6px;padding:7px 10px;background:#201534;color:var(--purple);cursor:pointer;font:inherit}.security{margin-top:28px;padding-top:18px;border-top:1px solid var(--line);font-size:13px}[hidden]{display:none!important}
+  </style>
+</head>
+<body>
+<main>
+  <h1>Welcome to uploads.sh</h1>
+  <p>This private invitation sets up the CLI for your pre-created workspace.</p>
+  <div class="status" id="status" role="status">Checking this invitation…</div>
+  <section id="instructions" hidden>
+    <ol>
+      <li>Install the CLI.<div class="command"><code>npm install --global @buildinternet/uploads</code><button data-copy="npm install --global @buildinternet/uploads">copy</button></div></li>
+      <li>Start login, then paste the separate one-time code from your invitation email.<div class="command"><code>uploads login</code><button data-copy="uploads login">copy</button></div></li>
+      <li>Confirm the CLI reports that credentials were saved and the doctor check passed.</li>
+    </ol>
+  </section>
+  <p class="security">This URL contains only a non-secret invitation identifier. It cannot create credentials without the separately delivered one-time code.</p>
+</main>
+<script>
+  function requireElement<T extends Element>(selector: string): T {
+    const element = document.querySelector<T>(selector);
+    if (!element) throw new Error(`invite page is missing ${selector}`);
+    return element;
+  }
+
+  const status = requireElement<HTMLElement>("#status");
+  const instructions = requireElement<HTMLElement>("#instructions");
+  const pageId = new URL(location.href).searchParams.get("id") ?? "";
+  async function checkInvitation() {
+    if (!/^upi_[A-Za-z0-9_-]{16}$/.test(pageId)) throw new Error("invalid");
+    const response = await fetch(`https://api.uploads.sh/auth/enrollments/${encodeURIComponent(pageId)}`, { cache:"no-store", credentials:"omit", referrerPolicy:"no-referrer" });
+    if (!response.ok) throw new Error("invalid");
+    const invitation = (await response.json()) as { used: boolean; expiresAt: string };
+    if (invitation.used) { status.textContent="This invitation has already been used."; status.dataset.state="closed"; return; }
+    status.textContent=`Invitation ready · expires ${new Date(invitation.expiresAt).toLocaleString()}`;
+    status.dataset.state="ready"; instructions.hidden=false;
+  }
+  checkInvitation().catch(() => { status.textContent="This invitation is invalid or has expired."; status.dataset.state="closed"; });
+  document.querySelectorAll<HTMLButtonElement>("[data-copy]").forEach((button) =>
+    button.addEventListener("click", async () => {
+      const value = button.dataset.copy;
+      if (!value) return;
+      await navigator.clipboard.writeText(value);
+      button.textContent = "copied";
+    }),
+  );
+</script>
+</body>
+</html>

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -34,41 +34,12 @@ On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
 the raw workspace token. Use `--force` only when intentionally replacing an existing
 configured token.
 
-## Administrator: create an invitation
+## Administrator overview
 
-Enrollment creation remains behind `ADMIN_TOKEN`; only an administrator runs this
-request. Do not paste the admin credential into agent prompts, configuration, issues,
-or shell commands shared with an agent.
-
-```bash
-curl -X POST https://api.uploads.sh/admin/enrollments \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"workspace":"default","label":"codex-cli","enrollmentSeconds":600,"tokenExpiresInSeconds":7776000,"scopes":["files:read","files:write"]}'
-```
-
-The admin CLI provides the same operation:
-
-```bash
-ADMIN_TOKEN=<admin-credential> uploads admin invite create \
-  --workspace default --label codex-cli
-```
-
-`ADMIN_TOKEN` is the primary environment name used by the existing API and admin
-workflow. `UPLOADS_ADMIN_TOKEN` may be accepted as a compatibility alias. Neither
-belongs in routine-agent configuration.
-
-The response includes a non-secret onboarding URL such as
-`https://uploads.sh/invite?id=upi_…` and shows the invitation code once. Send them as
-separate fields. The URL exposes only expiry and used status; it cannot mint credentials.
-The code expires after 10 minutes and is consumed by a successful exchange. Invalid, expired, and consumed codes receive the same public error shape. The invite page is
-served without analytics or third-party assets and requests `no-store`, `no-referrer`, and
-`noindex` handling so the code never needs to appear in a URL.
-
-Enrollment creation accepts `files:delete` only when the administrator explicitly
-includes it in `scopes`. Keep the default read/write scopes for routine agents;
-reserve delete for short-lived maintenance or smoke-test credentials that clean up
-their own objects.
+Administrators issue invitations for existing workspaces. Invitation codes are
+single-use and default to a 10-minute expiry; issued tokens default to read/write
+scope without delete access. See the [operator runbook](ops.md#invitations) for
+commands, secret handling, delivery, and troubleshooting.
 
 ## Token policy
 

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -1,8 +1,8 @@
-# Agent enrollment and `uploads login`
+# Invitations and `uploads login`
 
-Routine agents authenticate through short-lived enrollment codes. They never receive
+Early adopters authenticate through short-lived invitation codes. They never receive
 the API's `ADMIN_TOKEN`. An administrator authorizes an existing workspace, shares the
-single-use code, and the agent runs `uploads login` to exchange it for a scoped,
+single-use code, and the adopter runs `uploads login` to exchange it for a scoped,
 expiring workspace token.
 
 ## Agent login
@@ -34,7 +34,7 @@ On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
 the raw workspace token. Use `--force` only when intentionally replacing an existing
 configured token.
 
-## Administrator: create an enrollment
+## Administrator: create an invitation
 
 Enrollment creation remains behind `ADMIN_TOKEN`; only an administrator runs this
 request. Do not paste the admin credential into agent prompts, configuration, issues,
@@ -50,7 +50,7 @@ curl -X POST https://api.uploads.sh/admin/enrollments \
 The admin CLI provides the same operation:
 
 ```bash
-ADMIN_TOKEN=<admin-credential> uploads admin enrollment create \
+ADMIN_TOKEN=<admin-credential> uploads admin invite create \
   --workspace default --label codex-cli
 ```
 
@@ -58,9 +58,12 @@ ADMIN_TOKEN=<admin-credential> uploads admin enrollment create \
 workflow. `UPLOADS_ADMIN_TOKEN` may be accepted as a compatibility alias. Neither
 belongs in routine-agent configuration.
 
-The response shows the enrollment code once. Transfer only that code to the routine
-agent. It expires after 10 minutes and is consumed by a successful exchange. Invalid,
-expired, and consumed codes receive the same public error shape.
+The response includes a non-secret onboarding URL such as
+`https://uploads.sh/invite?id=upi_…` and shows the invitation code once. Send them as
+separate fields. The URL exposes only expiry and used status; it cannot mint credentials.
+The code expires after 10 minutes and is consumed by a successful exchange. Invalid, expired, and consumed codes receive the same public error shape. The invite page is
+served without analytics or third-party assets and requests `no-store`, `no-referrer`, and
+`noindex` handling so the code never needs to appear in a URL.
 
 Enrollment creation accepts `files:delete` only when the administrator explicitly
 includes it in `scopes`. Keep the default read/write scopes for routine agents;

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -39,6 +39,28 @@ uploads purge-expired      # needs retentionDays
 
 The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every workspace with `retentionDays` set. Logs: `retention_sweep` JSON.
 
+## Invitations
+
+Invitation creation is an operator-only action behind `ADMIN_TOKEN`. Keep that secret
+in the operator environment; never place it in agent configuration, prompts, issues,
+or commands shared with adopters. Create an invitation for an existing workspace with:
+
+```bash
+ADMIN_TOKEN=<admin-credential> uploads admin invite create \
+  --workspace default --label early-adopter
+```
+
+The admin API at `POST /admin/enrollments` provides the same operation. Its response
+contains a non-secret onboarding URL and a one-time code. Share them as separate
+fields; the URL exposes only expiry and used status and cannot mint credentials.
+Invitation codes default to a 10-minute expiry (configurable at creation) and are
+consumed by one successful exchange. Unknown, expired, and consumed codes return the
+same public error shape.
+
+The invite page loads no analytics or third-party assets. Response controls request
+`no-store`, `no-referrer`, `noindex`, a restrictive CSP, and disabled browser
+permissions. The one-time code never belongs in the URL.
+
 ## Secrets
 
 | Secret                           | Purpose                                                               |

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -64,7 +64,7 @@ Commands:
   setup               Inspect/configure advanced CLI settings
   install             Install the agent skill + register the remote MCP server
   login               Exchange an enrollment code and configure credentials
-  admin               Admin enrollment management
+  admin               Admin invitation management
   config              Show path, init, or set shared config
   doctor              Health + auth + workspace checks
   health              API liveness (no auth)

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -113,6 +113,7 @@ export interface EnrollmentExchangeResult {
 }
 
 export interface EnrollmentCreateResult {
+  pageId: string;
   code: string;
   expiresAt: string;
   tokenExpiresAt: string;

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -15,10 +15,26 @@ Options:
   --token-expires-in <seconds>  Upload token lifetime (default: server policy)
   --scopes <list>        Comma-separated files:read,files:write,files:delete
   --api-url <url>        Default: https://api.uploads.sh
+  --web-url <url>        Invite-page origin (defaults from --api-url)
 `;
 
 type FileScope = "files:read" | "files:write" | "files:delete";
 const FILE_SCOPES = new Set<FileScope>(["files:read", "files:write", "files:delete"]);
+
+export function invitePageUrl(apiUrl: string, pageId: string, webUrl?: string): string {
+  let url: URL;
+  try {
+    url = new URL(webUrl ?? apiUrl);
+  } catch {
+    throw new UsageError("invalid invite web URL");
+  }
+  if (!webUrl && url.hostname.startsWith("api.")) url.hostname = url.hostname.slice(4);
+  url.pathname = "/invite";
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set("id", pageId);
+  return url.toString();
+}
 
 export function parseScopes(raw: string | undefined): FileScope[] | undefined {
   if (raw === undefined) return undefined;
@@ -56,6 +72,7 @@ export async function runAdmin(
     process.env.UPLOADS_ADMIN_TOKEN;
   if (!adminToken) throw new UsageError("ADMIN_TOKEN is required for admin enrollment creation");
   const apiUrl = flagString(parsed.flags, "--api-url") ?? opts.apiUrl ?? "https://api.uploads.sh";
+  const webUrl = flagString(parsed.flags, "--web-url");
   const workspace = flagString(parsed.flags, "--workspace") ?? "default";
   const label = flagString(parsed.flags, "--label");
   const result = await createEnrollment(apiUrl, adminToken, {
@@ -71,7 +88,7 @@ export async function runAdmin(
     );
   else
     process.stdout.write(
-      `Invite page: https://uploads.sh/invite?id=${result.pageId}\nOne-time code (share separately): ${result.code}\nworkspace: ${workspace}\nexpires: ${result.expiresAt}\n`,
+      `Invite page: ${invitePageUrl(apiUrl, result.pageId, webUrl)}\nOne-time code (share separately): ${result.code}\nworkspace: ${workspace}\nexpires: ${result.expiresAt}\n`,
     );
   return 0;
 }

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -1,9 +1,11 @@
 import { createEnrollment } from "../client.js";
 import { flagInt, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
 
-const HELP = `uploads admin enrollment create [options]
+const HELP = `uploads admin invite create [options]
 
-Admin-only: create a short-lived, one-time enrollment code.
+Admin-only: create a short-lived invitation for an existing workspace.
+The invitation page ID is not a credential; share its URL and the one-time code
+as separate fields. The legacy "admin enrollment create" spelling is accepted.
 
 Options:
   --admin-token <token>  Or ADMIN_TOKEN (UPLOADS_ADMIN_TOKEN is a legacy alias)
@@ -43,8 +45,11 @@ export async function runAdmin(
     process.stderr.write(HELP);
     return 0;
   }
-  if (parsed.positionals[0] !== "enrollment" || parsed.positionals[1] !== "create")
-    throw new UsageError("expected: uploads admin enrollment create");
+  if (
+    !["invite", "enrollment"].includes(parsed.positionals[0] ?? "") ||
+    parsed.positionals[1] !== "create"
+  )
+    throw new UsageError("expected: uploads admin invite create");
   const adminToken =
     flagString(parsed.flags, "--admin-token") ??
     process.env.ADMIN_TOKEN ??
@@ -66,7 +71,7 @@ export async function runAdmin(
     );
   else
     process.stdout.write(
-      `Enrollment code (share once): ${result.code}\nworkspace: ${workspace}\nexpires: ${result.expiresAt}\n`,
+      `Invite page: https://uploads.sh/invite?id=${result.pageId}\nOne-time code (share separately): ${result.code}\nworkspace: ${workspace}\nexpires: ${result.expiresAt}\n`,
     );
   return 0;
 }

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveEnrollmentCode, runLogin, validateEnrollmentCode } from "../src/commands/login.js";
-import { parseScopes, runAdmin } from "../src/commands/admin-enrollment.js";
+import { invitePageUrl, parseScopes, runAdmin } from "../src/commands/admin-enrollment.js";
 import { parseCommandArgs } from "../src/cli-args.js";
 import { loadConfigFile, writeConfigKeys } from "../src/config-file.js";
 
@@ -188,6 +188,18 @@ describe("admin enrollment", () => {
     expect(JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body))).toEqual({
       workspace: "default",
     });
+  });
+
+  it("derives or overrides the invite page origin", () => {
+    expect(invitePageUrl("https://api.uploads.sh", "upi_abcdefghijklmnop")).toBe(
+      "https://uploads.sh/invite?id=upi_abcdefghijklmnop",
+    );
+    expect(invitePageUrl("https://api.staging.example.com/v1", "upi_abcdefghijklmnop")).toBe(
+      "https://staging.example.com/invite?id=upi_abcdefghijklmnop",
+    );
+    expect(
+      invitePageUrl("http://localhost:8787", "upi_abcdefghijklmnop", "http://localhost:4321/setup"),
+    ).toBe("http://localhost:4321/invite?id=upi_abcdefghijklmnop");
   });
 
   it("validates scopes locally", () => {

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -133,6 +133,7 @@ describe("admin enrollment", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       response(
         {
+          pageId: "upi_abcdefghijklmnop",
           code: "upe_abcdefghijklmnopqrstuvwxyz012345",
           expiresAt: "2030-01-01T00:00:00Z",
           tokenExpiresAt: "2030-02-01T00:00:00Z",
@@ -144,7 +145,7 @@ describe("admin enrollment", () => {
     expect(
       await runAdmin(
         [
-          "enrollment",
+          "invite",
           "create",
           "--workspace",
           "default",
@@ -174,6 +175,7 @@ describe("admin enrollment", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       response(
         {
+          pageId: "upi_abcdefghijklmnop",
           code: "upe_abcdefghijklmnopqrstuvwxyz012345",
           expiresAt: "2030-01-01T00:00:00Z",
           tokenExpiresAt: "2030-02-01T00:00:00Z",


### PR DESCRIPTION
## In plain terms

This gives early adopters a smoother invitation flow without turning the onboarding URL into a credential. An operator creates an invite for an existing workspace, sends a log-safe setup-page URL and a separate one-time code, and the adopter uses the existing `uploads login` flow to receive scoped credentials.

## What it does

- Adds a random public page identifier that is stored separately from the hashed one-time enrollment code.
- Adds a private-looking but non-secret `/invite?id=upi_…` page with installation steps and minimal ready/used/expired status.
- Keeps the existing enrollment API and `uploads admin enrollment create` spelling compatible.
- Adds `uploads admin invite create` as the user-facing command and prints the page URL and code as separate fields.
- Rate limits public invitation lookup and exchange separately from authenticated workspace writes.
- Adds no-store, no-referrer, noindex, CSP, permissions-policy, and no-third-party-resource protections to the invite page.
- Enforces the exchange body limit against actual bytes, not only `Content-Length`.

This does not create workspaces during redemption, send email, or put the invite code in the URL. Retry-safe recovery after a successful server-side exchange but lost response is deliberately deferred.

## How to try it after deploy

Create a short-lived invite through the admin API:

```bash
curl -X POST https://api.uploads.sh/admin/enrollments \
  -H "Authorization: Bearer $ADMIN_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"workspace":"default","label":"invite-smoke","enrollmentSeconds":600}'
```

1. Open `https://uploads.sh/invite?id=<pageId>` and confirm it shows ready without exposing workspace, label, scopes, or code.
2. Run `uploads login` and paste the separately returned `upe_…` code.
3. Confirm the CLI saves and verifies credentials.
4. Refresh the page and confirm it shows already used.
5. Confirm a second exchange receives the same uniform invalid/expired response as an unknown code.

Once the CLI release ships, operators can create the same invite with:

```bash
uploads admin invite create --workspace default --label invite-smoke
```

## Technical notes

- Adds the D1 `auth_enrollments.page_id` column and unique partial index.
- Adds an `INVITE_LIMITER` Cloudflare rate-limit binding at 30 requests/minute/IP.
- API deployment applies the D1 migration before the Worker deploy; production deploys otherwise follow the existing merge-to-main Workers Builds flow.
- The CLI change includes a minor changeset for `@buildinternet/uploads`.

## Test plan

- [x] `pnpm check`
- [x] API TypeScript + generated Worker bindings
- [x] CLI source and test TypeScript
- [x] API suite: 98 tests
- [x] CLI suite: 119 tests
- [x] Astro production build, including `/invite/`
- [ ] Production smoke test after API migration and API/web deploy
- [ ] Repository-wide `pnpm typecheck` remains blocked by pre-existing strict-DOM errors in `apps/web/src/pages/console.astro`; the new invite page has no Astro diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `uploads admin invite create` for generating invitations.
  - Displays a shareable onboarding page URL alongside a separate one-time login code.
  - Added an invitation page that validates status, shows expiration details, and provides copyable CLI instructions.
  - Preserved support for the legacy `admin enrollment create` command.

- **Security**
  - Added rate limiting and privacy-focused protections for invitation pages and exchange endpoints.

- **Documentation**
  - Updated invitation workflow, expiration, single-use, privacy, and error behavior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->