### PR TITLE
feat: subtle pixel-edge workspace usage progress bars

### DIFF
--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -59,13 +59,15 @@ export const prerender = false;
       return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
     }
 
-    function formatUsage(usage: {
+    type UsageSnapshot = {
       bytes: number;
       objects: number;
       uploadsInPeriod: number;
       maxStorageBytes?: number;
       maxUploadsPerPeriod?: number;
-    }): string {
+    };
+
+    function formatUsage(usage: UsageSnapshot): string {
       const used = formatBytes(usage.bytes);
       const size = usage.maxStorageBytes
         ? `${used} of ${formatBytes(usage.maxStorageBytes)}`
@@ -77,6 +79,38 @@ export const prerender = false;
         parts.push(`${usage.uploadsInPeriod} of ${usage.maxUploadsPerPeriod} uploads this month`);
       }
       return parts.join(" · ");
+    }
+
+    /** 0–100, one decimal. Missing/invalid caps → no bar. */
+    function usagePct(value: number, max: number | undefined): number | null {
+      if (typeof max !== "number" || !(max > 0) || !Number.isFinite(value)) return null;
+      return Math.min(100, Math.max(0, Math.round((value / max) * 1000) / 10));
+    }
+
+    /** DS `.ul-progress` markup — keep in sync with `Progress` in @uploads/ui. */
+    function progressRowHtml(label: string, pct: number): string {
+      let levelAttr = "";
+      if (pct >= 100) levelAttr = ' data-level="full"';
+      else if (pct >= 85) levelAttr = ' data-level="high"';
+      return `<div class="ul-progress__row">
+        <div class="ul-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(pct)}" aria-label="${escapeHtml(label)}">
+          <div class="ul-progress__fill"${levelAttr} style="width:${pct}%"></div>
+        </div>
+      </div>`;
+    }
+
+    function renderUsageHtml(usage: UsageSnapshot): string {
+      const text = escapeHtml(formatUsage(usage));
+      const rows = (
+        [
+          ["Storage used", usagePct(usage.bytes, usage.maxStorageBytes)],
+          ["Uploads this month", usagePct(usage.uploadsInPeriod, usage.maxUploadsPerPeriod)],
+        ] as const
+      )
+        .filter((entry): entry is readonly [string, number] => entry[1] !== null)
+        .map(([label, pct]) => progressRowHtml(label, pct));
+      const bars = rows.length ? `<div class="ul-progress">${rows.join("")}</div>` : "";
+      return `<div class="usage-text">${text}</div>${bars}`;
     }
 
     // Operator enrollment CLI — site-wide ADMIN_TOKEN only (not workspace role).
@@ -188,7 +222,11 @@ export const prerender = false;
           if (usageEl) {
             tasks.push(
               getMyWorkspaceUsage(apiOrigin, ws.workspace).then((usage) => {
-                usageEl.textContent = usage ? formatUsage(usage) : "Usage unavailable.";
+                if (!usage) {
+                  usageEl.textContent = "Usage unavailable.";
+                  return;
+                }
+                usageEl.innerHTML = renderUsageHtml(usage);
               }),
             );
           }

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -67,16 +67,13 @@ export const prerender = false;
       maxUploadsPerPeriod?: number;
     };
 
