### PR TITLE
test(auth): fake D1 harness for internal routes

### DIFF
--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -187,18 +187,12 @@ describe("DB-backed behavior", () => {
   });
 
   describe("POST /internal/orgs", () => {
-    // Discovered by this harness, not by design: Better Auth's
-    // `organization.create` endpoint (better-auth/dist/plugins/organization/
-    // routes/crud-org.mjs) requires either a resolvable session OR an
-    // explicit `body.userId` ("server-only" per its own schema comment) —
-    // but internal-routes.ts's `/internal/orgs` calls
-    // `auth.api.createOrganization({ body: { slug, name } })` with neither,
-    // since admin-provisioned orgs have no natural owner user. That means
-    // creating a genuinely *new* org via this route always throws
-    // UNAUTHORIZED today; only the idempotent existing-slug path (which
-    // never reaches Better Auth) works. Pre-existing bug, out of scope for
-    // this test-harness change — flagged separately rather than fixed here.
-    it("500s creating a brand-new org (pre-existing bug: Better Auth requires a session or body.userId)", async () => {
+    // The success path below only exists because of the direct-insert fix
+    // (PR #99): the original implementation went through Better Auth's
+    // `createOrganization`, which requires a session or `body.userId` and
+    // threw UNAUTHORIZED on every genuinely new org — a bug this harness
+    // surfaced when it was first written.
+    it("creates a brand-new org (201) with the row inserted and created_at set", async () => {
       const slug = `new-org-${crypto.randomUUID()}`;
       const res = await app().request(
         "/internal/orgs",
@@ -209,13 +203,36 @@ describe("DB-backed behavior", () => {
         },
         dbEnv(),
       );
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        organization: { id: string; slug: string; name: string };
+      };
+      expect(body.organization).toMatchObject({ slug, name: "New Org" });
 
       const rows = await orm
         .select()
         .from(schema.organization)
         .where(eq(schema.organization.slug, slug));
-      expect(rows).toHaveLength(0);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(body.organization.id);
+      expect(rows[0].name).toBe("New Org");
+      expect(rows[0].createdAt).toBeInstanceOf(Date);
+    });
+
+    it("defaults name to the slug when name is omitted", async () => {
+      const slug = `nameless-${crypto.randomUUID()}`;
+      const res = await app().request(
+        "/internal/orgs",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ slug }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { organization: { name: string } };
+      expect(body.organization.name).toBe(slug);
     });
 
     it("is idempotent — an existing slug returns 200 with the existing org", async () => {
@@ -242,17 +259,38 @@ describe("DB-backed behavior", () => {
       expect(rows).toHaveLength(1);
     });
 
-    it("treats a concurrent create-race as idempotent (winner already inserted)", async () => {
-      // Simulates the TOCTOU path in internal-routes.ts: the pre-check finds
-      // nothing, but by the time Better Auth's createOrganization tries to
-      // insert, another request has already won the unique-slug race.
+    it("treats a concurrent create-race as idempotent (loser recovers via catch-and-re-query)", async () => {
+      // Genuinely exercises the TOCTOU catch path in internal-routes.ts:
+      // the route's pre-check SELECT is made to see an empty table (as if
+      // the winner hadn't inserted yet), the winner's row is injected right
+      // after, and the route's direct INSERT then hits the UNIQUE slug
+      // constraint — it must recover by re-querying and returning 200 with
+      // the winner's row instead of propagating a 500.
       const slug = `race-${crypto.randomUUID()}`;
-      const winner = await seedOrg({ slug, name: "Winner" });
-      // Insert happened *after* the route's own pre-check would have run in
-      // a real race; here we just assert the catch-and-re-query fallback:
-      // Better Auth's createOrganization will throw on the unique constraint
-      // since `winner` already occupies the slug, and the route should
-      // recover by re-querying and returning 200 with the existing row.
+      const winner = { id: crypto.randomUUID(), slug, name: "Winner" };
+      const realPrepare = db.prepare.bind(db);
+      let raceArmed = true;
+      db.prepare = ((sql: string) => {
+        const stmt = realPrepare(sql);
+        if (raceArmed && /select/i.test(sql) && sql.includes(`"organization"`)) {
+          raceArmed = false;
+          // Empty pre-check result, then the winner lands before the insert.
+          const emptied = Object.create(stmt) as typeof stmt;
+          emptied.bind = (...params: unknown[]) => {
+            db.__sqlite
+              .prepare("INSERT INTO organization (id, name, slug, created_at) VALUES (?, ?, ?, ?)")
+              .run(winner.id, winner.name, winner.slug, Date.now());
+            const bound = stmt.bind(...params);
+            return Object.assign(Object.create(bound), {
+              all: async () => ({ success: true, results: [], meta: {} }),
+              raw: async () => [],
+            });
+          };
+          return emptied;
+        }
+        return stmt;
+      }) as typeof db.prepare;
+
       const res = await app().request(
         "/internal/orgs",
         {
@@ -265,6 +303,14 @@ describe("DB-backed behavior", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { organization: { id: string; slug: string } };
       expect(body.organization).toMatchObject({ id: winner.id, slug });
+
+      // Only the winner's row exists — the loser's insert was rejected.
+      const rows = await orm
+        .select()
+        .from(schema.organization)
+        .where(eq(schema.organization.slug, slug));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].name).toBe("Winner");
     });
   });
 

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1,18 +1,16 @@
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { AuthEnv } from "./auth";
 import { internal } from "./internal-routes";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
 
 /**
  * These cover the request-validation short-circuits on the Phase 3
  * `/internal/*` routes (memberships/orgs/invite) that fail before touching
- * D1 — validated by using a DB stub that throws on first access. Full
- * DB-backed behavior (successful creates/lookups against real `organization`/
- * `member`/`invitation` rows) is NOT covered here: this repo has no
- * drizzle-over-D1 test harness yet (unlike apps/api's hand-rolled FakeD1 for
- * raw SQL in auth-db.test.ts, drizzle's D1 driver issues its own prepared
- * statements that a hand-written fake would need to parse). Flagged in the
- * Phase 3 handoff report as a follow-up rather than built here.
+ * D1 — validated by using a DB stub that throws on first access.
  */
 function poisonDB(): D1Database {
   return new Proxy(
@@ -88,6 +86,389 @@ describe("POST /internal/invite", () => {
     expect(res.status).toBe(400);
     expect((await res.json()) as { error: { code: string } }).toMatchObject({
       error: { code: "invalid_role" },
+    });
+  });
+});
+
+/**
+ * Behavioral coverage against the fake D1 harness (src/test/fake-d1.ts):
+ * real migrations applied, real drizzle queries, real Better Auth
+ * `organization` plugin writes for the `/internal/orgs` create path. No
+ * `EMAIL` binding is configured, so `sendAuthEmail` (src/email.ts) logs
+ * instead of sending — nothing here talks to a real email provider.
+ */
+describe("DB-backed behavior", () => {
+  let db: FakeD1Database;
+  let orm: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeEach(() => {
+    db = createFakeD1();
+    orm = drizzle(db, { schema });
+  });
+
+  function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+    return {
+      DB: db,
+      WEB_ORIGIN: "https://uploads.sh",
+      ENVIRONMENT: "development",
+      BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+      ...overrides,
+    };
+  }
+
+  async function seedUser(overrides: Partial<schema.AuthUser> = {}): Promise<schema.AuthUser> {
+    const user: schema.AuthUser = {
+      id: overrides.id ?? crypto.randomUUID(),
+      name: overrides.name ?? "Ada Lovelace",
+      email: overrides.email ?? `ada-${crypto.randomUUID()}@example.com`,
+      emailVerified: overrides.emailVerified ?? true,
+      image: overrides.image ?? null,
+      createdAt: overrides.createdAt ?? new Date(),
+      updatedAt: overrides.updatedAt ?? new Date(),
+      role: overrides.role ?? "user",
+      banned: overrides.banned ?? null,
+      banReason: overrides.banReason ?? null,
+      banExpires: overrides.banExpires ?? null,
+    };
+    await orm.insert(schema.user).values(user);
+    return user;
+  }
+
+  async function seedOrg(
+    overrides: Partial<schema.AuthOrganization> = {},
+  ): Promise<schema.AuthOrganization> {
+    const org: schema.AuthOrganization = {
+      id: overrides.id ?? crypto.randomUUID(),
+      name: overrides.name ?? "Acme",
+      slug: overrides.slug ?? `acme-${crypto.randomUUID()}`,
+      logo: overrides.logo ?? null,
+      createdAt: overrides.createdAt ?? new Date(),
+      metadata: overrides.metadata ?? null,
+    };
+    await orm.insert(schema.organization).values(org);
+    return org;
+  }
+
+  describe("POST /internal/promote-admin", () => {
+    it("promotes an existing user to admin", async () => {
+      const user = await seedUser({ role: "user" });
+      const res = await app().request(
+        "/internal/promote-admin",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: user.email }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; user: { role: string; email: string } };
+      expect(body).toMatchObject({ ok: true, user: { email: user.email, role: "admin" } });
+
+      const [updated] = await orm.select().from(schema.user).where(eq(schema.user.id, user.id));
+      expect(updated.role).toBe("admin");
+    });
+
+    it("404s when no user has that email", async () => {
+      const res = await app().request(
+        "/internal/promote-admin",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: "nobody@example.com" }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "user_not_found" },
+      });
+    });
+  });
+
+  describe("POST /internal/orgs", () => {
+    // Discovered by this harness, not by design: Better Auth's
+    // `organization.create` endpoint (better-auth/dist/plugins/organization/
+    // routes/crud-org.mjs) requires either a resolvable session OR an
+    // explicit `body.userId` ("server-only" per its own schema comment) —
+    // but internal-routes.ts's `/internal/orgs` calls
+    // `auth.api.createOrganization({ body: { slug, name } })` with neither,
+    // since admin-provisioned orgs have no natural owner user. That means
+    // creating a genuinely *new* org via this route always throws
+    // UNAUTHORIZED today; only the idempotent existing-slug path (which
+    // never reaches Better Auth) works. Pre-existing bug, out of scope for
+    // this test-harness change — flagged separately rather than fixed here.
+    it("500s creating a brand-new org (pre-existing bug: Better Auth requires a session or body.userId)", async () => {
+      const slug = `new-org-${crypto.randomUUID()}`;
+      const res = await app().request(
+        "/internal/orgs",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ slug, name: "New Org" }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(500);
+
+      const rows = await orm
+        .select()
+        .from(schema.organization)
+        .where(eq(schema.organization.slug, slug));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("is idempotent — an existing slug returns 200 with the existing org", async () => {
+      const org = await seedOrg();
+      const res = await app().request(
+        "/internal/orgs",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ slug: org.slug, name: "Ignored New Name" }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        organization: { id: string; slug: string; name: string };
+      };
+      expect(body.organization).toMatchObject({ id: org.id, slug: org.slug, name: org.name });
+
+      const rows = await orm
+        .select()
+        .from(schema.organization)
+        .where(eq(schema.organization.slug, org.slug));
+      expect(rows).toHaveLength(1);
+    });
+
+    it("treats a concurrent create-race as idempotent (winner already inserted)", async () => {
+      // Simulates the TOCTOU path in internal-routes.ts: the pre-check finds
+      // nothing, but by the time Better Auth's createOrganization tries to
+      // insert, another request has already won the unique-slug race.
+      const slug = `race-${crypto.randomUUID()}`;
+      const winner = await seedOrg({ slug, name: "Winner" });
+      // Insert happened *after* the route's own pre-check would have run in
+      // a real race; here we just assert the catch-and-re-query fallback:
+      // Better Auth's createOrganization will throw on the unique constraint
+      // since `winner` already occupies the slug, and the route should
+      // recover by re-querying and returning 200 with the existing row.
+      const res = await app().request(
+        "/internal/orgs",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ slug, name: "Loser" }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { organization: { id: string; slug: string } };
+      expect(body.organization).toMatchObject({ id: winner.id, slug });
+    });
+  });
+
+  describe("GET /internal/memberships", () => {
+    it("lists an org membership for a user", async () => {
+      const user = await seedUser();
+      const org = await seedOrg();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: user.id,
+        role: "owner",
+        createdAt: new Date(),
+      });
+
+      const res = await app().request(`/internal/memberships?userId=${user.id}`, {}, dbEnv());
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{
+        organizationId: string;
+        organizationSlug: string;
+        role: string;
+      }>;
+      expect(body).toEqual([{ organizationId: org.id, organizationSlug: org.slug, role: "owner" }]);
+    });
+
+    it("returns an empty list for a user with no memberships", async () => {
+      const user = await seedUser();
+      const res = await app().request(`/internal/memberships?userId=${user.id}`, {}, dbEnv());
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([]);
+    });
+  });
+
+  describe("GET /internal/orgs/:slug and /internal/orgs/:slug/invites", () => {
+    it("reports member and pending-invite counts, filtering out non-pending invites", async () => {
+      const org = await seedOrg();
+      const inviter = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: inviter.id,
+        role: "owner",
+        createdAt: new Date(),
+      });
+      await orm.insert(schema.invitation).values([
+        {
+          id: crypto.randomUUID(),
+          organizationId: org.id,
+          email: "pending@example.com",
+          role: "member",
+          status: "pending",
+          expiresAt: new Date(Date.now() + 86_400_000),
+          inviterId: inviter.id,
+          createdAt: new Date(),
+        },
+        {
+          id: crypto.randomUUID(),
+          organizationId: org.id,
+          email: "accepted@example.com",
+          role: "member",
+          status: "accepted",
+          expiresAt: new Date(Date.now() + 86_400_000),
+          inviterId: inviter.id,
+          createdAt: new Date(),
+        },
+      ]);
+
+      const orgRes = await app().request(`/internal/orgs/${org.slug}`, {}, dbEnv());
+      expect(orgRes.status).toBe(200);
+      expect(await orgRes.json()).toMatchObject({ memberCount: 1, pendingInviteCount: 1 });
+
+      const invitesRes = await app().request(`/internal/orgs/${org.slug}/invites`, {}, dbEnv());
+      expect(invitesRes.status).toBe(200);
+      const invitesBody = (await invitesRes.json()) as { invites: Array<{ email: string }> };
+      expect(invitesBody.invites).toHaveLength(1);
+      expect(invitesBody.invites[0]).toMatchObject({ email: "pending@example.com" });
+    });
+
+    it("404s for an unknown slug", async () => {
+      const res = await app().request("/internal/orgs/does-not-exist", {}, dbEnv());
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /internal/invite", () => {
+    it("inserts a pending invite with created_at set and logs the email (no EMAIL binding)", async () => {
+      const org = await seedOrg();
+      const inviter = await seedUser();
+      const res = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: org.slug,
+            email: "invitee@example.com",
+            role: "member",
+            inviterUserId: inviter.id,
+          }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { invitation: { id: string; status: string } };
+
+      const rows = await orm
+        .select()
+        .from(schema.invitation)
+        .where(eq(schema.invitation.id, body.invitation.id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].status).toBe("pending");
+      expect(rows[0].createdAt).toBeInstanceOf(Date);
+    });
+
+    it("returns the existing pending invite instead of inserting a duplicate", async () => {
+      const org = await seedOrg();
+      const inviter = await seedUser();
+      const email = "dupe@example.com";
+      const first = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: org.slug,
+            email,
+            role: "member",
+            inviterUserId: inviter.id,
+          }),
+        },
+        dbEnv(),
+      );
+      expect(first.status).toBe(201);
+      const firstBody = (await first.json()) as { invitation: { id: string } };
+
+      const second = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: org.slug,
+            email,
+            role: "member",
+            inviterUserId: inviter.id,
+          }),
+        },
+        dbEnv(),
+      );
+      expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as { invitation: { id: string } };
+      expect(secondBody.invitation.id).toBe(firstBody.invitation.id);
+
+      const rows = await orm
+        .select()
+        .from(schema.invitation)
+        .where(
+          and(eq(schema.invitation.organizationId, org.id), eq(schema.invitation.email, email)),
+        );
+      expect(rows).toHaveLength(1);
+    });
+
+    it("404s when the organization slug is unknown", async () => {
+      const inviter = await seedUser();
+      const res = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: "does-not-exist",
+            email: "a@b.com",
+            role: "member",
+            inviterUserId: inviter.id,
+          }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "organization_not_found" },
+      });
+    });
+
+    it("404s when the inviter user is unknown", async () => {
+      const org = await seedOrg();
+      const res = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: org.slug,
+            email: "a@b.com",
+            role: "member",
+            inviterUserId: crypto.randomUUID(),
+          }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "inviter_not_found" },
+      });
     });
   });
 });

