### PR TITLE
feat: show linked galleries in managed GitHub comments

### DIFF
--- a/.changeset/gallery-aware-github-comments.md
+++ b/.changeset/gallery-aware-github-comments.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Show public galleries linked to a GitHub PR or issue in the existing managed attachments comment, alongside legacy loose attachments.

--- a/.changeset/gallery-aware-github-comments.md
+++ b/.changeset/gallery-aware-github-comments.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": patch
 ---
 
-Show public galleries linked to a GitHub PR or issue in the existing managed attachments comment, alongside legacy loose attachments.
+Show public galleries linked to a GitHub PR or issue in the existing managed attachments comment, alongside legacy loose attachments, with up to three available images previewed inline per gallery.

--- a/apps/api/src/galleries.ts
+++ b/apps/api/src/galleries.ts
@@ -1,3 +1,5 @@
+/** Per-workspace cap; gallery membership remains independently capped below. */
+export const MAX_GALLERIES_PER_WORKSPACE = 100;
 export const MAX_GALLERY_ITEMS = 100;
 export const MAX_GALLERY_REFERENCES = 20;
 export const MAX_GALLERY_PAGE_SIZE = 100;
@@ -150,14 +152,29 @@ export async function createGallery(
     updated_at: now,
     deleted_at: null,
   };
