### PR TITLE
test: cover gallery client and MCP contracts

### DIFF
--- a/apps/mcp/test/gallery-fake-d1.ts
+++ b/apps/mcp/test/gallery-fake-d1.ts
@@ -1,0 +1,313 @@
+type Gallery = {
+  id: string;
+  workspace: string;
+  title: string;
+  description: string | null;
+  visibility: "public";
+  cover_item_id: string | null;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+type Item = {
+  id: string;
+  gallery_id: string;
+  object_key: string;
+  position: number;
+  caption: string | null;
+  alt_text: string | null;
+  created_at: string;
+};
+
+type Reference = {
+  id: string;
+  gallery_id: string;
+  provider: string;
+  resource_type: string;
+  normalized_key: string;
+  locator_json: string;
+  canonical_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function query(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Small D1 double for the hosted MCP gallery workflow. It deliberately
+ * recognizes only exercised SQL so a persistence change expands the fixture
+ * instead of silently weakening the test.
+ */
+export class GalleryFakeD1 {
+  readonly galleries: Gallery[] = [];
+  readonly items: Item[] = [];
+  readonly references: Reference[] = [];
+
+  prepare(sql: string) {
+    return new GalleryFakeStatement(this, query(sql));
+  }
+
+  async batch(statements: GalleryFakeStatement[]) {
+    const results = [];
+    for (const statement of statements) results.push(await statement.run());
+    return results;
+  }
+}
+
+class GalleryFakeStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly database: GalleryFakeD1,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    if (this.sql.includes("FROM auth_tokens")) return null;
+    if (this.sql.includes("FROM galleries WHERE id = ? AND workspace = ?")) {
+      const [id, workspace] = this.values as [string, string];
+      return (this.gallery(id, workspace) ?? null) as T | null;
+    }
+    throw new Error("unsupported D1 first query: " + this.sql);
+  }
+
+  async all<T>(): Promise<D1Result<T>> {
+    if (this.sql.includes("FROM gallery_items i JOIN galleries g")) {
+      const [galleryId, workspace] = this.values as [string, string];
+      return this.result(
+        this.database.items
+          .filter(
+            (item) => item.gallery_id === galleryId && this.gallery(item.gallery_id, workspace),
+          )
+          .sort((a, b) => a.position - b.position || a.id.localeCompare(b.id)) as T[],
+      );
+    }
+    if (this.sql.includes("FROM gallery_external_references r JOIN galleries g")) {
+      const [galleryId, workspace] = this.values as [string, string];
+      return this.result(
+        this.database.references
+          .filter(
+            (reference) => reference.gallery_id === galleryId && this.gallery(galleryId, workspace),
+          )
+          .sort(
+            (a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id),
+          ) as T[],
+      );
+    }
+    if (this.sql.includes("FROM galleries g JOIN gallery_external_references r")) {
+      const [normalizedKey, workspace, , , , , limit] = this.values as [
+        string,
+        string,
+        unknown,
+        unknown,
+        unknown,
+        unknown,
+        number,
+      ];
+      const galleries = this.database.galleries
+        .filter(
+          (gallery) =>
+            gallery.workspace === workspace &&
+            gallery.deleted_at === null &&
+            this.database.references.some(
+              (reference) =>
+                reference.gallery_id === gallery.id && reference.normalized_key === normalizedKey,
+            ),
+        )
+        .sort((a, b) => b.created_at.localeCompare(a.created_at) || b.id.localeCompare(a.id))
+        .slice(0, limit);
+      return this.result(galleries as T[]);
+    }
+    throw new Error("unsupported D1 all query: " + this.sql);
+  }
+
+  async run(): Promise<D1Result> {
+    if (this.sql.startsWith("INSERT INTO galleries")) return this.createGallery();
+    if (this.sql.startsWith("INSERT INTO gallery_items")) return this.insertItem();
+    if (this.sql.startsWith("INSERT INTO gallery_external_references"))
+      return this.insertReference();
+    if (this.sql.startsWith("UPDATE galleries SET version = version + 1"))
+      return this.bumpVersion();
+    throw new Error("unsupported D1 run query: " + this.sql);
+  }
+
+  private createGallery(): D1Result {
+    const [id, workspace, title, description, createdAt, updatedAt, countWorkspace, limit] = this
+      .values as [string, string, string, string | null, string, string, string, number];
+    const changes =
+      this.database.galleries.filter(
+        (gallery) => gallery.workspace === countWorkspace && gallery.deleted_at === null,
+      ).length < limit
+        ? 1
+        : 0;
+    if (changes) {
+      this.database.galleries.push({
+        id,
+        workspace,
+        title,
+        description,
+        visibility: "public",
+        cover_item_id: null,
+        version: 1,
+        created_at: createdAt,
+        updated_at: updatedAt,
+        deleted_at: null,
+      });
+    }
+    return this.mutation(changes);
+  }
+
+  private insertItem(): D1Result {
+    const [
+      id,
+      objectKey,
+      caption,
+      altText,
+      createdAt,
+      galleryId,
+      workspace,
+      expectedVersion,
+      duplicateKey,
+      limit,
+    ] = this.values as [
+      string,
+      string,
+      string | null,
+      string | null,
+      string,
+      string,
+      string,
+      number,
+      string,
+      number,
+    ];
+    const gallery = this.gallery(galleryId, workspace);
+    const items = this.database.items.filter((item) => item.gallery_id === galleryId);
+    const changes =
+      gallery &&
+      gallery.version === expectedVersion &&
+      !items.some((item) => item.object_key === duplicateKey) &&
+      items.length < limit
+        ? 1
+        : 0;
+    if (changes) {
+      this.database.items.push({
+        id,
+        gallery_id: galleryId,
+        object_key: objectKey,
+        position: (items.reduce((max, item) => Math.max(max, item.position), 0) || 0) + 1000,
+        caption,
+        alt_text: altText,
+        created_at: createdAt,
+      });
+    }
+    return this.mutation(changes);
+  }
+
+  private insertReference(): D1Result {
+    const [
+      id,
+      provider,
+      resourceType,
+      normalizedKey,
+      locatorJson,
+      canonicalUrl,
+      createdAt,
+      updatedAt,
+      galleryId,
+      workspace,
+      expectedVersion,
+      duplicateKey,
+      limit,
+    ] = this.values as [
+      string,
+      string,
+      string,
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      string,
+      string,
+      number,
+      string,
+      number,
+    ];
+    const gallery = this.gallery(galleryId, workspace);
+    const references = this.database.references.filter(
+      (reference) => reference.gallery_id === galleryId,
+    );
+    const changes =
+      gallery &&
+      gallery.version === expectedVersion &&
+      !references.some((reference) => reference.normalized_key === duplicateKey) &&
+      references.length < limit
+        ? 1
+        : 0;
+    if (changes) {
+      this.database.references.push({
+        id,
+        gallery_id: galleryId,
+        provider,
+        resource_type: resourceType,
+        normalized_key: normalizedKey,
+        locator_json: locatorJson,
+        canonical_url: canonicalUrl,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      });
+    }
+    return this.mutation(changes);
+  }
+
+  private bumpVersion(): D1Result {
+    const [updatedAt, galleryId, workspace, expectedVersion, childId] = this.values as [
+      string,
+      string,
+      string,
+      number,
+      string,
+    ];
+    const gallery = this.gallery(galleryId, workspace);
+    const childExists = this.sql.includes("gallery_items")
+      ? this.database.items.some((item) => item.id === childId && item.gallery_id === galleryId)
+      : this.database.references.some(
+          (reference) => reference.id === childId && reference.gallery_id === galleryId,
+        );
+    const changes = gallery && gallery.version === expectedVersion && childExists ? 1 : 0;
+    if (changes && gallery) {
+      gallery.version++;
+      gallery.updated_at = updatedAt;
+    }
+    return this.mutation(changes);
+  }
+
+  private gallery(id: string, workspace: string): Gallery | undefined {
+    return this.database.galleries.find(
+      (gallery) =>
+        gallery.id === id && gallery.workspace === workspace && gallery.deleted_at === null,
+    );
+  }
+
+  private mutation(changes: number): D1Result {
+    return { success: true, results: [], meta: { changes } } as unknown as D1Result;
+  }
+
+  private result<T>(results: T[]): D1Result<T> {
+    return {
+      success: true,
+      results: results.map((result) => ({ ...result })),
+      meta: {},
+    } as D1Result<T>;
+  }
+}

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -2,8 +2,11 @@ import { beforeAll, describe, expect, it } from "vitest";
 import app from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
 import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
+import { GalleryFakeD1 } from "./gallery-fake-d1";
 
 const TOKEN = "up_test-ws_legacy-token-value";
+const ALPHA_TOKEN = "up_alpha_gallery-test";
+const BETA_TOKEN = "up_beta_gallery-test";
 
 const workspace: WorkspaceRecord = {
   provider: "r2",
@@ -88,6 +91,37 @@ async function makeEnv(
   return { env, bucket };
 }
 
+async function makeGalleryEnv(): Promise<{ env: Env; bucket: FakeR2Bucket }> {
+  const bucket = new FakeR2Bucket();
+  await bucket.put("alpha/screenshots/one.png", PNG_BYTES);
+  const records: Record<string, WorkspaceRecord> = {
+    alpha: {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "alpha/",
+      publicBaseUrl: "https://storage.example.com",
+      tokenHash: await sha256Hex(ALPHA_TOKEN),
+    },
+    beta: {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "beta/",
+      publicBaseUrl: "https://storage.example.com",
+      tokenHash: await sha256Hex(BETA_TOKEN),
+    },
+  };
+  const env = {
+    DB: new GalleryFakeD1(),
+    WEB_ORIGIN: "https://uploads.test",
+    REGISTRY: { get: async (key: string) => records[key.slice(3)] ?? null },
+    UPLOADS_DEFAULT: bucket,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+  } as unknown as Env;
+  return { env, bucket };
+}
+
 async function rpc(
   env: Env,
   body: unknown,
@@ -105,11 +139,18 @@ async function rpc(
   );
 }
 
-async function callTool(env: Env, name: string, args: Record<string, unknown>, token = TOKEN) {
+async function callTool(
+  env: Env,
+  name: string,
+  args: Record<string, unknown>,
+  token = TOKEN,
+  path = "/test-ws/mcp",
+) {
   const response = await rpc(
     env,
     { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
     token,
+    path,
   );
   expect(response.status).toBe(200);
   const body = (await response.json()) as {
@@ -122,6 +163,84 @@ async function callTool(env: Env, name: string, args: Record<string, unknown>, t
 // putObject sniffs the stored content type from these bytes (guards.ts).
 const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
 const PNG_B64 = btoa(String.fromCharCode(...PNG_BYTES));
+
+describe("hosted gallery tenant isolation", () => {
+  it("keeps gallery get and reference lookup tenant-scoped while returning alpha canonical URLs", async () => {
+    const { env } = await makeGalleryEnv();
+    const alphaPath = "/alpha/mcp";
+    const betaPath = "/beta/mcp";
+
+    const created = await callTool(
+      env,
+      "gallery_create",
+      { title: "Alpha launch" },
+      ALPHA_TOKEN,
+      alphaPath,
+    );
+    expect(created.isError).toBe(false);
+    const gallery = created.structuredContent as { id: string; url: string; version: number };
+    expect(gallery.url).toBe("https://uploads.test/g/" + gallery.id);
+
+    const added = await callTool(
+      env,
+      "gallery_add",
+      { galleryId: gallery.id, objectKey: "screenshots/one.png" },
+      ALPHA_TOKEN,
+      alphaPath,
+    );
+    expect(added.structuredContent).toMatchObject({
+      objectKey: "screenshots/one.png",
+      url: "https://storage.example.com/alpha/screenshots/one.png",
+    });
+
+    const linked = await callTool(
+      env,
+      "gallery_link",
+      {
+        galleryId: gallery.id,
+        provider: "github",
+        coordinate: "buildinternet/uploads#57",
+      },
+      ALPHA_TOKEN,
+      alphaPath,
+    );
+    expect(linked.structuredContent).toMatchObject({
+      canonicalUrl: "https://github.com/buildinternet/uploads/issues/57",
+    });
+
+    const alphaFound = await callTool(
+      env,
+      "gallery_find_by_reference",
+      { provider: "github", coordinate: "buildinternet/uploads#57" },
+      ALPHA_TOKEN,
+      alphaPath,
+    );
+    expect(alphaFound.structuredContent).toMatchObject({
+      galleries: [{ id: gallery.id, url: gallery.url, version: 3 }],
+      nextCursor: null,
+    });
+
+    const betaGet = await callTool(
+      env,
+      "gallery_get",
+      { galleryId: gallery.id },
+      BETA_TOKEN,
+      betaPath,
+    );
+    expect(betaGet).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: "gallery not found" }],
+    });
+    const betaFound = await callTool(
+      env,
+      "gallery_find_by_reference",
+      { provider: "github", coordinate: "buildinternet/uploads#57" },
+      BETA_TOKEN,
+      betaPath,
+    );
+    expect(betaFound.structuredContent).toEqual({ galleries: [], nextCursor: null });
+  });
+});
 
 describe("mcp worker", () => {
   it("serves an unauthenticated MCP server card for discovery", async () => {

--- a/packages/uploads/test/client-gallery.test.ts
+++ b/packages/uploads/test/client-gallery.test.ts
@@ -133,3 +133,50 @@ describe("gallery external-reference client methods", () => {
     ]);
   });
 });
+
+describe("gallery client workspace isolation", () => {
+  it("keeps alpha and beta gallery requests under their own workspace paths", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const workspace = url.includes("/v1/alpha/") ? "alpha" : "beta";
+      if (url.endsWith("/galleries") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            ...gallery,
+            id: "gal_" + workspace,
+            workspace,
+            url: "https://uploads.test/g/gal_" + workspace,
+          }),
+          { status: 201 },
+        );
+      }
+      if (url.includes("/galleries?") && init?.method === "GET") {
+        return new Response(JSON.stringify({ galleries: [], nextCursor: null }));
+      }
+      throw new Error("unexpected URL: " + url);
+    });
+    vi.stubGlobal("fetch", fetch);
+    const alpha = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "alpha",
+      token: "up_alpha_test",
+    });
+    const beta = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "beta",
+      token: "up_beta_test",
+    });
+
+    await alpha.createGallery({ title: "Alpha" });
+    await beta.createGallery({ title: "Beta" });
+    await alpha.listGalleries({ limit: 1 });
+    await beta.listGalleries({ limit: 1 });
+
+    expect(fetch.mock.calls.map(([input]) => String(input))).toEqual([
+      "https://api.test/v1/alpha/galleries",
+      "https://api.test/v1/beta/galleries",
+      "https://api.test/v1/alpha/galleries?limit=1",
+      "https://api.test/v1/beta/galleries?limit=1",
+    ]);
+  });
+});

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -4,7 +4,12 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { GlobalFlags } from "../src/cli-args.js";
-import type { UploadsClient } from "../src/client.js";
+import type {
+  AddGalleryItemOptions,
+  CreateGalleryOptions,
+  LinkGalleryExternalReferenceOptions,
+  UploadsClient,
+} from "../src/client.js";
 import type { UploadsClientConfig } from "../src/config.js";
 import type { CommandRunner } from "../src/github-gh.js";
 import { createMcpServer, type McpServer } from "../src/mcp/server.js";
