### PR TITLE
feat(web): account CLI setup, sessions, and clearer invite copy

### DIFF
--- a/.changeset/cli-session-user-agent.md
+++ b/.changeset/cli-session-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Device login (`uploads login`) now sends a recognizable CLI User-Agent so the web account page can tell when you've already signed in from the terminal.

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getSession, startLocalDemoSession } from "./auth-client";
+import {
+  getSession,
+  listAccounts,
+  listSessions,
+  revokeSession,
+  startLocalDemoSession,
+} from "./auth-client";
 import { BROWSER_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "./request";
 
 const timeoutFetch: typeof fetch = async (_input, init) =>
@@ -57,6 +63,70 @@ describe("getSession", () => {
       kind: "unavailable",
       reason: "network",
     });
+  });
+});
+
+describe("listSessions / listAccounts", () => {
+  it("returns rows on success and null on outage", async () => {
+    const rows = [
+      {
+        id: "s1",
+        token: "tok-1",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+        userAgent: "@buildinternet/uploads/1.0.0 (device-token)",
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json(rows)),
+    );
+    await expect(listSessions("http://127.0.0.1:8788")).resolves.toEqual(rows);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+    await expect(listSessions("http://127.0.0.1:8788")).resolves.toBeNull();
+  });
+
+  it("filters malformed rows and loads accounts", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("list-sessions")) {
+          return Response.json([
+            { id: "ok", token: "t", createdAt: "x", updatedAt: "x", expiresAt: "x" },
+            { id: "no-token" },
+          ]);
+        }
+        return Response.json([{ id: "a1", providerId: "github", accountId: "12345" }]);
+      }),
+    );
+    await expect(listSessions("http://127.0.0.1:8788")).resolves.toEqual([
+      { id: "ok", token: "t", createdAt: "x", updatedAt: "x", expiresAt: "x" },
+    ]);
+    await expect(listAccounts("https://auth.uploads.sh")).resolves.toEqual([
+      { id: "a1", providerId: "github", accountId: "12345" },
+    ]);
+  });
+});
+
+describe("revokeSession", () => {
+  it("returns true only on 2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 })),
+    );
+    await expect(revokeSession("http://127.0.0.1:8788", "tok")).resolves.toBe(true);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 403 })),
+    );
+    await expect(revokeSession("http://127.0.0.1:8788", "tok")).resolves.toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -34,9 +34,30 @@ export interface SessionUser {
   role?: string | null;
 }
 
