### PR TITLE
fix(web): slash-free URLs via Astro file build format

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -2,4 +2,12 @@ import { defineConfig } from "astro/config";
 
 export default defineConfig({
   site: "https://uploads.sh",
+  // Slash-free URLs end to end. `format: "file"` emits `docs.html` instead of
+  // `docs/index.html`, so Workers assets (default auto-trailing-slash) serve
+  // /docs directly and redirect /docs/ → /docs — matching the canonical tags,
+  // sitemap, robots rules, and every internal link, which are all slash-free.
+  trailingSlash: "never",
+  build: {
+    format: "file",
+  },
 });


### PR DESCRIPTION
## What

Follow-up to #68: pages were built directory-style (`docs/index.html`), so Workers assets 307-redirected `/docs` → `/docs/` — while the canonical tags, sitemap, robots rules, `_headers` matchers, and every internal link on the site are slash-free.

This sets `build.format: "file"` (emits flat `docs.html`, `terms.html`, …) with `trailingSlash: "never"` so the dev server matches. Workers' default `auto-trailing-slash` handling then serves `/docs` directly with a 200 and redirects `/docs/` → `/docs`, the direction that matches everything already published.

## Config audit

Reviewed the rest of the Astro config and web wiring for similar mismatches — nothing else needed:

- Canonicals, `sitemap.xml`, `robots.txt`, and internal links were already slash-free (now consistent instead of contradicted by redirects)
- `_headers` rules use globs (`/invite*`, `/console*`) or exact slash-free paths — unaffected
- `404.html` still lands at the dist root, which `not_found_handling: "404-page"` expects
- `site` is set correctly; no `base`, no adapter needed (static output + thin worker is right for this app)

## Verified

Under `wrangler dev` (real Workers asset routing):

```
/docs   → 200
/docs/  → 307 → /docs
/terms/ → 307 → /terms
/       → 200
/nope   → 404
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
