### PR TITLE
fix(api): reserve API route segments as workspace names

### DIFF
--- a/apps/api/src/slug-policy.test.ts
+++ b/apps/api/src/slug-policy.test.ts
@@ -13,7 +13,20 @@ describe("validateSlug", () => {
     }
   });
   it("rejects reserved names with reserved_workspace_name", () => {
-    for (const s of ["default", "admin", "api", "storage", "me"]) {
+    for (const s of [
+      "default",
+      "admin",
+      "api",
+      "storage",
+      "me",
+      "workspaces",
+      "tokens",
+      "files",
+      "galleries",
+      "usage",
+      "health",
+      "admin-ui",
+    ]) {
       expect(validateSlug(s)).toEqual({ ok: false, code: "reserved_workspace_name" });
     }
   });

--- a/apps/api/src/slug-policy.ts
+++ b/apps/api/src/slug-policy.ts
@@ -19,6 +19,13 @@ export const RESERVED_WORKSPACE_NAMES: ReadonlySet<string> = new Set([
   "uploads",
   "internal",
   "v1",
+  "workspaces",
+  "tokens",
+  "files",
+  "galleries",
+  "usage",
+  "health",
+  "admin-ui",
 ]);
 
 export type SlugVerdict =


### PR DESCRIPTION
## Summary
- Extend `RESERVED_WORKSPACE_NAMES` in `apps/api/src/slug-policy.ts` (from #171) with API route-segment words that were still registerable as workspace slugs: `workspaces`, `tokens`, `files`, `galleries`, `usage`, plus `health` and `admin-ui` found while reviewing the route mounts in `apps/api/src/index.ts`.
- These don't break routing today (Hono falls through correctly), but they produce confusing URLs like `/v1/tokens/files` for a workspace literally named `tokens`.
- Extend the reserved-names test in `slug-policy.test.ts` to cover the new entries. `docs/workspaces.md` describes the list non-exhaustively ("and similar route/subdomain collisions"), so no doc change needed.

## Testing
- `pnpm --filter @uploads/api test` — 377 tests pass.