+/** Session row from get-session / list-sessions. */
+export interface AuthSession {
+  id: string;
+  token: string;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+  expiresAt: string | Date;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
 export interface SessionResponse {
   user: SessionUser;
-  session: unknown;
+  /** Better Auth session; `token` is present on a full cookie path response. */
+  session: Partial<AuthSession> & Record<string, unknown>;
+}
+
+/** Linked identity provider from list-accounts (e.g. providerId: "github"). */
+export interface LinkedAccount {
+  id: string;
+  providerId: string;
+  accountId: string;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
 }
 
 export type SessionResult =
@@ -295,5 +316,60 @@ export async function acceptInvitation(
     return { ok: false, status: res.status, code: body?.error?.code };
   } catch {
     return { ok: false, status: 0 };
+  }
+}
+
+/**
+ * GET a JSON array from the auth worker. Returns null on outage/auth/malformed
+ * so callers can distinguish "couldn't load" from an empty list.
+ */
+async function getAuthArray(origin: string, path: string): Promise<unknown[] | null> {
+  const result = await fetchWithTimeout(`${authOrigin(origin)}${path}`, {
+    credentials: "include",
+    cache: "no-store",
+  });
+  if (result.kind === "unavailable" || !result.response.ok) return null;
+  const body = (await result.response.json().catch(() => undefined)) as unknown;
+  return Array.isArray(body) ? body : null;
+}
+
+/** GET /api/auth/list-sessions — active sessions (browser + CLI device flow). */
+export async function listSessions(origin: string): Promise<AuthSession[] | null> {
+  const body = await getAuthArray(origin, "/api/auth/list-sessions");
+  if (!body) return null;
+  return body.filter((row): row is AuthSession => {
+    if (!row || typeof row !== "object") return false;
+    const r = row as Record<string, unknown>;
+    return typeof r.id === "string" && typeof r.token === "string";
+  });
+}
+
+/** GET /api/auth/list-accounts — linked identity providers (e.g. GitHub). */
+export async function listAccounts(origin: string): Promise<LinkedAccount[] | null> {
+  const body = await getAuthArray(origin, "/api/auth/list-accounts");
+  if (!body) return null;
+  return body.filter((row): row is LinkedAccount => {
+    if (!row || typeof row !== "object") return false;
+    const r = row as Record<string, unknown>;
+    return (
+      typeof r.id === "string" &&
+      typeof r.providerId === "string" &&
+      typeof r.accountId === "string"
+    );
+  });
+}
+
+/** POST /api/auth/revoke-session — end one other session. */
+export async function revokeSession(origin: string, token: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/revoke-session`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    return res.ok;
+  } catch {
+    return false;
   }
 }

--- a/apps/web/src/lib/session-device.test.ts
+++ b/apps/web/src/lib/session-device.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { deviceLabel, formatSessionTime, isCliUserAgent } from "./session-device";
+
+describe("isCliUserAgent", () => {
+  it("recognizes the CLI user-agent prefix", () => {
+    expect(isCliUserAgent("@buildinternet/uploads/0.4.2")).toBe(true);
+    expect(isCliUserAgent("@buildinternet/uploads/0.4.2 (device-login)")).toBe(true);
+    expect(isCliUserAgent("Mozilla/5.0 (Macintosh) Chrome/120.0")).toBe(false);
+    expect(isCliUserAgent(null)).toBe(false);
+    expect(isCliUserAgent("")).toBe(false);
+  });
+});
+
+describe("deviceLabel", () => {
+  it("labels the CLI and common browsers", () => {
+    expect(deviceLabel("@buildinternet/uploads/1.2.3")).toBe("uploads CLI 1.2.3");
+    expect(deviceLabel("@buildinternet/uploads")).toBe("uploads CLI");
+    expect(
+      deviceLabel("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/537.36 Chrome/120"),
+    ).toBe("Chrome on macOS");
+    expect(deviceLabel("Mozilla/5.0 (Windows NT 10.0) Firefox/128.0")).toBe("Firefox on Windows");
+    expect(deviceLabel(null)).toBe("Unknown device");
+  });
+});
+
+describe("formatSessionTime", () => {
+  it("returns an em dash for empty/invalid values", () => {
+    expect(formatSessionTime(null)).toBe("—");
+    expect(formatSessionTime("not-a-date")).toBe("—");
+  });
+
+  it("formats a real date", () => {
+    const out = formatSessionTime("2026-07-13T12:00:00.000Z");
+    expect(out).not.toBe("—");
+    expect(out.length).toBeGreaterThan(4);
+  });
+});

--- a/apps/web/src/lib/session-device.ts
+++ b/apps/web/src/lib/session-device.ts
@@ -1,0 +1,44 @@
+/**
+ * Labels for Better Auth session User-Agent strings + CLI detection.
+ * Keep the CLI prefix in sync with packages/uploads `cliUserAgent()`.
+ */
+
+const BROWSERS: [RegExp, string][] = [
+  [/Edg\//, "Edge"],
+  [/OPR\/|Opera/, "Opera"],
+  [/Firefox\//, "Firefox"],
+  [/Chrome\//, "Chrome"],
+  [/Safari\//, "Safari"],
+];
+const OSES: [RegExp, string][] = [
+  [/iPhone|iPad|iPod/, "iOS"],
+  [/Android/, "Android"],
+  [/Mac OS X|Macintosh/, "macOS"],
+  [/Windows/, "Windows"],
+  [/Linux/, "Linux"],
+];
+
+export const CLI_USER_AGENT_RE = /@buildinternet\/uploads(?:\/[\w.-]+)?/i;
+
+export function isCliUserAgent(ua?: string | null): boolean {
+  return Boolean(ua && CLI_USER_AGENT_RE.test(ua));
+}
+
+/** "Chrome on macOS" / "uploads CLI 1.2.3" / "Unknown device". */
+export function deviceLabel(ua?: string | null): string {
+  if (!ua) return "Unknown device";
+  if (isCliUserAgent(ua)) {
+    const version = ua.match(/@buildinternet\/uploads\/([\w.-]+)/i)?.[1];
+    return version ? `uploads CLI ${version}` : "uploads CLI";
+  }
+  const browser = BROWSERS.find(([re]) => re.test(ua))?.[1] ?? "Browser";
+  const os = OSES.find(([re]) => re.test(ua))?.[1] ?? "";
+  return os ? `${browser} on ${os}` : browser;
+}
+
+export function formatSessionTime(value: string | Date | null | undefined): string {
+  if (!value) return "—";
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -201,8 +201,8 @@ const csp = [
     acceptBtn.disabled = true;
     const result = await acceptInvitation(authOrigin, invitationId);
     if (result.ok) {
-      // Same post-sign-in landing as /login — no dead-end "close this page".
-      location.assign(`${location.origin}/account`);
+      // Native fragment scroll to the CLI setup card on the account overview.
+      location.assign(`${location.origin}/account#cli-setup`);
       return;
     }
     acceptBtn.disabled = false;

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -11,7 +11,10 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
 <AccountLayout section="developers">
   <section class="card">
     <h2>Developers</h2>
