### PR TITLE
feat: Better Auth Phase 3 — organizations, membership, invites

### DIFF
--- a/apps/api/scripts/backfill-orgs.mjs
+++ b/apps/api/scripts/backfill-orgs.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Thin client for POST /admin/orgs/backfill (plan D4/D9, Phase 3).
+ *
+ * Creates a Better Auth organization (slug = workspace name) for every KV
+ * workspace that doesn't already have one — idempotent, safe to re-run.
+ *
+ * Equivalent curl (this script just wraps this call — see
+ * reencrypt-workspace-secrets.mjs for the sibling pattern this mirrors):
+ *   curl -X POST "$UPLOADS_API_URL/admin/orgs/backfill" \
+ *     -H "Authorization: Bearer $ADMIN_TOKEN"
+ *
+ * Usage:
+ *   UPLOADS_API_URL=https://api.uploads.sh ADMIN_TOKEN=… \
+ *     node scripts/backfill-orgs.mjs
+ *
+ * Or from monorepo root after setting ADMIN_TOKEN in .env:
+ *   node --env-file=.env apps/api/scripts/backfill-orgs.mjs
+ */
+const api = (process.env.UPLOADS_API_URL ?? "https://api.uploads.sh").replace(/\/$/, "");
+const token = process.env.ADMIN_TOKEN ?? process.env.UPLOADS_ADMIN_TOKEN ?? "";
+
+if (!token) {
+  console.error("error: ADMIN_TOKEN (or UPLOADS_ADMIN_TOKEN) is required");
+  process.exit(1);
+}
+
+const res = await fetch(`${api}/admin/orgs/backfill`, {
+  method: "POST",
+  headers: { Authorization: `Bearer ${token}` },
+});
+const text = await res.text();
+let body;
+try {
+  body = JSON.parse(text);
+} catch {
+  body = text;
+}
+if (!res.ok) {
+  console.error(`HTTP ${res.status}`, body);
+  process.exit(1);
+}
+console.log(JSON.stringify(body, null, 2));
+console.log(
+  `\nCreated ${body.created?.length ?? 0}, already existed ${body.existing?.length ?? 0}.`,
+);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { workspaceAuth, type WorkspaceVars } from "./workspace";
 import { files } from "./routes/files";
 import { usage } from "./routes/usage";
 import { admin } from "./routes/admin";
+import { adminUi } from "./routes/admin-ui";
 import { auth } from "./routes/auth";
 import { runRetentionSweep } from "./retention-sweep";
 import { galleries } from "./routes/galleries";
@@ -25,12 +26,31 @@ const consoleCors = cors({
   maxAge: 86400,
 });
 
+// /admin-ui/* is session-cookie-authenticated (requireAdminUser, see
+// src/session-auth.ts), so unlike consoleCors above it must be credentialed
+// — same treatment as apps/auth's authCors for the web origin's cross-origin
+// browser calls (uploads.sh -> api.uploads.sh). The ADMIN_TOKEN-gated
+// `/admin/*` surface is bearer-token-only and deliberately untouched.
+const adminUiCors = cors({
+  origin: (origin, c) => {
+    if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;
+    if (/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) return origin;
+    return null;
+  },
+  credentials: true,
+  allowMethods: ["GET", "POST", "OPTIONS"],
+  allowHeaders: ["Content-Type"],
+  maxAge: 86400,
+});
+
 /** Hono app — also re-exported for vitest (`app.request`). */
 export const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
   .use("/admin/*", consoleCors)
+  .use("/admin-ui/*", adminUiCors)
   .use("/v1/*", consoleCors)
   .route("/admin", admin)
+  .route("/admin-ui", adminUi)
   .route("/auth", auth)
   .route("/public/galleries", publicGalleries)
   .use("/v1/:workspace/*", workspaceAuth)

