### PR TITLE
feat: magic-link invites with email delivery, workspace display, and longer expiry

### DIFF
--- a/.changeset/invite-email-delivery.md
+++ b/.changeset/invite-email-delivery.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads admin invite create --email <address>` now delivers the invite magic link
+by email instead of printing it. The API sends from `invites@uploads.sh` via
+Cloudflare Email Sending; delivery is rate-limited per recipient and audit-logged
+without the code or link. On success the CLI confirms delivery and does not print the
+secret; if delivery fails the invite is still created and the CLI prints the link as a
+fallback.

--- a/.changeset/magic-link-invites.md
+++ b/.changeset/magic-link-invites.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads admin invite create` now prints a single self-contained magic link by
+default. The one-time code rides in the link's URL fragment (`…/invite?id=…#code=…`),
+which browsers never send to a server, so the invite page can offer a one-click login
+command while the code stays out of query strings, server logs, and referrers—and
+opening the page neither logs nor consumes it. Pass `--separate-code` for the previous
+two-channel output (a non-secret page URL plus a code you deliver separately). The
+invite page also now shows which workspace the invitation is for.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev:web"],
       "port": 4321
+    },
+    {
+      "name": "web-preview",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@uploads/web", "preview", "--port", "4322"],
+      "port": 4322
     }
   ]
 }

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -3,7 +3,10 @@ import { sha256Hex } from "./workspace";
 export const FILE_SCOPES = ["files:read", "files:write", "files:delete"] as const;
 export type FileScope = (typeof FILE_SCOPES)[number];
 
-export const DEFAULT_ENROLLMENT_SECONDS = 10 * 60;
+// Invite code lifetime. 2h gives a human time to onboard after receiving the
+// link out-of-band, while keeping the single-use secret short-lived. Override
+// per-invite with --expires-in up to MAX_ENROLLMENT_SECONDS (see routes/admin).
+export const DEFAULT_ENROLLMENT_SECONDS = 2 * 60 * 60;
 export const DEFAULT_TOKEN_SECONDS = 90 * 24 * 60 * 60;
 export const MAX_TOKEN_SECONDS = 365 * 24 * 60 * 60;
 

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -177,16 +177,18 @@ export async function findEnrollmentPage(
   db: D1Database,
   pageId: string,
   now = new Date(),
-): Promise<{ expiresAt: string; used: boolean } | null> {
+): Promise<{ workspace: string; expiresAt: string; used: boolean } | null> {
   if (!/^upi_[A-Za-z0-9_-]{16}$/.test(pageId)) return null;
   const record = await db
     .prepare(
-      `SELECT expires_at, used_at FROM auth_enrollments
+      `SELECT workspace, expires_at, used_at FROM auth_enrollments
        WHERE page_id = ? AND expires_at > ? LIMIT 1`,
     )
     .bind(pageId, now.toISOString())
-    .first<Pick<EnrollmentRecord, "expires_at" | "used_at">>();
-  return record ? { expiresAt: record.expires_at, used: record.used_at !== null } : null;
+    .first<Pick<EnrollmentRecord, "workspace" | "expires_at" | "used_at">>();
+  return record
+    ? { workspace: record.workspace, expiresAt: record.expires_at, used: record.used_at !== null }
+    : null;
 }
 
 export async function exchangeEnrollment(

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -18,8 +18,10 @@ import type { WorkspaceRecord } from "../workspace";
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 const HASH_PREFIX_LEN = 8;
-const MAX_ENROLLMENT_SECONDS = 60 * 60;
 const SECONDS_PER_DAY = 24 * 60 * 60;
+// Ceiling for --expires-in. 24h caps how long a single-use invite secret can
+// live; the floor stays 60s at the validation site below.
+const MAX_ENROLLMENT_SECONDS = SECONDS_PER_DAY;
 
 interface LegacyToken {
   hash: string;

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,4 +1,4 @@
-import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
+import { ConflictError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { adminAuth } from "../admin";
 import {
@@ -22,6 +22,51 @@ const SECONDS_PER_DAY = 24 * 60 * 60;
 // Ceiling for --expires-in. 24h caps how long a single-use invite secret can
 // live; the floor stays 60s at the validation site below.
 const MAX_ENROLLMENT_SECONDS = SECONDS_PER_DAY;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Invitations are delivered from this address; uploads.sh is onboarded for
+// Cloudflare Email Sending, so any @uploads.sh sender works.
+const INVITE_FROM = { name: "uploads.sh", email: "invites@uploads.sh" } as const;
+
+// The invite page lives on the web origin, which mirrors the API host without
+// the `api.` prefix (api.uploads.sh -> uploads.sh), matching the CLI default.
+function deriveWebOrigin(requestUrl: string): string {
+  const url = new URL(requestUrl);
+  url.hostname = url.hostname.replace(/^api\./, "");
+  return url.origin;
+}
+
+// Self-contained magic link: the single-use code rides in the URL fragment, which
+// browsers never send to a server, so it stays out of logs and referrers.
+function inviteMagicLink(webOrigin: string, pageId: string, code: string): string {
+  return `${webOrigin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
+}
+
+function renderInviteEmail(to: string, workspaceName: string, link: string, expiresAt: string) {
+  const expires = new Date(expiresAt).toUTCString();
+  const text = [
+    `You've been invited to the "${workspaceName}" workspace on uploads.sh.`,
+    "",
+    "1. Install the CLI:",
+    "   npm install --global @buildinternet/uploads",
+    "",
+    "2. Open your invitation and run the one-click login command it shows:",
+    `   ${link}`,
+    "",
+    "This link includes a single-use code — treat it like a password. It can be",
+    `used once and expires ${expires}.`,
+  ].join("\n");
+  const html =
+    `<div style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;line-height:1.6;color:#1a1523">` +
+    `<h1 style="font-size:20px">Your uploads.sh invitation</h1>` +
+    `<p>You've been invited to the <strong>${workspaceName}</strong> workspace on uploads.sh.</p>` +
+    `<ol><li>Install the CLI: <code>npm install --global @buildinternet/uploads</code></li>` +
+    `<li>Open your invitation and run the one-click login command it shows:<br>` +
+    `<a href="${link}">Open invitation</a></li></ol>` +
+    `<p style="color:#6b6478;font-size:13px">This link includes a single-use code — treat it like ` +
+    `a password. It can be used once and expires ${expires}.</p></div>`;
+  return { to, from: INVITE_FROM, subject: "Your uploads.sh invitation", text, html };
+}
 
 interface LegacyToken {
   hash: string;
@@ -140,6 +185,7 @@ export const admin = new Hono<{ Bindings: Env }>()
         scopes?: unknown;
         enrollmentSeconds?: number;
         tokenExpiresInSeconds?: number;
+        email?: string;
       }>()
       .catch(
         () =>
@@ -149,6 +195,7 @@ export const admin = new Hono<{ Bindings: Env }>()
             scopes?: unknown;
             enrollmentSeconds?: number;
             tokenExpiresInSeconds?: number;
+            email?: string;
           },
       );
     const name = body.workspace?.trim() || "default";
@@ -180,6 +227,20 @@ export const admin = new Hono<{ Bindings: Env }>()
       );
     }
 