--- a/apps/auth/src/test/fake-d1.ts
+++ b/apps/auth/src/test/fake-d1.ts
@@ -1,0 +1,179 @@
+/**
+ * In-memory D1 test harness (node:sqlite-backed) — see the follow-up flagged
+ * in internal-routes.test.ts. Implements just enough of the `D1Database`
+ * surface that drizzle-orm's D1 driver (`drizzle-orm/d1/session.cjs`) and
+ * Better Auth's `drizzleAdapter` issue: `prepare().bind().run()/.all()`,
+ * `.raw()` (used when a query has field selectors — see `SQLiteD1Session`'s
+ * `values()` path), and `client.batch(...)`.
+ *
+ * Schema is loaded by applying the real `apps/auth/migrations/*.sql` files
+ * in order, so drift between `src/schema.ts` and the migrations is caught by
+ * tests instead of only at `wrangler d1 migrations apply` time.
+ *
+ * Deliberately NOT a full D1 emulator: no `.dump()`, no `sessions`/bookmark
+ * API, and `meta` fields are minimal stubs. Good enough for drizzle+Better
+ * Auth's query patterns against this worker's tables.
+ */
+/// <reference types="node" />
+// Test-only file (never bundled into the Worker): pulls in Node's global
+// types locally via the reference above rather than adding "node" to the
+// worker-wide tsconfig, since this repo deliberately keeps Workers-runtime
+// source free of Node ambient globals.
+import { DatabaseSync, type StatementSync } from "node:sqlite";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, "..", "..", "migrations");
+
+function applyMigrations(db: DatabaseSync): void {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f: string) => f.endsWith(".sql"))
+    .sort();
+  for (const file of files) {
+    const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
+    db.exec(sql);
+  }
+}
+
+type D1Meta = {
+  duration: number;
+  size_after: number;
+  rows_read: number;
+  rows_written: number;
+  last_row_id: number;
+  changed_db: boolean;
+  changes: number;
+};
+
+function emptyMeta(): D1Meta {
+  return {
+    duration: 0,
+    size_after: 0,
+    rows_read: 0,
+    rows_written: 0,
+    last_row_id: 0,
+    changed_db: false,
+    changes: 0,
+  };
+}
+
+/** Rows as returned by node:sqlite's `.all()` — plain objects, one per row. */
+type Row = Record<string, unknown>;
+
+class FakeBoundStatement {
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+    private readonly params: unknown[],
+  ) {}
+
+  private stmt(): StatementSync {
+    return this.db.prepare(this.sql);
+  }
+
+  async run(): Promise<{ success: true; results: []; meta: D1Meta }> {
+    const stmt = this.stmt();
+    const info = stmt.run(...(this.params as never[]));
+    return {
+      success: true,
+      results: [],
+      meta: {
+        duration: 0,
+        size_after: 0,
+        rows_read: 0,
+        rows_written: Number(info.changes ?? 0),
+        last_row_id: Number(info.lastInsertRowid ?? 0),
+        changed_db: Number(info.changes ?? 0) > 0,
+        changes: Number(info.changes ?? 0),
+      },
+    };
+  }
+
+  async all<T = Row>(): Promise<{ success: true; results: T[]; meta: D1Meta }> {
+    const stmt = this.stmt();
+    const rows = stmt.all(...(this.params as never[])) as T[];
+    return { success: true, results: rows, meta: emptyMeta() };
+  }
+
+  async raw<T = unknown[]>(): Promise<T[]> {
+    const stmt = this.stmt();
+    const rows = stmt.all(...(this.params as never[])) as Row[];
+    return rows.map((row) => Object.values(row)) as T[];
+  }
+
+  async first<T = Row>(column?: string): Promise<T | null> {
+    const { results } = await this.all<Row>();
+    const row = results[0];
+    if (!row) return null;
+    if (column) return (row[column] as T) ?? null;
+    return row as T;
+  }
+}
+
+class FakePreparedStatement {
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...params: unknown[]): FakeBoundStatement {
+    return new FakeBoundStatement(this.db, this.sql, params);
+  }
+
+  // Drizzle's D1 batch path binds with zero params directly against the
+  // prepared statement when a query has none — support calling the
+  // bound-statement methods with no `.bind()` call too.
+  run() {
+    return new FakeBoundStatement(this.db, this.sql, []).run();
+  }
+  all() {
+    return new FakeBoundStatement(this.db, this.sql, []).all();
+  }
+  raw() {
+    return new FakeBoundStatement(this.db, this.sql, []).raw();
+  }
+  first(column?: string) {
+    return new FakeBoundStatement(this.db, this.sql, []).first(column);
+  }
+}
+
+export type FakeD1Database = D1Database & {
+  /** Test-only escape hatch to run raw SQL/assertions outside drizzle. */
+  __sqlite: DatabaseSync;
+};
+
+/**
+ * Create a fresh in-memory D1-shaped database with the real migrations
+ * applied. Each call gets an isolated `DatabaseSync(":memory:")` — tests
+ * should call this in `beforeEach` rather than sharing one instance.
+ */
+export function createFakeD1(): FakeD1Database {
+  const sqlite = new DatabaseSync(":memory:");
+  applyMigrations(sqlite);
+
+  const fake = {
+    prepare(sql: string) {
+      return new FakePreparedStatement(sqlite, sql) as unknown as D1PreparedStatement;
+    },
+    async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+      const results: D1Result<T>[] = [];
+      for (const statement of statements) {
+        const bound = statement as unknown as FakeBoundStatement;
+        results.push((await bound.all()) as unknown as D1Result<T>);
+      }
+      return results;
+    },
+    async exec(sql: string) {
+      sqlite.exec(sql);
+      return { count: 0, duration: 0 };
+    },
+    async dump() {
+      throw new Error("FakeD1Database.dump() is not implemented");
+    },
+    __sqlite: sqlite,
+  };
+
+  return fake as unknown as FakeD1Database;
+}


