### PR TITLE
feat(web): /account landing page for signed-in users

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -130,6 +130,33 @@ export async function getInvitation(origin: string, id: string): Promise<Invitat
   }
 }
 
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+  slug: string;
+  createdAt?: string;
+}
+
+/**
+ * GET /api/auth/organization/list — the signed-in user's organizations
+ * (Better Auth organization plugin). Returns [] on any failure — the
+ * /account page treats "no orgs" and "couldn't load" the same way visually,
+ * with copy that covers both.
+ */
+export async function listOrganizations(origin: string): Promise<OrganizationSummary[]> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/organization/list`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (!res.ok) return [];
+    const body = (await res.json().catch(() => null)) as OrganizationSummary[] | null;
+    return Array.isArray(body) ? body : [];
+  } catch {
+    return [];
+  }
+}
+
 export type AcceptInvitationResult = { ok: true } | { ok: false; status: number; code?: string };
 
 /**

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -34,6 +34,7 @@ describe.each([
   { path: "/login", title: "Sign in · uploads.sh" },
   { path: "/admin", title: "Admin · uploads.sh" },
   { path: "/accept-invitation/upi_abc123", title: "Accept invitation · uploads.sh" },
+  { path: "/account", title: "Account · uploads.sh" },
 ])("route reachability: $path", ({ path, title }) => {
   it("reaches the page handler (not a static 404) on a browser navigation request", async () => {
     let handlerCalled = false;

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -1,0 +1,261 @@
+---
+// Authenticated landing page — where /login drops people after sign-in.
+// The console (/console) stays as the raw developer surface; this page is
+// the friendlier "you're in, here's what you have" view: session info,
+// workspaces (organizations), and pointers to the CLI/API/console.
+// Client-side session gating here is a UX affordance only — every data
+// call goes to apps/auth, which enforces the session server-side.
+import { env } from "cloudflare:workers";
+import {
+  CF_RUM_CONNECT_SRC,
+  CF_RUM_SCRIPT_SRC,
+  STYLE_SRC_SELF_AND_INLINE,
+} from "../lib/csp";
+
+export const prerender = false;
+
+const authOrigin =
+  env.UPLOADS_AUTH_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
+  "https://auth.uploads.sh";
+
+const csp = [
+  "default-src 'none'",
+  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "img-src data: https:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const FAVICON =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+---
+
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow, noarchive" />
+  <meta name="referrer" content="no-referrer" />
+  <meta http-equiv="Content-Security-Policy" content={csp} />
+  <title>Account · uploads.sh</title>
+  <link rel="icon" href={FAVICON} />
+  <style>
+    :root{color-scheme:dark;--bg:#0a0a0b;--panel:#121214;--line:#232327;--fg:#ececea;--body:#b3b3ad;--muted:#7d7d77;--accent:#b794ff;--red:#d98a9c;--mono:"Geist Mono Variable",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace}
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100dvh;background:var(--bg);color:var(--fg);font:14px/1.6 var(--mono);font-variant-ligatures:none;font-feature-settings:"calt" 0,"liga" 0}
+    a{color:var(--fg);text-decoration:underline;text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent);text-underline-offset:3px}
+    a:hover,a:focus-visible{color:var(--accent);outline:none}
+    code{color:var(--fg);background:var(--panel);border:1px solid var(--line);border-radius:5px;padding:1px 6px;font-size:.9em}
+    [hidden]{display:none!important}
+
+    .shell{max-width:960px;margin:0 auto;padding:28px 20px 56px}
+    header.top{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:22px}
+    header.top h1{font-size:1.1rem;font-weight:600;margin:0;letter-spacing:-.01em}
+    header.top .who{color:var(--muted);font-size:12.5px}
+    .status{border-left:3px solid var(--accent);padding:9px 14px;background:var(--panel);border:1px solid var(--line);border-radius:8px}
+    .status[data-state=denied]{border-color:var(--red);color:var(--red)}
+    a.button{display:inline-block;margin-top:12px;font:12px var(--mono);color:var(--accent);text-decoration:none;border:1px solid var(--line);border-radius:7px;padding:9px 13px;background:var(--panel)}
+    a.button:hover,a.button:focus-visible{border-color:var(--accent);outline:none}
+
+    .layout{display:grid;grid-template-columns:190px 1fr;gap:24px;align-items:start}
+    nav.side{display:grid;gap:4px;position:sticky;top:28px}
+    nav.side a{display:block;padding:8px 12px;border-radius:7px;border:1px solid transparent;color:var(--muted);text-decoration:none;font-size:13px}
+    nav.side a:hover{color:var(--fg)}
+    nav.side a[aria-current=true]{color:var(--accent);background:var(--panel);border-color:var(--line)}
+    nav.side .side-foot{margin-top:14px;padding-top:14px;border-top:1px solid var(--line);display:grid;gap:4px}
+    nav.side .side-foot a{font-size:12px}
+    nav.side button{text-align:left;font:12px var(--mono);color:var(--muted);background:none;border:1px solid transparent;border-radius:7px;padding:8px 12px;cursor:pointer}
+    nav.side button:hover,nav.side button:focus-visible{color:var(--red);outline:none}
+
+    .content{display:grid;gap:16px;min-width:0}
+    section.card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px 20px}
+    section.card h2{margin:0 0 4px;font-size:.95rem;font-weight:600}
+    section.card p{color:var(--body);margin:6px 0 0;font-size:13px}
+    p.muted,span.muted{color:var(--muted)}
+    .kv{display:grid;grid-template-columns:max-content 1fr;gap:6px 18px;margin-top:12px;font-size:13px}
+    .kv dt{color:var(--muted);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;align-self:center}
+    .kv dd{margin:0;color:var(--fg);word-break:break-word}
+    ul.plain{list-style:none;margin:12px 0 0;padding:0;display:grid;gap:8px}
+    /* :global() so JS-injected <li>s (#orgs-list) match despite Astro's style scoping. */
+    ul.plain :global(li){display:flex;justify-content:space-between;gap:10px;padding:10px 12px;border:1px solid var(--line);border-radius:8px;background:var(--bg);font-size:13px}
+    ul.plain :global(.slug){color:var(--muted)}
+    .pill{display:inline-block;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);border:1px solid var(--line);border-radius:99px;padding:2px 9px;background:var(--bg)}
+
+    @media (max-width:680px){
+      .layout{grid-template-columns:1fr}
+      nav.side{position:static;grid-template-columns:repeat(auto-fit,minmax(90px,max-content));gap:6px}
+      nav.side .side-foot{grid-column:1/-1;border:0;margin:0;padding:0;grid-template-columns:subgrid}
+    }
+  </style>
+</head>
+<body>
+<div class="shell">
+  <div id="checking" class="status" role="status">Checking your session…</div>
+
+  <div id="signed-out" hidden>
+    <div class="status" data-state="denied" role="alert">You're not signed in.</div>
+    <a class="button" href="/login">Sign in</a>
+  </div>
+
+  <div id="app" hidden>
+    <header class="top">
+      <h1>uploads.sh</h1>
+      <span class="who" id="who"></span>
+    </header>
+
+    <div class="layout">
+      <nav class="side" aria-label="Account sections">
+        <a href="#overview" data-panel="overview" aria-current="true">Overview</a>
+        <a href="#workspaces" data-panel="workspaces">Workspaces</a>
+        <a href="#account" data-panel="account">Account</a>
+        <a href="#developers" data-panel="developers">Developers</a>
+        <div class="side-foot">
+          <a href="/console">console →</a>
+          <a href="/admin" id="admin-link" hidden>admin →</a>
+          <button type="button" id="sign-out-btn">Sign out</button>
+        </div>
+      </nav>
+
+      <div class="content">
+        <div data-panel-body="overview">
+          <section class="card">
+            <h2>Welcome back<span id="hello-name"></span></h2>
+            <p>
+              uploads.sh hosts files you want to link to — PR screenshots, agent
+              artifacts, quick shares. Your workspaces and account details are in
+              the sections on the left.
+            </p>
+          </section>
+          <section class="card" style="margin-top:16px">
+            <h2>Uploading</h2>
+            <p>
+              Uploads go through the <code>uploads</code> CLI or the API with a
+              workspace token. The web console is a developer tool, not the main
+              path. The <a href="/docs">docs</a> cover setup.
+            </p>
+          </section>
+        </div>
+
+        <div data-panel-body="workspaces" hidden>
+          <section class="card">
+            <h2>Workspaces</h2>
+            <p>Workspaces group your files and tokens. You belong to these:</p>
+            <div id="orgs-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+            <ul class="plain" id="orgs-list" hidden></ul>
+            <p class="muted" style="margin-top:12px">
+              Need another workspace? Ask its admin for an invite.
+            </p>
+          </section>
+        </div>
+
+        <div data-panel-body="account" hidden>
+          <section class="card">
+            <h2>Account</h2>
+            <dl class="kv">
+              <dt>Email</dt><dd id="acct-email"></dd>
+              <dt>Name</dt><dd id="acct-name"></dd>
+              <dt>Role</dt><dd id="acct-role"></dd>
+            </dl>
+            <p class="muted" style="margin-top:14px">
+              Your name and avatar come from your sign-in provider. There's
+              nothing to edit here yet.
+            </p>
+          </section>
+        </div>
+
+        <div data-panel-body="developers" hidden>
+          <section class="card">
+            <h2>Developers</h2>
+            <p>These tools need a workspace token.</p>
+            <ul class="plain">
+              <li><span><a href="/console">Console</a></span><span class="slug">usage, files, invites — bring a token</span></li>
+              <li><span><a href="/docs">API docs</a></span><span class="slug">endpoints &amp; auth</span></li>
+              <li><span><a href="https://github.com/buildinternet/uploads">GitHub</a></span><span class="slug">source &amp; issues</span></li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script define:vars={{ authOrigin }}>
+  window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
+</script>
+<script>
+  import { getSession, listOrganizations, signOut } from "../lib/auth-client";
+
+  const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+    .__UPLOADS_AUTH_ORIGIN__;
+
+  function requireElement<T extends Element>(selector: string): T {
+    const element = document.querySelector<T>(selector);
+    if (!element) throw new Error(`account page is missing ${selector}`);
+    return element as T;
+  }
+
+  const checking = requireElement<HTMLElement>("#checking");
+  const signedOut = requireElement<HTMLElement>("#signed-out");
+  const app = requireElement<HTMLElement>("#app");
+
+  // Hash-based panel switching — no router, just show/hide.
+  const navLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>("nav.side a[data-panel]"));
+  const panels = Array.from(document.querySelectorAll<HTMLElement>("[data-panel-body]"));
+  function showPanel(name: string) {
+    const known = panels.some((p) => p.dataset.panelBody === name);
+    const target = known ? name : "overview";
+    for (const p of panels) p.hidden = p.dataset.panelBody !== target;
+    for (const l of navLinks) l.setAttribute("aria-current", String(l.dataset.panel === target));
+  }
+  window.addEventListener("hashchange", () => showPanel(location.hash.slice(1)));
+  showPanel(location.hash.slice(1));
+
+  const escapeHtml = (value: string) =>
+    value.replace(/[&<>"']/g, (ch) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+    );
+
+  getSession(authOrigin).then(async (result) => {
+    checking.hidden = true;
+    if (!result) {
+      signedOut.hidden = false;
+      return;
+    }
+    const { user } = result;
+    app.hidden = false;
+    requireElement<HTMLElement>("#who").textContent = user.email;
+    requireElement<HTMLElement>("#hello-name").textContent = user.name ? `, ${user.name}` : "";
+    requireElement<HTMLElement>("#acct-email").textContent = user.email;
+    requireElement<HTMLElement>("#acct-name").textContent = user.name || "—";
+    requireElement<HTMLElement>("#acct-role").textContent = user.role || "member";
+    if (user.role === "admin") requireElement<HTMLElement>("#admin-link").hidden = false;
+
+    const orgsStatus = requireElement<HTMLElement>("#orgs-status");
+    const orgsList = requireElement<HTMLUListElement>("#orgs-list");
+    const orgs = await listOrganizations(authOrigin);
+    if (!orgs.length) {
+      orgsStatus.textContent =
+        "No workspaces on this account yet — accept an invite to join one.";
+      return;
+    }
+    orgsStatus.hidden = true;
+    orgsList.hidden = false;
+    orgsList.innerHTML = orgs
+      .map(
+        (org) =>
+          `<li><span>${escapeHtml(org.name)}</span><span class="slug">${escapeHtml(org.slug)}</span></li>`,
+      )
+      .join("");
+  });
+
+  requireElement<HTMLButtonElement>("#sign-out-btn").addEventListener("click", async () => {
+    await signOut(authOrigin);
+    location.href = "/login";
+  });
+</script>
+</body>
+</html>

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -134,7 +134,8 @@ const FAVICON =
         <h1>uploads console</h1>
         <span id="signed-out"><a href="/login">Sign in</a></span>
         <span id="signed-in" hidden>
-          <span id="session-who" class="muted"></span>
+          <a href="/account">account</a>
+          &#32;<span id="session-who" class="muted"></span>
           &#32;<button type="button" id="sign-out-btn">Sign out</button>
         </span>
       </div>

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -115,7 +115,7 @@ const FAVICON =
   const magicSubmit = requireElement<HTMLButtonElement>("#magic-submit");
   const emailInput = requireElement<HTMLInputElement>("#email");
 
-  const callbackURL = `${location.origin}/console`;
+  const callbackURL = `${location.origin}/account`;
 
   githubBtn.addEventListener("click", async () => {
     errorBox.hidden = true;


### PR DESCRIPTION
## What

Signed-in users now land on a new `/account` page instead of the token-oriented `/console`. The console stays as the developer surface, with an "account" link in its session bar.

<img width="700" alt="New /account landing page, signed-in overview" src="https://storage.uploads.sh/default/screenshots/buildinternet-uploads/account-landing/account-overview-efb5d5.webp">

## Why

The console reads like a control panel but needs a bearer token for everything — dropping fresh sign-ins there implies capabilities they don't have. `/account` is a plain "you're in, here's what you have" surface.

## Changes

- **`apps/web/src/pages/account.astro`** (new): left sidebar + content panels (Overview, Workspaces, Account, Developers) switched by URL hash — no router, no client framework, same design tokens/CSP/session-gating pattern as `/login` and `/admin`. Admin link shows only for `role === "admin"`. Client-side gating is UX-only; data calls hit apps/auth which enforces the session.
- **`auth-client.ts`**: `listOrganizations()` wrapper (GET `/api/auth/organization/list`), defensive like the existing wrappers.
- **`login.astro`**: post-sign-in callback `/console` → `/account`.
- **`console.astro`**: "account" link in the session bar.
- **`pages-reachability.test.ts`**: `/account` added to the `run_worker_first` regression rows.

## Notes

- No usage/files/gallery data is shown: the only session-cookie API surface today is admin-gated `/admin-ui/*`; `/v1/:ws/*` requires bearer tokens. A per-user usage panel needs a session-authenticated API surface first (Phase 4/5 candidate).
- Verified in the browser (signed-out gate, hash panel switching, mobile wrap, no console errors). `pnpm test` 17/17; typecheck clean for the new page (2 pre-existing errors in admin.astro untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
