### PR TITLE
feat(web): CONSOLE_MODE var: configurable /console visibility

### DIFF
--- a/apps/web/src/lib/console-mode.test.ts
+++ b/apps/web/src/lib/console-mode.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveConsoleMode } from "./console-mode";
+
+function flags(value: string | Error) {
+  return {
+    getStringValue: async (_key: string, defaultValue: string) => {
+      if (value instanceof Error) throw value;
+      return value || defaultValue;
+    },
+  };
+}
+
+describe("resolveConsoleMode", () => {
+  it("defaults to linked-only with no flag binding and no env var", async () => {
+    expect(await resolveConsoleMode({})).toBe("linked-only");
+  });
+
+  it("uses CONSOLE_MODE when there is no flag binding", async () => {
+    expect(await resolveConsoleMode({ CONSOLE_MODE: "public" })).toBe("public");
+  });
+
+  it("treats an invalid CONSOLE_MODE as linked-only", async () => {
+    expect(await resolveConsoleMode({ CONSOLE_MODE: "banana" })).toBe("linked-only");
+  });
+
+  it("prefers the flag over the env var", async () => {
+    expect(await resolveConsoleMode({ CONSOLE_MODE: "public", FLAGS: flags("off") })).toBe("off");
+  });
+
+  it("falls back to the env var on an invalid flag value", async () => {
+    expect(await resolveConsoleMode({ CONSOLE_MODE: "public", FLAGS: flags("banana") })).toBe(
+      "public",
+    );
+  });
+
+  it("falls back to the env var when the binding throws", async () => {
+    expect(await resolveConsoleMode({ CONSOLE_MODE: "off", FLAGS: flags(new Error("boom")) })).toBe(
+      "off",
+    );
+  });
+});

