### PR TITLE
feat: session-authed invite links for workspace admins

### DIFF
--- a/apps/api/src/invite-links.ts
+++ b/apps/api/src/invite-links.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared invite-link URL helpers used by both the ADMIN_TOKEN-gated
+ * POST /admin/enrollments path (routes/admin.ts) and the session-authed
+ * POST /admin-ui/workspaces/:name/invite-links path (routes/admin-ui.ts).
+ * Keeping this logic in one place avoids the two routes drifting apart.
+ */
+
+// The invite page lives on the web origin, which mirrors the API host without
+// the `api.` prefix (api.uploads.sh -> uploads.sh), matching the CLI default.
+export function deriveWebOrigin(requestUrl: string): string {
+  const url = new URL(requestUrl);
+  url.hostname = url.hostname.replace(/^api\./, "");
+  return url.origin;
+}
+
+// Self-contained magic link: the single-use code rides in the URL fragment, which
+// browsers never send to a server, so it stays out of logs and referrers.
+export function inviteLinkUrl(webOrigin: string, pageId: string, code: string): string {
+  return `${webOrigin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
+}

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -297,6 +297,54 @@ describe("POST /admin-ui/workspaces/:name/invite-links", () => {
     expect(res.status).toBe(404);
   });
 
+  it("400s for an empty label", async () => {
+    const env = envWithDb(ADMIN_USER, ["acme"]);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ label: "" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("invalid_label");
+  });
+
+  it("400s for a label over 100 characters", async () => {
+    const env = envWithDb(ADMIN_USER, ["acme"]);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ label: "x".repeat(101) }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("invalid_label");
+  });
+
+  it("400s for invalid scopes", async () => {
+    const env = envWithDb(ADMIN_USER, ["acme"]);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scopes: ["not:a:real:scope"] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("invalid_scopes");
+  });
+
   it("429s when the per-workspace write budget is exhausted", async () => {
     const env = envWithDb(ADMIN_USER, ["acme"]) as Env & {
       WRITE_LIMITER: { limit: (opts: { key: string }) => Promise<{ success: boolean }> };

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -187,6 +187,130 @@ describe("POST /admin-ui/workspaces/:name/invites", () => {
   });
 });
 
+describe("POST /admin-ui/workspaces/:name/invite-links", () => {
+  type Row = Record<string, unknown>;
+
+  class FakeStatement {
+    values: unknown[] = [];
+    constructor(
+      readonly db: FakeD1,
+      readonly sql: string,
+    ) {}
+    bind(...values: unknown[]): FakeStatement {
+      this.values = values;
+      return this;
+    }
+    run(): Promise<D1Result> {
+      this.db.enrollments.push({
+        id: this.values[0],
+        workspace: this.values[1],
+        code_hash: this.values[2],
+        label: this.values[3],
+        scopes: this.values[4],
+        created_at: this.values[5],
+        expires_at: this.values[6],
+        token_expires_at: this.values[7],
+        used_at: null,
+        page_id: this.values[8],
+      });
+      return Promise.resolve({ success: true } as unknown as D1Result);
+    }
+  }
+
+  class FakeD1 {
+    enrollments: Row[] = [];
+    prepare(sql: string): FakeStatement {
+      return new FakeStatement(this, sql);
+    }
+  }
+
+  function envWithDb(
+    user: typeof ADMIN_USER | null,
+    registryNames: string[],
+  ): Env & { DB: FakeD1 } {
+    const base = stubEnv(user, () => new Response(null, { status: 404 }));
+    const db = new FakeD1();
+    return {
+      ...base,
+      REGISTRY: {
+        get: (async (key: string) =>
+          registryNames.some((n) => `ws:${n}` === key)
+            ? "{}"
+            : null) as unknown as KVNamespace["get"],
+      } as unknown as KVNamespace,
+      DB: db,
+    } as unknown as Env & { DB: FakeD1 };
+  }
+
+  it("mints a redeemable code for an admin session", async () => {
+    const env = envWithDb(ADMIN_USER, ["acme"]);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const payload = (await res.json()) as {
+      workspace: string;
+      code: string;
+      pageId: string;
+      url: string;
+      scopes: string[];
+      expiresAt: string;
+    };
+    expect(payload.workspace).toBe("acme");
+    expect(payload.code).toMatch(/^upe_/);
+    expect(payload.pageId).toMatch(/^upi_/);
+    expect(payload.url).toContain(payload.pageId);
+    expect(payload.url).toContain("#code=");
+    expect(payload.scopes).toEqual(["files:read", "files:write"]);
+    expect(env.DB.enrollments).toHaveLength(1);
+  });
+
+  it("401s with no session", async () => {
+    const env = envWithDb(null, ["acme"]);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const env = envWithDb(NON_ADMIN_USER, ["acme"]);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("404s for an unknown workspace", async () => {
+    const env = envWithDb(ADMIN_USER, []);
+    const res = await app().request(
+      "/admin-ui/workspaces/nope/invite-links",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("429s when the per-workspace write budget is exhausted", async () => {
+    const env = envWithDb(ADMIN_USER, ["acme"]) as Env & {
+      WRITE_LIMITER: { limit: (opts: { key: string }) => Promise<{ success: boolean }> };
+    };
+    env.WRITE_LIMITER = { limit: async () => ({ success: false }) };
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/invite-links",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(429);
+  });
+});
+
 describe("GET /admin-ui/workspaces/:name/members", () => {
   it("proxies the internal member list", async () => {
     const env = stubEnv(ADMIN_USER, (path) => {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -7,6 +7,12 @@
  */
 import { NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
+import {
+  DEFAULT_ENROLLMENT_SECONDS,
+  DEFAULT_TOKEN_SECONDS,
+  createEnrollment,
+  validateScopes,
+} from "../auth-db";
 import { allowWrite } from "../guards";
 import { orgForWorkspace } from "../org-workspaces";
 import {
@@ -17,6 +23,31 @@ import {
 } from "../session-auth";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Invite links share the same D1 enrollment records as the ADMIN_TOKEN-gated
+// POST /admin/enrollments path (apps/api/src/routes/admin.ts) — same code
+// format, same TTL defaults, same redemption flow (apps/web's /invite page
+// and `uploads login --code`). This route only adds a session-authed way to
+// mint one without an email recipient.
+function labelValue(value: unknown): string | undefined | null {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") return null;
+  const label = value.trim();
+  return label.length >= 1 && label.length <= 100 ? label : null;
+}
+
+// Mirrors deriveWebOrigin/inviteMagicLink in routes/admin.ts. The invite page
+// lives on the web origin, which mirrors the API host without the `api.`
+// prefix (api.uploads.sh -> uploads.sh).
+function deriveWebOrigin(requestUrl: string): string {
+  const url = new URL(requestUrl);
+  url.hostname = url.hostname.replace(/^api\./, "");
+  return url.origin;
+}
+
+function inviteLinkUrl(webOrigin: string, pageId: string, code: string): string {
+  return `${webOrigin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
+}
 
 interface OrgSummary {
   organization: { id: string; slug: string; name: string };
@@ -143,4 +174,54 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("failed to create invitation", { details: payload });
     }
     return c.json(payload as object, 201);
+  })
+
+  // Mint a redeemable invite link/code for this workspace — the session-authed
+  // counterpart to POST /admin/enrollments, for sharing a URL/code without
+  // knowing the invitee's email. Backed by the same auth_enrollments table
+  // (see createEnrollment in ../auth-db), so the resulting link works
+  // unchanged with apps/web's /invite page and `uploads login --code`.
+  .post("/workspaces/:name/invite-links", async (c) => {
+    const name = c.req.param("name");
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    const existing = await c.env.REGISTRY.get(`ws:${name}`);
+    if (!existing) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const body = await c.req
+      .json<{ label?: unknown; scopes?: unknown }>()
+      .catch(() => ({}) as { label?: unknown; scopes?: unknown });
+    const label = labelValue(body.label);
+    if (label === null) {
+      throw new ValidationError("label must be between 1 and 100 characters", {
+        code: "invalid_label",
+      });
+    }
+    const scopes = validateScopes(body.scopes, ["files:read", "files:write"]);
+    if (!scopes) throw new ValidationError("invalid scopes", { code: "invalid_scopes" });
+
+    const enrollment = await createEnrollment(c.env.DB, {
+      workspace: name,
+      label,
+      scopes,
+      enrollmentSeconds: DEFAULT_ENROLLMENT_SECONDS,
+      tokenSeconds: DEFAULT_TOKEN_SECONDS,
+    });
+
+    const webOrigin = c.env.WEB_ORIGIN || deriveWebOrigin(c.req.url);
+    const url = inviteLinkUrl(webOrigin, enrollment.pageId, enrollment.code);
+
+    return c.json(
+      {
+        workspace: name,
+        label: label ?? null,
+        scopes,
+        url,
+        ...enrollment,
+      },
+      201,
+    );
   });

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -14,6 +14,7 @@ import {
   validateScopes,
 } from "../auth-db";
 import { allowWrite } from "../guards";
