### PR TITLE
chore: tighten gitignore for local scratch and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ worker-configuration.d.ts
 # Local agent notes, private plans, pricing scratch (not for the public repo)
 .context/
 .claude/worktrees/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,21 @@ dist/
 .astro/
 .wrangler/
 .dev.vars
+.dev.vars.*
+!.dev.vars.example
 .env
+.env.*
+!.env.example
 *.local
 .DS_Store
+Thumbs.db
 worker-configuration.d.ts
+*.log
+pnpm-debug.log*
+coverage/
 .impeccable/
 # Local agent notes, private plans, pricing scratch (not for the public repo)
 .context/
+.superpowers/
 .claude/worktrees/
 .worktrees/


### PR DESCRIPTION
## In plain terms

Local agent worktrees and other on-disk scratch were showing up in git status, and env secret patterns were too narrow. This broadens `.gitignore` so local tooling noise and accidental secret copies stay out of the tree.

## What it does

- Ignores `.worktrees/` and `.superpowers/` (alongside existing `.claude/worktrees/`, `.context/`, `.impeccable/`)
- Broadens secret globs: `.env.*` / `.dev.vars.*`, with exceptions for the tracked `*.example` templates
- Adds cheap tool/OS noise: `*.log`, `pnpm-debug.log*`, `coverage/`, `Thumbs.db`

## What it is not

- No runtime or deploy changes
- Does not ignore intentionally tracked agent config (`.codex/`, `.claude/launch.json`)

## Test plan

- [x] Confirm new patterns are in `.gitignore`
- [x] `git check-ignore` covers `.worktrees/`, `.superpowers/`, `.env.production`-style names while keeping `.env.example` trackable
- [ ] After merge, local worktrees / superpowers / env variants no longer appear in `git status`