### PR TITLE
refactor(web): share CopyAsControls on file and gallery pages

### DIFF
--- a/apps/web/src/components/CopyAsControls.astro
+++ b/apps/web/src/components/CopyAsControls.astro
@@ -1,0 +1,179 @@
+---
+/**
+ * Shared Copy / Copy as / Download controls for public file and gallery-item
+ * pages — one place for markup, styles, and the CSP-safe `define:vars` script.
+ *
+ * Default slot: optional same-row links (e.g. "Open original"). Slotted `<a
+ * class="original">` is styled via `:global` so parent-scoped markup still matches.
+ */
+import type { EmbedFormatOption } from "../lib/embed-formats";
+
+interface Props {
+  formats: EmbedFormatOption[];
+  downloadUrl?: string | null;
+}
+
+const { formats, downloadUrl = null } = Astro.props;
+const defaultCopyValue = formats[0]?.value ?? "";
+const show = Boolean(downloadUrl) || formats.length > 0;
+---
+
+{
+  show && (
+    <div class="actions">
+      <slot />
+      {downloadUrl && (
+        <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>
+      )}
+      {formats.length > 0 && (
+        <span class="linkfield">
+          <label for="copy-format">Copy as</label>
+          <div class="copyrow">
+            <select id="copy-format" aria-label="Copy as format">
+              {formats.map((format) => <option value={format.id}>{format.label}</option>)}
+            </select>
+            <input
+              id="copy-value"
+              type="text"
+              readonly
+              value={defaultCopyValue}
+              aria-label="Value to copy"
+            />
+            <button
+              type="button"
+              id="copy-format-btn"
+              data-copy={defaultCopyValue}
+              aria-live="polite"
+            >
+              Copy
+            </button>
+          </div>
+        </span>
+      )}
+    </div>
+  )
+}
+
+{
+  formats.length > 0 && (
+    // dataset.copyLabel keeps the label stable across a rapid double-click
+    // while the "copied ✓" timeout is still pending.
+    <script define:vars={{ formats }}>
+      (function () {
+        const shell = document.querySelector(".shell");
+        if (!shell) return;
+
+        shell.addEventListener("click", (event) => {
+          const target = event.target;
+          if (!(target instanceof Element)) return;
+          const button = target.closest("button[data-copy]");
+          if (!(button instanceof HTMLButtonElement)) return;
+          void navigator.clipboard
+            .writeText(button.dataset.copy || "")
+            .then(() => {
+              const original = button.dataset.copyLabel ?? button.textContent ?? "Copy";
+              button.dataset.copyLabel = original;
+              button.textContent = "copied ✓";
+              setTimeout(() => {
+                button.textContent = original;
+              }, 1500);
+            })
+            .catch(() => {
+              // Clipboard blocked — leave the label.
+            });
+        });
+
+        const select = document.getElementById("copy-format");
+        const input = document.getElementById("copy-value");
+        const copyButton = document.getElementById("copy-format-btn");
+        if (
+          select instanceof HTMLSelectElement &&
+          input instanceof HTMLInputElement &&
+          copyButton instanceof HTMLButtonElement
+        ) {
+          select.addEventListener("change", () => {
+            const format = formats.find((f) => f.id === select.value) ?? formats[0];
+            if (!format) return;
+            input.value = format.value;
+            copyButton.dataset.copy = format.value;
+          });
+        }
+      })();
+    </script>
+  )
+}
+
+<style>
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    margin-top: 14px;
+  }
+  /* :global so slotted Open original (parent scope) and Download match alike */
+  .actions :global(a.original) {
+    display: inline-block;
+    padding: 9px 15px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: var(--panel);
+    color: var(--fg);
+    font: 12px var(--mono);
+    text-decoration: none;
+    margin-top: 0;
+  }
+  .actions :global(a.original:hover),
+  .actions :global(a.original:focus-visible) {
+    border-color: var(--accent);
+    color: var(--accent);
+    outline: none;
+  }
+  .linkfield {
+    flex: 1;
+    min-width: 260px;
+  }
+  .linkfield label {
+    display: block;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font: 11px var(--mono);
+    margin-bottom: 5px;
+  }
+  .copyrow {
+    display: flex;
+    gap: 6px;
+    align-items: stretch;
+  }
+  .copyrow select,
+  .copyrow input,
+  .copyrow button {
+    padding: 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    font: 12px var(--mono);
+  }
+  .copyrow select,
+  .copyrow input {
+    background: var(--bg);
+    color: var(--body);
+  }
+  .copyrow input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+  }
+  .copyrow button {
+    padding: 8px 12px;
+    background: var(--panel);
+    color: var(--fg);
+    cursor: pointer;
+  }
+  .copyrow button:hover,
+  .copyrow button:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent);
+    outline: none;
+  }
+</style>

