### PR TITLE
feat: workspace admins can invite teammates (API, account UI, CLI)

### DIFF
--- a/.changeset/workspace-admin-invite.md
+++ b/.changeset/workspace-admin-invite.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads invite create` so workspace admins/owners can invite teammates by email via device login (no `ADMIN_TOKEN`). Invitees accept in the browser and run `uploads login`.

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -722,3 +722,144 @@ describe("/me/workspaces/:name/file-browser", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("POST /me/workspaces/:name/invites", () => {
+  function inviteEnv(opts: {
+    role: string;
+    onInvite?: (body: unknown) => Response | Promise<Response>;
+  }): Env {
+    const { role, onInvite } = opts;
+    const auth = stubAuth(async (req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/memberships") {
+        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role }]);
+      }
+      if (url.pathname === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } });
+      }
+      if (url.pathname === "/internal/invite" && req.method === "POST") {
+        const body = await req.json();
+        if (onInvite) return onInvite(body);
+        return Response.json(
+          {
+            invitation: {
+              id: "inv1",
+              organizationId: "org1",
+              email: (body as { email?: string }).email,
+              role: "member",
+              status: "pending",
+            },
+          },
+          { status: 201 },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+    return { AUTH: auth, DB: new UsageFakeD1() } as unknown as Env;
+  }
+
+  it("lets an org owner invite a teammate", async () => {
+    let captured: unknown;
+    const env = inviteEnv({
+      role: "owner",
+      onInvite: (body) => {
+        captured = body;
+        return Response.json(
+          { invitation: { id: "inv1", email: "t@example.com", status: "pending" } },
+          { status: 201 },
+        );
+      },
+    });
+    const res = await app().request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(captured).toMatchObject({
+      organizationSlug: "acme",
+      email: "t@example.com",
+      role: "member",
+      inviterUserId: USER.id,
+    });
+  });
+
+  it("403s for an org member without admin/owner", async () => {
+    const env = inviteEnv({ role: "member" });
+    const res = await app().request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "workspace_admin_required" },
+    });
+  });
+
+  it("404s for a workspace the caller is not a member of", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("400s on an invalid email", async () => {
+    const env = inviteEnv({ role: "admin" });
+    const res = await app().request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "not-an-email" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /me/workspaces/:name/invites", () => {
+  it("lists pending invites for a workspace admin", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role: "admin" }]);
+      }
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } });
+      }
+      if (path === "/internal/orgs/acme/invites") {
+        return Response.json({
+          invites: [{ id: "i1", email: "pending@x.com", role: "member", status: "pending" }],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/invites", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      invites: [{ id: "i1", email: "pending@x.com", role: "member", status: "pending" }],
+    });
+  });
+});

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -839,27 +839,3 @@ describe("POST /me/workspaces/:name/invites", () => {
     expect(res.status).toBe(400);
   });
 });
-
-describe("GET /me/workspaces/:name/invites", () => {
-  it("lists pending invites for a workspace admin", async () => {
-    const env = stubEnv(USER, (path) => {
-      if (path === "/internal/memberships") {
-        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role: "admin" }]);
-      }
-      if (path === "/internal/orgs/acme") {
-        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } });
-      }
-      if (path === "/internal/orgs/acme/invites") {
-        return Response.json({
-          invites: [{ id: "i1", email: "pending@x.com", role: "member", status: "pending" }],
-        });
-      }
-      return new Response(null, { status: 404 });
-    });
-    const res = await app().request("/me/workspaces/acme/invites", {}, env);
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      invites: [{ id: "i1", email: "pending@x.com", role: "member", status: "pending" }],
-    });
-  });
-});

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,7 +9,7 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
-import { NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
+import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
@@ -23,6 +23,8 @@ import { publicUrl, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { loadWorkspaceRecord } from "../workspace";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 interface MyWorkspace {
   workspace: string;
@@ -90,6 +92,17 @@ function requireUserId(c: Context<SessionVars>): string {
   const userId = c.get("sessionUser")?.id;
   if (!userId) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
   return userId;
+}
+
+/** Membership admin|owner for this workspace — 404 if not a member, 403 if member but not privileged. */
+async function adminWorkspaceOr403(env: Env, userId: string, name: string): Promise<MyWorkspace> {
+  const ws = await memberWorkspaceOr404(env, userId, name);
+  if (ws.role !== "admin" && ws.role !== "owner") {
+    throw new ForbiddenError("workspace admin or owner role required", {
+      code: "workspace_admin_required",
+    });
+  }
+  return ws;
 }
 
 export const me = new Hono<SessionVars>()
@@ -253,4 +266,86 @@ export const me = new Hono<SessionVars>()
       secret: `readonly-list:${name}`,
     });
     return router.handle(c.req.raw);
+  })
+
+  // Pending org invitations for a workspace — workspace admin|owner only.
+  // Non-members 404 (same anti-enumeration as other /me workspace routes).
+  .get("/workspaces/:name/invites", async (c) => {
+    const name = c.req.param("name");
+    await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    const org = await orgForWorkspace(c.env, name);
+    if (!org) {
+      throw new NotFoundError("no organization for this workspace", { code: "org_not_found" });
+    }
+    const response = await c.env.AUTH.fetch(
+      `https://auth.internal/internal/orgs/${encodeURIComponent(org.slug)}/invites`,
+      { headers: { "x-uploads-internal": "1" } },
+    );
+    if (!response.ok) {
+      throw new ValidationError("failed to list invites", {
+        details: await response.json().catch(() => null),
+      });
+    }
+    return c.json(await response.json());
+  })
+
+  // Invite an email to the org backing this workspace (Better Auth invitation).
+  // Workspace org admin|owner only — not ADMIN_TOKEN, not global site admin.
+  // Invitee accepts at /accept-invitation/:id then runs `uploads login`.
+  .post("/workspaces/:name/invites", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    await adminWorkspaceOr403(c.env, userId, name);
+
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+
+    const org = await orgForWorkspace(c.env, name);
+    if (!org) {
+      throw new NotFoundError("no organization for this workspace — ask a site operator", {
+        code: "org_not_found",
+      });
+    }
+
+    const body = await c.req
+      .json<{ email?: unknown; role?: unknown }>()
+      .catch(() => ({}) as { email?: unknown; role?: unknown });
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    const role = typeof body.role === "string" ? body.role.trim() : "member";
+    if (!email || !EMAIL_RE.test(email)) {
+      throw new ValidationError("invalid email address", { code: "invalid_email" });
+    }
+    if (role !== "member" && role !== "admin") {
+      throw new ValidationError("role must be member or admin", { code: "invalid_role" });
+    }
+
+    // Per-recipient rate limit (same namespace as operator enrollments).
+    const limiter = c.env.INVITE_LIMITER;
+    if (limiter) {
+      const { success } = await limiter.limit({ key: `invite:email:${email.toLowerCase()}` });
+      if (!success) throw new RateLimitedError("invite rate limit exceeded");
+    }
+
+    const response = await c.env.AUTH.fetch("https://auth.internal/internal/invite", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+      body: JSON.stringify({
+        organizationSlug: org.slug,
+        email,
+        role,
+        inviterUserId: userId,
+      }),
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok) {
+      if (response.status === 403) {
+        throw new ForbiddenError("not authorized to invite to this workspace", {
+          code: "inviter_not_authorized",
+          details: payload,
+        });
+      }
+      throw new ValidationError("failed to create invitation", { details: payload });
+    }
+    return c.json(payload as object, response.status === 200 ? 200 : 201);
   });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -268,30 +268,9 @@ export const me = new Hono<SessionVars>()
     return router.handle(c.req.raw);
   })
 
