### PR TITLE
docs: rewrite user-facing auth docs for uploads login + org invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lightweight file-hosting backend on Cloudflare Workers, built on
 
 ## Agent quick start
 
-Install the CLI, enroll once, then attach media from a checked-out PR branch:
+Install the CLI, sign in once, then attach media from a checked-out PR branch:
 
 ```bash
 npm install --global @buildinternet/uploads
@@ -30,11 +30,11 @@ files, and creates or updates one managed attachments comment. Use
 `--pr <number>` or `--issue <number>` when inference is not possible, and
 `--no-comment` when only the public URLs and Markdown are wanted.
 
-An uploads.sh administrator creates a short-lived, single-use enrollment code;
-`uploads login` exchanges it and saves the resulting workspace token. Routine
-agents never receive or need `ADMIN_TOKEN`. See [enrollment](docs/enrollment.md).
-Hosted files are public, including media attached to private repositories. Do
-not upload secrets or sensitive UI.
+An uploads.sh administrator invites your email to a workspace; `uploads login`
+opens a browser to sign in (GitHub or a magic link) and saves the resulting
+workspace token. Routine agents never receive or need `ADMIN_TOKEN`. See
+[enrollment](docs/enrollment.md). Hosted files are public, including media
+attached to private repositories. Do not upload secrets or sensitive UI.
 
 For agent runtimes, install the checked-in skill as well:
 

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -1,7 +1,7 @@
 # auth.md
 
-Agent authentication for **uploads.sh** — invitation enrollment and workspace
-bearer tokens (not browser OAuth / OIDC).
+Agent authentication for **uploads.sh** — device sign-in and workspace bearer
+tokens.
 
 ## Audience
 
@@ -10,23 +10,36 @@ flow via `uploads login`. Routine agents never receive `ADMIN_TOKEN`.
 
 ## How agents get credentials
 
-1. An uploads.sh administrator creates a short-lived, single-use invitation for
-   an existing workspace (`uploads admin invite create`, optional `--email`).
-2. Open the magic link (or receive the code out of band with `--separate-code`).
-3. Exchange the code once:
+1. Someone with workspace access (see "Getting workspace access" below) runs:
 
 ```bash
 npm install --global @buildinternet/uploads
 uploads login
-# non-interactive:
-UPLOADS_ENROLLMENT_CODE=upe_… uploads login
 ```
 
-4. On success the CLI writes `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
-   `UPLOADS_TOKEN` to the shared buildinternet config and runs `uploads doctor`.
-   The raw token is not printed.
+2. `uploads login` opens a browser device-authorization flow (GitHub or
+   magic-link sign-in) and prints the URL/code too, for headless machines
+   where the auto-opened browser isn't the one you'll approve in. Approve the
+   sign-in, and the CLI mints and saves a workspace token.
+3. If the account can access more than one workspace, pass
+   `--workspace <name>`.
+
+```bash
+uploads login --workspace acme
+```
+
+On success the CLI writes `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
+`UPLOADS_TOKEN` to the shared buildinternet config and runs `uploads doctor`.
+The raw token is not printed.
 
 Details: [enrollment docs](https://github.com/buildinternet/uploads/blob/main/docs/enrollment.md).
+
+## Getting workspace access
+
+An uploads.sh administrator invites your email address to the workspace's
+organization from the session-authenticated `/admin` UI. Accept the
+invitation (GitHub or magic-link sign-in), then run `uploads login` as above.
+There is no self-serve signup.
 
 ## Using the credential
 
@@ -36,11 +49,11 @@ Send the workspace token on every protected request:
 Authorization: Bearer up_<workspace>_…
 ```
 
