### PR TITLE
feat: add gallery MCP tools

### DIFF
--- a/.changeset/mcp-gallery-tools.md
+++ b/.changeset/mcp-gallery-tools.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Add public gallery operations to local and hosted MCP tools.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,10 @@
     "./budget": "./src/budget.ts",
     "./usage": "./src/usage.ts",
     "./reconcile": "./src/reconcile.ts",
-    "./retention": "./src/retention.ts"
+    "./retention": "./src/retention.ts",
+    "./galleries": "./src/galleries.ts",
+    "./gallery-service": "./src/gallery-service.ts",
+    "./external-references": "./src/external-references.ts"
   },
   "scripts": {
     "dev": "wrangler dev",

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -21,7 +21,6 @@ import {
   gallerySummary,
   hydrateOwnerGallery,
   referenceDto,
-  requireExpectedVersion,
   unwrapMutation,
 } from "@uploads/api/gallery-service";
 import { parseExternalReference } from "@uploads/api/external-references";

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -7,6 +7,25 @@
  */
 import { buildMarkdown, buildScreenshotKey } from "@buildinternet/uploads";
 import { optPosInt, optString, usage, type McpTool } from "@buildinternet/uploads/mcp";
+import { badKey } from "@uploads/api/files";
+import {
+  addExternalReference,
+  addGalleryItem,
+  createGallery,
+  findGalleriesByReference,
+  getGallery,
+  listGalleryItems,
+} from "@uploads/api/galleries";
+import {
+  encodeGalleryCursor,
+  gallerySummary,
+  hydrateOwnerGallery,
+  referenceDto,
+  requireExpectedVersion,
+  unwrapMutation,
+} from "@uploads/api/gallery-service";
+import { parseExternalReference } from "@uploads/api/external-references";
+import { publicUrl, storage, storageConfig } from "@uploads/api/storage";
 import { deleteObject, listObjects, putObject } from "@uploads/api/files";
 import { allowWrite, resolveUploadPolicy } from "@uploads/api/guards";
 import { usageWithLimits } from "@uploads/api/budget";
@@ -53,7 +72,194 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     if (!(await allowWrite(env, workspaceName))) throw new Error("rate limit exceeded");
   }
 
