### PR TITLE
feat(uploads): agent-friendly put + install/auth onboarding

### DIFF
--- a/.changeset/uploads-agent-dx.md
+++ b/.changeset/uploads-agent-dx.md
@@ -1,0 +1,15 @@
+---
+"@buildinternet/uploads": minor
+---
+
+CLI onboarding and agent-friendly put:
+
+- **`uploads install`** — short progress, no child stdout unless `--verbose`/failure;
+  non-interactive skills (`-g -y -a '*'`); success next-steps; MCP without a token is
+  skipped with a login nudge (skill still installs).
+- **Missing token** — onboarding copy (no `error:` prefix); exit non-zero; `--json`
+  keeps `MISSING_TOKEN`. Rejected tokens stay `UNAUTHORIZED` with a re-login hint.
+- **`put --name <leaf>`** — clean key leaf on the stable `--pr`/default path.
+- **`put --dry-run`** — resolve key + public URL without writing (API `?dryRun=1`).
+- **Scripted failures** — `--format json|url|markdown` also print on stdout.
+- **`FILE_NOT_FOUND`** — distinct code (exit 2) for a missing local file.

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -83,6 +83,21 @@ export const files = new Hono<WorkspaceVars>()
   .put("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
+
+    // ?dryRun=1 — validate key + resolve public URL; no R2 write, no usage/budget check.
+    // Prefixed keys match a real put; bare keys may re-govern to a new f/<id>/… on upload.
+    const dryRun = c.req.query("dryRun");
+    if (dryRun === "1" || dryRun === "true") {
+      const ws = c.get("workspace");
+      const finalKey = finalizeUploadKey(key, ws);
+      return c.json({
+        workspace: c.get("workspaceName"),
+        key: finalKey,
+        url: publicUrl(await storageConfig(c.env, ws), finalKey),
+        dryRun: true,
+      });
+    }
+
     const policy = resolveUploadPolicy(c.get("workspace"));
     const declared = checkDeclaredLength(c.req.header("Content-Length"), policy);
     if (declared) throw declared.error;

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -127,6 +127,34 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(res.status).toBe(429);
   });
 
