### PR TITLE
feat: connect GitHub from account profile after magic-link sign-in

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -111,6 +111,15 @@ function buildAuth(
     // D3: gate GitHub on both id+secret resolving; adding a provider later is
     // just another resolved secret pair, no code change here.
     socialProviders: github ? { github } : {},
+    // Magic-link first, then Connect GitHub on /account/profile (link-social).
+    // trustedProviders + allowDifferentEmails: signed-in explicit link; GitHub
+    // email often differs from the magic-link address.
+    account: {
+      accountLinking: {
+        trustedProviders: github ? ["github"] : [],
+        allowDifferentEmails: true,
+      },
+    },
     plugins: [
       magicLink({
         expiresIn: 60 * 15,

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getAccountInfo,
   getSession,
+  linkGitHub,
   listAccounts,
   listSessions,
   revokeSession,
@@ -175,6 +176,60 @@ describe("revokeSession", () => {
       vi.fn(async () => new Response(null, { status: 403 })),
     );
     await expect(revokeSession("http://127.0.0.1:8788", "tok")).resolves.toBe(false);
+  });
+});
+
+describe("linkGitHub", () => {
+  it("posts link-social and navigates to the authorize URL", async () => {
+    const hrefSetter = vi.fn();
+    vi.stubGlobal("location", {
+      get href() {
+        return "https://uploads.sh/account/profile";
+      },
+      set href(value: string) {
+        hrefSetter(value);
+      },
+    });
+    const fetcher = vi.fn(async () =>
+      Response.json({ url: "https://github.com/login/oauth/authorize?x=1" }),
+    );
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(
+      linkGitHub("https://auth.uploads.sh", "https://uploads.sh/account/profile"),
+    ).resolves.toBe(true);
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/link-social",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify({
+          provider: "github",
+          callbackURL: "https://uploads.sh/account/profile",
+          errorCallbackURL: "https://uploads.sh/account/profile",
+        }),
+      }),
+    );
+    expect(hrefSetter).toHaveBeenCalledWith("https://github.com/login/oauth/authorize?x=1");
+  });
+
+  it("returns false when the auth worker rejects or omits a URL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+    await expect(
+      linkGitHub("https://auth.uploads.sh", "https://uploads.sh/account/profile"),
+    ).resolves.toBe(false);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({})),
+    );
+    await expect(
+      linkGitHub("https://auth.uploads.sh", "https://uploads.sh/account/profile"),
+    ).resolves.toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -7,11 +7,10 @@
  * are plain inline `<script>` tags with no component-island framework (no
  * React in this repo) and a deliberately strict CSP. Pulling in
  * `better-auth/client` would be this app's first client-bundle dependency,