--- a/apps/api/src/org-workspaces.test.ts
+++ b/apps/api/src/org-workspaces.test.ts
@@ -35,10 +35,9 @@ describe("orgForWorkspace", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null on a non-2xx, non-404 response rather than throwing", async () => {
+  it("throws on a non-2xx, non-404 response instead of masquerading as org_not_found", async () => {
     const auth = stubAuth(() => new Response(null, { status: 500 }));
-    const result = await orgForWorkspace(envWith(auth), "acme");
-    expect(result).toBeNull();
+    await expect(orgForWorkspace(envWith(auth), "acme")).rejects.toThrow();
   });
 
   it("URL-encodes the workspace name", async () => {

--- a/apps/api/src/org-workspaces.test.ts
+++ b/apps/api/src/org-workspaces.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { orgForWorkspace, workspacesForOrg } from "./org-workspaces";
+
+/** Stub matching the Fetcher interface's `.fetch()` shape used by env.AUTH. */
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+function envWith(auth: Pick<Fetcher, "fetch">): Env {
+  return { AUTH: auth } as unknown as Env;
+}
+
+describe("orgForWorkspace", () => {
+  it("resolves the org for a known workspace slug, calling the internal endpoint", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.url).toBe("https://auth.internal/internal/orgs/acme");
+      expect(req.headers.get("x-uploads-internal")).toBe("1");
+      return new Response(
+        JSON.stringify({ organization: { id: "org1", slug: "acme", name: "Acme" } }),
+        { status: 200 },
+      );
+    });
+    const result = await orgForWorkspace(envWith(auth), "acme");
+    expect(result).toEqual({ id: "org1", slug: "acme", name: "Acme" });
+  });
+
+  it("returns null for a 404 (no org provisioned for this workspace yet)", async () => {
+    const auth = stubAuth(() => new Response(null, { status: 404 }));
+    const result = await orgForWorkspace(envWith(auth), "no-such-workspace");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on a non-2xx, non-404 response rather than throwing", async () => {
+    const auth = stubAuth(() => new Response(null, { status: 500 }));
+    const result = await orgForWorkspace(envWith(auth), "acme");
+    expect(result).toBeNull();
+  });
+
+  it("URL-encodes the workspace name", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.url).toBe("https://auth.internal/internal/orgs/has%20space");
+      return new Response(null, { status: 404 });
+    });
+    await orgForWorkspace(envWith(auth), "has space");
+  });
+});
+
+describe("workspacesForOrg", () => {
+  it("returns the 1:1 workspace (the org's slug) as a single-element array", async () => {
+    const auth = stubAuth(() =>
+      Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } }),
+    );
+    const result = await workspacesForOrg(envWith(auth), "acme");
+    expect(result).toEqual(["acme"]);
+  });
+
+  it("returns an empty array when the org doesn't exist", async () => {
+    const auth = stubAuth(() => new Response(null, { status: 404 }));
+    const result = await workspacesForOrg(envWith(auth), "unknown");
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -16,6 +16,8 @@
  * database, by design, see plan D1's "ownership boundary").
  */
 
+import { ServiceUnavailableError } from "@uploads/errors";
+
 export interface OrgSummary {
   id: string;
   slug: string;
@@ -40,7 +42,15 @@ export async function orgForWorkspace(env: Env, workspaceName: string): Promise<
     { headers: internalHeaders() },
   );
   if (response.status === 404) return null;
-  if (!response.ok) return null;
+  if (!response.ok) {
+    // Any other non-ok status is an outage/bug in the auth worker, not "no
+    // org for this workspace" — throw so it surfaces as a 5xx via the API's
+    // error middleware instead of silently masquerading as org_not_found.
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: response.status },
+    });
+  }
   const body = (await response.json().catch(() => null)) as { organization?: OrgSummary } | null;
   return body?.organization ?? null;
 }

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -1,0 +1,62 @@
+/**
+ * Org <-> workspace indirection (plan D4, Phase 3).
+ *
+ * Today an "org" (a Better Auth `organization` row, owned by the auth
+ * worker's D1) maps 1:1 onto a "workspace" (a KV `ws:<name>` record, owned by
+ * this worker) by `organization.slug === workspace name`. That 1:1 mapping is
+ * an implementation detail of this module only — every other org<->workspace
+ * lookup in apps/api MUST go through `orgForWorkspace`/`workspacesForOrg`
+ * rather than assuming the slug equals the workspace name directly. If a
+ * future org ever owns more than one workspace, this module is the only file
+ * that needs to change (e.g. to consult a join table instead of doing a
+ * pass-through slug lookup) — callers keep working unmodified.
+ *
+ * All lookups go through the `AUTH` service binding's internal API (never a
+ * direct D1 read — this worker has no D1 binding into the auth worker's
+ * database, by design, see plan D1's "ownership boundary").
+ */
+
+export interface OrgSummary {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+const INTERNAL_ORIGIN = "https://auth.internal";
+
+function internalHeaders(): Headers {
+  return new Headers({ "x-uploads-internal": "1" });
+}
+
+/**
+ * The organization for a given workspace name, or null if none exists yet
+ * (e.g. the workspace predates the Phase 3 backfill, or was never
+ * provisioned as an org). Today: `GET /internal/orgs/:slug` with
+ * `slug = workspace name`.
+ */
+export async function orgForWorkspace(env: Env, workspaceName: string): Promise<OrgSummary | null> {
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(workspaceName)}`,
+    { headers: internalHeaders() },
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) return null;
+  const body = (await response.json().catch(() => null)) as { organization?: OrgSummary } | null;
+  return body?.organization ?? null;
+}
+
+/**
+ * Workspace names an org grants access to. Today: exactly `[org.slug]` (1:1)
+ * — this is intentionally NOT `[orgIdOrSlug]` verbatim, since the input may
+ * be an id; resolving through the org record keeps the contract stable if
+ * the mapping ever becomes one-to-many.
+ */
+export async function workspacesForOrg(env: Env, orgIdOrSlug: string): Promise<string[]> {
+  // Today's org records are looked up by slug on the auth worker; when the
+  // input is already a slug this is a single round trip. If a caller passes
+  // an id instead, this still resolves via the same endpoint since
+  // organization.slug is unique and ids/slugs never collide in this schema —
+  // callers of this module should prefer passing the slug they already have.
+  const org = await orgForWorkspace(env, orgIdOrSlug);
+  return org ? [org.slug] : [];
+}

--- a/apps/api/src/routes/admin-orgs-backfill.test.ts
+++ b/apps/api/src/routes/admin-orgs-backfill.test.ts
@@ -1,0 +1,92 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { admin } from "./admin";
+
+const ADMIN_TOKEN = "test-admin-token";
+
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+function fakeKv(names: string[]): Pick<KVNamespace, "list"> {
+  return {
+    list: (async () => ({
+      keys: names.map((name) => ({ name: `ws:${name}` })),
+      list_complete: true,
+      cacheStatus: null,
+    })) as unknown as KVNamespace["list"],
+  };
+}
+
+function appWith(auth: Pick<Fetcher, "fetch">, kv: Pick<KVNamespace, "list">) {
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/admin", admin)
+    .onError((err, c) => respondError(c, err));
+  return { app, env: { ADMIN_TOKEN, AUTH: auth, REGISTRY: kv } as unknown as Env };
+}
+
+function backfillRequest() {
+  return new Request("https://api.uploads.sh/admin/orgs/backfill", {
+    method: "POST",
+    headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
+describe("POST /admin/orgs/backfill", () => {
+  it("creates an org per workspace and reports created vs existing", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.headers.get("x-uploads-internal")).toBe("1");
+      return new Response(
+        JSON.stringify({ organization: { id: "x", slug: "acme", name: "acme" } }),
+        {
+          status: 201,
+        },
+      );
+    });
+    const { app, env } = appWith(auth, fakeKv(["acme", "beta"]));
+    const res = await app.request(backfillRequest(), {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ created: ["acme", "beta"], existing: [] });
+  });
+
+  it("reports existing orgs as existing (idempotent re-run), not created", async () => {
+    const auth = stubAuth(
+      () =>
+        new Response(JSON.stringify({ organization: { id: "x", slug: "acme", name: "acme" } }), {
+          status: 200,
+        }),
+    );
+    const { app, env } = appWith(auth, fakeKv(["acme"]));
+    const res = await app.request(backfillRequest(), {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ created: [], existing: ["acme"] });
+  });
+
+  it("401s without a valid admin token", async () => {
+    const auth = stubAuth(() => new Response("{}", { status: 200 }));
+    const { app, env } = appWith(auth, fakeKv([]));
+    const req = new Request("https://api.uploads.sh/admin/orgs/backfill", { method: "POST" });
+    const res = await app.request(req, {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("surfaces an auth-worker failure as an error rather than silently continuing", async () => {
+    const auth = stubAuth(() => new Response(JSON.stringify({ error: "boom" }), { status: 500 }));
+    const { app, env } = appWith(auth, fakeKv(["acme"]));
+    const res = await app.request(backfillRequest(), {}, env);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -168,6 +168,23 @@ describe("POST /admin-ui/workspaces/:name/invites", () => {
     );
     expect(res.status).toBe(403);
   });
+
+  it("429s when the per-workspace write budget is exhausted", async () => {
+    const env = stubEnv(ADMIN_USER, () => new Response(null, { status: 404 })) as Env & {
+      WRITE_LIMITER: { limit: (opts: { key: string }) => Promise<{ success: boolean }> };
+    };
+    env.WRITE_LIMITER = { limit: async () => ({ success: false }) };
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "x@y.com", role: "member" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(429);
+  });
 });
 
 describe("GET /admin-ui/workspaces/:name/members", () => {
@@ -184,5 +201,32 @@ describe("GET /admin-ui/workspaces/:name/members", () => {
     const res = await app().request("/admin-ui/workspaces/acme/members", {}, env);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ members: [{ id: "m1", email: "x@y.com", role: "member" }] });
+  });
+});
+
+describe("GET /admin-ui/workspaces/:name/invites", () => {
+  it("proxies the internal pending-invite list", async () => {
+    const env = stubEnv(ADMIN_USER, (path) => {
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "acme" } });
+      }
+      if (path === "/internal/orgs/acme/invites") {
+        return Response.json({
+          invites: [{ id: "inv1", email: "x@y.com", role: "member", status: "pending" }],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/workspaces/acme/invites", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      invites: [{ id: "inv1", email: "x@y.com", role: "member", status: "pending" }],
+    });
+  });
+
+  it("404s when no org exists for the workspace", async () => {
+    const env = stubEnv(ADMIN_USER, () => new Response(null, { status: 404 }));
+    const res = await app().request("/admin-ui/workspaces/no-org/invites", {}, env);
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -1,0 +1,188 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { adminUi } from "./admin-ui";
+
+const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
+const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** A single stub that answers get-session with `user`, and everything else via `onInternal`. */
+function stubEnv(
+  user: typeof ADMIN_USER | null,
+  onInternal: (path: string, req: Request) => Response | Promise<Response>,
+): Env {
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+    }
+    return onInternal(url.pathname, req);
+  });
+  return { AUTH: auth, REGISTRY: fakeKv([]) } as unknown as Env;
+}
+
+function fakeKv(names: string[]): Pick<KVNamespace, "list"> {
+  return {
+    list: (async () => ({
+      keys: names.map((name) => ({ name: `ws:${name}` })),
+      list_complete: true,
+      cacheStatus: null,
+    })) as unknown as KVNamespace["list"],
+  };
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/admin-ui", adminUi)
+    .onError((err, c) => respondError(c, err));
+}
+
+describe("admin-ui auth gate", () => {
+  it("401s with no session", async () => {
+    const env = stubEnv(null, () => new Response("{}"));
+    const res = await app().request("/admin-ui/workspaces", {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const env = stubEnv(NON_ADMIN_USER, () => new Response("{}"));
+    const res = await app().request("/admin-ui/workspaces", {}, env);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /admin-ui/workspaces", () => {
+  it("lists KV workspaces joined with org summaries", async () => {
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: ADMIN_USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/orgs/acme") {
+        return Response.json({
+          organization: { id: "org1", slug: "acme", name: "acme" },
+          memberCount: 2,
+          pendingInviteCount: 1,
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const env = { AUTH: auth, REGISTRY: fakeKv(["acme"]) } as unknown as Env;
+    const res = await app().request("/admin-ui/workspaces", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspaces: [
+        {
+          workspace: "acme",
+          organization: { id: "org1", slug: "acme", name: "acme" },
+          memberCount: 2,
+          pendingInviteCount: 1,
+        },
+      ],
+    });
+  });
+});
+
+describe("POST /admin-ui/workspaces/:name/invites", () => {
+  it("creates an invitation via the internal endpoint", async () => {
+    const env = stubEnv(ADMIN_USER, (path, req) => {
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "acme" } });
+      }
+      if (path === "/internal/invite") {
+        expect(req.headers.get("x-uploads-internal")).toBe("1");
+        return new Response(
+          JSON.stringify({ invitation: { id: "inv1", email: "x@y.com", role: "member" } }),
+          { status: 201 },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "x@y.com", role: "member" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("404s when no org exists for the workspace", async () => {
+    const env = stubEnv(ADMIN_USER, () => new Response(null, { status: 404 }));
+    const res = await app().request(
+      "/admin-ui/workspaces/no-org/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "x@y.com", role: "member" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("400s on an invalid email without calling the internal invite endpoint", async () => {
+    let inviteCalled = false;
+    const env = stubEnv(ADMIN_USER, (path) => {
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "acme" } });
+      }
+      if (path === "/internal/invite") inviteCalled = true;
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "not-an-email", role: "member" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(inviteCalled).toBe(false);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const env = stubEnv(NON_ADMIN_USER, () => new Response(null, { status: 404 }));
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "x@y.com", role: "member" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /admin-ui/workspaces/:name/members", () => {
+  it("proxies the internal member list", async () => {
+    const env = stubEnv(ADMIN_USER, (path) => {
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "acme" } });
+      }
+      if (path === "/internal/orgs/acme/members") {
+        return Response.json({ members: [{ id: "m1", email: "x@y.com", role: "member" }] });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ members: [{ id: "m1", email: "x@y.com", role: "member" }] });
+  });
+});

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -5,8 +5,9 @@
  * the ops/CI `/admin` surface stays untouched. Backs the /admin page's
  * Workspaces slot on apps/web.
  */
-import { NotFoundError, ValidationError } from "@uploads/errors";
+import { NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
+import { allowWrite } from "../guards";
 import { orgForWorkspace } from "../org-workspaces";
 import {
   requireAdminUser,
@@ -29,7 +30,7 @@ async function orgSummaryForWorkspace(env: Env, name: string): Promise<OrgSummar
     { headers: { "x-uploads-internal": "1" } },
   );
   if (!response.ok) return null;
-  return (await response.json()) as OrgSummary;
+  return (await response.json().catch(() => null)) as OrgSummary | null;
 }
 
 export const adminUi = new Hono<SessionVars>()
@@ -103,6 +104,9 @@ export const adminUi = new Hono<SessionVars>()
   // Invite an email to the org backing this workspace.
   .post("/workspaces/:name/invites", async (c) => {
     const name = c.req.param("name");
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
     const org = await orgForWorkspace(c.env, name);
     if (!org) {
       // KV workspace exists but no org has been provisioned for it yet

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -1,0 +1,142 @@
+/**
+ * Session-authenticated admin dashboard endpoints (plan D6/Phase 3 scope B).
+ * Gated by `requireAdminUser` (Phase 2's session-based global admin auth,
+ * NOT the `ADMIN_TOKEN` gating `/admin/*`) — distinct `/admin-ui/*` prefix so
+ * the ops/CI `/admin` surface stays untouched. Backs the /admin page's
+ * Workspaces slot on apps/web.
+ */
+import { NotFoundError, ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import { orgForWorkspace } from "../org-workspaces";
+import {
+  requireAdminUser,
+  requireSessionUser,
+  sessionAuth,
+  type SessionVars,
+} from "../session-auth";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface OrgSummary {
+  organization: { id: string; slug: string; name: string };
+  memberCount: number;
+  pendingInviteCount: number;
+}
+
+async function orgSummaryForWorkspace(env: Env, name: string): Promise<OrgSummary | null> {
+  const response = await env.AUTH.fetch(
+    `https://auth.internal/internal/orgs/${encodeURIComponent(name)}`,
+    { headers: { "x-uploads-internal": "1" } },
+  );
+  if (!response.ok) return null;
+  return (await response.json()) as OrgSummary;
+}
+
+export const adminUi = new Hono<SessionVars>()
+  .use("/*", sessionAuth, requireSessionUser, requireAdminUser)
+
+  // List every KV workspace joined with its org + member/invite counts.
+  .get("/workspaces", async (c) => {
+    const names: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await c.env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
+      for (const entry of page.keys) {
+        const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
+        if (name) names.push(name);
+      }
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
+
+    const workspaces = await Promise.all(
+      names.map(async (name) => {
+        const summary = await orgSummaryForWorkspace(c.env, name);
+        return {
+          workspace: name,
+          organization: summary?.organization ?? null,
+          memberCount: summary?.memberCount ?? 0,
+          pendingInviteCount: summary?.pendingInviteCount ?? 0,
+        };
+      }),
+    );
+    return c.json({ workspaces });
+  })
+
+  // Members of the org backing this workspace.
+  .get("/workspaces/:name/members", async (c) => {
+    const name = c.req.param("name");
+    const org = await orgForWorkspace(c.env, name);
+    if (!org)
+      throw new NotFoundError("no organization for this workspace", { code: "org_not_found" });
+
+    const response = await c.env.AUTH.fetch(
+      `https://auth.internal/internal/orgs/${encodeURIComponent(org.slug)}/members`,
+      { headers: { "x-uploads-internal": "1" } },
+    );
+    if (!response.ok) {
+      throw new ValidationError("failed to list members", {
+        details: await response.json().catch(() => null),
+      });
+    }
+    return c.json(await response.json());
+  })
+
+  // Pending invites for the org backing this workspace.
+  .get("/workspaces/:name/invites", async (c) => {
+    const name = c.req.param("name");
+    const org = await orgForWorkspace(c.env, name);
+    if (!org)
+      throw new NotFoundError("no organization for this workspace", { code: "org_not_found" });
+
+    const response = await c.env.AUTH.fetch(
+      `https://auth.internal/internal/orgs/${encodeURIComponent(org.slug)}/invites`,
+      { headers: { "x-uploads-internal": "1" } },
+    );
+    if (!response.ok) {
+      throw new ValidationError("failed to list invites", {
+        details: await response.json().catch(() => null),
+      });
+    }
+    return c.json(await response.json());
+  })
+
+  // Invite an email to the org backing this workspace.
+  .post("/workspaces/:name/invites", async (c) => {
+    const name = c.req.param("name");
+    const org = await orgForWorkspace(c.env, name);
+    if (!org) {
+      // KV workspace exists but no org has been provisioned for it yet
+      // (backfill hasn't run, or it's a fresh workspace). Point the caller
+      // at the backfill rather than silently auto-provisioning here.
+      throw new NotFoundError("no organization for this workspace — run the org backfill first", {
+        code: "org_not_found",
+      });
+    }
+
+    const body = await c.req
+      .json<{ email?: unknown; role?: unknown }>()
+      .catch(() => ({}) as { email?: unknown; role?: unknown });
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const role = typeof body.role === "string" ? body.role.trim() : "member";
+    if (!email || !EMAIL_RE.test(email)) {
+      throw new ValidationError("invalid email address", { code: "invalid_email" });
+    }
+    if (role !== "member" && role !== "admin") {
+      throw new ValidationError("role must be member or admin", { code: "invalid_role" });
+    }
+
+    const inviterUserId = c.get("sessionUser")?.id;
+    if (!inviterUserId)
+      throw new ValidationError("missing session user", { code: "invalid_session" });
+
+    const response = await c.env.AUTH.fetch("https://auth.internal/internal/invite", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+      body: JSON.stringify({ organizationSlug: org.slug, email, role, inviterUserId }),
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new ValidationError("failed to create invitation", { details: payload });
+    }
+    return c.json(payload as object, 201);
+  });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -207,6 +207,44 @@ export const admin = new Hono<{ Bindings: Env }>()
     return c.json(payload as object, 200);
   })
 
