### PR TITLE
fix: accept-invite redirect and shared invite email cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ scripts in `buildinternet-skills/github-screenshots`.
 apps/api            Hono worker — REST API, deploys to api.uploads.sh
 apps/mcp            Hono worker — remote MCP server, deploys to agents.uploads.sh (alt: mcp.uploads.sh)
 apps/web            Astro placeholder — future browse/manage UI (separate deploy)
+packages/email      @uploads/email — shared invite/notify email card HTML
 packages/errors     @uploads/errors — typed AppError hierarchy + nested wire envelope
 packages/storage    @uploads/storage — files-sdk adapter factory
 packages/uploads    @buildinternet/uploads — CLI + client for GitHub image embeds

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@uploads/email": "workspace:^",
     "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",
     "hono": "^4.12.28"

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,3 +1,4 @@
+import { renderEnrollmentInvitationEmail } from "@uploads/email";
 import { ConflictError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { adminAuth } from "../admin";
@@ -42,88 +43,11 @@ function inviteMagicLink(webOrigin: string, pageId: string, code: string): strin
   return `${webOrigin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
 }
 
-function renderInviteEmail(to: string, workspaceName: string, link: string, expiresAt: string) {
-  const expires = new Date(expiresAt).toLocaleString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    timeZone: "UTC",
-    timeZoneName: "short",
-  });
-  const webOrigin = new URL(link).origin;
-  // "default" is the shared entry workspace — naming it reads as jargon, so that
-  // case is framed as access to uploads.sh itself.
-  const isDefault = workspaceName === "default";
-  const invitedTo = isDefault
-    ? "You've been given access to uploads.sh"
-    : `You've been invited to the ${workspaceName} workspace on uploads.sh`;
-  const pitch =
-    "an easy way to include screenshots and media in your GitHub pull requests, straight from the terminal";
-  const text = [
-    `${invitedTo} — ${pitch}.`,
-    "",
-    "Accept your invitation (you'll need to do this from your laptop, not your phone):",
-    `${link}`,
-    "",
-    `This link works once and expires ${expires}. If you weren't expecting it,`,
-    "you can safely ignore this email.",
-    "",
-    "—",
-    "uploads.sh · a Build Internet project",
-    `Terms: ${webOrigin}/terms · Privacy: ${webOrigin}/privacy`,
-  ].join("\n");
-  // Email-client HTML: tables for layout, inline styles, explicit hex colors so the
-  // dark card renders intentionally in both light- and dark-mode clients.
-  const mono = "ui-monospace,'SF Mono',SFMono-Regular,Menlo,Consolas,monospace";
-  const preheader = `${invitedTo} — one click to accept, link expires ${expires}.`;
-  const html = `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"></head>
-<body style="margin:0;padding:0;background-color:#0b0813;">
-<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0813;">
-<tr><td align="center" style="padding:40px 16px;">
-  <table role="presentation" width="520" cellpadding="0" cellspacing="0" style="max-width:520px;width:100%;">
-    <tr><td style="font-family:${mono};font-size:13px;letter-spacing:.08em;color:#b794ff;padding:0 4px 14px;">&#9650; uploads.sh</td></tr>
-    <tr><td style="background-color:#151024;border:1px solid #2b1f46;border-radius:12px;padding:36px 34px;">
-      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-        <tr><td style="font-family:${mono};font-size:24px;line-height:1.3;font-weight:700;color:#f2edfb;padding-bottom:12px;">You're invited</td></tr>
-        <tr><td style="font-family:${mono};font-size:14px;line-height:1.7;color:#b9b0cf;padding-bottom:26px;">${
-          isDefault
-            ? `You've been given access to <strong style="color:#f2edfb;">uploads.sh</strong>`
-            : `You've been invited to the <strong style="color:#f2edfb;">${workspaceName}</strong> workspace on uploads.sh`
-        } &mdash; an easy way to include screenshots and media in your GitHub pull requests, straight from the terminal.</td></tr>
-        <tr><td>
-          <table role="presentation" cellpadding="0" cellspacing="0"><tr>
-            <td style="background-color:#b794ff;border-radius:8px;">
-              <a href="${link}" style="display:inline-block;padding:13px 26px;font-family:${mono};font-size:15px;font-weight:700;color:#171128;text-decoration:none;">Accept invitation &rarr;</a>
-            </td>
-          </tr></table>
-        </td></tr>
-        <tr><td style="font-family:${mono};font-size:12px;line-height:1.6;color:#8e86a5;padding-top:14px;">You'll need to do this from your laptop, not your phone.</td></tr>
-        <tr><td style="padding-top:26px;"><div style="border-top:1px solid #2b1f46;"></div></td></tr>
-        <tr><td style="font-family:${mono};font-size:12px;line-height:1.7;color:#8e86a5;padding-top:18px;">This link works once and expires <span style="color:#b9b0cf;">${expires}</span>. If you weren't expecting it, you can safely ignore this email.</td></tr>
-      </table>
-    </td></tr>
-    <tr><td align="center" style="font-family:${mono};font-size:11px;line-height:1.8;color:#6f6787;padding:22px 4px 0;">
-      uploads.sh &middot; a <a href="https://buildinternet.com" style="color:#8e86a5;text-decoration:underline;">Build Internet</a> project<br>
-      <a href="${webOrigin}/terms" style="color:#8e86a5;text-decoration:underline;">Terms</a> &nbsp;&middot;&nbsp; <a href="${webOrigin}/privacy" style="color:#8e86a5;text-decoration:underline;">Privacy</a>
-    </td></tr>
-  </table>
-</td></tr>
-</table>
-</body>
-</html>`;
+function inviteEmail(to: string, workspaceName: string, link: string, expiresAt: string) {
   return {
     to,
     from: INVITE_FROM,
-    subject: isDefault
-      ? "You've been given access to uploads.sh"
-      : `You're invited to ${workspaceName} on uploads.sh`,
-    text,
-    html,
+    ...renderEnrollmentInvitationEmail({ workspaceName, link, expiresAt }),
   };
 }
 