--- a/apps/web/src/lib/embed-formats.test.ts
+++ b/apps/web/src/lib/embed-formats.test.ts
@@ -70,4 +70,13 @@ describe("buildEmbedFormats", () => {
     expect(alt).not.toContain('"');
     expect(alt).not.toContain("<");
   });
+
+  it.each([
+    // ] would close the link text early; \ must be escaped first so \] stays literal
+    ["a](evil).png", `[a\\](evil).png](${base.canonical})`],
+    ["a\\].png", `[a\\\\\\].png](${base.canonical})`],
+  ] as const)("escapes markdown-link filename %j", (filename, expected) => {
+    const formats = buildEmbedFormats({ ...base, filename, kind: "file" });
+    expect(formats.find((f) => f.id === "markdown-link")!.value).toBe(expected);
+  });
 });

--- a/apps/web/src/lib/embed-formats.ts
+++ b/apps/web/src/lib/embed-formats.ts
@@ -1,20 +1,26 @@
 /**
- * Pure embed-format-string builder shared by the public file page
- * (`pages/f/[workspace]/[...key].astro`) and the public gallery-item page
- * (`pages/g/[id]/[item].astro`) — issue's "Copy as" control (design spec
- * §3.3). Kept dependency-free and framework-free so both `.astro` pages can
- * import it directly and it stays unit-testable without a render harness.
+ * Pure embed-format-string builder for the public file + gallery-item "Copy as"
+ * control (design spec §3.3). Consumed by `CopyAsControls.astro` on both pages.
+ * Dependency-free so it stays unit-testable without a render harness.
  */
 
 export type EmbedFormatId = "page" | "url" | "markdown-image" | "markdown-link" | "html-img";
 