-| Scope          | Default on enrollment | Use                               |
-| -------------- | --------------------- | --------------------------------- |
-| `files:read`   | yes                   | list, metadata, usage             |
-| `files:write`  | yes                   | upload, reconcile                 |
-| `files:delete` | no                    | delete / purge (admin must grant) |
+| Scope          | Default on login | Use                               |
+| -------------- | ---------------- | --------------------------------- |
+| `files:read`   | yes              | list, metadata, usage             |
+| `files:write`  | yes              | upload, reconcile                 |
+| `files:delete` | no               | delete / purge (admin must grant) |
 
 Tokens default to a 90-day lifetime. Hosted MCP at
 `https://agents.uploads.sh/mcp` uses the same bearer scheme (workspace is
@@ -62,12 +75,15 @@ inferred from the `up_<workspace>_…` token form).
 
 ## What we deliberately do not publish
 
-There is **no** public OAuth/OIDC authorization server for uploads.sh today.
-`/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server`
-are intentionally absent — agents authenticate with invitation-issued bearer
-tokens as above. Do not invent OAuth client registration against this origin.
+There is **no** public OAuth authorization server for third-party clients
+today. `uploads login`'s device flow talks to our own dedicated auth worker
+with a fixed CLI client id — it is not a general-purpose OAuth client
+registration surface. `/.well-known/openid-configuration` and
+`/.well-known/oauth-authorization-server` are intentionally absent. Do not
+invent OAuth client registration against this origin.
 
 ## Operator note
 
-`ADMIN_TOKEN` is for workspace and invitation administration only. Never place it
-in agent configs, prompts, or shared issue comments.
+`ADMIN_TOKEN` is a break-glass ops/CI credential, not the routine way to
+invite people or mint tokens — see [admin-tokens](https://github.com/buildinternet/uploads/blob/main/docs/admin-tokens.md).
+Never place it in agent configs, prompts, or shared issue comments.

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -412,10 +412,10 @@ MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp
           <button type="button" data-copy="uploads login">copy</button>
         </div>
         <p>
-          <code>uploads login</code> asks for an enrollment code. Access is by invitation — an
-          uploads.sh administrator sends you a short-lived, single-use code (usually as a link).
-          The CLI trades it for a workspace token and saves it, so you only do this once per
-          machine.
+          <code>uploads login</code> opens a browser so you can approve the sign-in (GitHub or a
+          magic link). Access is by invitation — an uploads.sh administrator invites your email to
+          a workspace first. Once approved, the CLI mints a workspace token and saves it, so you
+          only do this once per machine.
         </p>
         <p>Prefer not to install anything? Every command works as a one-off with <code>npx</code>:</p>
         <div class="cmd">

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -1,9 +1,13 @@
 # Admin tokens
 
-`ADMIN_TOKEN` is a server-administration credential. Routine agents must never
-receive it. The normal onboarding path is for an administrator to create a
-short-lived enrollment code and for the agent to exchange it with `uploads login`.
-The workspace must already exist (`pnpm workspace:add …`).
+`ADMIN_TOKEN` is a break-glass ops/CI credential — it is **not** how someone
+gets onto a workspace day-to-day. The normal path is a session-authenticated
+organization invitation sent from the `/admin` UI, followed by the invitee
+running `uploads login` themselves (see [enrollment](enrollment.md)).
+`ADMIN_TOKEN` stays reserved for things the session-authed admin UI doesn't
+cover: minting or revoking tokens on behalf of a workspace, the second-admin
+promote fallback, credential re-encryption, org backfills, and CI smoke
+tests. The workspace must already exist (`pnpm workspace:add …`).
 
 ## Setup
 
@@ -21,8 +25,9 @@ value in routine-agent configuration.
 
 ## Mint a token
 
-Direct minting is retained for CI, migration, and break-glass use. Interactive and
-routine agent setup should use [enrollment](enrollment.md) instead.
+Direct minting is retained for CI, migration, and break-glass use. Everyday
+setup should use `uploads login` instead (see [enrollment](enrollment.md)) —
+end users mint their own token that way, with no `ADMIN_TOKEN` involved.
 
 Defaults to the `default` workspace:
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,13 +13,13 @@ subdomain.
 
 1. Create the registry: `wrangler kv namespace create REGISTRY`, paste the id
    into `apps/api/wrangler.jsonc`.
-2. Create the enrollment database and add the emitted binding to
-   `apps/api/wrangler.jsonc` as `DB`:
+2. Create the API's D1 database (tokens, usage ledger, legacy enrollment
+   state) and add the emitted binding to `apps/api/wrangler.jsonc` as `DB`:
    ```bash
    cd apps/api
    pnpm exec wrangler d1 create uploads-production
    ```
