### PR TITLE
fix(web): stop sequentially revealing homepage content below the terminal

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -322,10 +322,10 @@ const FAVICON =
         </div>
       </section>
 
-      <p class="flow-note hidden"><span class="arrow">└─▶</span> which lands on your pull request as:</p>
+      <p class="flow-note"><span class="arrow">└─▶</span> which lands on your pull request as:</p>
 
       <section
-        class="ghc hidden"
+        class="ghc"
         role="img"
         aria-label="Wireframe of the managed GitHub attachments comment with two inline images"
       >
@@ -366,7 +366,7 @@ const FAVICON =
         </div>
       </section>
 
-      <section class="install hidden" aria-label="Install commands">
+      <section class="install" aria-label="Install commands">
         <p class="head"># get set up — click to copy</p>
         <div class="rows">
           <div class="cmdrow">
@@ -401,16 +401,15 @@ const FAVICON =
     </main>
 
     <script>
-      // Reveal like a session replaying; no per-char typing to keep it calm.
+      // Replay the terminal session; content below the fold-line is static.
       const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      const hidden = document.querySelectorAll(".hidden");
+      const hidden = document.querySelectorAll(".screen .hidden");
       if (!reduced) {
         let t = 350;
         for (const el of hidden) {
           const isCmd = el.matches(".line") && el.querySelector(".cmd") !== null;
-          const isBlock = !el.matches(".line");
           setTimeout(() => el.classList.remove("hidden"), t);
-          t += isBlock ? 420 : isCmd ? 620 : 240;
+          t += isCmd ? 620 : 240;
         }
       } else {
         hidden.forEach((el) => el.classList.remove("hidden"));


### PR DESCRIPTION
## What

The homepage revealed everything sequentially: install/copy commands, the docs and repo links, and the comment wireframe were `visibility: hidden` and un-hidden one element at a time over ~3–4 seconds of `setTimeout` steps. Functional content shouldn't wait for theater — someone arriving to copy a command had to sit through the replay.

Now **only the terminal session replays**. The connector note, the GitHub-comment wireframe, and the whole setup block render immediately and are stable from the first frame.

## Changes (`apps/web/src/pages/index.astro` only)

- Removed the `hidden` class from `.flow-note`, `.ghc`, and `.install`
- Scoped the reveal script to `.screen .hidden` (the five terminal lines) and dropped the now-dead `isBlock` branch
- Terminal replay timing, reduced-motion handling, and copy buttons unchanged

## Verified (Playwright)

- **t≈300ms:** install block / wireframe / connector all visible; 5 terminal lines still pending
- **t≈3.5s:** replay complete, nothing left hidden
- **`prefers-reduced-motion`:** everything visible instantly
- Copy buttons work immediately on load; build passes

Mid-replay frame (~700ms) — terminal still typing, everything else already there:

<img width="700" alt="Homepage mid-replay: terminal typing its second command while the comment wireframe, setup commands, and links are already fully visible" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/70/home-early.webp">

🤖 Generated with [Claude Code](https://claude.com/claude-code)
