### PR TITLE
docs(uploads): lead CLI copy with device login, --code as fallback

### DIFF
--- a/.changeset/cli-login-first-copy.md
+++ b/.changeset/cli-login-first-copy.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads setup` and `uploads login --help` now lead with `uploads login` (device authorization) as the recommended way to sign in. Enrollment codes (`--code` / `--code-stdin`) are still supported and are now clearly described as a fallback for pre-existing invites. No behavior changes.

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -21,9 +21,9 @@ import { parseScopes } from "./admin-enrollment.js";
 
 const HELP = `uploads login [options]
 
-Sign in and save workspace credentials. With no code, opens a browser to
-authorize this device (recommended). Pass an enrollment code to use the
-one-time code path instead.
+Sign in and save workspace credentials. With no flags, opens a browser to
+authorize this device — the recommended way to sign in. Pass an enrollment
+code only if you were given one from before device login (fallback path).
 
 Options:
   --workspace <name>  Workspace to mint a token for (device flow; required if
@@ -32,8 +32,9 @@ Options:
   --label <text>      Token label (default: this machine's hostname)
   --auth-url <url>    Auth base (default: https://auth.uploads.sh)
   --no-open           Don't try to open a browser automatically
-  --code <code>       Enrollment code in argv (visible in shell history)
-  --code-stdin        Read an enrollment code from stdin
+  --code <code>       Fallback: use a pre-existing enrollment code instead of
+                      device login (visible in shell history)
+  --code-stdin        Fallback: read a pre-existing enrollment code from stdin
   --non-interactive   Never prompt
   --api-url <url>     API base (default: https://api.uploads.sh)
   --path <file>       Config destination
@@ -43,7 +44,7 @@ Options:
 Examples:
   uploads login
   uploads login --workspace acme
-  uploads login --code upe_… --force
+  uploads login --code upe_… --force              # fallback: pre-existing invite
   printf '%s' upe_… | uploads login --code-stdin --non-interactive
 `;
 

--- a/packages/uploads/src/commands/setup.ts
+++ b/packages/uploads/src/commands/setup.ts
@@ -87,8 +87,10 @@ function formatWizard(status: SetupStatus): string {
 
   if (!status.token) {
     lines.push("Step 1 — Sign in");
-    lines.push("  Ask your uploads.sh administrator for a one-time enrollment code, then run:");
+    lines.push("  Run:");
     lines.push("    uploads login");
+    lines.push("  This opens a browser to authorize this device.");
+    lines.push("  Have a pre-existing enrollment code instead? uploads login --code upe_…");
     lines.push("  If you already have a bearer token:");
     lines.push("    uploads setup --token up_<workspace>_…");
     lines.push("");
@@ -253,7 +255,9 @@ export async function runSetup(
   } else if (token || checkExplicit) {
     process.stderr.write("hint: run uploads doctor to verify\n");
   } else {
-    process.stderr.write("hint: run uploads login with an admin-provided enrollment code\n");
+    process.stderr.write(
+      "hint: run uploads login (or uploads login --code <code> if you have one)\n",
+    );
   }
 
   return doctorOk === false ? 1 : 0;


### PR DESCRIPTION
## Summary
- `uploads setup`'s Step 1 copy now leads with `uploads login` (device authorization) instead of pointing users to an admin-provided enrollment code first; the enrollment-code path (`uploads login --code ...`) is now framed as a fallback for people who already have a pre-existing invite code.
- `uploads login --help` intro and `--code`/`--code-stdin` flag descriptions now explicitly call out the enrollment-code path as a fallback, and the example line is annotated accordingly.
- Copy/help-text only — no flags, commands, or behavior changed.

Part of #102 (item 2, first step of enrollment deprecation).

## Test plan
- [x] `pnpm test` in `packages/uploads` — 165 tests passed, no assertions on this copy needed updating
- [x] `pnpm oxlint` on the two changed files — no new warnings
- [x] `pnpm format:check` on the two changed files — clean (pre-commit hook also ran oxfmt/oxlint on staged files)
- [x] Added a changeset (`patch`) for `@buildinternet/uploads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)