### PR TITLE
feat(auth): enable Better Auth experimental joins

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -85,6 +85,9 @@ function buildAuth(
       provider: "sqlite",
       schema,
     }),
+    // Fetch related rows in one query (session→user, org→members, …). Requires
+    // drizzle `relations()` on the schema object — see schema.ts.
+    experimental: { joins: true },
     // D3: gate GitHub on both id+secret resolving; adding a provider later is
     // just another resolved secret pair, no code change here.
     socialProviders: github ? { github } : {},

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -11,7 +11,10 @@
  * ⚠ footgun: this file and ./migrations/*.sql are hand-synced — there is no
  * generator wired into CI. Each table below is annotated with the migration
  * file that created it; keep that comment current when the schema changes.
+ * Drizzle `relations()` below are TS-only (for experimental.joins) and do not
+ * need a migration.
  */
+import { relations } from "drizzle-orm";
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 /** Non-null integer `timestamp` column with a JS-side default of "now". */
@@ -206,6 +209,73 @@ export const invitation = sqliteTable(
   },
   (t) => [index("idx_invitation_organization_id").on(t.organizationId)],
 );
+
+/**
+ * Drizzle relations for Better Auth `experimental.joins` (adapter needs these
+ * on the same schema object as the tables). No SQL/migration impact.
+ *
+ * session has two FKs to user (`userId`, `impersonatedBy`) so both sides use
+ * matching `relationName`s — see better-auth drizzle adapter docs.
+ */
+export const userRelations = relations(user, ({ many }) => ({
+  sessions: many(session, { relationName: "session_userId" }),
+  impersonatedSessions: many(session, { relationName: "session_impersonatedBy" }),
+  accounts: many(account),
+  members: many(member),
+  invitations: many(invitation),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+    relationName: "session_userId",
+  }),
+  impersonatedByUser: one(user, {
+    fields: [session.impersonatedBy],
+    references: [user.id],
+    relationName: "session_impersonatedBy",
+  }),
+  activeOrganization: one(organization, {
+    fields: [session.activeOrganizationId],
+    references: [organization.id],
+  }),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));
+
+export const organizationRelations = relations(organization, ({ many }) => ({
+  members: many(member),
+  invitations: many(invitation),
+  sessions: many(session),
+}));
+
+export const memberRelations = relations(member, ({ one }) => ({
+  organization: one(organization, {
+    fields: [member.organizationId],
+    references: [organization.id],
+  }),
+  user: one(user, {
+    fields: [member.userId],
+    references: [user.id],
+  }),
+}));
+
+export const invitationRelations = relations(invitation, ({ one }) => ({
+  organization: one(organization, {
+    fields: [invitation.organizationId],
+    references: [organization.id],
+  }),
+  user: one(user, {
+    fields: [invitation.inviterId],
+    references: [user.id],
+  }),
+}));
 
 export type AuthUser = typeof user.$inferSelect;
 export type AuthSession = typeof session.$inferSelect;


### PR DESCRIPTION
## In plain terms

Speeds up Better Auth endpoints that load related data (session + user, orgs + members) by letting the adapter join tables in one query instead of several round-trips to D1.

## What it does

- Adds Drizzle `relations()` for user/session/account/organization/member/invitation (TS-only — no migration)
- Sets `experimental: { joins: true }` on the auth worker
- Disambiguates session’s two FKs to user (`userId` vs `impersonatedBy`) with matching `relationName`s

## What it is not

- Not a schema/SQL change
- Does not turn on activity tracking or sentinel
- Cookie cache (5 min) still covers most warm `get-session` hits; joins help cache misses and org/admin paths

## Test plan

- [x] `pnpm --filter @uploads/auth test`
- [x] `pnpm --filter @uploads/auth typecheck`
- [ ] After deploy: sign-in → get-session; open org membership in dashboard; watch `/api/auth/*` error rate