-3. Apply enrollment migrations locally during development:
+3. Apply migrations locally during development:
    ```bash
    pnpm --filter @uploads/api run migrate:d1:local
    # equivalent: CI=1 wrangler d1 migrations apply DB --local  (from apps/api)
@@ -44,11 +44,21 @@ subdomain.
    database `uploads-production`) so schema lands before new code. Manual-only:
    `pnpm --filter @uploads/api run migrate:d1`.
 
-D1 owns short-lived enrollment state, redemption, scoped/expiring tokens, and
-the workspace usage ledger. KV remains the source of truth for workspace
-storage configuration and legacy tokens. Never deploy a Worker that reads a
-new D1 schema before the corresponding remote migration succeeds. Check in
-every migration under `apps/api/migrations/`.
+D1 owns short-lived legacy enrollment state, redemption, scoped/expiring
+tokens, and the workspace usage ledger. KV remains the source of truth for
+workspace storage configuration and legacy tokens. Never deploy a Worker that
+reads a new D1 schema before the corresponding remote migration succeeds.
+Check in every migration under `apps/api/migrations/`.
+
+### The `apps/auth` worker
+
+Sign-in (`uploads login`, `/admin`, `/accept-invitation`) is served by a
+separate Better Auth worker, `apps/auth`, deploying to `auth.uploads.sh` with
+its own D1 database (`uploads-auth`) and migrations under
+`apps/auth/migrations/`. It needs a GitHub OAuth app, a signing secret, and
+(for `apps/api` to verify sessions) a `services` binding named `AUTH` from
+`apps/api` → the `uploads-auth` worker. See `apps/auth/README.md` for setup,
+including the first-admin bootstrap.
 
 ### CI: migrations on merge
 

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -1,17 +1,11 @@
-# Invitations and `uploads login`
+# Signing in with `uploads login`
 
-Early adopters authenticate through short-lived invitations. They never receive
-the API's `ADMIN_TOKEN`. An administrator authorizes an existing workspace and shares
-a single-use **magic link**; the adopter opens it and runs the one-click `uploads
-login` command it shows to exchange the code for a scoped, expiring workspace token.
+`uploads login` is how people and agents get workspace credentials. Run with
+no flags it opens a browser for a device sign-in (GitHub or a magic link); on
+approval the CLI mints a scoped, expiring workspace token and saves it
+locally. Nobody needs the API's `ADMIN_TOKEN` to sign in.
 
-The one-time code travels in the link's URL fragment (`…/invite?id=…#code=…`), which
-browsers never send to a server—so opening the page neither logs nor consumes the
-code; only the CLI's exchange call redeems it. Treat the link like a password. For
-security-sensitive deployments that prefer two channels, `uploads admin invite create
---separate-code` prints a non-secret page URL plus a code you deliver separately.
-
-## Agent login
+## Everyday login (device flow)
 
 Install once for repeated use:
 
@@ -27,46 +21,71 @@ Or run it once without a global install:
 npx @buildinternet/uploads login
 ```
 
-Interactive login prompts without echoing the enrollment code. For automation, use an
-ephemeral environment value rather than putting the code in shell history or the
-process list:
+With no code, `uploads login` prints a URL and a short code, opens the URL in
+a browser automatically (unless `--no-open`), and waits while you approve the
+sign-in there. Once approved, the CLI mints a token and saves it.
+
+Pass `--workspace <name>` if your account can access more than one workspace:
 
 ```bash
-UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login
+uploads login --workspace acme
 ```
 
 On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
-`UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never prints
-the raw workspace token. Use `--force` only when intentionally replacing an existing
-configured token.
+`UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never
+prints the raw workspace token. Use `--force` only when intentionally
+replacing an existing configured token. See `uploads login --help` for the
+full flag list (`--label`, `--scopes`, `--auth-url`, `--no-open`,
+`--non-interactive`, and more).
 
-## Administrator overview
+## How you get access to a workspace
 
-Administrators issue invitations for existing workspaces. Invitation codes are
-single-use and default to a 2-hour expiry (override with `--expires-in`, up to 24
-hours); issued tokens default to read/write scope without delete access. See the [operator runbook](ops.md#invitations) for
-commands, secret handling, delivery, and troubleshooting.
+Workspace access comes from an **organization invitation**, not a code you
+redeem. An administrator invites your email address to the workspace's
+organization from the session-authenticated admin UI at `/admin`. Accepting
+the invitation (GitHub or magic-link sign-in) makes you a member — from
+there, `uploads login` mints a token for that workspace. See the
+[operator runbook](ops.md#invitations) for how administrators send invites.
+
+## Legacy: enrollment codes (`--code`)
+
+Before device login existed, administrators minted single-use **enrollment
+codes** (`upe_…`) via `ADMIN_TOKEN`-authenticated `POST /admin/enrollments`,
+and `uploads login --code` exchanged one for a token directly, with no
+organization membership involved. **This path is deprecated** and kept only
+so enrollment invites already sent out keep working — it is not the way to
+invite new people. Use org invitations above for that.
+
+```bash
+uploads login --code upe_…
+# or, to avoid the code in shell history:
+UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login --code-stdin
+```
+
+Interactive `--code` prompts without echoing the code. For automation, use an
+ephemeral environment value rather than putting the code in shell history or
+the process list.
 
 ## Token policy
 
-Enrollment-issued tokens default to:
+Login-issued tokens default to:
 
 - 90-day lifetime;
 - `files:read` for list and metadata operations;
 - `files:write` for uploads;
 - no `files:delete` unless explicitly authorized.
 
-The API stores token hashes, scopes, labels, creation time, and expiry—not raw tokens.
-Revocation continues to use the admin token-list and revoke endpoints. Existing tokens
-without scopes or expiry remain valid with their legacy access until deliberately
-rotated or revoked.
+The API stores token hashes, scopes, labels, creation time, and expiry — not
+raw tokens. Revocation uses the admin token-list and revoke endpoints (see
+[admin-tokens](admin-tokens.md)). Existing tokens without scopes or expiry
+remain valid with their legacy access until deliberately rotated or revoked.
 
 ## D1 state and deployment
 
-D1 stores enrollment requests and every new scoped/expiring token, and guarantees
-atomic single-use redemption. `REGISTRY` KV retains workspace storage configuration
-and legacy tokens. Create and migrate the database before deploying enrollment-aware
-API code:
+D1 stores every scoped/expiring token and, for the legacy enrollment path,
+enrollment requests with atomic single-use redemption. `REGISTRY` KV retains
+workspace storage configuration and legacy tokens. Create and migrate the
+database before deploying auth-aware API code:
 
 ```bash
 cd apps/api
@@ -80,15 +99,13 @@ Bind the database as `DB` in `apps/api/wrangler.jsonc`. Commit migrations under
 `apps/api/migrations/`; remote apply runs via `deploy:api`, the **D1 Migrations**
 GitHub Action on merge to main, or `migrate:d1` manually. See [deploy](deploy.md).
 
-## Migration and future auth
+The dedicated `apps/auth` worker and its own `uploads-auth` D1 database carry
+Better Auth's session/organization/device-code tables that back
+`uploads login` and the `/admin` UI — see `apps/auth/README.md`.
 
