### PR TITLE
feat: Better Auth Phase 4 — CLI device login (uploads login)

### DIFF
--- a/.changeset/cli-device-login.md
+++ b/.changeset/cli-device-login.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads login` now signs you in through a browser by default: it opens a device-authorization page, you approve the request, and the CLI mints and saves a workspace token — no enrollment code to copy. When your account can access more than one workspace, pass `--workspace <name>`. The one-time enrollment-code path still works via `--code` / `--code-stdin`.

--- a/apps/api/migrations/20260712230000_token_minting_user.sql
+++ b/apps/api/migrations/20260712230000_token_minting_user.sql
@@ -1,0 +1,6 @@
+-- Phase 4 (plan D5): record which Better Auth user minted a workspace token.
+-- Populated by POST /v1/tokens (device-flow / session mints); NULL for tokens
+-- created before this migration and for the enrollment-code path (which has no
+-- user identity). Nullable so it never blocks the existing exchange flow.
+-- Enables future revocation-by-user and per-user token caps.
+ALTER TABLE auth_tokens ADD COLUMN minting_user_id TEXT;

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -19,6 +19,9 @@ export interface AuthTokenRecord {
   created_at: string;
   expires_at: string | null;
   revoked_at: string | null;
+  // Better Auth user id that minted this token (POST /v1/tokens), or null for
+  // enrollment-code tokens and rows created before the Phase 4 migration.
+  minting_user_id: string | null;
 }
 
 interface EnrollmentRecord {
@@ -75,7 +78,8 @@ export async function findActiveToken(
   const hash = await sha256Hex(rawToken);
   return db
     .prepare(
-      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at
+      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
+              minting_user_id
        FROM auth_tokens
        WHERE workspace = ? AND token_hash = ? AND revoked_at IS NULL
          AND (expires_at IS NULL OR expires_at > ?)
@@ -92,6 +96,7 @@ export async function createToken(
     label?: string;
     scopes: FileScope[];
     expiresAt?: Date;
+    mintedByUserId?: string | null;
     now?: Date;
   },
 ): Promise<{ token: string; record: AuthTokenRecord }> {
@@ -106,12 +111,14 @@ export async function createToken(
     created_at: now.toISOString(),
     expires_at: input.expiresAt?.toISOString() ?? null,
     revoked_at: null,
+    minting_user_id: input.mintedByUserId ?? null,
   };
   await db
     .prepare(
       `INSERT INTO auth_tokens
-       (id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, NULL)`,
+       (id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
+        minting_user_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
     )
     .bind(
       record.id,
@@ -121,6 +128,7 @@ export async function createToken(
       record.scopes,
       record.created_at,
       record.expires_at,
+      record.minting_user_id,
     )
     .run();
   return { token, record };
@@ -249,7 +257,8 @@ export async function exchangeEnrollment(
 export async function listTokens(db: D1Database, workspace: string): Promise<AuthTokenRecord[]> {
   const result = await db
     .prepare(
-      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at
+      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
+              minting_user_id
        FROM auth_tokens WHERE workspace = ? ORDER BY created_at ASC`,
     )
     .bind(workspace)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { usage } from "./routes/usage";
 import { admin } from "./routes/admin";
 import { adminUi } from "./routes/admin-ui";
 import { auth } from "./routes/auth";
+import { tokens } from "./routes/tokens";
 import { runRetentionSweep } from "./retention-sweep";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
@@ -53,6 +54,11 @@ export const app = new Hono<WorkspaceVars>()
   .route("/admin-ui", adminUi)
   .route("/auth", auth)
   .route("/public/galleries", publicGalleries)
+  // Session-authenticated workspace-token mint (Phase 4). Registered BEFORE the
+  // `/v1/:workspace/*` bearer guard: `/v1/tokens` does NOT match that pattern
+  // (no trailing segment), so `workspaceAuth` never runs for it — this route
+  // brings its own session auth. See routes/tokens.ts.
+  .route("/v1/tokens", tokens)
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/galleries", galleries)
   .route("/v1/:workspace/files", files)

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -24,10 +24,44 @@ export interface OrgSummary {
   name: string;
 }
 
