### PR TITLE
feat(web): persistent auth indicator + CLI-first account copy

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -1,0 +1,69 @@
+---
+// Persistent signed-in indicator for the top nav area of pages that don't
+// already have their own session UI. Signed out -> "sign in" link to
+// /login. Signed in -> the user's email, linking to /account. Reserves a
+// fixed-height slot so the async session check causes no layout shift; the
+// slot shows a muted "…" placeholder until getSession resolves.
+export interface Props {
+  authOrigin: string;
+}
+
+const { authOrigin } = Astro.props;
+---
+
+<span class="auth-indicator">
+  <span id="auth-indicator-slot" class="slot">…</span>
+</span>
+<script define:vars={{ authOrigin }}>
+  // Multiple instances/pages may set this; first one wins, all read the same value.
+  window.__UPLOADS_AUTH_ORIGIN__ = window.__UPLOADS_AUTH_ORIGIN__ || authOrigin;
+</script>
+<script>
+  import { getSession } from "../lib/auth-client";
+
+  const escapeHtml = (value: string) =>
+    value.replace(/[&<>"']/g, (ch) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+    );
+
+  const origin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
+  const slot = document.getElementById("auth-indicator-slot");
+
+  getSession(origin).then((result) => {
+    if (!slot) return;
+    if (!result) {
+      slot.innerHTML = '<a href="/login">sign in</a>';
+      return;
+    }
+    slot.innerHTML = `<a href="/account">${escapeHtml(result.user.email)}</a>`;
+  });
+</script>
+
+<style>
+  .auth-indicator {
+    display: inline-flex;
+    align-items: center;
+    font-size: 12.5px;
+    font-family: "Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    color: var(--muted, #7d7d77);
+    /* Reserves horizontal space so "…" -> "sign in" / email causes no
+       reflow of anything to its right. */
+    min-width: 3.5em;
+    text-align: right;
+    white-space: nowrap;
+  }
+  .auth-indicator .slot {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+  }
+  .auth-indicator :global(a) {
+    color: var(--muted, #7d7d77);
+    text-decoration: none;
+  }
+  .auth-indicator :global(a:hover),
+  .auth-indicator :global(a:focus-visible) {
+    color: var(--accent, #b794ff);
+    outline: none;
+  }
+</style>

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -145,9 +145,11 @@ const FAVICON =
           <section class="card" style="margin-top:16px">
             <h2>Uploading</h2>
             <p>
-              Uploads go through the <code>uploads</code> CLI or the API with a
-              workspace token. The web console is a developer tool, not the main
-              path. The <a href="/docs">docs</a> cover setup.
+              Install the CLI, run <code>uploads login</code>, and it connects to
+              your workspaces. From there <code>uploads attach</code> puts files
+              on GitHub PRs and <code>uploads put</code> gets you a URL for
+              anything else. Workspace tokens are for the API and CI, not the
+              everyday path. The <a href="/docs">docs</a> cover setup.
             </p>
           </section>
         </div>
@@ -182,7 +184,7 @@ const FAVICON =
         <div data-panel-body="developers" hidden>
           <section class="card">
             <h2>Developers</h2>
-            <p>These tools need a workspace token.</p>
+            <p>Most people just need <code>uploads login</code>. These are for API and CI use.</p>
             <ul class="plain">
               {showConsoleLinks ? <li><span><a href="/console">Console</a></span><span class="slug">usage, files, invites — bring a token</span></li> : null}
               <li><span><a href="/docs">API docs</a></span><span class="slug">endpoints &amp; auth</span></li>

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -5,6 +5,7 @@ import {
   CF_RUM_SCRIPT_SRC,
   STYLE_SRC_SELF_AND_INLINE,
 } from "../lib/csp";
+import AuthIndicator from "../components/AuthIndicator.astro";
 
 export const prerender = false;
 
@@ -46,6 +47,7 @@ const FAVICON =
     *{box-sizing:border-box}
     body{margin:0;min-height:100dvh;background:var(--bg);color:var(--fg);font:14px/1.5 var(--mono);padding:32px 20px 48px}
     main{max-width:720px;margin:0 auto;display:grid;gap:16px}
+    .admin-top{display:flex;align-items:center;justify-content:space-between;gap:12px}
     h1{font-size:1.15rem;font-weight:600;margin:0}
     p.muted{color:var(--muted);margin:0;font-size:.9rem}
     .status{border-left:3px solid var(--accent);padding:9px 14px;margin:8px 0;background:var(--panel);border:1px solid var(--line);border-radius:8px}
@@ -77,7 +79,10 @@ const FAVICON =
 </head>
 <body>
 <main>
-  <h1>uploads.sh admin</h1>
+  <div class="admin-top">
+    <h1>uploads.sh admin</h1>
+    <AuthIndicator authOrigin={authOrigin} />
+  </div>
 
   <div id="checking" class="status" role="status">Checking your session…</div>
 

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -4,8 +4,12 @@
 // Purpose-first: getting media onto GitHub PRs, issues, and code reviews.
 import "@fontsource-variable/geist/index.css";
 import "@fontsource-variable/geist-mono/index.css";
+import AuthIndicator from "../components/AuthIndicator.astro";
 
 const REPO = "https://github.com/buildinternet/uploads";
+// Static page (no `prerender = false`) — auth origin is baked at build time,
+// not read from request-time env. See src/lib/auth-client.ts.
+const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
 const FAVICON =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
 ---
@@ -67,6 +71,7 @@ const FAVICON =
         padding: 48px 24px 64px;
       }
       main { width: min(720px, 100%); margin: 0 auto; }
+      .doc-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
       .home {
         color: var(--muted);
         text-decoration: none;
@@ -340,7 +345,10 @@ const FAVICON =
   </head>
   <body>
     <main>
-      <a class="home" href="/">← uploads.sh</a>
+      <div class="doc-top">
+        <a class="home" href="/">← uploads.sh</a>
+        <AuthIndicator authOrigin={authOrigin} />
+      </div>
       <h1>Docs</h1>
       <p class="tagline">
         Put screenshots and other media on GitHub — PRs, issues, code reviews — with one command.

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -3,8 +3,12 @@
 // the GitHub comment it produces, what else it does, and copyable setup rows.
 import "@fontsource-variable/geist/index.css";
 import "@fontsource-variable/geist-mono/index.css";
+import AuthIndicator from "../components/AuthIndicator.astro";
 
 const REPO = "https://github.com/buildinternet/uploads";
+// Static page (no `prerender = false`) — auth origin is baked at build time,
+// not read from request-time env. See src/lib/auth-client.ts.
+const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
 // Stacked up-chevrons, fading as they rise — inline so the page stays a single request.
 const FAVICON =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23121214'/%3E%3Cg fill='none' stroke='%23b794ff' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 12.5 L16 5 L24 12.5'/%3E%3Cpath d='M8 19.5 L16 12 L24 19.5' opacity='.55'/%3E%3Cpath d='M8 26.5 L16 19 L24 26.5' opacity='.28'/%3E%3C/g%3E%3C/svg%3E";
@@ -418,6 +422,7 @@ const FAVICON =
           Star on GitHub
           <span class="count" id="star-count"></span>
         </a>
+        <AuthIndicator authOrigin={authOrigin} />
       </div>
 
       <h1>Agents can put screenshots on pull requests now, too.</h1>


### PR DESCRIPTION
## Summary

Two bundled changes to `apps/web`:

**1. Persistent auth status indicator in the top nav**

Adds a shared `src/components/AuthIndicator.astro` — signed out shows a "sign in" link to `/login`; signed in shows the user's email linking to `/account`. It reserves a fixed slot (starts as a muted "…") so the async session check causes no layout shift.

Pages touched:
- `src/pages/index.astro` — added to the header row next to the "Star on GitHub" CTA. Static page, so the auth origin is baked at build time via `import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN`, matching the pattern used elsewhere.
- `src/pages/docs.astro` — added next to the "← uploads.sh" home link (wrapped in a new flex row, `.doc-top`). Same static-page origin handling.
- `src/pages/admin.astro` — added next to the page `<h1>`. SSR page, so the auth origin comes from `env.UPLOADS_AUTH_ORIGIN` at request time (already computed in this file); its CSP `connect-src` already includes the auth origin.
- `src/pages/console.astro` and `src/pages/account.astro` — left untouched. Both already implement equivalent (or stronger) behavior: console has a `session-bar` with sign-in/sign-out; account gates the whole page on session state and shows the signed-in email. Refactoring them onto the shared component didn't simplify anything given their existing sign-out flows, so they're left as-is per the brief.

No CSP changes were needed on `index.astro`, `docs.astro`, or `console.astro` — none of them set a CSP meta tag.

**2. `/account` copy update — CLI login is now the primary path**

In `src/pages/account.astro`, the "Uploading" card and "Developers" panel now lead with `uploads login` (Phase 4 CLI device login) instead of bring-your-own-bearer-token. Workspace tokens are now framed as the secondary, API/CI path rather than removed.

`src/pages/docs.astro` already documents `uploads login` as the primary CLI auth step (Install & sign in section) — no change needed there.

## Verification

- `pnpm test` (apps/web): 24/24 passing.
- Typecheck on Node 24 (`pnpm run typecheck`): 2 errors remain, both pre-existing in `admin.astro` (an unrelated `HTMLSelectElement` querySelector generic issue) — nothing new from this change.
- Browser-verified all 5 in-scope pages against the local dev server: indicator renders "sign in" in the signed-out state (no real session cookie available in this environment), no console errors, no visible layout shift.

![Top nav auth indicator on the uploads.sh landing page](https://storage.uploads.sh/default/screenshots/buildinternet-uploads/2026-07-13/screenshot-20260712-205723-6b6448.webp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