+import { deriveWebOrigin, inviteLinkUrl } from "../invite-links";
 import { orgForWorkspace } from "../org-workspaces";
 import {
   requireAdminUser,
@@ -30,23 +31,10 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // and `uploads login --code`). This route only adds a session-authed way to
 // mint one without an email recipient.
 function labelValue(value: unknown): string | undefined | null {
-  if (value === undefined) return undefined;
+  if (value === undefined || value === null) return undefined;
   if (typeof value !== "string") return null;
   const label = value.trim();
   return label.length >= 1 && label.length <= 100 ? label : null;
-}
-
-// Mirrors deriveWebOrigin/inviteMagicLink in routes/admin.ts. The invite page
-// lives on the web origin, which mirrors the API host without the `api.`
-// prefix (api.uploads.sh -> uploads.sh).
-function deriveWebOrigin(requestUrl: string): string {
-  const url = new URL(requestUrl);
-  url.hostname = url.hostname.replace(/^api\./, "");
-  return url.origin;
-}
-
-function inviteLinkUrl(webOrigin: string, pageId: string, code: string): string {
-  return `${webOrigin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
 }
 
 interface OrgSummary {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -14,6 +14,7 @@ import {
   revokeToken,
   validateScopes,
 } from "../auth-db";
+import { deriveWebOrigin, inviteLinkUrl as inviteMagicLink } from "../invite-links";
 import { reencryptRegistryCredentials } from "../reencrypt-registry";
 import type { WorkspaceRecord } from "../workspace";
 
@@ -28,20 +29,6 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // Invitations are delivered from this address; uploads.sh is onboarded for
 // Cloudflare Email Sending, so any @uploads.sh sender works.
 const INVITE_FROM = { name: "uploads.sh", email: "invites@uploads.sh" } as const;
-
-// The invite page lives on the web origin, which mirrors the API host without
-// the `api.` prefix (api.uploads.sh -> uploads.sh), matching the CLI default.
-function deriveWebOrigin(requestUrl: string): string {
-  const url = new URL(requestUrl);
-  url.hostname = url.hostname.replace(/^api\./, "");
-  return url.origin;
-}
-
-// Self-contained magic link: the single-use code rides in the URL fragment, which
-// browsers never send to a server, so it stays out of logs and referrers.
-function inviteMagicLink(webOrigin: string, pageId: string, code: string): string {
-  return `${webOrigin}/invite?id=${encodeURIComponent(pageId)}#code=${encodeURIComponent(code)}`;
-}
 
 function inviteEmail(to: string, workspaceName: string, link: string, expiresAt: string) {
   return {

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -74,6 +74,10 @@ const FAVICON =
     .invite-status{font-size:.8rem;margin-top:4px}
     .invite-status[data-state=error]{color:var(--red)}
     .invite-status[data-state=ready]{color:var(--accent)}
+    .invite-link-row{display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding-top:10px;border-top:1px solid var(--line)}
+    .invite-link-row button{font:11px var(--mono);color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:6px;padding:7px 12px;cursor:pointer}
+    .invite-link-row button:hover,.invite-link-row button:focus-visible{border-color:var(--accent);outline:none}
+    .invite-link-url{flex:1;min-width:200px;background:var(--bg);border:1px solid var(--line);border-radius:6px;color:var(--fg);padding:7px 9px;font:11px var(--mono)}
     [hidden]{display:none!important}
   </style>
 </head>
@@ -194,6 +198,12 @@ const FAVICON =
               <div class="invite-status" hidden></div>`
             : `<p class="muted">No organization provisioned for this workspace yet — run the org backfill.</p>`
         }
+        <div class="invite-link-row">
+          <button type="button" class="invite-link-generate">Generate invite link</button>
+          <input type="text" class="invite-link-url" readonly hidden aria-label="Invite link" />
+          <button type="button" class="invite-link-copy" hidden>Copy</button>
+        </div>
+        <div class="invite-status invite-link-status" hidden></div>
       </div>
     `;
 
@@ -273,6 +283,62 @@ const FAVICON =
         }
       } finally {
         if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+
+    const generateBtn = details.querySelector<HTMLButtonElement>(".invite-link-generate");
+    const urlInput = details.querySelector<HTMLInputElement>(".invite-link-url");
+    const copyBtn = details.querySelector<HTMLButtonElement>(".invite-link-copy");
+    const linkStatusEl = details.querySelector<HTMLElement>(".invite-link-status");
+    generateBtn?.addEventListener("click", async () => {
+      generateBtn.disabled = true;
+      if (linkStatusEl) linkStatusEl.hidden = true;
+      if (urlInput) urlInput.hidden = true;
+      if (copyBtn) copyBtn.hidden = true;
+      try {
+        const res = await fetch(
+          `${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/invite-links`,
+          {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+          },
+        );
+        if (!res.ok) {
+          const payload = (await res.json().catch(() => null)) as
+            | { error?: { message?: string } }
+            | null;
+          throw new Error(payload?.error?.message || `invite link failed: ${res.status}`);
+        }
+        const { url } = (await res.json()) as { url: string };
+        if (urlInput) {
+          urlInput.value = url;
+          urlInput.hidden = false;
+        }
+        if (copyBtn) copyBtn.hidden = false;
+      } catch (err) {
+        if (linkStatusEl) {
+          linkStatusEl.dataset.state = "error";
+          linkStatusEl.textContent =
+            err instanceof Error && err.message ? err.message : "Couldn't generate an invite link.";
+          linkStatusEl.hidden = false;
+        }
+      } finally {
+        generateBtn.disabled = false;
+      }
+    });
+    copyBtn?.addEventListener("click", async () => {
+      if (!urlInput?.value) return;
+      try {
+        await navigator.clipboard.writeText(urlInput.value);
+        if (linkStatusEl) {
+          linkStatusEl.dataset.state = "ready";
+          linkStatusEl.textContent = "Copied.";
+          linkStatusEl.hidden = false;
+        }
+      } catch {
+        urlInput.select();
       }
     });
 

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -203,7 +203,7 @@ const FAVICON =
           <input type="text" class="invite-link-url" readonly hidden aria-label="Invite link" />
           <button type="button" class="invite-link-copy" hidden>Copy</button>
         </div>
-        <div class="invite-status invite-link-status" hidden></div>
+        <div class="invite-status invite-link-status" role="status" aria-live="polite" hidden></div>
       </div>
     `;
 
@@ -338,6 +338,12 @@ const FAVICON =
           linkStatusEl.hidden = false;
         }
       } catch {
+        if (linkStatusEl) {
+          linkStatusEl.dataset.state = "error";
+          linkStatusEl.textContent = "Clipboard unavailable; copy the selected link manually.";
+          linkStatusEl.hidden = false;
+        }
+        urlInput.focus();
         urlInput.select();
       }
     });


### PR DESCRIPTION
## Summary

Follow-up to #102 (Better Auth Phase 5). Adds a session-authed way for a workspace admin signed into `/admin` to generate an invite link/code without knowing a recipient's email.

- `POST /admin-ui/workspaces/:name/invite-links` (`apps/api/src/routes/admin-ui.ts`) — gated by the existing `requireAdminUser` session middleware (same as `/admin-ui/workspaces/:name/invites`), rate-limited via `allowWrite`, requires the workspace to exist. Backed by `createEnrollment` (`apps/api/src/auth-db.ts`), the same D1-backed helper the ADMIN_TOKEN-gated `POST /admin/enrollments` uses — same code format, same `DEFAULT_ENROLLMENT_SECONDS`/`DEFAULT_TOKEN_SECONDS` defaults, same redeem URL shape. The resulting link works unchanged with `apps/web/src/pages/invite.astro` and `uploads login --code`.
- The ADMIN_TOKEN `/admin/*` surface is untouched — this is a new, distinct `/admin-ui/*` route.
- Web UI: `apps/web/src/pages/admin.astro` gets a "Generate invite link" control in each workspace's detail panel, alongside the existing email-invite form, that displays the URL for copying.

Org invitations (email-based) remain the primary flow; invite links are the "share a URL/code" alternative, per maintainer direction on #102.

## Test plan
- [x] `pnpm --filter @uploads/api test` — 212 passed (16 in `admin-ui.test.ts`, including 5 new cases: mints a code, 401/403 auth gate, 404 unknown workspace, 429 rate limit)
- [x] `pnpm --filter @uploads/api typecheck`
- [x] `pnpm --filter @uploads/web typecheck` (Node 24 — the two `admin.astro` type warnings are pre-existing on `main`, unrelated to this change)
- [x] `pnpm run lint` / `pnpm run format` — clean on touched files (unrelated pre-existing errors elsewhere in the repo)
- [ ] Manual click-through of "Generate invite link" in a running `/admin` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin action to generate redeemable workspace invite links.
  * Invite links can include an optional label and are limited to selectable file access scopes.
  * The admin workspace page now generates links via a button and provides a one-click copy workflow with success/error feedback.

* **Bug Fixes**
  * Improved request handling with clear responses for unauthorized/forbidden access, unknown workspaces, and rate-limited submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->