### PR TITLE
auth: daily retention sweep for expired verification/device_code rows

### DIFF
--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -4,6 +4,7 @@ import { createAuth, type AuthEnv } from "./auth";
 import { internal } from "./internal-routes";
 import { isInternalRequest } from "./internal";
 import { isTrustedOrigin } from "./trusted-origins";
+import { runAuthRetentionSweep } from "./retention-sweep";
 
 // Credentialed CORS for the web origin (+ dev origins), scoped to /api/auth/*
 // only — this worker has no other public surface (D1: "CORS becomes trivial").
@@ -52,4 +53,19 @@ export const app = new Hono<{ Bindings: AuthEnv }>()
 
 export default {
   fetch: app.fetch.bind(app),
+  // Daily retention sweep (plan Phase 5, uploads#102 item 4): expired
+  // `verification`/`device_code` rows that Better Auth doesn't proactively
+  // clean up. See src/retention-sweep.ts.
+  async scheduled(_controller: ScheduledController, env: AuthEnv, ctx: ExecutionContext) {
+    ctx.waitUntil(
+      runAuthRetentionSweep(env).catch((err) => {
+        console.error(
+          JSON.stringify({
+            message: "auth_retention_sweep_failed",
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }),
+    );
+  },
 };

--- a/apps/auth/src/retention-sweep.test.ts
+++ b/apps/auth/src/retention-sweep.test.ts
@@ -1,0 +1,95 @@
+import { drizzle } from "drizzle-orm/d1";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { runAuthRetentionSweep } from "./retention-sweep";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+let db: FakeD1Database;
+let env: AuthEnv;
+
+beforeEach(() => {
+  db = createFakeD1();
+  env = { DB: db, WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
+});
+
+function seedVerification(id: string, expiresAt: Date) {
+  return drizzle(db, { schema })
+    .insert(schema.verification)
+    .values({
+      id,
+      identifier: `${id}@example.com`,
+      value: "token",
+      expiresAt,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+}
+
+function seedDeviceCode(id: string, expiresAt: Date) {
+  return drizzle(db, { schema })
+    .insert(schema.deviceCode)
+    .values({
+      id,
+      deviceCode: `dc-${id}`,
+      userCode: `uc-${id}`,
+      expiresAt,
+      status: "pending",
+    });
+}
+
+describe("runAuthRetentionSweep", () => {
+  it("deletes expired verification and device_code rows, keeps unexpired ones", async () => {
+    const past = new Date(Date.now() - 60_000);
+    const future = new Date(Date.now() + 60_000);
+
+    await seedVerification("expired-1", past);
+    await seedVerification("expired-2", past);
+    await seedVerification("live-1", future);
+
+    await seedDeviceCode("expired-1", past);
+    await seedDeviceCode("live-1", future);
+
+    const result = await runAuthRetentionSweep(env);
+
+    expect(result).toEqual({ verificationDeleted: 2, deviceCodeDeleted: 1 });
+
+    const dz = drizzle(db, { schema });
+    const remainingVerification = await dz.select().from(schema.verification);
+    const remainingDeviceCode = await dz.select().from(schema.deviceCode);
+
+    expect(remainingVerification.map((r) => r.id)).toEqual(["live-1"]);
+    expect(remainingDeviceCode.map((r) => r.id)).toEqual(["live-1"]);
+  });
+
+  it("is a no-op when nothing is expired", async () => {
+    const future = new Date(Date.now() + 60_000);
+    await seedVerification("live-1", future);
+    await seedDeviceCode("live-1", future);
+
+    const result = await runAuthRetentionSweep(env);
+
+    expect(result).toEqual({ verificationDeleted: 0, deviceCodeDeleted: 0 });
+  });
+
+  it("batches beyond a single page of results", async () => {
+    const past = new Date(Date.now() - 60_000);
+    const dz = drizzle(db, { schema });
+    for (let i = 0; i < 520; i++) {
+      await dz.insert(schema.verification).values({
+        id: `expired-${i}`,
+        identifier: `${i}@example.com`,
+        value: "token",
+        expiresAt: past,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+
+    const result = await runAuthRetentionSweep(env);
+
+    expect(result.verificationDeleted).toBe(520);
+    const remaining = await dz.select().from(schema.verification);
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/apps/auth/src/retention-sweep.ts
+++ b/apps/auth/src/retention-sweep.ts
@@ -1,0 +1,90 @@
+/**
+ * Retention sweep for Better Auth D1 tables that Better Auth itself does not
+ * proactively clean up (plan Phase 5, item 4 of buildinternet/uploads#102):
+ *
+ * - `verification`: magic-link tokens. Better Auth deletes a row when it is
+ *   successfully consumed, but an unused link just expires in place — rows
+ *   accumulate for every magic-link send that's ignored or expires.
+ * - `device_code`: device-authorization (RFC 8628) pending requests. Better
+ *   Auth only deletes a row when a poll notices `expired_token` — an
+ *   abandoned `uploads login` (user never opens the approval page, or opens
+ *   it but never approves) leaves the row behind forever. Growth here is
+ *   unauthenticated (`POST /device/code` needs no auth), bounded only by the
+ *   AUTH_RATE_LIMITER binding.
+ *
+ * Deletes are batched (id-select then delete-by-id, looped) so a table that
+ * has grown large doesn't turn one sweep into a single unbounded statement.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { inArray, lt } from "drizzle-orm";
+import * as schema from "./schema";
+import type { AuthEnv } from "./auth";
+
+const BATCH_SIZE = 500;
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+
+/** Batched delete of expired `verification` rows: select ids, delete by id, repeat. */
+async function purgeExpiredVerification(db: Db, now: Date): Promise<number> {
+  let deleted = 0;
+  for (;;) {
+    const rows = await db
+      .select({ id: schema.verification.id })
+      .from(schema.verification)
+      .where(lt(schema.verification.expiresAt, now))
+      .limit(BATCH_SIZE);
+    if (rows.length === 0) break;
+
+    const ids = rows.map((r) => r.id);
+    await db.delete(schema.verification).where(inArray(schema.verification.id, ids));
+    deleted += ids.length;
+
+    // A batch smaller than the page size means there's nothing left to page
+    // through; avoid one extra round-trip that would just return empty.
+    if (rows.length < BATCH_SIZE) break;
+  }
+  return deleted;
+}
+
+/** Batched delete of expired `device_code` rows: select ids, delete by id, repeat. */
+async function purgeExpiredDeviceCode(db: Db, now: Date): Promise<number> {
+  let deleted = 0;
+  for (;;) {
+    const rows = await db
+      .select({ id: schema.deviceCode.id })
+      .from(schema.deviceCode)
+      .where(lt(schema.deviceCode.expiresAt, now))
+      .limit(BATCH_SIZE);
+    if (rows.length === 0) break;
+
+    const ids = rows.map((r) => r.id);
+    await db.delete(schema.deviceCode).where(inArray(schema.deviceCode.id, ids));
+    deleted += ids.length;
+
+    if (rows.length < BATCH_SIZE) break;
+  }
+  return deleted;
+}
+
+export interface RetentionSweepResult {
+  verificationDeleted: number;
+  deviceCodeDeleted: number;
+}
+
+export async function runAuthRetentionSweep(env: AuthEnv): Promise<RetentionSweepResult> {
+  const db = drizzle(env.DB, { schema });
+  const now = new Date();
+
+  const verificationDeleted = await purgeExpiredVerification(db, now);
+  const deviceCodeDeleted = await purgeExpiredDeviceCode(db, now);
+
+  console.log(
+    JSON.stringify({
+      message: "auth_retention_sweep",
+      verificationDeleted,
+      deviceCodeDeleted,
+    }),
+  );
+
+  return { verificationDeleted, deviceCodeDeleted };
+}

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -29,6 +29,13 @@
     "enabled": true,
     "head_sampling_rate": 1,
   },
+  // Daily retention sweep for expired verification/device_code rows (plan
+  // Phase 5, uploads#102 item 4 — see src/retention-sweep.ts). Offset 15
+  // minutes from apps/api's own daily sweep (0 6 * * *) so the two crons
+  // don't fire in the same minute.
+  "triggers": {
+    "crons": ["15 6 * * *"],
+  },
   // Dedicated D1 database (see docs/superpowers/plans/2026-07-12-better-auth-introduction.md,
   // decision D1) — auth tables never live in uploads-production. Database
   // created 2026-07-12 (region ENAM); migrations in ./migrations.


### PR DESCRIPTION
## Summary

- Adds item 4 of #102 (Better Auth Phase 5): a scheduled retention sweep on the `uploads-auth` worker for expired `verification` and `device_code` D1 rows.
- Better Auth doesn't proactively clean these up: unauthenticated `POST /device/code` lets abandoned device-login flows accumulate (Better Auth only deletes a `device_code` row when it's polled after expiry), and unused magic-link `verification` tokens just expire in place instead of being deleted.
- The sweep lives on `apps/auth` rather than folded into `apps/api`'s existing retention cron, since the auth worker owns the auth D1 binding and `apps/api` has zero knowledge of auth tables by design (plan D1).
- `src/retention-sweep.ts`: batched delete (select up to 500 expired ids, delete by id, repeat) per table, logs counts. Wired into a new `scheduled` handler in `apps/auth/src/index.ts`.
- `apps/auth/wrangler.jsonc`: added a `triggers.crons` entry (`15 6 * * *`), offset 15 minutes from `apps/api`'s existing daily sweep (`0 6 * * *`) so the two crons don't collide.
- Tests in `src/retention-sweep.test.ts` using the repo's fake-D1 harness: deletes expired rows and keeps unexpired ones, no-ops when nothing is expired, and exercises the batching loop past a single page (520 rows).

## Test plan

- [x] `pnpm --filter @uploads/auth exec vitest run` — 9 files / 74 tests pass (including the 3 new tests)
- [x] `pnpm --filter @uploads/auth run types` (`wrangler types`) — cron trigger parses cleanly
- [x] `pnpm --filter @uploads/auth exec oxlint src/retention-sweep.ts src/retention-sweep.test.ts src/index.ts` — clean
- [x] `pnpm --filter @uploads/auth exec tsc --noEmit` — clean
- No changeset: `apps/auth` is `"private": true`, same as `apps/api`.

Refs #102 (item 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)