### PR TITLE
fix(dev): keep dev:stack alive through astro dev daemonization

### DIFF
--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -70,7 +70,12 @@ describe("startLocalDemoSession", () => {
     ).resolves.toEqual({ kind: "started" });
     expect(fetcher).toHaveBeenCalledWith(
       "http://127.0.0.1:8788/api/auth/dev-session",
-      expect.objectContaining({ credentials: "include", method: "POST" }),
+      expect.objectContaining({
+        credentials: "include",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
     );
 
     await expect(

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -90,6 +90,11 @@ export async function startLocalDemoSession(
   const result = await fetchWithTimeout(`${normalizedOrigin}/api/auth/dev-session`, {
     method: "POST",
     credentials: "include",
+    // better-call (better-auth's router) sees a non-null `request.body` for
+    // every POST under the Workers runtime, even with no body supplied, so
+    // it always runs its Content-Type gate and 415s without this header.
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
   });
   if (result.kind === "unavailable") return result;
   if (result.response.ok) return { kind: "started" };

--- a/scripts/dev-stack-common.mjs
+++ b/scripts/dev-stack-common.mjs
@@ -93,7 +93,15 @@ export async function runSmoke() {
   const jar = new Map();
   const demo = await request(
     `${AUTH_ORIGIN}/api/auth/dev-session`,
-    { method: "POST", headers: { Origin: WEB_ORIGIN } },
+    {
+      method: "POST",
+      // better-call (better-auth's router) sees a non-null `request.body`
+      // for every POST under the Workers runtime, even with no body
+      // supplied, so it always runs its Content-Type gate and 415s without
+      // this header (see apps/web/src/lib/auth-client.ts's matching fix).
+      headers: { Origin: WEB_ORIGIN, "Content-Type": "application/json" },
+      body: "{}",
+    },
     jar,
   );
   await requireOk(demo, "local demo session");

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -169,6 +169,17 @@ async function main() {
       // /login, /device, and invitations as well as to the SSR account shell.
       PUBLIC_UPLOADS_AUTH_ORIGIN: AUTH_ORIGIN,
       PUBLIC_UPLOADS_API_ORIGIN: API_ORIGIN,
+      // Astro 7's CLI auto-detects "agentic" shells (via am-i-vibing) and
+      // silently forks `astro dev` into a detached background daemon,
+      // exiting the foreground process with code 0. This supervisor treats
+      // any exit of a started child as a crash (see start()), so an
+      // unpatched astro dev tears down the whole stack the instant it
+      // daemonizes, leaving the orphaned daemon running at :4321. Setting
+      // ASTRO_DEV_BACKGROUND short-circuits astro's agent detection
+      // (dist/cli/dev/index.js: `!process.env.ASTRO_DEV_BACKGROUND &&
+      // isRunByAgent()`) so it stays in the foreground and is supervised
+      // like auth/api.
+      ASTRO_DEV_BACKGROUND: "1",
     },
   );
   await waitFor(PREVIEW_URL, "web");

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -158,6 +158,14 @@ async function main() {
   await waitFor(`${API_ORIGIN}/health`, "api");
   if (stopping) return;
 
+  // Web starts via `exec astro dev` (below) instead of `pnpm run dev`, so the
+  // `predev` hook that builds @uploads/ui never fires. Build it explicitly:
+  // a fresh checkout has no packages/ui/dist, and the account shell imports
+  // `@uploads/ui/styles.css`, so without this web 500s on a missing module.
+  // Idempotent and quick when already built.
+  await run("pnpm", ["--filter", "@uploads/ui", "build"]);
+  if (stopping) return;
+
   start(
     "web",
     ["--filter", "@uploads/web", "exec", "astro", "dev", "--host", "127.0.0.1", "--port", "4321"],

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -186,8 +186,10 @@ async function main() {
       // ASTRO_DEV_BACKGROUND short-circuits astro's agent detection
       // (dist/cli/dev/index.js: `!process.env.ASTRO_DEV_BACKGROUND &&
       // isRunByAgent()`) so it stays in the foreground and is supervised
-      // like auth/api.
-      ASTRO_DEV_BACKGROUND: "1",
+      // like auth/api. 7.0.6 only checks the var's presence, but "0" is
+      // Astro's documented opt-out and the intent-correct value (background
+      // off) — future-proof if a later version parses the value.
+      ASTRO_DEV_BACKGROUND: "0",
     },
   );
   await waitFor(PREVIEW_URL, "web");


### PR DESCRIPTION
## Root cause

Astro 7's CLI auto-detects agentic shells (`am-i-vibing`) and, when detected,
silently runs `astro dev` as a **background daemon**: it forks a detached
child, writes a lockfile, prints `Dev server running at ... (pid NNNN)` /
`Stop: astro dev stop` etc., and the *foreground* process exits **0**
immediately (`astro/dist/cli/dev/index.js`: `agentDetected =
!process.env.ASTRO_DEV_BACKGROUND && isRunByAgent()`, which forces
`--background` mode + `--json` on the detached child).

`scripts/dev-stack.mjs`'s `start()` treats any child exit — even code 0 — as
a crash (`child.once("exit", ...) => requestStop(1)`). So the instant `astro
dev` daemonized, the supervisor thought web had crashed, tore down auth+api
via `killGroup`, and left the orphaned astro daemon running at `:4321`.
`pnpm dev:stack` never reached the `{"ready":true,...}` line.

## Fix

Set `ASTRO_DEV_BACKGROUND=1` on the web child's env in `scripts/dev-stack.mjs`.
That short-circuits astro's own agent-detection check, so `astro dev` stays
in the foreground exactly like a human running it in a terminal, and the
existing process-group supervision (SIGTERM → SIGKILL, `killGroup`) works
unchanged. No change to the supervisor's exit/crash logic, no polling for a
background daemon, nothing to reap separately — the cleanest of the three
options in the brief.

## Second bug this uncovered

Getting past the daemon issue exposed a second, previously-unreachable bug:
the local demo-session endpoint (`POST /api/auth/dev-session`) 415'd with
`UNSUPPORTED_MEDIA_TYPE`. `better-call` (better-auth's router) sees a
non-null `request.body` for *every* POST under the Workers runtime, even
with no body supplied, so it always runs its Content-Type gate. Both the
smoke script (`scripts/dev-stack-common.mjs`) and the real `/login` "start
demo" flow (`apps/web/src/lib/auth-client.ts`) sent the POST with no
Content-Type, so both were broken — this had just never been exercised
end-to-end because the daemon bug always killed the stack before reaching
this step. Fixed by sending `Content-Type: application/json` + a `"{}"`
body on both call sites (test in `auth-client.test.ts` updated to match).

## Verification

`pnpm dev:stack` (Node 24) now reaches and stays up at the ready line:

```
{"ready":true,"previewUrl":"http://127.0.0.1:4321/account/workspaces","smoke":{"user":"dev-demo@uploads.local","workspace":"dev-demo","files":["gh/pr-120/before.png","screenshots/feature/after.png"],"previewUrl":"http://127.0.0.1:4321/account/workspaces"}}
```

All three services respond 200 while it's up:

```
web  (127.0.0.1:4321/account/workspaces): 200
api  (127.0.0.1:8787/health):             200
auth (127.0.0.1:8788/health):             200
```

`SIGINT` on the dev-stack process reaps everything cleanly — confirmed with
`pgrep -fl "workerd serve|wrangler dev|astro.*dev"` returning nothing
(checked immediately after and again 3s later):

```
$ pgrep -fl "workerd serve|wrangler dev|astro.*dev|dev-stack.mjs"
(no output)
```

`astro dev` ran in the foreground the whole time (no `pid NNNN` / `--json`
daemon message) — confirmed via `pgrep` showing the astro process alive
under the dev-stack process group throughout, and reaped on SIGINT along
with auth/api's wrangler+workerd children.

Also ran `pnpm --filter @uploads/web exec vitest run` (52 tests, all pass)
and the `auth-client` suite specifically to confirm the Content-Type fix
didn't regress the existing mocked-fetch assertions.

## Also bundled: fresh-checkout build fix

`dev-stack.mjs` starts web via `pnpm --filter @uploads/web exec astro dev ...`
rather than `pnpm run dev`, which bypasses `apps/web/package.json`'s `predev`
hook (`pnpm --filter @uploads/ui build`). On a fresh checkout with no
`packages/ui/dist`, that surfaced as `Cannot find module
'@uploads/ui/styles.css'` and a 500 on the account shell. Fixed by building
`@uploads/ui` as an ordered step before web starts (idempotent, quick when
already built) — folded into this PR rather than a separate follow-up.

Re-verified from a **wiped `packages/ui/dist`** (simulating a fresh checkout):
`pnpm dev:stack` rebuilt the DS, reached `{"ready":true,...}` with a passing
smoke, all three services returned 200, and SIGINT reaped every child with no
orphaned `astro`/`workerd`/`wrangler`.

This branch is also merged up to current `main`.

## Test plan

- [x] `pnpm dev:stack` reaches `{"ready":true,...}` and stays up
- [x] web/api/auth all respond 200 while up
- [x] SIGINT reaps all wrangler/workerd/astro children — `pgrep` confirms nothing orphaned
- [x] `pnpm --filter @uploads/web exec vitest run` passes (52/52)
- [x] fresh-checkout (`packages/ui/dist` wiped) → `dev:stack` rebuilds the DS and still reaches ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local demo session startup by sending a valid JSON request to the authentication endpoint.
  * Updated development smoke checks to use the same request format, improving session validation reliability.
  * Ensured the Astro development server remains attached to the supervisor, allowing crashes and exits to be detected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