-    <p>Most people just need <code>uploads login</code>. These are for API and CI use.</p>
+    <p>
+      Most people just need <code>uploads login</code> from the
+      <a href="/account#cli-setup">account overview</a>. These are for API and CI use.
+    </p>
     <ul class="plain">
       {showConsoleLinks ? (
         <li>

--- a/apps/web/src/pages/account/index.astro
+++ b/apps/web/src/pages/account/index.astro
@@ -1,39 +1,106 @@
 ---
-// Authenticated landing page — where /login drops people after sign-in.
-// Client-side session gating is a UX affordance only — every data call goes
-// to apps/auth / apps/api, which enforce the session server-side.
+// Authenticated landing — /login and post-invite drop people here.
+// Session gating is UX only; data calls enforce auth server-side.
 import AccountLayout from "../../layouts/AccountLayout.astro";
 
 export const prerender = false;
 ---
 
 <AccountLayout section="overview">
+  <!--
+    Static setup card. Script only toggles the status line + emphasis once
+    list-sessions tells us whether a CLI device session exists.
+    Deep link: /account#cli-setup (used after invite accept / first sign-in).
+  -->
+  <section class="card is-pending" id="cli-setup">
+    <h2>Set up the CLI</h2>
+    <p>
+      Most of uploads is used from the terminal. Install once, run
+      <code>uploads login</code>, then <code>uploads attach</code> /
+      <code>uploads put</code> against this account’s workspaces.
+    </p>
+    <div id="cli-setup-status" class="ul-callout" data-state="muted" role="status">
+      Checking for a CLI sign-in…
+    </div>
+    <div class="cli-steps">
+      <div class="command">
+        <code>npm install -g @buildinternet/uploads</code>
+        <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite">copy</button>
+      </div>
+      <div class="command">
+        <code>uploads login</code>
+        <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
+      </div>
+    </div>
+    <p class="muted cli-note">
+      Prefer no global install? <code>npx @buildinternet/uploads login</code>.
+      Full walkthrough in the <a href="/docs#install">docs</a>.
+    </p>
+  </section>
+
   <section class="card">
     <h2>Welcome back<span id="hello-name"></span></h2>
     <p>
       uploads.sh hosts files you want to link to — PR screenshots, agent
-      artifacts, quick shares. Your workspaces and account details are in
-      the sections on the left.
-    </p>
-  </section>
-  <section class="card" style="margin-top:16px">
-    <h2>Uploading</h2>
-    <p>
-      Install the CLI, run <code>uploads login</code>, and it connects to
-      your workspaces. From there <code>uploads attach</code> puts files
-      on GitHub PRs and <code>uploads put</code> gets you a URL for
-      anything else. Workspace tokens are for the API and CI, not the
-      everyday path. The <a href="/docs">docs</a> cover setup.
+      artifacts, quick shares. Workspaces and account details are in the
+      sidebar.
     </p>
   </section>
 
   <script>
     import { onSession, requireElement } from "../../lib/account-shell";
+    import { listSessions } from "../../lib/auth-client";
+    import { isCliUserAgent } from "../../lib/session-device";
+
+    const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+      .__UPLOADS_AUTH_ORIGIN__;
+
+    // Same delegated copy pattern as workspaces invite commands.
+    requireElement<HTMLElement>("#cli-setup", "account overview").addEventListener(
+      "click",
+      (event) => {
+        void (async () => {
+          const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+            "button[data-copy]",
+          );
+          if (!button) return;
+          try {
+            await navigator.clipboard.writeText(button.dataset.copy ?? "");
+            const previous = button.textContent;
+            button.textContent = "copied ✓";
+            setTimeout(() => {
+              button.textContent = previous;
+            }, 1500);
+          } catch {
+            // Clipboard blocked — leave the label.
+          }
+        })();
+      },
+    );
 
     onSession((user) => {
       requireElement<HTMLElement>("#hello-name", "account overview").textContent = user.name
         ? `, ${user.name}`
         : "";
+
+      const status = requireElement<HTMLElement>("#cli-setup-status", "account overview");
+      const card = requireElement<HTMLElement>("#cli-setup", "account overview");
+
+      void listSessions(authOrigin).then((sessions) => {
+        const hasCli = sessions?.some((s) => isCliUserAgent(s.userAgent)) ?? false;
+        if (hasCli) {
+          status.dataset.state = "ready";
+          status.textContent = "CLI sign-in found on an active session. You’re set.";
+          card.classList.remove("is-pending");
+          return;
+        }
+        delete status.dataset.state;
+        status.textContent =
+          sessions === null
+            ? "Couldn’t check CLI sessions — run uploads login if you haven’t yet."
+            : "No CLI session yet. Finish setup below so your terminal and agents can upload.";
+        card.classList.add("is-pending");
+      });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -13,19 +13,205 @@ export const prerender = false;
       <dt>Role</dt><dd id="acct-role"></dd>
     </dl>
     <p class="muted" style="margin-top:14px">
-      Your name and avatar come from your sign-in provider. There's
-      nothing to edit here yet.
+      Name and avatar come from your sign-in provider. Nothing to edit here yet.
     </p>
+  </section>
+
+  <section class="card">
+    <h2>Sign-in methods</h2>
+    <p class="muted">How you sign in to the web app and approve <code>uploads login</code>.</p>
+    <div id="accounts-status" class="muted detail-status">Loading…</div>
+    <ul class="detail-list" id="accounts-list" hidden></ul>
+  </section>
+
+  <section class="card">
+    <h2>Active sessions</h2>
+    <p class="muted">
+      Browsers and CLI devices signed in to this account. Revoking a CLI session
+      doesn’t remove workspace tokens already saved on that machine.
+    </p>
+    <div id="sessions-status" class="muted detail-status">Loading…</div>
+    <ul class="detail-list" id="sessions-list" hidden></ul>
+    <p id="sessions-error" class="detail-error" role="alert" hidden></p>
   </section>
 
   <script>
     import { onSession, requireElement } from "../../lib/account-shell";
+    import { getSession, listAccounts, listSessions, revokeSession } from "../../lib/auth-client";
+    import { deviceLabel, formatSessionTime, isCliUserAgent } from "../../lib/session-device";
+
+    const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+      .__UPLOADS_AUTH_ORIGIN__;
+
+    const escapeHtml = (value: string) =>
+      value.replace(/[&<>"']/g, (ch) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+      );
+
+    function showStatus(el: HTMLElement, text: string): void {
+      el.hidden = false;
+      el.textContent = text;
+    }
+
+    async function loadAccounts(): Promise<void> {
+      const status = requireElement<HTMLElement>("#accounts-status", "account profile");
+      const list = requireElement<HTMLUListElement>("#accounts-list", "account profile");
+      list.hidden = true;
+      showStatus(status, "Loading…");
+
+      const accounts = await listAccounts(authOrigin);
+      if (accounts === null) {
+        showStatus(status, "Couldn’t load sign-in methods.");
+        return;
+      }
+
+      const rows =
+        accounts.length > 0
+          ? accounts.map((a) => {
+              if (a.providerId === "github") {
+                return {
+                  title: "GitHub",
+                  detail: `Connected · user id ${a.accountId}`,
+                  ok: true,
+                };
+              }
+              return {
+                title: a.providerId,
+                detail: a.createdAt ? `Linked ${formatSessionTime(a.createdAt)}` : "Connected",
+                ok: true,
+              };
+            })
+          : [{ title: "Email", detail: "Magic link sign-in", ok: true }];
+
+      // Surface a missing GitHub link without inventing connect/disconnect UI.
+      if (!accounts.some((a) => a.providerId === "github")) {
+        rows.push({
+          title: "GitHub",
+          detail: "Not connected — use GitHub next time you sign in to link it.",
+          ok: false,
+        });
+      }
+
+      status.hidden = true;
+      list.hidden = false;
+      list.innerHTML = rows
+        .map(
+          (row) => `<li>
+            <div class="detail-main">
+              <div class="detail-title">
+                <span>${escapeHtml(row.title)}</span>
+                ${
+                  row.ok
+                    ? `<span class="ul-badge ul-badge--ok">Connected</span>`
+                    : `<span class="ul-badge">Not connected</span>`
+                }
+              </div>
+              <div class="detail-meta">${escapeHtml(row.detail)}</div>
+            </div>
+          </li>`,
+        )
+        .join("");
+    }
+
+    let currentToken: string | undefined;
+
+    async function loadSessions(): Promise<void> {
+      const status = requireElement<HTMLElement>("#sessions-status", "account profile");
+      const list = requireElement<HTMLUListElement>("#sessions-list", "account profile");
+      const error = requireElement<HTMLElement>("#sessions-error", "account profile");
+      error.hidden = true;
+      list.hidden = true;
+      showStatus(status, "Loading…");
+
+      const [sessionResult, sessions] = await Promise.all([
+        getSession(authOrigin),
+        listSessions(authOrigin),
+      ]);
+
+      if (sessionResult.kind === "signed_in") {
+        const token = sessionResult.session.session?.token;
+        currentToken = typeof token === "string" ? token : undefined;
+      }
+
+      if (sessions === null) {
+        showStatus(status, "Couldn’t load sessions.");
+        return;
+      }
+      if (!sessions.length) {
+        showStatus(status, "No active sessions.");
+        return;
+      }
+
+      const ordered = sessions.toSorted((a, b) => {
+        if (currentToken && a.token === currentToken) return -1;
+        if (currentToken && b.token === currentToken) return 1;
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      });
+
+      status.hidden = true;
+      list.hidden = false;
+      list.innerHTML = ordered
+        .map((s) => {
+          const current = currentToken != null && s.token === currentToken;
+          const badge = current
+            ? `<span class="ul-badge ul-badge--accent">This device</span>`
+            : isCliUserAgent(s.userAgent)
+              ? `<span class="ul-badge">CLI</span>`
+              : "";
+          const meta = [
+            s.ipAddress ? escapeHtml(s.ipAddress) : null,
+            `Active ${escapeHtml(formatSessionTime(s.updatedAt))}`,
+          ]
+            .filter(Boolean)
+            .join(" · ");
+          const action = current
+            ? `<span class="detail-current">Current</span>`
+            : `<button type="button" class="text-btn" data-revoke="${escapeHtml(s.token)}">Sign out</button>`;
+          return `<li>
+            <div class="detail-main">
+              <div class="detail-title">
+                <span>${escapeHtml(deviceLabel(s.userAgent))}</span>
+                ${badge}
+              </div>
+              <div class="detail-meta">${meta}</div>
+            </div>
+            <div class="detail-action">${action}</div>
+          </li>`;
+        })
+        .join("");
+    }
+
+    requireElement<HTMLUListElement>("#sessions-list", "account profile").addEventListener(
+      "click",
+      (event) => {
+        void (async () => {
+          const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+            "button[data-revoke]",
+          );
+          if (!button?.dataset.revoke) return;
+          button.disabled = true;
+          button.textContent = "Signing out…";
+          const error = requireElement<HTMLElement>("#sessions-error", "account profile");
+          error.hidden = true;
+          if (!(await revokeSession(authOrigin, button.dataset.revoke))) {
+            error.textContent = "Couldn’t sign out that session.";
+            error.hidden = false;
+            button.disabled = false;
+            button.textContent = "Sign out";
+            return;
+          }
+          await loadSessions();
+        })();
+      },
+    );
 
     onSession((user) => {
       requireElement<HTMLElement>("#acct-email", "account profile").textContent = user.email;
       requireElement<HTMLElement>("#acct-name", "account profile").textContent = user.name || "—";
       requireElement<HTMLElement>("#acct-role", "account profile").textContent =
         user.role || "member";
+      void loadAccounts();
+      void loadSessions();
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -12,7 +12,8 @@ export const prerender = false;
     <button id="orgs-retry" type="button" hidden>Try again</button>
     <ul class="plain" id="orgs-list" hidden></ul>
     <p class="muted" style="margin-top:12px">
-      Need another workspace? Ask its admin for an invite.
+      Joining another workspace is invite-only — someone who already manages
+      that workspace has to add you. Workspaces aren’t created from this page.
     </p>
   </section>
 
@@ -77,12 +78,15 @@ export const prerender = false;
       return parts.join(" · ");
     }
 
-    const isAdminRole = (role: string) => role === "admin" || role === "owner";
-
-    // The command an admin runs to invite a teammate. Workspace names are
-    // [a-z0-9-] on the API; escapeHtml is applied at the render site regardless.
-    const inviteCommand = (workspace: string) =>
+    // Operator enrollment CLI for a given workspace. Needs site-wide
+    // ADMIN_TOKEN (not a workspace upload token / membership role). The
+    // workspace name is pre-filled only as a convenience — it does not create
+    // a workspace.
+    const operatorInviteCommand = (workspace: string) =>
       `uploads admin invite create --workspace ${workspace} --email teammate@example.com`;
+
+    // Captured from onSession so the invite block can gate on global role.
+    let sessionUser: { role?: string | null } | null = null;
 
     function renderGalleries(container: HTMLElement, galleries: GallerySummary[]): void {
       const head = `<div class="ws-section-head">Galleries${galleries.length ? ` (${galleries.length})` : ""}</div>`;
@@ -121,6 +125,9 @@ export const prerender = false;
       }
       orgsStatus.hidden = true;
       orgsList.hidden = false;
+      // Global Better Auth role (site operator), not workspace membership role.
+      // Only operators hold ADMIN_TOKEN and should see the enrollment CLI snippet.
+      const isSiteOperator = sessionUser?.role === "admin";
       orgsList.innerHTML = workspaces
         .map((ws) => {
           // Communal workspace = the shared, world-readable dumping ground; it
@@ -129,13 +136,14 @@ export const prerender = false;
             ? `<p class="ws-note">This is the shared, public space — anything here is world-readable at <code>storage.uploads.sh</code>. Browse and upload with the CLI.</p>`
             : `<div class="ws-section" data-galleries><div class="ws-section-head">Galleries</div><p class="ws-empty">Loading&#32;…</p></div>
                <div class="ws-section" data-files><div class="ws-section-head">Files</div><p class="ws-empty">Loading&#32;…</p></div>`;
-          // Workspace admins get a copy-paste invite command.
-          const cmd = inviteCommand(ws.workspace);
-          const invite = isAdminRole(ws.role)
+          // Site operators: copy-paste enrollment invite for *this* workspace
+          // (name pre-filled). Day-to-day email invites go through /admin.
+          const cmd = operatorInviteCommand(ws.workspace);
+          const invite = isSiteOperator
             ? `<div class="ws-section">
-                 <div class="ws-section-head">Invite a teammate</div>
+                 <div class="ws-section-head">Operator invite to this workspace</div>
                  <div class="command"><code>${escapeHtml(cmd)}</code><button type="button" aria-live="polite" data-copy="${escapeHtml(cmd)}">copy</button></div>
-                 <p class="muted cli-note">Runs with the workspace's admin token.</p>
+                 <p class="muted cli-note">Needs the site <code>ADMIN_TOKEN</code> — not a workspace upload token. Prefer <a href="/admin">/admin</a> for email invites.</p>
                </div>`
             : "";
           return `<li data-workspace="${escapeHtml(ws.workspace)}">
@@ -235,7 +243,8 @@ export const prerender = false;
       void loadWorkspaces();
     });
 
-    onSession(() => {
+    onSession((user) => {
+      sessionUser = user;
       void loadWorkspaces();
     });
   </script>

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -111,7 +111,8 @@ const csp = [
   const magicSubmit = requireElement<HTMLButtonElement>("#magic-submit");
   const emailInput = requireElement<HTMLInputElement>("#email");
 
-  const callbackURL = `${location.origin}/account`;
+  // Land on the CLI setup card (#cli-setup) so first-time users see next steps.
+  const callbackURL = `${location.origin}/account#cli-setup`;
 
   githubBtn.addEventListener("click", async () => {
     errorBox.hidden = true;

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -144,3 +144,134 @@ ul.plain .cli-note {
   margin: 7px 0 0;
   font-size: 11px;
 }
+
+/* Overview CLI setup ──────────────────────────────────────────────────── */
+
+/* Pending setup — no CLI session yet (hash #cli-setup still scrolls natively). */
+section.card.is-pending {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+#cli-setup-status {
+  margin-top: 14px;
+}
+.cli-steps {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+.cli-steps .command {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.cli-steps .command code {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow-x: auto;
+  display: block;
+  border: 0;
+  background: none;
+  padding: 0;
+  font-size: 12px;
+}
+.cli-steps .command button {
+  flex-shrink: 0;
+  font: 11px var(--mono);
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 10px;
+  background: var(--panel);
+  cursor: pointer;
+}
+.cli-steps .command button:hover,
+.cli-steps .command button:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+section.card .cli-note {
+  margin: 12px 0 0;
+  font-size: 12px;
+}
+
+/* Profile sign-in methods + sessions ──────────────────────────────────── */
+
+.detail-status {
+  margin-top: 12px;
+  font-size: 13px;
+}
+.detail-error {
+  margin: 10px 0 0;
+  font-size: 12px;
+  color: var(--red);
+}
+ul.detail-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg);
+  overflow: hidden;
+}
+ul.detail-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 12px;
+  font-size: 13px;
+}
+ul.detail-list li + li {
+  border-top: 1px solid var(--line);
+}
+ul.detail-list .detail-main {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+ul.detail-list .detail-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 8px;
+  color: var(--fg);
+}
+ul.detail-list .detail-meta {
+  color: var(--muted);
+  font-size: 11px;
+}
+ul.detail-list .detail-action {
+  flex-shrink: 0;
+}
+ul.detail-list .detail-current {
+  font-size: 11px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+button.text-btn {
+  font: 12px var(--mono);
+  letter-spacing: 0.03em;
+  color: var(--muted);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 5px 9px;
+  cursor: pointer;
+}
+button.text-btn:hover,
+button.text-btn:focus-visible {
+  color: var(--fg);
+  border-color: var(--line);
+  outline: none;
+}
+button.text-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -3,9 +3,14 @@
 * {
   box-sizing: border-box;
 }
+html {
+  height: 100%;
+}
 body {
   margin: 0;
   min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
   background: var(--bg);
   color: var(--fg);
   font: 14px/1.6 var(--mono);
@@ -37,10 +42,29 @@ code {
   display: none !important;
 }
 
+/* Sticky footer (signed-in shells only): body/shell are flex columns;
+   #app / #dashboard grow; .layout takes free space so content stays top-
+   aligned and the footer sits at the viewport bottom when the page is short.
+   When content is taller than the viewport, the footer scrolls after it. */
 .shell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
   max-width: 960px;
   margin: 0 auto;
-  padding: 28px 20px 56px;
+  padding: 28px 20px 28px;
+  box-sizing: border-box;
+}
+#app,
+#dashboard {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+#app > .layout,
+#dashboard > .layout {
+  flex: 1 0 auto;
 }
 header.top {
   display: flex;

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -2,6 +2,7 @@ import { inferContentType } from "./embed.js";
 import type { UploadsClientConfig } from "./config.js";
 import { UploadsError } from "./errors.js";
 import { buildScreenshotKey } from "./keys.js";
+import { packageVersion } from "./package-version.js";
 
 /** Allowlisted object provenance (maps to X-Uploads-Meta-* on put). */
 export type ProvenanceInput = {
@@ -266,6 +267,16 @@ export function createEnrollment(
 /** Static OAuth client id allowlisted by the auth worker's `validateClient`. */
 export const DEVICE_CLIENT_ID = "uploads-cli";
 
+/**
+ * User-Agent for device-flow requests. Stored on the Better Auth session row
+ * when `/device/token` creates the session, so the web account UI can tell a
+ * completed `uploads login` apart from a browser tab. Keep the
+ * `@buildinternet/uploads` prefix in sync with apps/web `CLI_USER_AGENT_RE`.
+ */
+export function cliUserAgent(purpose = "device-login"): string {
+  return `@buildinternet/uploads/${packageVersion()} (${purpose})`;
+}
+
 export interface DeviceCodeResponse {
   device_code: string;
   user_code: string;
@@ -282,7 +293,10 @@ export function requestDeviceCode(
 ): Promise<DeviceCodeResponse> {
   return jsonRequest(`${authUrl.replace(/\/$/, "")}/api/auth/device/code`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": cliUserAgent("device-code"),
+    },
     body: JSON.stringify({ client_id: clientId }),
   });
 }
@@ -309,7 +323,12 @@ export async function requestDeviceToken(
   try {
     res = await fetch(`${authUrl.replace(/\/$/, "")}/api/auth/device/token`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        // Session user_agent is taken from this request when the token is
+        // exchanged — identify as the CLI so /account can surface it.
+        "User-Agent": cliUserAgent("device-token"),
+      },
       body: JSON.stringify({
         grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         device_code: input.deviceCode,


### PR DESCRIPTION
## In plain terms

After someone signs in or accepts an invite, the account area now steers them toward installing the CLI and running `uploads login`, instead of leaving them on a vague welcome page. The account page also shows basic sign-in details (GitHub, active sessions), and the signed-in layout keeps the footer at the bottom of short pages.

## What it does

- **Overview** — CLI setup card first, with install / `uploads login` copy buttons; softens when a CLI device session is detected
- **Post-invite / post-login** — lands on `/account#cli-setup` so the next step is obvious
- **Account (profile)** — sign-in methods via Better Auth `list-accounts` (GitHub connected or not), active sessions via `list-sessions` with per-session revoke
- **CLI detection** — device-flow requests send a recognizable User-Agent so sessions can be labeled as CLI (changeset for `@buildinternet/uploads`)
- **Workspaces invite copy** — operator enrollment snippet only for site operators, correctly labeled as needing `ADMIN_TOKEN`; footer no longer implies you can create workspaces here
- **Signed-in shell** — sticky footer (content top-aligned when short; footer scrolls after content when long)

## What it is not

- Not a workspace-admin invite CLI (tracked in #146)
- No connect/disconnect GitHub UI — read-only status for now
- No “sign out other sessions” bulk action (single-session revoke only)

## How to try it

```bash
# after sign-in or accepting an invite
# open /account — CLI setup is first
# finish setup:
npm install -g @buildinternet/uploads
uploads login
# then refresh /account — setup card should soften when CLI session is present
# /account/profile — GitHub + sessions
```

## Technical notes

- Auth client wrappers: `listSessions`, `listAccounts`, `revokeSession` (plain fetch, same style as the rest of apps/web)
- `session-device.ts` for UA labels / CLI detection
- Deep link uses native `#cli-setup` fragment

## Test plan

- [x] `pnpm --filter @uploads/web test` (67 passed)
- [x] pre-commit types + lint-staged
- [ ] Manual: accept invite → lands on CLI setup
- [ ] Manual: `uploads login` → overview shows CLI connected
- [ ] Manual: profile sessions list + revoke
- [ ] Manual: short account page footer at viewport bottom