### PR TITLE
fix(auth,web): list sessions without freshAge; sticky CLI onboarded flag

### DIFF
--- a/apps/auth/migrations/20260714120000_cli_onboarded_at.sql
+++ b/apps/auth/migrations/20260714120000_cli_onboarded_at.sql
@@ -1,0 +1,18 @@
+-- Sticky "completed CLI login once" (schema: user.cliOnboardedAt).
+-- Set on CLI device-flow session create; backfill from existing CLI sessions.
+
+ALTER TABLE user ADD COLUMN cli_onboarded_at INTEGER;
+
+UPDATE user
+SET cli_onboarded_at = (
+  SELECT MIN(s.created_at)
+  FROM session s
+  WHERE s.user_id = user.id
+    AND s.user_agent LIKE '%@buildinternet/uploads%'
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM session s
+  WHERE s.user_id = user.id
+    AND s.user_agent LIKE '%@buildinternet/uploads%'
+);

--- a/apps/auth/src/auth.test.ts
+++ b/apps/auth/src/auth.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { deriveCookieDomain } from "./auth";
+import { deriveCookieDomain, isCliSessionUserAgent } from "./auth";
+
+describe("isCliSessionUserAgent", () => {
+  it("matches the uploads CLI device-flow User-Agent", () => {
+    expect(isCliSessionUserAgent("@buildinternet/uploads/1.2.3 (device-token)")).toBe(true);
+    expect(isCliSessionUserAgent("@buildinternet/uploads")).toBe(true);
+  });
+
+  it("rejects browsers and empty values", () => {
+    expect(isCliSessionUserAgent("Mozilla/5.0 (Macintosh) Chrome/120")).toBe(false);
+    expect(isCliSessionUserAgent(null)).toBe(false);
+    expect(isCliSessionUserAgent(undefined)).toBe(false);
+  });
+});
 
 describe("deriveCookieDomain", () => {
   it("shares the whole apex host for a 2-label domain (no public-suffix leak)", () => {

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -8,7 +8,7 @@
 import { dash } from "@better-auth/infra";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { admin, bearer, deviceAuthorization, magicLink, organization } from "better-auth/plugins";
 import { sendAuthEmail } from "./email";
@@ -32,6 +32,11 @@ import {
  * of scope for v1 (D3); when it lands, this stays the CLI's reserved id.
  */
 export const UPLOADS_CLI_CLIENT_ID = "uploads-cli";
+
+/** CLI device-flow User-Agent — keep in sync with apps/web `CLI_USER_AGENT_RE`. */
+export function isCliSessionUserAgent(ua?: string | null): boolean {
+  return Boolean(ua && /@buildinternet\/uploads(?:\/[\w.-]+)?/i.test(ua));
+}
 
 export type AuthEnv = GitHubCredentialsEnv &
   DashApiKeyEnv & {
@@ -194,10 +199,30 @@ function buildAuth(
       // standard Better Auth cookie and leaves membership checks to apps/api.
       ...(localDemoEnabled(env) ? [localDemoPlugin(env)] : []),
     ],
+    // Sticky "completed uploads login once" for account overview UX.
+    user: {
+      additionalFields: {
+        cliOnboardedAt: { type: "date", required: false, input: false },
+      },
+    },
     session: {
-      cookieCache: {
-        enabled: true,
-        maxAge: 5 * 60,
+      // /list-sessions uses freshSessionMiddleware (default 24h → SESSION_NOT_FRESH).
+      // We only use it for account UX, not high-sensitivity actions — disable.
+      freshAge: 0,
+      cookieCache: { enabled: true, maxAge: 5 * 60 },
+    },
+    databaseHooks: {
+      session: {
+        create: {
+          after: async (session) => {
+            const userId = session?.userId;
+            if (!userId || !isCliSessionUserAgent(session.userAgent)) return;
+            await db
+              .update(schema.user)
+              .set({ cliOnboardedAt: new Date(), updatedAt: new Date() })
+              .where(and(eq(schema.user.id, userId), isNull(schema.user.cliOnboardedAt)));
+          },
+        },
       },
     },
     // Fail-closed in production, decoupled from secret resolution (D3/D7):

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -129,6 +129,7 @@ describe("DB-backed behavior", () => {
       banned: overrides.banned ?? null,
       banReason: overrides.banReason ?? null,
       banExpires: overrides.banExpires ?? null,
+      cliOnboardedAt: overrides.cliOnboardedAt ?? null,
     };
     await orm.insert(schema.user).values(user);
     return user;

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -30,7 +30,8 @@ const timestampCol = (name: string) =>
  * additive-free for this table (verified: no ALTER TABLE for `user` in
  * `migrations/20260712210000_admin_plugin.sql`).
  *
- * Paired migration: `migrations/20260712200000_better_auth_core.sql`.
+ * Paired migrations: `20260712200000_better_auth_core.sql`,
+ * `20260714120000_cli_onboarded_at.sql` (`cli_onboarded_at`).
  */
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -46,6 +47,8 @@ export const user = sqliteTable("user", {
   banned: integer("banned", { mode: "boolean" }),
   banReason: text("ban_reason"),
   banExpires: integer("ban_expires", { mode: "timestamp" }),
+  /** First CLI device-flow session; sticky. */
+  cliOnboardedAt: integer("cli_onboarded_at", { mode: "timestamp" }),
 });
 
 /**

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -32,6 +32,8 @@ export interface SessionUser {
   name: string;
   image?: string | null;
   role?: string | null;
+  /** First CLI device-flow session (sticky); de-emphasizes account setup. */
+  cliOnboardedAt?: string | Date | null;
 }
 
 /** Session row from get-session / list-sessions. */

--- a/apps/web/src/lib/cli-setup-state.test.ts
+++ b/apps/web/src/lib/cli-setup-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveCliSetupState } from "./cli-setup-state";
+
+const CLI_UA = "@buildinternet/uploads/1.0.0 (device-token)";
+const BROWSER_UA = "Mozilla/5.0 Chrome/120";
+
+describe("resolveCliSetupState", () => {
+  it("stays checking until sessions are loaded", () => {
+    expect(resolveCliSetupState({ sessions: null, loaded: false }).kind).toBe("checking");
+  });
+
+  it("is ready when an active CLI session exists", () => {
+    const state = resolveCliSetupState({
+      loaded: true,
+      sessions: [{ userAgent: CLI_UA }, { userAgent: BROWSER_UA }],
+    });
+    expect(state).toMatchObject({ kind: "ready", statusState: "ready" });
+  });
+
+  it("reconnects when onboarded but no active CLI session", () => {
+    const state = resolveCliSetupState({
+      loaded: true,
+      sessions: [{ userAgent: BROWSER_UA }],
+      cliOnboardedAt: "2026-06-01T00:00:00.000Z",
+    });
+    expect(state.kind).toBe("reconnect");
+  });
+
+  it("nudges install when list-sessions fails and user never onboarded", () => {
+    const state = resolveCliSetupState({
+      loaded: true,
+      sessions: null,
+      cliOnboardedAt: null,
+    });
+    expect(state.kind).toBe("setup");
+    expect(state.statusText.toLowerCase()).not.toMatch(/couldn.?t/);
+  });
+
+  it("prefers reconnect when list fails but onboarded flag is set", () => {
+    expect(
+      resolveCliSetupState({
+        loaded: true,
+        sessions: null,
+        cliOnboardedAt: new Date("2026-06-01"),
+      }).kind,
+    ).toBe("reconnect");
+  });
+
+  it("shows setup when loaded with no CLI and never onboarded", () => {
+    expect(
+      resolveCliSetupState({
+        loaded: true,
+        sessions: [{ userAgent: BROWSER_UA }],
+      }).kind,
+    ).toBe("setup");
+  });
+});

--- a/apps/web/src/lib/cli-setup-state.ts
+++ b/apps/web/src/lib/cli-setup-state.ts
@@ -1,0 +1,58 @@
+/**
+ * Account overview CLI setup card: list-sessions + sticky `cliOnboardedAt`.
+ */
+
+import { isCliUserAgent } from "./session-device";
+
+export type CliSetupKind = "checking" | "ready" | "reconnect" | "setup";
+
+export type CliSetupPresentation = {
+  kind: CliSetupKind;
+  statusText: string;
+  statusState?: "muted" | "ready";
+};
+
+export function resolveCliSetupState(input: {
+  sessions: Array<{ userAgent?: string | null }> | null;
+  cliOnboardedAt?: string | Date | null;
+  loaded: boolean;
+}): CliSetupPresentation {
+  if (!input.loaded) {
+    return {
+      kind: "checking",
+      statusText: "Checking for a CLI sign-in…",
+      statusState: "muted",
+    };
+  }
+
+  const hasCli = input.sessions?.some((s) => isCliUserAgent(s.userAgent)) ?? false;
+  if (hasCli) {
+    return {
+      kind: "ready",
+      statusText: "CLI sign-in found on an active session. You’re set.",
+      statusState: "ready",
+    };
+  }
+
+  // Sticky flag survives expired CLI sessions (list-sessions is active-only).
+  if (input.cliOnboardedAt != null && input.cliOnboardedAt !== "") {
+    return {
+      kind: "reconnect",
+      statusText: "You’ve set up the CLI before. Run uploads login on a machine that needs tokens.",
+    };
+  }
+
+  // list-sessions failed: still nudge install — don't frame it as a hard error.
+  if (input.sessions === null) {
+    return {
+      kind: "setup",
+      statusText:
+        "Install the CLI and run uploads login to connect this account from your terminal.",
+    };
+  }
+
+  return {
+    kind: "setup",
+    statusText: "No CLI session yet. Finish setup below so your terminal and agents can upload.",
+  };
+}

--- a/apps/web/src/pages/account/index.astro
+++ b/apps/web/src/pages/account/index.astro
@@ -8,11 +8,10 @@ export const prerender = false;
 
 <AccountLayout section="overview">
   <!--
-    Static setup card. Script only toggles the status line + emphasis once
-    list-sessions tells us whether a CLI device session exists.
-    Deep link: /account#cli-setup (used after invite accept / first sign-in).
+    CLI setup card. Script toggles status from list-sessions + sticky
+    user.cliOnboardedAt. Deep link: /account#cli-setup.
   -->
-  <section class="card is-pending" id="cli-setup">
+  <section class="card is-pending" id="cli-setup" data-setup="checking">
     <h2>Set up the CLI</h2>
     <p>
       Most of uploads is used from the terminal. Install once, run
@@ -22,8 +21,8 @@ export const prerender = false;
     <div id="cli-setup-status" class="ul-callout" data-state="muted" role="status">
       Checking for a CLI sign-in…
     </div>
-    <div class="cli-steps">
-      <div class="command">
+    <div class="cli-steps" id="cli-steps">
+      <div class="command" id="cli-install-cmd">
         <code>npm install -g @buildinternet/uploads</code>
         <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite">copy</button>
       </div>
@@ -32,7 +31,7 @@ export const prerender = false;
         <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
       </div>
     </div>
-    <p class="muted cli-note">
+    <p class="muted cli-note" id="cli-setup-note">
       Prefer no global install? <code>npx @buildinternet/uploads login</code>.
       Full walkthrough in the <a href="/docs#install">docs</a>.
     </p>
@@ -50,12 +49,11 @@ export const prerender = false;
   <script>
     import { onSession, requireElement } from "../../lib/account-shell";
     import { listSessions } from "../../lib/auth-client";
-    import { isCliUserAgent } from "../../lib/session-device";
+    import { resolveCliSetupState } from "../../lib/cli-setup-state";
 
     const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
       .__UPLOADS_AUTH_ORIGIN__;
 
-    // Same delegated copy pattern as workspaces invite commands.
     requireElement<HTMLElement>("#cli-setup", "account overview").addEventListener(
       "click",
       (event) => {
@@ -78,28 +76,42 @@ export const prerender = false;
       },
     );
 
+    function applyCliSetup(
+      sessions: Awaited<ReturnType<typeof listSessions>>,
+      cliOnboardedAt: string | Date | null | undefined,
+      loaded: boolean,
+    ): void {
+      const { kind, statusText, statusState } = resolveCliSetupState({
+        sessions,
+        cliOnboardedAt,
+        loaded,
+      });
+      const status = requireElement<HTMLElement>("#cli-setup-status", "account overview");
+      const card = requireElement<HTMLElement>("#cli-setup", "account overview");
+      const steps = requireElement<HTMLElement>("#cli-steps", "account overview");
+      const installCmd = requireElement<HTMLElement>("#cli-install-cmd", "account overview");
+      const note = requireElement<HTMLElement>("#cli-setup-note", "account overview");
+
+      card.dataset.setup = kind;
+      card.classList.toggle("is-pending", kind === "checking" || kind === "setup");
+      if (statusState) status.dataset.state = statusState;
+      else delete status.dataset.state;
+      status.textContent = statusText;
+
+      // ready: hide commands; reconnect: login only; setup/checking: full install.
+      steps.hidden = kind === "ready";
+      installCmd.hidden = kind === "reconnect";
+      note.hidden = kind === "ready" || kind === "reconnect";
+    }
+
     onSession((user) => {
       requireElement<HTMLElement>("#hello-name", "account overview").textContent = user.name
         ? `, ${user.name}`
         : "";
 
-      const status = requireElement<HTMLElement>("#cli-setup-status", "account overview");
-      const card = requireElement<HTMLElement>("#cli-setup", "account overview");
-
+      applyCliSetup(null, user.cliOnboardedAt, false);
       void listSessions(authOrigin).then((sessions) => {
-        const hasCli = sessions?.some((s) => isCliUserAgent(s.userAgent)) ?? false;
-        if (hasCli) {
-          status.dataset.state = "ready";
-          status.textContent = "CLI sign-in found on an active session. You’re set.";
-          card.classList.remove("is-pending");
-          return;
-        }
-        delete status.dataset.state;
-        status.textContent =
-          sessions === null
-            ? "Couldn’t check CLI sessions — run uploads login if you haven’t yet."
-            : "No CLI session yet. Finish setup below so your terminal and agents can upload.";
-        card.classList.add("is-pending");
+        applyCliSetup(sessions, user.cliOnboardedAt, true);
       });
     });
   </script>

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -42,6 +42,13 @@ export const prerender = false;
     </p>
     <div id="sessions-status" class="muted detail-status">Loading…</div>
     <ul class="detail-list" id="sessions-list" hidden></ul>
+    <div id="sessions-recover" class="sessions-recover" hidden>
+      <p class="muted">
+        Couldn’t load the session list. Sign in again to refresh it — browsing
+        still works with your current session.
+      </p>
+      <a class="text-btn" id="sessions-reauth" href="/login">Sign in again</a>
+    </div>
     <p id="sessions-error" class="detail-error" role="alert" hidden></p>
   </section>
 
@@ -222,10 +229,16 @@ export const prerender = false;
     async function loadSessions(): Promise<void> {
       const status = requireElement<HTMLElement>("#sessions-status", "account profile");
       const list = requireElement<HTMLUListElement>("#sessions-list", "account profile");
+      const recover = requireElement<HTMLElement>("#sessions-recover", "account profile");
+      const reauth = requireElement<HTMLAnchorElement>("#sessions-reauth", "account profile");
       const error = requireElement<HTMLElement>("#sessions-error", "account profile");
       error.hidden = true;
       list.hidden = true;
+      recover.hidden = true;
       showStatus(status, "Loading…");
+
+      // Point recovery at this page so re-auth lands back on the sessions list.
+      reauth.href = `/login?callbackURL=${encodeURIComponent(`${location.origin}/account/profile`)}`;
 
       const [sessionResult, sessions] = await Promise.all([
         getSession(authOrigin),
@@ -238,7 +251,8 @@ export const prerender = false;
       }
 
       if (sessions === null) {
-        showStatus(status, "Couldn’t load sessions.");
+        status.hidden = true;
+        recover.hidden = false;
         return;
       }
       if (!sessions.length) {

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -98,8 +98,18 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const magicSubmit = requireElement<HTMLButtonElement>("#magic-submit");
   const emailInput = requireElement<HTMLInputElement>("#email");
 
-  // Land on the CLI setup card (#cli-setup) so first-time users see next steps.
-  const callbackURL = `${location.origin}/account#cli-setup`;
+  // Default: CLI setup card. Same-origin ?callbackURL= allowed (session recovery).
+  const defaultCallback = `${location.origin}/account#cli-setup`;
+  let callbackURL = defaultCallback;
+  const rawCallback = new URLSearchParams(location.search).get("callbackURL");
+  if (rawCallback) {
+    try {
+      const url = new URL(rawCallback, location.origin);
+      if (url.origin === location.origin) callbackURL = url.href;
+    } catch {
+      // keep default
+    }
+  }
 
   githubBtn.addEventListener("click", async () => {
     errorBox.hidden = true;

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -259,6 +259,15 @@ section.card .cli-note {
 
 /* Profile sign-in methods + sessions ──────────────────────────────────── */
 
+.sessions-recover {
+  margin-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+.sessions-recover .text-btn {
+  display: inline-block;
+}
+
 .detail-status {
   margin-top: 12px;
   font-size: 13px;


### PR DESCRIPTION
## In plain terms

Long-lived browser sessions could open the account UI fine but failed to list active sessions — so the overview said it “couldn’t check CLI sessions” and the profile page couldn’t show devices. Better Auth treats session listing as a “fresh” action (default 24h). We don’t need that bar for account UX, and we now remember that someone finished CLI setup even after the CLI session expires.

## What it does

- Sets Better Auth `session.freshAge: 0` so `/list-sessions` works for normal account browsing (revoke still uses an authoritative DB session read).
- Adds sticky `user.cliOnboardedAt` (migration + backfill from existing CLI User-Agents; set on first CLI device-flow session create).
- Softens overview CLI setup: ready / reconnect / install nudge — no scary “couldn’t check” framing when listing fails.
- Profile sessions: recovery path with “Sign in again” (same-origin `callbackURL` on `/login`).

## What it is not

- Not a security change to revoke/sign-out (still sensitive-session / DB-backed).
- No CLI package / changeset (auth + web only).

## How to try it

1. Deploy auth (migration applies with auth deploy) + web.
2. On a browser session older than a day, open `/account` and `/account/profile` — sessions should list without re-auth.
3. After `uploads login` once, revoke or expire the CLI session: overview should stay de-emphasized with reconnect copy.

## Technical notes

- Root cause: `list-sessions` → `freshSessionMiddleware` → default `freshAge` 24h → `SESSION_NOT_FRESH`.
- Flag lives on the Better Auth user row; overview prefers active CLI UA when present.

## Test plan

- [x] `pnpm --filter @uploads/auth test`
- [x] `pnpm --filter @uploads/web` cli-setup-state + auth-client tests
- [ ] Deploy auth migration; spot-check overview + profile on a long-lived session