@@ -385,7 +309,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       const webOrigin = c.env.WEB_ORIGIN || deriveWebOrigin(c.req.url);
       const link = inviteMagicLink(webOrigin, enrollment.pageId, enrollment.code);
       try {
-        await c.env.EMAIL.send(renderInviteEmail(email, name, link, enrollment.expiresAt));
+        await c.env.EMAIL.send(inviteEmail(email, name, link, enrollment.expiresAt));
         emailed = true;
         // Audit only non-secret metadata — never the code, magic link, or URL.
         console.log(

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@better-auth/infra": "^0.3.6",
+    "@uploads/email": "workspace:^",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.28"

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -8,6 +8,7 @@
 import { dash } from "@better-auth/infra";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { admin, magicLink, organization } from "better-auth/plugins";
 import { sendAuthEmail } from "./email";
@@ -124,6 +125,23 @@ function buildAuth(
               inviterEmail: inviter.user.email,
             },
           });
+        },
+        organizationHooks: {
+          // Notify inviter; sendAuthEmail never throws so accept can't roll back.
+          afterAcceptInvitation: async ({ invitation, user, organization: org }) => {
+            if (!invitation.inviterId) return;
+            const [inviter] = await db
+              .select({ email: schema.user.email })
+              .from(schema.user)
+              .where(eq(schema.user.id, invitation.inviterId))
+              .limit(1);
+            if (!inviter?.email || inviter.email.toLowerCase() === user.email.toLowerCase()) return;
+            await sendAuthEmail(env, {
+              to: inviter.email,
+              template: "member-joined",
+              context: { organizationName: org.name, memberEmail: user.email },
+            });
+          },
         },
       }),
       // Hosted dashboard (`@better-auth/infra`). Omit when the API key is unset.

--- a/apps/auth/src/email.test.ts
+++ b/apps/auth/src/email.test.ts
@@ -51,27 +51,39 @@ describe("sendAuthEmail", () => {
     expect(args.text).toContain("https://auth.uploads.sh/x");
   });
 
