### PR TITLE
feat: workspace file/gallery visibility on /account + unified admin shell

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -169,6 +169,23 @@ export async function putObject(
   };
 }
 
+/**
+ * Provider object metadata → the JSON-safe `{ size, contentType, uploaded? }`
+ * subset shared by HEAD and list responses. Normalizes the epoch `lastModified`
+ * to an ISO `uploaded` and applies the fallback size/content type.
+ */
+function storedMetaJson(meta: { size?: number; type?: string; lastModified?: number }): {
+  size: number;
+  contentType: string;
+  uploaded?: string;
+} {
+  return {
+    size: meta.size ?? 0,
+    contentType: meta.type ?? "application/octet-stream",
+    ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+  };
+}
+
 /** Shape HEAD/list-friendly metadata for API JSON. */
 export function headObjectJson(
   key: string,
@@ -183,27 +200,39 @@ export function headObjectJson(
   const provenance = provenanceForResponse(meta.metadata ?? undefined);
   return {
     key,
-    size: meta.size ?? 0,
-    contentType: meta.type ?? "application/octet-stream",
-    ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+    ...storedMetaJson(meta),
     url,
     ...(provenance ? { metadata: provenance } : {}),
   };
+}
+
+/** A listed object, normalized to the same field convention as `headObjectJson`. */
+export interface ListedObject {
+  key: string;
+  url: string | null;
+  size: number;
+  contentType: string;
+  /** ISO timestamp when the provider reports a last-modified time. */
+  uploaded?: string;
 }
 
 export async function listObjects(
   env: Env,
   ws: WorkspaceRecord,
   opts: { prefix?: string; limit?: number; cursor?: string } = {},
-) {
+): Promise<{ items: ListedObject[]; cursor: string | null }> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 1000);
   const store = await storage(env, ws);
   const result = await store.list({ prefix: opts.prefix, limit, cursor: opts.cursor });
   const cfg = await storageConfig(env, ws);
+  // files-sdk returns rich StoredFile items (size, type, lastModified); project
+  // each to the shared HEAD/list subset (`storedMetaJson`) rather than spreading
+  // the StoredFile, which carries reader methods and a raw epoch timestamp.
   return {
-    items: result.items.map((item: { key: string }) => ({
-      ...item,
+    items: result.items.map((item) => ({
+      key: item.key,
       url: publicUrl(cfg, item.key),
+      ...storedMetaJson(item),
     })),
     cursor: result.cursor ?? null,
   };

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1,8 +1,12 @@
+import { readFileSync } from "node:fs";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { fileURLToPath, URL as NodeURL } from "node:url";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
+import { FakeR2Bucket } from "../../test/fake-r2";
 
 const USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
 
@@ -69,9 +73,32 @@ describe("GET /me/workspaces", () => {
           workspace: "acme",
           organization: { id: "org1", slug: "acme", name: "Acme Inc" },
           role: "owner",
+          communal: false,
         },
       ],
     });
+  });
+
+  it("flags the default workspace as communal", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          { organizationId: "org1", organizationSlug: "acme", role: "admin" },
+          { organizationId: "org2", organizationSlug: "default", role: "member" },
+        ]);
+      }
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+      }
+      if (path === "/internal/orgs/default") {
+        return Response.json({ organization: { id: "org2", slug: "default", name: "Default" } });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    const body = (await res.json()) as { workspaces: { workspace: string; communal: boolean }[] };
+    const byName = Object.fromEntries(body.workspaces.map((w) => [w.workspace, w.communal]));
+    expect(byName).toEqual({ acme: false, default: true });
   });
 
   it("503s when the memberships lookup fails (AUTH outage is not zero memberships)", async () => {
@@ -147,6 +174,167 @@ describe("GET /me/workspaces/:name/usage", () => {
       updatedAt: "2026-07-10T00:00:00.000Z",
       maxStorageBytes: 1000,
       storageRemainingBytes: 500,
+    });
+  });
+});
+
+// Real in-memory D1 for the galleries endpoint (UsageFakeD1 only knows
+// workspace_usage). Mirrors the SQLite stand-in in routes-galleries.test.ts.
+class SQLiteStatement {
+  values: unknown[] = [];
+  constructor(
+    readonly database: DatabaseSync,
+    readonly sql: string,
+  ) {}
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+  all<T>() {
+    return Promise.resolve({
+      success: true,
+      results: this.database.prepare(this.sql).all(...(this.values as SQLInputValue[])) as T[],
+      meta: {},
+    } as D1Result<T>);
+  }
+}
+class SQLiteD1 {
+  constructor(readonly database: DatabaseSync) {}
+  prepare(sql: string) {
+    return new SQLiteStatement(this.database, sql);
+  }
+}
+
+function galleriesDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(
+    readFileSync(
+      fileURLToPath(new NodeURL("../../migrations/20260711180000_galleries.sql", import.meta.url)),
+      "utf8",
+    ),
+  );
+  return db;
+}
+
+/** AUTH + a single membership → one non-communal (or communal) workspace. */
+function memberEnv(opts: {
+  workspace: string;
+  role?: string;
+  db: unknown;
+  bucket?: FakeR2Bucket;
+  record?: unknown;
+}): Env {
+  const { workspace, role = "member", db, bucket, record } = opts;
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+    }
+    if (url.pathname === "/internal/memberships") {
+      return Response.json([{ organizationId: "org1", organizationSlug: workspace, role }]);
+    }
+    if (url.pathname === `/internal/orgs/${workspace}`) {
+      return Response.json({ organization: { id: "org1", slug: workspace, name: workspace } });
+    }
+    return new Response(null, { status: 404 });
+  });
+  return {
+    AUTH: auth,
+    DB: db,
+    WEB_ORIGIN: "https://uploads.test",
+    REGISTRY: fakeKv(record ? { [`ws:${workspace}`]: record } : {}),
+    ...(bucket ? { UPLOADS_DEFAULT: bucket } : {}),
+  } as unknown as Env;
+}
+
+describe("GET /me/workspaces/:name/galleries", () => {
+  it("404s for a workspace the caller is not a member of", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/galleries", {}, env);
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_not_found" },
+    });
+  });
+
+  it("short-circuits the communal workspace with an empty list", async () => {
+    // The default workspace is communal; the endpoint returns before touching
+    // the DB, so UsageFakeD1 (which can't run the galleries query) is fine here.
+    const env = memberEnv({ workspace: "default", db: new UsageFakeD1() });
+    const res = await app().request("/me/workspaces/default/galleries", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ communal: true, galleries: [] });
+  });
+
+  it("returns gallery summaries for a member's workspace", async () => {
+    const db = galleriesDb();
+    db.exec(
+      `INSERT INTO galleries
+         (id, workspace, title, description, visibility, cover_item_id, version, created_at, updated_at, deleted_at)
+       VALUES
+         ('gal_aaaaaaaaaaaaaaaaaaaaaa', 'acme', 'Launch media', NULL, 'public', NULL, 1,
+          '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z', NULL)`,
+    );
+    const env = memberEnv({ workspace: "acme", db: new SQLiteD1(db) });
+    const res = await app().request("/me/workspaces/acme/galleries", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      communal: false,
+      galleries: [
+        {
+          id: "gal_aaaaaaaaaaaaaaaaaaaaaa",
+          url: "https://uploads.test/g/gal_aaaaaaaaaaaaaaaaaaaaaa",
+          workspace: "acme",
+          title: "Launch media",
+          description: null,
+          visibility: "public",
+          coverItemId: null,
+          version: 1,
+          createdAt: "2026-07-01T00:00:00.000Z",
+          updatedAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+});
+
+describe("GET /me/workspaces/:name/files", () => {
+  it("short-circuits the communal workspace with an empty list", async () => {
+    const env = memberEnv({ workspace: "default", db: new UsageFakeD1() });
+    const res = await app().request("/me/workspaces/default/files", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ communal: true, files: [] });
+  });
+
+  it("returns a page of files with public URLs for a member's workspace", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/f/x/shot.png", new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+    const env = memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        publicBaseUrl: "https://storage.uploads.sh",
+      },
+    });
+    const res = await app().request("/me/workspaces/acme/files", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      communal: boolean;
+      files: { key: string; url: string }[];
+    };
+    expect(body.communal).toBe(false);
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0]).toMatchObject({
+      key: "f/x/shot.png",
+      url: "https://storage.uploads.sh/acme/f/x/shot.png",
     });
   });
 });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -10,8 +10,11 @@
  * for workspace existence any more precisely than for any other workspace.
  */
 import { NotFoundError } from "@uploads/errors";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
