### PR TITLE
fix(web): deliver CSP as HTTP header so frame-ancestors applies

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -17,6 +17,8 @@
   Referrer-Policy: no-referrer
   X-Robots-Tag: noindex, nofollow, noarchive
   X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin
   Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh 'self' https://cloudflareinsights.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
   Permissions-Policy: camera=(), microphone=(), geolocation=()
 

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -10,13 +10,14 @@
   Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
   X-Content-Type-Options: nosniff
 
-# Keep CSP in sync with src/pages/invite.astro (header + meta both apply).
+# Keep CSP identical to INVITE_CSP in src/lib/signed-in-page.ts (header only —
+# meta CSP is not used; frame-ancestors requires an HTTP header).
 /invite*
   Cache-Control: no-store
   Referrer-Policy: no-referrer
   X-Robots-Tag: noindex, nofollow, noarchive
   X-Content-Type-Options: nosniff
-  Content-Security-Policy: default-src 'none'; connect-src 'self' https://api.uploads.sh https://cloudflareinsights.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'none'; connect-src https://api.uploads.sh 'self' https://cloudflareinsights.com; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
   Permissions-Policy: camera=(), microphone=(), geolocation=()
 
 # Operator browser console — not a public product surface

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -5,6 +5,7 @@
  */
 import { env } from "cloudflare:workers";
 import {
+  applyCspHeader,
   resolveShowConsoleLinks,
   resolveSignedInOrigins,
   signedInCsp,
@@ -33,7 +34,8 @@ const docTitle = `${titles[section]} · uploads.sh`;
 
 const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
-const csp = signedInCsp(authOrigin, apiOrigin);
+// Header (not meta): frame-ancestors is ignored on meta CSP.
+applyCspHeader(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 
 const nav: { href: string; section: AccountSection; label: string }[] = [
   { href: "/account", section: "overview", label: "Overview" },
@@ -48,7 +50,6 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
   <BaseHead />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>{docTitle}</title>
 </head>
 <body>

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -5,7 +5,7 @@
  */
 import { env } from "cloudflare:workers";
 import {
-  applyCspHeader,
+  applyAuthSecurityHeaders,
   resolveShowConsoleLinks,
   resolveSignedInOrigins,
   signedInCsp,
@@ -35,7 +35,7 @@ const docTitle = `${titles[section]} · uploads.sh`;
 const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 // Header (not meta): frame-ancestors is ignored on meta CSP.
-applyCspHeader(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
+applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 
 const nav: { href: string; section: AccountSection; label: string }[] = [
   { href: "/account", section: "overview", label: "Overview" },

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -48,8 +48,6 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
 <html lang="en">
 <head>
   <BaseHead />
-  <meta name="robots" content="noindex, nofollow, noarchive" />
-  <meta name="referrer" content="no-referrer" />
   <title>{docTitle}</title>
 </head>
 <body>

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -6,6 +6,7 @@
  */
 import { env } from "cloudflare:workers";
 import {
+  applyCspHeader,
   resolveShowConsoleLinks,
   resolveSignedInOrigins,
   signedInCsp,
@@ -31,7 +32,8 @@ const docTitle = `${titles[section]} · uploads.sh`;
 
 const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
-const csp = signedInCsp(authOrigin, apiOrigin);
+// Header (not meta): frame-ancestors is ignored on meta CSP.
+applyCspHeader(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 
 const nav: { href: string; section: AdminSection; label: string }[] = [
   { href: "/admin", section: "workspaces", label: "Workspaces" },
@@ -44,7 +46,6 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
   <BaseHead />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>{docTitle}</title>
 </head>
 <body>

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -44,8 +44,6 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
 <html lang="en">
 <head>
   <BaseHead />
-  <meta name="robots" content="noindex, nofollow, noarchive" />
-  <meta name="referrer" content="no-referrer" />
   <title>{docTitle}</title>
 </head>
 <body>

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -6,7 +6,7 @@
  */
 import { env } from "cloudflare:workers";
 import {
-  applyCspHeader,
+  applyAuthSecurityHeaders,
   resolveShowConsoleLinks,
   resolveSignedInOrigins,
   signedInCsp,
@@ -33,7 +33,7 @@ const docTitle = `${titles[section]} · uploads.sh`;
 const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 // Header (not meta): frame-ancestors is ignored on meta CSP.
-applyCspHeader(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
+applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 
 const nav: { href: string; section: AdminSection; label: string }[] = [
   { href: "/admin", section: "workspaces", label: "Workspaces" },

--- a/apps/web/src/lib/signed-in-page.test.ts
+++ b/apps/web/src/lib/signed-in-page.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { applyCspHeader, authPageCsp, INVITE_CSP, signedInCsp } from "./signed-in-page";
+import { applyAuthSecurityHeaders, authPageCsp, INVITE_CSP, signedInCsp } from "./signed-in-page";
 
 const AUTH = "https://auth.uploads.sh";
 const API = "https://api.uploads.sh";
@@ -45,15 +45,23 @@ describe("signed-in / auth CSP builders", () => {
     expect(INVITE_CSP).toContain("img-src data:");
   });
 
-  it("applyCspHeader sets Content-Security-Policy on the response", () => {
+  it("applyAuthSecurityHeaders matches public-file baseline + page CSP", () => {
     const headers = new Headers();
     const csp = signedInCsp(AUTH, API);
-    applyCspHeader(headers, csp);
+    applyAuthSecurityHeaders(headers, csp);
     expect(headers.get("Content-Security-Policy")).toBe(csp);
+    expect(headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(headers.get("X-Frame-Options")).toBe("DENY");
+    expect(headers.get("X-Robots-Tag")).toBe("noindex, nofollow, noarchive");
+    expect(headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
+    expect(headers.get("Permissions-Policy")).toBe("camera=(), microphone=(), geolocation=()");
+    expect(headers.get("Cache-Control")).toBe("no-store");
 
     const authHeaders = new Headers();
-    applyCspHeader(authHeaders, authPageCsp(AUTH));
+    applyAuthSecurityHeaders(authHeaders, authPageCsp(AUTH));
     expect(authHeaders.get("Content-Security-Policy")).toBe(authPageCsp(AUTH));
+    expect(authHeaders.get("X-Frame-Options")).toBe("DENY");
   });
 
   it("public/_headers /invite* CSP matches INVITE_CSP (single authoritative policy)", () => {
@@ -62,5 +70,7 @@ describe("signed-in / auth CSP builders", () => {
     const line = text.match(/\/invite\*[\s\S]*?^\s*Content-Security-Policy:\s*(.+)$/m);
     expect(line, "expected Content-Security-Policy under /invite* in public/_headers").toBeTruthy();
     expect(line![1].trim()).toBe(INVITE_CSP);
+    expect(text).toMatch(/\/invite\*[\s\S]*?X-Frame-Options:\s*DENY/);
+    expect(text).toMatch(/\/invite\*[\s\S]*?Cross-Origin-Opener-Policy:\s*same-origin/);
   });
 });

--- a/apps/web/src/lib/signed-in-page.test.ts
+++ b/apps/web/src/lib/signed-in-page.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { applyCspHeader, authPageCsp, INVITE_CSP, signedInCsp } from "./signed-in-page";
+
+const AUTH = "https://auth.uploads.sh";
+const API = "https://api.uploads.sh";
+
+describe("signed-in / auth CSP builders", () => {
+  it("signedInCsp locks down and allows session + API + RUM", () => {
+    const csp = signedInCsp(AUTH, API);
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain(`connect-src ${AUTH} ${API}`);
+    expect(csp).toContain("'self'");
+    expect(csp).toContain("https://cloudflareinsights.com");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("https://static.cloudflareinsights.com");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("img-src data: https:");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  it("authPageCsp is tighter: auth origin only, data: images", () => {
+    const csp = authPageCsp(AUTH);
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain(`connect-src ${AUTH}`);
+    expect(csp).toContain("'self'");
+    expect(csp).toContain("https://cloudflareinsights.com");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("img-src data:");
+    expect(csp).not.toContain("img-src data: https:");
+    expect(csp).not.toContain(API);
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("INVITE_CSP targets prod API and keeps frame-ancestors", () => {
+    expect(INVITE_CSP).toContain("default-src 'none'");
+    expect(INVITE_CSP).toContain(`connect-src ${API}`);
+    expect(INVITE_CSP).toContain("'self'");
+    expect(INVITE_CSP).toContain("https://cloudflareinsights.com");
+    expect(INVITE_CSP).toContain("frame-ancestors 'none'");
+    expect(INVITE_CSP).toContain("img-src data:");
+  });
+
+  it("applyCspHeader sets Content-Security-Policy on the response", () => {
+    const headers = new Headers();
+    const csp = signedInCsp(AUTH, API);
+    applyCspHeader(headers, csp);
+    expect(headers.get("Content-Security-Policy")).toBe(csp);
+
+    const authHeaders = new Headers();
+    applyCspHeader(authHeaders, authPageCsp(AUTH));
+    expect(authHeaders.get("Content-Security-Policy")).toBe(authPageCsp(AUTH));
+  });
+
+  it("public/_headers /invite* CSP matches INVITE_CSP (single authoritative policy)", () => {
+    const headersPath = join(dirname(fileURLToPath(import.meta.url)), "../../public/_headers");
+    const text = readFileSync(headersPath, "utf8");
+    const line = text.match(/\/invite\*[\s\S]*?^\s*Content-Security-Policy:\s*(.+)$/m);
+    expect(line, "expected Content-Security-Policy under /invite* in public/_headers").toBeTruthy();
+    expect(line![1].trim()).toBe(INVITE_CSP);
+  });
+});

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -1,6 +1,11 @@
 /**
- * Shared server helpers for the signed-in shells (/account/*, /admin/*):
- * origins, CSP, and console-link visibility. The favicon ships via BaseHead.
+ * Shared server helpers for the signed-in shells (/account/*, /admin/*) and
+ * auth surfaces (login, device, accept-invitation, invite): origins, CSP, and
+ * console-link visibility. The favicon ships via BaseHead.
+ *
+ * CSP is applied as an HTTP response header (not `<meta http-equiv>`) so
+ * `frame-ancestors` is honored — browsers ignore that directive in meta.
+ * Same delivery model as `applyPublicFileHeaders` / `applyPublicGalleryHeaders`.
  */
 import { resolveConsoleMode } from "./console-mode";
 import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
@@ -39,6 +44,54 @@ export function signedInCsp(authOrigin: string, apiOrigin: string): string {
     "form-action 'none'",
     "frame-ancestors 'none'",
   ].join("; ");
+}
+
+/**
+ * CSP for auth pages that only talk to the auth origin (login, device,
+ * accept-invitation). Slightly tighter than the signed-in shells: no API
+ * origin and no https: images.
+ */
+export function authPageCsp(authOrigin: string): string {
+  return [
+    "default-src 'none'",
+    `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
+    // 'self' covers Astro-bundled /_astro/*.js; CF RUM is edge-injected.
+    `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+    `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+    "font-src 'self'",
+    "img-src data:",
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'none'",
+  ].join("; ");
+}
+
+/**
+ * CSP for the CLI enroll invite page (`/invite`). Prod API origin is fixed
+ * (page hard-codes api.uploads.sh). Delivered via `public/_headers` for the
+ * static asset path — keep that file's Content-Security-Policy value identical
+ * to this constant (see tests).
+ */
+export const INVITE_CSP = [
+  "default-src 'none'",
+  `connect-src https://api.uploads.sh ${CF_RUM_CONNECT_SRC}`,
+  // 'self' future-proofs if Astro extracts the page script to /_astro/*.js.
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
+  "font-src 'self'",
+  "img-src data:",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+/**
+ * Set Content-Security-Policy as a response header so `frame-ancestors` applies.
+ * Prefer this over `<meta http-equiv="Content-Security-Policy">` (meta ignores
+ * frame-ancestors; stacking divergent meta + header policies is a footgun).
+ */
+export function applyCspHeader(headers: Headers, csp: string): void {
+  headers.set("Content-Security-Policy", csp);
 }
 
 /**

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -86,12 +86,20 @@ export const INVITE_CSP = [
 ].join("; ");
 
 /**
- * Set Content-Security-Policy as a response header so `frame-ancestors` applies.
- * Prefer this over `<meta http-equiv="Content-Security-Policy">` (meta ignores
- * frame-ancestors; stacking divergent meta + header policies is a footgun).
+ * Security headers for signed-in shells and auth pages.
+ * Same baseline as public file/gallery pages (`applyPublicFileHeaders`), with a
+ * page-specific CSP. CSP must be a response header (not meta) so
+ * `frame-ancestors` is enforced.
  */
-export function applyCspHeader(headers: Headers, csp: string): void {
+export function applyAuthSecurityHeaders(headers: Headers, csp: string): void {
   headers.set("Content-Security-Policy", csp);
+  headers.set("Referrer-Policy", "no-referrer");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("X-Robots-Tag", "noindex, nofollow, noarchive");
+  headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  headers.set("Cache-Control", "no-store");
 }
 
 /**

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -1,10 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import {
-  CF_RUM_CONNECT_SRC,
-  CF_RUM_SCRIPT_SRC,
-  STYLE_SRC_SELF_AND_INLINE,
-} from "../../lib/csp";
+import { applyCspHeader, authPageCsp } from "../../lib/signed-in-page";
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
 import Footer from "../../components/Footer.astro";
@@ -18,17 +14,8 @@ const authOrigin =
 
 const { id } = Astro.params;
 
-const csp = [
-  "default-src 'none'",
-  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
-  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-  "font-src 'self'",
-  "img-src data:",
-  "base-uri 'none'",
-  "form-action 'none'",
-  "frame-ancestors 'none'",
-].join("; ");
+// Header (not meta): frame-ancestors is ignored on meta CSP.
+applyCspHeader(Astro.response.headers, authPageCsp(authOrigin));
 ---
 
 <html lang="en">
@@ -36,7 +23,6 @@ const csp = [
   <BaseHead />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Accept invitation · uploads.sh</title>
   <style>
     *{box-sizing:border-box}

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -1,6 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import { applyCspHeader, authPageCsp } from "../../lib/signed-in-page";
+import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page";
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
 import Footer from "../../components/Footer.astro";
@@ -15,7 +15,7 @@ const authOrigin =
 const { id } = Astro.params;
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
-applyCspHeader(Astro.response.headers, authPageCsp(authOrigin));
+applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 ---
 
 <html lang="en">

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -21,8 +21,6 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 <html lang="en">
 <head>
   <BaseHead />
-  <meta name="robots" content="noindex, nofollow, noarchive" />
-  <meta name="referrer" content="no-referrer" />
   <title>Accept invitation · uploads.sh</title>
   <style>
     *{box-sizing:border-box}

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -1,10 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import {
-  CF_RUM_CONNECT_SRC,
-  CF_RUM_SCRIPT_SRC,
-  STYLE_SRC_SELF_AND_INLINE,
-} from "../lib/csp";
+import { applyCspHeader, authPageCsp } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
@@ -17,18 +13,8 @@ const authOrigin =
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
   "https://auth.uploads.sh";
 
-const csp = [
-  "default-src 'none'",
-  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
-  // 'self' covers Astro-bundled /_astro/*.js; CF RUM is edge-injected.
-  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-  "font-src 'self'",
-  "img-src data:",
-  "base-uri 'none'",
-  "form-action 'none'",
-  "frame-ancestors 'none'",
-].join("; ");
+// Header (not meta): frame-ancestors is ignored on meta CSP.
+applyCspHeader(Astro.response.headers, authPageCsp(authOrigin));
 ---
 
 <html lang="en">
@@ -36,7 +22,6 @@ const csp = [
   <BaseHead />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Authorize device · uploads.sh</title>
   <style>
     *{box-sizing:border-box}

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -1,6 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import { applyCspHeader, authPageCsp } from "../lib/signed-in-page";
+import { applyAuthSecurityHeaders, authPageCsp } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
@@ -14,7 +14,7 @@ const authOrigin =
   "https://auth.uploads.sh";
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
-applyCspHeader(Astro.response.headers, authPageCsp(authOrigin));
+applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 ---
 
 <html lang="en">

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -20,8 +20,6 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 <html lang="en">
 <head>
   <BaseHead />
-  <meta name="robots" content="noindex, nofollow, noarchive" />
-  <meta name="referrer" content="no-referrer" />
   <title>Authorize device · uploads.sh</title>
   <style>
     *{box-sizing:border-box}

--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -1,34 +1,15 @@
 ---
-import {
-  CF_RUM_CONNECT_SRC,
-  CF_RUM_SCRIPT_SRC,
-  STYLE_SRC_SELF_AND_INLINE,
-} from "../lib/csp";
+// CSP is the HTTP header on /invite* in public/_headers (INVITE_CSP in
+// signed-in-page.ts). Meta CSP cannot enforce frame-ancestors; header only.
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
-
-// Keep in sync with public/_headers `/invite*` CSP (header + meta both apply).
-const csp = [
-  "default-src 'none'",
-  `connect-src https://api.uploads.sh ${CF_RUM_CONNECT_SRC}`,
-  // 'self' future-proofs if Astro extracts the page script to /_astro/*.js
-  // (login/admin already do this once they import modules).
-  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-  "font-src 'self'",
-  "img-src data:",
-  "base-uri 'none'",
-  "form-action 'none'",
-  "frame-ancestors 'none'",
-].join("; ");
 ---
 <html lang="en">
 <head>
   <BaseHead />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Accept your invite · uploads.sh</title>
   <style>
     *{box-sizing:border-box}body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:var(--bg);color:var(--fg);font:14.5px/1.65 var(--mono)}main{width:min(640px,100%);background:var(--panel);border:1px solid var(--line);border-radius:var(--radius-lg);padding:clamp(24px,6vw,44px)}.brandbar{display:flex;justify-content:center;margin-bottom:24px}h1{margin:0 0 8px;font-size:clamp(23px,5vw,30px);font-weight:600;letter-spacing:-.015em;line-height:1.25}p{color:var(--body)}.status{padding:12px 14px;margin:24px 0;border:1px solid var(--line);border-radius:var(--radius-md);background:var(--bg);color:var(--body)}.status[data-state=ready]{color:var(--green)}.status[data-state=closed]{color:var(--red)}ol{padding-left:20px}li{margin:16px 0}.command{display:flex;gap:12px;align-items:center;margin-top:8px;padding:12px 14px;border:1px solid var(--line);border-radius:var(--radius-md);background:var(--bg)}.command code{flex:1;min-width:0;white-space:nowrap;overflow-x:auto;display:block;font-variant-ligatures:none;font-feature-settings:"calt" 0,"liga" 0}.command button{flex-shrink:0}button{font-size:11px;letter-spacing:.06em;border:1px solid var(--line);border-radius:6px;padding:6px 10px;background:none;color:var(--accent);cursor:pointer;font-family:inherit}button:hover,button:focus-visible{border-color:var(--accent);outline:none}.security{margin-top:26px;padding-top:18px;border-top:1px solid var(--line);font-size:13px;color:var(--muted)}[hidden]{display:none!important}

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -20,8 +20,6 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 <html lang="en">
 <head>
   <BaseHead />
-  <meta name="robots" content="noindex, nofollow, noarchive" />
-  <meta name="referrer" content="no-referrer" />
   <title>Sign in · uploads.sh</title>
   <style>
     *{box-sizing:border-box}

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -1,10 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import {
-  CF_RUM_CONNECT_SRC,
-  CF_RUM_SCRIPT_SRC,
-  STYLE_SRC_SELF_AND_INLINE,
-} from "../lib/csp";
+import { applyCspHeader, authPageCsp } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
@@ -17,18 +13,8 @@ const authOrigin =
   import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
   "https://auth.uploads.sh";
 
-const csp = [
-  "default-src 'none'",
-  `connect-src ${authOrigin} ${CF_RUM_CONNECT_SRC}`,
-  // 'self' covers Astro-bundled /_astro/*.js; CF RUM is edge-injected.
-  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
-  `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-  "font-src 'self'",
-  "img-src data:",
-  "base-uri 'none'",
-  "form-action 'none'",
-  "frame-ancestors 'none'",
-].join("; ");
+// Header (not meta): frame-ancestors is ignored on meta CSP.
+applyCspHeader(Astro.response.headers, authPageCsp(authOrigin));
 ---
 
 <html lang="en">
@@ -36,7 +22,6 @@ const csp = [
   <BaseHead />
   <meta name="robots" content="noindex, nofollow, noarchive" />
   <meta name="referrer" content="no-referrer" />
-  <meta http-equiv="Content-Security-Policy" content={csp} />
   <title>Sign in · uploads.sh</title>
   <style>
     *{box-sizing:border-box}

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -1,6 +1,6 @@
 ---
 import { env } from "cloudflare:workers";
-import { applyCspHeader, authPageCsp } from "../lib/signed-in-page";
+import { applyAuthSecurityHeaders, authPageCsp } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
@@ -14,7 +14,7 @@ const authOrigin =
   "https://auth.uploads.sh";
 
 // Header (not meta): frame-ancestors is ignored on meta CSP.
-applyCspHeader(Astro.response.headers, authPageCsp(authOrigin));
+applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 ---
 
 <html lang="en">


### PR DESCRIPTION
## In plain terms

Browsers were ignoring clickjacking protection (`frame-ancestors`) because CSP was only set in a `<meta>` tag. Account, admin, and auth pages now send CSP as a real HTTP header, and they get the same security-header baseline as public file/gallery pages (not just CSP).

## What it does

- Sets **CSP via `Astro.response.headers`** (not meta) on `/account/*`, `/admin/*`, login, device, accept-invitation
- Shared helper **`applyAuthSecurityHeaders`**: CSP + `Referrer-Policy`, `nosniff`, `X-Frame-Options`, `COOP`, `Permissions-Policy`, `noindex`, `no-store` — same suite as public file/gallery
- `/invite*`: header-only CSP via `public/_headers` (synced to `INVITE_CSP`), plus matching frame/COOP headers
- Removes meta CSP to avoid stacked divergent policies

## What it is not

- Does not change CSP allowlists (RUM/`'self'` already fixed elsewhere)
- Does not cover HSTS (Cloudflare zone) or marketing-page baseline — see #156

## Technical notes

- Builders: `signedInCsp`, `authPageCsp`, `INVITE_CSP` in `apps/web/src/lib/signed-in-page.ts`
- Unit tests assert header suite + `_headers` ↔ `INVITE_CSP` equality

## Test plan

- [x] `pnpm --filter @uploads/web test` (78 tests)
- [ ] Spot-check production response headers after deploy (`curl -sI` account/login)

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Authentication, invitation, device, and account pages now apply Content Security Policy and related protections through response headers.
  * Invitation pages enforce consistent security policies, including framing restrictions, referrer controls, caching rules, and crawler protections.
  * Removed HTML-based CSP handling in favor of more reliable server-delivered security headers.

* **Tests**
  * Added coverage to verify security policies and required response headers across authentication and invitation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->