### PR TITLE
feat: dual-host embedUrl for GitHub Camo (+ CF RUM CSP)

### DIFF
--- a/.changeset/embed-url-dual-host.md
+++ b/.changeset/embed-url-dual-host.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Return `embedUrl` alongside durable `url` for shared dual-host CDN (GitHub Camo–friendly). CLI/MCP markdown and managed attachment comments prefer the embed host; override with `UPLOADS_EMBED_PUBLIC_BASE_URL`.

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,13 @@ R2_SECRET_ACCESS_KEY=
 # Public custom domain of that bucket, if any (becomes the workspace's publicBaseUrl)
 R2_PUBLIC_BASE_URL=
 
+# Optional: dual-host embed CDN for GitHub Camo (same object path as publicBaseUrl).
+# Client/CLI: UPLOADS_EMBED_PUBLIC_BASE_URL — unset uses https://embed.uploads.sh when
+# the stable host is storage.uploads.sh / store.uploads.sh; empty string disables.
+# Worker (apps/api): EMBED_PUBLIC_BASE_URL with the same semantics (see docs/ops.md).
+# UPLOADS_EMBED_PUBLIC_BASE_URL=
+# EMBED_PUBLIC_BASE_URL=
+
 # ---------------------------------------------------------------------------
 # Deploying the stack to your own Cloudflare account.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ the record carries `prefix: "<name>/"` and creating one is a pure KV write.
 The prefix is applied in exactly one place — `createStorage()` in
 `packages/storage` (files-sdk instance prefix) — so route code and clients
 never see it; public URLs are `https://storage.uploads.sh/<name>/<key>`.
+The same keys are also served on `https://embed.uploads.sh/<name>/<key>` with
+freshness-oriented Cache-Control (zone Transform Rule) for GitHub Camo; API/CLI
+return `embedUrl` alongside `url` — prefer embed for PR/issue markdown. See
+[docs/ops.md](docs/ops.md#dual-public-hosts-stable-vs-embed--github-camo).
 Bring-your-own-bucket is the advanced case: register with `--bucket` and the
 record points at a dedicated bucket (own binding or S3 credentials, own
 `publicBaseUrl`, no prefix) — `buildinternet` on `buildinternet-dev` is the

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -9,4 +9,9 @@ interface Env {
    * Remove after reencrypt-workspace-secrets.mjs completes.
    */
   WORKSPACE_SECRETS_KEY_PREVIOUS?: string;
+  /**
+   * Optional embed CDN base (GitHub Camo dual-host). Unset = default twin for
+   * storage/store.uploads.sh; empty = never emit embedUrl; URL = self-host.
+   */
+  EMBED_PUBLIC_BASE_URL?: string;
 }

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -21,7 +21,7 @@ import {
   sanitizeProvenance,
   type ProvenanceMap,
 } from "./provenance";
-import { publicUrl, storage, storageConfig } from "./storage";
+import { objectPublicUrls, storage, storageConfig } from "./storage";
 import { getWorkspaceUsage, recordUsageSafe } from "./usage";
 import { objectVisibility, VISIBILITY_META_KEY, type Visibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
@@ -117,6 +117,8 @@ export async function putObject(
 ): Promise<{
   key: string;
   url: string | null;
+  /** Same object on the embed host when dual-host cache policy applies; else null. */
+  embedUrl: string | null;
   size: number;
   contentType: string;
   metadata?: ProvenanceMap;
@@ -175,9 +177,12 @@ export async function putObject(
     uploads: 1,
   });
 
+  const cfg = await storageConfig(env, ws);
+  const urls = objectPublicUrls(env, cfg, finalKey);
   return {
     key: finalKey,
-    url: publicUrl(await storageConfig(env, ws), finalKey),
+    url: urls.url,
+    embedUrl: urls.embedUrl,
     size: newSize,
     contentType: inspection.contentType,
     metadata: provenance,
@@ -261,6 +266,7 @@ export function headObjectJson(
     metadata?: Record<string, string>;
   },
   url: string | null,
+  embedUrl: string | null = null,
 ) {
   const provenance = provenanceForResponse(meta.metadata ?? undefined);
   const visibility = objectVisibility(meta.metadata ?? undefined);
@@ -268,6 +274,7 @@ export function headObjectJson(
     key,
     ...storedMetaJson(meta),
     url,
+    embedUrl,
     ...(provenance ? { metadata: provenance } : {}),
     ...(visibility ? { visibility } : {}),
   };
@@ -277,6 +284,7 @@ export function headObjectJson(
 export interface ListedObject {
   key: string;
   url: string | null;
+  embedUrl: string | null;
   size: number;
   contentType: string;
   /** ISO timestamp when the provider reports a last-modified time. */
@@ -300,9 +308,11 @@ export async function listObjects(
   return {
     items: result.items.map((item) => {
       const visibility = objectVisibility(item.metadata ?? undefined);
+      const urls = objectPublicUrls(env, cfg, item.key);
       return {
         key: item.key,
-        url: publicUrl(cfg, item.key),
+        url: urls.url,
+        embedUrl: urls.embedUrl,
         ...storedMetaJson(item),
         ...(visibility ? { visibility } : {}),
       };

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -13,7 +13,7 @@ import {
   type PublicGallery,
   projectPublicGallery,
 } from "./galleries";
-import { publicUrl, storage, storageConfig } from "./storage";
+import { objectPublicUrls, storage, storageConfig } from "./storage";
 import type { WorkspaceRecord } from "./workspace";
 
 export interface GalleryItemDto {
@@ -25,6 +25,8 @@ export interface GalleryItemDto {
   createdAt: string;
   status: "available" | "missing";
   url: string | null;
+  /** Same object on the embed host when dual-host policy applies; for GitHub markdown. */
+  embedUrl: string | null;
   pageUrl: string;
   contentType: string | null;
   size: number | null;
@@ -37,6 +39,7 @@ export interface PublicGalleryItemDto {
   altText: string | null;
   status: "available" | "missing";
   url: string | null;
+  embedUrl: string | null;
   contentType: string | null;
 }
 export interface GalleryDto {
@@ -238,8 +241,10 @@ export async function hydrateGalleryItems(
         cause,
       });
     }
-    const url = meta ? publicUrl(config, item.object_key) : null;
-    if (meta && url === null)
+    const urls = meta
+      ? objectPublicUrls(env, config, item.object_key)
+      : { url: null, embedUrl: null };
+    if (meta && urls.url === null)
       throw new ServiceUnavailableError("Gallery object is not publicly served.", {
         code: "gallery_object_not_public",
       });
@@ -251,7 +256,8 @@ export async function hydrateGalleryItems(
       altText: item.alt_text,
       createdAt: item.created_at,
       status: meta ? "available" : "missing",
-      url,
+      url: urls.url,
+      embedUrl: urls.embedUrl,
       contentType: meta?.type ?? null,
       size: meta?.size ?? null,
     };
@@ -327,6 +333,7 @@ export async function hydratePublicGallery(
       altText: item.altText,
       status: item.status,
       url: item.url,
+      embedUrl: item.embedUrl,
       contentType: item.contentType,
     })),
     references: references.map(publicReferenceDto),

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -9,7 +9,7 @@ import {
   putObject,
 } from "../files-core";
 import { provenanceFromHeaders } from "../provenance";
-import { publicUrl, storage, storageConfig } from "../storage";
+import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../guards";
 import { sanitizeVisibility } from "../visibility";
@@ -60,12 +60,14 @@ export const files = new Hono<WorkspaceVars>()
         maxSize,
       });
       const cfg = await storageConfig(c.env, ws);
+      const urls = objectPublicUrls(c.env, cfg, key);
       return c.json({
         workspace: c.get("workspaceName"),
         key,
         maxSize,
         expiresIn,
-        publicUrl: publicUrl(cfg, key),
+        publicUrl: urls.url,
+        embedUrl: urls.embedUrl,
         upload,
       });
     } catch (err) {
@@ -91,10 +93,12 @@ export const files = new Hono<WorkspaceVars>()
     if (dryRun === "1" || dryRun === "true") {
       const ws = c.get("workspace");
       const finalKey = finalizeUploadKey(key, ws);
+      const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
       return c.json({
         workspace: c.get("workspaceName"),
         key: finalKey,
-        url: publicUrl(await storageConfig(c.env, ws), finalKey),
+        url: urls.url,
+        embedUrl: urls.embedUrl,
         dryRun: true,
       });
     }
@@ -129,7 +133,8 @@ export const files = new Hono<WorkspaceVars>()
     const store = await storage(c.env, ws);
     if (!(await store.exists(key))) throw new NotFoundError();
     const meta = await store.head(key);
-    return c.json(headObjectJson(key, meta, publicUrl(await storageConfig(c.env, ws), key)));
+    const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), key);
+    return c.json(headObjectJson(key, meta, urls.url, urls.embedUrl));
   })
 
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -1,6 +1,27 @@
-import { createStorage, publicUrl, type StorageConfig } from "@uploads/storage";
+import {
+  createStorage,
+  publicAndEmbedUrls,
+  publicUrl,
+  type EmbedUrlOptions,
+  type StorageConfig,
+} from "@uploads/storage";
 import { openCredentialFields, secretsKeyRingFromEnv } from "./secrets";
 import type { WorkspaceRecord } from "./workspace";
+
+/** Worker env override for the embed CDN base (self-host / disable). */
+function embedUrlOptionsFromEnv(env: Env): EmbedUrlOptions {
+  // undefined → default twin; "" → disable; else custom base
+  if (env.EMBED_PUBLIC_BASE_URL === undefined) return {};
+  return { embedBaseUrl: env.EMBED_PUBLIC_BASE_URL };
+}
+
+export function objectPublicUrls(
+  env: Env,
+  cfg: StorageConfig,
+  key: string,
+): { url: string | null; embedUrl: string | null } {
+  return publicAndEmbedUrls(cfg, key, embedUrlOptionsFromEnv(env));
+}
 
 export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<StorageConfig> {
   let binding: R2Bucket | undefined;

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -83,10 +83,16 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     const { env, bucket } = await makeEnv();
     const res = await putShot(env);
     expect(res.status).toBe(201);
-    const json = (await res.json()) as { contentType: string; url: string; key: string };
+    const json = (await res.json()) as {
+      contentType: string;
+      url: string;
+      embedUrl: string | null;
+      key: string;
+    };
     expect(json.contentType).toBe("image/png");
     expect(json.key).toBe("screenshots/shot.png");
     expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+    expect(json.embedUrl).toBe("https://embed.uploads.sh/default/screenshots/shot.png");
     expect(bucket.store.has("default/screenshots/shot.png")).toBe(true);
   });
 
@@ -135,11 +141,17 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
       env,
     );
     expect(res.status).toBe(200);
