### PR TITLE
feat: file page & gallery-item polish — GitHub chip, copy, embed formats, download (#159)

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -271,6 +271,45 @@ export async function setObjectVisibility(
   });
 }
 
+/** Non-ASCII-safe fallback for the `filename=` param (browsers that ignore `filename*`). */
+function asciiFilenameFallback(filename: string): string {
+  return filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+}
+
+/** RFC 5987 `filename*=UTF-8''...` value for a Content-Disposition header. */
+function encodeRfc5987Filename(filename: string): string {
+  return encodeURIComponent(filename)
+    .replace(/['()]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/\*/g, "%2A");
+}
+
+/**
+ * Stream a stored object as a forced-download `Response`. Shared by the
+ * public file (`routes/public-files.ts`, behind `?download=1`) and public
+ * gallery-item (`routes/public-galleries.ts`) download routes (design spec
+ * §3.4) — bytes are proxied through this Worker specifically for the download
+ * action (the inline-preview path keeps using the R2 custom domain directly,
+ * unchanged). Full-file only: no `Range` support. Uses `StoredFile.stream()`
+ * so the whole object is never buffered into Worker memory.
+ */
+export async function downloadResponse(
+  store: Files,
+  key: string,
+  filename: string,
+): Promise<Response> {
+  const file = await store.download(key);
+  const headers = new Headers();
+  headers.set("Content-Type", file.type || "application/octet-stream");
+  headers.set(
+    "Content-Disposition",
+    `attachment; filename="${asciiFilenameFallback(filename)}"; ` +
+      `filename*=UTF-8''${encodeRfc5987Filename(filename)}`,
+  );
+  if (typeof file.size === "number") headers.set("Content-Length", String(file.size));
+  headers.set("Cache-Control", "no-store");
+  return new Response(file.stream(), { headers });
+}
+
 /**
  * Provider object metadata → the JSON-safe `{ size, contentType, uploaded? }`
  * subset shared by HEAD and list responses. Normalizes the epoch `lastModified`

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -196,6 +196,11 @@ export function decodeGalleryCursor(value: string | undefined): GalleryCursor | 
   }
 }
 
+/** The filename shown/used on public gallery surfaces: the object key's basename. */
+export function galleryItemFilename(objectKey: string): string {
+  return objectKey.split("/").at(-1) ?? objectKey;
+}
+
 async function mapBounded<T, R>(
   values: T[],
   concurrency: number,
@@ -327,7 +332,7 @@ export async function hydratePublicGallery(
     ...projectPublicGallery(record),
     items: hydrated.map((item) => ({
       id: item.id,
-      filename: item.objectKey.split("/").at(-1) ?? item.objectKey,
+      filename: galleryItemFilename(item.objectKey),
       position: item.position,
       caption: item.caption,
       altText: item.altText,

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,6 +1,7 @@
 import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
-import { badKey } from "../files-core";
+import type { Files } from "@uploads/storage";
+import { badKey, downloadResponse } from "../files-core";
 import { getFileMetadata } from "../file-metadata";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
@@ -41,6 +42,49 @@ function deriveGithubContext(metadata: Record<string, string>): GithubContext | 
   return { repo, kind, number, url: `https://github.com/${repo}/${path}/${number}` };
 }
 
+interface ResolvedPublicObject {
+  store: Files;
+  meta: { size?: number; type?: string; lastModified?: number; metadata?: Record<string, string> };
+  urls: { url: string | null; embedUrl: string | null };
+}
+
+/**
+ * Shared lookup + visibility gate for the `/public/files/:workspace/:key*` GET
+ * handler below: workspace record → publicUrl existence → store.exists/head →
+ * objectVisibility 401. Both the JSON-metadata response and the `?download=1`
+ * streaming branch call this exact same gate (run once per request) so the
+ * two can never disagree about who gets to see — or download — an object.
+ */
+async function resolvePublicObject(
+  env: Env,
+  workspace: string,
+  key: string,
+): Promise<ResolvedPublicObject> {
+  if (badKey(key)) throw new NotFoundError();
+
+  // Validates the workspace name (WS_NAME_RE) before the KV lookup, matching the
+  // authenticated paths rather than trusting the raw path param.
+  const record = await loadWorkspaceRecord(env, workspace);
+  if (!record) throw new NotFoundError();
+
+  // Phase 1 is public-workspace-only: resolving the public URL doubles as the
+  // visibility gate. A workspace without a public base URL cannot be wrapped
+  // here — that is #123's signed-URL territory, swapped in when it lands.
+  const cfg = await storageConfig(env, record);
+  const urls = objectPublicUrls(env, cfg, key);
+  if (!urls.url) throw new NotFoundError();
+
+  const store = await storage(env, record);
+  if (!(await store.exists(key))) throw new NotFoundError();
+  const meta = await store.head(key);
+
+  if (objectVisibility(meta.metadata ?? undefined)) {
+    throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
+  }
+
+  return { store, meta, urls };
+}
+
 /**
  * Public, unauthenticated metadata for a single object, so `apps/web` (which has
  * no storage bindings) can render a chrome-wrapped file page at
@@ -61,30 +105,26 @@ function deriveGithubContext(metadata: Record<string, string>): GithubContext | 
  * route never controlled byte access, only this curated view. Real privacy for a
  * "private" object requires a workspace with no `publicBaseUrl` (signed URLs only),
  * which is out of scope for this endpoint.
+ *
+ * `?download=1` (task 3) switches the response from JSON to a streamed
+ * `Content-Disposition: attachment` body via `downloadResponse` — a query
+ * flag rather than a `/download` suffix route, because a static suffix after
+ * the greedy `:key{.+}` param is inherently ambiguous (a request for
+ * `.../screenshots/download` could mean the suffix OR an object literally
+ * named `screenshots/download`; see the `?metadata=1` precedent in
+ * routes/files.ts for the same reasoning). The gate above runs exactly once
+ * either way — this is purely a "stream vs json" branch on the same
+ * resolved object.
  */
 export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}", async (c) => {
   const workspace = c.req.param("workspace");
   const key = c.req.param("key");
-  if (badKey(key)) throw new NotFoundError();
+  const { store, meta, urls } = await resolvePublicObject(c.env, workspace, key);
 
-  // Validates the workspace name (WS_NAME_RE) before the KV lookup, matching the
-  // authenticated paths rather than trusting the raw path param.
-  const record = await loadWorkspaceRecord(c.env, workspace);
-  if (!record) throw new NotFoundError();
-
-  // Phase 1 is public-workspace-only: resolving the public URL doubles as the
-  // visibility gate. A workspace without a public base URL cannot be wrapped
-  // here — that is #123's signed-URL territory, swapped in when it lands.
-  const cfg = await storageConfig(c.env, record);
-  const urls = objectPublicUrls(c.env, cfg, key);
-  if (!urls.url) throw new NotFoundError();
-
-  const store = await storage(c.env, record);
-  if (!(await store.exists(key))) throw new NotFoundError();
-  const meta = await store.head(key);
-
-  if (objectVisibility(meta.metadata ?? undefined)) {
-    throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
+  const downloadParam = c.req.query("download");
+  if (downloadParam === "1" || downloadParam === "true") {
+    const filename = key.split("/").filter(Boolean).pop() ?? key;
+    return downloadResponse(store, key, filename);
   }
 
   // Fetched only after the visibility gate above — a private object 401s

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -2,7 +2,7 @@ import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import { badKey } from "../files-core";
 import { getFileMetadata } from "../file-metadata";
-import { publicUrl, storage, storageConfig } from "../storage";
+import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 
@@ -75,8 +75,9 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   // Phase 1 is public-workspace-only: resolving the public URL doubles as the
   // visibility gate. A workspace without a public base URL cannot be wrapped
   // here — that is #123's signed-URL territory, swapped in when it lands.
-  const url = publicUrl(await storageConfig(c.env, record), key);
-  if (!url) throw new NotFoundError();
+  const cfg = await storageConfig(c.env, record);
+  const urls = objectPublicUrls(c.env, cfg, key);
+  if (!urls.url) throw new NotFoundError();
 
   const store = await storage(c.env, record);
   if (!(await store.exists(key))) throw new NotFoundError();
@@ -94,7 +95,8 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   return c.json({
     workspace,
     key,
-    url,
+    url: urls.url,
+    embedUrl: urls.embedUrl,
     size: meta.size ?? 0,
     contentType: meta.type ?? "application/octet-stream",
     ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { downloadResponse } from "../files-core";
 import { listExternalReferences, listGalleryItems, resolvePublicGallery } from "../galleries";
 import { hydratePublicGallery } from "../gallery-service";
-import { storage } from "../storage";
+import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { type WorkspaceRecord, type WorkspaceVars } from "../workspace";
 
 export const publicGalleries = new Hono<WorkspaceVars>()
@@ -27,6 +27,18 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     if (!(await store.exists(item.object_key))) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
+
+    // Mirrors hydrateGalleryItems (gallery-service.ts): the object may have
+    // been public at item-add time but the workspace's publicBaseUrl is
+    // mutable afterward. Withhold the bytes here exactly when the gallery's
+    // own read path would withhold the URL, so this route can't be used to
+    // bypass that gate.
+    const config = await storageConfig(c.env, workspace);
+    const urls = objectPublicUrls(c.env, config, item.object_key);
+    if (!urls.url) {
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    }
+
     const filename = item.object_key.split("/").filter(Boolean).pop() ?? item.object_key;
     return downloadResponse(store, item.object_key, filename);
   })

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -6,6 +6,18 @@ import { galleryItemFilename, hydratePublicGallery } from "../gallery-service";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { type WorkspaceRecord, type WorkspaceVars } from "../workspace";
 
+/** Runs `action`, mapping any thrown error to the 503 the gallery storage routes commit to. */
+async function withGalleryStorageErrors<T>(action: () => Promise<T>): Promise<T> {
+  try {
+    return await action();
+  } catch (cause) {
+    throw new ServiceUnavailableError("Gallery storage unavailable.", {
+      code: "gallery_storage_unavailable",
+      cause,
+    });
+  }
+}
+
 export const publicGalleries = new Hono<WorkspaceVars>()
   .get("/:id/items/:item/download", async (c) => {
     const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
@@ -23,15 +35,7 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     });
     if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
 
-    let store: Awaited<ReturnType<typeof storage>>;
-    try {
-      store = await storage(c.env, workspace);
-    } catch (cause) {
-      throw new ServiceUnavailableError("Gallery storage unavailable.", {
-        code: "gallery_storage_unavailable",
-        cause,
-      });
-    }
+    const store = await withGalleryStorageErrors(() => storage(c.env, workspace));
     if (!(await store.exists(item.object_key))) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
@@ -41,15 +45,7 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     // mutable afterward. Withhold the bytes here exactly when the gallery's
     // own read path would withhold the URL, so this route can't be used to
     // bypass that gate.
-    let config: Awaited<ReturnType<typeof storageConfig>>;
-    try {
-      config = await storageConfig(c.env, workspace);
-    } catch (cause) {
-      throw new ServiceUnavailableError("Gallery storage unavailable.", {
-        code: "gallery_storage_unavailable",
-        cause,
-      });
-    }
+    const config = await withGalleryStorageErrors(() => storageConfig(c.env, workspace));
     const urls = objectPublicUrls(c.env, config, item.object_key);
     if (!urls.url) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -1,20 +1,46 @@
 import { NotFoundError } from "@uploads/errors";
 import { Hono } from "hono";
+import { downloadResponse } from "../files-core";
 import { listExternalReferences, listGalleryItems, resolvePublicGallery } from "../galleries";
 import { hydratePublicGallery } from "../gallery-service";
+import { storage } from "../storage";
 import { type WorkspaceRecord, type WorkspaceVars } from "../workspace";
 
-export const publicGalleries = new Hono<WorkspaceVars>().get("/:id", async (c) => {
-  const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
-  if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-  const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
-    type: "json",
-    cacheTtl: 60,
+export const publicGalleries = new Hono<WorkspaceVars>()
+  .get("/:id/items/:item/download", async (c) => {
+    const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
+    if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+
+    const items = await listGalleryItems(c.env.DB, record.workspace, record.id);
+    const item = items.find((entry) => entry.id === c.req.param("item"));
+    if (!item) {
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    }
+
+    const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
+      type: "json",
+      cacheTtl: 60,
+    });
+    if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+
+    const store = await storage(c.env, workspace);
+    if (!(await store.exists(item.object_key))) {
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    }
+    const filename = item.object_key.split("/").filter(Boolean).pop() ?? item.object_key;
+    return downloadResponse(store, item.object_key, filename);
+  })
+  .get("/:id", async (c) => {
+    const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
+    if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
+      type: "json",
+      cacheTtl: 60,
+    });
+    if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    const [items, references] = await Promise.all([
+      listGalleryItems(c.env.DB, record.workspace, record.id),
+      listExternalReferences(c.env.DB, record.workspace, record.id),
+    ]);
+    return c.json(await hydratePublicGallery(c.env, workspace, record, items, references));
   });
-  if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-  const [items, references] = await Promise.all([
-    listGalleryItems(c.env.DB, record.workspace, record.id),
-    listExternalReferences(c.env.DB, record.workspace, record.id),
-  ]);
-  return c.json(await hydratePublicGallery(c.env, workspace, record, items, references));
-});

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -36,7 +36,8 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
 
     const store = await withGalleryStorageErrors(() => storage(c.env, workspace));
-    if (!(await store.exists(item.object_key))) {
+    const exists = await withGalleryStorageErrors(() => store.exists(item.object_key));
+    if (!exists) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
 
@@ -51,7 +52,9 @@ export const publicGalleries = new Hono<WorkspaceVars>()
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
 
-    return downloadResponse(store, item.object_key, galleryItemFilename(item.object_key));
+    return withGalleryStorageErrors(() =>
+      downloadResponse(store, item.object_key, galleryItemFilename(item.object_key)),
+    );
   })
   .get("/:id", async (c) => {
     const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -1,8 +1,8 @@
-import { NotFoundError } from "@uploads/errors";
+import { NotFoundError, ServiceUnavailableError } from "@uploads/errors";
 import { Hono } from "hono";
 import { downloadResponse } from "../files-core";
 import { listExternalReferences, listGalleryItems, resolvePublicGallery } from "../galleries";
-import { hydratePublicGallery } from "../gallery-service";
+import { galleryItemFilename, hydratePublicGallery } from "../gallery-service";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { type WorkspaceRecord, type WorkspaceVars } from "../workspace";
 
@@ -23,7 +23,15 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     });
     if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
 
-    const store = await storage(c.env, workspace);
+    let store: Awaited<ReturnType<typeof storage>>;
+    try {
+      store = await storage(c.env, workspace);
+    } catch (cause) {
+      throw new ServiceUnavailableError("Gallery storage unavailable.", {
+        code: "gallery_storage_unavailable",
+        cause,
+      });
+    }
     if (!(await store.exists(item.object_key))) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
@@ -33,14 +41,21 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     // mutable afterward. Withhold the bytes here exactly when the gallery's
     // own read path would withhold the URL, so this route can't be used to
     // bypass that gate.
-    const config = await storageConfig(c.env, workspace);
+    let config: Awaited<ReturnType<typeof storageConfig>>;
+    try {
+      config = await storageConfig(c.env, workspace);
+    } catch (cause) {
+      throw new ServiceUnavailableError("Gallery storage unavailable.", {
+        code: "gallery_storage_unavailable",
+        cause,
+      });
+    }
     const urls = objectPublicUrls(c.env, config, item.object_key);
     if (!urls.url) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
 
-    const filename = item.object_key.split("/").filter(Boolean).pop() ?? item.object_key;
-    return downloadResponse(store, item.object_key, filename);
+    return downloadResponse(store, item.object_key, galleryItemFilename(item.object_key));
   })
   .get("/:id", async (c) => {
     const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -702,3 +702,59 @@ describe("gallery routes with SQLite D1", () => {
     ).toBe(429);
   });
 });
+
+describe("GET /public/galleries/:id/items/:item/download", () => {
+  it("streams the item's object with a forced attachment disposition", async () => {
+    const gallery = await create();
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+    });
+    expect(added.status).toBe(201);
+    const item = (await added.json()) as { id: string };
+
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/${item.id}/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toBe(
+      "attachment; filename=\"one.png\"; filename*=UTF-8''one.png",
+    );
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(bytes).toEqual(PNG);
+  });
+
+  it("404s for an unknown item id", async () => {
+    const gallery = await create();
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/item_missing/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a non-public (unknown) gallery id", async () => {
+    const res = await app.request("/public/galleries/gal_doesnotexist/items/x/download", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when the item's underlying object has been deleted (tombstone)", async () => {
+    const gallery = await create();
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+    });
+    const item = (await added.json()) as { id: string };
+    await bucket.delete("alpha/screenshots/one.png");
+
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/${item.id}/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -757,4 +757,38 @@ describe("GET /public/galleries/:id/items/:item/download", () => {
     );
     expect(res.status).toBe(404);
   });
+
+  it("404s when the workspace has no publicBaseUrl, matching what the gallery view withholds", async () => {
+    const gallery = await create();
+    // Item add itself requires a public URL (routes/galleries.ts rejects
+    // objects with no publicUrl at add time), so seed the item while alpha
+    // is publicly served, then drop publicBaseUrl to simulate the workspace
+    // losing public serving afterward — publicUrl() is derived at request
+    // time, not pinned when the item was added to the gallery.
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+    });
+    expect(added.status).toBe(201);
+    const item = (await added.json()) as { id: string };
+
+    const { publicBaseUrl: _publicBaseUrl, ...rest } = records.alpha;
+    records.alpha = rest as WorkspaceRecord;
+
+    // The gallery's own hydration path (hydrateGalleryItems) now refuses the
+    // object too — 503 gallery_object_not_public — confirming the download
+    // route isn't withholding more or less than the read path does.
+    const view = await request(`/v1/alpha/galleries/${gallery.id}`);
+    expect(view.status).toBe(503);
+    expect(await view.json()).toMatchObject({
+      error: { code: "gallery_object_not_public" },
+    });
+
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/${item.id}/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
 });

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -151,6 +151,17 @@ describe("GET /public/files/:workspace/:key", () => {
     expect(json.size).toBeGreaterThan(0);
   });
 
+  it("includes an embedUrl alongside the stable url", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { url: string; embedUrl: string | null };
+    expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+    expect(json.embedUrl).toBe("https://embed.uploads.sh/default/screenshots/shot.png");
+  });
+
   it("never surfaces provenance metadata on the public surface", async () => {
     const { env } = await makeEnv();
     // The server always writes content-sha256 provenance itself; a client

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -343,3 +343,94 @@ describe("GET /public/files/:workspace/:key", () => {
     expect(json).not.toHaveProperty("github");
   });
 });
+
+// Task 3 (corrected): forced-download streaming lives behind a `?download=1`
+// query flag on the SAME handler as the metadata route above, mirroring the
+// `?metadata=1` convention already used by routes/files.ts (see the comment
+// there). A sibling `/download` suffix route was rejected: a static suffix
+// after the greedy `:key{.+}` param is inherently ambiguous — a request for
+// `/public/files/default/screenshots/download` can never be distinguished
+// from a request for the object whose key literally is
+// `screenshots/download` (the #158 trap, reverse direction). The query param
+// has no such shadowing, proven by the last test in this block.
+describe("GET /public/files/:workspace/:key?download=1", () => {
+  it("streams the object with a forced attachment disposition", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+
+    const res = await app.request("/public/files/default/screenshots/shot.png?download=1", {}, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Content-Disposition")).toBe(
+      "attachment; filename=\"shot.png\"; filename*=UTF-8''shot.png",
+    );
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(bytes).toEqual(PNG);
+  });
+
+  it("401s with auth_required for a private object, without streaming bytes", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env, { "X-Uploads-Visibility": "private" });
+
+    const res = await app.request("/public/files/default/screenshots/shot.png?download=1", {}, env);
+    expect(res.status).toBe(401);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "auth_required" },
+    });
+  });
+
+  it("404s for a missing object", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/public/files/default/screenshots/missing.png?download=1",
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the unchanged JSON metadata response when the flag is absent (regression guard)", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toBeNull();
+    const json = (await res.json()) as { workspace: string; key: string; url: string };
+    expect(json.workspace).toBe("default");
+    expect(json.key).toBe("screenshots/shot.png");
+    expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+  });
+
+  it("does not shadow a key that literally contains a 'download' segment", async () => {
+    // Proof the query-param design has no ambiguity: a key ending in
+    // "screenshots/download.png" is served correctly both ways.
+    const { env } = await makeEnv();
+    const put = await app.request(
+      "/v1/default/files/screenshots/download.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(put.status).toBe(201);
+
+    const meta = await app.request("/public/files/default/screenshots/download.png", {}, env);
+    expect(meta.status).toBe(200);
+    expect(((await meta.json()) as { key: string }).key).toBe("screenshots/download.png");
+
+    const download = await app.request(
+      "/public/files/default/screenshots/download.png?download=1",
+      {},
+      env,
+    );
+    expect(download.status).toBe(200);
+    expect(download.headers.get("Content-Disposition")).toBe(
+      "attachment; filename=\"download.png\"; filename*=UTF-8''download.png",
+    );
+    const bytes = new Uint8Array(await download.arrayBuffer());
+    expect(bytes).toEqual(PNG);
+  });
+});