-  // Pending org invitations for a workspace — workspace admin|owner only.
-  // Non-members 404 (same anti-enumeration as other /me workspace routes).
-  .get("/workspaces/:name/invites", async (c) => {
-    const name = c.req.param("name");
-    await adminWorkspaceOr403(c.env, requireUserId(c), name);
-    const org = await orgForWorkspace(c.env, name);
-    if (!org) {
-      throw new NotFoundError("no organization for this workspace", { code: "org_not_found" });
-    }
-    const response = await c.env.AUTH.fetch(
-      `https://auth.internal/internal/orgs/${encodeURIComponent(org.slug)}/invites`,
-      { headers: { "x-uploads-internal": "1" } },
-    );
-    if (!response.ok) {
-      throw new ValidationError("failed to list invites", {
-        details: await response.json().catch(() => null),
-      });
-    }
-    return c.json(await response.json());
-  })
-
   // Invite an email to the org backing this workspace (Better Auth invitation).
-  // Workspace org admin|owner only — not ADMIN_TOKEN, not global site admin.
-  // Invitee accepts at /accept-invitation/:id then runs `uploads login`.
+  // Workspace org admin|owner only. Returns acceptUrl so self-hosted installs
+  // without Email Sending can still hand the invitee a link.
   .post("/workspaces/:name/invites", async (c) => {
     const name = c.req.param("name");
     const userId = requireUserId(c);
@@ -311,7 +290,8 @@ export const me = new Hono<SessionVars>()
     const body = await c.req
       .json<{ email?: unknown; role?: unknown }>()
       .catch(() => ({}) as { email?: unknown; role?: unknown });
-    const email = typeof body.email === "string" ? body.email.trim() : "";
+    // Account UI always invites as member; API still accepts role for CLI.
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
     const role = typeof body.role === "string" ? body.role.trim() : "member";
     if (!email || !EMAIL_RE.test(email)) {
       throw new ValidationError("invalid email address", { code: "invalid_email" });
@@ -320,10 +300,12 @@ export const me = new Hono<SessionVars>()
       throw new ValidationError("role must be member or admin", { code: "invalid_role" });
     }
 
-    // Per-recipient rate limit (same namespace as operator enrollments).
+    // Per-recipient rate limit when the binding is configured (hosted always;
+    // self-hosted opt-in via wrangler). Absent binding = no RL (same as other
+    // optional limiters).
     const limiter = c.env.INVITE_LIMITER;
     if (limiter) {
-      const { success } = await limiter.limit({ key: `invite:email:${email.toLowerCase()}` });
+      const { success } = await limiter.limit({ key: `invite:email:${email}` });
       if (!success) throw new RateLimitedError("invite rate limit exceeded");
     }
 
@@ -337,7 +319,10 @@ export const me = new Hono<SessionVars>()
         inviterUserId: userId,
       }),
     });
