### PR TITLE
feat: link galleries to GitHub work

### DIFF
--- a/.changeset/tidy-gallery-github-links.md
+++ b/.changeset/tidy-gallery-github-links.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Add CLI and typed-client support for linking public galleries to GitHub issues and pull requests.

--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ Create one and add uploads with the installed CLI:
 uploads gallery create --title "Release screenshots"
 uploads put ./after.png --gallery gal_example
 uploads gallery show gal_example
+uploads gallery link gal_example --github buildinternet/uploads#58
+uploads gallery list --github https://github.com/buildinternet/uploads/pull/58
 ```
 
 > **Privacy:** A gallery is public to anyone with its URL; it does not inherit GitHub or
 > repository visibility. Removing or deleting a gallery does not delete its uploaded media or
 > exempt it from retention.
+
+Use `uploads gallery link <gallery-id> --github <owner/repo#number>` to record an optional GitHub issue or PR reference. `uploads gallery list --github <coordinate-or-github-url>` performs an authenticated reverse lookup. The link does not change gallery identity or visibility.
 
 ### GitHub embeds
 

--- a/apps/api/src/external-references.ts
+++ b/apps/api/src/external-references.ts
@@ -21,7 +21,28 @@ export function parseExternalReference(
     return { ok: false, message: "provider must be github" };
   if (typeof coordinate !== "string")
     return { ok: false, message: "coordinate must be owner/repo#number" };
-  const match = /^([^/]+)\/([^#]+)#([1-9][0-9]*)$/.exec(coordinate.trim());
+  let normalized = coordinate.trim();
+  if (!normalized.includes("#")) {
+    try {
+      const url = new URL(normalized);
+      if (
+        url.protocol !== "https:" ||
+        url.hostname.toLowerCase() !== "github.com" ||
+        url.port ||
+        url.username ||
+        url.password ||
+        url.search ||
+        url.hash
+      )
+        return { ok: false, message: "coordinate must be owner/repo#number" };
+      const urlMatch = /^\/([^/]+)\/([^/]+)\/(?:issues|pull)\/([1-9][0-9]*)\/?$/.exec(url.pathname);
+      if (!urlMatch) return { ok: false, message: "coordinate must be owner/repo#number" };
+      normalized = urlMatch[1] + "/" + urlMatch[2] + "#" + urlMatch[3];
+    } catch {
+      return { ok: false, message: "coordinate must be owner/repo#number" };
+    }
+  }
+  const match = /^([^/]+)\/([^#]+)#([1-9][0-9]*)$/.exec(normalized);
   if (
     !match ||
     !OWNER.test(match[1]) ||

--- a/apps/api/test/external-references.test.ts
+++ b/apps/api/test/external-references.test.ts
@@ -14,6 +14,20 @@ describe("external reference providers", () => {
       },
     });
   });
+  it("accepts strict GitHub issue and pull URLs as the same coordinate", () => {
+    expect(
+      parseExternalReference("github", "https://github.com/BuildInternet/Uploads/pull/123"),
+    ).toMatchObject({
+      ok: true,
+      value: {
+        normalizedKey: "github:item:buildinternet/uploads#123",
+        canonicalUrl: "https://github.com/buildinternet/uploads/issues/123",
+      },
+    });
+    expect(
+      parseExternalReference("github", "https://github.com/buildinternet/uploads/issues/123?x=1"),
+    ).toMatchObject({ ok: false });
+  });
   it("trims input, accepts case-insensitive providers and valid boundary names", () => {
     expect(parseExternalReference(" GitHub ", " a/.github#1 ")).toMatchObject({
       ok: true,

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat"],
+  "preview_urls": true,
   "vars": {
     // Origin of the invite page that magic links point at. Defaults to the API
     // host without the `api.` prefix; set explicitly for other deployments.

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -4,6 +4,7 @@
   "compatibility_date": "2026-07-06",
   "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "preview_urls": true,
   "vars": {
     "UPLOADS_API_ORIGIN": "https://api.uploads.sh",
   },

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -64,11 +64,15 @@ uploads gallery create --title "Release screenshots"
 uploads gallery add gal_example screenshots/myapp/42/after.webp --alt "Updated dashboard"
 uploads put ./before.png --gallery gal_example
 uploads gallery show gal_example
+uploads gallery link gal_example --github buildinternet/uploads#58
+uploads gallery list --github https://github.com/buildinternet/uploads/pull/58
 ```
 
 When adding several keys, `uploads gallery add` processes them sequentially and reports any
 individual failures in `--json` output. Gallery item updates use the API's current version to
 avoid overwriting concurrent changes.
+
+Link a gallery to a GitHub issue or pull request with `gallery link --github`. Coordinates and strict `https://github.com/<owner>/<repo>/issues|pull/<number>` URLs are accepted; `gallery list --github` performs the authenticated reverse lookup. Links never change gallery identity, and GitHub repository visibility does not make the public gallery private.
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -121,6 +121,36 @@ export interface DeleteGalleryOptions {
   expectedVersion: number;
 }
 
+export interface GalleryExternalReference {
+  id: string;
+  provider: "github";
+  resourceType: "item";
+  coordinate: string;
+  canonicalUrl: string | null;
+  createdAt: string;
+}
+
+export interface GalleryExternalReferenceListResult {
+  references: GalleryExternalReference[];
+}
+
+export interface LinkGalleryExternalReferenceOptions {
+  expectedVersion: number;
+  provider: "github";
+  coordinate: string;
+}
+
+export interface UnlinkGalleryExternalReferenceOptions {
+  expectedVersion: number;
+}
+
+export interface FindGalleriesByReferenceOptions {
+  provider: "github";
+  coordinate: string;
+  limit?: number;
+  cursor?: string;
+}
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -450,6 +480,55 @@ export function createUploadsClient(config: UploadsClientConfig) {
           headers: { "Content-Type": "application/json" },
         },
       );
+    },
+
+    async listGalleryExternalReferences(id: string): Promise<GalleryExternalReferenceListResult> {
+      return request<GalleryExternalReferenceListResult>(
+        "GET",
+        galleriesBase(config) + "/" + encodeURIComponent(id) + "/external-references",
+      );
+    },
+
+    async linkGalleryExternalReference(
+      id: string,
+      opts: LinkGalleryExternalReferenceOptions,
+    ): Promise<GalleryExternalReference> {
+      return request<GalleryExternalReference>(
+        "POST",
+        galleriesBase(config) + "/" + encodeURIComponent(id) + "/external-references",
+        {
+          body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+
+    async unlinkGalleryExternalReference(
+      id: string,
+      referenceId: string,
+      opts: UnlinkGalleryExternalReferenceOptions,
+    ): Promise<{ deleted: boolean; id: string }> {
+      return request<{ deleted: boolean; id: string }>(
+        "DELETE",
+        galleriesBase(config) +
+          "/" +
+          encodeURIComponent(id) +
+          "/external-references/" +
+          encodeURIComponent(referenceId),
+        {
+          body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+
+    async findGalleriesByReference(
+      opts: FindGalleriesByReferenceOptions,
+    ): Promise<GalleryListResult> {
+      const params = new URLSearchParams({ provider: opts.provider, coordinate: opts.coordinate });
+      if (opts.limit != null) params.set("limit", String(opts.limit));
+      if (opts.cursor) params.set("cursor", opts.cursor);
+      return request<GalleryListResult>("GET", galleriesBase(config) + "/by-reference?" + params);
     },
 
     async health(): Promise<HealthResult> {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -24,6 +24,7 @@ import {
   attachmentsCommentBody,
   type GhTarget,
   type AttachmentItem,
+  normalizeGithubCoordinate,
 } from "./github.js";
 import {
   resolveRepo,
@@ -589,12 +590,31 @@ Commands:
   list [--limit <n>] [--cursor <c>] [--all]
   delete <gallery-id>
   add <gallery-id> <object-key...> [--caption <text>] [--alt <text>]
+  link <gallery-id> --github <owner/repo#number|github-url>
+  unlink <gallery-id> --github <owner/repo#number|github-url>
+  list --github <owner/repo#number|github-url> [--limit <n>] [--cursor <c>] [--all]
 
 Examples:
   uploads gallery create --title "Settings redesign"
   uploads gallery add gal_example screenshots/app/after.webp --alt "Updated settings page"
   uploads gallery show gal_example
+  uploads gallery link gal_example --github buildinternet/uploads#58
+  uploads gallery list --github https://github.com/buildinternet/uploads/pull/58
 `;
+
+function githubCoordinateFromFlags(flags: CommandFlags["flags"]): string {
+  const value = flagString(flags, "--github");
+  if (!value)
+    throw new UsageError(
+      "--github requires an owner/repo#number coordinate or GitHub issue/PR URL",
+    );
+  const normalized = normalizeGithubCoordinate(value);
+  if (!normalized)
+    throw new UsageError(
+      "--github must be owner/repo#number or an https://github.com/.../issues|pull/number URL",
+    );
+  return normalized.coordinate;
+}
 
 export async function runGallery(ctx: CliContext, args: string[], help = false): Promise<number> {
   const parsed = parseCommandArgs(args);
@@ -629,11 +649,21 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
     case "list": {
       const limit = flagInt(parsed.flags, "--limit", "--limit");
       const cursor = flagString(parsed.flags, "--cursor");
+      const github = parsed.flags.has("--github")
+        ? githubCoordinateFromFlags(parsed.flags)
+        : undefined;
       if (flagBool(parsed.flags, "--all")) {
         const galleries = [];
         let nextCursor: string | undefined = cursor;
         do {
-          const page = await ctx.client.listGalleries({ limit, cursor: nextCursor });
+          const page = github
+            ? await ctx.client.findGalleriesByReference({
+                provider: "github",
+                coordinate: github,
+                limit,
+                cursor: nextCursor,
+              })
+            : await ctx.client.listGalleries({ limit, cursor: nextCursor });
           galleries.push(...page.galleries);
           nextCursor = page.nextCursor ?? undefined;
         } while (nextCursor);
@@ -643,13 +673,56 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
             await writeStdout(`${gallery.id}  ${gallery.url}  ${gallery.title}\n`);
         return 0;
       }
-      const page = await ctx.client.listGalleries({ limit, cursor });
+      const page = github
+        ? await ctx.client.findGalleriesByReference({
+            provider: "github",
+            coordinate: github,
+            limit,
+            cursor,
+          })
+        : await ctx.client.listGalleries({ limit, cursor });
       if (ctx.json) await writeJson(page);
       else {
         for (const gallery of page.galleries)
           await writeStdout(`${gallery.id}  ${gallery.url}  ${gallery.title}\n`);
         if (page.nextCursor) process.stderr.write(`cursor: ${page.nextCursor}\n`);
       }
+      return 0;
+    }
+    case "link": {
+      const id = parsed.positionals[1];
+      if (!id) throw new UsageError("gallery link requires a gallery ID");
+      const coordinate = githubCoordinateFromFlags(parsed.flags);
+      const current = await ctx.client.getGallery(id);
+      const reference = await ctx.client.linkGalleryExternalReference(id, {
+        expectedVersion: current.version,
+        provider: "github",
+        coordinate,
+      });
+      if (ctx.json) await writeJson({ galleryId: id, reference });
+      else await writeStdout((reference.canonicalUrl ?? reference.coordinate) + "\n");
+      return 0;
+    }
+    case "unlink": {
+      const id = parsed.positionals[1];
+      if (!id) throw new UsageError("gallery unlink requires a gallery ID");
+      const coordinate = githubCoordinateFromFlags(parsed.flags);
+      const references = await ctx.client.listGalleryExternalReferences(id);
+      const reference = references.references.find(
+        (entry) => entry.provider === "github" && entry.coordinate === coordinate,
+      );
+      if (!reference) {
+        const output = { galleryId: id, coordinate, deleted: false };
+        if (ctx.json) await writeJson(output);
+        else if (!ctx.quiet) process.stderr.write("GitHub reference was already absent\n");
+        return 0;
+      }
+      const current = await ctx.client.getGallery(id);
+      const result = await ctx.client.unlinkGalleryExternalReference(id, reference.id, {
+        expectedVersion: current.version,
+      });
+      if (ctx.json) await writeJson({ galleryId: id, coordinate, ...result });
+      else if (!ctx.quiet) process.stderr.write("unlinked " + coordinate + "\n");
       return 0;
     }
     case "delete": {

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -10,6 +10,12 @@ export interface GhTarget {
   num: number;
 }
 
+/** A normalized GitHub issue/PR coordinate used for gallery references. */
+export interface GithubCoordinate {
+  coordinate: string;
+  canonicalUrl: string;
+}
+
 const REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 
 export function isValidRepo(repo: string): boolean {
@@ -21,6 +27,48 @@ export function parseRepoFromRemoteUrl(url: string): string | undefined {
   const match = url.trim().match(/[/:]([^/:\s]+\/[^/:\s]+?)(?:\.git)?\/?$/);
   const repo = match?.[1];
   return repo && isValidRepo(repo) ? repo : undefined;
+}
+
+/** Normalize a GitHub issue or pull-request coordinate for gallery linking. */
+export function normalizeGithubCoordinate(value: string): GithubCoordinate | undefined {
+  const input = value.trim();
+  let match = /^([^/\s#]+)\/([^/\s#]+)#([1-9][0-9]*)$/.exec(input);
+  if (!match) {
+    try {
+      const url = new URL(input);
+      if (
+        url.protocol !== "https:" ||
+        url.hostname.toLowerCase() !== "github.com" ||
+        url.port ||
+        url.username ||
+        url.password ||
+        url.search ||
+        url.hash
+      )
+        return undefined;
+      match = /^\/([^/]+)\/([^/]+)\/(?:issues|pull)\/([1-9][0-9]*)\/?$/.exec(url.pathname);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!match) return undefined;
+  const [, ownerRaw, repositoryRaw, numberRaw] = match;
+  const repo = ownerRaw + "/" + repositoryRaw;
+  const number = Number(numberRaw);
+  if (!isValidRepo(repo) || !Number.isSafeInteger(number)) return undefined;
+  const owner = ownerRaw.toLowerCase();
+  const repository = repositoryRaw.toLowerCase();
+  const coordinate = owner + "/" + repository + "#" + number;
+  return {
+    coordinate,
+    canonicalUrl:
+      "https://github.com/" +
+      encodeURIComponent(owner) +
+      "/" +
+      encodeURIComponent(repository) +
+      "/issues/" +
+      number,
+  };
 }
 
 export function ghKeyPrefix(target: GhTarget): string {

--- a/packages/uploads/test/client-gallery.test.ts
+++ b/packages/uploads/test/client-gallery.test.ts
@@ -76,3 +76,60 @@ describe("gallery client methods", () => {
     expect(fetch.mock.calls[4][0]).toBe("https://api.test/v1/test/galleries/gal_example");
   });
 });
+
+describe("gallery external-reference client methods", () => {
+  it("uses workspace-scoped reference paths and encodes reverse lookup queries", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/galleries/gal_example/external-references") && init?.method === "GET")
+        return new Response(JSON.stringify({ references: [] }));
+      if (url.endsWith("/galleries/gal_example/external-references") && init?.method === "POST")
+        return new Response(
+          JSON.stringify({
+            id: "ref-1",
+            provider: "github",
+            resourceType: "item",
+            coordinate: "buildinternet/uploads#58",
+            canonicalUrl: "https://github.com/buildinternet/uploads/issues/58",
+            createdAt: gallery.createdAt,
+          }),
+          { status: 201 },
+        );
+      if (
+        url.endsWith("/galleries/gal_example/external-references/ref-1") &&
+        init?.method === "DELETE"
+      )
+        return new Response(JSON.stringify({ deleted: true, id: "ref-1" }));
+      if (url.includes("/galleries/by-reference?") && init?.method === "GET")
+        return new Response(JSON.stringify({ galleries: [gallery], nextCursor: null }));
+      throw new Error("unexpected URL: " + url);
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+
+    await client.listGalleryExternalReferences("gal_example");
+    await client.linkGalleryExternalReference("gal_example", {
+      expectedVersion: 1,
+      provider: "github",
+      coordinate: "buildinternet/uploads#58",
+    });
+    await client.unlinkGalleryExternalReference("gal_example", "ref-1", { expectedVersion: 2 });
+    await client.findGalleriesByReference({
+      provider: "github",
+      coordinate: "buildinternet/uploads#58",
+      limit: 10,
+      cursor: "next",
+    });
+
+    expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
+      "https://api.test/v1/test/galleries/gal_example/external-references",
+      "https://api.test/v1/test/galleries/gal_example/external-references",
+      "https://api.test/v1/test/galleries/gal_example/external-references/ref-1",
+      "https://api.test/v1/test/galleries/by-reference?provider=github&coordinate=buildinternet%2Fuploads%2358&limit=10&cursor=next",
+    ]);
+  });
+});

--- a/packages/uploads/test/commands-gallery.test.ts
+++ b/packages/uploads/test/commands-gallery.test.ts
@@ -101,3 +101,72 @@ describe("runGallery", () => {
     expect(attempted).toEqual(["first.png", "missing.png", "last.png"]);
   });
 });
+
+it("links GitHub coordinates after reading the current gallery version", async () => {
+  const versions: number[] = [];
+  const client = {
+    getGallery: async () => gallery(7),
+    linkGalleryExternalReference: async (
+      _id: string,
+      opts: { expectedVersion: number; coordinate: string },
+    ) => {
+      versions.push(opts.expectedVersion);
+      expect(opts.coordinate).toBe("buildinternet/uploads#58");
+      return {
+        id: "ref-1",
+        provider: "github" as const,
+        resourceType: "item" as const,
+        coordinate: opts.coordinate,
+        canonicalUrl: "https://github.com/buildinternet/uploads/issues/58",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+    },
+  } as unknown as UploadsClient;
+
+  expect(
+    await runGallery(ctxWith(client), [
+      "link",
+      "gal_example",
+      "--github",
+      "https://github.com/BuildInternet/Uploads/pull/58",
+    ]),
+  ).toBe(0);
+  expect(versions).toEqual([7]);
+});
+
+it("treats an absent GitHub reference as an idempotent unlink", async () => {
+  const client = {
+    listGalleryExternalReferences: async () => ({ references: [] }),
+    getGallery: async () => {
+      throw new Error("should not read version when reference is absent");
+    },
+  } as unknown as UploadsClient;
+
+  expect(
+    await runGallery(ctxWith(client), [
+      "unlink",
+      "gal_example",
+      "--github",
+      "buildinternet/uploads#58",
+    ]),
+  ).toBe(0);
+});
+
+it("uses reverse lookup for gallery list --github", async () => {
+  const coordinates: string[] = [];
+  const client = {
+    findGalleriesByReference: async (opts: { coordinate: string }) => {
+      coordinates.push(opts.coordinate);
+      return { galleries: [gallery(1)], nextCursor: null };
+    },
+  } as unknown as UploadsClient;
+
+  expect(
+    await runGallery(ctxWith(client), [
+      "list",
+      "--github",
+      "https://github.com/buildinternet/uploads/issues/58",
+    ]),
+  ).toBe(0);
+  expect(coordinates).toEqual(["buildinternet/uploads#58"]);
+});

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -5,6 +5,7 @@ import {
   ghAttachmentKey,
   ghKeyPrefix,
   isValidRepo,
+  normalizeGithubCoordinate,
   parseRepoFromRemoteUrl,
   type GhTarget,
 } from "../src/github.js";
@@ -19,6 +20,28 @@ describe("isValidRepo", () => {
     expect(isValidRepo("a/b/c")).toBe(false);
     expect(isValidRepo("")).toBe(false);
     expect(isValidRepo("owner/")).toBe(false);
+  });
+});
+
+describe("normalizeGithubCoordinate", () => {
+  it("normalizes owner/repo coordinates and strict GitHub issue or pull URLs", () => {
+    expect(normalizeGithubCoordinate("BuildInternet/Uploads#58")).toMatchObject({
+      coordinate: "buildinternet/uploads#58",
+    });
+    expect(
+      normalizeGithubCoordinate("https://github.com/BuildInternet/Uploads/pull/58"),
+    ).toMatchObject({
+      coordinate: "buildinternet/uploads#58",
+      canonicalUrl: "https://github.com/buildinternet/uploads/issues/58",
+    });
+  });
+  it.each([
+    "http://github.com/o/r/issues/1",
+    "https://github.com/o/r/issues/1?x=1",
+    "https://github.com/o/r/pulls/1",
+    "https://evil.example/o/r/issues/1",
+  ])("rejects non-canonical GitHub URLs: %s", (value) => {
+    expect(normalizeGithubCoordinate(value)).toBeUndefined();
   });
 });
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -186,11 +186,15 @@ uploads gallery create --title "Settings redesign"
 uploads gallery add gal_example screenshots/app/settings-before.webp screenshots/app/settings-after.webp
 uploads put ./after.png --gallery gal_example --alt "Updated settings page"
 uploads gallery show gal_example
+uploads gallery link gal_example --github buildinternet/uploads#58
+uploads gallery list --github https://github.com/buildinternet/uploads/pull/58
 ```
 
 `gallery add` processes keys sequentially so it obtains a current optimistic version before
 each mutation. With `--json`, its stable `added` and `failures` arrays make partial failures
 safe for agents to inspect. Deleting a gallery removes only its gallery record—not the objects.
+
+Optionally link a gallery to a GitHub issue or PR with `uploads gallery link <gallery-id> --github <owner/repo#number>`. The CLI also accepts strict `https://github.com/<owner>/<repo>/issues|pull/<number>` URLs. Use `uploads gallery list --github <coordinate-or-url>` for the authenticated reverse lookup. This is metadata only: it does not make a gallery private or change its opaque identity.
 
 ## Embedding in a GitHub PR or issue
 


### PR DESCRIPTION
## In plain terms

This lets a gallery be explicitly associated with GitHub work without making GitHub its identity. A gallery keeps its opaque uploads.sh URL; a PR or issue coordinate is only an optional, many-to-many reference.

## What it does

- Accepts `owner/repo#123` and canonical GitHub issue or pull-request URLs as the same reference.
- Adds `uploads gallery link`, `unlink`, and `list --github`.
- Returns every linked gallery, with idempotent link and unlink behavior.
- Uses no GitHub API, GitHub App, autolinks, or automatic backlink detection.

## How to try it

```bash
uploads gallery link <gallery-id> --github buildinternet/uploads#123
uploads gallery list --github https://github.com/buildinternet/uploads/pull/123
uploads gallery unlink <gallery-id> --github buildinternet/uploads#123
```

Galleries and their media remain public; a private GitHub repository does not make linked media private.

## Test plan

- [x] Focused API and CLI tests
- [x] `pnpm typecheck`
- [x] `pnpm check`
- [x] `pnpm --filter @buildinternet/uploads run pack:check`