### PR TITLE
feat(api,web,ui): per-file private visibility for the file page (#139)

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -199,6 +199,13 @@ export async function putObject(
  * Throws `NotFoundError` when the object doesn't exist and `ValidationError`
  * (`code: "file_too_large"`) when it exceeds `maxBytes` — callers should let
  * both propagate to the route's error mapping.
+ *
+ * KNOWN RACE: the download→upload pair is not compare-and-swap — files-sdk
+ * (2.1.0) exposes no conditional writes (etag/onlyIf), so an upload to the
+ * same key that lands between the two steps is overwritten with this
+ * request's older bytes (last-write-wins). Acceptable for now: toggles are
+ * rare, member-initiated, and workspace-write-rate-limited. Revisit if
+ * files-sdk grows conditional writes or a metadata-update API.
  */
 export async function setObjectVisibility(
   store: Files,

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -5,10 +5,15 @@
  * from `@uploads/errors`; REST serializes via `respondError`, MCP surfaces
  * `message` in the tool error.
  */
-import { InsufficientStorageError, RateLimitedError, ValidationError } from "@uploads/errors";
+import {
+  InsufficientStorageError,
+  NotFoundError,
+  RateLimitedError,
+  ValidationError,
+} from "@uploads/errors";
 import type { Files } from "@uploads/storage";
 import { checkPutBudget } from "./budget";
-import { inspectUpload, resolveUploadPolicy } from "./guards";
+import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
 import {
   contentSha256Hex,
@@ -178,6 +183,48 @@ export async function putObject(
     metadata: provenance,
     ...(storedVisibility ? { visibility: storedVisibility } : {}),
   };
+}
+
+/**
+ * Toggle an object's `visibility` custom-metadata flag. R2 custom metadata is
+ * immutable in place, so this rewrites the object under the same key: a
+ * `head` first (to enforce the same size cap as ordinary uploads, since the
+ * rewrite buffers the whole body in memory) then a `download` + `upload` with
+ * the toggled metadata. `contentType` and provenance metadata come straight
+ * off the existing object; `cacheControl` is reapplied from
+ * `UPLOAD_CACHE_CONTROL` (the same constant every upload already uses), so
+ * this is a no-op for objects written by this API and a one-time
+ * normalization for anything written before that constant existed.
+ *
+ * Throws `NotFoundError` when the object doesn't exist and `ValidationError`
+ * (`code: "file_too_large"`) when it exceeds `maxBytes` — callers should let
+ * both propagate to the route's error mapping.
+ */
+export async function setObjectVisibility(
+  store: Files,
+  key: string,
+  visibility: Visibility,
+  maxBytes: number = DEFAULT_MAX_UPLOAD_BYTES,
+): Promise<void> {
+  const meta = await store.head(key).catch(() => null);
+  if (!meta) throw new NotFoundError();
+  if (meta.size > maxBytes) {
+    throw new ValidationError("file too large to change visibility", {
+      code: "file_too_large",
+    });
+  }
+
+  const current = await store.download(key);
+  const bytes = new Uint8Array(await current.arrayBuffer());
+  const metadata: Record<string, string> = { ...current.metadata };
+  if (visibility === "private") metadata[VISIBILITY_META_KEY] = "private";
+  else delete metadata[VISIBILITY_META_KEY];
+
+  await store.upload(key, bytes, {
+    contentType: current.type,
+    cacheControl: UPLOAD_CACHE_CONTROL,
+    metadata,
+  });
 }
 
 /**

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -18,6 +18,7 @@ import {
 } from "./provenance";
 import { publicUrl, storage, storageConfig } from "./storage";
 import { getWorkspaceUsage, recordUsageSafe } from "./usage";
+import { objectVisibility, VISIBILITY_META_KEY, type Visibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
 
 // The freshness floor on overwrite for every bucket. This is the operative lever
@@ -107,13 +108,14 @@ export async function putObject(
   key: string,
   bytes: Uint8Array,
   workspaceName: string,
-  opts?: { provenance?: Record<string, string> },
+  opts?: { provenance?: Record<string, string>; visibility?: Visibility },
 ): Promise<{
   key: string;
   url: string | null;
   size: number;
   contentType: string;
   metadata?: ProvenanceMap;
+  visibility?: Visibility;
 }> {
   const finalKey = finalizeUploadKey(key, ws);
   if (bytes.byteLength === 0) throw new ValidationError("empty body", { code: "empty_body" });
@@ -142,16 +144,24 @@ export async function putObject(
   }
 
   // Client headers first; always attach content-sha256 of the final stored body
-  // (never trust a client-supplied hash).
-  const metadata: ProvenanceMap = {
+  // (never trust a client-supplied hash). Visibility lives alongside provenance
+  // in the same custom-metadata bag but is tracked separately (not client-free-form).
+  const provenance: ProvenanceMap = {
     ...sanitizeProvenance(opts?.provenance, { clientOnly: true }),
     "content-sha256": await contentSha256Hex(bytes),
+  };
+  const storedVisibility = opts?.visibility === "private" ? "private" : undefined;
+  const storageMetadata: Record<string, string> = {
+    ...provenance,
+    // Only written when private — absence is the (majority) public default,
+    // matching the historical shape of objects uploaded before this existed.
+    ...(storedVisibility ? { [VISIBILITY_META_KEY]: storedVisibility } : {}),
   };
 
   await store.upload(finalKey, bytes, {
     contentType: inspection.contentType,
     cacheControl: UPLOAD_CACHE_CONTROL,
-    metadata,
+    metadata: storageMetadata,
   });
 
   await recordUsageSafe(env.DB, workspaceName, {
@@ -165,7 +175,8 @@ export async function putObject(
     url: publicUrl(await storageConfig(env, ws), finalKey),
     size: newSize,
     contentType: inspection.contentType,
-    metadata,
+    metadata: provenance,
+    ...(storedVisibility ? { visibility: storedVisibility } : {}),
   };
 }
 
@@ -198,11 +209,13 @@ export function headObjectJson(
   url: string | null,
 ) {
   const provenance = provenanceForResponse(meta.metadata ?? undefined);
+  const visibility = objectVisibility(meta.metadata ?? undefined);
   return {
     key,
     ...storedMetaJson(meta),
     url,
     ...(provenance ? { metadata: provenance } : {}),
+    ...(visibility ? { visibility } : {}),
   };
 }
 
@@ -214,6 +227,8 @@ export interface ListedObject {
   contentType: string;
   /** ISO timestamp when the provider reports a last-modified time. */
   uploaded?: string;
+  /** Present (== "private") only when the object was uploaded as private. */
+  visibility?: "private";
 }
 
 export async function listObjects(
@@ -229,11 +244,15 @@ export async function listObjects(
   // each to the shared HEAD/list subset (`storedMetaJson`) rather than spreading
   // the StoredFile, which carries reader methods and a raw epoch timestamp.
   return {
-    items: result.items.map((item) => ({
-      key: item.key,
-      url: publicUrl(cfg, item.key),
-      ...storedMetaJson(item),
-    })),
+    items: result.items.map((item) => {
+      const visibility = objectVisibility(item.metadata ?? undefined);
+      return {
+        key: item.key,
+        url: publicUrl(cfg, item.key),
+        ...storedMetaJson(item),
+        ...(visibility ? { visibility } : {}),
+      };
+    }),
     cursor: result.cursor ?? null,
   };
 }

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -12,6 +12,7 @@ import { provenanceFromHeaders } from "../provenance";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../guards";
+import { sanitizeVisibility } from "../visibility";
 
 export const files = new Hono<WorkspaceVars>()
 
@@ -88,13 +89,14 @@ export const files = new Hono<WorkspaceVars>()
     if (declared) throw declared.error;
 
     const body = await c.req.arrayBuffer();
+    const visibility = sanitizeVisibility(c.req.header("x-uploads-visibility"));
     const result = await putObject(
       c.env,
       c.get("workspace"),
       key,
       new Uint8Array(body),
       c.get("workspaceName"),
-      { provenance: provenanceFromHeaders((n) => c.req.header(n)) },
+      { provenance: provenanceFromHeaders((n) => c.req.header(n)), visibility },
     );
     return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
   })

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -584,6 +584,21 @@ describe("PATCH /me/workspaces/:name/files/visibility", () => {
     });
   });
 