+export interface Membership {
+  organizationId: string;
+  organizationSlug: string;
+  role: string;
+}
+
 const INTERNAL_ORIGIN = "https://auth.internal";
 
 function internalHeaders(): Headers {
   return new Headers({ "x-uploads-internal": "1" });
+}
+
+/**
+ * A user's org memberships via `GET /internal/memberships?userId=` over the
+ * AUTH binding. Like `orgForWorkspace`, a non-ok (or malformed) response is an
+ * auth-worker outage/bug — surfaced as a 5xx — NOT "this user has no
+ * memberships", so an outage can never masquerade as lost access. A user with
+ * genuinely no memberships gets a 200 with `[]`. Shared by the session-auth
+ * surfaces that need it (src/routes/me.ts, src/routes/tokens.ts).
+ */
+export async function membershipsForUser(env: Env, userId: string): Promise<Membership[]> {
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/memberships?userId=${encodeURIComponent(userId)}`,
+    { headers: internalHeaders() },
+  );
+  if (!response.ok) {
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: response.status },
+    });
+  }
+  const body = await response.json().catch(() => null);
+  if (!Array.isArray(body)) {
+    throw new ServiceUnavailableError("auth service returned a malformed body", {
+      code: "auth_lookup_failed",
+    });
+  }
+  return body as Membership[];
 }
 
 /**

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,47 +9,18 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
-import { NotFoundError, ServiceUnavailableError } from "@uploads/errors";
+import { NotFoundError } from "@uploads/errors";
 import { Hono } from "hono";
 import { usageWithLimits } from "../budget";
-import { orgForWorkspace, workspacesForOrg } from "../org-workspaces";
+import { membershipsForUser, orgForWorkspace, workspacesForOrg } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { getWorkspaceUsage } from "../usage";
 import { loadWorkspaceRecord } from "../workspace";
-
-interface Membership {
-  organizationId: string;
-  organizationSlug: string;
-  role: string;
-}
 
 interface MyWorkspace {
   workspace: string;
   organization: { id: string; slug: string; name: string };
   role: string;
-}
-
-/** GET /internal/memberships?userId=<id> via the AUTH service binding. */
-async function membershipsForUser(env: Env, userId: string): Promise<Membership[]> {
-  const response = await env.AUTH.fetch(
-    `https://auth.internal/internal/memberships?userId=${encodeURIComponent(userId)}`,
-    { headers: { "x-uploads-internal": "1" } },
-  );
-  if (!response.ok) {
-    // An AUTH outage is a 5xx, never "no memberships" — same treatment as
-    // orgForWorkspace in src/org-workspaces.ts.
-    throw new ServiceUnavailableError("auth service returned an unexpected status", {
-      code: "auth_lookup_failed",
-      details: { status: response.status },
-    });
-  }
-  const body = await response.json().catch(() => null);
-  if (!Array.isArray(body)) {
-    throw new ServiceUnavailableError("auth service returned a malformed body", {
-      code: "auth_lookup_failed",
-    });
-  }
-  return body as Membership[];
 }
 
 /**

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -41,6 +41,8 @@ interface EnvOpts {
   org?: typeof ORG | null;
   workspaces?: Record<string, object>;
   db?: D1Database;
+  /** When set, the WRITE_LIMITER binding reports this success value. */
+  writeLimitOk?: boolean;
 }
 
 function stubEnv(opts: EnvOpts = {}): Env {
@@ -50,6 +52,7 @@ function stubEnv(opts: EnvOpts = {}): Env {
     org = ORG,
     workspaces = { acme: { provider: "r2", bucket: "b" } },
     db = captureDb().db,
+    writeLimitOk,
   } = opts;
 
   const auth = stubAuth((req) => {
@@ -74,7 +77,10 @@ function stubEnv(opts: EnvOpts = {}): Env {
     }) as unknown as KVNamespace["get"],
   };
 
-  return { AUTH: auth, REGISTRY: registry, DB: db } as unknown as Env;
+  const WRITE_LIMITER =
+    writeLimitOk === undefined ? undefined : { limit: async () => ({ success: writeLimitOk }) };
+
+  return { AUTH: auth, REGISTRY: registry, DB: db, WRITE_LIMITER } as unknown as Env;
 }
 
 function app() {
@@ -261,5 +267,18 @@ describe("POST /v1/tokens mint", () => {
     expect(res.status).toBe(201);
     const body = (await res.json()) as { scopes: string[] };
     expect(body.scopes).toEqual(["files:read", "files:write"]);
+  });
+
+  it("429s when the workspace's write rate limit is exhausted", async () => {
+    const cap = captureDb();
+    const res = await post(stubEnv({ db: cap.db, writeLimitOk: false }), oneGrant);
+    expect(res.status).toBe(429);
+    // Rate-limited before any token row is written.
+    expect(cap.insert).toBeUndefined();
+  });
+
+  it("mints when the rate limiter allows the request", async () => {
+    const res = await post(stubEnv({ writeLimitOk: true }), oneGrant);
+    expect(res.status).toBe(201);
   });
 });

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -1,0 +1,265 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { tokens } from "./tokens";
+
+const USER = { id: "u-1", email: "a@b.com", name: "Ada", role: "user" };
+const ORG = { id: "org-acme", slug: "acme", name: "Acme" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** Captures the last auth_tokens INSERT bind values so tests can assert on them. */
+function captureDb(): { insert?: unknown[] } & { db: D1Database } {
+  const box: { insert?: unknown[] } = {};
+  const db = {
+    prepare(_sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          return {
+            run: async () => {
+              box.insert = values;
+              return { meta: { changes: 1 }, success: true, results: [] };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+  return Object.assign(box, { db });
+}
+
+interface EnvOpts {
+  user?: typeof USER | null;
+  memberships?: { organizationId: string; organizationSlug: string; role: string }[];
+  org?: typeof ORG | null;
+  workspaces?: Record<string, object>;
+  db?: D1Database;
+}
+
+function stubEnv(opts: EnvOpts = {}): Env {
+  const {
+    user = USER,
+    memberships = [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "member" }],
+    org = ORG,
+    workspaces = { acme: { provider: "r2", bucket: "b" } },
+    db = captureDb().db,
+  } = opts;
+
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+    }
+    if (url.pathname === "/internal/memberships") {
+      return new Response(JSON.stringify(memberships), { status: 200 });
+    }
+    if (url.pathname.startsWith("/internal/orgs/")) {
+      if (!org) return new Response(JSON.stringify({ error: {} }), { status: 404 });
+      return new Response(JSON.stringify({ organization: org }), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  });
+
+  const registry = {
+    get: (async (key: string) => {
+      const name = key.startsWith("ws:") ? key.slice(3) : key;
+      return workspaces[name] ?? null;
+    }) as unknown as KVNamespace["get"],
+  };
+
+  return { AUTH: auth, REGISTRY: registry, DB: db } as unknown as Env;
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/v1/tokens", tokens)
+    .onError((err, c) => respondError(c, err));
+}
+
+function post(env: Env, body: unknown, headers: Record<string, string> = {}) {
+  return app().request(
+    "/v1/tokens",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer sess", ...headers },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+const oneGrant = { grants: [{ workspace: "acme", scopes: ["files:read", "files:write"] }] };
+
+describe("POST /v1/tokens auth", () => {
+  it("401s without a session", async () => {
+    const res = await post(stubEnv({ user: null }), oneGrant);
+    expect(res.status).toBe(401);
+  });
+
+  it("403s when the user is not a member of the workspace's org", async () => {
+    const res = await post(stubEnv({ memberships: [] }), oneGrant);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_forbidden" },
+    });
+  });
+
+  it("403s (same code) when the workspace KV record does not exist", async () => {
+    const res = await post(stubEnv({ workspaces: {} }), oneGrant);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_forbidden" },
+    });
+  });
+
+  it("403s when the workspace has no backing org yet", async () => {
+    const res = await post(stubEnv({ org: null }), oneGrant);
+    expect(res.status).toBe(403);
+  });
+
+  it("503s (not 403) when the membership lookup fails — outage, not 'no access'", async () => {
+    // AUTH binding answers get-session (valid user) but 500s on /internal/memberships.
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname.startsWith("/internal/orgs/")) {
+        return new Response(JSON.stringify({ organization: ORG }), { status: 200 });
+      }
+      return new Response("boom", { status: 500 });
+    });
+    const env = {
+      AUTH: auth,
+      REGISTRY: { get: async () => ({ provider: "r2", bucket: "b" }) },
+      DB: captureDb().db,
+    } as unknown as Env;
+    const res = await post(env, oneGrant);
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("POST /v1/tokens request validation", () => {
+  it("400s on multiple grants (not yet supported)", async () => {
+    const res = await post(stubEnv(), {
+      grants: [
+        { workspace: "acme", scopes: ["files:read"] },
+        { workspace: "beta", scopes: ["files:read"] },
+      ],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "multi_grant_unsupported" },
+    });
+  });
+
+  it("400s on an empty grants array", async () => {
+    const res = await post(stubEnv(), { grants: [] });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_grants" },
+    });
+  });
+
+  it("400s on a missing grants field", async () => {
+    const res = await post(stubEnv(), { label: "x" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on an invalid workspace name", async () => {
+    const res = await post(stubEnv(), {
+      grants: [{ workspace: "Bad Name", scopes: ["files:read"] }],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_workspace" },
+    });
+  });
+
+  it("400s on an unknown scope", async () => {
+    const res = await post(stubEnv(), { grants: [{ workspace: "acme", scopes: ["files:nuke"] }] });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_scopes" },
+    });
+  });
+
+  it("400s on an out-of-range ttlSeconds", async () => {
+    const res = await post(stubEnv(), { ...oneGrant, ttlSeconds: 99 * 365 * 24 * 60 * 60 });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_ttl" },
+    });
+  });
+});
+
+describe("GET /v1/tokens (workspace listing)", () => {
+  it("401s without a session", async () => {
+    const res = await app().request(
+      "/v1/tokens",
+      { headers: { authorization: "Bearer x" } },
+      stubEnv({ user: null }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("lists memberships whose workspace still exists in KV", async () => {
+    const env = stubEnv({
+      memberships: [
+        { organizationId: "org-acme", organizationSlug: "acme", role: "owner" },
+        { organizationId: "org-gone", organizationSlug: "gone", role: "member" },
+      ],
+      workspaces: { acme: { provider: "r2", bucket: "b" } },
+    });
+    const res = await app().request(
+      "/v1/tokens",
+      { headers: { authorization: "Bearer sess" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workspaces: { workspace: string; role: string }[] };
+    // "gone" is filtered out (no KV record); "acme" carries its org role.
+    expect(body.workspaces).toEqual([{ workspace: "acme", role: "owner" }]);
+  });
+});
+
+describe("POST /v1/tokens mint", () => {
+  it("mints a workspace token and records the minting user", async () => {
+    const cap = captureDb();
+    const res = await post(stubEnv({ db: cap.db }), {
+      ...oneGrant,
+      label: "zach-laptop",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      token: string;
+      workspace: string;
+      scopes: string[];
+      label: string | null;
+      expiresAt: string | null;
+    };
+    expect(body.token).toMatch(/^up_acme_/);
+    expect(body.workspace).toBe("acme");
+    expect(body.scopes).toEqual(["files:read", "files:write"]);
+    expect(body.label).toBe("zach-laptop");
+    expect(body.expiresAt).toBeTruthy();
+    // INSERT binds: id, workspace, token_hash, label, scopes, created_at,
+    // expires_at, minting_user_id — the last is the session user's id.
+    expect(cap.insert?.[7]).toBe(USER.id);
+    expect(cap.insert?.[1]).toBe("acme");
+  });
+
+  it("defaults scopes to read+write when the grant omits them", async () => {
+    const res = await post(stubEnv(), { grants: [{ workspace: "acme" }] });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["files:read", "files:write"]);
+  });
+});

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -13,7 +13,7 @@
  * user-generated API tokens): the request carries a `grants` array, but v1
  * accepts exactly one grant and rejects >1 with a clear "not yet supported".
  */
-import { ForbiddenError, ValidationError } from "@uploads/errors";
+import { ForbiddenError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import {
   createToken,
@@ -22,13 +22,13 @@ import {
   MAX_TOKEN_SECONDS,
   type FileScope,
 } from "../auth-db";
+import { allowWrite } from "../guards";
 import { membershipsForUser, orgForWorkspace } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
-import { loadWorkspaceRecord } from "../workspace";
+import { loadWorkspaceRecord, WS_NAME_RE } from "../workspace";
 
 const MAX_BODY_BYTES = 4096;
 const MAX_LABEL_LEN = 200;
-const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 // Scopes a mint defaults to when the grant omits them — read+write, but not
 // delete (least surprise; the CLI sends explicit scopes anyway).
 const DEFAULT_MINT_SCOPES: FileScope[] = ["files:read", "files:write"];
@@ -167,6 +167,13 @@ export const tokens = new Hono<SessionVars>()
     ]);
     if (!record || !org || !memberships.some((m) => m.organizationId === org.id)) {
       throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
+    }
+
+    // Throttle minting per workspace — checked only after the membership gate,
+    // so a non-member can't burn a workspace's mint budget by griefing this
+    // endpoint. Same WRITE_LIMITER other mutating routes use (see guards.ts).
+    if (!(await allowWrite(c.env, grant.workspace))) {
+      throw new RateLimitedError("token minting rate limit exceeded");
     }
 
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000);

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -1,0 +1,230 @@
+/**
+ * POST /v1/tokens (plan D5/Phase 4): mint a `up_<workspace>_…` workspace token
+ * from a Better Auth session.
+ *
+ * The device flow (`uploads login`) authenticates the *user* and hands the CLI
+ * a session access token (bearer plugin). The CLI presents it here as
+ * `Authorization: Bearer <session>`; this route verifies the session over the
+ * AUTH service binding (`sessionAuth`), confirms the user is a member of the
+ * org backing the requested workspace, then mints via the existing
+ * `createToken` path — the same `auth_tokens` row `workspaceAuth` consumes.
+ *
+ * Wire format is grant-based for forward-compat (multi-workspace tokens,
+ * user-generated API tokens): the request carries a `grants` array, but v1
+ * accepts exactly one grant and rejects >1 with a clear "not yet supported".
+ */
+import { ForbiddenError, ServiceUnavailableError, ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import {
+  createToken,
+  validateScopes,
+  DEFAULT_TOKEN_SECONDS,
+  MAX_TOKEN_SECONDS,
+  type FileScope,
+} from "../auth-db";
+import { orgForWorkspace } from "../org-workspaces";
+import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
+import type { WorkspaceRecord } from "../workspace";
+
+const MAX_BODY_BYTES = 4096;
+const MAX_LABEL_LEN = 200;
+const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
+// Scopes a mint defaults to when the grant omits them — read+write, but not
+// delete (least surprise; the CLI sends explicit scopes anyway).
+const DEFAULT_MINT_SCOPES: FileScope[] = ["files:read", "files:write"];
+
+interface MembershipRow {
+  organizationId: string;
+  organizationSlug: string;
+  role: string;
+}
+
+interface Grant {
+  workspace: string;
+  scopes: FileScope[];
+}
+
+/**
+ * Memberships for a user via the AUTH binding's service-binding-only API.
+ *
+ * A non-ok status is an auth-worker outage/bug, NOT "this user has no
+ * memberships" — surface it as a 503 rather than letting an empty list
+ * masquerade as a 403 (which would tell a legitimate user they've lost access
+ * during an outage). Mirrors `orgForWorkspace`'s deliberate throw-on-unexpected
+ * behavior. A user with genuinely no memberships gets a 200 with `[]`.
+ */
+async function membershipsForUser(env: Env, userId: string): Promise<MembershipRow[]> {
+  const res = await env.AUTH.fetch(
+    `https://auth.internal/internal/memberships?userId=${encodeURIComponent(userId)}`,
+    { headers: { "x-uploads-internal": "1" } },
+  );
+  if (!res.ok) {
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: res.status },
+    });
+  }
+  const body = (await res.json().catch(() => null)) as MembershipRow[] | null;
+  return Array.isArray(body) ? body : [];
+}
+
+/**
+ * Validate the request body into a single normalized grant + label/ttl.
+ * Throws ValidationError (400) on any malformed input. `grants` is an array by
+ * contract, but v1 permits exactly one entry.
+ */
+function parseMintRequest(parsed: unknown): {
+  grant: Grant;
+  label?: string;
+  ttlSeconds: number;
+} {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ValidationError("request body must be a JSON object", { code: "invalid_request" });
+  }
+  const body = parsed as Record<string, unknown>;
+
+  if (!Array.isArray(body.grants)) {
+    throw new ValidationError("grants must be an array", { code: "invalid_grants" });
+  }
+  if (body.grants.length === 0) {
+    throw new ValidationError("at least one grant is required", { code: "invalid_grants" });
+  }
+  if (body.grants.length > 1) {
+    throw new ValidationError("multiple grants are not yet supported", {
+      code: "multi_grant_unsupported",
+    });
+  }
+
+  const raw = body.grants[0];
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ValidationError("grant must be an object", { code: "invalid_grant" });
+  }
+  const grantObj = raw as Record<string, unknown>;
+  const workspace = typeof grantObj.workspace === "string" ? grantObj.workspace.trim() : "";
+  if (!WS_NAME_RE.test(workspace)) {
+    throw new ValidationError("grant.workspace is invalid", { code: "invalid_workspace" });
+  }
+  const scopes = validateScopes(grantObj.scopes, DEFAULT_MINT_SCOPES);
+  if (scopes === null) {
+    throw new ValidationError("grant.scopes contains an unknown scope", { code: "invalid_scopes" });
+  }
+
+  let label: string | undefined;
+  if (body.label !== undefined) {
+    if (typeof body.label !== "string") {
+      throw new ValidationError("label must be a string", { code: "invalid_label" });
+    }
+    const trimmed = body.label.trim();
+    if (trimmed.length > MAX_LABEL_LEN) {
+      throw new ValidationError(`label must be ${MAX_LABEL_LEN} characters or fewer`, {
+        code: "invalid_label",
+      });
+    }
+    label = trimmed || undefined;
+  }
+
+  let ttlSeconds = DEFAULT_TOKEN_SECONDS;
+  if (body.ttlSeconds !== undefined) {
+    if (
+      typeof body.ttlSeconds !== "number" ||
+      !Number.isInteger(body.ttlSeconds) ||
+      body.ttlSeconds < 1 ||
+      body.ttlSeconds > MAX_TOKEN_SECONDS
+    ) {
+      throw new ValidationError(
+        `ttlSeconds must be an integer between 1 and ${MAX_TOKEN_SECONDS}`,
+        {
+          code: "invalid_ttl",
+        },
+      );
+    }
+    ttlSeconds = body.ttlSeconds;
+  }
+
+  return { grant: { workspace, scopes }, label, ttlSeconds };
+}
+
+export const tokens = new Hono<SessionVars>()
+  // List the workspaces the signed-in user can mint a token for — the CLI uses
+  // this to auto-select when the account has exactly one, or to prompt/require
+  // --workspace when it has several. Derived from org memberships (D4: org
+  // slug === workspace name), filtered to workspaces that still exist in KV.
+  .get("/", sessionAuth, requireSessionUser, async (c) => {
+    const user = c.get("sessionUser")!;
+    const memberships = await membershipsForUser(c.env, user.id);
+    const workspaces = (
+      await Promise.all(
+        memberships.map(async (m) => {
+          const name = m.organizationSlug;
+          if (!WS_NAME_RE.test(name)) return null;
+          const record = await c.env.REGISTRY.get(`ws:${name}`, { type: "json", cacheTtl: 60 });
+          return record ? { workspace: name, role: m.role } : null;
+        }),
+      )
+    ).filter((w): w is { workspace: string; role: string } => w !== null);
+    return c.json({ workspaces });
+  })
+  .post("/", sessionAuth, requireSessionUser, async (c) => {
+    const contentLength = Number(c.req.header("Content-Length") ?? 0);
+    if (contentLength > MAX_BODY_BYTES) {
+      throw new ValidationError("request body too large", { code: "invalid_request" });
+    }
+    const bytes = await c.req.arrayBuffer();
+    if (bytes.byteLength > MAX_BODY_BYTES) {
+      throw new ValidationError("request body too large", { code: "invalid_request" });
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      throw new ValidationError("request body must be valid JSON", { code: "invalid_request" });
+    }
+
+    const { grant, label, ttlSeconds } = parseMintRequest(parsed);
+
+    // requireSessionUser guarantees this is set.
+    const user = c.get("sessionUser")!;
+
+    // The workspace must exist as a KV tenant record — a token is meaningless
+    // otherwise, and it prevents minting for typo'd/non-existent workspaces.
+    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${grant.workspace}`, {
+      type: "json",
+      cacheTtl: 60,
+    });
+    if (!record) {
+      throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
+    }
+
+    // Membership gate: resolve the org backing this workspace (through the D4
+    // indirection), then require the session user to be a member of it. Same
+    // 403/`workspace_forbidden` as the missing-workspace case so a non-member
+    // can't distinguish "workspace doesn't exist" from "you're not a member".
+    const org = await orgForWorkspace(c.env, grant.workspace);
+    if (!org) {
+      throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
+    }
+    const memberships = await membershipsForUser(c.env, user.id);
+    if (!memberships.some((m) => m.organizationId === org.id)) {
+      throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
+    }
+
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+    const { token, record: tokenRecord } = await createToken(c.env.DB, {
+      workspace: grant.workspace,
+      label,
+      scopes: grant.scopes,
+      expiresAt,
+      mintedByUserId: user.id,
+    });
+
+    return c.json(
+      {
+        token,
+        workspace: grant.workspace,
+        scopes: grant.scopes,
+        label: tokenRecord.label,
+        expiresAt: tokenRecord.expires_at,
+      },
+      201,
+    );
+  });

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -13,7 +13,7 @@
  * user-generated API tokens): the request carries a `grants` array, but v1
  * accepts exactly one grant and rejects >1 with a clear "not yet supported".
  */
-import { ForbiddenError, ServiceUnavailableError, ValidationError } from "@uploads/errors";
+import { ForbiddenError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import {
   createToken,
@@ -22,9 +22,9 @@ import {
   MAX_TOKEN_SECONDS,
   type FileScope,
 } from "../auth-db";
-import { orgForWorkspace } from "../org-workspaces";
+import { membershipsForUser, orgForWorkspace } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
-import type { WorkspaceRecord } from "../workspace";
+import { loadWorkspaceRecord } from "../workspace";
 
 const MAX_BODY_BYTES = 4096;
 const MAX_LABEL_LEN = 200;
@@ -33,39 +33,9 @@ const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 // delete (least surprise; the CLI sends explicit scopes anyway).
 const DEFAULT_MINT_SCOPES: FileScope[] = ["files:read", "files:write"];
 
-interface MembershipRow {
-  organizationId: string;
-  organizationSlug: string;
-  role: string;
-}
-
 interface Grant {
   workspace: string;
   scopes: FileScope[];
-}
-
-/**
- * Memberships for a user via the AUTH binding's service-binding-only API.
- *
- * A non-ok status is an auth-worker outage/bug, NOT "this user has no
- * memberships" — surface it as a 503 rather than letting an empty list
- * masquerade as a 403 (which would tell a legitimate user they've lost access
- * during an outage). Mirrors `orgForWorkspace`'s deliberate throw-on-unexpected
- * behavior. A user with genuinely no memberships gets a 200 with `[]`.
- */
-async function membershipsForUser(env: Env, userId: string): Promise<MembershipRow[]> {
-  const res = await env.AUTH.fetch(
-    `https://auth.internal/internal/memberships?userId=${encodeURIComponent(userId)}`,
-    { headers: { "x-uploads-internal": "1" } },
-  );
-  if (!res.ok) {
-    throw new ServiceUnavailableError("auth service returned an unexpected status", {
-      code: "auth_lookup_failed",
-      details: { status: res.status },
-    });
-  }
-  const body = (await res.json().catch(() => null)) as MembershipRow[] | null;
-  return Array.isArray(body) ? body : [];
 }
 
 /**
@@ -156,8 +126,7 @@ export const tokens = new Hono<SessionVars>()
       await Promise.all(
         memberships.map(async (m) => {
           const name = m.organizationSlug;
-          if (!WS_NAME_RE.test(name)) return null;
-          const record = await c.env.REGISTRY.get(`ws:${name}`, { type: "json", cacheTtl: 60 });
+          const record = await loadWorkspaceRecord(c.env, name);
           return record ? { workspace: name, role: m.role } : null;
         }),
       )
@@ -185,26 +154,18 @@ export const tokens = new Hono<SessionVars>()
     // requireSessionUser guarantees this is set.
     const user = c.get("sessionUser")!;
 
-    // The workspace must exist as a KV tenant record — a token is meaningless
-    // otherwise, and it prevents minting for typo'd/non-existent workspaces.
-    const record = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${grant.workspace}`, {
-      type: "json",
-      cacheTtl: 60,
-    });
-    if (!record) {
-      throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
-    }
-
-    // Membership gate: resolve the org backing this workspace (through the D4
-    // indirection), then require the session user to be a member of it. Same
-    // 403/`workspace_forbidden` as the missing-workspace case so a non-member
-    // can't distinguish "workspace doesn't exist" from "you're not a member".
-    const org = await orgForWorkspace(c.env, grant.workspace);
-    if (!org) {
-      throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
-    }
-    const memberships = await membershipsForUser(c.env, user.id);
-    if (!memberships.some((m) => m.organizationId === org.id)) {
+    // Three independent lookups — resolve them concurrently, then gate. The
+    // workspace must exist as a KV tenant record (a token is meaningless
+    // otherwise, and this blocks typo'd/non-existent workspaces); the session
+    // user must be a member of the org backing it. All checks collapse to the
+    // same 403/`workspace_forbidden` so a non-member can't distinguish
+    // "workspace doesn't exist" from "you're not a member".
+    const [record, org, memberships] = await Promise.all([
+      loadWorkspaceRecord(c.env, grant.workspace),
+      orgForWorkspace(c.env, grant.workspace),
+      membershipsForUser(c.env, user.id),
+    ]);
+    if (!record || !org || !memberships.some((m) => m.organizationId === org.id)) {
       throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
     }
 

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -77,7 +77,10 @@ export type WorkspaceVars = {
   Bindings: Env;
 };
 
-const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
+/** Canonical workspace-name shape (lowercase, 2–63 chars). Shared so callers
+ * that validate a name — `loadWorkspaceRecord` here, the token-mint route —
+ * don't drift from one another. */
+export const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 
 export function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -105,6 +105,16 @@ beforeEach(async () => {
       "utf8",
     ),
   );