+  // Phase 3 (plan scope B): one-time/idempotent backfill — creates an org
+  // (slug = workspace name) for every KV workspace that doesn't have one yet.
+  // Mirrors reencrypt-registry.ts's `ws:` KV pagination. ADMIN_TOKEN-gated
+  // (this stays on the ops/CI `/admin` surface, not `/admin-ui`) since it's a
+  // one-off migration operation, not part of the session-authenticated
+  // admin dashboard.
+  .post("/orgs/backfill", async (c) => {
+    const created: string[] = [];
+    const existing: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await c.env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
+      for (const entry of page.keys) {
+        const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
+        if (!name) continue;
+
+        const response = await c.env.AUTH.fetch("https://auth.internal/internal/orgs", {
+          method: "POST",
+          headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+          body: JSON.stringify({ slug: name, name }),
+        });
+        if (!response.ok) {
+          throw new ValidationError(`failed to create org for workspace "${name}"`, {
+            details: await response.json().catch(() => null),
+          });
+        }
+        if (response.status === 201) {
+          created.push(name);
+        } else {
+          existing.push(name);
+        }
+      }
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
+
+    return c.json({ created, existing });
+  })
+
   // Mint a scoped bearer token for an existing workspace (defaults to "default").
   // New credentials live in D1; legacy KV credentials remain readable/revocable.
   .post("/tokens", async (c) => {

--- a/apps/auth/migrations/20260712220000_organization.sql
+++ b/apps/auth/migrations/20260712220000_organization.sql
@@ -1,0 +1,48 @@
+-- Phase 3: `organization` plugin (see src/auth.ts, plan D3/D4).
+--
+-- No `team` support (explicitly out of scope, D3) and no personal-org
+-- auto-provisioning (D4 — orgs are admin-provisioned only via
+-- /internal/orgs or the KV-workspace backfill script). Table shapes
+-- reconciled against `npx @better-auth/cli generate` for the organization
+-- plugin and ~/Code/releases/workers/api/src/db/schema-auth.ts (trimmed:
+-- that repo's org auto-provisioning hook is deliberately not copied).
+-- Paired with src/schema.ts — keep both in sync by hand (see the JSDoc there).
+
+CREATE TABLE organization (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  logo TEXT,
+  created_at INTEGER NOT NULL,
+  metadata TEXT
+);
+
+CREATE TABLE member (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organization (id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'member',
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_member_organization_id ON member (organization_id);
+CREATE INDEX idx_member_user_id ON member (user_id);
+
+CREATE TABLE invitation (
+  id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL REFERENCES organization (id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  expires_at INTEGER NOT NULL,
+  inviter_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_invitation_organization_id ON invitation (organization_id);
+
+-- session.active_organization_id: written by the organization plugin to
+-- track which org a multi-org user is currently acting as. Verified against
+-- `migrations/20260712200000_better_auth_core.sql` and
+-- `migrations/20260712210000_admin_plugin.sql` — this is the only Phase 3
+-- ALTER TABLE needed on `session`.
+ALTER TABLE session ADD COLUMN active_organization_id TEXT;

--- a/apps/auth/migrations/20260712220000_organization.sql
+++ b/apps/auth/migrations/20260712220000_organization.sql
@@ -35,7 +35,8 @@ CREATE TABLE invitation (
   role TEXT,
   status TEXT NOT NULL DEFAULT 'pending',
   expires_at INTEGER NOT NULL,
-  inviter_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE
+  inviter_id TEXT NOT NULL REFERENCES user (id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL
 );
 
 CREATE INDEX idx_invitation_organization_id ON invitation (organization_id);

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -8,7 +8,7 @@
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
 import { drizzle } from "drizzle-orm/d1";
-import { admin, magicLink } from "better-auth/plugins";
+import { admin, magicLink, organization } from "better-auth/plugins";
 import { sendAuthEmail } from "./email";
 import * as schema from "./schema";
 import { authTrustedOrigins, isTrustedOrigin } from "./trusted-origins";
@@ -96,6 +96,26 @@ function buildAuth(
       admin({
         defaultRole: "user",
         adminRoles: ["admin"],
+      }),
+      // D3/D4 (Phase 3): orgs, membership, invitations. No `team` support.
+      // No org auto-provisioning hook — workspaces (and their 1:1 orgs) are
+      // admin-provisioned only, via /internal/orgs or the backfill script;
+      // do NOT add a `organizationCreation`/session hook here (see D4).
+      organization({
+        membershipLimit: 100,
+        sendInvitationEmail: async ({ id, email, organization: org, inviter }) => {
+          const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
+          const url = `${webOrigin}/accept-invitation/${id}`;
+          await sendAuthEmail(env, {
+            to: email,
+            template: "invitation",
+            context: {
+              url,
+              organizationName: org.name,
+              inviterEmail: inviter.user.email,
+            },
+          });
+        },
       }),
     ],
     session: {

--- a/apps/auth/src/email.test.ts
+++ b/apps/auth/src/email.test.ts
@@ -51,6 +51,29 @@ describe("sendAuthEmail", () => {
     expect(args.text).toContain("https://auth.uploads.sh/x");
   });
 
+  it("HTML-escapes organization name and inviter email in the invitation template", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const EMAIL: EmailBinding = { send };
+    await sendAuthEmail(
+      { EMAIL, ENVIRONMENT: "production" },
+      {
+        to: "a@example.com",
+        template: "invitation",
+        context: {
+          url: "https://auth.uploads.sh/accept",
+          organizationName: `<img src=x onerror=alert(1)>`,
+          inviterEmail: `"><script>alert(2)</script>`,
+        },
+      },
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+    const args = send.mock.calls[0]?.[0];
+    expect(args.html).not.toContain("<img src=x onerror=alert(1)>");
+    expect(args.html).not.toContain("<script>alert(2)</script>");
+    expect(args.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(args.html).toContain("&lt;script&gt;alert(2)&lt;/script&gt;");
+  });
+
   it("never throws when the send fails", async () => {
     const send = vi.fn().mockRejectedValue(new Error("boom"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -44,6 +44,14 @@ function isDev(env: SendAuthEmailEnv): boolean {
   return env.ENVIRONMENT !== "production";
 }
 
+/** Escape a string for safe interpolation into an HTML email body. */
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+  );
+}
+
 function renderMagicLink(context: MagicLinkContext): {
   subject: string;
   text: string;
@@ -51,7 +59,8 @@ function renderMagicLink(context: MagicLinkContext): {
 } {
   const subject = "Sign in to uploads.sh";
   const text = `Sign in to uploads.sh by opening this link (expires in 15 minutes):\n\n${context.url}\n\nIf you didn't request this, you can ignore this email.`;
-  const html = `<p>Sign in to uploads.sh by clicking the link below. It expires in 15 minutes.</p><p><a href="${context.url}">Sign in to uploads.sh</a></p><p>If you didn't request this, you can ignore this email.</p>`;
+  const url = escapeHtml(context.url);
+  const html = `<p>Sign in to uploads.sh by clicking the link below. It expires in 15 minutes.</p><p><a href="${url}">Sign in to uploads.sh</a></p><p>If you didn't request this, you can ignore this email.</p>`;
   return { subject, text, html };
 }
 
@@ -62,7 +71,10 @@ function renderInvitation(context: InvitationContext): {
 } {
   const subject = `You've been invited to ${context.organizationName} on uploads.sh`;
   const text = `${context.inviterEmail} invited you to join ${context.organizationName} on uploads.sh.\n\nAccept the invitation:\n\n${context.url}\n\nIf you weren't expecting this, you can ignore this email.`;
-  const html = `<p><strong>${context.inviterEmail}</strong> invited you to join <strong>${context.organizationName}</strong> on uploads.sh.</p><p><a href="${context.url}">Accept invitation</a></p><p>If you weren't expecting this, you can ignore this email.</p>`;
+  const organizationName = escapeHtml(context.organizationName);
+  const inviterEmail = escapeHtml(context.inviterEmail);
+  const url = escapeHtml(context.url);
+  const html = `<p><strong>${inviterEmail}</strong> invited you to join <strong>${organizationName}</strong> on uploads.sh.</p><p><a href="${url}">Accept invitation</a></p><p>If you weren't expecting this, you can ignore this email.</p>`;
   return { subject, text, html };
 }
 

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -29,7 +29,16 @@ export type SendAuthEmailEnv = {
 
 export type MagicLinkContext = { url: string };
 
-export type SendAuthEmailArgs = { to: string; template: "magic-link"; context: MagicLinkContext };
+/** Phase 3: `organization` plugin's `sendInvitationEmail` context (src/auth.ts). */
+export type InvitationContext = {
+  url: string;
+  organizationName: string;
+  inviterEmail: string;
+};
+
+export type SendAuthEmailArgs =
+  | { to: string; template: "magic-link"; context: MagicLinkContext }
+  | { to: string; template: "invitation"; context: InvitationContext };
 
 function isDev(env: SendAuthEmailEnv): boolean {
   return env.ENVIRONMENT !== "production";
@@ -46,10 +55,23 @@ function renderMagicLink(context: MagicLinkContext): {
   return { subject, text, html };
 }
 
+function renderInvitation(context: InvitationContext): {
+  subject: string;
+  text: string;
+  html: string;
+} {
+  const subject = `You've been invited to ${context.organizationName} on uploads.sh`;
+  const text = `${context.inviterEmail} invited you to join ${context.organizationName} on uploads.sh.\n\nAccept the invitation:\n\n${context.url}\n\nIf you weren't expecting this, you can ignore this email.`;
+  const html = `<p><strong>${context.inviterEmail}</strong> invited you to join <strong>${context.organizationName}</strong> on uploads.sh.</p><p><a href="${context.url}">Accept invitation</a></p><p>If you weren't expecting this, you can ignore this email.</p>`;
+  return { subject, text, html };
+}
+
 function render(args: SendAuthEmailArgs): { subject: string; text: string; html: string } {
   switch (args.template) {
     case "magic-link":
       return renderMagicLink(args.context);
+    case "invitation":
+      return renderInvitation(args.context);
   }
 }
 

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1,0 +1,93 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { internal } from "./internal-routes";
+
+/**
+ * These cover the request-validation short-circuits on the Phase 3
+ * `/internal/*` routes (memberships/orgs/invite) that fail before touching
+ * D1 — validated by using a DB stub that throws on first access. Full
+ * DB-backed behavior (successful creates/lookups against real `organization`/
+ * `member`/`invitation` rows) is NOT covered here: this repo has no
+ * drizzle-over-D1 test harness yet (unlike apps/api's hand-rolled FakeD1 for
+ * raw SQL in auth-db.test.ts, drizzle's D1 driver issues its own prepared
+ * statements that a hand-written fake would need to parse). Flagged in the
+ * Phase 3 handoff report as a follow-up rather than built here.
+ */
+function poisonDB(): D1Database {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("DB should not be touched for this request");
+      },
+    },
+  ) as D1Database;
+}
+
+function app() {
+  return new Hono<{ Bindings: AuthEnv }>().route("/internal", internal);
+}
+
+function env(): AuthEnv {
+  return { DB: poisonDB(), WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
+}
+
+describe("GET /internal/memberships", () => {
+  it("400s when userId is missing", async () => {
+    const res = await app().request("/internal/memberships", {}, env());
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_user_id" },
+    });
+  });
+});
+
+describe("POST /internal/orgs", () => {
+  it("400s when slug is missing", async () => {
+    const res = await app().request(
+      "/internal/orgs",
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({}) },
+      env(),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_slug" },
+    });
+  });
+});
+
+describe("POST /internal/invite", () => {
+  it("400s when required fields are missing", async () => {
+    const res = await app().request(
+      "/internal/invite",
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({}) },
+      env(),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_request" },
+    });
+  });
+
+  it("400s on an invalid role without touching the DB", async () => {
+    const res = await app().request(
+      "/internal/invite",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          organizationSlug: "acme",
+          email: "a@b.com",
+          role: "owner",
+          inviterUserId: "u1",
+        }),
+      },
+      env(),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_role" },
+    });
+  });
+});

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -67,9 +67,30 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (!auth) {
       return c.json(errorJson("auth_unavailable", "Auth is not configured yet."), 503);
     }
-    const created = await auth.api.createOrganization({
-      body: { slug, name: name || slug },
-    });
+    // TOCTOU: two concurrent callers can both pass the `existing` check above
+    // and race to create the same slug — Better Auth enforces the unique
+    // constraint and throws on the loser. Treat that as "already exists"
+    // (re-query and return the winner's row as 200) rather than propagating
+    // a 500 for what is really an idempotent no-op from the caller's POV.
+    let created: Awaited<ReturnType<typeof auth.api.createOrganization>>;
+    try {
+      created = await auth.api.createOrganization({
+        body: { slug, name: name || slug },
+      });
+    } catch (err) {
+      const [winner] = await db
+        .select()
+        .from(schema.organization)
+        .where(eq(schema.organization.slug, slug))
+        .limit(1);
+      if (winner) {
+        return c.json(
+          { organization: { id: winner.id, slug: winner.slug, name: winner.name } },
+          200,
+        );
+      }
+      throw err;
+    }
     if (!created) {
       return c.json(errorJson("create_failed", "failed to create organization"), 500);
     }
@@ -155,8 +176,10 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
         expiresAt: schema.invitation.expiresAt,
       })
       .from(schema.invitation)
-      .where(eq(schema.invitation.organizationId, org.id));
-    return c.json({ invites: rows.filter((r) => r.status === "pending") });
+      .where(
+        and(eq(schema.invitation.organizationId, org.id), eq(schema.invitation.status, "pending")),
+      );
+    return c.json({ invites: rows });
   })
   // Phase 3 (plan scope B): server-side invite creation for
   // POST /admin-ui/workspaces/:name/invites on apps/api.