-  it("HTML-escapes organization name and inviter email in the invitation template", async () => {
+  it("routes invitation + member-joined through the shared templates", async () => {
     const send = vi.fn().mockResolvedValue({});
     const EMAIL: EmailBinding = { send };
+
     await sendAuthEmail(
       { EMAIL, ENVIRONMENT: "production" },
       {
         to: "a@example.com",
         template: "invitation",
         context: {
-          url: "https://auth.uploads.sh/accept",
+          url: "https://uploads.sh/accept-invitation/abc",
           organizationName: `<img src=x onerror=alert(1)>`,
           inviterEmail: `"><script>alert(2)</script>`,
         },
       },
     );
-    expect(send).toHaveBeenCalledTimes(1);
-    const args = send.mock.calls[0]?.[0];
-    expect(args.html).not.toContain("<img src=x onerror=alert(1)>");
-    expect(args.html).not.toContain("<script>alert(2)</script>");
-    expect(args.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
-    expect(args.html).toContain("&lt;script&gt;alert(2)&lt;/script&gt;");
+    await sendAuthEmail(
+      { EMAIL, ENVIRONMENT: "production" },
+      {
+        to: "admin@example.com",
+        template: "member-joined",
+        context: { organizationName: "buildinternet", memberEmail: "new@example.com" },
+      },
+    );
+
+    const invite = send.mock.calls[0]?.[0];
+    expect(invite.html).toContain("<!doctype html>");
+    expect(invite.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(invite.html).not.toContain("<script>alert(2)</script>");
+
+    const joined = send.mock.calls[1]?.[0];
+    expect(joined.to).toBe("admin@example.com");
+    expect(joined.subject).toBe("new@example.com joined buildinternet on uploads.sh");
   });
 
   it("never throws when the send fails", async () => {

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -1,17 +1,18 @@
 /**
- * Auth email module (plan D8 seam: keep outbound send in one narrow-interface
- * module so a future webhooks/notifications service can absorb it without
- * touching src/auth.ts). Modeled on
- * `~/Code/room-configurator/apps/api/src/betterauth/email.ts` and the invite
- * email rendering in `apps/api/src/routes/admin.ts`.
- *
- * Sender is fixed at noreply@uploads.sh (D7) — must stay in
- * `send_email.allowed_sender_addresses` in wrangler.jsonc.
+ * Auth outbound mail. Templates for invites/notifies live in `@uploads/email`;
+ * this module only sends (and owns the magic-link template). Sender is always
+ * noreply@uploads.sh (must stay in wrangler send_email allowed addresses).
  */
+
+import {
+  escapeHtml,
+  renderMemberJoinedEmail,
+  renderOrgInvitationEmail,
+  type RenderedEmail,
+} from "@uploads/email";
 
 const FROM = { name: "uploads.sh", email: "noreply@uploads.sh" } as const;
 
-/** Minimal shape of the `send_email` binding this module needs. */
 export type EmailBinding = {
   send: (message: {
     to: string;
@@ -25,99 +26,59 @@ export type EmailBinding = {
 export type SendAuthEmailEnv = {
   EMAIL?: EmailBinding;
   ENVIRONMENT?: string;
-};
-
-export type MagicLinkContext = { url: string };
-
-/** Phase 3: `organization` plugin's `sendInvitationEmail` context (src/auth.ts). */
-export type InvitationContext = {
-  url: string;
-  organizationName: string;
-  inviterEmail: string;
+  WEB_ORIGIN?: string;
 };
 
 export type SendAuthEmailArgs =
-  | { to: string; template: "magic-link"; context: MagicLinkContext }
-  | { to: string; template: "invitation"; context: InvitationContext };
+  | { to: string; template: "magic-link"; context: { url: string } }
+  | {
+      to: string;
+      template: "invitation";
+      context: { url: string; organizationName: string; inviterEmail: string };
+    }
+  | {
+      to: string;
+      template: "member-joined";
+      context: { organizationName: string; memberEmail: string };
+    };
 
-function isDev(env: SendAuthEmailEnv): boolean {
-  return env.ENVIRONMENT !== "production";
-}
-
-/** Escape a string for safe interpolation into an HTML email body. */
-function escapeHtml(value: string): string {
-  return value.replace(
-    /[&<>"']/g,
-    (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
-  );
-}
-
-function renderMagicLink(context: MagicLinkContext): {
-  subject: string;
-  text: string;
-  html: string;
-} {
-  const subject = "Sign in to uploads.sh";
-  const text = `Sign in to uploads.sh by opening this link (expires in 15 minutes):\n\n${context.url}\n\nIf you didn't request this, you can ignore this email.`;
-  const url = escapeHtml(context.url);
-  const html = `<p>Sign in to uploads.sh by clicking the link below. It expires in 15 minutes.</p><p><a href="${url}">Sign in to uploads.sh</a></p><p>If you didn't request this, you can ignore this email.</p>`;
-  return { subject, text, html };
-}
-
-function renderInvitation(context: InvitationContext): {
-  subject: string;
-  text: string;
-  html: string;
-} {
-  const subject = `You've been invited to ${context.organizationName} on uploads.sh`;
-  const text = `${context.inviterEmail} invited you to join ${context.organizationName} on uploads.sh.\n\nAccept the invitation:\n\n${context.url}\n\nIf you weren't expecting this, you can ignore this email.`;
-  const organizationName = escapeHtml(context.organizationName);
-  const inviterEmail = escapeHtml(context.inviterEmail);
-  const url = escapeHtml(context.url);
-  const html = `<p><strong>${inviterEmail}</strong> invited you to join <strong>${organizationName}</strong> on uploads.sh.</p><p><a href="${url}">Accept invitation</a></p><p>If you weren't expecting this, you can ignore this email.</p>`;
-  return { subject, text, html };
-}
-
-function render(args: SendAuthEmailArgs): { subject: string; text: string; html: string } {
+function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
   switch (args.template) {
-    case "magic-link":
-      return renderMagicLink(args.context);
+    case "magic-link": {
+      const { url } = args.context;
+      return {
+        subject: "Sign in to uploads.sh",
+        text: `Sign in to uploads.sh by opening this link (expires in 15 minutes):\n\n${url}\n\nIf you didn't request this, you can ignore this email.`,
+        html: `<p>Sign in to uploads.sh by clicking the link below. It expires in 15 minutes.</p><p><a href="${escapeHtml(url)}">Sign in to uploads.sh</a></p><p>If you didn't request this, you can ignore this email.</p>`,
+      };
+    }
     case "invitation":
-      return renderInvitation(args.context);
+      return renderOrgInvitationEmail({ ...args.context, webOrigin });
+    case "member-joined":
+      return renderMemberJoinedEmail({ ...args.context, webOrigin });
   }
 }
 
 /**
- * Send an auth email. Never throws: a missing `EMAIL` binding (local dev) or
- * a send failure both degrade to a logged message rather than surfacing as an
- * unhandled rejection inside Better Auth's flow — Better Auth's `sendMagicLink`
- * callback expects fire-and-forget semantics here, not error propagation.
- *
- * In dev (no EMAIL binding), logs the link instead of sending — this is the
- * "email captured via local binding stub/log" acceptance criterion for Phase 1.
+ * Never throws — missing EMAIL (local) or send failures only log, so Better
+ * Auth hooks/callbacks stay fire-and-forget.
  */
 export async function sendAuthEmail(env: SendAuthEmailEnv, args: SendAuthEmailArgs): Promise<void> {
-  const { subject, text, html } = render(args);
+  const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
+  const { subject, text, html } = render(args, webOrigin);
+  const isDev = env.ENVIRONMENT !== "production";
+  const magicLink = args.template === "magic-link" && isDev ? ` Link: ${args.context.url}` : "";
 
   if (!env.EMAIL) {
-    // Only log the magic-link URL in dev — logging it in production would
-    // leak a live sign-in link to anywhere console output ends up.
-    const linkNote =
-      isDev(env) && args.template === "magic-link" ? ` Link: ${args.context.url}` : "";
     console.warn(
-      `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${linkNote}`,
+      `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${magicLink}`,
     );
     return;
   }
 
   try {
     await env.EMAIL.send({ to: args.to, from: FROM, subject, text, html });
-    if (isDev(env)) {
-      const linkNote = args.template === "magic-link" ? ` Link: ${args.context.url}` : "";
-      console.log(`[auth email] sent "${subject}" to ${args.to}.${linkNote}`);
-    } else {
-      console.log(`[auth email] sent "${subject}" to ${args.to}`);
-    }
+    console.log(`[auth email] sent "${subject}" to ${args.to}${magicLink}`);
   } catch (err) {
     console.error(
       `[auth email] send failed for "${subject}" to ${args.to}`,

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -99,10 +99,6 @@ const FAVICON =
     <div class="status" id="accept-error" data-state="error" role="alert" hidden></div>
   </div>
 
-  <div id="accepted" hidden>
-    <div class="status" data-state="ready" role="status">You've joined the workspace. You can close this page.</div>
-  </div>
-
   <p class="legal">a <a href="https://buildinternet.com">Build Internet</a> project · <a href="/terms">terms</a> · <a href="/privacy">privacy</a></p>
 </main>
 <script define:vars={{ authOrigin, invitationId: id }}>
@@ -127,7 +123,6 @@ const FAVICON =
   const signedOut = requireElement<HTMLElement>("#signed-out");
   const sentState = requireElement<HTMLElement>("#sent-state");
   const ready = requireElement<HTMLElement>("#ready");
-  const accepted = requireElement<HTMLElement>("#accepted");
   const who = requireElement<HTMLElement>("#who");
   const githubBtn = requireElement<HTMLButtonElement>("#github-btn");
   const magicForm = requireElement<HTMLFormElement>("#magic-form");
@@ -192,8 +187,8 @@ const FAVICON =
     acceptBtn.disabled = true;
     const result = await acceptInvitation(authOrigin, invitationId);
     if (result.ok) {
-      ready.hidden = true;
-      accepted.hidden = false;
+      // Same post-sign-in landing as /login — no dead-end "close this page".
+      location.assign(`${location.origin}/account`);
       return;
     }
     acceptBtn.disabled = false;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,12 @@
 - **More providers**: add cases to `packages/storage` (`s3`, `gcs`, …).
 - **Point `github-screenshots` at this API** — replaces its bundled SigV4
   script with one authenticated PUT.
+- **Enrollment “token used” notify** — org-membership accepts already email
+  the inviter (`member-joined` via Better Auth `afterAcceptInvitation`). The
+  CLI enrollment path (`/admin/enrollments` → `/invite#code`) has no durable
+  inviter identity (admin bearer only); if we want “someone redeemed your
+  enrollment link,” store inviter email/label on the enrollment row and send
+  from the API after exchange.
 - **Private-repo embed privacy** — today every hosted file is on a public CDN;
   `--pr`/`--issue` keys are predictable (`gh/<owner>/<repo>/pull/<n>/<name>`),
   so attachments on private repos are not secret from anyone who can guess the

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,6 +4,7 @@ Shared libraries consumed by `apps/api` and published/used from the CLI.
 
 | Directory  | Package                  | Role                                                               |
 | ---------- | ------------------------ | ------------------------------------------------------------------ |
+| `email/`   | `@uploads/email`         | Shared invite / notify email card HTML (API enrollment + auth org) |
 | `errors/`  | `@uploads/errors`        | Shared error taxonomy + wire envelope (`AppError`, codes, types)   |
 | `storage/` | `@uploads/storage`       | files-sdk adapter factory — single entry point for all storage I/O |
 | `uploads/` | `@buildinternet/uploads` | CLI (`uploads` bin) + programmatic client for GitHub image embeds  |

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@uploads/email",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/email/src/card.ts
+++ b/packages/email/src/card.ts
@@ -1,0 +1,100 @@
+export type RenderedEmail = {
+  subject: string;
+  text: string;
+  html: string;
+};
+
+export type EmailCardInput = {
+  subject: string;
+  preheader: string;
+  title: string;
+  /** May include pre-escaped markup (e.g. from `strong()`). Escape user values first. */
+  bodyHtml: string;
+  text: string;
+  cta?: { url: string; label: string };
+  noteHtml?: string;
+  footNoteHtml?: string;
+  webOrigin?: string;
+};
+
+const MONO = "ui-monospace,'SF Mono',SFMono-Regular,Menlo,Consolas,monospace";
+const DEFAULT_WEB_ORIGIN = "https://uploads.sh";
+
+export function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+  );
+}
+
+/** Escaped emphasis span for bodyHtml. */
+export function strong(value: string): string {
+  return `<strong style="color:#f2edfb;">${escapeHtml(value)}</strong>`;
+}
+
+function webOriginOf(input: EmailCardInput): string {
+  if (input.webOrigin) return input.webOrigin.replace(/\/$/, "");
+  if (input.cta?.url) {
+    try {
+      return new URL(input.cta.url).origin;
+    } catch {
+      /* fall through */
+    }
+  }
+  return DEFAULT_WEB_ORIGIN;
+}
+
+/** Dark-card shell shared by invite and membership emails (API + auth). */
+export function renderEmailCard(input: EmailCardInput): RenderedEmail {
+  const webOrigin = webOriginOf(input);
+  const title = escapeHtml(input.title);
+  const preheader = escapeHtml(input.preheader);
+  const cta = input.cta
+    ? `<tr><td>
+          <table role="presentation" cellpadding="0" cellspacing="0"><tr>
+            <td style="background-color:#b794ff;border-radius:8px;">
+              <a href="${escapeHtml(input.cta.url)}" style="display:inline-block;padding:13px 26px;font-family:${MONO};font-size:15px;font-weight:700;color:#171128;text-decoration:none;">${escapeHtml(input.cta.label)}</a>
+            </td>
+          </tr></table>
+        </td></tr>`
+    : "";
+  const note = input.noteHtml
+    ? `<tr><td style="font-family:${MONO};font-size:12px;line-height:1.6;color:#8e86a5;padding-top:14px;">${input.noteHtml}</td></tr>`
+    : "";
+  const foot = input.footNoteHtml
+    ? `<tr><td style="padding-top:26px;"><div style="border-top:1px solid #2b1f46;"></div></td></tr>
+        <tr><td style="font-family:${MONO};font-size:12px;line-height:1.7;color:#8e86a5;padding-top:18px;">${input.footNoteHtml}</td></tr>`
+    : "";
+  const terms = escapeHtml(`${webOrigin}/terms`);
+  const privacy = escapeHtml(`${webOrigin}/privacy`);
+
+  const html = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"></head>
+<body style="margin:0;padding:0;background-color:#0b0813;">
+<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0813;">
+<tr><td align="center" style="padding:40px 16px;">
+  <table role="presentation" width="520" cellpadding="0" cellspacing="0" style="max-width:520px;width:100%;">
+    <tr><td style="font-family:${MONO};font-size:13px;letter-spacing:.08em;color:#b794ff;padding:0 4px 14px;">&#9650; uploads.sh</td></tr>
+    <tr><td style="background-color:#151024;border:1px solid #2b1f46;border-radius:12px;padding:36px 34px;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+        <tr><td style="font-family:${MONO};font-size:24px;line-height:1.3;font-weight:700;color:#f2edfb;padding-bottom:12px;">${title}</td></tr>
+        <tr><td style="font-family:${MONO};font-size:14px;line-height:1.7;color:#b9b0cf;padding-bottom:26px;">${input.bodyHtml}</td></tr>
+        ${cta}
+        ${note}
+        ${foot}
+      </table>
+    </td></tr>
+    <tr><td align="center" style="font-family:${MONO};font-size:11px;line-height:1.8;color:#6f6787;padding:22px 4px 0;">
+      uploads.sh &middot; a <a href="https://buildinternet.com" style="color:#8e86a5;text-decoration:underline;">Build Internet</a> project<br>
+      <a href="${terms}" style="color:#8e86a5;text-decoration:underline;">Terms</a> &nbsp;&middot;&nbsp; <a href="${privacy}" style="color:#8e86a5;text-decoration:underline;">Privacy</a>
+    </td></tr>
+  </table>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+  return { subject: input.subject, text: input.text, html };
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  escapeHtml,
+  renderEmailCard,
+  strong,
+  type EmailCardInput,
+  type RenderedEmail,
+} from "./card";
+export {
+  renderEnrollmentInvitationEmail,
+  renderMemberJoinedEmail,
+  renderOrgInvitationEmail,
+} from "./invites";

--- a/packages/email/src/invites.ts
+++ b/packages/email/src/invites.ts
@@ -1,0 +1,111 @@
+import { escapeHtml, renderEmailCard, strong, type RenderedEmail } from "./card";
+
+const CTA = "Accept invitation →";
+const IGNORE = "If you weren't expecting this, you can ignore this email.";
+const PITCH =
+  "an easy way to include screenshots and media in your GitHub pull requests, straight from the terminal";
+
+/** Org membership invite (admin panel → /accept-invitation/:id). */
+export function renderOrgInvitationEmail(ctx: {
+  url: string;
+  organizationName: string;
+  inviterEmail: string;
+  webOrigin?: string;
+}): RenderedEmail {
+  const lead = `${ctx.inviterEmail} invited you to join ${ctx.organizationName} on uploads.sh.`;
+  return renderEmailCard({
+    subject: `You're invited to ${ctx.organizationName} on uploads.sh`,
+    preheader: lead,
+    title: "You're invited",
+    bodyHtml: `${strong(ctx.inviterEmail)} invited you to join ${strong(ctx.organizationName)} on uploads.sh.`,
+    text: [
+      lead,
+      "",
+      "Accept the invitation:",
+      ctx.url,
+      "",
+      IGNORE,
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+    ].join("\n"),
+    cta: { url: ctx.url, label: CTA },
+    footNoteHtml: IGNORE,
+    webOrigin: ctx.webOrigin,
+  });
+}
+
+/**
+ * Token enrollment invite (console / CLI → /invite#code).
+ * "default" is framed as access to uploads.sh itself.
+ */
+export function renderEnrollmentInvitationEmail(ctx: {
+  workspaceName: string;
+  link: string;
+  expiresAt: string;
+}): RenderedEmail {
+  const expires = new Date(ctx.expiresAt).toLocaleString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+  const isDefault = ctx.workspaceName === "default";
+  const invitedTo = isDefault
+    ? "You've been given access to uploads.sh"
+    : `You've been invited to the ${ctx.workspaceName} workspace on uploads.sh`;
+  let webOrigin = "https://uploads.sh";
+  try {
+    webOrigin = new URL(ctx.link).origin;
+  } catch {
+    /* keep default */
+  }
+
+  return renderEmailCard({
+    subject: isDefault
+      ? "You've been given access to uploads.sh"
+      : `You're invited to ${ctx.workspaceName} on uploads.sh`,
+    preheader: `${invitedTo} — one click to accept, link expires ${expires}.`,
+    title: "You're invited",
+    bodyHtml: isDefault
+      ? `You've been given access to ${strong("uploads.sh")} &mdash; ${PITCH}.`
+      : `You've been invited to the ${strong(ctx.workspaceName)} workspace on uploads.sh &mdash; ${PITCH}.`,
+    text: [
+      `${invitedTo} — ${PITCH}.`,
+      "",
+      "Accept your invitation (you'll need to do this from your laptop, not your phone):",
+      ctx.link,
+      "",
+      `This link works once and expires ${expires}. If you weren't expecting it,`,
+      "you can safely ignore this email.",
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+      `Terms: ${webOrigin}/terms · Privacy: ${webOrigin}/privacy`,
+    ].join("\n"),
+    cta: { url: ctx.link, label: CTA },
+    noteHtml: "You'll need to do this from your laptop, not your phone.",
+    footNoteHtml: `This link works once and expires <span style="color:#b9b0cf;">${escapeHtml(expires)}</span>. If you weren't expecting it, you can safely ignore this email.`,
+  });
+}
+
+/** Inviter notify when an org invite is accepted. */
+export function renderMemberJoinedEmail(ctx: {
+  organizationName: string;
+  memberEmail: string;
+  webOrigin?: string;
+}): RenderedEmail {
+  const lead = `${ctx.memberEmail} accepted your invitation and joined ${ctx.organizationName} on uploads.sh.`;
+  return renderEmailCard({
+    subject: `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh`,
+    preheader: `${ctx.memberEmail} joined ${ctx.organizationName}.`,
+    title: "Someone joined",
+    bodyHtml: `${strong(ctx.memberEmail)} accepted your invitation and joined ${strong(ctx.organizationName)} on uploads.sh.`,
+    text: [lead, "", "—", "uploads.sh · a Build Internet project"].join("\n"),
+    footNoteHtml: "You received this because you invited them to this workspace.",
+    webOrigin: ctx.webOrigin,
+  });
+}

--- a/packages/email/test/invites.test.ts
+++ b/packages/email/test/invites.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeHtml,
+  renderEmailCard,
+  renderEnrollmentInvitationEmail,
+  renderMemberJoinedEmail,
+  renderOrgInvitationEmail,
+} from "../src/index";
+
+describe("escapeHtml", () => {
+  it("escapes angle brackets and quotes", () => {
+    expect(escapeHtml(`<img src=x onerror=alert(1)>`)).toBe("&lt;img src=x onerror=alert(1)&gt;");
+    expect(escapeHtml(`"><script>`)).toBe("&quot;&gt;&lt;script&gt;");
+  });
+});
+
+describe("renderEmailCard", () => {
+  it("builds a full HTML document with CTA", () => {
+    const out = renderEmailCard({
+      subject: "Test",
+      preheader: "Preview line",
+      title: "Hello",
+      bodyHtml: "Body <strong>here</strong>",
+      text: "Body here",
+      cta: { url: "https://uploads.sh/x", label: "Go →" },
+    });
+    expect(out.subject).toBe("Test");
+    expect(out.html).toContain("<!doctype html>");
+    expect(out.html).toContain("Hello");
+    expect(out.html).toContain("https://uploads.sh/x");
+    expect(out.html).toContain("Go →");
+    expect(out.html).toContain("/terms");
+    expect(out.html).toContain("/privacy");
+  });
+
+  it("omits the CTA block when not provided", () => {
+    const out = renderEmailCard({
+      subject: "Notify",
+      preheader: "p",
+      title: "Joined",
+      bodyHtml: "ok",
+      text: "ok",
+    });
+    expect(out.html).not.toContain("background-color:#b794ff");
+  });
+});
+
+describe("renderOrgInvitationEmail", () => {
+  it("escapes org name and inviter in HTML", () => {
+    const out = renderOrgInvitationEmail({
+      url: "https://uploads.sh/accept-invitation/abc",
+      organizationName: `<img src=x onerror=alert(1)>`,
+      inviterEmail: `"><script>alert(2)</script>`,
+    });
+    expect(out.html).not.toContain("<img src=x onerror=alert(1)>");
+    expect(out.html).not.toContain("<script>alert(2)</script>");
+    expect(out.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(out.subject).toContain("<img");
+    expect(out.html).toContain("Accept invitation");
+    expect(out.text).toContain("https://uploads.sh/accept-invitation/abc");
+  });
+});
+
+describe("renderEnrollmentInvitationEmail", () => {
+  it("special-cases the default workspace subject and body", () => {
+    const out = renderEnrollmentInvitationEmail({
+      workspaceName: "default",
+      link: "https://uploads.sh/invite?id=upi_x#code=secret",
+      expiresAt: "2030-01-15T12:00:00.000Z",
+    });
+    expect(out.subject).toBe("You've been given access to uploads.sh");
+    expect(out.text).toContain("#code=secret");
+    expect(out.html).toContain("You've been given access");
+    expect(out.html).toContain("laptop");
+  });
+
+  it("names a non-default workspace in the subject", () => {
+    const out = renderEnrollmentInvitationEmail({
+      workspaceName: "buildinternet",
+      link: "https://uploads.sh/invite?id=upi_y#code=z",
+      expiresAt: "2030-01-15T12:00:00.000Z",
+    });
+    expect(out.subject).toBe("You're invited to buildinternet on uploads.sh");
+    expect(out.html).toContain("buildinternet");
+  });
+
+  it("escapes a hostile workspace name in HTML", () => {
+    const out = renderEnrollmentInvitationEmail({
+      workspaceName: `<script>x</script>`,
+      link: "https://uploads.sh/invite?id=upi_z#code=z",
+      expiresAt: "2030-01-15T12:00:00.000Z",
+    });
+    expect(out.html).not.toContain("<script>x</script>");
+    expect(out.html).toContain("&lt;script&gt;x&lt;/script&gt;");
+  });
+});
+
+describe("renderMemberJoinedEmail", () => {
+  it("names the joiner and workspace", () => {
+    const out = renderMemberJoinedEmail({
+      organizationName: "buildinternet",
+      memberEmail: "new@example.com",
+    });
+    expect(out.subject).toBe("new@example.com joined buildinternet on uploads.sh");
+    expect(out.html).toContain("Someone joined");
+    expect(out.html).toContain("new@example.com");
+    expect(out.html).toContain("buildinternet");
+    expect(out.text).toContain("accepted your invitation");
+  });
+});

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": []
+  },
+  "include": ["src", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@uploads/email':
+        specifier: workspace:^
+        version: link:../../packages/email
       '@uploads/errors':
         specifier: workspace:^
         version: link:../../packages/errors
@@ -66,6 +69,9 @@ importers:
       '@better-auth/infra':
         specifier: ^0.3.6
         version: 0.3.6(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(zod@4.4.3)
+      '@uploads/email':
+        specifier: workspace:^
+        version: link:../../packages/email
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)))
@@ -153,6 +159,15 @@ importers:
       wrangler:
         specifier: ^4.110.0
         version: 4.110.0
+
+  packages/email:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/errors:
     devDependencies:


### PR DESCRIPTION
## In plain terms

Accepting a workspace invite no longer leaves you on a dead-end “close this page” screen. After accept you go to `/account`, same as after sign-in. Invite emails from the admin panel and the CLI enrollment path now share one dark-card HTML template, and the person who sent an org invite gets a short “someone joined” email when it’s accepted.

## What it does

- On successful accept at `/accept-invitation/:id`, redirect to `/account` (no intermediate “you can close this page” state).
- Add `@uploads/email` with a shared card shell + three templates: org invite, enrollment invite, member-joined.
- Wire API enrollment and auth org invites through that package.
- On org invite accept, notify the inviter via Better Auth’s `afterAcceptInvitation` hook.
- Escape user-controlled values in enrollment HTML (workspace name) as part of the shared builder.

## What it is not

- Does **not** merge the two invite *systems* (org membership vs token enrollment). Only the email presentation is shared.
- Does **not** notify anyone when a CLI enrollment link is redeemed (no durable inviter on that path) — noted on the roadmap.

## How to try it

1. From `/admin`, invite an email to a workspace.
2. Open the invite while signed in as that email, accept it.
3. You should land on `/account` with the new workspace listed; the inviter should get a “Someone joined” email.
4. Optionally send a CLI enrollment invite (`uploads admin invite create --email …`) and confirm the HTML card still looks right.

## Technical notes

- Shared package: `packages/email` (`renderOrgInvitationEmail`, `renderEnrollmentInvitationEmail`, `renderMemberJoinedEmail`).
- Auth send path remains `sendAuthEmail` (noreply@); API enrollment still uses invites@.
- Tests: `@uploads/email`, `@uploads/auth`, `@uploads/api` invite routes.

## Test plan

- [x] `pnpm --filter @uploads/email test`
- [x] `pnpm --filter @uploads/auth test`
- [x] `pnpm --filter @uploads/api test`
- [ ] Manual: accept org invite while already signed in → lands on `/account`
- [ ] Manual: confirm invite + member-joined emails render as HTML cards in Gmail