+import { listObjects } from "../files-core";
+import { listGalleries } from "../galleries";
+import { gallerySummary } from "../gallery-service";
 import { membershipsForUser, orgForWorkspace, workspacesForOrg } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { getWorkspaceUsage } from "../usage";
@@ -21,6 +24,18 @@ interface MyWorkspace {
   workspace: string;
   organization: { id: string; slug: string; name: string };
   role: string;
+  /** True for the communal, world-readable workspace (see isCommunal). */
+  communal: boolean;
+}
+
+/**
+ * The communal workspace — the shared public dumping ground — is identified by
+ * name (the shared bucket hosts many prefixed workspaces, so the bucket can't
+ * mark it). Configurable via the `DEFAULT_WORKSPACE` var; defaults to
+ * "default". Member surfaces skip the personal galleries/files browser for it.
+ */
+function isCommunal(env: Env, name: string): boolean {
+  return name === (env.DEFAULT_WORKSPACE || "default");
 }
 
 /**
@@ -45,10 +60,32 @@ async function myWorkspaces(env: Env, userId: string): Promise<MyWorkspace[]> {
           name: membership.organizationSlug,
         },
         role: membership.role,
+        communal: isCommunal(env, workspace),
       });
     }
   }
   return out;
+}
+
+/**
+ * The caller's membership entry for `name`, or a uniform 404. Authorization for
+ * every `/workspaces/:name/*` route is this lookup: a workspace absent from the
+ * caller's memberships 404s (`workspace_not_found`) rather than 403ing, so
+ * membership can't be probed for workspace existence.
+ */
+async function memberWorkspaceOr404(env: Env, userId: string, name: string): Promise<MyWorkspace> {
+  const workspaces = await myWorkspaces(env, userId);
+  const ws = workspaces.find((w) => w.workspace === name);
+  if (!ws) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  return ws;
+}
+
+function requireUserId(c: Context<SessionVars>): string {
+  // requireSessionUser guarantees a session user; the guard is belt-and-braces
+  // and keeps the 404 (not 401) shape uniform with the not-a-member case.
+  const userId = c.get("sessionUser")?.id;
+  if (!userId) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  return userId;
 }
 
 export const me = new Hono<SessionVars>()
@@ -65,13 +102,7 @@ export const me = new Hono<SessionVars>()
   // Usage + limits for one workspace — 404s unless the caller is a member.
   .get("/workspaces/:name/usage", async (c) => {
     const name = c.req.param("name");
-    const userId = c.get("sessionUser")?.id;
-    if (!userId) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-
-    const workspaces = await myWorkspaces(c.env, userId);
-    if (!workspaces.some((ws) => ws.workspace === name)) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
+    await memberWorkspaceOr404(c.env, requireUserId(c), name);
 
     const record = await loadWorkspaceRecord(c.env, name);
     if (!record) {
@@ -80,4 +111,35 @@ export const me = new Hono<SessionVars>()
 
     const usage = await getWorkspaceUsage(c.env.DB, name);
     return c.json(usageWithLimits(usage, record));
+  })
+
+  // Galleries in one workspace — member-gated. The communal workspace is a
+  // shared public dumping ground, so we don't enumerate it here; the response
+  // stays branch-free for clients with `communal: true` and an empty list.
+  .get("/workspaces/:name/galleries", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    if (ws.communal) return c.json({ communal: true, galleries: [] });
+
+    const page = await listGalleries(c.env.DB, name, { limit: 50 });
+    return c.json({
+      communal: false,
+      galleries: page.galleries.map((gallery) => gallerySummary(c.env, gallery)),
+    });
+  })
+
+  // A page of a workspace's files (public URLs) — member-gated. Skipped for the
+  // communal workspace for the same reason as galleries; returns `communal:
+  // true` with an empty list rather than listing the shared bucket to a member.
+  .get("/workspaces/:name/files", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    if (ws.communal) return c.json({ communal: true, files: [] });
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+    const { items } = await listObjects(c.env, record, { limit: 25 });
+    return c.json({ communal: false, files: items });
   });

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -9,6 +9,12 @@
     // Origin of the invite page that magic links point at. Defaults to the API
     // host without the `api.` prefix; set explicitly for other deployments.
     "WEB_ORIGIN": "https://uploads.sh",