--- a/apps/web/src/lib/console-mode.ts
+++ b/apps/web/src/lib/console-mode.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolves the /console visibility mode: Flagship flag first, CONSOLE_MODE
+ * env var as the fallback, "linked-only" as the final default.
+ *
+ * This is a visibility knob, not a security boundary — the console is
+ * bearer-token authenticated, so anyone with a valid workspace token can use
+ * it regardless of this setting.
+ *
+ * Resolution order:
+ * 1. `console-mode` flag on the FLAGS Flagship binding (app "uploads"),
+ *    when the binding exists. The env-var fallback is passed in as the
+ *    flag's default value, so a disabled flag or Flagship outage degrades
+ *    to the env var rather than to a hardcoded value.
+ * 2. `CONSOLE_MODE` env var (wrangler.jsonc vars) — also what self-hosters
+ *    without Flagship use; they can delete the flagship binding entirely.
+ * 3. "linked-only": the route serves, but nothing links to it.
+ */
+
+export type ConsoleMode = "public" | "linked-only" | "off";
+
+const MODES: readonly ConsoleMode[] = ["public", "linked-only", "off"];
+
+function asMode(value: unknown, fallback: ConsoleMode): ConsoleMode {
+  return MODES.includes(value as ConsoleMode) ? (value as ConsoleMode) : fallback;
+}
+
+/** Minimal structural slice of the Flagship binding so this module doesn't
+ * depend on generated worker types (worker-configuration.d.ts is gitignored
+ * and absent until `wrangler types` runs). */
+interface FlagshipLike {
+  getStringValue(flagKey: string, defaultValue: string): Promise<string>;
+}
+
+export async function resolveConsoleMode(env: {
+  CONSOLE_MODE?: string;
+  FLAGS?: FlagshipLike;
+}): Promise<ConsoleMode> {
+  const fallback = asMode(env.CONSOLE_MODE, "linked-only");
+  if (!env.FLAGS) return fallback;
+  try {
+    // The binding contract is "never throws, returns defaultValue on error",
+    // but guard anyway — a fallback here must never take the page down.
+    return asMode(await env.FLAGS.getStringValue("console-mode", fallback), fallback);
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -35,6 +35,7 @@ describe.each([
   { path: "/admin", title: "Admin · uploads.sh" },
   { path: "/accept-invitation/upi_abc123", title: "Accept invitation · uploads.sh" },
   { path: "/account", title: "Account · uploads.sh" },
+  { path: "/console", title: "uploads.sh console" },
 ])("route reachability: $path", ({ path, title }) => {
   it("reaches the page handler (not a static 404) on a browser navigation request", async () => {
     let handlerCalled = false;

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -14,6 +14,13 @@ import {
 
 export const prerender = false;
 
+// Visibility knob, not a security boundary — console auth is bearer-token
+// based, not session-based (see console.astro). Only "public" mode links
+// to it from here; "linked-only" and "off" still let the route serve.
+// See console.astro for why this is widened from the inferred literal type.
+const consoleMode = (env.CONSOLE_MODE as string | undefined) ?? "public";
+const showConsoleLinks = consoleMode === "public";
+
 const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
@@ -120,7 +127,7 @@ const FAVICON =
         <a href="#account" data-panel="account">Account</a>
         <a href="#developers" data-panel="developers">Developers</a>
         <div class="side-foot">
-          <a href="/console">console →</a>
+          {showConsoleLinks ? <a href="/console">console →</a> : null}
           <a href="/admin" id="admin-link" hidden>admin →</a>
           <button type="button" id="sign-out-btn">Sign out</button>
         </div>
@@ -178,7 +185,7 @@ const FAVICON =
             <h2>Developers</h2>
             <p>These tools need a workspace token.</p>
             <ul class="plain">
-              <li><span><a href="/console">Console</a></span><span class="slug">usage, files, invites — bring a token</span></li>
+              {showConsoleLinks ? <li><span><a href="/console">Console</a></span><span class="slug">usage, files, invites — bring a token</span></li> : null}
               <li><span><a href="/docs">API docs</a></span><span class="slug">endpoints &amp; auth</span></li>
               <li><span><a href="https://github.com/buildinternet/uploads">GitHub</a></span><span class="slug">source &amp; issues</span></li>
             </ul>

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -6,6 +6,7 @@
 // Client-side session gating here is a UX affordance only — every data
 // call goes to apps/auth, which enforces the session server-side.
 import { env } from "cloudflare:workers";
+import { resolveConsoleMode } from "../lib/console-mode";
 import {
   CF_RUM_CONNECT_SRC,
   CF_RUM_SCRIPT_SRC,
@@ -17,9 +18,7 @@ export const prerender = false;
 // Visibility knob, not a security boundary — console auth is bearer-token
 // based, not session-based (see console.astro). Only "public" mode links
 // to it from here; "linked-only" and "off" still let the route serve.
-// See console.astro for why this is widened from the inferred literal type.
-const consoleMode = (env.CONSOLE_MODE as string | undefined) ?? "public";
-const showConsoleLinks = consoleMode === "public";
+const showConsoleLinks = (await resolveConsoleMode(env)) === "public";
 
 const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -7,6 +7,20 @@ import { env } from "cloudflare:workers";
 
 export const prerender = false;
 
+// Visibility knob, not a security boundary — console auth is bearer-token
+// based (see comment above); this only controls whether the route serves
+// and whether anything links to it. "off" mimics the static 404 page.
+// wrangler types infers CONSOLE_MODE as the literal "public" from the default
+// in wrangler.jsonc; widen so runtime overrides ("linked-only"/"off") typecheck.
+const consoleMode = (env.CONSOLE_MODE as string | undefined) ?? "public";
+if (consoleMode === "off") {
+  // Reroute to the real 404 page so this matches an unknown route exactly
+  // (same markup) rather than hand-rolling markup; force the status since
+  // rewrite() doesn't inherit the target's own status code.
+  Astro.response.status = 404;
+  return Astro.rewrite("/404");
+}
+
 const API_DEFAULT = "https://api.uploads.sh";
 const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -4,15 +4,14 @@
 import "@fontsource-variable/geist/index.css";
 import "@fontsource-variable/geist-mono/index.css";
 import { env } from "cloudflare:workers";
+import { resolveConsoleMode } from "../lib/console-mode";
 
 export const prerender = false;
 
 // Visibility knob, not a security boundary — console auth is bearer-token
 // based (see comment above); this only controls whether the route serves
 // and whether anything links to it. "off" mimics the static 404 page.
-// wrangler types infers CONSOLE_MODE as the literal "public" from the default
-// in wrangler.jsonc; widen so runtime overrides ("linked-only"/"off") typecheck.
-const consoleMode = (env.CONSOLE_MODE as string | undefined) ?? "public";
+const consoleMode = await resolveConsoleMode(env);
 if (consoleMode === "off") {
   // Reroute to the real 404 page so this matches an unknown route exactly
   // (same markup) rather than hand-rolling markup; force the status since

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -19,9 +19,20 @@
     // pattern as WEB_ORIGIN in apps/auth/.dev.vars.example.
     "UPLOADS_AUTH_ORIGIN": "https://auth.uploads.sh",
     // Visibility knob for /console (not a security boundary — auth is
-    // bearer-token based): "public" | "linked-only" | "off". See console.astro.
-    "CONSOLE_MODE": "public",
+    // bearer-token based): "public" | "linked-only" | "off". Fallback when
+    // the Flagship `console-mode` flag (FLAGS binding below) is unavailable;
+    // see src/lib/console-mode.ts for the resolution order.
+    "CONSOLE_MODE": "linked-only",
   },
+  // Flagship feature flags (app "uploads"). Runtime override for CONSOLE_MODE
+  // without a redeploy. Self-hosters without Flagship can delete this block —
+  // everything falls back to the CONSOLE_MODE var above.
+  "flagship": [
+    {
+      "binding": "FLAGS",
+      "app_id": "8371bfe7-9767-4b4d-b75a-37b94d2724f7",
+    },
+  ],
   "assets": {
     "binding": "ASSETS",
     "directory": "./dist",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -18,6 +18,9 @@
     // apps/auth/wrangler.jsonc); override via .dev.vars for local dev, same
     // pattern as WEB_ORIGIN in apps/auth/.dev.vars.example.
     "UPLOADS_AUTH_ORIGIN": "https://auth.uploads.sh",
+    // Visibility knob for /console (not a security boundary — auth is
+    // bearer-token based): "public" | "linked-only" | "off". See console.astro.
+    "CONSOLE_MODE": "public",
   },
   "assets": {
     "binding": "ASSETS",

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -166,7 +166,9 @@ Do **not** delete PREVIOUS before re-encrypt completes.
 
 ## Console visibility
 
-`CONSOLE_MODE` (apps/web `wrangler.jsonc` vars) controls `/console` link visibility, not security — the console is bearer-token authenticated, so anyone with a valid workspace token can use it regardless of this setting. `"public"` (default) links to it from `/account`; `"linked-only"` keeps the route serving but drops those links, useful if you'd rather people find it deliberately; `"off"` makes `/console` 404. Self-hosters can leave the default.
+Console visibility controls links, not security — the console is bearer-token authenticated, so anyone with a valid workspace token can use it regardless of this setting. Three modes: `"public"` links to it from `/account`; `"linked-only"` (default) keeps the route serving but drops those links, so people find it deliberately; `"off"` makes `/console` 404.
+
+Resolution order (see apps/web `src/lib/console-mode.ts`): the Flagship `console-mode` flag (app "uploads", `FLAGS` binding) wins when present, so prod can flip modes without a redeploy — `wrangler flagship flags update <app-id> console-mode --default <mode>`. The `CONSOLE_MODE` var in apps/web `wrangler.jsonc` is the fallback. Self-hosters without Flagship: delete the `flagship` block from wrangler.jsonc and set the var.
 
 ## Deploys
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -164,6 +164,10 @@ Do **not** delete PREVIOUS before re-encrypt completes.
 
 `POST /v1/:ws/files/sign` — workspace needs HTTP S3 credentials (not binding-only).
 
+## Console visibility
+
+`CONSOLE_MODE` (apps/web `wrangler.jsonc` vars) controls `/console` link visibility, not security — the console is bearer-token authenticated, so anyone with a valid workspace token can use it regardless of this setting. `"public"` (default) links to it from `/account`; `"linked-only"` keeps the route serving but drops those links, useful if you'd rather people find it deliberately; `"off"` makes `/console` 404. Self-hosters can leave the default.
+
 ## Deploys
 
 Code via Workers Builds / `pnpm run deploy`. D1 migrations on merge. npm CLI via changesets.


### PR DESCRIPTION
## Summary

- Adds `CONSOLE_MODE` (apps/web `wrangler.jsonc` vars, default `"public"`) with three values: `"public"` (today's behavior), `"linked-only"` (route still serves, no links to it anywhere), `"off"` (`/console` 404s).
- `console.astro` reads `env.CONSOLE_MODE ?? "public"`; when `"off"`, rewrites to `/404` (same markup as an unknown route) with a forced 404 status.
- `account.astro` gates both console links (sidebar footer, Developers panel row) behind `mode === "public"`.
- `wrangler.jsonc` gets the new var + comment; `wrangler types` rerun.
- `pages-reachability.test.ts` gets a `/console` row.
- One paragraph added to `docs/ops.md` for self-hosters.

This is a visibility knob, not a security boundary — the console is bearer-token authenticated, not session-gated, so this only controls discoverability.

Closes #109

## Test plan

- [x] `pnpm test` in apps/web (18 tests passing)
- [x] `pnpm run typecheck` under Node 24 — clean except 2 pre-existing `admin.astro` errors unrelated to this change
- [x] Verified `/console` and `/account` render correctly in default (`public`) mode via local dev server
- [ ] `linked-only`/`off` modes verified by code review only — toggling `CONSOLE_MODE` locally wasn't practical without a dev-server restart cycle, and the account-page console links are behind client-side session gating so they aren't visible unauthenticated anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update: Flagship integration + default flip

Second commit hooks the mode into Cloudflare Flagship with the env var as fallback, and changes the default so the console is unlinked by default:

- Resolution order (`apps/web/src/lib/console-mode.ts`): `console-mode` flag on the `FLAGS` binding (Flagship app "uploads", already created and enabled with default `linked-only`) → `CONSOLE_MODE` var → `"linked-only"`. The env fallback is passed to the flag call as its default value, so a Flagship outage or disabled flag degrades to the var.
- Default is now **linked-only**: `/console` serves but nothing links to it. Prod can flip modes without a redeploy via `wrangler flagship flags update <app-id> console-mode`.
- Self-hosters without Flagship delete the `flagship` block in wrangler.jsonc and set the var.
- Unit tests for the resolver (6 cases); 24/24 web tests pass; verified in dev that the no-binding fallback serves `/console` and renders `/account` without console links.
