### PR TITLE
fix: bound remaining local wrangler CLIs against orphan hangs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ path. Prefer:
 - **`pnpm doctor` / `pnpm bootstrap`** for “is local `default` registered?” —
   they check miniflare’s on-disk SQLite first and only fall back to a
   **time-bounded** wrangler call (`scripts/lib-local.sh`).
+- **`pnpm workspace:add` / `workspace:limits` / `migrate:d1:local`** go through
+  `apps/api/scripts/run-timed.mjs` (local get/put ~30–60s, D1 migrate 60s).
+  Do not reimplement bare `execFileSync(wrangler … --local)`.
 - When you must run wrangler yourself, wrap it:  
   `timeout 20s pnpm --filter @uploads/api exec wrangler kv key get ws:default --binding REGISTRY --local`
 - Never leave bare `wrangler kv|d1 … --local` running in the background. If an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,8 @@ path. Prefer:
 - **`pnpm workspace:add` / `workspace:limits` / `migrate:d1:local`** go through
   `apps/api/scripts/run-timed.mjs` (local get/put ~30–60s, D1 migrate 60s).
   Do not reimplement bare `execFileSync(wrangler … --local)`.
-- When you must run wrangler yourself, wrap it:  
-  `timeout 20s pnpm --filter @uploads/api exec wrangler kv key get ws:default --binding REGISTRY --local`
+- When you must run wrangler yourself, wrap it in the timed runner:  
+  `node apps/api/scripts/run-timed.mjs 20 -- pnpm --filter @uploads/api exec wrangler kv key get ws:default --binding REGISTRY --local`
 - Never leave bare `wrangler kv|d1 … --local` running in the background. If an
   agent times out a command, **kill the process group** (`pkill -f 'wrangler.*--local'`
   only after confirming PIDs), not just the shell wrapper.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "migrate:d1": "node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js d1 migrations apply DB --remote",
-    "migrate:d1:local": "CI=1 wrangler d1 migrations apply DB --local",
+    "migrate:d1:local": "CI=1 node scripts/run-timed.mjs 60 -- wrangler d1 migrations apply DB --local",
     "deploy": "pnpm run migrate:d1 && node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
     "types": "wrangler types",
     "workspace:add": "node --env-file-if-exists=../../.env scripts/add-workspace.mjs",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,6 +38,6 @@
     "@types/node": "^26.1.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",
-    "wrangler": "^4.107.0"
+    "wrangler": "^4.110.0"
   }
 }

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -232,13 +232,25 @@ const appliedLimits = {
 };
 
 // Bound wall-clock: local miniflare can hang/orphan multi-GB after agent timeouts.
-wranglerKvKey({
-  op: "put",
-  key: `ws:${name}`,
-  value: JSON.stringify(record),
-  local: opts.local,
-  stdio: "inherit",
-});
+try {
+  wranglerKvKey({
+    op: "put",
+    key: `ws:${name}`,
+    value: JSON.stringify(record),
+    local: opts.local,
+    stdio: "inherit",
+  });
+} catch (err) {
+  if (err?.timedOut) {
+    console.error(
+      `error: wrangler kv put timed out for ws:${name} (${opts.local ? "local" : "remote"}) — ` +
+        `workspace NOT saved; kill orphaned wrangler if memory is climbing ` +
+        `(see docs/ops.md#local-wrangler-gotchas)`,
+    );
+    process.exit(1);
+  }
+  throw err;
+}
 
 console.log(`\nworkspace : ${name}${opts.local ? " (local)" : ""}`);
 console.log(`token     : ${token}`);

--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -31,8 +31,8 @@
  * Env fallbacks apply ONLY in BYO mode — shared-mode records never inherit
  * BYO-bucket credentials from the environment.
  */
-import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
+import { wranglerKvKey } from "./run-timed.mjs";
 import { sharedAgentLimitFields } from "./workspace-limit-defaults.mjs";
 
 /** Match apps/api/src/secrets.ts: enc:v1: + base64url(iv || ct || tag). */
@@ -231,22 +231,14 @@ const appliedLimits = {
   maxKeyDepth: record.maxKeyDepth,
 };
 
