### PR TITLE
feat: session-authenticated /me usage surface + account Usage panel

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { usage } from "./routes/usage";
 import { admin } from "./routes/admin";
 import { adminUi } from "./routes/admin-ui";
 import { auth } from "./routes/auth";
+import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
@@ -26,9 +27,10 @@ const consoleCors = cors({
   maxAge: 86400,
 });
 
-// /admin-ui/* is session-cookie-authenticated (requireAdminUser, see
-// src/session-auth.ts), so unlike consoleCors above it must be credentialed
-// — same treatment as apps/auth's authCors for the web origin's cross-origin
+// /admin-ui/* and /me/* are both session-cookie-authenticated (see
+// src/session-auth.ts — requireAdminUser for /admin-ui, requireSessionUser
+// only for /me), so unlike consoleCors above they must be credentialed —
+// same treatment as apps/auth's authCors for the web origin's cross-origin
 // browser calls (uploads.sh -> api.uploads.sh). The ADMIN_TOKEN-gated
 // `/admin/*` surface is bearer-token-only and deliberately untouched.
 const adminUiCors = cors({
@@ -48,9 +50,11 @@ export const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
   .use("/admin/*", consoleCors)
   .use("/admin-ui/*", adminUiCors)
+  .use("/me/*", adminUiCors)
   .use("/v1/*", consoleCors)
   .route("/admin", admin)
   .route("/admin-ui", adminUi)
+  .route("/me", me)
   .route("/auth", auth)
   .route("/public/galleries", publicGalleries)
   .use("/v1/:workspace/*", workspaceAuth)

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1,0 +1,143 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { me } from "./me";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+const USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** A single stub that answers get-session with `user`, and everything else via `onInternal`. */
+function stubEnv(
+  user: typeof USER | null,
+  onInternal: (path: string, req: Request) => Response | Promise<Response>,
+  db: unknown = new UsageFakeD1(),
+): Env {
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+    }
+    return onInternal(url.pathname, req);
+  });
+  return { AUTH: auth, DB: db, REGISTRY: fakeKv({}) } as unknown as Env;
+}
+
+function fakeKv(records: Record<string, unknown>): Pick<KVNamespace, "get"> {
+  return {
+    get: (async (key: string) =>
+      key in records ? records[key] : null) as unknown as KVNamespace["get"],
+  };
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>().route("/me", me).onError((err, c) => respondError(c, err));
+}
+
+describe("/me auth gate", () => {
+  it("401s with no session cookie", async () => {
+    const env = stubEnv(null, () => new Response(null, { status: 404 }));
+    const res = await app().request("/me/workspaces", {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /me/workspaces", () => {
+  it("maps memberships to workspaces via workspacesForOrg", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role: "owner" }]);
+      }
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspaces: [
+        {
+          workspace: "acme",
+          organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+          role: "owner",
+        },
+      ],
+    });
+  });
+
+  it("returns an empty list for a user with no memberships", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspaces: [] });
+  });
+});
+
+describe("GET /me/workspaces/:name/usage", () => {
+  it("404s for a workspace the caller is not a member of", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/usage", {}, env);
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_not_found" },
+    });
+  });
+
+  it("returns usage + limits for a workspace the caller is a member of", async () => {
+    const db = new UsageFakeD1();
+    db.usage.set("acme", {
+      workspace: "acme",
+      bytes: 500,
+      objects: 3,
+      uploads_in_period: 2,
+      period_start: "2026-07",
+      updated_at: "2026-07-10T00:00:00.000Z",
+    });
+    const env = stubEnv(
+      USER,
+      (path) => {
+        if (path === "/internal/memberships") {
+          return Response.json([
+            { organizationId: "org1", organizationSlug: "acme", role: "member" },
+          ]);
+        }
+        if (path === "/internal/orgs/acme") {
+          return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+        }
+        return new Response(null, { status: 404 });
+      },
+      db,
+    );
+    (env as unknown as { REGISTRY: Pick<KVNamespace, "get"> }).REGISTRY = fakeKv({
+      "ws:acme": { provider: "r2", bucket: "acme-bucket", maxStorageBytes: 1000 },
+    });
+
+    const res = await app().request("/me/workspaces/acme/usage", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      bytes: 500,
+      objects: 3,
+      uploadsInPeriod: 2,
+      periodStart: "2026-07",
+      updatedAt: "2026-07-10T00:00:00.000Z",
+      maxStorageBytes: 1000,
+      storageRemainingBytes: 500,
+    });
+  });
+});

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -74,6 +74,15 @@ describe("GET /me/workspaces", () => {
     });
   });
 