-    function formatUsage(usage: UsageSnapshot): string {
-      const used = formatBytes(usage.bytes);
-      const size = usage.maxStorageBytes
-        ? `${used} of ${formatBytes(usage.maxStorageBytes)}`
-        : used;
+    /** Plain one-liner when no cumulative caps are set (no bars to attach labels to). */
+    function formatUsagePlain(usage: UsageSnapshot): string {
+      const size = formatBytes(usage.bytes);
       const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
       const parts = [size, objects];
-      // Only present when the workspace has a monthly upload cap.
-      if (usage.maxUploadsPerPeriod) {
-        parts.push(`${usage.uploadsInPeriod} of ${usage.maxUploadsPerPeriod} uploads this month`);
+      if (usage.uploadsInPeriod > 0) {
+        parts.push(`${usage.uploadsInPeriod} uploads this month`);
       }
       return parts.join(" · ");
     }
@@ -87,12 +84,19 @@ export const prerender = false;
       return Math.min(100, Math.max(0, Math.round((value / max) * 1000) / 10));
     }
 
-    /** DS `.ul-progress` markup — keep in sync with `Progress` in @uploads/ui. */
-    function progressRowHtml(label: string, pct: number): string {
+    /**
+     * One labeled meter: label + detail above the bar.
+     * Keep markup in sync with `Progress` in @uploads/ui.
+     */
+    function progressRowHtml(label: string, detail: string, pct: number): string {
       let levelAttr = "";
       if (pct >= 100) levelAttr = ' data-level="full"';
       else if (pct >= 85) levelAttr = ' data-level="high"';
       return `<div class="ul-progress__row">
+        <div class="ul-progress__head">
+          <span class="ul-progress__label">${escapeHtml(label)}</span>
+          <span class="ul-progress__value">${escapeHtml(detail)}</span>
+        </div>
         <div class="ul-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(pct)}" aria-label="${escapeHtml(label)}">
           <div class="ul-progress__fill"${levelAttr} style="width:${pct}%"></div>
         </div>
@@ -100,17 +104,27 @@ export const prerender = false;
     }
 
     function renderUsageHtml(usage: UsageSnapshot): string {
-      const text = escapeHtml(formatUsage(usage));
-      const rows = (
-        [
-          ["Storage used", usagePct(usage.bytes, usage.maxStorageBytes)],
-          ["Uploads this month", usagePct(usage.uploadsInPeriod, usage.maxUploadsPerPeriod)],
-        ] as const
-      )
-        .filter((entry): entry is readonly [string, number] => entry[1] !== null)
-        .map(([label, pct]) => progressRowHtml(label, pct));
-      const bars = rows.length ? `<div class="ul-progress">${rows.join("")}</div>` : "";
-      return `<div class="usage-text">${text}</div>${bars}`;
+      const meters: { label: string; detail: string; pct: number }[] = [];
+      const storagePct = usagePct(usage.bytes, usage.maxStorageBytes);
+      if (storagePct !== null && usage.maxStorageBytes) {
+        const detail = `${formatBytes(usage.bytes)} of ${formatBytes(usage.maxStorageBytes)}`;
+        meters.push({ label: "Storage", detail, pct: storagePct });
+      }
+      const uploadsPct = usagePct(usage.uploadsInPeriod, usage.maxUploadsPerPeriod);
+      if (uploadsPct !== null && usage.maxUploadsPerPeriod) {
+        meters.push({
+          label: "Uploads this month",
+          detail: `${usage.uploadsInPeriod} of ${usage.maxUploadsPerPeriod}`,
+          pct: uploadsPct,
+        });
+      }
+      if (!meters.length) {
+        return `<div class="usage-text">${escapeHtml(formatUsagePlain(usage))}</div>`;
+      }
+      // Object count is informational (no quota) — keep it as a quiet footer.
+      const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
+      const rows = meters.map((m) => progressRowHtml(m.label, m.detail, m.pct)).join("");
+      return `<div class="ul-progress">${rows}</div><div class="usage-meta">${escapeHtml(objects)}</div>`;
     }
 
     // Operator enrollment CLI — site-wide ADMIN_TOKEN only (not workspace role).

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -60,6 +60,16 @@ ul.plain .slug {
 ul.plain .usage {
   color: var(--muted);
   font-size: 12px;
+  display: grid;
+  gap: 5px;
+  /* Floor so bars can appear under the label without layout jump. */
+  min-height: 1.2em;
+}
+ul.plain .usage .usage-text {
+  line-height: 1.35;
+}
+ul.plain .usage .ul-progress {
+  margin-top: 1px;
 }
 ul.plain .ws-detail {
   display: grid;

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -61,15 +61,16 @@ ul.plain .usage {
   color: var(--muted);
   font-size: 12px;
   display: grid;
-  gap: 5px;
-  /* Floor so bars can appear under the label without layout jump. */
+  gap: 6px;
   min-height: 1.2em;
 }
-ul.plain .usage .usage-text {
+ul.plain .usage .usage-text,
+ul.plain .usage .usage-meta {
   line-height: 1.35;
 }
-ul.plain .usage .ul-progress {
-  margin-top: 1px;
+ul.plain .usage .usage-meta {
+  font-size: 11px;
+  opacity: 0.9;
 }
 ul.plain .ws-detail {
   display: grid;

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -39,7 +39,7 @@ never write the internal `ul-` classes yourself.
 ## Components
 
 `Surface` · `Brand` · `Button` · `Panel` · `Field` / `Input` / `Label` ·
-`Callout` · `Badge` · `Divider` · `GalleryTile` · `FileBrowser`
+`Callout` · `Badge` · `Divider` · `Progress` · `GalleryTile` · `FileBrowser`
 
 ## Build
 

--- a/packages/ui/src/Progress.tsx
+++ b/packages/ui/src/Progress.tsx
@@ -1,12 +1,14 @@
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 export interface ProgressProps extends Omit<ComponentPropsWithoutRef<"div">, "children"> {
   /** Current value toward the quota. */
   value: number;
   /** Cap. Defaults to 100 (percentage mode). */
   max?: number;
-  /** Accessible name, e.g. "Storage" or "Uploads this month". */
+  /** Left label above the bar, e.g. "Storage". */
   label: string;
+  /** Right-side usage text above the bar, e.g. "3.2 GB of 25 GB". */
+  detail?: ReactNode;
 }
 
 function clampRatio(value: number, max: number): number {
@@ -22,23 +24,26 @@ function levelFor(ratio: number): "high" | "full" | undefined {
 }
 
 /**
- * Narrow horizontal progress bar with stepped pixel corners and a soft
- * dithered leading edge. Stack inside `.ul-progress` for multiple meters
- * (storage, monthly uploads) without shifting surrounding layout.
+ * Labeled quota meter: label + usage on one line, narrow pixel-edge bar below.
+ * Stack inside `.ul-progress` for multiple meters without layout thrash.
  *
  * @example
  * <div className="ul-progress">
- *   <Progress label="Storage" value={bytes} max={maxBytes} />
- *   <Progress label="Uploads this month" value={n} max={cap} />
+ *   <Progress label="Storage" detail="3.2 GB of 25 GB" value={bytes} max={maxBytes} />
+ *   <Progress label="Uploads this month" detail="420 of 10000" value={n} max={cap} />
  * </div>
  */
-export function Progress({ value, max = 100, label, className, ...rest }: ProgressProps) {
+export function Progress({ value, max = 100, label, detail, className, ...rest }: ProgressProps) {
   const ratio = clampRatio(value, max);
   const pct = Math.round(ratio * 1000) / 10;
   const level = levelFor(ratio);
 
   return (
     <div className={["ul-progress__row", className].filter(Boolean).join(" ")} {...rest}>
+      <div className="ul-progress__head">
+        <span className="ul-progress__label">{label}</span>
+        {detail != null && detail !== "" && <span className="ul-progress__value">{detail}</span>}
+      </div>
       <div
         className="ul-progress__track"
         role="progressbar"

--- a/packages/ui/src/Progress.tsx
+++ b/packages/ui/src/Progress.tsx
@@ -1,0 +1,54 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+export interface ProgressProps extends Omit<ComponentPropsWithoutRef<"div">, "children"> {
+  /** Current value toward the quota. */
+  value: number;
+  /** Cap. Defaults to 100 (percentage mode). */
+  max?: number;
+  /** Accessible name, e.g. "Storage" or "Uploads this month". */
+  label: string;
+}
+
+function clampRatio(value: number, max: number): number {
+  if (!(max > 0) || !Number.isFinite(value) || !Number.isFinite(max)) return 0;
+  return Math.min(1, Math.max(0, value / max));
+}
+
+/** Visual band for the fill: quiet until high, accent only at full. */
+function levelFor(ratio: number): "high" | "full" | undefined {
+  if (ratio >= 1) return "full";
+  if (ratio >= 0.85) return "high";
+  return undefined;
+}
+
+/**
+ * Narrow horizontal progress bar with stepped pixel corners and a soft
+ * dithered leading edge. Stack inside `.ul-progress` for multiple meters
+ * (storage, monthly uploads) without shifting surrounding layout.
+ *
+ * @example
+ * <div className="ul-progress">
+ *   <Progress label="Storage" value={bytes} max={maxBytes} />
+ *   <Progress label="Uploads this month" value={n} max={cap} />
+ * </div>
+ */
+export function Progress({ value, max = 100, label, className, ...rest }: ProgressProps) {
+  const ratio = clampRatio(value, max);
+  const pct = Math.round(ratio * 1000) / 10;
+  const level = levelFor(ratio);
+
+  return (
+    <div className={["ul-progress__row", className].filter(Boolean).join(" ")} {...rest}>
+      <div
+        className="ul-progress__track"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(pct)}
+        aria-label={label}
+      >
+        <div className="ul-progress__fill" data-level={level} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,6 +29,9 @@ export type { BadgeProps } from "./Badge";
 export { Divider } from "./Divider";
 export type { DividerProps } from "./Divider";
 
+export { Progress } from "./Progress";
+export type { ProgressProps } from "./Progress";
+
 export { GalleryTile } from "./GalleryTile";
 export type { GalleryTileProps } from "./GalleryTile";
 

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -391,17 +391,36 @@
 
 /* ── Progress ──────────────────────────────────────────────────────────── */
 /*
- * Narrow quota bar: 1px stepped corners (no border-radius), soft 2px checker
- * on the fill tip. Stack `.ul-progress__row` inside `.ul-progress`.
+ * Labeled quota meters: each row is label + usage above a narrow bar.
+ * 1px stepped corners (no border-radius), soft 2px checker on the fill tip.
+ * Stack `.ul-progress__row` inside `.ul-progress`.
  */
 .ul-progress {
   display: grid;
-  gap: 3px;
+  gap: 10px;
   width: 100%;
-  max-width: 14rem;
 }
 .ul-progress__row {
+  display: grid;
+  gap: 4px;
   min-width: 0;
+}
+.ul-progress__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  font: 12px/1.35 var(--mono);
+  color: var(--muted);
+}
+.ul-progress__label {
+  min-width: 0;
+  color: var(--body);
+}
+.ul-progress__value {
+  flex: none;
+  text-align: right;
+  white-space: nowrap;
 }
 .ul-progress__track {
   height: 3px;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -389,6 +389,70 @@
   flex: none;
 }
 
+/* ── Progress ──────────────────────────────────────────────────────────── */
+/*
+ * Narrow quota bar: 1px stepped corners (no border-radius), soft 2px checker
+ * on the fill tip. Stack `.ul-progress__row` inside `.ul-progress`.
+ */
+.ul-progress {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  max-width: 14rem;
+}
+.ul-progress__row {
+  min-width: 0;
+}
+.ul-progress__track {
+  height: 3px;
+  width: 100%;
+  background: var(--line);
+  overflow: hidden;
+  /* 1px stepped corners on a 3px bar */
+  clip-path: polygon(
+    1px 0,
+    calc(100% - 1px) 0,
+    100% 1px,
+    100% calc(100% - 1px),
+    calc(100% - 1px) 100%,
+    1px 100%,
+    0 calc(100% - 1px),
+    0 1px
+  );
+}
+.ul-progress__fill {
+  --ul-progress-fill: var(--muted);
+  position: relative;
+  height: 100%;
+  width: 0%;
+  max-width: 100%;
+  background: var(--ul-progress-fill);
+}
+/* Solid body + 1-bit dither on the last two pixels */
+.ul-progress__fill::after {
+  content: "";
+  position: absolute;
+  inset: 0 0 0 auto;
+  width: 2px;
+  background-color: var(--line);
+  background-image: linear-gradient(
+    45deg,
+    var(--ul-progress-fill) 25%,
+    transparent 25% 50%,
+    var(--ul-progress-fill) 50% 75%,
+    transparent 75%
+  );
+  background-size: 2px 2px;
+  image-rendering: pixelated;
+  pointer-events: none;
+}
+.ul-progress__fill[data-level="high"] {
+  --ul-progress-fill: var(--body);
+}
+.ul-progress__fill[data-level="full"] {
+  --ul-progress-fill: var(--accent);
+}
+
 /* ── GalleryTile ───────────────────────────────────────────────────────── */
 /*
  * The product's core object: a hosted image / PR screenshot with its metadata.


### PR DESCRIPTION
## In plain terms

Workspace usage on the account page was text-only. This adds thin, labeled progress meters so people can see at a glance how close they are to storage and monthly upload caps — each bar sits under its own label and value.

<img width="560" alt="Labeled usage meters: Storage and Uploads this month each with value above bar" src="https://storage.uploads.sh/default/gh/buildinternet/uploads/pull/151/usage-progress-bars.webp">

## What it does

- Adds a `Progress` component + `.ul-progress` styles to `@uploads/ui`: label + detail above a 3px bar with 1px stepped corners and a 2px checker tip (pixel edge, pure CSS — [dither-kit](https://www.tripwire.sh/dither-kit) as aesthetic inspiration, not a dependency).
- On `/account/workspaces`, each capped dimension is its own row:
  - **Storage** · `3.2 GB of 25 GB` · bar
  - **Uploads this month** · `420 of 10000` · bar
- Object count stays a quiet footer (no object quota today).
- Unlimited dimensions stay a plain text line (no empty bars).
- Near-quota (≥85%) brightens slightly; full quota uses the accent color.

## What it is not

- No new API or limit knobs.
- No reset timers or forced percentages (those can come later).
- No per-file size / retention / key-policy meters.

## How to try it

1. Sign in and open `/account/workspaces`.
2. For a workspace with shared/agent defaults (25 GB / 10k uploads), each cap shows as a labeled meter.

## Technical notes

- Account page markup is string HTML matching the DS classes (same pattern as other non-React account surfaces).
- Rebuild `@uploads/ui` so `dist/uploads-ui.css` picks up styles (`pnpm --filter @uploads/ui build`).

## Test plan

- [x] `pnpm --filter @uploads/ui build` + typecheck
- [x] lint-staged on commit
- [x] Visual preview of labeled stacked meters at low / high / full
- [ ] Manual check on local account workspaces with a capped workspace