### PR TITLE
fix(api,web): resolve file URLs by storage capability, not just publicBaseUrl

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -74,6 +74,62 @@ describe("GET /me/workspaces", () => {
           organization: { id: "org1", slug: "acme", name: "Acme Inc" },
           role: "owner",
           communal: false,
+          hasPublicUrl: false,
+        },
+      ],
+    });
+  });
+
+  it("flags hasPublicUrl for a workspace whose storage record has a publicBaseUrl", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role: "owner" }]);
+      }
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+      }
+      return new Response(null, { status: 404 });
+    });
+    (env as unknown as { REGISTRY: Pick<KVNamespace, "get"> }).REGISTRY = fakeKv({
+      "ws:acme": {
+        provider: "r2",
+        bucket: "shared",
+        publicBaseUrl: "https://storage.uploads.sh",
+      },
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    const body = (await res.json()) as {
+      workspaces: { workspace: string; hasPublicUrl: boolean }[];
+    };
+    expect(body.workspaces).toEqual([
+      expect.objectContaining({ workspace: "acme", hasPublicUrl: true }),
+    ]);
+  });
+
+  it("never checks hasPublicUrl for the communal workspace", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          { organizationId: "org2", organizationSlug: "default", role: "member" },
+        ]);
+      }
+      if (path === "/internal/orgs/default") {
+        return Response.json({ organization: { id: "org2", slug: "default", name: "Default" } });
+      }
+      return new Response(null, { status: 404 });
+    });
+    // No REGISTRY record for "default" at all — a lookup would 404/throw were
+    // one attempted; the communal short-circuit means it never happens.
+    const res = await app().request("/me/workspaces", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspaces: [
+        {
+          workspace: "default",
+          organization: { id: "org2", slug: "default", name: "Default" },
+          role: "member",
+          communal: true,
+          hasPublicUrl: false,
         },
       ],
     });
@@ -335,6 +391,135 @@ describe("GET /me/workspaces/:name/files", () => {
     expect(body.files[0]).toMatchObject({
       key: "f/x/shot.png",
       url: "https://storage.uploads.sh/acme/f/x/shot.png",
+    });
+  });
+});
+
+describe("GET /me/workspaces/:name/file-url", () => {
+  it("404s for a workspace the caller is not a member of", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/file-url?key=a.png", {}, env);
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_not_found" },
+    });
+  });
+
+  it("404s for the communal workspace", async () => {
+    const env = memberEnv({ workspace: "default", db: new UsageFakeD1() });
+    const res = await app().request("/me/workspaces/default/file-url?key=a.png", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for an invalid key", async () => {
+    const bucket = new FakeR2Bucket();
+    const env = memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        publicBaseUrl: "https://storage.uploads.sh",
+      },
+    });
+    const res = await app().request(
+      "/me/workspaces/acme/file-url?key=" + encodeURIComponent("../etc/passwd"),
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a key that does not exist in the bucket", async () => {
+    const bucket = new FakeR2Bucket();
+    const env = memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        publicBaseUrl: "https://storage.uploads.sh",
+      },
+    });
+    const res = await app().request("/me/workspaces/acme/file-url?key=missing.png", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("prefers the stable public URL when publicBaseUrl is configured", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1]));
+    const env = memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        publicBaseUrl: "https://storage.uploads.sh",
+        // Hybrid signing creds are also present — publicBaseUrl must still win.
+        accountId: "acct",
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      },
+    });
+    const res = await app().request("/me/workspaces/acme/file-url?key=a.png", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://storage.uploads.sh/acme/a.png" });
+  });
+
+  it("falls back to a short-lived signed URL when the provider has signing credentials but no publicBaseUrl", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1]));
+    const env = memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        accountId: "acct",
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      },
+    });
+    const res = await app().request("/me/workspaces/acme/file-url?key=a.png", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toMatch(/^https:\/\/acct\.r2\.cloudflarestorage\.com\/shared\/acme\/a\.png\?/);
+    expect(body.url).toContain("response-content-disposition=attachment");
+  });
+
+  it("returns a typed error for a binding-only workspace with no publicBaseUrl or signing credentials", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1]));
+    const env = memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+      },
+    });
+    const res = await app().request("/me/workspaces/acme/file-url?key=a.png", {}, env);
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "file_url_unavailable" },
     });
   });
 });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,8 +9,8 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