--- a/apps/web/src/lib/embed-formats.test.ts
+++ b/apps/web/src/lib/embed-formats.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildEmbedFormats } from "./embed-formats";
+
+const base = {
+  canonical: "https://uploads.sh/f/acme/screenshots/shot.png",
+  url: "https://storage.uploads.sh/acme/screenshots/shot.png",
+  embedUrl: "https://embed.uploads.sh/acme/screenshots/shot.png" as string | null,
+  filename: "shot.png",
+};
+
+describe("buildEmbedFormats", () => {
+  it("returns all five formats, in order, for an image", () => {
+    const formats = buildEmbedFormats({ ...base, kind: "image" });
+    expect(formats.map((f) => f.id)).toEqual([
+      "page",
+      "url",
+      "markdown-image",
+      "markdown-link",
+      "html-img",
+    ]);
+    expect(formats).toEqual([
+      { id: "page", label: "Page link", value: base.canonical },
+      { id: "url", label: "Direct file URL", value: base.url },
+      { id: "markdown-image", label: "Markdown image", value: `![](${base.embedUrl})` },
+      { id: "markdown-link", label: "Markdown link", value: `[shot.png](${base.canonical})` },
+      {
+        id: "html-img",
+        label: "HTML <img>",
+        value: `<img src="${base.embedUrl}" alt="shot.png">`,
+      },
+    ]);
+  });
+
+  it("drops the markdown-image and html-img formats for video/file/unsupported kinds", () => {
+    for (const kind of ["video", "file", "unsupported"] as const) {
+      const formats = buildEmbedFormats({ ...base, kind });
+      expect(formats.map((f) => f.id)).toEqual(["page", "url", "markdown-link"]);
+    }
+  });
+
+  it("embed snippet formats prefer embedUrl over url; Direct file URL always uses the stable url", () => {
+    const formats = buildEmbedFormats({ ...base, kind: "image" });
+    const direct = formats.find((f) => f.id === "url")!;
+    const mdImage = formats.find((f) => f.id === "markdown-image")!;
+    const html = formats.find((f) => f.id === "html-img")!;
+    expect(direct.value).toBe(base.url);
+    expect(mdImage.value).toContain(base.embedUrl);
+    expect(html.value).toContain(base.embedUrl);
+  });
+
+  it("falls back to url for embed snippets when embedUrl is null", () => {
+    const formats = buildEmbedFormats({ ...base, embedUrl: null, kind: "image" });
+    expect(formats.find((f) => f.id === "markdown-image")!.value).toBe(`![](${base.url})`);
+    expect(formats.find((f) => f.id === "html-img")!.value).toBe(
+      `<img src="${base.url}" alt="shot.png">`,
+    );
+  });
+});

--- a/apps/web/src/lib/embed-formats.test.ts
+++ b/apps/web/src/lib/embed-formats.test.ts
@@ -55,4 +55,19 @@ describe("buildEmbedFormats", () => {
       `<img src="${base.url}" alt="shot.png">`,
     );
   });
+
+  it("HTML-escapes the filename in the html-img alt attribute", () => {
+    const formats = buildEmbedFormats({
+      ...base,
+      filename: 'a"><b.png',
+      kind: "image",
+    });
+    const html = formats.find((f) => f.id === "html-img")!;
+    expect(html.value).toBe(`<img src="${base.embedUrl}" alt="a&quot;&gt;&lt;b.png">`);
+    const altStart = html.value.indexOf('alt="') + 'alt="'.length;
+    const alt = html.value.slice(altStart, html.value.length - '">'.length);
+    expect(alt).toBe("a&quot;&gt;&lt;b.png");
+    expect(alt).not.toContain('"');
+    expect(alt).not.toContain("<");
+  });
 });

--- a/apps/web/src/lib/embed-formats.ts
+++ b/apps/web/src/lib/embed-formats.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure embed-format-string builder shared by the public file page
+ * (`pages/f/[workspace]/[...key].astro`) and the public gallery-item page
+ * (`pages/g/[id]/[item].astro`) — issue's "Copy as" control (design spec
+ * §3.3). Kept dependency-free and framework-free so both `.astro` pages can
+ * import it directly and it stays unit-testable without a render harness.
+ */
+
+export type EmbedFormatId = "page" | "url" | "markdown-image" | "markdown-link" | "html-img";
+
+export interface EmbedFormatOption {
+  id: EmbedFormatId;
+  label: string;
+  value: string;
+}
+
+export interface EmbedFormatInput {
+  /** On-site canonical page URL (`/f/<workspace>/<key>` or `/g/<id>/<item>`). */
+  canonical: string;
+  /** Stable public URL — `PublicFile.url` / `PublicGalleryItem.url`. */
+  url: string;
+  /** Embed-host URL when available (dual-host GitHub Camo policy); null otherwise. */
+  embedUrl: string | null;
+  filename: string;
+  /** `"missing"` gallery items never reach this — callers only call it when a URL exists. */
+  kind: "image" | "video" | "file" | "unsupported";
+}
+
+/**
+ * Five candidate formats, gated by `kind`, in the fixed order the design
+ * spec's §3.3 table lists them: Page link, Direct file URL, Markdown image
+ * (image only), Markdown link, HTML `<img>` (image only). Embed *snippet*
+ * formats (Markdown image, HTML img) prefer `embedUrl` and fall back to the
+ * stable `url`; "Direct file URL" always uses the stable `url` — mirrors
+ * `packages/uploads/src/commands.ts`'s existing "MARKDOWN prefers embedUrl"
+ * convention.
+ */
+export function buildEmbedFormats(input: EmbedFormatInput): EmbedFormatOption[] {
+  const embedSrc = input.embedUrl ?? input.url;
+  const options: EmbedFormatOption[] = [
+    { id: "page", label: "Page link", value: input.canonical },
+    { id: "url", label: "Direct file URL", value: input.url },
+  ];
+  if (input.kind === "image") {
+    options.push({ id: "markdown-image", label: "Markdown image", value: `![](${embedSrc})` });
+  }
+  options.push({
+    id: "markdown-link",
+    label: "Markdown link",
+    value: `[${input.filename}](${input.canonical})`,
+  });
+  if (input.kind === "image") {
+    options.push({
+      id: "html-img",
+      label: "HTML <img>",
+      value: `<img src="${embedSrc}" alt="${input.filename}">`,
+    });
+  }
+  return options;
+}

--- a/apps/web/src/lib/embed-formats.ts
+++ b/apps/web/src/lib/embed-formats.ts
@@ -8,6 +8,15 @@
 
 export type EmbedFormatId = "page" | "url" | "markdown-image" | "markdown-link" | "html-img";
 