-    const json = (await res.json()) as { key: string; url: string; dryRun: boolean };
+    const json = (await res.json()) as {
+      key: string;
+      url: string;
+      embedUrl: string | null;
+      dryRun: boolean;
+    };
     expect(json).toEqual({
       workspace: "default",
       key: "screenshots/shot.png",
       url: "https://storage.uploads.sh/default/screenshots/shot.png",
+      embedUrl: "https://embed.uploads.sh/default/screenshots/shot.png",
       dryRun: true,
     });
     expect(bucket.store.has("default/screenshots/shot.png")).toBe(false);

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -453,6 +453,7 @@ describe("gallery routes with SQLite D1", () => {
       "altText",
       "status",
       "url",
+      "embedUrl",
       "contentType",
     ]);
     expect(publicItem).toMatchObject({

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -16,7 +16,7 @@
   Referrer-Policy: no-referrer
   X-Robots-Tag: noindex, nofollow, noarchive
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh https://cloudflareinsights.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'none'; connect-src 'self' https://api.uploads.sh https://cloudflareinsights.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
   Permissions-Policy: camera=(), microphone=(), geolocation=()
 
 # Operator browser console — not a public product surface

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -5,10 +5,13 @@
  * - Astro often extracts page `<style>` into `/_astro/*.css`. `style-src
  *   'unsafe-inline'` alone blocks those stylesheets; always allow `'self'`.
  * - Cloudflare Web Analytics injects a RUM beacon. With `default-src 'none'`
- *   you must allow its script host and connect endpoint explicitly.
+ *   you must allow its script host and connect endpoints explicitly:
+ *   - third-party: `https://cloudflareinsights.com`
+ *   - first-party on proxied zones: same-origin `/cdn-cgi/rum` (needs `'self'`)
  */
 export const CF_RUM_SCRIPT_SRC = "https://static.cloudflareinsights.com";
-export const CF_RUM_CONNECT_SRC = "https://cloudflareinsights.com";
+/** connect-src fragment for CF Web Analytics (RUM beacon + first-party /cdn-cgi/rum). */
+export const CF_RUM_CONNECT_SRC = "'self' https://cloudflareinsights.com";
 
 /** style-src value that survives Astro CSS extraction. */
 export const STYLE_SRC_SELF_AND_INLINE = "'self' 'unsafe-inline'";

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -37,6 +37,8 @@ describe("public file headers", () => {
     expect(csp).toContain("default-src 'none'");
     expect(csp).toContain("script-src 'self' 'unsafe-inline'");
     expect(csp).toContain("connect-src https://api.uploads.sh");
+    expect(csp).toContain("'self'");
+    expect(csp).toContain("https://cloudflareinsights.com");
     expect(csp).toContain("frame-ancestors 'none'");
 
     const headers = new Headers();

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -44,7 +44,7 @@ describe("public gallery headers", () => {
     expect(PUBLIC_GALLERY_CSP).toContain("style-src 'self' 'unsafe-inline'");
     // Cloudflare injects the RUM beacon; default-src 'none' blocks it without these.
     expect(PUBLIC_GALLERY_CSP).toContain("script-src https://static.cloudflareinsights.com");
-    expect(PUBLIC_GALLERY_CSP).toContain("connect-src https://cloudflareinsights.com");
+    expect(PUBLIC_GALLERY_CSP).toContain("connect-src 'self' https://cloudflareinsights.com");
     expect(PUBLIC_GALLERY_CSP).toContain("default-src 'none'");
     expect(PUBLIC_GALLERY_CSP).toContain("frame-ancestors 'none'");
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,8 +53,14 @@ Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
 | `GET/POST /v1/:workspace/galleries/:id/external-references`          | List or link coordinates; writes require `files:write`                                           |
 | `DELETE /v1/:workspace/galleries/:id/external-references/:reference` | Unlink a coordinate; requires `files:write`                                                      |
 
-`url` in responses is the public URL when the workspace has a
-`publicBaseUrl`, otherwise `null`.
+`url` in responses is the durable public CDN URL when the workspace has a
+`publicBaseUrl`, otherwise `null`. File put/list/head, presign, and gallery
+item payloads also include `embedUrl`: the same object on the embed host when
+dual-host policy applies (default for `storage.uploads.sh` /
+`store.uploads.sh`), else `null`. Prefer `embedUrl` in GitHub markdown so
+in-place overwrites revalidate through Camo; keep `url` for durable links.
+Worker override: optional `EMBED_PUBLIC_BASE_URL` (empty disables; any URL is
+a self-hosted embed base). See [ops.md](./ops.md#dual-public-hosts-stable-vs-embed--github-camo).
 
 ### Galleries
 
@@ -62,9 +68,9 @@ Gallery IDs are opaque `gal_…` identifiers and do not encode a workspace or
 GitHub coordinate. Owner responses use camelCase and include the workspace;
 the unauthenticated public response uses an explicit allowlist and never emits
 workspace ownership or object keys. Public items contain only `id`, `filename`,
-`position`, `caption`, `altText`, `status`, `url`, and `contentType`. Missing
-stored objects remain ordered tombstones with `status: "missing"` and
-`url: null`.
+`position`, `caption`, `altText`, `status`, `url`, `embedUrl`, and `contentType`.
+Missing stored objects remain ordered tombstones with `status: "missing"` and
+`url: null` / `embedUrl: null`.
 
 The owner collection route returns metadata summaries without `items`; it does
 not probe object storage. Fetch an individual gallery to hydrate current item

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -29,6 +29,43 @@ you run `workspace:limits`.
 
 KV cache ~60s. Agents: `uploads usage`.
 
+## Dual public hosts (stable vs embed / GitHub Camo)
+
+Shared-bucket objects are available on two custom domains of `uploads-default`
+(same keys, same bytes):
+
+| Host                                           | Role                                                  | Cache-Control (origin)                                                |
+| ---------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| `storage.uploads.sh` (also `store.uploads.sh`) | Durable public URL                                    | Object metadata: `public, max-age=60`                                 |
+| `embed.uploads.sh`                             | GitHub / Camo embeds that may be overwritten in place | Zone Transform Rule: `max-age=0, no-cache, no-store, must-revalidate` |
+
+**Why:** GitHub proxies external images through Camo. Short `max-age` alone is
+not enough for reliable hot-swap; badge-style no-cache headers on a dedicated
+host are. See [#152](https://github.com/buildinternet/uploads/issues/152).
+
+**Setup (once per account):**
+
+1. R2 → `uploads-default` → Custom Domains → connect `embed.uploads.sh` (same
+   zone as `uploads.sh`).
+2. Rules → Transform Rules → Modify Response Header:
+   - When: `http.host eq "embed.uploads.sh"`
+   - Set: `Cache-Control` =
+     `max-age=0, no-cache, no-store, must-revalidate`
+
+**API / CLI:** put, list, head, and gallery items return `url` (stable) and
+`embedUrl` (embed twin when the workspace `publicBaseUrl` host is
+`storage.uploads.sh` / `store.uploads.sh`). CLI/MCP markdown and the managed
+attachments comment prefer `embedUrl` for `<img src>`.
+
+**Overrides (self-host):**
+
+| Side         | Variable                        | Behavior                                                                                                   |
+| ------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Worker       | `EMBED_PUBLIC_BASE_URL`         | Unset → default embed host for known storage hosts; empty → never emit `embedUrl`; URL → use as embed base |
+| CLI / client | `UPLOADS_EMBED_PUBLIC_BASE_URL` | Same semantics client-side (also used if an older API omits `embedUrl`)                                    |
+
+No Worker proxies image bytes — dual host is DNS + zone rules only.
+
 ## Ledger + retention
 
 ```bash

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -61,6 +61,92 @@ export function publicUrl(config: StorageConfig, key: string): string | null {
   return `${base}/${fullKey.split("/").map(encodeURIComponent).join("/")}`;
 }
 
+/**
+ * Embed twin for the shared bucket (`embed.uploads.sh`): same keys as the
+ * durable storage host, badge-style Cache-Control via zone Transform Rule so
+ * GitHub Camo revalidates after in-place overwrites.
+ */
+export const DEFAULT_EMBED_PUBLIC_BASE_URL = "https://embed.uploads.sh";
+
+/** Hosts that get an automatic embed twin when no override is set. */
+const DEFAULT_EMBEDDABLE_HOSTS = new Set(["storage.uploads.sh", "store.uploads.sh"]);
+
+export type EmbedUrlOptions = {
+  /**
+   * Embed CDN base.
+   * - omit → default twin when `publicBaseUrl` host is embeddable
+   * - empty string → disable
+   * - URL → self-hosted override
+   */
+  embedBaseUrl?: string | null;
+};
+
+/** Resolve embed CDN base for a workspace public base (or disable / override). */
+export function resolveEmbedBaseUrl(
+  publicBaseUrl?: string | null,
+  embedBaseUrl?: string | null,
+): string | null {
+  if (embedBaseUrl != null) {
+    const trimmed = embedBaseUrl.trim();
+    return trimmed ? trimmed.replace(/\/$/, "") : null;
+  }
+  if (!publicBaseUrl) return null;
+  try {
+    const host = new URL(publicBaseUrl).hostname.toLowerCase();
+    if (DEFAULT_EMBEDDABLE_HOSTS.has(host)) return DEFAULT_EMBED_PUBLIC_BASE_URL;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Map a stable public object URL to the embed twin.
+ * When `publicBaseUrl` is omitted, infers it from known embeddable hosts on the URL.
+ */
+export function embedUrlFromPublic(
+  publicObjectUrl: string | null | undefined,
+  opts: EmbedUrlOptions & { publicBaseUrl?: string | null } = {},
+): string | null {
+  if (!publicObjectUrl) return null;
+
+  let publicBaseUrl = opts.publicBaseUrl ?? null;
+  if (!publicBaseUrl) {
+    try {
+      const u = new URL(publicObjectUrl);
+      if (DEFAULT_EMBEDDABLE_HOSTS.has(u.hostname.toLowerCase())) {
+        publicBaseUrl = `${u.protocol}//${u.host}`;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  const embedBase = resolveEmbedBaseUrl(publicBaseUrl, opts.embedBaseUrl);
+  if (!embedBase || !publicBaseUrl) return null;
+  const stableBase = publicBaseUrl.replace(/\/$/, "");
+  if (publicObjectUrl === stableBase || publicObjectUrl.startsWith(`${stableBase}/`)) {
+    return `${embedBase}${publicObjectUrl.slice(stableBase.length)}`;
+  }
+  return null;
+}
+
+/** Stable + embed public URLs for a key (either may be null). */
+export function publicAndEmbedUrls(
+  config: StorageConfig,
+  key: string,
+  opts?: EmbedUrlOptions,
+): { url: string | null; embedUrl: string | null } {
+  const url = publicUrl(config, key);
+  return {
+    url,
+    embedUrl: embedUrlFromPublic(url, {
+      publicBaseUrl: config.publicBaseUrl,
+      embedBaseUrl: opts?.embedBaseUrl,
+    }),
+  };
+}
+
 /** Options for {@link signedDownloadUrl}. */
 export interface SignedDownloadUrlOptions {
   /** How long the URL stays valid, in seconds. Defaults to 3600 (files-sdk's own default). */

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { R2Bucket } from "@cloudflare/workers-types";
-import { createStorage, publicUrl, signedDownloadUrl, type StorageConfig } from "../src/index.js";
+import {
+  createStorage,
+  embedUrlFromPublic,
+  publicAndEmbedUrls,
+  publicUrl,
+  resolveEmbedBaseUrl,
+  signedDownloadUrl,
+  type StorageConfig,
+} from "../src/index.js";
 import { FakeR2Bucket } from "./fake-r2.js";
 
 const base: StorageConfig = {
@@ -56,6 +64,76 @@ describe("publicUrl", () => {
 
   it("returns null without a publicBaseUrl", () => {
     expect(publicUrl({ ...base, prefix: "myws/" }, "a.png")).toBeNull();
+  });
+});
+
+describe("embedUrlFromPublic", () => {
+  it("rewrites storage.uploads.sh to embed.uploads.sh by default", () => {
+    expect(
+      embedUrlFromPublic("https://storage.uploads.sh/default/gh/o/r/pull/1/a.webp", {
+        publicBaseUrl: "https://storage.uploads.sh",
+      }),
+    ).toBe("https://embed.uploads.sh/default/gh/o/r/pull/1/a.webp");
+  });
+
+  it("infers publicBaseUrl from a known embeddable host when omitted", () => {
+    expect(embedUrlFromPublic("https://storage.uploads.sh/default/a.webp")).toBe(
+      "https://embed.uploads.sh/default/a.webp",
+    );
+  });
+
+  it("rewrites store.uploads.sh twin as well", () => {
+    expect(
+      embedUrlFromPublic("https://store.uploads.sh/default/a.png", {
+        publicBaseUrl: "https://store.uploads.sh",
+      }),
+    ).toBe("https://embed.uploads.sh/default/a.png");
+  });
+
+  it("returns null for BYO public bases without an embed override", () => {
+    expect(
+      embedUrlFromPublic("https://cdn.example.com/ws/a.png", {
+        publicBaseUrl: "https://cdn.example.com",
+      }),
+    ).toBeNull();
+  });
+
+  it("honors an explicit embed base for self-host", () => {
+    expect(
+      embedUrlFromPublic("https://cdn.example.com/ws/a.png", {
+        publicBaseUrl: "https://cdn.example.com",
+        embedBaseUrl: "https://embed.example.com",
+      }),
+    ).toBe("https://embed.example.com/ws/a.png");
+  });
+
+  it("disables embed when embedBaseUrl is empty", () => {
+    expect(
+      embedUrlFromPublic("https://storage.uploads.sh/default/a.png", {
+        publicBaseUrl: "https://storage.uploads.sh",
+        embedBaseUrl: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("publicAndEmbedUrls pairs both", () => {
+    expect(
+      publicAndEmbedUrls(
+        { ...base, publicBaseUrl: "https://storage.uploads.sh", prefix: "default/" },
+        "gh/x.png",
+      ),
+    ).toEqual({
+      url: "https://storage.uploads.sh/default/gh/x.png",
+      embedUrl: "https://embed.uploads.sh/default/gh/x.png",
+    });
+  });
+
+  it("resolveEmbedBaseUrl defaults only for known hosts", () => {
+    expect(resolveEmbedBaseUrl("https://storage.uploads.sh")).toBe("https://embed.uploads.sh");
+    expect(resolveEmbedBaseUrl("https://cdn.other.com")).toBeNull();
+    expect(resolveEmbedBaseUrl("https://cdn.other.com", "https://e.other.com/")).toBe(
+      "https://e.other.com",
+    );
   });
 });
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -3,6 +3,7 @@ import type { UploadsClientConfig } from "./config.js";
 import { UploadsError } from "./errors.js";
 import { buildScreenshotKey } from "./keys.js";
 import { packageVersion } from "./package-version.js";
+import { resolveEmbedUrl } from "./public-urls.js";
 
 /** Allowlisted object provenance (maps to X-Uploads-Meta-* on put). */
 export type ProvenanceInput = {
@@ -37,6 +38,8 @@ export interface PutResult {
   workspace: string;
   key: string;
   url: string;
+  /** Same object on the embed host when dual-host applies; prefer for GitHub markdown. */
+  embedUrl: string | null;
   size: number;
   contentType: string;
   metadata?: Record<string, string>;
@@ -45,6 +48,7 @@ export interface PutResult {
 export interface ListItem {
   key: string;
   url: string | null;
+  embedUrl?: string | null;
   size?: number;
   uploaded?: string;
 }
@@ -57,6 +61,7 @@ export interface ListResult {
 export interface HeadResult {
   key: string;
   url: string | null;
+  embedUrl?: string | null;
   size: number;
   contentType: string;
   uploaded?: string;
@@ -78,6 +83,8 @@ export interface GalleryItem {
   createdAt: string;
   status: "available" | "missing";
   url: string | null;
+  /** Dual-host embed URL when available. */
+  embedUrl?: string | null;
   /** Standalone web page for this item (gallery URL + item id). Absent on older API deployments. */
   pageUrl?: string;
   contentType: string | null;
@@ -561,7 +568,14 @@ export function createUploadsClient(config: UploadsClientConfig) {
     if (opts.limit != null) params.set("limit", String(opts.limit));
     if (opts.cursor) params.set("cursor", opts.cursor);
     const qs = params.toString();
-    return request<ListResult>("GET", `${filesBase(config)}${qs ? `?${qs}` : ""}`);
+    const page = await request<ListResult>("GET", `${filesBase(config)}${qs ? `?${qs}` : ""}`);
+    return {
+      ...page,
+      items: page.items.map((item) => ({
+        ...item,
+        embedUrl: resolveEmbedUrl(item.url, item.embedUrl),
+      })),
+    };
   }
 
   async function getGallery(id: string): Promise<Gallery> {
@@ -583,10 +597,12 @@ export function createUploadsClient(config: UploadsClientConfig) {
       const contentType = opts.contentType ?? inferContentType(opts.filename);
 
       if (opts.dryRun) {
-        const preview = await request<{ workspace: string; key: string; url: string | null }>(
-          "PUT",
-          `${filesBase(config)}/${encodeKeyPath(key)}?dryRun=1`,
-        );
+        const preview = await request<{
+          workspace: string;
+          key: string;
+          url: string | null;
+          embedUrl?: string | null;
+        }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}?dryRun=1`);
         if (preview.url == null) {
           throw new UploadsError(
             "workspace has no publicBaseUrl (cannot resolve a public URL)",
@@ -597,6 +613,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
           workspace: preview.workspace,
           key: preview.key,
           url: preview.url,
+          embedUrl: resolveEmbedUrl(preview.url, preview.embedUrl),
           size: body.byteLength,
           contentType,
         };
@@ -613,6 +630,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
         workspace: string;
         key: string;
         url: string | null;
+        embedUrl?: string | null;
         size: number;
         contentType: string;
         metadata?: Record<string, string>;
@@ -629,7 +647,11 @@ export function createUploadsClient(config: UploadsClientConfig) {
         );
       }
 
-      return { ...result, url: result.url };
+      return {
+        ...result,
+        url: result.url,
+        embedUrl: resolveEmbedUrl(result.url, result.embedUrl),
+      };
     },
 
     list,
@@ -653,7 +675,8 @@ export function createUploadsClient(config: UploadsClientConfig) {
     },
 
     async head(key: string): Promise<HeadResult> {
-      return request<HeadResult>("GET", `${filesBase(config)}/${encodeKeyPath(key)}`);
+      const result = await request<HeadResult>("GET", `${filesBase(config)}/${encodeKeyPath(key)}`);
+      return { ...result, embedUrl: resolveEmbedUrl(result.url, result.embedUrl) };
     },
 
     async createGallery(opts: CreateGalleryOptions): Promise<Gallery> {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -16,6 +16,7 @@ import {
   type ResolvedConfig,
 } from "./config.js";
 import { buildMarkdown } from "./embed.js";
+import { urlForGithubEmbed } from "./public-urls.js";
 import { UploadsError } from "./errors.js";
 import { writeJson, writeStdout } from "./io.js";
 import {
@@ -83,6 +84,9 @@ Optional --frame wraps the image in a device/browser chrome before optimize
 Uploads are public. --pr/--issue keys include the repo, number, and filename and
 remain public even for private/internal GitHub repositories. Upload only media
 that is safe at a predictable public URL.
+
+Human/json output includes durable url and (when dual-host applies) embedUrl.
+MARKDOWN prefers embedUrl for GitHub. Override: UPLOADS_EMBED_PUBLIC_BASE_URL.
 
 Options:
   --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
@@ -261,7 +265,7 @@ export async function syncAttachmentsComment(
   run: CommandRunner,
 ): Promise<{ action: "created" | "updated" | "skipped"; count: number }> {
   const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
-    ({ key, url }) => ({ key, url }),
+    ({ key, url, embedUrl }) => ({ key, url, embedUrl }),
   );
 
   const galleries: (GalleryCommentItem & { id: string })[] = [];
@@ -291,6 +295,7 @@ export async function syncAttachmentsComment(
             .slice(0, 3)
             .map((item) => ({
               url: item.url!,
+              embedUrl: item.embedUrl,
               alt: item.altText ?? item.objectKey,
               itemUrl: item.pageUrl,
             })),
@@ -398,9 +403,10 @@ export async function runAttach(
         keepExif: optimizeOpts.keepExif === true,
       }),
     });
+    const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
     results.push({
       ...result,
-      markdown: buildMarkdown(result.url, { alt: sourceName }),
+      markdown: buildMarkdown(embedSrc, { alt: sourceName }),
       optimize: {
         optimized: prepared.optimized,
         skippedReason: prepared.skippedReason,
@@ -429,7 +435,8 @@ export async function runAttach(
     await writeJson({ target, uploads: results, comment, commentError });
   } else {
     for (const result of results) {
-      await writeStdout(`URL: ${result.url}\nMARKDOWN: ${result.markdown}\n`);
+      const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
+      await writeStdout(`URL: ${result.url}\n${embedLine}MARKDOWN: ${result.markdown}\n`);
     }
     if (!ctx.quiet && comment) process.stderr.write(`>> attachments comment ${comment.action}\n`);
   }
@@ -565,7 +572,8 @@ export async function runPut(
     }),
   });
 
-  const markdown = buildMarkdown(result.url, { alt, width });
+  const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
+  const markdown = buildMarkdown(embedSrc, { alt, width });
   let gallery:
     | {
         id: string;
@@ -617,10 +625,12 @@ export async function runPut(
     case "markdown":
       await writeStdout(`${markdown}\n`);
       break;
-    default:
+    default: {
+      const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
       await writeStdout(
-        `URL: ${result.url}\nMARKDOWN: ${markdown}${gallery?.url ? `\nGALLERY: ${gallery.url}` : ""}\n`,
+        `URL: ${result.url}\n${embedLine}MARKDOWN: ${markdown}${gallery?.url ? `\nGALLERY: ${gallery.url}` : ""}\n`,
       );
+    }
   }
 
   if (gallery?.url && format !== "human") {

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -91,6 +91,8 @@ export const ATTACHMENTS_MARKER = "<!-- uploads.sh:attachments -->";
 export interface AttachmentItem {
   key: string;
   url: string | null;
+  /** Prefer for `<img src>` on GitHub (Camo-friendly host). Falls back to `url`. */
+  embedUrl?: string | null;
 }
 
 /** A public gallery linked to the PR or issue whose managed comment is syncing. */
@@ -99,7 +101,7 @@ export interface GalleryCommentItem {
   /** Canonical URL returned by the API; callers must not synthesize it. */
   url: string;
   /** A bounded set of available images; each links to its item page when known, else the gallery. */
-  previews?: { url: string; alt: string; itemUrl?: string }[];
+  previews?: { url: string; alt: string; embedUrl?: string | null; itemUrl?: string }[];
 }
 
 /** Default max width for images in the managed attachments comment (HTML img). */
@@ -155,8 +157,9 @@ export function attachmentsCommentBody(
       lines.push(`#### <a href="${href}">${escapeHtmlText(gallery.title)}</a>`);
       for (const preview of gallery.previews ?? []) {
         const previewHref = preview.itemUrl ? escapeHtmlAttr(preview.itemUrl) : href;
+        const previewSrc = escapeHtmlAttr(preview.embedUrl ?? preview.url);
         lines.push(
-          `<a href="${previewHref}"><img width="320" alt="${escapeHtmlAttr(preview.alt)}" src="${escapeHtmlAttr(preview.url)}"></a>`,
+          `<a href="${previewHref}"><img width="320" alt="${escapeHtmlAttr(preview.alt)}" src="${previewSrc}"></a>`,
         );
       }
       lines.push(`<sub><a href="${href}">Open gallery</a></sub>`, "");
@@ -166,16 +169,19 @@ export function attachmentsCommentBody(
   if (sorted.length > 0 || sortedGalleries.length === 0) lines.push("### 📎 Attachments", "");
   for (const item of sorted) {
     const name = item.key.slice(item.key.lastIndexOf("/") + 1);
-    if (item.url && inferContentType(name).startsWith("image/")) {
+    const stable = item.url;
+    const src = item.embedUrl ?? item.url;
+    if (src && inferContentType(name).startsWith("image/")) {
       // Markdown ![]() has no width control — phone frames become full-column giants.
-      // Link to the asset so a click opens the full image (no "open in new tab" hunt).
+      // img src uses embed host when available (Camo revalidates); click-through keeps stable URL.
       const w = attachmentImageWidth(name);
       const alt = escapeHtmlAttr(name);
-      const href = escapeHtmlAttr(item.url);
-      lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${href}"></a>`);
+      const href = escapeHtmlAttr(stable ?? src);
+      const imgSrc = escapeHtmlAttr(src);
+      lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
       lines.push("");
-    } else if (item.url) {
-      lines.push(`- [${name}](${item.url})`);
+    } else if (stable) {
+      lines.push(`- [${name}](${stable})`);
     } else {
       lines.push(`- ${name}`);
     }

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -1,4 +1,12 @@
 export { inferContentType, buildMarkdown } from "./embed.js";
+export {
+  DEFAULT_EMBED_PUBLIC_BASE_URL,
+  embedBaseUrlFromEnv,
+  embedUrlFromPublic,
+  resolveEmbedBaseUrl,
+  resolveEmbedUrl,
+  urlForGithubEmbed,
+} from "./public-urls.js";
 export { sanitizeKeySegment, sha256Short, deriveRepoFromGit, buildScreenshotKey } from "./keys.js";
 export {
   BUILTIN_DESTINATIONS,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -23,6 +23,7 @@ import {
   type UploadsClientConfig,
 } from "../config.js";
 import { buildMarkdown } from "../embed.js";
+import { urlForGithubEmbed } from "../public-urls.js";
 import { resolvePutPrefix } from "../destinations.js";
 import { ghAttachmentKey, ghKeyPrefix, type GhTarget } from "../github.js";
 import { rewriteKeyExtension, type OptimizeImageOptions } from "../optimize.js";
@@ -318,7 +319,7 @@ export function createUploadsMcpTools(opts: {
     {
       name: "put",
       description:
-        "Upload a file to uploads.sh and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Pass `file` (a local path) or `contentBase64` + `filename` for in-memory content; with `pr`/`issue` the key is stable (same filename → same URL) and `comment` syncs the managed attachments comment. All uploads are public; pr/issue keys are predictable and remain public for private/internal GitHub repositories, so upload only non-sensitive media.",
+        "Upload a file to uploads.sh and get a public URL plus GitHub-ready embed markdown. Returns `url` (durable CDN) and `embedUrl` (same object, freshness-oriented host for GitHub Camo — prefer this in PR/issue markdown). The returned `markdown` already uses embedUrl when available. Pass `file` or `contentBase64` + `filename`; with `pr`/`issue` the key is stable and `comment` syncs the managed attachments comment. All uploads are public; pr/issue keys are predictable, so upload only non-sensitive media.",
       inputSchema: {
         type: "object",
         properties: {
@@ -476,7 +477,7 @@ export function createUploadsMcpTools(opts: {
             keepExif: optimizeOpts.keepExif === true,
           }),
         });
-        const markdown = buildMarkdown(result.url, {
+        const markdown = buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
           alt: optString(args, "alt") ?? sourceName,
           width: optPosInt(args, "width") ?? defaults.width,
         });
@@ -504,7 +505,7 @@ export function createUploadsMcpTools(opts: {
     {
       name: "attach",
       description:
-        "Upload one or more files as stable PR/issue attachments and maintain a single managed GitHub comment listing them (each upload's `markdown` is ready to paste into GitHub). With no pr/issue, targets the pull request for the current branch. Attachments are public and their repo/number/filename keys are predictable even for private/internal GitHub repositories; upload only non-sensitive media.",
+        "Upload one or more files as stable PR/issue attachments and maintain a single managed GitHub comment listing them. Each upload returns `url`, `embedUrl` (when dual-host applies), and `markdown` (uses embedUrl for GitHub). With no pr/issue, targets the pull request for the current branch. Attachments are public and keys are predictable; upload only non-sensitive media.",
       inputSchema: {
         type: "object",
         properties: {
@@ -582,7 +583,9 @@ export function createUploadsMcpTools(opts: {
           });
           uploads.push({
             ...result,
-            markdown: buildMarkdown(result.url, { alt: sourceName }),
+            markdown: buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+              alt: sourceName,
+            }),
             frame: prepared.frame,
             optimize: {
               optimized: prepared.optimized,

--- a/packages/uploads/src/public-urls.ts
+++ b/packages/uploads/src/public-urls.ts
@@ -1,0 +1,90 @@
+/**
+ * Client-side dual-host helpers (published package; no @uploads/storage dep).
+ * Keep behavior aligned with packages/storage.
+ *
+ * `UPLOADS_EMBED_PUBLIC_BASE_URL`: unset = default twin; empty = disable; URL = override.
+ */
+
+export const DEFAULT_EMBED_PUBLIC_BASE_URL = "https://embed.uploads.sh";
+
+const DEFAULT_EMBEDDABLE_HOSTS = new Set(["storage.uploads.sh", "store.uploads.sh"]);
+
+export type ClientEmbedUrlOptions = {
+  embedBaseUrl?: string | null;
+  publicBaseUrl?: string | null;
+};
+
+export function embedBaseUrlFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null | undefined {
+  if (!Object.prototype.hasOwnProperty.call(env, "UPLOADS_EMBED_PUBLIC_BASE_URL")) {
+    return undefined;
+  }
+  return env.UPLOADS_EMBED_PUBLIC_BASE_URL ?? "";
+}
+
+export function resolveEmbedBaseUrl(
+  publicBaseUrl?: string | null,
+  embedBaseUrl?: string | null,
+): string | null {
+  if (embedBaseUrl != null) {
+    const trimmed = embedBaseUrl.trim();
+    return trimmed ? trimmed.replace(/\/$/, "") : null;
+  }
+  if (!publicBaseUrl) return null;
+  try {
+    const host = new URL(publicBaseUrl).hostname.toLowerCase();
+    if (DEFAULT_EMBEDDABLE_HOSTS.has(host)) return DEFAULT_EMBED_PUBLIC_BASE_URL;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function embedUrlFromPublic(
+  publicObjectUrl: string | null | undefined,
+  opts: ClientEmbedUrlOptions = {},
+): string | null {
+  if (!publicObjectUrl) return null;
+
+  let publicBaseUrl = opts.publicBaseUrl ?? null;
+  if (!publicBaseUrl) {
+    try {
+      const u = new URL(publicObjectUrl);
+      if (DEFAULT_EMBEDDABLE_HOSTS.has(u.hostname.toLowerCase())) {
+        publicBaseUrl = `${u.protocol}//${u.host}`;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  const embedBase = resolveEmbedBaseUrl(publicBaseUrl, opts.embedBaseUrl);
+  if (!embedBase || !publicBaseUrl) return null;
+  const stableBase = publicBaseUrl.replace(/\/$/, "");
+  if (publicObjectUrl === stableBase || publicObjectUrl.startsWith(`${stableBase}/`)) {
+    return `${embedBase}${publicObjectUrl.slice(stableBase.length)}`;
+  }
+  return null;
+}
+
+/** Prefer API `embedUrl`; otherwise derive (incl. env override). */
+export function resolveEmbedUrl(
+  publicObjectUrl: string | null | undefined,
+  apiEmbedUrl?: string | null,
+  opts: ClientEmbedUrlOptions = {},
+): string | null {
+  if (apiEmbedUrl) return apiEmbedUrl;
+  const embedBaseUrl = opts.embedBaseUrl !== undefined ? opts.embedBaseUrl : embedBaseUrlFromEnv();
+  return embedUrlFromPublic(publicObjectUrl, { ...opts, embedBaseUrl });
+}
+
+/** Prefer embed host for GitHub markdown; fall back to stable public URL. */
+export function urlForGithubEmbed(
+  publicObjectUrl: string | null | undefined,
+  apiEmbedUrl?: string | null,
+  opts: ClientEmbedUrlOptions = {},
+): string | null {
+  if (!publicObjectUrl) return null;
+  return resolveEmbedUrl(publicObjectUrl, apiEmbedUrl, opts) ?? publicObjectUrl;
+}

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -31,6 +31,7 @@ function fakeClient() {
         workspace: "test",
         key: opts.key,
         url: `https://x.test/${opts.key}`,
+        embedUrl: null,
         size: 3,
         contentType: "image/png",
       };

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -33,6 +33,7 @@ function fakeClient() {
         workspace: "test",
         key: opts.key ?? "generated/key.png",
         url: `https://x.test/${opts.key ?? "generated/key.png"}`,
+        embedUrl: null,
         size: body.byteLength,
         contentType: "image/png",
       };

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -188,6 +188,18 @@ describe("attachmentsCommentBody", () => {
     expect(body).toContain("after.png");
   });
 
+  it("uses embedUrl for image src while linking to the stable url", () => {
+    const body = attachmentsCommentBody([
+      {
+        key: "gh/o/r/pull/1/shot.webp",
+        url: "https://storage.uploads.sh/default/gh/o/r/pull/1/shot.webp",
+        embedUrl: "https://embed.uploads.sh/default/gh/o/r/pull/1/shot.webp",
+      },
+    ]);
+    expect(body).toContain('src="https://embed.uploads.sh/default/gh/o/r/pull/1/shot.webp"');
+    expect(body).toContain('href="https://storage.uploads.sh/default/gh/o/r/pull/1/shot.webp"');
+  });
+
   it("renders the empty body without either content section", () => {
     const body = attachmentsCommentBody([], []);
     expect(body).toContain(ATTACHMENTS_MARKER);

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -41,6 +41,7 @@ function fakeFactory() {
           workspace: config.workspace,
           key,
           url: `https://x.test/${key}`,
+          embedUrl: null,
           size: body.length,
           contentType: opts.contentType ?? "image/png",
         };

--- a/packages/uploads/test/public-urls.test.ts
+++ b/packages/uploads/test/public-urls.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  embedUrlFromPublic,
+  resolveEmbedBaseUrl,
+  resolveEmbedUrl,
+  urlForGithubEmbed,
+} from "../src/public-urls.js";
+
+describe("public-urls / embed", () => {
+  afterEach(() => {
+    delete process.env.UPLOADS_EMBED_PUBLIC_BASE_URL;
+  });
+
+  it("rewrites storage.uploads.sh to embed by default", () => {
+    expect(embedUrlFromPublic("https://storage.uploads.sh/default/gh/o/r/pull/1/a.webp")).toBe(
+      "https://embed.uploads.sh/default/gh/o/r/pull/1/a.webp",
+    );
+  });
+
+  it("honors UPLOADS_EMBED_PUBLIC_BASE_URL", () => {
+    process.env.UPLOADS_EMBED_PUBLIC_BASE_URL = "https://embed.example.com";
+    expect(
+      resolveEmbedUrl("https://cdn.example.com/ws/a.png", null, {
+        publicBaseUrl: "https://cdn.example.com",
+        embedBaseUrl: process.env.UPLOADS_EMBED_PUBLIC_BASE_URL,
+      }),
+    ).toBe("https://embed.example.com/ws/a.png");
+  });
+
+  it("disables with empty UPLOADS_EMBED_PUBLIC_BASE_URL", () => {
+    expect(
+      embedUrlFromPublic("https://storage.uploads.sh/default/a.png", {
+        publicBaseUrl: "https://storage.uploads.sh",
+        embedBaseUrl: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("prefers API embedUrl when provided", () => {
+    expect(
+      resolveEmbedUrl(
+        "https://storage.uploads.sh/default/a.png",
+        "https://embed.uploads.sh/default/a.png",
+      ),
+    ).toBe("https://embed.uploads.sh/default/a.png");
+  });
+
+  it("urlForGithubEmbed falls back to stable url", () => {
+    expect(urlForGithubEmbed("https://cdn.byo.test/x.png", null)).toBe(
+      "https://cdn.byo.test/x.png",
+    );
+  });
+
+  it("resolveEmbedBaseUrl defaults only for known hosts", () => {
+    expect(resolveEmbedBaseUrl("https://storage.uploads.sh")).toBe("https://embed.uploads.sh");
+    expect(resolveEmbedBaseUrl("https://other.test")).toBeNull();
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -42,9 +42,18 @@ naming and output control.
 
 The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
-in place and the URL never changes — you can update a screenshot after review and the
-PR keeps rendering the new one (the API sets `Cache-Control: max-age=60`, so edits
-propagate within ~a minute).
+in place and the URL never changes. Responses include **two** public URLs when the
+shared dual-host setup applies:
+
+| Field      | Host (default)       | Use for                                              |
+| ---------- | -------------------- | ---------------------------------------------------- |
+| `url`      | `storage.uploads.sh` | Durable link, click-through, non-GitHub embeds       |
+| `embedUrl` | `embed.uploads.sh`   | **GitHub PR/issue markdown** (`<img src>` / `![]()`) |
+
+`embedUrl` is the same object with badge-style no-cache headers so GitHub Camo
+revalidates after an overwrite. CLI/MCP `markdown` and the managed attachments
+comment already prefer `embedUrl`. Override with `UPLOADS_EMBED_PUBLIC_BASE_URL`
+(empty disables; self-host set your no-cache CDN base).
 
 ## Prerequisites
 
@@ -244,11 +253,14 @@ or internal repository does **not** make the uploaded file private. Before using
 mode, confirm the media is safe for a public, guessable URL; otherwise redact it or do
 not upload it.
 
-Then reference the URL in the PR/issue markdown you write with `gh`:
+Then reference the **embed** URL in the PR/issue markdown you write with `gh`
+(CLI `--format markdown` / MCP `markdown` already do this):
 
 ```markdown
-<img width="700" alt="Dashboard after" src="https://storage.uploads.sh/gh/myorg/myapp/pull/123/after.png">
+<img width="700" alt="Dashboard after" src="https://embed.uploads.sh/default/gh/myorg/myapp/pull/123/after.webp">
 ```
+
+Keep `url` (storage host) when you need a durable share link outside GitHub.
 
 ### Option B — managed attachments comment (`--comment` / `comment`)
 
@@ -321,6 +333,7 @@ uploads config init --api-url http://localhost:8787 --workspace default --token 
 Recognized keys: `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, `UPLOADS_TOKEN`,
 `UPLOADS_DEFAULT_PREFIX`, `UPLOADS_DEFAULT_REPO`, `UPLOADS_DEFAULT_REF`,
 `UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`, `UPLOADS_NO_OPTIMIZE`, `UPLOADS_KEEP_EXIF`.
+Also read (env only, not config-file keys): `UPLOADS_EMBED_PUBLIC_BASE_URL`.
 
 ## Local development
 
@@ -339,9 +352,10 @@ uploads --api-url http://localhost:8787 doctor
   public, and `gh/<owner>/<repo>/pull|issues/<num>/<filename>` keys are predictable.
   Never upload secrets, tokens, internal dashboards with sensitive data, or customer
   PII visible in a shot — crop/redact first.
-- **Edge cache:** responses carry `Cache-Control: max-age=60`, so an overwrite or a
-  delete can keep serving the old bytes from the edge for up to ~a minute. The object
-  in storage changes immediately.
+- **Edge cache / dual host:** stable `url` responses carry `Cache-Control: max-age=60`.
+  For GitHub, use `embedUrl` (no-cache host) so overwrites propagate through Camo.
+  Prefer CLI/MCP `markdown` rather than hand-building storage URLs into PR bodies.
+  See repo `docs/ops.md` (dual public hosts).
 - **Exit codes:** `2` usage/token/file, `3` auth/policy, `4` network, `1` other.
   `--json` emits `{error,code,status}` — branch on `code`. Scripted formats
   (`json|url|markdown`) also print failures on stdout. Usage errors:


### PR DESCRIPTION
## In plain terms

When you overwrite a screenshot under a stable URL, GitHub’s image proxy (Camo) often keeps showing the old image. This adds a second public host for the same object — built for GitHub embeds — so agents can hot-swap in place without waiting on sticky caches, while durable storage links stay as they are.

## What it does

- Returns **`url`** (stable, `storage.uploads.sh`) and **`embedUrl`** (same key on `embed.uploads.sh`) from API put/list/head, galleries, CLI, and MCP
- CLI/MCP **markdown** and the managed attachments comment use `embedUrl` for `<img src>` (click-through still prefers the stable URL)
- Documented dual-host setup (R2 custom domain + Transform Rule) in `docs/ops.md`; skill + API docs updated
- Self-host overrides: Worker `EMBED_PUBLIC_BASE_URL`, client `UPLOADS_EMBED_PUBLIC_BASE_URL` (empty disables)
- **CSP:** allow same-origin `/cdn-cgi/rum` via `connect-src 'self'` so Cloudflare Web Analytics isn’t blocked under `default-src 'none'`

## What it is not

- Not a Worker proxy in front of every image (DNS + zone rules only)
- Does not change BYO-bucket `publicBaseUrl` hosts unless an embed override is set
- Does not deliver full CSP as HTTP headers for `frame-ancestors` (tracked in #153)

## How to try it

```bash
uploads put ./shot.png --pr <n> --json
# → url + embedUrl; markdown uses embedUrl

curl -sI "$url" | rg cache-control
# public, max-age=60
curl -sI "$embedUrl" | rg cache-control
# max-age=0, no-cache, no-store, must-revalidate
```

Live Camo A/B (pass): https://github.com/buildinternet/uploads/issues/152

## Technical notes

- Shared helpers in `@uploads/storage`; client mirror in `packages/uploads/src/public-urls.ts` (no private dep on publish)
- Changeset for `@buildinternet/uploads` (minor)
- Infra already live: `embed.uploads.sh` on `uploads-default` + Transform Rule

## Test plan

- [x] `pnpm --filter @uploads/storage test`
- [x] `pnpm --filter @uploads/api test`
- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @uploads/web test`
- [x] Issue #152 overwrite experiment (stable stale / embed fresh)

Closes #152
