### PR TITLE
fix(web): allow Astro CSS and Cloudflare RUM on CSP pages

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -10,12 +10,13 @@
   Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
   X-Content-Type-Options: nosniff
 
+# Keep CSP in sync with src/pages/invite.astro (header + meta both apply).
 /invite*
   Cache-Control: no-store
   Referrer-Policy: no-referrer
   X-Robots-Tag: noindex, nofollow, noarchive
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh https://cloudflareinsights.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
   Permissions-Policy: camera=(), microphone=(), geolocation=()
 
 # Operator browser console — not a public product surface

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared CSP fragments for pages that ship a Content-Security-Policy.
+ *
+ * Gotchas this encodes (seen on /g/* and latent elsewhere):
+ * - Astro often extracts page `<style>` into `/_astro/*.css`. `style-src
+ *   'unsafe-inline'` alone blocks those stylesheets; always allow `'self'`.
+ * - Cloudflare Web Analytics injects a RUM beacon. With `default-src 'none'`
+ *   you must allow its script host and connect endpoint explicitly.
+ */
+export const CF_RUM_SCRIPT_SRC = "https://static.cloudflareinsights.com";
+export const CF_RUM_CONNECT_SRC = "https://cloudflareinsights.com";
+
+/** style-src value that survives Astro CSS extraction. */
+export const STYLE_SRC_SELF_AND_INLINE = "'self' 'unsafe-inline'";

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchPublicGallery, isPublicGallery } from "./public-gallery";
+import {
+  applyPublicGalleryHeaders,
+  fetchPublicGallery,
+  isPublicGallery,
+  PUBLIC_GALLERY_CSP,
+} from "./public-gallery";
 
 const ID = "gal_abcdefghijklmnopqrstuv";
 const gallery = {
@@ -32,6 +37,24 @@ const gallery = {
     },
   ],
 } as const;