- * for a page surface (`/login`, the console session indicator, `/admin`)
- * that only needs three calls: get-session, magic-link sign-in, sign-out,
- * plus a redirect to the GitHub social sign-in URL. The plan explicitly
- * sanctions this fallback when the client-bundle approach is awkward for the
- * inline-script model (see plan D6) — this is that case.
+ * for a page surface (`/login`, console, `/admin`, `/account/profile`) that
+ * needs session, magic-link, sign-out, GitHub sign-in, and link-social — not a
+ * full client SDK. The plan explicitly sanctions this fallback when the
+ * client-bundle approach is awkward for the inline-script model (see plan D6).
  *
  * `credentials: "include"` on every call so the cross-subdomain session
  * cookie (`.uploads.sh`, see apps/auth/src/auth.ts's crossSubDomainCookies)
@@ -144,23 +143,51 @@ export async function startLocalDemoSession(
 }
 
 /**
- * Starts the GitHub social sign-in flow: POSTs sign-in/social (Better Auth's
- * contract — it returns `{ url }` to redirect to rather than 302ing itself),
- * then navigates the browser there. Returns false (without navigating) if
- * the auth worker rejects the request, e.g. GitHub not configured (D3's gate).
+ * Better Auth social/link endpoints return `{ url }` instead of 302ing.
+ * Navigate when present; return false if the worker rejects or GitHub is
+ * unconfigured (D3's gate).
  */
+async function redirectToGitHubOAuth(
+  origin: string,
+  path: "/api/auth/sign-in/social" | "/api/auth/link-social",
+  body: Record<string, unknown>,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}${path}`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return false;
+    const data = (await res.json().catch(() => null)) as { url?: string } | null;
+    if (!data?.url) return false;
+    location.href = data.url;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Start GitHub sign-in (unauthenticated). */
 export async function signInWithGitHub(origin: string, callbackURL: string): Promise<boolean> {
-  const res = await fetch(`${authOrigin(origin)}/api/auth/sign-in/social`, {
-    method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ provider: "github", callbackURL }),
+  return redirectToGitHubOAuth(origin, "/api/auth/sign-in/social", {
+    provider: "github",
+    callbackURL,
   });
-  if (!res.ok) return false;
-  const body = (await res.json().catch(() => null)) as { url?: string } | null;
-  if (!body?.url) return false;
-  location.href = body.url;
-  return true;
+}
+
+/**
+ * Link GitHub to the current session (POST /link-social). Profile page uses
+ * this so magic-link users can add GitHub without signing out. Failures return
+ * to `callbackURL` with `?error=` (also used as errorCallbackURL).
+ */
+export async function linkGitHub(origin: string, callbackURL: string): Promise<boolean> {
+  return redirectToGitHubOAuth(origin, "/api/auth/link-social", {
+    provider: "github",
+    callbackURL,
+    errorCallbackURL: callbackURL,
+  });
 }
 
 /** POST /api/auth/sign-in/magic-link. Returns true when the auth worker accepted the request. */

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -22,6 +22,7 @@ export const prerender = false;
     <p class="muted">How you sign in to the web app and approve <code>uploads login</code>.</p>
     <div id="accounts-status" class="muted detail-status">Loading…</div>
     <ul class="detail-list" id="accounts-list" hidden></ul>
+    <p id="accounts-error" class="detail-error" role="alert" hidden></p>
   </section>
 
   <section class="card">
@@ -57,6 +58,7 @@ export const prerender = false;
     import {
       getAccountInfo,
       getSession,
+      linkGitHub,
       listAccounts,
       listSessions,
       revokeSession,
@@ -88,6 +90,12 @@ export const prerender = false;
       return typeof value === "string" && value.length > 0 ? value : null;
     }
 
+    function setAccountsError(message: string | null): void {
+      const error = requireElement<HTMLElement>("#accounts-error", "account profile");
+      error.textContent = message ?? "";
+      error.hidden = !message;
+    }
+
     // Official GitHub mark (same path as releases AccountIcon) — not a Lucide
     // brand icon; Lucide dropped brand logos.
     const GITHUB_ICON = githubMarkSvg({ size: 14, className: "detail-icon" });
@@ -104,7 +112,13 @@ export const prerender = false;
       return parts.join(" · ");
     }
 
-    type MethodRow = { title: string; detail: string; ok: boolean; icon?: string };
+    type MethodRow = {
+      title: string;
+      detail: string;
+      ok: boolean;
+      icon?: string;
+      connectGithub?: boolean;
+    };
 
     async function loadAccounts(): Promise<void> {
       const status = requireElement<HTMLElement>("#accounts-status", "account profile");
@@ -118,8 +132,7 @@ export const prerender = false;
         return;
       }
 
-      // Live GitHub profile (username/email) when a linked account exists.
-      // account-info needs the numeric accountId from list-accounts.
+      // Live GitHub profile when linked (account-info needs list-accounts id).
       const github = accounts.find((a) => a.providerId === "github");
       const githubInfo = github
         ? await getAccountInfo(authOrigin, {
@@ -147,35 +160,40 @@ export const prerender = false;
             })
           : [{ title: "Email", detail: "Magic link sign-in", ok: true }];
 
-      // Surface a missing GitHub link without inventing connect/disconnect UI.
       if (!github) {
         rows.push({
           title: "GitHub",
-          detail: "Not connected — use GitHub next time you sign in to link it.",
+          detail: "Not connected — connect it to sign in with GitHub next time.",
           ok: false,
           icon: GITHUB_ICON,
+          connectGithub: true,
         });
       }
 
       status.hidden = true;
       list.hidden = false;
       list.innerHTML = rows
-        .map(
-          (row) => `<li>
+        .map((row) => {
+          const action = row.connectGithub
+            ? `<div class="detail-action">
+                <button type="button" class="text-btn" data-connect-github>Connect</button>
+              </div>`
+            : "";
+          const badge = row.ok
+            ? `<span class="ul-badge ul-badge--ok">Connected</span>`
+            : `<span class="ul-badge">Not connected</span>`;
+          return `<li>
             <div class="detail-main">
               <div class="detail-title">
                 ${row.icon ?? ""}
                 <span>${escapeHtml(row.title)}</span>
-                ${
-                  row.ok
-                    ? `<span class="ul-badge ul-badge--ok">Connected</span>`
-                    : `<span class="ul-badge">Not connected</span>`
-                }
+                ${badge}
               </div>
               <div class="detail-meta">${escapeHtml(row.detail)}</div>
             </div>
-          </li>`,
-        )
+            ${action}
+          </li>`;
+        })
         .join("");
     }
 
@@ -322,6 +340,41 @@ export const prerender = false;
         })();
       },
     );
+
+    requireElement<HTMLUListElement>("#accounts-list", "account profile").addEventListener(
+      "click",
+      (event) => {
+        void (async () => {
+          const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+            "button[data-connect-github]",
+          );
+          if (!button) return;
+          setAccountsError(null);
+          button.disabled = true;
+          button.textContent = "Redirecting…";
+          const returnTo = `${location.origin}/account/profile`;
+          if (!(await linkGitHub(authOrigin, returnTo))) {
+            setAccountsError("GitHub linking isn’t available right now.");
+            button.disabled = false;
+            button.textContent = "Connect";
+          }
+        })();
+      },
+    );
+
+    // Better Auth link-social failures redirect back with ?error=.
+    const linkError = new URLSearchParams(location.search).get("error");
+    if (linkError) {
+      setAccountsError(
+        linkError === "account_already_linked_to_different_user"
+          ? "That GitHub account is already linked to a different uploads.sh user."
+          : "Couldn’t connect GitHub. Try again.",
+      );
+      const clean = new URL(location.href);
+      clean.searchParams.delete("error");
+      clean.searchParams.delete("error_description");
+      history.replaceState(null, "", clean.pathname + clean.search + clean.hash);
+    }
 
     onSession((user) => {
       requireElement<HTMLElement>("#acct-email", "account profile").textContent = user.email;


### PR DESCRIPTION
## In plain terms

If you first signed in with a magic link, the account page now lets you **Connect GitHub** while you’re already logged in. After that, you can use GitHub on future sign-ins — you don’t have to discover linking only by signing in with GitHub later.

## What it does

- Profile **Sign-in methods** shows a **Connect** button when GitHub isn’t linked
- Uses Better Auth `POST /link-social` (signed-in OAuth link), returning to `/account/profile`
- Surfaces OAuth failures via `?error=` with short copy (including “already linked to another user”)
- Auth worker: enable account linking for GitHub (`trustedProviders`, `allowDifferentEmails` for explicit connect when GitHub email ≠ magic-link email)
- Shared client helper for GitHub sign-in and link OAuth redirects

## What it is not

- No disconnect/unlink UI yet
- Not a new identity provider — GitHub was already a sign-in option

## How to try it

1. Sign in with a magic link (account with no GitHub link).
2. Open `/account/profile` → **Sign-in methods**.
3. Click **Connect** on GitHub and finish OAuth.
4. Confirm GitHub shows as **Connected**; sign out and sign in with GitHub.

Deploy **auth** and **web** for production.

## Technical notes

- `apps/web/src/lib/auth-client.ts` — `linkGitHub` + shared `redirectToGitHubOAuth`
- `apps/auth/src/auth.ts` — `account.accountLinking`
- `apps/web/src/pages/account/profile.astro` — Connect button + error UI

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/auth-client.test.ts`
- [ ] Manual: magic-link user connects GitHub on profile
- [ ] Manual: already-linked GitHub error path
- [ ] Deploy auth + web, smoke on production/staging