-    const payload = await response.json().catch(() => null);
+    const payload = (await response.json().catch(() => null)) as {
+      invitation?: { id?: string };
+      acceptUrl?: string;
+    } | null;
     if (!response.ok) {
       if (response.status === 403) {
         throw new ForbiddenError("not authorized to invite to this workspace", {
@@ -347,5 +332,10 @@ export const me = new Hono<SessionVars>()
       }
       throw new ValidationError("failed to create invitation", { details: payload });
     }
-    return c.json(payload as object, response.status === 200 ? 200 : 201);
+    // Ensure acceptUrl even if an older auth worker omits it.
+    const webOrigin = (c.env.WEB_ORIGIN || "https://uploads.sh").replace(/\/$/, "");
+    const id = payload?.invitation?.id;
+    const acceptUrl =
+      payload?.acceptUrl ?? (id ? `${webOrigin}/accept-invitation/${id}` : undefined);
+    return c.json({ ...payload, acceptUrl }, response.status === 200 ? 200 : 201);
   });

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -70,8 +70,14 @@ export async function sendAuthEmail(env: SendAuthEmailEnv, args: SendAuthEmailAr
   const magicLink = args.template === "magic-link" && isDev ? ` Link: ${args.context.url}` : "";
 
   if (!env.EMAIL) {
+    // Invitation accept URLs are always logged so self-hosted operators without
+    // Email Sending can copy them. Magic-link URLs stay dev-only (secrets).
+    const inviteLink =
+      args.template === "invitation" && typeof args.context.url === "string"
+        ? ` Link: ${args.context.url}`
+        : "";
     console.warn(
-      `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${magicLink}`,
+      `[auth email] no EMAIL binding — not sent. To: ${args.to}. "${subject}".${inviteLink || magicLink}`,
     );
     return;
   }

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -396,9 +396,23 @@ describe("DB-backed behavior", () => {
   });
 
   describe("POST /internal/invite", () => {
-    it("inserts a pending invite with created_at set and logs the email (no EMAIL binding)", async () => {
+    async function seedOrgAdmin(
+      role: "owner" | "admin" | "member" = "owner",
+    ): Promise<{ org: schema.AuthOrganization; inviter: schema.AuthUser }> {
       const org = await seedOrg();
       const inviter = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: inviter.id,
+        role,
+        createdAt: new Date(),
+      });
+      return { org, inviter };
+    }
+
+    it("inserts a pending invite with created_at set and logs the email (no EMAIL binding)", async () => {
+      const { org, inviter } = await seedOrgAdmin("owner");
       const res = await app().request(
         "/internal/invite",
         {
@@ -425,9 +439,50 @@ describe("DB-backed behavior", () => {
       expect(rows[0].createdAt).toBeInstanceOf(Date);
     });
 
-    it("returns the existing pending invite instead of inserting a duplicate", async () => {
+    it("allows a global site admin to invite without org membership", async () => {
       const org = await seedOrg();
-      const inviter = await seedUser();
+      const inviter = await seedUser({ role: "admin" });
+      const res = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: org.slug,
+            email: "ops@example.com",
+            role: "member",
+            inviterUserId: inviter.id,
+          }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(201);
+    });
+
+    it("403s when the inviter is only an org member", async () => {
+      const { org, inviter } = await seedOrgAdmin("member");
+      const res = await app().request(
+        "/internal/invite",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationSlug: org.slug,
+            email: "nope@example.com",
+            role: "member",
+            inviterUserId: inviter.id,
+          }),
+        },
+        dbEnv(),
+      );
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "inviter_not_authorized" },
+      });
+    });
+
+    it("returns the existing pending invite instead of inserting a duplicate", async () => {
+      const { org, inviter } = await seedOrgAdmin("admin");
       const email = "dupe@example.com";
       const first = await app().request(
         "/internal/invite",
@@ -474,7 +529,7 @@ describe("DB-backed behavior", () => {
     });
 
     it("404s when the organization slug is unknown", async () => {
-      const inviter = await seedUser();
+      const inviter = await seedUser({ role: "admin" });
       const res = await app().request(
         "/internal/invite",
         {

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -428,7 +428,12 @@ describe("DB-backed behavior", () => {
         dbEnv(),
       );
       expect(res.status).toBe(201);
-      const body = (await res.json()) as { invitation: { id: string; status: string } };
+      const body = (await res.json()) as {
+        invitation: { id: string; status: string; email: string };
+        acceptUrl: string;
+      };
+      expect(body.acceptUrl).toContain(`/accept-invitation/${body.invitation.id}`);
+      expect(body.invitation.email).toBe("invitee@example.com");
 
       const rows = await orm
         .select()

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -270,6 +270,11 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       }
     }
 
+    // Normalize so "Ada@x.com" and "ada@x.com" hit the same pending row.
+    const normalizedEmail = email.toLowerCase();
+    const webOrigin = (c.env.WEB_ORIGIN || "https://uploads.sh").replace(/\/$/, "");
+    const acceptUrlFor = (invitationId: string) => `${webOrigin}/accept-invitation/${invitationId}`;
+
     // Idempotency: an existing pending invite for this (org, email) is
     // returned as-is rather than inserting a duplicate row and re-sending
     // the invitation email (e.g. the admin double-clicks Invite).
@@ -279,11 +284,12 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .where(
         and(
           eq(schema.invitation.organizationId, org.id),
-          eq(schema.invitation.email, email),
+          eq(schema.invitation.email, normalizedEmail),
           eq(schema.invitation.status, "pending"),
         ),
       )
       .limit(1);
+
     if (existingInvite) {
       return c.json(
         {
@@ -295,6 +301,8 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
             status: existingInvite.status,
             expiresAt: existingInvite.expiresAt,
           },
+          // Always return so self-hosted (no EMAIL binding) can share the link.
+          acceptUrl: acceptUrlFor(existingInvite.id),
         },
         200,
       );
@@ -305,7 +313,7 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     await db.insert(schema.invitation).values({
       id,
       organizationId: org.id,
-      email,
+      email: normalizedEmail,
       role,
       status: "pending",
       expiresAt,
@@ -313,19 +321,29 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       createdAt: new Date(),
     });
 
-    const webOrigin = c.env.WEB_ORIGIN || "https://uploads.sh";
+    const acceptUrl = acceptUrlFor(id);
     await sendAuthEmail(c.env, {
-      to: email,
+      to: normalizedEmail,
       template: "invitation",
       context: {
-        url: `${webOrigin}/accept-invitation/${id}`,
+        url: acceptUrl,
         organizationName: org.name,
         inviterEmail: inviter.email,
       },
     });
 
     return c.json(
-      { invitation: { id, organizationId: org.id, email, role, status: "pending", expiresAt } },
+      {
+        invitation: {
+          id,
+          organizationId: org.id,
+          email: normalizedEmail,
+          role,
+          status: "pending",
+          expiresAt,
+        },
+        acceptUrl,
+      },
       201,
     );
   })

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -248,6 +248,28 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       return c.json(errorJson("inviter_not_found", "no user with that id"), 404);
     }
 
+    // Authorization: either a global site operator (user.role === "admin") —
+    // used by /admin-ui when the operator is not an org member of every
+    // workspace — or an org member with role admin|owner. Unprivileged
+    // callers (or a fabricated inviterUserId) must not create invites.
+    const isGlobalAdmin = inviter.role === "admin";
+    if (!isGlobalAdmin) {
+      const [membership] = await db
+        .select({ role: schema.member.role })
+        .from(schema.member)
+        .where(and(eq(schema.member.organizationId, org.id), eq(schema.member.userId, inviter.id)))
+        .limit(1);
+      if (!membership || (membership.role !== "admin" && membership.role !== "owner")) {
+        return c.json(
+          errorJson(
+            "inviter_not_authorized",
+            "inviter must be a global admin or an org admin/owner",
+          ),
+          403,
+        );
+      }
+    }
+
     // Idempotency: an existing pending invite for this (org, email) is
     // returned as-is rather than inserting a duplicate row and re-sending
     // the invitation email (e.g. the admin double-clicks Invite).

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -222,17 +222,17 @@ export async function setFileVisibility(
 }
 
 export type InviteResult =
-  | { kind: "ok"; invitationId?: string; status?: string }
+  | { kind: "ok"; invitationId?: string; status?: string; acceptUrl?: string }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "forbidden" | "invalid" };
 
 /**
- * POST /me/workspaces/:name/invites — workspace admin|owner invites an email
- * to the org (Better Auth invitation). Session cookie only.
+ * POST /me/workspaces/:name/invites — workspace admin|owner invites an email.
+ * Always prefer showing `acceptUrl` (works without outbound email).
  */
 export async function inviteToWorkspace(
   apiOrigin: string,
   name: string,
-  input: { email: string; role?: "member" | "admin" },
+  email: string,
 ): Promise<InviteResult> {
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/invites`,
@@ -241,7 +241,7 @@ export async function inviteToWorkspace(
       credentials: "include",
       cache: "no-store",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: input.email, role: input.role ?? "member" }),
+      body: JSON.stringify({ email, role: "member" }),
     },
   );
   if (result.kind === "unavailable") return result;
@@ -251,10 +251,12 @@ export async function inviteToWorkspace(
   if (!response.ok) return { kind: "unavailable", reason: "server" };
   const body = (await response.json().catch(() => null)) as {
     invitation?: { id?: string; status?: string };
+    acceptUrl?: string;
   } | null;
   return {
     kind: "ok",
     invitationId: body?.invitation?.id,
     status: body?.invitation?.status,
+    acceptUrl: typeof body?.acceptUrl === "string" ? body.acceptUrl : undefined,
   };
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -220,3 +220,41 @@ export async function setFileVisibility(
   }
   return { kind: "success", visibility: body.visibility };
 }
+
+export type InviteResult =
+  | { kind: "ok"; invitationId?: string; status?: string }
+  | { kind: "unavailable"; reason: RequestFailure | "server" | "forbidden" | "invalid" };
+
+/**
+ * POST /me/workspaces/:name/invites — workspace admin|owner invites an email
+ * to the org (Better Auth invitation). Session cookie only.
+ */
+export async function inviteToWorkspace(
+  apiOrigin: string,
+  name: string,
+  input: { email: string; role?: "member" | "admin" },
+): Promise<InviteResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/invites`,
+    {
+      method: "POST",
+      credentials: "include",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: input.email, role: input.role ?? "member" }),
+    },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (response.status === 400) return { kind: "unavailable", reason: "invalid" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as {
+    invitation?: { id?: string; status?: string };
+  } | null;
+  return {
+    kind: "ok",
+    invitationId: body?.invitation?.id,
+    status: body?.invitation?.status,
+  };
+}

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -136,7 +136,8 @@ export const prerender = false;
             ? `<p class="ws-note">This is the shared, public space — anything here is world-readable at <code>storage.uploads.sh</code>. Browse and upload with the CLI.</p>`
             : `<div class="ws-section" data-galleries><div class="ws-section-head">Galleries</div><p class="ws-empty">Loading&#32;…</p></div>
                <div class="ws-section" data-files><div class="ws-section-head">Files</div><p class="ws-empty">Loading&#32;…</p></div>`;
-          // Workspace org admin|owner: email invite form (session-authed org invitation).
+          // Workspace org admin|owner: invite by email (session). Accept URL is
+          // always returned so installs without outbound email still work.
           const memberInvite = isWorkspaceAdminRole(ws.role)
             ? `<div class="ws-section" data-invite>
                  <div class="ws-section-head">Invite a teammate</div>
@@ -145,19 +146,20 @@ export const prerender = false;
                      <span class="sr-only">Email</span>
                      <input type="email" name="email" required autocomplete="email" placeholder="teammate@example.com" />
                    </label>
-                   <button type="submit">Send invite</button>
+                   <button type="submit">Invite</button>
                  </form>
                  <p class="muted cli-note" data-invite-status role="status"></p>
-                 <p class="muted cli-note">They accept by email, then run <code>uploads login</code>. CLI: <code>uploads invite create --workspace ${escapeHtml(ws.workspace)} --email …</code></p>
+                 <p class="muted cli-note" data-invite-link hidden></p>
+                 <p class="muted cli-note">They open the accept link, then run <code>uploads login</code>.</p>
                </div>`
             : "";
-          // Site operators: enrollment codes (ADMIN_TOKEN), separate from org invites.
+          // Site operators only: enrollment codes need ADMIN_TOKEN (separate product path).
           const cmd = operatorInviteCommand(ws.workspace);
           const operatorInvite = isSiteOperator
             ? `<div class="ws-section">
-                 <div class="ws-section-head">Operator enrollment (ADMIN_TOKEN)</div>
+                 <div class="ws-section-head">Operator enrollment code</div>
                  <div class="command"><code>${escapeHtml(cmd)}</code><button type="button" aria-live="polite" data-copy="${escapeHtml(cmd)}">copy</button></div>
-                 <p class="muted cli-note">Break-glass link/code path — not required for normal teammate invites above.</p>
+                 <p class="muted cli-note"><code>ADMIN_TOKEN</code> only — not for everyday teammate invites.</p>
                </div>`
             : "";
           return `<li data-workspace="${escapeHtml(ws.workspace)}">
@@ -259,16 +261,25 @@ export const prerender = false;
         if (!workspace) return;
         const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
         const status = form.parentElement?.querySelector<HTMLElement>("[data-invite-status]");
+        const linkEl = form.parentElement?.querySelector<HTMLElement>("[data-invite-link]");
         const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
         const email = emailInput?.value.trim() ?? "";
         if (!email || !status || !submit) return;
-        status.textContent = "Sending…";
+        status.textContent = "Creating invite…";
+        if (linkEl) {
+          linkEl.hidden = true;
+          linkEl.textContent = "";
+        }
         submit.disabled = true;
-        const result = await inviteToWorkspace(apiOrigin, workspace, { email });
+        const result = await inviteToWorkspace(apiOrigin, workspace, email);
         submit.disabled = false;
         if (result.kind === "ok") {
-          status.textContent = `Invite sent to ${email}.`;
+          status.textContent = `Invite created for ${email}.`;
           if (emailInput) emailInput.value = "";
+          if (linkEl && result.acceptUrl) {
+            linkEl.hidden = false;
+            linkEl.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
+          }
           return;
         }
         status.textContent =
@@ -276,7 +287,7 @@ export const prerender = false;
             ? "You need workspace admin access to invite."
             : result.reason === "invalid"
               ? "That email doesn’t look valid."
-              : "Couldn’t send the invite. Try again.";
+              : "Couldn’t create the invite. Try again.";
       })();
     });
 

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -23,6 +23,7 @@ export const prerender = false;
       getMyWorkspaces,
       getMyWorkspaceUsage,
       getMyWorkspaceGalleries,
+      inviteToWorkspace,
       type GallerySummary,
     } from "../../lib/api-client";
     import { AccountFileBrowser } from "../../components/AccountFileBrowser";
@@ -78,14 +79,13 @@ export const prerender = false;
       return parts.join(" · ");
     }
 
-    // Operator enrollment CLI for a given workspace. Needs site-wide
-    // ADMIN_TOKEN (not a workspace upload token / membership role). The
-    // workspace name is pre-filled only as a convenience — it does not create
-    // a workspace.
+    // Operator enrollment CLI — site-wide ADMIN_TOKEN only (not workspace role).
     const operatorInviteCommand = (workspace: string) =>
       `uploads admin invite create --workspace ${workspace} --email teammate@example.com`;
 
-    // Captured from onSession so the invite block can gate on global role.
+    const isWorkspaceAdminRole = (role: string) => role === "admin" || role === "owner";
+
+    // Captured from onSession so the operator CLI block can gate on global role.
     let sessionUser: { role?: string | null } | null = null;
 
     function renderGalleries(container: HTMLElement, galleries: GallerySummary[]): void {
@@ -136,14 +136,28 @@ export const prerender = false;
             ? `<p class="ws-note">This is the shared, public space — anything here is world-readable at <code>storage.uploads.sh</code>. Browse and upload with the CLI.</p>`
             : `<div class="ws-section" data-galleries><div class="ws-section-head">Galleries</div><p class="ws-empty">Loading&#32;…</p></div>
                <div class="ws-section" data-files><div class="ws-section-head">Files</div><p class="ws-empty">Loading&#32;…</p></div>`;
-          // Site operators: copy-paste enrollment invite for *this* workspace
-          // (name pre-filled). Day-to-day email invites go through /admin.
+          // Workspace org admin|owner: email invite form (session-authed org invitation).
+          const memberInvite = isWorkspaceAdminRole(ws.role)
+            ? `<div class="ws-section" data-invite>
+                 <div class="ws-section-head">Invite a teammate</div>
+                 <form class="invite-form" data-workspace="${escapeHtml(ws.workspace)}">
+                   <label class="invite-label">
+                     <span class="sr-only">Email</span>
+                     <input type="email" name="email" required autocomplete="email" placeholder="teammate@example.com" />
+                   </label>
+                   <button type="submit">Send invite</button>
+                 </form>
+                 <p class="muted cli-note" data-invite-status role="status"></p>
+                 <p class="muted cli-note">They accept by email, then run <code>uploads login</code>. CLI: <code>uploads invite create --workspace ${escapeHtml(ws.workspace)} --email …</code></p>
+               </div>`
+            : "";
+          // Site operators: enrollment codes (ADMIN_TOKEN), separate from org invites.
           const cmd = operatorInviteCommand(ws.workspace);
-          const invite = isSiteOperator
+          const operatorInvite = isSiteOperator
             ? `<div class="ws-section">
-                 <div class="ws-section-head">Operator invite to this workspace</div>
+                 <div class="ws-section-head">Operator enrollment (ADMIN_TOKEN)</div>
                  <div class="command"><code>${escapeHtml(cmd)}</code><button type="button" aria-live="polite" data-copy="${escapeHtml(cmd)}">copy</button></div>
-                 <p class="muted cli-note">Needs the site <code>ADMIN_TOKEN</code> — not a workspace upload token. Prefer <a href="/admin">/admin</a> for email invites.</p>
+                 <p class="muted cli-note">Break-glass link/code path — not required for normal teammate invites above.</p>
                </div>`
             : "";
           return `<li data-workspace="${escapeHtml(ws.workspace)}">
@@ -152,7 +166,7 @@ export const prerender = false;
                 <span class="slug">${escapeHtml(ws.role)}</span>
               </div>
               <div class="usage">Loading usage&#32;…</div>
-              <div class="ws-detail">${body}${invite}</div>
+              <div class="ws-detail">${body}${memberInvite}${operatorInvite}</div>
             </li>`;
         })
         .join("");
@@ -218,26 +232,53 @@ export const prerender = false;
       );
     }
 
