### PR TITLE
fix: metadata endpoints 404 on real keys in production

### DIFF
--- a/.changeset/file-metadata.md
+++ b/.changeset/file-metadata.md
@@ -11,3 +11,8 @@ MCP parity: the local stdio MCP's `put`/`attach` tools gain a `metadata` param
 (same gh.\* auto-injection as `attach`), and two new tools — `set_metadata`
 (merge-set/delete) and `find_files` (metadata filter) — mirror the CLI's
 `meta set`/`find`. The hosted MCP's `put` tool also gains a `metadata` param.
+
+`meta get`/`meta set` now hit `GET /v1/:workspace/files/:key?metadata=1` and
+`PATCH /v1/:workspace/files/:key` instead of a `/:key/metadata` sibling route
+— the original suffix route 404'd on real (slash-containing) keys once
+deployed.

--- a/apps/api/scripts/backfill-gh-metadata.mjs
+++ b/apps/api/scripts/backfill-gh-metadata.mjs
@@ -6,7 +6,7 @@
  * packages/uploads/src/github.ts — this script mirrors that mapping).
  *
  * Pages GET /v1/:ws/files?prefix=gh/ (cursor loop), parses each key against
- * GH_KEY_RE, and PATCHes /v1/:ws/files/<key>/metadata with `{ set: {...} }`
+ * GH_KEY_RE, and PATCHes /v1/:ws/files/<key> with `{ set: {...} }`
  * for every match. Non-matching keys under gh/ are skipped and counted, not
  * treated as errors. Merge-semantics PATCH means re-running is harmless
  * (idempotent) — safe to re-run after interruption.