-import { NotFoundError } from "@uploads/errors";
-import { createFilesRouter } from "@uploads/storage";
+import { NotFoundError, ValidationError } from "@uploads/errors";
+import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { badKey, listObjects } from "../files-core";
@@ -93,12 +93,26 @@ function requireUserId(c: Context<SessionVars>): string {
 export const me = new Hono<SessionVars>()
   .use("/*", sessionAuth, requireSessionUser)
 
-  // Workspaces the caller belongs to, via their org memberships.
+  // Workspaces the caller belongs to, via their org memberships. `hasPublicUrl`
+  // lets the account UI decide, per workspace, whether opening a file should
+  // navigate to the public /f/ page (issue #135) or resolve through the
+  // signed-URL-capable /file-url endpoint (issue #123) — see
+  // apps/web's AccountFileBrowser. Loaded here (not in `myWorkspaces`, which
+  // every member-gated route calls for authorization) so the extra KV read
+  // per workspace stays confined to this one listing endpoint.
   .get("/workspaces", async (c) => {
     const userId = c.get("sessionUser")?.id;
     if (!userId) throw new NotFoundError("no session user", { code: "workspace_not_found" });
     const workspaces = await myWorkspaces(c.env, userId);
-    return c.json({ workspaces });
+    const withPublicUrl = await Promise.all(
+      workspaces.map(async (ws) => {
+        const hasPublicUrl = ws.communal
+          ? false
+          : Boolean((await loadWorkspaceRecord(c.env, ws.workspace))?.publicBaseUrl);
+        return Object.assign({}, ws, { hasPublicUrl });
+      }),
+    );
+    return c.json({ workspaces: withPublicUrl });
   })
 
   // Usage + limits for one workspace — 404s unless the caller is a member.
@@ -146,7 +160,10 @@ export const me = new Hono<SessionVars>()
     return c.json({ communal: false, files: items });
   })
 
-  // Resolve a selected browser item to its provider-aware public URL. This is
+  // Resolve a selected browser item to a usable URL, by storage capability
+  // (issue #123): the stable public URL when `publicBaseUrl` is configured;
+  // otherwise a short-lived signed download URL when the provider can sign;
+  // otherwise a typed error rather than a 200 with `url: null`. This is
   // separate from the gateway's `url` verb because its forced attachment
   // disposition requires signing, while binding-mode R2 uses publicBaseUrl.
   .get("/workspaces/:name/file-url", async (c) => {
@@ -158,7 +175,18 @@ export const me = new Hono<SessionVars>()
     if (!record) throw new NotFoundError();
     const store = await storage(c.env, record);
     if (!(await store.exists(key))) throw new NotFoundError();
-    return c.json({ url: publicUrl(await storageConfig(c.env, record), key) });
+
+    const cfg = await storageConfig(c.env, record);
+    const url = publicUrl(cfg, key);
+    if (url) return c.json({ url });
+
+    const signed = await signedDownloadUrl(store, key);
+    if (signed) return c.json({ url: signed });
+
+    throw new ValidationError(
+      "no public or signed URL available for this workspace's storage configuration",
+      { code: "file_url_unavailable" },
+    );
   })
 
   // files-sdk's folder-aware browser gateway. Authorization happens before a

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -6,6 +6,14 @@ import { filePath } from "../lib/public-file";
 interface Props {
   apiOrigin: string;
   workspace: string;
+  /**
+   * Whether this workspace has a stable public custom domain configured (from
+   * `GET /me/workspaces`' `hasPublicUrl`). Workspaces without one (private/BYO
+   * without a public domain) can't be opened via the public `/f/` page — it
+   * 404s there (issue #123) — so those resolve through the authenticated,
+   * signed-URL-capable `/me/.../file-url` endpoint instead.
+   */
+  hasPublicUrl: boolean;
 }
 
 const credentialedFetch: typeof fetch = async (input, init) => {
@@ -23,18 +31,49 @@ const credentialedFetch: typeof fetch = async (input, init) => {
   }
 };
 
