### PR TITLE
fix(web): stop account nav session-check flicker

### DIFF
--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -91,6 +91,30 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
   </div>
 </div>
 
+{/* Sync optimistic paint: show the shell before deferred modules run so
+    /account → /account/workspaces does not flash "Checking your session…".
+    Key must match SESSION_CACHE_KEY in account-shell.ts. Not a security
+    boundary — revalidated by resolveSessionGate immediately after. */}
+<script is:inline>
+  (function () {
+    try {
+      var raw = sessionStorage.getItem("uploads:sessionUser");
+      if (!raw) return;
+      var user = JSON.parse(raw);
+      if (!user || !user.email) return;
+      var checking = document.getElementById("checking");
+      var app = document.getElementById("app");
+      var who = document.getElementById("who");
+      var adminLink = document.getElementById("admin-link");
+      if (checking) checking.hidden = true;
+      if (app) app.hidden = false;
+      if (who) who.textContent = user.email;
+      if (adminLink && user.role === "admin") adminLink.hidden = false;
+      window.__uploadsSessionUser = user;
+    } catch (e) {}
+  })();
+</script>
+
 <script define:vars={{ authOrigin, apiOrigin }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
@@ -116,10 +140,8 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
     app: requireElement<HTMLElement>("#app", "account"),
     who: requireElement<HTMLElement>("#who", "account"),
   }).then((result) => {
-    if (!result) return;
-    if (result.user.role === "admin") {
-      requireElement<HTMLElement>("#admin-link", "account").hidden = false;
-    }
+    const adminLink = requireElement<HTMLElement>("#admin-link", "account");
+    adminLink.hidden = result?.user.role !== "admin";
   });
 </script>
 </body>

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -94,6 +94,25 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
   </div>
 </div>
 
