### PR TITLE
chore: make the web dev launch config portable across sessions

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,9 +3,13 @@
   "configurations": [
     {
       "name": "web",
-      "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["dev:web"],
-      "port": 4321
+      "runtimeExecutable": "zsh",
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"${NVM_DIR:-$HOME/.nvm}\"; [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm use --silent; pnpm --filter @uploads/web exec astro dev --port ${PORT:-4321}"
+      ],
+      "port": 4321,
+      "autoPort": true
     },
     {
       "name": "web-preview",


### PR DESCRIPTION
## What

Two small fixes to `.claude/launch.json`'s `web` dev-server config:

- **Source nvm before launching** so `astro dev` runs on the repo's `.nvmrc` Node (24.18.0). Shells whose PATH pins an older Node (e.g. a hardcoded nvm-version export in a dotfile) otherwise crash astro's config loader (`node:module` has no `registerHooks` before Node 22.15). Falls through harmlessly when nvm isn't installed.
- **`autoPort: true`** with a `--port ${PORT:-4321}` passthrough, so parallel agent sessions/worktrees don't fail when another session already holds 4321.

No behavior change for `pnpm dev:web` run by hand.

## Test plan

- [x] `preview_start` on a shell defaulting to Node 22.14 now boots astro dev on 24.18.0 and serves the landing page
- [x] Port conflict case verified earlier in the session (auto-assigned a free port while 4321 was held by another session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)