@@ -55,6 +60,74 @@ function fakeFactory() {
     } as unknown as UploadsClient;
   };
   return { factory, puts, deletes, configs };
+}
+
+/** In-memory gallery API contract used to exercise the MCP mutation workflow. */
+function galleryFactory() {
+  const configs: UploadsClientConfig[] = [];
+  const calls: Array<{ method: string; expectedVersion?: number }> = [];
+  const gallery = {
+    id: "gal_stateful",
+    url: "https://uploads.test/g/gal_stateful",
+    workspace: "alpha",
+    title: "Launch media",
+    description: null,
+    visibility: "public" as const,
+    coverItemId: null,
+    version: 1,
+    createdAt: "2026-07-12T00:00:00.000Z",
+    updatedAt: "2026-07-12T00:00:00.000Z",
+    items: [],
+  };
+  const factory = (config: UploadsClientConfig): UploadsClient => {
+    configs.push(config);
+    return {
+      createGallery: async ({ title, description }: CreateGalleryOptions) => ({
+        ...gallery,
+        title,
+        description: description ?? null,
+      }),
+      getGallery: async () => ({ ...gallery }),
+      addGalleryItem: async (_id: string, objectKey: string, opts: AddGalleryItemOptions) => {
+        calls.push({ method: "add", expectedVersion: opts.expectedVersion });
+        if (opts.expectedVersion !== gallery.version) throw new Error("stale gallery version");
+        gallery.version++;
+        return {
+          id: "item_stateful",
+          objectKey,
+          position: 1000,
+          caption: opts.caption ?? null,
+          altText: opts.altText ?? null,
+          createdAt: gallery.createdAt,
+          status: "available" as const,
+          url: "https://storage.uploads.sh/alpha/screenshots/launch.png",
+          contentType: "image/png",
+          size: 11,
+        };
+      },
+      linkGalleryExternalReference: async (
+        _id: string,
+        opts: LinkGalleryExternalReferenceOptions,
+      ) => {
+        calls.push({ method: "link", expectedVersion: opts.expectedVersion });
+        if (opts.expectedVersion !== gallery.version) throw new Error("stale gallery version");
+        gallery.version++;
+        return {
+          id: "ref_stateful",
+          provider: opts.provider,
+          resourceType: "item",
+          coordinate: opts.coordinate,
+          canonicalUrl: "https://github.com/buildinternet/uploads/issues/57",
+          createdAt: gallery.createdAt,
+        };
+      },
+      findGalleriesByReference: async () => ({
+        galleries: [{ ...gallery }],
+        nextCursor: null,
+      }),
+    } as unknown as UploadsClient;
+  };
+  return { factory, configs, calls };
 }
 
 function ghRunner() {
@@ -215,6 +288,72 @@ describe("tools/list", () => {
       expect(tool.inputSchema.additionalProperties).toBe(false);
       expect(typeof tool.inputSchema.properties).toBe("object");
     }
+  });
+});
+
+describe("gallery tool workflow", () => {
+  it("creates, adds, links, and finds with current versions and canonical URLs", async () => {
+    const state = galleryFactory();
+    const server = createMcpServer({
+      serverInfo: { name: "uploads", version: "0.0.0-test" },
+      tools: createUploadsMcpTools({
+        globals: { apiUrl: "https://api.test", token: "up_alpha_test" },
+        runner: noRun,
+        clientFactory: state.factory,
+      }),
+    });
+
+    const created = await rpc(server, "tools/call", {
+      name: "gallery_create",
+      arguments: { title: "Launch media", workspace: "alpha" },
+    });
+    const id = created.result.structuredContent.id as string;
+    expect(created.result.structuredContent.url).toBe("https://uploads.test/g/gal_stateful");
+
+    const added = await rpc(server, "tools/call", {
+      name: "gallery_add",
+      arguments: { galleryId: id, objectKey: "screenshots/launch.png", workspace: "alpha" },
+    });
+    expect(added.result.structuredContent).toMatchObject({
+      objectKey: "screenshots/launch.png",
+      url: "https://storage.uploads.sh/alpha/screenshots/launch.png",
+    });
+
+    const linked = await rpc(server, "tools/call", {
+      name: "gallery_link",
+      arguments: {
+        galleryId: id,
+        provider: "github",
+        coordinate: "buildinternet/uploads#57",
+        workspace: "alpha",
+      },
+    });
+    expect(linked.result.structuredContent.canonicalUrl).toBe(
+      "https://github.com/buildinternet/uploads/issues/57",
+    );
+
+    const found = await rpc(server, "tools/call", {
+      name: "gallery_find_by_reference",
+      arguments: {
+        provider: "github",
+        coordinate: "buildinternet/uploads#57",
+        workspace: "alpha",
+      },
+    });
+    expect(found.result.structuredContent).toMatchObject({
+      galleries: [{ id, url: "https://uploads.test/g/gal_stateful", version: 3 }],
+      nextCursor: null,
+    });
+    expect(state.calls).toEqual([
+      { method: "add", expectedVersion: 1 },
+      { method: "link", expectedVersion: 2 },
+    ]);
+    expect(state.configs.map((config) => config.workspace)).toEqual([
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+    ]);
   });
 });
 


### PR DESCRIPTION
## In plain terms

This adds the missing client and MCP contract coverage for public galleries, so tenant boundaries, version handling, and public URLs stay protected as the gallery launch work continues.

## What it does

- Exercises the stdio MCP gallery create → add → link → reference-find workflow with current-version assertions.
- Verifies alpha and beta clients use separate workspace API paths.
- Adds a Workers-compatible in-memory D1 fixture for hosted MCP tests, proving beta cannot read or find alpha gallery data.
- Keeps public opaque lookup behavior in the API’s existing public-gallery coverage; no visibility behavior changes.

## Technical notes

The hosted fixture intentionally models only the D1 queries used by the gallery workflow and fails on unexpected SQL.

## Test plan

- [x] Focused `@buildinternet/uploads` gallery client and MCP tests
- [x] Focused `@uploads/mcp` hosted MCP tests
- [x] `pnpm check`
- [x] `pnpm typecheck`

Browser visual smoke is deliberately deferred.