+  function requiredString(args: Record<string, unknown>, name: string): string {
+    const value = optString(args, name);
+    if (!value) usage(name + " is required");
+    return value;
+  }
+
+  async function ownerGallery(id: string) {
+    const record = await getGallery(env.DB, workspaceName, id);
+    if (!record) throw new Error("gallery not found");
+    return hydrateOwnerGallery(
+      env,
+      workspace,
+      record,
+      await listGalleryItems(env.DB, workspaceName, id),
+    );
+  }
+
   return [
+    {
+      name: "gallery_create",
+      description:
+        "Create a public ordered media gallery in this workspace. The returned canonical URL is suitable for an agent response, but anyone who knows it can view the gallery and its media.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Gallery title (1–120 characters)." },
+          description: { type: "string", description: "Optional public gallery description." },
+        },
+        required: ["title"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:write");
+        await requireWriteBudget();
+        const result = unwrapMutation(
+          await createGallery(env.DB, {
+            workspace: workspaceName,
+            title: requiredString(args, "title"),
+            description: optString(args, "description"),
+          }),
+        );
+        return ownerGallery(result.value.id);
+      },
+    },
+    {
+      name: "gallery_get",
+      description:
+        "Get a workspace-owned gallery, including its ordered media and canonical public URL. Gallery media is public to anyone with the URL.",
+      inputSchema: {
+        type: "object",
+        properties: { galleryId: { type: "string", description: "Opaque gallery ID." } },
+        required: ["galleryId"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:read");
+        return ownerGallery(requiredString(args, "galleryId"));
+      },
+    },
+    {
+      name: "gallery_add",
+      description:
+        "Add one existing, publicly served workspace object to a gallery. The tool reads the current version before writing and does not upload or delete the object.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          galleryId: { type: "string", description: "Opaque gallery ID." },
+          objectKey: { type: "string", description: "Existing public object key to add." },
+          caption: { type: "string", description: "Optional public caption." },
+          altText: { type: "string", description: "Optional public alt text." },
+        },
+        required: ["galleryId", "objectKey"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:write");
+        await requireWriteBudget();
+        const id = requiredString(args, "galleryId");
+        const objectKey = requiredString(args, "objectKey");
+        if (badKey(objectKey)) usage("invalid key");
+        const gallery = await getGallery(env.DB, workspaceName, id);
+        if (!gallery) throw new Error("gallery not found");
+        const existing = (await listGalleryItems(env.DB, workspaceName, id)).find(
+          (item) => item.object_key === objectKey,
+        );
+        if (existing) {
+          const item = (await ownerGallery(id)).items.find((entry) => entry.id === existing.id);
+          if (!item) throw new Error("gallery item not found");
+          return item;
+        }
+        try {
+          const [store, config] = await Promise.all([
+            storage(env, workspace),
+            storageConfig(env, workspace),
+          ]);
+          if (!(await store.exists(objectKey))) throw new Error("object not found");
+          if (publicUrl(config, objectKey) === null) throw new Error("object has no public URL");
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            ["object not found", "object has no public URL"].includes(err.message)
+          ) {
+            throw err;
+          }
+          throw new Error("gallery storage unavailable");
+        }
+        const result = unwrapMutation(
+          await addGalleryItem(env.DB, workspaceName, id, {
+            expectedVersion: gallery.version,
+            objectKey,
+            caption: optString(args, "caption"),
+            altText: optString(args, "altText"),
+          }),
+        );
+        const item = (await ownerGallery(id)).items.find((entry) => entry.id === result.value.id);
+        if (!item) throw new Error("gallery item not found");
+        return item;
+      },
+    },
+    {
+      name: "gallery_link",
+      description:
+        "Link a gallery to an external reference. Uses provider-neutral fields; github currently accepts owner/repo#number or a strict GitHub issue/PR URL. No GitHub credentials or API calls are used.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          galleryId: { type: "string", description: "Opaque gallery ID." },
+          provider: { type: "string", description: "External provider (currently github)." },
+          coordinate: {
+            type: "string",
+            description: "Provider-native external reference coordinate.",
+          },
+        },
+        required: ["galleryId", "provider", "coordinate"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:write");
+        await requireWriteBudget();
+        const id = requiredString(args, "galleryId");
+        const gallery = await getGallery(env.DB, workspaceName, id);
+        if (!gallery) throw new Error("gallery not found");
+        const parsed = parseExternalReference(args.provider, args.coordinate);
+        if (!parsed.ok) usage(parsed.message);
+        const result = unwrapMutation(
+          await addExternalReference(env.DB, workspaceName, id, {
+            expectedVersion: gallery.version,
+            ...parsed.value,
+          }),
+        );
+        return referenceDto(result.value);
+      },
+    },
+    {
+      name: "gallery_find_by_reference",
+      description:
+        "Find galleries in this workspace linked to an external reference. Returns canonical public gallery URLs without contacting the provider.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          provider: { type: "string", description: "External provider (currently github)." },
+          coordinate: {
+            type: "string",
+            description: "Provider-native external reference coordinate.",
+          },
+          limit: { type: "number", description: "Page size (default 50, max 100)." },
+        },
+        required: ["provider", "coordinate"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:read");
+        const parsed = parseExternalReference(args.provider, args.coordinate);
+        if (!parsed.ok) usage(parsed.message);
+        const page = await findGalleriesByReference(
+          env.DB,
+          workspaceName,
+          parsed.value.normalizedKey,
+          {
+            limit: optPosInt(args, "limit"),
+          },
+        );
+        return {
+          galleries: page.galleries.map((gallery) => gallerySummary(env, gallery)),
+          nextCursor: page.nextCursor ? encodeGalleryCursor(page.nextCursor) : null,
+        };
+      },
+    },
     {
       name: "put",
       description:

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -176,6 +176,11 @@ describe("mcp worker", () => {
     const body = (await response.json()) as { result: { tools: { name: string }[] } };
     expect(body.result.tools.map((tool) => tool.name).sort()).toEqual([
       "delete",
+      "gallery_add",
+      "gallery_create",
+      "gallery_find_by_reference",
+      "gallery_get",
+      "gallery_link",
       "health",
       "list",
       "purge_expired",

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -4,6 +4,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat"],
+  "vars": {
+    "WEB_ORIGIN": "https://uploads.sh",
+  },
   "routes": [
     // Primary domain; mcp.uploads.sh is kept as a working alternate.
     {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -5,6 +5,10 @@
   "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "preview_urls": true,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
   "vars": {
     "UPLOADS_API_ORIGIN": "https://api.uploads.sh",
   },

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -78,7 +78,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 
 ## MCP server
 
-`uploads mcp` serves the Model Context Protocol over stdio (newline-delimited JSON-RPC, no extra dependencies). Tools mirror the CLI commands one-to-one — `put`, `attach`, `list`, `delete`, `usage`, `reconcile`, `purge_expired`, `comment`, `health`, `doctor` — with the same config resolution and defaults, plus a per-call `workspace` argument. Interactive/credential commands (`setup`, `login`, `admin`, `config`) are not exposed. A token isn't required to start the server; auth errors surface per tool call (`health` needs no auth).
+`uploads mcp` serves the Model Context Protocol over stdio (newline-delimited JSON-RPC, no extra dependencies). Tools include file operations plus public gallery workflows: `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`. Gallery tools return API-provided canonical URLs and never need GitHub credentials. The remaining stdio tools are `put`, `attach`, `list`, `delete`, `usage`, `reconcile`, `purge_expired`, `comment`, `health`, and `doctor` — with the same config resolution and defaults, plus a per-call `workspace` argument. Interactive/credential commands (`setup`, `login`, `admin`, `config`) are not exposed. A token isn't required to start the server; auth errors surface per tool call (`health` needs no auth).
 
 ```json
 { "command": "uploads", "args": ["--env-file", "/path/to/.env", "mcp"] }
@@ -86,7 +86,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 
 Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
 
-For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: put/list/delete/health, same bearer tokens as the REST API — see `apps/mcp` in the repo. `uploads install` registers it with Claude Code (and installs the agent skill) in one step. Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
+For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. `uploads install` registers it with Claude Code (and installs the agent skill) in one step. Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 
 ## Programmatic use
 

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -117,6 +117,21 @@ function ghTargetFromArgs(args: ToolArgs, run: CommandRunner): GhTarget | undefi
   );
 }
 
+function galleryId(args: ToolArgs): string {
+  const id = optString(args, "galleryId");
+  if (!id) usage("galleryId is required");
+  return id;
+}
+
+function galleryReference(args: ToolArgs): { provider: "github"; coordinate: string } {
+  const provider = optString(args, "provider");
+  const coordinate = optString(args, "coordinate");
+  if (!provider) usage("provider is required");
+  if (!coordinate) usage("coordinate is required");
+  if (provider !== "github") usage("provider must be github");
+  return { provider, coordinate };
+}
+
 const workspaceProp = {
   type: "string",
   description: "Override the workspace for this call (like the CLI's --workspace flag).",
@@ -176,6 +191,130 @@ export function createUploadsMcpTools(opts: {
   };
 
   return [
+    {
+      name: "gallery_create",
+      description:
+        "Create a public ordered media gallery in the workspace. The returned canonical URL is safe to give users, but anyone who knows it can view the gallery and its media.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Gallery title (1–120 characters)." },
+          description: { type: "string", description: "Optional public gallery description." },
+          workspace: workspaceProp,
+        },
+        required: ["title"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const title = optString(args, "title");
+        if (!title) usage("title is required");
+        const { client } = clientFor(args);
+        return client.createGallery({ title, description: optString(args, "description") });
+      },
+    },
+    {
+      name: "gallery_get",
+      description:
+        "Get a workspace-owned gallery, including ordered media and its canonical public URL. Gallery media is public to anyone with the URL.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          galleryId: { type: "string", description: "Opaque gallery ID." },
+          workspace: workspaceProp,
+        },
+        required: ["galleryId"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const { client } = clientFor(args);
+        return client.getGallery(galleryId(args));
+      },
+    },
+    {
+      name: "gallery_add",
+      description:
+        "Add one existing, publicly served workspace object to a gallery. Reads the latest gallery version before writing, so the optimistic API version is handled safely. Does not upload or delete the object.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          galleryId: { type: "string", description: "Opaque gallery ID." },
+          objectKey: { type: "string", description: "Existing public object key to add." },
+          caption: { type: "string", description: "Optional public caption." },
+          altText: { type: "string", description: "Optional public alt text." },
+          workspace: workspaceProp,
+        },
+        required: ["galleryId", "objectKey"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const objectKey = optString(args, "objectKey");
+        if (!objectKey) usage("objectKey is required");
+        const { client } = clientFor(args);
+        const id = galleryId(args);
+        const current = await client.getGallery(id);
+        return client.addGalleryItem(id, objectKey, {
+          expectedVersion: current.version,
+          caption: optString(args, "caption"),
+          altText: optString(args, "altText"),
+        });
+      },
+    },
+    {
+      name: "gallery_link",
+      description:
+        "Link a gallery to an external reference. References use provider-neutral fields; github currently accepts owner/repo#number or a strict GitHub issue/PR URL. No GitHub credentials or API calls are used.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          galleryId: { type: "string", description: "Opaque gallery ID." },
+          provider: { type: "string", description: "External provider (currently github)." },
+          coordinate: {
+            type: "string",
+            description: "Provider-native external reference coordinate.",
+          },
+          workspace: workspaceProp,
+        },
+        required: ["galleryId", "provider", "coordinate"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const { client } = clientFor(args);
+        const id = galleryId(args);
+        const current = await client.getGallery(id);
+        return client.linkGalleryExternalReference(id, {
+          expectedVersion: current.version,
+          ...galleryReference(args),
+        });
+      },
+    },
+    {
+      name: "gallery_find_by_reference",
+      description:
+        "Find workspace galleries linked to an external reference. Returns gallery summaries and canonical public URLs without contacting the provider.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          provider: { type: "string", description: "External provider (currently github)." },
+          coordinate: {
+            type: "string",
+            description: "Provider-native external reference coordinate.",
+          },
+          limit: { type: "number", description: "Page size (default 50, max 100)." },
+          cursor: { type: "string", description: "Pagination cursor from a previous response." },
+          workspace: workspaceProp,
+        },
+        required: ["provider", "coordinate"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const { client } = clientFor(args);
+        return client.findGalleriesByReference({
+          ...galleryReference(args),
+          limit: optPosInt(args, "limit"),
+          cursor: optString(args, "cursor"),
+        });
+      },
+    },
     {
       name: "put",
       description:

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -191,6 +191,11 @@ describe("tools/list", () => {
     // oxlint-disable-next-line no-explicit-any
     const tools = res.result.tools as Array<any>;
     expect(tools.map((t) => t.name)).toEqual([
+      "gallery_create",
+      "gallery_get",
+      "gallery_add",
+      "gallery_link",
+      "gallery_find_by_reference",
       "put",
       "attach",
       "list",

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -319,7 +319,7 @@ uploads --api-url http://localhost:8787 doctor
 - **Exit codes** (useful in scripts): `2` usage/missing-token, `3` unauthorized or
   not-found, `4` network, `1` other. `--json` also emits `{error,code,status}`.
 - **MCP server:** the CLI can also be exposed to agents as a local stdio MCP server —
-  `uploads mcp` — with tools mirroring the commands described here (`put`, `attach`,
+  `uploads mcp` (including gallery_create, gallery_get, gallery_add, gallery_link, and gallery_find_by_reference) — with tools mirroring the commands described here (`put`, `attach`,
   `list`, `delete`, `usage`, `reconcile`, `purge_expired`, `comment`, `health`,
   `doctor`) under the same config resolution.
   Every tool also accepts a per-call `workspace` argument to override the configured


### PR DESCRIPTION
## In plain terms

Agents can now create and manage public media galleries through either uploads MCP surface. The local stdio server and hosted MCP worker expose the same gallery workflow without GitHub credentials.

## What it does

- Adds `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`.
- Returns API-provided canonical gallery URLs.
- Keeps hosted MCP operations scoped to the workspace resolved from the bearer token.
- Validates object keys, public storage availability, reference inputs, and write scopes before mutation.
- Configures the hosted MCP worker with `WEB_ORIGIN` for canonical URLs.

It does not add gallery comments, GitHub Apps, autolinks, or automatic backlinks.

## Test plan

- [x] Local MCP gallery tests
- [x] Remote MCP tests
- [x] Package and MCP typechecks
- [x] `pnpm check`
- [x] Package pack validation