### PR TITLE
fix(auth): set Better Auth appName

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -77,6 +77,7 @@ function buildAuth(
   const isProduction = env.ENVIRONMENT === "production";
 
   return betterAuth({
+    appName: "uploads.sh",
     baseURL: betterAuthUrl,
     basePath: "/api/auth",
     secret: signingSecret,


### PR DESCRIPTION
## In plain terms

Tells Better Auth this product is **uploads.sh**, so the Infrastructure dashboard and any BA-owned UI stop treating the app as unnamed.

## What it does

- Sets `appName: "uploads.sh"` on the auth worker’s `betterAuth()` config

## What it is not

- No schema, secrets, or dashboard connection changes
- Does not address experimental joins (separate follow-up)

## Test plan

- [x] One-line config change; existing auth tests unaffected
- [ ] After deploy, confirm the dashboard “Missing Application Name” insight clears