### PR TITLE
chore: add bootstrap and doctor for local contributor setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,10 @@ in `createStorage` plus its files-sdk peer deps.
 ## Commands
 
 ```bash
+pnpm bootstrap           # one-command local setup (tooling, deps, env, types, D1, default workspace)
+pnpm doctor              # read-only diagnose of the local setup
 pnpm install
-pnpm dev                 # API on :8787 (local R2 + KV simulation)
+pnpm dev                 # API on :8787 (local R2 + KV + D1 simulation)
 pnpm dev:web             # Astro site
 pnpm typecheck           # wrangler types + tsc across workspaces
 pnpm run deploy          # all workers; or deploy:api / deploy:web / deploy:mcp
@@ -41,6 +43,7 @@ pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
 pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] \
   [--allowed-prefixes default|f,screenshots,gh] [--max-key-depth 8] \
   [--clear-max-storage] [--clear-allowed-prefixes] […]
+pnpm --filter @uploads/api run migrate:d1:local   # apply apps/api/migrations to local D1
 pnpm uploads put <file> --env-file .env   # monorepo only: builds package first
 pnpm uploads put <file> --pr <num> --comment
 ```
@@ -66,6 +69,23 @@ worker deploys normally happen via Workers Builds on push to main.
 
 Operator runbook: [docs/ops.md](docs/ops.md). Daily retention cron on the API
 worker; BYO secrets use `WORKSPACE_SECRETS_KEY`; bare upload keys get `f/<id>/…`.