-/** Escapes `&`, `<`, `>`, and `"` for safe interpolation into an HTML attribute value. */
+/** Escapes `&`, `<`, `>`, and `"` for HTML attribute values. */
 function escapeHtmlAttr(s: string): string {
   return s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
+}
+
+/**
+ * Escapes `\` then `]` so CommonMark link text (`[text](url)`) stays one link.
+ * Cosmetic only — not a security sink (confirmed on #168).
+ */
+function escapeMarkdownLinkText(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/]/g, "\\]");
 }
 
 export interface EmbedFormatOption {
@@ -36,34 +42,33 @@ export interface EmbedFormatInput {
 }
 
 /**
- * Five candidate formats, gated by `kind`, in the fixed order the design
- * spec's §3.3 table lists them: Page link, Direct file URL, Markdown image
+ * Formats in design-spec §3.3 order: Page link, Direct file URL, Markdown image
  * (image only), Markdown link, HTML `<img>` (image only). Embed *snippet*
- * formats (Markdown image, HTML img) prefer `embedUrl` and fall back to the
- * stable `url`; "Direct file URL" always uses the stable `url` — mirrors
- * `packages/uploads/src/commands.ts`'s existing "MARKDOWN prefers embedUrl"
- * convention.
+ * formats prefer `embedUrl` and fall back to `url`; "Direct file URL" always
+ * uses the stable `url` (same convention as the CLI MARKDOWN path).
  */
 export function buildEmbedFormats(input: EmbedFormatInput): EmbedFormatOption[] {
   const embedSrc = input.embedUrl ?? input.url;
-  const options: EmbedFormatOption[] = [
+  const isImage = input.kind === "image";
+  return [
     { id: "page", label: "Page link", value: input.canonical },
     { id: "url", label: "Direct file URL", value: input.url },
+    ...(isImage
+      ? [{ id: "markdown-image" as const, label: "Markdown image", value: `![](${embedSrc})` }]
+      : []),
+    {
+      id: "markdown-link",
+      label: "Markdown link",
+      value: `[${escapeMarkdownLinkText(input.filename)}](${input.canonical})`,
+    },
+    ...(isImage
+      ? [
+          {
+            id: "html-img" as const,
+            label: "HTML <img>",
+            value: `<img src="${embedSrc}" alt="${escapeHtmlAttr(input.filename)}">`,
+          },
+        ]
+      : []),
   ];
-  if (input.kind === "image") {
-    options.push({ id: "markdown-image", label: "Markdown image", value: `![](${embedSrc})` });
-  }
-  options.push({
-    id: "markdown-link",
-    label: "Markdown link",
-    value: `[${input.filename}](${input.canonical})`,
-  });
-  if (input.kind === "image") {
-    options.push({
-      id: "html-img",
-      label: "HTML <img>",
-      value: `<img src="${embedSrc}" alt="${escapeHtmlAttr(input.filename)}">`,
-    });
-  }
-  return options;
 }

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -1,6 +1,7 @@
 ---
 import BaseHead from "../../../components/BaseHead.astro";
 import Brand from "../../../components/Brand.astro";
+import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
 import GitHubMark from "../../../components/GitHubMark.astro";
 import { buildEmbedFormats } from "../../../lib/embed-formats";
@@ -50,9 +51,7 @@ const metadataEntries = file?.metadata
       .filter(([metaKey]) => !metaKey.startsWith("gh."))
       .sort(([a], [b]) => a.localeCompare(b))
   : [];
-// "Copy as" format options (Task 1's builder) and the forced-download link
-// (Task 3's `?download=1` route, via `fileDownloadUrl`) — both `null`/`[]`
-// when there's no file to link.
+// Empty when there's no file — CopyAsControls hides itself when both are empty.
 const embedFormats = file
   ? buildEmbedFormats({
       canonical,
@@ -63,9 +62,6 @@ const embedFormats = file
     })
   : [];
 const downloadUrl = file ? fileDownloadUrl(origin, workspace, key) : null;
-// The "Copy as" input/button start on the first format (Page link) until the
-// select is changed client-side.
-const defaultCopyValue = embedFormats[0]?.value ?? canonical;
 const title = file
   ? `${filename} · uploads.sh`
   : result.status === "auth_required"
@@ -109,16 +105,6 @@ const title = file
       .gh-chip-kind { padding:1px 5px; border:1px solid var(--line); border-radius:4px; color:var(--muted); font-size:10px; text-transform:uppercase; letter-spacing:.06em; }
       .section-label { margin:16px 0 0; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); }
       dl.meta.metadata { margin-top:6px; }
-      .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-top:16px; }
-      .actions a.original { display:inline-block; padding:9px 15px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
-      .actions a.original:hover, .actions a.original:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
-      .linkfield { flex:1; min-width:260px; }
-      .linkfield label { display:block; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); margin-bottom:5px; }
-      .copyrow { display:flex; gap:6px; align-items:stretch; }
-      .copyrow select { padding:8px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
-      .copyrow input { flex:1; min-width:0; padding:8px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--body); font:12px var(--mono); }
-      .copyrow button { padding:8px 12px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); cursor:pointer; }
-      .copyrow button:hover, .copyrow button:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
       .error .signin { display:inline-block; margin-top:18px; padding:9px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--fg); font:12px var(--mono); text-decoration:none; }