### PR DESCRIPTION
## Summary

- Adds `apps/auth/src/test/fake-d1.ts`: an in-memory `node:sqlite`-backed fake implementing the `D1Database` surface that drizzle-orm's D1 driver and Better Auth's `drizzleAdapter` actually use (`prepare().bind().run()/.all()/.raw()`, `.batch()`). Each call to `createFakeD1()` gets a fresh `DatabaseSync(":memory:")` with the real `apps/auth/migrations/*.sql` files applied in order, so drift between `src/schema.ts` and the migrations is caught by tests instead of only at `wrangler d1 migrations apply` time.
- `node:sqlite` (not `better-sqlite3`) since it's built into Node and verified working on both CI's Node 24 (`.nvmrc`) and local Node 22.14 — no new dependency needed, no lockfile change.
- Extends `apps/auth/src/internal-routes.test.ts` with a new "DB-backed behavior" describe block covering: promote-admin (found/not-found), org-create idempotency (existing slug, plus a simulated concurrent-create race that hits the catch-and-re-query fallback), memberships listing, org lookup with member/pending-invite counts, the pending-invites SQL filter (accepted invites excluded), invite creation with `created_at` set, duplicate-pending-invite idempotency, and the invite 404 paths. No real emails are sent — no `EMAIL` binding is configured, so `sendAuthEmail` (`src/email.ts`) logs instead per its documented dev fallback.
- The prior validation-only tests (DB-poisoning proxy, 400-path coverage) are kept as-is.

## Bug found along the way

Writing a real success-path test for `POST /internal/orgs` surfaced a pre-existing issue: Better Auth's `organization.create` endpoint requires either a session or an explicit `body.userId` ("server-only" per its own schema), but `internal-routes.ts` calls `auth.api.createOrganization({ body: { slug, name } })` with neither. Creating a genuinely *new* org via this route throws `UNAUTHORIZED` today — only the idempotent existing-slug path (which never reaches Better Auth) works. This is documented in the new test as current behavior rather than fixed here, since it's out of scope for a test-harness change.

## Test plan

- [x] `pnpm --filter @uploads/auth test` — 64/64 passing
- [x] `pnpm --filter @uploads/auth typecheck` — clean
- [x] `pnpm lint` — no new errors/warnings (pre-existing `apps/web`/`apps/api`/`apps/mcp` tsconfig errors unrelated to this change, confirmed present on `origin/main` too)