+
+### Local Wrangler / agent hygiene
+
+`wrangler … --local` boots miniflare and can **orphan + balloon RAM** (multi‑GB)
+if the parent shell/agent dies mid-command or the process hangs in an error
+path. Prefer:
+
+- **`pnpm doctor` / `pnpm bootstrap`** for “is local `default` registered?” —
+  they check miniflare’s on-disk SQLite first and only fall back to a
+  **time-bounded** wrangler call (`scripts/lib-local.sh`).
+- When you must run wrangler yourself, wrap it:  
+  `timeout 20s pnpm --filter @uploads/api exec wrangler kv key get ws:default --binding REGISTRY --local`
+- Never leave bare `wrangler kv|d1 … --local` running in the background. If an
+  agent times out a command, **kill the process group** (`pkill -f 'wrangler.*--local'`
+  only after confirming PIDs), not just the shell wrapper.
+
+See [docs/ops.md](docs/ops.md#local-wrangler-gotchas).
 
 ### Releasing `@buildinternet/uploads` (changesets)
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,35 @@ npx skills add buildinternet/uploads --skill uploads-cli
 
 ## Local development quick start
 
+**Prerequisites:** Node ≥24 and pnpm ≥11 (`corepack enable`; versions pinned in
+`package.json` / `.nvmrc`). No Cloudflare account is required for the core
+local loop — `wrangler dev` simulates R2, KV, and D1 on disk.
+
 ```bash
-pnpm install
-cp apps/api/.dev.vars.example apps/api/.dev.vars
-pnpm workspace:add default --local
-pnpm dev            # API on :8787; pnpm dev:web for the site
+pnpm bootstrap        # one-command setup: tooling, deps, env files, types, local D1, default workspace
+pnpm doctor           # diagnose the setup — reports what's missing and how to fix it
+
+pnpm dev              # API on :8787 (local R2 + KV + D1)
+pnpm dev:web          # Astro site
+pnpm check            # lint + format (CI gate)
+pnpm typecheck        # wrangler types + tsc across workspaces
 ```
 
-Upload a file:
+`bootstrap` is idempotent (safe to re-run; never overwrites your env files or
+re-mints an existing local workspace) and `doctor` is read-only. Prefer the
+manual steps?
+
+```bash
+pnpm install
+cp apps/api/.dev.vars.example apps/api/.dev.vars   # set ADMIN_TOKEN to any non-empty string
+cp .env.example .env                               # point UPLOADS_API_URL at http://localhost:8787
+pnpm types
+pnpm --filter @uploads/api run migrate:d1:local
+pnpm workspace:add default --local                 # prints a bearer token once — save to .env
+pnpm dev
+```
+
+Upload a file (with `UPLOADS_TOKEN` from workspace seed in the environment or `.env`):
 
 ```bash
 curl -X PUT http://localhost:8787/v1/default/files/test.txt \

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -32,12 +32,16 @@ scripts/
 
 ```bash
 pnpm dev                              # wrangler dev (:8787)
-pnpm run deploy                       # D1 migrate + production deploy
+pnpm run migrate:d1:local             # apply migrations to local D1
+pnpm run deploy                       # remote D1 migrate + production deploy
 pnpm types                            # regenerate worker-configuration.d.ts
 pnpm workspace:add <name> --local     # dev KV; shared/agent limits applied by default
 pnpm workspace:add <name> --no-default-limits --local  # unlimited (legacy create)
 pnpm workspace:limits <name> --allowed-prefixes default --max-key-depth 8
 ```
+
+From the monorepo root, prefer `pnpm bootstrap` / `pnpm doctor` for first-time
+setup and troubleshooting (see root README).
 
 After editing `wrangler.jsonc`, run `pnpm types` — `Env` is generated, never hand-written.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "migrate:d1": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js d1 migrations apply DB --remote",
+    "migrate:d1:local": "CI=1 wrangler d1 migrations apply DB --local",
     "deploy": "pnpm run migrate:d1 && node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
     "types": "wrangler types",
     "workspace:add": "node --env-file-if-exists=../../.env scripts/add-workspace.mjs",

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -21,8 +21,10 @@ subdomain.
    ```
 3. Apply enrollment migrations locally during development:
    ```bash
-   pnpm exec wrangler d1 migrations apply uploads-production --local
+   pnpm --filter @uploads/api run migrate:d1:local
+   # equivalent: CI=1 wrangler d1 migrations apply DB --local  (from apps/api)
    ```
+   Or run the full contributor setup from the monorepo root: `pnpm bootstrap`.
 4. Point `bucket_name` in `apps/api/wrangler.jsonc` at your bucket (the
    default binding expects `uploads-default`), or create one with
    `wrangler r2 bucket create`. Same-account buckets get binding-mode I/O;

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -70,6 +70,42 @@ restrictive CSP, and disabled browser permissions. The code lives only in the UR
 fragment—never the query string—so it stays out of server logs and referrers, and the
 page reads it client-side without sending it anywhere.
 
+## Local Wrangler gotchas
+
+`wrangler … --local` starts miniflare against `apps/api/.wrangler/state`. That is
+fine for short interactive use, but:
+
+1. **Agent timeouts orphan the process.** If a coding agent kills only the shell
+   wrapper, the Node/wrangler child reparents to PID 1 and can keep running.
+2. **Hangs can balloon RAM.** A stuck `wrangler kv key get … --local` has been
+   observed past **10–17 GB** while spinning in exception/stack formatting.
+3. **Existence checks do not need wrangler.** Local REGISTRY keys live in
+   miniflare SQLite under
+   `apps/api/.wrangler/state/v3/kv/miniflare-KVNamespaceObject/*.sqlite`
+   (`_mf_entries.key`). `pnpm doctor` / `pnpm bootstrap` use
+   `scripts/lib-local.sh` to read that first, with a **~20s timed** wrangler
+   fallback only when `sqlite3` is missing.
+
+**Do this instead of bare ad-hoc checks:**
+
+```bash
+pnpm doctor                    # “is default registered?”
+# or, if you must call wrangler:
+timeout 20s pnpm --filter @uploads/api exec wrangler kv key get ws:default \
+  --binding REGISTRY --local
+```
+
+**If memory creeps again**, look for orphans first:
+
+```bash
+pgrep -fl 'wrangler.*(kv|d1).*--local'
+# confirm PID, then:
+kill <pid>          # escalate to kill -9 only if needed
+```
+
+Avoid concurrent `wrangler --local` against the same state while one is hung —
+SQLite WAL/SHM files under `.wrangler/state` are what miniflare locks.
+
 ## Secrets
 
 | Secret                           | Purpose                                                               |

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "bootstrap": "bash scripts/bootstrap.sh",
+    "doctor": "bash scripts/doctor.sh",
     "dev": "pnpm run dev:api",
     "dev:api": "pnpm --filter @uploads/api dev",
     "dev:web": "pnpm --filter @uploads/web dev",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# One-command local setup — the whole thing on autopilot, idempotently.
+# Re-running is safe: every step skips what's already done and never overwrites
+# your real env files or re-mints a workspace that already exists.
+#
+# Steps:
+#   1. tooling     — Node ≥24 + corepack (pnpm is pinned via packageManager)
+#   2. install     — pnpm install
+#   3. env files   — scaffold .env / apps/api/.dev.vars from *.example (only if
+#                    absent); mint ADMIN_TOKEN when still empty
+#   4. types       — wrangler types → worker-configuration.d.ts (gitignored)
+#   5. database    — apply local D1 migrations (enrollment, usage, galleries)
+#   6. workspace   — seed the local `default` workspace in REGISTRY KV (once)
+#   7. doctor      — verify the result
+#
+# Usage:
+#   pnpm bootstrap                 # full setup
+#   pnpm bootstrap --skip-db       # tooling + deps + env + types only
+#   pnpm bootstrap --skip-workspace  # skip local workspace seed
+#
+# After it finishes:  pnpm dev   (API on :8787)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+# shellcheck source=lib-local.sh
+. "$ROOT/scripts/lib-local.sh"
+
+SKIP_DB=0
+SKIP_WORKSPACE=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-db) SKIP_DB=1 ;;
+    --skip-workspace) SKIP_WORKSPACE=1 ;;
+    -h | --help)
+      sed -n '3,22p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+step() { printf '\n\033[1m▶ %s\033[0m\n' "$1"; }
+ok() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+add() { printf '  \033[33m+\033[0m %s\n' "$1"; }
+note() { printf '  \033[36mi\033[0m %s\n' "$1"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Copy a committed template to its real path only if the real one is absent.
+scaffold() {
+  local example="$1" real="$2"
+  if [ -f "$real" ]; then
+    ok "$real already exists — left untouched"
+  elif [ -f "$example" ]; then
+    cp "$example" "$real"
+    add "created $real from $(basename "$example")"
+  else
+    note "no template at $example — skipped"
+  fi
+}
+
+# Append KEY=value to a file when KEY is missing or empty.
+ensure_secret() {
+  local file="$1" key="$2" value="$3" comment="$4"
+  if [ ! -f "$file" ]; then
+    return
+  fi
+  if grep -qE "^${key}=.+$" "$file" 2>/dev/null; then
+    ok "$key already set in $(basename "$(dirname "$file")")/$(basename "$file")"
+    return
+  fi
+  # Drop an empty KEY= line so we don't leave a duplicate.
+  if grep -qE "^${key}=$" "$file" 2>/dev/null; then
+    local tmp
+    tmp="$(mktemp)"
+    grep -vE "^${key}=$" "$file" >"$tmp" && mv "$tmp" "$file"
+  fi
+  {
+    printf '\n# Added by scripts/bootstrap.sh — %s\n' "$comment"
+    printf '%s=%s\n' "$key" "$value"
+  } >>"$file"
+  add "minted $key in $file"
+}
+
+echo "uploads — local setup"
+
+# ── 1. tooling ───────────────────────────────────────────────────────────────
+step "Tooling (Node, pnpm)"
+
+if have node; then
+  node_major="$(node -v | sed 's/^v\([0-9]*\).*/\1/')"
+  if [ "$node_major" -ge 24 ]; then
+    ok "node $(node -v) (≥24)"
+  else
+    note "node $(node -v) is below the required ≥24 — install Node 24+ (see .nvmrc)"
+  fi
+else
+  note "node not found — install Node ≥24 (see .nvmrc: $(cat "$ROOT/.nvmrc" 2>/dev/null || echo 24.x))"
+  note "Node is required; aborting the rest of setup until it's on PATH"
+  exit 1
+fi
+
+if have corepack; then
+  corepack enable >/dev/null 2>&1 && ok "corepack enabled (activates the pinned pnpm)" \
+    || note "corepack present but 'corepack enable' needs sudo — run it yourself, then re-run bootstrap"
+else
+  note "corepack not found — install a recent Node (ships corepack) so pnpm is activated from packageManager"
+fi
+
+if have pnpm; then
+  ok "pnpm $(pnpm -v)"
+else
+  note "pnpm not on PATH — try: corepack enable && corepack prepare --activate"
+  note "pnpm is required; aborting"
+  exit 1
+fi
+
+# ── 2. deps ──────────────────────────────────────────────────────────────────
+step "Installing workspace dependencies"
+pnpm install
+
+# ── 3. env files ─────────────────────────────────────────────────────────────
+step "Scaffolding env files (non-destructive)"
+scaffold "$ROOT/.env.example" "$ROOT/.env"
+scaffold "$ROOT/apps/api/.dev.vars.example" "$ROOT/apps/api/.dev.vars"
+
+DEV_VARS="$ROOT/apps/api/.dev.vars"
+if have openssl; then
+  ensure_secret "$DEV_VARS" "ADMIN_TOKEN" "$(openssl rand -base64 32)" \
+    "local admin gate for /admin/* (any non-empty string works)"
+  # Optional encryption key for BYO S3 credentials in REGISTRY — harmless if unused.
+  ensure_secret "$DEV_VARS" "WORKSPACE_SECRETS_KEY" "$(openssl rand -base64 32)" \
+    "local encryption for BYO workspace secrets in REGISTRY KV"
+else
+  note "openssl not found — set ADMIN_TOKEN (and optionally WORKSPACE_SECRETS_KEY) in apps/api/.dev.vars by hand"
+fi
+
+# Point the root client .env at local wrangler if still on the prod defaults.
+ENV_FILE="$ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+  if grep -qE '^UPLOADS_API_URL=https://api\.uploads\.sh/?$' "$ENV_FILE" 2>/dev/null; then
+    tmp="$(mktemp)"
+    sed 's#^UPLOADS_API_URL=https://api\.uploads\.sh/?$#UPLOADS_API_URL=http://localhost:8787#' \
+      "$ENV_FILE" >"$tmp" && mv "$tmp" "$ENV_FILE"
+    add "pointed UPLOADS_API_URL at http://localhost:8787 in .env"
+  elif grep -qE '^UPLOADS_API_URL=http://localhost:8787/?$' "$ENV_FILE" 2>/dev/null; then
+    ok "UPLOADS_API_URL already points at local wrangler"
+  else
+    note "UPLOADS_API_URL is custom — left as-is (set to http://localhost:8787 for local API)"
+  fi
+fi
+
+# ── 4. types ─────────────────────────────────────────────────────────────────
+step "Generating wrangler types (worker-configuration.d.ts)"
+if pnpm types; then
+  ok "types generated for api / mcp / web"
+else
+  note "pnpm types failed — see output above; typecheck/lint may fail until it succeeds"
+fi
+
+# ── 5. local D1 ──────────────────────────────────────────────────────────────
+if [ "$SKIP_DB" = 1 ]; then
+  step "Skipping local D1 migrations (--skip-db)"
+else
+  step "Applying local D1 migrations"
+  if pnpm --filter @uploads/api run migrate:d1:local; then
+    ok "local D1 migrations applied"
+  else
+    note "D1 migrate failed — see output above; 'pnpm doctor' will detail what's missing"
+  fi
+fi
+
+# ── 6. seed workspace ────────────────────────────────────────────────────────
+if [ "$SKIP_WORKSPACE" = 1 ]; then
+  step "Skipping local workspace seed (--skip-workspace)"
+else
+  step "Seeding local workspace (default)"
+  # Prefer miniflare SQLite (instant, no wrangler process). Wrangler --local
+  # boots miniflare and has been seen to hang/orphan when agents time out.
+  already=0
+  if local_registry_has_key "ws:default"; then
+    already=1
+  else
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+      # sqlite3 missing — timed wrangler fallback (bounded so it cannot orphan).
+      existing="$(local_registry_get_via_wrangler "ws:default" 20)"
+      if [ -n "$existing" ] && [ "$existing" != "Value not found" ]; then
+        already=1
+      fi
+    fi
+  fi
+  if [ "$already" -eq 1 ]; then
+    ok "local workspace 'default' already registered — left as-is"
+    note "need a fresh token?  pnpm workspace:add default --local  (prints a new bearer once)"
+  else
+    add "registering local workspace 'default'…"
+    # Capture stdout so we can offer to write UPLOADS_TOKEN into .env.
+    token_out=""
+    if token_out="$(pnpm workspace:add default --local 2>&1)"; then
+      printf '%s\n' "$token_out"
+      ok "workspace 'default' registered in local REGISTRY KV"
+      token="$(printf '%s\n' "$token_out" | sed -n 's/^token     : //p' | head -1)"
+      if [ -n "$token" ] && [ -f "$ENV_FILE" ]; then
+        if grep -qE '^UPLOADS_TOKEN=.+$' "$ENV_FILE" 2>/dev/null; then
+          ok "UPLOADS_TOKEN already set in .env — left untouched (new token printed above)"
+        else
+          if grep -qE '^UPLOADS_TOKEN=$' "$ENV_FILE" 2>/dev/null; then
+            tmp="$(mktemp)"
+            # shellcheck disable=SC2016
+            sed "s#^UPLOADS_TOKEN=\$#UPLOADS_TOKEN=${token}#" "$ENV_FILE" >"$tmp" && mv "$tmp" "$ENV_FILE"
+          else
+            printf '\n# Added by scripts/bootstrap.sh — local workspace bearer (default).\nUPLOADS_TOKEN=%s\n' \
+              "$token" >>"$ENV_FILE"
+          fi
+          add "wrote UPLOADS_TOKEN into .env for local CLI use"
+        fi
+      else
+        note "store the token printed above — only its hash is kept in KV"
+      fi
+    else
+      printf '%s\n' "$token_out"
+      note "workspace seed failed — see output above; re-run: pnpm workspace:add default --local"
+    fi
+  fi
+fi
+
+# ── 7. verify ────────────────────────────────────────────────────────────────
+step "Verifying setup"
+bash "$ROOT/scripts/doctor.sh" || true
+
+cat <<'EOF'
+
+Setup complete. Start the app:
+
+  pnpm dev              # API worker on :8787 (local R2 + KV + D1)
+  pnpm dev:web          # Astro site
+  pnpm uploads put ./shot.png --env-file .env   # monorepo CLI against local API
+
+Run `pnpm check` and `pnpm typecheck` before opening a PR.
+If something looks off later: `pnpm doctor`
+
+EOF

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Diagnose the local dev setup — the read-only inverse of bootstrap.sh.
+#
+# Scans installed tooling, local D1 / REGISTRY KV, and env files, then reports
+# what's present, what's missing, and how to fix each gap. Never installs or
+# mutates anything. Exits non-zero if a REQUIRED check fails (usable as a
+# pre-flight gate).
+#
+#   pnpm doctor           # report
+#   pnpm doctor --strict  # treat warnings as failures too
+set -uo pipefail
+
+STRICT=0
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=1 ;;
+    -h | --help)
+      sed -n '3,11p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=lib-local.sh
+. "$ROOT/scripts/lib-local.sh"
+ERRORS=0
+WARNS=0
+
+c_green=$'\033[32m'
+c_yellow=$'\033[33m'
+c_red=$'\033[31m'
+c_cyan=$'\033[36m'
+c_dim=$'\033[2m'
+c_off=$'\033[0m'
+
+pass() { printf '  %s✓%s %s\n' "$c_green" "$c_off" "$1"; }
+info() { printf '  %si%s %s\n' "$c_cyan" "$c_off" "$1"; }
+# warn <label> <fix>
+warn() {
+  WARNS=$((WARNS + 1))
+  printf '  %s⚠%s %s\n' "$c_yellow" "$c_off" "$1"
+  [ -n "${2:-}" ] && printf '      %s→ %s%s\n' "$c_dim" "$2" "$c_off"
+}
+# fail <label> <fix>
+fail() {
+  ERRORS=$((ERRORS + 1))
+  printf '  %s✗%s %s\n' "$c_red" "$c_off" "$1"
+  [ -n "${2:-}" ] && printf '      %s→ %s%s\n' "$c_dim" "$2" "$c_off"
+}
+have() { command -v "$1" >/dev/null 2>&1; }
+section() { printf '\n%s\n' "$1"; }
+
+echo "uploads — environment doctor"
+
+# ── Runtime ──────────────────────────────────────────────────────────────────
+section "Runtime"
+if have node; then
+  node_major="$(node -v | sed 's/^v\([0-9]*\).*/\1/')"
+  if [ "$node_major" -ge 24 ]; then
+    pass "node $(node -v) (≥24)"
+  else
+    fail "node $(node -v) is below the required ≥24" \
+      "install Node 24+ (see .nvmrc: $(cat "$ROOT/.nvmrc" 2>/dev/null || echo 24.x))"
+  fi
+  if [ -f "$ROOT/.nvmrc" ] && [ "$(node -v | sed 's/^v//')" != "$(cat "$ROOT/.nvmrc")" ]; then
+    info "node $(node -v) differs from pinned .nvmrc ($(cat "$ROOT/.nvmrc")) — fine if major matches"
+  fi
+else
+  fail "node not found" "install Node ≥24, then 'corepack enable'"
+fi
+
+if have pnpm; then
+  pnpm_major="$(pnpm -v | sed 's/\..*//')"
+  if [ "$pnpm_major" -ge 11 ]; then
+    pass "pnpm $(pnpm -v) (≥11)"
+  else
+    fail "pnpm $(pnpm -v) is below the required ≥11" \
+      "corepack enable && corepack prepare --activate"
+  fi
+else
+  fail "pnpm not found" "corepack enable (pnpm is pinned via packageManager)"
+fi
+
+if [ -d "$ROOT/node_modules" ]; then
+  pass "dependencies installed (node_modules present)"
+else
+  fail "dependencies not installed" "pnpm install  (or: pnpm bootstrap)"
+fi
+
+# ── Generated types ──────────────────────────────────────────────────────────
+section "Generated types"
+# worker-configuration.d.ts is gitignored; CI / pre-commit run `pnpm types` first.
+for app in api mcp web; do
+  types_file="$ROOT/apps/$app/worker-configuration.d.ts"
+  if [ -f "$types_file" ]; then
+    pass "apps/$app/worker-configuration.d.ts present"
+  else
+    warn "apps/$app/worker-configuration.d.ts missing — type-aware lint/typecheck need it" \
+      "pnpm types  (or: pnpm bootstrap)"
+  fi
+done
+
+# ── Local D1 ─────────────────────────────────────────────────────────────────
+section "Local D1 database"
+D1_STATE="$ROOT/apps/api/.wrangler/state/v3/d1"
+if [ -d "$D1_STATE" ]; then
+  pass "local D1 state present (apps/api/.wrangler/state/v3/d1)"
+else
+  warn "local D1 not built yet — enrollment / usage / gallery routes need migrations" \
+    "pnpm --filter @uploads/api run migrate:d1:local  (or: pnpm bootstrap)"
+fi
+
+# Best-effort pending-migration check (needs deps; skip if wrangler unavailable).
+# Always time-bound: unbounded wrangler --local has orphaned multi-GB processes.
+if [ -d "$ROOT/apps/api/node_modules/wrangler" ] || [ -d "$ROOT/node_modules/wrangler" ]; then
+  mig_out="$(
+    run_with_timeout 30 pnpm --filter @uploads/api exec wrangler d1 migrations list DB --local 2>/dev/null || true
+  )"
+  if printf '%s\n' "$mig_out" | grep -qiE 'No migrations.*(to apply|pending|waiting)'; then
+    pass "no pending local D1 migrations"
+  elif printf '%s\n' "$mig_out" | grep -qE 'Migrations to be applied|┌─'; then
+    warn "local D1 has pending migrations" \
+      "pnpm --filter @uploads/api run migrate:d1:local"
+  else
+    info "could not parse 'wrangler d1 migrations list' — skip if migrate:d1:local already ran"
+  fi
+fi
+
+# ── Local workspace registry ─────────────────────────────────────────────────
+section "Local workspace (REGISTRY KV)"
+# Prefer miniflare SQLite over `wrangler kv key get --local` (see scripts/lib-local.sh).
+if local_registry_has_key "ws:default"; then
+  pass "local workspace 'default' registered in REGISTRY KV"
+else
+  rc=$?
+  if [ "$rc" -eq 2 ] && { [ -d "$ROOT/apps/api/node_modules/wrangler" ] || [ -d "$ROOT/node_modules/wrangler" ]; }; then
+    ws_out="$(local_registry_get_via_wrangler "ws:default" 20)"
+    if [ -n "$ws_out" ] && [ "$ws_out" != "Value not found" ] && printf '%s' "$ws_out" | grep -q '{'; then
+      pass "local workspace 'default' registered in REGISTRY KV"
+    else
+      warn "local workspace 'default' not found — authenticated routes return 401" \
+        "pnpm workspace:add default --local  (or: pnpm bootstrap)"
+    fi
+  elif [ -d "$ROOT/apps/api/.wrangler/state/v3/kv" ] || [ -d "$ROOT/apps/api/node_modules/wrangler" ] || [ -d "$ROOT/node_modules/wrangler" ]; then
+    warn "local workspace 'default' not found — authenticated routes return 401" \
+      "pnpm workspace:add default --local  (or: pnpm bootstrap)"
+  else
+    info "local REGISTRY state not built yet — skip after 'pnpm bootstrap' / workspace:add --local"
+  fi
+fi
+
+# ── Env files ────────────────────────────────────────────────────────────────
+section "Env files"
+API_DEV_VARS="$ROOT/apps/api/.dev.vars"
+if [ -f "$API_DEV_VARS" ]; then
+  pass "apps/api/.dev.vars present"
+  if grep -qE '^ADMIN_TOKEN=.+$' "$API_DEV_VARS"; then
+    pass "ADMIN_TOKEN is set (gates /admin/* locally)"
+  else
+    warn "ADMIN_TOKEN is empty — local /admin/* rejects every request" \
+      "set any non-empty string in apps/api/.dev.vars  (or: pnpm bootstrap)"
+  fi
+  if grep -qE '^WORKSPACE_SECRETS_KEY=.+$' "$API_DEV_VARS"; then
+    pass "WORKSPACE_SECRETS_KEY is set (BYO secret encryption)"
+  else
+    info "WORKSPACE_SECRETS_KEY unset — only needed for encrypted BYO S3 credentials"
+  fi
+else
+  warn "apps/api/.dev.vars missing — wrangler will not load local secrets" \
+    "cp apps/api/.dev.vars.example apps/api/.dev.vars  (or: pnpm bootstrap)"
+fi
+
+if [ -f "$ROOT/.env" ]; then
+  pass "root .env present (CLI + optional deploy credentials)"
+  if grep -qE '^UPLOADS_API_URL=http://localhost:8787/?$' "$ROOT/.env"; then
+    pass "UPLOADS_API_URL points at local wrangler (:8787)"
+  elif grep -qE '^UPLOADS_API_URL=.+$' "$ROOT/.env"; then
+    info "UPLOADS_API_URL is not localhost — fine for talking to prod; use http://localhost:8787 for local API"
+  else
+    warn "UPLOADS_API_URL unset in .env" "set UPLOADS_API_URL=http://localhost:8787 for local CLI"
+  fi
+  if grep -qE '^UPLOADS_TOKEN=.+$' "$ROOT/.env"; then
+    pass "UPLOADS_TOKEN is set (CLI can authenticate)"
+  else
+    warn "UPLOADS_TOKEN empty — 'pnpm uploads put' / curl need a workspace bearer" \
+      "pnpm workspace:add default --local  (prints token once) then paste into .env"
+  fi
+else
+  info "root .env absent — optional for pure API work; needed for monorepo CLI + headless deploy"
+fi
+
+# ── Optional deploy credentials ──────────────────────────────────────────────
+section "Deploy credentials (optional)"
+env_has() { [ -f "$ROOT/.env" ] && grep -qE "^$1=.+" "$ROOT/.env" 2>/dev/null; }
+for key in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN; do
+  if [ -n "${!key:-}" ] || env_has "$key"; then
+    pass "$key set"
+  else
+    info "$key not set — only needed for 'pnpm deploy' / remote D1 without 'wrangler login'"
+  fi
+done
+for key in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+  if [ -n "${!key:-}" ] || env_has "$key"; then
+    pass "$key set"
+  else
+    info "$key not set — only needed for HTTP-mode / real-bucket dev workspaces"
+  fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+section "Summary"
+if [ "$ERRORS" -gt 0 ]; then
+  printf '  %s%s error(s)%s, %s warning(s) — fix the ✗ items above\n' "$c_red" "$ERRORS" "$c_off" "$WARNS"
+  exit 1
+elif [ "$WARNS" -gt 0 ]; then
+  printf '  0 errors, %s%s warning(s)%s\n' "$c_yellow" "$WARNS" "$c_off"
+  [ "$STRICT" = 1 ] && exit 1
+  exit 0
+else
+  printf '  %sall checks passed%s — run `pnpm check` before opening a PR\n' "$c_green" "$c_off"
+  exit 0
+fi

--- a/scripts/lib-local.sh
+++ b/scripts/lib-local.sh
@@ -1,0 +1,62 @@
+# Shared helpers for bootstrap/doctor — keep local checks cheap and bounded.
+# Sourced by other scripts; not executable on its own.
+#
+# Why this exists: `wrangler kv key get … --local` boots miniflare and has been
+# observed to orphan + balloon to multi-GB when the parent shell/agent dies or
+# the process hangs in an error path. Prefer reading miniflare's on-disk SQLite
+# for existence checks; when wrangler must run, always wrap it with a timeout.
+
+# run_with_timeout SECONDS CMD [ARGS…]
+# Prefer GNU coreutils `timeout` / `gtimeout`; fall back to perl alarm.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --kill-after=5s "${secs}s" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout --kill-after=5s "${secs}s" "$@"
+  else
+    perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
+  fi
+}
+
+# local_registry_has_key KEY
+# True if miniflare local REGISTRY KV has KEY (e.g. ws:default).
+# Exit 0 = present, 1 = absent / no state, 2 = sqlite3 missing (caller may
+# fall back to a timed wrangler get).
+# Expects ROOT to point at the monorepo root.
+local_registry_has_key() {
+  local key="$1"
+  local dir="${ROOT}/apps/api/.wrangler/state/v3/kv/miniflare-KVNamespaceObject"
+  local db
+  if [ ! -d "$dir" ]; then
+    return 1
+  fi
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    return 2
+  fi
+  # key is a fixed workspace id from our scripts — quote for SQL safety anyway.
+  local qkey
+  qkey=$(printf "%s" "$key" | sed "s/'/''/g")
+  for db in "$dir"/*.sqlite; do
+    [ -f "$db" ] || continue
+    case "$(basename "$db")" in
+      metadata.sqlite) continue ;;
+    esac
+    if [ "$(sqlite3 "$db" "SELECT 1 FROM _mf_entries WHERE key = '${qkey}' LIMIT 1;" 2>/dev/null)" = "1" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# local_registry_get_via_wrangler KEY
+# Timed wrangler fallback when SQLite is unavailable. Caps wall time so agent
+# timeouts cannot leave a multi-GB orphan behind.
+local_registry_get_via_wrangler() {
+  local key="$1"
+  local secs="${2:-20}"
+  run_with_timeout "$secs" \
+    pnpm --filter @uploads/api exec wrangler kv key get "$key" \
+    --binding REGISTRY --local 2>/dev/null || true
+}


### PR DESCRIPTION
## In plain terms

Contributors can get a working local environment with one command, and diagnose broken setups without guessing. `pnpm bootstrap` wires tooling, env files, types, local D1, and a `default` workspace; `pnpm doctor` is a read-only checklist that says what is missing and how to fix it.

## What it does

- Adds `pnpm bootstrap` / `pnpm doctor` (same idea as either/releases)
- Scaffolds `.env` + `apps/api/.dev.vars` only when absent; mints empty `ADMIN_TOKEN` / `WORKSPACE_SECRETS_KEY`; points local `UPLOADS_API_URL` when still on prod defaults
- Generates wrangler types, applies local D1 migrations (`migrate:d1:local`), seeds local `default` workspace once
- Checks miniflare REGISTRY SQLite first (with a time-bounded wrangler fallback) so agent/local probes do not hang or balloon RAM
- Documents the flow in README / AGENTS / deploy / ops

## What it is not

- Not a deploy or production change
- Does not overwrite existing env files or re-mint an existing local workspace
- No CodeRabbit request (docs + scripts only)

## How to try it

```bash
pnpm bootstrap
pnpm doctor
pnpm dev
```

Flags: `--skip-db`, `--skip-workspace` on bootstrap; `--strict` on doctor.

## Test plan

- [x] `pnpm doctor` runs and reports runtime / env / D1 / workspace status
- [x] `pnpm bootstrap --skip-db --skip-workspace` is idempotent on an already-set-up machine
- [x] `pnpm --filter @uploads/api run migrate:d1:local` applies pending migrations non-interactively
- [ ] Fresh clone (or clean env) path: bootstrap end-to-end, then hit local API with the minted token