@@ -169,20 +155,11 @@ const title = file
                   </dl>
                 </>
               )}
-              <div class="actions">
-                {kind(file.contentType) !== "unsupported" && <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>}
-                {downloadUrl && <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>}
-                <span class="linkfield">
-                  <label for="copy-format">Copy as</label>
-                  <div class="copyrow">
-                    <select id="copy-format" aria-label="Copy as format">
-                      {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
-                    </select>
-                    <input id="copy-value" type="text" readonly value={defaultCopyValue} aria-label="Value to copy" />
-                    <button type="button" id="copy-format-btn" data-copy={defaultCopyValue} aria-live="polite">Copy</button>
-                  </div>
-                </span>
-              </div>
+              <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
+                {kind(file.contentType) !== "unsupported" && (
+                  <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>
+                )}
+              </CopyAsControls>
             </figcaption>
           </figure>
           <Footer />
@@ -199,49 +176,6 @@ const title = file
         <section class="error"><code>{result.status === "unavailable" ? "file.unavailable" : "file.not_found"}</code><h1>{result.status === "unavailable" ? "File temporarily unavailable" : "File not found"}</h1><p>{result.status === "unavailable" ? "The file service could not be reached. Please try again shortly." : "This file may have been removed, or the link is incorrect."}</p></section>
       )}
     </main>