+  it("503s when the memberships lookup fails (AUTH outage is not zero memberships)", async () => {
+    const env = stubEnv(USER, () => new Response(null, { status: 500 }));
+    const res = await app().request("/me/workspaces", {}, env);
+    expect(res.status).toBe(503);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "auth_lookup_failed" },
+    });
+  });
+
   it("returns an empty list for a user with no memberships", async () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") return Response.json([]);

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,0 +1,100 @@
+/**
+ * Session-authenticated, read-only usage surface for signed-in users (issue
+ * #107 — follow-on to /admin-ui/*'s Phase 3 pattern). Gated by
+ * `requireSessionUser` only — NOT `requireAdminUser` — so any signed-in user
+ * can see their own workspace memberships and usage, not just admins.
+ *
+ * Authorization for `/workspaces/:name/usage` is the membership lookup
+ * itself: a workspace not present in the caller's own memberships 404s
+ * (`workspace_not_found`) rather than 403ing, so membership can't be probed
+ * for workspace existence any more precisely than for any other workspace.
+ */
+import { NotFoundError } from "@uploads/errors";
+import { Hono } from "hono";
+import { usageWithLimits } from "../budget";
+import { orgForWorkspace, workspacesForOrg } from "../org-workspaces";
+import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
+import { getWorkspaceUsage } from "../usage";
+import { loadWorkspaceRecord } from "../workspace";
+
+interface Membership {
+  organizationId: string;
+  organizationSlug: string;
+  role: string;
+}
+
+interface MyWorkspace {
+  workspace: string;
+  organization: { id: string; slug: string; name: string };
+  role: string;
+}
+
+/** GET /internal/memberships?userId=<id> via the AUTH service binding. */
+async function membershipsForUser(env: Env, userId: string): Promise<Membership[]> {
+  const response = await env.AUTH.fetch(
+    `https://auth.internal/internal/memberships?userId=${encodeURIComponent(userId)}`,
+    { headers: { "x-uploads-internal": "1" } },
+  );
+  if (!response.ok) return [];
+  const body = await response.json().catch(() => null);
+  return Array.isArray(body) ? (body as Membership[]) : [];
+}
+
+/**
+ * Every workspace the user's memberships map to, one entry per (workspace,
+ * membership) pair — `workspacesForOrg` never assumes slug === workspace
+ * name directly, so this is a small fan-out rather than a 1:1 zip.
+ */
+async function myWorkspaces(env: Env, userId: string): Promise<MyWorkspace[]> {
+  const memberships = await membershipsForUser(env, userId);
+  const out: MyWorkspace[] = [];
+  for (const membership of memberships) {
+    const [org, names] = await Promise.all([
+      orgForWorkspace(env, membership.organizationSlug),
+      workspacesForOrg(env, membership.organizationSlug),
+    ]);
+    for (const workspace of names) {
+      out.push({
+        workspace,
+        organization: org ?? {
+          id: membership.organizationId,
+          slug: membership.organizationSlug,
+          name: membership.organizationSlug,
+        },
+        role: membership.role,
+      });
+    }
+  }
+  return out;
+}
+
+export const me = new Hono<SessionVars>()
+  .use("/*", sessionAuth, requireSessionUser)
+
+  // Workspaces the caller belongs to, via their org memberships.
+  .get("/workspaces", async (c) => {
+    const userId = c.get("sessionUser")?.id;
+    if (!userId) throw new NotFoundError("no session user", { code: "workspace_not_found" });
+    const workspaces = await myWorkspaces(c.env, userId);
+    return c.json({ workspaces });
+  })
+
+  // Usage + limits for one workspace — 404s unless the caller is a member.
+  .get("/workspaces/:name/usage", async (c) => {
+    const name = c.req.param("name");
+    const userId = c.get("sessionUser")?.id;
+    if (!userId) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+
+    const workspaces = await myWorkspaces(c.env, userId);
+    if (!workspaces.some((ws) => ws.workspace === name)) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const usage = await getWorkspaceUsage(c.env.DB, name);
+    return c.json(usageWithLimits(usage, record));
+  });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,7 +9,7 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
-import { NotFoundError } from "@uploads/errors";
+import { NotFoundError, ServiceUnavailableError } from "@uploads/errors";
 import { Hono } from "hono";
 import { usageWithLimits } from "../budget";
 import { orgForWorkspace, workspacesForOrg } from "../org-workspaces";
@@ -35,9 +35,21 @@ async function membershipsForUser(env: Env, userId: string): Promise<Membership[
     `https://auth.internal/internal/memberships?userId=${encodeURIComponent(userId)}`,
     { headers: { "x-uploads-internal": "1" } },
   );
-  if (!response.ok) return [];
+  if (!response.ok) {
+    // An AUTH outage is a 5xx, never "no memberships" — same treatment as
+    // orgForWorkspace in src/org-workspaces.ts.
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: response.status },
+    });
+  }
   const body = await response.json().catch(() => null);