@@ -224,6 +247,36 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       return c.json(errorJson("inviter_not_found", "no user with that id"), 404);
     }
 
+    // Idempotency: an existing pending invite for this (org, email) is
+    // returned as-is rather than inserting a duplicate row and re-sending
+    // the invitation email (e.g. the admin double-clicks Invite).
+    const [existingInvite] = await db
+      .select()
+      .from(schema.invitation)
+      .where(
+        and(
+          eq(schema.invitation.organizationId, org.id),
+          eq(schema.invitation.email, email),
+          eq(schema.invitation.status, "pending"),
+        ),
+      )
+      .limit(1);
+    if (existingInvite) {
+      return c.json(
+        {
+          invitation: {
+            id: existingInvite.id,
+            organizationId: existingInvite.organizationId,
+            email: existingInvite.email,
+            role: existingInvite.role,
+            status: existingInvite.status,
+            expiresAt: existingInvite.expiresAt,
+          },
+        },
+        200,
+      );
+    }
+
     const id = crypto.randomUUID();
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7); // 7 days
     await db.insert(schema.invitation).values({
@@ -234,6 +287,7 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       status: "pending",
       expiresAt,
       inviterId: inviter.id,
+      createdAt: new Date(),
     });
 
     const webOrigin = c.env.WEB_ORIGIN || "https://uploads.sh";

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -4,7 +4,7 @@
  * applied in src/index.ts before this router is even reached).
  */
 import { drizzle } from "drizzle-orm/d1";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { createAuth, type AuthEnv } from "./auth";
 import { sendAuthEmail } from "./email";
@@ -98,8 +98,10 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     const invites = await db
       .select({ id: schema.invitation.id })
       .from(schema.invitation)