-    {file && (
-      // Click-to-copy + "Copy as" format switching — CSP allows inline script
-      // on this branch as of the file-page-polish work (see PUBLIC_FILE_CSP
-      // in lib/public-file.ts). Same data-copy delegated-listener pattern as
-      // account/index.astro and account/workspaces.astro. The Download link
-      // needs no script — it's a plain <a> to the API's `?download=1` route.
-      <script define:vars={{ formats: embedFormats }}>
-        (function () {
-          const shell = document.querySelector(".shell");
-          if (!shell) return;
-
-          shell.addEventListener("click", (event) => {
-            void (async () => {
-              const button = event.target.closest("button[data-copy]");
-              if (!button) return;
-              try {
-                await navigator.clipboard.writeText(button.dataset.copy || "");
-                const original = button.dataset.copyLabel ?? button.textContent ?? "Copy";
-                button.dataset.copyLabel = original;
-                button.textContent = "copied ✓";
-                setTimeout(() => {
-                  button.textContent = original;
-                }, 1500);
-              } catch {
-                // Clipboard blocked — leave the label.
-              }
-            })();
-          });
-
-          const select = document.getElementById("copy-format");
-          const input = document.getElementById("copy-value");
-          const copyButton = document.getElementById("copy-format-btn");
-          if (select instanceof HTMLSelectElement && input instanceof HTMLInputElement && copyButton) {
-            select.addEventListener("change", () => {
-              const format = formats.find((f) => f.id === select.value) ?? formats[0];
-              if (!format) return;
-              input.value = format.value;
-              copyButton.dataset.copy = format.value;
-            });
-          }
-        })();
-      </script>
-    )}
     {result.status === "auth_required" && (
       // Progressive-enhancement, client-side authorization path — a second
       // gate parallel to the server-side one this page already applied via

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -1,8 +1,9 @@
 ---
 import BaseHead from "../../../components/BaseHead.astro";
-import GalleryReferences from "../../../components/GalleryReferences.astro";
 import Brand from "../../../components/Brand.astro";
+import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
+import GalleryReferences from "../../../components/GalleryReferences.astro";
 import { buildEmbedFormats, type EmbedFormatOption } from "../../../lib/embed-formats";
 import {
   applyPublicGalleryHeaders,
@@ -55,9 +56,6 @@ const embedFormats: EmbedFormatOption[] =
     : [];
 const downloadUrl =
   item && item.status === "available" ? galleryItemDownloadUrl(origin, id, item.id) : null;
-// The "Copy as" input/button start on the first format (Page link) until the
-// select is changed client-side.
-const defaultCopyValue = embedFormats[0]?.value ?? canonical;
 ---
 
 <!doctype html>
@@ -91,80 +89,6 @@ const defaultCopyValue = embedFormats[0]?.value ?? canonical;
       .caption { margin-top:10px; color:var(--body); font-size:15px; line-height:1.6; white-space:pre-wrap; }
       .original { display:inline-block; margin-top:12px; color:var(--muted); font:12px var(--mono); }
       .original:hover, .original:focus-visible { color:var(--accent); outline:none; }
-      .actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 10px;
-        align-items: center;
-        margin-top: 14px;
-      }
-      .actions a.original {
-        display: inline-block;
-        padding: 9px 15px;
-        border: 1px solid var(--line);
-        border-radius: var(--radius-md);
-        background: var(--panel);
-        color: var(--fg);
-        font: 12px var(--mono);
-        text-decoration: none;
-        margin-top: 0;
-      }
-      .actions a.original:hover,
-      .actions a.original:focus-visible {
-        border-color: var(--accent);
-        color: var(--accent);
-        outline: none;
-      }
-      .linkfield {
-        flex: 1;
-        min-width: 260px;
-      }
-      .linkfield label {
-        display: block;
-        color: var(--muted);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        font: 11px var(--mono);
-        margin-bottom: 5px;
-      }
-      .copyrow {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-      }
-      .copyrow select {
-        padding: 8px;
-        border: 1px solid var(--line);
-        border-radius: var(--radius-md);
-        background: var(--bg);
-        color: var(--body);
-        font: 12px var(--mono);
-      }
-      .copyrow input {
-        flex: 1;
-        min-width: 0;
-        padding: 8px 10px;
-        border: 1px solid var(--line);
-        border-radius: var(--radius-md);
-        background: var(--bg);
-        color: var(--body);
-        font: 12px var(--mono);
-      }
-      .copyrow button {
-        padding: 8px 12px;
-        border: 1px solid var(--line);
-        border-radius: var(--radius-md);
-        background: var(--panel);
-        color: var(--fg);
-        font: 12px var(--mono);
-        cursor: pointer;
-      }
-      .copyrow button:hover,
-      .copyrow button:focus-visible {
-        border-color: var(--accent);
-        color: var(--accent);
-        outline: none;
-      }
       .pager { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:22px 0 0; font:13px var(--mono); }
       .pager a, .pager span.disabled { display:inline-block; padding:10px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); text-decoration:none; }
       .pager a:hover, .pager a:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
@@ -195,21 +119,11 @@ const defaultCopyValue = embedFormats[0]?.value ?? canonical;
             <figcaption class="details" id="item-caption">
               <div class="filename">{item.filename}</div>
               {item.caption && <div class="caption">{item.caption}</div>}
-              {item.status === "available" && kind(item) !== "unsupported" && <a class="original" href={item.url!} rel="noopener noreferrer">Open original</a>}
+              {item.status === "available" && kind(item) !== "unsupported" && (
+                <a class="original" href={item.url!} rel="noopener noreferrer">Open original</a>
+              )}
               {item.status === "available" && (
-                <div class="actions">
-                  {downloadUrl && <a class="original download" href={downloadUrl} rel="noopener noreferrer">Download</a>}
-                  <span class="linkfield">
-                    <label for="copy-format">Copy as</label>
-                    <div class="copyrow">
-                      <select id="copy-format" aria-label="Copy as format">
-                        {embedFormats.map((format) => <option value={format.id}>{format.label}</option>)}
-                      </select>
-                      <input id="copy-value" type="text" readonly value={defaultCopyValue} aria-label="Value to copy" />
-                      <button type="button" id="copy-format-btn" data-copy={defaultCopyValue} aria-live="polite">Copy</button>
-                    </div>
-                  </span>
-                </div>
+                <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl} />
               )}
             </figcaption>
           </figure>