-  return Array.isArray(body) ? (body as Membership[]) : [];
+  if (!Array.isArray(body)) {
+    throw new ServiceUnavailableError("auth service returned a malformed body", {
+      code: "auth_lookup_failed",
+    });
+  }
+  return body as Membership[];
 }
 
 /**

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -113,6 +113,20 @@ export function workspaceNameFromToken(token: string): string | undefined {
  * from the path for the REST API, or from the token itself for endpoints
  * without a workspace segment (the remote MCP worker's `/mcp`).
  */
+/**
+ * Loads a workspace record from the REGISTRY KV (`ws:<name>`), or null for an
+ * unknown/malformed name. The single source of truth for that lookup —
+ * `workspaceAuthWith` below and `src/routes/me.ts` (session-authenticated
+ * usage surface) both go through this rather than duplicating the KV read.
+ */
+export async function loadWorkspaceRecord(
+  env: Env,
+  name: string | undefined,
+): Promise<WorkspaceRecord | null> {
+  if (!name || !WS_NAME_RE.test(name)) return null;
+  return env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json", cacheTtl: 60 });
+}
+
 function workspaceAuthWith(
   nameOf: (c: Parameters<MiddlewareHandler<WorkspaceVars>>[0], token: string) => string | undefined,
 ): MiddlewareHandler<WorkspaceVars> {
@@ -120,10 +134,7 @@ function workspaceAuthWith(
     const token = bearerToken(c.req.header("Authorization"));
     const name = nameOf(c, token);
 
-    const record =
-      name && WS_NAME_RE.test(name)
-        ? await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json", cacheTtl: 60 })
-        : null;
+    const record = await loadWorkspaceRecord(c.env, name);
 
     const providedHash = await sha256Hex(token);
     const providedBytes = hexToBytes(providedHash);

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,0 +1,63 @@
+/**
+ * Session-cookie-authenticated wrappers for apps/api's `/me/*` surface
+ * (issue #107). Same conventions as `src/lib/auth-client.ts`'s wrappers:
+ * `credentials: "include"` so the cross-subdomain session cookie rides
+ * along, and defensive null/[] returns on any failure rather than throwing
+ * — the /account page treats "no data" and "couldn't load" the same way.
+ */
+
+function trimOrigin(origin: string): string {
+  return origin.replace(/\/$/, "");
+}
+
+export interface MyWorkspace {
+  workspace: string;
+  organization: { id: string; slug: string; name: string };
+  role: string;
+}
+
+/** GET /me/workspaces. Returns [] on any non-2xx or malformed body. */
+export async function getMyWorkspaces(apiOrigin: string): Promise<MyWorkspace[]> {
+  try {
+    const res = await fetch(`${trimOrigin(apiOrigin)}/me/workspaces`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (!res.ok) return [];
+    const body = (await res.json().catch(() => null)) as { workspaces?: MyWorkspace[] } | null;
+    return Array.isArray(body?.workspaces) ? body.workspaces : [];
+  } catch {
+    return [];
+  }
+}
+
+export interface WorkspaceUsage {
+  workspace: string;
+  bytes: number;
+  objects: number;
+  uploadsInPeriod: number;
+  periodStart: string;
+  updatedAt: string;
+  maxStorageBytes?: number;
+  storageRemainingBytes?: number;
+  maxUploadsPerPeriod?: number;
+  uploadsRemaining?: number;
+}
+
+/** GET /me/workspaces/:name/usage. Returns null on any non-2xx or malformed body. */
+export async function getMyWorkspaceUsage(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceUsage | null> {
+  try {
+    const res = await fetch(
+      `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/usage`,
+      { credentials: "include", cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as WorkspaceUsage | null;
+    return body ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -16,7 +16,21 @@ export interface MyWorkspace {
   role: string;
 }
 
-/** GET /me/workspaces. Returns [] on any non-2xx or malformed body. */
+function isMyWorkspace(value: unknown): value is MyWorkspace {
+  if (!value || typeof value !== "object") return false;
+  const ws = value as Record<string, unknown>;
+  const org = ws.organization as Record<string, unknown> | null | undefined;
+  return (
+    typeof ws.workspace === "string" &&
+    typeof ws.role === "string" &&
+    !!org &&
+    typeof org === "object" &&
+    typeof org.name === "string" &&
+    typeof org.slug === "string"
+  );
+}
+
+/** GET /me/workspaces. Returns [] on any non-2xx or malformed body; drops malformed entries. */
 export async function getMyWorkspaces(apiOrigin: string): Promise<MyWorkspace[]> {
   try {
     const res = await fetch(`${trimOrigin(apiOrigin)}/me/workspaces`, {
@@ -24,8 +38,9 @@ export async function getMyWorkspaces(apiOrigin: string): Promise<MyWorkspace[]>
       cache: "no-store",
     });
     if (!res.ok) return [];
-    const body = (await res.json().catch(() => null)) as { workspaces?: MyWorkspace[] } | null;
-    return Array.isArray(body?.workspaces) ? body.workspaces : [];
+    const body = (await res.json().catch(() => null)) as { workspaces?: unknown[] } | null;
+    if (!Array.isArray(body?.workspaces)) return [];
+    return body.workspaces.filter(isMyWorkspace);
   } catch {
     return [];
   }
@@ -56,7 +71,16 @@ export async function getMyWorkspaceUsage(
     );
     if (!res.ok) return null;
     const body = (await res.json().catch(() => null)) as WorkspaceUsage | null;
-    return body ?? null;
+    if (
+      !body ||
+      typeof body !== "object" ||
+      typeof body.bytes !== "number" ||
+      typeof body.objects !== "number" ||
+      typeof body.uploadsInPeriod !== "number"
+    ) {
+      return null;
+    }
+    return body;
   } catch {
     return null;
   }

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -18,10 +18,14 @@ const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
   "https://auth.uploads.sh";
+const apiOrigin =
+  env.UPLOADS_API_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ??
+  "https://api.uploads.sh";
 
 const csp = [
   "default-src 'none'",
-  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  `connect-src ${authOrigin} ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
   `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
   `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
   "img-src data: https:",
@@ -81,8 +85,10 @@ const FAVICON =
     .kv dd{margin:0;color:var(--fg);word-break:break-word}
     ul.plain{list-style:none;margin:12px 0 0;padding:0;display:grid;gap:8px}
     /* :global() so JS-injected <li>s (#orgs-list) match despite Astro's style scoping. */
-    ul.plain :global(li){display:flex;justify-content:space-between;gap:10px;padding:10px 12px;border:1px solid var(--line);border-radius:8px;background:var(--bg);font-size:13px}
+    ul.plain :global(li){display:flex;flex-direction:column;gap:4px;padding:10px 12px;border:1px solid var(--line);border-radius:8px;background:var(--bg);font-size:13px}
+    ul.plain :global(.row){display:flex;justify-content:space-between;gap:10px}
     ul.plain :global(.slug){color:var(--muted)}
+    ul.plain :global(.usage){color:var(--muted);font-size:12px}
     .pill{display:inline-block;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);border:1px solid var(--line);border-radius:99px;padding:2px 9px;background:var(--bg)}
 
     @media (max-width:680px){
@@ -183,14 +189,20 @@ const FAVICON =
   </div>
 </div>
 
-<script define:vars={{ authOrigin }}>
+<script define:vars={{ authOrigin, apiOrigin }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
+  window.__UPLOADS_API_ORIGIN__ = apiOrigin;
 </script>
 <script>
-  import { getSession, listOrganizations, signOut } from "../lib/auth-client";
+  import { getSession, signOut } from "../lib/auth-client";
+  import { getMyWorkspaces, getMyWorkspaceUsage } from "../lib/api-client";
 
-  const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
-    .__UPLOADS_AUTH_ORIGIN__;
+  const w = window as unknown as {
+    __UPLOADS_AUTH_ORIGIN__: string;
+    __UPLOADS_API_ORIGIN__: string;
+  };
+  const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+  const apiOrigin = w.__UPLOADS_API_ORIGIN__;
 
   function requireElement<T extends Element>(selector: string): T {
     const element = document.querySelector<T>(selector);
@@ -219,6 +231,36 @@ const FAVICON =
       ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
     );
 
+  // Workspace names are already restricted to [a-z0-9-] on the API, but
+  // escape defensively for the attribute-selector lookup below regardless.
+  const cssEscape = (value: string) =>
+    typeof CSS !== "undefined" && CSS.escape ? CSS.escape(value) : value.replace(/["\\]/g, "\\$&");
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    const units = ["KB", "MB", "GB", "TB"];
+    let value = bytes / 1024;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+      value /= 1024;
+      unit += 1;
+    }
+    return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
+  }
+
+  function formatUsage(usage: {
+    bytes: number;
+    objects: number;
+    maxStorageBytes?: number;
+  }): string {
+    const used = formatBytes(usage.bytes);
+    const size = usage.maxStorageBytes
+      ? `${used} of ${formatBytes(usage.maxStorageBytes)}`
+      : used;
+    const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
+    return `${size} · ${objects}`;
+  }
+
   getSession(authOrigin).then(async (result) => {
     checking.hidden = true;
     if (!result) {
@@ -236,20 +278,38 @@ const FAVICON =
 
     const orgsStatus = requireElement<HTMLElement>("#orgs-status");
     const orgsList = requireElement<HTMLUListElement>("#orgs-list");
-    const orgs = await listOrganizations(authOrigin);
-    if (!orgs.length) {
+    const workspaces = await getMyWorkspaces(apiOrigin);
+    if (!workspaces.length) {
       orgsStatus.textContent =
         "No workspaces on this account yet — accept an invite to join one.";
       return;
     }
     orgsStatus.hidden = true;
     orgsList.hidden = false;
-    orgsList.innerHTML = orgs
+    orgsList.innerHTML = workspaces
       .map(
-        (org) =>
-          `<li><span>${escapeHtml(org.name)}</span><span class="slug">${escapeHtml(org.slug)}</span></li>`,
+        (ws) =>
+          `<li data-workspace="${escapeHtml(ws.workspace)}">
+            <div class="row">
+              <span>${escapeHtml(ws.organization.name)}</span>
+              <span class="slug">${escapeHtml(ws.role)}</span>
+            </div>
+            <div class="usage">Loading usage&#32;…</div>
+          </li>`,
       )
       .join("");
+
+    // Usage is fetched per workspace, after the list renders, so a slow or
+    // failing usage call for one workspace never blocks the others.
+    for (const ws of workspaces) {
+      const li = orgsList.querySelector<HTMLElement>(
+        `li[data-workspace="${cssEscape(ws.workspace)}"]`,
+      );
+      const usageEl = li?.querySelector<HTMLElement>(".usage");
+      if (!usageEl) continue;
+      const usage = await getMyWorkspaceUsage(apiOrigin, ws.workspace);
+      usageEl.textContent = usage ? formatUsage(usage) : "Usage unavailable.";
+    }
   });
 
   requireElement<HTMLButtonElement>("#sign-out-btn").addEventListener("click", async () => {

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -251,14 +251,21 @@ const FAVICON =
   function formatUsage(usage: {
     bytes: number;
     objects: number;
+    uploadsInPeriod: number;
     maxStorageBytes?: number;
+    maxUploadsPerPeriod?: number;
   }): string {
     const used = formatBytes(usage.bytes);
     const size = usage.maxStorageBytes
       ? `${used} of ${formatBytes(usage.maxStorageBytes)}`
       : used;
     const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
-    return `${size} · ${objects}`;
+    const parts = [size, objects];
+    // Only present when the workspace has a monthly upload cap.
+    if (usage.maxUploadsPerPeriod) {
+      parts.push(`${usage.uploadsInPeriod} of ${usage.maxUploadsPerPeriod} uploads this month`);
+    }
+    return parts.join(" · ");
   }
 
   getSession(authOrigin).then(async (result) => {
@@ -299,17 +306,20 @@ const FAVICON =
       )
       .join("");
 
-    // Usage is fetched per workspace, after the list renders, so a slow or
-    // failing usage call for one workspace never blocks the others.
-    for (const ws of workspaces) {
-      const li = orgsList.querySelector<HTMLElement>(
-        `li[data-workspace="${cssEscape(ws.workspace)}"]`,
-      );
-      const usageEl = li?.querySelector<HTMLElement>(".usage");
-      if (!usageEl) continue;
-      const usage = await getMyWorkspaceUsage(apiOrigin, ws.workspace);
-      usageEl.textContent = usage ? formatUsage(usage) : "Usage unavailable.";
-    }
+    // Usage is fetched per workspace, concurrently, after the list renders,
+    // so a slow or failing usage call for one workspace never blocks the
+    // others.
+    await Promise.all(
+      workspaces.map(async (ws) => {
+        const li = orgsList.querySelector<HTMLElement>(
+          `li[data-workspace="${cssEscape(ws.workspace)}"]`,
+        );
+        const usageEl = li?.querySelector<HTMLElement>(".usage");
+        if (!usageEl) return;
+        const usage = await getMyWorkspaceUsage(apiOrigin, ws.workspace);
+        usageEl.textContent = usage ? formatUsage(usage) : "Usage unavailable.";
+      }),
+    );
   });
 
   requireElement<HTMLButtonElement>("#sign-out-btn").addEventListener("click", async () => {


### PR DESCRIPTION
Closes #107.

## Summary

- apps/api: new `src/routes/me.ts` — session-cookie-authenticated `GET /me/workspaces` and `GET /me/workspaces/:name/usage`, gated by `sessionAuth, requireSessionUser` (not `requireAdminUser`). Memberships resolve via the `AUTH` service binding's `/internal/memberships`, mapped to workspace names with `workspacesForOrg`. Usage reuses `getWorkspaceUsage` + `usageWithLimits`, same shape as `GET /v1/:ws/usage`. A workspace the caller isn't a member of 404s (`workspace_not_found`) — that membership check is the authorization boundary.
- apps/api: extracted `loadWorkspaceRecord` out of `workspace.ts`'s `workspaceAuthWith` so `/me/workspaces/:name/usage` reuses the same KV read instead of duplicating it.
- apps/api: wired `/me` into `src/index.ts` behind the existing `adminUiCors` policy (same origins, `credentials: true`, GET+OPTIONS) — CORS isn't the security boundary, the session check is.
- apps/api tests: `src/routes/me.test.ts`, mirroring `admin-ui.test.ts`'s stub-AUTH pattern plus the `UsageFakeD1` harness — 401 with no session, membership-to-workspace mapping, 404 for a non-member workspace, and the usage+limits shape for a member.
- apps/web: new `src/lib/api-client.ts` with `getMyWorkspaces` / `getMyWorkspaceUsage`, `credentials: "include"`, defensive `[]`/`null` on failure (same convention as `auth-client.ts`).
- apps/web: `account.astro` now passes `UPLOADS_API_ORIGIN` through like `admin.astro`, adds it to the CSP `connect-src`, and the Workspaces panel now sources from `/me/workspaces` (shows role) instead of `listOrganizations()`, with per-workspace usage (bytes used vs. limit, object count) fetched and rendered underneath each row.

## Non-goals (per the issue)

No file listing, no token UI, no write operations over the session surface.

## Test plan

- [x] `pnpm test` in `apps/api` (189 tests) and `apps/web` (17 tests) — all pass
- [x] `pnpm run typecheck` in both apps under Node 24 — no new errors (the 2 pre-existing `admin.astro` errors are untouched and not from this PR)
- [ ] Manual browser check of `/account` signed-in (not run in this session — no live session cookie in the sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a signed-in account view showing the workspaces available to you.
  * Added per-workspace storage usage, limits, remaining capacity, and usage-period details.
  * Added session-authenticated workspace and usage API access.

* **Bug Fixes**
  * Workspace access and usage requests now consistently enforce authentication and membership permissions.
  * Improved handling of unavailable or malformed workspace data with safe fallback states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->