+  it("dry run resolves the key + public URL without writing", async () => {
+    const { env, bucket } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/screenshots/shot.png?dryRun=1",
+      { method: "PUT", headers: { Authorization: `Bearer ${TOKEN}` }, body: new Uint8Array(0) },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { key: string; url: string; dryRun: boolean };
+    expect(json).toEqual({
+      workspace: "default",
+      key: "screenshots/shot.png",
+      url: "https://storage.uploads.sh/default/screenshots/shot.png",
+      dryRun: true,
+    });
+    expect(bucket.store.has("default/screenshots/shot.png")).toBe(false);
+  });
+
+  it("dry run rejects a key the workspace policy disallows", async () => {
+    const { env } = await makeEnv({ allowedKeyPrefixes: ["gh"] });
+    const res = await app.request(
+      "/v1/default/files/screenshots/shot.png?dryRun=1",
+      { method: "PUT", headers: { Authorization: `Bearer ${TOKEN}` }, body: new Uint8Array(0) },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("stores allowlisted provenance metadata and returns it on put + head", async () => {
     const { env, bucket } = await makeEnv();
     const res = await putShot(env, {

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -21,6 +21,8 @@ uploads put ./shot.png --no-optimize
 uploads put ./mobile.png --frame phone
 uploads put ./ui.png --frame browser --frame-url "https://app.example"
 uploads put ./after.png --pr 123 --comment
+uploads put ./capture-2026-…Z.png --pr 123 --name hero.png   # clean leaf, stable path
+uploads put ./shot.png --pr 123 --name hero.png --dry-run --format url  # preview URL, no upload
 uploads gallery create --title "Release screenshots"
 uploads put ./after.png --gallery gal_example
 uploads doctor
@@ -40,6 +42,11 @@ Commands: `attach`, `put`, `gallery`, `comment`, `list`, `delete`, `usage`, `rec
 newer npm release is available (at most once/day, `~/.cache/uploads/`). Silence
 with `--quiet`, `--json`, `UPLOADS_NO_UPDATE=1`, or `NO_UPDATE_NOTIFIER=1`. Not used
 for `uploads mcp`.
+
+**Exit codes:** `0` ok, `2` usage/token/file, `3` auth/policy, `4` network, `1` other.
+Failures go to stderr; under `--format json|url|markdown` they also go to stdout so
+piped runs stay self-diagnosing. Prefer JSON `code` over message text. `put --dry-run`
+previews the key + public URL without uploading.
 
 `attach` is the agent-friendly default for GitHub media. It accepts one or more files,
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
@@ -95,7 +102,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 
 Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
 
-For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. `uploads install` registers it with Claude Code (and installs the agent skill) in one step. Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
+For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. `uploads install` registers the skill + hosted MCP (short progress; `--verbose` for underlying output). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 
 ## Programmatic use
 

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -3,6 +3,7 @@ import { resolveApiUrl, resolveConfig } from "./config.js";
 import { UploadsError } from "./errors.js";
 import {
   commandWorkspace,
+  flagString,
   isHelpFlag,
   parseArgv,
   parseCommandArgs,
@@ -124,6 +125,7 @@ function exitCode(err: unknown): number {
     switch (err.code) {
       case "MISSING_TOKEN":
       case "USAGE":
+      case "FILE_NOT_FOUND":
         return 2;
       case "UNAUTHORIZED":
       case "NOT_FOUND":
@@ -140,33 +142,69 @@ function exitCode(err: unknown): number {
   return 1;
 }
 
-function errorOut(err: unknown, json: boolean): void {
+/** Effective stdout format, so failures surface where the caller reads output. */
+type OutputFormat = "json" | "url" | "markdown" | "human";
+
+/** Global `--json` wins; else put-style `--format`. Drives where failures print. */
+export function outputFormat(argv: string[]): OutputFormat {
+  const flags = parseCommandArgs(argv.slice(2)).flags;
+  if (flags.has("--json")) return "json";
+  const value = flagString(flags, "--format");
+  if (value === "json" || value === "url" || value === "markdown") return value;
+  return "human";
+}
+
+const QUOTA_HINT =
+  "hint: run `uploads usage` then delete objects or raise limits (`pnpm workspace:limits`)\n";
+const ERROR_HINTS: Partial<Record<UploadsError["code"], string>> = {
+  STORAGE_QUOTA: QUOTA_HINT,
+  UPLOAD_BUDGET: QUOTA_HINT,
+  KEY_POLICY:
+    "hint: use a typed destination (`--destination screenshots|gh`) or an allowed prefix; operators set allowlists with `pnpm workspace:limits --allowed-prefixes`\n",
+  UNAUTHORIZED:
+    "hint: token rejected — run `uploads login` to sign in again, or check UPLOADS_TOKEN / --token\n",
+};
+
+function errorOut(err: unknown, format: OutputFormat): void {
   const payload =
     err instanceof UploadsError
       ? { error: err.message, code: err.code, status: err.status }
       : err instanceof UsageError
         ? { error: err.message, code: "USAGE" }
         : { error: err instanceof Error ? err.message : String(err) };
-  if (json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
-  else {
-    const msg = payload.error;
-    if (msg.includes("\n")) process.stderr.write(`${msg}\n`);
-    else process.stderr.write(`error: ${msg}\n`);
-    if (err instanceof UploadsError) {
-      if (err.code === "STORAGE_QUOTA" || err.code === "UPLOAD_BUDGET") {
-        process.stderr.write(
-          "hint: run `uploads usage` then delete objects or raise limits (`pnpm workspace:limits`)\n",
-        );
-      } else if (err.code === "KEY_POLICY") {
-        process.stderr.write(
-          "hint: use a typed destination (`--destination screenshots|gh`) or an allowed prefix; operators set allowlists with `pnpm workspace:limits --allowed-prefixes`\n",
-        );
-      } else if (err.status === 413 || err.message.toLowerCase().includes("too large")) {
-        process.stderr.write(
-          "hint: file exceeds workspace size policy (images vs video may differ); compress or raise --max-upload-bytes / --max-video-bytes\n",
-        );
-      }
+
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    return;
+  }
+
+  const msg = payload.error;
+
+  // No token: onboarding nudge (no "error:" prefix). Exit stays non-zero; JSON keeps MISSING_TOKEN.
+  if (err instanceof UploadsError && err.code === "MISSING_TOKEN") {
+    process.stderr.write(`${msg}\n`);
+    if (format === "url" || format === "markdown") {
+      process.stdout.write("not signed in — run uploads login\n");
     }
+    return;
+  }
+
+  if (msg.includes("\n")) process.stderr.write(`${msg}\n`);
+  else process.stderr.write(`error: ${msg}\n`);
+
+  if (err instanceof UploadsError) {
+    const hint = ERROR_HINTS[err.code];
+    if (hint) process.stderr.write(hint);
+    else if (err.status === 413 || err.message.toLowerCase().includes("too large")) {
+      process.stderr.write(
+        "hint: file exceeds workspace size policy (images vs video may differ); compress or raise --max-upload-bytes / --max-video-bytes\n",
+      );
+    }
+  }
+
+  // Scripted formats often drop stderr — mirror a one-line reason on stdout.
+  if (format === "url" || format === "markdown") {
+    process.stdout.write(`error: ${msg.replace(/\s*\n\s*/g, " ")}\n`);
   }
 }
 
@@ -278,8 +316,9 @@ export async function runCli(argv: string[]): Promise<number> {
     }
     return code;
   } catch (err) {
-    errorOut(err, argv.includes("--json"));
-    if (err instanceof UsageError && !argv.includes("--json")) usageHint(argv);
+    const format = outputFormat(argv);
+    errorOut(err, format);
+    if (err instanceof UsageError && format !== "json") usageHint(argv);
     return exitCode(err);
   }
 }

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -22,6 +22,8 @@ export interface PutOptions {
   deriveRepoFromGit?: boolean;
   /** Stored as R2 custom metadata; echoed on put/head. */
   provenance?: ProvenanceInput;
+  /** Validate key + resolve public URL without writing. `size` is local bytes only. */
+  dryRun?: boolean;
 }
 
 export interface ListOptions {
@@ -532,6 +534,27 @@ export function createUploadsClient(config: UploadsClientConfig) {
           deriveRepoFromGit: opts.deriveRepoFromGit,
         }));
       const contentType = opts.contentType ?? inferContentType(opts.filename);
+
+      if (opts.dryRun) {
+        const preview = await request<{ workspace: string; key: string; url: string | null }>(
+          "PUT",
+          `${filesBase(config)}/${encodeKeyPath(key)}?dryRun=1`,
+        );
+        if (preview.url == null) {
+          throw new UploadsError(
+            "workspace has no publicBaseUrl (cannot resolve a public URL)",
+            "NO_PUBLIC_URL",
+          );
+        }
+        return {
+          workspace: preview.workspace,
+          key: preview.key,
+          url: preview.url,
+          size: body.byteLength,
+          contentType,
+        };
+      }
+
       const headers: Record<string, string> = { "Content-Type": contentType };
       if (opts.provenance) {
         for (const [k, v] of Object.entries(opts.provenance)) {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -54,6 +54,18 @@ export interface CliContext {
   envFile?: string;
 }
 
+/** Read a local file (or `-` for stdin). Missing path → FILE_NOT_FOUND (exit 2). */
+export function readFileArg(fileArg: string): Uint8Array {
+  try {
+    return new Uint8Array(readFileSync(fileArg === "-" ? 0 : fileArg));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      throw new UploadsError(`file not found: ${fileArg}`, "FILE_NOT_FOUND");
+    }
+    throw err;
+  }
+}
+
 // --- put ---
 
 const PUT_HELP = `uploads put <file> [options]
@@ -74,6 +86,7 @@ that is safe at a predictable public URL.
 
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
+  --name <leaf>         Clean key leaf + default alt (no '/'); keeps --pr/default path. Not with --key
   --destination <id>    Typed root: screenshots | gh | f (sets --prefix)
   --prefix <path>       Key prefix (default: screenshots, or UPLOADS_DEFAULT_PREFIX)
   --repo <owner/repo>   Repo segment (default: git remote, or UPLOADS_DEFAULT_REPO)
@@ -95,12 +108,18 @@ Options:
   --issue <num>         Attach to an issue: key gh/<owner>/<repo>/issues/<num>/<name>
   --comment             With --pr/--issue: update one managed comment with attachments and linked galleries via local gh auth
   --gallery <id>         Add the uploaded object to this public gallery
+  --dry-run             Print key + public URL without uploading. Not with --comment/--gallery
+
+Exit codes: 0 ok · 2 usage/token/file · 3 auth/policy · 4 network · 1 other.
+Scripted formats (json|url|markdown) also print failures on stdout.
 
 Examples:
   uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
   uploads put ./mobile.png --frame phone
   uploads put ./ui.png --frame browser --frame-url "https://app.example/settings"
   uploads put ./shot.png --destination screenshots
+  uploads put ./capture-….webp --pr 128 --name hero.webp
+  uploads put ./shot.png --pr 128 --name hero.webp --dry-run --format url
   uploads put ./after.png --gallery gal_example
 `;
 
@@ -359,7 +378,7 @@ export async function runAttach(
       throw new UsageError("attach does not support stdin; pass one or more file paths");
     const sourceName = basename(file);
     if (!ctx.quiet && !ctx.json) process.stderr.write(`>> uploading ${file}\n`);
-    const prepared = await prepareImageForUpload(new Uint8Array(readFileSync(file)), sourceName, {
+    const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
       ...frameOpts,
       optimize: optimizeOpts,
     });
@@ -445,16 +464,32 @@ export async function runPut(
   const ghTarget = ghTargetFromFlags(parsed.flags, run);
   const wantComment = parsed.flags.has("--comment");
   const galleryId = flagString(parsed.flags, "--gallery");
+  const nameFlag = flagString(parsed.flags, "--name");
+  const dryRun = flagBool(parsed.flags, "--dry-run");
   if (wantComment && typeof parsed.flags.get("--comment") === "string") {
     throw new UsageError("--comment takes no value — place it after the file argument");
   }
   if (wantComment && !ghTarget) throw new UsageError("--comment requires --pr or --issue");
   if (ghTarget) {
-    if (keyHint) throw new UsageError("--key cannot be combined with --pr/--issue");
+    if (keyHint) {
+      throw new UsageError(
+        "--key cannot be combined with --pr/--issue; use --name <leaf> to set a clean filename on the stable path",
+      );
+    }
     if (flagString(parsed.flags, "--ref")) {
       throw new UsageError("--ref cannot be combined with --pr/--issue");
     }
     if (prefixFlag) throw new UsageError("--prefix cannot be combined with --pr/--issue");
+  }
+  if (nameFlag !== undefined) {
+    if (nameFlag === "" || nameFlag.includes("/")) {
+      throw new UsageError("--name must be a bare filename with no '/'");
+    }
+    if (keyHint) throw new UsageError("--name cannot be combined with --key");
+  }
+  if (dryRun) {
+    if (wantComment) throw new UsageError("--dry-run cannot be combined with --comment");
+    if (galleryId) throw new UsageError("--dry-run cannot be combined with --gallery");
   }
   let resolvedPrefix: string | undefined;
   try {
@@ -467,10 +502,9 @@ export async function runPut(
   } catch (err) {
     throw new UsageError(err instanceof Error ? err.message : String(err));
   }
-  const bytes =
-    fileArg === "-" ? new Uint8Array(readFileSync(0)) : new Uint8Array(readFileSync(fileArg));
+  const bytes = readFileArg(fileArg);
   const sourceName =
-    fileArg === "-" ? (keyHint ? basename(keyHint) : "stdin.bin") : basename(fileArg);
+    nameFlag ?? (fileArg === "-" ? (keyHint ? basename(keyHint) : "stdin.bin") : basename(fileArg));
 
   const format = ctx.json
     ? "json"
@@ -484,6 +518,7 @@ export async function runPut(
   const defaults = resolvePutDefaults({ envFile: ctx.envFile });
   const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, defaults);
   const frameOpts = frameOptionsFromFlags(parsed.flags);
+  // Optimize even on --dry-run so the preview key extension/hash match a real put.
   const prepared = await prepareImageForUpload(bytes, sourceName, {
     ...frameOpts,
     optimize: optimizeOpts,
@@ -502,7 +537,9 @@ export async function runPut(
         : defaults.width;
 
   if (!ctx.quiet && format === "human") {
-    process.stderr.write(`>> uploading ${fileArg === "-" ? "stdin" : fileArg}\n`);
+    process.stderr.write(
+      `>> ${dryRun ? "dry run" : "uploading"} ${fileArg === "-" ? "stdin" : fileArg}\n`,
+    );
     if (prepared.frame?.framed) process.stderr.write(`>> framed with ${prepared.frame.frameId}\n`);
     const note = formatOptimizeNote(prepared);
     if (note) process.stderr.write(`>> ${note}\n`);
@@ -519,6 +556,7 @@ export async function runPut(
     ref: flagString(parsed.flags, "--ref") ?? defaults.ref,
     contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
     deriveRepoFromGit: !noGit,
+    dryRun,
     provenance: buildCliProvenance({
       sourceName,
       optimized: prepared.optimized,
@@ -559,7 +597,7 @@ export async function runPut(
   };
 
   if (!ctx.quiet && format === "human") {
-    process.stderr.write(`>> key: ${result.key}\n\n`);
+    process.stderr.write(`>> key: ${result.key}${dryRun ? " (dry run — not uploaded)" : ""}\n\n`);
   }
 
   switch (format) {
@@ -570,6 +608,7 @@ export async function runPut(
         optimize: optimizeMeta,
         frame: prepared.frame,
         gallery,
+        ...(dryRun ? { dryRun: true } : {}),
       });
       break;
     case "url":

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -21,35 +21,37 @@ bearer token, so only the token is needed.
 Usage:
   uploads install [skill|mcp|all]     (default: all)
 
-What runs:
-  skill   npx -y skills add ${SKILL_SOURCE} --skill ${SKILL_NAME}
+What it does:
+  skill   Agent skill (via npx skills) — when to host files / embed in PRs
+  mcp     Hosted MCP server in Claude Code — put, list, attach, galleries
+
+What runs under the hood:
+  skill   npx -y skills add ${SKILL_SOURCE} --skill ${SKILL_NAME} -g -y -a '*'
   mcp     claude mcp add --transport http uploads ${DEFAULT_MCP_URL} \\
             --header "Authorization: Bearer <token>"
 
 Options:
   --url <endpoint>    Remote MCP endpoint (default: ${DEFAULT_MCP_URL})
   --name <name>       MCP server name in the client (default: uploads)
-  --dry-run           Print the commands without running them
+  --dry-run           Print the plan without running anything
+  --verbose           Show underlying command output (default: errors only)
 
 Examples:
   uploads install
   uploads install skill
-  uploads install mcp --dry-run
+  uploads install mcp
+  uploads install --dry-run
 `;
 
 interface StepResult {
   command: string[];
   ok: boolean;
-  skipped?: string;
+  skipped?: "dry-run" | "sign-in";
   error?: string;
   output?: string;
 }
 
-/**
- * Masks the configured token (and any Bearer credential) in text destined
- * for stdout/stderr/JSON — command echoes, child-process output, and error
- * messages can all embed it.
- */
+/** Mask Bearer credentials and the configured token in any printed text. */
 function redactor(token: string | undefined): (text: string) => string {
   return (text) => {
     let out = text.replace(/Bearer \S+/g, "Bearer ***");
@@ -64,12 +66,83 @@ function runStep(run: CommandRunner, command: string[]): StepResult {
     return { command, ok: true, output: output || undefined };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // execFileSync's ENOENT means the binary itself is missing.
     const hint =
       (err as NodeJS.ErrnoException).code === "ENOENT"
-        ? `${command[0]} not found on PATH — run manually: ${command.join(" ")}`
+        ? `${command[0]} not found on PATH — install it, or run manually: ${command.join(" ")}`
         : message;
     return { command, ok: false, error: hint };
+  }
+}
+
+function skillCommand(): string[] {
+  // -g global, -y non-interactive, -a '*' every agent (skips the multi-select TUI)
+  return ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", SKILL_NAME, "-g", "-y", "-a", "*"];
+}
+
+function mcpCommand(name: string, url: string, bearer: string): string[] {
+  return [
+    "claude",
+    "mcp",
+    "add",
+    "--transport",
+    "http",
+    name,
+    url,
+    "--header",
+    `Authorization: Bearer ${bearer}`,
+  ];
+}
+
+function peekToken(globals: GlobalFlags): string | undefined {
+  try {
+    const config = resolveConfig({
+      apiUrl: globals.apiUrl,
+      workspace: globals.workspace,
+      token: globals.token,
+      envFile: globals.envFile,
+      requireToken: false,
+    });
+    return config.token || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function printHumanSteps(
+  results: Record<string, StepResult>,
+  redact: (s: string) => string,
+  verbose: boolean,
+): void {
+  for (const [step, r] of Object.entries(results)) {
+    const cmd = redact(r.command.join(" "));
+    if (r.skipped === "dry-run") {
+      process.stdout.write(`${step}: would run — ${cmd}\n`);
+    } else if (r.skipped === "sign-in") {
+      process.stdout.write(`${step}: skipped — ${redact(r.error ?? "needs sign-in")}\n`);
+    } else if (r.ok) {
+      process.stdout.write(`${step}: ok\n`);
+      if (verbose && r.output) {
+        process.stdout.write(`  ${redact(r.output).split("\n").join("\n  ")}\n`);
+      }
+    } else {
+      process.stderr.write(`${step}: failed — ${redact(r.error ?? "")}\n`);
+      if (verbose) process.stderr.write(`  command: ${cmd}\n`);
+    }
+  }
+}
+
+function printSuccessFooter(steps: string[], signedIn: boolean): void {
+  process.stdout.write(
+    `\nDone — ${steps.join(" and ")} ready.\n` +
+      "Restart your agent session so it picks up the new skill/server.\n" +
+      "Then ask it to host a screenshot or attach images to a PR — for example:\n" +
+      '  "upload this screenshot and put it in the PR description"\n' +
+      '  "attach before.png and after.png to this PR"\n',
+  );
+  if (!signedIn) {
+    process.stdout.write(
+      "\nNot signed in yet? Run `uploads login` once so put/attach/MCP can authenticate.\n",
+    );
   }
 }
 
@@ -88,73 +161,70 @@ export async function runInstall(
   if (!["skill", "mcp", "all"].includes(target)) {
     throw new UsageError(`unknown install target: ${target} (expected skill, mcp, or all)`);
   }
+
   const url = flagString(parsed.flags, "--url") ?? DEFAULT_MCP_URL;
   const name = flagString(parsed.flags, "--name") ?? "uploads";
   const dryRun = flagBool(parsed.flags, "--dry-run");
+  const verbose = flagBool(parsed.flags, "--verbose");
   const run = opts.runner ?? execRunner;
+  const human = !opts.json && !dryRun;
 
+  const token = peekToken(opts.globals);
+  const signedIn = Boolean(token);
+  const redact = redactor(token);
   const results: Record<string, StepResult> = {};
-  let redact = redactor(undefined);
 
   if (target === "skill" || target === "all") {
-    const command = ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", SKILL_NAME];
+    const command = skillCommand();
+    if (human) process.stdout.write("Installing skill…\n");
     results.skill = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
   }
 
   if (target === "mcp" || target === "all") {
-    const config = resolveConfig({
-      apiUrl: opts.globals.apiUrl,
-      workspace: opts.globals.workspace,
-      token: opts.globals.token,
-      envFile: opts.globals.envFile,
-      requireToken: !dryRun,
-    });
-    const bearer = config.token || "<token>";
-    redact = redactor(config.token || undefined);
-    const command = [
-      "claude",
-      "mcp",
-      "add",
-      "--transport",
-      "http",
-      name,
-      url,
-      "--header",
-      `Authorization: Bearer ${bearer}`,
-    ];
-    results.mcp = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
+    if (!dryRun && !token) {
+      results.mcp = {
+        command: mcpCommand(name, url, "<token>"),
+        ok: false,
+        skipped: "sign-in",
+        error: "needs sign-in — run `uploads login`, then `uploads install mcp`",
+      };
+    } else {
+      const command = mcpCommand(name, url, token || "<token>");
+      if (human) process.stdout.write("Installing MCP server…\n");
+      results.mcp = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
+    }
   }
 
   const failed = Object.values(results).some((r) => !r.ok);
 
   if (opts.json) {
-    // Never echo the token in structured output — commands, child output,
-    // and error text can all embed it.
-    const redacted = Object.fromEntries(
+    const steps = Object.fromEntries(
       Object.entries(results).map(([key, r]) => [
         key,
         {
-          ...r,
           command: r.command.map(redact),
+          ok: r.ok,
+          skipped: r.skipped,
           output: r.output === undefined ? undefined : redact(r.output),
           error: r.error === undefined ? undefined : redact(r.error),
         },
       ]),
     );
-    process.stdout.write(JSON.stringify({ ok: !failed, steps: redacted }, null, 2) + "\n");
+    process.stdout.write(JSON.stringify({ ok: !failed, steps }, null, 2) + "\n");
     return failed ? 1 : 0;
   }
 
-  for (const [step, r] of Object.entries(results)) {
-    const shown = redact(r.command.join(" "));
-    if (r.skipped) process.stdout.write(`${step}: would run — ${shown}\n`);
-    else if (r.ok) {
-      process.stdout.write(`${step}: ok — ${shown}\n`);
-      if (r.output) process.stdout.write(`  ${redact(r.output).split("\n").join("\n  ")}\n`);
-    } else process.stderr.write(`${step}: failed — ${redact(r.error ?? "")}\n`);
-  }
+  printHumanSteps(results, redact, verbose);
+
   if (!failed && !dryRun) {
-    process.stderr.write("hint: restart your agent session to pick up the new skill/server\n");
+    printSuccessFooter(Object.keys(results), signedIn);
+  } else if (failed && !dryRun && results.skill?.ok && results.mcp && !results.mcp.ok) {
+    const next =
+      results.mcp.skipped === "sign-in"
+        ? "Sign in with `uploads login`, then re-run `uploads install mcp`."
+        : "Fix the MCP step above, then re-run `uploads install mcp`.";
+    process.stdout.write(`\nSkill is installed. ${next}\n`);
   }
+
   return failed ? 1 : 0;
 }

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -185,11 +185,14 @@ export function resolveConfig(
 
 function missingTokenMessage(configPath: string): string {
   return [
-    "UPLOADS_TOKEN is required.",
-    "  uploads login                         # exchange an admin-provided enrollment code",
+    "You're not signed in yet — one quick step and you're set:",
+    "",
+    "  uploads login                         # open a browser and authorize this device",
+    "",
+    "Already have a token?",
     `  uploads setup --token <token>         # guided setup → ${configPath}`,
     `  uploads config init --token <token>   # writes ${configPath}`,
-    "  or set UPLOADS_TOKEN in env, pass --token, or use --env-file",
+    "  or set UPLOADS_TOKEN / pass --token / use --env-file",
   ].join("\n");
 }
 

--- a/packages/uploads/src/errors.ts
+++ b/packages/uploads/src/errors.ts
@@ -1,6 +1,7 @@
 export type UploadsErrorCode =
   | "MISSING_TOKEN"
   | "NO_PUBLIC_URL"
+  | "FILE_NOT_FOUND"
   | "NOT_FOUND"
   | "UNAUTHORIZED"
   | "INVALID_KEY"

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -5,7 +5,6 @@
  * per-call `workspace` argument behaves like the CLI's --workspace flag, and
  * a missing token surfaces as a tool error rather than a startup failure.
  */
-import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import type { GlobalFlags } from "../cli-args.js";
 import { createUploadsClient, type UploadsClient } from "../client.js";
@@ -13,6 +12,7 @@ import {
   buildDoctorReport,
   makeGhTarget,
   prepareImageForUpload,
+  readFileArg,
   syncAttachmentsComment,
 } from "../commands.js";
 import { resolveFrameId } from "../frame.js";
@@ -333,7 +333,8 @@ export function createUploadsMcpTools(opts: {
           },
           filename: {
             type: "string",
-            description: "Filename for contentBase64 content (drives the key and content type).",
+            description:
+              "Filename for contentBase64 content (drives the key and content type). With `file`, overrides the key's leaf (clean name) while keeping the pr/default path.",
           },
           key: {
             type: "string",
@@ -395,6 +396,10 @@ export function createUploadsMcpTools(opts: {
             description:
               "With pr/issue: create or update the managed attachments comment via local gh auth (best-effort).",
           },
+          dryRun: {
+            type: "boolean",
+            description: "Resolve key + public URL without uploading. Not with comment.",
+          },
           workspace: workspaceProp,
         },
         additionalProperties: false,
@@ -412,11 +417,13 @@ export function createUploadsMcpTools(opts: {
 
         const target = ghTargetFromArgs(args, run);
         const wantComment = optBool(args, "comment");
+        const dryRun = optBool(args, "dryRun");
         const keyArg = optString(args, "key");
         const destArg = optString(args, "destination");
         const prefixArg = optString(args, "prefix");
         const refArg = optString(args, "ref");
         if (wantComment && !target) usage("comment requires pr or issue");
+        if (dryRun && wantComment) usage("dryRun cannot be combined with comment");
         if (target) {
           if (keyArg) usage("key cannot be combined with pr/issue");
           if (refArg) usage("ref cannot be combined with pr/issue");
@@ -437,7 +444,7 @@ export function createUploadsMcpTools(opts: {
         const { client } = clientFor(args);
         const bytes =
           file !== undefined
-            ? new Uint8Array(readFileSync(file))
+            ? readFileArg(file)
             : new Uint8Array(Buffer.from(contentBase64!, "base64"));
         const sourceName = file !== undefined ? (filenameArg ?? basename(file)) : filenameArg!;
 
@@ -460,6 +467,7 @@ export function createUploadsMcpTools(opts: {
           ref: refArg ?? defaults.ref,
           contentType: prepared.optimized ? prepared.contentType : optString(args, "contentType"),
           deriveRepoFromGit: !noGit,
+          dryRun,
           provenance: buildCliProvenance({
             sourceName,
             client: "uploads-mcp",
@@ -484,7 +492,13 @@ export function createUploadsMcpTools(opts: {
           const { comment, commentError } = await syncComment(client, target);
           return { ...result, markdown, optimize, frame: prepared.frame, comment, commentError };
         }
-        return { ...result, markdown, optimize, frame: prepared.frame };
+        return {
+          ...result,
+          markdown,
+          optimize,
+          frame: prepared.frame,
+          ...(dryRun ? { dryRun: true } : {}),
+        };
       },
     },
     {
@@ -550,11 +564,10 @@ export function createUploadsMcpTools(opts: {
         const uploads = [];
         for (const file of files) {
           const sourceName = basename(file);
-          const prepared = await prepareImageForUpload(
-            new Uint8Array(readFileSync(file)),
-            sourceName,
-            { ...frameOpts, optimize: optimizeOpts },
-          );
+          const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
+            ...frameOpts,
+            optimize: optimizeOpts,
+          });
           const result = await client.put(prepared.bytes, {
             filename: prepared.filename,
             key: ghAttachmentKey(target, prepared.filename),

--- a/packages/uploads/test/cli-error-output.test.ts
+++ b/packages/uploads/test/cli-error-output.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { outputFormat, runCli } from "../src/cli.js";
+
+describe("outputFormat", () => {
+  it("global --json wins over --format", () => {
+    expect(outputFormat(["n", "u", "put", "x", "--format", "url", "--json"])).toBe("json");
+  });
+  it("detects a --format json value", () => {
+    expect(outputFormat(["n", "u", "put", "x", "--format", "json"])).toBe("json");
+  });
+  it("detects --format=url", () => {
+    expect(outputFormat(["n", "u", "put", "x", "--format=url"])).toBe("url");
+  });
+  it("defaults to human", () => {
+    expect(outputFormat(["n", "u", "put", "x"])).toBe("human");
+  });
+});
+
+describe("runCli surfaces failures on stdout for scripted output", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("writes a structured JSON error to stdout under --json", async () => {
+    const out: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    // `--token` with no value throws a UsageError through the top-level catch.
+    const code = await runCli(["node", "uploads", "--json", "--token"]);
+
+    expect(code).toBe(2);
+    const parsed = JSON.parse(out.join("")) as { error: string; code: string };
+    expect(parsed.error).toMatch(/missing value for --token/);
+    expect(parsed.code).toBe("USAGE");
+  });
+});
+
+describe("missing token is an onboarding nudge, not an error: framing", () => {
+  beforeEach(() => {
+    vi.stubEnv("BUILDINTERNET_CONFIG", "/nonexistent/uploads-missing-token-test-config");
+    vi.stubEnv("UPLOADS_TOKEN", "");
+    vi.stubEnv("UPLOADS_WORKSPACE", "");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("human put without a token has no 'error:' prefix and leads with login", async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      err.push(String(chunk));
+      return true;
+    });
+
+    const code = await runCli(["node", "uploads", "put", "/tmp/does-not-need-to-exist.png"]);
+    expect(code).toBe(2);
+    const printed = err.join("");
+    expect(printed).toMatch(/not signed in yet/i);
+    expect(printed).toMatch(/uploads login/);
+    expect(printed).not.toMatch(/^error:/m);
+    expect(printed).not.toMatch(/\nerror:/);
+  });
+
+  it("--format url without a token writes a short non-error nudge to stdout", async () => {
+    const out: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const code = await runCli(["node", "uploads", "put", "/tmp/x.png", "--format", "url"]);
+    expect(code).toBe(2);
+    const printed = out.join("");
+    expect(printed).toMatch(/not signed in/i);
+    expect(printed).toMatch(/uploads login/);
+    expect(printed).not.toMatch(/^error:/m);
+  });
+
+  it("--json still exposes MISSING_TOKEN for agents", async () => {
+    const out: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const code = await runCli(["node", "uploads", "--json", "put", "/tmp/x.png"]);
+    expect(code).toBe(2);
+    const parsed = JSON.parse(out.join("")) as { error: string; code: string };
+    expect(parsed.code).toBe("MISSING_TOKEN");
+    expect(parsed.error).toMatch(/uploads login/);
+  });
+});

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { UsageError } from "../src/cli-args.js";
+import { UploadsError } from "../src/errors.js";
 import type { UploadsClient } from "../src/client.js";
 import { runPut, type CliContext } from "../src/commands.js";
 import type { CommandRunner } from "../src/github-gh.js";
@@ -9,10 +10,25 @@ import { join } from "node:path";
 
 /** Fake client capturing put() calls; other methods throw if reached. */
 function fakeClient() {
-  const puts: { key?: string; filename: string; prefix?: string; body: Uint8Array }[] = [];
+  const puts: {
+    key?: string;
+    filename: string;
+    prefix?: string;
+    dryRun?: boolean;
+    body: Uint8Array;
+  }[] = [];
   const client = {
-    put: async (body: Uint8Array, opts: { filename: string; key?: string; prefix?: string }) => {
-      puts.push({ key: opts.key, filename: opts.filename, prefix: opts.prefix, body });
+    put: async (
+      body: Uint8Array,
+      opts: { filename: string; key?: string; prefix?: string; dryRun?: boolean },
+    ) => {
+      puts.push({
+        key: opts.key,
+        filename: opts.filename,
+        prefix: opts.prefix,
+        dryRun: opts.dryRun,
+        body,
+      });
       return {
         workspace: "test",
         key: opts.key ?? "generated/key.png",
@@ -140,6 +156,91 @@ describe("runPut --pr/--issue", () => {
     );
     expect(puts[0].filename).toBe("shot.png");
     expect(puts[0].key).toBe("gh/o/r/pull/9/shot.png");
+  });
+});
+
+describe("runPut --name", () => {
+  it("overrides the key leaf while keeping the stable --pr path", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "128", "--repo", "o/r", "--name", "hero.png"],
+      false,
+      noRun,
+    );
+    expect(code).toBe(0);
+    expect(puts[0].filename).toBe("hero.png");
+    expect(puts[0].key).toBe("gh/o/r/pull/128/hero.png");
+  });
+
+  it("overrides the leaf on the default hashed key path", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--repo", "myapp", "--no-git", "--name", "clean.png"],
+      false,
+      noRun,
+    );
+    expect(puts[0].filename).toBe("clean.png"); // client hashes <name>-<hash>.<ext>
+  });
+
+  it("rejects --name with a slash", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), [tmpFile(), "--name", "a/b.png"], false, noRun),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("rejects --name combined with --key", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), [tmpFile(), "--key", "x/y.png", "--name", "z.png"], false, noRun),
+    ).rejects.toThrow(UsageError);
+  });
+});
+
+describe("runPut --dry-run", () => {
+  it("passes dryRun to the client and returns 0", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "5", "--repo", "o/r", "--dry-run"],
+      false,
+      noRun,
+    );
+    expect(code).toBe(0);
+    expect(puts[0].dryRun).toBe(true);
+    expect(puts[0].key).toBe("gh/o/r/pull/5/shot.png");
+  });
+
+  it("rejects --dry-run with --comment", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), [tmpFile(), "--pr", "5", "--dry-run", "--comment"], false, noRun),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("rejects --dry-run with --gallery", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), [tmpFile(), "--dry-run", "--gallery", "gal_x"], false, noRun),
+    ).rejects.toThrow(UsageError);
+  });
+});
+
+describe("runPut missing file", () => {
+  it("throws FILE_NOT_FOUND for a nonexistent path", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), ["/no/such/file-xyz.png"], false, noRun),
+    ).rejects.toMatchObject({ code: "FILE_NOT_FOUND" });
+  });
+
+  it("surfaces FILE_NOT_FOUND as an UploadsError", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), ["/no/such/file-xyz.png"], false, noRun),
+    ).rejects.toBeInstanceOf(UploadsError);
   });
 });
 