-  await db
+  // The count check lives in the INSERT so concurrent creates cannot exceed the
+  // tenant quota. Soft-deleted galleries deliberately do not consume a slot.
+  const result = await db
     .prepare(
       `INSERT INTO galleries
       (id, workspace, title, description, visibility, cover_item_id, version, created_at, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, 'public', NULL, 1, ?, ?, NULL)`,
+     SELECT ?, ?, ?, ?, 'public', NULL, 1, ?, ?, NULL
+     WHERE (SELECT COUNT(*) FROM galleries WHERE workspace = ? AND deleted_at IS NULL) < ?`,
     )
-    .bind(record.id, record.workspace, record.title, record.description, now, now)
+    .bind(
+      record.id,
+      record.workspace,
+      record.title,
+      record.description,
+      now,
+      now,
+      record.workspace,
+      MAX_GALLERIES_PER_WORKSPACE,
+    )
     .run();
+  if ((result.meta.changes ?? 0) === 0) {
+    return { status: "limit", limit: MAX_GALLERIES_PER_WORKSPACE };
+  }
   return { status: "ok", value: record };
 }
 

--- a/apps/api/test/galleries-sqlite.test.ts
+++ b/apps/api/test/galleries-sqlite.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import {
+  MAX_GALLERIES_PER_WORKSPACE,
   MAX_GALLERY_ITEMS,
   addExternalReference,
   addGalleryItem,
@@ -187,6 +188,23 @@ describe("gallery persistence against SQLite", () => {
       await expect(getGallery(database(sqlite), "alpha", created.id)).resolves.toMatchObject({
         version: 5,
       });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("enforces the active-gallery cap atomically per workspace", async () => {
+    const sqlite = new SqliteD1();
+    try {
+      for (let index = 0; index < MAX_GALLERIES_PER_WORKSPACE; index++) {
+        await expect(gallery(sqlite)).resolves.toMatchObject({ workspace: "alpha" });
+      }
+      await expect(
+        createGallery(database(sqlite), { workspace: "alpha", title: "Overflow gallery" }),
+      ).resolves.toEqual({ status: "limit", limit: MAX_GALLERIES_PER_WORKSPACE });
+      await expect(
+        createGallery(database(sqlite), { workspace: "beta", title: "Beta gallery" }),
+      ).resolves.toMatchObject({ status: "ok" });
     } finally {
       sqlite.close();
     }

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -43,7 +43,7 @@ for `uploads mcp`.
 
 `attach` is the agent-friendly default for GitHub media. It accepts one or more files,
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
-or updates one marker-owned GitHub comment. It keeps loose `gh/...` attachments and linked public galleries in distinct sections, and updates that same comment in place on every sync. Use `--pr`, `--issue`, and `--repo` to select
+or updates one marker-owned GitHub comment. It keeps loose `gh/...` attachments and linked public galleries in distinct sections, shows up to three available gallery images inline, and updates that same comment in place on every sync. Use `--pr`, `--issue`, and `--repo` to select
 the target explicitly, or `--no-comment` to upload without changing GitHub comments.
 
 **Keys / destinations:** default put uses the `screenshots` layout. Typed destinations

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -43,7 +43,7 @@ for `uploads mcp`.
 
 `attach` is the agent-friendly default for GitHub media. It accepts one or more files,
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
-or updates one managed attachments comment. Use `--pr`, `--issue`, and `--repo` to select
+or updates one marker-owned GitHub comment. It keeps loose `gh/...` attachments and linked public galleries in distinct sections, and updates that same comment in place on every sync. Use `--pr`, `--issue`, and `--repo` to select
 the target explicitly, or `--no-comment` to upload without changing GitHub comments.
 
 **Keys / destinations:** default put uses the `screenshots` layout. Typed destinations
@@ -66,7 +66,7 @@ into `~/.cache/uploads/frames` (not bundled).
 Create an ordered gallery, then add existing uploads by key. The API returns the canonical
 public URL; the CLI never constructs it. **Anyone who knows that URL can view the gallery and
 its media**—GitHub or repository visibility does not restrict it. Deleting a gallery removes
-only the gallery record, not its uploaded objects or their retention policy.
+only the gallery record, not its uploaded objects or their retention policy. A workspace can hold up to 100 active galleries, each with up to 100 items and 20 external references.
 
 ```bash
 uploads gallery create --title "Release screenshots"
@@ -81,7 +81,7 @@ When adding several keys, `uploads gallery add` processes them sequentially and 
 individual failures in `--json` output. Gallery item updates use the API's current version to
 avoid overwriting concurrent changes.
 
-Link a gallery to a GitHub issue or pull request with `gallery link --github`. Coordinates and strict `https://github.com/<owner>/<repo>/issues|pull/<number>` URLs are accepted; `gallery list --github` performs the authenticated reverse lookup. Links never change gallery identity, and GitHub repository visibility does not make the public gallery private.
+Link a gallery to a GitHub issue or pull request with `gallery link --github`. Run `uploads comment --pr <number>` (or use `put --comment`) to refresh that target’s one managed comment with every linked gallery and loose attachment. Coordinates and strict `https://github.com/<owner>/<repo>/issues|pull/<number>` URLs are accepted; `gallery list --github` performs the authenticated reverse lookup. Links never change gallery identity, and GitHub repository visibility does not make the public gallery private.
 
 Config layers (first match wins): CLI flags → env vars → `--env-file` → `~/.config/buildinternet/config`. See `config.example` for keys.
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -245,7 +245,7 @@ export async function syncAttachmentsComment(
     ({ key, url }) => ({ key, url }),
   );
 
-  const galleries: GalleryCommentItem[] = [];
+  const galleries: (GalleryCommentItem & { id: string })[] = [];
   let cursor: string | undefined;
   do {
     const page = await client.findGalleriesByReference({
@@ -254,15 +254,36 @@ export async function syncAttachmentsComment(
       coordinate: `${target.repo.toLowerCase()}#${target.num}`,
       cursor,
     });
-    galleries.push(...page.galleries.map(({ title, url }) => ({ title, url })));
+    galleries.push(...page.galleries.map(({ id, title, url }) => ({ title, url, id })));
     cursor = page.nextCursor ?? undefined;
   } while (cursor);
 
-  if (items.length === 0 && galleries.length === 0) return { action: "skipped", count: 0 };
+  const previewGalleries = await Promise.all(
+    galleries.map(async ({ id, ...gallery }) => {
+      try {
+        const detail = await client.getGallery(id);
+        return {
+          ...gallery,
+          previews: detail.items
+            .filter(
+              (item) =>
+                item.status === "available" && item.url && item.contentType?.startsWith("image/"),
+            )
+            .slice(0, 3)
+            .map((item) => ({ url: item.url!, alt: item.altText ?? item.objectKey })),
+        };
+      } catch {
+        // A deleted or temporarily unavailable gallery still gets a safe title link.
+        return gallery;
+      }
+    }),
+  );
 
-  const body = attachmentsCommentBody(items, galleries);
+  if (items.length === 0 && previewGalleries.length === 0) return { action: "skipped", count: 0 };
+
+  const body = attachmentsCommentBody(items, previewGalleries);
   const { created } = upsertAttachmentsComment(target, body, run);
-  return { action: created ? "created" : "updated", count: items.length + galleries.length };
+  return { action: created ? "created" : "updated", count: items.length + previewGalleries.length };
 }
 
 // --- attach ---

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -24,6 +24,7 @@ import {
   attachmentsCommentBody,
   type GhTarget,
   type AttachmentItem,
+  type GalleryCommentItem,
   normalizeGithubCoordinate,
 } from "./github.js";
 import {
@@ -92,7 +93,7 @@ Options:
   --format human|url|markdown|json
   --pr <num>            Attach to a pull request: key gh/<owner>/<repo>/pull/<num>/<name> (stable URL, no hash)
   --issue <num>         Attach to an issue: key gh/<owner>/<repo>/issues/<num>/<name>
-  --comment             With --pr/--issue: create/update the attachments comment via your local gh auth
+  --comment             With --pr/--issue: update one managed comment with attachments and linked galleries via local gh auth
   --gallery <id>         Add the uploaded object to this public gallery
 
 Examples:
@@ -244,11 +245,24 @@ export async function syncAttachmentsComment(
     ({ key, url }) => ({ key, url }),
   );
 
-  if (items.length === 0) return { action: "skipped", count: 0 };
+  const galleries: GalleryCommentItem[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await client.findGalleriesByReference({
+      provider: "github",
+      // GitHub references intentionally do not distinguish PRs from issues.
+      coordinate: `${target.repo.toLowerCase()}#${target.num}`,
+      cursor,
+    });
+    galleries.push(...page.galleries.map(({ title, url }) => ({ title, url })));
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
 
-  const body = attachmentsCommentBody(items);
+  if (items.length === 0 && galleries.length === 0) return { action: "skipped", count: 0 };
+
+  const body = attachmentsCommentBody(items, galleries);
   const { created } = upsertAttachmentsComment(target, body, run);
-  return { action: created ? "created" : "updated", count: items.length };
+  return { action: created ? "created" : "updated", count: items.length + galleries.length };
 }
 
 // --- attach ---

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -93,6 +93,13 @@ export interface AttachmentItem {
   url: string | null;
 }
 
+/** A public gallery linked to the PR or issue whose managed comment is syncing. */
+export interface GalleryCommentItem {
+  title: string;
+  /** Canonical URL returned by the API; callers must not synthesize it. */
+  url: string;
+}
+
 /** Default max width for images in the managed attachments comment (HTML img). */
 export const ATTACHMENT_IMAGE_WIDTH_DEFAULT = 400;
 /** Portrait / device mockups — keep phones readable, not full-column. */
@@ -122,9 +129,31 @@ function escapeHtmlAttr(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
 }
 
-export function attachmentsCommentBody(items: AttachmentItem[]): string {
+function escapeHtmlText(s: string): string {
+  return escapeHtmlAttr(s).replace(/'/g, "&#39;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Render the one marker-owned GitHub comment. When there are no galleries this
+ * intentionally preserves the legacy attachment-only body byte-for-byte.
+ */
+export function attachmentsCommentBody(
+  items: AttachmentItem[],
+  galleries: GalleryCommentItem[] = [],
+): string {
   const sorted = items.toSorted((a, b) => a.key.localeCompare(b.key));
-  const lines: string[] = [ATTACHMENTS_MARKER, "### 📎 Attachments", ""];
+  const sortedGalleries = galleries.toSorted(
+    (a, b) => a.title.localeCompare(b.title) || a.url.localeCompare(b.url),
+  );
+  const lines: string[] = [ATTACHMENTS_MARKER];
+  if (sortedGalleries.length > 0) {
+    lines.push("### 🖼️ Galleries", "");
+    for (const gallery of sortedGalleries) {
+      lines.push(`<a href="${escapeHtmlAttr(gallery.url)}">${escapeHtmlText(gallery.title)}</a>`);
+    }
+    lines.push("");
+  }
+  if (sorted.length > 0 || sortedGalleries.length === 0) lines.push("### 📎 Attachments", "");
   for (const item of sorted) {
     const name = item.key.slice(item.key.lastIndexOf("/") + 1);
     if (item.url && inferContentType(name).startsWith("image/")) {

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -98,6 +98,8 @@ export interface GalleryCommentItem {
   title: string;
   /** Canonical URL returned by the API; callers must not synthesize it. */
   url: string;
+  /** A bounded set of available images, all of which link back to the gallery. */
+  previews?: { url: string; alt: string }[];
 }
 
 /** Default max width for images in the managed attachments comment (HTML img). */
@@ -149,7 +151,14 @@ export function attachmentsCommentBody(
   if (sortedGalleries.length > 0) {
     lines.push("### 🖼️ Galleries", "");
     for (const gallery of sortedGalleries) {
-      lines.push(`<a href="${escapeHtmlAttr(gallery.url)}">${escapeHtmlText(gallery.title)}</a>`);
+      const href = escapeHtmlAttr(gallery.url);
+      lines.push(`#### <a href="${href}">${escapeHtmlText(gallery.title)}</a>`);
+      for (const preview of gallery.previews ?? []) {
+        lines.push(
+          `<a href="${href}"><img width="320" alt="${escapeHtmlAttr(preview.alt)}" src="${escapeHtmlAttr(preview.url)}"></a>`,
+        );
+      }
+      lines.push(`<sub><a href="${href}">Open gallery</a></sub>`, "");
     }
     lines.push("");
   }

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -38,6 +38,7 @@ function fakeClient() {
     list,
     listAll: async (opts: { prefix?: string } = {}) => (await list(opts)).items,
     findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+    getGallery: async () => ({ items: [] }),
   } as unknown as UploadsClient;
   return { client, puts };
 }

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -37,6 +37,7 @@ function fakeClient() {
     },
     list,
     listAll: async (opts: { prefix?: string } = {}) => (await list(opts)).items,
+    findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
   } as unknown as UploadsClient;
   return { client, puts };
 }

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -7,7 +7,10 @@ import type { CommandRunner } from "../src/github-gh.js";
 
 function listClient(
   items: { key: string; url: string | null }[],
-  galleryPages: { galleries: { title: string; url: string }[]; nextCursor: string | null }[] = [],
+  galleryPages: {
+    galleries: { id: string; title: string; url: string }[];
+    nextCursor: string | null;
+  }[] = [],
 ) {
   let page = 0;
   return {
@@ -15,6 +18,7 @@ function listClient(
     listAll: async () => items,
     findGalleriesByReference: async () =>
       galleryPages[page++] ?? { galleries: [], nextCursor: null },
+    getGallery: async (id: string) => ({ id, items: [] }),
   } as unknown as UploadsClient;
 }
 
@@ -75,5 +79,50 @@ describe("runComment", () => {
     );
     expect(code).toBe(0);
     expect(calls.length).toBe(0);
+  });
+  it("renders available gallery images inline and falls back for missing media", async () => {
+    const { run, calls } = ghRunner();
+    const client = {
+      ...listClient(
+        [],
+        [
+          {
+            galleries: [
+              { id: "gal_preview", title: "Preview", url: "https://uploads.test/g/gal_preview" },
+            ],
+            nextCursor: null,
+          },
+        ],
+      ),
+      getGallery: async () => ({
+        items: [
+          {
+            status: "available",
+            url: "https://storage.test/one.webp",
+            contentType: "image/webp",
+            altText: "One",
+            objectKey: "one.webp",
+          },
+          {
+            status: "missing",
+            url: null,
+            contentType: null,
+            altText: null,
+            objectKey: "gone.webp",
+          },
+          {
+            status: "available",
+            url: "https://storage.test/movie.mp4",
+            contentType: "video/mp4",
+            altText: null,
+            objectKey: "movie.mp4",
+          },
+        ],
+      }),
+    } as unknown as UploadsClient;
+    await runComment(ctxWith(client), ["--pr", "5", "--repo", "o/r"], false, run);
+    const create = calls.find((call) => call.args.includes("repos/o/r/issues/5/comments"));
+    expect(create?.input).toContain('src="https://storage.test/one.webp"');
+    expect(create?.input).not.toContain("movie.mp4");
   });
 });

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -5,10 +5,16 @@ import { runComment, type CliContext } from "../src/commands.js";
 import { ATTACHMENTS_MARKER } from "../src/github.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
-function listClient(items: { key: string; url: string | null }[]) {
+function listClient(
+  items: { key: string; url: string | null }[],
+  galleryPages: { galleries: { title: string; url: string }[]; nextCursor: string | null }[] = [],
+) {
+  let page = 0;
   return {
     list: async () => ({ items, cursor: null }),
     listAll: async () => items,
+    findGalleriesByReference: async () =>
+      galleryPages[page++] ?? { galleries: [], nextCursor: null },
   } as unknown as UploadsClient;
 }
 

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -137,4 +137,33 @@ describe("attachmentsCommentBody", () => {
     const body = attachmentsCommentBody([{ key: "gh/o/r/pull/1/x.bin", url: null }]);
     expect(body).toContain("- x.bin");
   });
+
+  it("renders a distinct, safely escaped Galleries section without attachments", () => {
+    const body = attachmentsCommentBody(
+      [],
+      [{ title: `A <gallery> & "quotes"`, url: "https://uploads.test/g/gal_a?x=1&y=2" }],
+    );
+    expect(body).toContain("### 🖼️ Galleries");
+    expect(body).toContain(
+      `<a href="https://uploads.test/g/gal_a?x=1&amp;y=2">A &lt;gallery&gt; &amp; &quot;quotes&quot;</a>`,
+    );
+    expect(body).not.toContain("### 📎 Attachments");
+  });
+
+  it("keeps galleries and loose attachments in clearly separate sections", () => {
+    const body = attachmentsCommentBody(
+      [{ key: "gh/o/r/pull/1/after.png", url: "https://x.test/after.png" }],
+      [{ title: "Release screenshots", url: "https://uploads.test/g/gal_release" }],
+    );
+    expect(body.indexOf("### 🖼️ Galleries")).toBeLessThan(body.indexOf("### 📎 Attachments"));
+    expect(body).toContain("Release screenshots");
+    expect(body).toContain("after.png");
+  });
+
+  it("renders the empty body without either content section", () => {
+    const body = attachmentsCommentBody([], []);
+    expect(body).toContain(ATTACHMENTS_MARKER);
+    expect(body).not.toContain("### 🖼️ Galleries");
+    expect(body).toContain("### 📎 Attachments");
+  });
 });

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -150,6 +150,27 @@ describe("attachmentsCommentBody", () => {
     expect(body).not.toContain("### 📎 Attachments");
   });
 
+  it("renders up to three inline previews that link back to the gallery", () => {
+    const body = attachmentsCommentBody(
+      [],
+      [
+        {
+          title: "Release screenshots",
+          url: "https://uploads.test/g/gal_release",
+          previews: [
+            { url: "https://storage.test/one.webp", alt: "First screen" },
+            { url: "https://storage.test/two.webp", alt: "Second screen" },
+            { url: "https://storage.test/three.webp", alt: "Third screen" },
+          ],
+        },
+      ],
+    );
+    expect(body).toContain(
+      '<a href="https://uploads.test/g/gal_release"><img width="320" alt="First screen" src="https://storage.test/one.webp"></a>',
+    );
+    expect(body).toContain("Open gallery");
+  });
+
   it("keeps galleries and loose attachments in clearly separate sections", () => {
     const body = attachmentsCommentBody(
       [{ key: "gh/o/r/pull/1/after.png", url: "https://x.test/after.png" }],

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -42,6 +42,7 @@ function fakeFactory() {
       },
       list,
       listAll: async (opts: { prefix?: string } = {}) => (await list(opts)).items,
+      findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
       delete: async (key: string) => {
         deletes.push(key);
         return { key, deleted: true };

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -43,6 +43,7 @@ function fakeFactory() {
       list,
       listAll: async (opts: { prefix?: string } = {}) => (await list(opts)).items,
       findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+      getGallery: async () => ({ items: [] }),
       delete: async (key: string) => {
         deletes.push(key);
         return { key, deleted: true };

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -196,7 +196,7 @@ uploads gallery list --github https://github.com/buildinternet/uploads/pull/58
 
 `gallery add` processes keys sequentially so it obtains a current optimistic version before
 each mutation. With `--json`, its stable `added` and `failures` arrays make partial failures
-safe for agents to inspect. Deleting a gallery removes only its gallery record—not the objects.
+safe for agents to inspect. A workspace may have up to 100 active galleries; each gallery permits up to 100 items and 20 linked external references. Deleting a gallery removes only its gallery record—not the objects.
 
 Optionally link a gallery to a GitHub issue or PR with `uploads gallery link <gallery-id> --github <owner/repo#number>`. The CLI also accepts strict `https://github.com/<owner>/<repo>/issues|pull/<number>` URLs. Use `uploads gallery list --github <coordinate-or-url>` for the authenticated reverse lookup. This is metadata only: it does not make a gallery private or change its opaque identity.
 
@@ -232,9 +232,7 @@ Then reference the URL in the PR/issue markdown you write with `gh`:
 
 ### Option B — managed attachments comment (`--comment` / `comment`)
 
-Add `--comment` to upload **and** create/update a single comment on the PR/issue that
-lists every file uploaded for it. It finds its own prior comment via a hidden marker
-and edits it in place — it never touches the description or other comments:
+Add `--comment` to upload **and** create/update a single marker-owned comment on the PR/issue. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections. It finds its own prior comment via a hidden marker and edits it in place — it never touches the description or other comments:
 
 ```bash
 uploads put ./after.png --pr 123 --comment
@@ -242,8 +240,7 @@ uploads put ./after.png --pr 123 --comment
 
 The upload is authoritative; the comment is best-effort — if `gh` is missing or
 unauthenticated, the upload still succeeds and you get a warning. To (re)sync the
-comment without uploading anything (e.g. after several `--pr` uploads), use the
-standalone command:
+comment without uploading anything (e.g. after several `--pr` uploads or gallery links), use the standalone command:
 
 ```bash
 uploads comment --pr 123

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -232,7 +232,7 @@ Then reference the URL in the PR/issue markdown you write with `gh`:
 
 ### Option B — managed attachments comment (`--comment` / `comment`)
 
-Add `--comment` to upload **and** create/update a single marker-owned comment on the PR/issue. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections. It finds its own prior comment via a hidden marker and edits it in place — it never touches the description or other comments:
+Add `--comment` to upload **and** create/update a single marker-owned comment on the PR/issue. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. It finds its own prior comment via a hidden marker and edits it in place — it never touches the description or other comments:
 
 ```bash
 uploads put ./after.png --pr 123 --comment


### PR DESCRIPTION
## In plain terms

Managed upload comments can now show the public galleries linked to the same GitHub PR or issue, alongside existing loose attachments, without creating additional comment noise. The gallery launch also gains a bounded active-gallery count per workspace.

## What it does

- Updates the existing marker-owned comment in place with distinct Galleries and Attachments sections.
- Preserves legacy loose `gh/...` attachment rendering when no galleries are linked.
- Supports paginated reverse lookup so every linked gallery is included; title and URL output is escaped.
- Skips GitHub writes when there are neither attachments nor galleries, and keeps comment failures best-effort for successful uploads.
- Caps a workspace at 100 active galleries; deleted galleries release their slot. Existing 100-item and 20-reference limits remain unchanged.

## What it is not

- No custom autolinks, GitHub App automation, private galleries, or Linear/Jira integration.

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @uploads/api test`
- [x] `pnpm check`
- [x] API type generation/typecheck