### PR TITLE
feat(auth): connect Better Auth Infrastructure dashboard

### DIFF
--- a/apps/auth/.dev.vars.example
+++ b/apps/auth/.dev.vars.example
@@ -24,6 +24,9 @@ WEB_ORIGIN=http://127.0.0.1:4321
 # it locally (see src/auth.ts).
 AUTH_RATE_LIMIT_DISABLED=true
 
+# Optional: infra dashboard API key (plain fallback for UPL_BETTER_AUTH_API_KEY).
+# BETTER_AUTH_API_KEY=
+
 # Optional: dev-only GitHub OAuth plain fallbacks (same store-vs-dev-var
 # footgun as the signing secret above). Leave unset to keep GitHub gated off
 # locally — magic link alone is enough for most dev flows.

--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -1,11 +1,14 @@
 # @uploads/auth
 
-Dedicated Better Auth worker for uploads.sh (`auth.uploads.sh`). GitHub OAuth
+Dedicated Better Auth worker for uploads.sh (`auth.uploads.sh`). GitHub OAuth +
+magic-link sign-in, its own D1 database (`uploads-auth`), and a small
+`/internal/*` API reachable only via the `AUTH` service binding from
+`apps/api`. See `docs/superpowers/plans/2026-07-12-better-auth-introduction.md`
+for the full design.
 
-- magic-link sign-in, its own D1 database (`uploads-auth`), and a small
-  `/internal/*` API reachable only via the `AUTH` service binding from
-  `apps/api`. See `docs/superpowers/plans/2026-07-12-better-auth-introduction.md`
-  for the full design.
+The Better Auth Infrastructure dashboard (`@better-auth/infra` `dash()`) mounts
+when `UPL_BETTER_AUTH_API_KEY` or local `BETTER_AUTH_API_KEY` resolves. Point the
+project at `https://auth.uploads.sh`.
 
 ## First admin
 

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@better-auth/infra": "^0.3.6",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.28"

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -5,6 +5,7 @@
  * after a redeploy, or a different D1 binding under `wrangler dev -c`) never
  * serves a stale instance.
  */
+import { dash } from "@better-auth/infra";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
 import { drizzle } from "drizzle-orm/d1";
@@ -13,22 +14,25 @@ import { sendAuthEmail } from "./email";
 import * as schema from "./schema";
 import { authTrustedOrigins, isTrustedOrigin } from "./trusted-origins";
 import {
+  resolveDashApiKey,
   resolveGitHubCredentials,
   resolveSigningSecret,
+  type DashApiKeyEnv,
   type GitHubCredentialsEnv,
 } from "./secrets";
 
-export type AuthEnv = GitHubCredentialsEnv & {
-  DB: D1Database;
-  EMAIL?: import("./email").EmailBinding;
-  BETTER_AUTH_URL?: string;
-  BETTER_AUTH_SECRET_DEV?: string;
-  UPL_BETTER_AUTH_SECRET?: import("./secrets").SecretLike;
-  WEB_ORIGIN?: string;
-  ENVIRONMENT?: string;
-  BETTER_AUTH_TRUSTED_ORIGINS?: string;
-  AUTH_RATE_LIMIT_DISABLED?: string;
-};
+export type AuthEnv = GitHubCredentialsEnv &
+  DashApiKeyEnv & {
+    DB: D1Database;
+    EMAIL?: import("./email").EmailBinding;
+    BETTER_AUTH_URL?: string;
+    BETTER_AUTH_SECRET_DEV?: string;
+    UPL_BETTER_AUTH_SECRET?: import("./secrets").SecretLike;
+    WEB_ORIGIN?: string;
+    ENVIRONMENT?: string;
+    BETTER_AUTH_TRUSTED_ORIGINS?: string;
+    AUTH_RATE_LIMIT_DISABLED?: string;
+  };
 
 export type BetterAuthInstance = ReturnType<typeof buildAuth>;
 
@@ -65,6 +69,7 @@ function buildAuth(
   env: AuthEnv,
   signingSecret: string,
   github: { clientId: string; clientSecret: string } | null,
+  dashApiKey: string | null,
 ) {
   const db = drizzle(env.DB, { schema });
   const betterAuthUrl = env.BETTER_AUTH_URL || "https://auth.uploads.sh";
@@ -117,6 +122,8 @@ function buildAuth(
           });
         },
       }),