+{/* Sync optimistic paint for admins only — same cache key as account-shell. */}
+<script is:inline>
+  (function () {
+    try {
+      var raw = sessionStorage.getItem("uploads:sessionUser");
+      if (!raw) return;
+      var user = JSON.parse(raw);
+      if (!user || !user.email || user.role !== "admin") return;
+      var checking = document.getElementById("checking");
+      var app = document.getElementById("dashboard");
+      var who = document.getElementById("who");
+      if (checking) checking.hidden = true;
+      if (app) app.hidden = false;
+      if (who) who.textContent = user.email;
+      window.__uploadsSessionUser = user;
+    } catch (e) {}
+  })();
+</script>
+
 <script define:vars={{ authOrigin, apiOrigin }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -1,20 +1,86 @@
 /**
  * Client helpers for /account/* and /admin/* shells: sign-out, session gate,
  * and page scripts that wait for the layout gate without racing it.
+ *
+ * Session gate UX: after a successful check we cache the user in sessionStorage.
+ * On the next navigation the layout applies that cache synchronously (inline
+ * script + here) so the chrome does not flash "Checking your session…", then
+ * revalidates in the background. Cache is a UX affordance only — every API
+ * call still enforces the real session server-side.
  */
 import { getSession, signOut, type SessionResponse, type SessionUser } from "./auth-client";
 
 const SESSION_EVENT = "uploads:session";
 
+/** sessionStorage key — keep in sync with the inline optimistic script in layouts. */
+export const SESSION_CACHE_KEY = "uploads:sessionUser";
+
 type SessionWindow = Window & {
   __uploadsSessionUser?: SessionUser;
 };
+
+export function readCachedSessionUser(requireRole?: string): SessionUser | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_CACHE_KEY);
+    if (!raw) return null;
+    const user = JSON.parse(raw) as SessionUser;
+    if (!user?.email) return null;
+    if (requireRole && user.role !== requireRole) return null;
+    return user;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedSessionUser(user: SessionUser): void {
+  try {
+    sessionStorage.setItem(SESSION_CACHE_KEY, JSON.stringify(user));
+  } catch {
+    // Private mode / quota — gate still works without the cache.
+  }
+}
+
+export function clearCachedSessionUser(): void {
+  try {
+    sessionStorage.removeItem(SESSION_CACHE_KEY);
+  } catch {
+    // ignore
+  }
+  delete (window as SessionWindow).__uploadsSessionUser;
+}
+
+function publishSession(user: SessionUser, force = false): void {
+  const win = window as SessionWindow;
+  const already = win.__uploadsSessionUser;
+  win.__uploadsSessionUser = user;
+  // Avoid double-firing when the inline optimistic script already set the user
+  // and page scripts already subscribed via onSession.
+  if (!force && already?.id === user.id && already.email === user.email) return;
+  window.dispatchEvent(new CustomEvent(SESSION_EVENT, { detail: { user } }));
+}
+
+function showApp(
+  user: SessionUser,
+  options: Pick<SessionGateOptions, "checking" | "denied" | "app" | "who">,
+): void {
+  options.checking.hidden = true;
+  options.denied.hidden = true;
+  options.app.hidden = false;
+  if (options.who) options.who.textContent = user.email;
+}
+
+function showDenied(options: Pick<SessionGateOptions, "checking" | "denied" | "app">): void {
+  options.checking.hidden = true;
+  options.app.hidden = true;
+  options.denied.hidden = false;
+}
 
 /** Wire `#sign-out-btn` to end the session and return to /login. */
 export function initSignOut(authOrigin: string): void {
   const button = document.querySelector<HTMLButtonElement>("#sign-out-btn");
   if (!button) return;
   button.addEventListener("click", () => {
+    clearCachedSessionUser();
     void signOut(authOrigin).then(() => {
       location.href = "/login";
     });
@@ -32,23 +98,34 @@ export type SessionGateOptions = {
 };
 
 /**
- * Toggle checking / denied / app shells from the session. On success, stores
- * the user and fires `uploads:session` so page scripts can use `onSession`.
+ * Toggle checking / denied / app shells from the session.
+ *
+ * If a valid cached user exists (same role requirement), the shell is shown
+ * immediately and the network check runs in the background. On success the
+ * cache is refreshed; on failure the shell flips to denied.
  */
 export async function resolveSessionGate(
   options: SessionGateOptions,
 ): Promise<SessionResponse | null> {
+  const cached = readCachedSessionUser(options.requireRole);
+  if (cached) {
+    showApp(cached, options);
+    // Publish so page scripts (onSession) run even if the inline script did
+    // not run (e.g. sessionStorage written mid-session without a full reload).
+    publishSession(cached);
+  }
+
   const result = await getSession(options.authOrigin);
-  options.checking.hidden = true;
   if (!result || (options.requireRole && result.user.role !== options.requireRole)) {
-    options.denied.hidden = false;
+    clearCachedSessionUser();
+    showDenied(options);
     return null;
   }
-  if (options.who) options.who.textContent = result.user.email;
-  options.app.hidden = false;
-  const win = window as SessionWindow;
-  win.__uploadsSessionUser = result.user;
-  window.dispatchEvent(new CustomEvent(SESSION_EVENT, { detail: { user: result.user } }));
+
+  writeCachedSessionUser(result.user);
+  showApp(result.user, options);
+  // Force so email/role updates still reach listeners if the user object changed.
+  publishSession(result.user, true);
   return result;
 }
 


### PR DESCRIPTION
## In plain terms

Moving between account sections (`/account` → `/account/workspaces`, etc.) was flashing “Checking your session…” and collapsing the layout on every click. That was the client session gate re-running from a blank slate on each full page load.

## What it does

- After a successful session check, cache a small user snapshot in `sessionStorage`
- On the next navigation, paint the signed-in shell **synchronously** (inline script) so the chrome never drops
- Revalidate with `get-session` in the background; if the session is gone, flip to signed-out and clear the cache
- Clear the cache on sign-out
- Same treatment for `/admin/*` (admin role required for optimistic paint)

## What it is not

- Not a security change — API/auth still enforce the real session
- Not View Transitions / ClientRouter (those alone wouldn’t fix the gate; this targets the root cause)
- First visit after login still shows “Checking…” once (no cache yet)

## Why not View Transitions?

`ClientRouter` would soft-navigate, but each account page still shipped with `#app` hidden and re-ran the gate, so the flicker would remain unless we also persisted or cached session state. Caching is the smaller, more direct fix; VT can still be layered later for content crossfades if we want polish.

## How to try it

1. Sign in and open `/account` (expect one “Checking…” on first load).
2. Click Workspaces, Account, Developers — the sidebar/header should stay put with no checking flash.
3. Hard-refresh a nested path — still no flash after the first successful check in the tab.
4. Sign out and open `/account` again — should show signed-out (cache cleared).

## Test plan

- [x] `pnpm --filter @uploads/web test`
- [x] `pnpm --filter @uploads/web typecheck`
- [ ] Manual: click through account sections on a deployed or local preview