### PR TITLE
feat: human-size optimize notes and report put overwrites

### DIFF
--- a/.changeset/human-sizes-replaced.md
+++ b/.changeset/human-sizes-replaced.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Print human-readable optimize sizes (e.g. `411.5 KB → 94.2 KB`) and note when a put overwrites an existing object (`replaced` on the API/JSON, `>> replaced existing object (same URL)` in human mode).

--- a/.changeset/human-sizes-replaced.md
+++ b/.changeset/human-sizes-replaced.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": patch
 ---
 
-Print human-readable optimize sizes (e.g. `411.5 KB → 94.2 KB`) and note when a put overwrites an existing object (`replaced` on the API/JSON, `>> replaced existing object (same URL)` in human mode).
+Print human-readable optimize sizes (e.g. `411.5 KB → 94.2 KB`) and note when a put overwrites an existing object (`replaced` on the API/JSON, `>> replaced existing object (same URL)` in human mode). `--dry-run` reports `would replace` / `"replaced": true` when the key already exists, without writing.

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -137,6 +137,8 @@ export async function putObject(
   embedUrl: string | null;
   size: number;
   contentType: string;
+  /** True when this put overwrote an existing key (messaging only; no confirm). */
+  replaced: boolean;
   metadata?: ProvenanceMap;
   visibility?: Visibility;
 }> {
@@ -151,7 +153,10 @@ export async function putObject(
   if (!inspection.ok) throw inspection.error;
 
   const store = await storage(env, ws);
+  // Pre-upload head: size for ledger delta. files-sdk upload() has no
+  // replaced/exists flag on UploadResult, so we derive it here.
   const prev = await existingSize(store, finalKey);
+  const replaced = prev !== null;
   const newSize = bytes.byteLength;
   const deltaBytes = prev === null ? newSize : newSize - prev;
 
@@ -197,7 +202,7 @@ export async function putObject(
   // stored but under-counted (recordUsageSafe never throws).
   await recordUsageSafe(env.DB, workspaceName, {
     bytes: deltaBytes,
-    objects: prev === null ? 1 : 0,
+    objects: replaced ? 0 : 1,
     uploads: 1,
   });
 
@@ -217,6 +222,7 @@ export async function putObject(
     embedUrl: urls.embedUrl,
     size: newSize,
     contentType: inspection.contentType,
+    replaced,
     metadata: provenance,
     ...(storedVisibility ? { visibility: storedVisibility } : {}),
   };

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -95,16 +95,20 @@ export const files = new Hono<WorkspaceVars>()
 
     // ?dryRun=1 — validate key + resolve public URL; no R2 write, no usage/budget check.
     // Prefixed keys match a real put; bare keys may re-govern to a new f/<id>/… on upload.
+    // `replaced` is whether an object already lives at the final key (would overwrite).
     const dryRun = c.req.query("dryRun");
     if (dryRun === "1" || dryRun === "true") {
       const ws = c.get("workspace");
       const finalKey = finalizeUploadKey(key, ws);
+      const store = await storage(c.env, ws);
+      const replaced = await store.exists(finalKey);
       const urls = objectPublicUrls(c.env, await storageConfig(c.env, ws), finalKey);
       return c.json({
         workspace: c.get("workspaceName"),
         key: finalKey,
         url: urls.url,
         embedUrl: urls.embedUrl,
+        replaced,
         dryRun: true,
       });
     }

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -427,6 +427,17 @@ describe("PUT /v1/:workspace/files custom metadata capture + cascade", () => {
     ).resolves.toEqual({});
   });
 
+  it("sets replaced=false on first put and replaced=true on overwrite", async () => {
+    const { env } = await makeEnv();
+    const first = await putShot(env);
+    expect(first.status).toBe(201);
+    expect(((await first.json()) as { replaced: boolean }).replaced).toBe(false);
+
+    const second = await putShot(env);
+    expect(second.status).toBe(201);
+    expect(((await second.json()) as { replaced: boolean }).replaced).toBe(true);
+  });
+
   it("re-PUT with at least one custom header still fully replaces prior custom metadata", async () => {
     const { env, db } = await makeEnv();
     const first = await putShot(env, {

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -209,15 +209,29 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
       url: string;
       embedUrl: string | null;
       dryRun: boolean;
+      replaced: boolean;
     };
     expect(json).toEqual({
       workspace: "default",
       key: "screenshots/shot.png",
       url: "https://storage.uploads.sh/default/screenshots/shot.png",
       embedUrl: "https://embed.uploads.sh/default/screenshots/shot.png",
+      replaced: false,
       dryRun: true,
     });
     expect(bucket.store.has("default/screenshots/shot.png")).toBe(false);
+  });
+
+  it("dry run reports replaced=true when the key already exists", async () => {
+    const { env } = await makeEnv();
+    expect((await putShot(env)).status).toBe(201);
+    const res = await app.request(
+      "/v1/default/files/screenshots/shot.png?dryRun=1",
+      { method: "PUT", headers: { Authorization: `Bearer ${TOKEN}` }, body: new Uint8Array(0) },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { replaced: boolean; dryRun: boolean }).replaced).toBe(true);
   });
 
   it("dry run rejects a key the workspace policy disallows", async () => {

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -126,7 +126,6 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
       .titlebar {
         display: flex;
         align-items: center;
-        justify-content: space-between;
         padding: 8px 14px;
         border-bottom: 1px solid var(--line);
         color: var(--muted);
@@ -411,14 +410,13 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
       <section class="terminal" aria-label="uploads.sh terminal">
         <div class="titlebar" aria-hidden="true">
           <span>uploads.sh — bash</span>
-          <span>80×24</span>
         </div>
         <div class="screen">
           <p class="line"><span class="prompt">$</span> <span class="cmd">uploads attach ./before.png ./after.png</span></p>
           <p class="line out hidden">&gt;&gt; uploading ./before.png</p>
-          <p class="line out hidden">&gt;&gt; optimized 421337 → 96412 bytes (before.webp)</p>
+          <p class="line out hidden">&gt;&gt; optimized 411.5 KB → 94.2 KB (before.webp)</p>
           <p class="line out hidden">&gt;&gt; uploading ./after.png</p>
-          <p class="line out hidden">&gt;&gt; optimized 407190 → 91205 bytes (after.webp)</p>
+          <p class="line out hidden">&gt;&gt; optimized 397.6 KB → 89.1 KB (after.webp)</p>
           <p class="line out hidden">URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/before.webp</span></p>
           <p class="line out hidden">MARKDOWN: ![before.png](https://storage.uploads.sh/gh/you/app/pull/123/before.webp)</p>
           <p class="line out hidden">URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</span></p>

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,28 +30,28 @@ Throw `AppError` subclasses from `@uploads/errors` in route code; the API's
 
 ## Routes
 
-| Route                                                                | Description                                                                                      |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `GET /health`                                                        | Liveness (no auth)                                                                               |
-| `PUT /v1/:workspace/files/:key`                                      | Upload raw body (sniffed type). Bare keys → `f/<id>/<name>`. Optional provenance headers (below) |
-| `POST /v1/:workspace/files/sign`                                     | Presigned upload (`signedUploadUrl`); needs HTTP S3 credentials on the workspace                 |
-| `GET /v1/:workspace/files?prefix=&limit=&cursor=`                    | List objects                                                                                     |
-| `GET /v1/:workspace/files/:key`                                      | Object metadata (includes allowlisted `metadata` when set)                                       |
-| `DELETE /v1/:workspace/files/:key`                                   | Delete object                                                                                    |
-| `GET /v1/:workspace/usage`                                           | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read`       |
-| `POST /v1/:workspace/usage/reconcile`                                | Rebuild `bytes`/`objects` from storage; requires `files:write`                                   |
-| `POST /v1/:workspace/usage/purge-expired`                            | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`               |
-| `POST /v1/:workspace/galleries`                                      | Create an empty public gallery; requires `files:write`                                           |
-| `GET /v1/:workspace/galleries`                                       | List workspace galleries with opaque cursor pagination; requires `files:read`                    |
-| `GET /v1/:workspace/galleries/:id`                                   | Read one owned gallery; requires `files:read`                                                    |
-| `PATCH/DELETE /v1/:workspace/galleries/:id`                          | Update or soft-delete gallery metadata; requires `files:write`                                   |
-| `POST /v1/:workspace/galleries/:id/items`                            | Add one existing, publicly served workspace object; requires `files:write`                       |
-| `PUT /v1/:workspace/galleries/:id/items/order`                       | Replace the complete item order; requires `files:write`                                          |
-| `DELETE /v1/:workspace/galleries/:id/items/:item`                    | Remove a gallery membership without deleting its object; requires `files:write`                  |
-| `GET /public/galleries/:id`                                          | Exact-ID public gallery read; no workspace listing or authentication                             |
-| `GET /v1/:workspace/galleries/by-reference`                          | Find linked gallery summaries by provider coordinate; requires `files:read`                      |
-| `GET/POST /v1/:workspace/galleries/:id/external-references`          | List or link coordinates; writes require `files:write`                                           |
-| `DELETE /v1/:workspace/galleries/:id/external-references/:reference` | Unlink a coordinate; requires `files:write`                                                      |
+| Route                                                                | Description                                                                                                                                                                   |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /health`                                                        | Liveness (no auth)                                                                                                                                                            |
+| `PUT /v1/:workspace/files/:key`                                      | Upload raw body (sniffed type). Bare keys → `f/<id>/<name>`. Response includes `replaced: true` when the key already existed (overwrite). Optional provenance headers (below) |
+| `POST /v1/:workspace/files/sign`                                     | Presigned upload (`signedUploadUrl`); needs HTTP S3 credentials on the workspace                                                                                              |
+| `GET /v1/:workspace/files?prefix=&limit=&cursor=`                    | List objects                                                                                                                                                                  |
+| `GET /v1/:workspace/files/:key`                                      | Object metadata (includes allowlisted `metadata` when set)                                                                                                                    |
+| `DELETE /v1/:workspace/files/:key`                                   | Delete object                                                                                                                                                                 |
+| `GET /v1/:workspace/usage`                                           | Workspace usage snapshot (`bytes`, `objects`, `uploadsInPeriod`, …); requires `files:read`                                                                                    |
+| `POST /v1/:workspace/usage/reconcile`                                | Rebuild `bytes`/`objects` from storage; requires `files:write`                                                                                                                |
+| `POST /v1/:workspace/usage/purge-expired`                            | Delete objects older than `retentionDays`, then reconcile; requires `files:delete`                                                                                            |
+| `POST /v1/:workspace/galleries`                                      | Create an empty public gallery; requires `files:write`                                                                                                                        |
+| `GET /v1/:workspace/galleries`                                       | List workspace galleries with opaque cursor pagination; requires `files:read`                                                                                                 |
+| `GET /v1/:workspace/galleries/:id`                                   | Read one owned gallery; requires `files:read`                                                                                                                                 |
+| `PATCH/DELETE /v1/:workspace/galleries/:id`                          | Update or soft-delete gallery metadata; requires `files:write`                                                                                                                |
+| `POST /v1/:workspace/galleries/:id/items`                            | Add one existing, publicly served workspace object; requires `files:write`                                                                                                    |
+| `PUT /v1/:workspace/galleries/:id/items/order`                       | Replace the complete item order; requires `files:write`                                                                                                                       |
+| `DELETE /v1/:workspace/galleries/:id/items/:item`                    | Remove a gallery membership without deleting its object; requires `files:write`                                                                                               |
+| `GET /public/galleries/:id`                                          | Exact-ID public gallery read; no workspace listing or authentication                                                                                                          |
+| `GET /v1/:workspace/galleries/by-reference`                          | Find linked gallery summaries by provider coordinate; requires `files:read`                                                                                                   |
+| `GET/POST /v1/:workspace/galleries/:id/external-references`          | List or link coordinates; writes require `files:write`                                                                                                                        |
+| `DELETE /v1/:workspace/galleries/:id/external-references/:reference` | Unlink a coordinate; requires `files:write`                                                                                                                                   |
 
 `url` in responses is the durable public CDN URL when the workspace has a
 `publicBaseUrl`, otherwise `null`. File put/list/head, presign, and gallery
@@ -59,6 +59,9 @@ item payloads also include `embedUrl`: the same object on the embed host when
 dual-host policy applies (default for `storage.uploads.sh` /
 `store.uploads.sh`), else `null`. Prefer `embedUrl` in GitHub markdown so
 in-place overwrites revalidate through Camo; keep `url` for durable links.
+Successful `PUT …/files/:key` also returns `replaced` (`true` when an object
+already lived at that key). Overwrites are intentional for stable attachment
+keys — there is no server-side confirmation gate.
 Worker override: optional `EMBED_PUBLIC_BASE_URL` (empty disables; any URL is
 a self-hosted embed base). See [ops.md](./ops.md#dual-public-hosts-stable-vs-embed--github-camo).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,8 +60,10 @@ dual-host policy applies (default for `storage.uploads.sh` /
 `store.uploads.sh`), else `null`. Prefer `embedUrl` in GitHub markdown so
 in-place overwrites revalidate through Camo; keep `url` for durable links.
 Successful `PUT …/files/:key` also returns `replaced` (`true` when an object
-already lived at that key). Overwrites are intentional for stable attachment
-keys — there is no server-side confirmation gate.
+already lived at that key). `PUT …?dryRun=1` returns the same field without
+writing — `replaced: true` means a real put would overwrite. Overwrites are
+intentional for stable attachment keys — there is no server-side confirmation
+gate.
 Worker override: optional `EMBED_PUBLIC_BASE_URL` (empty disables; any URL is
 a self-hosted embed base). See [ops.md](./ops.md#dual-public-hosts-stable-vs-embed--github-camo).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,8 +73,11 @@ wanted.
 **Re-upload / hot-swap:** putting again to the same key overwrites the object
 in place. There is no confirmation prompt (agents and re-runs need this). The
 public URL stays the same so every embed updates after cache revalidation.
-Human mode prints `>> replaced existing object (same URL)` when the API
-reports an overwrite; JSON includes `"replaced": true|false`.
+Human mode prints `>> replaced existing object (same URL)` after a real put;
+JSON includes `"replaced": true|false`. Preview first with
+`uploads put … --dry-run` — if the key already exists it reports
+`>> would replace existing object (same URL)` (and `"replaced": true` in JSON)
+without writing.
 
 > **Privacy:** Hosted files are served from a public CDN with no link to GitHub
 > repo visibility. A screenshot on a private PR is still reachable by anyone who

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,12 @@ attachments comment. Use `--pr <number>` or `--issue <number>` when inference
 is not possible, and `--no-comment` when only the public URLs and Markdown are
 wanted.
 
+**Re-upload / hot-swap:** putting again to the same key overwrites the object
+in place. There is no confirmation prompt (agents and re-runs need this). The
+public URL stays the same so every embed updates after cache revalidation.
+Human mode prints `>> replaced existing object (same URL)` when the API
+reports an overwrite; JSON includes `"replaced": true|false`.
+
 > **Privacy:** Hosted files are served from a public CDN with no link to GitHub
 > repo visibility. A screenshot on a private PR is still reachable by anyone who
 > knows or guesses the URL — `--pr`/`--issue` keys embed the repo path and
@@ -77,6 +83,45 @@ wanted.
 > to guess than hashed keys. Treat uploads as public; don't host secrets or
 > sensitive UI. Tighter access controls for private repos are planned — see
 > [roadmap](roadmap.md).
+
+## Custom metadata
+
+Tag uploads with queryable key/value pairs so you can find them later
+(`uploads find`, `uploads list --meta`, the account search UI). Distinct from
+optimize/frame provenance.
+
+Suggested pairs for screenshots:
+
+| Key    | Example                             | Meaning                          |
+| ------ | ----------------------------------- | -------------------------------- |
+| `url`  | `https://app.example/settings`      | Page URL the shot was taken from |
+| `path` | `/settings` or `Settings > Profile` | In-app route or nav path         |
+| `app`  | `web`, `ios`, `android`             | Surface / product shown          |
+
+```bash
+uploads put ./settings.png \
+  --meta url=https://app.example/settings \
+  --meta path=/settings \
+  --meta app=web
+
+uploads attach ./mobile-checkout.png \
+  --meta url=https://app.example/checkout \
+  --meta path=/checkout \
+  --meta app=ios
+
+uploads find app=web path=/settings
+uploads meta get screenshots/myapp/42/settings.webp
+uploads meta set screenshots/myapp/42/settings.webp page=onboarding --delete path
+```
+
+Rules: keys `^[a-z][a-z0-9._-]{0,63}$` (lowercase; dots allowed); values 1–512
+printable ASCII; at most 24 pairs per request. Re-upload **with** `--meta`
+replaces the whole metadata set; re-upload **without** `--meta` leaves existing
+pairs alone. `uploads attach` and `put --pr`/`--issue` also stamp `gh.repo` /
+`gh.kind` / `gh.number` / `gh.ref` automatically.
+
+Non-`gh.*` metadata may appear on the public `/f/…` file page — don't store
+secrets or private notes.
 
 ## Public galleries
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -71,7 +71,8 @@ notes print human sizes (e.g. `411.5 KB → 94.2 KB`).
 
 **Re-upload / hot-swap:** the same key overwrites in place with no prompt (stable
 `--pr` / `attach` paths). Human mode notes `>> replaced existing object (same URL)`;
-JSON includes `replaced`.
+JSON includes `replaced`. Preview with `--dry-run` (reports _would replace_ when
+the key already exists).
 
 **Frames (opt-in):** `--frame phone|browser|iphone-16-pro` composites chrome
 **before** optimize. `phone`/`browser` are procedural; `iphone-16-pro` fetches

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -25,10 +25,11 @@ uploads put ./capture-2026-…Z.png --pr 123 --name hero.png   # clean leaf, sta
 uploads put ./shot.png --pr 123 --name hero.png --dry-run --format url  # preview URL, no upload
 uploads gallery create --title "Release screenshots"
 uploads put ./after.png --gallery gal_example
-uploads put ./shot.png --meta app=myapp --meta page=settings   # queryable custom metadata
-uploads meta get screenshots/myapp/42/shot.png
-uploads meta set screenshots/myapp/42/shot.png page=onboarding --delete device
-uploads find app=myapp page=settings                            # or: list --meta app=myapp
+# custom metadata (queryable): page URL, in-app path, which surface
+uploads put ./shot.png --meta url=https://app.example/settings --meta path=/settings --meta app=web
+uploads meta get screenshots/myapp/42/shot.webp
+uploads meta set screenshots/myapp/42/shot.webp path=/onboarding --delete url
+uploads find app=web path=/settings                             # or: list --meta app=web
 uploads doctor
 ```
 
@@ -65,7 +66,12 @@ use `gh/…`. Workspaces may restrict put/sign to those roots via
 **Image optimization:** by default, still images are re-encoded to WebP (long edge
 capped, high quality) before upload so GitHub embeds stay small, and **EXIF is
 stripped**. Pass `--keep-exif` / `UPLOADS_KEEP_EXIF=1` to preserve image metadata, or
-`--no-optimize` / `UPLOADS_NO_OPTIMIZE=1` to upload originals unchanged.
+`--no-optimize` / `UPLOADS_NO_OPTIMIZE=1` to upload originals unchanged. Optimize
+notes print human sizes (e.g. `411.5 KB → 94.2 KB`).
+
+**Re-upload / hot-swap:** the same key overwrites in place with no prompt (stable
+`--pr` / `attach` paths). Human mode notes `>> replaced existing object (same URL)`;
+JSON includes `replaced`.
 
 **Frames (opt-in):** `--frame phone|browser|iphone-16-pro` composites chrome
 **before** optimize. `phone`/`browser` are procedural; `iphone-16-pro` fetches

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -75,6 +75,8 @@ export interface PutResult {
   embedUrl: string | null;
   size: number;
   contentType: string;
+  /** True when the put overwrote an existing key. Omitted on dry-run. */
+  replaced?: boolean;
   metadata?: Record<string, string>;
 }
 
@@ -716,6 +718,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
         embedUrl?: string | null;
         size: number;
         contentType: string;
+        replaced?: boolean;
         metadata?: Record<string, string>;
       }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}`, {
         body,
@@ -734,6 +737,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
         ...result,
         url: result.url,
         embedUrl: resolveEmbedUrl(result.url, result.embedUrl),
+        replaced: result.replaced === true,
       };
     },
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -75,7 +75,10 @@ export interface PutResult {
   embedUrl: string | null;
   size: number;
   contentType: string;
-  /** True when the put overwrote an existing key. Omitted on dry-run. */
+  /**
+   * True when the put overwrote an existing key, or (with dryRun) when a put
+   * at this key would overwrite. Always set by the API for put/dry-run.
+   */
   replaced?: boolean;
   metadata?: Record<string, string>;
 }
@@ -680,6 +683,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
           key: string;
           url: string | null;
           embedUrl?: string | null;
+          replaced?: boolean;
         }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}?dryRun=1`);
         if (preview.url == null) {
           throw new UploadsError(
@@ -694,6 +698,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
           embedUrl: resolveEmbedUrl(preview.url, preview.embedUrl),
           size: body.byteLength,
           contentType,
+          replaced: preview.replaced === true,
         };
       }
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -91,7 +91,9 @@ remain public even for private/internal GitHub repositories. Upload only media
 that is safe at a predictable public URL.
 
 Re-uploading the same key overwrites in place (no prompt) so embeds hot-swap;
-human mode prints ">> replaced existing object (same URL)" when that happens.
+human mode prints ">> replaced existing object (same URL)" after a real put,
+or ">> would replace existing object (same URL)" on --dry-run when the key
+already exists.
 
 Human/json output includes durable url and (when dual-host applies) embedUrl.
 MARKDOWN prefers embedUrl for GitHub. Override: UPLOADS_EMBED_PUBLIC_BASE_URL.
@@ -126,7 +128,7 @@ Options:
                         Re-uploading to an existing key WITH --meta replaces that file's
                         entire metadata set; without --meta the existing metadata is
                         preserved. Use "uploads meta set" to edit individual keys.
-  --dry-run             Print key + public URL without uploading. Not with --comment/--gallery
+  --dry-run             Print key + public URL without uploading; reports if the key would replace an existing object. Not with --comment/--gallery
 
 Exit codes: 0 ok · 2 usage/token/file · 3 auth/policy · 4 network · 1 other.
 Scripted formats (json|url|markdown) also print failures on stdout.
@@ -225,8 +227,14 @@ function formatOptimizeNote(opt: OptimizeImageResult): string | undefined {
   return undefined;
 }
 
-function writeReplacedNote(replaced: boolean | undefined, quiet: boolean): void {
-  if (!quiet && replaced) process.stderr.write(`>> replaced existing object (same URL)\n`);
+function writeReplacedNote(replaced: boolean | undefined, quiet: boolean, dryRun = false): void {
+  if (!quiet && replaced) {
+    process.stderr.write(
+      dryRun
+        ? `>> would replace existing object (same URL)\n`
+        : `>> replaced existing object (same URL)\n`,
+    );
+  }
 }
 
 export type PreparedUpload = OptimizeImageResult & {
@@ -690,7 +698,7 @@ export async function runPut(
     }),
     metadata,
   });
-  if (!dryRun && format === "human") writeReplacedNote(result.replaced, ctx.quiet);
+  if (format === "human") writeReplacedNote(result.replaced, ctx.quiet, dryRun);
 
   const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
   const markdown = buildMarkdown(embedSrc, { alt, width });

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -48,6 +48,7 @@ import {
 } from "./optimize.js";
 import { applyFrame, resolveFrameId, type FrameResult } from "./frame.js";
 import { buildCliProvenance } from "./provenance.js";
+import { formatByteSize } from "./format-bytes.js";
 import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
 
@@ -88,6 +89,9 @@ Optional --frame wraps the image in a device/browser chrome before optimize
 Uploads are public. --pr/--issue keys include the repo, number, and filename and
 remain public even for private/internal GitHub repositories. Upload only media
 that is safe at a predictable public URL.
+
+Re-uploading the same key overwrites in place (no prompt) so embeds hot-swap;
+human mode prints ">> replaced existing object (same URL)" when that happens.
 
 Human/json output includes durable url and (when dual-host applies) embedUrl.
 MARKDOWN prefers embedUrl for GitHub. Override: UPLOADS_EMBED_PUBLIC_BASE_URL.
@@ -213,12 +217,16 @@ export function optimizeOptionsFromFlags(
 
 function formatOptimizeNote(opt: OptimizeImageResult): string | undefined {
   if (opt.optimized) {
-    return `optimized ${opt.originalBytes} → ${opt.outputBytes} bytes (${opt.filename})`;
+    return `optimized ${formatByteSize(opt.originalBytes)} → ${formatByteSize(opt.outputBytes)} (${opt.filename})`;
   }
   if (opt.skippedReason && opt.skippedReason !== "disabled") {
     return `optimize skipped (${opt.skippedReason})`;
   }
   return undefined;
+}
+
+function writeReplacedNote(replaced: boolean | undefined, quiet: boolean): void {
+  if (!quiet && replaced) process.stderr.write(`>> replaced existing object (same URL)\n`);
 }
 
 export type PreparedUpload = OptimizeImageResult & {
@@ -358,6 +366,10 @@ Attachments are public and their repo/number/filename keys are predictable.
 Private/internal GitHub repository visibility does not restrict access; upload
 only media that is safe at a public URL.
 
+Same filename under the same PR/issue overwrites in place (no prompt) so the
+URL and every embed hot-swap. Human mode prints ">> replaced existing object
+(same URL)" when that happens.
+
 Still images are optimized to WebP by default (same as put). Use --no-optimize
 to upload originals. Optional --frame wraps images in device/browser chrome.
 
@@ -452,6 +464,7 @@ export async function runAttach(
       }),
       metadata,
     });
+    writeReplacedNote(result.replaced, ctx.quiet || ctx.json);
     const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
     results.push({
       ...result,
@@ -677,6 +690,7 @@ export async function runPut(
     }),
     metadata,
   });
+  if (!dryRun && format === "human") writeReplacedNote(result.replaced, ctx.quiet);
 
   const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
   const markdown = buildMarkdown(embedSrc, { alt, width });

--- a/packages/uploads/src/format-bytes.ts
+++ b/packages/uploads/src/format-bytes.ts
@@ -1,0 +1,10 @@
+/**
+ * Human-readable size for CLI notes (1024-based).
+ * files-sdk has no size formatter — only raw `size` on head/upload results.
+ */
+export function formatByteSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"] as const;
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -222,6 +222,43 @@ describe("runPut --dry-run", () => {
     expect(puts[0].key).toBe("gh/o/r/pull/5/shot.png");
   });
 
+  it("prints would-replace note when dry-run reports replaced", async () => {
+    const puts: unknown[] = [];
+    const client = {
+      put: async (body: Uint8Array, opts: { filename: string; key?: string; dryRun?: boolean }) => {
+        puts.push(opts);
+        return {
+          workspace: "test",
+          key: opts.key ?? "k",
+          url: "https://x.test/k",
+          embedUrl: null,
+          size: body.byteLength,
+          contentType: "image/png",
+          replaced: true,
+        };
+      },
+    } as unknown as UploadsClient;
+    const stderr: string[] = [];
+    const write = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const ctx = { ...ctxWith(client), quiet: false };
+      const code = await runPut(
+        ctx,
+        [tmpFile(), "--pr", "5", "--repo", "o/r", "--dry-run", "--no-optimize"],
+        false,
+        noRun,
+      );
+      expect(code).toBe(0);
+      expect(stderr.join("")).toContain(">> would replace existing object (same URL)");
+    } finally {
+      process.stderr.write = write;
+    }
+  });
+
   it("rejects --dry-run with --comment", async () => {
     const { client } = fakeClient();
     await expect(

--- a/packages/uploads/test/format-bytes.test.ts
+++ b/packages/uploads/test/format-bytes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatByteSize } from "../src/format-bytes.js";
+
+describe("formatByteSize", () => {
+  it("keeps small values in bytes", () => {
+    expect(formatByteSize(0)).toBe("0 B");
+    expect(formatByteSize(512)).toBe("512 B");
+    expect(formatByteSize(1023)).toBe("1023 B");
+  });
+
+  it("formats KB and MB with one decimal", () => {
+    expect(formatByteSize(1024)).toBe("1.0 KB");
+    expect(formatByteSize(96412)).toBe("94.2 KB");
+    expect(formatByteSize(421337)).toBe("411.5 KB");
+    expect(formatByteSize(1024 * 1024)).toBe("1.0 MB");
+    expect(formatByteSize(1.5 * 1024 * 1024)).toBe("1.5 MB");
+  });
+
+  it("handles non-finite input", () => {
+    expect(formatByteSize(Number.NaN)).toBe("0 B");
+    expect(formatByteSize(-1)).toBe("0 B");
+  });
+});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -42,7 +42,10 @@ naming and output control.
 
 The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
-in place and the URL never changes. Responses include **two** public URLs when the
+in place and the URL never changes. There is **no confirmation prompt** — hot-swap is
+intentional for agents and re-runs. Human mode prints
+`>> replaced existing object (same URL)` when the key already existed; JSON has
+`"replaced": true|false`. Responses include **two** public URLs when the
 shared dual-host setup applies:
 
 | Field      | Host (default)       | Use for                                              |
@@ -210,14 +213,30 @@ uploads put ./shot.png --json              # {workspace,key,url,size,markdown}
 ## Custom metadata & search
 
 Every object can carry queryable key-value metadata (distinct from optimize/frame
-provenance) — tag uploads at put time, then find them later:
+provenance) — tag uploads at put time, then find them later. Useful pairs for
+screenshots:
+
+| Key    | Example                        | Use                                |
+| ------ | ------------------------------ | ---------------------------------- |
+| `url`  | `https://app.example/settings` | Page URL the screenshot represents |
+| `path` | `/settings`                    | In-app route or navigation path    |
+| `app`  | `web` / `ios` / `android`      | Which surface is shown             |
 
 ```bash
-uploads put ./shot.png --meta app=myapp --meta page=settings --meta device=iphone-16
-uploads meta get screenshots/myapp/42/shot.png
-uploads meta set screenshots/myapp/42/shot.png page=onboarding --delete device
-uploads list --meta app=myapp --meta page=settings   # ANDed, repeatable
-uploads find app=myapp page=settings                 # same filter, positional pairs
+uploads put ./settings.png \
+  --meta url=https://app.example/settings \
+  --meta path=/settings \
+  --meta app=web
+
+uploads attach ./checkout.png \
+  --meta url=https://app.example/checkout \
+  --meta path=/checkout \
+  --meta app=ios
+
+uploads meta get screenshots/myapp/42/settings.webp
+uploads meta set screenshots/myapp/42/settings.webp path=/onboarding --delete url
+uploads list --meta app=web --meta path=/settings   # ANDed, repeatable
+uploads find app=web path=/settings                 # same filter, positional pairs
 ```
 
 Rules (validated client-side, fail-fast, before uploading): key

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -44,8 +44,10 @@ The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
 in place and the URL never changes. There is **no confirmation prompt** — hot-swap is
 intentional for agents and re-runs. Human mode prints
-`>> replaced existing object (same URL)` when the key already existed; JSON has
-`"replaced": true|false`. Responses include **two** public URLs when the
+`>> replaced existing object (same URL)` after overwrite; JSON has
+`"replaced": true|false`. Use `--dry-run` to preview: it prints
+`>> would replace existing object (same URL)` when the key already exists,
+without writing. Responses include **two** public URLs when the
 shared dual-host setup applies:
 
 | Field      | Host (default)       | Use for                                              |
@@ -146,28 +148,28 @@ capture them. Use `-` as the file to read from stdin.
 
 Key options (`uploads put --help` for all):
 
-| Flag                                  | Purpose                                                                                                                |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                                       |
-| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                                       |
-| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                                         |
-| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                                               |
-| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                                            |
-| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                                      |
-| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                                            |
-| `--name <leaf>`                       | Clean filename for the key's leaf + default alt (no `/`); keeps the `--pr`/default path. Not with `--key`.             |
-| `--dry-run`                           | Resolve + print the key and final public URL without uploading (one read, no write). Not with `--comment`/`--gallery`. |
-| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body).                     |
-| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                                    |
-| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                                                |
-| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                                      |
-| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.                        |
-| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                                         |
-| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                                            |
-| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.                          |
-| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                                     |
-| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                                         |
-| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                                                |
+| Flag                                  | Purpose                                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                                                                       |
+| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                                                                       |
+| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                                                                         |
+| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                                                                               |
+| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                                                                            |
+| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                                                                      |
+| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                                                                            |
+| `--name <leaf>`                       | Clean filename for the key's leaf + default alt (no `/`); keeps the `--pr`/default path. Not with `--key`.                                             |
+| `--dry-run`                           | Resolve + print the key and final public URL without uploading; reports if the key would replace an existing object. Not with `--comment`/`--gallery`. |
+| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body).                                                     |
+| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                                                                    |
+| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                                                                                |
+| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                                                                      |
+| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.                                                        |
+| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                                                                         |
+| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                                                                            |
+| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.                                                          |
+| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                                                                     |
+| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                                                                         |
+| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                                                                                |
 
 **Image optimization (default on):** PNG/JPEG and similar still images are re-encoded to
 WebP (long edge capped at 2400px, quality 85) before upload so PR/issue embeds stay


### PR DESCRIPTION
## In plain terms

The CLI now prints readable optimize sizes (e.g. `411.5 KB → 94.2 KB`) and tells you when a re-upload overwrote an existing object instead of creating a new one. Overwrites stay silent on purpose — no opt-in prompt — so stable PR attachment URLs keep hot-swapping for agents. Docs cover custom metadata examples (`url`, `path`, `app`) and re-upload behavior.

## What it does

- API `PUT` responses include `replaced: true|false` (derived from the pre-upload head already used for metering; files-sdk has no size formatter or replaced flag on `UploadResult`)
- CLI human mode: `>> replaced existing object (same URL)` when overwriting
- Optimize notes use human sizes; homepage terminal mock matches
- Docs/skill/README: hot-swap semantics + metadata examples for screenshot context
- Changeset for `@buildinternet/uploads` (patch)

## What it is not

- Not a confirmation/`--force` gate on overwrite (would break agent re-runs)
- Does not change public URL behavior or embed cache policy

## How to try it

```bash
uploads attach ./before.png
# re-run the same filename on the same PR:
uploads attach ./before.png
# expect: >> replaced existing object (same URL)
# optimize line like: >> optimized 411.5 KB → 94.2 KB (before.webp)
```

## Technical notes

- files-sdk: `exists()` / `head().size` only — no `formatBytes`; `UploadResult` is `{ key, size, contentType, etag?, lastModified? }`
- `putObject` already HEADs for ledger delta; `replaced` is that signal surfaced to clients
- `formatByteSize` lives in `@buildinternet/uploads` (CLI); UI keeps its own formatter

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test` (includes format-bytes)
- [x] `pnpm --filter @uploads/api test` (replaced flag on re-PUT)
- [x] package typecheck for uploads + api
- [ ] Spot-check homepage terminal mock locally if deploying web