+      // Hosted dashboard (`@better-auth/infra`). Omit when the API key is unset.
+      ...(dashApiKey ? [dash({ apiKey: dashApiKey })] : []),
     ],
     session: {
       cookieCache: {
@@ -160,6 +167,7 @@ function cacheKey(
   env: AuthEnv,
   signingSecret: string,
   github: { clientId: string; clientSecret: string } | null,
+  dashApiKey: string | null,
 ): string {
   return JSON.stringify({
     betterAuthUrl: env.BETTER_AUTH_URL,
@@ -170,6 +178,7 @@ function cacheKey(
     signingSecret,
     githubClientId: github?.clientId ?? null,
     githubClientSecret: github?.clientSecret ?? null,
+    dashApiKey,
     hasEmail: Boolean(env.EMAIL),
   });
 }
@@ -191,6 +200,7 @@ let cachedEmail: AuthEnv["EMAIL"] | undefined;
 // lifetime on a transient Secrets Store hiccup.
 let cachedSigningSecret: string | undefined;
 let cachedGithub: { clientId: string; clientSecret: string } | null | undefined;
+let cachedDashApiKey: string | null | undefined;
 
 /**
  * Build (or reuse) the Better Auth instance for this isolate. Returns null
@@ -209,14 +219,19 @@ export async function createAuth(env: AuthEnv): Promise<BetterAuthInstance | nul
   if (cachedGithub === undefined) {
     cachedGithub = await resolveGitHubCredentials(env);
   }
+  if (cachedDashApiKey === undefined) {
+    cachedDashApiKey = await resolveDashApiKey(env);
+  }
   const github = cachedGithub;
-  const key = cacheKey(env, signingSecret, github);
+  const dashApiKey = cachedDashApiKey;
+
+  const key = cacheKey(env, signingSecret, github, dashApiKey);
 
   if (cachedInstance && cachedKey === key && cachedDB === env.DB && cachedEmail === env.EMAIL) {
     return cachedInstance;
   }
 
-  cachedInstance = buildAuth(env, signingSecret, github);
+  cachedInstance = buildAuth(env, signingSecret, github, dashApiKey);
   cachedKey = key;
   cachedDB = env.DB;
   cachedEmail = env.EMAIL;

--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -8,6 +8,8 @@ interface Env {
    * src/secrets.ts and the D7 footgun note there.
    */
   BETTER_AUTH_SECRET_DEV?: string;
+  /** Dev plain fallback for UPL_BETTER_AUTH_API_KEY (mounts `dash()` when set). */
+  BETTER_AUTH_API_KEY?: string;
   /** Dev-only plain fallbacks for GitHub OAuth, gated the same way as the store pair. */
   GITHUB_CLIENT_ID?: string;
   GITHUB_CLIENT_SECRET?: string;

--- a/apps/auth/src/secrets.test.ts
+++ b/apps/auth/src/secrets.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveDashApiKey,
   resolveGitHubCredentials,
   resolveSecret,
   resolveSigningSecret,
@@ -110,5 +111,23 @@ describe("resolveGitHubCredentials", () => {
 
   it("returns null with neither store nor dev vars set", async () => {
     expect(await resolveGitHubCredentials({})).toBeNull();
+  });
+});
+
+describe("resolveDashApiKey", () => {
+  it("prefers the store, falls back to BETTER_AUTH_API_KEY, else null", async () => {
+    expect(
+      await resolveDashApiKey({
+        UPL_BETTER_AUTH_API_KEY: store("store-key"),
+        BETTER_AUTH_API_KEY: "dev-key",
+      }),
+    ).toBe("store-key");
+    expect(
+      await resolveDashApiKey({
+        UPL_BETTER_AUTH_API_KEY: failingStore(),
+        BETTER_AUTH_API_KEY: "dev-key",
+      }),
+    ).toBe("dev-key");
+    expect(await resolveDashApiKey({})).toBeNull();
   });
 });

--- a/apps/auth/src/secrets.ts
+++ b/apps/auth/src/secrets.ts
@@ -13,8 +13,8 @@
  * NOT override an unpopulated Secrets Store binding — the binding still
  * "exists" and its `.get()` just rejects/returns empty. That's why the dev
  * fallback vars below are distinctly named (`BETTER_AUTH_SECRET_DEV`,
- * `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`) rather than shadowing the
- * `UPL_`-prefixed binding names.
+ * `BETTER_AUTH_API_KEY`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`) rather
+ * than shadowing the `UPL_`-prefixed binding names.
  */
 
 /** Minimal shape of a Cloudflare Secrets Store binding. */
@@ -77,4 +77,16 @@ export async function resolveGitHubCredentials(
   ]);
   if (!clientId || !clientSecret) return null;
   return { clientId, clientSecret };
+}
+
+export type DashApiKeyEnv = {
+  UPL_BETTER_AUTH_API_KEY?: SecretLike;
+  /** Dev plain fallback (same store-vs-dev-var footgun as the signing secret). */
+  BETTER_AUTH_API_KEY?: string;
+};
+
+/** Infra dashboard API key; null → omit `dash()`. Store wins over plain fallback. */
+export async function resolveDashApiKey(env: DashApiKeyEnv): Promise<string | null> {
+  const fromStore = await resolveSecret(env.UPL_BETTER_AUTH_API_KEY);
+  return fromStore || env.BETTER_AUTH_API_KEY || null;
 }

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -46,17 +46,20 @@
   // (confirmed via `wrangler secrets-store store list --remote`); it's
   // shared across buildinternet-org repos the same way KV/D1 IDs are noted
   // inline elsewhere in this repo. Wrangler FAILS a deploy when a declared
-  // secrets_store_secrets entry doesn't exist in the store yet — these three
-  // (UPL_BETTER_AUTH_SECRET, UPL_GITHUB_CLIENT_ID, UPL_GITHUB_CLIENT_SECRET)
-  // are Phase 0 human follow-ups (see plan). Until populated, the worker
-  // boots gated/inert: GitHub stays omitted from socialProviders (D3) and
-  // /api/auth/* answers 503 (see src/secrets.ts) rather than booting on an
-  // ephemeral signing secret.
+  // secrets_store_secrets entry doesn't exist in the store yet. Until
+  // populated: GitHub stays omitted from socialProviders (D3), dash() stays
+  // omitted (no infra API key), and /api/auth/* answers 503 without a signing
+  // secret (see src/secrets.ts) rather than booting on an ephemeral secret.
   "secrets_store_secrets": [
     {
       "binding": "UPL_BETTER_AUTH_SECRET",
       "store_id": "a887a71cab084105b79706df23380723",
       "secret_name": "UPL_BETTER_AUTH_SECRET",
+    },
+    {
+      "binding": "UPL_BETTER_AUTH_API_KEY",
+      "store_id": "a887a71cab084105b79706df23380723",
+      "secret_name": "UPL_BETTER_AUTH_API_KEY",
     },
     {
       "binding": "UPL_GITHUB_CLIENT_ID",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
 
   apps/auth:
     dependencies:
+      '@better-auth/infra':
+        specifier: ^0.3.6
+        version: 0.3.6(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(zod@4.4.3)
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)))
@@ -463,6 +466,29 @@ packages:
       drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
+        optional: true
+
+  '@better-auth/infra@0.3.6':
+    resolution: {integrity: sha512-g5WwUMSQ0IuyRUMthBAdSRFoC+lHVLpv+diM8i3ls5kROMSomnZTA265g+SN3QqPM6ohVTWcyVtXvMQzl3eSgA==}
+    peerDependencies:
+      '@better-auth/core': '>=1.4.0'
+      '@react-native-async-storage/async-storage': '>=1.21.0'
+      better-auth: '>=1.4.0'
+      expo-constants: '>=16.0.0'
+      expo-crypto: '>=13.0.0'
+      expo-device: '>=6.0.0'
+      react-native: '>=0.74.0'
+      zod: '>=4.1.12'
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+      expo-constants:
+        optional: true
+      expo-crypto:
+        optional: true
+      expo-device:
+        optional: true
+      react-native:
         optional: true
 
   '@better-auth/kysely-adapter@1.6.23':
@@ -2872,6 +2898,9 @@ packages:
     resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
     engines: {node: '>=22.0.0'}
 
+  libphonenumber-js@1.13.8:
+    resolution: {integrity: sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==}
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -4431,6 +4460,17 @@ snapshots:
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3)
+
+  '@better-auth/infra@0.3.6(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(zod@4.4.3)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)))
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      libphonenumber-js: 1.13.8
+      zod: 4.4.3
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
     dependencies:
@@ -6420,6 +6460,8 @@ snapshots:
   kleur@4.1.5: {}
 
   kysely@0.29.3: {}
+
+  libphonenumber-js@1.13.8: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true


### PR DESCRIPTION
## In plain terms

Hooks the auth worker up to Better Auth’s hosted dashboard so operators can inspect users, sessions, and orgs without building that UI ourselves. The plugin only turns on when the infrastructure API key is present.

## What it does

- Adds `@better-auth/infra` and mounts `dash()` when `UPL_BETTER_AUTH_API_KEY` (Secrets Store) or local `BETTER_AUTH_API_KEY` resolves
- Binds `UPL_BETTER_AUTH_API_KEY` in `apps/auth/wrangler.jsonc` (secret already set in the store)
- Leaves auth fully working when the key is missing — plugin is simply omitted
- Documents the local `.dev.vars` fallback

## What it is not

- No `sentinel()` / abuse protection (dashboard only)
- No activity-tracking schema changes (`lastActiveAt`) — can land later if we want that dashboard metric
- Not a user-facing CLI change (no changeset)

## How to try it

1. Deploy auth (`pnpm deploy:auth`) so the worker boots with the Secrets Store key
2. In the Better Auth dashboard, point the project at `https://auth.uploads.sh`
3. Locally: set `BETTER_AUTH_API_KEY` in `apps/auth/.dev.vars` and run `pnpm dev:auth`

## Test plan

- [x] `pnpm --filter @uploads/auth test`
- [x] `pnpm --filter @uploads/auth typecheck`
- [ ] Deploy auth and confirm the dashboard can talk to production