### PR TITLE
feat(api,web): standalone public file page (#135)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
+import { publicFiles } from "./routes/public-files";
 
 // Lets the browser console on the web origin (and local dev) call the token-
 // authenticated endpoints. CORS is not the security boundary — bearer tokens
@@ -58,6 +59,9 @@ export const app = new Hono<WorkspaceVars>()
   .route("/me", me)
   .route("/auth", auth)
   .route("/public/galleries", publicGalleries)
+  // Public single-object metadata for the file page (#135). Like public
+  // galleries, fetched server-side by apps/web; no CORS (not a browser call).
+  .route("/public/files", publicFiles)
   // Session-authenticated workspace-token mint (Phase 4). Registered BEFORE the
   // `/v1/:workspace/*` bearer guard: `/v1/tokens` does NOT match that pattern
   // (no trailing segment), so `workspaceAuth` never runs for it — this route

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,0 +1,45 @@
+import { NotFoundError } from "@uploads/errors";
+import { Hono } from "hono";
+import { badKey } from "../files-core";
+import { publicUrl, storage, storageConfig } from "../storage";
+import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
+
+/**
+ * Public, unauthenticated metadata for a single object, so `apps/web` (which has
+ * no storage bindings) can render a chrome-wrapped file page at
+ * `uploads.sh/f/<workspace>/<key>` (issue #135).
+ *
+ * Security posture mirrors public galleries: exact-key lookup only, no listing,
+ * no bearer token in the browser. It adds no new *access* — the bytes are already
+ * served unsigned off the R2 public domain — only a curated metadata view. Raw
+ * provenance is deliberately omitted here (unlike the authenticated HEAD).
+ */
+export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}", async (c) => {
+  const workspace = c.req.param("workspace");
+  const key = c.req.param("key");
+  if (badKey(key)) throw new NotFoundError();
+
+  // Validates the workspace name (WS_NAME_RE) before the KV lookup, matching the
+  // authenticated paths rather than trusting the raw path param.
+  const record = await loadWorkspaceRecord(c.env, workspace);
+  if (!record) throw new NotFoundError();
+
+  // Phase 1 is public-workspace-only: resolving the public URL doubles as the
+  // visibility gate. A workspace without a public base URL cannot be wrapped
+  // here — that is #123's signed-URL territory, swapped in when it lands.
+  const url = publicUrl(await storageConfig(c.env, record), key);
+  if (!url) throw new NotFoundError();
+
+  const store = await storage(c.env, record);
+  if (!(await store.exists(key))) throw new NotFoundError();
+  const meta = await store.head(key);
+
+  return c.json({
+    workspace,
+    key,
+    url,
+    size: meta.size ?? 0,
+    contentType: meta.type ?? "application/octet-stream",
+    ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+  });
+});

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -1,0 +1,150 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+
+// The public file page (issue #135) is served over HTTP from this endpoint:
+// apps/web has no storage bindings, so it fetches metadata + a resolved URL
+// from `GET /public/files/:workspace/:key`. The endpoint — not the Astro page —
+// is the security surface: unauthenticated, single-key, no listing, and only
+// for publicly-served (publicBaseUrl) workspaces in Phase 1.
+
+const TOKEN = "secret-token";
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+async function makeEnv(overrides: Partial<WorkspaceRecord> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...overrides,
+  };
+  const bucket = new FakeR2Bucket();
+  const env = {
+    REGISTRY: { get: async () => record, put: async () => undefined },
+    DB: {
+      prepare: () => ({
+        bind() {
+          return this;
+        },
+        async first() {
+          return null;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+      }),
+      async batch(stmts: { run: () => Promise<unknown> }[]) {
+        return Promise.all(stmts.map((s) => s.run()));
+      },
+    },
+    UPLOADS_DEFAULT: bucket,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+  };
+  return { env, bucket };
+}
+
+/** PUT a nested key (so auto-prefix does not rewrite it), returning the stored key. */
+async function seedShot(
+  env: Parameters<typeof app.request>[2],
+  headers: Record<string, string> = {},
+) {
+  const res = await app.request(
+    "/v1/default/files/screenshots/shot.png",
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png", ...headers },
+      body: PNG,
+    },
+    env,
+  );
+  if (res.status !== 201) throw new Error(`seed failed: ${res.status}`);
+  return "screenshots/shot.png";
+}
+
+describe("GET /public/files/:workspace/:key", () => {
+  it("returns metadata + the public URL for a stored object without auth", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      workspace: string;
+      key: string;
+      url: string;
+      size: number;
+      contentType: string;
+    };
+    expect(json.workspace).toBe("default");
+    expect(json.key).toBe("screenshots/shot.png");
+    expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+    expect(json.contentType).toBe("image/png");
+    expect(json.size).toBeGreaterThan(0);
+  });
+
+  it("never surfaces provenance metadata on the public surface", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env, {
+      "X-Uploads-Meta-Client": "uploads-cli",
+      "X-Uploads-Meta-Content-Sha256": "0".repeat(64),
+    });
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    expect((await res.json()) as Record<string, unknown>).not.toHaveProperty("metadata");
+  });
+
+  it("404s for a missing object", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/public/files/default/screenshots/missing.png", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when the workspace is not publicly served (no publicBaseUrl)", async () => {
+    const { env } = await makeEnv({ publicBaseUrl: undefined });
+    // Seeding still works (bucket write); only public resolution should refuse.
+    await app.request(
+      "/v1/default/files/screenshots/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s on a traversal / bad key rather than resolving it", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/public/files/default/../../etc/passwd", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("exposes no listing/enumeration surface (workspace root has no route)", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/public/files/default", {}, env);
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -1,6 +1,7 @@
 import { useFiles } from "files-sdk/react";
 import { FileBrowser } from "@uploads/ui";
 import "@uploads/ui/styles.css";
+import { filePath } from "../lib/public-file";
 
 interface Props {
   apiOrigin: string;
@@ -16,28 +17,18 @@ export function AccountFileBrowser({ apiOrigin, workspace }: Props) {
     fetchImpl: credentialedFetch,
   });
 
-  const openFile = async (key: string) => {
-    // Open synchronously so popup blockers recognize this as the row click;
-    // resolve the files-sdk URL into that tab afterward.
-    const tab = window.open("about:blank", "_blank");
+  // Open the chrome-wrapped file page (issue #135) rather than dumping the raw
+  // bytes into a tab. The page presents metadata and links to the original; for
+  // non-public workspaces it depends on the #123 URL resolver.
+  const openFile = (key: string) => {
+    const tab = window.open(filePath(workspace, key), "_blank");
     if (tab) tab.opener = null;
-    try {
-      const response = await credentialedFetch(
-        `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-url?key=${encodeURIComponent(key)}`,
-      );
-      const body = (await response.json()) as { url?: string };
-      if (!(response.ok && body.url)) throw new Error("file URL unavailable");
-      if (tab) tab.location.replace(body.url);
-      else window.location.assign(body.url);
-    } catch {
-      tab?.close();
-    }
   };
 
   return (
     <>
       <div className="ws-section-head">Files</div>
-      <FileBrowser files={files} onSelect={(file) => void openFile(file.key)} />
+      <FileBrowser files={files} onSelect={(file) => openFile(file.key)} />
     </>
   );
 }

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyPublicFileHeaders,
+  fetchPublicFile,
+  fileKind,
+  filePath,
+  formatBytes,
+  isPublicFile,
+  isSafeKey,
+  PUBLIC_FILE_CSP,
+} from "./public-file";
+
+const file = {
+  workspace: "acme",
+  key: "screenshots/shot.png",
+  url: "https://storage.uploads.sh/acme/screenshots/shot.png",
+  size: 20480,
+  contentType: "image/png",
+  uploaded: "2026-07-13T12:00:00.000Z",
+} as const;
+
+describe("public file headers", () => {
+  it("locks down like the public gallery: no-store, noindex, strict CSP", () => {
+    expect(PUBLIC_FILE_CSP).toContain("default-src 'none'");
+    expect(PUBLIC_FILE_CSP).toContain("frame-ancestors 'none'");
+    expect(PUBLIC_FILE_CSP).toContain("style-src 'self' 'unsafe-inline'");
+    const headers = new Headers();
+    applyPublicFileHeaders(headers);
+    expect(headers.get("Content-Security-Policy")).toBe(PUBLIC_FILE_CSP);
+    expect(headers.get("Cache-Control")).toBe("no-store");
+    expect(headers.get("X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+  });
+});
+
+describe("isPublicFile", () => {
+  it("accepts the bounded DTO and tolerates a missing/null uploaded", () => {
+    expect(isPublicFile(file)).toBe(true);
+    expect(isPublicFile({ ...file, uploaded: null })).toBe(true);
+    const { uploaded: _omit, ...noUploaded } = file;
+    expect(isPublicFile(noUploaded)).toBe(true);
+  });
+
+  it("rejects non-https URLs, bad sizes, and over-long content types", () => {
+    expect(isPublicFile({ ...file, url: "http://storage.uploads.sh/x" })).toBe(false);
+    expect(isPublicFile({ ...file, size: -1 })).toBe(false);
+    expect(isPublicFile({ ...file, size: 1.5 })).toBe(false);
+    expect(isPublicFile({ ...file, contentType: "x".repeat(129) })).toBe(false);
+    expect(isPublicFile(null)).toBe(false);
+  });
+});
+
+describe("key safety + path building", () => {
+  it("rejects traversal, absolute, empty, and over-long keys", () => {
+    expect(isSafeKey("f/AbC123/logo.png")).toBe(true);
+    expect(isSafeKey("../etc/passwd")).toBe(false);
+    expect(isSafeKey("a/../b")).toBe(false);
+    expect(isSafeKey("/leading")).toBe(false);
+    expect(isSafeKey("")).toBe(false);
+    expect(isSafeKey("x".repeat(1025))).toBe(false);
+  });
+
+  it("URL-encodes each key segment but preserves the slashes", () => {
+    expect(filePath("acme", "f/My Shot#1.png")).toBe("/f/acme/f/My%20Shot%231.png");
+  });
+});
+
+describe("fileKind", () => {
+  it("maps images and videos, treats svg as unsupported, else file", () => {
+    expect(fileKind("image/png")).toBe("image");
+    expect(fileKind("video/mp4")).toBe("video");
+    expect(fileKind("image/svg+xml")).toBe("unsupported");
+    expect(fileKind("application/pdf")).toBe("file");
+  });
+});
+
+describe("formatBytes", () => {
+  it("renders human sizes", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(20480)).toBe("20 KB");
+    expect(formatBytes(1_500_000)).toBe("1.4 MB");
+  });
+});
+
+describe("fetchPublicFile", () => {
+  it("returns ok for a valid DTO and calls the single-object endpoint", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL) => Response.json(file));
+    const result = await fetchPublicFile("acme", "screenshots/shot.png", {
+      origin: "https://api.uploads.sh",
+      fetch: fetcher,
+    });
+    expect(result).toEqual({ status: "ok", file: { ...file } });
+    expect(String(fetcher.mock.calls[0][0])).toBe(
+      "https://api.uploads.sh/public/files/acme/screenshots/shot.png",
+    );
+  });
+
+  it("short-circuits bad workspace/key without a network call", async () => {
+    const fetcher = vi.fn();
+    expect(
+      await fetchPublicFile("bad ws", "k", { origin: "https://api.uploads.sh", fetch: fetcher }),
+    ).toEqual({ status: "not_found" });
+    expect(
+      await fetchPublicFile("acme", "../escape", {
+        origin: "https://api.uploads.sh",
+        fetch: fetcher,
+      }),
+    ).toEqual({ status: "not_found" });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("maps 404 to not_found and other failures to unavailable", async () => {
+    expect(
+      await fetchPublicFile("acme", "k.png", {
+        origin: "https://api.uploads.sh",
+        fetch: async () => new Response(null, { status: 404 }),
+      }),
+    ).toEqual({ status: "not_found" });
+    expect(
+      await fetchPublicFile("acme", "k.png", {
+        origin: "https://api.uploads.sh",
+        fetch: async () => new Response("nope", { status: 503 }),
+      }),
+    ).toEqual({ status: "unavailable" });
+  });
+
+  it("refuses non-loopback plaintext origins but allows loopback dev", async () => {
+    const fetcher = vi.fn(async () => Response.json(file));
+    expect(
+      await fetchPublicFile("acme", "k.png", { origin: "http://evil.test", fetch: fetcher }),
+    ).toEqual({ status: "unavailable" });
+    expect(
+      (await fetchPublicFile("acme", "k.png", { origin: "http://127.0.0.1:8787", fetch: fetcher }))
+        .status,
+    ).toBe("ok");
+  });
+});

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -1,0 +1,194 @@
+import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
+
+// Client model for the standalone public file page (issue #135). Fetched
+// server-side from the API's `GET /public/files/:workspace/:key` — apps/web has
+// no storage bindings, so the API endpoint is the single-object security
+// surface. This mirrors public-gallery.ts, minus collection/ordering concerns.
+
+/** Allowlisted metadata for one public object, as returned by the API. */
+export interface PublicFile {
+  workspace: string;
+  key: string;
+  url: string;
+  size: number;
+  contentType: string;
+  uploaded: string | null;
+}
+
+/** Result of resolving a public file: the DTO, a hard 404, or a soft outage. */
+export type FileFetchResult =
+  | { status: "ok"; file: PublicFile }
+  | { status: "not_found" }
+  | { status: "unavailable" };
+
+/** How a file should be presented in the page's media stage. */
+export type MediaKind = "image" | "video" | "file" | "unsupported";
+
+const imageTypes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
+const videoTypes = new Set(["video/mp4", "video/webm"]);
+
+/** Classify a content type for rendering; SVG is unsupported per upload policy. */
+export function fileKind(contentType: string): MediaKind {
+  if (imageTypes.has(contentType)) return "image";
+  if (videoTypes.has(contentType)) return "video";
+  if (contentType === "image/svg+xml") return "unsupported";
+  return "file";
+}
+
+/** A workspace name as it appears in registry keys / public URLs. */
+const WORKSPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/** Reject empty, over-long, traversal, or absolute keys before they reach the API. */
+export function isSafeKey(key: string): boolean {
+  if (key.length === 0 || key.length > 1024) return false;
+  if (key.startsWith("/")) return false;
+  return key.split("/").every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+/** Encode each path segment so filenames with spaces / `#` / `%` round-trip. */
+function encodeKey(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+/** Build the on-site page path (`/f/<workspace>/<key>`) with each segment encoded. */
+export function filePath(workspace: string, key: string): string {
+  return `/f/${encodeURIComponent(workspace)}/${encodeKey(key)}`;
+}
+
+/**
+ * Public file page CSP — identical posture to the public gallery: locked down
+ * except for self-hosted styles/fonts and the Cloudflare RUM beacon.
+ */
+export const PUBLIC_FILE_CSP = [
+  "default-src 'none'",
+  "img-src https: data:",
+  "media-src https:",
+  "font-src 'self'",
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  `script-src ${CF_RUM_SCRIPT_SRC}`,
+  `connect-src ${CF_RUM_CONNECT_SRC}`,
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+].join("; ");
+
+/** Strict CSP, noindex, no-store — matches the public gallery pages. */
+export function applyPublicFileHeaders(headers: Headers): void {
+  headers.set("Content-Security-Policy", PUBLIC_FILE_CSP);
+  headers.set("Referrer-Policy", "no-referrer");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("X-Robots-Tag", "noindex, nofollow, noarchive");
+  headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  headers.set("Cache-Control", "no-store");
+}
+
+/** Bounded plain text: a string within `max` chars and free of control/format code points. */
+function text(value: unknown, max: number): value is string {
+  if (typeof value !== "string" || value.length > max) return false;
+  return Array.from(value).every((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    if (code === 9 || code === 10 || code === 13) return true;
+    if (code < 32 || code === 127 || (code >= 0x80 && code <= 0x9f)) return false;
+    return !/\p{Cf}/u.test(character);
+  });
+}
+
+/** A bounded, well-formed `https:` URL — the only scheme the page will render/link. */
+function httpsUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 4096) return false;
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** Validate an untrusted API response against the bounded {@link PublicFile} shape. */
+export function isPublicFile(value: unknown): value is PublicFile {
+  if (typeof value !== "object" || value === null) return false;
+  const file = value as Record<string, unknown>;
+  const uploadedOk =
+    file.uploaded === undefined ||
+    file.uploaded === null ||
+    (text(file.uploaded, 64) && Number.isFinite(Date.parse(file.uploaded as string)));
+  return (
+    text(file.workspace, 64) &&
+    text(file.key, 1024) &&
+    httpsUrl(file.url) &&
+    Number.isSafeInteger(file.size) &&
+    (file.size as number) >= 0 &&
+    text(file.contentType, 128) &&
+    uploadedOk
+  );
+}
+
+/**
+ * Resolve one public object's metadata from the API.
+ *
+ * Rejects unsafe workspace/key inputs up front, restricts the origin to
+ * `https:` (or loopback `http:` for dev), and validates the response before
+ * returning. Maps a 404 to `not_found` and any other failure to `unavailable`.
+ */
+export async function fetchPublicFile(
+  workspace: string,
+  key: string,
+  options: { origin: string; fetch?: typeof globalThis.fetch; timeoutMs?: number },
+): Promise<FileFetchResult> {
+  if (!WORKSPACE_PATTERN.test(workspace) || !isSafeKey(key)) return { status: "not_found" };
+
+  let origin: URL;
+  try {
+    origin = new URL(options.origin);
+  } catch {
+    return { status: "unavailable" };
+  }
+  const loopback =
+    origin.hostname === "localhost" ||
+    origin.hostname === "127.0.0.1" ||
+    origin.hostname === "[::1]";
+  if (origin.protocol !== "https:" && !(origin.protocol === "http:" && loopback))
+    return { status: "unavailable" };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? 4000);
+  try {
+    const endpoint = new URL(
+      `/public/files/${encodeURIComponent(workspace)}/${encodeKey(key)}`,
+      origin,
+    );
+    const response = await (options.fetch ?? globalThis.fetch)(endpoint, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+    });
+    if (response.status === 404) return { status: "not_found" };
+    if (!response.ok) return { status: "unavailable" };
+    const value: unknown = await response.json();
+    return isPublicFile(value)
+      ? { status: "ok", file: { ...value, uploaded: value.uploaded ?? null } }
+      : { status: "unavailable" };
+  } catch {
+    return { status: "unavailable" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Human-readable byte size for the metadata block. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -40,6 +40,7 @@ describe.each([
   { path: "/account/profile", title: "Account · uploads.sh" },
   { path: "/account/developers", title: "Developers · uploads.sh" },
   { path: "/console", title: "uploads.sh console" },
+  { path: "/f/acme/screenshots/shot.png", title: "shot.png · uploads.sh" },
 ])("route reachability: $path", ({ path, title }) => {
   it("reaches the page handler (not a static 404) on a browser navigation request", async () => {
     let handlerCalled = false;

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -1,0 +1,120 @@
+---
+import BaseHead from "../../../components/BaseHead.astro";
+import Brand from "../../../components/Brand.astro";
+import Footer from "../../../components/Footer.astro";
+import {
+  applyPublicFileHeaders,
+  fetchPublicFile,
+  fileKind as kind,
+  filePath,
+  formatBytes,
+} from "../../../lib/public-file";
+import { env } from "cloudflare:workers";
+
+export const prerender = false;
+
+const workspace = Astro.params.workspace ?? "";
+const key = Astro.params.key ?? "";
+const origin =
+  env.UPLOADS_API_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ??
+  "https://api.uploads.sh";
+const result = await fetchPublicFile(workspace, key, { origin });
+
+applyPublicFileHeaders(Astro.response.headers);
+
+const file = result.status === "ok" ? result.file : null;
+if (result.status === "unavailable") Astro.response.status = 503;
+else if (!file) Astro.response.status = 404;
+
+const filename = key.split("/").filter(Boolean).pop() ?? key;
+const uploaded = file?.uploaded ? new Date(file.uploaded) : null;
+const uploadedLabel =
+  uploaded && Number.isFinite(uploaded.getTime())
+    ? uploaded.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })
+    : null;
+const canonical = new URL(file ? filePath(workspace, key) : Astro.url.pathname, Astro.url.origin)
+  .href;
+const title = file ? `${filename} · uploads.sh` : "File unavailable · uploads.sh";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead />
+    <meta name="robots" content="noindex, nofollow, noarchive" />
+    <link rel="canonical" href={canonical} />
+    <title>{title}</title>
+    <meta name="description" content="Public file hosted by uploads.sh." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={file ? filename : "File unavailable"} />
+    <meta property="og:description" content="Public file hosted by uploads.sh." />
+    <meta property="og:url" content={canonical} />
+    {file && kind(file.contentType) === "image" && <meta property="og:image" content={file.url} />}
+    <style>
+      * { box-sizing:border-box; }
+      body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }
+      .shell { width:min(1080px,calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
+      nav.top { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
+      .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
+      .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
+      .media { min-height:320px; max-height:78vh; background:var(--bg); display:grid; place-items:center; overflow:hidden; }
+      img,video { max-width:100%; max-height:78vh; width:auto; height:auto; object-fit:contain; display:block; }
+      .fallback { padding:60px 30px; text-align:center; color:var(--muted); font:13px/1.6 var(--mono); }
+      .fallback strong { display:block; color:var(--fg); margin-bottom:8px; }
+      .fallback a { color:var(--fg); overflow-wrap:anywhere; }
+      .details { padding:18px 20px 22px; border-top:1px solid var(--line); }
+      .filename { color:var(--fg); font:600 14px var(--mono); overflow-wrap:anywhere; }
+      dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:14px 0 0; font:12px var(--mono); }
+      dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
+      dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
+      .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-top:16px; }
+      .actions a.original { display:inline-block; padding:9px 15px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
+      .actions a.original:hover, .actions a.original:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      .linkfield { flex:1; min-width:220px; }
+      .linkfield label { display:block; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); margin-bottom:5px; }
+      .linkfield input { width:100%; padding:8px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
+      .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
+      .error code { color:var(--accent); font-family:var(--mono); }
+      a { color:var(--fg); text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent); text-underline-offset:3px; }
+      @media (max-width:760px) { .shell{width:min(100% - 32px,1080px);padding-top:24px} .media{min-height:220px} }
+      .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); clip-path:inset(50%); white-space:nowrap; border:0; }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <nav class="top"><Brand /><span class="public">public file</span></nav>
+      {file ? (
+        <>
+          <h1 class="sr-only">{filename}</h1>
+          <figure class="stage" style="margin:0">
+            <div class="media">
+              {kind(file.contentType) === "image" && <img src={file.url} alt={filename} decoding="async" />}
+              {kind(file.contentType) === "video" && <video src={file.url} controls playsinline preload="metadata">Your browser cannot play this video.</video>}
+              {kind(file.contentType) === "file" && <div class="fallback"><strong>Preview unavailable</strong><a href={file.url} rel="noopener noreferrer">Open {filename}</a></div>}
+              {kind(file.contentType) === "unsupported" && <div class="fallback"><strong>Unsupported media type</strong><span>This file cannot be previewed inline.</span></div>}
+            </div>
+            <figcaption class="details">
+              <div class="filename">{filename}</div>
+              <dl class="meta">
+                <dt>Type</dt><dd>{file.contentType}</dd>
+                <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
+                {uploadedLabel && <><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>}
+              </dl>
+              <div class="actions">
+                {kind(file.contentType) !== "unsupported" && <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>}
+                <span class="linkfield">
+                  <label for="page-link">Page link</label>
+                  <input id="page-link" type="text" readonly value={canonical} aria-label="Page link" />
+                </span>
+              </div>
+            </figcaption>
+          </figure>
+          <Footer />
+        </>
+      ) : (
+        <section class="error"><code>{result.status === "unavailable" ? "file.unavailable" : "file.not_found"}</code><h1>{result.status === "unavailable" ? "File temporarily unavailable" : "File not found"}</h1><p>{result.status === "unavailable" ? "The file service could not be reached. Please try again shortly." : "This file may have been removed, or the link is incorrect."}</p></section>
+      )}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds a standalone **public file page** — a chrome-wrapped view of a single stored object at `uploads.sh/f/<workspace>/<key>`, the single-item sibling of the public gallery (`/g/<id>`). Clicking a file in the account file browser now opens this page instead of dumping raw bytes into a tab.

Closes #135 (Phase 1) — full design, security analysis, and acceptance criteria are in that issue.

## Why

There was no way to view one file with metadata and context outside a gallery — the file tree linked straight to raw R2 bytes. This wraps those already-public bytes with filename, type, size, and upload time, and a one-click link to the original.

## How it works

`apps/web` has no storage bindings, so (like the public gallery) the page fetches from a new **unauthenticated API endpoint** — `GET /public/files/:workspace/:key` — which is the real security surface:

- **No new access.** Bytes are already served fully public/unsigned off the R2 custom domain; this only adds a curated metadata view.
- **Single-key lookup only — no listing/enumeration.** Mirrors the gallery contract's "exact-key lookup, no unauthenticated workspace listing."
- **Traversal-safe independent of the client:** `badKey` (`KEY_RE` + `.`/`..` segment rejection) gates the endpoint directly; resolution is always scoped to the named workspace's prefixed storage, so workspace-crossing is impossible.
- **Public-workspace-only (Phase 1):** resolving the public URL doubles as the visibility gate — a workspace without a `publicBaseUrl` returns 404. Private/BYO buckets are out of scope until the #123 signed-URL resolver lands.
- **Minimized disclosure:** raw provenance metadata is deliberately omitted (unlike the authenticated HEAD).

The page copies the public gallery's rendering discipline: strict CSP, `noindex`, `no-store`, escaped untrusted filename/metadata, SVG unsupported, image/video/file/unsupported/not-found/unavailable states.

## Changes

- `apps/api/src/routes/public-files.ts` — new endpoint; mounted at `/public/files` in `index.ts`.
- `apps/web/src/lib/public-file.ts` — fetch, DTO validation, key-safety guard, per-segment URL encoding, CSP/header helper, `formatBytes`.
- `apps/web/src/pages/f/[workspace]/[...key].astro` — the SSR page.
- `apps/web/src/components/AccountFileBrowser.tsx` — row click → file page.

## Verification

- **API:** 230/230 tests pass (6 new in `routes-public-files.test.ts`), clean `tsc`.
- **Web:** 40/40 tests pass (16 new in `public-file.test.ts`, + a `/f/…` reachability entry), `astro check` 0 errors, `astro build` succeeds (`/f` in the SSR bundle, not prerendered).
- **Live SSR render:** page serves without white-screening; not-found state renders on-brand with a 404 status; response carries the strict CSP, `noindex`, `no-store`, `DENY`, `no-referrer` headers.
- **Not** live-verified: the happy-path render (real image + metadata) needs a seeded local authenticated stack (#120); its JSON shape/URL are covered by the API unit tests, and the endpoint returns correct data in prod once deployed.

## Follow-ups (not in this PR)

- **#123** — wire the signed-URL resolver into `/public/files` so private/BYO workspaces render (until then their file browser opens a 404 page; public shared-bucket — the default — works now).
- **#35** — swap the HEAD for the object index and add a retention-removed tombstone state (a bare 404 can't distinguish removed from never-existed).
- **#92** — reconcile: this page is a candidate "lighter-weight per-file page" that lets `attach` self-*links* point here without burning gallery caps (embeds must stay raw URLs — camo).
- Phase 2 — optional per-file `visibility: private` serving through the worker (roadmap "Private-repo embed privacy").

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public, unauthenticated file pages with previews for images and videos.
  * Added file metadata displays, including size, type, upload date, and an option to open the original.
  * Added secure public file URL handling and protection against unsafe paths.
  * Updated the file browser to open files directly in the public viewer.

* **Bug Fixes**
  * Added clear handling for missing or temporarily unavailable files.
  * Prevented file listings and unsafe path access through public URLs.

* **Tests**
  * Added coverage for public file retrieval, validation, security headers, media handling, and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->