+
+describe("public gallery headers", () => {
+  it("allows same-origin stylesheets and Cloudflare Web Analytics (RUM)", () => {
+    // Astro extracts page <style> into /_astro/*.css; 'unsafe-inline' alone blocks that.
+    expect(PUBLIC_GALLERY_CSP).toContain("style-src 'self' 'unsafe-inline'");
+    // Cloudflare injects the RUM beacon; default-src 'none' blocks it without these.
+    expect(PUBLIC_GALLERY_CSP).toContain("script-src https://static.cloudflareinsights.com");
+    expect(PUBLIC_GALLERY_CSP).toContain("connect-src https://cloudflareinsights.com");
+    expect(PUBLIC_GALLERY_CSP).toContain("default-src 'none'");
+    expect(PUBLIC_GALLERY_CSP).toContain("frame-ancestors 'none'");
+
+    const headers = new Headers();
+    applyPublicGalleryHeaders(headers);
+    expect(headers.get("Content-Security-Policy")).toBe(PUBLIC_GALLERY_CSP);
+    expect(headers.get("Cache-Control")).toBe("no-store");
+    expect(headers.get("X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+  });
+});
 
 describe("public gallery API", () => {
   it("accepts the bounded public DTO including multiline plain text", () => {

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -1,3 +1,5 @@
+import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
+
 export interface PublicGalleryItem {
   id: string;
   filename: string;
@@ -55,12 +57,29 @@ export function galleryItemPath(galleryId: string, itemId: string): string {
   return `${galleryPath(galleryId)}/${encodeURIComponent(itemId)}`;
 }
 
+/**
+ * Public gallery CSP.
+ *
+ * - style-src 'self' for Astro-extracted `/_astro/*.css` (not only 'unsafe-inline')
+ * - script/connect for Cloudflare Web Analytics (RUM) beacon injection
+ * - otherwise locked down: no default-src, no framing, no plugins
+ */
+export const PUBLIC_GALLERY_CSP = [
+  "default-src 'none'",
+  "img-src https: data:",
+  "media-src https:",
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  `script-src ${CF_RUM_SCRIPT_SRC}`,
+  `connect-src ${CF_RUM_CONNECT_SRC}`,
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+].join("; ");
+
 /** Shared security posture for the public gallery pages: strict CSP, noindex, no-store. */
 export function applyPublicGalleryHeaders(headers: Headers): void {
-  headers.set(
-    "Content-Security-Policy",
-    "default-src 'none'; img-src https: data:; media-src https:; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'",
-  );
+  headers.set("Content-Security-Policy", PUBLIC_GALLERY_CSP);
   headers.set("Referrer-Policy", "no-referrer");
   headers.set("X-Content-Type-Options", "nosniff");
   headers.set("X-Frame-Options", "DENY");

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -1,5 +1,10 @@
 ---
 import { env } from "cloudflare:workers";
+import {
+  CF_RUM_CONNECT_SRC,
+  CF_RUM_SCRIPT_SRC,
+  STYLE_SRC_SELF_AND_INLINE,
+} from "../lib/csp";
 
 export const prerender = false;
 
@@ -7,6 +12,17 @@ const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
   "https://auth.uploads.sh";
+
+const csp = [
+  "default-src 'none'",
+  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "img-src data: https:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
 
 const FAVICON =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
@@ -18,7 +34,7 @@ const FAVICON =
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={`default-src 'none'; connect-src ${authOrigin}; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: https:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`} />
+  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Admin · uploads.sh</title>
   <link rel="icon" href={FAVICON} />
   <style>

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -1,4 +1,24 @@
 ---
+import {
+  CF_RUM_CONNECT_SRC,
+  CF_RUM_SCRIPT_SRC,
+  STYLE_SRC_SELF_AND_INLINE,
+} from "../lib/csp";
+
+// Keep in sync with public/_headers `/invite*` CSP (header + meta both apply).
+const csp = [
+  "default-src 'none'",
+  `connect-src https://api.uploads.sh ${CF_RUM_CONNECT_SRC}`,
+  // 'self' future-proofs if Astro extracts the page script to /_astro/*.js
+  // (login/admin already do this once they import modules).
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "img-src data:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
 const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
 ---
 <html lang="en">
@@ -7,7 +27,7 @@ const FAVICON = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' vi
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://api.uploads.sh; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'" />
+  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Accept your invite · uploads.sh</title>
   <link rel="icon" href={FAVICON} />
   <style>

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -1,5 +1,10 @@
 ---
 import { env } from "cloudflare:workers";
+import {
+  CF_RUM_CONNECT_SRC,
+  CF_RUM_SCRIPT_SRC,
+  STYLE_SRC_SELF_AND_INLINE,
+} from "../lib/csp";
 
 export const prerender = false;
 
@@ -7,6 +12,18 @@ const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
   "https://auth.uploads.sh";
+
+const csp = [
+  "default-src 'none'",
+  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  // 'self' covers Astro-bundled /_astro/*.js; CF RUM is edge-injected.
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "img-src data:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
 
 const FAVICON =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
@@ -18,7 +35,7 @@ const FAVICON =
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={`default-src 'none'; connect-src ${authOrigin}; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`} />
+  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Sign in · uploads.sh</title>
   <link rel="icon" href={FAVICON} />
   <style>


### PR DESCRIPTION
## In plain terms

Missing gallery pages (and other CSP-locked surfaces) were unstyled in the browser, and Cloudflare Web Analytics was blocked. Astro ships page styles as `/_astro/*.css`, but our CSP only allowed inline styles — so the stylesheet never loaded. This fix opens the minimum holes for same-origin CSS and the RUM beacon.

## What it does

- Widen public-gallery `style-src` to `'self' 'unsafe-inline'` so Astro-extracted CSS loads on `/g/*` (including 404/not-found).
- Allow Cloudflare Web Analytics (RUM): `script-src https://static.cloudflareinsights.com` and `connect-src https://cloudflareinsights.com`.
- Apply the same posture on `/login`, `/admin`, and `/invite` (and sync invite `public/_headers`) so those pages do not hit the same footguns when Astro extracts assets or CF injects the beacon.
- Share the CSP fragments in `apps/web/src/lib/csp.ts` to keep the allowlists consistent.

## What it is not

- Not a redesign of gallery security posture — still `default-src 'none'`, no framing, no plugins.
- Does not add CSP to public marketing pages (they already load CSS/RUM freely).
- No CodeRabbit request (small, CSP-only change).

## How to try it

After deploy:

1. Open a missing gallery, e.g. `https://uploads.sh/g/gal_T` — page should be styled (dark panel error card), not raw unstyled HTML.
2. DevTools console should no longer report CSP blocks for `/_astro/*.css` or `static.cloudflareinsights.com/beacon.min.js` on gallery/login/admin/invite.

## Technical notes

- Root cause confirmed in production HTML: gallery responses include `<link rel="stylesheet" href="/_astro/_id_.….css">` under a CSP of only `style-src 'unsafe-inline'`.
- Login/admin currently keep styles inline but already load external `/_astro/*.js`; invite currently inlines its script — hardening is proactive + unblocks RUM.

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/public-gallery.test.ts`
- [x] Pre-commit types + oxlint/oxfmt via husky
- [ ] After merge/deploy: spot-check `/g/gal_T`, `/login`, `/invite` for styles + no CSP console errors for CSS/RUM