-    // Delegated copy handler for the injected invite-command buttons.
-    requireElement<HTMLUListElement>("#orgs-list", "account workspaces").addEventListener(
-      "click",
-      (event) => {
-        void (async () => {
-          const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
-            "button[data-copy]",
-          );
-          if (!button) return;
-          try {
-            await navigator.clipboard.writeText(button.dataset.copy ?? "");
-            const previous = button.textContent;
-            button.textContent = "copied ✓";
-            setTimeout(() => (button.textContent = previous), 1500);
-          } catch {
-            // Clipboard blocked (permissions/insecure context) — leave the label.
-          }
-        })();
-      },
-    );
+    // Delegated handlers for copy buttons + workspace invite forms.
+    const orgsListEl = requireElement<HTMLUListElement>("#orgs-list", "account workspaces");
+    orgsListEl.addEventListener("click", (event) => {
+      void (async () => {
+        const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+          "button[data-copy]",
+        );
+        if (!button) return;
+        try {
+          await navigator.clipboard.writeText(button.dataset.copy ?? "");
+          const previous = button.textContent;
+          button.textContent = "copied ✓";
+          setTimeout(() => (button.textContent = previous), 1500);
+        } catch {
+          // Clipboard blocked (permissions/insecure context) — leave the label.
+        }
+      })();
+    });
+    orgsListEl.addEventListener("submit", (event) => {
+      void (async () => {
+        const form = (event.target as HTMLElement).closest<HTMLFormElement>("form.invite-form");
+        if (!form) return;
+        event.preventDefault();
+        const workspace = form.dataset.workspace;
+        if (!workspace) return;
+        const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
+        const status = form.parentElement?.querySelector<HTMLElement>("[data-invite-status]");
+        const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+        const email = emailInput?.value.trim() ?? "";
+        if (!email || !status || !submit) return;
+        status.textContent = "Sending…";
+        submit.disabled = true;
+        const result = await inviteToWorkspace(apiOrigin, workspace, { email });
+        submit.disabled = false;
+        if (result.kind === "ok") {
+          status.textContent = `Invite sent to ${email}.`;
+          if (emailInput) emailInput.value = "";
+          return;
+        }
+        status.textContent =
+          result.reason === "forbidden"
+            ? "You need workspace admin access to invite."
+            : result.reason === "invalid"
+              ? "That email doesn’t look valid."
+              : "Couldn’t send the invite. Try again.";
+      })();
+    });
 
     requireElement<HTMLButtonElement>("#orgs-retry", "account workspaces").addEventListener("click", () => {
       void loadWorkspaces();

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -144,6 +144,52 @@ ul.plain .cli-note {
   margin: 7px 0 0;
   font-size: 11px;
 }
+ul.plain .invite-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-top: 2px;
+}
+ul.plain .invite-form .invite-label {
+  flex: 1;
+  min-width: 12rem;
+  margin: 0;
+}
+ul.plain .invite-form input[type="email"] {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  padding: 8px 10px;
+  font: 13px var(--mono);
+}
+ul.plain .invite-form input[type="email"]:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+ul.plain .invite-form button[type="submit"] {
+  flex-shrink: 0;
+  font: 12px var(--mono);
+  letter-spacing: 0.03em;
+  color: var(--accent);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 7px 12px;
+  background: var(--panel);
+  cursor: pointer;
+}
+ul.plain .invite-form button[type="submit"]:hover,
+ul.plain .invite-form button[type="submit"]:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+ul.plain .invite-form button[type="submit"]:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
 
 /* Overview CLI setup ──────────────────────────────────────────────────── */
 

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -44,14 +44,15 @@ Workspace access comes from an **organization invitation**, not a code you
 redeem. Someone who already **admins that workspace** (org role admin/owner)
 invites your email:
 
-- **Account UI** — signed in at `/account/workspaces`, “Invite a teammate”
+- **Account UI** — `/account/workspaces` → “Invite a teammate”
 - **CLI** — `uploads invite create --email you@example.com --workspace <name>`
   (device login as the inviter; no `ADMIN_TOKEN`)
 - **Site operators** can also invite from `/admin` (global admin session)
 
-Accepting the invitation (GitHub or magic-link sign-in) makes you a member —
-from there, `uploads login` mints a token for that workspace. See the
-[operator runbook](ops.md#invitations) for operator-only enrollment codes.
+You get an accept link (email when Email Sending is configured; otherwise the
+inviter shares the link from the UI/CLI). After accepting (GitHub or magic-link
+sign-in), run `uploads login`. See [ops.md#invitations](ops.md#invitations) for
+operator-only enrollment codes and self-hosted email notes.
 
 ## Alternative: enrollment codes / invite links (`--code`)
 

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -41,11 +41,17 @@ full flag list (`--label`, `--scopes`, `--auth-url`, `--no-open`,
 ## How you get access to a workspace
 
 Workspace access comes from an **organization invitation**, not a code you
-redeem. An administrator invites your email address to the workspace's
-organization from the session-authenticated admin UI at `/admin`. Accepting
-the invitation (GitHub or magic-link sign-in) makes you a member — from
-there, `uploads login` mints a token for that workspace. See the
-[operator runbook](ops.md#invitations) for how administrators send invites.
+redeem. Someone who already **admins that workspace** (org role admin/owner)
+invites your email:
+
+- **Account UI** — signed in at `/account/workspaces`, “Invite a teammate”
+- **CLI** — `uploads invite create --email you@example.com --workspace <name>`
+  (device login as the inviter; no `ADMIN_TOKEN`)
+- **Site operators** can also invite from `/admin` (global admin session)
+
+Accepting the invitation (GitHub or magic-link sign-in) makes you a member —
+from there, `uploads login` mints a token for that workspace. See the
+[operator runbook](ops.md#invitations) for operator-only enrollment codes.
 
 ## Alternative: enrollment codes / invite links (`--code`)
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -41,14 +41,25 @@ The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every wo
 
 ## Invitations
 
-Invite people through the session-authenticated **admin UI at `/admin`**, signed in
-as a global admin (`user.role === "admin"` in the Better Auth `user` table — see
-`apps/auth/README.md#first-admin`). Pick the workspace, enter an email, and the
-UI calls `POST /admin-ui/workspaces/:name/invites`, which invites that address to
-the organization backing the workspace. The invitee accepts (GitHub or magic-link
-sign-in), becomes an org member, and can then run `uploads login` to mint their
-own workspace token. This is the normal way to bring someone onto a workspace —
-no `ADMIN_TOKEN` involved, and nothing to hand-deliver.
+### Workspace admins (normal path)
+
+People with org role **admin** or **owner** on a workspace invite teammates
+without `ADMIN_TOKEN` or a global site-admin role:
+
+- **Web:** `/account/workspaces` → “Invite a teammate” (session cookie →
+  `POST /me/workspaces/:name/invites`)
+- **CLI:** `uploads invite create --email teammate@example.com --workspace <name>`
+  (device login as the inviter, then the same `/me/…/invites` API)
+
+The invitee accepts at `/accept-invitation/:id`, becomes an org member, and runs
+`uploads login` to mint their own workspace token.
+
+### Site operators (global admin)
+
+Signed in as a global admin (`user.role === "admin"` — see
+`apps/auth/README.md#first-admin`), the **`/admin`** UI can invite any workspace
+via `POST /admin-ui/workspaces/:name/invites`. Use this for bootstrap or when
+you are not an org member of the workspace.
 
 A workspace needs an organization behind it before it can be invited into — see
 the org backfill note in `docs/superpowers/plans/2026-07-12-better-auth-introduction.md`

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -51,8 +51,11 @@ without `ADMIN_TOKEN` or a global site-admin role:
 - **CLI:** `uploads invite create --email teammate@example.com --workspace <name>`
   (device login as the inviter, then the same `/me/…/invites` API)
 
-The invitee accepts at `/accept-invitation/:id`, becomes an org member, and runs
-`uploads login` to mint their own workspace token.
+Both return an **accept URL** (`/accept-invitation/:id`). On hosted uploads.sh,
+Cloudflare Email Sending also emails that link. **Self-hosted without an `EMAIL`
+binding:** no mail is sent — share the accept URL yourself (UI shows it; CLI
+prints it; auth worker logs it). The invitee opens the link, becomes an org
+member, and runs `uploads login`.
 
 ### Site operators (global admin)
 

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -26,6 +26,7 @@ import {
 import { runConfig } from "./commands/config.js";
 import { runSetup } from "./commands/setup.js";
 import { runLogin } from "./commands/login.js";
+import { runInvite } from "./commands/invite.js";
 import { runAdmin } from "./commands/admin-enrollment.js";
 import { runMcp } from "./commands/mcp.js";
 import { runInstall } from "./commands/install.js";
@@ -70,7 +71,8 @@ Commands:
   setup               Inspect/configure advanced CLI settings
   install             Install the agent skill + register the remote MCP server
   login               Sign in via browser (or an enrollment code) and save credentials
-  admin               Admin invitation management
+  invite              Invite a teammate to a workspace (workspace admin; device login)
+  admin               Site-operator invitation management (ADMIN_TOKEN)
   config              Show path, init, or set shared config
   doctor              Health + auth + workspace checks
   health              API liveness (no auth)
@@ -250,6 +252,9 @@ export async function runCli(argv: string[]): Promise<number> {
         break;
       case "login":
         code = await runLogin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        break;
+      case "invite":
+        code = await runInvite(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
         break;
       case "admin":
         code = await runAdmin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -402,14 +402,18 @@ export interface MintTokenResult {
 /**
  * POST /me/workspaces/:name/invites — org invitation for a workspace.
  * Requires a Better Auth session bearer (device flow), not a workspace token.
- * Caller must be org admin|owner for that workspace.
+ * Caller must be org admin|owner. `acceptUrl` is always returned so
+ * self-hosted deploys without email can still share the link.
  */
 export function createWorkspaceInvite(
   apiUrl: string,
   accessToken: string,
   workspace: string,
   input: { email: string; role?: "member" | "admin" },
-): Promise<{ invitation: { id: string; email: string; role: string; status: string } }> {
+): Promise<{
+  invitation: { id: string; email: string; role: string; status: string };
+  acceptUrl?: string;
+}> {
   return jsonRequest(
     `${apiUrl.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/invites`,
     {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -400,6 +400,30 @@ export interface MintTokenResult {
 }
 
 /**
+ * POST /me/workspaces/:name/invites — org invitation for a workspace.
+ * Requires a Better Auth session bearer (device flow), not a workspace token.
+ * Caller must be org admin|owner for that workspace.
+ */
+export function createWorkspaceInvite(
+  apiUrl: string,
+  accessToken: string,
+  workspace: string,
+  input: { email: string; role?: "member" | "admin" },
+): Promise<{ invitation: { id: string; email: string; role: string; status: string } }> {
+  return jsonRequest(
+    `${apiUrl.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/invites`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: input.email, role: input.role ?? "member" }),
+    },
+  );
+}
+
+/**
  * POST /v1/tokens — mint a `up_<workspace>_…` workspace token from a device-flow
  * session (presented as a bearer). v1 sends exactly one grant.
  */

--- a/packages/uploads/src/commands/invite.ts
+++ b/packages/uploads/src/commands/invite.ts
@@ -1,0 +1,193 @@
+/**
+ * Workspace-admin email invite via ephemeral device session.
+ * Does not use ADMIN_TOKEN or workspace upload tokens.
+ */
+import { spawn } from "node:child_process";
+import {
+  createWorkspaceInvite,
+  listMintWorkspaces,
+  requestDeviceCode,
+  requestDeviceToken,
+} from "../client.js";
+import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+import { resolveAuthUrl } from "./login.js";
+
+const HELP = `uploads invite create [options]
+
+Invite someone to a workspace by email. Opens a browser so you can approve
+with your account (device login) — you must be an admin or owner of that
+workspace. Does NOT use ADMIN_TOKEN or a workspace upload token.
+
+The invitee gets an email, accepts at uploads.sh, then runs uploads login.
+
+Options:
+  --email <address>     Required. Invitee email
+  --workspace <name>    Workspace to invite into (required if you admin more than one)
+  --role member|admin   Org role for the invitee (default: member)
+  --auth-url <url>      Auth base (default: derived from --api-url)
+  --api-url <url>       API base (default: https://api.uploads.sh)
+  --no-open             Don't open a browser automatically
+
+Examples:
+  uploads invite create --email teammate@example.com
+  uploads invite create --workspace acme --email teammate@example.com --role member
+`;
+
+type DeviceIo = {
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  openUrl: (url: string) => void;
+  write: (text: string) => void;
+};
+
+function openUrl(url: string): void {
+  try {
+    const isWin = process.platform === "win32";
+    const command = process.platform === "darwin" ? "open" : isWin ? "cmd" : "xdg-open";
+    const args = isWin ? ["/c", "start", "", url] : [url];
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // URL is printed for manual navigation.
+  }
+}
+
+const defaultIo: DeviceIo = {
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  now: () => Date.now(),
+  openUrl,
+  write: (text) => {
+    process.stderr.write(text);
+  },
+};
+
+async function pollForDeviceToken(
+  authUrl: string,
+  code: { device_code: string; interval: number; expires_in: number },
+  io: DeviceIo,
+): Promise<string> {
+  let intervalMs = Math.max(1, code.interval) * 1000;
+  const deadline = io.now() + Math.max(1, code.expires_in) * 1000;
+  while (io.now() < deadline) {
+    await io.sleep(intervalMs);
+    let result: Awaited<ReturnType<typeof requestDeviceToken>>;
+    try {
+      result = await requestDeviceToken(authUrl, { deviceCode: code.device_code });
+    } catch {
+      continue;
+    }
+    switch (result.status) {
+      case "ok":
+        return result.accessToken;
+      case "pending":
+        continue;
+      case "slow_down":
+        intervalMs += 5000;
+        continue;
+      case "denied":
+        throw new UsageError("device authorization was denied");
+      case "expired":
+        throw new UsageError("the device code expired before it was approved");
+      default:
+        throw new UsageError(
+          `device authorization failed: ${result.error}${
+            result.description ? ` — ${result.description}` : ""
+          }`,
+        );
+    }
+  }
+  throw new UsageError("timed out waiting for device authorization");
+}
+
+/** Exported for unit tests. */
+export function resolveInviteWorkspace(
+  workspaces: Array<{ workspace: string; role: string }>,
+  requested: string | undefined,
+): string {
+  const adminable = workspaces.filter((w) => w.role === "admin" || w.role === "owner");
+  if (requested) {
+    const hit = adminable.find((w) => w.workspace === requested);
+    if (!hit) {
+      const roles = workspaces
+        .filter((w) => w.workspace === requested)
+        .map((w) => w.role)
+        .join(", ");
+      if (roles) {
+        throw new UsageError(
+          `you are ${roles} on ${requested}, not admin/owner — only workspace admins can invite`,
+        );
+      }
+      throw new UsageError(`no admin access to workspace ${requested}`);
+    }
+    return hit.workspace;
+  }
+  if (adminable.length === 1) return adminable[0]!.workspace;
+  if (adminable.length === 0) {
+    throw new UsageError(
+      "your account has no workspace admin access — ask a site operator or existing admin",
+    );
+  }
+  const names = adminable.map((w) => w.workspace).join(", ");
+  throw new UsageError(`multiple workspaces you admin (${names}); pass --workspace <name>`);
+}
+
+export async function runInvite(
+  args: string[],
+  opts: { json?: boolean; apiUrl?: string },
+  help = false,
+  io: DeviceIo = defaultIo,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    process.stderr.write(HELP);
+    return 0;
+  }
+  if (parsed.positionals[0] !== "create") {
+    throw new UsageError("expected: uploads invite create");
+  }
+
+  const email = flagString(parsed.flags, "--email");
+  if (!email) throw new UsageError("--email is required");
+  const roleRaw = flagString(parsed.flags, "--role") ?? "member";
+  if (roleRaw !== "member" && roleRaw !== "admin") {
+    throw new UsageError("--role must be member or admin");
+  }
+  const role = roleRaw as "member" | "admin";
+  const requestedWorkspace = flagString(parsed.flags, "--workspace");
+  const apiUrl = flagString(parsed.flags, "--api-url") ?? opts.apiUrl ?? "https://api.uploads.sh";
+  const authUrl = resolveAuthUrl(parsed, apiUrl);
+
+  if (flagBool(parsed.flags, "--non-interactive")) {
+    throw new UsageError("invite requires a browser for device approval");
+  }
+
+  const code = await requestDeviceCode(authUrl);
+  const verifyUrl = code.verification_uri_complete ?? code.verification_uri;
+  io.write(
+    `To invite as your account, open:\n\n  ${verifyUrl}\n\nand confirm this code:\n\n  ${code.user_code}\n\n`,
+  );
+  if (!flagBool(parsed.flags, "--no-open")) io.openUrl(verifyUrl);
+  io.write("Waiting for approval…\n");
+
+  const accessToken = await pollForDeviceToken(authUrl, code, io);
+  const { workspaces } = await listMintWorkspaces(apiUrl, accessToken);
+  const workspace = resolveInviteWorkspace(workspaces, requestedWorkspace);
+
+  const result = await createWorkspaceInvite(apiUrl, accessToken, workspace, { email, role });
+  const payload = {
+    ok: true,
+    workspace,
+    email: result.invitation.email,
+    role: result.invitation.role,
+    invitationId: result.invitation.id,
+    status: result.invitation.status,
+  };
+  if (opts.json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+  else {
+    process.stdout.write(
+      `Invited ${email} to ${workspace} as ${role} (${result.invitation.status}).\nThey should check email, accept, then run uploads login.\n`,
+    );
+  }
+  return 0;
+}

--- a/packages/uploads/src/commands/invite.ts
+++ b/packages/uploads/src/commands/invite.ts
@@ -1,104 +1,36 @@
 /**
  * Workspace-admin email invite via ephemeral device session.
- * Does not use ADMIN_TOKEN or workspace upload tokens.
+ * Not ADMIN_TOKEN, not a workspace upload token.
  */
-import { spawn } from "node:child_process";
-import {
-  createWorkspaceInvite,
-  listMintWorkspaces,
-  requestDeviceCode,
-  requestDeviceToken,
-} from "../client.js";
+import { createWorkspaceInvite, listMintWorkspaces } from "../client.js";
 import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
-import { resolveAuthUrl } from "./login.js";
+import {
+  defaultDeviceIo,
+  obtainDeviceAccessToken,
+  resolveAuthUrl,
+  type DeviceLoginIo,
+} from "./login.js";
 
 const HELP = `uploads invite create [options]
 
-Invite someone to a workspace by email. Opens a browser so you can approve
-with your account (device login) — you must be an admin or owner of that
-workspace. Does NOT use ADMIN_TOKEN or a workspace upload token.
+Invite someone to a workspace by email. Opens a browser so you approve as
+yourself (device login). You must be an admin or owner of that workspace.
 
-The invitee gets an email, accepts at uploads.sh, then runs uploads login.
+The invitee gets email when Email Sending is configured; either way the
+CLI prints an accept URL you can share. After accepting they run uploads login.
 
 Options:
-  --email <address>     Required. Invitee email
-  --workspace <name>    Workspace to invite into (required if you admin more than one)
-  --role member|admin   Org role for the invitee (default: member)
-  --auth-url <url>      Auth base (default: derived from --api-url)
-  --api-url <url>       API base (default: https://api.uploads.sh)
-  --no-open             Don't open a browser automatically
+  --email <address>     Required
+  --workspace <name>    Required if you admin more than one workspace
+  --role member|admin   Invitee org role (default: member)
+  --auth-url <url>      Auth origin (default: derived from --api-url)
+  --api-url <url>       API origin (default: https://api.uploads.sh)
+  --no-open             Print the approval URL only
 
 Examples:
   uploads invite create --email teammate@example.com
-  uploads invite create --workspace acme --email teammate@example.com --role member
+  uploads invite create --workspace acme --email teammate@example.com
 `;
-
-type DeviceIo = {
-  sleep: (ms: number) => Promise<void>;
-  now: () => number;
-  openUrl: (url: string) => void;
-  write: (text: string) => void;
-};
-
-function openUrl(url: string): void {
-  try {
-    const isWin = process.platform === "win32";
-    const command = process.platform === "darwin" ? "open" : isWin ? "cmd" : "xdg-open";
-    const args = isWin ? ["/c", "start", "", url] : [url];
-    const child = spawn(command, args, { stdio: "ignore", detached: true });
-    child.on("error", () => {});
-    child.unref();
-  } catch {
-    // URL is printed for manual navigation.
-  }
-}
-
-const defaultIo: DeviceIo = {
-  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
-  now: () => Date.now(),
-  openUrl,
-  write: (text) => {
-    process.stderr.write(text);
-  },
-};
-
-async function pollForDeviceToken(
-  authUrl: string,
-  code: { device_code: string; interval: number; expires_in: number },
-  io: DeviceIo,
-): Promise<string> {
-  let intervalMs = Math.max(1, code.interval) * 1000;
-  const deadline = io.now() + Math.max(1, code.expires_in) * 1000;
-  while (io.now() < deadline) {
-    await io.sleep(intervalMs);
-    let result: Awaited<ReturnType<typeof requestDeviceToken>>;
-    try {
-      result = await requestDeviceToken(authUrl, { deviceCode: code.device_code });
-    } catch {
-      continue;
-    }
-    switch (result.status) {
-      case "ok":
-        return result.accessToken;
-      case "pending":
-        continue;
-      case "slow_down":
-        intervalMs += 5000;
-        continue;
-      case "denied":
-        throw new UsageError("device authorization was denied");
-      case "expired":
-        throw new UsageError("the device code expired before it was approved");
-      default:
-        throw new UsageError(
-          `device authorization failed: ${result.error}${
-            result.description ? ` — ${result.description}` : ""
-          }`,
-        );
-    }
-  }
-  throw new UsageError("timed out waiting for device authorization");
-}
 
 /** Exported for unit tests. */
 export function resolveInviteWorkspace(
@@ -136,7 +68,7 @@ export async function runInvite(
   args: string[],
   opts: { json?: boolean; apiUrl?: string },
   help = false,
-  io: DeviceIo = defaultIo,
+  io: DeviceLoginIo = defaultDeviceIo,
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
@@ -162,15 +94,14 @@ export async function runInvite(
     throw new UsageError("invite requires a browser for device approval");
   }
 
-  const code = await requestDeviceCode(authUrl);
-  const verifyUrl = code.verification_uri_complete ?? code.verification_uri;
-  io.write(
-    `To invite as your account, open:\n\n  ${verifyUrl}\n\nand confirm this code:\n\n  ${code.user_code}\n\n`,
+  const accessToken = await obtainDeviceAccessToken(
+    authUrl,
+    {
+      noOpen: flagBool(parsed.flags, "--no-open"),
+      prompt: "To invite as your account, open:",
+    },
+    io,
   );
-  if (!flagBool(parsed.flags, "--no-open")) io.openUrl(verifyUrl);
-  io.write("Waiting for approval…\n");
-
-  const accessToken = await pollForDeviceToken(authUrl, code, io);
   const { workspaces } = await listMintWorkspaces(apiUrl, accessToken);
   const workspace = resolveInviteWorkspace(workspaces, requestedWorkspace);
 
@@ -182,12 +113,19 @@ export async function runInvite(
     role: result.invitation.role,
     invitationId: result.invitation.id,
     status: result.invitation.status,
+    acceptUrl: result.acceptUrl ?? null,
   };
   if (opts.json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
   else {
     process.stdout.write(
-      `Invited ${email} to ${workspace} as ${role} (${result.invitation.status}).\nThey should check email, accept, then run uploads login.\n`,
+      `Invited ${email} to ${workspace} as ${role} (${result.invitation.status}).\n`,
     );
+    if (result.acceptUrl) {
+      process.stdout.write(
+        `Accept link (share if email isn't configured):\n  ${result.acceptUrl}\n`,
+      );
+    }
+    process.stdout.write("They accept, then run: uploads login\n");
   }
   return 0;
 }

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -175,7 +175,7 @@ export interface DeviceLoginIo {
   write: (text: string) => void;
 }
 
-const defaultDeviceIo: DeviceLoginIo = {
+export const defaultDeviceIo: DeviceLoginIo = {
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   now: () => Date.now(),
   openUrl,
@@ -183,6 +183,24 @@ const defaultDeviceIo: DeviceLoginIo = {
     process.stderr.write(text);
   },
 };
+
+/**
+ * Browser device-authorization session only (no workspace token mint).
+ * Shared by `uploads login` and `uploads invite create`.
+ */
+export async function obtainDeviceAccessToken(
+  authUrl: string,
+  opts: { noOpen?: boolean; prompt?: string } = {},
+  io: DeviceLoginIo = defaultDeviceIo,
+): Promise<string> {
+  const code = await requestDeviceCode(authUrl);
+  const verifyUrl = code.verification_uri_complete ?? code.verification_uri;
+  const prompt = opts.prompt ?? "To sign in, open:";
+  io.write(`${prompt}\n\n  ${verifyUrl}\n\nand confirm this code:\n\n  ${code.user_code}\n\n`);
+  if (!opts.noOpen) io.openUrl(verifyUrl);
+  io.write("Waiting for approval…\n");
+  return pollForDeviceToken(authUrl, code, io);
+}
 
 interface LoginResult {
   workspace: string;
@@ -203,15 +221,7 @@ async function runDeviceLogin(
   const label = flagString(parsed.flags, "--label") ?? safeHostname();
   const requestedWorkspace = flagString(parsed.flags, "--workspace");
 
-  const code = await requestDeviceCode(opts.authUrl);
-  const verifyUrl = code.verification_uri_complete ?? code.verification_uri;
-  io.write(
-    `To sign in, open:\n\n  ${verifyUrl}\n\nand confirm this code:\n\n  ${code.user_code}\n\n`,
-  );
-  if (!opts.noOpen) io.openUrl(verifyUrl);
-  io.write("Waiting for approval…\n");
-
-  const accessToken = await pollForDeviceToken(opts.authUrl, code, io);
+  const accessToken = await obtainDeviceAccessToken(opts.authUrl, { noOpen: opts.noOpen }, io);
 
   const workspace = await resolveMintWorkspace(opts.apiUrl, accessToken, requestedWorkspace);
   const minted = await mintWorkspaceToken(opts.apiUrl, accessToken, { workspace, scopes, label });
@@ -227,7 +237,7 @@ function safeHostname(): string {
 }
 
 /** Poll device/token honoring interval / slow_down / pending until approved or expired. */
-async function pollForDeviceToken(
+export async function pollForDeviceToken(
   authUrl: string,
   code: { device_code: string; interval: number; expires_in: number },
   io: DeviceLoginIo,

--- a/packages/uploads/test/commands-invite.test.ts
+++ b/packages/uploads/test/commands-invite.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveInviteWorkspace } from "../src/commands/invite.js";
+import { UsageError } from "../src/cli-args.js";
+
+describe("resolveInviteWorkspace", () => {
+  it("picks the only adminable workspace", () => {
+    expect(
+      resolveInviteWorkspace(
+        [
+          { workspace: "acme", role: "owner" },
+          { workspace: "other", role: "member" },
+        ],
+        undefined,
+      ),
+    ).toBe("acme");
+  });
+
+  it("honors --workspace when the user is admin there", () => {
+    expect(
+      resolveInviteWorkspace(
+        [
+          { workspace: "acme", role: "admin" },
+          { workspace: "beta", role: "owner" },
+        ],
+        "beta",
+      ),
+    ).toBe("beta");
+  });
+
+  it("rejects member-only access", () => {
+    expect(() => resolveInviteWorkspace([{ workspace: "acme", role: "member" }], "acme")).toThrow(
+      UsageError,
+    );
+  });
+
+  it("requires --workspace when multiple admin workspaces exist", () => {
+    expect(() =>
+      resolveInviteWorkspace(
+        [
+          { workspace: "acme", role: "admin" },
+          { workspace: "beta", role: "owner" },
+        ],
+        undefined,
+      ),
+    ).toThrow(/pass --workspace/);
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -77,7 +77,7 @@ Resolution is **per key, first match wins**: CLI flags (`--api-url`, `--token`,
 `$BUILDINTERNET_CONFIG` → the shared config file. For a one-off against a different
 API or workspace, just export the var or pass `--env-file`.
 
-The fastest path is `uploads login`. Have an uploads.sh administrator invite your
+The fastest path is `uploads login`. Have a workspace admin invite your
 email to a workspace first, then run it once, interactively, to sign in:
 
 ```bash
@@ -89,6 +89,17 @@ That's a one-time, human-in-the-loop step (device sign-in needs a browser); once
 config file is written, every later `uploads` invocation — including from a
 non-interactive agent — just reads the saved token. Routine agents never need
 `ADMIN_TOKEN`.
+
+**Inviting a teammate** (you must be workspace admin/owner): either use
+`/account/workspaces` in the browser, or:
+
+```bash
+uploads invite create --email teammate@example.com --workspace acme
+```
+
+That opens a browser so you approve as yourself (device login). It does **not** use
+`ADMIN_TOKEN` or a workspace upload token. The invitee accepts the email, then runs
+`uploads login`.
 
 For headless machines with no browser at all, an operator can mint a token directly
 (`/admin/tokens`, `ADMIN_TOKEN`-gated — see `docs/admin-tokens.md`) and hand it to the

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -90,16 +90,15 @@ config file is written, every later `uploads` invocation — including from a
 non-interactive agent — just reads the saved token. Routine agents never need
 `ADMIN_TOKEN`.
 
-**Inviting a teammate** (you must be workspace admin/owner): either use
-`/account/workspaces` in the browser, or:
+**Inviting a teammate** (workspace admin/owner only): `/account/workspaces` in the
+browser, or:
 
 ```bash
 uploads invite create --email teammate@example.com --workspace acme
 ```
 
-That opens a browser so you approve as yourself (device login). It does **not** use
-`ADMIN_TOKEN` or a workspace upload token. The invitee accepts the email, then runs
-`uploads login`.
+Device login as you (not `ADMIN_TOKEN` / not a workspace token). The CLI prints an
+accept URL to share if email isn’t configured. Invitee accepts, then `uploads login`.
 
 For headless machines with no browser at all, an operator can mint a token directly
 (`/admin/tokens`, `ADMIN_TOKEN`-gated — see `docs/admin-tokens.md`) and hand it to the


### PR DESCRIPTION
## In plain terms

Workspace admins and owners can invite teammates by email without holding the site `ADMIN_TOKEN` or a global `/admin` role. Invitees accept in the browser, join the org, then run `uploads login`.

Closes #146.

## What it does

- **API** — `POST` / `GET /me/workspaces/:name/invites` for session users with org role `admin` or `owner` (non-members 404; members without privilege 403)
- **Auth** — `/internal/invite` requires the inviter to be a global site admin **or** org admin/owner (so `/admin-ui` operators still work without org membership)
- **Account UI** — email invite form on `/account/workspaces` for workspace admins; operator `ADMIN_TOKEN` enrollment snippet stays separate and labeled
- **CLI** — `uploads invite create --email … [--workspace …]` via ephemeral device login (not a workspace token, not `ADMIN_TOKEN`)
- Docs / skill / changeset for the published CLI

## What it is not

- Does not create workspaces
- Does not change `uploads admin invite create` enrollment codes
- Does not authorize invites with `UPLOADS_TOKEN` alone

## How to try it

```bash
# as a workspace admin/owner, signed into the web app:
# open /account/workspaces → Invite a teammate → send

# or CLI:
uploads invite create --email teammate@example.com --workspace acme
# approve in the browser, then they accept email and:
uploads login --workspace acme
```

## Technical notes

- Reuses Better Auth org invitations (`/accept-invitation/:id`), not enrollment codes
- Rate limit: workspace write limiter + per-email `INVITE_LIMITER` on POST
- Internal invite authorization is defense-in-depth for any service-binding caller

## Test plan

- [x] `pnpm --filter @uploads/auth test` (78)
- [x] `pnpm --filter @uploads/api test` (263, including me invite cases)
- [x] `pnpm --filter @buildinternet/uploads test` (190)
- [x] `pnpm --filter @uploads/web test` (67)
- [ ] Manual: workspace owner invites from account UI
- [ ] Manual: org member cannot invite (403)
- [ ] Manual: `uploads invite create` device flow