### PR TITLE
feat: create invites from the operator console

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import { AppError, NotFoundError } from "@uploads/errors";
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { respondError } from "./error-response";
 import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
@@ -10,9 +11,25 @@ import { runRetentionSweep } from "./retention-sweep";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 
+// Lets the browser console on the web origin (and local dev) call the token-
+// authenticated endpoints. CORS is not the security boundary — bearer tokens
+// are — but without these headers the preflight for Authorization fails.
+const consoleCors = cors({
+  origin: (origin, c) => {
+    if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;
+    if (/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) return origin;
+    return null;
+  },
+  allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+  allowHeaders: ["Authorization", "Content-Type"],
+  maxAge: 86400,
+});
+
 /** Hono app — also re-exported for vitest (`app.request`). */
 export const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
+  .use("/admin/*", consoleCors)
+  .use("/v1/*", consoleCors)
   .route("/admin", admin)
   .route("/auth", auth)
   .route("/public/galleries", publicGalleries)

--- a/apps/api/test/cors.test.ts
+++ b/apps/api/test/cors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../src/index";
+
+const env = { WEB_ORIGIN: "https://uploads.sh" } as unknown as Env;
+
+function preflight(path: string, origin: string) {
+  return app.request(
+    path,
+    {
+      method: "OPTIONS",
+      headers: {
+        Origin: origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    },
+    env,
+  );
+}
+
+describe("console CORS", () => {
+  it("answers the preflight for the web origin on /admin", async () => {
+    const response = await preflight("/admin/enrollments", "https://uploads.sh");
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(response.headers.get("Access-Control-Allow-Headers")?.toLowerCase()).toContain(
+      "authorization",
+    );
+  });
+
+  it("answers the preflight for local dev origins on /v1", async () => {
+    const response = await preflight("/v1/default/usage", "http://localhost:4321");
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:4321");
+  });
+
+  it("does not reflect arbitrary origins", async () => {
+    const response = await preflight("/admin/enrollments", "https://evil.example");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("adds the allow-origin header to actual admin responses", async () => {
+    const response = await app.request(
+      "/admin/enrollments",
+      { method: "POST", headers: { Origin: "https://uploads.sh" }, body: "{}" },
+      env,
+    );
+    // Unauthorized without a token, but the CORS header must still be present
+    // so the browser can read the error body.
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+  });
+});

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -93,6 +93,21 @@ const FAVICON =
       }
       a:hover, a:focus-visible { color: var(--accent); outline: none; }
       code { color: var(--fg); }
+      .admin {
+        display: grid;
+        gap: 16px;
+        margin-top: 16px;
+        padding-top: 20px;
+        border-top: 1px solid var(--line);
+      }
+      .sect-head {
+        color: var(--muted);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin: 0;
+      }
+      [hidden] { display: none !important; }
     </style>
   </head>
   <body>
@@ -121,6 +136,26 @@ const FAVICON =
         <button type="button" id="btn-reconcile">Reconcile</button>
       </div>
       <pre id="out">Ready.</pre>
+
+      <section class="admin" aria-label="Invites">
+        <p class="sect-head"># invites — admin token required</p>
+        <p class="muted">
+          Creates a single-use enrollment code for the workspace above and prints the
+          magic link. Uses the token field as the admin bearer token.
+        </p>
+        <label>
+          Email invite to (optional)
+          <input id="invite-email" type="email" placeholder="them@example.com" autocomplete="off" />
+        </label>
+        <label>
+          Label (optional)
+          <input id="invite-label" type="text" placeholder="who or what this invite is for" autocomplete="off" />
+        </label>
+        <div class="row">
+          <button type="button" id="btn-invite">Create invite</button>
+          <button type="button" id="btn-invite-copy" hidden>Copy invite link</button>
+        </div>
+      </section>
     </main>
     <script>
       function el<T extends HTMLElement>(id: string): T {
@@ -161,6 +196,59 @@ const FAVICON =
       el<HTMLButtonElement>("btn-usage").onclick = () => call("/usage");
       el<HTMLButtonElement>("btn-list").onclick = () => call("/files?limit=50");
       el<HTMLButtonElement>("btn-reconcile").onclick = () => call("/usage/reconcile", "POST");
+
+      // Invite creation hits the admin API (POST /admin/enrollments) with the token
+      // field as the admin bearer token. The one-time code is shown once, here only.
+      const copyBtn = el<HTMLButtonElement>("btn-invite-copy");
+      let inviteLink = "";
+      el<HTMLButtonElement>("btn-invite").onclick = async () => {
+        const { api, ws, token } = cfg();
+        if (!token) {
+          out.textContent = "Paste the admin token into the token field first.";
+          return;
+        }
+        copyBtn.hidden = true;
+        out.textContent = "…";
+        const email = el<HTMLInputElement>("invite-email").value.trim();
+        const label = el<HTMLInputElement>("invite-label").value.trim();
+        try {
+          const res = await fetch(`${api}/admin/enrollments`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+            body: JSON.stringify({
+              workspace: ws || "default",
+              ...(email ? { email } : {}),
+              ...(label ? { label } : {}),
+            }),
+          });
+          const body = (await res.json().catch(() => null)) as {
+            pageId?: string;
+            code?: string;
+            expiresAt?: string;
+            emailed?: boolean;
+            error?: string;
+            message?: string;
+          } | null;
+          if (!res.ok || !body?.pageId || !body.code) {
+            out.textContent = `HTTP ${res.status}\n${JSON.stringify(body, null, 2)}`;
+            return;
+          }
+          inviteLink = `${location.origin}/invite?id=${encodeURIComponent(body.pageId)}#code=${encodeURIComponent(body.code)}`;
+          const emailedNote =
+            body.emailed === undefined ? "" : body.emailed ? `\nemailed:  ${email}` : "\nemailed:  send FAILED — share the link yourself";
+          out.textContent =
+            `Invite created for "${ws || "default"}" — the link below is shown once. Treat it like a password.\n\n` +
+            `${inviteLink}\n\nexpires:  ${body.expiresAt ?? "?"}${emailedNote}`;
+          copyBtn.hidden = false;
+        } catch (e) {
+          out.textContent = String(e);
+        }
+      };
+      copyBtn.onclick = async () => {
+        await navigator.clipboard.writeText(inviteLink);
+        copyBtn.textContent = "copied ✓";
+        setTimeout(() => (copyBtn.textContent = "Copy invite link"), 1500);
+      };
     </script>
   </body>
 </html>


### PR DESCRIPTION
Adds invite creation to the developer-only `/console` page, so an operator can mint an enrollment code without reaching for curl.

## What changed

- **Console (`/console`):** new "invites" section. It POSTs to `/admin/enrollments` using the token field as the admin bearer token, then prints the single-use magic link (`/invite?id=…#code=…` — same format the invite page parses) with its expiry, plus a copy button. Optional fields: email the invite directly (the API's existing delivery + per-recipient rate limit) and a label. The code is displayed once and never stored anywhere client-side beyond the output box.
- **API CORS:** `/admin/*` and `/v1/*` now answer preflights for the web origin (`WEB_ORIGIN`, falling back to `https://uploads.sh`) and localhost dev origins. Without this the browser console couldn't call the token-authenticated API at all — including the pre-existing usage/list/reconcile buttons, whose cross-origin requests failed preflight. CORS is not the security boundary here; bearer tokens are. Arbitrary origins are not reflected.

## Screenshot

<img width="600" alt="Console invites section with a created invite showing the magic link, expiry, and copy button" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/87/console-invites.webp">

*(Response stubbed in the screenshot; the real call is the same shape — verified against the existing `/admin/enrollments` route tests.)*

## Testing

- New [cors.test.ts](apps/api/test/cors.test.ts): preflight allowed for web origin and localhost, arbitrary origins not reflected, allow-origin header present on actual (401) admin responses.
- Full API suite passes (157 tests); `astro check` + `tsc` clean.
- UI flow exercised in the built app (`astro build` + `astro preview`) with a stubbed response: no-token guard, link construction, emailed note, copy button.

Note: the console's invite button only works in production once this API change deploys (merge → Workers Builds), since prod currently rejects the preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