@@ -110,7 +110,7 @@ export async function runBackfill({
         continue;
       }
 
-      const patchUrl = `${base}/v1/${workspace}/files/${plan.key}/metadata`;
+      const patchUrl = `${base}/v1/${workspace}/files/${plan.key}`;
       let patchRes;
       try {
         patchRes = await fetchImpl(patchUrl, {

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -192,32 +192,33 @@ export const files = new Hono<WorkspaceVars>()
     return c.json(await listObjects(c.env, c.get("workspace"), { prefix, limit, cursor }));
   })
 
-  // Queryable metadata (file_metadata D1 table) — registered before the raw
-  // `/:key{.+}` GET route below. Verified by test (see
-  // "an object whose key literally ends in '/metadata'" in
-  // test/routes-files.test.ts): with this registration order, Hono's router
-  // resolves GET `.../<key>/metadata` to *this* route even when `<key>`
-  // happens to be a real object whose own key ends in the literal
-  // `/metadata` segment (e.g. `screenshots/shot.png/metadata`) — the raw
-  // `/:key{.+}` GET route never sees that request, so that object's own
-  // metadata/contentType/url are not fetchable via GET, only its sibling
-  // `.../metadata` reads the *other* object's (`screenshots/shot.png`)
-  // metadata map instead. PUT/DELETE are unaffected (no PUT/DELETE metadata
-  // route exists to shadow them), so such an object can still be uploaded
-  // and deleted via the raw route — only its GET is shadowed. Accepted
-  // tradeoff: metadata is a first-class sibling resource, and keys ending in
-  // the literal `/metadata` suffix are not a realistic upload pattern.
-  .get("/:key{.+}/metadata", requireScope("files:read"), async (c) => {
+  // Metadata now lives on the key-at-tail routes (same shape PUT/GET/DELETE
+  // already use) instead of a `/:key{.+}/metadata` suffix route: Hono's
+  // production router does not reliably match a `{.+}` param followed by a
+  // static suffix once the key contains raw slashes (real object keys always
+  // do) — the vitest harness matches raw slashes so this passed locally, but
+  // the deployed worker 404s on any real key. `?metadata=1` on GET and a bare
+  // PATCH (which has no other meaning on this route) avoid the fragile
+  // suffix pattern entirely.
+  .get("/:key{.+}", requireScope("files:read"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
     const ws = c.get("workspace");
     const store = await storage(c.env, ws);
     if (!(await store.exists(key))) throw new NotFoundError();
-    const metadata = await getFileMetadata(c.env.DB, c.get("workspaceName"), key);
-    return c.json({ metadata });
+
+    const metadataParam = c.req.query("metadata");
+    if (metadataParam === "1" || metadataParam === "true") {
+      const metadata = await getFileMetadata(c.env.DB, c.get("workspaceName"), key);
+      return c.json({ metadata });
+    }
+
+    const meta = await store.head(key);
+    const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), key);
+    return c.json(headObjectJson(key, meta, urls.url, urls.embedUrl));
   })
 
-  .patch("/:key{.+}/metadata", writeRateLimit, requireScope("files:write"), async (c) => {
+  .patch("/:key{.+}", writeRateLimit, requireScope("files:write"), async (c) => {
     const key = c.req.param("key");
     if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
     const ws = c.get("workspace");
@@ -261,17 +262,6 @@ export const files = new Hono<WorkspaceVars>()
       (remove as string[] | undefined) ?? [],
     );
     return c.json({ metadata });
-  })
-
-  .get("/:key{.+}", requireScope("files:read"), async (c) => {
-    const key = c.req.param("key");
-    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
-    const ws = c.get("workspace");
-    const store = await storage(c.env, ws);
-    if (!(await store.exists(key))) throw new NotFoundError();
-    const meta = await store.head(key);
-    const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), key);
-    return c.json(headObjectJson(key, meta, urls.url, urls.embedUrl));
   })
 
   .delete("/:key{.+}", writeRateLimit, requireScope("files:delete"), async (c) => {

--- a/apps/api/test/backfill-gh-metadata.test.ts
+++ b/apps/api/test/backfill-gh-metadata.test.ts
@@ -87,7 +87,7 @@ describe("runBackfill", () => {
           cursor: "page2",
         });
       }
-      if (url.includes("/metadata")) {
+      if (url.includes("/files/gh/")) {
         return jsonResponse({ metadata: {} });
       }
       throw new Error(`unexpected fetch: ${url}`);
@@ -101,9 +101,10 @@ describe("runBackfill", () => {
     expect(listCalls).toHaveLength(2);
     expect(listCalls[1].url).toContain("cursor=page2");
 
-    const patchCalls = calls.filter((c) => c.url.includes("/metadata"));
+    const patchCalls = calls.filter((c) => c.url.includes("/files/gh/"));
     expect(patchCalls).toHaveLength(2);
-    expect(patchCalls[0].url).toContain("gh/owner/repo/pull/12/a.png/metadata");
+    expect(patchCalls[0].url).toContain("gh/owner/repo/pull/12/a.png");
+    expect(patchCalls[0].url).not.toContain("/metadata");
     expect(patchCalls[0].init?.method).toBe("PATCH");
     expect(JSON.parse(patchCalls[0].init?.body as string)).toEqual({
       set: {
@@ -139,10 +140,10 @@ describe("runBackfill", () => {
           cursor: null,
         });
       }
-      if (url.includes("/pull/12/a.png/metadata")) {
+      if (url.includes("/pull/12/a.png")) {
         return jsonResponse({ error: "boom" }, 500);
       }
-      if (url.includes("/pull/13/b.png/metadata")) {
+      if (url.includes("/pull/13/b.png")) {
         return jsonResponse({ metadata: {} });
       }
       throw new Error(`unexpected fetch: ${url}`);
@@ -161,10 +162,10 @@ describe("runBackfill", () => {
           cursor: null,
         });
       }
-      if (url.includes("/pull/12/a.png/metadata")) {
+      if (url.includes("/pull/12/a.png")) {
         throw new TypeError("fetch failed: connection reset");
       }
-      if (url.includes("/pull/13/b.png/metadata")) {
+      if (url.includes("/pull/13/b.png")) {
         return jsonResponse({ metadata: {} });
       }
       throw new Error(`unexpected fetch: ${url}`);
@@ -174,7 +175,7 @@ describe("runBackfill", () => {
 
     expect(summary).toEqual({ matched: 2, patched: 1, skipped: 0, errors: 1 });
     // Both PATCHes were attempted despite the first one throwing.
-    expect(fetchImpl.mock.calls.filter(([url]) => url.includes("/metadata"))).toHaveLength(2);
+    expect(fetchImpl.mock.calls.filter(([url]) => url.includes("/files/gh/"))).toHaveLength(2);
   });
 
   it("aborts cleanly with an error counted when the list fetch throws (transport error)", async () => {

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -478,7 +478,7 @@ describe("PUT /v1/:workspace/files custom metadata capture + cascade", () => {
 
 function getMeta(env: Parameters<typeof app.request>[2], key: string, token = TOKEN) {
   return app.request(
-    `/v1/default/files/${key}/metadata`,
+    `/v1/default/files/${key}?metadata=1`,
     { headers: { Authorization: `Bearer ${token}` } },
     env,
   );
@@ -491,7 +491,7 @@ function patchMeta(
   token = TOKEN,
 ) {
   return app.request(
-    `/v1/default/files/${key}/metadata`,
+    `/v1/default/files/${key}`,
     {
       method: "PATCH",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -501,7 +501,7 @@ function patchMeta(
   );
 }
 
-describe("GET/PATCH /v1/:workspace/files/:key/metadata", () => {
+describe("GET ?metadata=1 / PATCH /v1/:workspace/files/:key", () => {
   it("GET returns an empty map for an object with no metadata", async () => {
     const { env } = await makeEnv();
     const put = await putShot(env);
@@ -610,7 +610,7 @@ describe("GET/PATCH /v1/:workspace/files/:key/metadata", () => {
     const { env } = await makeEnv();
     await putShot(env);
     const res = await app.request(
-      "/v1/default/files/screenshots/shot.png/metadata",
+      "/v1/default/files/screenshots/shot.png",
       {
         method: "PATCH",
         headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
@@ -627,7 +627,7 @@ describe("GET/PATCH /v1/:workspace/files/:key/metadata", () => {
     const { env } = await makeEnv();
     await putShot(env);
     const res = await app.request(
-      "/v1/default/files/screenshots/shot.png/metadata",
+      "/v1/default/files/screenshots/shot.png",
       {
         method: "PATCH",
         headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
@@ -655,23 +655,11 @@ describe("GET/PATCH /v1/:workspace/files/:key/metadata", () => {
     expect(json.error.type).toBe("insufficient_scope");
   });
 
-  it("an object whose key literally ends in '/metadata' can be PUT but its GET is shadowed by the metadata route", async () => {
-    const { env, bucket } = await makeEnv();
-    const put = await putShot(env, {
-      body: PNG,
-    });
-    expect(put.status).toBe(201);
-    // Now PUT a *second* object whose key ends in the literal "/metadata"
-    // segment. PUT still lands on the raw `/:key{.+}` route (no PUT metadata
-    // route exists to compete), so the object is stored under its full,
-    // literal key. But a GET to that same path resolves to the *metadata*
-    // route instead (see routes/files.ts): it is read back as the metadata
-    // sibling resource of "screenshots/shot.png", not as this object's own
-    // file. Documented tradeoff — keys ending in the literal "/metadata"
-    // suffix are not a realistic upload pattern.
-    const weirdKey = "screenshots/shot.png/metadata";
-    const putWeird = await app.request(
-      `/v1/default/files/${weirdKey}`,
+  it("GET ?metadata=1 / PATCH round-trip on a key with several raw slashes", async () => {
+    const { env } = await makeEnv();
+    const deepKey = "a/b/c/d/deep.png";
+    const put = await app.request(
+      `/v1/default/files/${deepKey}`,
       {
         method: "PUT",
         headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
@@ -679,18 +667,31 @@ describe("GET/PATCH /v1/:workspace/files/:key/metadata", () => {
       },
       env,
     );
-    expect(putWeird.status).toBe(201);
-    expect(bucket.store.has(`default/${weirdKey}`)).toBe(true);
+    expect(put.status).toBe(201);
 
+    const patch = await patchMeta(env, deepKey, { set: { app: "web" } });
+    expect(patch.status).toBe(200);
+    expect(await patch.json()).toEqual({ metadata: { app: "web" } });
+
+    const res = await getMeta(env, deepKey);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ metadata: { app: "web" } });
+  });
+
+  it("dryRun is a PUT-only param and has no effect on GET ?metadata=1", async () => {
+    const { env } = await makeEnv();
+    await putShot(env);
+    await patchMeta(env, "screenshots/shot.png", { set: { app: "web" } });
+
+    // dryRun only means anything on PUT; a stray dryRun=1 alongside
+    // metadata=1 on a GET is simply ignored, not misread as a dry-run upload.
     const res = await app.request(
-      `/v1/default/files/${weirdKey}`,
+      "/v1/default/files/screenshots/shot.png?metadata=1&dryRun=1",
       { headers: { Authorization: `Bearer ${TOKEN}` } },
       env,
     );
-    // This assertion documents actual behavior — see comment above.
-    const json = (await res.json()) as { metadata?: unknown; key?: string };
     expect(res.status).toBe(200);
-    expect(json).toEqual({ metadata: {} });
+    expect(await res.json()).toEqual({ metadata: { app: "web" } });
   });
 });
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -713,24 +713,20 @@ export function createUploadsClient(config: UploadsClientConfig) {
       return request<DeleteResult>("DELETE", `${filesBase(config)}/${encodeKeyPath(key)}`);
     },
 
-    /** `GET /v1/:workspace/files/:key/metadata` — the object's queryable metadata. */
+    /** `GET /v1/:workspace/files/:key?metadata=1` — the object's queryable metadata. */
     async getMetadata(key: string): Promise<GetMetadataResult> {
       return request<GetMetadataResult>(
         "GET",
-        `${filesBase(config)}/${encodeKeyPath(key)}/metadata`,
+        `${filesBase(config)}/${encodeKeyPath(key)}?metadata=1`,
       );
     },
 
-    /** `PATCH /v1/:workspace/files/:key/metadata` — merge `set`/`delete`; returns the merged map. */
+    /** `PATCH /v1/:workspace/files/:key` — merge `set`/`delete`; returns the merged map. */
     async patchMetadata(key: string, opts: PatchMetadataOptions): Promise<GetMetadataResult> {
-      return request<GetMetadataResult>(
-        "PATCH",
-        `${filesBase(config)}/${encodeKeyPath(key)}/metadata`,
-        {
-          body: new TextEncoder().encode(JSON.stringify(opts)),
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      return request<GetMetadataResult>("PATCH", `${filesBase(config)}/${encodeKeyPath(key)}`, {
+        body: new TextEncoder().encode(JSON.stringify(opts)),
+        headers: { "Content-Type": "application/json" },
+      });
     },
 
     /**

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -69,9 +69,9 @@ describe("put metadata headers", () => {
 });
 
 describe("metadata CRUD client methods", () => {
-  it("getMetadata GETs the /metadata sibling route", async () => {
+  it("getMetadata GETs the key-at-tail route with ?metadata=1", async () => {
     const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      expect(String(input)).toBe("https://api.test/v1/test/files/screenshots/a.png/metadata");
+      expect(String(input)).toBe("https://api.test/v1/test/files/screenshots/a.png?metadata=1");
       expect(init?.method).toBe("GET");
       return new Response(JSON.stringify({ metadata: { app: "myapp" } }));
     });
@@ -84,9 +84,9 @@ describe("metadata CRUD client methods", () => {
     expect(await client.getMetadata("screenshots/a.png")).toEqual({ metadata: { app: "myapp" } });
   });
 
-  it("patchMetadata PATCHes { set, delete } and returns the merged map", async () => {
+  it("patchMetadata PATCHes { set, delete } to the key-at-tail route and returns the merged map", async () => {
     const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      expect(String(input)).toBe("https://api.test/v1/test/files/screenshots/a.png/metadata");
+      expect(String(input)).toBe("https://api.test/v1/test/files/screenshots/a.png");
       expect(init?.method).toBe("PATCH");
       const body = JSON.parse(new TextDecoder().decode(init?.body as Uint8Array));
       expect(body).toEqual({ set: { app: "myapp" }, delete: ["page"] });


### PR DESCRIPTION
## In plain terms

The new per-file metadata endpoints worked in tests but 404 in production for every real object key. The deployed router doesn't match `/:key{.+}/metadata` across slashes (percent-encoding the slashes returns 200, which pinpointed the router as the culprit). This blocked the gh backfill.

## What it does

- Moves metadata reads to `GET /v1/:ws/files/:key?metadata=1` and writes to `PATCH /v1/:ws/files/:key` — the key-at-tail shape every other file route already uses and that provably matches in production.
- Removes the old suffix routes and the now-moot "keys ending in /metadata" shadowing tradeoff + its test.
- Updates the CLI client, backfill script, and docs. No published CLI ever shipped the old paths (0.7.0 predates the feature; version PR #144 is unmerged), so nothing external breaks.

## Test plan

- [x] api 340 / uploads 281 / mcp 32 / web 81 tests pass; check + typecheck clean
- [ ] Post-merge: verify `GET …?metadata=1` and PATCH against prod, then run the gh backfill