+/** Escapes `&`, `<`, `>`, and `"` for safe interpolation into an HTML attribute value. */
+function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 export interface EmbedFormatOption {
   id: EmbedFormatId;
   label: string;
@@ -53,7 +62,7 @@ export function buildEmbedFormats(input: EmbedFormatInput): EmbedFormatOption[] 
     options.push({
       id: "html-img",
       label: "HTML <img>",
-      value: `<img src="${embedSrc}" alt="${input.filename}">`,
+      value: `<img src="${embedSrc}" alt="${escapeHtmlAttr(input.filename)}">`,
     });
   }
   return options;

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -3,6 +3,7 @@ import {
   applyPublicFileHeaders,
   authRequiredFileCsp,
   fetchPublicFile,
+  fileDownloadUrl,
   fileKind,
   filePath,
   formatBytes,
@@ -129,6 +130,14 @@ describe("key safety + path building", () => {
 
   it("URL-encodes each key segment but preserves the slashes", () => {
     expect(filePath("acme", "f/My Shot#1.png")).toBe("/f/acme/f/My%20Shot%231.png");
+  });
+
+  it("builds the absolute download-route URL, encoding each key segment", () => {
+    // `?download=1` query flag (Task 3), not a `/download` suffix — a static
+    // suffix after the greedy key route param would be ambiguous.
+    expect(fileDownloadUrl("https://api.uploads.sh", "acme", "f/My Shot#1.png")).toBe(
+      "https://api.uploads.sh/public/files/acme/f/My%20Shot%231.png?download=1",
+    );
   });
 });
 

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -15,6 +15,7 @@ const file = {
   workspace: "acme",
   key: "screenshots/shot.png",
   url: "https://storage.uploads.sh/acme/screenshots/shot.png",
+  embedUrl: "https://embed.uploads.sh/acme/screenshots/shot.png" as string | null,
   size: 20480,
   contentType: "image/png",
   uploaded: "2026-07-13T12:00:00.000Z",
@@ -59,6 +60,13 @@ describe("isPublicFile", () => {
     expect(isPublicFile({ ...file, uploaded: null })).toBe(true);
     const { uploaded: _omit, ...noUploaded } = file;
     expect(isPublicFile(noUploaded)).toBe(true);
+  });
+
+  it("accepts a null embedUrl but rejects a non-https one", () => {
+    expect(isPublicFile({ ...file, embedUrl: null })).toBe(true);
+    expect(isPublicFile({ ...file, embedUrl: "http://embed.uploads.sh/x" })).toBe(false);
+    const { embedUrl: _omit, ...noEmbedUrl } = file;
+    expect(isPublicFile(noEmbedUrl)).toBe(false);
   });
 
   it("rejects non-https URLs, bad sizes, and over-long content types", () => {

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -52,6 +52,12 @@ describe("public file headers", () => {
     applyPublicFileHeaders(defaultHeaders);
     expect(defaultHeaders.get("Content-Security-Policy")).toBe(PUBLIC_FILE_CSP);
   });
+
+  it("widens script-src on the ok branch too — same posture as authRequiredFileCsp", () => {
+    expect(PUBLIC_FILE_CSP).toContain(
+      "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
+    );
+  });
 });
 
 describe("isPublicFile", () => {

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -71,6 +71,20 @@ export function filePath(workspace: string, key: string): string {
 }
 
 /**
+ * Build the API's forced-download URL (absolute) for a public file — Task 3's
+ * `?download=1` query flag on `GET /public/files/:workspace/:key`, *not* a
+ * `/download` suffix route. A static suffix after the greedy `:key{.+}` route
+ * param is ambiguous (`.../screenshots/download` could mean the suffix or an
+ * object literally named `screenshots/download`); the query flag sidesteps
+ * that, mirroring the existing `?metadata=1` precedent.
+ */
+export function fileDownloadUrl(origin: string, workspace: string, key: string): string {
+  const url = new URL(`/public/files/${encodeURIComponent(workspace)}/${encodeKey(key)}`, origin);
+  url.searchParams.set("download", "1");
+  return url.href;
+}
+
+/**
  * Shared directives behind both {@link PUBLIC_FILE_CSP} and
  * {@link authRequiredFileCsp} — locked down except for self-hosted
  * styles/fonts and the Cloudflare RUM beacon. `scriptSrc`/`connectSrc`

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -18,6 +18,8 @@ export interface PublicFile {
   workspace: string;
   key: string;
   url: string;
+  /** Embed-host URL when the dual-host policy applies (GitHub Camo); null otherwise. */
+  embedUrl: string | null;
   size: number;
   contentType: string;
   uploaded: string | null;
@@ -148,6 +150,11 @@ function httpsUrl(value: unknown): value is string {
   }
 }
 
+/** `httpsUrl`, but also accepts `null` — for optional-but-typed URL fields like `embedUrl`. */
+function nullableHttpsUrl(value: unknown): value is string | null {
+  return value === null || httpsUrl(value);
+}
+
 /**
  * Validate a 401 error body against the bounded shape the API commits to
  * (issue #139 Task A): `{"error":{"code":"auth_required","message":"..."}}`.
@@ -202,6 +209,7 @@ export function isPublicFile(value: unknown): value is PublicFile {
     text(file.workspace, 64) &&
     text(file.key, 1024) &&
     httpsUrl(file.url) &&
+    nullableHttpsUrl(file.embedUrl) &&
     Number.isSafeInteger(file.size) &&
     (file.size as number) >= 0 &&
     text(file.contentType, 128) &&

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -93,10 +93,15 @@ function buildFileCsp(overrides?: { scriptSrc?: string; connectSrc?: string }): 
 }
 
 /**
- * Public file page CSP — identical posture to the public gallery: locked down
- * except for self-hosted styles/fonts and the Cloudflare RUM beacon.
+ * Public file page CSP — same posture as the public gallery: locked down
+ * except for self-hosted styles/fonts, the Cloudflare RUM beacon, and (as of
+ * the file-page-polish work) inline script for the click-to-copy button and
+ * "Copy as" control. `connect-src` stays untouched — clipboard writes never
+ * hit the network, and the download link needs no script at all.
  */
-export const PUBLIC_FILE_CSP = buildFileCsp();
+export const PUBLIC_FILE_CSP = buildFileCsp({
+  scriptSrc: `'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+});
 
 /**
  * CSP for the `auth_required` branch only: same posture as {@link PUBLIC_FILE_CSP}

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -106,6 +106,8 @@ describe("public gallery API", () => {
         items: [{ ...gallery.items[0], embedUrl: "http://embed.uploads.sh/x" }],
       }),
     ).toBe(false);
+    const { embedUrl: _omit, ...noEmbedUrl } = gallery.items[0];
+    expect(isPublicGallery({ ...gallery, items: [noEmbedUrl] })).toBe(false);
   });
 
   it("bounds and sanitizes external references, tolerating their absence", () => {

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyPublicGalleryHeaders,
   fetchPublicGallery,
+  galleryItemDownloadUrl,
   isPublicGallery,
   PUBLIC_GALLERY_CSP,
 } from "./public-gallery";
@@ -201,5 +202,13 @@ describe("public gallery API", () => {
     await expect(
       fetchPublicGallery(ID, { origin: "http://[::1]:8787", fetch: fetcher }),
     ).resolves.toMatchObject({ status: "ok" });
+  });
+});
+
+describe("galleryItemDownloadUrl", () => {
+  it("builds the absolute download-route URL for a gallery item", () => {
+    expect(galleryItemDownloadUrl("https://api.uploads.sh", ID, "item-1")).toBe(
+      `https://api.uploads.sh/public/galleries/${ID}/items/item-1/download`,
+    );
   });
 });

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -44,7 +44,12 @@ describe("public gallery headers", () => {
     // Astro extracts page <style> into /_astro/*.css; 'unsafe-inline' alone blocks that.
     expect(PUBLIC_GALLERY_CSP).toContain("style-src 'self' 'unsafe-inline'");
     // Cloudflare injects the RUM beacon; default-src 'none' blocks it without these.
-    expect(PUBLIC_GALLERY_CSP).toContain("script-src https://static.cloudflareinsights.com");
+    // Copy button + Copy-as control (design spec §3.2/§3.3) need inline
+    // script — same posture the file page's auth_required branch already
+    // shipped and tested.
+    expect(PUBLIC_GALLERY_CSP).toContain(
+      "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
+    );
     expect(PUBLIC_GALLERY_CSP).toContain("connect-src 'self' https://cloudflareinsights.com");
     expect(PUBLIC_GALLERY_CSP).toContain("default-src 'none'");
     expect(PUBLIC_GALLERY_CSP).toContain("frame-ancestors 'none'");

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -25,6 +25,7 @@ const gallery = {
       altText: "Screenshot",
       status: "available",
       url: "https://storage.uploads.sh/screen.png",
+      embedUrl: "https://embed.uploads.sh/screen.png" as string | null,
       contentType: "image/png",
     },
   ],
@@ -85,6 +86,18 @@ describe("public gallery API", () => {
       isPublicGallery({
         ...gallery,
         items: Array.from({ length: 101 }, () => gallery.items[0]),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a null item embedUrl but rejects a non-https one", () => {
+    expect(isPublicGallery({ ...gallery, items: [{ ...gallery.items[0], embedUrl: null }] })).toBe(
+      true,
+    );
+    expect(
+      isPublicGallery({
+        ...gallery,
+        items: [{ ...gallery.items[0], embedUrl: "http://embed.uploads.sh/x" }],
       }),
     ).toBe(false);
   });

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -73,7 +73,10 @@ export const PUBLIC_GALLERY_CSP = [
   // Self-hosted Geist Pixel woff2 for the <Brand /> wordmark.
   "font-src 'self'",
   `style-src ${STYLE_SRC_SELF_AND_INLINE}`,
-  `script-src ${CF_RUM_SCRIPT_SRC}`,
+  // Widened for the copy button + "Copy as" control on the item page (design
+  // spec §4.5); the gallery index page shares this constant and inherits the
+  // widening even though it adds no script of its own.
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
   `connect-src ${CF_RUM_CONNECT_SRC}`,
   "base-uri 'none'",
   "form-action 'none'",

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -8,6 +8,8 @@ export interface PublicGalleryItem {
   altText: string | null;
   status: "available" | "missing";
   url: string | null;
+  /** Embed-host URL when the dual-host policy applies; null otherwise. Always present (see gallery-service.ts). */
+  embedUrl: string | null;
   contentType: string | null;
 }
 
@@ -163,6 +165,7 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
       nullableText(item.altText, 300) &&
       (item.status === "available" || item.status === "missing") &&
       safeUrl(item.url) &&
+      safeUrl(item.embedUrl) &&
       nullableText(item.contentType, 128) &&
       (item.status === "missing" ? item.url === null : item.url !== null)
     );

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -59,6 +59,14 @@ export function galleryItemPath(galleryId: string, itemId: string): string {
   return `${galleryPath(galleryId)}/${encodeURIComponent(itemId)}`;
 }
 
+/** Build the API's forced-download URL (absolute) for a gallery item — Task 4's `/download` route. */
+export function galleryItemDownloadUrl(origin: string, galleryId: string, itemId: string): string {
+  return new URL(
+    `/public/galleries/${encodeURIComponent(galleryId)}/items/${encodeURIComponent(itemId)}/download`,
+    origin,
+  ).href;
+}
+
 /**
  * Public gallery CSP.
  *

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -3,10 +3,12 @@ import BaseHead from "../../../components/BaseHead.astro";
 import Brand from "../../../components/Brand.astro";
 import Footer from "../../../components/Footer.astro";
 import GitHubMark from "../../../components/GitHubMark.astro";
+import { buildEmbedFormats } from "../../../lib/embed-formats";
 import {
   applyPublicFileHeaders,
   authRequiredFileCsp,
   fetchPublicFile,
+  fileDownloadUrl,
   fileKind as kind,
   filePath,
   formatBytes,
@@ -48,6 +50,19 @@ const metadataEntries = file?.metadata
       .filter(([metaKey]) => !metaKey.startsWith("gh."))
       .sort(([a], [b]) => a.localeCompare(b))
   : [];
+// "Copy as" format options (Task 1's builder) and the forced-download link
+// (Task 3's `?download=1` route, via `fileDownloadUrl`) — both `null`/`[]`
+// when there's no file to link.
+const embedFormats = file
+  ? buildEmbedFormats({
+      canonical,
+      url: file.url,
+      embedUrl: file.embedUrl,
+      filename,
+      kind: kind(file.contentType),
+    })
+  : [];
+const downloadUrl = file ? fileDownloadUrl(origin, workspace, key) : null;
 const title = file
   ? `${filename} · uploads.sh`
   : result.status === "auth_required"
@@ -93,9 +108,13 @@ const title = file
       .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-top:16px; }
       .actions a.original { display:inline-block; padding:9px 15px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
       .actions a.original:hover, .actions a.original:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
-      .linkfield { flex:1; min-width:220px; }
+      .linkfield { flex:1; min-width:260px; }
       .linkfield label { display:block; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); margin-bottom:5px; }
-      .linkfield input { width:100%; padding:8px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
+      .copyrow { display:flex; gap:6px; align-items:stretch; }
+      .copyrow select { padding:8px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
+      .copyrow input { flex:1; min-width:0; padding:8px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
+      .copyrow button { padding:8px 12px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); cursor:pointer; }
+      .copyrow button:hover, .copyrow button:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
       .error .signin { display:inline-block; margin-top:18px; padding:9px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--fg); font:12px var(--mono); text-decoration:none; }
@@ -148,9 +167,16 @@ const title = file
               )}
               <div class="actions">
                 {kind(file.contentType) !== "unsupported" && <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>}
+                {downloadUrl && <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>}
                 <span class="linkfield">
-                  <label for="page-link">Page link</label>
-                  <input id="page-link" type="text" readonly value={canonical} aria-label="Page link" />
+                  <label for="copy-format">Copy as</label>
+                  <div class="copyrow">
+                    <select id="copy-format" aria-label="Copy as format">
+                      {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
+                    </select>
+                    <input id="copy-value" type="text" readonly value={embedFormats[0]?.value ?? canonical} aria-label="Value to copy" />
+                    <button type="button" id="copy-format-btn" data-copy={embedFormats[0]?.value ?? canonical} aria-live="polite">Copy</button>
+                  </div>
                 </span>
               </div>
             </figcaption>
@@ -169,6 +195,48 @@ const title = file
         <section class="error"><code>{result.status === "unavailable" ? "file.unavailable" : "file.not_found"}</code><h1>{result.status === "unavailable" ? "File temporarily unavailable" : "File not found"}</h1><p>{result.status === "unavailable" ? "The file service could not be reached. Please try again shortly." : "This file may have been removed, or the link is incorrect."}</p></section>
       )}
     </main>
+    {file && (
+      // Click-to-copy + "Copy as" format switching — CSP allows inline script
+      // on this branch as of the file-page-polish work (see PUBLIC_FILE_CSP
+      // in lib/public-file.ts). Same data-copy delegated-listener pattern as
+      // account/index.astro and account/workspaces.astro. The Download link
+      // needs no script — it's a plain <a> to the API's `?download=1` route.
+      <script define:vars={{ formats: embedFormats }}>
+        (function () {
+          const shell = document.querySelector(".shell");
+          if (!shell) return;
+
+          shell.addEventListener("click", (event) => {
+            void (async () => {
+              const button = event.target.closest("button[data-copy]");
+              if (!button) return;
+              try {
+                await navigator.clipboard.writeText(button.dataset.copy || "");
+                const previous = button.textContent;
+                button.textContent = "copied ✓";
+                setTimeout(() => {
+                  button.textContent = previous;
+                }, 1500);
+              } catch {
+                // Clipboard blocked — leave the label.
+              }
+            })();
+          });
+
+          const select = document.getElementById("copy-format");
+          const input = document.getElementById("copy-value");
+          const copyButton = document.getElementById("copy-format-btn");
+          if (select instanceof HTMLSelectElement && input instanceof HTMLInputElement && copyButton) {
+            select.addEventListener("change", () => {
+              const format = formats.find((f) => f.id === select.value) ?? formats[0];
+              if (!format) return;
+              input.value = format.value;
+              copyButton.dataset.copy = format.value;
+            });
+          }
+        })();
+      </script>
+    )}
     {result.status === "auth_required" && (
       // Progressive-enhancement, client-side authorization path — a second
       // gate parallel to the server-side one this page already applied via

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -63,6 +63,9 @@ const embedFormats = file
     })
   : [];
 const downloadUrl = file ? fileDownloadUrl(origin, workspace, key) : null;
+// The "Copy as" input/button start on the first format (Page link) until the
+// select is changed client-side.
+const defaultCopyValue = embedFormats[0]?.value ?? canonical;
 const title = file
   ? `${filename} · uploads.sh`
   : result.status === "auth_required"
@@ -175,8 +178,8 @@ const title = file
                     <select id="copy-format" aria-label="Copy as format">
                       {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
                     </select>
-                    <input id="copy-value" type="text" readonly value={embedFormats[0]?.value ?? canonical} aria-label="Value to copy" />
-                    <button type="button" id="copy-format-btn" data-copy={embedFormats[0]?.value ?? canonical} aria-live="polite">Copy</button>
+                    <input id="copy-value" type="text" readonly value={defaultCopyValue} aria-label="Value to copy" />
+                    <button type="button" id="copy-format-btn" data-copy={defaultCopyValue} aria-live="polite">Copy</button>
                   </div>
                 </span>
               </div>

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -216,10 +216,11 @@ const title = file
               if (!button) return;
               try {
                 await navigator.clipboard.writeText(button.dataset.copy || "");
-                const previous = button.textContent;
+                const original = button.dataset.copyLabel ?? button.textContent ?? "Copy";
+                button.dataset.copyLabel = original;
                 button.textContent = "copied ✓";
                 setTimeout(() => {
-                  button.textContent = previous;
+                  button.textContent = original;
                 }, 1500);
               } catch {
                 // Clipboard blocked — leave the label.

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -102,6 +102,7 @@ const title = file
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
       .gh-chip { display:inline-flex; align-items:center; gap:6px; margin:10px 0 0; padding:6px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
       .gh-chip:hover, .gh-chip:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      .gh-chip-name { overflow-wrap:anywhere; }
       .gh-chip-kind { padding:1px 5px; border:1px solid var(--line); border-radius:4px; color:var(--muted); font-size:10px; text-transform:uppercase; letter-spacing:.06em; }
       .section-label { margin:16px 0 0; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); }
       dl.meta.metadata { margin-top:6px; }

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -2,6 +2,7 @@
 import BaseHead from "../../../components/BaseHead.astro";
 import Brand from "../../../components/Brand.astro";
 import Footer from "../../../components/Footer.astro";
+import GitHubMark from "../../../components/GitHubMark.astro";
 import {
   applyPublicFileHeaders,
   authRequiredFileCsp,
@@ -40,8 +41,8 @@ const uploadedLabel =
     : null;
 const canonical = new URL(file ? filePath(workspace, key) : Astro.url.pathname, Astro.url.origin)
   .href;
-// Generic metadata list excludes `gh.*` pairs — those render as the "Attached to"
-// row above via `file.github` instead of duplicating them here.
+// Generic metadata list excludes `gh.*` pairs — those render as the GitHub
+// chip above via `file.github` instead of duplicating them here.
 const metadataEntries = file?.metadata
   ? Object.entries(file.metadata)
       .filter(([metaKey]) => !metaKey.startsWith("gh."))
@@ -84,7 +85,9 @@ const title = file
       dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:14px 0 0; font:12px var(--mono); }
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
-      .gh-kind { margin-left:8px; padding:1px 5px; border:1px solid var(--line); border-radius:4px; color:var(--muted); font-size:10px; text-transform:uppercase; letter-spacing:.06em; }
+      .gh-chip { display:inline-flex; align-items:center; gap:6px; margin:10px 0 0; padding:6px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
+      .gh-chip:hover, .gh-chip:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      .gh-chip-kind { padding:1px 5px; border:1px solid var(--line); border-radius:4px; color:var(--muted); font-size:10px; text-transform:uppercase; letter-spacing:.06em; }
       .section-label { margin:16px 0 0; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); }
       dl.meta.metadata { margin-top:6px; }
       .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-top:16px; }
@@ -118,19 +121,17 @@ const title = file
             </div>
             <figcaption class="details">
               <div class="filename">{filename}</div>
+              {file.github && (
+                <a class="gh-chip" href={file.github.url} rel="noopener noreferrer">
+                  <GitHubMark size={14} />
+                  <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+                  <span class="gh-chip-kind">{file.github.kind === "pull" ? "PR" : "Issue"}</span>
+                </a>
+              )}
               <dl class="meta">
                 <dt>Type</dt><dd>{file.contentType}</dd>
                 <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
                 {uploadedLabel && <><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>}
-                {file.github && (
-                  <>
-                    <dt>Attached to</dt>
-                    <dd>
-                      <a href={file.github.url} rel="noopener noreferrer">{file.github.repo}#{file.github.number}</a>
-                      <span class="gh-kind">{file.github.kind === "pull" ? "PR" : "Issue"}</span>
-                    </dd>
-                  </>
-                )}
               </dl>
               {metadataEntries.length > 0 && (
                 <>

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -241,9 +241,10 @@ const defaultCopyValue = embedFormats[0]?.value ?? canonical;
               if (!button) return;
               try {
                 await navigator.clipboard.writeText(button.dataset.copy || "");
-                const previous = button.textContent;
+                const original = button.dataset.copyLabel ?? button.textContent ?? "Copy";
+                button.dataset.copyLabel = original;
                 button.textContent = "copied ✓";
-                setTimeout(() => (button.textContent = previous), 1500);
+                setTimeout(() => (button.textContent = original), 1500);
               } catch {
                 // Clipboard blocked — leave the label.
               }

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -48,7 +48,9 @@ const embedFormats: EmbedFormatOption[] =
         url: item.url,
         embedUrl: item.embedUrl,
         filename: item.filename,
-        kind: itemKind === "missing" ? "file" : itemKind,
+        // item.status === "available" above means mediaKind() (itemKind) never
+        // returns "missing" here — that variant only occurs for missing items.
+        kind: itemKind as Exclude<typeof itemKind, "missing">,
       })
     : [];
 const downloadUrl =

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -3,9 +3,11 @@ import BaseHead from "../../../components/BaseHead.astro";
 import GalleryReferences from "../../../components/GalleryReferences.astro";
 import Brand from "../../../components/Brand.astro";
 import Footer from "../../../components/Footer.astro";
+import { buildEmbedFormats, type EmbedFormatOption } from "../../../lib/embed-formats";
 import {
   applyPublicGalleryHeaders,
   fetchPublicGallery,
+  galleryItemDownloadUrl,
   galleryItemPath,
   galleryPath,
   mediaKind as kind,
@@ -38,6 +40,19 @@ const listPath = galleryPath(id);
 const itemPath = (target: PublicGalleryItem) => galleryItemPath(id, target.id);
 const canonical = new URL(item ? itemPath(item) : listPath, Astro.url.origin).href;
 const title = item && gallery ? `${item.filename} · ${gallery.title} · uploads.sh` : "Media unavailable · uploads.sh";
+const itemKind = item ? kind(item) : null;
+const embedFormats: EmbedFormatOption[] =
+  item && item.status === "available" && item.url && itemKind
+    ? buildEmbedFormats({
+        canonical,
+        url: item.url,
+        embedUrl: item.embedUrl,
+        filename: item.filename,
+        kind: itemKind === "missing" ? "file" : itemKind,
+      })
+    : [];
+const downloadUrl =
+  item && item.status === "available" ? galleryItemDownloadUrl(origin, id, item.id) : null;
 ---
 
 <!doctype html>
@@ -71,6 +86,80 @@ const title = item && gallery ? `${item.filename} · ${gallery.title} · uploads
       .caption { margin-top:10px; color:var(--body); font-size:15px; line-height:1.6; white-space:pre-wrap; }
       .original { display:inline-block; margin-top:12px; color:var(--muted); font:12px var(--mono); }
       .original:hover, .original:focus-visible { color:var(--accent); outline:none; }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+        margin-top: 14px;
+      }
+      .actions a.original {
+        display: inline-block;
+        padding: 9px 15px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius-md);
+        background: var(--panel);
+        color: var(--fg);
+        font: 12px var(--mono);
+        text-decoration: none;
+        margin-top: 0;
+      }
+      .actions a.original:hover,
+      .actions a.original:focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+        outline: none;
+      }
+      .linkfield {
+        flex: 1;
+        min-width: 260px;
+      }
+      .linkfield label {
+        display: block;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font: 11px var(--mono);
+        margin-bottom: 5px;
+      }
+      .copyrow {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+      }
+      .copyrow select {
+        padding: 8px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius-md);
+        background: var(--bg);
+        color: var(--body);
+        font: 12px var(--mono);
+      }
+      .copyrow input {
+        flex: 1;
+        min-width: 0;
+        padding: 8px 10px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius-md);
+        background: var(--bg);
+        color: var(--body);
+        font: 12px var(--mono);
+      }
+      .copyrow button {
+        padding: 8px 12px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius-md);
+        background: var(--panel);
+        color: var(--fg);
+        font: 12px var(--mono);
+        cursor: pointer;
+      }
+      .copyrow button:hover,
+      .copyrow button:focus-visible {
+        border-color: var(--accent);
+        color: var(--accent);
+        outline: none;
+      }
       .pager { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:22px 0 0; font:13px var(--mono); }
       .pager a, .pager span.disabled { display:inline-block; padding:10px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); text-decoration:none; }
       .pager a:hover, .pager a:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
@@ -102,6 +191,21 @@ const title = item && gallery ? `${item.filename} · ${gallery.title} · uploads
               <div class="filename">{item.filename}</div>
               {item.caption && <div class="caption">{item.caption}</div>}
               {item.status === "available" && kind(item) !== "unsupported" && <a class="original" href={item.url!} rel="noopener noreferrer">Open original</a>}
+              {item.status === "available" && (
+                <div class="actions">
+                  {downloadUrl && <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>}
+                  <span class="linkfield">
+                    <label for="copy-format">Copy as</label>
+                    <div class="copyrow">
+                      <select id="copy-format" aria-label="Copy as format">
+                        {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
+                      </select>
+                      <input id="copy-value" type="text" readonly value={embedFormats[0]?.value ?? canonical} aria-label="Value to copy" />
+                      <button type="button" id="copy-format-btn" data-copy={embedFormats[0]?.value ?? canonical} aria-live="polite">Copy</button>
+                    </div>
+                  </span>
+                </div>
+              )}
             </figcaption>
           </figure>
           <nav class="pager" aria-label="Gallery items">
@@ -116,5 +220,44 @@ const title = item && gallery ? `${item.filename} · ${gallery.title} · uploads
         <section class="error"><code>{result.status === "unavailable" ? "gallery.unavailable" : "gallery.item_not_found"}</code><h1>{result.status === "unavailable" ? "Gallery temporarily unavailable" : "Media not found"}</h1><p>{result.status === "unavailable" ? "The gallery service could not be reached. Please try again shortly." : "This item may have been removed, or the link is incorrect."}</p>{result.status !== "unavailable" && <p><a href={listPath}>View the gallery</a></p>}</section>
       )}
     </main>
+    {item && item.status === "available" && (
+      // Click-to-copy + "Copy as" format switching — same delegated-listener
+      // pattern as the public file page's Task 8 script; the gallery CSP was
+      // widened for inline script in Task 6. Download needs no script — it's
+      // a plain <a> to Task 4's `/download` suffix route.
+      <script define:vars={{ formats: embedFormats }}>
+        (function () {
+          const shell = document.querySelector(".shell");
+          if (!shell) return;
+
+          shell.addEventListener("click", (event) => {
+            void (async () => {
+              const button = event.target.closest("button[data-copy]");
+              if (!button) return;
+              try {
+                await navigator.clipboard.writeText(button.dataset.copy || "");
+                const previous = button.textContent;
+                button.textContent = "copied ✓";
+                setTimeout(() => (button.textContent = previous), 1500);
+              } catch {
+                // Clipboard blocked — leave the label.
+              }
+            })();
+          });
+
+          const select = document.getElementById("copy-format");
+          const input = document.getElementById("copy-value");
+          const copyButton = document.getElementById("copy-format-btn");
+          if (select instanceof HTMLSelectElement && input instanceof HTMLInputElement && copyButton) {
+            select.addEventListener("change", () => {
+              const format = formats.find((f) => f.id === select.value) ?? formats[0];
+              if (!format) return;
+              input.value = format.value;
+              copyButton.dataset.copy = format.value;
+            });
+          }
+        })();
+      </script>
+    )}
   </body>
 </html>

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -55,6 +55,9 @@ const embedFormats: EmbedFormatOption[] =
     : [];
 const downloadUrl =
   item && item.status === "available" ? galleryItemDownloadUrl(origin, id, item.id) : null;
+// The "Copy as" input/button start on the first format (Page link) until the
+// select is changed client-side.
+const defaultCopyValue = embedFormats[0]?.value ?? canonical;
 ---
 
 <!doctype html>
@@ -202,8 +205,8 @@ const downloadUrl =
                       <select id="copy-format" aria-label="Copy as format">
                         {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
                       </select>
-                      <input id="copy-value" type="text" readonly value={embedFormats[0]?.value ?? canonical} aria-label="Value to copy" />
-                      <button type="button" id="copy-format-btn" data-copy={embedFormats[0]?.value ?? canonical} aria-live="polite">Copy</button>
+                      <input id="copy-value" type="text" readonly value={defaultCopyValue} aria-label="Value to copy" />
+                      <button type="button" id="copy-format-btn" data-copy={defaultCopyValue} aria-live="polite">Copy</button>
                     </div>
                   </span>
                 </div>

--- a/docs/superpowers/plans/2026-07-14-file-page-polish.md
+++ b/docs/superpowers/plans/2026-07-14-file-page-polish.md
@@ -1,0 +1,1722 @@
+# File Page Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish the public file page (`apps/web/src/pages/f/[workspace]/[...key].astro`, `ok` branch) and the per-item gallery page (`apps/web/src/pages/g/[id]/[item].astro`) with four improvements: a static GitHub chip, a real click-to-copy control, a single "Copy as" embed-format picker, and a working one-click Download — per the approved design spec (`docs/superpowers/specs/2026-07-14-file-page-polish-design.md`).
+
+**Architecture:** Two small `apps/api` additions (a new `embedUrl` field on the public-files JSON, and two new streaming download routes sharing one helper) unlock the web-side work. A pure, unit-tested embed-format-string builder (`apps/web/src/lib/embed-formats.ts`) is shared by both `.astro` pages. Both pages' CSPs widen `script-src` to allow one small inline `<script>` per page (the same `data-copy` delegated-listener pattern already used on `/account/index.astro` and `/account/workspaces.astro`). No React, no `@uploads/ui`, no new dependencies.
+
+**Tech Stack:** Hono (Cloudflare Workers API), Astro SSR pages with plain inline `<style>`/`<script>` (web), files-sdk 2.1.0 (`StoredFile.stream()`), vitest.
+
+## Global Constraints
+
+- **Static chip only.** No live GitHub fetch, no per-item gallery chip — gallery items carry no per-item GitHub context in the data model. The gallery-level `GalleryReferences` block is unchanged.
+- **Embed snippet formats use `embedUrl ?? url`.** "Direct file URL" (the plain-URL option) uses the stable `url`, not the embed host.
+- **CSP `script-src` widens to EXACTLY** `'self' 'unsafe-inline' https://static.cloudflareinsights.com` on both `PUBLIC_FILE_CSP` (file page `ok` branch) and `PUBLIC_GALLERY_CSP` (gallery pages). No `connect-src` change on either. Note: `PUBLIC_GALLERY_CSP` is a single shared constant used by both `/g/[id].astro` (index) and `/g/[id]/[item].astro` (item) — widening it affects the index page's headers too, even though only the item page gains a script. This is the accepted default per the design spec ("applied to `PUBLIC_GALLERY_CSP`... the same way").
+- **Download routes** stream via `StoredFile.stream()` (no full-buffer), set `Content-Disposition: attachment; filename="..."` (RFC 5987 `filename*=UTF-8''...` plus an ASCII `filename=` fallback) and the correct `Content-Type`, reuse the existing public-visibility gate (workspace/gallery record → public-URL existence → `store.exists`/`head` → `objectVisibility` 401), full-file only (no range support). The download link renders **unconditionally** (even for `unsupported`/SVG file kinds) — forced `attachment` disposition sidesteps the inline-render XSS concern that hides "Open original" for those kinds, so Download is actually the _safer_ affordance there.
+- **Route-ordering hazard (the #158 lesson, concretely):** the file route's key param is `:key{.+}` — a greedy multi-segment match. In Hono, the _first-registered_ route whose compiled pattern matches wins. `/:workspace/:key{.+}/download` MUST be registered before the generic `/:workspace/:key{.+}` in the same `Hono` chain, or the generic route silently swallows `/download` as part of the key and the download route is never reached. (The gallery route's `:id` is a single, non-greedy segment, so `/:id/items/:item/download` vs `/:id` has no such hazard — but verify on a preview worker anyway per the global lesson.) Before calling either download route done, hit it through a live preview worker with a real key containing `/` and an extension, not just vitest.
+- **Preserve all existing branches/headers/metadata list; no media-stage redesign.** Plain Astro + inline `<style>`/`<script>`, no `@uploads/ui`, no new deps.
+- **Discovery — gallery-side `embedUrl` is already shipped.** `apps/api/src/gallery-service.ts`'s `hydratePublicGallery` (and `PublicGalleryItemDto`) already return `embedUrl` on the public gallery item payload — landed in PR #154 (`c5b36a3`, "dual-host embedUrl for GitHub Camo"), and `apps/api/test/routes-galleries.test.ts` (~line 464) already asserts it's in the public item's field list. The design spec's claim that this is "simply dropped before reaching the web" is **stale** as of this plan's writing. Only the **web-side** type (`PublicGalleryItem`) and validator (`isPublicGallery`) are missing the field — Task 5 covers that; there is no gallery API change in this plan. The **file-page** `embedUrl` (Task 2) genuinely does not exist yet and is real, new work.
+- Web typecheck command is `pnpm --filter @uploads/web typecheck` (**not** `types` — that's the narrower `wrangler types` codegen step `typecheck` already runs first). API tests: `pnpm --filter @uploads/api test`. Web has no React/Astro render harness — `.astro` "tests" are typecheck + build + preview-worker verification, not vitest; say so explicitly rather than fabricating a render test.
+- Commit after each task.
+
+---
+
+### Task 1: Shared embed-format-string builder
+
+**Files:**
+
+- Create: `apps/web/src/lib/embed-formats.ts`
+- Test: `apps/web/src/lib/embed-formats.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  ```ts
+  export type EmbedFormatId = "page" | "url" | "markdown-image" | "markdown-link" | "html-img";
+  export interface EmbedFormatOption {
+    id: EmbedFormatId;
+    label: string;
+    value: string;
+  }
+  export interface EmbedFormatInput {
+    canonical: string;
+    url: string;
+    embedUrl: string | null;
+    filename: string;
+    kind: "image" | "video" | "file" | "unsupported";
+  }
+  export function buildEmbedFormats(input: EmbedFormatInput): EmbedFormatOption[];
+  ```
+- Consumed by: Task 8 (file page) and Task 9 (gallery item page) with the exact same signature — file page's `MediaKind` (`fileKind()` in `public-file.ts`) and gallery's `MediaKind` minus `"missing"` (only called when an item is `"available"`) both satisfy `kind`.
+
+This is the pure function the design spec's §3.3 table maps to: Page link (always) → Direct file URL (always) → Markdown image (image only) → Markdown link (always) → HTML `<img>` (image only), in that order. `embedSrc` (used by the two embed-snippet formats) is `embedUrl ?? url`; "Direct file URL" always uses the stable `url`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/lib/embed-formats.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildEmbedFormats } from "./embed-formats";
+
+const base = {
+  canonical: "https://uploads.sh/f/acme/screenshots/shot.png",
+  url: "https://storage.uploads.sh/acme/screenshots/shot.png",
+  embedUrl: "https://embed.uploads.sh/acme/screenshots/shot.png" as string | null,
+  filename: "shot.png",
+};
+
+describe("buildEmbedFormats", () => {
+  it("returns all five formats, in order, for an image", () => {
+    const formats = buildEmbedFormats({ ...base, kind: "image" });
+    expect(formats.map((f) => f.id)).toEqual([
+      "page",
+      "url",
+      "markdown-image",
+      "markdown-link",
+      "html-img",
+    ]);
+    expect(formats).toEqual([
+      { id: "page", label: "Page link", value: base.canonical },
+      { id: "url", label: "Direct file URL", value: base.url },
+      { id: "markdown-image", label: "Markdown image", value: `![](${base.embedUrl})` },
+      { id: "markdown-link", label: "Markdown link", value: `[shot.png](${base.canonical})` },
+      {
+        id: "html-img",
+        label: "HTML <img>",
+        value: `<img src="${base.embedUrl}" alt="shot.png">`,
+      },
+    ]);
+  });
+
+  it("drops the markdown-image and html-img formats for video/file/unsupported kinds", () => {
+    for (const kind of ["video", "file", "unsupported"] as const) {
+      const formats = buildEmbedFormats({ ...base, kind });
+      expect(formats.map((f) => f.id)).toEqual(["page", "url", "markdown-link"]);
+    }
+  });
+
+  it("embed snippet formats prefer embedUrl over url; Direct file URL always uses the stable url", () => {
+    const formats = buildEmbedFormats({ ...base, kind: "image" });
+    const direct = formats.find((f) => f.id === "url")!;
+    const mdImage = formats.find((f) => f.id === "markdown-image")!;
+    const html = formats.find((f) => f.id === "html-img")!;
+    expect(direct.value).toBe(base.url);
+    expect(mdImage.value).toContain(base.embedUrl);
+    expect(html.value).toContain(base.embedUrl);
+  });
+
+  it("falls back to url for embed snippets when embedUrl is null", () => {
+    const formats = buildEmbedFormats({ ...base, embedUrl: null, kind: "image" });
+    expect(formats.find((f) => f.id === "markdown-image")!.value).toBe(`![](${base.url})`);
+    expect(formats.find((f) => f.id === "html-img")!.value).toBe(
+      `<img src="${base.url}" alt="shot.png">`,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @uploads/web test -- embed-formats.test.ts`
+Expected: FAIL — `./embed-formats` module does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/web/src/lib/embed-formats.ts`:
+
+```ts
+/**
+ * Pure embed-format-string builder shared by the public file page
+ * (`pages/f/[workspace]/[...key].astro`) and the public gallery-item page
+ * (`pages/g/[id]/[item].astro`) — issue's "Copy as" control (design spec
+ * §3.3). Kept dependency-free and framework-free so both `.astro` pages can
+ * import it directly and it stays unit-testable without a render harness.
+ */
+
+export type EmbedFormatId = "page" | "url" | "markdown-image" | "markdown-link" | "html-img";
+
+export interface EmbedFormatOption {
+  id: EmbedFormatId;
+  label: string;
+  value: string;
+}
+
+export interface EmbedFormatInput {
+  /** On-site canonical page URL (`/f/<workspace>/<key>` or `/g/<id>/<item>`). */
+  canonical: string;
+  /** Stable public URL — `PublicFile.url` / `PublicGalleryItem.url`. */
+  url: string;
+  /** Embed-host URL when available (dual-host GitHub Camo policy); null otherwise. */
+  embedUrl: string | null;
+  filename: string;
+  /** `"missing"` gallery items never reach this — callers only call it when a URL exists. */
+  kind: "image" | "video" | "file" | "unsupported";
+}
+
+/**
+ * Five candidate formats, gated by `kind`, in the fixed order the design
+ * spec's §3.3 table lists them: Page link, Direct file URL, Markdown image
+ * (image only), Markdown link, HTML `<img>` (image only). Embed *snippet*
+ * formats (Markdown image, HTML img) prefer `embedUrl` and fall back to the
+ * stable `url`; "Direct file URL" always uses the stable `url` — mirrors
+ * `packages/uploads/src/commands.ts`'s existing "MARKDOWN prefers embedUrl"
+ * convention.
+ */
+export function buildEmbedFormats(input: EmbedFormatInput): EmbedFormatOption[] {
+  const embedSrc = input.embedUrl ?? input.url;
+  const options: EmbedFormatOption[] = [
+    { id: "page", label: "Page link", value: input.canonical },
+    { id: "url", label: "Direct file URL", value: input.url },
+  ];
+  if (input.kind === "image") {
+    options.push({ id: "markdown-image", label: "Markdown image", value: `![](${embedSrc})` });
+  }
+  options.push({
+    id: "markdown-link",
+    label: "Markdown link",
+    value: `[${input.filename}](${input.canonical})`,
+  });
+  if (input.kind === "image") {
+    options.push({
+      id: "html-img",
+      label: "HTML <img>",
+      value: `<img src="${embedSrc}" alt="${input.filename}">`,
+    });
+  }
+  return options;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @uploads/web test -- embed-formats.test.ts`
+Expected: PASS (all four cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/embed-formats.ts apps/web/src/lib/embed-formats.test.ts
+git commit -m "feat(web): shared embed-format-string builder for the Copy-as control"
+```
+
+---
+
+### Task 2: API — surface `embedUrl` on the public file route
+
+**Files:**
+
+- Modify: `apps/api/src/routes/public-files.ts`
+- Test: `apps/api/test/routes-public-files.test.ts`
+
+**Interfaces:**
+
+- Consumes: `objectPublicUrls(env, cfg, key) => { url: string | null; embedUrl: string | null }` from `../storage` (already used by `files.ts`/`gallery-service.ts`; swaps out the narrower `publicUrl()` this route currently calls).
+- Produces: `GET /public/files/:workspace/:key` response gains `embedUrl: string | null` alongside the existing `url`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/api/test/routes-public-files.test.ts`, inside the existing `describe("GET /public/files/:workspace/:key", ...)` block (after the `"returns metadata + the public URL..."` test):
+
+```ts
+it("includes an embedUrl alongside the stable url", async () => {
+  const { env } = await makeEnv();
+  await seedShot(env);
+
+  const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+  expect(res.status).toBe(200);
+  const json = (await res.json()) as { url: string; embedUrl: string | null };
+  expect(json.url).toBe("https://storage.uploads.sh/default/screenshots/shot.png");
+  expect(json.embedUrl).toBe("https://embed.uploads.sh/default/screenshots/shot.png");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @uploads/api test -- routes-public-files.test.ts`
+Expected: FAIL — `json.embedUrl` is `undefined`, not the expected string.
+
+- [ ] **Step 3: Add `embedUrl` to the route**
+
+In `apps/api/src/routes/public-files.ts`, change the import (line 5):
+
+```ts
+import { objectPublicUrls, storage, storageConfig } from "../storage";
+```
+
+(drops `publicUrl`, adds `objectPublicUrls`.)
+
+Replace the URL resolution + response body:
+
+```ts
+// Phase 1 is public-workspace-only: resolving the public URL doubles as the
+// visibility gate. A workspace without a public base URL cannot be wrapped
+// here — that is #123's signed-URL territory, swapped in when it lands.
+const cfg = await storageConfig(c.env, record);
+const urls = objectPublicUrls(c.env, cfg, key);
+if (!urls.url) throw new NotFoundError();
+
+const store = await storage(c.env, record);
+if (!(await store.exists(key))) throw new NotFoundError();
+const meta = await store.head(key);
+
+if (objectVisibility(meta.metadata ?? undefined)) {
+  throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
+}
+
+// Fetched only after the visibility gate above — a private object 401s
+// before this D1 read ever happens, so metadata never leaks.
+const metadata = await getFileMetadata(c.env.DB, workspace, key);
+const github = deriveGithubContext(metadata);
+
+return c.json({
+  workspace,
+  key,
+  url: urls.url,
+  embedUrl: urls.embedUrl,
+  size: meta.size ?? 0,
+  contentType: meta.type ?? "application/octet-stream",
+  ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+  ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  ...(github ? { github } : {}),
+});
+```
+
+(This is the same handler body, just resolving `url`/`embedUrl` together via `objectPublicUrls` instead of `publicUrl`, and adding `embedUrl` to the JSON. No other behavior changes.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @uploads/api test -- routes-public-files.test.ts`
+Expected: PASS — including all pre-existing tests in the file (embedUrl is additive; nothing else in the response shape changed).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @uploads/api typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/public-files.ts apps/api/test/routes-public-files.test.ts
+git commit -m "feat(api): surface embedUrl on the public file route"
+```
+
+---
+
+### Task 3: API — shared streaming download helper + file download route
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts` (new `downloadResponse` helper, next to the existing `store.download()` use in `setObjectVisibility`)
+- Modify: `apps/api/src/routes/public-files.ts` (new `resolvePublicObject` helper + `/download` route, registered before the generic route)
+- Test: `apps/api/test/routes-public-files.test.ts`
+
+**Interfaces:**
+
+- Produces (in `files-core.ts`):
+  ```ts
+  export function downloadResponse(store: Files, key: string, filename: string): Promise<Response>;
+  ```
+  Streams `store.download(key)` straight into a `Response` body (`StoredFile.stream()`, never buffered), with `Content-Type` from the stored object and `Content-Disposition: attachment; filename="<ascii fallback>"; filename*=UTF-8''<RFC 5987 encoded>`.
+- Consumed by: `public-files.ts`'s new download route (this task) and `public-galleries.ts`'s new download route (Task 4) — the one shared streaming helper the design spec calls for.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/test/routes-public-files.test.ts`, as a new `describe` block after the existing `describe("GET /public/files/:workspace/:key", ...)`:
+
+```ts
+describe("GET /public/files/:workspace/:key/download", () => {
+  it("streams the object with a forced attachment disposition", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+
+    const res = await app.request("/public/files/default/screenshots/shot.png/download", {}, env);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Content-Disposition")).toBe(
+      "attachment; filename=\"shot.png\"; filename*=UTF-8''shot.png",
+    );
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(bytes).toEqual(PNG);
+  });
+
+  it("401s with auth_required for a private object, without streaming bytes", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env, { "X-Uploads-Visibility": "private" });
+
+    const res = await app.request("/public/files/default/screenshots/shot.png/download", {}, env);
+    expect(res.status).toBe(401);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "auth_required" },
+    });
+  });
+
+  it("404s for a missing object", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/public/files/default/screenshots/missing.png/download",
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("does not let the /download suffix route shadow a key literally named 'download'", async () => {
+    // Regression for the #158-style routing risk: :key{.+} is greedy, so the
+    // /download route must be registered before the generic metadata route,
+    // or a key ending in "/download" would always hit the download handler,
+    // AND a key that just happens to be named "download" must still resolve
+    // through the plain metadata route unharmed.
+    const { env } = await makeEnv();
+    const put = await app.request(
+      "/v1/default/files/screenshots/download",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(put.status).toBe(201);
+    const meta = await app.request("/public/files/default/screenshots/download", {}, env);
+    expect(meta.status).toBe(200);
+    expect(((await meta.json()) as { key: string }).key).toBe("screenshots/download");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api test -- routes-public-files.test.ts`
+Expected: FAIL — `/download` 404s (no such route yet), so the first three new tests fail on status; the fourth already passes today (no code change needed for it yet) but keep it here so it stays green as a regression guard through the rest of this task.
+
+- [ ] **Step 3: Add the streaming helper to `files-core.ts`**
+
+In `apps/api/src/files-core.ts`, add after `setObjectVisibility` (after the closing brace that currently ends around line 272):
+
+```ts
+/** Non-ASCII-safe fallback for the `filename=` param (browsers that ignore `filename*`). */
+function asciiFilenameFallback(filename: string): string {
+  return filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+}
+
+/** RFC 5987 `filename*=UTF-8''...` value for a Content-Disposition header. */
+function encodeRfc5987Filename(filename: string): string {
+  return encodeURIComponent(filename)
+    .replace(/['()]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/\*/g, "%2A");
+}
+
+/**
+ * Stream a stored object as a forced-download `Response`. Shared by the
+ * public file (`routes/public-files.ts`) and public gallery-item
+ * (`routes/public-galleries.ts`) download routes (design spec §3.4) — bytes
+ * are proxied through this Worker specifically for the download action (the
+ * inline-preview path keeps using the R2 custom domain directly, unchanged).
+ * Full-file only: no `Range` support. Uses `StoredFile.stream()` so the whole
+ * object is never buffered into Worker memory.
+ */
+export async function downloadResponse(
+  store: Files,
+  key: string,
+  filename: string,
+): Promise<Response> {
+  const file = await store.download(key);
+  const headers = new Headers();
+  headers.set("Content-Type", file.type || "application/octet-stream");
+  headers.set(
+    "Content-Disposition",
+    `attachment; filename="${asciiFilenameFallback(filename)}"; ` +
+      `filename*=UTF-8''${encodeRfc5987Filename(filename)}`,
+  );
+  if (typeof file.size === "number") headers.set("Content-Length", String(file.size));
+  headers.set("Cache-Control", "no-store");
+  return new Response(file.stream(), { headers });
+}
+```
+
+- [ ] **Step 4: Add the resolver + download route to `public-files.ts`**
+
+In `apps/api/src/routes/public-files.ts`, update the imports:
+
+```ts
+import { NotFoundError, UnauthorizedError } from "@uploads/errors";
+import { Hono } from "hono";
+import type { Files } from "@uploads/storage";
+import { badKey, downloadResponse } from "../files-core";
+import { getFileMetadata } from "../file-metadata";
+import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { objectVisibility } from "../visibility";
+import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
+```
+
+Add a shared resolver above the route definitions (after `deriveGithubContext`):
+
+```ts
+interface ResolvedPublicObject {
+  store: Files;
+  meta: { size?: number; type?: string; lastModified?: number; metadata?: Record<string, string> };
+  urls: { url: string | null; embedUrl: string | null };
+}
+
+/**
+ * Shared lookup + visibility gate for every `/public/files/:workspace/:key*`
+ * GET handler: workspace record → publicUrl existence → store.exists/head →
+ * objectVisibility 401. Both the metadata route and the download route below
+ * call this so the two can never disagree about who gets to see (or
+ * download) an object.
+ */
+async function resolvePublicObject(
+  env: Env,
+  workspace: string,
+  key: string,
+): Promise<ResolvedPublicObject> {
+  if (badKey(key)) throw new NotFoundError();
+  const record = await loadWorkspaceRecord(env, workspace);
+  if (!record) throw new NotFoundError();
+  const cfg = await storageConfig(env, record);
+  const urls = objectPublicUrls(env, cfg, key);
+  if (!urls.url) throw new NotFoundError();
+  const store = await storage(env, record);
+  if (!(await store.exists(key))) throw new NotFoundError();
+  const meta = await store.head(key);
+  if (objectVisibility(meta.metadata ?? undefined)) {
+    throw new UnauthorizedError("sign in to view this file", { code: "auth_required" });
+  }
+  return { store, meta, urls };
+}
+```
+
+Replace the `export const publicFiles = ...` block with (download route registered FIRST — see the Global Constraints route-ordering note):
+
+```ts
+export const publicFiles = new Hono<WorkspaceVars>()
+  // MUST be registered before the generic "/:workspace/:key{.+}" route below:
+  // :key{.+} is a greedy multi-segment match, so if the generic route were
+  // registered first it would swallow "/download" as part of the key and this
+  // route would never be reached (the #158 lesson).
+  .get("/:workspace/:key{.+}/download", async (c) => {
+    const workspace = c.req.param("workspace");
+    const key = c.req.param("key");
+    const { store } = await resolvePublicObject(c.env, workspace, key);
+    const filename = key.split("/").filter(Boolean).pop() ?? key;
+    return downloadResponse(store, key, filename);
+  })
+  .get("/:workspace/:key{.+}", async (c) => {
+    const workspace = c.req.param("workspace");
+    const key = c.req.param("key");
+    const { store: _store, meta, urls } = await resolvePublicObject(c.env, workspace, key);
+
+    const metadata = await getFileMetadata(c.env.DB, workspace, key);
+    const github = deriveGithubContext(metadata);
+
+    return c.json({
+      workspace,
+      key,
+      url: urls.url,
+      embedUrl: urls.embedUrl,
+      size: meta.size ?? 0,
+      contentType: meta.type ?? "application/octet-stream",
+      ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      ...(github ? { github } : {}),
+    });
+  });
+```
+
+(The metadata route no longer needs `store` directly — prefixed `_store` to keep it visible in the destructure without an unused-var lint failure; drop the prefix if the lint config allows an unused destructured field.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test -- routes-public-files.test.ts`
+Expected: PASS — all tests in the file, including the new `/download` describe block and the pre-existing metadata-route tests (unchanged behavior via `resolvePublicObject`).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @uploads/api typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/files-core.ts apps/api/src/routes/public-files.ts apps/api/test/routes-public-files.test.ts
+git commit -m "feat(api): stream a forced-download response for public files"
+```
+
+---
+
+### Task 4: API — gallery-item download route
+
+**Files:**
+
+- Modify: `apps/api/src/routes/public-galleries.ts`
+- Test: `apps/api/test/routes-galleries.test.ts`
+
+**Interfaces:**
+
+- Consumes: `downloadResponse` from `../files-core` (Task 3); `storage` from `../storage`; `resolvePublicGallery`, `listGalleryItems` from `../galleries` (already imported).
+- Produces: `GET /public/galleries/:id/items/:item/download` — 200 streaming the item's object, 404 for an unknown/non-public gallery or item, 404 when the underlying object no longer exists (tombstoned item).
+
+Unlike the file route, `:id` is a single non-greedy path segment, so there's no `{.+}`-shadowing hazard between `/:id/items/:item/download` and `/:id` — but register the more specific route first anyway for consistency, and still verify on a preview worker per the global routing lesson.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/test/routes-galleries.test.ts`, as a new `describe` block near the end of the file (same `env`/`request`/`create` helpers already set up by the file's `beforeEach`):
+
+```ts
+describe("GET /public/galleries/:id/items/:item/download", () => {
+  it("streams the item's object with a forced attachment disposition", async () => {
+    const gallery = await create();
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+    });
+    expect(added.status).toBe(201);
+    const item = (await added.json()) as { id: string };
+
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/${item.id}/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toBe(
+      "attachment; filename=\"one.png\"; filename*=UTF-8''one.png",
+    );
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(bytes).toEqual(PNG);
+  });
+
+  it("404s for an unknown item id", async () => {
+    const gallery = await create();
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/item_missing/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a non-public (unknown) gallery id", async () => {
+    const res = await app.request("/public/galleries/gal_doesnotexist/items/x/download", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when the item's underlying object has been deleted (tombstone)", async () => {
+    const gallery = await create();
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+    });
+    const item = (await added.json()) as { id: string };
+    await bucket.delete("alpha/screenshots/one.png");
+
+    const res = await app.request(
+      `/public/galleries/${gallery.id}/items/${item.id}/download`,
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api test -- routes-galleries.test.ts`
+Expected: FAIL — `/download` 404s across the board (no such route), so the first test's `200` assertion fails.
+
+- [ ] **Step 3: Add the download route**
+
+In `apps/api/src/routes/public-galleries.ts`, update the imports:
+
+```ts
+import { NotFoundError } from "@uploads/errors";
+import { Hono } from "hono";
+import { downloadResponse } from "../files-core";
+import { listExternalReferences, listGalleryItems, resolvePublicGallery } from "../galleries";
+import { hydratePublicGallery } from "../gallery-service";
+import { storage } from "../storage";
+import { type WorkspaceRecord, type WorkspaceVars } from "../workspace";
+```
+
+Replace the `export const publicGalleries = ...` block with (download route registered first, matching the file route's convention):
+
+```ts
+export const publicGalleries = new Hono<WorkspaceVars>()
+  .get("/:id/items/:item/download", async (c) => {
+    const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
+    if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+
+    const items = await listGalleryItems(c.env.DB, record.workspace, record.id);
+    const item = items.find((entry) => entry.id === c.req.param("item"));
+    if (!item) {
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    }
+
+    const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
+      type: "json",
+      cacheTtl: 60,
+    });
+    if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+
+    const store = await storage(c.env, workspace);
+    if (!(await store.exists(item.object_key))) {
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    }
+    const filename = item.object_key.split("/").filter(Boolean).pop() ?? item.object_key;
+    return downloadResponse(store, item.object_key, filename);
+  })
+  .get("/:id", async (c) => {
+    const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
+    if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
+      type: "json",
+      cacheTtl: 60,
+    });
+    if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    const [items, references] = await Promise.all([
+      listGalleryItems(c.env.DB, record.workspace, record.id),
+      listExternalReferences(c.env.DB, record.workspace, record.id),
+    ]);
+    return c.json(await hydratePublicGallery(c.env, workspace, record, items, references));
+  });
+```
+
+(The `/:id` handler body is unchanged from today — only re-pasted here because it now sits after the new `.get(...)` in the same chained expression.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api test -- routes-galleries.test.ts`
+Expected: PASS — new download-route tests plus every pre-existing test in the file.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @uploads/api typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/public-galleries.ts apps/api/test/routes-galleries.test.ts
+git commit -m "feat(api): stream a forced-download response for gallery items"
+```
+
+---
+
+### Task 5: Web — surface `embedUrl` on both public DTOs
+
+**Files:**
+
+- Modify: `apps/web/src/lib/public-file.ts`, `apps/web/src/lib/public-file.test.ts`
+- Modify: `apps/web/src/lib/public-gallery.ts`, `apps/web/src/lib/public-gallery.test.ts`
+
+**Interfaces:**
+
+- Produces: `PublicFile.embedUrl: string | null` (required field) + `isPublicFile` validates it; `PublicGalleryItem.embedUrl: string | null` (required field) + `isPublicGallery` validates it per-item.
+- As noted in Global Constraints, the gallery API side already returns `embedUrl` (PR #154) — this task's gallery half is a type/validator-only change that _unlocks_ an already-shipped field for the web page (Task 9); its file-page half is genuinely new, unblocked by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `apps/web/src/lib/public-file.test.ts`, update the shared `file` fixture (top of the file) to include `embedUrl`:
+
+```ts
+const file = {
+  workspace: "acme",
+  key: "screenshots/shot.png",
+  url: "https://storage.uploads.sh/acme/screenshots/shot.png",
+  embedUrl: "https://embed.uploads.sh/acme/screenshots/shot.png" as string | null,
+  size: 20480,
+  contentType: "image/png",
+  uploaded: "2026-07-13T12:00:00.000Z",
+} as const;
+```
+
+Add a new test inside `describe("isPublicFile", ...)`, after the `"accepts the bounded DTO..."` case:
+
+```ts
+it("accepts a null embedUrl but rejects a non-https one", () => {
+  expect(isPublicFile({ ...file, embedUrl: null })).toBe(true);
+  expect(isPublicFile({ ...file, embedUrl: "http://embed.uploads.sh/x" })).toBe(false);
+  const { embedUrl: _omit, ...noEmbedUrl } = file;
+  expect(isPublicFile(noEmbedUrl)).toBe(false);
+});
+```
+
+In `apps/web/src/lib/public-gallery.test.ts`, update the shared `gallery` fixture's single item to include `embedUrl`:
+
+```ts
+  items: [
+    {
+      id: "item-1",
+      filename: "screen.png",
+      position: 1000,
+      caption: "<img onerror=alert(1)>",
+      altText: "Screenshot",
+      status: "available",
+      url: "https://storage.uploads.sh/screen.png",
+      embedUrl: "https://embed.uploads.sh/screen.png" as string | null,
+      contentType: "image/png",
+    },
+  ],
+```
+
+Add a new case inside `describe("public gallery API", ...)`, after the `"rejects unsafe URLs..."` case:
+
+```ts
+it("accepts a null item embedUrl but rejects a non-https one", () => {
+  expect(isPublicGallery({ ...gallery, items: [{ ...gallery.items[0], embedUrl: null }] })).toBe(
+    true,
+  );
+  expect(
+    isPublicGallery({
+      ...gallery,
+      items: [{ ...gallery.items[0], embedUrl: "http://embed.uploads.sh/x" }],
+    }),
+  ).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @uploads/web test -- public-file.test.ts public-gallery.test.ts`
+Expected: FAIL — `PublicFile`/`PublicGalleryItem` don't have `embedUrl` yet, so the fixtures fail to typecheck-adjacent-validate (`isPublicFile`/`isPublicGallery` currently ignore the extra field and, for the "rejects... non-https" and "requires the field" cases, wrongly return `true`).
+
+- [ ] **Step 3: Add `embedUrl` to `public-file.ts`**
+
+Update the `PublicFile` interface:
+
+```ts
+export interface PublicFile {
+  workspace: string;
+  key: string;
+  url: string;
+  /** Embed-host URL when the dual-host policy applies (GitHub Camo); null otherwise. */
+  embedUrl: string | null;
+  size: number;
+  contentType: string;
+  uploaded: string | null;
+  /** Queryable `gh.*`-and-other custom metadata pairs; omitted when there are none. */
+  metadata?: Record<string, string>;
+  /** Convenience view of `gh.repo`/`gh.kind`/`gh.number`, when all three are present and valid. */
+  github?: GithubContext;
+}
+```
+
+Add a nullable variant of the existing `httpsUrl` check, right after it:
+
+```ts
+/** `httpsUrl`, but also accepts `null` — for optional-but-typed URL fields like `embedUrl`. */
+function nullableHttpsUrl(value: unknown): value is string | null {
+  return value === null || httpsUrl(value);
+}
+```
+
+Update `isPublicFile`'s return expression to require it:
+
+```ts
+return (
+  text(file.workspace, 64) &&
+  text(file.key, 1024) &&
+  httpsUrl(file.url) &&
+  nullableHttpsUrl(file.embedUrl) &&
+  Number.isSafeInteger(file.size) &&
+  (file.size as number) >= 0 &&
+  text(file.contentType, 128) &&
+  uploadedOk &&
+  metadataOk &&
+  githubOk
+);
+```
+
+- [ ] **Step 4: Add `embedUrl` to `public-gallery.ts`**
+
+Update the `PublicGalleryItem` interface:
+
+```ts
+export interface PublicGalleryItem {
+  id: string;
+  filename: string;
+  position: number;
+  caption: string | null;
+  altText: string | null;
+  status: "available" | "missing";
+  url: string | null;
+  /** Embed-host URL when the dual-host policy applies; null otherwise. Always present (see gallery-service.ts). */
+  embedUrl: string | null;
+  contentType: string | null;
+}
+```
+
+Update the per-item validator inside `isPublicGallery` (the `gallery.items.every(...)` block):
+
+```ts
+return gallery.items.every((entry) => {
+  if (typeof entry !== "object" || entry === null) return false;
+  const item = entry as Record<string, unknown>;
+  return (
+    text(item.id, 64) &&
+    text(item.filename, 1024) &&
+    Number.isSafeInteger(item.position) &&
+    (item.position as number) > 0 &&
+    nullableText(item.caption, 500) &&
+    nullableText(item.altText, 300) &&
+    (item.status === "available" || item.status === "missing") &&
+    safeUrl(item.url) &&
+    safeUrl(item.embedUrl) &&
+    nullableText(item.contentType, 128) &&
+    (item.status === "missing" ? item.url === null : item.url !== null)
+  );
+});
+```
+
+(`safeUrl` already accepts `null` — same helper the existing `url` field uses.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @uploads/web test -- public-file.test.ts public-gallery.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @uploads/web typecheck`
+Expected: no errors. (This is also where a stale `PublicFile`/`PublicGalleryItem` literal elsewhere in `apps/web` would surface as a missing-field error — grep confirmed the only other references are the two `.astro` pages themselves, updated in Tasks 8–9, and `AccountFileBrowser.tsx`'s unrelated `openPublicFile` function name.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/public-file.ts apps/web/src/lib/public-file.test.ts apps/web/src/lib/public-gallery.ts apps/web/src/lib/public-gallery.test.ts
+git commit -m "feat(web): surface embedUrl on the public file + gallery item types"
+```
+
+---
+
+### Task 6: CSP — widen `script-src` on both public pages
+
+**Files:**
+
+- Modify: `apps/web/src/lib/public-file.ts`, `apps/web/src/lib/public-file.test.ts`
+- Modify: `apps/web/src/lib/public-gallery.ts`, `apps/web/src/lib/public-gallery.test.ts`
+
+**Interfaces:**
+
+- `PUBLIC_FILE_CSP` and `PUBLIC_GALLERY_CSP`'s `script-src` directive both become `'self' 'unsafe-inline' https://static.cloudflareinsights.com` (imports `CF_RUM_SCRIPT_SRC` from `./csp`, unchanged constant). No other directive changes on either.
+
+- [ ] **Step 1: Update (RED) the existing gallery CSP test**
+
+In `apps/web/src/lib/public-gallery.test.ts`, the existing assertion at line 46 currently pins the _old_ strict value and will fail once Step 3 below ships:
+
+```ts
+expect(PUBLIC_GALLERY_CSP).toContain("script-src https://static.cloudflareinsights.com");
+```
+
+Change it to assert the widened value:
+
+```ts
+// Copy button + Copy-as control (design spec §3.2/§3.3) need inline
+// script — same posture the file page's auth_required branch already
+// shipped and tested.
+expect(PUBLIC_GALLERY_CSP).toContain(
+  "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
+);
+```
+
+Add the equivalent new assertion to `apps/web/src/lib/public-file.test.ts`'s `describe("public file headers", ...)` block, after the existing `"locks down like the public gallery..."` test:
+
+```ts
+it("widens script-src on the ok branch too — same posture as authRequiredFileCsp", () => {
+  expect(PUBLIC_FILE_CSP).toContain(
+    "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @uploads/web test -- public-file.test.ts public-gallery.test.ts`
+Expected: FAIL — `PUBLIC_GALLERY_CSP` still has the old strict `script-src`; `PUBLIC_FILE_CSP`'s new assertion fails too.
+
+- [ ] **Step 3: Widen `PUBLIC_FILE_CSP`**
+
+In `apps/web/src/lib/public-file.ts`, change:
+
+```ts
+export const PUBLIC_FILE_CSP = buildFileCsp();
+```
+
+to:
+
+```ts
+/**
+ * Public file page CSP — same posture as the public gallery: locked down
+ * except for self-hosted styles/fonts, the Cloudflare RUM beacon, and (as of
+ * the file-page-polish work) inline script for the click-to-copy button and
+ * "Copy as" control. `connect-src` stays untouched — clipboard writes never
+ * hit the network, and the download link needs no script at all.
+ */
+export const PUBLIC_FILE_CSP = buildFileCsp({
+  scriptSrc: `'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+});
+```
+
+- [ ] **Step 4: Widen `PUBLIC_GALLERY_CSP`**
+
+In `apps/web/src/lib/public-gallery.ts`, change:
+
+```ts
+  `script-src ${CF_RUM_SCRIPT_SRC}`,
+```
+
+to:
+
+```ts
+  // Widened for the copy button + "Copy as" control on the item page (design
+  // spec §4.5); the gallery index page shares this constant and inherits the
+  // widening even though it adds no script of its own.
+  `script-src 'self' 'unsafe-inline' ${CF_RUM_SCRIPT_SRC}`,
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @uploads/web test -- public-file.test.ts public-gallery.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/public-file.ts apps/web/src/lib/public-file.test.ts apps/web/src/lib/public-gallery.ts apps/web/src/lib/public-gallery.test.ts
+git commit -m "feat(web): widen script-src on the public file + gallery CSPs for copy/embed controls"
+```
+
+---
+
+### Task 7: File page — GitHub chip
+
+**Files:**
+
+- Modify: `apps/web/src/pages/f/[workspace]/[...key].astro`
+
+**Interfaces:**
+
+- Consumes: `GitHubMark` (`../../../components/GitHubMark.astro`, already exists), `file.github: GithubContext | undefined`.
+- No test harness for `.astro` — this task's "test" is typecheck + build; visual confirmation happens in Task 10.
+
+- [ ] **Step 1: Import `GitHubMark`**
+
+In `apps/web/src/pages/f/[workspace]/[...key].astro`, add to the frontmatter imports:
+
+```astro
+---
+import BaseHead from "../../../components/BaseHead.astro";
+import Brand from "../../../components/Brand.astro";
+import Footer from "../../../components/Footer.astro";
+import GitHubMark from "../../../components/GitHubMark.astro";
+import {
+  applyPublicFileHeaders,
+  authRequiredFileCsp,
+  fetchPublicFile,
+  fileKind as kind,
+  filePath,
+  formatBytes,
+} from "../../../lib/public-file";
+import { env } from "cloudflare:workers";
+```
+
+- [ ] **Step 2: Move the chip out of `dl.meta` into its own row**
+
+Remove this block from inside `<dl class="meta">` (currently between the `Uploaded` pair and the closing `</dl>`):
+
+```astro
+                {file.github && (
+                  <>
+                    <dt>Attached to</dt>
+                    <dd>
+                      <a href={file.github.url} rel="noopener noreferrer">{file.github.repo}#{file.github.number}</a>
+                      <span class="gh-kind">{file.github.kind === "pull" ? "PR" : "Issue"}</span>
+                    </dd>
+                  </>
+                )}
+```
+
+Insert a standalone chip directly after `<div class="filename">{filename}</div>` and before `<dl class="meta">`:
+
+```astro
+              <div class="filename">{filename}</div>
+              {file.github && (
+                <a class="gh-chip" href={file.github.url} rel="noopener noreferrer">
+                  <GitHubMark size={14} />
+                  <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+                  <span class="gh-chip-kind">{file.github.kind === "pull" ? "PR" : "Issue"}</span>
+                </a>
+              )}
+              <dl class="meta">
+```
+
+- [ ] **Step 3: Replace the `.gh-kind` style with `.gh-chip` styles**
+
+Remove:
+
+```css
+.gh-kind {
+  margin-left: 8px;
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+```
+
+Add, in the same spot:
+
+```css
+.gh-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 0 0;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--fg);
+  font: 12px var(--mono);
+  text-decoration: none;
+}
+.gh-chip:hover,
+.gh-chip:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+.gh-chip-kind {
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+```
+
+- [ ] **Step 4: Typecheck + build**
+
+Run: `pnpm --filter @uploads/web typecheck && pnpm --filter @uploads/web build`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/pages/f/[workspace]/[...key].astro"
+git commit -m "feat(web): Notion-style GitHub chip on the public file page"
+```
+
+---
+
+### Task 8: File page — copy, Copy-as, and Download
+
+**Files:**
+
+- Modify: `apps/web/src/lib/public-file.ts`, `apps/web/src/lib/public-file.test.ts` (new `fileDownloadUrl` helper)
+- Modify: `apps/web/src/pages/f/[workspace]/[...key].astro`
+
+**Interfaces:**
+
+- Produces: `export function fileDownloadUrl(origin: string, workspace: string, key: string): string` in `public-file.ts` — the absolute URL for the Task 3 download route.
+- Consumes: `buildEmbedFormats` (Task 1) with `kind: fileKind(file.contentType)` (file page's own `MediaKind`, which already excludes `"missing"` — a direct match for `EmbedFormatInput["kind"]`).
+- No test harness for the `.astro` markup/script itself — verified via typecheck + build here, and end-to-end on a preview worker in Task 10.
+
+- [ ] **Step 1: Write the failing test for `fileDownloadUrl`**
+
+Add to `apps/web/src/lib/public-file.test.ts`, in the `describe("key safety + path building", ...)` block, after the `filePath` test:
+
+```ts
+it("builds the absolute download-route URL, encoding each key segment", () => {
+  expect(fileDownloadUrl("https://api.uploads.sh", "acme", "f/My Shot#1.png")).toBe(
+    "https://api.uploads.sh/public/files/acme/f/My%20Shot%231.png/download",
+  );
+});
+```
+
+Add `fileDownloadUrl` to the test file's import list:
+
+```ts
+import {
+  applyPublicFileHeaders,
+  authRequiredFileCsp,
+  fetchPublicFile,
+  fileDownloadUrl,
+  fileKind,
+  filePath,
+  formatBytes,
+  isPublicFile,
+  isSafeKey,
+  PUBLIC_FILE_CSP,
+} from "./public-file";
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @uploads/web test -- public-file.test.ts`
+Expected: FAIL — `fileDownloadUrl` is not exported.
+
+- [ ] **Step 3: Implement `fileDownloadUrl`**
+
+In `apps/web/src/lib/public-file.ts`, add right after `filePath`:
+
+```ts
+/** Build the API's forced-download URL (absolute) for a public file — Task 3's `/download` route. */
+export function fileDownloadUrl(origin: string, workspace: string, key: string): string {
+  return new URL(
+    `/public/files/${encodeURIComponent(workspace)}/${encodeKey(key)}/download`,
+    origin,
+  ).href;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @uploads/web test -- public-file.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire up the page**
+
+In `apps/web/src/pages/f/[workspace]/[...key].astro`, update the frontmatter imports:
+
+```astro
+---
+import BaseHead from "../../../components/BaseHead.astro";
+import Brand from "../../../components/Brand.astro";
+import Footer from "../../../components/Footer.astro";
+import GitHubMark from "../../../components/GitHubMark.astro";
+import { buildEmbedFormats } from "../../../lib/embed-formats";
+import {
+  applyPublicFileHeaders,
+  authRequiredFileCsp,
+  fetchPublicFile,
+  fileDownloadUrl,
+  fileKind as kind,
+  filePath,
+  formatBytes,
+} from "../../../lib/public-file";
+import { env } from "cloudflare:workers";
+```
+
+After the existing `metadataEntries` computation, add:
+
+```ts
+const embedFormats = file
+  ? buildEmbedFormats({
+      canonical,
+      url: file.url,
+      embedUrl: file.embedUrl,
+      filename,
+      kind: kind(file.contentType),
+    })
+  : [];
+const downloadUrl = file ? fileDownloadUrl(origin, workspace, key) : null;
+```
+
+Replace the `.actions` block:
+
+```astro
+              <div class="actions">
+                {kind(file.contentType) !== "unsupported" && <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>}
+                {downloadUrl && <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>}
+                <span class="linkfield">
+                  <label for="copy-format">Copy as</label>
+                  <div class="copyrow">
+                    <select id="copy-format" aria-label="Copy as format">
+                      {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
+                    </select>
+                    <input id="copy-value" type="text" readonly value={embedFormats[0]?.value ?? canonical} aria-label="Value to copy" />
+                    <button type="button" id="copy-format-btn" data-copy={embedFormats[0]?.value ?? canonical} aria-live="polite">Copy</button>
+                  </div>
+                </span>
+              </div>
+```
+
+Add the copy script right after `</main>`, alongside (not replacing) the existing `auth_required` progressive-enhancement script — same file, two independent conditionals:
+
+```astro
+    {file && (
+      <script define:vars={{ formats: embedFormats }}>
+        (function () {
+          const shell = document.querySelector(".shell");
+          if (!shell) return;
+
+          // Same data-copy delegated-listener pattern as account/index.astro
+          // and account/workspaces.astro.
+          shell.addEventListener("click", (event) => {
+            void (async () => {
+              const button = event.target.closest("button[data-copy]");
+              if (!button) return;
+              try {
+                await navigator.clipboard.writeText(button.dataset.copy || "");
+                const previous = button.textContent;
+                button.textContent = "copied ✓";
+                setTimeout(() => (button.textContent = previous), 1500);
+              } catch {
+                // Clipboard blocked — leave the label.
+              }
+            })();
+          });
+
+          const select = document.getElementById("copy-format");
+          const input = document.getElementById("copy-value");
+          const copyButton = document.getElementById("copy-format-btn");
+          if (select instanceof HTMLSelectElement && input instanceof HTMLInputElement && copyButton) {
+            select.addEventListener("change", () => {
+              const format = formats.find((f) => f.id === select.value) ?? formats[0];
+              if (!format) return;
+              input.value = format.value;
+              copyButton.dataset.copy = format.value;
+            });
+          }
+        })();
+      </script>
+    )}
+```
+
+- [ ] **Step 6: Update styles**
+
+Replace the `.linkfield` styles block:
+
+```css
+.linkfield {
+  flex: 1;
+  min-width: 220px;
+}
+.linkfield label {
+  display: block;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font: 11px var(--mono);
+  margin-bottom: 5px;
+}
+.linkfield input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--body);
+  font: 12px var(--mono);
+}
+```
+
+with:
+
+```css
+.linkfield {
+  flex: 1;
+  min-width: 260px;
+}
+.linkfield label {
+  display: block;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font: 11px var(--mono);
+  margin-bottom: 5px;
+}
+.copyrow {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+.copyrow select {
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--body);
+  font: 12px var(--mono);
+}
+.copyrow input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--body);
+  font: 12px var(--mono);
+}
+.copyrow button {
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--fg);
+  font: 12px var(--mono);
+  cursor: pointer;
+}
+.copyrow button:hover,
+.copyrow button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+```
+
+(`.actions a.original` already covers the new `.download` link's look — `.download` is an additional class only for potential future differentiation, no new rule needed.)
+
+- [ ] **Step 7: Typecheck + build**
+
+Run: `pnpm --filter @uploads/web typecheck && pnpm --filter @uploads/web build`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/lib/public-file.ts apps/web/src/lib/public-file.test.ts "apps/web/src/pages/f/[workspace]/[...key].astro"
+git commit -m "feat(web): click-to-copy, Copy-as, and Download on the public file page"
+```
+
+---
+
+### Task 9: Gallery item page — copy, Copy-as, and Download
+
+**Files:**
+
+- Modify: `apps/web/src/lib/public-gallery.ts`, `apps/web/src/lib/public-gallery.test.ts` (new `galleryItemDownloadUrl` helper)
+- Modify: `apps/web/src/pages/g/[id]/[item].astro`
+
+**Interfaces:**
+
+- Produces: `export function galleryItemDownloadUrl(origin: string, galleryId: string, itemId: string): string` in `public-gallery.ts`.
+- Consumes: `buildEmbedFormats` (Task 1), called only when `item.status === "available"` (guarantees `item.url !== null` per the `isPublicGallery` invariant) with `kind: mediaKind(item) === "missing" ? "file" : mediaKind(item)` narrowed to drop `"missing"` (unreachable in the `available` branch, but keeps the type checker happy without an assertion).
+- **No GitHub chip on this page** — per spec §4.5, gallery items carry no per-item GitHub context; the existing `GalleryReferences` block is untouched.
+
+- [ ] **Step 1: Write the failing test for `galleryItemDownloadUrl`**
+
+Add to `apps/web/src/lib/public-gallery.test.ts`, as a new `describe` block:
+
+```ts
+describe("galleryItemDownloadUrl", () => {
+  it("builds the absolute download-route URL for a gallery item", () => {
+    expect(galleryItemDownloadUrl("https://api.uploads.sh", ID, "item-1")).toBe(
+      `https://api.uploads.sh/public/galleries/${ID}/items/item-1/download`,
+    );
+  });
+});
+```
+
+Add `galleryItemDownloadUrl` to the file's import list:
+
+```ts
+import {
+  applyPublicGalleryHeaders,
+  fetchPublicGallery,
+  galleryItemDownloadUrl,
+  isPublicGallery,
+  PUBLIC_GALLERY_CSP,
+} from "./public-gallery";
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @uploads/web test -- public-gallery.test.ts`
+Expected: FAIL — `galleryItemDownloadUrl` is not exported.
+
+- [ ] **Step 3: Implement `galleryItemDownloadUrl`**
+
+In `apps/web/src/lib/public-gallery.ts`, add right after `galleryItemPath`:
+
+```ts
+/** Build the API's forced-download URL (absolute) for a gallery item — Task 4's `/download` route. */
+export function galleryItemDownloadUrl(origin: string, galleryId: string, itemId: string): string {
+  return new URL(
+    `/public/galleries/${encodeURIComponent(galleryId)}/items/${encodeURIComponent(itemId)}/download`,
+    origin,
+  ).href;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @uploads/web test -- public-gallery.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire up the page**
+
+In `apps/web/src/pages/g/[id]/[item].astro`, update the frontmatter imports:
+
+```astro
+---
+import BaseHead from "../../../components/BaseHead.astro";
+import GalleryReferences from "../../../components/GalleryReferences.astro";
+import Brand from "../../../components/Brand.astro";
+import Footer from "../../../components/Footer.astro";
+import { buildEmbedFormats, type EmbedFormatOption } from "../../../lib/embed-formats";
+import {
+  applyPublicGalleryHeaders,
+  fetchPublicGallery,
+  galleryItemDownloadUrl,
+  galleryItemPath,
+  galleryPath,
+  mediaKind as kind,
+  type PublicGalleryItem,
+} from "../../../lib/public-gallery";
+import { env } from "cloudflare:workers";
+```
+
+After the existing `title` computation, add:
+
+```ts
+const embedFormats: EmbedFormatOption[] =
+  item && item.status === "available" && item.url
+    ? buildEmbedFormats({
+        canonical,
+        url: item.url,
+        embedUrl: item.embedUrl,
+        filename: item.filename,
+        kind: kind(item) === "missing" ? "file" : kind(item),
+      })
+    : [];
+const downloadUrl =
+  item && item.status === "available" ? galleryItemDownloadUrl(origin, id, item.id) : null;
+```
+
+Replace the `<figcaption>` block:
+
+```astro
+            <figcaption class="details" id="item-caption">
+              <div class="filename">{item.filename}</div>
+              {item.caption && <div class="caption">{item.caption}</div>}
+              {item.status === "available" && kind(item) !== "unsupported" && <a class="original" href={item.url!} rel="noopener noreferrer">Open original</a>}
+              {item.status === "available" && (
+                <div class="actions">
+                  {downloadUrl && <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>}
+                  <span class="linkfield">
+                    <label for="copy-format">Copy as</label>
+                    <div class="copyrow">
+                      <select id="copy-format" aria-label="Copy as format">
+                        {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
+                      </select>
+                      <input id="copy-value" type="text" readonly value={embedFormats[0]?.value ?? canonical} aria-label="Value to copy" />
+                      <button type="button" id="copy-format-btn" data-copy={embedFormats[0]?.value ?? canonical} aria-live="polite">Copy</button>
+                    </div>
+                  </span>
+                </div>
+              )}
+            </figcaption>
+```
+
+Add the copy script right before `</body>` (this page has no scripts today, unlike the file page):
+
+```astro
+      {item && item.status === "available" && (
+        <script define:vars={{ formats: embedFormats }}>
+          (function () {
+            const shell = document.querySelector(".shell");
+            if (!shell) return;
+
+            shell.addEventListener("click", (event) => {
+              void (async () => {
+                const button = event.target.closest("button[data-copy]");
+                if (!button) return;
+                try {
+                  await navigator.clipboard.writeText(button.dataset.copy || "");
+                  const previous = button.textContent;
+                  button.textContent = "copied ✓";
+                  setTimeout(() => (button.textContent = previous), 1500);
+                } catch {
+                  // Clipboard blocked — leave the label.
+                }
+              })();
+            });
+
+            const select = document.getElementById("copy-format");
+            const input = document.getElementById("copy-value");
+            const copyButton = document.getElementById("copy-format-btn");
+            if (select instanceof HTMLSelectElement && input instanceof HTMLInputElement && copyButton) {
+              select.addEventListener("change", () => {
+                const format = formats.find((f) => f.id === select.value) ?? formats[0];
+                if (!format) return;
+                input.value = format.value;
+                copyButton.dataset.copy = format.value;
+              });
+            }
+          })();
+        </script>
+      )}
+    </main>
+  </body>
+</html>
+```
+
+(The `</main>` / `</body>` / `</html>` closing tags already exist at the end of the file — this step wraps the new conditional script around them; make sure the file ends with exactly one copy of each closing tag after the edit.)
+
+- [ ] **Step 6: Add styles**
+
+Add to the `<style>` block (this page currently has no `.actions`/`.linkfield`/`.copyrow` rules — copy the same block Task 8 added to the file page, right after the existing `.original:hover, .original:focus-visible` rule):
+
+```css
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 14px;
+}
+.actions a.original {
+  display: inline-block;
+  padding: 9px 15px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--fg);
+  font: 12px var(--mono);
+  text-decoration: none;
+  margin-top: 0;
+}
+.actions a.original:hover,
+.actions a.original:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+.linkfield {
+  flex: 1;
+  min-width: 260px;
+}
+.linkfield label {
+  display: block;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font: 11px var(--mono);
+  margin-bottom: 5px;
+}
+.copyrow {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+.copyrow select {
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--body);
+  font: 12px var(--mono);
+}
+.copyrow input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--body);
+  font: 12px var(--mono);
+}
+.copyrow button {
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  color: var(--fg);
+  font: 12px var(--mono);
+  cursor: pointer;
+}
+.copyrow button:hover,
+.copyrow button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+```
+
+(The pre-existing `.original` rule at the top of the block, used by the standalone "Open original" link outside `.actions`, is untouched — `.actions a.original` above is scoped narrowly enough not to conflict.)
+
+- [ ] **Step 7: Typecheck + build**
+
+Run: `pnpm --filter @uploads/web typecheck && pnpm --filter @uploads/web build`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/lib/public-gallery.ts apps/web/src/lib/public-gallery.test.ts "apps/web/src/pages/g/[id]/[item].astro"
+git commit -m "feat(web): click-to-copy, Copy-as, and Download on the gallery item page"
+```
+
+---
+
+### Task 10: Preview-worker verification (routing + visual)
+
+**Files:** none (verification only — no code changes).
+
+The #158 lesson: vitest exercises the Hono app directly, not the deployed router. Every new route added in Tasks 3, 4, 8, and 9 needs a pass through a real preview worker before this feature is considered done.
+
+- [ ] **Step 1: Start the dev stack**
+
+Use this repo's existing dev-server launch config (per `docs/superpowers/plans/2026-07-14-metadata-search-ui.md`'s Task 5 Step 5 precedent and the `uploads dev-server-gotchas` project notes) to bring up both `apps/api` and `apps/web` against a real Worker runtime, not just `vitest`.
+
+- [ ] **Step 2: Verify the file download route**
+
+Upload or pick an existing public file whose key contains a `/` and an extension (e.g. `screenshots/shot.png`). Confirm:
+
+- `GET /public/files/<workspace>/<key>` still returns 200 JSON with `embedUrl` present (Task 2).
+- `GET /public/files/<workspace>/<key>/download` returns 200, **not 404** — this is the routing check (the #158 hazard from Global Constraints) — with `Content-Disposition: attachment` and the browser actually offers a save dialog / lands the file in Downloads, not a new tab.
+- A key path that ends with a segment literally named the same as an existing file also still resolves through the plain metadata route (spot-check, not just the vitest regression from Task 3).
+
+- [ ] **Step 3: Verify the gallery-item download route**
+
+Pick a gallery with at least one item. Confirm `GET /public/galleries/<id>/items/<item>/download` returns 200 with the right `Content-Disposition` and actually downloads (not a routing 404, and not an "Open original" redirect).
+
+- [ ] **Step 4: Visual check — file page**
+
+Load `/f/<workspace>/<key>` for:
+
+- One image file with a `gh.*`-derived GitHub attachment: confirm the chip renders with the GitHub glyph, links out to the correct PR/issue URL, and reads `{repo}#{number}` + `PR`/`Issue`.
+- One file without GitHub metadata: confirm no chip renders and nothing else shifts oddly.
+- Confirm: the Copy button copies the "Page link" value by default and shows "copied ✓"; switching "Copy as" to each option updates both the readonly input and what gets copied; "Markdown image"/"HTML `<img>`" only appear for the image file, not for a PDF/video test file; "Download" triggers a save, "Open original ↗" still opens inline as before.
+
+- [ ] **Step 5: Visual check — gallery item page**
+
+Load `/g/<id>/<item>` for an available item: confirm the same copy/Copy-as/Download behavior, confirm there is **no** GitHub chip anywhere on this page, and confirm the gallery-level "Connected work items" (`GalleryReferences`) block still renders unchanged below the pager.
+
+- [ ] **Step 6: Confirm no horizontal scroll at the narrow breakpoint**
+
+Resize to ≤760px (or use the browser's preview device toolbar) on both pages and confirm the `.actions` row wraps (chip / Open original / Download / Copy-as all stack) without introducing horizontal scroll — the shell has none today (design spec §5).
+
+- [ ] **Step 7: Report**
+
+No commit for this task (verification only). Summarize pass/fail for each check above in the PR description; attach a screenshot of the file page's chip + Copy-as control per the `github-screenshots` skill if a review would benefit from seeing it (optional, at PR-creation time, not part of this plan's task list).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- (a) Static GitHub chip, file page only, moved out of `dl.meta` into its own row → Task 7. ✓
+- (b) Server-side download routes (file + gallery item), streamed, shared helper, plain `<a>` no JS → Tasks 3, 4, 8, 9. ✓
+- (c) Five-format "Copy as" control, `embedUrl ?? url` for snippets / stable `url` for Direct file URL, `embedUrl` surfaced on both public payloads → Tasks 1, 2, 5, 8, 9. ✓ (Gallery-side API field was already shipped by #154 — confirmed rather than re-implemented; see Global Constraints discovery note.)
+- (d) CSP `script-src` widened to the exact agreed value on both `PUBLIC_FILE_CSP` and `PUBLIC_GALLERY_CSP` → Task 6. ✓
+- Click-to-copy reuses the `data-copy` delegated-listener pattern from `account/index.astro`/`workspaces.astro` → Tasks 8, 9 (same listener body, same `copied ✓` swap, same `aria-live="polite"`). ✓
+- §4.5 gallery scope: copy/embed/download apply to the item page; no per-item GitHub chip; `GalleryReferences` untouched → Tasks 4, 5, 9 explicitly skip the chip. ✓
+- §5 accessibility/responsive notes: real `<a>` for the chip (not a button), visible `PR`/`Issue` text (not `::before`), `aria-live="polite"` copy buttons, native `<select>` for the format picker (lower-risk than a segmented-button `radiogroup`), Download uses a distinct verb with no reused ↗ glyph, wrap-without-scroll verified in Task 10 Step 6 → all addressed. ✓
+- §6 testing approach: unit tests for every new pure helper (embed-format builder, CSP constants, `isPublicFile`/`isPublicGallery`, download-URL builders), API route tests for both download routes (200/401/404 + the #158 routing regression), preview-worker verification as its own task, no fabricated `.astro` render tests → Tasks 1–9 + Task 10. ✓
+- §7 out-of-scope items (live unfurl, auth route changes beyond the additive field, media-stage redesign, `@uploads/ui` extraction, signed/expiring downloads, range support, per-item GitHub, gallery-index page changes) — none implemented; gallery-index page only passively inherits the widened CSP constant, called out explicitly in Global Constraints and Task 6, not a functional change. ✓
+
+**Placeholder scan:** No TBD/TODO in any step. Every code block is complete, copy-pasteable code — no "add error handling here" stubs. Task 9's closing-tag note (Step 5) is a structural instruction, not a placeholder — it tells the implementer exactly which existing tags the new block wraps.
+
+**Type consistency:** `EmbedFormatInput`/`EmbedFormatOption` defined once in Task 1, consumed with identical shape by Task 8 (file page, `fileKind()`'s `MediaKind` matches `EmbedFormatInput["kind"]` exactly) and Task 9 (gallery page, `mediaKind()`'s `MediaKind` narrowed to drop the unreachable `"missing"` case in the `available` branch). `downloadResponse(store, key, filename)` defined once in Task 3 (`files-core.ts`), consumed unchanged by Task 4's gallery route. `fileDownloadUrl`/`galleryItemDownloadUrl` follow the same `(origin, ...ids) => absolute URL` shape as the existing `filePath`/`galleryItemPath` siblings they sit next to. `PublicFile.embedUrl`/`PublicGalleryItem.embedUrl` are both `string | null`, required (not optional), matching the already-shipped `PublicGalleryItemDto.embedUrl` convention in `apps/api/src/gallery-service.ts`.
+
+**Judgment calls made while grounding this plan (flagged for the human, not buried in the diff):**
+
+1. **Gallery-side `embedUrl` API work is already done (PR #154).** The design spec's §4.5 claims it's "simply dropped before reaching the web," but `apps/api/src/gallery-service.ts`'s `hydratePublicGallery`/`PublicGalleryItemDto` already return it, and `apps/api/test/routes-galleries.test.ts` (~line 464) already asserts it in the public payload's field list. Task 5 is scoped as a web-only type/validator change for the gallery half; only the file-page half (Task 2) is genuinely new API work. Flagged prominently in Global Constraints so nobody re-does already-shipped work.
+2. **§3.2 and §3.3 merged into one control, not two.** The design doc's §3.2 mockup (readonly input + copy button, page-link only) and §3.3's "single Copy-as control" (select + one button, five formats including Page link) read as two separate proposals but describe overlapping UI. This plan implements the design's final, more specific §3.3 shape as the _only_ copy control (one `<select>` + one readonly `<input>` that mirrors the selected format's value + one `<button data-copy>`), with "Page link" as format `id: "page"`, the first/default option — rather than shipping both a separate page-link-only copy button _and_ a Copy-as selector, which would be redundant. Worth a design sign-off glance before implementation if this reading is wrong.
+3. **Download link renders unconditionally**, including for `kind === "unsupported"` (SVG) files/items, where "Open original ↗" is deliberately hidden. This isn't explicitly stated either way in the spec, but it's the safer reading: forced `Content-Disposition: attachment` sidesteps the inline-render XSS concern that motivates hiding "Open original" for SVG in the first place, so there's no reason to also hide Download there.
+4. **`embedUrl` is a required (non-optional) field on both `PublicFile` and `PublicGalleryItem`**, not `embedUrl?:`. This matches the already-shipped `PublicGalleryItemDto` convention and keeps `isPublicFile`/`isPublicGallery` strict, but it does mean any hand-built fixture object missing the field now fails validation — confirmed via grep that the only other places constructing these types are the two `.astro` pages (updated in this plan) and one unrelated same-named function (`openPublicFile` in `AccountFileBrowser.tsx`, not the type).
+5. **Copy script container selector is `.shell`** (the page's top-level wrapper) rather than a narrower ID, since neither `.astro` page currently has a dedicated container id around just the actions row. Functionally equivalent to the account pages' pattern (delegated listener on an ancestor), just a broader ancestor.

--- a/docs/superpowers/plans/2026-07-14-file-page-polish.md
+++ b/docs/superpowers/plans/2026-07-14-file-page-polish.md
@@ -488,44 +488,43 @@ async function resolvePublicObject(
 }
 ```
 
-Replace the `export const publicFiles = ...` block with (download route registered FIRST — see the Global Constraints route-ordering note):
+Replace the `export const publicFiles = ...` block with (a `?download=1` query
+flag on the existing handler, not a separate `/download` suffix route — a
+static suffix after the greedy `:key{.+}` param is inherently ambiguous, since
+a request for `.../screenshots/download` could mean the suffix OR an object
+literally named `screenshots/download`; see the `?metadata=1` precedent in
+`routes/files.ts` for the same reasoning. The visibility gate in
+`resolvePublicObject` runs exactly once either way — this is purely a
+"stream vs json" branch on the same resolved object):
 
 ```ts
-export const publicFiles = new Hono<WorkspaceVars>()
-  // MUST be registered before the generic "/:workspace/:key{.+}" route below:
-  // :key{.+} is a greedy multi-segment match, so if the generic route were
-  // registered first it would swallow "/download" as part of the key and this
-  // route would never be reached (the #158 lesson).
-  .get("/:workspace/:key{.+}/download", async (c) => {
-    const workspace = c.req.param("workspace");
-    const key = c.req.param("key");
-    const { store } = await resolvePublicObject(c.env, workspace, key);
+export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}", async (c) => {
+  const workspace = c.req.param("workspace");
+  const key = c.req.param("key");
+  const { store, meta, urls } = await resolvePublicObject(c.env, workspace, key);
+
+  const downloadParam = c.req.query("download");
+  if (downloadParam === "1" || downloadParam === "true") {
     const filename = key.split("/").filter(Boolean).pop() ?? key;
     return downloadResponse(store, key, filename);
-  })
-  .get("/:workspace/:key{.+}", async (c) => {
-    const workspace = c.req.param("workspace");
-    const key = c.req.param("key");
-    const { store: _store, meta, urls } = await resolvePublicObject(c.env, workspace, key);
+  }
 
-    const metadata = await getFileMetadata(c.env.DB, workspace, key);
-    const github = deriveGithubContext(metadata);
+  const metadata = await getFileMetadata(c.env.DB, workspace, key);
+  const github = deriveGithubContext(metadata);
 
-    return c.json({
-      workspace,
-      key,
-      url: urls.url,
-      embedUrl: urls.embedUrl,
-      size: meta.size ?? 0,
-      contentType: meta.type ?? "application/octet-stream",
-      ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
-      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-      ...(github ? { github } : {}),
-    });
+  return c.json({
+    workspace,
+    key,
+    url: urls.url,
+    embedUrl: urls.embedUrl,
+    size: meta.size ?? 0,
+    contentType: meta.type ?? "application/octet-stream",
+    ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+    ...(github ? { github } : {}),
   });
+});
 ```
-
-(The metadata route no longer needs `store` directly — prefixed `_store` to keep it visible in the destructure without an unused-var lint failure; drop the prefix if the lint config allows an unused destructured field.)
 
 - [ ] **Step 5: Run the tests to verify they pass**
 

--- a/docs/superpowers/specs/2026-07-14-file-page-polish-design.md
+++ b/docs/superpowers/specs/2026-07-14-file-page-polish-design.md
@@ -293,18 +293,32 @@ subject to the cross-origin restriction. That means this needs no
 no CSP `connect-src` widening: `<a href={downloadUrl} rel="noopener noreferrer">Download</a>`
 just works.
 
-Concretely: add `GET /public/files/:workspace/:key/download` to
+Concretely: add a `?download=1` query flag to the existing
+`GET /public/files/:workspace/:key{.+}` handler in
 `apps/api/src/routes/public-files.ts`, reusing the exact same
 lookup/visibility gate as the existing handler (workspace record → `publicUrl`
 existence check → `store.exists`/`head` → `objectVisibility` 401 gate), then
-stream the bytes: `files-sdk` 2.1.0's `StoredFile` (what `store.download(key)`
-resolves to) exposes `.stream()` — a `ReadableStream<Uint8Array>` — so the
-route can pass that straight into a `new Response(stream, { headers: {
-"Content-Disposition": \`attachment; filename="${encodeRfc5987(filename)}"\`,
-"Content-Type": meta.type, ... } })`without buffering the whole object in
-Worker memory. This mirrors`setObjectVisibility`'s existing use of
-`store.download()` (`apps/api/src/files-core.ts`lines 261–265) but reads the
-stream instead of`arrayBuffer()`.
+stream the bytes. A query flag rather than a `/download` suffix route, because
+a static suffix after the greedy `:key{.+}` param is ambiguous — e.g.
+`.../screenshots/download` could mean the suffix OR an object literally named
+`screenshots/download` (the #158 lesson). `files-sdk` 2.1.0's `StoredFile`
+(what `store.download(key)` resolves to) exposes `.stream()` — a
+`ReadableStream<Uint8Array>` — so the route can pass that straight into a
+`Response` without buffering the whole object in Worker memory:
+
+```ts
+new Response(stream, {
+  headers: {
+    "Content-Disposition": `attachment; filename="${encodeRfc5987(filename)}"`,
+    "Content-Type": meta.type,
+    // ...
+  },
+});
+```
+
+This mirrors `setObjectVisibility`'s existing use of `store.download()`
+(`apps/api/src/files-core.ts` lines 261–265) but reads the stream instead of
+`arrayBuffer()`.
 
 **Tradeoff to name explicitly:** this moves file bytes from "served directly
 off the R2 custom domain, zero Worker involvement" to "proxied through the
@@ -355,9 +369,11 @@ to justify a GitHub App token + caching layer — that's a materially bigger
 project, not a polish pass.
 
 **(b) Download mechanism.**
-New `GET /public/files/:workspace/:key/download` API route that streams
-bytes with `Content-Disposition: attachment`, linked via a plain `<a>` (no
-client JS, no CSP change for this feature specifically).
+A `?download=1` query flag on the existing `GET /public/files/:workspace/:key{.+}`
+API route (not a `/download` suffix — ambiguous after the greedy `:key{.+}`
+param, the #158 trap) that streams bytes with `Content-Disposition: attachment`,
+linked via a plain `<a>` (no client JS, no CSP change for this feature
+specifically).
 _Recommended default: yes, build this route._ Alternative (client-side
 fetch→blob) needs CORS on the storage host plus a CSP `connect-src` widen and
 is strictly worse on every axis investigated (§3.4). Flag if there's a

--- a/docs/superpowers/specs/2026-07-14-file-page-polish-design.md
+++ b/docs/superpowers/specs/2026-07-14-file-page-polish-design.md
@@ -1,0 +1,547 @@
+# Public file page polish — design spec
+
+**Date:** 2026-07-14
+**Scope:** the public file page `apps/web/src/pages/f/[workspace]/[...key].astro`
+(the `ok`/file-found branch) **and the per-item gallery page**
+`apps/web/src/pages/g/[id]/[item].astro`, plus small, clearly-scoped additions
+to `apps/api`'s public files and public galleries routes (download controls +
+surfacing an already-computed `embedUrl` per gallery item). No React, no new
+dependencies beyond what's already in the monorepo.
+**Status:** design approved (2026-07-14). Open decisions (a)–(d) resolved to
+their recommended defaults — see §4. Gallery-item scope added — see §4.5.
+Nothing in this doc has been implemented yet.
+
+## 1. Current state
+
+The page (`apps/web/src/pages/f/[workspace]/[...key].astro`) is a single Astro
+SSR route with plain inline `<style>` and, for the `ok` branch, **no
+`<script>` at all**. The only script on the page today is the progressive
+auth-check probe in the `auth_required` branch (lines 179–208).
+
+Relevant structure in the `ok` (file found) branch:
+
+- **Attached to / GitHub row** (lines 125–133): a plain `<a>` reading
+  `{repo}#{number}` next to a `.gh-kind` badge (`PR` / `Issue`, styled at line
+  87). No GitHub glyph, no visual grouping — it reads as one more metadata
+  row, not a linked-object reference.
+- **Actions row** (lines 148–154, styles 90–95): `Open original ↗` (an `<a>`
+  to `file.url`, opens the raw file/object in a new context) sits next to a
+  `.linkfield` — a `<label>` + **readonly `<input>`** holding the canonical
+  page URL. There is no copy button and no way to download the raw file
+  except "open, then save-as" from the browser's own UI.
+- **Metadata list** (`dl.meta`, lines 121–134) and the generic **Metadata**
+  section (lines 135–147) render `Type`, `Size`, `Uploaded`, and non-`gh.*`
+  metadata pairs. This structure is unaffected by this work and must be
+  preserved as-is (see Non-goals).
+
+**The load-bearing constraint for every feature below:** the `ok` branch's
+CSP (`PUBLIC_FILE_CSP`, built by `buildFileCsp()` in
+`apps/web/src/lib/public-file.ts` lines 77–97) sets
+`script-src https://static.cloudflareinsights.com` — no `'self'`, no
+`'unsafe-inline'`. This is a deliberate, tested posture
+(`apps/web/src/lib/public-file.test.ts` lines 24–33: "locks down like the
+public gallery... script-free"). The page is script-free today specifically
+on this branch — the `auth_required` branch already accepts a widened CSP
+(`authRequiredFileCsp`, lines 107–112) because it needs to probe the API, but
+that widening has never been applied to the branch every public file view
+actually hits. Any feature here that needs JS (click-to-copy, "copy as"
+controls) means widening `script-src` on the highest-traffic branch of this
+route. This is flagged as Open Decision (d) below — it's real enough to
+deserve an explicit yes, not an assumption buried in the diff.
+
+`file.url` (`PublicFile.url` in `apps/web/src/lib/public-file.ts` line 20) is
+always `https:` (validated by `httpsUrl()`, lines 142–149) and always
+cross-origin from the page — it points at the storage host (R2 custom domain
+/ `publicBaseUrl`), never at `uploads.sh`. Confirmed via
+`apps/api/src/routes/public-files.ts` line 78 (`publicUrl(...)`) and
+`apps/api/src/storage.ts`: object bytes are served directly off that host,
+never proxied through the API Worker. That host is a bare R2 custom domain
+(see `apps/api/src/files-core.ts`'s `UPLOAD_CACHE_CONTROL` comment: "R2's
+custom-domain default") — it has no Worker in front of it, so today there is
+no code path that can attach a per-request `Content-Disposition` header to
+those bytes.
+
+`apps/api/src/routes/public-files.ts` (the `GET /public/files/:workspace/:key`
+endpoint this page calls) returns `workspace, key, url, size, contentType,
+uploaded?, metadata?, github?` — **no `embedUrl`**. `embedUrl` exists only on
+the _authenticated_ endpoints (`apps/api/src/routes/files.ts`,
+`apps/api/src/gallery-service.ts`, both via `objectPublicUrls`/
+`publicAndEmbedUrls` in `apps/api/src/storage.ts` and
+`packages/storage/src/index.ts` lines 107–148). The task brief's premise that
+"the API also exposes an `embedUrl`" is true for those endpoints but **not**
+for the one this page actually calls — see Open Decision (c) and §3.3.
+
+## 2. Goals & non-goals
+
+**Goals**
+
+- Make the GitHub attachment read as a recognizable, glyph-bearing chip
+  (Notion-style), reusing the existing `GitHubMark.astro` component.
+- Replace the plain readonly `<input>` with a real click-to-copy control that
+  gives feedback, reusing the established `data-copy` pattern.
+- Offer the URL forms people actually paste (raw file, page URL, Markdown,
+  HTML `<img>`) in one coherent, low-chrome control — not four competing
+  inputs.
+- Give the file a working one-click "Download" that doesn't silently open a
+  new tab instead of saving.
+- Keep every existing security/behavior guarantee intact (see Non-goals).
+
+**Non-goals**
+
+- No live GitHub API calls, no PR/issue titles, no open/closed/merged state,
+  no avatars. Only `GithubContext` (`repo`, `kind`, `number`, `url`) is
+  available without a live fetch, and a live fetch has real costs (rate
+  limits with no token, added latency on every public file view, a new
+  outbound dependency on a page whose CSP is currently locked to
+  `default-src 'none'`). See Open Decision (a).
+- No change to the `auth_required` / `unavailable` / `not_found` branches,
+  their status codes, or their copy.
+- No change to the `noindex`/CSP/`Cache-Control: no-store` header posture
+  beyond what's explicitly decided in Open Decision (d).
+- No change to the generic metadata list or the `gh.*` filtering
+  (`metadataEntries`, lines 45–49).
+- No redesign of the media stage (`.media`, `img`/`video`/fallback rendering).
+- No new frameworks/components; this stays plain Astro + inline `<style>` +
+  (if approved) inline `<script>`, matching every other page in `apps/web`
+  that isn't built on `@uploads/ui`.
+- No thumbnail/OG-image changes.
+
+## 3. Design per feature
+
+### 3.1 GitHub chip / unfurl
+
+**Recommended approach — static chip, not a live unfurl.** Replace the plain
+`<a>` + `.gh-kind` badge (lines 125–133) with a single chip-shaped `<a>`:
+`GitHubMark.astro` icon + `{repo}#{number}` + a small kind label, all inside
+one bordered, rounded, padded anchor — Notion's "linked page" chip shape,
+built from tokens already in this file (`var(--line)`, `var(--panel)`,
+`var(--radius-md)`, `var(--mono)`), same visual language as `.actions
+a.original` (lines 91–92) so it doesn't introduce a new component style.
+
+```html
+<a class="gh-chip" href="{file.github.url}" rel="noopener noreferrer">
+  <GitHubMark size="{14}" />
+  <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+  <span class="gh-chip-kind">{file.github.kind === "pull" ? "PR" : "Issue"}</span>
+</a>
+```
+
+Move this out of `dl.meta` into its own row (it stops being a `dt`/`dd` pair
+and becomes a standalone chip), directly under the filename or directly above
+the Metadata section — placement is a minor open call, default: directly
+under the filename, above `dl.meta`, since it's the most identity-bearing
+piece of context for the file (mirrors how `GalleryReferences.astro`'s
+"Connected work items" list, lines 11–23, already sits as its own block
+rather than inside a metadata table).
+
+**Rationale:** zero new network calls, zero new latency, works within the
+existing `default-src 'none'` CSP (a static chip needs no script — just the
+existing `GitHubMark.astro` SVG import, which Astro inlines at build time).
+Matches `GalleryReferences.astro`'s existing "linked work item" visual
+vocabulary (`.refs .provider` + link) rather than inventing a third pattern.
+
+**Alternative considered — live unfurl** (fetch title + open/closed/merged
+state from `api.github.com` server-side during SSR): rejected as the
+default. It would need: an unauthenticated GitHub API call per page render
+(60 req/hr per IP, shared across every visitor hitting the API's outbound
+IP — trivially exhausted), a timeout/fallback path when the call fails, and
+either a new outbound `connect-src` in the CSP or moving the fetch
+server-side (SSR-side fetch avoids the CSP concern, but not the rate limit or
+latency — every file page load would block on a third-party round trip).
+See Open Decision (a).
+
+**Smaller alternative** — keep the two-piece layout but add the glyph:
+`<GitHubMark /> {repo}#{number}` with the `.gh-kind` badge unchanged. Simpler
+diff, but doesn't deliver "Notion-style chip" — worth calling out as a
+fallback if the chip's visual weight feels wrong in review, not as the
+primary recommendation.
+
+### 3.2 Click-to-copy link cleanup
+
+**Recommended approach:** reuse the exact pattern from
+`apps/web/src/pages/account/index.astro` (lines 26–34, 58–79) and
+`apps/web/src/pages/account/workspaces.astro` (lines 215, 305+): a
+`data-copy="<value>"` attribute on a `<button>`, one delegated `click`
+listener on a container (`await navigator.clipboard.writeText(...)`, swap the
+button's `textContent` to `copied ✓` for 1500ms, silently no-op in the
+`catch` since clipboard access can be blocked). Replace the current
+`<label>` + readonly `<input>` (lines 150–153) with:
+
+```html
+<div class="linkfield">
+  <label for="page-link">Page link</label>
+  <div class="copyrow">
+    <input id="page-link" type="text" readonly value="{canonical}" aria-label="Page link" />
+    <button type="button" data-copy="{canonical}" aria-live="polite">Copy</button>
+  </div>
+</div>
+```
+
+Keep the `<input>` — it's still useful for people who want to select/edit
+manually or for password-manager-style drag, and it degrades gracefully to
+"select and Ctrl/Cmd+C" if JS is blocked or disabled (progressive
+enhancement, same posture as the `auth_required` branch's script). The button
+is the primary affordance; the input is the fallback, not vice versa.
+
+**Rationale:** don't invent a third copy pattern when two pages already
+established one. Consistency here also means any future account-page ↔
+file-page shared component extraction (not proposed now, but plausible) has
+one pattern to lift, not three.
+
+**Requires:** widening `script-src` on the `ok` branch — see Open Decision
+(d). This is the one feature in this doc that cannot ship script-free.
+
+**Alternative considered** — `<input readonly>` with `onclick="this.select()"`
+inline handler: rejected, `onclick=` attributes need `'unsafe-inline'`
+
+- _event-handler_ allowance which is a bigger CSP hole than a `<script>`
+  block, and it's a worse UX (select, then the user still has to know to hit
+  Ctrl/Cmd+C — no "copied ✓" feedback).
+
+### 3.3 Organize embed link types
+
+**Recommended approach:** a single "Copy as" control — one `<select>` (or a
+small segmented row of buttons for ≤4 options, cheaper to style than a
+custom select) next to _one_ copy button, rather than N stacked readonly
+inputs. Selecting a format updates a hidden value the copy button's
+`data-copy` reads (or the click handler re-derives the string per selected
+format from the same delegated listener as §3.2 — no extra script wiring). A
+plain `<details>`/segmented-row shape (matching this page's existing
+no-JS-required collapsible-free posture) is simpler to implement correctly
+than a JS-driven tab panel and doesn't need any new CSS beyond what's already
+token-based here.
+
+Formats, gated by `kind(file.contentType)` (already computed via `fileKind()`
+in `apps/web/src/lib/public-file.ts` lines 44–49):
+
+| Format          | Value                                       | Shown when         |
+| --------------- | ------------------------------------------- | ------------------ |
+| Page link       | `canonical`                                 | always             |
+| Direct file URL | `file.url`                                  | always             |
+| Markdown image  | `![​](${embedSrc})`                         | `kind === "image"` |
+| Markdown link   | `[${filename}](${canonical})`               | always             |
+| HTML `<img>`    | `<img src="${embedSrc}" alt="${filename}">` | `kind === "image"` |
+
+`embedSrc` = `file.embedUrl ?? file.url` — see the `embedUrl` gap below.
+Video (`kind === "video"`) gets Page link / Direct URL / Markdown link only;
+Markdown/HTML image forms don't apply. Non-previewable `file`/`unsupported`
+kinds get the same three.
+
+**The `embedUrl` gap.** `apps/api/src/routes/public-files.ts` does not
+return `embedUrl` today (§1). Two ways to close it, in order of preference:
+
+1. **Extend the API response** (preferred): add `embedUrl` to
+   `public-files.ts`'s JSON, computed the same way `files-core.ts` /
+   `routes/files.ts` already do it — `objectPublicUrls()` /
+   `publicAndEmbedUrls()` in `apps/api/src/storage.ts` — instead of just
+   `publicUrl()` (line 78). This is a small, additive, backward-compatible
+   API change (new optional field), keeps `PublicFile`'s Zod-adjacent
+   validator (`isPublicFile` in `apps/web/src/lib/public-file.ts`)
+   symmetric with the authenticated DTOs, and keeps embed-host config
+   (`EMBED_PUBLIC_BASE_URL`) where it already lives — server-side, in the
+   API's env — rather than duplicating that env var into `apps/web`.
+2. **Derive client-side in `apps/web`**: add `@uploads/storage` as a
+   dependency of `apps/web` and call the pure `embedUrlFromPublic(file.url)`
+   (`packages/storage/src/index.ts` lines 107–132) at render time. Rejected
+   as the default — `apps/web` has "no storage bindings" by design (comment,
+   `public-file.ts` line 4), and this would reintroduce exactly the kind of
+   storage-layer coupling that design note exists to avoid, purely to save
+   one API field.
+
+Default: (1). See Open Decision (c) for the exact format list/layout, which
+is the part that most needs a human call.
+
+**Rationale for "one control, not four inputs":** four stacked readonly
+inputs (the literal reading of "surface the different URL forms") is a wall
+of near-identical text most visitors don't need — most file-page visitors
+either grab the page link or the raw file URL, and Markdown/HTML forms are a
+power-user path (mirrors how `packages/uploads/src/commands.ts` already
+treats Markdown as an _opt-in_ output format, not the default `uploads put`
+output). A single selector keeps the "actions" row's visual weight roughly
+where it is today instead of tripling it.
+
+**Alternative considered** — tabs (one visible field, format tabs above it):
+functionally similar to the select/segmented-row option, more DOM/CSS for
+the same outcome; only worth it if the format list grows past ~5, which
+isn't the case here (YAGNI).
+
+### 3.4 Download the file easily
+
+**Investigation summary.** The `download` HTML attribute is a _client-side_
+hint the browser is free to ignore, and both Chrome and Firefox ignore it for
+cross-origin targets — which `file.url` always is (§1). A plain
+`<a download href={file.url}>` today would just open the file, exactly as
+"Open original ↗" already does. Confirmed no existing code path sets
+`Content-Disposition` for public file bytes: they're served straight off the
+R2 custom domain (`publicBaseUrl`), which has no Worker in front of it and no
+per-request header override available on that domain. The one existing
+`Content-Disposition: attachment` mechanism in this codebase
+(`signedDownloadUrl()`, `packages/storage/src/index.ts` lines 170–180, used
+by `apps/api/src/routes/me.ts`'s `/me/workspaces/:name/file-url`) only fires
+when a workspace has **no** `publicBaseUrl` and falls back to provider
+signing — i.e. it's the private/no-public-domain path, and it's
+authenticated. It doesn't reach this page's case (a workspace with
+`publicBaseUrl`, unauthenticated).
+
+**Recommended approach — a new, small public API route that sets
+`Content-Disposition` server-side, linked with a plain `<a>` (no JS).**
+`Content-Disposition: attachment` is a _response header_ the browser honors
+on navigation regardless of the origin serving it or whether the linking
+page used the `download` attribute — unlike the HTML attribute, it isn't
+subject to the cross-origin restriction. That means this needs no
+`fetch`/blob/object-URL dance, no CORS configuration on the storage host, and
+no CSP `connect-src` widening: `<a href={downloadUrl} rel="noopener noreferrer">Download</a>`
+just works.
+
+Concretely: add `GET /public/files/:workspace/:key/download` to
+`apps/api/src/routes/public-files.ts`, reusing the exact same
+lookup/visibility gate as the existing handler (workspace record → `publicUrl`
+existence check → `store.exists`/`head` → `objectVisibility` 401 gate), then
+stream the bytes: `files-sdk` 2.1.0's `StoredFile` (what `store.download(key)`
+resolves to) exposes `.stream()` — a `ReadableStream<Uint8Array>` — so the
+route can pass that straight into a `new Response(stream, { headers: {
+"Content-Disposition": \`attachment; filename="${encodeRfc5987(filename)}"\`,
+"Content-Type": meta.type, ... } })`without buffering the whole object in
+Worker memory. This mirrors`setObjectVisibility`'s existing use of
+`store.download()` (`apps/api/src/files-core.ts`lines 261–265) but reads the
+stream instead of`arrayBuffer()`.
+
+**Tradeoff to name explicitly:** this moves file bytes from "served directly
+off the R2 custom domain, zero Worker involvement" to "proxied through the
+API Worker" for the download path specifically (not the inline-preview path,
+which keeps using `file.url` unchanged). That's a real cost/latency
+difference for large files and a new code path to keep correct (range
+requests aren't needed here since it's a full-file download, but very large
+files could bump into Worker response/CPU limits — worth a size gut-check
+before this ships, not blocking the design). It only affects the _download_
+action, which is opt-in and lower-traffic than inline preview, so the
+tradeoff is contained.
+
+**Why not client-side fetch → blob → object URL?** It would need
+`Access-Control-Allow-Origin` on the storage host (not configured anywhere
+in this repo — R2 custom domains don't send CORS by default and nothing here
+sets it) _and_ widening the CSP's `connect-src` on the `ok` branch to include
+the storage origin _and_ JS (same CSP cost as §3.2, but layered with an
+additional cross-origin-fetch dependency the server-side option doesn't
+need). Strictly more moving parts for the same result — rejected.
+
+**Why not a dashboard-level Cloudflare Transform Rule** (force
+`Content-Disposition` for a path pattern on the R2 custom domain)?
+Rejected: disposition would be static per path, not per-request, so the same
+URL couldn't serve both "inline preview" (`<img src>`, `<video src>`) and
+"force download" — this page needs both from the same object. Out of code
+review entirely (dashboard config, not this repo), and less discoverable /
+harder to test than an API route.
+
+See Open Decision (b).
+
+## 4. RESOLVED DECISIONS
+
+All four decisions below were **resolved to their recommended defaults** on
+2026-07-14 (design approval). They are retained here with their rationale so
+nobody re-litigates them. Summary: (a) **static chip**, (b) **build the
+server-side download route**, (c) **five embed formats via a new `embedUrl`
+API field**, (d) **accept the CSP `script-src` widening**.
+
+**(a) GitHub chip: static vs. live unfurl.** → **RESOLVED: static.**
+Static chip built from `GithubContext` (`repo`/`kind`/`number`/`url`) only —
+no title, no open/closed/merged state, no live fetch.
+_Recommended default: static._ Reasons: no rate-limit exposure (unauthenticated
+GitHub API calls are 60/hr per source IP — shared across every visitor
+hitting the API's egress IP, easily exhausted), no added latency on every
+public file view, no new outbound dependency inside a CSP that's currently
+`default-src 'none'`. Revisit only if product wants title/state badly enough
+to justify a GitHub App token + caching layer — that's a materially bigger
+project, not a polish pass.
+
+**(b) Download mechanism.**
+New `GET /public/files/:workspace/:key/download` API route that streams
+bytes with `Content-Disposition: attachment`, linked via a plain `<a>` (no
+client JS, no CSP change for this feature specifically).
+_Recommended default: yes, build this route._ Alternative (client-side
+fetch→blob) needs CORS on the storage host plus a CSP `connect-src` widen and
+is strictly worse on every axis investigated (§3.4). Flag if there's a
+reason to avoid proxying bytes through the API Worker (cost/quota) that
+outweighs the UX gain — in that case the fallback is "Open original ↗" stays
+the only download affordance and this feature is dropped for now.
+
+**(c) Embed format set and layout.**
+Five formats — Page link, Direct file URL, Markdown image (image kind only),
+Markdown link, HTML `<img>` (image kind only) — in a single "Copy as"
+select/segmented-row control (§3.3), backed by adding `embedUrl` to
+`apps/api/src/routes/public-files.ts`'s response.
+_Recommended default: as listed._ Open sub-questions for the human:
+
+- Include HTML `<img>` at all, or is Markdown-only enough for v1? (Markdown
+  covers GitHub/most chat tools; HTML mainly matters for people embedding
+  in raw HTML/CMS content — narrower audience.)
+- Should "Direct file URL" prefer `embedUrl` (freshness-oriented Camo host)
+  or the stable `url`? `packages/uploads/src/commands.ts` line 93 already
+  documents "MARKDOWN prefers embedUrl for GitHub" as the CLI's convention
+  — recommend mirroring that here: embed formats use `embedUrl ?? url`,
+  but "Direct file URL" (the plain-URL option, not an embed snippet) stays
+  the stable `url` since that's the one meant for long-lived linking.
+- Confirm going with API route change (§3.3 option 1) over the
+  `apps/web`-side derivation (option 2) — recommended default is option 1.
+
+**(d) CSP `script-src` widening on the `ok` branch.**
+Widen `PUBLIC_FILE_CSP`'s `script-src` for the file-found branch from
+`https://static.cloudflareinsights.com` only, to
+`'self' 'unsafe-inline' https://static.cloudflareinsights.com` — the same
+posture `authRequiredFileCsp` already uses (lines 107–112) — scoped strictly
+to enabling the click-to-copy button (§3.2) and the "Copy as" control (§3.3).
+No `connect-src` widening needed (clipboard writes don't touch the network,
+and the download control in §3.4 deliberately needs no script at all).
+_Recommended default: accept the widening._ It's the same posture already
+shipped and tested on the `auth_required` branch, it's inline-script-only
+(no third-party script host added), and copy-to-clipboard is not
+implementable without it. If this is rejected, §3.2/§3.3 degrade to
+"readonly input, select-to-copy" (no button, no feedback, no format
+switcher) — worth stating plainly as the fallback rather than silently
+shipping a broken button.
+
+## 4.5 Gallery items (per-item gallery page)
+
+The same polish applies to the per-item gallery page
+`apps/web/src/pages/g/[id]/[item].astro`, which is structurally a twin of the
+file page: same media stage, a `.details` figcaption with filename/caption,
+and today only an "Open original" link (line 104) — no copy, no embed, no
+download. **Decision (2026-07-14): apply copy-link, embed formats, and
+download to gallery items; keep GitHub attribution at the gallery level (the
+existing `GalleryReferences` "Connected work items" block already rendered on
+the item page, line 112). No per-item GitHub chip** — gallery items carry no
+per-item GitHub context in the data model (`PublicGalleryItem` has
+`filename`/`url`/`contentType`/`caption`; the projection in
+`apps/api/src/gallery-service.ts` lines 251–263 has no `github`/`metadata`
+per item), and associating it per item is a separate data-modeling project,
+explicitly out of scope here.
+
+What maps over, and the one API gap each needs:
+
+- **Copy-link cleanup (§3.2):** applies directly. The item page already has a
+  `canonical` page URL (line 39). Reuse the same `data-copy` button + delegated
+  listener. Needs the gallery CSP widened (see below).
+- **Embed formats (§3.3):** applies. `embedUrl` is **already computed
+  server-side** for each item (`gallery-service.ts` line 262 returns
+  `embedUrl` from `objectPublicUrls`) — it is simply dropped before reaching
+  the web. Surface it: add `embedUrl` to the public gallery item payload
+  (`apps/api/src/routes/public-galleries.ts` → `hydratePublicGallery`) and to
+  the `PublicGalleryItem` type + `isPublicGallery` validator in
+  `apps/web/src/lib/public-gallery.ts`. This is the gallery twin of Decision
+  (c)'s file-page `embedUrl` change and is even smaller (the value already
+  exists; it just isn't forwarded). Format list is gated by the item's
+  `mediaKind` exactly as the file page gates on `fileKind`.
+- **Download (§3.4):** applies. Add a gallery-item download route that streams
+  bytes with `Content-Disposition: attachment`, reusing the **same shared
+  streaming helper** as the file-page download route (§3.4). The gallery
+  route resolves the item's `object_key` (known server-side —
+  `gallery-service.ts` line 256 `objectKey`) within the gallery's workspace
+  and applies the gallery's existing public-visibility gate, rather than
+  taking a raw workspace+key from the URL. Route shape:
+  `GET /public/galleries/:id/items/:item/download`.
+- **GitHub chip (§3.1):** **not applied per item.** The gallery-level
+  `GalleryReferences` block stays as-is. No change.
+
+**CSP.** The gallery pages use `PUBLIC_GALLERY_CSP`
+(`apps/web/src/lib/public-gallery.ts` lines 67–74), which is the same
+`default-src 'none'` + `script-src <CF RUM only>` script-free posture as the
+file page. Copy-link and "Copy as" on the item page need the **same
+`script-src` widening decided in (d)**, applied to `PUBLIC_GALLERY_CSP` (or
+just the per-item page's response) the same way. The download link needs no
+script and no CSP change (same as §3.4).
+
+**Shared code.** To avoid two divergent copies, extract the pure
+embed-format-string builder (Decision (c)'s format table) into a testable
+helper shared by both pages — natural home is alongside the existing
+`fileKind`/`mediaKind` helpers, or a small shared `embed-formats.ts` both
+`public-file.ts` and `public-gallery.ts` import. The two download routes share
+one streaming helper (in `apps/api/src/files-core.ts`, next to the existing
+`store.download()` usage). The `data-copy` copy-button inline-script pattern is
+identical on both pages; keep it as the same small inline `<script>` on each
+(no shared component — consistent with the "no `@uploads/ui` extraction"
+non-goal), or lift it to a tiny shared client module if the duplication is
+judged worth removing during implementation.
+
+## 5. Accessibility & responsive notes
+
+- GitHub chip: keep it a real `<a>` (not a `<button>` faking a link) so it's
+  keyboard-reachable and shows up correctly in the accessibility tree as a
+  link to an external site; `GitHubMark`'s `aria-hidden="true"` (already set
+  in the component) means the chip's accessible name comes entirely from its
+  text content (`{repo}#{number}` + kind) — don't add a redundant `alt`/`aria-label`
+  on the icon.
+  - `PR`/`Issue` text stays in the DOM as visible text (not `::before`
+    content), so it's announced and stays copy-pasteable/selectable.
+- Copy buttons: `aria-live="polite"` on the button (matching the existing
+  pattern) so "copied ✓" is announced without stealing focus; keep the label
+  swap on `textContent`, not a separate visually-hidden node, to match the
+  existing pattern exactly (`account/index.astro` lines 69–73).
+- "Copy as" selector: if built as a native `<select>`, it's free
+  keyboard/screen-reader support; if built as a segmented button row, each
+  button needs `aria-pressed`, and the group needs a `role="radiogroup"` or
+  equivalent — this pushes towards the native `<select>` as the lower-risk
+  default unless the visual design specifically wants a segmented look.
+- Download link: plain `<a>`, no `aria-label` override needed beyond the
+  existing "Download" text; keep it visually distinct from "Open original ↗"
+  (different verb, different icon or none — don't reuse the ↗ external-link
+  glyph, since download isn't "leaving the page" in the same sense).
+- Responsive: the `.actions` row is already `flex-wrap:wrap` (line 90) with
+  `.linkfield { flex:1; min-width:220px }` (line 93) — the chip, copy
+  control, and download link should all fit into that same wrapping flex
+  row without new breakpoints; verify at the existing `@media (max-width:760px)`
+  cut (line 102) that the "Copy as" control doesn't force horizontal scroll
+  on narrow viewports (the shell has no horizontal scroll anywhere today —
+  don't introduce the first instance).
+
+## 6. Testing approach
+
+- **Unit (vitest):** extend `apps/web/src/lib/public-file.test.ts` for any
+  new pure helpers (e.g. an embed-format-string builder, if extracted out of
+  the `.astro` file into `public-file.ts` for testability — recommended,
+  since `.astro` template logic is awkward to unit test directly). Extend
+  `apps/api`'s route tests (pattern: `apps/api/test/routes-files.test.ts`,
+  which already asserts `embedUrl` shape, e.g. line 158) with a test for the
+  new download route: 200 with correct `Content-Disposition`/`Content-Type`
+  for a public object, 401 `auth_required` for a private one (same gate as
+  the existing metadata route), 404 for a missing key.
+- **The #158 lesson — verify routing on a real preview worker, not just
+  vitest.** #158 was a prod router mismatch (key-at-tail routes) that vitest
+  didn't catch because the test harness didn't exercise the actual Wrangler
+  router the way a real request path does. Before calling the download route
+  done, hit it through a live `wrangler dev`/preview worker (not just the
+  Hono app under vitest) with a real `key` containing a `/` and an extension,
+  and confirm the browser actually saves the file (not just that the
+  response object looks right in a test assertion).
+- **Manual/visual check (recommended, not required):** load the file page in
+  a real browser for one image object with a GitHub attachment and one
+  without, confirm: chip renders and links out correctly; copy button copies
+  the right string and shows feedback; "Copy as" switches formats correctly
+  for an image vs. a non-image file; Download actually triggers a save
+  dialog / lands in Downloads, not a new tab.
+- No new CSP regression tests are optional — extend
+  `public-file.test.ts`'s existing CSP assertions (lines 24–53) to cover
+  whatever `script-src` ships per Open Decision (d), the same way
+  `authRequiredFileCsp` is already tested.
+
+## 7. Out of scope
+
+- Live GitHub unfurl (title, state, avatar) — Open Decision (a) default is no.
+- Any change to `apps/api`'s _authenticated_ file/gallery routes or their
+  `embedUrl` computation — this only adds a matching field to the public
+  route.
+- Thumbnail/OG-image work, video poster frames, or any change to the media
+  stage.
+- A shared/extracted "copy button" or "chip" component in `@uploads/ui` —
+  this stays plain Astro/inline-script, matching the rest of `apps/web`'s
+  non-React surfaces; extraction is a follow-up if the pattern gets reused a
+  third time, not a prerequisite here.
+- Signed/expiring download links, download analytics/counting, or any
+  rate-limiting on the new download route beyond what the existing public
+  file lookup already has.
+- Range-request support on the download route (full-file download only).
+- **Per-item GitHub context on gallery items** (a per-item chip on the gallery
+  page). Gallery items have no per-item GitHub association in the data model;
+  adding one is a separate data-modeling project (§4.5). The gallery-level
+  "Connected work items" block is unchanged.
+- Any change to the gallery _index_ page (`g/[id].astro`) or its tiles — this
+  touches only the per-item page (`g/[id]/[item].astro`).

--- a/docs/superpowers/specs/2026-07-14-file-page-polish-design.md
+++ b/docs/superpowers/specs/2026-07-14-file-page-polish-design.md
@@ -421,15 +421,14 @@ What maps over, and the one API gap each needs:
 - **Copy-link cleanup (§3.2):** applies directly. The item page already has a
   `canonical` page URL (line 39). Reuse the same `data-copy` button + delegated
   listener. Needs the gallery CSP widened (see below).
-- **Embed formats (§3.3):** applies. `embedUrl` is **already computed
-  server-side** for each item (`gallery-service.ts` line 262 returns
-  `embedUrl` from `objectPublicUrls`) — it is simply dropped before reaching
-  the web. Surface it: add `embedUrl` to the public gallery item payload
-  (`apps/api/src/routes/public-galleries.ts` → `hydratePublicGallery`) and to
-  the `PublicGalleryItem` type + `isPublicGallery` validator in
-  `apps/web/src/lib/public-gallery.ts`. This is the gallery twin of Decision
-  (c)'s file-page `embedUrl` change and is even smaller (the value already
-  exists; it just isn't forwarded). Format list is gated by the item's
+- **Embed formats (§3.3):** applies. **The API already returns `embedUrl` per
+  gallery item** — `gallery-service.ts`'s public DTO includes it (line ~336,
+  asserted in `apps/api/test/routes-galleries.test.ts` ~line 464). Only the
+  **web** side drops it: add `embedUrl` to the `PublicGalleryItem` type +
+  `isPublicGallery` validator in `apps/web/src/lib/public-gallery.ts`. So the
+  gallery half of Decision (c) is **web-type-only** — no gallery API change
+  (unlike the file page, whose public route genuinely lacks `embedUrl` and
+  must be extended). Format list is gated by the item's
   `mediaKind` exactly as the file page gates on `fileKind`.
 - **Download (§3.4):** applies. Add a gallery-item download route that streams
   bytes with `Content-Disposition: attachment`, reusing the **same shared


### PR DESCRIPTION
Polishes the public **file page** (`/f/…`) and the per-item **gallery page** (`/g/…/…`) with four affordances, plus the small API work to support them. Follow-up from #159.

## What's in it
**File page** (`f/[workspace]/[...key].astro`)
- **GitHub chip** — the "Attached to" row becomes a Notion-style chip (GitHub glyph + `repo#number` + PR/Issue), reusing `GitHubMark.astro`. Static (no live GitHub fetch).
- **Copy** — real click-to-copy with "copied ✓" feedback (the established `data-copy` pattern), replacing the bare readonly input.
- **Copy as** — one `<select>` offering Page link, Direct file URL, Markdown image/link, HTML `<img>` (image-only formats gated by kind). Snippets use `embedUrl ?? url`; direct URL stays the stable `url`.
- **Download** — a real one-click download that saves instead of opening.

**Gallery item page** (`g/[id]/[item].astro`) — the same copy / Copy-as / download controls. GitHub attribution stays at the gallery level (the existing "Connected work items" block); no per-item chip (gallery items carry no per-item GitHub context).

**API**
- `embedUrl` added to the public file route (galleries already returned it).
- File download via **`?download=1`** on the public file route — streams with `Content-Disposition: attachment` (a shared `downloadResponse` helper). *Note:* the plan first proposed a `/download` path suffix; that's ambiguous after the greedy `:key{.+}` param (the #158 trap — `screenshots/download` is undecidable), so it was corrected to a query param, mirroring the repo's existing `?metadata=1` convention.
- Gallery-item download route `/public/galleries/:id/items/:item/download` (safe suffix — non-greedy ids), reusing the same helper, **gated on public-URL reachability** (not just object existence) so it can't stream bytes the gallery view itself would withhold.

**CSP** — `script-src` widened to `'self' 'unsafe-inline' https://static.cloudflareinsights.com` on `PUBLIC_FILE_CSP` and `PUBLIC_GALLERY_CSP` (same posture already shipped on the auth-required branch), to enable the copy/Copy-as inline script. `connect-src` untouched. The `define:vars` format data is JSON-escaped (`<`), so filenames/metadata can't break out of the script.

## Design & plan
- Spec: `docs/superpowers/specs/2026-07-14-file-page-polish-design.md`
- Plan: `docs/superpowers/plans/2026-07-14-file-page-polish.md`

## Testing
- API `351/351`, web `96/96`, web build clean.
- Download routing covered by vitest, including an explicit key-named-`download` ambiguity test proving the query-param design doesn't shadow real keys.
- Built and reviewed task-by-task + a whole-branch review (verdict: ready to merge). One real security finding was caught and fixed mid-build: the gallery download route initially checked only object existence, not public-URL reachability — closed in `2fc5377` with a regression test.
- ⚠️ **Deferred to the deploy preview:** the live browser clickthrough — copy feedback, format switching, and an actual file-save via `Content-Disposition`. The download routes aren't in prod yet, so the end-to-end save can only be exercised once this branch is deployed. Please verify on the preview: chip renders + links out; Copy / Copy-as copy the right strings; Download saves (doesn't open) on both a file page and a gallery item.

## Accepted tradeoffs
- Static GitHub chip only (no titles/state) — a live unfurl would need a GitHub App token + caching, out of scope.
- Download proxies bytes through the API Worker for the download action only (inline preview still serves straight off R2). Full-file only, no range.
- Gallery per-object `visibility: private` is not separately enforced on download — it matches the gallery *read* path exactly (existence + public-URL), and raw bytes on a `publicBaseUrl` workspace are already unsigned-reachable, so this exposes nothing new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added download links for public files and gallery items, with reliable attachment filenames.
  * Added “Copy as” controls supporting page links, direct URLs, Markdown, and HTML image embeds.
  * Added GitHub attachment chips to public file pages.
  * Public file responses now include embed URLs.
* **Bug Fixes**
  * Improved handling of missing, private, or unavailable public files and gallery items.
  * Preserved correct URL behavior for keys containing reserved path segments.
* **Tests**
  * Added coverage for downloads, embed formats, URL validation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->