### PR TITLE
docs: durable design-sync harness home + worktree copy

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -2,6 +2,40 @@
 
 Repo-specific gotchas for future syncs of the uploads.sh design system.
 
+## Converter harness (`.ds-sync/`)
+
+Same layout as either/releases: **project inputs** live under committed
+`.design-sync/`; the **converter scripts** are staged into gitignored
+`.ds-sync/` at the repo root (never committed). Invocations always use
+`node .ds-sync/…` against this tree.
+
+### Restaging after a clean
+
+`.ds-sync/` is machine state. A fresh clone, `git clean`, or wiping the dir
+removes it — re-stage from the `/design-sync` skill (or any surviving sibling
+checkout that still has the tree, e.g. another repo's `.ds-sync/`):
+
+```bash
+mkdir -p .ds-sync
+# From the skill base dir, or a known-good .ds-sync copy:
+cp -R <skill-or-copy>/{package-build.mjs,package-validate.mjs,package-capture.mjs,resync.mjs,lib,storybook} .ds-sync/
+# Install converter deps in ONE npm command (separate --no-save installs prune
+# each other):
+(cd .ds-sync && npm i esbuild ts-morph @types/react playwright)
+# Optional render/capture browser:
+(cd .ds-sync && npx playwright install chromium)
+```
+
+Do not commit `.ds-sync/` or its `node_modules`.
+
+### Claude worktrees
+
+`.worktreeinclude` lists `.ds-sync/` so Claude Code copies the staged harness
+from the **main checkout** into new worktrees (same mechanism as `.env`). That
+only helps when main already has a staged tree; it does not replace restaging
+after a full clean. Plain `git worktree add` does not read `.worktreeinclude` —
+restage by hand (or copy from main) in those worktrees.
+
 ## Build
 
 - Shape is **package** (no Storybook). Source lives in `packages/ui/src/`, built
@@ -39,9 +73,9 @@ Repo-specific gotchas for future syncs of the uploads.sh design system.
 
 ## Render check
 
-- Playwright + chromium were installed into `.ds-sync/node_modules` (`npm i playwright`
-  + `npx playwright install chromium`). On a fresh clone the `.ds-sync/` tree is
-  gitignored and regenerated, so reinstall before validating.
+- Playwright + chromium live under `.ds-sync/node_modules` (see restage above —
+  install with the other converter deps in one `npm i`). On a fresh clone the
+  `.ds-sync/` tree is gitignored and regenerated, so reinstall before validating.
 - 5 components use `cfg.overrides.<Name>.cardMode = "column"` (Button, Divider,
   Field, GalleryTile, Panel) to resolve `[GRID_OVERFLOW]` — their previews are wider
   than a grid cell. Not a warn once the override is applied.
@@ -49,6 +83,9 @@ Repo-specific gotchas for future syncs of the uploads.sh design system.
 
 ## Re-sync risks
 
+- **Harness is not in git** — if `.ds-sync/` is missing, restage before build/
+  validate (see "Converter harness" above). Worktrees only inherit it when main
+  already has a staged copy.
 - Previews (`.design-sync/previews/*.tsx`) import from `'@uploads/ui'` and are fully
   self-contained: no network, no fixtures. `GalleryTile` thumbnails are inline SVG
   data-URIs. Safe to re-render on any machine.

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ coverage/
 .claude/worktrees/
 .worktrees/
 
-# design-sync (staged converter scripts, build output, machine state)
+# design-sync — staged converter scripts, generated bundle, and machine state
+# are regenerated per run. Durable inputs under .design-sync/ (config.json,
+# conventions.md, previews/, NOTES.md) ARE committed. Claude worktrees can
+# copy a staged .ds-sync/ from main via .worktreeinclude (see NOTES.md).
 .ds-sync/
 ds-bundle/
 .design-sync/.cache/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,10 @@
+# Files copied from the main checkout into Claude Code worktrees on creation.
+# Uses .gitignore syntax; only matching paths that are ALSO gitignored are
+# copied, so tracked files are never duplicated.
+# https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees
 .env
 apps/api/.dev.vars
+
+# design-sync converter (scripts + node_modules). Staged on main only — see
+# .design-sync/NOTES.md. No-op when main has no .ds-sync/ yet.
+.ds-sync/


### PR DESCRIPTION
## In plain terms

The design-sync converter scripts live in gitignored `.ds-sync/` (same model as either/releases), so a clean checkout or cleaned tree can leave you without a harness. This documents how to restage it, notes the converter-deps install quirk, and copies a staged `.ds-sync/` into Claude Code worktrees when main already has one.

## What it does / what it is not

- **Does:** treat the harness as in-repo but gitignored (either-style); document restage + one-shot `npm i esbuild ts-morph @types/react playwright` in `.design-sync/NOTES.md`
- **Does:** add `.ds-sync/` to `.worktreeinclude` so Claude worktrees inherit a staged main tree ([docs](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees))
- **Does:** clarify the gitignore contract (committed `.design-sync/` inputs vs staged converter)
- **Does not:** vendor converter scripts into git, share one config across either/releases/uploads, or commit `node_modules`

Closes #132.

## Technical notes

- Project-specific config stays committed under `.design-sync/` (per repo).
- `.worktreeinclude` is a no-op until main has a staged `.ds-sync/`; plain `git worktree add` does not use it.

## Test plan

- [x] Diff reviewed: only NOTES, `.worktreeinclude`, `.gitignore` comments
- [ ] After merge: once main has a staged `.ds-sync/`, open a Claude worktree and confirm the tree is copied
- [ ] Restage steps in NOTES work on a clean tree (manual, when next re-sync runs)