### PR TITLE
feat(cli): hint when a newer package version is available

### DIFF
--- a/.changeset/cli-update-hint.md
+++ b/.changeset/cli-update-hint.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Hint on stderr when a newer npm release of the CLI is available (cached daily; silence with `--quiet`, `UPLOADS_NO_UPDATE=1`, or `NO_UPDATE_NOTIFIER=1`). Add `--version`/`-V`, include the CLI version on `uploads doctor`, add Examples to login/admin help, and point usage errors at layered `uploads <cmd> --help` instead of dumping the full root manual.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ More output control:
 uploads put ./shot.png --format url
 uploads put ./shot.png --repo myorg/myapp --ref 1722 --width 700
 uploads put ./mobile.png --frame phone
+uploads --version
+uploads doctor
 ```
+
+See [`packages/uploads/README.md`](packages/uploads/README.md) for globals
+(`--version`, update hints, quiet/json) and the full command list.
 
 ### Public galleries
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -13,6 +13,7 @@ npx @buildinternet/uploads --help
 
 ```bash
 uploads setup
+uploads --version
 uploads attach ./before.png ./after.png
 uploads put ./shot.png
 uploads put ./shot.png --destination screenshots
@@ -31,6 +32,14 @@ global `uploads` form above.
 
 Commands: `attach`, `put`, `gallery`, `comment`, `list`, `delete`, `usage`, `reconcile`,
 `purge-expired`, `setup`, `install`, `config`, `doctor`, `health`, `mcp`.