-      .where(eq(schema.invitation.organizationId, org.id));
-    const pendingInvites = invites.length; // status filtering happens client-side today; see /invites below for detail
+      .where(
+        and(eq(schema.invitation.organizationId, org.id), eq(schema.invitation.status, "pending")),
+      );
+    const pendingInvites = invites.length;
     return c.json({
       organization: { id: org.id, slug: org.slug, name: org.name },
       memberCount: members.length,

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -6,7 +6,8 @@
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import type { AuthEnv } from "./auth";
+import { createAuth, type AuthEnv } from "./auth";
+import { sendAuthEmail } from "./email";
 import * as schema from "./schema";
 
 function errorJson(code: string, message: string) {
@@ -14,6 +15,241 @@ function errorJson(code: string, message: string) {
 }
 
 export const internal = new Hono<{ Bindings: AuthEnv }>()
+  // Phase 3 (plan scope A): memberships for a user, used by
+  // apps/api/src/org-workspaces.ts and the admin-ui endpoints to resolve
+  // "what orgs/workspaces can this user act on".
+  .get("/memberships", async (c) => {
+    const userId = c.req.query("userId")?.trim();
+    if (!userId) {
+      return c.json(errorJson("invalid_user_id", "userId is required"), 400);
+    }
+
+    const db = drizzle(c.env.DB, { schema });
+    const rows = await db
+      .select({
+        organizationId: schema.member.organizationId,
+        organizationSlug: schema.organization.slug,
+        role: schema.member.role,
+      })
+      .from(schema.member)
+      .innerJoin(schema.organization, eq(schema.member.organizationId, schema.organization.id))
+      .where(eq(schema.member.userId, userId));
+
+    return c.json(rows);
+  })
+  // Phase 3 (plan scope A): admin-provisioned org creation, idempotent on
+  // slug — the backfill script (apps/api/scripts/backfill-orgs.mjs) and
+  // apps/api's /admin/orgs/backfill both call this per KV workspace.
+  .post("/orgs", async (c) => {
+    const body = await c.req
+      .json<{ slug?: unknown; name?: unknown }>()
+      .catch(() => ({}) as { slug?: unknown; name?: unknown });
+    const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    if (!slug) {
+      return c.json(errorJson("invalid_slug", "slug is required"), 400);
+    }
+
+    const db = drizzle(c.env.DB, { schema });
+    const [existing] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (existing) {
+      return c.json(
+        { organization: { id: existing.id, slug: existing.slug, name: existing.name } },
+        200,
+      );
+    }
+
+    const auth = await createAuth(c.env);
+    if (!auth) {
+      return c.json(errorJson("auth_unavailable", "Auth is not configured yet."), 503);
+    }
+    const created = await auth.api.createOrganization({
+      body: { slug, name: name || slug },
+    });
+    if (!created) {
+      return c.json(errorJson("create_failed", "failed to create organization"), 500);
+    }
+    return c.json(
+      { organization: { id: created.id, slug: created.slug, name: created.name } },
+      201,
+    );
+  })
+  // Phase 3 (plan scope B): org lookup + member/invite counts for
+  // GET /admin-ui/workspaces on apps/api.
+  .get("/orgs/:slug", async (c) => {
+    const slug = c.req.param("slug");
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const members = await db
+      .select({ id: schema.member.id })
+      .from(schema.member)
+      .where(eq(schema.member.organizationId, org.id));
+    const invites = await db
+      .select({ id: schema.invitation.id })
+      .from(schema.invitation)
+      .where(eq(schema.invitation.organizationId, org.id));
+    const pendingInvites = invites.length; // status filtering happens client-side today; see /invites below for detail
+    return c.json({
+      organization: { id: org.id, slug: org.slug, name: org.name },
+      memberCount: members.length,
+      pendingInviteCount: pendingInvites,
+    });
+  })
+  // Phase 3 (plan scope B): member list for GET /admin-ui/workspaces/:name/members.
+  .get("/orgs/:slug/members", async (c) => {
+    const slug = c.req.param("slug");
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const rows = await db
+      .select({
+        id: schema.member.id,
+        role: schema.member.role,
+        userId: schema.user.id,
+        email: schema.user.email,
+        name: schema.user.name,
+        createdAt: schema.member.createdAt,
+      })
+      .from(schema.member)
+      .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
+      .where(eq(schema.member.organizationId, org.id));
+    return c.json({ members: rows });
+  })
+  // Phase 3 (plan scope B): pending invites for the admin-ui workspace detail view.
+  .get("/orgs/:slug/invites", async (c) => {
+    const slug = c.req.param("slug");
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const rows = await db
+      .select({
+        id: schema.invitation.id,
+        email: schema.invitation.email,
+        role: schema.invitation.role,
+        status: schema.invitation.status,
+        expiresAt: schema.invitation.expiresAt,
+      })
+      .from(schema.invitation)
+      .where(eq(schema.invitation.organizationId, org.id));
+    return c.json({ invites: rows.filter((r) => r.status === "pending") });
+  })
+  // Phase 3 (plan scope B): server-side invite creation for
+  // POST /admin-ui/workspaces/:name/invites on apps/api.
+  //
+  // Implementation choice: this writes the `invitation` row directly via
+  // drizzle (same pattern as promote-admin above) and sends the email itself,
+  // rather than calling the organization plugin's `auth.api.createInvitation`
+  // server method. That method authorizes the *inviter* off a Better Auth
+  // session it resolves from request headers/cookies — but this route is
+  // reached from apps/api's requireAdminUser (session-based *global* admin
+  // auth, Phase 2), not an org-membership session, and there is no
+  // browser-forwarded Better Auth session token that maps to "is this admin
+  // an owner/admin of this org" (admins provision orgs, they aren't
+  // necessarily members of every one). Re-deriving a synthetic session to
+  // satisfy the plugin's own authorization would be more fragile than just
+  // inserting the row this route is already trusted (service-binding +
+  // requireAdminUser upstream) to create.
+  .post("/invite", async (c) => {
+    const body = await c.req
+      .json<{
+        organizationSlug?: unknown;
+        email?: unknown;
+        role?: unknown;
+        inviterUserId?: unknown;
+      }>()
+      .catch(
+        () =>
+          ({}) as {
+            organizationSlug?: unknown;
+            email?: unknown;
+            role?: unknown;
+            inviterUserId?: unknown;
+          },
+      );
+    const organizationSlug =
+      typeof body.organizationSlug === "string" ? body.organizationSlug.trim() : "";
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const role = typeof body.role === "string" ? body.role.trim() : "member";
+    const inviterUserId = typeof body.inviterUserId === "string" ? body.inviterUserId.trim() : "";
+    if (!organizationSlug || !email || !inviterUserId) {
+      return c.json(
+        errorJson("invalid_request", "organizationSlug, email, and inviterUserId are required"),
+        400,
+      );
+    }
+    if (role !== "member" && role !== "admin") {
+      return c.json(errorJson("invalid_role", "role must be member or admin"), 400);
+    }
+
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, organizationSlug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const [inviter] = await db
+      .select()
+      .from(schema.user)
+      .where(eq(schema.user.id, inviterUserId))
+      .limit(1);
+    if (!inviter) {
+      return c.json(errorJson("inviter_not_found", "no user with that id"), 404);
+    }
+
+    const id = crypto.randomUUID();
+    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7); // 7 days
+    await db.insert(schema.invitation).values({
+      id,
+      organizationId: org.id,
+      email,
+      role,
+      status: "pending",
+      expiresAt,
+      inviterId: inviter.id,
+    });
+
+    const webOrigin = c.env.WEB_ORIGIN || "https://uploads.sh";
+    await sendAuthEmail(c.env, {
+      to: email,
+      template: "invitation",
+      context: {
+        url: `${webOrigin}/accept-invitation/${id}`,
+        organizationName: org.name,
+        inviterEmail: inviter.email,
+      },
+    });
+
+    return c.json(
+      { invitation: { id, organizationId: org.id, email, role, status: "pending", expiresAt } },
+      201,
+    );
+  })
   // D9 fallback: ADMIN_TOKEN-gated promote endpoint on apps/api proxies here.
   // Looked up by email since that's the only identifier ops/CI reliably has;
   // 404s (rather than a generic 400) if no such user has ever signed in.

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -202,6 +202,7 @@ export const invitation = sqliteTable(
     inviterId: text("inviter_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestampCol("created_at"),
   },
   (t) => [index("idx_invitation_organization_id").on(t.organizationId)],
 );

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -51,7 +51,9 @@ export const user = sqliteTable("user", {
  *
  * Paired migrations: `migrations/20260712200000_better_auth_core.sql` (core
  * columns), `migrations/20260712210000_admin_plugin.sql` (`impersonated_by`,
- * written by the `admin` plugin's impersonation feature — Phase 2).
+ * written by the `admin` plugin's impersonation feature — Phase 2),
+ * `migrations/20260712220000_organization.sql` (`active_organization_id`,
+ * written by the `organization` plugin — Phase 3).
  */
 export const session = sqliteTable(
   "session",
@@ -67,6 +69,7 @@ export const session = sqliteTable(
     createdAt: timestampCol("created_at"),
     updatedAt: timestampCol("updated_at"),
     impersonatedBy: text("impersonated_by"),
+    activeOrganizationId: text("active_organization_id"),
   },
   (t) => [index("idx_session_user_id").on(t.userId)],
 );
@@ -134,8 +137,80 @@ export const rateLimit = sqliteTable("rate_limit", {
   lastRequest: integer("last_request").notNull(),
 });
 
+/**
+ * Organizations (plan D4/Phase 3): `organization.slug === workspace name`,
+ * 1:1 for now (see apps/api/src/org-workspaces.ts for the indirection that
+ * keeps this an implementation detail). No `team` support (D3 explicitly
+ * excludes it) and no auto-provisioning hooks — orgs are only created via
+ * `/internal/orgs` (admin-provisioned, per D4) or the backfill script.
+ *
+ * Paired migration: `migrations/20260712220000_organization.sql`.
+ */
+export const organization = sqliteTable("organization", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  slug: text("slug").notNull().unique(),
+  logo: text("logo"),
+  createdAt: timestampCol("created_at"),
+  metadata: text("metadata"),
+});
+
+/**
+ * Org membership. `role` here is the org-scoped `owner`/`admin`/`member`
+ * role (stock organization-plugin roles, no custom access control) — distinct
+ * from the global `user.role` written by the `admin` plugin (Phase 2).
+ *
+ * Paired migration: `migrations/20260712220000_organization.sql`.
+ */
+export const member = sqliteTable(
+  "member",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    role: text("role").notNull().default("member"),
+    createdAt: timestampCol("created_at"),
+  },
+  (t) => [
+    index("idx_member_organization_id").on(t.organizationId),
+    index("idx_member_user_id").on(t.userId),
+  ],
+);
+
+/**
+ * Pending org invitations. `sendInvitationEmail` (src/auth.ts) links to
+ * `${WEB_ORIGIN}/accept-invitation/<id>` — this table's `id` is that path
+ * segment.
+ *
+ * Paired migration: `migrations/20260712220000_organization.sql`.
+ */
+export const invitation = sqliteTable(
+  "invitation",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    role: text("role"),
+    status: text("status").notNull().default("pending"),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+    inviterId: text("inviter_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (t) => [index("idx_invitation_organization_id").on(t.organizationId)],
+);
+
 export type AuthUser = typeof user.$inferSelect;
 export type AuthSession = typeof session.$inferSelect;
 export type AuthAccount = typeof account.$inferSelect;
 export type AuthVerification = typeof verification.$inferSelect;
 export type AuthRateLimit = typeof rateLimit.$inferSelect;
+export type AuthOrganization = typeof organization.$inferSelect;
+export type AuthMember = typeof member.$inferSelect;
+export type AuthInvitation = typeof invitation.$inferSelect;

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -132,18 +132,27 @@ export async function getInvitation(origin: string, id: string): Promise<Invitat
 
 export type AcceptInvitationResult = { ok: true } | { ok: false; status: number; code?: string };
 
-/** POST /api/auth/organization/accept-invitation. Requires a valid session. */
+/**
+ * POST /api/auth/organization/accept-invitation. Requires a valid session.
+ * Returns `{ ok: false, status: 0 }` on a thrown fetch (network error, CSP
+ * block, etc.) rather than throwing — matching getSession/getInvitation's
+ * defensiveness so a caller can always branch on the result.
+ */
 export async function acceptInvitation(
   origin: string,
   id: string,
 ): Promise<AcceptInvitationResult> {
-  const res = await fetch(`${authOrigin(origin)}/api/auth/organization/accept-invitation`, {
-    method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ invitationId: id }),
-  });
-  if (res.ok) return { ok: true };
-  const body = (await res.json().catch(() => null)) as { error?: { code?: string } } | null;
-  return { ok: false, status: res.status, code: body?.error?.code };
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/organization/accept-invitation`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invitationId: id }),
+    });
+    if (res.ok) return { ok: true };
+    const body = (await res.json().catch(() => null)) as { error?: { code?: string } } | null;
+    return { ok: false, status: res.status, code: body?.error?.code };
+  } catch {
+    return { ok: false, status: 0 };
+  }
 }

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -96,3 +96,54 @@ export async function signOut(origin: string): Promise<void> {
     credentials: "include",
   }).catch(() => undefined);
 }
+
+/**
+ * Phase 3 (plan D4/D6): organization-plugin wrappers for the
+ * `/accept-invitation/[id]` page.
+ */
+export interface InvitationInfo {
+  id: string;
+  email: string;
+  status: string;
+  organizationName?: string;
+  organizationId: string;
+}
+
+/**
+ * GET /api/auth/organization/get-invitation?id=. Better Auth's own endpoint
+ * requires an authenticated session whose email matches the invite (it 401s
+ * otherwise) — this page calls it after sign-in to show invite context and
+ * confirm before accepting; it also tolerates the pre-sign-in case by
+ * returning null on any non-2xx rather than throwing.
+ */
+export async function getInvitation(origin: string, id: string): Promise<InvitationInfo | null> {
+  try {
+    const res = await fetch(
+      `${authOrigin(origin)}/api/auth/organization/get-invitation?id=${encodeURIComponent(id)}`,
+      { credentials: "include", cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as InvitationInfo | null;
+    return body ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export type AcceptInvitationResult = { ok: true } | { ok: false; status: number; code?: string };
+
+/** POST /api/auth/organization/accept-invitation. Requires a valid session. */
+export async function acceptInvitation(
+  origin: string,
+  id: string,
+): Promise<AcceptInvitationResult> {
+  const res = await fetch(`${authOrigin(origin)}/api/auth/organization/accept-invitation`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ invitationId: id }),
+  });
+  if (res.ok) return { ok: true };
+  const body = (await res.json().catch(() => null)) as { error?: { code?: string } } | null;
+  return { ok: false, status: res.status, code: body?.error?.code };
+}

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -1,10 +1,11 @@
 /**
  * Regression coverage for the repo-wide `run_worker_first` static-404 gotcha
- * (apps/web/wrangler.jsonc, plan D6 ⚠) as it applies to the two Phase 2
- * pages: `/login` and `/admin`.
+ * (apps/web/wrangler.jsonc, plan D6 ⚠) as it applies to the Phase 2 pages
+ * (`/login`, `/admin`) and the Phase 3 `/accept-invitation/[id]` page.
  *
- * Scope note: both pages set `export const prerender = false` (see
- * login.astro / admin.astro) — they're SSR routes, always served by
+ * Scope note: all three pages set `export const prerender = false` (see
+ * login.astro / admin.astro / accept-invitation/[id].astro) — they're SSR
+ * routes, always served by
  * `src/entry.ts`'s handler, never prerendered HTML served straight off the
  * `ASSETS` binding. The static-404 failure mode this gotcha describes is
  * specifically about *prerendered* pages bypassing the worker when
@@ -32,6 +33,7 @@ function ssrPageResponse(title: string): Response {
 describe.each([
   { path: "/login", title: "Sign in · uploads.sh" },
   { path: "/admin", title: "Admin · uploads.sh" },
+  { path: "/accept-invitation/upi_abc123", title: "Accept invitation · uploads.sh" },
 ])("route reachability: $path", ({ path, title }) => {
   it("reaches the page handler (not a static 404) on a browser navigation request", async () => {
     let handlerCalled = false;

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -1,0 +1,196 @@
+---
+import { env } from "cloudflare:workers";
+
+export const prerender = false;
+
+const authOrigin =
+  env.UPLOADS_AUTH_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
+  "https://auth.uploads.sh";
+
+const { id } = Astro.params;
+
+const FAVICON =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+---
+
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow, noarchive" />
+  <meta name="referrer" content="no-referrer" />
+  <meta http-equiv="Content-Security-Policy" content={`default-src 'none'; connect-src ${authOrigin}; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`} />
+  <title>Accept invitation · uploads.sh</title>
+  <link rel="icon" href={FAVICON} />
+  <style>
+    :root{color-scheme:dark;--bg:#0a0a0b;--panel:#121214;--line:#232327;--fg:#ececea;--body:#b3b3ad;--muted:#7d7d77;--accent:#b794ff;--green:#8fae62;--red:#d98a9c;--mono:"Geist Mono Variable",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace}
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:var(--bg);color:var(--fg);font:14.5px/1.65 var(--mono)}
+    main{width:min(480px,100%);background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:clamp(24px,6vw,40px)}
+    h1{margin:0 0 8px;font-size:clamp(21px,5vw,26px);font-weight:600;letter-spacing:-.015em;line-height:1.25}
+    p{color:var(--body);margin:0 0 20px}
+    .status{border-left:3px solid var(--accent);padding:9px 14px;margin:16px 0;background:var(--bg);color:var(--fg)}
+    .status[data-state=ready]{border-color:var(--green)}
+    .status[data-state=error]{border-color:var(--red);color:var(--red)}
+    button.github{width:100%;display:flex;align-items:center;justify-content:center;gap:10px;font:14px var(--mono);letter-spacing:.02em;color:var(--fg);background:var(--bg);border:1px solid var(--line);border-radius:8px;padding:12px 16px;cursor:pointer}
+    button.github:hover,button.github:focus-visible{border-color:var(--accent);outline:none}
+    .divider{display:flex;align-items:center;gap:12px;margin:22px 0;color:var(--muted);font-size:11px;letter-spacing:.08em;text-transform:uppercase}
+    .divider::before,.divider::after{content:"";flex:1;height:1px;background:var(--line)}
+    form{display:grid;gap:10px}
+    label{display:grid;gap:6px;color:var(--muted);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase}
+    input{background:var(--bg);border:1px solid var(--line);border-radius:8px;color:var(--fg);padding:10px 12px;font:14px var(--mono)}
+    input:focus-visible{border-color:var(--accent);outline:none}
+    button[type=submit],button#accept-btn{font:12px var(--mono);letter-spacing:.04em;color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:7px;padding:10px 13px;cursor:pointer}
+    button[type=submit]:hover,button[type=submit]:focus-visible,button#accept-btn:hover,button#accept-btn:focus-visible{border-color:var(--accent);outline:none}
+    button:disabled{opacity:.6;cursor:default}
+    .legal{margin:22px 0 0;font-size:11.5px;color:var(--muted)}
+    .legal a{color:var(--muted)}
+    [hidden]{display:none!important}
+  </style>
+</head>
+<body>
+<main>
+  <h1>You've been invited</h1>
+
+  <div id="checking" class="status" role="status">Checking your invitation…</div>
+
+  <div id="invalid" hidden>
+    <div class="status" data-state="error" role="alert">This invitation is invalid or has expired.</div>
+  </div>
+
+  <div id="signed-out" hidden>
+    <p>Sign in to accept this invitation.</p>
+    <button type="button" class="github" id="github-btn">Continue with GitHub</button>
+    <div class="divider">or</div>
+    <form id="magic-form">
+      <label>
+        Email
+        <input id="email" type="email" required autocomplete="email" placeholder="you@example.com" />
+      </label>
+      <button type="submit" id="magic-submit">Send sign-in link</button>
+    </form>
+    <div class="status" id="signin-error" data-state="error" role="alert" hidden></div>
+  </div>
+
+  <div id="sent-state" hidden>
+    <div class="status" data-state="ready" role="status">Check your email — we sent you a sign-in link. Come back to this page after signing in.</div>
+  </div>
+
+  <div id="ready" hidden>
+    <p>Signed in as <span id="who"></span>.</p>
+    <button type="button" id="accept-btn">Accept invitation</button>
+    <div class="status" id="accept-error" data-state="error" role="alert" hidden></div>
+  </div>
+
+  <div id="accepted" hidden>
+    <div class="status" data-state="ready" role="status">You've joined the workspace. You can close this page.</div>
+  </div>
+
+  <p class="legal">a <a href="https://buildinternet.com">Build Internet</a> project · <a href="/terms">terms</a> · <a href="/privacy">privacy</a></p>
+</main>
+<script define:vars={{ authOrigin, invitationId: id }}>
+  window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
+  window.__UPLOADS_INVITATION_ID__ = invitationId;
+</script>
+<script>
+  import { acceptInvitation, getSession, sendMagicLink, signInWithGitHub } from "../../lib/auth-client";
+
+  const w = window as unknown as { __UPLOADS_AUTH_ORIGIN__: string; __UPLOADS_INVITATION_ID__: string };
+  const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+  const invitationId = w.__UPLOADS_INVITATION_ID__;
+
+  function requireElement<T extends Element>(selector: string): T {
+    const element = document.querySelector<T>(selector);
+    if (!element) throw new Error(`accept-invitation page is missing ${selector}`);
+    return element as T;
+  }
+
+  const checking = requireElement<HTMLElement>("#checking");
+  const invalid = requireElement<HTMLElement>("#invalid");
+  const signedOut = requireElement<HTMLElement>("#signed-out");
+  const sentState = requireElement<HTMLElement>("#sent-state");
+  const ready = requireElement<HTMLElement>("#ready");
+  const accepted = requireElement<HTMLElement>("#accepted");
+  const who = requireElement<HTMLElement>("#who");
+  const githubBtn = requireElement<HTMLButtonElement>("#github-btn");
+  const magicForm = requireElement<HTMLFormElement>("#magic-form");
+  const magicSubmit = requireElement<HTMLButtonElement>("#magic-submit");
+  const emailInput = requireElement<HTMLInputElement>("#email");
+  const signinError = requireElement<HTMLElement>("#signin-error");
+  const acceptBtn = requireElement<HTMLButtonElement>("#accept-btn");
+  const acceptError = requireElement<HTMLElement>("#accept-error");
+
+  const callbackURL = location.href;
+
+  async function init() {
+    if (!invitationId) {
+      checking.hidden = true;
+      invalid.hidden = false;
+      return;
+    }
+
+    const session = await getSession(authOrigin);
+    checking.hidden = true;
+
+    if (!session) {
+      signedOut.hidden = false;
+      return;
+    }
+
+    who.textContent = session.user.email;
+    ready.hidden = false;
+  }
+
+  githubBtn.addEventListener("click", async () => {
+    signinError.hidden = true;
+    githubBtn.disabled = true;
+    const ok = await signInWithGitHub(authOrigin, callbackURL);
+    if (!ok) {
+      githubBtn.disabled = false;
+      signinError.textContent = "GitHub sign-in isn't available right now.";
+      signinError.hidden = false;
+    }
+  });
+
+  magicForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    signinError.hidden = true;
+    magicSubmit.disabled = true;
+    const email = emailInput.value.trim();
+    try {
+      const ok = await sendMagicLink(authOrigin, email, callbackURL);
+      if (!ok) throw new Error("send failed");
+      signedOut.hidden = true;
+      sentState.hidden = false;
+    } catch {
+      signinError.textContent = "Couldn't send the sign-in link. Try again.";
+      signinError.hidden = false;
+    } finally {
+      magicSubmit.disabled = false;
+    }
+  });
+
+  acceptBtn.addEventListener("click", async () => {
+    acceptError.hidden = true;
+    acceptBtn.disabled = true;
+    const result = await acceptInvitation(authOrigin, invitationId);
+    if (result.ok) {
+      ready.hidden = true;
+      accepted.hidden = false;
+      return;
+    }
+    acceptBtn.disabled = false;
+    acceptError.textContent =
+      result.status === 404
+        ? "This invitation no longer exists."
+        : result.status === 410 || result.code === "invitation_expired"
+          ? "This invitation has expired."
+          : "Couldn't accept this invitation. It may already have been used.";
+    acceptError.hidden = false;
+  });
+
+  init();
+</script>
+</body>
+</html>

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -1,5 +1,10 @@
 ---
 import { env } from "cloudflare:workers";
+import {
+  CF_RUM_CONNECT_SRC,
+  CF_RUM_SCRIPT_SRC,
+  STYLE_SRC_SELF_AND_INLINE,
+} from "../../lib/csp";
 
 export const prerender = false;
 
@@ -9,6 +14,17 @@ const authOrigin =
   "https://auth.uploads.sh";
 
 const { id } = Astro.params;
+
+const csp = [
+  "default-src 'none'",
+  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "img-src data:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
 
 const FAVICON =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
@@ -20,7 +36,7 @@ const FAVICON =
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={`default-src 'none'; connect-src ${authOrigin}; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`} />
+  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Accept invitation · uploads.sh</title>
   <link rel="icon" href={FAVICON} />
   <style>

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -190,7 +190,7 @@ const FAVICON =
     acceptError.hidden = false;
   });
 
-  init();
+  void init();
 </script>
 </body>
 </html>

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -71,7 +71,7 @@ const FAVICON =
     .invite-form button:hover,.invite-form button:focus-visible{border-color:var(--accent);outline:none}
     .invite-status{font-size:.8rem;margin-top:4px}
     .invite-status[data-state=error]{color:var(--red)}
-    .invite-status[data-state=ready]{color:var(--green)}
+    .invite-status[data-state=ready]{color:var(--accent)}
     [hidden]{display:none!important}
   </style>
 </head>
@@ -195,11 +195,11 @@ const FAVICON =
     let loaded = false;
     details.addEventListener("toggle", async () => {
       if (!details.open || loaded) return;
-      loaded = true;
       const membersEl = details.querySelector<HTMLElement>(".members");
       const invitesEl = details.querySelector<HTMLElement>(".invites");
       if (!ws.organization) {
         if (membersEl) membersEl.textContent = "";
+        loaded = true;
         return;
       }
       try {
@@ -217,6 +217,10 @@ const FAVICON =
             ? `<ul>${invites.map((i) => `<li><span>${escapeHtml(i.email)}</span><span class="role">pending</span></li>`).join("")}</ul>`
             : "";
         }
+        // Only mark as loaded once the fetch actually succeeded — a failure
+        // leaves `loaded` false so re-toggling the <details> retries instead
+        // of permanently showing "Failed to load members."
+        loaded = true;
       } catch {
         if (membersEl) membersEl.textContent = "Failed to load members.";
       }
@@ -240,7 +244,12 @@ const FAVICON =
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ email, role }),
         });
-        if (!res.ok) throw new Error(`invite failed: ${res.status}`);
+        if (!res.ok) {
+          const payload = (await res.json().catch(() => null)) as
+            | { error?: { message?: string } }
+            | null;
+          throw new Error(payload?.error?.message || `invite failed: ${res.status}`);
+        }
         if (statusEl) {
           statusEl.dataset.state = "ready";
           statusEl.textContent = `Invited ${email}.`;
@@ -250,10 +259,11 @@ const FAVICON =
         loaded = false;
         details.open = false;
         details.open = true;
-      } catch {
+      } catch (err) {
         if (statusEl) {
           statusEl.dataset.state = "error";
-          statusEl.textContent = "Couldn't send the invite.";
+          statusEl.textContent =
+            err instanceof Error && err.message ? err.message : "Couldn't send the invite.";
           statusEl.hidden = false;
         }
       } finally {

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -12,10 +12,14 @@ const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
   "https://auth.uploads.sh";
+const apiOrigin =
+  env.UPLOADS_API_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ??
+  "https://api.uploads.sh";
 
 const csp = [
   "default-src 'none'",
-  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  `connect-src ${authOrigin} ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
   `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
   `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
   "img-src data: https:",
@@ -51,6 +55,23 @@ const FAVICON =
     nav.sections{display:grid;gap:10px;margin-top:8px}
     nav.sections .item{padding:14px 16px;border:1px solid var(--line);border-radius:8px;background:var(--panel);color:var(--muted)}
     nav.sections .item strong{color:var(--fg);display:block;font-size:.95rem;margin-bottom:2px}
+    .workspace{padding:14px 16px;border:1px solid var(--line);border-radius:8px;background:var(--panel);margin-bottom:10px}
+    .workspace summary{cursor:pointer;list-style:none;display:flex;align-items:center;justify-content:space-between;gap:10px}
+    .workspace summary::-webkit-details-marker{display:none}
+    .workspace .name{color:var(--fg);font-weight:600}
+    .workspace .counts{color:var(--muted);font-size:.85rem}
+    .workspace .detail{margin-top:14px;padding-top:14px;border-top:1px solid var(--line);display:grid;gap:12px}
+    .workspace ul{list-style:none;margin:0;padding:0;display:grid;gap:6px}
+    .workspace li{font-size:.85rem;color:var(--body);display:flex;justify-content:space-between;gap:8px}
+    .workspace li .role{color:var(--muted)}
+    .invite-form{display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end}
+    .invite-form label{display:grid;gap:4px;color:var(--muted);font-size:10px;letter-spacing:.08em;text-transform:uppercase}
+    .invite-form input,.invite-form select{background:var(--bg);border:1px solid var(--line);border-radius:6px;color:var(--fg);padding:7px 9px;font:12px var(--mono)}
+    .invite-form button{font:11px var(--mono);color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:6px;padding:7px 12px;cursor:pointer}
+    .invite-form button:hover,.invite-form button:focus-visible{border-color:var(--accent);outline:none}
+    .invite-status{font-size:.8rem;margin-top:4px}
+    .invite-status[data-state=error]{color:var(--red)}
+    .invite-status[data-state=ready]{color:var(--green)}
     [hidden]{display:none!important}
   </style>
 </head>
@@ -69,27 +90,33 @@ const FAVICON =
     <p class="muted">Signed in as <span id="who"></span>.</p>
     <!--
       Client-side gating here is a UX affordance ONLY — it just avoids
-      flashing admin nav at a non-admin visitor. It is NOT the security
-      boundary: this page fetches no sensitive data itself in Phase 2. The
-      real boundary is server-side, on apps/api, via requireAdminUser
-      (src/session-auth.ts) checking the session over the AUTH service
-      binding — every admin data endpoint enforces that independently of
-      whatever this page shows or hides.
+      flashing admin nav (and firing admin-ui fetches) at a non-admin
+      visitor. It is NOT the security boundary: the workspaces data below is
+      fetched from apps/api's /admin-ui/* surface, which independently
+      enforces requireAdminUser (src/session-auth.ts) over the AUTH service
+      binding on every request, regardless of whatever this page shows or
+      hides.
     -->
     <nav class="sections" aria-label="Admin sections">
-      <div class="item"><strong>Workspaces</strong>Coming in Phase 3.</div>
-      <div class="item"><strong>Invites</strong>Coming in Phase 3.</div>
-      <div class="item"><strong>Users</strong>Coming in Phase 3.</div>
+      <div class="item">
+        <strong>Workspaces</strong>
+        <div id="workspaces-status" class="muted" style="margin-top:6px">Loading…</div>
+        <div id="workspaces-list"></div>
+      </div>
+      <div class="item"><strong>Users</strong>Coming in a later phase.</div>
     </nav>
   </div>
 </main>
-<script define:vars={{ authOrigin }}>
+<script define:vars={{ authOrigin, apiOrigin }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
+  window.__UPLOADS_API_ORIGIN__ = apiOrigin;
 </script>
 <script>
   import { getSession } from "../lib/auth-client";
 
-  const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
+  const w = window as unknown as { __UPLOADS_AUTH_ORIGIN__: string; __UPLOADS_API_ORIGIN__: string };
+  const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+  const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
 
   function requireElement<T extends Element>(selector: string): T {
     const element = document.querySelector<T>(selector);
@@ -101,6 +128,157 @@ const FAVICON =
   const denied = requireElement<HTMLElement>("#denied");
   const dashboard = requireElement<HTMLElement>("#dashboard");
   const who = requireElement<HTMLElement>("#who");
+  const workspacesStatus = requireElement<HTMLElement>("#workspaces-status");
+  const workspacesList = requireElement<HTMLElement>("#workspaces-list");
+
+  interface WorkspaceSummary {
+    workspace: string;
+    organization: { id: string; slug: string; name: string } | null;
+    memberCount: number;
+    pendingInviteCount: number;
+  }
+  interface Member {
+    id: string;
+    email: string;
+    name: string;
+    role: string;
+  }
+  interface Invite {
+    id: string;
+    email: string;
+    role: string | null;
+    status: string;
+  }
+
+  function escapeHtml(value: string): string {
+    return value.replace(/[&<>"']/g, (ch) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+    );
+  }
+
+  async function apiGet<T>(path: string): Promise<T> {
+    const res = await fetch(`${apiOrigin}${path}`, { credentials: "include", cache: "no-store" });
+    if (!res.ok) throw new Error(`request failed: ${res.status}`);
+    return (await res.json()) as T;
+  }
+
+  function renderWorkspace(ws: WorkspaceSummary): HTMLElement {
+    const details = document.createElement("details");
+    details.className = "workspace";
+    const org = ws.organization ? ws.organization.name : "no organization yet";
+    details.innerHTML = `
+      <summary>
+        <span class="name">${escapeHtml(ws.workspace)}</span>
+        <span class="counts">${escapeHtml(org)} · ${ws.memberCount} member${ws.memberCount === 1 ? "" : "s"} · ${ws.pendingInviteCount} pending</span>
+      </summary>
+      <div class="detail">
+        <div class="members" data-state="unloaded">Members load when expanded.</div>
+        <div class="invites"></div>
+        ${
+          ws.organization
+            ? `<form class="invite-form" data-workspace="${escapeHtml(ws.workspace)}">
+                <label>Email<input type="email" required class="invite-email" placeholder="you@example.com" /></label>
+                <label>Role
+                  <select class="invite-role">
+                    <option value="member">member</option>
+                    <option value="admin">admin</option>
+                  </select>
+                </label>
+                <button type="submit">Invite</button>
+              </form>
+              <div class="invite-status" hidden></div>`
+            : `<p class="muted">No organization provisioned for this workspace yet — run the org backfill.</p>`
+        }
+      </div>
+    `;
+
+    let loaded = false;
+    details.addEventListener("toggle", async () => {
+      if (!details.open || loaded) return;
+      loaded = true;
+      const membersEl = details.querySelector<HTMLElement>(".members");
+      const invitesEl = details.querySelector<HTMLElement>(".invites");
+      if (!ws.organization) {
+        if (membersEl) membersEl.textContent = "";
+        return;
+      }
+      try {
+        const [{ members }, { invites }] = await Promise.all([
+          apiGet<{ members: Member[] }>(`/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/members`),
+          apiGet<{ invites: Invite[] }>(`/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/invites`),
+        ]);
+        if (membersEl) {
+          membersEl.innerHTML = members.length
+            ? `<ul>${members.map((m) => `<li><span>${escapeHtml(m.email)}</span><span class="role">${escapeHtml(m.role)}</span></li>`).join("")}</ul>`
+            : `<p class="muted">No members yet.</p>`;
+        }
+        if (invitesEl) {
+          invitesEl.innerHTML = invites.length
+            ? `<ul>${invites.map((i) => `<li><span>${escapeHtml(i.email)}</span><span class="role">pending</span></li>`).join("")}</ul>`
+            : "";
+        }
+      } catch {
+        if (membersEl) membersEl.textContent = "Failed to load members.";
+      }
+    });
+
+    const form = details.querySelector<HTMLFormElement>(".invite-form");
+    const statusEl = details.querySelector<HTMLElement>(".invite-status");
+    form?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const emailInput = form.querySelector<HTMLInputElement>(".invite-email");
+      const roleSelect = form.querySelector<HTMLSelectElement>(".invite-role");
+      const email = emailInput?.value.trim() ?? "";
+      const role = roleSelect?.value ?? "member";
+      const submitBtn = form.querySelector<HTMLButtonElement>("button[type=submit]");
+      if (submitBtn) submitBtn.disabled = true;
+      if (statusEl) statusEl.hidden = true;
+      try {
+        const res = await fetch(`${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/invites`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, role }),
+        });
+        if (!res.ok) throw new Error(`invite failed: ${res.status}`);
+        if (statusEl) {
+          statusEl.dataset.state = "ready";
+          statusEl.textContent = `Invited ${email}.`;
+          statusEl.hidden = false;
+        }
+        if (emailInput) emailInput.value = "";
+        loaded = false;
+        details.open = false;
+        details.open = true;
+      } catch {
+        if (statusEl) {
+          statusEl.dataset.state = "error";
+          statusEl.textContent = "Couldn't send the invite.";
+          statusEl.hidden = false;
+        }
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+
+    return details;
+  }
+
+  async function loadWorkspaces() {
+    try {
+      const { workspaces } = await apiGet<{ workspaces: WorkspaceSummary[] }>("/admin-ui/workspaces");
+      workspacesStatus.hidden = true;
+      workspacesList.innerHTML = "";
+      if (!workspaces.length) {
+        workspacesStatus.hidden = false;
+        workspacesStatus.textContent = "No workspaces yet.";
+        return;
+      }
+      for (const ws of workspaces) workspacesList.appendChild(renderWorkspace(ws));
+    } catch {
+      workspacesStatus.textContent = "Failed to load workspaces.";
+    }
+  }
 
   getSession(authOrigin).then((result) => {
     checking.hidden = true;
@@ -110,6 +288,7 @@ const FAVICON =
     }
     who.textContent = result.user.email;
     dashboard.hidden = false;
+    loadWorkspaces();
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary

Phase 3 of the Better Auth plan (stacked on #94 — merge that first). Maps organizations onto workspaces and replaces ad-hoc admin invites with org invitations.

**apps/auth**
- `organization` plugin (membership limit 100, no teams, deliberately NO personal-org auto-provisioning — workspaces stay admin-provisioned per plan D4) + `organization`/`member`/`invitation` migration and `session.active_organization_id`.
- Invitation email template on the shared email module; accept links point at `uploads.sh/accept-invitation/<id>`.
- Internal routes (service-binding-guarded): `GET /internal/memberships`, idempotent `POST /internal/orgs` (slug collision returns the existing org), and `POST /internal/invite`. Invites insert directly rather than going through the plugin's `createInvitation`, because global admins must be able to invite into orgs they aren't members of — the plugin authorizes off org-membership sessions.

**apps/api**
- `org-workspaces.ts` indirection module: all org↔workspace resolution goes through `orgForWorkspace`/`workspacesForOrg` so today's slug === workspace-name 1:1 mapping can become one-to-many later without touching callers (plan D4).
- `POST /admin/orgs/backfill` (ADMIN_TOKEN-gated, idempotent) creates an org per existing KV workspace; `scripts/backfill-orgs.mjs` documents/drives it.
- New session-authenticated `/admin-ui/*` surface (gated by `requireAdminUser` from Phase 2, distinct from the token-gated `/admin`): workspace list with org + member/invite counts, members, pending invites, invite creation.

**apps/web**
- `/accept-invitation/[id]` page (sign-in prompt → accept → confirmation; handles expired/invalid states).
- Admin Workspaces panel: workspace list, per-workspace members + pending invites, invite form.

## Testing

auth 50/50, api 181/181, web 14/14 after rebasing onto the phase-2 tip; lint/format/types clean. Migration applied to local D1 and tables verified. Known gap: the DB-writing internal routes are unit-tested at the validation layer only (no fake-D1 harness yet — queued as a follow-up task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization and workspace management for administrators.
  * Admins can view workspace members, review pending invitations, and invite new members.
  * Added invitation emails and a page for recipients to accept invitations.
  * Added support for organization membership and active organization selection.
  * Added a tool to create organizations for existing workspaces.
* **Bug Fixes**
  * Improved handling of invalid, expired, missing, or failed invitations.
  * Added safer validation and error responses for organization and invitation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->