+  // Phase 4: adds auth_tokens.minting_user_id, which findActiveToken (used by
+  // workspaceAuth on these routes) now selects.
+  db.exec(
+    readFileSync(
+      fileURLToPath(
+        new NodeURL("../migrations/20260712230000_token_minting_user.sql", import.meta.url),
+      ),
+      "utf8",
+    ),
+  );
   bucket = new FakeR2Bucket();
   await bucket.put("alpha/screenshots/one.png", PNG);
   records = {

--- a/apps/auth/migrations/20260712230000_device_code.sql
+++ b/apps/auth/migrations/20260712230000_device_code.sql
@@ -1,0 +1,26 @@
+-- Phase 4: `deviceAuthorization` plugin store — the OAuth 2.0 Device
+-- Authorization Grant (RFC 8628) pending-request table backing `uploads login`
+-- from the CLI (see src/auth.ts, plan D5). Paired with the `deviceCode` table
+-- in src/schema.ts.
+--
+-- Field set is mandated by the plugin (its schema.mjs): note there are NO
+-- created_at/updated_at columns. Like `rate_limit`, the SQL name is snake_case
+-- but the drizzle-adapter schema KEY must stay the camelCase model name
+-- `deviceCode`. Reconciled against `npx @better-auth/cli generate` for the
+-- device-authorization plugin and ~/Code/releases/workers/api/migrations/
+-- 20260605000000_add_device_code.sql.
+CREATE TABLE device_code (
+  id TEXT PRIMARY KEY NOT NULL,
+  device_code TEXT NOT NULL,
+  user_code TEXT NOT NULL,
+  user_id TEXT,
+  expires_at INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  last_polled_at INTEGER,
+  polling_interval INTEGER,
+  client_id TEXT,
+  scope TEXT
+);
+
+CREATE INDEX idx_device_code_device_code ON device_code (device_code);
+CREATE INDEX idx_device_code_user_code ON device_code (user_code);

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -8,7 +8,7 @@
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
 import { drizzle } from "drizzle-orm/d1";
-import { admin, magicLink, organization } from "better-auth/plugins";
+import { admin, bearer, deviceAuthorization, magicLink, organization } from "better-auth/plugins";
 import { sendAuthEmail } from "./email";
 import * as schema from "./schema";
 import { authTrustedOrigins, isTrustedOrigin } from "./trusted-origins";
@@ -17,6 +17,16 @@ import {
   resolveSigningSecret,
   type GitHubCredentialsEnv,
 } from "./secrets";
+
+/**
+ * Static OAuth client id for the CLI's device flow (plan D5/Phase 4). The
+ * `deviceAuthorization` plugin accepts ANY `client_id` unless `validateClient`
+ * is supplied, so this is the sole allowlisted id — the CLI
+ * (`@buildinternet/uploads`) sends the same literal when starting a device
+ * flow. The full `oauthProvider` plugin (dynamic third-party clients) is out
+ * of scope for v1 (D3); when it lands, this stays the CLI's reserved id.
+ */
+export const UPLOADS_CLI_CLIENT_ID = "uploads-cli";
 
 export type AuthEnv = GitHubCredentialsEnv & {
   DB: D1Database;
@@ -68,6 +78,7 @@ function buildAuth(
 ) {
   const db = drizzle(env.DB, { schema });
   const betterAuthUrl = env.BETTER_AUTH_URL || "https://auth.uploads.sh";
+  const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
   const cookieDomain = deriveCookieDomain(betterAuthUrl);
   const isProduction = env.ENVIRONMENT === "production";
 
@@ -104,7 +115,6 @@ function buildAuth(
       organization({
         membershipLimit: 100,
         sendInvitationEmail: async ({ id, email, organization: org, inviter }) => {
-          const webOrigin = env.WEB_ORIGIN || "https://uploads.sh";
           const url = `${webOrigin}/accept-invitation/${id}`;
           await sendAuthEmail(env, {
             to: email,
@@ -116,6 +126,36 @@ function buildAuth(
             },
           });
         },
+      }),
+      // D5/Phase 4: bearer() lets the CLI present the device-flow session token
+      // as `Authorization: Bearer <token>` so apps/api's session verification
+      // (GET /api/auth/get-session over the AUTH binding) honors it instead of
+      // only the cookie. It MUST ride alongside deviceAuthorization(): the
+      // device/token endpoint returns that session token, and POST /v1/tokens
+      // then presents it as a bearer to mint the workspace token.
+      bearer(),
+      // D5/Phase 4: RFC 8628 device flow for `uploads login`.
+      //
+      // verificationUri MUST be an ABSOLUTE URL on the WEB origin — the /device
+      // approval page is served by apps/web (uploads.sh), not this worker
+      // (auth.uploads.sh). The plugin only prefixes baseURL when the value is
+      // relative, so a bare "/device" would resolve to
+      // https://auth.uploads.sh/device and 404. The session cookie is
+      // `.uploads.sh`-scoped (crossSubDomainCookies below) so it rides across
+      // the two subdomains.
+      //
+      // validateClient is a fail-closed allowlist: only the static CLI client
+      // id may start a device flow or exchange a code. Without it the plugin
+      // accepts ANY client_id — an unknown id could never obtain a token
+      // (approval is interactive) but the allowlist is defense in depth.
+      //
+      // No `schema: {}` workaround needed: better-auth 1.6.23 declares the
+      // plugin's `schema` option as `.optional()`, which zod 4.4.3 accepts when
+      // omitted (verified — the releases repo's workaround targeted an older
+      // build whose `schema` field lacked `.optional()`).
+      deviceAuthorization({
+        verificationUri: `${webOrigin}/device`,
+        validateClient: (clientId) => clientId === UPLOADS_CLI_CLIENT_ID,
       }),
     ],
     session: {

--- a/apps/auth/src/device.test.ts
+++ b/apps/auth/src/device.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Phase 4 (plan D5): the `deviceAuthorization` plugin's `validateClient`
+ * allowlist plus a full claim → approve → token exchange. These drive the real
+ * Better Auth handler (via src/index.ts's `app`) against the fake-D1 harness,
+ * so they exercise the actual plugin wiring — not a re-implementation — and, in
+ * the end-to-end case, prove the harness handles the plugin's
+ * `consumeOne`/`incrementOne` (RETURNING + `WHERE id IN (SELECT …)`) SQL.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, it } from "vitest";
+import { app } from "./index";
+import { UPLOADS_CLI_CLIENT_ID, type AuthEnv } from "./auth";
+import * as schema from "./schema";
+import { createFakeD1 } from "./test/fake-d1";
+
+function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+/** POST /api/auth/device/code with an application/json body (D5: NOT form-encoded). */
+function requestDeviceCode(env: AuthEnv, body: Record<string, unknown>) {
+  return app.request(
+    "/api/auth/device/code",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("device/code validateClient allowlist", () => {
+  it("issues a device + user code for the allowlisted CLI client id", async () => {
+    const res = await requestDeviceCode(dbEnv(), { client_id: UPLOADS_CLI_CLIENT_ID });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      device_code?: string;
+      user_code?: string;
+      verification_uri?: string;
+      expires_in?: number;
+      interval?: number;
+    };
+    expect(typeof body.device_code).toBe("string");
+    expect(typeof body.user_code).toBe("string");
+    // verificationUri is an absolute URL on the WEB origin (the /device page is
+    // served by apps/web, not this worker).
+    expect(body.verification_uri).toBe("https://uploads.sh/device");
+    expect(body.expires_in).toBeGreaterThan(0);
+    expect(body.interval).toBeGreaterThan(0);
+  });
+
+  it("rejects an unknown client id with invalid_client", async () => {
+    const res = await requestDeviceCode(dbEnv(), { client_id: "not-the-cli" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("rejects a device/token exchange for an unknown client id", async () => {
+    const res = await app.request(
+      "/api/auth/device/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code: "whatever",
+          client_id: "not-the-cli",
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("invalid_grant");
+  });
+});
+
+describe("device flow end-to-end (claim → approve → token)", () => {
+  /** Seed a user + an active session, returning the raw session token to present as a bearer. */
+  async function seedSignedInUser(env: AuthEnv): Promise<string> {
+    const orm = drizzle(env.DB, { schema });
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.user).values({
+      id: userId,
+      name: "Ada Lovelace",
+      email: `ada-${userId}@example.com`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      role: "user",
+    });
+    const token = `sess-${crypto.randomUUID()}`;
+    await orm.insert(schema.session).values({
+      id: crypto.randomUUID(),
+      userId,
+      token,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return token;
+  }
+
+  it("claims a code, approves it, and exchanges it for a session access token", async () => {
+    // One env (one fake D1) reused across every request in the flow.
+    const env = dbEnv();
+    const sessionToken = await seedSignedInUser(env);
+
+    // 1. CLI starts the flow (no session).
+    const codeRes = await requestDeviceCode(env, { client_id: UPLOADS_CLI_CLIENT_ID });
+    expect(codeRes.status).toBe(200);
+    const { device_code, user_code } = (await codeRes.json()) as {
+      device_code: string;
+      user_code: string;
+    };
+
+    // 2. Signed-in browser hits GET /device — this CLAIMS the code (binds userId
+    //    via the plugin's `incrementOne`, i.e. UPDATE … WHERE id IN (SELECT …)).
+    const verifyRes = await app.request(
+      `/api/auth/device?user_code=${encodeURIComponent(user_code)}`,
+      { headers: { Authorization: `Bearer ${sessionToken}` } },
+      env,
+    );
+    expect(verifyRes.status).toBe(200);
+    expect((await verifyRes.json()) as { status?: string }).toMatchObject({ status: "pending" });
+
+    // 3. Approve.
+    const approveRes = await app.request(
+      "/api/auth/device/approve",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", Authorization: `Bearer ${sessionToken}` },
+        body: JSON.stringify({ userCode: user_code }),
+      },
+      env,
+    );
+    expect(approveRes.status).toBe(200);
+    expect((await approveRes.json()) as { success?: boolean }).toMatchObject({ success: true });
+
+    // 4. CLI polls device/token and gets a session access token (the plugin's
+    //    `consumeOne`, i.e. DELETE … WHERE deviceCode = ? … RETURNING).
+    const tokenRes = await app.request(
+      "/api/auth/device/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code,
+          client_id: UPLOADS_CLI_CLIENT_ID,
+        }),
+      },
+      env,
+    );
+    expect(tokenRes.status).toBe(200);
+    const token = (await tokenRes.json()) as { access_token?: string; token_type?: string };
+    expect(typeof token.access_token).toBe("string");
+    expect(token.token_type).toBe("Bearer");
+  });
+
+  it("returns authorization_pending until the code is approved", async () => {
+    const env = dbEnv();
+    const codeRes = await requestDeviceCode(env, { client_id: UPLOADS_CLI_CLIENT_ID });
+    const { device_code } = (await codeRes.json()) as { device_code: string };
+
+    const tokenRes = await app.request(
+      "/api/auth/device/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code,
+          client_id: UPLOADS_CLI_CLIENT_ID,
+        }),
+      },
+      env,
+    );
+    expect(tokenRes.status).toBe(400);
+    expect((await tokenRes.json()) as { error?: string }).toMatchObject({
+      error: "authorization_pending",
+    });
+  });
+});

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -207,6 +207,43 @@ export const invitation = sqliteTable(
   (t) => [index("idx_invitation_organization_id").on(t.organizationId)],
 );
 
+/**
+ * Device-authorization (RFC 8628) pending requests (plan D5/Phase 4): the
+ * `deviceAuthorization` plugin's store backing `uploads login`. The field set
+ * is mandated by the plugin (see its `schema.mjs`) — note there are NO
+ * created/updated timestamps. `expires_at`/`last_polled_at` use drizzle's
+ * `mode: "timestamp"` (stored as integer epoch *seconds*, not ms): the plugin
+ * writes/reads `Date` objects the adapter serializes, so the round-trip is
+ * second-precision — deliberately not this file's non-null `timestampCol`
+ * helper, since both may be null/absent. Like `rate_limit`, the SQL table name
+ * is snake_case but the drizzle-adapter schema KEY must stay the camelCase
+ * model name `deviceCode`.
+ *
+ * Paired migration: `migrations/20260712230000_device_code.sql`.
+ */
+export const deviceCode = sqliteTable(
+  "device_code",
+  {
+    id: text("id").primaryKey(),
+    deviceCode: text("device_code").notNull(),
+    userCode: text("user_code").notNull(),
+    // null until a signed-in session claims/approves the request (see the
+    // /device page on apps/web and the plugin's device/approve endpoint).
+    userId: text("user_id"),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+    // pending | approved | denied
+    status: text("status").notNull(),
+    lastPolledAt: integer("last_polled_at", { mode: "timestamp" }),
+    pollingInterval: integer("polling_interval"),
+    clientId: text("client_id"),
+    scope: text("scope"),
+  },
+  (t) => [
+    index("idx_device_code_device_code").on(t.deviceCode),
+    index("idx_device_code_user_code").on(t.userCode),
+  ],
+);
+
 export type AuthUser = typeof user.$inferSelect;
 export type AuthSession = typeof session.$inferSelect;
 export type AuthAccount = typeof account.$inferSelect;
@@ -215,3 +252,4 @@ export type AuthRateLimit = typeof rateLimit.$inferSelect;
 export type AuthOrganization = typeof organization.$inferSelect;
 export type AuthMember = typeof member.$inferSelect;
 export type AuthInvitation = typeof invitation.$inferSelect;
+export type AuthDeviceCode = typeof deviceCode.$inferSelect;

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -130,6 +130,71 @@ export async function getInvitation(origin: string, id: string): Promise<Invitat
   }
 }
 
+/**
+ * Phase 4 (plan D5/D6): device-authorization (RFC 8628) wrappers for the
+ * `/device` approval page — the browser half of `uploads login`. The CLI
+ * speaks the `/device/code` + `/device/token` endpoints directly; this page
+ * only needs to look up, approve, or deny a user code.
+ */
+export type DeviceStatus = "pending" | "approved" | "denied";
+export type DeviceLookup = { ok: true; status: DeviceStatus } | { ok: false; code?: string };
+
+/**
+ * GET /api/auth/device?user_code=. Verifies the code and — when a session is
+ * present and the code is still pending+unclaimed — CLAIMS it (binds it to the
+ * signed-in user), which is what makes a subsequent approve succeed. Returns
+ * `{ ok: false, code }` for an invalid/expired code, mirroring the other
+ * helpers' never-throw contract.
+ */
+export async function getDeviceStatus(origin: string, userCode: string): Promise<DeviceLookup> {
+  try {
+    const res = await fetch(
+      `${authOrigin(origin)}/api/auth/device?user_code=${encodeURIComponent(userCode)}`,
+      { credentials: "include", cache: "no-store" },
+    );
+    const body = (await res.json().catch(() => null)) as {
+      status?: DeviceStatus;
+      error?: string;
+    } | null;
+    if (!res.ok) return { ok: false, code: body?.error };
+    const status = body?.status;
+    if (status !== "pending" && status !== "approved" && status !== "denied") return { ok: false };
+    return { ok: true, status };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** POST /api/auth/device/approve — grants the CLI a session. Requires a session. */
+export async function approveDevice(origin: string, userCode: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/device/approve`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userCode }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** POST /api/auth/device/deny — rejects the pending request. Requires a session. */
+export async function denyDevice(origin: string, userCode: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/device/deny`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userCode }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export type AcceptInvitationResult = { ok: true } | { ok: false; status: number; code?: string };
 
 /**

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -264,37 +264,31 @@ const FAVICON =
     }
   });
 
-  approveBtn.addEventListener("click", async () => {
-    confirmError.hidden = true;
-    approveBtn.disabled = true;
-    denyBtn.disabled = true;
-    const ok = await approveDevice(authOrigin, userCode);
-    if (ok) {
-      hideAll();
-      approved.hidden = false;
-      return;
-    }
-    approveBtn.disabled = false;
-    denyBtn.disabled = false;
-    confirmError.textContent = "Couldn't approve the device. The code may have expired.";
-    confirmError.hidden = false;
-  });
+  // Approve and deny share everything but the action call, the verb in the
+  // error copy, and which final panel to reveal.
+  function decide(
+    action: (origin: string, code: string) => Promise<boolean>,
+    verb: string,
+    resultPanel: HTMLElement,
+  ) {
+    return async () => {
+      confirmError.hidden = true;
+      approveBtn.disabled = true;
+      denyBtn.disabled = true;
+      if (await action(authOrigin, userCode)) {
+        hideAll();
+        resultPanel.hidden = false;
+        return;
+      }
+      approveBtn.disabled = false;
+      denyBtn.disabled = false;
+      confirmError.textContent = `Couldn't ${verb} the device. The code may have expired.`;
+      confirmError.hidden = false;
+    };
+  }
 
-  denyBtn.addEventListener("click", async () => {
-    confirmError.hidden = true;
-    approveBtn.disabled = true;
-    denyBtn.disabled = true;
-    const ok = await denyDevice(authOrigin, userCode);
-    if (ok) {
-      hideAll();
-      denied.hidden = false;
-      return;
-    }
-    approveBtn.disabled = false;
-    denyBtn.disabled = false;
-    confirmError.textContent = "Couldn't deny the device. The code may have expired.";
-    confirmError.hidden = false;
-  });
+  approveBtn.addEventListener("click", decide(approveDevice, "approve", approved));
+  denyBtn.addEventListener("click", decide(denyDevice, "deny", denied));
 
   init();
 </script>

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -1,0 +1,302 @@
+---
+import { env } from "cloudflare:workers";
+import {
+  CF_RUM_CONNECT_SRC,
+  CF_RUM_SCRIPT_SRC,
+  STYLE_SRC_SELF_AND_INLINE,
+} from "../lib/csp";
+
+export const prerender = false;
+
+const authOrigin =
+  env.UPLOADS_AUTH_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
+  "https://auth.uploads.sh";
+
+const csp = [
+  "default-src 'none'",
+  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+  // 'self' covers Astro-bundled /_astro/*.js; CF RUM is edge-injected.
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "img-src data:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const FAVICON =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
+---
+
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow, noarchive" />
+  <meta name="referrer" content="no-referrer" />
+  <meta http-equiv="Content-Security-Policy" content={csp} />
+  <title>Authorize device · uploads.sh</title>
+  <link rel="icon" href={FAVICON} />
+  <style>
+    :root{color-scheme:dark;--bg:#0a0a0b;--panel:#121214;--line:#232327;--fg:#ececea;--body:#b3b3ad;--muted:#7d7d77;--accent:#b794ff;--green:#8fae62;--red:#d98a9c;--mono:"Geist Mono Variable",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace}
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:var(--bg);color:var(--fg);font:14.5px/1.65 var(--mono)}
+    main{width:min(480px,100%);background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:clamp(24px,6vw,40px)}
+    h1{margin:0 0 8px;font-size:clamp(21px,5vw,26px);font-weight:600;letter-spacing:-.015em;line-height:1.25}
+    p{color:var(--body);margin:0 0 20px}
+    .status{border-left:3px solid var(--accent);padding:9px 14px;margin:16px 0;background:var(--bg);color:var(--fg)}
+    .status[data-state=ready]{border-color:var(--green)}
+    .status[data-state=error]{border-color:var(--red);color:var(--red)}
+    .code{font-size:clamp(24px,7vw,32px);letter-spacing:.28em;font-weight:600;color:var(--fg);text-align:center;padding:16px 10px;margin:12px 0 22px;background:var(--bg);border:1px solid var(--line);border-radius:8px}
+    button.github{width:100%;display:flex;align-items:center;justify-content:center;gap:10px;font:14px var(--mono);letter-spacing:.02em;color:var(--fg);background:var(--bg);border:1px solid var(--line);border-radius:8px;padding:12px 16px;cursor:pointer}
+    button.github:hover,button.github:focus-visible{border-color:var(--accent);outline:none}
+    .divider{display:flex;align-items:center;gap:12px;margin:22px 0;color:var(--muted);font-size:11px;letter-spacing:.08em;text-transform:uppercase}
+    .divider::before,.divider::after{content:"";flex:1;height:1px;background:var(--line)}
+    form{display:grid;gap:10px}
+    label{display:grid;gap:6px;color:var(--muted);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase}
+    input{background:var(--bg);border:1px solid var(--line);border-radius:8px;color:var(--fg);padding:10px 12px;font:14px var(--mono)}
+    input:focus-visible{border-color:var(--accent);outline:none}
+    .actions{display:flex;gap:10px}
+    button.primary,button.secondary,button[type=submit]{flex:1;font:12px var(--mono);letter-spacing:.04em;color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:7px;padding:11px 13px;cursor:pointer}
+    button.secondary{color:var(--muted)}
+    button.primary:hover,button.primary:focus-visible,button[type=submit]:hover,button[type=submit]:focus-visible{border-color:var(--accent);outline:none}
+    button.secondary:hover,button.secondary:focus-visible{border-color:var(--red);color:var(--red);outline:none}
+    button:disabled{opacity:.6;cursor:default}
+    .legal{margin:22px 0 0;font-size:11.5px;color:var(--muted)}
+    .legal a{color:var(--muted)}
+    [hidden]{display:none!important}
+  </style>
+</head>
+<body>
+<main>
+  <h1>Authorize device</h1>
+
+  <div id="checking" class="status" role="status">Checking…</div>
+
+  <div id="code-entry" hidden>
+    <p>Enter the code shown in your terminal to continue.</p>
+    <form id="code-form">
+      <label>
+        Device code
+        <input id="code-input" type="text" required autocomplete="off" autocapitalize="characters" spellcheck="false" placeholder="XXXX-XXXX" />
+      </label>
+      <button type="submit">Continue</button>
+    </form>
+  </div>
+
+  <div id="invalid" hidden>
+    <div class="status" data-state="error" role="alert">That code is invalid or has expired. Start a new sign-in from the CLI.</div>
+  </div>
+
+  <div id="signed-out" hidden>
+    <p>Sign in to authorize the device.</p>
+    <button type="button" class="github" id="github-btn">Continue with GitHub</button>
+    <div class="divider">or</div>
+    <form id="magic-form">
+      <label>
+        Email
+        <input id="email" type="email" required autocomplete="email" placeholder="you@example.com" />
+      </label>
+      <button type="submit" id="magic-submit">Send sign-in link</button>
+    </form>
+    <div class="status" id="signin-error" data-state="error" role="alert" hidden></div>
+  </div>
+
+  <div id="sent-state" hidden>
+    <div class="status" data-state="ready" role="status">Check your email — we sent you a sign-in link. Come back to this page after signing in.</div>
+  </div>
+
+  <div id="confirm" hidden>
+    <p>Signed in as <span id="who"></span>. A device is requesting access to your account:</p>
+    <div class="code" id="code-display" aria-label="device code"></div>
+    <div class="actions">
+      <button type="button" class="primary" id="approve-btn">Approve</button>
+      <button type="button" class="secondary" id="deny-btn">Deny</button>
+    </div>
+    <div class="status" id="confirm-error" data-state="error" role="alert" hidden></div>
+  </div>
+
+  <div id="approved" hidden>
+    <div class="status" data-state="ready" role="status">Device approved. Return to your terminal — you're signed in. You can close this page.</div>
+  </div>
+
+  <div id="denied" hidden>
+    <div class="status" role="status">Request denied. The device was not granted access.</div>
+  </div>
+
+  <p class="legal">a <a href="https://buildinternet.com">Build Internet</a> project · <a href="/terms">terms</a> · <a href="/privacy">privacy</a></p>
+</main>
+<script define:vars={{ authOrigin }}>
+  window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
+</script>
+<script>
+  import {
+    approveDevice,
+    denyDevice,
+    getDeviceStatus,
+    getSession,
+    sendMagicLink,
+    signInWithGitHub,
+  } from "../lib/auth-client";
+
+  const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
+
+  function requireElement<T extends Element>(selector: string): T {
+    const element = document.querySelector<T>(selector);
+    if (!element) throw new Error(`device page is missing ${selector}`);
+    return element as T;
+  }
+
+  const checking = requireElement<HTMLElement>("#checking");
+  const codeEntry = requireElement<HTMLElement>("#code-entry");
+  const codeForm = requireElement<HTMLFormElement>("#code-form");
+  const codeInput = requireElement<HTMLInputElement>("#code-input");
+  const invalid = requireElement<HTMLElement>("#invalid");
+  const signedOut = requireElement<HTMLElement>("#signed-out");
+  const sentState = requireElement<HTMLElement>("#sent-state");
+  const confirmBox = requireElement<HTMLElement>("#confirm");
+  const codeDisplay = requireElement<HTMLElement>("#code-display");
+  const who = requireElement<HTMLElement>("#who");
+  const approved = requireElement<HTMLElement>("#approved");
+  const denied = requireElement<HTMLElement>("#denied");
+  const githubBtn = requireElement<HTMLButtonElement>("#github-btn");
+  const magicForm = requireElement<HTMLFormElement>("#magic-form");
+  const magicSubmit = requireElement<HTMLButtonElement>("#magic-submit");
+  const emailInput = requireElement<HTMLInputElement>("#email");
+  const signinError = requireElement<HTMLElement>("#signin-error");
+  const approveBtn = requireElement<HTMLButtonElement>("#approve-btn");
+  const denyBtn = requireElement<HTMLButtonElement>("#deny-btn");
+  const confirmError = requireElement<HTMLElement>("#confirm-error");
+
+  let userCode = new URLSearchParams(location.search).get("user_code")?.trim() ?? "";
+
+  const callbackURL = () => location.href;
+
+  /** Group an 8-char code as XXXX-XXXX for legibility; leave other lengths as-is. */
+  function formatUserCode(code: string): string {
+    const clean = code.replace(/-/g, "").toUpperCase();
+    return clean.length === 8 ? `${clean.slice(0, 4)}-${clean.slice(4)}` : clean;
+  }
+
+  function hideAll() {
+    for (const el of [checking, codeEntry, invalid, signedOut, sentState, confirmBox, approved, denied]) {
+      el.hidden = true;
+    }
+  }
+
+  async function proceed() {
+    hideAll();
+    checking.hidden = false;
+
+    const session = await getSession(authOrigin);
+    if (!session) {
+      hideAll();
+      signedOut.hidden = false;
+      return;
+    }
+    who.textContent = session.user.email;
+
+    const lookup = await getDeviceStatus(authOrigin, userCode);
+    hideAll();
+    if (!lookup.ok) {
+      invalid.hidden = false;
+      return;
+    }
+    if (lookup.status === "approved") {
+      approved.hidden = false;
+      return;
+    }
+    if (lookup.status === "denied") {
+      denied.hidden = false;
+      return;
+    }
+    codeDisplay.textContent = formatUserCode(userCode);
+    confirmBox.hidden = false;
+  }
+
+  function init() {
+    if (!userCode) {
+      hideAll();
+      codeEntry.hidden = false;
+      return;
+    }
+    void proceed();
+  }
+
+  codeForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    userCode = codeInput.value.trim();
+    if (!userCode) return;
+    // Reflect the code into the URL so a sign-in round-trip returns here with it.
+    const url = new URL(location.href);
+    url.searchParams.set("user_code", userCode);
+    history.replaceState(null, "", url.toString());
+    void proceed();
+  });
+
+  githubBtn.addEventListener("click", async () => {
+    signinError.hidden = true;
+    githubBtn.disabled = true;
+    const ok = await signInWithGitHub(authOrigin, callbackURL());
+    if (!ok) {
+      githubBtn.disabled = false;
+      signinError.textContent = "GitHub sign-in isn't available right now.";
+      signinError.hidden = false;
+    }
+  });
+
+  magicForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    signinError.hidden = true;
+    magicSubmit.disabled = true;
+    const email = emailInput.value.trim();
+    try {
+      const ok = await sendMagicLink(authOrigin, email, callbackURL());
+      if (!ok) throw new Error("send failed");
+      hideAll();
+      sentState.hidden = false;
+    } catch {
+      signinError.textContent = "Couldn't send the sign-in link. Try again.";
+      signinError.hidden = false;
+    } finally {
+      magicSubmit.disabled = false;
+    }
+  });
+
+  approveBtn.addEventListener("click", async () => {
+    confirmError.hidden = true;
+    approveBtn.disabled = true;
+    denyBtn.disabled = true;
+    const ok = await approveDevice(authOrigin, userCode);
+    if (ok) {
+      hideAll();
+      approved.hidden = false;
+      return;
+    }
+    approveBtn.disabled = false;
+    denyBtn.disabled = false;
+    confirmError.textContent = "Couldn't approve the device. The code may have expired.";
+    confirmError.hidden = false;
+  });
+
+  denyBtn.addEventListener("click", async () => {
+    confirmError.hidden = true;
+    approveBtn.disabled = true;
+    denyBtn.disabled = true;
+    const ok = await denyDevice(authOrigin, userCode);
+    if (ok) {
+      hideAll();
+      denied.hidden = false;
+      return;
+    }
+    approveBtn.disabled = false;
+    denyBtn.disabled = false;
+    confirmError.textContent = "Couldn't deny the device. The code may have expired.";
+    confirmError.hidden = false;
+  });
+
+  init();
+</script>
+</body>
+</html>

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -68,7 +68,7 @@ Commands:
   purge-expired       Delete objects past retentionDays
   setup               Inspect/configure advanced CLI settings
   install             Install the agent skill + register the remote MCP server