@@ -225,45 +139,5 @@ const defaultCopyValue = embedFormats[0]?.value ?? canonical;
         <section class="error"><code>{result.status === "unavailable" ? "gallery.unavailable" : "gallery.item_not_found"}</code><h1>{result.status === "unavailable" ? "Gallery temporarily unavailable" : "Media not found"}</h1><p>{result.status === "unavailable" ? "The gallery service could not be reached. Please try again shortly." : "This item may have been removed, or the link is incorrect."}</p>{result.status !== "unavailable" && <p><a href={listPath}>View the gallery</a></p>}</section>
       )}
     </main>
-    {item && item.status === "available" && (
-      // Click-to-copy + "Copy as" format switching — same delegated-listener
-      // pattern as the public file page's Task 8 script; the gallery CSP was
-      // widened for inline script in Task 6. Download needs no script — it's
-      // a plain <a> to Task 4's `/download` suffix route.
-      <script define:vars={{ formats: embedFormats }}>
-        (function () {
-          const shell = document.querySelector(".shell");
-          if (!shell) return;
-
-          shell.addEventListener("click", (event) => {
-            void (async () => {
-              const button = event.target.closest("button[data-copy]");
-              if (!button) return;
-              try {
-                await navigator.clipboard.writeText(button.dataset.copy || "");
-                const original = button.dataset.copyLabel ?? button.textContent ?? "Copy";
-                button.dataset.copyLabel = original;
-                button.textContent = "copied ✓";
-                setTimeout(() => (button.textContent = original), 1500);
-              } catch {
-                // Clipboard blocked — leave the label.
-              }
-            })();
-          });
-
-          const select = document.getElementById("copy-format");
-          const input = document.getElementById("copy-value");
-          const copyButton = document.getElementById("copy-format-btn");
-          if (select instanceof HTMLSelectElement && input instanceof HTMLInputElement && copyButton) {
-            select.addEventListener("change", () => {
-              const format = formats.find((f) => f.id === select.value) ?? formats[0];
-              if (!format) return;
-              input.value = format.value;
-              copyButton.dataset.copy = format.value;
-            });
-          }
-        })();
-      </script>
-    )}
   </body>
 </html>


### PR DESCRIPTION
## In plain terms

The public file page and gallery item page both had the same Copy / Copy as / Download UI copy-pasted — styles, markup, and the click-to-copy script. That meant bugs (like the copy button getting stuck on “copied ✓”) had to be fixed twice. This extracts one shared component and uses it on both pages.

## What it does

- Adds `CopyAsControls.astro` with shared markup, styles, and CSP-safe `define:vars` script
- Wires it into `pages/f/[workspace]/[...key].astro` and `pages/g/[id]/[item].astro`
- Optional slot for page-specific action links (file page: “Open original”)
- Escapes `]` and `\` in Markdown link filenames so odd names don’t break the copied snippet (cosmetic; not a security fix)

## What it is not

- No behavior change to formats, download URLs, or CSP
- No new user-facing CLI/package surface (no changeset)

## How to try it

Open a public file page (`/f/…`) and a gallery item page (`/g/…/…`) with an available asset:

1. Change **Copy as** formats — input and copy payload should update
2. Click **Copy** (and double-click quickly) — label should return to “Copy”, not stick on “copied ✓”
3. **Download** should still force a download as before

## Technical notes

- Keeps inline `define:vars` (Astro escapes vars; do not switch off it)
- Closes #169 (deferred nit from #168)

## Test plan

- [x] `pnpm --filter @uploads/web test`
- [x] `pnpm --filter @uploads/web typecheck` (earlier in session; 0 errors)
- [ ] Spot-check file + gallery item pages in browser