--- a/packages/uploads/test/install.test.ts
+++ b/packages/uploads/test/install.test.ts
@@ -6,19 +6,23 @@ function fakeRunner() {
   const calls: string[][] = [];
   const run: CommandRunner = (cmd, args) => {
     calls.push([cmd, ...args]);
-    return "installed\n";
+    return "installed\nwith multi-line child output\n";
   };
   return { run, calls };
 }
 
-function captureStdout() {
-  const chunks: string[] = [];
+function captureStreams() {
+  const out: string[] = [];
+  const err: string[] = [];
   vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-    chunks.push(String(chunk));
+    out.push(String(chunk));
     return true;
   });
-  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-  return chunks;
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    err.push(String(chunk));
+    return true;
+  });
+  return { out, err };
 }
 
 const GLOBALS = { apiUrl: "https://x.test", token: "up_acme_secret" };
@@ -27,7 +31,7 @@ beforeEach(() => {
   vi.stubEnv("BUILDINTERNET_CONFIG", "/nonexistent/uploads-install-test-config");
   vi.stubEnv("UPLOADS_TOKEN", "");
   vi.stubEnv("UPLOADS_WORKSPACE", "");
-  captureStdout();
+  captureStreams();
 });
 
 afterEach(() => {
@@ -41,7 +45,19 @@ describe("uploads install", () => {
     const code = await runInstall([], { globals: GLOBALS, runner: run });
     expect(code).toBe(0);
     expect(calls).toEqual([
-      ["npx", "-y", "skills", "add", "buildinternet/uploads", "--skill", "uploads-cli"],
+      [
+        "npx",
+        "-y",
+        "skills",
+        "add",
+        "buildinternet/uploads",
+        "--skill",
+        "uploads-cli",
+        "-g",
+        "-y",
+        "-a",
+        "*",
+      ],
       [
         "claude",
         "mcp",
@@ -56,11 +72,45 @@ describe("uploads install", () => {
     ]);
   });
 
+  it("prints step progress and suppresses child output on success", async () => {
+    const { run } = fakeRunner();
+    const { out, err } = captureStreams();
+    const code = await runInstall([], { globals: GLOBALS, runner: run });
+    expect(code).toBe(0);
+    const printed = out.join("");
+    expect(printed).toContain("Installing skill…");
+    expect(printed).toContain("Installing MCP server…");
+    expect(printed).toMatch(/skill: ok/);
+    expect(printed).toMatch(/mcp: ok/);
+    // Child process noise stays out of the happy path.
+    expect(printed).not.toContain("multi-line child output");
+    expect(printed).not.toContain("claude mcp add");
+    expect(printed).toContain("Restart your agent session");
+    expect(printed).toMatch(/upload this screenshot/i);
+    expect(err.join("")).toBe("");
+  });
+
+  it("--verbose includes child output on success", async () => {
+    const { run } = fakeRunner();
+    const { out } = captureStreams();
+    expect(await runInstall(["--verbose"], { globals: GLOBALS, runner: run })).toBe(0);
+    expect(out.join("")).toContain("multi-line child output");
+  });
+
   it("install skill runs only the skills step", async () => {
     const { run, calls } = fakeRunner();
     expect(await runInstall(["skill"], { globals: GLOBALS, runner: run })).toBe(0);
     expect(calls).toHaveLength(1);
     expect(calls[0][0]).toBe("npx");
+  });
+
+  it("skill-only success still nudges login when unsigned", async () => {
+    const { run } = fakeRunner();
+    const { out } = captureStreams();
+    expect(
+      await runInstall(["skill"], { globals: { apiUrl: "https://x.test" }, runner: run }),
+    ).toBe(0);
+    expect(out.join("")).toMatch(/uploads login/);
   });
 
   it("install mcp honors --url and --name", async () => {
@@ -76,24 +126,47 @@ describe("uploads install", () => {
 
   it("--dry-run runs nothing and never prints the token", async () => {
     const { run, calls } = fakeRunner();
-    const chunks: string[] = [];
-    vi.mocked(process.stdout.write).mockImplementation((chunk) => {
-      chunks.push(String(chunk));
-      return true;
-    });
+    const { out } = captureStreams();
     const code = await runInstall(["--dry-run"], { globals: GLOBALS, json: true, runner: run });
     expect(code).toBe(0);
     expect(calls).toEqual([]);
-    const printed = chunks.join("");
+    const printed = out.join("");
     expect(printed).not.toContain("up_acme_secret");
     expect(printed).toContain("Bearer ***");
   });
 
-  it("install mcp without a token is a tool error, not a crash", async () => {
-    const { run } = fakeRunner();
-    await expect(
-      runInstall(["mcp"], { globals: { apiUrl: "https://x.test" }, runner: run }),
-    ).rejects.toThrow(/UPLOADS_TOKEN|token/i);
+  it("install mcp without a token skips with a login nudge (no crash, not 'failed')", async () => {
+    const { run, calls } = fakeRunner();
+    const { out, err } = captureStreams();
+    const code = await runInstall(["mcp"], {
+      globals: { apiUrl: "https://x.test" },
+      runner: run,
+    });
+    expect(code).toBe(1);
+    expect(calls).toEqual([]);
+    const printed = out.join("");
+    expect(printed).toMatch(/mcp: skipped/);
+    expect(printed).toMatch(/uploads login/);
+    expect(printed).not.toMatch(/mcp: failed/);
+    expect(err.join("")).not.toMatch(/error:/i);
+  });
+
+  it("install all without a token still installs the skill, then nudges login for MCP", async () => {
+    const { run, calls } = fakeRunner();
+    const { out, err } = captureStreams();
+    const code = await runInstall(["all"], {
+      globals: { apiUrl: "https://x.test" },
+      runner: run,
+    });
+    expect(code).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe("npx");
+    expect(out.join("")).toMatch(/skill: ok/);
+    expect(out.join("")).toMatch(/mcp: skipped/);
+    expect(out.join("")).not.toMatch(/mcp: failed/);
+    expect(out.join("")).toMatch(/uploads login/);
+    expect(out.join("")).toMatch(/Skill is installed/);
+    expect(err.join("")).not.toMatch(/error:/i);
   });
 
   it("reports a missing binary with a manual-command hint, redacted, and exits 1", async () => {
@@ -102,18 +175,14 @@ describe("uploads install", () => {
       err.code = "ENOENT";
       throw err;
     };
-    const errChunks: string[] = [];
-    vi.mocked(process.stderr.write).mockImplementation((chunk) => {
-      errChunks.push(String(chunk));
-      return true;
-    });
+    const { err } = captureStreams();
     const code = await runInstall(["mcp"], { globals: GLOBALS, runner: enoent });
     expect(code).toBe(1);
-    const printed = errChunks.join("");
-    // The manual-command hint embeds the full command — token must be masked.
+    const printed = err.join("");
     expect(printed).toContain("claude not found on PATH");
     expect(printed).not.toContain("up_acme_secret");
-    expect(printed).toContain("Bearer ***");
+    // Full command (with token) only with --verbose; still redacted if shown.
+    expect(printed).not.toContain("Bearer up_acme");
   });
 
   it("rejects unknown targets", async () => {

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -124,26 +124,28 @@ capture them. Use `-` as the file to read from stdin.
 
 Key options (`uploads put --help` for all):
 
-| Flag                                  | Purpose                                                                                            |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                   |
-| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                   |
-| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                     |
-| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                           |
-| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                        |
-| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                  |
-| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                        |
-| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body). |
-| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                |
-| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                            |
-| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                  |
-| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.    |
-| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                     |
-| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                        |
-| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.      |
-| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                 |
-| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                     |
-| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                            |
+| Flag                                  | Purpose                                                                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                                       |
+| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                                       |
+| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                                         |
+| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                                               |
+| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                                            |
+| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                                      |
+| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                                            |
+| `--name <leaf>`                       | Clean filename for the key's leaf + default alt (no `/`); keeps the `--pr`/default path. Not with `--key`.             |
+| `--dry-run`                           | Resolve + print the key and final public URL without uploading (one read, no write). Not with `--comment`/`--gallery`. |
+| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body).                     |
+| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                                    |
+| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                                                |
+| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                                      |
+| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.                        |
+| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                                         |
+| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                                            |
+| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.                          |
+| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                                     |
+| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                                         |
+| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                                                |
 
 **Image optimization (default on):** PNG/JPEG and similar still images are re-encoded to
 WebP (long edge capped at 2400px, quality 85) before upload so PR/issue embeds stay
@@ -159,12 +161,16 @@ the original is uploaded. Use `--no-optimize` when you need lossless originals.
 
 **How keys work** — three paths, no extra naming modes:
 
-| Intent                                | Command                                            |
-| ------------------------------------- | -------------------------------------------------- |
-| Just upload it, give me a URL         | `uploads put ./file.png`                           |
-| Explicit typed destination            | `uploads put ./file.png --destination screenshots` |
-| Stable GitHub embed I might re-upload | `uploads put ./file.png --pr <num>`                |
-| I know exactly where it goes          | `uploads put ./file.png --key screenshots/…/x.png` |
+| Intent                                | Command                                                        |
+| ------------------------------------- | -------------------------------------------------------------- |
+| Just upload it, give me a URL         | `uploads put ./file.png`                                       |
+| Explicit typed destination            | `uploads put ./file.png --destination screenshots`             |
+| Stable GitHub embed I might re-upload | `uploads put ./file.png --pr <num>`                            |
+| Stable `--pr` path but a clean leaf   | `uploads put ./capture-2026-…Z.png --pr <num> --name hero.png` |
+| I know exactly where it goes          | `uploads put ./file.png --key screenshots/…/x.png`             |
+
+Timestamped captures break stable `--pr` keys — pass `--name hero.webp` to keep a
+clean leaf. Use `--dry-run` to preview the exact public URL before uploading.
 
 Default `put` is the fast path; you don't need `--key`, `--prefix`, or `--repo`. Without
 `--key`, keys look like
@@ -326,22 +332,15 @@ uploads --api-url http://localhost:8787 doctor
 - **Edge cache:** responses carry `Cache-Control: max-age=60`, so an overwrite or a
   delete can keep serving the old bytes from the edge for up to ~a minute. The object
   in storage changes immediately.
-- **Exit codes** (useful in scripts): `2` usage/missing-token, `3` unauthorized or
-  not-found, `4` network, `1` other. `--json` also emits `{error,code,status}`.
-  Usage errors print `hint: uploads <cmd> --help` (not the full root manual).
+- **Exit codes:** `2` usage/token/file, `3` auth/policy, `4` network, `1` other.
+  `--json` emits `{error,code,status}` — branch on `code`. Scripted formats
+  (`json|url|markdown`) also print failures on stdout. Usage errors:
+  `hint: uploads <cmd> --help`.
 - **Update hints (stderr):** successful human runs may note a newer npm release
   (daily). Silence with `--quiet` / `--json` / `UPLOADS_NO_UPDATE=1`.
-- **MCP server:** the CLI can also be exposed to agents as a local stdio MCP server —
-  `uploads mcp` (including gallery_create, gallery_get, gallery_add, gallery_link, and gallery_find_by_reference) — with tools mirroring the commands described here (`put`, `attach`,
-  `list`, `delete`, `usage`, `reconcile`, `purge_expired`, `comment`, `health`,
-  `doctor`) under the same config resolution.
-  Every tool also accepts a per-call `workspace` argument to override the configured
-  workspace (mirrors `--workspace`).
-  E.g. `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
-  There is also a hosted MCP server at `https://agents.uploads.sh/mcp` (workspace
-  inferred from the bearer token; `mcp.uploads.sh` is an alternate hostname).
-  `uploads install` sets up both this skill (via `npx skills`) and the hosted MCP
-  server in Claude Code; `uploads install --dry-run` prints the commands instead.
+- **MCP:** `uploads mcp` (stdio) mirrors CLI tools; hosted MCP at
+  `https://agents.uploads.sh/mcp`. `uploads install` sets up this skill + hosted MCP
+  (short progress; `--verbose` / `--dry-run` available).
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing
   upload/list/delete as AI-SDK tools inside a Worker — only relevant if you're


### PR DESCRIPTION
Makes the `uploads` CLI friendlier for the two callers that hit the most friction: agents driving `put` non-interactively, and first-time humans setting it up. Grounded in live agent feedback.

## `put` — agent DX

- **Failures surface on stdout for scripted formats.** With `--format json` (or global `--json`) a failure prints the `{error,code,status}` object to stdout; with `--format url`/`markdown` it prints a one-line `error: …` to stdout too. So `uploads put … --format url 2>/dev/null` is no longer silently blank on failure — the single thing that actually cost the reporting agent a retry. Human/default format is unchanged (stderr only).
- **`--name <leaf>`** overrides just the key's leaf (and default alt) while keeping the stable `--pr`/`--issue` and default-key paths — so an auto-timestamped capture (`wf-hero-2026-…Z.webp`) becomes a clean, stable public URL. Not combinable with `--key`; the `--key`-with-`--pr` error now points at `--name`.
- **`--dry-run`** resolves the object key **and** the exact final public URL without uploading, via a server-side `PUT ?dryRun=1` branch (`apps/api`) that validates key policy and computes the URL from the same `publicUrl` source of truth — no R2 write, no ledger. Lets an agent commit the URL to a PR body before uploading.
- **`FILE_NOT_FOUND`** — distinct error code (exit 2) for a missing local file, so agents branch on `code` instead of parsing messages. A shared `readFileArg` covers both CLI and MCP reads.
- The `put` **MCP tool** mirrors `dryRun`; `filename` doubles as the key-leaf override.

## `install` / auth — onboarding

- Shorter `uploads install` progress (step labels, no child stdout unless `--verbose` or on failure); non-interactive skills install; success next-steps; MCP-without-a-token is skipped with a `uploads login` nudge while the skill still installs.
- Missing-token output reads as onboarding (no `error:` prefix) but still exits non-zero; `--json` keeps `MISSING_TOKEN`. A rejected token stays `UNAUTHORIZED` with a re-login hint.

## Notes

- Exit-code contract: `0` ok · `2` usage/token/file · `3` auth/policy/quota · `4` network · `1` other.
- Server `--dry-run` caveat (commented in code): the key is exact for prefixed keys (what CLI/MCP always send); a bare key re-governs to a fresh `f/<id>/…` on the real upload, and dry-run skips the budget check.
- Docs: `uploads-cli` skill + package README updated. Changeset: `minor` on `@buildinternet/uploads` (the API worker deploys rather than publishes).

## Testing

- `@buildinternet/uploads`: 186 tests pass (added `--name`/`--dry-run`/`FILE_NOT_FOUND` CLI tests, an error-surfacing test, and the concurrent install/auth tests).
- `@uploads/api`: 242 pass (added dry-run route tests: resolves key+URL without writing, rejects a policy-disallowed key).
- Typecheck, lint, and format clean across the repo. Built CLI exercised end-to-end for the error paths.
- Not verifiable end-to-end until deployed: `--dry-run` against prod (the server branch ships with this PR); covered by unit tests on both sides.