+  it("429s when the workspace write limiter is over budget", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const env = {
+      ...acmeEnv(bucket),
+      WRITE_LIMITER: { limit: async () => ({ success: false }) },
+    } as unknown as Env;
+
+    const res = await patchVisibility("acme", "a.png", "private", env);
+    expect(res.status).toBe(429);
+    expect(bucket.store.get("acme/a.png")?.customMetadata ?? {}).not.toHaveProperty("visibility");
+  });
+
   it("404s for a workspace the caller is not a member of", async () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") return Response.json([]);

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -524,6 +524,116 @@ describe("GET /me/workspaces/:name/file-url", () => {
   });
 });
 
+describe("PATCH /me/workspaces/:name/files/visibility", () => {
+  function patchVisibility(name: string, key: string, visibility: unknown, env: Env) {
+    return app().request(
+      `/me/workspaces/${name}/files/visibility?key=${encodeURIComponent(key)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ visibility }),
+      },
+      env,
+    );
+  }
+
+  function acmeEnv(bucket: FakeR2Bucket) {
+    return memberEnv({
+      workspace: "acme",
+      db: new UsageFakeD1(),
+      bucket,
+      record: {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        publicBaseUrl: "https://storage.uploads.sh",
+      },
+    });
+  }
+
+  it("flips a public file to private and back, preserving provenance metadata", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1, 2, 3]), {
+      httpMetadata: { contentType: "image/png" },
+      customMetadata: { "source-name": "a.png", "content-sha256": "abc123" },
+    });
+    const env = acmeEnv(bucket);
+
+    const toPrivate = await patchVisibility("acme", "a.png", "private", env);
+    expect(toPrivate.status).toBe(200);
+    expect(await toPrivate.json()).toEqual({ key: "a.png", visibility: "private" });
+
+    const stored = bucket.store.get("acme/a.png");
+    expect(stored?.customMetadata).toEqual({
+      "source-name": "a.png",
+      "content-sha256": "abc123",
+      visibility: "private",
+    });
+    expect(stored?.contentType).toBe("image/png");
+    expect(Array.from(stored!.data)).toEqual([1, 2, 3]);
+
+    const toPublic = await patchVisibility("acme", "a.png", "public", env);
+    expect(toPublic.status).toBe(200);
+    expect(await toPublic.json()).toEqual({ key: "a.png", visibility: "public" });
+
+    const storedAgain = bucket.store.get("acme/a.png");
+    expect(storedAgain?.customMetadata).toEqual({
+      "source-name": "a.png",
+      "content-sha256": "abc123",
+    });
+  });
+
+  it("404s for a workspace the caller is not a member of", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await patchVisibility("acme", "a.png", "private", env);
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_not_found" },
+    });
+  });
+
+  it("404s for the communal workspace", async () => {
+    const env = memberEnv({ workspace: "default", db: new UsageFakeD1() });
+    const res = await patchVisibility("default", "a.png", "private", env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a bad key", async () => {
+    const env = acmeEnv(new FakeR2Bucket());
+    const res = await patchVisibility("acme", "../etc/passwd", "private", env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a key that does not exist", async () => {
+    const env = acmeEnv(new FakeR2Bucket());
+    const res = await patchVisibility("acme", "missing.png", "private", env);
+    expect(res.status).toBe(404);
+  });
+
+  it("400s for an invalid visibility value", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1]));
+    const env = acmeEnv(bucket);
+    const res = await patchVisibility("acme", "a.png", "hidden", env);
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_visibility" },
+    });
+  });
+
+  it("400s for a missing visibility field", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/a.png", new Uint8Array([1]));
+    const env = acmeEnv(bucket);
+    const res = await patchVisibility("acme", "a.png", undefined, env);
+    expect(res.status).toBe(400);
+  });
+});
+
 describe("/me/workspaces/:name/file-browser", () => {
   function browserEnv(workspace = "acme") {
     const bucket = new FakeR2Bucket();

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,13 +9,14 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
-import { NotFoundError, ValidationError } from "@uploads/errors";
+import { NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { gallerySummary } from "../gallery-service";
+import { allowWrite } from "../guards";
 import { membershipsForUser, orgForWorkspace, workspacesForOrg } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { publicUrl, storage, storageConfig } from "../storage";
@@ -201,6 +202,13 @@ export const me = new Hono<SessionVars>()
     const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
     const key = c.req.query("key") ?? "";
     if (ws.communal || badKey(key)) throw new NotFoundError();
+
+    // Throttle rewrites per workspace — checked only after the membership
+    // gate, so a non-member can't burn a workspace's write budget. Same
+    // WRITE_LIMITER the token-scoped mutating routes use (see guards.ts).
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
 
     const body = await c.req.json().catch(() => null);
     const requested = (body as { visibility?: unknown } | null)?.visibility;

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -13,13 +13,15 @@ import { NotFoundError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
-import { badKey, listObjects } from "../files-core";
+import { badKey, listObjects, UPLOAD_CACHE_CONTROL } from "../files-core";
 import { listGalleries } from "../galleries";
 import { gallerySummary } from "../gallery-service";
+import { DEFAULT_MAX_UPLOAD_BYTES } from "../guards";
 import { membershipsForUser, orgForWorkspace, workspacesForOrg } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
+import { sanitizeVisibility, VISIBILITY_META_KEY, VISIBILITY_VALUES } from "../visibility";
 import { loadWorkspaceRecord } from "../workspace";
 
 interface MyWorkspace {
@@ -187,6 +189,61 @@ export const me = new Hono<SessionVars>()
       "no public or signed URL available for this workspace's storage configuration",
       { code: "file_url_unavailable" },
     );
+  })
+
+  // Toggle a file's `visibility` custom-metadata flag — member-gated, same key
+  // convention as `file-url` (key via query param; embedding it in the path
+  // segment fights Hono's routing for keys containing `/`). R2 custom metadata
+  // is immutable in place, so this rewrites the object under the same key: a
+  // `head` first (to enforce the same size cap as ordinary uploads, since the
+  // rewrite buffers the whole body in memory) then a `download` + `upload`
+  // with the toggled metadata. `contentType` and provenance metadata come
+  // straight off the existing object; `cacheControl` is reapplied from the
+  // same constant every upload already uses (`UPLOAD_CACHE_CONTROL`), so this
+  // is a no-op for objects written by this API and a one-time normalization
+  // for anything written before that constant existed.
+  .patch("/workspaces/:name/files/visibility", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    const key = c.req.query("key") ?? "";
+    if (ws.communal || badKey(key)) throw new NotFoundError();
+
+    const body = await c.req.json().catch(() => null);
+    const requested = (body as { visibility?: unknown } | null)?.visibility;
+    if (
+      typeof requested !== "string" ||
+      !(VISIBILITY_VALUES as readonly string[]).includes(requested)
+    ) {
+      throw new ValidationError('visibility must be "public" or "private"', {
+        code: "invalid_visibility",
+      });
+    }
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError();
+    const store = await storage(c.env, record);
+
+    const meta = await store.head(key).catch(() => null);
+    if (!meta) throw new NotFoundError();
+    if (meta.size > DEFAULT_MAX_UPLOAD_BYTES) {
+      throw new ValidationError("file too large to change visibility", {
+        code: "file_too_large",
+      });
+    }
+
+    const current = await store.download(key);
+    const bytes = new Uint8Array(await current.arrayBuffer());
+    const metadata: Record<string, string> = { ...current.metadata };
+    if (requested === "private") metadata[VISIBILITY_META_KEY] = "private";
+    else delete metadata[VISIBILITY_META_KEY];
+
+    await store.upload(key, bytes, {
+      contentType: current.type,
+      cacheControl: UPLOAD_CACHE_CONTROL,
+      metadata,
+    });
+
+    return c.json({ key, visibility: sanitizeVisibility(requested) ?? "public" });
   })
 
   // files-sdk's folder-aware browser gateway. Authorization happens before a

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -13,15 +13,14 @@ import { NotFoundError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
-import { badKey, listObjects, UPLOAD_CACHE_CONTROL } from "../files-core";
+import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { gallerySummary } from "../gallery-service";
-import { DEFAULT_MAX_UPLOAD_BYTES } from "../guards";
 import { membershipsForUser, orgForWorkspace, workspacesForOrg } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
-import { sanitizeVisibility, VISIBILITY_META_KEY, VISIBILITY_VALUES } from "../visibility";
+import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { loadWorkspaceRecord } from "../workspace";
 
 interface MyWorkspace {
@@ -193,15 +192,10 @@ export const me = new Hono<SessionVars>()
 
   // Toggle a file's `visibility` custom-metadata flag — member-gated, same key
   // convention as `file-url` (key via query param; embedding it in the path
-  // segment fights Hono's routing for keys containing `/`). R2 custom metadata
-  // is immutable in place, so this rewrites the object under the same key: a
-  // `head` first (to enforce the same size cap as ordinary uploads, since the
-  // rewrite buffers the whole body in memory) then a `download` + `upload`
-  // with the toggled metadata. `contentType` and provenance metadata come
-  // straight off the existing object; `cacheControl` is reapplied from the
-  // same constant every upload already uses (`UPLOAD_CACHE_CONTROL`), so this
-  // is a no-op for objects written by this API and a one-time normalization
-  // for anything written before that constant existed.
+  // segment fights Hono's routing for keys containing `/`). Storage mechanics
+  // (head/size-cap/download/re-upload) live in files-core's
+  // `setObjectVisibility`; this route keeps auth, key validation, body
+  // validation, and error mapping.
   .patch("/workspaces/:name/files/visibility", async (c) => {
     const name = c.req.param("name");
     const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
@@ -223,25 +217,7 @@ export const me = new Hono<SessionVars>()
     if (!record) throw new NotFoundError();
     const store = await storage(c.env, record);
 
-    const meta = await store.head(key).catch(() => null);
-    if (!meta) throw new NotFoundError();
-    if (meta.size > DEFAULT_MAX_UPLOAD_BYTES) {
-      throw new ValidationError("file too large to change visibility", {
-        code: "file_too_large",
-      });
-    }
-
-    const current = await store.download(key);
-    const bytes = new Uint8Array(await current.arrayBuffer());
-    const metadata: Record<string, string> = { ...current.metadata };
-    if (requested === "private") metadata[VISIBILITY_META_KEY] = "private";
-    else delete metadata[VISIBILITY_META_KEY];
-
-    await store.upload(key, bytes, {
-      contentType: current.type,
-      cacheControl: UPLOAD_CACHE_CONTROL,
-      metadata,
-    });
+    await setObjectVisibility(store, key, requested as "public" | "private");
 
     return c.json({ key, visibility: sanitizeVisibility(requested) ?? "public" });
   })

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,7 +1,8 @@
-import { NotFoundError } from "@uploads/errors";
+import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import { badKey } from "../files-core";
 import { publicUrl, storage, storageConfig } from "../storage";
+import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 
 /**
@@ -13,6 +14,13 @@ import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
  * no bearer token in the browser. It adds no new *access* — the bytes are already
  * served unsigned off the R2 public domain — only a curated metadata view. Raw
  * provenance is deliberately omitted here (unlike the authenticated HEAD).
+ *
+ * `visibility: "private"` (#139) gates this JSON endpoint with 401 `auth_required`.
+ * NOTE this is metadata-only enforcement: on a workspace with `publicBaseUrl`, the
+ * raw object bytes remain reachable unsigned straight off that public domain — this
+ * route never controlled byte access, only this curated view. Real privacy for a
+ * "private" object requires a workspace with no `publicBaseUrl` (signed URLs only),
+ * which is out of scope for this endpoint.
  */
 export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}", async (c) => {
   const workspace = c.req.param("workspace");
@@ -33,6 +41,10 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   const store = await storage(c.env, record);
   if (!(await store.exists(key))) throw new NotFoundError();
   const meta = await store.head(key);
+
+  if (objectVisibility(meta.metadata ?? undefined)) {
+    throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
+  }
 
   return c.json({
     workspace,

--- a/apps/api/src/visibility.ts
+++ b/apps/api/src/visibility.ts
@@ -1,0 +1,25 @@
+/**
+ * Per-object `visibility` (R2 custom metadata), private-by-exception.
+ *
+ * Absence of the key (or any value other than "private") means public — the
+ * historical default for every object uploaded before this existed. Follows
+ * the provenance pattern (`apps/api/src/provenance.ts`): a small sanitizer
+ * plus a reader, threaded through `putObject`/`headObjectJson`/`listObjects`.
+ */
+
+export const VISIBILITY_META_KEY = "visibility";
+
+export const VISIBILITY_VALUES = ["public", "private"] as const;
+export type Visibility = (typeof VISIBILITY_VALUES)[number];
+
+/** Anything other than exactly "private" collapses to `undefined` (public). */
+export function sanitizeVisibility(raw: string | undefined | null): "private" | undefined {
+  return raw === "private" ? "private" : undefined;
+}
+
+/** Read visibility off stored object metadata. `undefined` means public. */
+export function objectVisibility(
+  metadata: Record<string, string> | undefined | null,
+): "private" | undefined {
+  return sanitizeVisibility(metadata?.[VISIBILITY_META_KEY]);
+}

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -167,6 +167,30 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(headJson.metadata).toEqual(json.metadata);
   });
 
+  it("stores private visibility from the upload header and surfaces it on authed head", async () => {
+    const { env } = await makeEnv();
+    const res = await putShot(env, { headers: { "X-Uploads-Visibility": "private" } });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { visibility?: string };
+    expect(json.visibility).toBe("private");
+
+    const head = await app.request(
+      "/v1/default/files/screenshots/shot.png",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    const headJson = (await head.json()) as { visibility?: string };
+    expect(headJson.visibility).toBe("private");
+  });
+
+  it("ignores an invalid visibility header value (stays public)", async () => {
+    const { env } = await makeEnv();
+    const res = await putShot(env, { headers: { "X-Uploads-Visibility": "hidden" } });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { visibility?: string };
+    expect(json.visibility).toBeUndefined();
+  });
+
   it("always sets content-sha256 even without client provenance headers", async () => {
     const { env } = await makeEnv();
     const res = await putShot(env);

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -147,4 +147,24 @@ describe("GET /public/files/:workspace/:key", () => {
     const res = await app.request("/public/files/default", {}, env);
     expect(res.status).toBe(404);
   });
+
+  it("401s with auth_required for a private object, without leaking metadata", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env, { "X-Uploads-Visibility": "private" });
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: { code: string; message: string } };
+    expect(json.error.code).toBe("auth_required");
+    expect(json).not.toHaveProperty("metadata");
+    expect(json).not.toHaveProperty("visibility");
+  });
+
+  it("stays public when the upload header is anything other than 'private'", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env, { "X-Uploads-Visibility": "public" });
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+  });
 });

--- a/apps/api/test/visibility.test.ts
+++ b/apps/api/test/visibility.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { objectVisibility, sanitizeVisibility, VISIBILITY_META_KEY } from "../src/visibility";
+
+describe("sanitizeVisibility", () => {
+  it("passes through exactly 'private'", () => {
+    expect(sanitizeVisibility("private")).toBe("private");
+  });
+
+  it("collapses anything else to undefined (public)", () => {
+    expect(sanitizeVisibility("public")).toBeUndefined();
+    expect(sanitizeVisibility("Private")).toBeUndefined();
+    expect(sanitizeVisibility("")).toBeUndefined();
+    expect(sanitizeVisibility(undefined)).toBeUndefined();
+    expect(sanitizeVisibility(null)).toBeUndefined();
+  });
+});
+
+describe("objectVisibility", () => {
+  it("reads the visibility key off stored metadata", () => {
+    expect(objectVisibility({ [VISIBILITY_META_KEY]: "private" })).toBe("private");
+  });
+
+  it("is public (undefined) when the key is absent or bogus", () => {
+    expect(objectVisibility({})).toBeUndefined();
+    expect(objectVisibility(undefined)).toBeUndefined();
+    expect(objectVisibility({ [VISIBILITY_META_KEY]: "nope" })).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -43,12 +43,16 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
   const [togglingKeys, setTogglingKeys] = useState<ReadonlySet<string>>(new Set());
   const [toggleError, setToggleError] = useState<string | null>(null);
 
-  const toggleVisibility = async (key: string, next: "public" | "private", refresh: () => void) => {
+  const toggleVisibility = async (
+    key: string,
+    next: "public" | "private",
+    onSuccess: () => void,
+  ) => {
     setTogglingKeys((prev) => new Set(prev).add(key));
     setToggleError(null);
     try {
       const result = await setFileVisibility(apiOrigin, workspace, key, next);
-      if (result.kind === "success") refresh();
+      if (result.kind === "success") onSuccess();
       else setToggleError(`Couldn't make "${key}" ${next}. Try again shortly.`);
     } finally {
       setTogglingKeys((prev) => {
@@ -110,17 +114,24 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
         files={files}
         onSelect={(file) => openFile(file.key)}
         isPrivate={(file) => file.metadata?.visibility === "private"}
-        itemActions={(file, { refresh }) => {
+        itemActions={(file, { patchItem }) => {
           const isPrivate = file.metadata?.visibility === "private";
+          const next = isPrivate ? "public" : "private";
           const busy = togglingKeys.has(file.key);
+          // On success, patch the one row in place (rather than refresh())
+          // so "Load more" pagination survives the toggle.
+          const applyLocally = () => {
+            const metadata = { ...file.metadata };
+            if (next === "private") metadata.visibility = "private";
+            else delete metadata.visibility;
+            patchItem(file.key, { metadata });
+          };
           return (
             <Button
               size="sm"
               variant="ghost"
               disabled={busy}
-              onClick={() =>
-                void toggleVisibility(file.key, isPrivate ? "public" : "private", refresh)
-              }
+              onClick={() => void toggleVisibility(file.key, next, applyLocally)}
             >
               {busy ? "…" : isPrivate ? "Make public" : "Make private"}
             </Button>

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -1,5 +1,5 @@
 import { useFiles } from "files-sdk/react";
-import { Button, FileBrowser } from "@uploads/ui";
+import { Button, Callout, FileBrowser } from "@uploads/ui";
 import "@uploads/ui/styles.css";
 import { useState } from "react";
 import { filePath } from "../lib/public-file";
@@ -41,12 +41,15 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
   // Keys with an in-flight visibility PATCH, so the toggle button disables
   // itself per-row instead of blocking the whole list.
   const [togglingKeys, setTogglingKeys] = useState<ReadonlySet<string>>(new Set());
+  const [toggleError, setToggleError] = useState<string | null>(null);
 
   const toggleVisibility = async (key: string, next: "public" | "private", refresh: () => void) => {
     setTogglingKeys((prev) => new Set(prev).add(key));
+    setToggleError(null);
     try {
       const result = await setFileVisibility(apiOrigin, workspace, key, next);
       if (result.kind === "success") refresh();
+      else setToggleError(`Couldn't make "${key}" ${next}. Try again shortly.`);
     } finally {
       setTogglingKeys((prev) => {
         const copy = new Set(prev);
@@ -98,6 +101,11 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
   return (
     <>
       <div className="ws-section-head">Files</div>
+      {toggleError && (
+        <Callout tone="error" role="alert">
+          {toggleError}
+        </Callout>
+      )}
       <FileBrowser
         files={files}
         onSelect={(file) => openFile(file.key)}

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -1,7 +1,9 @@
 import { useFiles } from "files-sdk/react";
 import { FileBrowser } from "@uploads/ui";
 import "@uploads/ui/styles.css";
+import { useState } from "react";
 import { filePath } from "../lib/public-file";
+import { setFileVisibility } from "../lib/api-client";
 
 interface Props {
   apiOrigin: string;
@@ -36,6 +38,23 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
     endpoint: `${apiOrigin.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/file-browser`,
     fetchImpl: credentialedFetch,
   });
+  // Keys with an in-flight visibility PATCH, so the toggle button disables
+  // itself per-row instead of blocking the whole list.
+  const [togglingKeys, setTogglingKeys] = useState<ReadonlySet<string>>(new Set());
+
+  const toggleVisibility = async (key: string, next: "public" | "private", refresh: () => void) => {
+    setTogglingKeys((prev) => new Set(prev).add(key));
+    try {
+      const result = await setFileVisibility(apiOrigin, workspace, key, next);
+      if (result.kind === "success") refresh();
+    } finally {
+      setTogglingKeys((prev) => {
+        const copy = new Set(prev);
+        copy.delete(key);
+        return copy;
+      });
+    }
+  };
 
   // Public workspaces open the chrome-wrapped file page (issue #135) rather
   // than dumping the raw bytes into a tab — it presents metadata and links to
@@ -79,7 +98,27 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
   return (
     <>
       <div className="ws-section-head">Files</div>
-      <FileBrowser files={files} onSelect={(file) => openFile(file.key)} />
+      <FileBrowser
+        files={files}
+        onSelect={(file) => openFile(file.key)}
+        isPrivate={(file) => file.metadata?.visibility === "private"}
+        itemActions={(file, { refresh }) => {
+          const isPrivate = file.metadata?.visibility === "private";
+          const busy = togglingKeys.has(file.key);
+          return (
+            <button
+              type="button"
+              className="ul-files__action"
+              disabled={busy}
+              onClick={() =>
+                void toggleVisibility(file.key, isPrivate ? "public" : "private", refresh)
+              }
+            >
+              {busy ? "…" : isPrivate ? "Make public" : "Make private"}
+            </button>
+          );
+        }}
+      />
     </>
   );
 }

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -1,5 +1,5 @@
 import { useFiles } from "files-sdk/react";
-import { FileBrowser } from "@uploads/ui";
+import { Button, FileBrowser } from "@uploads/ui";
 import "@uploads/ui/styles.css";
 import { useState } from "react";
 import { filePath } from "../lib/public-file";
@@ -106,16 +106,16 @@ export function AccountFileBrowser({ apiOrigin, workspace, hasPublicUrl }: Props
           const isPrivate = file.metadata?.visibility === "private";
           const busy = togglingKeys.has(file.key);
           return (
-            <button
-              type="button"
-              className="ul-files__action"
+            <Button
+              size="sm"
+              variant="ghost"
               disabled={busy}
               onClick={() =>
                 void toggleVisibility(file.key, isPrivate ? "public" : "private", refresh)
               }
             >
               {busy ? "…" : isPrivate ? "Make public" : "Make private"}
-            </button>
+            </Button>
           );
         }}
       />

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getMyWorkspaces } from "./api-client";
+import { getMyWorkspaces, setFileVisibility } from "./api-client";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -86,5 +86,58 @@ describe("getMyWorkspaces", () => {
       ["acme", true],
       ["byo", false],
     ]);
+  });
+});
+
+describe("setFileVisibility", () => {
+  it("PATCHes with credentials and returns the resulting visibility", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe(
+        "http://127.0.0.1:8787/me/workspaces/acme/files/visibility?key=f%2Fx%2Fshot.png",
+      );
+      expect(init?.method).toBe("PATCH");
+      expect(init?.credentials).toBe("include");
+      expect(JSON.parse(init!.body as string)).toEqual({ visibility: "private" });
+      return Response.json({ key: "f/x/shot.png", visibility: "private" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      setFileVisibility("http://127.0.0.1:8787", "acme", "f/x/shot.png", "private"),
+    ).resolves.toEqual({ kind: "success", visibility: "private" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("reports non-2xx responses as unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+
+    await expect(
+      setFileVisibility("http://127.0.0.1:8787", "acme", "a.png", "public"),
+    ).resolves.toEqual({ kind: "unavailable", reason: "server" });
+  });
+
+  it("reports a malformed body as unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ key: "a.png" })),
+    );
+
+    await expect(
+      setFileVisibility("http://127.0.0.1:8787", "acme", "a.png", "public"),
+    ).resolves.toEqual({ kind: "unavailable", reason: "malformed" });
+  });
+
+  it("propagates network failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new TypeError("network down"))),
+    );
+
+    await expect(
+      setFileVisibility("http://127.0.0.1:8787", "acme", "a.png", "public"),
+    ).resolves.toEqual({ kind: "unavailable", reason: "network" });
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -166,6 +166,8 @@ export interface WorkspaceFile {
   size?: number;
   contentType?: string;
   uploaded?: string;
+  /** Present (== "private") only when the file was marked private (issue #139). */
+  visibility?: "private";
 }
 
 function isWorkspaceFile(value: unknown): value is WorkspaceFile {
@@ -177,4 +179,44 @@ function isWorkspaceFile(value: unknown): value is WorkspaceFile {
 /** GET /me/workspaces/:name/files. See {@link fetchWorkspaceList}. */
 export function getMyWorkspaceFiles(apiOrigin: string, name: string): Promise<WorkspaceFile[]> {
   return fetchWorkspaceList(apiOrigin, name, "files", "files", isWorkspaceFile);
+}
+
+export type FileVisibility = "public" | "private";
+
+export type SetFileVisibilityResult =
+  | { kind: "success"; visibility: FileVisibility }
+  | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
+
+/**
+ * PATCH /me/workspaces/:name/files/visibility — toggles a file's private flag
+ * (issue #139). Key travels as a query param, matching `file-url`'s
+ * convention, since embedding an arbitrary (possibly `/`-containing) key in
+ * the path segment fights routing.
+ */
+export async function setFileVisibility(
+  apiOrigin: string,
+  name: string,
+  key: string,
+  visibility: FileVisibility,
+): Promise<SetFileVisibilityResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/files/visibility?key=${encodeURIComponent(key)}`,
+    {
+      method: "PATCH",
+      credentials: "include",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ visibility }),
+    },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => undefined)) as
+    | { visibility?: unknown }
+    | undefined;
+  if (body?.visibility !== "public" && body?.visibility !== "private") {
+    return { kind: "unavailable", reason: "malformed" };
+  }
+  return { kind: "success", visibility: body.visibility };
 }

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   applyPublicFileHeaders,
+  authRequiredFileCsp,
   fetchPublicFile,
   fileKind,
   filePath,
@@ -29,6 +30,24 @@ describe("public file headers", () => {
     expect(headers.get("Content-Security-Policy")).toBe(PUBLIC_FILE_CSP);
     expect(headers.get("Cache-Control")).toBe("no-store");
     expect(headers.get("X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+  });
+
+  it("authRequiredFileCsp widens script-src/connect-src but keeps the rest locked down", () => {
+    const csp = authRequiredFileCsp("https://api.uploads.sh");
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("connect-src https://api.uploads.sh");
+    expect(csp).toContain("frame-ancestors 'none'");
+
+    const headers = new Headers();
+    applyPublicFileHeaders(headers, { csp });
+    expect(headers.get("Content-Security-Policy")).toBe(csp);
+    expect(headers.get("Cache-Control")).toBe("no-store");
+
+    // Default call (no override) still gets the strict, script-free policy.
+    const defaultHeaders = new Headers();
+    applyPublicFileHeaders(defaultHeaders);
+    expect(defaultHeaders.get("Content-Security-Policy")).toBe(PUBLIC_FILE_CSP);
   });
 });
 
@@ -119,6 +138,38 @@ describe("fetchPublicFile", () => {
       await fetchPublicFile("acme", "k.png", {
         origin: "https://api.uploads.sh",
         fetch: async () => new Response("nope", { status: 503 }),
+      }),
+    ).toEqual({ status: "unavailable" });
+  });
+
+  it("maps a well-formed 401 auth_required body to auth_required", async () => {
+    const body = { error: { code: "auth_required", message: "sign in to view this file" } };
+    expect(
+      await fetchPublicFile("acme", "k.png", {
+        origin: "https://api.uploads.sh",
+        fetch: async () => Response.json(body, { status: 401 }),
+      }),
+    ).toEqual({ status: "auth_required" });
+  });
+
+  it("treats a malformed or wrong-code 401 body as unavailable", async () => {
+    expect(
+      await fetchPublicFile("acme", "k.png", {
+        origin: "https://api.uploads.sh",
+        fetch: async () => new Response("nope", { status: 401 }),
+      }),
+    ).toEqual({ status: "unavailable" });
+    expect(
+      await fetchPublicFile("acme", "k.png", {
+        origin: "https://api.uploads.sh",
+        fetch: async () =>
+          Response.json({ error: { code: "other", message: "x" } }, { status: 401 }),
+      }),
+    ).toEqual({ status: "unavailable" });
+    expect(
+      await fetchPublicFile("acme", "k.png", {
+        origin: "https://api.uploads.sh",
+        fetch: async () => Response.json({ nope: true }, { status: 401 }),
       }),
     ).toEqual({ status: "unavailable" });
   });

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -57,22 +57,32 @@ export function filePath(workspace: string, key: string): string {
 }
 
 /**
+ * Shared directives behind both {@link PUBLIC_FILE_CSP} and
+ * {@link authRequiredFileCsp} — locked down except for self-hosted
+ * styles/fonts and the Cloudflare RUM beacon. `scriptSrc`/`connectSrc`
+ * override the default (script-free) posture for the auth-required branch.
+ */
+function buildFileCsp(overrides?: { scriptSrc?: string; connectSrc?: string }): string {
+  return [
+    "default-src 'none'",
+    "img-src https: data:",
+    "media-src https:",
+    "font-src 'self'",
+    `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+    `script-src ${overrides?.scriptSrc ?? CF_RUM_SCRIPT_SRC}`,
+    `connect-src ${overrides?.connectSrc ?? CF_RUM_CONNECT_SRC}`,
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+  ].join("; ");
+}
+
+/**
  * Public file page CSP — identical posture to the public gallery: locked down
  * except for self-hosted styles/fonts and the Cloudflare RUM beacon.
  */
-export const PUBLIC_FILE_CSP = [
-  "default-src 'none'",
-  "img-src https: data:",
-  "media-src https:",
-  "font-src 'self'",
-  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-  `script-src ${CF_RUM_SCRIPT_SRC}`,
-  `connect-src ${CF_RUM_CONNECT_SRC}`,
-  "base-uri 'none'",
-  "form-action 'none'",
-  "frame-ancestors 'none'",
-  "object-src 'none'",
-].join("; ");
+export const PUBLIC_FILE_CSP = buildFileCsp();
 
 /**
  * CSP for the `auth_required` branch only: same posture as {@link PUBLIC_FILE_CSP}
@@ -83,19 +93,10 @@ export const PUBLIC_FILE_CSP = [
  * branch keeps the strict, script-free policy.
  */
 export function authRequiredFileCsp(apiOrigin: string): string {
-  return [
-    "default-src 'none'",
-    "img-src https: data:",
-    "media-src https:",
-    "font-src 'self'",
-    `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-    `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-    `connect-src ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
-    "base-uri 'none'",
-    "form-action 'none'",
-    "frame-ancestors 'none'",
-    "object-src 'none'",
-  ].join("; ");
+  return buildFileCsp({
+    scriptSrc: `'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+    connectSrc: `${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
+  });
 }
 
 /**

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -15,10 +15,11 @@ export interface PublicFile {
   uploaded: string | null;
 }
 
-/** Result of resolving a public file: the DTO, a hard 404, or a soft outage. */
+/** Result of resolving a public file: the DTO, a hard 404, a private gate, or a soft outage. */
 export type FileFetchResult =
   | { status: "ok"; file: PublicFile }
   | { status: "not_found" }
+  | { status: "auth_required" }
   | { status: "unavailable" };
 
 /** How a file should be presented in the page's media stage. */
@@ -73,9 +74,37 @@ export const PUBLIC_FILE_CSP = [
   "object-src 'none'",
 ].join("; ");
 
-/** Strict CSP, noindex, no-store — matches the public gallery pages. */
-export function applyPublicFileHeaders(headers: Headers): void {
-  headers.set("Content-Security-Policy", PUBLIC_FILE_CSP);
+/**
+ * CSP for the `auth_required` branch only: same posture as {@link PUBLIC_FILE_CSP}
+ * plus `'self' 'unsafe-inline'` script-src (Astro-processed inline `<script>`,
+ * same allowance as the signed-in shells — see `signed-in-page.ts`) and
+ * `connect-src` widened to the API origin, so the progressive-enhancement
+ * script can probe `/me/workspaces/:workspace/file-url`. The normal public
+ * branch keeps the strict, script-free policy.
+ */
+export function authRequiredFileCsp(apiOrigin: string): string {
+  return [
+    "default-src 'none'",
+    "img-src https: data:",
+    "media-src https:",
+    "font-src 'self'",
+    `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+    `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+    `connect-src ${apiOrigin} ${CF_RUM_CONNECT_SRC}`,
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+  ].join("; ");
+}
+
+/**
+ * Strict CSP, noindex, no-store — matches the public gallery pages. Pass a
+ * `csp` override (e.g. {@link authRequiredFileCsp}) for the auth-required
+ * branch, which needs script execution and API connectivity.
+ */
+export function applyPublicFileHeaders(headers: Headers, options?: { csp?: string }): void {
+  headers.set("Content-Security-Policy", options?.csp ?? PUBLIC_FILE_CSP);
   headers.set("Referrer-Policy", "no-referrer");
   headers.set("X-Content-Type-Options", "nosniff");
   headers.set("X-Frame-Options", "DENY");
@@ -104,6 +133,19 @@ function httpsUrl(value: unknown): value is string {
   } catch {
     return false;
   }
+}
+
+/**
+ * Validate a 401 error body against the bounded shape the API commits to
+ * (issue #139 Task A): `{"error":{"code":"auth_required","message":"..."}}`.
+ * Any other shape — or any other `code` — is treated as a malformed 401.
+ */
+function isAuthRequiredError(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const body = value as Record<string, unknown>;
+  if (typeof body.error !== "object" || body.error === null) return false;
+  const error = body.error as Record<string, unknown>;
+  return error.code === "auth_required" && text(error.message, 512);
 }
 
 /** Validate an untrusted API response against the bounded {@link PublicFile} shape. */
@@ -167,6 +209,15 @@ export async function fetchPublicFile(
       referrerPolicy: "no-referrer",
     });
     if (response.status === 404) return { status: "not_found" };
+    if (response.status === 401) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        return { status: "unavailable" };
+      }
+      return isAuthRequiredError(body) ? { status: "auth_required" } : { status: "unavailable" };
+    }
     if (!response.ok) return { status: "unavailable" };
     const value: unknown = await response.json();
     return isPublicFile(value)

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -137,6 +137,13 @@ const title = file
       )}
     </main>
     {result.status === "auth_required" && (
+      // Progressive-enhancement, client-side authorization path — a second
+      // gate parallel to the server-side one this page already applied via
+      // fetchPublicFile()/objectVisibility (apps/api's GET /public/files/...,
+      // see apps/api/src/routes/public-files.ts). Both this probe and the
+      // /me/workspaces/:name/file-url resolver it calls must keep enforcing
+      // the same auth_required condition as that server gate, or a signed-out
+      // viewer could see one page disagree with the other about access.
       <script define:vars={{ apiOrigin: origin, workspace, key }}>
         (async function () {
           const checking = document.getElementById("auth-checking");

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -4,6 +4,7 @@ import Brand from "../../../components/Brand.astro";
 import Footer from "../../../components/Footer.astro";
 import {
   applyPublicFileHeaders,
+  authRequiredFileCsp,
   fetchPublicFile,
   fileKind as kind,
   filePath,
@@ -21,10 +22,14 @@ const origin =
   "https://api.uploads.sh";
 const result = await fetchPublicFile(workspace, key, { origin });
 
-applyPublicFileHeaders(Astro.response.headers);
+applyPublicFileHeaders(
+  Astro.response.headers,
+  result.status === "auth_required" ? { csp: authRequiredFileCsp(origin) } : undefined,
+);
 
 const file = result.status === "ok" ? result.file : null;
 if (result.status === "unavailable") Astro.response.status = 503;
+else if (result.status === "auth_required") Astro.response.status = 401;
 else if (!file) Astro.response.status = 404;
 
 const filename = key.split("/").filter(Boolean).pop() ?? key;
@@ -35,7 +40,11 @@ const uploadedLabel =
     : null;
 const canonical = new URL(file ? filePath(workspace, key) : Astro.url.pathname, Astro.url.origin)
   .href;
-const title = file ? `${filename} · uploads.sh` : "File unavailable · uploads.sh";
+const title = file
+  ? `${filename} · uploads.sh`
+  : result.status === "auth_required"
+    ? "Sign in to view · uploads.sh"
+    : "File unavailable · uploads.sh";
 ---
 
 <!doctype html>
@@ -76,6 +85,9 @@ const title = file ? `${filename} · uploads.sh` : "File unavailable · uploads.
       .linkfield input { width:100%; padding:8px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
+      .error .signin { display:inline-block; margin-top:18px; padding:9px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--fg); font:12px var(--mono); text-decoration:none; }
+      .error .signin:hover, .error .signin:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      .error .checking { display:block; margin-top:14px; color:var(--muted); font:12px var(--mono); }
       a { color:var(--fg); text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent); text-underline-offset:3px; }
       @media (max-width:760px) { .shell{width:min(100% - 32px,1080px);padding-top:24px} .media{min-height:220px} }
       .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); clip-path:inset(50%); white-space:nowrap; border:0; }
@@ -112,9 +124,49 @@ const title = file ? `${filename} · uploads.sh` : "File unavailable · uploads.
           </figure>
           <Footer />
         </>
+      ) : result.status === "auth_required" ? (
+        <section class="error" id="auth-required">
+          <code>file.auth_required</code>
+          <h1>This file is private</h1>
+          <p>Sign in to view this file if you're a member of this workspace.</p>
+          <a class="signin" id="signin-link" href="/login">Sign in</a>
+          <span class="checking" id="auth-checking" hidden>Checking your session…</span>
+        </section>
       ) : (
         <section class="error"><code>{result.status === "unavailable" ? "file.unavailable" : "file.not_found"}</code><h1>{result.status === "unavailable" ? "File temporarily unavailable" : "File not found"}</h1><p>{result.status === "unavailable" ? "The file service could not be reached. Please try again shortly." : "This file may have been removed, or the link is incorrect."}</p></section>
       )}
     </main>
+    {result.status === "auth_required" && (
+      <script define:vars={{ apiOrigin: origin, workspace, key }}>
+        (async function () {
+          const checking = document.getElementById("auth-checking");
+          try {
+            const endpoint = new URL(
+              `/me/workspaces/${encodeURIComponent(workspace)}/file-url`,
+              apiOrigin,
+            );
+            endpoint.searchParams.set("key", key);
+            if (checking) checking.hidden = false;
+            const response = await fetch(endpoint, {
+              credentials: "include",
+              headers: { Accept: "application/json" },
+              cache: "no-store",
+            });
+            if (!response.ok) {
+              if (checking) checking.hidden = true;
+              return;
+            }
+            const body = await response.json();
+            if (body && typeof body.url === "string" && body.url.startsWith("https://")) {
+              window.location.replace(body.url);
+              return;
+            }
+          } catch (e) {
+            // Network hiccup / signed-out — leave the sign-in state as-is.
+          }
+          if (checking) checking.hidden = true;
+        })();
+      </script>
+    )}
   </body>
 </html>

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -34,6 +34,7 @@ export const ERROR_CODES = [
   "key_too_deep",
   "presign_unavailable",
   "file_url_unavailable",
+  "auth_required",
 
   // Budgets
   "storage_quota_exceeded",

--- a/packages/ui/src/FileBrowser.tsx
+++ b/packages/ui/src/FileBrowser.tsx
@@ -4,6 +4,7 @@ import type { StoredFile } from "files-sdk";
 import type { UseFilesResult } from "files-sdk/react";
 import { ChevronRight, File, Folder, Home, LoaderCircle } from "lucide-react";
 import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { Badge } from "./Badge";
 
 export interface FileBrowserProps {
   files: UseFilesResult;
@@ -163,7 +164,7 @@ export function FileBrowser({
                       {formatBytes(item.size)} · {item.type || "unknown"}
                     </small>
                   </span>
-                  {isPrivate?.(item) ? <span className="ul-files__badge">Private</span> : null}
+                  {isPrivate?.(item) ? <Badge tone="neutral">Private</Badge> : null}
                 </button>
                 {itemActions?.(item, { refresh: () => void load() })}
               </div>

--- a/packages/ui/src/FileBrowser.tsx
+++ b/packages/ui/src/FileBrowser.tsx
@@ -16,10 +16,15 @@ export interface FileBrowserProps {
   /**
    * Renders a per-item action (e.g. a visibility toggle) alongside the
    * select row rather than inside it — `<button>` can't nest another
-   * `<button>`. `refresh` re-runs the current listing in place, for use
-   * after an action mutates the item.
+   * `<button>`. `refresh` re-runs the current listing (resetting any
+   * "Load more" pagination); `patchItem` updates one already-listed row in
+   * place — prefer it after a mutation whose result the caller already
+   * knows, so paginated results survive.
    */
-  itemActions?: (file: StoredFile, helpers: { refresh: () => void }) => React.ReactNode;
+  itemActions?: (
+    file: StoredFile,
+    helpers: { refresh: () => void; patchItem: (key: string, patch: Partial<StoredFile>) => void },
+  ) => React.ReactNode;
 }
 
 const formatBytes = (bytes: number): string => {
@@ -166,7 +171,11 @@ export function FileBrowser({
                   </span>
                   {isPrivate?.(item) ? <Badge tone="neutral">Private</Badge> : null}
                 </button>
-                {itemActions?.(item, { refresh: () => void load() })}
+                {itemActions?.(item, {
+                  refresh: () => void load(),
+                  patchItem: (key, patch) =>
+                    setItems((prev) => prev.map((i) => (i.key === key ? { ...i, ...patch } : i))),
+                })}
               </div>
             </li>
           ))}

--- a/packages/ui/src/FileBrowser.tsx
+++ b/packages/ui/src/FileBrowser.tsx
@@ -10,6 +10,15 @@ export interface FileBrowserProps {
   initialPrefix?: string;
   delimiter?: string;
   onSelect?: (file: StoredFile) => void;
+  /** When it returns true, a small "Private" badge renders next to the item. */
+  isPrivate?: (file: StoredFile) => boolean;
+  /**
+   * Renders a per-item action (e.g. a visibility toggle) alongside the
+   * select row rather than inside it — `<button>` can't nest another
+   * `<button>`. `refresh` re-runs the current listing in place, for use
+   * after an action mutates the item.
+   */
+  itemActions?: (file: StoredFile, helpers: { refresh: () => void }) => React.ReactNode;
 }
 
 const formatBytes = (bytes: number): string => {
@@ -39,6 +48,8 @@ export function FileBrowser({
   initialPrefix = "",
   delimiter = "/",
   onSelect,
+  isPrivate,
+  itemActions,
 }: FileBrowserProps) {
   const [prefix, setPrefix] = useState(initialPrefix);
   const [folders, setFolders] = useState<string[]>([]);
@@ -136,22 +147,26 @@ export function FileBrowser({
           ))}
           {items.map((item) => (
             <li key={item.key}>
-              <button
-                className="ul-files__row"
-                disabled={!onSelect}
-                onClick={() => onSelect?.(item)}
-                type="button"
-              >
-                <span className="ul-files__icon">
-                  <File aria-hidden="true" />
-                </span>
-                <span className="ul-files__name">
-                  <span>{childName(item.key, prefix, delimiter) || item.key}</span>
-                  <small>
-                    {formatBytes(item.size)} · {item.type || "unknown"}
-                  </small>
-                </span>
-              </button>
+              <div className="ul-files__row-wrap">
+                <button
+                  className="ul-files__row"
+                  disabled={!onSelect}
+                  onClick={() => onSelect?.(item)}
+                  type="button"
+                >
+                  <span className="ul-files__icon">
+                    <File aria-hidden="true" />
+                  </span>
+                  <span className="ul-files__name">
+                    <span>{childName(item.key, prefix, delimiter) || item.key}</span>
+                    <small>
+                      {formatBytes(item.size)} · {item.type || "unknown"}
+                    </small>
+                  </span>
+                  {isPrivate?.(item) ? <span className="ul-files__badge">Private</span> : null}
+                </button>
+                {itemActions?.(item, { refresh: () => void load() })}
+              </div>
             </li>
           ))}
         </ul>

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -520,6 +520,15 @@
 .ul-files__list li:last-child {
   border-bottom: 0;
 }
+.ul-files__row-wrap {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.ul-files__row-wrap .ul-files__row {
+  flex: 1;
+  min-width: 0;
+}
 .ul-files__row {
   width: 100%;
   display: flex;
@@ -533,6 +542,37 @@
   padding: 7px 8px;
   background: none;
   cursor: pointer;
+}
+.ul-files__badge {
+  flex: none;
+  font: 10.5px var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+.ul-files__action {
+  flex: none;
+  font: 11px var(--mono);
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  background: none;
+  cursor: pointer;
+}
+.ul-files__action:hover,
+.ul-files__action:focus-visible {
+  color: var(--accent);
+  border-color: var(--accent);
+  outline: none;
+}
+.ul-files__action:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 .ul-files__row:hover,
 .ul-files__row:focus-visible {

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -543,37 +543,6 @@
   background: none;
   cursor: pointer;
 }
-.ul-files__badge {
-  flex: none;
-  font: 10.5px var(--mono);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  padding: 2px 6px;
-}
-.ul-files__action {
-  flex: none;
-  font: 11px var(--mono);
-  color: var(--muted);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  padding: 5px 8px;
-  background: none;
-  cursor: pointer;
-}
-.ul-files__action:hover,
-.ul-files__action:focus-visible {
-  color: var(--accent);
-  border-color: var(--accent);
-  outline: none;
-}
-.ul-files__action:disabled {
-  cursor: default;
-  opacity: 0.6;
-}
 .ul-files__row:hover,
 .ul-files__row:focus-visible {
   background: color-mix(in srgb, var(--accent) 12%, transparent);


### PR DESCRIPTION
Implements phase 2 of the standalone file page (#139): a per-file `visibility` flag so a private file's page and metadata endpoint require auth. Built on the #123/#141 resolver ladder.

## What changed

**API**
- `visibility` stored as R2 object custom metadata (`private` only; absence = public), following the provenance pattern (`apps/api/src/visibility.ts`).
- `PUT /v1/:ws/files/:key` accepts `X-Uploads-Visibility: private` (sanitized; flows through the shared `putObject`, so MCP is covered too).
- `GET /public/files/:ws/:key` now returns `401 {"error":{"code":"auth_required","type":"unauthorized","message":"sign in to view this file"}}` for private objects. Metadata is still never leaked publicly.
- Authed head/list responses surface `visibility: "private"` (omitted when public).
- New member-gated `PATCH /me/workspaces/:name/files/visibility?key=…` toggles the flag via same-key rewrite (head-first size cap at the standard 25 MiB upload limit; contentType + provenance preserved).

**Web**
- `/f/:ws/:key` gains a third state: 401 + "This file is private" with a sign-in link. Progressive enhancement (matching the account-shell convention): a signed-in member is redirected to the signed URL from `/me/workspaces/:ws/file-url`. The loosened CSP (`script-src`, `connect-src` to the API origin) applies only to the auth-required branch; the public branch keeps the strict script-free policy.
- Account file browser shows a Private badge and a per-file make-private/make-public toggle (`packages/ui` FileBrowser gains optional `isPrivate`/`itemActions` props, backward-compatible).

## Known limitation (by design, documented in the route)

On a workspace with a `publicBaseUrl` custom domain, raw bucket bytes remain world-readable regardless of the flag — this endpoint never controlled byte access. Real privacy requires a workspace without a public domain (signed-URL-only), per the issue.

## Testing

- `pnpm -r test`: 625 tests passing across 8 packages (255 api, 60 web, 15 errors, …), including new coverage: private → 401 `auth_required` with no metadata leak, upload-header sanitization, toggle round-trip preserving provenance, non-member 404, malformed-401 handling on the page client, CSP variant behavior.
- Typechecks and builds clean for api, web, ui, errors.
- Not verified in a live browser session (needs seeded workspace + session locally); the redirect path reuses the already-shipped `/me/…/file-url` endpoint unchanged.

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Files can now be marked private or public.
  - File listings show a “Private” badge and provide controls to change visibility.
  - Uploads support private visibility, which is reflected in file details and listings.
  - Private public-file links now display an authentication prompt and redirect signed-in users to the file.
- **Bug Fixes**
  - Private files are no longer exposed through unauthenticated public metadata endpoints.
- **Security**
  - Access controls and responses now consistently enforce private-file visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->