+    // Name of the communal workspace — the shared, world-readable dumping
+    // ground. It's the workspace *name* (not the shared bucket, which hosts
+    // many prefixed workspaces) that marks it communal. Member-facing surfaces
+    // (see routes/me.ts) skip the personal galleries/files browser for it.
+    // Defaults to "default" in code, so this only needs setting to rename it.
+    "DEFAULT_WORKSPACE": "default",
   },
   "routes": [
     {

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared client wiring for the signed-in shell used by both /account and
+ * /admin: hash-based panel switching and the sidebar sign-out button. The two
+ * pages share the same DOM contract (`nav.side a[data-panel]`,
+ * `[data-panel-body]`, `#sign-out-btn`); only the default panel differs.
+ */
+import { signOut } from "./auth-client";
+
+/**
+ * Wire the sidebar nav to show the `[data-panel-body]` panel matching the URL
+ * hash (updating `aria-current` on the nav links), falling back to
+ * `defaultPanel` for an unknown or empty hash. Applies once immediately, then
+ * on every `hashchange`.
+ */
+export function initPanelSwitcher(defaultPanel: string): void {
+  const navLinks = Array.from(
+    document.querySelectorAll<HTMLAnchorElement>("nav.side a[data-panel]"),
+  );
+  const panels = Array.from(document.querySelectorAll<HTMLElement>("[data-panel-body]"));
+  const show = (name: string) => {
+    const target = panels.some((p) => p.dataset.panelBody === name) ? name : defaultPanel;
+    for (const p of panels) p.hidden = p.dataset.panelBody !== target;
+    for (const l of navLinks) l.setAttribute("aria-current", String(l.dataset.panel === target));
+  };
+  window.addEventListener("hashchange", () => show(location.hash.slice(1)));
+  show(location.hash.slice(1));
+}
+
+/** Wire the sidebar `#sign-out-btn` to end the session and return to /login. */
+export function initSignOut(authOrigin: string): void {
+  const button = document.querySelector<HTMLButtonElement>("#sign-out-btn");
+  if (!button) return;
+  // Keep the listener void-returning (no-misused-promises); `void` marks the
+  // promise as intentionally fire-and-forget (no-floating-promises).
+  button.addEventListener("click", () => {
+    void signOut(authOrigin).then(() => {
+      location.href = "/login";
+    });
+  });
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -14,9 +14,14 @@ export interface MyWorkspace {
   workspace: string;
   organization: { id: string; slug: string; name: string };
   role: string;
+  /** True for the communal, world-readable workspace (no personal browser). */
+  communal: boolean;
 }
 
-function isMyWorkspace(value: unknown): value is MyWorkspace {
+// `communal` is intentionally NOT required here: web and api deploy
+// independently, so an older api may omit it. We accept the entry and coerce a
+// missing/other value to `false` in the mapper below.
+function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "communal"> {
   if (!value || typeof value !== "object") return false;
   const ws = value as Record<string, unknown>;
   const org = ws.organization as Record<string, unknown> | null | undefined;
@@ -40,7 +45,14 @@ export async function getMyWorkspaces(apiOrigin: string): Promise<MyWorkspace[]>
     if (!res.ok) return [];
     const body = (await res.json().catch(() => null)) as { workspaces?: unknown[] } | null;
     if (!Array.isArray(body?.workspaces)) return [];
-    return body.workspaces.filter(isMyWorkspace);
+    return body.workspaces.filter(isMyWorkspaceCore).map(
+      (ws): MyWorkspace => ({
+        workspace: ws.workspace,
+        organization: ws.organization,
+        role: ws.role,
+        communal: (ws as { communal?: unknown }).communal === true,
+      }),
+    );
   } catch {
     return [];
   }
@@ -84,4 +96,75 @@ export async function getMyWorkspaceUsage(
   } catch {
     return null;
   }
+}
+
+/**
+ * Shared GET for the array-returning `/me/workspaces/:name/<segment>` endpoints
+ * (galleries, files). Reads `body[key]`, drops malformed entries via `isValid`,
+ * and returns [] on any non-2xx, malformed body, or communal workspace (which
+ * the API returns with an empty list).
+ */
+async function fetchWorkspaceList<T>(
+  apiOrigin: string,
+  name: string,
+  segment: string,
+  key: string,
+  isValid: (value: unknown) => value is T,
+): Promise<T[]> {
+  try {
+    const res = await fetch(
+      `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/${segment}`,
+      { credentials: "include", cache: "no-store" },
+    );
+    if (!res.ok) return [];
+    const body = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    const list = body?.[key];
+    if (!Array.isArray(list)) return [];
+    return list.filter(isValid);
+  } catch {
+    return [];
+  }
+}
+
+export interface GallerySummary {
+  id: string;
+  url: string;
+  title: string;
+  description: string | null;
+  coverItemId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function isGallerySummary(value: unknown): value is GallerySummary {
+  if (!value || typeof value !== "object") return false;
+  const g = value as Record<string, unknown>;
+  return typeof g.id === "string" && typeof g.url === "string" && typeof g.title === "string";
+}
+
+/** GET /me/workspaces/:name/galleries. See {@link fetchWorkspaceList}. */
+export function getMyWorkspaceGalleries(
+  apiOrigin: string,
+  name: string,
+): Promise<GallerySummary[]> {
+  return fetchWorkspaceList(apiOrigin, name, "galleries", "galleries", isGallerySummary);
+}
+
+export interface WorkspaceFile {
+  key: string;
+  url: string | null;
+  size?: number;
+  contentType?: string;
+  uploaded?: string;
+}
+
+function isWorkspaceFile(value: unknown): value is WorkspaceFile {
+  if (!value || typeof value !== "object") return false;
+  const f = value as Record<string, unknown>;
+  return typeof f.key === "string" && (f.url === null || typeof f.url === "string");
+}
+
+/** GET /me/workspaces/:name/files. See {@link fetchWorkspaceList}. */
+export function getMyWorkspaceFiles(apiOrigin: string, name: string): Promise<WorkspaceFile[]> {
+  return fetchWorkspaceList(apiOrigin, name, "files", "files", isWorkspaceFile);
 }

--- a/apps/web/src/pages/account.astro
+++ b/apps/web/src/pages/account.astro
@@ -95,6 +95,21 @@ const FAVICON =
     ul.plain :global(.row){display:flex;justify-content:space-between;gap:10px}
     ul.plain :global(.slug){color:var(--muted)}
     ul.plain :global(.usage){color:var(--muted);font-size:12px}
+    /* Per-workspace detail: galleries, files, communal note, invite command. */
+    ul.plain :global(.ws-detail){display:grid;gap:14px;margin-top:11px;padding-top:11px;border-top:1px solid var(--line)}
+    ul.plain :global(.ws-section-head){font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:7px}
+    ul.plain :global(.ws-items){list-style:none;margin:0;padding:0;display:grid;gap:5px}
+    ul.plain :global(.ws-items li){display:block;padding:0;border:0;border-radius:0;background:none;font-size:12.5px}
+    ul.plain :global(.ws-items .fkey){color:var(--muted)}
+    ul.plain :global(.ws-items .fsize){color:var(--muted);font-size:11.5px}
+    ul.plain :global(.ws-empty){color:var(--muted);font-size:12px;margin:0}
+    ul.plain :global(.ws-note){color:var(--body);font-size:12.5px;margin:0}
+    ul.plain :global(.cli-hint){display:inline-block;margin-top:8px;font-size:12px;color:var(--muted)}
+    ul.plain :global(.command){display:flex;gap:10px;align-items:center;margin-top:2px;padding:9px 11px;border:1px solid var(--line);border-radius:7px;background:var(--panel)}
+    ul.plain :global(.command code){flex:1;min-width:0;white-space:nowrap;overflow-x:auto;display:block;border:0;background:none;padding:0;font-size:12px}
+    ul.plain :global(.command button){flex-shrink:0;font:11px var(--mono);letter-spacing:.05em;color:var(--accent);border:1px solid var(--line);border-radius:6px;padding:5px 10px;background:var(--bg);cursor:pointer}
+    ul.plain :global(.command button:hover),ul.plain :global(.command button:focus-visible){border-color:var(--accent);outline:none}
+    ul.plain :global(.cli-note){margin:7px 0 0;font-size:11px}
     .pill{display:inline-block;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);border:1px solid var(--line);border-radius:99px;padding:2px 9px;background:var(--bg)}
 
     @media (max-width:680px){
@@ -202,8 +217,16 @@ const FAVICON =
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
 </script>
 <script>
-  import { getSession, signOut } from "../lib/auth-client";
-  import { getMyWorkspaces, getMyWorkspaceUsage } from "../lib/api-client";
+  import { getSession } from "../lib/auth-client";
+  import { initPanelSwitcher, initSignOut } from "../lib/account-shell";
+  import {
+    getMyWorkspaces,
+    getMyWorkspaceUsage,
+    getMyWorkspaceGalleries,
+    getMyWorkspaceFiles,
+    type GallerySummary,
+    type WorkspaceFile,
+  } from "../lib/api-client";
 
   const w = window as unknown as {
     __UPLOADS_AUTH_ORIGIN__: string;
@@ -222,17 +245,8 @@ const FAVICON =
   const signedOut = requireElement<HTMLElement>("#signed-out");
   const app = requireElement<HTMLElement>("#app");
 
-  // Hash-based panel switching — no router, just show/hide.
-  const navLinks = Array.from(document.querySelectorAll<HTMLAnchorElement>("nav.side a[data-panel]"));
-  const panels = Array.from(document.querySelectorAll<HTMLElement>("[data-panel-body]"));
-  function showPanel(name: string) {
-    const known = panels.some((p) => p.dataset.panelBody === name);
-    const target = known ? name : "overview";
-    for (const p of panels) p.hidden = p.dataset.panelBody !== target;
-    for (const l of navLinks) l.setAttribute("aria-current", String(l.dataset.panel === target));
-  }
-  window.addEventListener("hashchange", () => showPanel(location.hash.slice(1)));
-  showPanel(location.hash.slice(1));
+  initPanelSwitcher("overview");
+  initSignOut(authOrigin);
 
   const escapeHtml = (value: string) =>
     value.replace(/[&<>"']/g, (ch) =>
@@ -276,6 +290,52 @@ const FAVICON =
     return parts.join(" · ");
   }
 
+  const isAdminRole = (role: string) => role === "admin" || role === "owner";
+
+  const basename = (key: string) => key.split("/").at(-1) || key;
+
+  // The command an admin runs to invite a teammate. Workspace names are
+  // [a-z0-9-] on the API; escapeHtml is applied at the render site regardless.
+  const inviteCommand = (workspace: string) =>
+    `uploads admin invite create --workspace ${workspace} --email teammate@example.com`;
+
+  function renderGalleries(container: HTMLElement, galleries: GallerySummary[]): void {
+    const head = `<div class="ws-section-head">Galleries${galleries.length ? ` (${galleries.length})` : ""}</div>`;
+    if (!galleries.length) {
+      container.innerHTML = `${head}<p class="ws-empty">No galleries yet.</p>`;
+      return;
+    }
+    const items = galleries
+      .map(
+        (g) =>
+          `<li><a href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a></li>`,
+      )
+      .join("");
+    container.innerHTML = `${head}<ul class="ws-items">${items}</ul>`;
+  }
+
+  function renderFiles(container: HTMLElement, files: WorkspaceFile[]): void {
+    const head = `<div class="ws-section-head">Files${files.length ? ` (${files.length})` : ""}</div>`;
+    if (!files.length) {
+      container.innerHTML = `${head}<p class="ws-empty">No files yet.</p>`;
+      return;
+    }
+    const items = files
+      .map((f) => {
+        const name = escapeHtml(basename(f.key));
+        // files-sdk reports each object's size on list; show it inline.
+        const size = typeof f.size === "number" ? ` <span class="fsize">${formatBytes(f.size)}</span>` : "";
+        const label = f.url
+          ? `<a href="${escapeHtml(f.url)}" target="_blank" rel="noopener noreferrer">${name}</a>`
+          : `<span class="fkey">${name}</span>`;
+        return `<li>${label}${size}</li>`;
+      })
+      .join("");
+    container.innerHTML =
+      `${head}<ul class="ws-items">${items}</ul>` +
+      `<a class="cli-hint" href="/docs">Browse all with the CLI</a>`;
+  }
+
   getSession(authOrigin).then(async (result) => {
     checking.hidden = true;
     if (!result) {
@@ -302,37 +362,87 @@ const FAVICON =
     orgsStatus.hidden = true;
     orgsList.hidden = false;
     orgsList.innerHTML = workspaces
-      .map(
-        (ws) =>
-          `<li data-workspace="${escapeHtml(ws.workspace)}">
+      .map((ws) => {
+        // Communal workspace = the shared, world-readable dumping ground; it
+        // gets a short note instead of the personal galleries/files browser.
+        const body = ws.communal
+          ? `<p class="ws-note">This is the shared, public space — anything here is world-readable at <code>storage.uploads.sh</code>. Browse and upload with the CLI.</p>`
+          : `<div class="ws-section" data-galleries><div class="ws-section-head">Galleries</div><p class="ws-empty">Loading&#32;…</p></div>
+             <div class="ws-section" data-files><div class="ws-section-head">Files</div><p class="ws-empty">Loading&#32;…</p></div>`;
+        // Workspace admins get a copy-paste invite command.
+        const cmd = inviteCommand(ws.workspace);
+        const invite = isAdminRole(ws.role)
+          ? `<div class="ws-section">
+               <div class="ws-section-head">Invite a teammate</div>
+               <div class="command"><code>${escapeHtml(cmd)}</code><button type="button" data-copy="${escapeHtml(cmd)}">copy</button></div>
+               <p class="muted cli-note">Runs with the workspace's admin token.</p>
+             </div>`
+          : "";
+        return `<li data-workspace="${escapeHtml(ws.workspace)}">
             <div class="row">
               <span>${escapeHtml(ws.organization.name)}</span>
               <span class="slug">${escapeHtml(ws.role)}</span>
             </div>
             <div class="usage">Loading usage&#32;…</div>
-          </li>`,
-      )
+            <div class="ws-detail">${body}${invite}</div>
+          </li>`;
+      })
       .join("");
 
-    // Usage is fetched per workspace, concurrently, after the list renders,
-    // so a slow or failing usage call for one workspace never blocks the
-    // others.
+    // Usage, galleries, and files are fetched per workspace, concurrently,
+    // after the list renders, so a slow or failing call for one workspace (or
+    // one surface) never blocks the others. Communal workspaces skip the
+    // galleries/files fetch entirely — the API returns them empty anyway.
     await Promise.all(
       workspaces.map(async (ws) => {
         const li = orgsList.querySelector<HTMLElement>(
           `li[data-workspace="${cssEscape(ws.workspace)}"]`,
         );
-        const usageEl = li?.querySelector<HTMLElement>(".usage");
-        if (!usageEl) return;
-        const usage = await getMyWorkspaceUsage(apiOrigin, ws.workspace);
-        usageEl.textContent = usage ? formatUsage(usage) : "Usage unavailable.";
+        if (!li) return;
+        const tasks: Promise<void>[] = [];
+        const usageEl = li.querySelector<HTMLElement>(".usage");
+        if (usageEl) {
+          tasks.push(
+            getMyWorkspaceUsage(apiOrigin, ws.workspace).then((usage) => {
+              usageEl.textContent = usage ? formatUsage(usage) : "Usage unavailable.";
+            }),
+          );
+        }
+        if (!ws.communal) {
+          const galleriesEl = li.querySelector<HTMLElement>("[data-galleries]");
+          if (galleriesEl) {
+            tasks.push(
+              getMyWorkspaceGalleries(apiOrigin, ws.workspace).then((galleries) => {
+                renderGalleries(galleriesEl, galleries);
+              }),
+            );
+          }
+          const filesEl = li.querySelector<HTMLElement>("[data-files]");
+          if (filesEl) {
+            tasks.push(
+              getMyWorkspaceFiles(apiOrigin, ws.workspace).then((files) => {
+                renderFiles(filesEl, files);
+              }),
+            );
+          }
+        }
+        await Promise.all(tasks);
       }),
     );
   });
 
-  requireElement<HTMLButtonElement>("#sign-out-btn").addEventListener("click", async () => {
-    await signOut(authOrigin);
-    location.href = "/login";
+  // Delegated copy handler for the injected invite-command buttons.
+  requireElement<HTMLUListElement>("#orgs-list").addEventListener("click", async (event) => {
+    const button = (event.target as HTMLElement).closest<HTMLButtonElement>("button[data-copy]");
+    if (!button) return;
+    try {
+      await navigator.clipboard.writeText(button.dataset.copy ?? "");
+      const previous = button.textContent;
+      button.textContent = "copied ✓";
+      setTimeout(() => (button.textContent = previous), 1500);
+    } catch {
+      // Clipboard blocked (permissions/insecure context) — leave the label.
+    }
   });
 </script>
 </body>

--- a/apps/web/src/pages/admin.astro
+++ b/apps/web/src/pages/admin.astro
@@ -1,13 +1,17 @@
 ---
 import { env } from "cloudflare:workers";
+import { resolveConsoleMode } from "../lib/console-mode";
 import {
   CF_RUM_CONNECT_SRC,
   CF_RUM_SCRIPT_SRC,
   STYLE_SRC_SELF_AND_INLINE,
 } from "../lib/csp";
-import AuthIndicator from "../components/AuthIndicator.astro";
 
 export const prerender = false;
+
+// Mirrors /account — only "public" console mode links to the raw /console
+// developer surface from the sidebar footer. Not a security boundary.
+const showConsoleLinks = (await resolveConsoleMode(env)) === "public";
 
 const authOrigin =
   env.UPLOADS_AUTH_ORIGIN ??
@@ -43,47 +47,73 @@ const FAVICON =
   <title>Admin · uploads.sh</title>
   <link rel="icon" href={FAVICON} />
   <style>
+    /* Shared shell/sidebar/panel styles kept in sync with account.astro so the
+       admin surface matches the rest of the signed-in pages. */
     :root{color-scheme:dark;--bg:#0a0a0b;--panel:#121214;--line:#232327;--fg:#ececea;--body:#b3b3ad;--muted:#7d7d77;--accent:#b794ff;--red:#d98a9c;--mono:"Geist Mono Variable",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace}
     *{box-sizing:border-box}
-    body{margin:0;min-height:100dvh;background:var(--bg);color:var(--fg);font:14px/1.5 var(--mono);padding:32px 20px 48px}
-    main{max-width:720px;margin:0 auto;display:grid;gap:16px}
-    .admin-top{display:flex;align-items:center;justify-content:space-between;gap:12px}
-    h1{font-size:1.15rem;font-weight:600;margin:0}
-    p.muted{color:var(--muted);margin:0;font-size:.9rem}
-    .status{border-left:3px solid var(--accent);padding:9px 14px;margin:8px 0;background:var(--panel);border:1px solid var(--line);border-radius:8px}
-    .status[data-state=denied]{border-color:var(--red);color:var(--red)}
-    a.button{display:inline-block;margin-top:4px;font:12px var(--mono);color:var(--accent);text-decoration:none;border:1px solid var(--line);border-radius:7px;padding:9px 13px;background:var(--panel)}
-    a.button:hover,a.button:focus-visible{border-color:var(--accent);outline:none}
-    nav.sections{display:grid;gap:10px;margin-top:8px}
-    nav.sections .item{padding:14px 16px;border:1px solid var(--line);border-radius:8px;background:var(--panel);color:var(--muted)}
-    nav.sections .item strong{color:var(--fg);display:block;font-size:.95rem;margin-bottom:2px}
-    .workspace{padding:14px 16px;border:1px solid var(--line);border-radius:8px;background:var(--panel);margin-bottom:10px}
-    .workspace summary{cursor:pointer;list-style:none;display:flex;align-items:center;justify-content:space-between;gap:10px}
-    .workspace summary::-webkit-details-marker{display:none}
-    .workspace .name{color:var(--fg);font-weight:600}
-    .workspace .counts{color:var(--muted);font-size:.85rem}
-    .workspace .detail{margin-top:14px;padding-top:14px;border-top:1px solid var(--line);display:grid;gap:12px}
-    .workspace ul{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-    .workspace li{font-size:.85rem;color:var(--body);display:flex;justify-content:space-between;gap:8px}
-    .workspace li .role{color:var(--muted)}
-    .invite-form{display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end}
-    .invite-form label{display:grid;gap:4px;color:var(--muted);font-size:10px;letter-spacing:.08em;text-transform:uppercase}
-    .invite-form input,.invite-form select{background:var(--bg);border:1px solid var(--line);border-radius:6px;color:var(--fg);padding:7px 9px;font:12px var(--mono)}
-    .invite-form button{font:11px var(--mono);color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:6px;padding:7px 12px;cursor:pointer}
-    .invite-form button:hover,.invite-form button:focus-visible{border-color:var(--accent);outline:none}
-    .invite-status{font-size:.8rem;margin-top:4px}
-    .invite-status[data-state=error]{color:var(--red)}
-    .invite-status[data-state=ready]{color:var(--accent)}
+    body{margin:0;min-height:100dvh;background:var(--bg);color:var(--fg);font:14px/1.6 var(--mono);font-variant-ligatures:none;font-feature-settings:"calt" 0,"liga" 0}
+    a{color:var(--fg);text-decoration:underline;text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent);text-underline-offset:3px}
+    a:hover,a:focus-visible{color:var(--accent);outline:none}
+    code{color:var(--fg);background:var(--panel);border:1px solid var(--line);border-radius:5px;padding:1px 6px;font-size:.9em}
     [hidden]{display:none!important}
+
+    .shell{max-width:960px;margin:0 auto;padding:28px 20px 56px}
+    header.top{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:22px}
+    header.top h1{font-size:1.1rem;font-weight:600;margin:0;letter-spacing:-.01em;display:flex;align-items:center;gap:9px}
+    header.top .who{color:var(--muted);font-size:12.5px}
+    .status{border-left:3px solid var(--accent);padding:9px 14px;background:var(--panel);border:1px solid var(--line);border-radius:8px}
+    .status[data-state=denied]{border-color:var(--red);color:var(--red)}
+    a.button{display:inline-block;margin-top:12px;font:12px var(--mono);color:var(--accent);text-decoration:none;border:1px solid var(--line);border-radius:7px;padding:9px 13px;background:var(--panel)}
+    a.button:hover,a.button:focus-visible{border-color:var(--accent);outline:none}
+
+    .layout{display:grid;grid-template-columns:190px 1fr;gap:24px;align-items:start}
+    nav.side{display:grid;gap:4px;position:sticky;top:28px}
+    nav.side a{display:block;padding:8px 12px;border-radius:7px;border:1px solid transparent;color:var(--muted);text-decoration:none;font-size:13px}
+    nav.side a:hover{color:var(--fg)}
+    nav.side a[aria-current=true]{color:var(--accent);background:var(--panel);border-color:var(--line)}
+    nav.side .side-foot{margin-top:14px;padding-top:14px;border-top:1px solid var(--line);display:grid;gap:4px}
+    nav.side .side-foot a{font-size:12px}
+    nav.side button{text-align:left;font:12px var(--mono);color:var(--muted);background:none;border:1px solid transparent;border-radius:7px;padding:8px 12px;cursor:pointer}
+    nav.side button:hover,nav.side button:focus-visible{color:var(--red);outline:none}
+
+    .content{display:grid;gap:16px;min-width:0}
+    section.card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px 20px}
+    section.card h2{margin:0 0 4px;font-size:.95rem;font-weight:600}
+    section.card p{color:var(--body);margin:6px 0 0;font-size:13px}
+    p.muted,span.muted{color:var(--muted)}
+    .pill{display:inline-block;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);border:1px solid var(--line);border-radius:99px;padding:2px 9px;background:var(--bg)}
+
+    /* Admin workspace accordions. :global() so the JS-injected <details> match
+       despite Astro's style scoping (same pattern as account.astro's list). */
+    #workspaces-list{display:grid;gap:10px;margin-top:12px}
+    #workspaces-list :global(.workspace){padding:12px 14px;border:1px solid var(--line);border-radius:8px;background:var(--bg)}
+    #workspaces-list :global(.workspace summary){cursor:pointer;list-style:none;display:flex;align-items:center;justify-content:space-between;gap:10px}
+    #workspaces-list :global(.workspace summary::-webkit-details-marker){display:none}
+    #workspaces-list :global(.workspace .name){color:var(--fg);font-weight:600;font-size:13px}
+    #workspaces-list :global(.workspace .counts){color:var(--muted);font-size:12px;text-align:right}
+    #workspaces-list :global(.workspace .detail){margin-top:12px;padding-top:12px;border-top:1px solid var(--line);display:grid;gap:12px}
+    #workspaces-list :global(.workspace ul){list-style:none;margin:0;padding:0;display:grid;gap:6px}
+    #workspaces-list :global(.workspace li){font-size:12.5px;color:var(--body);display:flex;justify-content:space-between;gap:8px}
+    #workspaces-list :global(.workspace li .role){color:var(--muted)}
+    #workspaces-list :global(.workspace .members),#workspaces-list :global(.workspace .muted){color:var(--muted);font-size:12.5px}
+    #workspaces-list :global(.invite-form){display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end}
+    #workspaces-list :global(.invite-form label){display:grid;gap:4px;color:var(--muted);font-size:10px;letter-spacing:.08em;text-transform:uppercase}
+    #workspaces-list :global(.invite-form input),#workspaces-list :global(.invite-form select){background:var(--panel);border:1px solid var(--line);border-radius:6px;color:var(--fg);padding:7px 9px;font:12px var(--mono)}
+    #workspaces-list :global(.invite-form button){font:11px var(--mono);color:var(--accent);background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:7px 12px;cursor:pointer}
+    #workspaces-list :global(.invite-form button:hover),#workspaces-list :global(.invite-form button:focus-visible){border-color:var(--accent);outline:none}
+    #workspaces-list :global(.invite-status){font-size:12px;margin-top:4px}
+    #workspaces-list :global(.invite-status[data-state=error]){color:var(--red)}
+    #workspaces-list :global(.invite-status[data-state=ready]){color:var(--accent)}
+
+    @media (max-width:680px){
+      .layout{grid-template-columns:1fr}
+      nav.side{position:static;grid-template-columns:repeat(auto-fit,minmax(90px,max-content));gap:6px}
+      nav.side .side-foot{grid-column:1/-1;border:0;margin:0;padding:0;grid-template-columns:subgrid}
+    }
   </style>
 </head>
 <body>
-<main>
-  <div class="admin-top">
-    <h1>uploads.sh admin</h1>
-    <AuthIndicator authOrigin={authOrigin} />
-  </div>
-
+<div class="shell">
   <div id="checking" class="status" role="status">Checking your session…</div>
 
   <div id="denied" hidden>
@@ -91,33 +121,58 @@ const FAVICON =
     <a class="button" href="/login">Sign in</a>
   </div>
 
+  <!--
+    Client-side gating here is a UX affordance ONLY — it just avoids flashing
+    admin nav (and firing admin-ui fetches) at a non-admin visitor. It is NOT
+    the security boundary: the workspaces data is fetched from apps/api's
+    /admin-ui/* surface, which independently enforces requireAdminUser
+    (src/session-auth.ts) over the AUTH service binding on every request,
+    regardless of whatever this page shows or hides.
+  -->
   <div id="dashboard" hidden>
-    <p class="muted">Signed in as <span id="who"></span>.</p>
-    <!--
-      Client-side gating here is a UX affordance ONLY — it just avoids
-      flashing admin nav (and firing admin-ui fetches) at a non-admin
-      visitor. It is NOT the security boundary: the workspaces data below is
-      fetched from apps/api's /admin-ui/* surface, which independently
-      enforces requireAdminUser (src/session-auth.ts) over the AUTH service
-      binding on every request, regardless of whatever this page shows or
-      hides.
-    -->
-    <nav class="sections" aria-label="Admin sections">
-      <div class="item">
-        <strong>Workspaces</strong>
-        <div id="workspaces-status" class="muted" style="margin-top:6px">Loading…</div>
-        <div id="workspaces-list"></div>
+    <header class="top">
+      <h1>uploads.sh <span class="pill">admin</span></h1>
+      <span class="who" id="who"></span>
+    </header>
+
+    <div class="layout">
+      <nav class="side" aria-label="Admin sections">
+        <a href="#workspaces" data-panel="workspaces" aria-current="true">Workspaces</a>
+        <a href="#users" data-panel="users">Users</a>
+        <div class="side-foot">
+          <a href="/account">← account</a>
+          {showConsoleLinks ? <a href="/console">console →</a> : null}
+          <button type="button" id="sign-out-btn">Sign out</button>
+        </div>
+      </nav>
+
+      <div class="content">
+        <div data-panel-body="workspaces">
+          <section class="card">
+            <h2>Workspaces</h2>
+            <p>Every registered workspace, with its members and pending invites. Expand one to load its people and invite someone.</p>
+            <div id="workspaces-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+            <div id="workspaces-list"></div>
+          </section>
+        </div>
+
+        <div data-panel-body="users" hidden>
+          <section class="card">
+            <h2>Users</h2>
+            <p class="muted">Coming in a later phase.</p>
+          </section>
+        </div>
       </div>
-      <div class="item"><strong>Users</strong>Coming in a later phase.</div>
-    </nav>
+    </div>
   </div>
-</main>
+</div>
 <script define:vars={{ authOrigin, apiOrigin }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
 </script>
 <script>
   import { getSession } from "../lib/auth-client";
+  import { initPanelSwitcher, initSignOut } from "../lib/account-shell";
 
   const w = window as unknown as { __UPLOADS_AUTH_ORIGIN__: string; __UPLOADS_API_ORIGIN__: string };
   const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
@@ -135,6 +190,8 @@ const FAVICON =
   const who = requireElement<HTMLElement>("#who");
   const workspacesStatus = requireElement<HTMLElement>("#workspaces-status");
   const workspacesList = requireElement<HTMLElement>("#workspaces-list");
+
+  initPanelSwitcher("workspaces");
 
   interface WorkspaceSummary {
     workspace: string;
@@ -235,8 +292,8 @@ const FAVICON =
     const statusEl = details.querySelector<HTMLElement>(".invite-status");
     form?.addEventListener("submit", async (event) => {
       event.preventDefault();
-      const emailInput = form.querySelector<HTMLInputElement>(".invite-email");
-      const roleSelect = form.querySelector<HTMLSelectElement>(".invite-role");
+      const emailInput = form.querySelector(".invite-email") as HTMLInputElement | null;
+      const roleSelect = form.querySelector(".invite-role") as HTMLSelectElement | null;
       const email = emailInput?.value.trim() ?? "";
       const role = roleSelect?.value ?? "member";
       const submitBtn = form.querySelector<HTMLButtonElement>("button[type=submit]");
@@ -305,6 +362,8 @@ const FAVICON =
     dashboard.hidden = false;
     loadWorkspaces();
   });
+
+  initSignOut(authOrigin);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## In plain terms

Today a signed-in user on **/account → Workspaces** sees only a workspace name, their role, and a usage line — nothing about what's actually *in* the workspace. This makes that view useful: it now shows the workspace's **galleries** (shareable `/g/<id>` links) and a page of its **files** (public URLs + sizes), and gives **workspace admins** a click-to-copy invite command.

It also brings **/admin** into the same sidebar + panel layout as /account, so the two signed-in surfaces feel like one product instead of two different-looking pages.

The shared `default` workspace is a public dumping ground, so it's deliberately exempted from the personal file/gallery browser — it shows a short "this is the shared public space" note instead.

> Screenshots below are rendered with representative data (the real pages need a signed-in session).

**/account → Workspaces** — a workspace you admin, a member-only one, and the communal `default`:

![account Workspaces panel: galleries, files with sizes, invite command, communal note](https://storage.uploads.sh/default/gh/uploads/2026-07-13/account-workspaces-e7c333.webp)

**/admin** — now the same shell as /account:

![restyled /admin dashboard matching account layout](https://storage.uploads.sh/default/gh/uploads/2026-07-13/admin-restyled-0ee535.webp)

## What it does

- **/account Workspaces panel** — per workspace: galleries (newest first), a files page with sizes, and (for admins/owners) a copyable `uploads admin invite create …` command.
- **Communal exemption** — the `default` workspace (configurable via a new `DEFAULT_WORKSPACE` var, defaulting to `"default"`) skips the browser and shows a note. It's the workspace *name* that marks it communal, not the shared bucket (which hosts many prefixed workspaces).
- **/admin restyle** — adopts account's shell (sidebar nav, panels, cards). Same workspace/member/invite management, just consistent styling. Drops the standalone `AuthIndicator` since it now owns its session like /account.
- **Richer file listing via files-sdk** — `listObjects` projects files-sdk's `StoredFile` items to the same `{ size, contentType, uploaded }` shape as HEAD, which also populates the CLI's `uploaded` list field (previously always `undefined`).

## What it is not

- **Not per-user attribution.** There's no `created_by` on files/galleries, and token/CLI/CI uploads carry no user identity — so "their stuff" is the workspace's content, not a true per-user filter. Galleries (ordered by recency) are the curated surface.
- **No schema migration, no new auth surface.** Everything hangs off the existing session-authenticated, member-gated `/me/*`.
- **Client gating is UX only.** `/me/*` (member) and `/admin-ui/*` (admin) enforce authorization server-side over the AUTH binding regardless of what the page shows.

## How to try it

Sign in at `/login`, then open `/account#workspaces`: a workspace you belong to shows its galleries and files; if you admin it, the invite command. A membership in `default` shows the shared-space note. Global admins can open `/admin` for the restyled dashboard.

## Technical notes

- New endpoints: `GET /me/workspaces/:name/galleries` and `/files` (member-gated via the existing `myWorkspaces` check; communal workspaces short-circuit to `{ communal: true, [] }` so the shared bucket is never enumerated to a member).
- Shared client wiring (hash panel-switcher + sign-out) extracted to `apps/web/src/lib/account-shell.ts`, used by both pages. `storedMetaJson` in `files-core.ts` is now shared by HEAD and list.
- Deliberately deferred: `/account` and `/admin` still duplicate the shell **CSS** (a scoped→global styling change better verified with a real render). One `default`-workspace admin still sees the invite command (role-gated, independent of communal) — easy to suppress if undesired.

## Test plan

- [x] `pnpm --filter @uploads/api test` — 213 pass (5 new `/me` cases: communal flag, galleries/files listing, communal short-circuit, member 404)
- [x] `pnpm --filter @uploads/mcp test` — 22 pass (covers the `listObjects` shape change)
- [x] `pnpm --filter @uploads/web test` — 24 pass (incl. pages-reachability)
- [x] `astro check` — 0 errors (also cleared 2 pre-existing errors in `admin.astro`)
- [x] `pnpm check` (oxlint + oxfmt) clean; `pnpm typecheck` clean (api/mcp)
- [x] Both panels rendered with representative data (screenshots above); no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
