### PR TITLE
feat(web): scaffold apps/web/.dev.vars for local origins in bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,10 @@ do not merge “version packages” PRs unless shipping is intentional.
   loads the file via `node --env-file-if-exists`). Copy to `.env`, gitignored.
 - `apps/api/.dev.vars.example` — the worker's local config (Workers
   convention). Currently empty of secrets; workspace secrets live in KV.
+- `apps/web/.dev.vars.example` — overrides `UPLOADS_AUTH_ORIGIN` /
+  `UPLOADS_API_ORIGIN` to point the signed-in shells (`/account/*`,
+  `/admin/*`) at the local auth/API workers instead of the prod origins baked
+  into `wrangler.jsonc` `vars`; no secrets.
 - Never edit a user's `.env` / `.dev.vars` directly; template files only.
 
 ## Roadmap (see docs/roadmap.md for detail)

--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -1,0 +1,13 @@
+# Copy to apps/web/.dev.vars for local `astro dev` / `wrangler dev` (gitignored).
+
+# REQUIRED locally: the Cloudflare adapter inherits the top-level (production)
+# wrangler vars from wrangler.jsonc, so without these overrides the signed-in
+# shells (/account/*, /admin/*) resolve https://auth.uploads.sh and
+# https://api.uploads.sh — and their strict CSP then blocks localhost fetches.
+# .dev.vars values take precedence over wrangler.jsonc vars, so setting these
+# here points the signed-in pages (and their CSP connect-src, which is derived
+# from the same origins — see resolveSignedInOrigins in
+# src/lib/signed-in-page.ts) at the local auth/API workers instead. Matches
+# the ports used by `pnpm dev:stack` (see scripts/dev-stack-common.mjs).
+UPLOADS_AUTH_ORIGIN=http://127.0.0.1:8788
+UPLOADS_API_ORIGIN=http://127.0.0.1:8787

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,8 +7,8 @@
 # Steps:
 #   1. tooling     — Node ≥24 + corepack (pnpm is pinned via packageManager)
 #   2. install     — pnpm install
-#   3. env files   — scaffold .env + API/Auth .dev.vars from *.example (only
-#                    if absent); mint the local-only signing/admin secrets
+#   3. env files   — scaffold .env + API/Auth/Web .dev.vars from *.example
+#                    (only if absent); mint the local-only signing/admin secrets
 #   4. types       — wrangler types → worker-configuration.d.ts (gitignored)
 #   5. database    — apply local API + Auth D1 migrations
 #   6. workspace   — seed the local `default` workspace in REGISTRY KV (once)
@@ -128,6 +128,7 @@ step "Scaffolding env files (non-destructive)"
 scaffold "$ROOT/.env.example" "$ROOT/.env"
 scaffold "$ROOT/apps/api/.dev.vars.example" "$ROOT/apps/api/.dev.vars"
 scaffold "$ROOT/apps/auth/.dev.vars.example" "$ROOT/apps/auth/.dev.vars"
+scaffold "$ROOT/apps/web/.dev.vars.example" "$ROOT/apps/web/.dev.vars"
 
 DEV_VARS="$ROOT/apps/api/.dev.vars"
 AUTH_DEV_VARS="$ROOT/apps/auth/.dev.vars"


### PR DESCRIPTION
## Problem

In local dev, the signed-in web pages (`/account/*`, `/admin/*`) resolve the production auth/API origins baked into `apps/web/wrangler.jsonc` (`UPLOADS_AUTH_ORIGIN`/`UPLOADS_API_ORIGIN`), and their strict CSP — derived from those same origins in `resolveSignedInOrigins`/`signedInCsp` (`apps/web/src/lib/signed-in-page.ts`) — blocks localhost fetches. `pnpm bootstrap` already scaffolds `.dev.vars` for `apps/api` and `apps/auth` from committed `.dev.vars.example` templates, but not for `apps/web`, so there was no supported way to exercise the real signed-in flow locally without hand-writing a file.

## Fix

- Added `apps/web/.dev.vars.example`, setting `UPLOADS_AUTH_ORIGIN=http://127.0.0.1:8788` and `UPLOADS_API_ORIGIN=http://127.0.0.1:8787` (matching the ports `pnpm dev:stack` uses — see `scripts/dev-stack-common.mjs`). `.dev.vars` values take precedence over `wrangler.jsonc` vars, so this overrides the prod defaults for local dev only. No secrets — these are just local loopback origins.
- Wired `scripts/bootstrap.sh`'s existing `scaffold()` step to copy it to `apps/web/.dev.vars` (non-destructive, same pattern as api/auth).
- `apps/web/.dev.vars` was already covered by the root `.gitignore` (`.dev.vars` / `.dev.vars.*` / `!.dev.vars.example`), so no gitignore change was needed.

## Verification

Built the design system, ran `pnpm bootstrap` (confirmed it scaffolded `apps/web/.dev.vars` from the new template, left existing files untouched), started `astro dev` directly, and fetched `/account/workspaces`:

```
$ curl -s http://127.0.0.1:4321/account/workspaces | grep -io "auth\.uploads\.sh\|api\.uploads\.sh\|127\.0\.0\.1:8788\|127\.0\.0\.1:8787"
127.0.0.1:8788
127.0.0.1:8787
```

And the CSP meta tag in the response body:

```
<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src http://127.0.0.1:8788 http://127.0.0.1:8787 https://cloudflareinsights.com; ...">
```

Both the resolved origins (injected as `window.__UPLOADS_AUTH_ORIGIN__` etc.) and the CSP `connect-src` now point at the local auth/API workers instead of `https://auth.uploads.sh` / `https://api.uploads.sh`, confirming the Cloudflare adapter reads `.dev.vars` over `wrangler.jsonc` vars as expected. Cleaned up with `astro dev stop`; no orphaned workerd/wrangler processes were left running.

## Not included

Looked at `scripts/dev-stack.mjs` (the auth+api+web supervisor) — it treats `astro dev` daemonizing (exit 0) as a web crash and tears the whole stack down, which sibling repos avoid via `concurrently`/`pnpm --parallel` instead of a custom supervisor. That's a separate, non-trivial change (crash-detection heuristic vs. process model), so it's left as a follow-up rather than bundled here.

## Test plan

- [x] `pnpm bootstrap` scaffolds `apps/web/.dev.vars` from the new example (non-destructive)
- [x] `astro dev` serves `/account/workspaces` with localhost origins in both the CSP and injected globals
- [x] no real `.dev.vars` file committed; `apps/web/.dev.vars` remains gitignored