### PR TITLE
feat(web): landing redesign — h1 + star CTA, real CLI output, features, agent-screenshots guide

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -35,16 +35,18 @@ wrangler.jsonc                       Hybrid Worker, static assets, skills index,
 
 ## Crawl / index policy
 
-Only the landing page is meant for search engines. Agent discovery docs are public
-but not listed in the sitemap.
+The landing page, `/docs`, and the `/github-screenshots` use-case guide are meant
+for search engines. Agent discovery docs are public but not listed in the sitemap.
 
-| Path                                      | Indexable | Notes                                                    |
-| ----------------------------------------- | --------- | -------------------------------------------------------- |
-| `/`                                       | yes       | Listed in `sitemap.xml`; Link headers advertise catalogs |
-| `/invite`                                 | **no**    | Magic-link enrollment; robots + meta + `X-Robots-Tag`    |
-| `/console`                                | **no**    | Operator scaffold; same triple coverage                  |
-| `/404`,`/500`                             | **no**    | Status pages                                             |
-| `/auth.md`, `/llms.txt`, `/.well-known/*` | n/a       | Machine-readable; not in sitemap                         |
+| Path                                      | Indexable | Notes                                                      |
+| ----------------------------------------- | --------- | ---------------------------------------------------------- |
+| `/`                                       | yes       | Listed in `sitemap.xml`; Link headers advertise catalogs   |
+| `/docs`                                   | yes       | Plain-language setup guide; in `sitemap.xml`               |
+| `/github-screenshots`                     | yes       | SEO landing: agents uploading media to GitHub; FAQ JSON-LD |
+| `/invite`                                 | **no**    | Magic-link enrollment; robots + meta + `X-Robots-Tag`      |
+| `/console`                                | **no**    | Operator scaffold; same triple coverage                    |
+| `/404`,`/500`                             | **no**    | Status pages                                               |
+| `/auth.md`, `/llms.txt`, `/.well-known/*` | n/a       | Machine-readable; not in sitemap                           |
 
 `robots.txt` includes explicit `User-agent` blocks for common AI crawlers and
 `Content-Signal` preferences (`search=yes`, `ai-input=yes`, `ai-train=no`).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^14.1.2",
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "astro": "^7.0.6"
   },
   "devDependencies": {

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -8,6 +8,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): plain-language guide — install, attach media to PRs/issues, agent setup
+- [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
 - [Auth for agents](https://uploads.sh/auth.md): invitation enrollment and bearer tokens
 - [Source & docs](https://github.com/buildinternet/uploads): repository, roadmap, and operator docs
 - [Enrollment](https://github.com/buildinternet/uploads/blob/main/docs/enrollment.md): how `uploads login` works

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,6 +1,6 @@
 # uploads.sh
 
-> File hosting for agents and humans — CLI, agent skill, and MCP server on Cloudflare Workers.
+> File hosting for agents and humans — hosted CLI, agent skill, and MCP server. Open source for self-hosting.
 
 Access is by invitation. Hosted files are public (including media attached to private repositories). Do not upload secrets or sensitive UI. APIs may change without notice while the project is in active development.
 

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://uploads.sh/github-screenshots</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://uploads.sh/terms</loc>
     <changefreq>yearly</changefreq>
     <priority>0.2</priority>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -316,12 +316,11 @@ const FAVICON =
         .ghc .imgs { grid-template-columns: 1fr; }
       }
       .note {
-        border-left: 3px solid var(--purple-faint);
-        padding: 2px 0 2px 14px;
-        margin: 16px 0;
+        margin: 20px 0 0;
         color: var(--muted);
         font-size: 13.5px;
       }
+      .note a { color: var(--muted); }
 
       footer {
         margin-top: 56px;
@@ -613,7 +612,7 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
       </section>
 
       <footer>
-        uploads.sh · a <a href="https://buildinternet.com">Build Internet</a> project ·
+        uploads.sh · a <a href="https://buildinternet.com">Build Internet</a> project ·&#32;
         <a href={REPO}>source</a> · <a href="/terms">terms</a> · <a href="/privacy">privacy</a>
       </footer>
     </main>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -2,9 +2,12 @@
 // uploads.sh — docs. A single linkable page that walks through the same setup
 // the GitHub README covers, in plain language with click-to-copy commands.
 // Purpose-first: getting media onto GitHub PRs, issues, and code reviews.
+import "@fontsource-variable/geist/index.css";
+import "@fontsource-variable/geist-mono/index.css";
+
 const REPO = "https://github.com/buildinternet/uploads";
 const FAVICON =
-	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23120d1e'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
 ---
 
 <html lang="en">
@@ -35,19 +38,20 @@ const FAVICON =
     <style>
       :root {
         color-scheme: dark;
-        --bg: #0b0813;
-        --panel: #120d1e;
-        --line: #2b1f46;
-        --bezel: #251a3d;
-        --fg: #e6dff5;
-        --body: #beb5d6;
-        --muted: #8e86a5;
+        --bg: #0a0a0b;
+        --panel: #121214;
+        --line: #232327;
+        --bezel: #232327;
+        --fg: #ececea;
+        --body: #b3b3ad;
+        --muted: #7d7d77;
         --purple: #b794ff;
-        --purple-dim: #8262c9;
-        --purple-faint: #53407e;
-        --cyan: #7dcfff;
-        --green-ok: #9ece6a;
-        --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        --purple-dim: #7d7d77;
+        --purple-faint: color-mix(in srgb, #b794ff 55%, transparent);
+        --cyan: #b3b3ad;
+        --green-ok: #8fae62;
+        --mono: "Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+        --sans: "Geist Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       }
       * { box-sizing: border-box; }
       html { scroll-behavior: smooth; }
@@ -57,20 +61,26 @@ const FAVICON =
       body {
         margin: 0;
         min-height: 100dvh;
-        background: radial-gradient(100% 60% at 50% 0%, #150e24, var(--bg) 55%);
+        background: var(--bg);
         color: var(--fg);
-        font: 15px/1.75 var(--mono);
+        font: 15.5px/1.7 var(--sans);
         padding: 48px 24px 64px;
       }
       main { width: min(720px, 100%); margin: 0 auto; }
       .home {
-        color: var(--purple);
+        color: var(--muted);
         text-decoration: none;
-        font-size: 13px;
-        letter-spacing: 0.08em;
+        font: 13px var(--mono);
+        letter-spacing: 0.04em;
       }
       .home:hover, .home:focus-visible { text-decoration: underline; outline: none; }
-      h1 { font-size: clamp(26px, 5vw, 34px); line-height: 1.25; margin: 20px 0 4px; }
+      h1 {
+        font-size: clamp(26px, 5vw, 34px);
+        font-weight: 600;
+        letter-spacing: -0.015em;
+        line-height: 1.25;
+        margin: 20px 0 4px;
+      }
       .tagline { color: var(--muted); font-size: 14px; margin: 0 0 28px; }
 
       /* on-page nav — in-flow box on narrow screens, sticky rail on wide */
@@ -132,10 +142,12 @@ const FAVICON =
         text-decoration-color: var(--purple-faint);
         text-underline-offset: 3px;
       }
-      a:hover, a:focus-visible { background: rgba(125, 207, 255, 0.12); outline: none; }
+      a:hover, a:focus-visible { color: var(--purple); outline: none; }
 
       section h2 {
         font-size: 19px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
         margin: 44px 0 10px;
         padding-top: 24px;
         border-top: 1px solid var(--line);
@@ -159,7 +171,7 @@ const FAVICON =
         border: 1px solid var(--line);
         border-radius: 5px;
         padding: 1px 6px;
-        font-size: 0.92em;
+        font: 0.88em var(--mono);
       }
 
       /* copyable command rows */
@@ -173,7 +185,7 @@ const FAVICON =
         border-radius: 8px;
         padding: 10px 12px;
         margin: 12px 0;
-        font-size: 13.5px;
+        font: 13px var(--mono);
       }
       .cmd .text {
         color: var(--fg);
@@ -188,19 +200,18 @@ const FAVICON =
         font: 11px var(--mono);
         letter-spacing: 0.06em;
         color: var(--purple);
-        background: rgba(183, 148, 255, 0.08);
-        border: 1px solid #38295c;
+        background: none;
+        border: 1px solid var(--line);
         border-radius: 6px;
         padding: 5px 10px;
         cursor: pointer;
       }
       .cmd button:hover,
       .cmd button:focus-visible {
-        background: rgba(183, 148, 255, 0.18);
         outline: none;
-        border-color: var(--purple-faint);
+        border-color: var(--purple);
       }
-      .cmd button.done { color: var(--green-ok); border-color: #3c4a2e; }
+      .cmd button.done { color: var(--green-ok); border-color: var(--green-ok); }
 
       /* multi-line output block (not copyable) */
       .block {
@@ -209,7 +220,7 @@ const FAVICON =
         border-radius: 8px;
         padding: 12px 14px;
         margin: 12px 0;
-        font-size: 13px;
+        font: 12.5px/1.6 var(--mono);
         color: var(--muted);
         overflow-x: auto;
       }
@@ -223,7 +234,7 @@ const FAVICON =
         grid-template-columns: 40px 1fr;
         gap: 12px;
         margin: 18px 0;
-        font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        font: 13px/1.5 var(--sans);
       }
       .ghc .avatar {
         width: 40px;
@@ -316,10 +327,16 @@ const FAVICON =
         margin-top: 56px;
         padding-top: 20px;
         border-top: 1px solid var(--line);
-        color: #6f6787;
-        font-size: 12px;
+        color: var(--muted);
+        font: 12px var(--mono);
       }
       footer a { color: var(--muted); }
+      /* Geist Mono merges " --" into a joined dash via calt - keep CLI flags literal.
+         Declared last: the font shorthand in earlier rules resets feature settings. */
+      code, pre, .cmd, .block, .screen, .cmdtext, .cmdrow, .terminal, .feature h3 {
+        font-variant-ligatures: none;
+        font-feature-settings: "calt" 0, "liga" 0;
+      }
     </style>
   </head>
   <body>
@@ -356,12 +373,23 @@ const FAVICON =
           <button type="button" data-copy="uploads attach ./before.png ./after.png">copy</button>
         </div>
         <div class="block" aria-label="Example output">
-          <pre><span class="ok">✓</span> uploaded 2 files → <span class="v">https://storage.uploads.sh/…</span>
-<span class="ok">✓</span> attachments comment updated on PR #123</pre>
+          <pre>&gt;&gt; uploading ./before.png
+&gt;&gt; optimized 421337 → 96412 bytes (before.webp)
+&gt;&gt; uploading ./after.png
+&gt;&gt; optimized 407190 → 91205 bytes (after.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/before.webp</span>
+MARKDOWN: ![before.png](https://storage.uploads.sh/gh/you/app/pull/123/before.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</span>
+MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp)
+<span class="ok">&gt;&gt; attachments comment updated</span></pre>
         </div>
         <p>
           That's it. The CLI figures out which repo and pull request you're on, uploads the files,
-          and keeps one tidy "Attachments" comment on the PR up to date.
+          and keeps one tidy "📎 Attachments" comment on the PR up to date.
+        </p>
+        <p>
+          Setting up a coding agent to do this end to end? There's a dedicated walkthrough:&#32;
+          <a href="/github-screenshots">how to get agents to upload screenshots &amp; video to GitHub</a>.
         </p>
       </section>
 
@@ -418,7 +446,7 @@ const FAVICON =
               <span class="badge">managed by uploads</span>
             </div>
             <div class="body">
-              <p class="md-title">Attachments</p>
+              <p class="md-title">📎 Attachments</p>
               <div class="imgs">
                 <figure>
                   <div class="ph" aria-hidden="true">
@@ -477,8 +505,12 @@ const FAVICON =
           <button type="button" data-copy="uploads put ./shot.png">copy</button>
         </div>
         <div class="block" aria-label="Example output">
-          <pre>URL: <span class="v">https://storage.uploads.sh/…/shot.webp</span>
-MARKDOWN: ![shot](<span class="v">https://storage.uploads.sh/…/shot.webp</span>)</pre>
+          <pre>&gt;&gt; uploading ./shot.png
+&gt;&gt; optimized 421337 → 96412 bytes (shot.webp)
+&gt;&gt; key: screenshots/app/2026-07-12/shot-9f2c1a.webp
+
+URL: <span class="v">https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp</span>
+MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp)</pre>
         </div>
         <p>A few useful variations:</p>
         <div class="cmd">
@@ -495,7 +527,7 @@ MARKDOWN: ![shot](<span class="v">https://storage.uploads.sh/…/shot.webp</span
         </div>
         <p>
           By default, images are re-encoded to WebP (capped size, high quality) so GitHub embeds
-          stay fast, and <strong>EXIF metadata is stripped</strong>. Use <code>--keep-exif</code>
+          stay fast, and <strong>EXIF metadata is stripped</strong>. Use <code>--keep-exif</code>&#32;
           to keep metadata, or <code>--no-optimize</code> to skip all processing.
         </p>
       </section>
@@ -522,7 +554,7 @@ MARKDOWN: ![shot](<span class="v">https://storage.uploads.sh/…/shot.webp</span
         <p>
           The <strong>skill</strong> teaches the agent when and how to use the CLI — for example,
           attaching before/after screenshots to the PR it just opened. The <strong>MCP
-          server</strong> gives agents the same tools (<code>put</code>, <code>attach</code>,
+          server</strong> gives agents the same tools (<code>put</code>, <code>attach</code>,&#32;
           <code>list</code>, <code>delete</code>, and more) over HTTP, using the same token as the
           CLI. There's also a local stdio variant if you prefer:
         </p>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -14,25 +14,25 @@ const FAVICON =
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Docs · uploads.sh</title>
+    <title>Docs — attach screenshots to GitHub PRs &amp; issues · uploads.sh</title>
     <meta
       name="description"
-      content="How to put screenshots and other media on GitHub PRs, issues, and code reviews with one command — install, attach, and agent setup."
+      content="Install the uploads CLI, attach screenshots and video to GitHub PRs, issues, and code reviews, and set up your agent. Hosted and open source."
     />
     <link rel="canonical" href="https://uploads.sh/docs" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://uploads.sh/docs" />
-    <meta property="og:title" content="Docs · uploads.sh" />
+    <meta property="og:title" content="Docs — attach screenshots to GitHub PRs & issues · uploads.sh" />
     <meta
       property="og:description"
-      content="How to put screenshots and other media on GitHub PRs, issues, and code reviews with one command."
+      content="Install the uploads CLI, attach screenshots and video to GitHub PRs, issues, and code reviews, and set up your agent. Hosted and open source."
     />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Docs · uploads.sh" />
+    <meta name="twitter:title" content="Docs — attach screenshots to GitHub PRs & issues · uploads.sh" />
     <meta
       name="twitter:description"
-      content="How to put screenshots and other media on GitHub PRs, issues, and code reviews with one command."
+      content="Install the uploads CLI, attach media to GitHub PRs and issues, and set up your agent."
     />
     <link rel="icon" href={FAVICON} />
     <style>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -1,0 +1,483 @@
+---
+// uploads.sh — discovery/landing page for the core use case: getting coding
+// agents (Claude Code, Codex, CI jobs, scripts) to upload screenshots and
+// video to GitHub PRs and issues. Prose targets the search question directly;
+// FAQ JSON-LD mirrors the on-page answers.
+import "@fontsource-variable/geist/index.css";
+import "@fontsource-variable/geist-mono/index.css";
+
+const REPO = "https://github.com/buildinternet/uploads";
+const FAVICON =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+
+const FAQ = [
+	{
+		q: "Why can't my agent upload images to GitHub directly?",
+		a: "GitHub's built-in image hosting (github.com/user-attachments) only works from an authenticated browser session — you drag a file into the comment box. There is no gh CLI command or REST API endpoint for it, so agents, scripts, and CI jobs can't use it. Any image in a comment they write must already be hosted at a public URL.",
+	},
+	{
+		q: "Do the image URLs change when I re-upload a screenshot?",
+		a: "No. PR and issue attachments get stable, hash-free keys like gh/owner/repo/pull/123/shot.webp. Re-uploading the same filename overwrites in place, and every embed of that URL shows the new image within about a minute.",
+	},
+	{
+		q: "Can agents upload video to GitHub pull requests?",
+		a: "Yes — MP4, WebM, and other binaries upload unchanged and get a stable public URL. GitHub only inline-plays video hosted on its own CDN, so the managed attachments comment links the file instead of embedding a player; reviewers click through to watch.",
+	},
+	{
+		q: "How do I set up Claude Code to attach screenshots to its pull requests?",
+		a: "Run `uploads install` once. It installs the uploads-cli agent skill (which teaches the agent when to attach before/after screenshots) and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads attach <files>` on its own when it changes something visual.",
+	},
+	{
+		q: "Are uploaded files private?",
+		a: "No — hosted files are public to anyone with the URL, including media attached to private repositories. Don't upload secrets or sensitive UI. Uploading requires an invitation-issued workspace token.",
+	},
+];
+
+const FAQ_JSON_LD = JSON.stringify({
+	"@context": "https://schema.org",
+	"@type": "FAQPage",
+	mainEntity: FAQ.map((item) => ({
+		"@type": "Question",
+		name: item.q,
+		acceptedAnswer: { "@type": "Answer", text: item.a },
+	})),
+});
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>How to get agents to upload screenshots &amp; video to GitHub · uploads.sh</title>
+    <meta
+      name="description"
+      content="Coding agents can't drag-and-drop into GitHub comments. Here's how to give Claude Code, CI jobs, and scripts one command that hosts screenshots and video at stable URLs and posts them to PRs and issues."
+    />
+    <link rel="canonical" href="https://uploads.sh/github-screenshots" />
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://uploads.sh/github-screenshots" />
+    <meta property="og:title" content="How to get agents to upload screenshots & video to GitHub" />
+    <meta
+      property="og:description"
+      content="Agents can't drag-and-drop into GitHub comments. Give them one command that hosts media at stable URLs and posts it to PRs and issues."
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="How to get agents to upload screenshots & video to GitHub" />
+    <meta
+      name="twitter:description"
+      content="Agents can't drag-and-drop into GitHub comments. Give them one command that hosts media at stable URLs and posts it to PRs and issues."
+    />
+    <link rel="icon" href={FAVICON} />
+    <script type="application/ld+json" set:html={FAQ_JSON_LD} />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0a0a0b;
+        --panel: #121214;
+        --line: #232327;
+        --fg: #ececea;
+        --body: #b3b3ad;
+        --muted: #7d7d77;
+        --accent: #b794ff;
+        --ok: #8fae62;
+        --mono: "Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+        --sans: "Geist Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      @media (prefers-reduced-motion: reduce) {
+        html { scroll-behavior: auto; }
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        background: var(--bg);
+        color: var(--fg);
+        font: 15.5px/1.7 var(--sans);
+        padding: 40px 24px 64px;
+      }
+      main { width: min(680px, 100%); margin: 0 auto; }
+      .top { display: flex; align-items: center; gap: 12px; }
+      .home {
+        color: var(--muted);
+        text-decoration: none;
+        font: 13px var(--mono);
+        letter-spacing: 0.04em;
+      }
+      .home:hover, .home:focus-visible { color: var(--accent); outline: none; }
+      .star-cta {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: var(--fg);
+        text-decoration: none;
+        font: 12.5px var(--mono);
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        padding: 6px 11px;
+        background: var(--panel);
+      }
+      .star-cta:hover, .star-cta:focus-visible { border-color: var(--accent); outline: none; }
+      .star-cta svg { width: 14px; height: 14px; fill: currentColor; }
+      .star-cta .count {
+        color: var(--muted);
+        border-left: 1px solid var(--line);
+        padding-left: 7px;
+        font-variant-numeric: tabular-nums;
+      }
+      .star-cta .count:empty { display: none; }
+
+      h1 {
+        font: 600 clamp(25px, 5vw, 34px)/1.22 var(--sans);
+        letter-spacing: -0.015em;
+        margin: 26px 0 8px;
+      }
+      .tagline { color: var(--muted); margin: 0 0 30px; }
+      h2 {
+        font: 600 20px/1.35 var(--sans);
+        letter-spacing: -0.01em;
+        margin: 42px 0 10px;
+        padding-top: 22px;
+        border-top: 1px solid var(--line);
+        scroll-margin-top: 24px;
+      }
+      h3 { font: 600 15px/1.4 var(--sans); margin: 22px 0 6px; }
+      p, li { color: var(--body); }
+      strong { color: var(--fg); }
+      ul, ol { padding-left: 22px; }
+      li { margin: 8px 0; }
+      a {
+        color: var(--fg);
+        text-decoration: underline;
+        text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
+        text-underline-offset: 3px;
+      }
+      a:hover, a:focus-visible { color: var(--accent); outline: none; }
+      code {
+        font: 0.88em var(--mono);
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        padding: 1px 6px;
+      }
+
+      /* copyable command rows */
+      .cmd {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 12px;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 10px 12px;
+        margin: 12px 0;
+        font: 13px var(--mono);
+      }
+      .cmd .text {
+        color: var(--fg);
+        overflow-x: auto;
+        white-space: nowrap;
+        scrollbar-width: none;
+      }
+      .cmd .text::before { content: "$ "; color: var(--accent); }
+      .cmd .text .cm { color: var(--muted); }
+      .cmd button {
+        font: 11px var(--mono);
+        letter-spacing: 0.06em;
+        color: var(--accent);
+        background: none;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 5px 10px;
+        cursor: pointer;
+      }
+      .cmd button:hover, .cmd button:focus-visible { border-color: var(--accent); outline: none; }
+      .cmd button.done { color: var(--ok); border-color: var(--ok); }
+
+      /* multi-line output block (not copyable) */
+      .block {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 12px 14px;
+        margin: 12px 0;
+        font: 12.5px/1.6 var(--mono);
+        color: var(--muted);
+        overflow-x: auto;
+      }
+      .block .ok { color: var(--ok); }
+      .block .v { color: var(--body); }
+      .block pre { margin: 0; white-space: pre; }
+
+      .note {
+        border-left: 3px solid var(--accent);
+        padding: 2px 0 2px 14px;
+        margin: 16px 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      /* faq */
+      .faq dt { color: var(--fg); font-weight: 600; margin-top: 18px; }
+      .faq dd { margin: 6px 0 0; color: var(--body); }
+
+      footer {
+        margin-top: 56px;
+        padding-top: 20px;
+        border-top: 1px solid var(--line);
+        color: var(--muted);
+        font: 12px var(--mono);
+      }
+      footer a { color: var(--muted); }
+      /* Geist Mono merges " --" into a joined dash via calt - keep CLI flags literal.
+         Declared last: the font shorthand in earlier rules resets feature settings. */
+      code, pre, .cmd, .block, .screen, .cmdtext, .cmdrow, .terminal, .feature h3 {
+        font-variant-ligatures: none;
+        font-feature-settings: "calt" 0, "liga" 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="top">
+        <a class="home" href="/">← uploads.sh</a>
+        <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"></path>
+          </svg>
+          Star on GitHub
+          <span class="count" id="star-count"></span>
+        </a>
+      </div>
+
+      <h1>How to get agents to upload screenshots &amp; video to GitHub</h1>
+      <p class="tagline">
+        Claude Code, CI jobs, review bots, plain scripts — anything without a browser.
+      </p>
+
+      <section id="problem">
+        <h2>The problem: no drag-and-drop from a terminal</h2>
+        <p>
+          When <em>you</em> put a screenshot on a pull request, you drag the file into the
+          comment box and GitHub hosts it at <code>github.com/user-attachments/…</code>. That
+          hosting is only reachable from an <strong>authenticated browser session</strong> —
+          there is no <code>gh</code> CLI command and no REST API endpoint for it.
+        </p>
+        <p>
+          So a coding agent that just changed your UI has no way to show its work. The usual
+          workarounds all hurt:
+        </p>
+        <ul>
+          <li><strong>Committing images to the repo</strong> bloats history forever for a screenshot that matters for one review.</li>
+          <li><strong>Generic image hosts</strong> hand back random URLs, expire links, or need a browser to upload.</li>
+          <li><strong>Hand-rolled S3/R2 scripts</strong> work — until you want stable URLs, optimization, comment management, and every agent repo carries its own copy.</li>
+        </ul>
+        <p>
+          The fix is a URL the agent can mint itself: host the file somewhere public and
+          stable, then write ordinary Markdown. That's what&#32;
+          <a href="/">uploads.sh</a> does, plus the GitHub-shaped parts around it.
+        </p>
+      </section>
+
+      <section id="setup">
+        <h2>Step 1 — install the CLI and sign in (once)</h2>
+        <div class="cmd">
+          <span class="text">npm install -g @buildinternet/uploads</span>
+          <button type="button" data-copy="npm install -g @buildinternet/uploads">copy</button>
+        </div>
+        <div class="cmd">
+          <span class="text">uploads login</span>
+          <button type="button" data-copy="uploads login">copy</button>
+        </div>
+        <p>
+          <code>uploads login</code> exchanges an invitation code for a workspace token and
+          saves it, so this is a one-time step per machine. Access is currently by invitation —
+          ask via <a href={REPO}>the GitHub repo</a>. Verify with <code>uploads doctor</code>.
+        </p>
+      </section>
+
+      <section id="agents">
+        <h2>Step 2 — teach your agent</h2>
+        <p>One command sets up both integration points for Claude Code:</p>
+        <div class="cmd">
+          <span class="text">uploads install</span>
+          <button type="button" data-copy="uploads install">copy</button>
+        </div>
+        <ul>
+          <li>
+            The <strong>agent skill</strong> teaches the agent when to reach for the CLI —
+            e.g. attaching before/after screenshots to the PR it just opened, or dropping a
+            repro GIF on an issue.
+          </li>
+          <li>
+            The <strong>MCP server</strong> exposes the same operations
+            (<code>put</code>, <code>attach</code>, <code>list</code>, <code>delete</code>, …)
+            as tools, for runtimes that prefer MCP over shelling out.
+          </li>
+        </ul>
+        <p>Or wire each piece up yourself, for other agent runtimes:</p>
+        <div class="cmd">
+          <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
+          <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli">copy</button>
+        </div>
+        <div class="cmd">
+          <span class="text">claude mcp add --transport http uploads https://agents.uploads.sh/mcp</span>
+          <button type="button" data-copy="claude mcp add --transport http uploads https://agents.uploads.sh/mcp">copy</button>
+        </div>
+      </section>
+
+      <section id="attach">
+        <h2>Step 3 — the agent attaches media with one command</h2>
+        <p>
+          From a branch with an open pull request, <code>attach</code> needs nothing but the
+          files. It finds the PR via <code>gh</code>, uploads each file to a stable URL, and
+          creates or updates a single managed attachments comment:
+        </p>
+        <div class="cmd">
+          <span class="text">uploads attach ./before.png ./after.png</span>
+          <button type="button" data-copy="uploads attach ./before.png ./after.png">copy</button>
+        </div>
+        <div class="block" aria-label="Example output">
+          <pre>&gt;&gt; uploading ./before.png
+&gt;&gt; optimized 421337 → 96412 bytes (before.webp)
+&gt;&gt; uploading ./after.png
+&gt;&gt; optimized 407190 → 91205 bytes (after.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/before.webp</span>
+MARKDOWN: ![before.png](https://storage.uploads.sh/gh/you/app/pull/123/before.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</span>
+MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp)
+<span class="ok">&gt;&gt; attachments comment updated</span></pre>
+        </div>
+        <p>Not on a PR branch, or targeting something else? Say so explicitly:</p>
+        <div class="cmd">
+          <span class="text">uploads attach ./repro.gif --issue 45</span>
+          <button type="button" data-copy="uploads attach ./repro.gif --issue 45">copy</button>
+        </div>
+        <div class="cmd">
+          <span class="text">uploads attach ./shot.png --repo owner/name --pr 123</span>
+          <button type="button" data-copy="uploads attach ./shot.png --repo owner/name --pr 123">copy</button>
+        </div>
+        <p>
+          Prefer to place the image yourself — in a PR description, review comment, or README?&#32;
+          <code>--no-comment</code> uploads and prints the URL and ready-to-paste Markdown
+          without touching any GitHub comment. <code>uploads put</code> gives full control over
+          naming and output format.
+        </p>
+        <h3>Why the URLs matter</h3>
+        <p>
+          Attachments get <strong>hash-free, stable keys</strong> —
+          <code>gh/owner/repo/pull/123/shot.webp</code>. Re-upload the same filename after
+          addressing review feedback and the PR re-renders the new image at the same URL within
+          about a minute. No stale screenshots, no edit trail.
+        </p>
+      </section>
+
+      <section id="video">
+        <h2>Video and everything else</h2>
+        <p>
+          Screen recordings are often the clearest way for an agent to prove an interaction
+          works. MP4, WebM, GIFs, zips, logs — anything — upload unchanged:
+        </p>
+        <div class="cmd">
+          <span class="text">uploads attach ./demo.mp4 <span class="cm"># linked from the comment</span></span>
+          <button type="button" data-copy="uploads attach ./demo.mp4">copy</button>
+        </div>
+        <p>
+          One honest caveat: GitHub only inline-plays video hosted on its own CDN, so external
+          video is <strong>linked, not embedded as a player</strong> — the managed comment lists
+          it as a click-through link with a stable URL. Animated GIFs embed inline like images.
+        </p>
+        <p>
+          Still images are optimized by default — re-encoded to WebP with a capped long edge and&#32;
+          <strong>EXIF stripped</strong> so embeds load fast and leak nothing. Opt out per file
+          with <code>--no-optimize</code> or keep metadata with <code>--keep-exif</code>. And&#32;
+          <code>--frame phone|browser|iphone-16-pro</code> wraps raw simulator or viewport shots
+          in device chrome first.
+        </p>
+      </section>
+
+      <section id="faq">
+        <h2>FAQ</h2>
+        <dl class="faq">
+          {FAQ.map((item) => (
+            <>
+              <dt>{item.q}</dt>
+              <dd>{item.a}</dd>
+            </>
+          ))}
+        </dl>
+        <div class="note">
+          More detail — every command, flag, and management operation — is in the&#32;
+          <a href="/docs">docs</a>. Agents can read <a href="/llms.txt">/llms.txt</a> for a
+          machine-friendly index. If this saved you a hand-rolled upload script,&#32;
+          <a href={REPO}>a star on GitHub</a> helps others find it.
+        </div>
+      </section>
+
+      <footer>
+        uploads.sh · a <a href="https://buildinternet.com">Build Internet</a> project ·
+        <a href={REPO}>source</a> · <a href="/docs">docs</a> · <a href="/terms">terms</a> ·
+        <a href="/privacy">privacy</a>
+      </footer>
+    </main>
+
+    <script>
+      // Live star count — cached for an hour, silently absent on failure.
+      (async () => {
+        const el = document.getElementById("star-count");
+        if (!el) return;
+        const show = (n: number) => {
+          el.textContent = n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+        };
+        try {
+          const cached = JSON.parse(localStorage.getItem("gh-stars") ?? "null");
+          if (cached && typeof cached.n === "number" && Date.now() - cached.t < 3_600_000) {
+            show(cached.n);
+            return;
+          }
+          const res = await fetch("https://api.github.com/repos/buildinternet/uploads");
+          if (!res.ok) return;
+          const n = ((await res.json()) as { stargazers_count?: unknown }).stargazers_count;
+          if (typeof n !== "number") return;
+          localStorage.setItem("gh-stars", JSON.stringify({ t: Date.now(), n }));
+          show(n);
+        } catch {
+          /* leave the count empty — the CTA still works */
+        }
+      })();
+
+      for (const btn of document.querySelectorAll(".cmd button")) {
+        btn.addEventListener("click", async () => {
+          const text = btn.getAttribute("data-copy") ?? "";
+          let ok = false;
+          try {
+            await navigator.clipboard.writeText(text);
+            ok = true;
+          } catch {
+            const ta = document.createElement("textarea");
+            ta.value = text;
+            ta.style.position = "fixed";
+            ta.style.opacity = "0";
+            document.body.appendChild(ta);
+            ta.select();
+            try {
+              ok = document.execCommand("copy");
+            } catch {
+              ok = false;
+            }
+            ta.remove();
+          }
+          btn.textContent = ok ? "copied ✓" : "copy failed";
+          btn.classList.toggle("done", ok);
+          setTimeout(() => {
+            btn.textContent = "copy";
+            btn.classList.remove("done");
+          }, 1500);
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -13,23 +13,23 @@ const FAVICON =
 const FAQ = [
 	{
 		q: "Why can't my agent upload images to GitHub directly?",
-		a: "GitHub's built-in image hosting (github.com/user-attachments) only works from an authenticated browser session — you drag a file into the comment box. There is no gh CLI command or REST API endpoint for it, so agents, scripts, and CI jobs can't use it. Any image in a comment they write must already be hosted at a public URL.",
+		a: "GitHub's own image hosting (github.com/user-attachments) only works when you drag a file into the comment box in a signed-in browser. There is no gh command or API for it. So any image an agent puts in a comment must already live at a public URL.",
 	},
 	{
 		q: "Do the image URLs change when I re-upload a screenshot?",
-		a: "No. PR and issue attachments get stable, hash-free keys like gh/owner/repo/pull/123/shot.webp. Re-uploading the same filename overwrites in place, and every embed of that URL shows the new image within about a minute.",
+		a: "No. PR and issue attachments get stable keys like gh/owner/repo/pull/123/shot.webp. Upload the same filename again and every embed shows the new image within about a minute.",
 	},
 	{
 		q: "Can agents upload video to GitHub pull requests?",
-		a: "Yes — MP4, WebM, and other binaries upload unchanged and get a stable public URL. GitHub only inline-plays video hosted on its own CDN, so the managed attachments comment links the file instead of embedding a player; reviewers click through to watch.",
+		a: "Yes. MP4, WebM, and other files upload as-is and get a stable public URL. GitHub only plays videos it hosts itself, so the comment links the file instead of embedding a player.",
 	},
 	{
 		q: "How do I set up Claude Code to attach screenshots to its pull requests?",
-		a: "Run `uploads install` once. It installs the uploads-cli agent skill (which teaches the agent when to attach before/after screenshots) and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads attach <files>` on its own when it changes something visual.",
+		a: "Run `uploads install` once. It installs the uploads-cli agent skill and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads attach <files>` on its own when it changes something visual.",
 	},
 	{
 		q: "Are uploaded files private?",
-		a: "No — hosted files are public to anyone with the URL, including media attached to private repositories. Don't upload secrets or sensitive UI. Uploading requires an invitation-issued workspace token.",
+		a: "No. Files are public to anyone with the URL — even media attached to private repos. Don't upload secrets or sensitive UI. Uploading itself requires an invite-issued workspace token.",
 	},
 ];
 
@@ -213,12 +213,11 @@ const FAQ_JSON_LD = JSON.stringify({
       .block pre { margin: 0; white-space: pre; }
 
       .note {
-        border-left: 3px solid var(--accent);
-        padding: 2px 0 2px 14px;
-        margin: 16px 0;
+        margin: 20px 0 0;
         color: var(--muted);
         font-size: 14px;
       }
+      .note a { color: var(--muted); }
 
       /* faq */
       .faq dt { color: var(--fg); font-weight: 600; margin-top: 18px; }
@@ -261,24 +260,23 @@ const FAQ_JSON_LD = JSON.stringify({
       <section id="problem">
         <h2>The problem: no drag-and-drop from a terminal</h2>
         <p>
-          When <em>you</em> put a screenshot on a pull request, you drag the file into the
-          comment box and GitHub hosts it at <code>github.com/user-attachments/…</code>. That
-          hosting is only reachable from an <strong>authenticated browser session</strong> —
-          there is no <code>gh</code> CLI command and no REST API endpoint for it.
+          You put a screenshot on a pull request by dragging the file into the comment box.
+          GitHub then hosts it at <code>github.com/user-attachments/…</code>. That only works
+          in a signed-in browser. There is no <code>gh</code> command and no API for it.
         </p>
         <p>
-          So a coding agent that just changed your UI has no way to show its work. The usual
-          workarounds all hurt:
+          So an agent that just changed your UI can't show its work. The usual workarounds
+          all hurt:
         </p>
         <ul>
-          <li><strong>Committing images to the repo</strong> bloats history forever for a screenshot that matters for one review.</li>
-          <li><strong>Generic image hosts</strong> hand back random URLs, expire links, or need a browser to upload.</li>
-          <li><strong>Hand-rolled S3/R2 scripts</strong> work — until you want stable URLs, optimization, comment management, and every agent repo carries its own copy.</li>
+          <li><strong>Committing images to the repo</strong> bloats it forever, for a screenshot that matters once.</li>
+          <li><strong>Random image hosts</strong> give you random URLs, expiring links, or need a browser anyway.</li>
+          <li><strong>A hand-rolled S3 script</strong> works — until you want stable URLs, image optimization, and comment cleanup.</li>
         </ul>
         <p>
-          The fix is a URL the agent can mint itself: host the file somewhere public and
-          stable, then write ordinary Markdown. That's what&#32;
-          <a href="/">uploads.sh</a> does, plus the GitHub-shaped parts around it.
+          The fix: host the file at a public URL the agent can create itself, then write
+          plain Markdown. That's what&#32;
+          <a href="/">uploads.sh</a> does.
         </p>
       </section>
 
@@ -293,32 +291,31 @@ const FAQ_JSON_LD = JSON.stringify({
           <button type="button" data-copy="uploads login">copy</button>
         </div>
         <p>
-          <code>uploads login</code> exchanges an invitation code for a workspace token and
-          saves it, so this is a one-time step per machine. Access is currently by invitation —
-          ask via <a href={REPO}>the GitHub repo</a>. Verify with <code>uploads doctor</code>.
+          <code>uploads login</code> trades an invite code for a workspace token and saves it.
+          You do this once per machine. Access is invite-only for now — ask via&#32;
+          <a href={REPO}>the GitHub repo</a>. Check your setup with <code>uploads doctor</code>.
         </p>
       </section>
 
       <section id="agents">
         <h2>Step 2 — teach your agent</h2>
-        <p>One command sets up both integration points for Claude Code:</p>
+        <p>One command sets up Claude Code:</p>
         <div class="cmd">
           <span class="text">uploads install</span>
           <button type="button" data-copy="uploads install">copy</button>
         </div>
         <ul>
           <li>
-            The <strong>agent skill</strong> teaches the agent when to reach for the CLI —
-            e.g. attaching before/after screenshots to the PR it just opened, or dropping a
-            repro GIF on an issue.
+            The <strong>agent skill</strong> teaches the agent when to attach screenshots —
+            like before/after shots on a PR it just opened.
           </li>
           <li>
-            The <strong>MCP server</strong> exposes the same operations
+            The <strong>MCP server</strong> offers the same tools
             (<code>put</code>, <code>attach</code>, <code>list</code>, <code>delete</code>, …)
-            as tools, for runtimes that prefer MCP over shelling out.
+            for runtimes that prefer MCP.
           </li>
         </ul>
-        <p>Or wire each piece up yourself, for other agent runtimes:</p>
+        <p>Or set up each piece yourself, for other agent runtimes:</p>
         <div class="cmd">
           <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
           <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli">copy</button>
@@ -332,9 +329,9 @@ const FAQ_JSON_LD = JSON.stringify({
       <section id="attach">
         <h2>Step 3 — the agent attaches media with one command</h2>
         <p>
-          From a branch with an open pull request, <code>attach</code> needs nothing but the
-          files. It finds the PR via <code>gh</code>, uploads each file to a stable URL, and
-          creates or updates a single managed attachments comment:
+          From a branch with an open pull request, <code>attach</code> only needs the files.
+          It finds the PR through <code>gh</code>, uploads each file to a stable URL, and
+          keeps one managed comment:
         </p>
         <div class="cmd">
           <span class="text">uploads attach ./before.png ./after.png</span>
@@ -351,7 +348,7 @@ URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</
 MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp)
 <span class="ok">&gt;&gt; attachments comment updated</span></pre>
         </div>
-        <p>Not on a PR branch, or targeting something else? Say so explicitly:</p>
+        <p>Not on a PR branch? Point it somewhere:</p>
         <div class="cmd">
           <span class="text">uploads attach ./repro.gif --issue 45</span>
           <button type="button" data-copy="uploads attach ./repro.gif --issue 45">copy</button>
@@ -361,41 +358,37 @@ MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp
           <button type="button" data-copy="uploads attach ./shot.png --repo owner/name --pr 123">copy</button>
         </div>
         <p>
-          Prefer to place the image yourself — in a PR description, review comment, or README?&#32;
-          <code>--no-comment</code> uploads and prints the URL and ready-to-paste Markdown
-          without touching any GitHub comment. <code>uploads put</code> gives full control over
-          naming and output format.
+          Want to place the image yourself — in a PR description or README?&#32;
+          <code>--no-comment</code> prints the URL and Markdown without posting anything.&#32;
+          <code>uploads put</code> gives full control over naming and output.
         </p>
         <h3>Why the URLs matter</h3>
         <p>
-          Attachments get <strong>hash-free, stable keys</strong> —
-          <code>gh/owner/repo/pull/123/shot.webp</code>. Re-upload the same filename after
-          addressing review feedback and the PR re-renders the new image at the same URL within
-          about a minute. No stale screenshots, no edit trail.
+          Attachments get <strong>stable keys</strong>, like&#32;
+          <code>gh/owner/repo/pull/123/shot.webp</code>. Upload the same filename again and
+          the PR shows the new image at the same URL within a minute. No stale screenshots.
         </p>
       </section>
 
       <section id="video">
         <h2>Video and everything else</h2>
         <p>
-          Screen recordings are often the clearest way for an agent to prove an interaction
-          works. MP4, WebM, GIFs, zips, logs — anything — upload unchanged:
+          A short screen recording is often the best proof that a change works. MP4, WebM,
+          GIFs, zips, logs — anything uploads as-is:
         </p>
         <div class="cmd">
           <span class="text">uploads attach ./demo.mp4 <span class="cm"># linked from the comment</span></span>
           <button type="button" data-copy="uploads attach ./demo.mp4">copy</button>
         </div>
         <p>
-          One honest caveat: GitHub only inline-plays video hosted on its own CDN, so external
-          video is <strong>linked, not embedded as a player</strong> — the managed comment lists
-          it as a click-through link with a stable URL. Animated GIFs embed inline like images.
+          One caveat: GitHub only plays videos it hosts itself. Outside video shows up as a&#32;
+          <strong>link, not a player</strong>. GIFs embed like images.
         </p>
         <p>
-          Still images are optimized by default — re-encoded to WebP with a capped long edge and&#32;
-          <strong>EXIF stripped</strong> so embeds load fast and leak nothing. Opt out per file
-          with <code>--no-optimize</code> or keep metadata with <code>--keep-exif</code>. And&#32;
-          <code>--frame phone|browser|iphone-16-pro</code> wraps raw simulator or viewport shots
-          in device chrome first.
+          Images are optimized by default: re-encoded to WebP, size capped, and&#32;
+          <strong>EXIF stripped</strong> so they load fast and leak nothing. Opt out with&#32;
+          <code>--no-optimize</code> or <code>--keep-exif</code>. Add device chrome with&#32;
+          <code>--frame phone|browser|iphone-16-pro</code>.
         </p>
       </section>
 
@@ -409,17 +402,16 @@ MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp
             </>
           ))}
         </dl>
-        <div class="note">
-          More detail — every command, flag, and management operation — is in the&#32;
-          <a href="/docs">docs</a>. Agents can read <a href="/llms.txt">/llms.txt</a> for a
-          machine-friendly index. If this saved you a hand-rolled upload script,&#32;
+        <p class="note">
+          Every command and flag is in the <a href="/docs">docs</a>. Agents can read&#32;
+          <a href="/llms.txt">/llms.txt</a>. If this saved you a hand-rolled upload script,&#32;
           <a href={REPO}>a star on GitHub</a> helps others find it.
-        </div>
+        </p>
       </section>
 
       <footer>
-        uploads.sh · a <a href="https://buildinternet.com">Build Internet</a> project ·
-        <a href={REPO}>source</a> · <a href="/docs">docs</a> · <a href="/terms">terms</a> ·
+        uploads.sh · a <a href="https://buildinternet.com">Build Internet</a> project ·&#32;
+        <a href={REPO}>source</a> · <a href="/docs">docs</a> · <a href="/terms">terms</a> ·&#32;
         <a href="/privacy">privacy</a>
       </footer>
     </main>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -51,7 +51,7 @@ const FAQ_JSON_LD = JSON.stringify({
     <title>How to get agents to upload screenshots &amp; video to GitHub · uploads.sh</title>
     <meta
       name="description"
-      content="Coding agents can't drag-and-drop into GitHub comments. Here's how to give Claude Code, CI jobs, and scripts one command that hosts screenshots and video at stable URLs and posts them to PRs and issues."
+      content="Agents can't drag-and-drop into GitHub comments. Give Claude Code, CI jobs, and scripts one command that posts screenshots and video to PRs and issues."
     />
     <link rel="canonical" href="https://uploads.sh/github-screenshots" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
@@ -60,7 +60,7 @@ const FAQ_JSON_LD = JSON.stringify({
     <meta property="og:title" content="How to get agents to upload screenshots & video to GitHub" />
     <meta
       property="og:description"
-      content="Agents can't drag-and-drop into GitHub comments. Give them one command that hosts media at stable URLs and posts it to PRs and issues."
+      content="Agents can't drag-and-drop into GitHub comments. Give Claude Code, CI jobs, and scripts one command that posts screenshots and video to PRs and issues."
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="How to get agents to upload screenshots & video to GitHub" />

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -315,13 +315,9 @@ const FAVICON =
 
       /* ---------- guide callout ---------- */
       .guide {
-        border: 1px solid var(--line);
-        border-left: 3px solid var(--accent);
-        border-radius: 8px;
-        background: var(--panel);
-        padding: 12px 14px;
         font: 13.5px/1.6 var(--sans);
-        color: var(--body);
+        color: var(--muted);
+        margin: 2px 2px 0;
       }
 
       /* ---------- install panel ---------- */
@@ -367,6 +363,12 @@ const FAVICON =
         outline: none;
       }
       .cmdrow button.done { color: var(--ok); border-color: var(--ok); }
+      .hero-install {
+        font-size: 14px;
+        margin-bottom: 2px;
+        border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+      }
+      .hero-install .cmdtext { font-weight: 500; }
       .install .foot { color: var(--muted); margin: 10px 2px 0; font-size: 12px; }
       .site-foot {
         color: var(--muted);
@@ -420,10 +422,16 @@ const FAVICON =
 
       <h1>Agents can put screenshots on pull requests now, too.</h1>
       <p class="lede">
-        GitHub's drag-and-drop image hosting doesn't work from a terminal — so agents ship
-        visual changes blind. uploads.sh fixes that with one command: <code>uploads attach</code>&#32;
-        hosts the file at a stable URL and keeps a single, tidy attachments comment on the PR.
+        You add a screenshot to GitHub by dragging it into the comment box. Agents can't.
+        uploads.sh gives them one command: <code>uploads attach</code>&#32;
+        hosts the file at a stable URL and keeps one tidy comment on the PR.
       </p>
+
+      <div class="cmdrow hero-install">
+        <span class="tag">install</span>
+        <span class="cmdtext">npm install -g @buildinternet/uploads</span>
+        <button type="button" data-copy="npm install -g @buildinternet/uploads">copy</button>
+      </div>
 
       <section class="terminal" aria-label="uploads.sh terminal">
         <div class="titlebar" aria-hidden="true">
@@ -496,50 +504,50 @@ const FAVICON =
           <div class="feature">
             <h3>one managed comment</h3>
             <p>
-              <code>attach</code> creates or updates a single attachments comment per PR or
-              issue. Re-run it all day — no trail of stale screenshot comments.
+              <code>attach</code> keeps a single attachments comment per PR or issue. Run it
+              again and the same comment updates — no comment spam.
             </p>
           </div>
           <div class="feature">
             <h3>stable, hash-free urls</h3>
             <p>
-              Keys like <code>gh/you/app/pull/123/shot.webp</code> mean re-uploading the same
-              filename updates every embed in place, within about a minute.
+              Keys like <code>gh/you/app/pull/123/shot.webp</code> never change. Re-upload the
+              same filename and every embed shows the new image in about a minute.
             </p>
           </div>
           <div class="feature">
             <h3>images optimized, video passed through</h3>
             <p>
-              Stills are re-encoded to WebP with EXIF stripped by default. MP4, WebM, GIFs, and
-              other binaries upload byte-for-byte.
+              Images are re-encoded to WebP with EXIF stripped. MP4, WebM, GIFs, and other
+              files upload as-is.
             </p>
           </div>
           <div class="feature">
             <h3>device frames</h3>
             <p>
               <code>--frame phone</code>, <code>browser</code>, or <code>iphone-16-pro</code>&#32;
-              wraps a raw screenshot in device chrome before optimizing.
+              puts a raw screenshot inside device chrome.
             </p>
           </div>
           <div class="feature">
             <h3>shareable galleries</h3>
             <p>
               Group uploads into a public gallery page at <code>uploads.sh/g/…</code> — one
-              link for a whole set of media, via the API.
+              link for a whole set of media (via the API).
             </p>
           </div>
           <div class="feature">
             <h3>workspaces</h3>
             <p>
-              Tenant-scoped tokens with storage caps, upload limits, key-prefix policy, and
-              optional retention. Nothing is shared between workspaces.
+              Each workspace gets its own tokens, storage caps, upload limits, and retention
+              rules. Nothing is shared between them.
             </p>
           </div>
         </div>
       </section>
 
       <p class="guide">
-        Setting up a coding agent to do this end to end? Read the guide:&#32;
+        Setting up an agent to do this end to end? Read the guide:&#32;
         <a href="/github-screenshots">how to get agents to upload screenshots &amp; video to GitHub</a>.
       </p>
 

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,64 +1,64 @@
 ---
-// uploads.sh — landing. Three beats: the two-command demo, the GitHub comment
-// it produces, and copyable setup rows for the CLI / skill / MCP server.
+// uploads.sh — landing. Beats: headline + star CTA, the real two-command demo,
+// the GitHub comment it produces, what else it does, and copyable setup rows.
+import "@fontsource-variable/geist/index.css";
+import "@fontsource-variable/geist-mono/index.css";
+
 const REPO = "https://github.com/buildinternet/uploads";
 // Stacked up-chevrons, fading as they rise — inline so the page stays a single request.
 const FAVICON =
-	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23120d1e'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>uploads.sh</title>
+    <title>uploads.sh — agents can put screenshots on pull requests, too</title>
     <meta
       name="description"
-      content="File hosting for agents & humans — CLI, agent skill, and MCP server on Cloudflare Workers."
+      content="One command hosts a screenshot at a stable URL and keeps a tidy attachments comment on your GitHub PR. CLI, agent skill, and MCP server for coding agents."
     />
     <link rel="canonical" href="https://uploads.sh/" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://uploads.sh/" />
-    <meta property="og:title" content="uploads.sh" />
+    <meta property="og:title" content="uploads.sh — agents can put screenshots on pull requests, too" />
     <meta
       property="og:description"
-      content="File hosting for agents & humans — CLI, agent skill, and MCP server on Cloudflare Workers."
+      content="One command hosts a screenshot at a stable URL and keeps a tidy attachments comment on your GitHub PR. CLI, agent skill, and MCP server."
     />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="uploads.sh" />
+    <meta name="twitter:title" content="uploads.sh — agents can put screenshots on pull requests, too" />
     <meta
       name="twitter:description"
-      content="File hosting for agents & humans — CLI, agent skill, and MCP server on Cloudflare Workers."
+      content="One command hosts a screenshot at a stable URL and keeps a tidy attachments comment on your GitHub PR."
     />
     <link rel="icon" href={FAVICON} />
     <style>
       :root {
-        --bg: #0b0813;
-        --screen: #120d1e;
-        --bezel: #251a3d;
-        --fg: #e6dff5;
-        --purple: #b794ff;
-        --purple-dim: #8262c9;
-        --purple-faint: #53407e;
-        --neutral: #726d8c;
-        --cyan: #7dcfff;
-        --green-ok: #9ece6a;
-        --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-        --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color-scheme: dark;
+        --bg: #0a0a0b;
+        --panel: #121214;
+        --line: #232327;
+        --fg: #ececea;
+        --body: #b3b3ad;
+        --muted: #7d7d77;
+        --accent: #b794ff;
+        --ok: #8fae62;
+        --mono: "Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+        --sans: "Geist Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       }
       * { box-sizing: border-box; }
       body {
         margin: 0;
         min-height: 100dvh;
-        background:
-          radial-gradient(120% 90% at 50% 0%, #150e24 0%, var(--bg) 60%),
-          var(--bg);
+        background: var(--bg);
         color: var(--fg);
-        font: 15px/1.65 var(--mono);
+        font: 14.5px/1.65 var(--mono);
         display: grid;
-        place-items: center;
-        padding: 40px 24px 56px;
+        justify-items: center;
+        padding: 36px 24px 56px;
       }
       main {
         width: min(680px, 100%);
@@ -70,61 +70,101 @@ const FAVICON =
         .hidden { visibility: visible; }
       }
 
+      /* ---------- header: brand + star CTA ---------- */
+      .top {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 6px;
+      }
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 14px;
+        letter-spacing: 0.02em;
+      }
+      .brand svg { width: 20px; height: 20px; border-radius: 5px; }
+      .star-cta {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: var(--fg);
+        text-decoration: none;
+        font-size: 12.5px;
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        padding: 6px 11px;
+        background: var(--panel);
+      }
+      .star-cta:hover,
+      .star-cta:focus-visible {
+        border-color: var(--accent);
+        outline: none;
+        background: var(--panel);
+      }
+      .star-cta svg { width: 14px; height: 14px; fill: currentColor; }
+      .star-cta .count {
+        color: var(--muted);
+        border-left: 1px solid var(--line);
+        padding-left: 7px;
+        font-variant-numeric: tabular-nums;
+      }
+      .star-cta .count:empty { display: none; }
+
+      /* ---------- headline ---------- */
+      h1 {
+        font: 600 clamp(24px, 5vw, 32px)/1.25 var(--sans);
+        letter-spacing: -0.015em;
+        margin: 6px 0 0;
+      }
+      .lede {
+        font: 15px/1.65 var(--sans);
+        color: var(--body);
+        margin: 0 0 8px;
+        max-width: 58ch;
+      }
+      .lede code {
+        font: 0.9em var(--mono);
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        padding: 1px 5px;
+      }
+
       /* ---------- terminal ---------- */
       .terminal {
-        background: var(--screen);
-        border: 1px solid var(--bezel);
+        background: var(--panel);
+        border: 1px solid var(--line);
         border-radius: 10px;
-        box-shadow:
-          0 0 0 1px #000,
-          0 24px 80px rgba(0, 0, 0, 0.6),
-          0 0 120px rgba(183, 148, 255, 0.08);
         overflow: hidden;
-        position: relative;
-      }
-      /* faint scanlines + phosphor glow */
-      .terminal::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        background: repeating-linear-gradient(
-          to bottom,
-          rgba(255, 255, 255, 0.016) 0px,
-          rgba(255, 255, 255, 0.016) 1px,
-          transparent 1px,
-          transparent 3px
-        );
-        mix-blend-mode: overlay;
       }
       .titlebar {
         display: flex;
         align-items: center;
-        gap: 8px;
-        padding: 10px 14px;
-        background: var(--bezel);
-        color: var(--purple-dim);
-        font-size: 12px;
-        letter-spacing: 0.08em;
+        justify-content: space-between;
+        padding: 8px 14px;
+        border-bottom: 1px solid var(--line);
+        color: var(--muted);
+        font-size: 11.5px;
+        letter-spacing: 0.06em;
       }
-      .titlebar .dot { width: 10px; height: 10px; border-radius: 50%; background: #382a58; }
-      .titlebar .label { margin-left: auto; margin-right: auto; }
-      .screen {
-        padding: 22px 22px 26px;
-        text-shadow: 0 0 6px rgba(183, 148, 255, 0.18);
-      }
+      .screen { padding: 20px 20px 24px; font-size: 13px; }
       .line { white-space: pre-wrap; word-break: break-word; margin: 0; }
-      .prompt { color: var(--purple); user-select: none; }
+      .prompt { color: var(--accent); user-select: none; }
       .cmd { color: var(--fg); }
-      .out { color: var(--neutral); }
-      .out .v { color: var(--cyan); }
-      .ok { color: var(--green-ok); }
+      .out { color: var(--muted); }
+      .out .v { color: var(--body); }
+      .ok { color: var(--ok); }
       .gap { height: 0.9em; }
       .cursor {
         display: inline-block;
         width: 0.6em;
         height: 1.1em;
-        background: var(--purple);
+        background: var(--accent);
         vertical-align: text-bottom;
         animation: blink 1.1s steps(1) infinite;
       }
@@ -136,11 +176,11 @@ const FAVICON =
       /* ---------- connector ---------- */
       .flow-note {
         font-size: 12px;
-        color: var(--neutral);
-        padding-left: 22px;
+        color: var(--muted);
+        padding-left: 20px;
         margin: -6px 0;
       }
-      .flow-note .arrow { color: var(--purple); }
+      .flow-note .arrow { color: var(--accent); }
 
       /* ---------- wireframe github comment ---------- */
       .ghc {
@@ -229,28 +269,76 @@ const FAVICON =
         .ghc .imgs { grid-template-columns: 1fr; }
       }
 
-      /* ---------- install panel ---------- */
-      .install { font-size: 13px; margin-top: 6px; }
-      .install .head {
-        color: var(--purple-dim);
+      /* ---------- section headers ---------- */
+      .sect-head {
+        color: var(--muted);
         font-size: 11px;
         letter-spacing: 0.14em;
         text-transform: uppercase;
         margin: 0 0 10px 2px;
       }
+
+      /* ---------- features ---------- */
+      .features { margin-top: 14px; }
+      .features .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+      .feature {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 12px 14px;
+      }
+      .feature h3 {
+        font: 600 13px/1.4 var(--mono);
+        color: var(--fg);
+        margin: 0 0 4px;
+      }
+      .feature p {
+        font: 12.5px/1.55 var(--sans);
+        color: var(--body);
+        margin: 0;
+      }
+      .feature code {
+        font: 11.5px var(--mono);
+        color: var(--fg);
+        background: var(--bg);
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        padding: 0 4px;
+      }
+      @media (max-width: 560px) {
+        .features .grid { grid-template-columns: 1fr; }
+      }
+
+      /* ---------- guide callout ---------- */
+      .guide {
+        border: 1px solid var(--line);
+        border-left: 3px solid var(--accent);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 12px 14px;
+        font: 13.5px/1.6 var(--sans);
+        color: var(--body);
+      }
+
+      /* ---------- install panel ---------- */
+      .install { font-size: 13px; margin-top: 6px; }
       .install .rows { display: grid; gap: 8px; }
       .cmdrow {
         display: grid;
         grid-template-columns: 74px 1fr auto;
         align-items: center;
         gap: 12px;
-        background: var(--screen);
-        border: 1px solid var(--bezel);
+        background: var(--panel);
+        border: 1px solid var(--line);
         border-radius: 8px;
         padding: 10px 12px;
       }
       .cmdrow .tag {
-        color: var(--purple-dim);
+        color: var(--muted);
         font-size: 10.5px;
         letter-spacing: 0.1em;
         text-transform: uppercase;
@@ -261,62 +349,98 @@ const FAVICON =
         white-space: nowrap;
         scrollbar-width: none;
       }
-      .cmdrow .cmdtext::before { content: "$ "; color: var(--purple); }
-      .cmdrow .cmdtext .url { color: var(--cyan); }
+      .cmdrow .cmdtext::before { content: "$ "; color: var(--accent); }
+      .cmdrow .cmdtext .url { color: var(--body); }
       .cmdrow button {
         font: 11px var(--mono);
         letter-spacing: 0.06em;
-        color: var(--purple);
-        background: rgba(183, 148, 255, 0.08);
-        border: 1px solid #38295c;
+        color: var(--accent);
+        background: none;
+        border: 1px solid var(--line);
         border-radius: 6px;
         padding: 5px 10px;
         cursor: pointer;
       }
       .cmdrow button:hover,
       .cmdrow button:focus-visible {
-        background: rgba(183, 148, 255, 0.18);
+        border-color: var(--accent);
         outline: none;
-        border-color: var(--purple-faint);
       }
-      .cmdrow button.done { color: var(--green-ok); border-color: #3c4a2e; }
-      .install .foot { color: var(--neutral); margin: 10px 2px 0; font-size: 12px; }
-      .install .foot a { color: var(--cyan); }
+      .cmdrow button.done { color: var(--ok); border-color: var(--ok); }
+      .install .foot { color: var(--muted); margin: 10px 2px 0; font-size: 12px; }
       .site-foot {
-        color: #575271;
+        color: var(--muted);
         font-size: 11.5px;
         text-align: center;
         margin-top: 10px;
       }
-      .site-foot a { color: var(--neutral); }
+      .site-foot a { color: var(--muted); }
       a {
-        color: var(--cyan);
+        color: var(--fg);
         text-decoration: underline;
-        text-decoration-color: var(--purple-faint);
+        text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
         text-underline-offset: 3px;
       }
       a:hover,
-      a:focus-visible { background: rgba(125, 207, 255, 0.12); outline: none; }
+      a:focus-visible { color: var(--accent); outline: none; }
       @media (max-width: 560px) {
         .cmdrow { grid-template-columns: 1fr auto; }
         .cmdrow .tag { grid-column: 1 / -1; }
+      }
+      /* Geist Mono merges " --" into a joined dash via calt - keep CLI flags literal.
+         Declared last: the font shorthand in earlier rules resets feature settings. */
+      code, pre, .cmd, .block, .screen, .cmdtext, .cmdrow, .terminal, .feature h3 {
+        font-variant-ligatures: none;
+        font-feature-settings: "calt" 0, "liga" 0;
       }
     </style>
   </head>
   <body>
     <main>
+      <div class="top">
+        <a class="brand" href="/" aria-label="uploads.sh home">
+          <svg viewBox="0 0 32 32" aria-hidden="true">
+            <rect width="32" height="32" rx="7" fill="#121214"></rect>
+            <g fill="none" stroke="#b794ff" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M8 12.5 L16 5 L24 12.5"></path>
+              <path d="M8 19.5 L16 12 L24 19.5" opacity=".55"></path>
+              <path d="M8 26.5 L16 19 L24 26.5" opacity=".28"></path>
+            </g>
+          </svg>
+          uploads.sh
+        </a>
+        <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"></path>
+          </svg>
+          Star on GitHub
+          <span class="count" id="star-count"></span>
+        </a>
+      </div>
+
+      <h1>Agents can put screenshots on pull requests now, too.</h1>
+      <p class="lede">
+        GitHub's drag-and-drop image hosting doesn't work from a terminal — so agents ship
+        visual changes blind. uploads.sh fixes that with one command: <code>uploads attach</code>&#32;
+        hosts the file at a stable URL and keeps a single, tidy attachments comment on the PR.
+      </p>
+
       <section class="terminal" aria-label="uploads.sh terminal">
         <div class="titlebar" aria-hidden="true">
-          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="label">uploads.sh — bash</span>
+          <span>uploads.sh — bash</span>
+          <span>80×24</span>
         </div>
         <div class="screen">
-          <p class="line"><span class="prompt">$</span> <span class="cmd">whatis uploads.sh</span></p>
-          <p class="line out hidden">uploads.sh (1)      - file hosting for agents &amp; humans</p>
-          <div class="gap"></div>
-          <p class="line hidden"><span class="prompt">$</span> <span class="cmd">uploads attach ./before.png ./after.png</span></p>
-          <p class="line out hidden"><span class="ok">✓</span> uploaded 2 files → <span class="v">https://storage.uploads.sh/…</span></p>
-          <p class="line out hidden"><span class="ok">✓</span> attachments comment updated on PR #123</p>
+          <p class="line"><span class="prompt">$</span> <span class="cmd">uploads attach ./before.png ./after.png</span></p>
+          <p class="line out hidden">&gt;&gt; uploading ./before.png</p>
+          <p class="line out hidden">&gt;&gt; optimized 421337 → 96412 bytes (before.webp)</p>
+          <p class="line out hidden">&gt;&gt; uploading ./after.png</p>
+          <p class="line out hidden">&gt;&gt; optimized 407190 → 91205 bytes (after.webp)</p>
+          <p class="line out hidden">URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/before.webp</span></p>
+          <p class="line out hidden">MARKDOWN: ![before.png](https://storage.uploads.sh/gh/you/app/pull/123/before.webp)</p>
+          <p class="line out hidden">URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</span></p>
+          <p class="line out hidden">MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp)</p>
+          <p class="line out hidden"><span class="ok">&gt;&gt; attachments comment updated</span></p>
           <div class="gap"></div>
           <p class="line hidden"><span class="prompt">$</span> <span class="cursor" aria-hidden="true"></span></p>
         </div>
@@ -337,7 +461,7 @@ const FAVICON =
             <span class="badge">managed by uploads</span>
           </div>
           <div class="body">
-            <p class="md-title">Attachments</p>
+            <p class="md-title">📎 Attachments</p>
             <div class="imgs">
               <figure>
                 <div class="ph" aria-hidden="true">
@@ -347,7 +471,7 @@ const FAVICON =
                     <path d="M3 17 L9.5 12.5 L13.5 15.5 L17 13 L21 16"></path>
                   </svg>
                 </div>
-                <figcaption><span>before.png</span><span class="host">storage.uploads.sh</span></figcaption>
+                <figcaption><span>before.webp</span><span class="host">storage.uploads.sh</span></figcaption>
               </figure>
               <figure>
                 <div class="ph" aria-hidden="true">
@@ -357,7 +481,7 @@ const FAVICON =
                     <path d="M3 17 L9.5 12.5 L13.5 15.5 L17 13 L21 16"></path>
                   </svg>
                 </div>
-                <figcaption><span>after.png</span><span class="host">storage.uploads.sh</span></figcaption>
+                <figcaption><span>after.webp</span><span class="host">storage.uploads.sh</span></figcaption>
               </figure>
             </div>
             <div class="skel w70"></div>
@@ -366,8 +490,61 @@ const FAVICON =
         </div>
       </section>
 
+      <section class="features" aria-label="Features">
+        <p class="sect-head"># what else it does</p>
+        <div class="grid">
+          <div class="feature">
+            <h3>one managed comment</h3>
+            <p>
+              <code>attach</code> creates or updates a single attachments comment per PR or
+              issue. Re-run it all day — no trail of stale screenshot comments.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>stable, hash-free urls</h3>
+            <p>
+              Keys like <code>gh/you/app/pull/123/shot.webp</code> mean re-uploading the same
+              filename updates every embed in place, within about a minute.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>images optimized, video passed through</h3>
+            <p>
+              Stills are re-encoded to WebP with EXIF stripped by default. MP4, WebM, GIFs, and
+              other binaries upload byte-for-byte.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>device frames</h3>
+            <p>
+              <code>--frame phone</code>, <code>browser</code>, or <code>iphone-16-pro</code>&#32;
+              wraps a raw screenshot in device chrome before optimizing.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>shareable galleries</h3>
+            <p>
+              Group uploads into a public gallery page at <code>uploads.sh/g/…</code> — one
+              link for a whole set of media, via the API.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>workspaces</h3>
+            <p>
+              Tenant-scoped tokens with storage caps, upload limits, key-prefix policy, and
+              optional retention. Nothing is shared between workspaces.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <p class="guide">
+        Setting up a coding agent to do this end to end? Read the guide:&#32;
+        <a href="/github-screenshots">how to get agents to upload screenshots &amp; video to GitHub</a>.
+      </p>
+
       <section class="install" aria-label="Install commands">
-        <p class="head"># get set up — click to copy</p>
+        <p class="sect-head"># get set up — click to copy</p>
         <div class="rows">
           <div class="cmdrow">
             <span class="tag">cli</span>
@@ -409,11 +586,35 @@ const FAVICON =
         for (const el of hidden) {
           const isCmd = el.matches(".line") && el.querySelector(".cmd") !== null;
           setTimeout(() => el.classList.remove("hidden"), t);
-          t += isCmd ? 620 : 240;
+          t += isCmd ? 620 : 170;
         }
       } else {
         hidden.forEach((el) => el.classList.remove("hidden"));
       }
+
+      // Live star count — cached for an hour, silently absent on failure.
+      (async () => {
+        const el = document.getElementById("star-count");
+        if (!el) return;
+        const show = (n: number) => {
+          el.textContent = n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+        };
+        try {
+          const cached = JSON.parse(localStorage.getItem("gh-stars") ?? "null");
+          if (cached && typeof cached.n === "number" && Date.now() - cached.t < 3_600_000) {
+            show(cached.n);
+            return;
+          }
+          const res = await fetch("https://api.github.com/repos/buildinternet/uploads");
+          if (!res.ok) return;
+          const n = ((await res.json()) as { stargazers_count?: unknown }).stargazers_count;
+          if (typeof n !== "number") return;
+          localStorage.setItem("gh-stars", JSON.stringify({ t: Date.now(), n }));
+          show(n);
+        } catch {
+          /* leave the count empty — the CTA still works */
+        }
+      })();
 
       for (const btn of document.querySelectorAll(".cmdrow button")) {
         btn.addEventListener("click", async () => {

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -14,25 +14,25 @@ const FAVICON =
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>uploads.sh — agents can put screenshots on pull requests, too</title>
+    <title>uploads.sh — screenshots on GitHub PRs, from agents &amp; the CLI</title>
     <meta
       name="description"
-      content="One command hosts a screenshot at a stable URL and keeps a tidy attachments comment on your GitHub PR. CLI, agent skill, and MCP server for coding agents."
+      content="One command hosts a file at a stable URL and keeps a tidy attachments comment on your GitHub PR. Hosted and open source — CLI, agent skill, and MCP server."
     />
     <link rel="canonical" href="https://uploads.sh/" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://uploads.sh/" />
-    <meta property="og:title" content="uploads.sh — agents can put screenshots on pull requests, too" />
+    <meta property="og:title" content="uploads.sh — screenshots on GitHub PRs, from agents & the CLI" />
     <meta
       property="og:description"
-      content="One command hosts a screenshot at a stable URL and keeps a tidy attachments comment on your GitHub PR. CLI, agent skill, and MCP server."
+      content="One command hosts a file at a stable URL and keeps a tidy attachments comment on your GitHub PR. Hosted and open source — CLI, agent skill, and MCP server."
     />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="uploads.sh — agents can put screenshots on pull requests, too" />
+    <meta name="twitter:title" content="uploads.sh — screenshots on GitHub PRs, from agents & the CLI" />
     <meta
       name="twitter:description"
-      content="One command hosts a screenshot at a stable URL and keeps a tidy attachments comment on your GitHub PR."
+      content="One command hosts a file at a stable URL and keeps a tidy attachments comment on your GitHub PR."
     />
     <link rel="icon" href={FAVICON} />
     <style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,12 @@ importers:
       '@astrojs/cloudflare':
         specifier: ^14.1.2
         version: 14.1.2(@types/node@26.1.0)(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(yaml@2.9.0))(esbuild@0.28.1)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)
+      '@fontsource-variable/geist':
+        specifier: ^5.2.9
+        version: 5.2.9
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       astro:
         specifier: ^7.0.6
         version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(yaml@2.9.0)
@@ -795,6 +801,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/geist-mono@5.2.8':
+    resolution: {integrity: sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==}
+
+  '@fontsource-variable/geist@5.2.9':
+    resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -4467,6 +4479,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource-variable/geist-mono@5.2.8': {}
+
+  '@fontsource-variable/geist@5.2.9': {}
 
   '@hono/node-server@1.19.14(hono@4.12.28)':
     dependencies:


### PR DESCRIPTION
- Landing gets a proper h1 ("Agents can put screenshots on pull requests
  now, too."), a GitHub star CTA with a live cached star count, and a
  features section covering the managed comment, stable URLs, optimization,
  device frames, galleries, and workspaces.
- Terminal demos on / and /docs now show the CLI's actual output
  (>> uploading / >> optimized / URL: / MARKDOWN: / >> attachments comment
  updated) instead of invented ✓ lines; put example shows the real
  screenshots/<repo>/<date>/<name>-<hash> key layout.
- New /github-screenshots discovery page targeting "how to get agents to
  upload screenshots/video to GitHub": problem, 3-step setup, honest video
  caveat, FAQ with JSON-LD; added to sitemap, llms.txt, and README crawl table.
- De-cliché design pass: neutral near-black palette instead of the purple-
  tinted CRT look; dropped scanlines, phosphor glow, glowing shadows, and
  traffic-light dots; self-hosted Geist + Geist Mono via fontsource; single
  purple accent retained for brand continuity.
- Disable Geist Mono's calt/liga on mono surfaces — its contextual dash
  ligature swallowed the space before CLI --flags.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Q8hKW4BykkfywtAAFQZfq