+    const email = typeof body.email === "string" ? body.email.trim() : undefined;
+    if (email !== undefined && !EMAIL_RE.test(email)) {
+      throw new ValidationError("invalid email address", { code: "invalid_email" });
+    }
+    if (email) {
+      // Rate-limit per recipient so invitations cannot be used to email-bomb a
+      // victim, even with a valid admin token. Reuses the invite limiter namespace.
+      const limiter = c.env.INVITE_LIMITER;
+      if (limiter) {
+        const { success } = await limiter.limit({ key: `invite:email:${email.toLowerCase()}` });
+        if (!success) throw new RateLimitedError("invitation email rate limit exceeded");
+      }
+    }
+
     const enrollment = await createEnrollment(c.env.DB, {
       workspace: name,
       label,
@@ -187,7 +248,38 @@ export const admin = new Hono<{ Bindings: Env }>()
       enrollmentSeconds: body.enrollmentSeconds ?? DEFAULT_ENROLLMENT_SECONDS,
       tokenSeconds: body.tokenExpiresInSeconds ?? DEFAULT_TOKEN_SECONDS,
     });
-    return c.json({ workspace: name, label: label ?? null, scopes, ...enrollment }, 201);
+
+    let emailed: boolean | undefined;
+    if (email) {
+      const webOrigin = c.env.WEB_ORIGIN || deriveWebOrigin(c.req.url);
+      const link = inviteMagicLink(webOrigin, enrollment.pageId, enrollment.code);
+      try {
+        await c.env.EMAIL.send(renderInviteEmail(email, name, link, enrollment.expiresAt));
+        emailed = true;
+        // Audit only non-secret metadata — never the code, magic link, or URL.
+        console.log(
+          JSON.stringify({
+            event: "invite_emailed",
+            workspace: name,
+            recipient: email,
+            pageId: enrollment.pageId,
+          }),
+        );
+      } catch (error) {
+        emailed = false;
+        console.log(
+          JSON.stringify({
+            event: "invite_email_failed",
+            workspace: name,
+            recipient: email,
+            pageId: enrollment.pageId,
+            error: (error as { code?: string }).code ?? (error as Error).message,
+          }),
+        );
+      }
+    }
+
+    return c.json({ workspace: name, label: label ?? null, scopes, emailed, ...enrollment }, 201);
   })
 
   // Lists D1 credentials and legacy KV credentials without exposing secrets.

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -44,12 +44,18 @@ class FakeD1 {
 
   first(statement: FakeStatement): Row | null {
     const { sql, values } = statement;
-    if (sql.startsWith("SELECT expires_at, used_at")) {
+    if (sql.startsWith("SELECT workspace, expires_at, used_at")) {
       const [pageId, now] = values as string[];
       const enrollment = this.enrollments.find(
         (row) => row.page_id === pageId && (row.expires_at as string) > now,
       );
-      return enrollment ? { expires_at: enrollment.expires_at, used_at: enrollment.used_at } : null;
+      return enrollment
+        ? {
+            workspace: enrollment.workspace,
+            expires_at: enrollment.expires_at,
+            used_at: enrollment.used_at,
+          }
+        : null;
     }
     if (sql.startsWith("SELECT id, workspace, code_hash")) {
       const [hash, now] = values as string[];
@@ -188,6 +194,7 @@ describe("D1 enrollment exchange", () => {
     });
 
     await expect(findEnrollmentPage(database(fake), enrollment.pageId, now)).resolves.toEqual({
+      workspace: "default",
       expiresAt: enrollment.expiresAt,
       used: false,
     });

--- a/apps/api/test/auth-db.test.ts
+++ b/apps/api/test/auth-db.test.ts
@@ -157,7 +157,7 @@ function database(fake: FakeD1): D1Database {
 }
 
 describe("D1 enrollment exchange", () => {
-  it("stores only a hash and applies the 10 minute / 90 day defaults", async () => {
+  it("stores only a hash and applies the 2 hour / 90 day defaults", async () => {
     const fake = new FakeD1();
     const now = new Date("2026-07-10T12:00:00.000Z");
     const enrollment = await createEnrollment(database(fake), {

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -19,11 +19,21 @@ beforeAll(() => {
   }
 });
 
+interface SentEmail {
+  to: unknown;
+  from: unknown;
+  subject: string;
+  text?: string;
+  html?: string;
+}
+
 function env(
   options: {
     legacyHash?: string;
     inviteAllowed?: boolean;
     inviteKeys?: string[];
+    emailOutbox?: SentEmail[];
+    emailThrows?: boolean;
     d1?: {
       tokenHash: string;
       scopes: string;
@@ -35,6 +45,16 @@ function env(
   const record = options.legacyHash ? { ...workspace, tokenHash: options.legacyHash } : workspace;
   return {
     ADMIN_TOKEN: "admin-secret",
+    EMAIL: options.emailOutbox
+      ? {
+          send: async (message: SentEmail) => {
+            if (options.emailThrows)
+              throw Object.assign(new Error("send failed"), { code: "E_DELIVERY_FAILED" });
+            options.emailOutbox?.push(message);
+            return { messageId: "test-message-id" };
+          },
+        }
+      : undefined,
     INVITE_LIMITER:
       options.inviteAllowed === undefined
         ? undefined
@@ -146,6 +166,74 @@ describe("auth routes", () => {
       label: "routine-agent",
       scopes: ["files:read", "files:write"],
     });
+  });
+
+  it("emails the invite magic link when a recipient is provided", async () => {
+    const emailOutbox: SentEmail[] = [];
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "adopter@example.com" }),
+      },
+      env({ emailOutbox }),
+    );
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ emailed: true });
+    expect(emailOutbox).toHaveLength(1);
+    const sent = emailOutbox[0]!;
+    expect(sent.to).toBe("adopter@example.com");
+    expect(sent.from).toMatchObject({ email: "invites@uploads.sh" });
+    // The magic link (with the code fragment) is delivered, but the raw code is
+    // never logged; the email body carries the single-use link.
+    expect(sent.text).toContain("#code=");
+    expect(sent.text).toContain("/invite?id=");
+  });
+
+  it("reports emailed:false when delivery fails but still creates the invite", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "adopter@example.com" }),
+      },
+      env({ emailOutbox: [], emailThrows: true }),
+    );
+    expect(response.status).toBe(201);
+    const json = (await response.json()) as { emailed: boolean; pageId: string };
+    expect(json.emailed).toBe(false);
+    expect(json.pageId).toMatch(/^upi_/);
+  });
+
+  it("rejects an invalid recipient email", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "not-an-email" }),
+      },
+      env({ emailOutbox: [] }),
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: { code: "invalid_email" } });
+  });
+
+  it("rate-limits invitation emails per recipient", async () => {
+    const inviteKeys: string[] = [];
+    const response = await app.request(
+      "/admin/enrollments",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "Adopter@Example.com" }),
+      },
+      env({ emailOutbox: [], inviteAllowed: false, inviteKeys }),
+    );
+    expect(response.status).toBe(429);
+    expect(inviteKeys).toContain("invite:email:adopter@example.com");
   });
 
   it("uses one uniform, non-cacheable public exchange error", async () => {

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -4,6 +4,11 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat"],
+  "vars": {
+    // Origin of the invite page that magic links point at. Defaults to the API
+    // host without the `api.` prefix; set explicitly for other deployments.
+    "WEB_ORIGIN": "https://uploads.sh",
+  },
   "routes": [
     {
       "pattern": "api.uploads.sh",
@@ -62,6 +67,10 @@
       },
     ],
   },
+  // Transactional email (Cloudflare Email Sending). uploads.sh is onboarded for
+  // sending; invites are delivered from invites@uploads.sh. Add "remote": true
+  // here to route real sends through `wrangler dev` (remove before deploy).
+  "send_email": [{ "name": "EMAIL" }],
   // One binding per same-account bucket a workspace wants binding-mode I/O on.
   // Workspaces reference these by name; workspaces without a binding fall back
   // to their S3 credentials over HTTP.

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -8,25 +8,24 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://api.uploads.sh; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'" />
-  <title>Your uploads.sh invitation</title>
+  <title>Accept your invite · uploads.sh</title>
   <link rel="icon" href={FAVICON} />
   <style>
-    :root{color-scheme:dark;--bg:#0b0813;--panel:#120d1e;--line:#2b1f46;--fg:#e6dff5;--muted:#8e86a5;--purple:#b794ff;--green:#9ece6a;--red:#f7768e}*{box-sizing:border-box}body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:radial-gradient(100% 80% at 50% 0%,#19102b,var(--bg) 62%);color:var(--fg);font:15px/1.6 ui-monospace,"SFMono-Regular",Consolas,monospace}main{width:min(680px,100%);background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:clamp(24px,6vw,44px);box-shadow:0 24px 90px #0009}h1{margin:0 0 8px;font-size:clamp(24px,5vw,34px)}p{color:var(--muted)}.status{border-left:3px solid var(--purple);padding:10px 14px;margin:24px 0;background:#0d0a16}.status[data-state=ready]{border-color:var(--green);color:var(--green)}.status[data-state=closed]{border-color:var(--red);color:var(--red)}li{margin:18px 0}.command{display:flex;gap:12px;align-items:center;padding:13px 14px;border:1px solid var(--line);border-radius:8px;background:#09070f}.command code{flex:1;min-width:0;white-space:nowrap;overflow-x:auto;display:block}.command button{flex-shrink:0}button{border:1px solid #553c88;border-radius:6px;padding:7px 10px;background:#201534;color:var(--purple);cursor:pointer;font:inherit}.security{margin-top:28px;padding-top:18px;border-top:1px solid var(--line);font-size:13px}[hidden]{display:none!important}
+    :root{color-scheme:dark;--bg:#0b0813;--panel:#120d1e;--line:#2b1f46;--fg:#e6dff5;--muted:#8e86a5;--purple:#b794ff;--green:#9ece6a;--red:#f7768e}*{box-sizing:border-box}body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:radial-gradient(100% 80% at 50% 0%,#19102b,var(--bg) 62%);color:var(--fg);font:15px/1.6 ui-monospace,"SFMono-Regular",Consolas,monospace}main{width:min(640px,100%);background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:clamp(24px,6vw,44px);box-shadow:0 24px 90px #0009}h1{margin:0 0 8px;font-size:clamp(23px,5vw,32px)}p{color:var(--muted)}.status{border-left:3px solid var(--purple);padding:9px 14px;margin:24px 0;background:#0d0a16;color:var(--fg)}.status[data-state=ready]{border-color:var(--green)}.status[data-state=closed]{border-color:var(--red);color:var(--red)}ol{padding-left:20px}li{margin:16px 0}.command{display:flex;gap:12px;align-items:center;margin-top:8px;padding:13px 14px;border:1px solid var(--line);border-radius:8px;background:#09070f}.command code{flex:1;min-width:0;white-space:nowrap;overflow-x:auto;display:block}.command button{flex-shrink:0}button{border:1px solid #553c88;border-radius:6px;padding:7px 10px;background:#201534;color:var(--purple);cursor:pointer;font:inherit}.security{margin-top:26px;padding-top:18px;border-top:1px solid var(--line);font-size:13px}[hidden]{display:none!important}
   </style>
 </head>
 <body>
 <main>
-  <h1>Welcome to uploads.sh</h1>
-  <p id="intro">This private invitation sets up the uploads.sh CLI.</p>
-  <div class="status" id="status" role="status">Checking this invitation…</div>
+  <h1>Accept your invite to uploads.sh</h1>
+  <p>Host files and screenshots straight from your terminal — upload, get a public link, attach them to a pull request.</p>
+  <div class="status" id="meta" role="status">Checking your invite…</div>
   <section id="instructions" hidden>
     <ol>
-      <li>Install the CLI.<div class="command"><code>npm install --global @buildinternet/uploads</code><button data-copy="npm install --global @buildinternet/uploads">copy</button></div></li>
-      <li id="login-step"><span id="login-desc">Start login, then paste the separately shared one-time code.</span><div class="command"><code id="login-cmd">uploads login</code><button id="login-copy" data-copy="uploads login">copy</button></div></li>
-      <li>Confirm the CLI reports that credentials were saved and the doctor check passed.</li>
+      <li>Install<div class="command"><code>npm install --global @buildinternet/uploads</code><button data-copy="npm install --global @buildinternet/uploads">copy</button></div></li>
+      <li>Log in<div class="command"><code id="login-cmd">uploads login</code><button id="login-copy" data-copy="uploads login">copy</button></div></li>
     </ol>
   </section>
-  <p class="security" id="security">This URL contains only a non-secret invitation identifier. It cannot create credentials without the separately delivered one-time code.</p>
+  <p class="security">Treat this link like a password — it's single-use and stops working once you log in.</p>
 </main>
 <script>
   function requireElement<T extends Element>(selector: string): T {
@@ -35,31 +34,22 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
     return element;
   }
 
-  const status = requireElement<HTMLElement>("#status");
+  const meta = requireElement<HTMLElement>("#meta");
   const instructions = requireElement<HTMLElement>("#instructions");
-  const intro = requireElement<HTMLElement>("#intro");
-  const security = requireElement<HTMLElement>("#security");
-  const loginDesc = requireElement<HTMLElement>("#login-desc");
   const loginCmd = requireElement<HTMLElement>("#login-cmd");
   const loginCopy = requireElement<HTMLButtonElement>("#login-copy");
 
   const url = new URL(location.href);
   const pageId = url.searchParams.get("id") ?? "";
-  // The one-time code rides in the URL fragment, which browsers never send to
-  // the server. Read it, then scrub it from the address bar so it is not
-  // shoulder-surfed or accidentally re-shared; the CLI still redeems it.
+  // The one-time code rides in the URL fragment, which browsers never send to the
+  // server. Read it, then scrub it from the address bar; the CLI still redeems it.
   const code = new URLSearchParams(url.hash.replace(/^#/, "")).get("code") ?? "";
   if (url.hash) history.replaceState(null, "", url.pathname + url.search);
 
-  function applyCode() {
-    // No code in the link: leave the markup's default two-channel security note
-    // and login command in place.
-    if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) return;
-    const command = `printf %s '${code}' | uploads login --code-stdin`;
-    loginDesc.textContent = "Run login — your one-time code is included, so you will not be prompted.";
+  if (/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) {
+    const command = `uploads login --code ${code}`;
     loginCmd.textContent = command;
     loginCopy.dataset.copy = command;
-    security.textContent = "This link includes your one-time code — treat it like a password. It is single-use and expires. The code rides in the link’s # fragment, so opening this page never sends it to our servers.";
   }
 
   async function checkInvitation() {
@@ -67,14 +57,15 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
     const response = await fetch(`https://api.uploads.sh/auth/enrollments/${encodeURIComponent(pageId)}`, { cache:"no-store", credentials:"omit", referrerPolicy:"no-referrer" });
     if (!response.ok) throw new Error("invalid");
     const invitation = (await response.json()) as { used: boolean; expiresAt: string; workspace: string };
-    if (invitation.workspace) intro.textContent = `This private invitation sets up the CLI for workspace “${invitation.workspace}”.`;
-    if (invitation.used) { status.textContent="This invitation has already been used."; status.dataset.state="closed"; return; }
-    status.textContent=`Invitation ready · expires ${new Date(invitation.expiresAt).toLocaleString()}`;
-    status.dataset.state="ready"; instructions.hidden=false;
+    if (invitation.used) { meta.textContent = "This invite has already been used."; meta.dataset.state = "closed"; return; }
+    const when = new Date(invitation.expiresAt).toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
+    const where = invitation.workspace ? `the ${invitation.workspace} workspace` : "uploads.sh";
+    meta.textContent = `You'll join ${where} · expires ${when}`;
+    meta.dataset.state = "ready";
+    instructions.hidden = false;
   }
 
-  applyCode();
-  checkInvitation().catch(() => { status.textContent="This invitation is invalid or has expired."; status.dataset.state="closed"; });
+  checkInvitation().catch(() => { meta.textContent = "This invite is invalid or has expired."; meta.dataset.state = "closed"; });
   document.querySelectorAll<HTMLButtonElement>("[data-copy]").forEach((button) =>
     button.addEventListener("click", async () => {
       const value = button.dataset.copy;

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -11,22 +11,22 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
   <title>Your uploads.sh invitation</title>
   <link rel="icon" href={FAVICON} />
   <style>
-    :root{color-scheme:dark;--bg:#0b0813;--panel:#120d1e;--line:#2b1f46;--fg:#e6dff5;--muted:#8e86a5;--purple:#b794ff;--green:#9ece6a;--red:#f7768e}*{box-sizing:border-box}body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:radial-gradient(100% 80% at 50% 0%,#19102b,var(--bg) 62%);color:var(--fg);font:15px/1.6 ui-monospace,"SFMono-Regular",Consolas,monospace}main{width:min(680px,100%);background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:clamp(24px,6vw,44px);box-shadow:0 24px 90px #0009}h1{margin:0 0 8px;font-size:clamp(24px,5vw,34px)}p{color:var(--muted)}.status{border-left:3px solid var(--purple);padding:10px 14px;margin:24px 0;background:#0d0a16}.status[data-state=ready]{border-color:var(--green);color:var(--green)}.status[data-state=closed]{border-color:var(--red);color:var(--red)}li{margin:18px 0}.command{display:flex;gap:12px;align-items:center;padding:13px 14px;border:1px solid var(--line);border-radius:8px;background:#09070f;overflow:auto}.command code{flex:1;white-space:nowrap}button{border:1px solid #553c88;border-radius:6px;padding:7px 10px;background:#201534;color:var(--purple);cursor:pointer;font:inherit}.security{margin-top:28px;padding-top:18px;border-top:1px solid var(--line);font-size:13px}[hidden]{display:none!important}
+    :root{color-scheme:dark;--bg:#0b0813;--panel:#120d1e;--line:#2b1f46;--fg:#e6dff5;--muted:#8e86a5;--purple:#b794ff;--green:#9ece6a;--red:#f7768e}*{box-sizing:border-box}body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:radial-gradient(100% 80% at 50% 0%,#19102b,var(--bg) 62%);color:var(--fg);font:15px/1.6 ui-monospace,"SFMono-Regular",Consolas,monospace}main{width:min(680px,100%);background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:clamp(24px,6vw,44px);box-shadow:0 24px 90px #0009}h1{margin:0 0 8px;font-size:clamp(24px,5vw,34px)}p{color:var(--muted)}.status{border-left:3px solid var(--purple);padding:10px 14px;margin:24px 0;background:#0d0a16}.status[data-state=ready]{border-color:var(--green);color:var(--green)}.status[data-state=closed]{border-color:var(--red);color:var(--red)}li{margin:18px 0}.command{display:flex;gap:12px;align-items:center;padding:13px 14px;border:1px solid var(--line);border-radius:8px;background:#09070f}.command code{flex:1;min-width:0;white-space:nowrap;overflow-x:auto;display:block}.command button{flex-shrink:0}button{border:1px solid #553c88;border-radius:6px;padding:7px 10px;background:#201534;color:var(--purple);cursor:pointer;font:inherit}.security{margin-top:28px;padding-top:18px;border-top:1px solid var(--line);font-size:13px}[hidden]{display:none!important}
   </style>
 </head>
 <body>
 <main>
   <h1>Welcome to uploads.sh</h1>
-  <p>This private invitation sets up the CLI for your pre-created workspace.</p>
+  <p id="intro">This private invitation sets up the uploads.sh CLI.</p>
   <div class="status" id="status" role="status">Checking this invitation…</div>
   <section id="instructions" hidden>
     <ol>
       <li>Install the CLI.<div class="command"><code>npm install --global @buildinternet/uploads</code><button data-copy="npm install --global @buildinternet/uploads">copy</button></div></li>
-      <li>Start login, then paste the separately shared one-time code.<div class="command"><code>uploads login</code><button data-copy="uploads login">copy</button></div></li>
+      <li id="login-step"><span id="login-desc">Start login, then paste the separately shared one-time code.</span><div class="command"><code id="login-cmd">uploads login</code><button id="login-copy" data-copy="uploads login">copy</button></div></li>
       <li>Confirm the CLI reports that credentials were saved and the doctor check passed.</li>
     </ol>
   </section>
-  <p class="security">This URL contains only a non-secret invitation identifier. It cannot create credentials without the separately delivered one-time code.</p>
+  <p class="security" id="security">This URL contains only a non-secret invitation identifier. It cannot create credentials without the separately delivered one-time code.</p>
 </main>
 <script>
   function requireElement<T extends Element>(selector: string): T {
@@ -37,16 +37,43 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
 
   const status = requireElement<HTMLElement>("#status");
   const instructions = requireElement<HTMLElement>("#instructions");
-  const pageId = new URL(location.href).searchParams.get("id") ?? "";
+  const intro = requireElement<HTMLElement>("#intro");
+  const security = requireElement<HTMLElement>("#security");
+  const loginDesc = requireElement<HTMLElement>("#login-desc");
+  const loginCmd = requireElement<HTMLElement>("#login-cmd");
+  const loginCopy = requireElement<HTMLButtonElement>("#login-copy");
+
+  const url = new URL(location.href);
+  const pageId = url.searchParams.get("id") ?? "";
+  // The one-time code rides in the URL fragment, which browsers never send to
+  // the server. Read it, then scrub it from the address bar so it is not
+  // shoulder-surfed or accidentally re-shared; the CLI still redeems it.
+  const code = new URLSearchParams(url.hash.replace(/^#/, "")).get("code") ?? "";
+  if (url.hash) history.replaceState(null, "", url.pathname + url.search);
+
+  function applyCode() {
+    // No code in the link: leave the markup's default two-channel security note
+    // and login command in place.
+    if (!/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) return;
+    const command = `printf %s '${code}' | uploads login --code-stdin`;
+    loginDesc.textContent = "Run login — your one-time code is included, so you will not be prompted.";
+    loginCmd.textContent = command;
+    loginCopy.dataset.copy = command;
+    security.textContent = "This link includes your one-time code — treat it like a password. It is single-use and expires. The code rides in the link’s # fragment, so opening this page never sends it to our servers.";
+  }
+
   async function checkInvitation() {
     if (!/^upi_[A-Za-z0-9_-]{16}$/.test(pageId)) throw new Error("invalid");
     const response = await fetch(`https://api.uploads.sh/auth/enrollments/${encodeURIComponent(pageId)}`, { cache:"no-store", credentials:"omit", referrerPolicy:"no-referrer" });
     if (!response.ok) throw new Error("invalid");
-    const invitation = (await response.json()) as { used: boolean; expiresAt: string };
+    const invitation = (await response.json()) as { used: boolean; expiresAt: string; workspace: string };
+    if (invitation.workspace) intro.textContent = `This private invitation sets up the CLI for workspace “${invitation.workspace}”.`;
     if (invitation.used) { status.textContent="This invitation has already been used."; status.dataset.state="closed"; return; }
     status.textContent=`Invitation ready · expires ${new Date(invitation.expiresAt).toLocaleString()}`;
     status.dataset.state="ready"; instructions.hidden=false;
   }
+
+  applyCode();
   checkInvitation().catch(() => { status.textContent="This invitation is invalid or has expired."; status.dataset.state="closed"; });
   document.querySelectorAll<HTMLButtonElement>("[data-copy]").forEach((button) =>
     button.addEventListener("click", async () => {

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -37,8 +37,8 @@ configured token.
 ## Administrator overview
 
 Administrators issue invitations for existing workspaces. Invitation codes are
-single-use and default to a 10-minute expiry; issued tokens default to read/write
-scope without delete access. See the [operator runbook](ops.md#invitations) for
+single-use and default to a 2-hour expiry (override with `--expires-in`, up to 24
+hours); issued tokens default to read/write scope without delete access. See the [operator runbook](ops.md#invitations) for
 commands, secret handling, delivery, and troubleshooting.
 
 ## Token policy

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -1,9 +1,15 @@
 # Invitations and `uploads login`
 
-Early adopters authenticate through short-lived invitation codes. They never receive
-the API's `ADMIN_TOKEN`. An administrator authorizes an existing workspace, shares the
-single-use code, and the adopter runs `uploads login` to exchange it for a scoped,
-expiring workspace token.
+Early adopters authenticate through short-lived invitations. They never receive
+the API's `ADMIN_TOKEN`. An administrator authorizes an existing workspace and shares
+a single-use **magic link**; the adopter opens it and runs the one-click `uploads
+login` command it shows to exchange the code for a scoped, expiring workspace token.
+
+The one-time code travels in the link's URL fragment (`…/invite?id=…#code=…`), which
+browsers never send to a server—so opening the page neither logs nor consumes the
+code; only the CLI's exchange call redeems it. Treat the link like a password. For
+security-sensitive deployments that prefer two channels, `uploads admin invite create
+--separate-code` prints a non-secret page URL plus a code you deliver separately.
 
 ## Agent login
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -50,16 +50,25 @@ ADMIN_TOKEN=<admin-credential> uploads admin invite create \
   --workspace default --label early-adopter
 ```
 
-The admin API at `POST /admin/enrollments` provides the same operation. Its response
-contains a non-secret onboarding URL and a one-time code. Share them as separate
-fields; the URL exposes only expiry and used status and cannot mint credentials.
-Invitation codes default to a 10-minute expiry (configurable at creation) and are
-consumed by one successful exchange. Unknown, expired, and consumed codes return the
-same public error shape.
+By default the command prints one **magic link** (`…/invite?id=…#code=…`): the
+single-use code rides in the URL fragment, so share the link over a single trusted
+channel and treat it like a password. Add `--separate-code` for two-channel output—a
+non-secret page URL plus a code you deliver separately—when a deployment prefers it.
+Pass `--email <address>` to deliver the link by email instead of printing it—sent
+from `invites@uploads.sh` via Cloudflare Email Sending (`uploads.sh` is onboarded).
+Delivery is rate-limited per recipient and audit-logged (`invite_emailed`) with only
+the workspace, recipient, and page id—never the code or link. If delivery fails the
+invite is still created and the CLI prints the link as a fallback.
+The admin API at `POST /admin/enrollments` returns the same fields. Invitation codes
+default to a 2-hour expiry (configurable at creation with `--expires-in`, from 60
+seconds up to 24 hours) and are consumed by one successful exchange. Unknown,
+expired, and consumed codes return the same public error shape.
 
-The invite page loads no analytics or third-party assets. Response controls request
-`no-store`, `no-referrer`, `noindex`, a restrictive CSP, and disabled browser
-permissions. The one-time code never belongs in the URL.
+The invite page shows the target workspace and expiry, and loads no analytics or
+third-party assets. Response controls request `no-store`, `no-referrer`, `noindex`, a
+restrictive CSP, and disabled browser permissions. The code lives only in the URL
+fragment—never the query string—so it stays out of server logs and referrers, and the
+page reads it client-side without sending it anywhere.
 
 ## Secrets
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -117,6 +117,8 @@ export interface EnrollmentCreateResult {
   code: string;
   expiresAt: string;
   tokenExpiresAt: string;
+  // Present only when an --email recipient was requested: whether delivery succeeded.
+  emailed?: boolean;
 }
 
 async function jsonRequest<T>(url: string, init: RequestInit): Promise<T> {
@@ -150,6 +152,7 @@ export function createEnrollment(
   input: {
     workspace?: string;
     label?: string;
+    email?: string;
     enrollmentSeconds?: number;
     tokenExpiresInSeconds?: number;
     scopes?: Array<"files:read" | "files:write" | "files:delete">;

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -1,11 +1,13 @@
 import { createEnrollment } from "../client.js";
-import { flagInt, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+import { flagBool, flagInt, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
 
 const HELP = `uploads admin invite create [options]
 
 Admin-only: create a short-lived invitation for an existing workspace.
-The invitation page ID is not a credential; share its URL and the one-time code
-as separate fields. The legacy "admin enrollment create" spelling is accepted.
+Prints one magic link whose URL fragment carries the single-use code — treat the
+link like a password. Pass --separate-code for the legacy two-channel output (a
+non-secret page URL plus a code you share separately). The legacy
+"admin enrollment create" spelling is accepted.
 
 Options:
   --admin-token <token>  Or ADMIN_TOKEN (UPLOADS_ADMIN_TOKEN is a legacy alias)
@@ -14,6 +16,7 @@ Options:
   --expires-in <seconds> Default: server policy
   --token-expires-in <seconds>  Upload token lifetime (default: server policy)
   --scopes <list>        Comma-separated files:read,files:write,files:delete
+  --separate-code        Two-channel output: non-secret page URL + separate code
   --api-url <url>        Default: https://api.uploads.sh
   --web-url <url>        Invite-page origin (defaults from --api-url)
 `;
@@ -34,6 +37,13 @@ export function invitePageUrl(apiUrl: string, pageId: string, webUrl?: string): 
   url.hash = "";
   url.searchParams.set("id", pageId);
   return url.toString();
+}
+
+// Compose the self-contained magic link. The one-time code rides in the URL
+// fragment (#code=…), which browsers never send to the server, so opening the
+// page neither leaks nor consumes it — only the CLI's exchange call redeems it.
+export function inviteMagicLink(pageUrl: string, code: string): string {
+  return `${pageUrl}#code=${encodeURIComponent(code)}`;
 }
 
 export function parseScopes(raw: string | undefined): FileScope[] | undefined {
@@ -82,13 +92,23 @@ export async function runAdmin(
     tokenExpiresInSeconds: flagInt(parsed.flags, "--token-expires-in", "--token-expires-in"),
     scopes: parseScopes(flagString(parsed.flags, "--scopes")),
   });
-  if (opts.json)
+  const separateCode = flagBool(parsed.flags, "--separate-code");
+  const pageUrl = invitePageUrl(apiUrl, result.pageId, webUrl);
+  const link = separateCode ? pageUrl : inviteMagicLink(pageUrl, result.code);
+  const footer = `workspace: ${workspace}\nexpires: ${result.expiresAt}\n`;
+  if (opts.json) {
     process.stdout.write(
-      JSON.stringify({ workspace, label: label ?? null, ...result }, null, 2) + "\n",
+      JSON.stringify({ workspace, label: label ?? null, url: link, ...result }, null, 2) + "\n",
+    );
+    return 0;
+  }
+  if (separateCode)
+    process.stdout.write(
+      `Invite page: ${pageUrl}\nOne-time code (share separately): ${result.code}\n${footer}`,
     );
   else
     process.stdout.write(
-      `Invite page: ${invitePageUrl(apiUrl, result.pageId, webUrl)}\nOne-time code (share separately): ${result.code}\nworkspace: ${workspace}\nexpires: ${result.expiresAt}\n`,
+      `Invite link (contains the one-time code — treat like a password):\n${link}\n${footer}`,
     );
   return 0;
 }

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -16,6 +16,7 @@ Options:
   --expires-in <seconds> Default: server policy
   --token-expires-in <seconds>  Upload token lifetime (default: server policy)
   --scopes <list>        Comma-separated files:read,files:write,files:delete
+  --email <address>      Email the invite link to this recipient (from invites@uploads.sh)
   --separate-code        Two-channel output: non-secret page URL + separate code
   --api-url <url>        Default: https://api.uploads.sh
   --web-url <url>        Invite-page origin (defaults from --api-url)
@@ -85,9 +86,11 @@ export async function runAdmin(
   const webUrl = flagString(parsed.flags, "--web-url");
   const workspace = flagString(parsed.flags, "--workspace") ?? "default";
   const label = flagString(parsed.flags, "--label");
+  const email = flagString(parsed.flags, "--email");
   const result = await createEnrollment(apiUrl, adminToken, {
     workspace,
     label,
+    email,
     enrollmentSeconds: flagInt(parsed.flags, "--expires-in", "--expires-in"),
     tokenExpiresInSeconds: flagInt(parsed.flags, "--token-expires-in", "--token-expires-in"),
     scopes: parseScopes(flagString(parsed.flags, "--scopes")),
@@ -102,6 +105,12 @@ export async function runAdmin(
     );
     return 0;
   }
+  if (email && result.emailed) {
+    process.stdout.write(`Invite emailed to ${email}\n${footer}`);
+    return 0;
+  }
+  if (email && result.emailed === false)
+    process.stderr.write("warning: email delivery failed; share this link instead\n");
   if (separateCode)
     process.stdout.write(
       `Invite page: ${pageUrl}\nOne-time code (share separately): ${result.code}\n${footer}`,

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -231,6 +231,50 @@ describe("admin enrollment", () => {
     expect(output.out()).not.toContain("#code=");
   });
 
+  it("emails the invite and confirms delivery without printing the code", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response(
+        {
+          pageId: "upi_abcdefghijklmnop",
+          code: "upe_abcdefghijklmnopqrstuvwxyz012345",
+          expiresAt: "2030-01-01T00:00:00Z",
+          tokenExpiresAt: "2030-02-01T00:00:00Z",
+          emailed: true,
+        },
+        201,
+      ),
+    );
+    const output = captureOutput();
+    expect(await runAdmin(["invite", "create", "--email", "adopter@example.com"], {})).toBe(0);
+    expect(JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body))).toMatchObject({
+      email: "adopter@example.com",
+    });
+    expect(output.out()).toContain("Invite emailed to adopter@example.com");
+    expect(output.out()).not.toContain("#code=");
+    expect(output.out()).not.toContain("upe_abcdefghijklmnopqrstuvwxyz012345");
+  });
+
+  it("warns and prints the link as a fallback when email delivery fails", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response(
+        {
+          pageId: "upi_abcdefghijklmnop",
+          code: "upe_abcdefghijklmnopqrstuvwxyz012345",
+          expiresAt: "2030-01-01T00:00:00Z",
+          tokenExpiresAt: "2030-02-01T00:00:00Z",
+          emailed: false,
+        },
+        201,
+      ),
+    );
+    const output = captureOutput();
+    expect(await runAdmin(["invite", "create", "--email", "adopter@example.com"], {})).toBe(0);
+    expect(output.err()).toContain("email delivery failed");
+    expect(output.out()).toContain("#code=upe_abcdefghijklmnopqrstuvwxyz012345");
+  });
+
   it("carries the one-time code in the magic link fragment", () => {
     expect(
       inviteMagicLink(

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveEnrollmentCode, runLogin, validateEnrollmentCode } from "../src/commands/login.js";
-import { invitePageUrl, parseScopes, runAdmin } from "../src/commands/admin-enrollment.js";
+import {
+  inviteMagicLink,
+  invitePageUrl,
+  parseScopes,
+  runAdmin,
+} from "../src/commands/admin-enrollment.js";
 import { parseCommandArgs } from "../src/cli-args.js";
 import { loadConfigFile, writeConfigKeys } from "../src/config-file.js";
 
@@ -188,6 +193,53 @@ describe("admin enrollment", () => {
     expect(JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body))).toEqual({
       workspace: "default",
     });
+  });
+
+  const enrollmentResponse = () =>
+    response(
+      {
+        pageId: "upi_abcdefghijklmnop",
+        code: "upe_abcdefghijklmnopqrstuvwxyz012345",
+        expiresAt: "2030-01-01T00:00:00Z",
+        tokenExpiresAt: "2030-02-01T00:00:00Z",
+      },
+      201,
+    );
+
+  it("prints a self-contained magic link by default", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(enrollmentResponse());
+    const output = captureOutput();
+    expect(await runAdmin(["invite", "create"], {})).toBe(0);
+    expect(output.out()).toContain(
+      "https://uploads.sh/invite?id=upi_abcdefghijklmnop#code=upe_abcdefghijklmnopqrstuvwxyz012345",
+    );
+    expect(output.out()).not.toContain("share separately");
+  });
+
+  it("prints a non-secret page URL and separate code with --separate-code", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(enrollmentResponse());
+    const output = captureOutput();
+    expect(await runAdmin(["invite", "create", "--separate-code"], {})).toBe(0);
+    expect(output.out()).toContain(
+      "Invite page: https://uploads.sh/invite?id=upi_abcdefghijklmnop",
+    );
+    expect(output.out()).toContain(
+      "One-time code (share separately): upe_abcdefghijklmnopqrstuvwxyz012345",
+    );
+    expect(output.out()).not.toContain("#code=");
+  });
+
+  it("carries the one-time code in the magic link fragment", () => {
+    expect(
+      inviteMagicLink(
+        "https://uploads.sh/invite?id=upi_abcdefghijklmnop",
+        "upe_abcdefghijklmnopqrstuvwxyz012345",
+      ),
+    ).toBe(
+      "https://uploads.sh/invite?id=upi_abcdefghijklmnop#code=upe_abcdefghijklmnopqrstuvwxyz012345",
+    );
   });
 
   it("derives or overrides the invite page origin", () => {

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -88,8 +88,8 @@ than a process-list-visible command argument:
 UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login
 ```
 
-Routine agents never need `ADMIN_TOKEN`. Enrollment codes expire after 10 minutes and
-can be redeemed once. The resulting token defaults to 90 days and `files:read` plus
+Routine agents never need `ADMIN_TOKEN`. Enrollment codes expire after 2 hours by
+default (up to 24 hours) and can be redeemed once. The resulting token defaults to 90 days and `files:read` plus
 `files:write`; it cannot delete files unless an administrator explicitly grants
 `files:delete`. Verify or inspect setup at any time:
 


### PR DESCRIPTION
Reworks the invite/onboarding flow across the API, CLI, and web invite page.

![Redesigned uploads.sh invite page](https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/52/invite-page.webp)

<sub>↑ The redesigned invite page — hosted via `uploads put` from this branch (dogfooding the CLI this PR ships).</sub>

## Commits

1. **`feat(api): raise invite code expiry to 2h default, 24h max`** — codes were 10-minute default / 1-hour max, too tight for human onboarding via a separate channel.
2. **`feat: magic-link invites with the workspace shown on the invite page`** — `uploads admin invite create` prints one self-contained magic link. The one-time code rides in the URL **fragment** (`…/invite?id=…#code=…`), which browsers never send to a server, so it stays out of query strings, server logs, and referrers; the page assembles a one-click login command and scrubs the fragment from the address bar. Redemption stays an explicit CLI `POST`, so *viewing the page never consumes the code* — immune to email/Slack link scanners that would otherwise burn a single-use link. The page also shows which workspace the invite is for. `--separate-code` keeps the legacy two-channel output.
3. **`feat: email invite delivery via Cloudflare Email Sending`** — `--email <address>` delivers the link from `invites@uploads.sh`. Per-recipient rate limiting (can't be used to email-bomb someone), audit logging that never records the code or link, a configurable `WEB_ORIGIN` for the link origin, and graceful fallback to printing the link when delivery fails.
4. **`chore: add web-preview launch config`** — dev tooling to exercise the invite page in the browser (its inline script is CSP-blocked under Astro's dev server).
5. **`refine: simplify the invite page and use uploads login --code`** — trims the page to feel dead-simple (real header, one-line "what it's for", workspace + expiry on one line, two steps) and switches the login command from the cryptic `printf … | --code-stdin` to the plain `uploads login --code <code>` (the code is single-use and inert the moment you log in, so the process-list hardening wasn't worth the confusing command).

## Release

The CLI-facing changesets (magic-link, email) roll into the held version PR [#47](https://github.com/buildinternet/uploads/pull/47) (→ `0.5.0`) after this merges. The API + web changes deploy via Workers Builds on merge; the `send_email` binding needs no secret — `uploads.sh` is already onboarded for Cloudflare Email Sending.

## Verification

- **103 API + 125 CLI tests** (16 new), typecheck, lint, and format all green.
- Invite page driven in the browser against the production build: fragment scrub, one-click command, workspace display, and security copy all confirmed — including a layout fix so the copy button stays visible with the longer command.
- **Not yet exercised:** a real end-to-end email send (needs the API deployed, or `wrangler dev --remote`). Once deployed, `uploads admin invite create --email <address>` closes out the original "send a test invite" request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