+
+**Globals (before the command):** `--api-url`, `--token`, `--workspace` / `-w`,
+`--env-file`, `--json`, `--quiet`, `--version` / `-V`, `-h` / `--help`.
+
+**Update hints:** after a successful run the CLI may print one stderr line when a
+newer npm release is available (at most once/day, `~/.cache/uploads/`). Silence
+with `--quiet`, `--json`, `UPLOADS_NO_UPDATE=1`, or `NO_UPDATE_NOTIFIER=1`. Not used
+for `uploads mcp`.
 
 `attach` is the agent-friendly default for GitHub media. It accepts one or more files,
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
@@ -100,14 +109,16 @@ Agent/MCP helpers: `@buildinternet/uploads/agent` (`createUploadsWorkerFileTools
 
 ```
 src/
-  cli.ts            Entry + help
-  commands.ts       put, list, delete, comment, …
-  commands/mcp.ts   `mcp` command entry
-  mcp/              Stdio MCP server (server.ts, tools.ts)
-  client.ts         HTTP client for the API
-  github.ts         PR/issue key paths + attachment comments
-  embed.ts          Markdown image output
-bin/uploads.js      Bin shim
+  cli.ts              Entry + help
+  package-version.ts  Shared version for --version / doctor / headers
+  update-check.ts     Optional npm update hint (stderr)
+  commands.ts         put, list, delete, comment, …
+  commands/mcp.ts     `mcp` command entry
+  mcp/                Stdio MCP server (server.ts, tools.ts)
+  client.ts           HTTP client for the API
+  github.ts           PR/issue key paths + attachment comments
+  embed.ts            Markdown image output
+bin/uploads.js        Bin shim
 ```
 
 ## Commands

--- a/packages/uploads/src/cli-args.ts
+++ b/packages/uploads/src/cli-args.ts
@@ -5,6 +5,8 @@ export interface GlobalFlags {
   envFile?: string;
   json?: boolean;
   quiet?: boolean;
+  /** `--version` / `-V` — print package version and exit. */
+  version?: boolean;
 }
 
 export interface ParsedArgv {
@@ -46,6 +48,11 @@ export function parseArgv(argv: string[]): ParsedArgv {
     }
     if (arg === "--quiet") {
       globals.quiet = true;
+      i++;
+      continue;
+    }
+    if (arg === "--version" || arg === "-V") {
+      globals.version = true;
       i++;
       continue;
     }

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -28,6 +28,8 @@ import { runLogin } from "./commands/login.js";
 import { runAdmin } from "./commands/admin-enrollment.js";
 import { runMcp } from "./commands/mcp.js";
 import { runInstall } from "./commands/install.js";
+import { packageVersion } from "./package-version.js";
+import { maybeHintUpdate } from "./update-check.js";
 
 const ROOT_HELP = `uploads — CLI for uploads.sh (GitHub image embeds)
 
@@ -51,7 +53,8 @@ Other globals (before command):
   --token <token>     or UPLOADS_TOKEN
   --env-file <path>
   --json              JSON on stdout
-  --quiet
+  --quiet             Suppress stderr progress and update hints
+  --version, -V       Print package version and exit
 
 Commands:
   attach <file...>     Attach media to the current PR (stable URLs + managed comment)
@@ -76,6 +79,8 @@ Put/list defaults (config file or env):
   UPLOADS_DEFAULT_PREFIX, UPLOADS_DEFAULT_REPO, UPLOADS_DEFAULT_REF
   UPLOADS_DEFAULT_WIDTH, UPLOADS_NO_GIT
 
+Update hints (stderr, once/day): silence with --quiet / UPLOADS_NO_UPDATE=1 / NO_UPDATE_NOTIFIER=1
+
 Examples:
   uploads setup
   uploads setup --token up_default_… --repo myorg/myapp
@@ -83,6 +88,7 @@ Examples:
   uploads put ./shot.png --ref 42
   uploads gallery create --title "Release screenshots"
   uploads doctor
+  uploads --version
 
 Agent/MCP: \`uploads install\` sets up the agent skill and the hosted MCP server
 (https://agents.uploads.sh/mcp, workspace inferred from the token). Run
@@ -164,10 +170,26 @@ function errorOut(err: unknown, json: boolean): void {
   }
 }
 
+/** Point agents at layered --help instead of dumping the full root manual. */
+function usageHint(argv: string[]): void {
+  try {
+    const cmd = parseArgv(argv).command;
+    process.stderr.write(cmd ? `hint: uploads ${cmd} --help\n` : "hint: uploads --help\n");
+  } catch {
+    process.stderr.write("hint: uploads --help\n");
+  }
+}
+
 export async function runCli(argv: string[]): Promise<number> {
   try {
     const parsed = parseArgv(argv);
     const json = parsed.globals.json ?? false;
+    const quiet = parsed.globals.quiet ?? false;
+
+    if (parsed.globals.version) {
+      process.stdout.write(`${packageVersion()}\n`);
+      return 0;
+    }
 
     if (!parsed.command) {
       process.stderr.write(ROOT_HELP);
@@ -176,22 +198,30 @@ export async function runCli(argv: string[]): Promise<number> {
 
     const cmdArgs = parsed.rest.slice(1);
     const showHelp = parsed.help || cmdArgs.some(isHelpFlag);
+    let code: number;
 
     switch (parsed.command) {
       case "health":
-        return runHealth({ apiUrl: resolveApiUrl(parsed.globals), json }, cmdArgs, showHelp);
+        code = await runHealth({ apiUrl: resolveApiUrl(parsed.globals), json }, cmdArgs, showHelp);
+        break;
       case "config":
-        return runConfig(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
+        code = await runConfig(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
+        break;
       case "setup":
-        return runSetup(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
+        code = await runSetup(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
+        break;
       case "login":
-        return runLogin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        code = await runLogin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        break;
       case "admin":
-        return runAdmin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        code = await runAdmin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        break;
       case "mcp":
-        return runMcp(cmdArgs, { globals: parsed.globals }, showHelp);
+        code = await runMcp(cmdArgs, { globals: parsed.globals }, showHelp);
+        break;
       case "install":
-        return runInstall(cmdArgs, { globals: parsed.globals, json }, showHelp);
+        code = await runInstall(cmdArgs, { globals: parsed.globals, json }, showHelp);
+        break;
       case "attach":
       case "put":
       case "gallery":
@@ -205,35 +235,51 @@ export async function runCli(argv: string[]): Promise<number> {
         const ctx = createContext(parsed.globals, !showHelp, cmdArgs);
         switch (parsed.command) {
           case "attach":
-            return runAttach(ctx, cmdArgs, showHelp);
+            code = await runAttach(ctx, cmdArgs, showHelp);
+            break;
           case "put":
-            return runPut(ctx, cmdArgs, showHelp);
+            code = await runPut(ctx, cmdArgs, showHelp);
+            break;
           case "gallery":
-            return runGallery(ctx, cmdArgs, showHelp);
+            code = await runGallery(ctx, cmdArgs, showHelp);
+            break;
           case "comment":
-            return runComment(ctx, cmdArgs, showHelp);
+            code = await runComment(ctx, cmdArgs, showHelp);
+            break;
           case "list":
-            return runList(ctx, cmdArgs, showHelp);
+            code = await runList(ctx, cmdArgs, showHelp);
+            break;
           case "delete":
-            return runDelete(ctx, cmdArgs, showHelp);
+            code = await runDelete(ctx, cmdArgs, showHelp);
+            break;
           case "usage":
-            return runUsage(ctx, cmdArgs, showHelp);
+            code = await runUsage(ctx, cmdArgs, showHelp);
+            break;
           case "reconcile":
-            return runReconcile(ctx, cmdArgs, showHelp);
+            code = await runReconcile(ctx, cmdArgs, showHelp);
+            break;
           case "purge-expired":
-            return runPurgeExpired(ctx, cmdArgs, showHelp);
+            code = await runPurgeExpired(ctx, cmdArgs, showHelp);
+            break;
           case "doctor":
-            return runDoctor(ctx, cmdArgs, showHelp);
+            code = await runDoctor(ctx, cmdArgs, showHelp);
+            break;
         }
+        break;
       }
       default:
         process.stderr.write(`unknown command: ${parsed.command}\n\n${ROOT_HELP}`);
         return 2;
     }
+
+    // Best-effort; skipped for mcp, --quiet/--json, and opt-out env vars.
+    if (code === 0 && !showHelp) {
+      await maybeHintUpdate({ quiet: quiet || json, command: parsed.command });
+    }
+    return code;
   } catch (err) {
     errorOut(err, argv.includes("--json"));
-    if (err instanceof UsageError && !argv.includes("--json"))
-      process.stderr.write(`\n${ROOT_HELP}`);
+    if (err instanceof UsageError && !argv.includes("--json")) usageHint(argv);
     return exitCode(err);
   }
 }

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -42,6 +42,7 @@ import {
 } from "./optimize.js";
 import { applyFrame, resolveFrameId, type FrameResult } from "./frame.js";
 import { buildCliProvenance } from "./provenance.js";
+import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
 
 export interface CliContext {
@@ -839,8 +840,13 @@ export async function runList(
 
 const DELETE_HELP = `uploads delete <key> [--dry-run] [--workspace <name>]
 
+Options:
+  --dry-run             Preview without deleting
+  --workspace, -w <name>
+
 Examples:
   uploads delete screenshots/myapp/42/shot-a1b2c3.png
+  uploads delete screenshots/myapp/42/shot-a1b2c3.png --dry-run
 `;
 
 export async function runDelete(ctx: CliContext, args: string[], help = false): Promise<number> {
@@ -1036,10 +1042,13 @@ Checks API health, token auth, and workspace/token alignment.
 Examples:
   uploads --env-file .env doctor
   uploads --workspace acme --env-file .env doctor
+  uploads doctor --json
 `;
 
 export interface DoctorReport {
   ok: boolean;
+  /** Installed @buildinternet/uploads package version. */
+  cliVersion: string;
   apiUrl: string;
   workspace: string;
   workspaceSource: ResolvedConfig["workspaceSource"];
@@ -1120,6 +1129,7 @@ export async function buildDoctorReport(
 
   return {
     ok: health.ok && authOk,
+    cliVersion: packageVersion(),
     apiUrl: config.apiUrl,
     workspace: config.workspace,
     workspaceSource: config.workspaceSource,
@@ -1148,6 +1158,7 @@ export async function runDoctor(ctx: CliContext, args: string[], help = false): 
   }
 
   const lines = [
+    `cli:       @buildinternet/uploads@${report.cliVersion}`,
     `config:    ${report.configPath}${report.configExists ? "" : " (missing)"}`,
     `api:       ${report.apiUrl} (${report.health.ok ? "ok" : "failed"})`,
     `workspace: ${report.workspace}`,

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -20,6 +20,11 @@ Options:
   --separate-code        Two-channel output: non-secret page URL + separate code
   --api-url <url>        Default: https://api.uploads.sh
   --web-url <url>        Invite-page origin (defaults from --api-url)
+
+Examples:
+  uploads admin invite create --workspace acme --email user@example.com
+  uploads admin invite create --workspace acme --separate-code --json
+  uploads admin invite create --admin-token $ADMIN_TOKEN --workspace acme --label "onboarding"
 `;
 
 type FileScope = "files:read" | "files:write" | "files:delete";

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -22,6 +22,12 @@ Options:
   --path <file>       Config destination
   --force             Replace existing saved credentials
   --no-check          Skip doctor verification
+
+Examples:
+  uploads login --code upe_…
+  uploads login --code-stdin --non-interactive < code.txt
+  printf '%s' upe_… | uploads login --code-stdin --non-interactive
+  uploads login --code upe_… --force --no-check
 `;
 
 export function validateEnrollmentCode(raw: string): string {

--- a/packages/uploads/src/commands/mcp.ts
+++ b/packages/uploads/src/commands/mcp.ts
@@ -1,8 +1,8 @@
-import { createRequire } from "node:module";
 import { parseCommandArgs, type GlobalFlags } from "../cli-args.js";
 import { createMcpServer } from "../mcp/server.js";
 import { serveStdio } from "../mcp/stdio.js";
 import { createUploadsMcpTools } from "../mcp/tools.js";
+import { packageVersion } from "../package-version.js";
 
 const MCP_HELP = `uploads [globals] mcp
 
@@ -24,10 +24,6 @@ Examples:
   uploads --token up_default_… mcp
 `;
 
-// Same relative depth from src/commands/ and dist/commands/, so this works
-// both under vitest (src) and at runtime (dist).
-const { version } = createRequire(import.meta.url)("../../package.json") as { version: string };
-
 export async function runMcp(
   args: string[],
   opts: { globals: GlobalFlags },
@@ -38,7 +34,7 @@ export async function runMcp(
     return 0;
   }
   const server = createMcpServer({
-    serverInfo: { name: "uploads", version },
+    serverInfo: { name: "uploads", version: packageVersion() },
     tools: createUploadsMcpTools({ globals: opts.globals }),
   });
   await serveStdio(server);

--- a/packages/uploads/src/package-version.ts
+++ b/packages/uploads/src/package-version.ts
@@ -1,0 +1,19 @@
+/**
+ * Resolve the published package version for CLI headers, --version, and
+ * update checks. Reads package.json once per process.
+ */
+import { createRequire } from "node:module";
+
+let cachedVersion: string | undefined;
+
+export function packageVersion(): string {
+  if (cachedVersion) return cachedVersion;
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require("../package.json") as { version?: string };
+    cachedVersion = pkg.version ?? "0.0.0";
+  } catch {
+    cachedVersion = "0.0.0";
+  }
+  return cachedVersion;
+}

--- a/packages/uploads/src/provenance.ts
+++ b/packages/uploads/src/provenance.ts
@@ -3,21 +3,7 @@
  * API allowlists keys; secrets never go here.
  */
 import type { ProvenanceInput } from "./client.js";
-import { createRequire } from "node:module";
-
-let cachedVersion: string | undefined;
-
-function packageVersion(): string {
-  if (cachedVersion) return cachedVersion;
-  try {
-    const require = createRequire(import.meta.url);
-    const pkg = require("../package.json") as { version?: string };
-    cachedVersion = pkg.version ?? "0.0.0";
-  } catch {
-    cachedVersion = "0.0.0";
-  }
-  return cachedVersion;
-}
+import { packageVersion } from "./package-version.js";
 
 export function buildCliProvenance(opts: {
   sourceName: string;

--- a/packages/uploads/src/update-check.ts
+++ b/packages/uploads/src/update-check.ts
@@ -1,0 +1,162 @@
+/**
+ * Optional npm update notifier for the CLI.
+ *
+ * Checks the registry at most once per day, never throws, never blocks longer
+ * than a short timeout, and writes only to stderr. Silence with --quiet,
+ * UPLOADS_NO_UPDATE=1, or NO_UPDATE_NOTIFIER=1.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { packageVersion } from "./package-version.js";
+
+export const PACKAGE_NAME = "@buildinternet/uploads";
+const REGISTRY_LATEST = `https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}/latest`;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 1500;
+
+export interface UpdateCache {
+  checkedAt: number;
+  latest: string;
+  current: string;
+}
+
+export interface UpdateCheckOptions {
+  quiet?: boolean;
+  /** mcp is always skipped (stdio purity). */
+  command?: string;
+  currentVersion?: string;
+  cachePath?: string;
+  now?: number;
+  /** Default 24h. Pass 0 in tests to force a network check. */
+  ttlMs?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  write?: (text: string) => void;
+}
+
+function truthyEnv(name: string): boolean {
+  const v = process.env[name];
+  if (!v) return false;
+  const lower = v.toLowerCase();
+  return lower !== "0" && lower !== "false" && lower !== "no";
+}
+
+function defaultCachePath(): string {
+  const base = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache");
+  return join(base, "uploads", "version-check.json");
+}
+
+/** Parse major.minor.patch (ignores pre-release). */
+export function parseSemver(version: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** True when `latest` is strictly greater than `current`. */
+export function isNewerVersion(latest: string, current: string): boolean {
+  const a = parseSemver(latest);
+  const b = parseSemver(current);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return false;
+}
+
+export function readUpdateCache(path: string): UpdateCache | undefined {
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<UpdateCache>;
+    if (
+      typeof raw.checkedAt !== "number" ||
+      typeof raw.latest !== "string" ||
+      typeof raw.current !== "string"
+    ) {
+      return undefined;
+    }
+    return { checkedAt: raw.checkedAt, latest: raw.latest, current: raw.current };
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeUpdateCache(path: string, cache: UpdateCache): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(cache) + "\n", { mode: 0o600 });
+  } catch {
+    // Best-effort — never fail the CLI for a cache write error.
+  }
+}
+
+/**
+ * If a newer published version is known (or can be fetched within the timeout),
+ * write a one-line stderr hint. Always resolves; never throws.
+ */
+export async function maybeHintUpdate(opts: UpdateCheckOptions = {}): Promise<void> {
+  try {
+    if (opts.quiet || opts.command === "mcp") return;
+    if (truthyEnv("UPLOADS_NO_UPDATE") || truthyEnv("NO_UPDATE_NOTIFIER")) return;
+
+    const current = opts.currentVersion ?? packageVersion();
+    const cachePath = opts.cachePath ?? defaultCachePath();
+    const now = opts.now ?? Date.now();
+    const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    const write = opts.write ?? ((text: string) => process.stderr.write(text));
+
+    const cached = readUpdateCache(cachePath);
+    let latest: string | undefined;
+
+    if (cached && now - cached.checkedAt < ttlMs && cached.current === current) {
+      latest = cached.latest;
+    } else {
+      const fetched = await fetchLatestVersion(
+        opts.fetchImpl,
+        opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      );
+      if (fetched) {
+        latest = fetched;
+        writeUpdateCache(cachePath, { checkedAt: now, latest: fetched, current });
+      } else if (cached?.current === current) {
+        latest = cached.latest; // stale cache if network failed
+      }
+    }
+
+    if (latest && isNewerVersion(latest, current)) {
+      write(
+        `hint: ${PACKAGE_NAME}@${latest} is available (you have ${current}). Update: npm i -g ${PACKAGE_NAME}\n`,
+      );
+    }
+  } catch {
+    // Never surface update-check failures.
+  }
+}
+
+async function fetchLatestVersion(
+  fetchImpl: typeof fetch | undefined,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  const fetchFn = fetchImpl ?? globalThis.fetch;
+  if (typeof fetchFn !== "function") return undefined;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(REGISTRY_LATEST, {
+      signal: controller.signal,
+      headers: {
+        accept: "application/json",
+        "user-agent": `${PACKAGE_NAME}/${packageVersion()} (update-check)`,
+      },
+    });
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === "string" ? body.version : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/uploads/test/cli-version.test.ts
+++ b/packages/uploads/test/cli-version.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseArgv } from "../src/cli-args.js";
+import { runCli } from "../src/cli.js";
+import { packageVersion } from "../src/package-version.js";
+
+describe("parseArgv --version", () => {
+  it("accepts --version and -V as globals", () => {
+    expect(parseArgv(["node", "uploads", "--version"]).globals.version).toBe(true);
+    expect(parseArgv(["node", "uploads", "-V"]).globals.version).toBe(true);
+    expect(parseArgv(["node", "uploads", "--json", "--version"]).globals).toMatchObject({
+      json: true,
+      version: true,
+    });
+  });
+});
+
+describe("runCli --version", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints the package version on stdout and exits 0", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+
+    const code = await runCli(["node", "uploads", "--version"]);
+    expect(code).toBe(0);
+    expect(stdout.join("").trim()).toBe(packageVersion());
+    expect(stderr.join("")).toBe("");
+  });
+});
+
+describe("runCli usage errors", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("points at layered --help instead of dumping the root manual", async () => {
+    const stderr: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    // Invalid install target throws UsageError without needing credentials.
+    const code = await runCli(["node", "uploads", "install", "not-a-target"]);
+    expect(code).toBe(2);
+    const text = stderr.join("");
+    expect(text).toMatch(/unknown install target/);
+    expect(text).toMatch(/hint: uploads install --help/);
+    expect(text).not.toMatch(/Agent\/MCP:/);
+    expect(text).not.toMatch(/UPLOADS_DEFAULT_PREFIX/);
+  });
+});

--- a/packages/uploads/test/update-check.test.ts
+++ b/packages/uploads/test/update-check.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isNewerVersion,
+  maybeHintUpdate,
+  parseSemver,
+  readUpdateCache,
+  writeUpdateCache,
+  type UpdateCache,
+} from "../src/update-check.js";
+
+describe("parseSemver / isNewerVersion", () => {
+  it("parses major.minor.patch and ignores pre-release", () => {
+    expect(parseSemver("1.2.3")).toEqual([1, 2, 3]);
+    expect(parseSemver("1.2.3-beta.1")).toEqual([1, 2, 3]);
+    expect(parseSemver("not-a-version")).toBeNull();
+  });
+
+  it("compares versions", () => {
+    expect(isNewerVersion("0.6.0", "0.5.0")).toBe(true);
+    expect(isNewerVersion("0.5.1", "0.5.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "0.9.9")).toBe(true);
+    expect(isNewerVersion("0.5.0", "0.5.0")).toBe(false);
+    expect(isNewerVersion("0.4.9", "0.5.0")).toBe(false);
+  });
+});
+
+describe("update cache", () => {
+  it("round-trips", () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-update-")), "version-check.json");
+    const cache: UpdateCache = { checkedAt: 1000, latest: "0.6.0", current: "0.5.0" };
+    writeUpdateCache(path, cache);
+    expect(readUpdateCache(path)).toEqual(cache);
+  });
+});
+
+describe("maybeHintUpdate", () => {
+  function cachePath(): string {
+    return join(mkdtempSync(join(tmpdir(), "uploads-update-")), "version-check.json");
+  }
+
+  function jsonResponse(version: string): Response {
+    return new Response(JSON.stringify({ version }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  it("prints a hint when the registry reports a newer version", async () => {
+    const lines: string[] = [];
+    const path = cachePath();
+    await maybeHintUpdate({
+      currentVersion: "0.5.0",
+      cachePath: path,
+      now: 10_000,
+      ttlMs: 0,
+      fetchImpl: async () => jsonResponse("0.6.0"),
+      write: (t) => lines.push(t),
+    });
+    expect(lines.join("")).toMatch(
+      /@buildinternet\/uploads@0\.6\.0 is available \(you have 0\.5\.0\)/,
+    );
+    expect(lines.join("")).toMatch(/npm i -g @buildinternet\/uploads/);
+    expect(readUpdateCache(path)?.latest).toBe("0.6.0");
+  });
+
+  it("stays silent when already up to date", async () => {
+    const lines: string[] = [];
+    await maybeHintUpdate({
+      currentVersion: "0.6.0",
+      cachePath: cachePath(),
+      ttlMs: 0,
+      fetchImpl: async () => jsonResponse("0.6.0"),
+      write: (t) => lines.push(t),
+    });
+    expect(lines).toEqual([]);
+  });
+
+  it("uses a fresh cache without fetching", async () => {
+    const path = cachePath();
+    writeUpdateCache(path, { checkedAt: 1_000, latest: "0.7.0", current: "0.5.0" });
+    const lines: string[] = [];
+    let fetches = 0;
+    await maybeHintUpdate({
+      currentVersion: "0.5.0",
+      cachePath: path,
+      now: 1_000 + 60_000,
+      fetchImpl: async () => {
+        fetches++;
+        throw new Error("should not fetch");
+      },
+      write: (t) => lines.push(t),
+    });
+    expect(fetches).toBe(0);
+    expect(lines.join("")).toMatch(/0\.7\.0/);
+  });
+
+  it("skips when quiet, mcp, or NO_UPDATE_NOTIFIER is set", async () => {
+    const lines: string[] = [];
+    const fetchImpl = async () => {
+      throw new Error("should not fetch");
+    };
+    await maybeHintUpdate({
+      quiet: true,
+      currentVersion: "0.1.0",
+      ttlMs: 0,
+      fetchImpl,
+      write: (t) => lines.push(t),
+    });
+    await maybeHintUpdate({
+      command: "mcp",
+      currentVersion: "0.1.0",
+      ttlMs: 0,
+      fetchImpl,
+      write: (t) => lines.push(t),
+    });
+    const prev = process.env.NO_UPDATE_NOTIFIER;
+    process.env.NO_UPDATE_NOTIFIER = "1";
+    try {
+      await maybeHintUpdate({
+        currentVersion: "0.1.0",
+        ttlMs: 0,
+        fetchImpl,
+        write: (t) => lines.push(t),
+      });
+    } finally {
+      if (prev === undefined) delete process.env.NO_UPDATE_NOTIFIER;
+      else process.env.NO_UPDATE_NOTIFIER = prev;
+    }
+    expect(lines).toEqual([]);
+  });
+
+  it("never throws on network failure", async () => {
+    const lines: string[] = [];
+    await expect(
+      maybeHintUpdate({
+        currentVersion: "0.5.0",
+        cachePath: cachePath(),
+        ttlMs: 0,
+        fetchImpl: async () => {
+          throw new Error("offline");
+        },
+        write: (t) => lines.push(t),
+      }),
+    ).resolves.toBeUndefined();
+    expect(lines).toEqual([]);
+  });
+
+  it("falls back to a stale cache when fetch fails", async () => {
+    const path = cachePath();
+    writeFileSync(path, JSON.stringify({ checkedAt: 1, latest: "0.9.0", current: "0.5.0" }) + "\n");
+    const lines: string[] = [];
+    await maybeHintUpdate({
+      currentVersion: "0.5.0",
+      cachePath: path,
+      now: 99_999_999,
+      ttlMs: 0,
+      fetchImpl: async () => {
+        throw new Error("offline");
+      },
+      write: (t) => lines.push(t),
+    });
+    expect(lines.join("")).toMatch(/0\.9\.0/);
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -53,10 +53,13 @@ propagate within ~a minute).
   ```bash
   npm install --global @buildinternet/uploads
   npx @buildinternet/uploads --help
+  uploads --version
   ```
   Every example in this skill uses the **global** `uploads …` binary (as after
   install). Inside the uploads monorepo only, `pnpm uploads …` builds from
   local source first — do not write product/PR examples that way.
+  Prefer `--json` or `--quiet` for scripted steps (keeps stderr clean and skips
+  optional update-available hints).
 - **A configured token** (one-time — see below). Check with `uploads doctor`.
 - **`gh` CLI, authenticated** — only for the `--comment` / `comment` features that
   write to a PR/issue. Plain uploads don't need it.
@@ -95,7 +98,8 @@ default (up to 24 hours) and can be redeemed once. The resulting token defaults 
 
 ```bash
 uploads setup                                  # shows effective configuration
-uploads doctor                                 # health + auth + workspace checks
+uploads doctor                                 # version + health + auth + workspace
+uploads doctor --json
 ```
 
 Tokens encode their workspace (`up_<workspace>_…`), so the CLI infers `--workspace`
@@ -273,12 +277,17 @@ uploads usage                              # storage / monthly upload counters (
 uploads reconcile                          # rebuild ledger from storage
 uploads purge-expired                      # delete past retentionDays (if set)
 uploads health                             # API liveness (no auth)
-uploads doctor                             # health + auth + workspace + usage
+uploads doctor                             # version + health + auth + workspace + usage
+uploads --version
 ```
 
-`doctor` is the first thing to run when something's off — it distinguishes a down
-API, a bad/missing token, a workspace/token mismatch, and a local-vs-prod URL
-mismatch, and prints targeted hints.
+`doctor` is the first thing to run when something's off — it reports the installed
+CLI version, distinguishes a down API / bad token / workspace mismatch /
+local-vs-prod URL, and prints targeted hints.
+
+**Destructive preview:** `delete` supports `--dry-run`. `purge-expired` does not
+yet ([#78](https://github.com/buildinternet/uploads/issues/78)); preview via
+`list` / `usage` and retention settings.
 
 ## Config commands
 
@@ -318,6 +327,9 @@ uploads --api-url http://localhost:8787 doctor
   in storage changes immediately.
 - **Exit codes** (useful in scripts): `2` usage/missing-token, `3` unauthorized or
   not-found, `4` network, `1` other. `--json` also emits `{error,code,status}`.
+  Usage errors print `hint: uploads <cmd> --help` (not the full root manual).
+- **Update hints (stderr):** successful human runs may note a newer npm release
+  (daily). Silence with `--quiet` / `--json` / `UPLOADS_NO_UPDATE=1`.
 - **MCP server:** the CLI can also be exposed to agents as a local stdio MCP server —
   `uploads mcp` (including gallery_create, gallery_get, gallery_add, gallery_link, and gallery_find_by_reference) — with tools mirroring the commands described here (`put`, `attach`,
   `list`, `delete`, `usage`, `reconcile`, `purge_expired`, `comment`, `health`,


### PR DESCRIPTION
## In plain terms

When a newer npm release of the CLI is available, successful runs can print a one-line stderr hint so agents and humans know to upgrade. This also tightens a few agent-facing CLI affordances (`--version`, doctor version, layered usage help) without changing command shape.

## What it does

- After successful non-help runs, optionally check npm (at most once/day, `~/.cache/uploads/`) and print:
  `hint: @buildinternet/uploads@X is available (you have Y). Update: npm i -g @buildinternet/uploads`
- Silence with `--quiet`, `--json`, `UPLOADS_NO_UPDATE=1`, or `NO_UPDATE_NOTIFIER=1`; never on `uploads mcp`
- Add global `--version` / `-V`
- Include installed CLI version on `uploads doctor` (human + JSON)
- Usage errors point at `uploads <cmd> --help` instead of dumping the full root manual
- Examples on `login` / `admin` help; clearer `delete --dry-run` help
- Docs + `skills/uploads-cli` skill updated

## What it is not

- Not a breaking change to commands or MCP tool names
- No dry-run for `purge-expired` and no resource/verb rewrite — tracked in #78

## How to try it

```bash
uploads --version
uploads doctor
# with a stale install and network, after any successful command you may see the update hint
UPLOADS_NO_UPDATE=1 uploads doctor   # silence
```

## Technical notes

- Shared `packageVersion()` for provenance headers, doctor, MCP server info, and the checker
- Tests cover semver compare, cache TTL, opt-outs, `--version`, and layered usage hints
- Changeset: patch for `@buildinternet/uploads`

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @buildinternet/uploads typecheck`
- [ ] CI green on the PR