-  login               Exchange an enrollment code and configure credentials
+  login               Sign in via browser (or an enrollment code) and save credentials
   admin               Admin invitation management
   config              Show path, init, or set shared config
   doctor              Health + auth + workspace checks

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -253,6 +253,156 @@ export function createEnrollment(
   });
 }
 
+// --- Device authorization (RFC 8628) — the `uploads login` device flow ---
+//
+// The CLI speaks the auth worker's OAuth-shaped endpoints directly with plain
+// `fetch` (no better-auth client dependency in the published package, per plan
+// D5). Better Auth's `device.code`/`device.token` endpoints take
+// `application/json` bodies, NOT the RFC's form-encoding — the JSON shapes
+// below are what the worker expects.
+
+/** Static OAuth client id allowlisted by the auth worker's `validateClient`. */
+export const DEVICE_CLIENT_ID = "uploads-cli";
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval: number;
+}
+
+/** POST /api/auth/device/code — start a device flow. Throws on a non-2xx. */
+export function requestDeviceCode(
+  authUrl: string,
+  clientId = DEVICE_CLIENT_ID,
+): Promise<DeviceCodeResponse> {
+  return jsonRequest(`${authUrl.replace(/\/$/, "")}/api/auth/device/code`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_id: clientId }),
+  });
+}
+
+/**
+ * One poll of POST /api/auth/device/token. Unlike most calls, the "not ready
+ * yet" outcomes (`authorization_pending`, `slow_down`) are EXPECTED 400s, so
+ * this returns a discriminated result instead of throwing — the caller's poll
+ * loop branches on `status`.
+ */
+export type DeviceTokenResult =
+  | { status: "ok"; accessToken: string; tokenType: string; expiresIn: number; scope: string }
+  | { status: "pending" }
+  | { status: "slow_down" }
+  | { status: "expired" }
+  | { status: "denied" }
+  | { status: "error"; error: string; description?: string };
+
+export async function requestDeviceToken(
+  authUrl: string,
+  input: { deviceCode: string; clientId?: string },
+): Promise<DeviceTokenResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${authUrl.replace(/\/$/, "")}/api/auth/device/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        device_code: input.deviceCode,
+        client_id: input.clientId ?? DEVICE_CLIENT_ID,
+      }),
+    });
+  } catch (err) {
+    throw new UploadsError(
+      err instanceof Error ? err.message : "network request failed",
+      "NETWORK",
+    );
+  }
+  const body = (await res.json().catch(() => null)) as {
+    access_token?: string;
+    token_type?: string;
+    expires_in?: number;
+    scope?: string;
+    error?: string;
+    error_description?: string;
+  } | null;
+  if (res.ok && body?.access_token) {
+    return {
+      status: "ok",
+      accessToken: body.access_token,
+      tokenType: body.token_type ?? "Bearer",
+      expiresIn: typeof body.expires_in === "number" ? body.expires_in : 0,
+      scope: body.scope ?? "",
+    };
+  }
+  switch (body?.error) {
+    case "authorization_pending":
+      return { status: "pending" };
+    case "slow_down":
+      return { status: "slow_down" };
+    case "expired_token":
+      return { status: "expired" };
+    case "access_denied":
+      return { status: "denied" };
+    default:
+      return {
+        status: "error",
+        error: body?.error ?? "unknown",
+        description: body?.error_description,
+      };
+  }
+}
+
+export interface MintWorkspaceSummary {
+  workspace: string;
+  role: string;
+}
+
+/** GET /v1/tokens — workspaces the signed-in user can mint tokens for. */
+export function listMintWorkspaces(
+  apiUrl: string,
+  accessToken: string,
+): Promise<{ workspaces: MintWorkspaceSummary[] }> {
+  return jsonRequest(`${apiUrl.replace(/\/$/, "")}/v1/tokens`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+export interface MintTokenResult {
+  token: string;
+  workspace: string;
+  scopes: Array<"files:read" | "files:write" | "files:delete">;
+  label: string | null;
+  expiresAt: string | null;
+}
+
+/**
+ * POST /v1/tokens — mint a `up_<workspace>_…` workspace token from a device-flow
+ * session (presented as a bearer). v1 sends exactly one grant.
+ */
+export function mintWorkspaceToken(
+  apiUrl: string,
+  accessToken: string,
+  input: {
+    workspace: string;
+    scopes?: Array<"files:read" | "files:write" | "files:delete">;
+    label?: string;
+    ttlSeconds?: number;
+  },
+): Promise<MintTokenResult> {
+  return jsonRequest(`${apiUrl.replace(/\/$/, "")}/v1/tokens`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grants: [{ workspace: input.workspace, ...(input.scopes ? { scopes: input.scopes } : {}) }],
+      ...(input.label ? { label: input.label } : {}),
+      ...(input.ttlSeconds ? { ttlSeconds: input.ttlSeconds } : {}),
+    }),
+  });
+}
+
 function encodeKeyPath(key: string): string {
   return key.split("/").map(encodeURIComponent).join("/");
 }

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -1,3 +1,5 @@
+import { hostname } from "node:os";
+import { spawn } from "node:child_process";
 import { stdin, stdout } from "node:process";
 import {
   loadConfigFile,
@@ -6,17 +8,34 @@ import {
   writeConfigKeys,
   workspaceFromToken,
 } from "../config.js";
-import { exchangeEnrollment, createUploadsClient } from "../client.js";
+import {
+  createUploadsClient,
+  exchangeEnrollment,
+  listMintWorkspaces,
+  mintWorkspaceToken,
+  requestDeviceCode,
+  requestDeviceToken,
+} from "../client.js";
 import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+
+type FileScope = "files:read" | "files:write" | "files:delete";
+const KNOWN_SCOPES = new Set<FileScope>(["files:read", "files:write", "files:delete"]);
 
 const HELP = `uploads login [options]
 
-Exchange a one-time enrollment code for workspace credentials, save them, and
-verify access. Ask your uploads.sh administrator for an enrollment code.
+Sign in and save workspace credentials. With no code, opens a browser to
+authorize this device (recommended). Pass an enrollment code to use the
+one-time code path instead.
 
 Options:
-  --code <code>       Code in argv (may be visible in shell history/process lists)
-  --code-stdin        Read one line from stdin
+  --workspace <name>  Workspace to mint a token for (device flow; required if
+                      your account can access more than one)
+  --scopes <list>     Comma-separated scopes (default: files:read,files:write)
+  --label <text>      Token label (default: this machine's hostname)
+  --auth-url <url>    Auth base (default: https://auth.uploads.sh)
+  --no-open           Don't try to open a browser automatically
+  --code <code>       Enrollment code in argv (visible in shell history)
+  --code-stdin        Read an enrollment code from stdin
   --non-interactive   Never prompt
   --api-url <url>     API base (default: https://api.uploads.sh)
   --path <file>       Config destination
@@ -24,10 +43,10 @@ Options:
   --no-check          Skip doctor verification
 
 Examples:
-  uploads login --code upe_…
-  uploads login --code-stdin --non-interactive < code.txt
+  uploads login
+  uploads login --workspace acme
+  uploads login --code upe_… --force
   printf '%s' upe_… | uploads login --code-stdin --non-interactive
-  uploads login --code upe_… --force --no-check
 `;
 
 export function validateEnrollmentCode(raw: string): string {
@@ -103,10 +122,193 @@ export async function resolveEnrollmentCode(
   return validateEnrollmentCode(await io.hiddenPrompt());
 }
 
+/** True when the caller supplied an enrollment code (via flag, stdin, or env). */
+function hasEnrollmentSource(parsed: ReturnType<typeof parseCommandArgs>): boolean {
+  return (
+    Boolean(flagString(parsed.flags, "--code")) ||
+    flagBool(parsed.flags, "--code-stdin") ||
+    Boolean(process.env.UPLOADS_ENROLLMENT_CODE)
+  );
+}
+
+/**
+ * Auth worker base URL: explicit flag > UPLOADS_AUTH_URL > swap an `api.` host
+ * label for `auth.` > the production default. Local multi-worker dev (where
+ * auth runs on a different loopback port than the API) needs an explicit
+ * --auth-url / UPLOADS_AUTH_URL.
+ */
+export function resolveAuthUrl(
+  parsed: ReturnType<typeof parseCommandArgs>,
+  apiUrl: string,
+): string {
+  const explicit = flagString(parsed.flags, "--auth-url") ?? process.env.UPLOADS_AUTH_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+  try {
+    const url = new URL(apiUrl);
+    if (url.hostname.startsWith("api.")) {
+      url.hostname = `auth.${url.hostname.slice(4)}`;
+      return url.origin;
+    }
+  } catch {
+    // fall through to the default
+  }
+  return "https://auth.uploads.sh";
+}
+
+function parseScopeFlag(value: string | undefined): FileScope[] | undefined {
+  if (!value) return undefined;
+  const parts = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return undefined;
+  for (const part of parts) {
+    if (!KNOWN_SCOPES.has(part as FileScope)) throw new UsageError(`invalid scope: ${part}`);
+  }
+  return [...new Set(parts)] as FileScope[];
+}
+
+/** Best-effort browser open. The URL is always printed too, so failures are silent. */
+function openUrl(url: string): void {
+  try {
+    const isWin = process.platform === "win32";
+    const command = process.platform === "darwin" ? "open" : isWin ? "cmd" : "xdg-open";
+    const args = isWin ? ["/c", "start", "", url] : [url];
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // ignore — the URL is printed for manual navigation.
+  }
+}
+
+export interface DeviceLoginIo {
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  openUrl: (url: string) => void;
+  write: (text: string) => void;
+}
+
+const defaultDeviceIo: DeviceLoginIo = {
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now: () => Date.now(),
+  openUrl,
+  write: (text) => {
+    process.stderr.write(text);
+  },
+};
+
+interface LoginResult {
+  workspace: string;
+  token: string;
+  apiUrl?: string;
+}
+
+/**
+ * Device-authorization login (RFC 8628): request a code, have the user approve
+ * it in a browser, poll for the session token, then mint a workspace token.
+ */
+async function runDeviceLogin(
+  parsed: ReturnType<typeof parseCommandArgs>,
+  opts: { apiUrl: string; authUrl: string; noOpen: boolean },
+  io: DeviceLoginIo,
+): Promise<LoginResult> {
+  const scopes = parseScopeFlag(flagString(parsed.flags, "--scopes"));
+  const label = flagString(parsed.flags, "--label") ?? safeHostname();
+  const requestedWorkspace = flagString(parsed.flags, "--workspace");
+
+  const code = await requestDeviceCode(opts.authUrl);
+  const verifyUrl = code.verification_uri_complete ?? code.verification_uri;
+  io.write(
+    `To sign in, open:\n\n  ${verifyUrl}\n\nand confirm this code:\n\n  ${code.user_code}\n\n`,
+  );
+  if (!opts.noOpen) io.openUrl(verifyUrl);
+  io.write("Waiting for approval…\n");
+
+  const accessToken = await pollForDeviceToken(opts.authUrl, code, io);
+
+  const workspace = await resolveMintWorkspace(opts.apiUrl, accessToken, requestedWorkspace);
+  const minted = await mintWorkspaceToken(opts.apiUrl, accessToken, { workspace, scopes, label });
+  return { workspace: minted.workspace, token: minted.token, apiUrl: opts.apiUrl };
+}
+
+function safeHostname(): string {
+  try {
+    return hostname() || "cli";
+  } catch {
+    return "cli";
+  }
+}
+
+/** Poll device/token honoring interval / slow_down / pending until approved or expired. */
+async function pollForDeviceToken(
+  authUrl: string,
+  code: { device_code: string; interval: number; expires_in: number },
+  io: DeviceLoginIo,
+): Promise<string> {
+  let intervalMs = Math.max(1, code.interval) * 1000;
+  const deadline = io.now() + Math.max(1, code.expires_in) * 1000;
+  while (io.now() < deadline) {
+    await io.sleep(intervalMs);
+    let result: Awaited<ReturnType<typeof requestDeviceToken>>;
+    try {
+      result = await requestDeviceToken(authUrl, { deviceCode: code.device_code });
+    } catch {
+      // A transient network blip mid-poll shouldn't abort a login the user may
+      // already have approved — keep polling until the device code's deadline.
+      continue;
+    }
+    switch (result.status) {
+      case "ok":
+        return result.accessToken;
+      case "pending":
+        continue;
+      case "slow_down":
+        // RFC 8628 §3.5: back off by 5s and keep polling.
+        intervalMs += 5000;
+        continue;
+      case "denied":
+        throw new UsageError("device authorization was denied");
+      case "expired":
+        throw new UsageError("the device code expired before it was approved");
+      default:
+        throw new UsageError(
+          `device authorization failed: ${result.error}${
+            result.description ? ` — ${result.description}` : ""
+          }`,
+        );
+    }
+  }
+  throw new UsageError("timed out waiting for device authorization");
+}
+
+/**
+ * Pick the workspace to mint for. An explicit --workspace wins; otherwise, if
+ * the account can access exactly one workspace, use it — and if it can access
+ * several, require the flag rather than guessing.
+ */
+async function resolveMintWorkspace(
+  apiUrl: string,
+  accessToken: string,
+  requested: string | undefined,
+): Promise<string> {
+  if (requested) return requested;
+  const { workspaces } = await listMintWorkspaces(apiUrl, accessToken);
+  if (workspaces.length === 1) return workspaces[0]!.workspace;
+  if (workspaces.length === 0) {
+    throw new UsageError(
+      "your account has no workspace access yet — ask an administrator for an invitation",
+    );
+  }
+  const names = workspaces.map((w) => w.workspace).join(", ");
+  throw new UsageError(`multiple workspaces available (${names}); pass --workspace <name>`);
+}
+
 export async function runLogin(
   args: string[],
   opts: { json?: boolean; apiUrl?: string },
   help = false,
+  deviceIo: DeviceLoginIo = defaultDeviceIo,
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
@@ -123,11 +325,31 @@ export async function runLogin(
     throw new UsageError(
       "UPLOADS_TOKEN is already set in the environment; unset it or use --force",
     );
-  const code = await resolveEnrollmentCode(parsed);
-  const result = await exchangeEnrollment(apiUrl, code);
+
+  let result: LoginResult;
+  if (hasEnrollmentSource(parsed)) {
+    const code = await resolveEnrollmentCode(parsed);
+    result = await exchangeEnrollment(apiUrl, code);
+  } else {
+    // The device flow is inherently interactive (browser approval, then a poll
+    // that runs to the device code's ~30-min deadline). Fail fast rather than
+    // hanging a non-interactive/CI invocation that has no code to fall back on.
+    if (flagBool(parsed.flags, "--non-interactive")) {
+      throw new UsageError(
+        "device login requires a browser; run interactively, or pass --code for the enrollment path",
+      );
+    }
+    const authUrl = resolveAuthUrl(parsed, apiUrl);
+    result = await runDeviceLogin(
+      parsed,
+      { apiUrl, authUrl, noOpen: flagBool(parsed.flags, "--no-open") },
+      deviceIo,
+    );
+  }
+
   const encoded = workspaceFromToken(result.token);
   if (!encoded || encoded !== result.workspace || /[\r\n]/.test(result.token))
-    throw new UsageError("enrollment returned invalid credentials");
+    throw new UsageError("login returned invalid credentials");
   const savedApiUrl = result.apiUrl ?? apiUrl;
   const write = writeConfigKeys(
     path,

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -17,9 +17,7 @@ import {
   requestDeviceToken,
 } from "../client.js";
 import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
-
-type FileScope = "files:read" | "files:write" | "files:delete";
-const KNOWN_SCOPES = new Set<FileScope>(["files:read", "files:write", "files:delete"]);
+import { parseScopes } from "./admin-enrollment.js";
 
 const HELP = `uploads login [options]
 
@@ -155,19 +153,6 @@ export function resolveAuthUrl(
   return "https://auth.uploads.sh";
 }
 
-function parseScopeFlag(value: string | undefined): FileScope[] | undefined {
-  if (!value) return undefined;
-  const parts = value
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  if (parts.length === 0) return undefined;
-  for (const part of parts) {
-    if (!KNOWN_SCOPES.has(part as FileScope)) throw new UsageError(`invalid scope: ${part}`);
-  }
-  return [...new Set(parts)] as FileScope[];
-}
-
 /** Best-effort browser open. The URL is always printed too, so failures are silent. */
 function openUrl(url: string): void {
   try {
@@ -213,7 +198,7 @@ async function runDeviceLogin(
   opts: { apiUrl: string; authUrl: string; noOpen: boolean },
   io: DeviceLoginIo,
 ): Promise<LoginResult> {
-  const scopes = parseScopeFlag(flagString(parsed.flags, "--scopes"));
+  const scopes = parseScopes(flagString(parsed.flags, "--scopes"));
   const label = flagString(parsed.flags, "--label") ?? safeHostname();
   const requestedWorkspace = flagString(parsed.flags, "--workspace");
 

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -2,7 +2,13 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveEnrollmentCode, runLogin, validateEnrollmentCode } from "../src/commands/login.js";
+import {
+  resolveAuthUrl,
+  resolveEnrollmentCode,
+  runLogin,
+  validateEnrollmentCode,
+  type DeviceLoginIo,
+} from "../src/commands/login.js";
 import {
   inviteMagicLink,
   invitePageUrl,
@@ -129,6 +135,200 @@ describe("runLogin", () => {
     await expect(runLogin(["--non-interactive", "--path", path], {})).rejects.toThrow(
       "invalid credentials",
     );
+  });
+});
+
+describe("resolveAuthUrl", () => {
+  it("prefers an explicit --auth-url", () => {
+    expect(resolveAuthUrl(parseCommandArgs(["--auth-url", "http://127.0.0.1:8788/"]), "x")).toBe(
+      "http://127.0.0.1:8788",
+    );
+  });
+
+  it("swaps an api. host label for auth.", () => {
+    expect(resolveAuthUrl(parseCommandArgs([]), "https://api.uploads.sh")).toBe(
+      "https://auth.uploads.sh",
+    );
+  });
+
+  it("falls back to the production default for non-api hosts", () => {
+    expect(resolveAuthUrl(parseCommandArgs([]), "http://localhost:8787")).toBe(
+      "https://auth.uploads.sh",
+    );
+  });
+});
+
+describe("runLogin device flow", () => {
+  const silentIo: DeviceLoginIo = {
+    sleep: async () => {},
+    now: () => Date.now(),
+    openUrl: () => {},
+    write: () => {},
+  };
+
+  const deviceCode = (over: Record<string, unknown> = {}) =>
+    response({
+      device_code: "dev-123",
+      user_code: "ABCD-EFGH",
+      verification_uri: "https://uploads.sh/device",
+      verification_uri_complete: "https://uploads.sh/device?user_code=ABCD-EFGH",
+      expires_in: 900,
+      interval: 5,
+      ...over,
+    });
+
+  it("runs code → poll → mint, then writes and verifies", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const token = "up_acme_abcdefghijklmnopqrstuvwxyz";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode()) // device/code
+      .mockResolvedValueOnce(response({ error: "authorization_pending" }, 400)) // poll 1
+      .mockResolvedValueOnce(
+        response({ access_token: "sess-tok", token_type: "Bearer", expires_in: 3600, scope: "" }),
+      ) // poll 2
+      .mockResolvedValueOnce(response({ workspaces: [{ workspace: "acme", role: "member" }] })) // GET /v1/tokens
+      .mockResolvedValueOnce(
+        response(
+          {
+            token,
+            workspace: "acme",
+            scopes: ["files:read", "files:write"],
+            label: "host",
+            expiresAt: null,
+          },
+          201,
+        ),
+      ) // POST /v1/tokens
+      .mockResolvedValueOnce(response({ ok: true })) // doctor health
+      .mockResolvedValueOnce(response({ items: [], cursor: null })); // doctor list
+    const output = captureOutput();
+
+    expect(await runLogin(["--path", path], { json: true }, false, silentIo)).toBe(0);
+
+    // The bearer session token is presented to /v1/tokens (GET + POST).
+    const mintCall = fetchMock.mock.calls.find(
+      (c) => String(c[0]).endsWith("/v1/tokens") && (c[1] as RequestInit)?.method === "POST",
+    );
+    expect((mintCall![1] as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer sess-tok",
+    });
+    expect(JSON.parse(String((mintCall![1] as RequestInit).body))).toMatchObject({
+      grants: [{ workspace: "acme" }],
+    });
+    expect(loadConfigFile(path).UPLOADS_TOKEN).toBe(token);
+    expect(loadConfigFile(path).UPLOADS_WORKSPACE).toBe("acme");
+    expect(output.out() + output.err()).not.toContain(token);
+  });
+
+  it("uses --workspace directly and skips the workspace lookup", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const token = "up_acme_abcdefghijklmnopqrstuvwxyz";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode())
+      .mockResolvedValueOnce(
+        response({ access_token: "sess-tok", token_type: "Bearer", expires_in: 3600, scope: "" }),
+      )
+      .mockResolvedValueOnce(
+        response(
+          { token, workspace: "acme", scopes: ["files:read"], label: "host", expiresAt: null },
+          201,
+        ),
+      );
+    captureOutput();
+
+    expect(
+      await runLogin(
+        ["--path", path, "--workspace", "acme", "--no-check"],
+        { json: true },
+        false,
+        silentIo,
+      ),
+    ).toBe(0);
+    // No GET /v1/tokens listing call happened.
+    expect(
+      fetchMock.mock.calls.some(
+        (c) => String(c[0]).endsWith("/v1/tokens") && (c[1] as RequestInit)?.method !== "POST",
+      ),
+    ).toBe(false);
+  });
+
+  it("errors when the account has multiple workspaces and none is chosen", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode())
+      .mockResolvedValueOnce(
+        response({ access_token: "sess-tok", token_type: "Bearer", expires_in: 3600, scope: "" }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          workspaces: [
+            { workspace: "acme", role: "member" },
+            { workspace: "beta", role: "member" },
+          ],
+        }),
+      );
+    captureOutput();
+    await expect(
+      runLogin(["--path", path, "--no-check"], { json: true }, false, silentIo),
+    ).rejects.toThrow("multiple workspaces");
+  });
+
+  it("fails fast (no polling) in non-interactive mode with no enrollment code", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(
+      runLogin(["--path", path, "--non-interactive"], { json: true }, false, silentIo),
+    ).rejects.toThrow(/device login requires a browser/);
+    // Never hit the network — no device/code request was made.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("stops when the user denies the request", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode())
+      .mockResolvedValueOnce(response({ error: "access_denied" }, 400));
+    captureOutput();
+    await expect(runLogin(["--path", path], { json: true }, false, silentIo)).rejects.toThrow(
+      "denied",
+    );
+  });
+
+  it("backs off on slow_down and keeps polling", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const token = "up_acme_abcdefghijklmnopqrstuvwxyz";
+    let slept = 0;
+    const io: DeviceLoginIo = {
+      ...silentIo,
+      sleep: async (ms) => {
+        slept = ms;
+      },
+    };
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode({ interval: 5 }))
+      .mockResolvedValueOnce(response({ error: "slow_down" }, 400))
+      .mockResolvedValueOnce(
+        response({ access_token: "sess-tok", token_type: "Bearer", expires_in: 3600, scope: "" }),
+      )
+      .mockResolvedValueOnce(
+        response(
+          { token, workspace: "acme", scopes: ["files:read"], label: "h", expiresAt: null },
+          201,
+        ),
+      );
+    captureOutput();
+    expect(
+      await runLogin(
+        ["--path", path, "--workspace", "acme", "--no-check"],
+        { json: true },
+        false,
+        io,
+      ),
+    ).toBe(0);
+    // interval started at 5s and grew by 5s after slow_down.
+    expect(slept).toBe(10000);
   });
 });
 


### PR DESCRIPTION
Phase 4 of the [Better Auth plan](https://github.com/buildinternet/uploads/blob/main/docs/superpowers/plans/2026-07-12-better-auth-introduction.md) — CLI device login. Closes #101.

`uploads login` now signs in through a browser by default (RFC 8628 device flow), mints a workspace token from the resulting session, and saves it — no enrollment code to paste. The `--code` enrollment path is retained.

## What's included

**apps/auth**
- `deviceAuthorization` + `bearer` plugins, with a fail-closed `validateClient` allowlisting only the static `uploads-cli` client id.
- `device_code` table + migration (`20260712230000_device_code.sql`).
- Verified the releases `schema: {}` zod workaround is unnecessary on better-auth 1.6.23 (its `schema` option is already `.optional()`).

**apps/api**
- `POST /v1/tokens` — session/bearer-authenticated mint over the `AUTH` service binding. Request is a `grants` array (forward-compat) with single-grant validation; gated on KV workspace existence + org membership; mints via the existing `createToken`.
- `GET /v1/tokens` — lists the caller's mintable workspaces so the CLI auto-selects when there's exactly one.
- `minting_user_id` column on `auth_tokens` (nullable migration) recorded on each mint.

**apps/web**
- `/device` approval page (session-gated approve/deny), plus device helpers in `auth-client.ts`.

**CLI (`@buildinternet/uploads`)**
- Device flow: `device/code` → open browser → poll `device/token` (honors `authorization_pending` / `slow_down` / `expired_token`) → mint → save. `--non-interactive` with no code fails fast rather than hanging. Changeset included.

## Notes for review
- **Auth-sensitive** — bearer/session verification and token minting. A fable advisory pass and a `/simplify` multi-agent pass were run before this PR; both fed fixes back in (fail-fast non-interactive guard, 503-on-outage instead of a misleading 403, shared `membershipsForUser`, `loadWorkspaceRecord` reuse, parallelized lookups).
- The browser-approval path (claim → approve → token exchange) is covered end-to-end against the fake-D1 harness in `apps/auth/src/device.test.ts`.
- The `/device` page couldn't be screenshotted here — it needs the live auth worker + GitHub OAuth to render past the "checking session" state.
- Expired `device_code` row cleanup is deferred to Phase 5 (per the plan); the plugin already deletes expired/denied codes on access.

## Verification
`pnpm types`, `pnpm check` (oxlint + oxfmt), and all suites green: auth 71, api 205, cli 165, web 17, mcp 22, storage 19, email 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based device authorization for `uploads login`.
  * Automatically mints and saves a workspace token after approval.
  * Added workspace selection with `--workspace` when multiple workspaces are available.
  * Added a browser page for entering, approving, or denying device login requests.
  * Preserved enrollment-code login through `--code` and `--code-stdin`.

* **Bug Fixes**
  * Improved validation and error handling for token creation, workspace access, and device authorization states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->