-export function AccountFileBrowser({ apiOrigin, workspace }: Props) {
+export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props) {
   const files = useFiles({
     endpoint: `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-browser`,
     fetchImpl: credentialedFetch,
   });
 
-  // Open the chrome-wrapped file page (issue #135) rather than dumping the raw
-  // bytes into a tab. The page presents metadata and links to the original; for
-  // non-public workspaces it depends on the #123 URL resolver.
-  const openFile = (key: string) => {
+  // Public workspaces open the chrome-wrapped file page (issue #135) rather
+  // than dumping the raw bytes into a tab — it presents metadata and links to
+  // the original.
+  const openPublicFile = (key: string) => {
     const tab = window.open(filePath(workspace, key), "_blank");
     if (tab) tab.opener = null;
+  };
+
+  // Private/BYO workspaces without a public domain have no `/f/` page to open
+  // (it 404s — publicUrl() has nothing to resolve). Resolve through the
+  // member-gated resolver instead, which signs a short-lived download URL when
+  // the workspace's storage credentials support it (issue #123). Opens
+  // "about:blank" synchronously so popup blockers see it as the row click,
+  // then navigates that tab once the URL resolves — the same approach this
+  // component used before the #135 public-page navigation replaced it here.
+  const openResolvedFile = async (key: string) => {
+    const tab = window.open("about:blank", "_blank");
+    if (tab) tab.opener = null;
+    try {
+      const response = await credentialedFetch(
+        `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-url?key=${encodeURIComponent(key)}`,
+      );
+      const body = (await response.json().catch(() => ({}))) as { url?: string };
+      if (!(response.ok && body.url)) throw new Error("file URL unavailable");
+      if (tab) tab.location.replace(body.url);
+      else window.location.assign(body.url);
+    } catch {
+      tab?.close();
+    }
+  };
+
+  const openFile = (key: string) => {
+    if (hasPublicUrl) {
+      openPublicFile(key);
+      return;
+    }
+    void openResolvedFile(key);
   };
 
   return (

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -53,4 +53,38 @@ describe("getMyWorkspaces", () => {
       reason: "network",
     });
   });
+
+  it("maps hasPublicUrl through and defaults it false when the API omits it (issue #123)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          workspaces: [
+            {
+              workspace: "acme",
+              organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+              role: "owner",
+              communal: false,
+              hasPublicUrl: true,
+            },
+            {
+              // Older api response, no hasPublicUrl field at all.
+              workspace: "byo",
+              organization: { id: "org2", slug: "byo", name: "BYO Inc" },
+              role: "member",
+              communal: false,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await getMyWorkspaces("http://127.0.0.1:8787");
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") throw new Error("expected success");
+    expect(result.workspaces.map((ws) => [ws.workspace, ws.hasPublicUrl])).toEqual([
+      ["acme", true],
+      ["byo", false],
+    ]);
+  });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -18,12 +18,21 @@ export interface MyWorkspace {
   role: string;
   /** True for the communal, world-readable workspace (no personal browser). */
   communal: boolean;
+  /**
+   * True when the workspace has a stable public custom domain configured.
+   * Lets the account file browser (issue #123) decide whether to open a
+   * selected file via the public `/f/` page or resolve it through the
+   * signed-URL-capable `/me/.../file-url` endpoint instead.
+   */
+  hasPublicUrl: boolean;
 }
 
-// `communal` is intentionally NOT required here: web and api deploy
-// independently, so an older api may omit it. We accept the entry and coerce a
-// missing/other value to `false` in the mapper below.
-function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "communal"> {
+// `communal` and `hasPublicUrl` are intentionally NOT required here: web and
+// api deploy independently, so an older api may omit them. We accept the
+// entry and coerce a missing/other value to `false` in the mapper below.
+function isMyWorkspaceCore(
+  value: unknown,
+): value is Omit<MyWorkspace, "communal" | "hasPublicUrl"> {
   if (!value || typeof value !== "object") return false;
   const ws = value as Record<string, unknown>;
   const org = ws.organization as Record<string, unknown> | null | undefined;
@@ -62,6 +71,7 @@ export async function getMyWorkspaces(apiOrigin: string): Promise<WorkspacesResu
         organization: ws.organization,
         role: ws.role,
         communal: (ws as { communal?: unknown }).communal === true,
+        hasPublicUrl: (ws as { hasPublicUrl?: unknown }).hasPublicUrl === true,
       }),
     ),
   };

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -183,7 +183,11 @@ export const prerender = false;
               // paying for once its container approaches the viewport.
               const mount = () =>
                 createRoot(filesEl).render(
-                  createElement(AccountFileBrowser, { apiOrigin, workspace: ws.workspace }),
+                  createElement(AccountFileBrowser, {
+                    apiOrigin,
+                    workspace: ws.workspace,
+                    hasPublicUrl: ws.hasPublicUrl,
+                  }),
                 );
               if (typeof IntersectionObserver === "undefined") {
                 mount();

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -33,6 +33,7 @@ export const ERROR_CODES = [
   "key_prefix_not_allowed",
   "key_too_deep",
   "presign_unavailable",
+  "file_url_unavailable",
 
   // Budgets
   "storage_quota_exceeded",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -61,4 +61,36 @@ export function publicUrl(config: StorageConfig, key: string): string | null {
   return `${base}/${fullKey.split("/").map(encodeURIComponent).join("/")}`;
 }
 
+/** Options for {@link signedDownloadUrl}. */
+export interface SignedDownloadUrlOptions {
+  /** How long the URL stays valid, in seconds. Defaults to 3600 (files-sdk's own default). */
+  expiresIn?: number;
+}
+
+/**
+ * Short-lived signed download URL for `key`, or `null` when the adapter has
+ * no signing primitive to mint one — e.g. an R2 binding with neither
+ * `publicBaseUrl` nor HTTP credentials (`accountId`/`accessKeyId`/`secretAccessKey`).
+ * Mirrors {@link Files.signedUploadUrl}'s presigning, but for reads: it forces
+ * `responseContentDisposition: "attachment"` so a user-uploaded HTML/SVG never
+ * renders inline at the bucket's origin (stored XSS).
+ *
+ * Checks {@link Files.capabilities}' `signedUrl.supported` flag up front so
+ * callers get a clean `null` instead of a thrown provider error when signing
+ * isn't possible. Callers should try {@link publicUrl} first — a workspace
+ * with `publicBaseUrl` configured should get its stable custom-domain URL
+ * instead of a short-lived signed one.
+ */
+export async function signedDownloadUrl(
+  store: Files,
+  key: string,
+  opts: SignedDownloadUrlOptions = {},
+): Promise<string | null> {
+  if (!store.capabilities.signedUrl.supported) return null;
+  return store.url(key, {
+    expiresIn: opts.expiresIn ?? 3600,
+    responseContentDisposition: "attachment",
+  });
+}
+
 export type { Files };

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { createStorage, publicUrl, type StorageConfig } from "../src/index.js";
+import type { R2Bucket } from "@cloudflare/workers-types";
+import { createStorage, publicUrl, signedDownloadUrl, type StorageConfig } from "../src/index.js";
+import { FakeR2Bucket } from "./fake-r2.js";
 
 const base: StorageConfig = {
   provider: "r2",
@@ -54,5 +56,45 @@ describe("publicUrl", () => {
 
   it("returns null without a publicBaseUrl", () => {
     expect(publicUrl({ ...base, prefix: "myws/" }, "a.png")).toBeNull();
+  });
+});
+
+describe("signedDownloadUrl", () => {
+  it("returns a presigned URL when the adapter can sign (HTTP mode)", async () => {
+    const files = createStorage(base);
+    const url = await signedDownloadUrl(files, "a.png");
+    expect(url).toMatch(/^https:\/\/acct\.r2\.cloudflarestorage\.com\/shared\/a\.png\?/);
+  });
+
+  it("forces an attachment Content-Disposition on the signed URL", async () => {
+    const files = createStorage(base);
+    const url = await signedDownloadUrl(files, "a.png");
+    expect(url).toContain("response-content-disposition=attachment");
+  });
+
+  it("honors a custom expiresIn", async () => {
+    const files = createStorage(base);
+    const url = await signedDownloadUrl(files, "a.png", { expiresIn: 60 });
+    expect(url).toContain("X-Amz-Expires=60");
+  });
+
+  it("returns null for a binding-only R2 workspace with no signing credentials", async () => {
+    const files = createStorage({
+      provider: "r2",
+      bucket: "shared",
+      r2Binding: new FakeR2Bucket() as unknown as R2Bucket,
+      prefix: "acme/",
+    });
+    await expect(signedDownloadUrl(files, "a.png")).resolves.toBeNull();
+  });
+
+  it("signs through a binding workspace when hybrid HTTP credentials are also configured", async () => {
+    const files = createStorage({
+      ...base,
+      r2Binding: new FakeR2Bucket() as unknown as R2Bucket,
+      prefix: "acme/",
+    });
+    const url = await signedDownloadUrl(files, "a.png");
+    expect(url).toMatch(/^https:\/\/acct\.r2\.cloudflarestorage\.com\/shared\/acme\/a\.png\?/);
   });
 });


### PR DESCRIPTION
## In plain terms

Opening a file from the account page used to fail silently for private and
BYO workspaces — you'd get a link to nowhere, with no explanation. This fixes
the resolver behind that link so it always returns something usable (or a
clear error), and updates the account file browser to actually use it.

## What it does

- `GET /me/workspaces/:name/file-url` now resolves a usable URL by storage
  capability instead of only reading `publicBaseUrl`:
  1. the stable public URL when `publicBaseUrl` is configured (unchanged),
  2. otherwise a short-lived **signed download URL** when the workspace has
     signing credentials,
  3. otherwise a typed `file_url_unavailable` error — never a 200 with
     `url: null`.
- Adds `signedDownloadUrl()` to `@uploads/storage`, mirroring
  `signedUploadUrl()`'s presigning but for reads. It forces an `attachment`
  Content-Disposition (so a stored HTML/SVG never renders inline at the
  bucket's origin) and checks the adapter's `capabilities().signedUrl.supported`
  flag up front, so callers get a clean `null` instead of a thrown provider
  error when signing isn't possible. Route code still never touches
  files-sdk adapters or the R2 binding directly — everything goes through
  `createStorage()`.
- `GET /me/workspaces` now reports `hasPublicUrl` per workspace. The account
  file browser (`AccountFileBrowser.tsx`) uses it to decide how to open a
  selected file: workspaces with a public URL still navigate to the
  chrome-wrapped `/f/<ws>/<key>` page (#135); everything else resolves
  through the authenticated `/file-url` endpoint and opens the signed URL
  directly — the same "open a blank tab, then navigate it" approach this
  component used before the `/f/` page replaced it for all workspaces.

## What it is not

- **Not** a change to `GET /public/files/:workspace/:key` (the unauthenticated
  endpoint backing the public `/f/` page). That stays public-workspace-only —
  no signed-URL fallback there, since signing a private object on an
  unauthenticated endpoint would leak private files. It still 404s without a
  `publicBaseUrl`. Private files on the public page is a separate future
  project (#139).
- Membership authorization, communal-workspace behavior, key validation
  (`badKey`), existence checks, and workspace-prefix isolation are all
  unchanged.

## How to try it

Sign in, open `/account#workspaces`, and select a file in a private or BYO
workspace's file browser (one with no public custom domain configured). It
now opens the raw file via a signed URL in a new tab instead of failing
silently. Workspaces with a public domain still open the `/f/` page as
before.

## Technical notes

- New error code: `file_url_unavailable` (validation/400), alongside the
  existing `presign_unavailable` used for the upload-signing route.
- `packages/storage/src/index.ts`: `signedDownloadUrl(store, key, opts?)`.
- `apps/api/src/routes/me.ts`: `/workspaces/:name/file-url` now branches on
  capability; `/workspaces` computes `hasPublicUrl` per workspace (loaded
  only in this listing handler, not in the shared `myWorkspaces()` helper
  every member-gated route uses for authorization — keeps the extra KV read
  off routes that don't need it).
- `apps/web/src/lib/api-client.ts`: `MyWorkspace.hasPublicUrl`, defaulted to
  `false` when an older API omits it (same pattern as `communal`).
- `apps/web/src/components/AccountFileBrowser.tsx`: branches `openFile` on
  the new `hasPublicUrl` prop.

## Test plan

- [x] `cd apps/api && npx vitest run` — 30 files, 240 tests
- [x] `cd packages/storage && npx vitest run` — 2 files, 24 tests
- [x] `cd apps/web && npx vitest run` — 8 files, 53 tests
- [x] `pnpm -r test` — all workspaces pass (api, auth, email, errors, mcp,
      storage, uploads, web)
- [x] `pnpm run typecheck` — clean across the monorepo
- [x] `pnpm run check` (oxlint + oxfmt) — clean, no new warnings

Closes #123.
