### PR TITLE
fix(web,ui): flatten account surfaces, add app-wide footer, stabilize file tree

### DIFF
--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -11,6 +11,7 @@ import {
 } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
+import Footer from "../components/Footer.astro";
 import "../styles/signed-in-shell.css";
 import "../styles/account-content.css";
 
@@ -94,6 +95,8 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
         <slot />
       </div>
     </div>
+
+    <Footer />
   </div>
 </div>
 

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -12,6 +12,7 @@ import {
 } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
+import Footer from "../components/Footer.astro";
 import "../styles/signed-in-shell.css";
 
 export type AdminSection = "workspaces" | "users";
@@ -97,6 +98,8 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
         <slot />
       </div>
     </div>
+
+    <Footer />
   </div>
 </div>
 

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -35,6 +35,20 @@ ul.plain li {
   background: var(--bg);
   font-size: 13px;
 }
+/* Workspace blocks flatten: the surrounding .card is the only box. Each
+   workspace is a borderless region, hairline-separated from the next. */
+ul.plain li[data-workspace] {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  gap: 6px;
+}
+ul.plain li[data-workspace] + li[data-workspace] {
+  margin-top: 8px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+}
 ul.plain .row {
   display: flex;
   justify-content: space-between;
@@ -86,15 +100,18 @@ ul.plain .ws-note {
   font-size: 12px;
   margin: 0;
 }
+/* Invite command: a light inset code row, not a raised bordered panel. The
+   card is already --panel, so a subtle --bg strip reads as a copy target
+   without adding another box to the stack. */
 ul.plain .command {
   display: flex;
   gap: 10px;
   align-items: center;
   margin-top: 2px;
-  padding: 9px 11px;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  background: var(--panel);
+  padding: 8px 10px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
 }
 ul.plain .command code {
   flex: 1;
@@ -115,7 +132,7 @@ ul.plain .command button {
   border: 1px solid var(--line);
   border-radius: 6px;
   padding: 5px 10px;
-  background: var(--bg);
+  background: var(--panel);
   cursor: pointer;
 }
 ul.plain .command button:hover,

--- a/docs/superpowers/specs/2026-07-13-accounts-layout-ux-design.md
+++ b/docs/superpowers/specs/2026-07-13-accounts-layout-ux-design.md
@@ -1,0 +1,87 @@
+# Accounts layout & file-tree UX pass
+
+**Date:** 2026-07-13
+**Scope:** `apps/web` account/admin chrome + `@uploads/ui` FileBrowser. No routes, no API, no data-flow changes.
+
+## Problem
+
+The signed-in `/account/workspaces` view reads as clutter, and the signed-in
+shell is missing chrome:
+
+1. **Too many boxes.** The Workspaces page nests bordered cards three deep:
+   outer `.card` → bordered workspace `<li>` → bordered sub-panels for
+   Galleries / Files / the invite command → bordered file rows. Boxes-in-boxes.
+2. **No footer** on `/account/*` or `/admin/*`. The canonical `<Footer />`
+   ([apps/web/src/components/Footer.astro](../../../apps/web/src/components/Footer.astro))
+   ships on docs/legal/auth pages but neither signed-in layout includes it.
+3. **File-tree layout shift.** `FileBrowser.navigate()` clears
+   `folders`/`items` to `[]` synchronously before fetching, so the container
+   collapses to breadcrumb + spinner, then re-expands when data lands — a
+   shrink-then-grow on every level change and on the initial lazy mount.
+
+## Design-system guardrail
+
+These pages are Astro/HTML and consume the DS through its **tokens**
+(`--line`, `--panel`, `--muted`, `--radius-*`, `--space-*`) and shared shell
+styles — not React components. The one React DS surface is `FileBrowser`.
+Every change here either reuses an existing token/pattern or **updates the DS
+in place** (`packages/ui/src/styles.css`). No divergent one-off styling.
+
+## Changes
+
+### 1. Footer as app-wide chrome
+
+Add `<Footer />` to `AccountLayout.astro` and `AdminLayout.astro`, placed
+after the `.layout` grid but inside the gated `#app` / `#dashboard` container,
+so it spans full width at page bottom and only appears once a session
+resolves (no flash under "Checking your session…"). Reuse the canonical
+component — no new markup. `.shell` already reserves bottom padding; the
+footer's own `margin-top` provides separation.
+
+### 2. Flatten the Workspaces surfaces (`account-content.css`)
+
+The outer `.card` stays the only "box." Inside it:
+
+- Remove `border` / `background` / `border-radius` from `ul.plain li`
+  (the workspace block) and from `.command` (the invite row). They become
+  hairline/whitespace-separated regions, not nested cards.
+- Keep the header row (name + role badge) and the usage line beneath it.
+- Galleries / Files / Invite keep the existing borderless `.ws-section` +
+  uppercase `.ws-section-head` label pattern, separated by a top hairline
+  (`border-top: 1px solid var(--line)`) and `--space-*` rhythm.
+- The invite command keeps mono + copy button but loses the heavy panel:
+  a lighter inline code row.
+- Multiple workspaces are separated from each other by a hairline rather than
+  each sitting in its own chip.
+
+### 3. File rows + stability (`packages/ui/src/styles.css`, `FileBrowser.tsx`)
+
+DS update (benefits every future consumer, currently only this page):
+
+- **Soften rows:** file/folder rows go from full bordered buttons to
+  hairline-separated list rows (bottom border on `li`, no per-row box), so
+  Files reads as one list.
+- **Reserve height:** give the list a `min-height` (a few rows tall) so the
+  container never collapses between navigations; loading/empty states render
+  within that reserved space.
+- **Don't blank on navigate:** stop clearing `folders`/`items` to `[]`
+  synchronously in `navigate()`. Keep the current listing visible (dimmed,
+  with the existing spinner affordance) until the new level resolves, then
+  swap. The `requestGeneration` guard already discards stale writes, so only
+  the visual clear is deferred. Removes both the shrink-then-grow and the
+  flash-of-empty; the reserved height also stops the initial lazy-mount pop.
+
+## Non-goals
+
+- No new routes or pages; Overview / Profile / Developers keep their single
+  clean card and simply gain the footer via the shared layout.
+- No API, endpoint, or data-fetching changes.
+- No new DS component; `FileBrowser` restyle is a token-based update to the
+  existing component.
+
+## Verification
+
+Drive the running dev server: sign-in shell renders footer on
+`/account/*` and `/admin/*`; Workspaces shows one outer card with flat
+interior; navigating folders in the file tree holds a stable height with no
+shrink-then-grow. Check light/dark + narrow viewport.

--- a/packages/ui/src/FileBrowser.tsx
+++ b/packages/ui/src/FileBrowser.tsx
@@ -81,15 +81,21 @@ export function FileBrowser({
   }, [load]);
 
   const navigate = (nextPrefix: string) => {
+    if (nextPrefix === prefix) return;
+    // Keep the current listing on screen while the next level loads. The
+    // requestGeneration bump discards any in-flight page from this level, and
+    // load() replaces folders/items wholesale on success — so we avoid the
+    // flash-of-empty (and the shrink-then-grow) that clearing state caused.
     requestGeneration.current++;
-    setFolders([]);
-    setItems([]);
-    setCursor(undefined);
     setHasError(false);
     setIsLoading(true);
     setPrefix(nextPrefix);
   };
-  const isEmpty = !(isLoading || hasError || folders.length || items.length);
+  const hasContent = folders.length > 0 || items.length > 0;
+  const isEmpty = !(isLoading || hasError || hasContent);
+  // While navigating with content already on screen, dim the old listing
+  // instead of collapsing it — the reserved-height viewport does the rest.
+  const isBusyOverlay = isLoading && hasContent;
 
   return (
     <div className="ul-files">
@@ -115,50 +121,57 @@ export function FileBrowser({
           </Fragment>
         ))}
       </nav>
-      <ul className="ul-files__list">
-        {folders.map((folder) => (
-          <li key={folder}>
-            <button className="ul-files__row" onClick={() => navigate(folder)} type="button">
-              <span className="ul-files__icon">
-                <Folder aria-hidden="true" />
-              </span>
-              <span className="ul-files__name">{childName(folder, prefix, delimiter)}</span>
-              <ChevronRight className="ul-files__chevron" aria-hidden="true" />
-            </button>
-          </li>
-        ))}
-        {items.map((item) => (
-          <li key={item.key}>
-            <button
-              className="ul-files__row"
-              disabled={!onSelect}
-              onClick={() => onSelect?.(item)}
-              type="button"
-            >
-              <span className="ul-files__icon">
-                <File aria-hidden="true" />
-              </span>
-              <span className="ul-files__name">
-                <span>{childName(item.key, prefix, delimiter) || item.key}</span>
-                <small>
-                  {formatBytes(item.size)} · {item.type || "unknown"}
-                </small>
-              </span>
-            </button>
-          </li>
-        ))}
-      </ul>
-      {isLoading ? (
-        <div className="ul-files__state">
-          <LoaderCircle className="ul-files__spin" aria-hidden="true" /> Loading…
-        </div>
-      ) : null}
-      {hasError ? <div className="ul-files__state">Files unavailable.</div> : null}
-      {isEmpty ? (
-        <div className="ul-files__state">
-          <Folder aria-hidden="true" /> This folder is empty.
-        </div>
-      ) : null}
+      <div className="ul-files__viewport" data-busy={isBusyOverlay ? "" : undefined}>
+        <ul className="ul-files__list">
+          {folders.map((folder) => (
+            <li key={folder}>
+              <button className="ul-files__row" onClick={() => navigate(folder)} type="button">
+                <span className="ul-files__icon">
+                  <Folder aria-hidden="true" />
+                </span>
+                <span className="ul-files__name">{childName(folder, prefix, delimiter)}</span>
+                <ChevronRight className="ul-files__chevron" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+          {items.map((item) => (
+            <li key={item.key}>
+              <button
+                className="ul-files__row"
+                disabled={!onSelect}
+                onClick={() => onSelect?.(item)}
+                type="button"
+              >
+                <span className="ul-files__icon">
+                  <File aria-hidden="true" />
+                </span>
+                <span className="ul-files__name">
+                  <span>{childName(item.key, prefix, delimiter) || item.key}</span>
+                  <small>
+                    {formatBytes(item.size)} · {item.type || "unknown"}
+                  </small>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        {isBusyOverlay ? (
+          <div className="ul-files__busy" aria-hidden="true">
+            <LoaderCircle className="ul-files__spin" />
+          </div>
+        ) : null}
+        {isLoading && !hasContent ? (
+          <div className="ul-files__state">
+            <LoaderCircle className="ul-files__spin" aria-hidden="true" /> Loading…
+          </div>
+        ) : null}
+        {hasError ? <div className="ul-files__state">Files unavailable.</div> : null}
+        {isEmpty ? (
+          <div className="ul-files__state">
+            <Folder aria-hidden="true" /> This folder is empty.
+          </div>
+        ) : null}
+      </div>
       {cursor && !isLoading ? (
         <button className="ul-files__more" onClick={() => void load(cursor)} type="button">
           Load more

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -493,18 +493,30 @@
   height: 13px;
   flex: none;
 }
+/* Reserved-height viewport: holds the list, loading/empty/error states, and
+   the busy overlay so navigating between folder levels never collapses the
+   browser to near-zero and re-expands. */
+.ul-files__viewport {
+  position: relative;
+  min-height: 116px;
+}
 .ul-files__list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 4px;
+  gap: 0;
 }
+/* Hairline-separated rows read as one list rather than a stack of chips. */
 .ul-files__list li {
   display: block;
   padding: 0;
   border: 0;
+  border-bottom: 1px solid var(--line);
   background: none;
+}
+.ul-files__list li:last-child {
+  border-bottom: 0;
 }
 .ul-files__row {
   width: 100%;
@@ -514,16 +526,33 @@
   text-align: left;
   font: 12.5px var(--mono);
   color: var(--fg);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  padding: 6px 8px;
-  background: var(--bg);
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 7px 8px;
+  background: none;
   cursor: pointer;
 }
 .ul-files__row:hover,
 .ul-files__row:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
   outline: none;
+}
+/* Dim (don't clear) the current listing while the next level loads. */
+.ul-files__viewport[data-busy] .ul-files__list {
+  opacity: 0.45;
+  pointer-events: none;
+}
+.ul-files__busy {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  color: var(--muted);
+  pointer-events: none;
+}
+.ul-files__busy svg {
+  width: 15px;
+  height: 15px;
 }
 .ul-files__row:disabled {
   cursor: default;
@@ -558,7 +587,11 @@
   color: var(--muted);
   font: 11px var(--mono);
 }
+/* Loading / empty / error states fill the reserved viewport so they neither
+   grow the container nor leave it collapsed. */
 .ul-files__state {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -498,7 +498,9 @@
    browser to near-zero and re-expands. */
 .ul-files__viewport {
   position: relative;
-  min-height: 116px;
+  /* Floor of ~two rows so a shallow or momentarily-empty level never collapses
+     the browser to near-zero; overridable per consumer via the custom prop. */
+  min-height: var(--ul-files-min-height, 116px);
 }
 .ul-files__list {
   list-style: none;


### PR DESCRIPTION
## What & why

The signed-in `/account/*` pages read as clutter — the Workspaces view nested
bordered cards three deep (card → workspace box → sub-boxes for Galleries /
Files / invite → bordered file rows). This flattens that, adds the missing
site footer to the signed-in chrome, and fixes the file tree's layout shift.

## Changes

- **Footer is app-wide chrome.** Added the canonical `<Footer/>` to
  `AccountLayout` and `AdminLayout` (inside the gated shell, after the layout
  grid), so `/account/*` and `/admin/*` carry the same footer as the rest of
  the site instead of ending abruptly.
- **Flattened the Workspaces surfaces.** The outer card is now the only box.
  Workspace blocks drop their borders (hairline-separated instead), and the
  invite command goes from a raised `--panel` panel to a light `--bg` inset
  code row. Scoped to workspace items so the Developers list keeps its
  treatment.
- **Stabilized the file tree.** `FileBrowser` now keeps the current listing on
  screen (dimmed) while navigating a level instead of clearing it to empty,
  inside a reserved-height viewport — so changing folders no longer
  shrinks-then-grows. Rows also soften from bordered chips to
  hairline-separated list rows. Lives in the shared design system
  (`@uploads/ui`), whose only consumer today is the account file browser.

All changes reuse existing design-system tokens (`--line`, `--panel`, `--bg`,
`--radius-*`); no new divergent styling.

## Verification

Ran against a local auth+api+web stack with seeded nested file fixtures and
verified via DOM measurement (the browser pane's screenshot capture was frozen
this session, so measurements are the proof):

| Check | Result |
| --- | --- |
| Workspace block | `border: 0`, transparent bg (no nested box) |
| Invite command | `border: 0`, `--bg` inset (was raised panel) |
| File rows | `border: 0`, `0` gap, `1px` hairline separators |
| **File-tree height during navigation** | **stays constant (content retained + dimmed); reserved floor as backstop — old code collapsed toward 0** |

`@uploads/ui` typecheck passes; pre-commit oxlint/oxfmt clean.

Ran `/simplify` (reuse / simplification / efficiency / altitude) over the diff:
no blocking findings. Applied one cleanup — the FileBrowser viewport
`min-height` is now the self-documenting `--ul-files-min-height` custom
property (same default). Noted as pre-existing follow-ups, out of scope here:
the two signed-in layouts duplicate most of their shell (a shared
`SignedInShell.astro` would be the deeper fix).

## Notes

- No route, API, or data-flow changes. Overview / Profile / Developers keep
  their single-card layout and simply gain the footer via the shared layout.
- Both `@uploads/ui` and `@uploads/web` are private (not published), so no
  changeset.

Design spec: `docs/superpowers/specs/2026-07-13-accounts-layout-ux-design.md`