-Enrollment is additive: existing direct-minted and workspace-bootstrap tokens continue
-to authenticate. New installations should use `uploads login`; direct token minting is
-reserved for CI and break-glass administration. Rotate legacy routine-agent tokens to
-scoped enrollment tokens gradually, then revoke the old hashes.
+## Migration notes
 
-Better Auth with D1 and its API Key and Device Authorization plugins remains a later
-migration path when uploads.sh has human accounts, organization membership, and an
-authenticated browser approval UI. The current D1 schema and explicit workspace/token
-boundary keep that migration possible without coupling storage configuration to an
-identity framework today.
+`uploads login`'s device flow (Better Auth's device-authorization grant) is
+the default onboarding path today. Direct token minting (`/admin/tokens`) is
+reserved for CI and break-glass administration. Rotate legacy routine-agent
+tokens to login-issued tokens gradually, then revoke the old hashes.

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -47,14 +47,16 @@ the invitation (GitHub or magic-link sign-in) makes you a member — from
 there, `uploads login` mints a token for that workspace. See the
 [operator runbook](ops.md#invitations) for how administrators send invites.
 
-## Legacy: enrollment codes (`--code`)
+## Alternative: enrollment codes / invite links (`--code`)
 
-Before device login existed, administrators minted single-use **enrollment
-codes** (`upe_…`) via `ADMIN_TOKEN`-authenticated `POST /admin/enrollments`,
-and `uploads login --code` exchanged one for a token directly, with no
-organization membership involved. **This path is deprecated** and kept only
-so enrollment invites already sent out keep working — it is not the way to
-invite new people. Use org invitations above for that.
+Administrators can also mint single-use **enrollment codes** (`upe_…`) via
+`ADMIN_TOKEN`-authenticated `POST /admin/enrollments`, and `uploads login
+--code` exchanges one for a token directly, with no organization membership
+involved. This is a secondary path, useful when you want to share a
+code or link without knowing the recipient's email address in advance
+(e.g. a link posted to a channel, or handed off out-of-band). Org
+invitations above remain the primary, recommended way to onboard someone
+whose email you know.
 
 ```bash
 uploads login --code upe_…

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -41,9 +41,26 @@ The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every wo
 
 ## Invitations
 
-Invitation creation is an operator-only action behind `ADMIN_TOKEN`. Keep that secret
-in the operator environment; never place it in agent configuration, prompts, issues,
-or commands shared with adopters. Create an invitation for an existing workspace with:
+Invite people through the session-authenticated **admin UI at `/admin`**, signed in
+as a global admin (`user.role === "admin"` in the Better Auth `user` table — see
+`apps/auth/README.md#first-admin`). Pick the workspace, enter an email, and the
+UI calls `POST /admin-ui/workspaces/:name/invites`, which invites that address to
+the organization backing the workspace. The invitee accepts (GitHub or magic-link
+sign-in), becomes an org member, and can then run `uploads login` to mint their
+own workspace token. This is the normal way to bring someone onto a workspace —
+no `ADMIN_TOKEN` involved, and nothing to hand-deliver.
+
+A workspace needs an organization behind it before it can be invited into — see
+the org backfill note in `docs/superpowers/plans/2026-07-12-better-auth-introduction.md`
+(Phase 3) if a workspace predates Better Auth and has no org yet.
+
+### Legacy: `ADMIN_TOKEN` enrollment invites (deprecated)
+
+Before organization invitations existed, operators minted single-use enrollment
+codes behind `ADMIN_TOKEN`. **This path is deprecated and slated for removal** —
+do not use it for new invites. It is documented here only because
+`uploads login --code` still honors codes issued this way, and the `/console`
+scaffold (behind the console-mode flag) still uses it internally.
 
 ```bash
 ADMIN_TOKEN=<admin-credential> uploads admin invite create \
@@ -114,11 +131,11 @@ SQLite WAL/SHM files under `.wrangler/state` are what miniflare locks.
 
 ## Secrets
 
-| Secret                           | Purpose                                                               |
-| -------------------------------- | --------------------------------------------------------------------- |
-| `ADMIN_TOKEN`                    | `/admin/*`                                                            |
-| `WORKSPACE_SECRETS_KEY`          | **Current** KEK for BYO credentials in KV (`enc:v1:…`)                |
-| `WORKSPACE_SECRETS_KEY_PREVIOUS` | **Previous** KEK during rotation only (decrypt fallback, then remove) |
+| Secret                           | Purpose                                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ADMIN_TOKEN`                    | `/admin/*` — break-glass ops/CI use, not routine admin work (see [admin-tokens](admin-tokens.md)) |
+| `WORKSPACE_SECRETS_KEY`          | **Current** KEK for BYO credentials in KV (`enc:v1:…`)                                            |
+| `WORKSPACE_SECRETS_KEY_PREVIOUS` | **Previous** KEK during rotation only (decrypt fallback, then remove)                             |
 
 ```bash
 # Generate

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -54,13 +54,14 @@ A workspace needs an organization behind it before it can be invited into — se
 the org backfill note in `docs/superpowers/plans/2026-07-12-better-auth-introduction.md`
 (Phase 3) if a workspace predates Better Auth and has no org yet.
 
-### Legacy: `ADMIN_TOKEN` enrollment invites (deprecated)
+### Alternative: `ADMIN_TOKEN` enrollment invites (invite links/codes)
 
-Before organization invitations existed, operators minted single-use enrollment
-codes behind `ADMIN_TOKEN`. **This path is deprecated and slated for removal** —
-do not use it for new invites. It is documented here only because
-`uploads login --code` still honors codes issued this way, and the `/console`
-scaffold (behind the console-mode flag) still uses it internally.
+Operators can also mint single-use enrollment codes behind `ADMIN_TOKEN`. This
+is a secondary path retained for cases where you want to share a code or link
+without needing the recipient's email address in advance — org invitations
+above remain the primary, recommended way to onboard someone whose email you
+know. `uploads login --code` honors codes issued this way, and the `/console`
+scaffold (behind the console-mode flag) uses it internally.
 
 ```bash
 ADMIN_TOKEN=<admin-credential> uploads admin invite create \

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,14 +21,16 @@
   script with one authenticated PUT.
 - **Enrollment “token used” notify** — org-membership accepts already email
   the inviter (`member-joined` via Better Auth `afterAcceptInvitation`). The
-  legacy, deprecated CLI enrollment path (`/admin/enrollments` → `/invite#code`)
+  secondary CLI enrollment path (`/admin/enrollments` → `/invite#code`)
   has no durable inviter identity (admin bearer only); low priority now that
   org invitations are the primary onboarding path.
-- **Remove the legacy `ADMIN_TOKEN` enrollment path** — `POST
-/admin/enrollments`, `uploads admin invite create`, and `uploads login
---code` are deprecated in favor of session-authed org invitations from
-  `/admin`. Remove once no known consumers still rely on outstanding
-  enrollment codes.
+- **Session-authed invite-link generator** — consider adding a way to mint
+  `ADMIN_TOKEN`-free enrollment codes/links from the session-authed `/admin`
+  UI, so link-style invites (share a code/URL without knowing the recipient's
+  email) don't require holding `ADMIN_TOKEN`. `POST /admin/enrollments`,
+  `uploads admin invite create`, and `uploads login --code` stay as the
+  underlying mechanism; org invitations from `/admin` remain the primary,
+  recommended onboarding path.
 - **Private-repo embed privacy** — today every hosted file is on a public CDN;
   `--pr`/`--issue` keys are predictable (`gh/<owner>/<repo>/pull/<n>/<name>`),
   so attachments on private repos are not secret from anyone who can guess the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,10 +21,14 @@
   script with one authenticated PUT.
 - **Enrollment “token used” notify** — org-membership accepts already email
   the inviter (`member-joined` via Better Auth `afterAcceptInvitation`). The
-  CLI enrollment path (`/admin/enrollments` → `/invite#code`) has no durable
-  inviter identity (admin bearer only); if we want “someone redeemed your
-  enrollment link,” store inviter email/label on the enrollment row and send
-  from the API after exchange.
+  legacy, deprecated CLI enrollment path (`/admin/enrollments` → `/invite#code`)
+  has no durable inviter identity (admin bearer only); low priority now that
+  org invitations are the primary onboarding path.
+- **Remove the legacy `ADMIN_TOKEN` enrollment path** — `POST
+/admin/enrollments`, `uploads admin invite create`, and `uploads login
+--code` are deprecated in favor of session-authed org invitations from
+  `/admin`. Remove once no known consumers still rely on outstanding
+  enrollment codes.
 - **Private-repo embed privacy** — today every hosted file is on a public CDN;
   `--pr`/`--issue` keys are predictable (`gh/<owner>/<repo>/pull/<n>/<name>`),
   so attachments on private repos are not secret from anyone who can guess the

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -88,12 +88,12 @@ the store (R2 upload time).
 (recycle bin, not TTL). Bucket lifecycle via `files.raw` is bucket-wide and
 doesn’t express per-workspace `retentionDays` on a shared bucket.
 
-New enrollment-issued tokens are stored in D1 and carry an expiry and explicit scopes.
-Workspace configuration and legacy tokens remain in `REGISTRY` KV. The routine-agent
-default is `files:read` plus `files:write`, which is sufficient for upload, listing,
-metadata, and managed attachment comments. Deletion requires `files:delete`. Existing
-tokens without scope or expiry metadata retain their legacy full-access behavior so
-deployment does not invalidate installed clients.
+New `uploads login`-issued tokens are stored in D1 and carry an expiry and explicit
+scopes. Workspace configuration and legacy tokens remain in `REGISTRY` KV. The
+routine-agent default is `files:read` plus `files:write`, which is sufficient for
+upload, listing, metadata, and managed attachment comments. Deletion requires
+`files:delete`. Existing tokens without scope or expiry metadata retain their legacy
+full-access behavior so deployment does not invalidate installed clients.
 
 ## Default model
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -92,9 +92,9 @@ non-interactive agent — just reads the saved token. Routine agents never need
 
 For headless machines with no browser at all, an operator can mint a token directly
 (`/admin/tokens`, `ADMIN_TOKEN`-gated — see `docs/admin-tokens.md`) and hand it to the
-agent as `UPLOADS_TOKEN`, or a pre-existing legacy enrollment code (deprecated, `upe_…`)
-can still be exchanged with `uploads login --code`. Neither is the normal path for new
-setups.
+agent as `UPLOADS_TOKEN`, or an enrollment code (`upe_…`, an alternative invite-link/code path — useful
+when you don't have the recipient's email) can be exchanged with `uploads login --code`.
+Neither is the normal path for new setups.
 
 The resulting token defaults to 90 days and `files:read` plus `files:write`; it cannot
 delete files unless an administrator explicitly grants `files:delete`. Verify or inspect

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -77,24 +77,28 @@ Resolution is **per key, first match wins**: CLI flags (`--api-url`, `--token`,
 `$BUILDINTERNET_CONFIG` → the shared config file. For a one-off against a different
 API or workspace, just export the var or pass `--env-file`.
 
-The fastest path is enrollment. Ask an uploads.sh administrator for a short-lived
-enrollment code, then run:
+The fastest path is `uploads login`. Have an uploads.sh administrator invite your
+email to a workspace first, then run it once, interactively, to sign in:
 
 ```bash
-uploads login          # prompts without echoing the code, saves config, runs doctor
+uploads login          # opens a browser to approve sign-in, saves config, runs doctor
+uploads login --workspace acme   # only needed if your account can access more than one
 ```
 
-For a non-interactive agent, pass the short-lived code through the environment rather
-than a process-list-visible command argument:
+That's a one-time, human-in-the-loop step (device sign-in needs a browser); once the
+config file is written, every later `uploads` invocation — including from a
+non-interactive agent — just reads the saved token. Routine agents never need
+`ADMIN_TOKEN`.
 
-```bash
-UPLOADS_ENROLLMENT_CODE=upe_<workspace>_… uploads login
-```
+For headless machines with no browser at all, an operator can mint a token directly
+(`/admin/tokens`, `ADMIN_TOKEN`-gated — see `docs/admin-tokens.md`) and hand it to the
+agent as `UPLOADS_TOKEN`, or a pre-existing legacy enrollment code (deprecated, `upe_…`)
+can still be exchanged with `uploads login --code`. Neither is the normal path for new
+setups.
 
-Routine agents never need `ADMIN_TOKEN`. Enrollment codes expire after 2 hours by
-default (up to 24 hours) and can be redeemed once. The resulting token defaults to 90 days and `files:read` plus
-`files:write`; it cannot delete files unless an administrator explicitly grants
-`files:delete`. Verify or inspect setup at any time:
+The resulting token defaults to 90 days and `files:read` plus `files:write`; it cannot
+delete files unless an administrator explicitly grants `files:delete`. Verify or inspect
+setup at any time:
 
 ```bash
 uploads setup                                  # shows effective configuration


### PR DESCRIPTION
## Summary

Rewrites the user-facing docs for how sign-in and workspace access work now
that Better Auth is live. `uploads login` (browser device flow) is the
documented default, `--workspace <name>` is called out for multi-workspace
accounts, and admin onboarding is described as session-authed org
invitations through the `/admin` UI rather than `ADMIN_TOKEN`-minted
enrollment codes.

Item 1 of #102 (Better Auth Phase 5).

## What it does / what it is not

- `docs/enrollment.md`: reframed around `uploads login`'s device flow, with
  `--code` documented as an alternative invite-link/code path — useful when
  you don't have the recipient's email — rather than a deprecated fallback.
  Org invitations remain the primary, recommended flow.
- `docs/admin-tokens.md`: `ADMIN_TOKEN` reframed as a break-glass ops/CI
  credential (token mint/list/revoke, second-admin promote, credential
  reencrypt, org backfill, CI smoke tests) — not the routine admin path.
- `docs/ops.md`: Invitations section now leads with the `/admin` UI →
  `POST /admin-ui/workspaces/:name/invites` flow; the `ADMIN_TOKEN`
  enrollment-invite flow is kept underneath as an alternative for
  invite-link/code use cases, not marked for removal.
- `docs/deploy.md`, `docs/roadmap.md`, `docs/workspaces.md`: touch-ups —
  drop "enrollment database" phrasing where it's really the general API D1
  database, add a short `apps/auth` worker deploy note, add a roadmap item
  to consider a session-authed invite-link generator in the admin UI so
  link invites don't require `ADMIN_TOKEN`.
- `apps/web/public/auth.md`: rewritten for agents — device sign-in first,
  workspace access via org invitation, `ADMIN_TOKEN` as an operator note.
- `apps/web/src/pages/docs.astro`, `README.md`, `skills/uploads-cli/SKILL.md`:
  copy updates so the "install & sign in" quick-starts match the device flow.
- Did **not** touch the `/console` scaffold or its docs — it's intentionally
  deferred behind the console-mode flag and still uses `ADMIN_TOKEN`
  enrollment invites internally; the ops.md alternative-path section notes
  that.
- Docs-only change, no code edits, no changeset (no `@buildinternet/uploads`
  package files touched).

## Test plan

- [x] `pnpm oxfmt --check` / `pnpm lint:fix` (via pre-commit `lint-staged`) on
      all touched files
- [x] Grepped for remaining stale "enrollment code" / "enrollment-issued"
      wording outside the intentional legacy sections
- [ ] No functional/runtime changes — nothing else to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