-execFileSync(
-  "pnpm",
-  [
-    "exec",
-    "wrangler",
-    "kv",
-    "key",
-    "put",
-    `ws:${name}`,
-    JSON.stringify(record),
-    "--binding",
-    "REGISTRY",
-    opts.local ? "--local" : "--remote",
-  ],
-  { stdio: "inherit" },
-);
+// Bound wall-clock: local miniflare can hang/orphan multi-GB after agent timeouts.
+wranglerKvKey({
+  op: "put",
+  key: `ws:${name}`,
+  value: JSON.stringify(record),
+  local: opts.local,
+  stdio: "inherit",
+});
 
 console.log(`\nworkspace : ${name}${opts.local ? " (local)" : ""}`);
 console.log(`token     : ${token}`);

--- a/apps/api/scripts/run-timed.mjs
+++ b/apps/api/scripts/run-timed.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Run a command with a wall-clock bound so hung wrangler/miniflare children
+ * cannot orphan and balloon RAM after an agent/shell dies.
+ *
+ * Usage:
+ *   node scripts/run-timed.mjs <seconds> -- <cmd> [args…]
+ *
+ * Library:
+ *   import { runTimed, wranglerKvKey } from "./run-timed.mjs";
+ *
+ * Prefers GNU `timeout` / `gtimeout` (kills the process group). Falls back to
+ * Node's spawnSync timeout + SIGKILL.
+ *
+ * Exit codes (CLI): command's status, or 124 on timeout (GNU timeout convention).
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {{
+ *   timeoutSec: number;
+ *   stdio?: "inherit" | "pipe";
+ *   encoding?: BufferEncoding;
+ *   env?: NodeJS.ProcessEnv;
+ *   cwd?: string;
+ * }} opts
+ */
+export function runTimed(cmd, args, opts) {
+  const { timeoutSec, stdio = "pipe", encoding = "utf8", env, cwd } = opts;
+  const timeoutBin = findTimeoutBin();
+
+  if (timeoutBin) {
+    const r = spawnSync(timeoutBin, ["--kill-after=5s", `${timeoutSec}s`, cmd, ...args], {
+      stdio,
+      encoding: stdio === "inherit" ? undefined : encoding,
+      env: env ?? process.env,
+      cwd,
+    });
+    // GNU timeout exits 124 when the deadline fires.
+    const timedOut = r.status === 124;
+    return {
+      status: r.status,
+      signal: r.signal,
+      stdout: r.stdout,
+      stderr: r.stderr,
+      error: r.error,
+      timedOut,
+    };
+  }
+
+  const r = spawnSync(cmd, args, {
+    stdio,
+    encoding: stdio === "inherit" ? undefined : encoding,
+    env: env ?? process.env,
+    cwd,
+    timeout: Math.round(timeoutSec * 1000),
+    killSignal: "SIGKILL",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const timedOut = r.error?.code === "ETIMEDOUT";
+  return {
+    status: timedOut ? 124 : r.status,
+    signal: r.signal,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    error: timedOut ? null : r.error,
+    timedOut,
+  };
+}
+
+/**
+ * Bound wrangler REGISTRY KV get/put. Local miniflare boots get short caps;
+ * remote keeps a longer ceiling so slow network does not false-timeout.
+ *
+ * @param {{
+ *   op: "get" | "put";
+ *   key: string;
+ *   value?: string;
+ *   local: boolean;
+ *   binding?: string;
+ *   timeoutSec?: number;
+ *   stdio?: "inherit" | "pipe";
+ * }} opts
+ */
+export function wranglerKvKey(opts) {
+  const { op, key, value, local, binding = "REGISTRY", stdio = "pipe" } = opts;
+  const timeoutSec = opts.timeoutSec ?? (local ? (op === "get" ? 30 : 60) : 120);
+
+  const args = ["exec", "wrangler", "kv", "key", op, key];
+  if (op === "put") {
+    if (value === undefined) throw new Error("wranglerKvKey put requires value");
+    args.push(value);
+  }
+  args.push("--binding", binding, local ? "--local" : "--remote");
+
+  const result = runTimed("pnpm", args, {
+    timeoutSec,
+    stdio,
+    encoding: "utf8",
+  });
+
+  if (result.timedOut) {
+    throw new Error(
+      `wrangler kv key ${op} timed out after ${timeoutSec}s (${local ? "local" : "remote"})`,
+    );
+  }
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const detail = result.stderr != null ? String(result.stderr).trim() : "";
+    const err = new Error(
+      `wrangler kv key ${op} exited ${result.status}${detail ? `: ${detail}` : ""}`,
+    );
+    /** @type {Error & { status?: number | null; stdout?: string; stderr?: string }} */
+    const e = err;
+    e.status = result.status;
+    e.stdout = result.stdout != null ? String(result.stdout) : "";
+    e.stderr = result.stderr != null ? String(result.stderr) : "";
+    throw e;
+  }
+
+  return result.stdout != null ? String(result.stdout) : "";
+}
+
+function findTimeoutBin() {
+  const names = ["timeout", "gtimeout"];
+  const pathEnv = process.env.PATH ?? "";
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  for (const candidate of [
+    "/opt/homebrew/bin/timeout",
+    "/opt/homebrew/bin/gtimeout",
+    "/usr/local/bin/timeout",
+    "/usr/local/bin/gtimeout",
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const sep = argv.indexOf("--");
+  if (sep < 1 || sep === argv.length - 1) {
+    console.error("usage: node scripts/run-timed.mjs <seconds> -- <cmd> [args…]");
+    process.exit(2);
+  }
+
+  const seconds = Number(argv[0]);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    console.error(`invalid timeout seconds: ${argv[0]}`);
+    process.exit(2);
+  }
+
+  const cmd = argv[sep + 1];
+  const args = argv.slice(sep + 2);
+
+  const result = runTimed(cmd, args, { timeoutSec: seconds, stdio: "inherit" });
+  if (result.timedOut) {
+    console.error(`[run-timed] killed after ${seconds}s: ${cmd} ${args.join(" ")}`.trim());
+    process.exit(124);
+  }
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+  process.exit(result.status === null ? 1 : result.status);
+}
+
+const isCli =
+  Boolean(process.argv[1]) && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isCli) {
+  main();
+}

--- a/apps/api/scripts/run-timed.mjs
+++ b/apps/api/scripts/run-timed.mjs
@@ -9,16 +9,19 @@
  * Library:
  *   import { runTimed, wranglerKvKey } from "./run-timed.mjs";
  *
- * Prefers GNU `timeout` / `gtimeout` (kills the process group). Falls back to
- * Node's spawnSync timeout + SIGKILL.
+ * Prefers GNU/BSD `timeout` / `gtimeout` (kills the process group). Falls back
+ * to a detached spawn where the child leads its own process group and the whole
+ * group gets SIGTERM, then SIGKILL after 5s — a plain child-only SIGKILL would
+ * orphan wrangler/miniflare grandchildren, the exact failure this guards against.
  *
  * Exit codes (CLI): command's status, or 124 on timeout (GNU timeout convention).
  */
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { delimiter, join } from "node:path";
-import { resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+const SELF_PATH = fileURLToPath(import.meta.url);
 
 /**
  * @param {string} cmd
@@ -54,24 +57,79 @@ export function runTimed(cmd, args, opts) {
     };
   }
 
-  const r = spawnSync(cmd, args, {
+  // No timeout binary: re-invoke this script's CLI, which does a detached
+  // process-group spawn + kill(-pgid). spawnSync's own `timeout` option only
+  // SIGKILLs the direct child, orphaning wrangler/miniflare grandchildren.
+  const r = spawnSync(process.execPath, [SELF_PATH, String(timeoutSec), "--", cmd, ...args], {
     stdio,
     encoding: stdio === "inherit" ? undefined : encoding,
     env: env ?? process.env,
     cwd,
-    timeout: Math.round(timeoutSec * 1000),
-    killSignal: "SIGKILL",
     maxBuffer: 20 * 1024 * 1024,
   });
-  const timedOut = r.error?.code === "ETIMEDOUT";
+  const timedOut = r.status === 124;
   return {
-    status: timedOut ? 124 : r.status,
+    status: r.status,
     signal: r.signal,
     stdout: r.stdout,
     stderr: r.stderr,
-    error: timedOut ? null : r.error,
+    error: r.error,
     timedOut,
   };
+}
+
+/**
+ * Async fallback used by the CLI when no `timeout` binary exists. The child is
+ * detached so it leads its own process group; on deadline the whole group gets
+ * SIGTERM, then SIGKILL after a 5s grace, so grandchildren die too. Parent
+ * SIGINT/SIGTERM are forwarded to the group (detached children don't share the
+ * terminal's foreground group, so Ctrl-C wouldn't reach them otherwise).
+ *
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {{ timeoutSec: number }} opts
+ */
+async function runDetachedGroup(cmd, args, { timeoutSec }) {
+  const child = spawn(cmd, args, {
+    stdio: "inherit",
+    detached: true,
+    env: process.env,
+  });
+
+  const killGroup = (signal) => {
+    try {
+      process.kill(-child.pid, signal);
+    } catch {
+      // group already gone
+    }
+  };
+
+  let timedOut = false;
+  const timer = setTimeout(
+    () => {
+      timedOut = true;
+      killGroup("SIGTERM");
+      setTimeout(() => killGroup("SIGKILL"), 5000).unref();
+    },
+    Math.round(timeoutSec * 1000),
+  );
+  timer.unref();
+
+  const forward = (signal) => () => killGroup(signal);
+  const onInt = forward("SIGINT");
+  const onTerm = forward("SIGTERM");
+  process.on("SIGINT", onInt);
+  process.on("SIGTERM", onTerm);
+
+  const [status, signal] = await new Promise((res) => {
+    child.on("error", () => res([1, null]));
+    child.on("exit", (code, sig) => res([code, sig]));
+  });
+
+  clearTimeout(timer);
+  process.off("SIGINT", onInt);
+  process.off("SIGTERM", onTerm);
+  return { status, signal, timedOut };
 }
 
 /**
@@ -130,6 +188,11 @@ export function wranglerKvKey(opts) {
 }
 
 function findTimeoutBin() {
+  // Windows' System32\timeout.exe is a wait command, not a killer; and the
+  // escape hatch lets tests exercise the detached-group fallback.
+  if (process.platform === "win32" || process.env.RUN_TIMED_FORCE_FALLBACK) {
+    return null;
+  }
   const names = ["timeout", "gtimeout"];
   const pathEnv = process.env.PATH ?? "";
   for (const dir of pathEnv.split(delimiter)) {
@@ -150,7 +213,7 @@ function findTimeoutBin() {
   return null;
 }
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   const sep = argv.indexOf("--");
   if (sep < 1 || sep === argv.length - 1) {
@@ -167,7 +230,9 @@ function main() {
   const cmd = argv[sep + 1];
   const args = argv.slice(sep + 2);
 
-  const result = runTimed(cmd, args, { timeoutSec: seconds, stdio: "inherit" });
+  const result = findTimeoutBin()
+    ? runTimed(cmd, args, { timeoutSec: seconds, stdio: "inherit" })
+    : await runDetachedGroup(cmd, args, { timeoutSec: seconds });
   if (result.timedOut) {
     console.error(`[run-timed] killed after ${seconds}s: ${cmd} ${args.join(" ")}`.trim());
     process.exit(124);
@@ -179,8 +244,7 @@ function main() {
   process.exit(result.status === null ? 1 : result.status);
 }
 
-const isCli =
-  Boolean(process.argv[1]) && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const isCli = Boolean(process.argv[1]) && resolve(process.argv[1]) === SELF_PATH;
 if (isCli) {
-  main();
+  await main();
 }

--- a/apps/api/scripts/run-timed.mjs
+++ b/apps/api/scripts/run-timed.mjs
@@ -44,9 +44,10 @@ export function runTimed(cmd, args, opts) {
       encoding: stdio === "inherit" ? undefined : encoding,
       env: env ?? process.env,
       cwd,
+      maxBuffer: 20 * 1024 * 1024,
     });
-    // GNU timeout exits 124 when the deadline fires.
-    const timedOut = r.status === 124;
+    // GNU timeout exits 124 on deadline, 137 (128+9) when --kill-after escalates to SIGKILL.
+    const timedOut = r.status === 124 || r.status === 137;
     return {
       status: r.status,
       signal: r.signal,
@@ -98,7 +99,12 @@ async function runDetachedGroup(cmd, args, { timeoutSec }) {
 
   const killGroup = (signal) => {
     try {
-      process.kill(-child.pid, signal);
+      if (process.platform === "win32") {
+        // No Unix process groups on Windows; taskkill /T kills the whole tree.
+        spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      } else {
+        process.kill(-child.pid, signal);
+      }
     } catch {
       // group already gone
     }
@@ -123,7 +129,13 @@ async function runDetachedGroup(cmd, args, { timeoutSec }) {
 
   const [status, signal] = await new Promise((res) => {
     child.on("error", () => res([1, null]));
-    child.on("exit", (code, sig) => res([code, sig]));
+    child.on("exit", (code, sig) => {
+      // On the timeout path the child may die from SIGTERM while grandchildren
+      // linger, and the unref'd SIGKILL timer would die with this process —
+      // force-kill any group stragglers before resolving.
+      if (timedOut) killGroup("SIGKILL");
+      res([code, sig]);
+    });
   });
 
   clearTimeout(timer);
@@ -164,9 +176,12 @@ export function wranglerKvKey(opts) {
   });
 
   if (result.timedOut) {
-    throw new Error(
+    /** @type {Error & { timedOut?: boolean }} */
+    const err = new Error(
       `wrangler kv key ${op} timed out after ${timeoutSec}s (${local ? "local" : "remote"})`,
     );
+    err.timedOut = true;
+    throw err;
   }
   if (result.error) {
     throw result.error;

--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -26,7 +26,7 @@
  * Show current limits only:
  *   node scripts/set-workspace-limits.mjs <name> [--local]
  */
-import { execFileSync } from "node:child_process";
+import { wranglerKvKey } from "./run-timed.mjs";
 
 const [name, ...rest] = process.argv.slice(2);
 const opts = { local: false };
@@ -136,27 +136,27 @@ function parseAllowedPrefixes(raw, label) {
 }
 
 function wranglerKv(args) {
-  return execFileSync(
-    "pnpm",
-    [
-      "exec",
-      "wrangler",
-      "kv",
-      "key",
-      ...args,
-      "--binding",
-      "REGISTRY",
-      opts.local ? "--local" : "--remote",
-    ],
-    { encoding: "utf8" },
-  );
+  const [op, key, value] = args;
+  return wranglerKvKey({
+    op,
+    key,
+    value,
+    local: opts.local,
+  });
 }
 
 const key = `ws:${name}`;
 let raw;
 try {
   raw = wranglerKv(["get", key]);
-} catch {
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("timed out")) {
+    fail(
+      `wrangler kv get timed out for ${key} (${opts.local ? "local" : "remote"}) — ` +
+        `kill orphaned wrangler if memory is climbing (see docs/ops.md#local-wrangler-gotchas)`,
+    );
+  }
   fail(`workspace not found in REGISTRY: ${key} (${opts.local ? "local" : "remote"})`);
 }
 

--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -237,7 +237,19 @@ for (const [field, value] of Object.entries(patch)) {
   else record[field] = value;
 }
 
-wranglerKv(["put", key, JSON.stringify(record)]);
+try {
+  wranglerKv(["put", key, JSON.stringify(record)]);
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes("timed out")) {
+    fail(
+      `wrangler kv put timed out for ${key} (${opts.local ? "local" : "remote"}) — ` +
+        `limits NOT saved; kill orphaned wrangler if memory is climbing ` +
+        `(see docs/ops.md#local-wrangler-gotchas)`,
+    );
+  }
+  fail(`wrangler kv put failed for ${key}: ${msg}`);
+}
 
 const after = {
   maxStorageBytes: record.maxStorageBytes,

--- a/apps/api/scripts/set-workspace-limits.mjs
+++ b/apps/api/scripts/set-workspace-limits.mjs
@@ -150,8 +150,7 @@ let raw;
 try {
   raw = wranglerKv(["get", key]);
 } catch (err) {
-  const msg = err instanceof Error ? err.message : String(err);
-  if (msg.includes("timed out")) {
+  if (err?.timedOut) {
     fail(
       `wrangler kv get timed out for ${key} (${opts.local ? "local" : "remote"}) — ` +
         `kill orphaned wrangler if memory is climbing (see docs/ops.md#local-wrangler-gotchas)`,
@@ -240,15 +239,14 @@ for (const [field, value] of Object.entries(patch)) {
 try {
   wranglerKv(["put", key, JSON.stringify(record)]);
 } catch (err) {
-  const msg = err instanceof Error ? err.message : String(err);
-  if (msg.includes("timed out")) {
+  if (err?.timedOut) {
     fail(
       `wrangler kv put timed out for ${key} (${opts.local ? "local" : "remote"}) — ` +
         `limits NOT saved; kill orphaned wrangler if memory is climbing ` +
         `(see docs/ops.md#local-wrangler-gotchas)`,
     );
   }
-  fail(`wrangler kv put failed for ${key}: ${msg}`);
+  fail(`wrangler kv put failed for ${key}: ${err instanceof Error ? err.message : String(err)}`);
 }
 
 const after = {

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -90,10 +90,15 @@ fine for short interactive use, but:
 
 ```bash
 pnpm doctor                    # “is default registered?”
-# or, if you must call wrangler:
+pnpm workspace:limits default --local   # already time-bounded
+pnpm --filter @uploads/api run migrate:d1:local   # 60s cap via run-timed.mjs
+# or, if you must call wrangler by hand:
 timeout 20s pnpm --filter @uploads/api exec wrangler kv key get ws:default \
   --binding REGISTRY --local
 ```
+
+Workspace scripts (`workspace:add`, `workspace:limits`) and local D1 migrate
+use `apps/api/scripts/run-timed.mjs` so a hung miniflare cannot run forever.
 
 **If memory creeps again**, look for orphans first:
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -92,8 +92,9 @@ fine for short interactive use, but:
 pnpm doctor                    # “is default registered?”
 pnpm workspace:limits default --local   # already time-bounded
 pnpm --filter @uploads/api run migrate:d1:local   # 60s cap via run-timed.mjs
-# or, if you must call wrangler by hand:
-timeout 20s pnpm --filter @uploads/api exec wrangler kv key get ws:default \
+# or, if you must call wrangler by hand (group-kills hung miniflare on deadline):
+node apps/api/scripts/run-timed.mjs 20 -- \
+  pnpm --filter @uploads/api exec wrangler kv key get ws:default \
   --binding REGISTRY --local
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
       wrangler:
-        specifier: ^4.107.0
-        version: 4.107.0
+        specifier: ^4.110.0
+        version: 4.110.0
 
   apps/mcp:
     dependencies:


### PR DESCRIPTION
## In plain terms

Local `wrangler … --local` boots miniflare. When an agent or shell times out and only kills the wrapper, the Node child can reparent and hang — we have seen multi‑GB RSS from a stuck `kv key get`. Bootstrap/doctor already avoid unbounded existence checks; this PR bounds the **remaining scripted** paths that still shell out to wrangler.

## What it does

- Adds `apps/api/scripts/run-timed.mjs` (GNU `timeout`/`gtimeout` preferred, Node spawn timeout fallback).
- Routes `workspace:add` / `workspace:limits` KV put/get through timed helpers (local ~30–60s, remote 120s).
- Caps `migrate:d1:local` at 60s via the same runner.
- Documents the operator path in AGENTS.md and docs/ops.md.

## What it is not

- Not a Cloudflare config change — Wrangler has no built-in wall-clock flag for one-shot `kv`/`d1` CLIs (skills + docs confirm this is process hygiene, not a wrangler.jsonc knob).
- Does not replace intentional long-lived `wrangler dev`.
- Does not change remote API behavior beyond a generous 120s ceiling on scripted KV ops.

## How to try it

```bash
# should complete quickly under the 60s cap
pnpm --filter @uploads/api run migrate:d1:local

# read-only limits dump via timed local get
pnpm workspace:limits default --local

# timeout path (expect exit 124)
node apps/api/scripts/run-timed.mjs 1 -- sleep 5
```

## Technical notes

- Prefer process-group kill via `timeout --kill-after=5s` so miniflare grandchildren die with the wrapper.
- Doctor/bootstrap still use SQLite-first registry checks (`scripts/lib-local.sh`) for existence.
- Sibling tracking: [releases#2121](https://github.com/buildinternet/releases/issues/2121), [room-configurator#333](https://github.com/buildinternet/room-configurator/issues/333), [either#794](https://github.com/buildinternet/either/issues/794).

## Test plan

- [x] `run-timed.mjs 5 -- echo ok` → 0
- [x] `run-timed.mjs 1 -- sleep 5` → 124
- [x] `workspace:limits default --local` succeeds
- [x] `migrate:d1:local` succeeds under wrapper
- [x] no leftover `wrangler.*(kv|d1).*--local` after runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of local workspace management and D1 migrations by enforcing time-bounded execution to prevent hung local processes.
  * Added clearer, more specific messaging when local operations time out or fail to persist changes.
  * Improved robustness of local KV read/write operations used during workspace setup and limits updates.
* **Documentation**
  * Expanded local operations runbook guidance with recommended timed/guarded workflows for workspace limits and database migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->