### PR TITLE
feat(web): add Astro 404 and 500 error pages

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,6 @@
 # @uploads/web
 
-Astro site — placeholder landing page for **uploads.sh**. Separate deploy from the API; future home for a browse/manage UI (likely files-sdk's `createFilesRouter` + browser client rather than more hand-rolled REST).
+Astro site — landing page for **uploads.sh**. Separate deploy from the API; future home for a browse/manage UI (likely files-sdk's `createFilesRouter` + browser client rather than more hand-rolled REST).
 
 ## Commands
 
@@ -15,7 +15,20 @@ From the repo root: `pnpm dev:web` / `pnpm run deploy:web`.
 ## Layout
 
 ```
-src/pages/        Astro pages (currently index.astro only)
+src/layouts/      Shared shells (error pages)
+src/pages/        Astro pages (index, console, invite, 404, 500)
+public/_headers   Per-path response headers for Workers assets
 astro.config.mjs
 wrangler.jsonc    Workers static assets deploy
 ```
+
+## Error pages
+
+Astro’s built-in conventions ([docs](https://docs.astro.build/en/basics/astro-pages/)):
+
+| Page                          | Role                                                                                                                                                                                                    |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `404.astro` → `dist/404.html` | **Missing route.** Host serves it for unknown paths via `assets.not_found_handling: "404-page"` in `wrangler.jsonc`.                                                                                    |
+| `500.astro` → `dist/500.html` | **Application error** (something failed, not “URL doesn’t exist”). Branded page at `/500` today; Astro will use this file for SSR render failures once any routes are on-demand (e.g. admin dashboard). |
+
+Shared shell: `ErrorLayout` (landing palette, `noindex`, home link). The **API** still returns JSON envelopes — these HTML pages are for browser traffic on the web origin.

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -5,3 +5,16 @@
   X-Content-Type-Options: nosniff
   Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
   Permissions-Policy: camera=(), microphone=(), geolocation=()
+
+# Astro status pages — noindex; short cache on 404, no-store on app errors
+/404
+  Cache-Control: public, max-age=60
+  X-Robots-Tag: noindex, nofollow, noarchive
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer
+
+/500
+  Cache-Control: no-store
+  X-Robots-Tag: noindex, nofollow, noarchive
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -1,0 +1,188 @@
+---
+/**
+ * Shared shell for Astro status pages (404 missing route, 500 application error).
+ * Matches the landing terminal palette so failures still feel on-brand.
+ */
+interface Props {
+  status: number;
+  title: string;
+  message: string;
+  /** Optional one-line hint under the message */
+  hint?: string;
+}
+
+const { status, title, message, hint } = Astro.props;
+
+const FAVICON =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23120d1e'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow, noarchive" />
+    <meta name="description" content={`${status} ${title} — uploads.sh`} />
+    <title>{status} · {title} · uploads.sh</title>
+    <link rel="icon" href={FAVICON} />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0813;
+        --screen: #120d1e;
+        --bezel: #251a3d;
+        --fg: #e6dff5;
+        --purple: #b794ff;
+        --purple-dim: #8262c9;
+        --purple-faint: #53407e;
+        --neutral: #726d8c;
+        --cyan: #7dcfff;
+        --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background:
+          radial-gradient(120% 90% at 50% 0%, #150e24 0%, var(--bg) 60%),
+          var(--bg);
+        color: var(--fg);
+        font: 15px/1.65 var(--mono);
+        display: grid;
+        place-items: center;
+        padding: 40px 24px 56px;
+      }
+      main {
+        width: min(420px, 100%);
+      }
+      .card {
+        background: var(--screen);
+        border: 1px solid var(--bezel);
+        border-radius: 10px;
+        box-shadow:
+          0 0 0 1px #000,
+          0 24px 80px rgba(0, 0, 0, 0.55),
+          0 0 100px rgba(183, 148, 255, 0.06);
+        overflow: hidden;
+      }
+      .titlebar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+        background: var(--bezel);
+        color: var(--purple-dim);
+        font-size: 12px;
+        letter-spacing: 0.08em;
+      }
+      .titlebar .dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #382a58;
+      }
+      .titlebar .label {
+        margin-left: auto;
+        margin-right: auto;
+      }
+      .body {
+        padding: 28px 22px 26px;
+      }
+      .status {
+        margin: 0 0 6px;
+        font-size: clamp(2.4rem, 8vw, 3.2rem);
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        color: var(--purple);
+        line-height: 1.1;
+        text-shadow: 0 0 24px rgba(183, 148, 255, 0.25);
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--fg);
+        letter-spacing: 0.02em;
+      }
+      p {
+        margin: 0;
+        color: var(--neutral);
+        font-size: 0.92rem;
+      }
+      .hint {
+        margin-top: 10px;
+        font-size: 0.85rem;
+        color: var(--purple-dim);
+      }
+      .actions {
+        margin-top: 22px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+      a {
+        color: var(--cyan);
+        text-decoration: underline;
+        text-decoration-color: var(--purple-faint);
+        text-underline-offset: 3px;
+      }
+      a:hover,
+      a:focus-visible {
+        background: rgba(125, 207, 255, 0.12);
+        outline: none;
+      }
+      .home {
+        display: inline-block;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        color: var(--purple);
+        background: rgba(183, 148, 255, 0.08);
+        border: 1px solid #38295c;
+        border-radius: 6px;
+        padding: 8px 14px;
+        text-decoration: none;
+      }
+      .home:hover,
+      .home:focus-visible {
+        background: rgba(183, 148, 255, 0.18);
+        border-color: var(--purple-faint);
+        outline: none;
+      }
+      .foot {
+        margin-top: 14px;
+        padding-left: 4px;
+        font-size: 12px;
+        color: var(--neutral);
+      }
+      .foot a {
+        color: var(--cyan);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="card" aria-labelledby="error-title">
+        <div class="titlebar" aria-hidden="true">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="label">uploads.sh — error</span>
+        </div>
+        <div class="body">
+          <p class="status" aria-hidden="true">{status}</p>
+          <h1 id="error-title">{title}</h1>
+          <p>{message}</p>
+          {hint ? <p class="hint">{hint}</p> : null}
+          <div class="actions">
+            <a class="home" href="/">← home</a>
+          </div>
+        </div>
+      </section>
+      <p class="foot">
+        <a href="https://github.com/buildinternet/uploads">source</a>
+        {" · "}file hosting for agents &amp; humans
+      </p>
+    </main>
+  </body>
+</html>

--- a/apps/web/src/pages/404.astro
+++ b/apps/web/src/pages/404.astro
@@ -1,0 +1,16 @@
+---
+/**
+ * Missing route — Astro builds dist/404.html.
+ * Workers static assets serve it for unknown paths when not_found_handling is
+ * "404-page" (wrangler.jsonc). Different from 500 (application failure).
+ * @see https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page
+ */
+import ErrorLayout from "../layouts/ErrorLayout.astro";
+---
+
+<ErrorLayout
+  status={404}
+  title="Not found"
+  message="That path doesn’t exist on uploads.sh — it may have moved, or the URL is wrong."
+  hint="Check the address, or head home and start over."
+/>

--- a/apps/web/src/pages/500.astro
+++ b/apps/web/src/pages/500.astro
@@ -1,0 +1,19 @@
+---
+/**
+ * Application error page — distinct from 404 (missing route).
+ *
+ * Astro builds this to dist/500.html. Today the site is fully static, so this is
+ * a branded page at /500 (and a ready target if we ever map app failures here).
+ * When pages move to on-demand rendering (admin dashboard, etc.), Astro will use
+ * this file for SSR render failures and can pass an `error` prop — see
+ * https://docs.astro.build/en/basics/astro-pages/#custom-500-error-page
+ */
+import ErrorLayout from "../layouts/ErrorLayout.astro";
+---
+
+<ErrorLayout
+  status={500}
+  title="Something went wrong"
+  message="An application error stopped this page from loading. This isn’t a missing URL — something failed on our side."
+  hint="Try again in a moment. If it keeps happening, open an issue on the repo."
+/>


### PR DESCRIPTION
## In plain terms

Unknown paths on **uploads.sh** and application failures currently don’t get a real branded HTML page. This adds Astro’s standard `404` and `500` pages so visitors see something on-brand instead of an empty/platform response.

## What it does / what it is not

- **Does:** `404.astro` (missing route) + `500.astro` (application error), shared `ErrorLayout`, status-page headers, web README notes
- **Does:** wires into existing Wrangler `not_found_handling: "404-page"` via `dist/404.html`
- **Does not:** change the API’s JSON error envelopes
- **Does not:** add a full matrix of edge statuses (403/502/503) or Cloudflare custom error rules — deferred to tech debt

## How to try it

After deploy (or local `pnpm --filter @uploads/web build` + preview):

- Visit a nonsense path → branded 404
- Visit `/500` → branded application-error page

## Technical notes

- Follows [Astro custom 404 / 500](https://docs.astro.build/en/basics/astro-pages/) conventions
- Static today; Astro’s SSR `500.astro` + `error` prop becomes relevant when on-demand routes land
- Follow-up: https://github.com/buildinternet/uploads/issues/53

## Test plan

- [x] `pnpm --filter @uploads/web build` emits `dist/404.html` and `dist/500.html`
- [ ] After merge/deploy: hit a missing path on uploads.sh and confirm branded 404
- [ ] Confirm `/500` renders the application-error copy