### PR TITLE
fix(web): make astro dev serve page scripts and keep preview healthy

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -106,6 +106,7 @@
     "**/*.d.ts",
     "packages/*/dist/**",
     "apps/api/scripts/**",
+    "apps/web/scripts/**",
     ".superpowers/**",
     ".worktrees/**"
   ]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview",
+    "preview": "node scripts/preview-supervisor.mjs",
+    "preview:raw": "astro preview",
     "deploy": "pnpm run build && node --env-file-if-exists=../../.env node_modules/wrangler/bin/wrangler.js deploy",
     "types": "wrangler types",
     "typecheck": "wrangler types && astro check && tsc -p tsconfig.worker.json --noEmit",

--- a/apps/web/scripts/preview-supervisor.mjs
+++ b/apps/web/scripts/preview-supervisor.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Supervise `astro preview` so it stays healthy.
+ *
+ * The Cloudflare vite plugin proxies preview requests into a workerd child via
+ * miniflare. That bridge can die after long uptime (every request then 500s
+ * with `TypeError: fetch failed … at _Miniflare.dispatchFetch` until restart;
+ * closest upstream ticket: cloudflare/workers-sdk#7376 — no released fix as of
+ * miniflare 4.20260708.1 / wrangler 4.110.0). This wrapper health-checks the
+ * server and restarts it when the bridge breaks, instead of leaving a dead
+ * preview behind.
+ *
+ * Usage: node scripts/preview-supervisor.mjs [astro preview args…]
+ *
+ * The child leads its own process group so a restart also reaps the workerd
+ * grandchild (same rationale as apps/api/scripts/run-timed.mjs).
+ */
+import { spawn } from "node:child_process";
+
+const CHECK_INTERVAL_MS = 20_000;
+const CHECK_TIMEOUT_MS = 10_000;
+const FAILURES_BEFORE_RESTART = 2;
+const RESTART_DELAY_MS = 1_000;
+
+let child;
+let previewUrl;
+let shuttingDown = false;
+
+function log(msg) {
+  console.error(`[preview-supervisor] ${msg}`);
+}
+
+function killGroup(proc, signal) {
+  if (!proc || proc.exitCode !== null || proc.signalCode !== null) return;
+  try {
+    process.kill(-proc.pid, signal);
+  } catch {
+    try {
+      proc.kill(signal);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+function start() {
+  previewUrl = undefined;
+  child = spawn("pnpm", ["exec", "astro", "preview", ...process.argv.slice(2)], {
+    detached: true,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  child.stdout.on("data", (chunk) => {
+    process.stdout.write(chunk);
+    if (!previewUrl) {
+      const m = String(chunk).match(/https?:\/\/localhost:\d+\//);
+      if (m) {
+        previewUrl = m[0];
+        log(`health-checking ${previewUrl} every ${CHECK_INTERVAL_MS / 1000}s`);
+      }
+    }
+  });
+  child.on("exit", (code, signal) => {
+    if (shuttingDown) return;
+    log(
+      `astro preview exited (code=${code} signal=${signal}); restarting in ${RESTART_DELAY_MS}ms`,
+    );
+    setTimeout(start, RESTART_DELAY_MS);
+  });
+}
+
+async function healthy() {
+  if (!previewUrl) return true; // still booting; exit handler covers boot failures
+  try {
+    const res = await fetch(previewUrl, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+    });
+    // Only 5xx counts as unhealthy — the dead workerd bridge turns every
+    // request into a 500, whereas 2xx–4xx means the server is serving.
+    return res.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+let consecutiveFailures = 0;
+setInterval(async () => {
+  if (shuttingDown) return;
+  if (await healthy()) {
+    consecutiveFailures = 0;
+    return;
+  }
+  consecutiveFailures += 1;
+  log(`health check failed (${consecutiveFailures}/${FAILURES_BEFORE_RESTART})`);
+  if (consecutiveFailures < FAILURES_BEFORE_RESTART) return;
+  consecutiveFailures = 0;
+  log("restarting astro preview (miniflare→workerd bridge looks dead)");
+  const proc = child; // capture: `child` is reassigned once the restart happens
+  killGroup(proc, "SIGTERM");
+  setTimeout(() => killGroup(proc, "SIGKILL"), 5_000).unref();
+  // child's exit handler schedules the restart
+}, CHECK_INTERVAL_MS).unref();
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    shuttingDown = true;
+    killGroup(child, "SIGTERM");
+    setTimeout(() => {
+      killGroup(child, "SIGKILL");
+      process.exit(0);
+    }, 5_000).unref();
+    child?.on("exit", () => process.exit(0));
+  });
+}
+
+start();
+// Keep the event loop alive even while the child is restarting.
+setInterval(() => {}, 60_000);

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -20,7 +20,17 @@
     "not_found_handling": "404-page",
     // Worker-first so static HTML also goes through markdown negotiation.
     // Without this, the asset server bypasses the Worker for prerendered pages.
-    "run_worker_first": true,
+    // Negations keep Vite-internal module URLs (/src/*, /@vite/*, /@fs/*, …)
+    // out of the Worker during `astro dev`; these paths never occur in production.
+    "run_worker_first": [
+      "/*",
+      "!/src/*",
+      "!/@vite/*",
+      "!/@fs/*",
+      "!/@id/*",
+      "!/node_modules/*",
+      "!/Users/*",
+    ],
   },
   "routes": [
     {


### PR DESCRIPTION
## What

Two dev-only server fixes in `apps/web` — no production behavior changes.

### 1. `astro dev` served pages whose scripts and styles all 404'd

Every page's `<script type="module">` and style module URLs returned the app's 404 page in dev, so no page JavaScript ran (copy buttons, invite status check, console actions). Even `/@vite/client` 404'd.

**Root cause:** `assets.run_worker_first: true` in `wrangler.jsonc`. When set to `true`, `@cloudflare/vite-plugin` (1.44.0) installs its middleware ahead of all of Vite's and maps the setting to a `user_worker: ["/*"]` rule with no exemptions — so every request, including Vite's own module URLs, is dispatched into workerd where the Astro handler 404s it. Vite's transform middleware never runs. No released plugin/adapter version fixes this.

**Fix:** the array form with negations, so Vite-internal paths fall through to Vite in dev:

```jsonc
"run_worker_first": ["/*", "!/src/*", "!/@vite/*", "!/@fs/*", "!/@id/*", "!/node_modules/*", "!/Users/*"]
```

`!/Users/*` covers the absolute-filesystem-path script URLs Astro emits in dev. None of these paths exist in production, and worker-first routing for real pages (markdown negotiation on prerendered HTML) is preserved — verified in dev with `Accept: text/markdown` and in prod shape via `astro build` + `wrangler deploy --dry-run`.

### 2. `astro preview` dies after long uptime

The miniflare→workerd bridge can break after a while: every request 500s with `TypeError: fetch failed … at _Miniflare.dispatchFetch` until the process is restarted. We're on the latest of everything (wrangler 4.110.0, miniflare 4.20260708.1); the closed upstream lookalikes (undici POST-body auth-retry, fixed since wrangler 4.83.0) don't apply, and the closest match — cloudflare/workers-sdk#7376 — is still open with no released fix.

**Fix:** `pnpm preview` now runs `scripts/preview-supervisor.mjs`, which spawns `astro preview` in its own process group, health-checks the served URL every 20s, and on two consecutive 5xx/connection failures kills the group (reaping the workerd child, same group-kill rationale as `apps/api/scripts/run-timed.mjs`) and restarts it. `pnpm preview:raw` keeps the unwrapped command.

## How it was verified

- Dev: after a clean `astro dev` restart, `/src/pages/console.astro?astro&type=style…`, `/@vite/client`, and the absolute-path `…console.astro?astro&type=script…` URL all return 200 and serve real transpiled JS/CSS; `/console` still renders through the worker.
- Preview: SIGKILLed the workerd child to reproduce the exact failure (every request 500s), then watched the supervisor detect it within two checks and recover to 200 in ~40s, with exactly one restart and no flapping afterwards.

## Notes for reviewers

- The supervisor treats any sustained 5xx on `/` as "bridge dead" and restarts — acceptable in dev, and a genuinely broken build would just restart-loop with visible logs.
- Dev-only tooling; no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
