### PR TITLE
feat(web,cli): smooth onboarding hand-offs, surface uploads install

### DIFF
--- a/.changeset/login-uploads-install-hint.md
+++ b/.changeset/login-uploads-install-hint.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads login` now ends with a pointer to `uploads install` so agent users discover the skill + MCP setup command after signing in.

--- a/.changeset/login-uploads-install-hint.md
+++ b/.changeset/login-uploads-install-hint.md
@@ -2,4 +2,4 @@
 "@buildinternet/uploads": patch
 ---
 
-`uploads login` now ends with a pointer to `uploads install` so agent users discover the skill + MCP setup command after signing in.
+`uploads login` now says which auth host it is signing in to (with a self-hosting hint), includes the saved API URL in its success output and `--json` payload, and ends with a pointer to `uploads install` so agent users discover the skill + MCP setup command.

--- a/apps/web/src/pages/account/index.astro
+++ b/apps/web/src/pages/account/index.astro
@@ -35,6 +35,16 @@ export const prerender = false;
       Prefer no global install? <code>npx @buildinternet/uploads login</code>.
       Full walkthrough in the <a href="/docs#install">docs</a>.
     </p>
+    <div id="cli-agents">
+      <p class="muted cli-note">
+        Using a coding agent? One more command adds the uploads skill and MCP
+        server to Claude Code, so agents attach screenshots on their own:
+      </p>
+      <div class="command">
+        <code>uploads install</code>
+        <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
+      </div>
+    </div>
   </section>
 
   <section class="card">

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -34,6 +34,28 @@ export const prerender = false;
       </label>
       <button type="submit">Create workspace</button>
     </form>
+    <div class="ul-callout" data-create-success role="status" hidden>
+      <p>
+        Workspace <strong data-created-name></strong> is ready. Uploading happens
+        from the terminal; run these to get your first file URL:
+      </p>
+      <div class="command">
+        <code>npm install -g @buildinternet/uploads</code>
+        <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite">copy</button>
+      </div>
+      <div class="command">
+        <code>uploads login</code>
+        <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
+      </div>
+      <div class="command">
+        <code>uploads put ./screenshot.png</code>
+        <button type="button" data-copy="uploads put ./screenshot.png" aria-live="polite">copy</button>
+      </div>
+      <p class="muted cli-note">
+        Using a coding agent? <code>uploads install</code> adds the uploads skill
+        and MCP server to Claude Code, so agents attach screenshots on their own.
+      </p>
+    </div>
     <p class="muted cli-note" data-create-error role="alert" hidden></p>
     <p class="muted cli-note" data-create-github role="status" hidden>
       Creating a workspace requires a linked GitHub account.
@@ -174,6 +196,8 @@ export const prerender = false;
     const createForm = document.querySelector<HTMLFormElement>("[data-create-form]");
     const createError = document.querySelector<HTMLElement>("[data-create-error]");
     const createGithub = document.querySelector<HTMLElement>("[data-create-github]");
+    const createSuccess = document.querySelector<HTMLElement>("[data-create-success]");
+    const createdName = document.querySelector<HTMLElement>("[data-created-name]");
 
     function showCreateSection(prefill?: string): void {
       if (!createSection) return;
@@ -219,13 +243,19 @@ export const prerender = false;
       void (async () => {
         if (createError) createError.hidden = true;
         if (createGithub) createGithub.hidden = true;
+        if (createSuccess) createSuccess.hidden = true;
         const input = createForm.elements.namedItem("name") as HTMLInputElement;
+        const name = input.value.trim();
         const button = createForm.querySelector("button");
         if (button) button.disabled = true;
-        const result = await createWorkspace(apiOrigin, input.value.trim());
+        const result = await createWorkspace(apiOrigin, name);
         if (button) button.disabled = false;
         if (result.kind === "created") {
           input.value = "";
+          // Hand off to the terminal: the web can create a workspace but not
+          // upload to it, so surface the exact next commands right here.
+          if (createdName) createdName.textContent = name;
+          if (createSuccess) createSuccess.hidden = false;
           await loadWorkspaces();
           return;
         }
@@ -408,7 +438,7 @@ export const prerender = false;
 
     // Delegated handlers for copy buttons + workspace invite forms.
     const orgsListEl = requireElement<HTMLUListElement>("#orgs-list", "account workspaces");
-    orgsListEl.addEventListener("click", (event) => {
+    const handleCopyClick = (event: Event) => {
       void (async () => {
         const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
           "button[data-copy]",
@@ -423,7 +453,9 @@ export const prerender = false;
           // Clipboard blocked (permissions/insecure context) — leave the label.
         }
       })();
-    });
+    };
+    orgsListEl.addEventListener("click", handleCopyClick);
+    createSection?.addEventListener("click", handleCopyClick);
     orgsListEl.addEventListener("submit", (event) => {
       void (async () => {
         const form = (event.target as HTMLElement).closest<HTMLFormElement>("form.invite-form");

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -551,7 +551,7 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
             </div>
           </div>
         </div>
-        <p class="foot">access by invitation</p>
+        <p class="foot">free to start: <a href="/login">sign in with GitHub</a> and create a workspace</p>
       </section>
 
       <Footer />

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -240,6 +240,11 @@ async function runDeviceLogin(
   const label = flagString(parsed.flags, "--label") ?? safeHostname();
   const requestedWorkspace = flagString(parsed.flags, "--workspace");
 
+  // Make the target explicit: a bare `uploads login` on a self-hosted install
+  // would otherwise silently sign in to the cloud service.
+  io.write(
+    `signing in to ${opts.authUrl} (self-hosted? pass --api-url or set UPLOADS_API_URL)\n\n`,
+  );
   const accessToken = await obtainDeviceAccessToken(opts.authUrl, { noOpen: opts.noOpen }, io);
 
   const workspace = await resolveMintWorkspace(opts.apiUrl, accessToken, requestedWorkspace, io);
@@ -410,6 +415,7 @@ export async function runLogin(
   const payload = {
     ok: doctor.ok,
     configPath: path,
+    apiUrl: savedApiUrl,
     workspace: result.workspace,
     token: redactToken(result.token),
     doctor: checked ? doctor : { skipped: true },
@@ -417,7 +423,7 @@ export async function runLogin(
   if (opts.json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
   else {
     process.stdout.write(
-      `saved credentials to ${path}\nworkspace: ${result.workspace}\ntoken: ${redactToken(result.token)}\n`,
+      `saved credentials to ${path}\napi: ${savedApiUrl}\nworkspace: ${result.workspace}\ntoken: ${redactToken(result.token)}\n`,
     );
     process[doctor.ok ? "stdout" : "stderr"].write(
       `doctor: ${checked ? (doctor.ok ? "ok" : `failed — ${doctor.error}`) : "skipped"}\n`,

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -422,6 +422,10 @@ export async function runLogin(
     process[doctor.ok ? "stdout" : "stderr"].write(
       `doctor: ${checked ? (doctor.ok ? "ok" : `failed — ${doctor.error}`) : "skipped"}\n`,
     );
+    if (doctor.ok)
+      process.stdout.write(
+        "\nusing a coding agent? run `uploads install` to add the uploads skill + MCP server to Claude Code\n",
+      );
   }
   return doctor.ok ? 0 : 1;
 }


### PR DESCRIPTION
Fixes the first batch of friction points from the onboarding walkthrough: the funnel said "invitation only" after self-serve shipped, and users who finished setup never learned `uploads install` exists.

## What changed

**Landing page** — the footer under "# get set up" read `access by invitation`, which predates self-serve registration (#171). It now says the product is free to start and links to sign-in.

**Account overview (`/account#cli-setup`)** — the CLI setup card only covered install + login. It now also shows `uploads install` with a one-line explanation (adds the uploads skill + MCP server to Claude Code). The agents block sits outside the collapsing steps, so it stays visible even after setup is complete — early feedback was that people never realized the command was available once they were set up.

**Workspaces page** — creating a workspace in the browser used to silently refresh the list, leaving the user with a workspace but no way to upload (no token is shown in the web UI and there's no web uploader). Success now shows a callout with the exact terminal commands: install, `uploads login`, `uploads put ./screenshot.png`, plus the `uploads install` agents note.

**CLI** — `uploads login` ends with a hint pointing at `uploads install` when the doctor check passes. Changeset included (patch).

## Not in this PR

Deliberately left for follow-ups: non-interactive `uploads login` provisioning for CI/agents, inlining the GitHub-connect step into the create flow, and enrollment-code hygiene (`--code-stdin` default on /invite).

## How to try it

- Visit `/` and check the footer under "# get set up".
- Sign in, visit `/account` — the setup card now ends with the agents block.
- On `/account/workspaces`, create a workspace — a next-steps callout appears with copyable commands.
- Run `uploads login` — the success output ends with the `uploads install` hint.
