### PR TITLE
feat: report emailConfigured on workspace invites

### DIFF
--- a/.changeset/invite-email-configured.md
+++ b/.changeset/invite-email-configured.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads invite create` now says whether the invitation was emailed or whether the install has no email configured and the accept link must be shared by hand (`emailConfigured` also appears in `--json` output). Older auth workers that don't report the field keep the previous hedged copy.

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -432,9 +432,12 @@ describe("DB-backed behavior", () => {
       const body = (await res.json()) as {
         invitation: { id: string; status: string; email: string };
         acceptUrl: string;
+        emailConfigured: boolean;
       };
       expect(body.acceptUrl).toContain(`/accept-invitation/${body.invitation.id}`);
       expect(body.invitation.email).toBe("invitee@example.com");
+      // Test env has no EMAIL binding, so the install reports it can't email.
+      expect(body.emailConfigured).toBe(false);
 
       const rows = await orm
         .select()

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -303,6 +303,7 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
           },
           // Always return so self-hosted (no EMAIL binding) can share the link.
           acceptUrl: acceptUrlFor(existingInvite.id),
+          emailConfigured: Boolean(c.env.EMAIL),
         },
         200,
       );
@@ -343,6 +344,9 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
           expiresAt,
         },
         acceptUrl,
+        // Binding presence, not delivery confirmation — sendAuthEmail is
+        // fire-and-forget. Lets clients say "emailed" vs "share this link".
+        emailConfigured: Boolean(c.env.EMAIL),
       },
       201,
     );

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -223,7 +223,14 @@ export async function setFileVisibility(
 }
 
 export type InviteResult =
-  | { kind: "ok"; invitationId?: string; status?: string; acceptUrl?: string }
+  | {
+      kind: "ok";
+      invitationId?: string;
+      status?: string;
+      acceptUrl?: string;
+      /** Whether this install can send invite emails; undefined = older auth worker. */
+      emailConfigured?: boolean;
+    }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "forbidden" | "invalid" };
 
 /**
@@ -253,12 +260,14 @@ export async function inviteToWorkspace(
   const body = (await response.json().catch(() => null)) as {
     invitation?: { id?: string; status?: string };
     acceptUrl?: string;
+    emailConfigured?: boolean;
   } | null;
   return {
     kind: "ok",
     invitationId: body?.invitation?.id,
     status: body?.invitation?.status,
     acceptUrl: typeof body?.acceptUrl === "string" ? body.acceptUrl : undefined,
+    emailConfigured: typeof body?.emailConfigured === "boolean" ? body.emailConfigured : undefined,
   };
 }
 

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -446,7 +446,14 @@ export const prerender = false;
         const result = await inviteToWorkspace(apiOrigin, workspace, email);
         submit.disabled = false;
         if (result.kind === "ok") {
-          status.textContent = `Invite created for ${email}.`;
+          // emailConfigured is binding presence on the auth worker; undefined
+          // means an older worker that doesn't report it — keep neutral copy.
+          status.textContent =
+            result.emailConfigured === true
+              ? `Invitation emailed to ${email}.`
+              : result.emailConfigured === false
+                ? `Invite created for ${email} — email isn't configured on this install, so share the accept link below yourself.`
+                : `Invite created for ${email}.`;
           if (emailInput) emailInput.value = "";
           if (linkEl && result.acceptUrl) {
             linkEl.hidden = false;

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -498,6 +498,8 @@ export function createWorkspaceInvite(
 ): Promise<{
   invitation: { id: string; email: string; role: string; status: string };
   acceptUrl?: string;
+  /** Whether the install can send invite emails; absent on older auth workers. */
+  emailConfigured?: boolean;
 }> {
   return jsonRequest(
     `${apiUrl.replace(/\/$/, "")}/me/workspaces/${encodeURIComponent(workspace)}/invites`,

--- a/packages/uploads/src/commands/invite.ts
+++ b/packages/uploads/src/commands/invite.ts
@@ -114,16 +114,28 @@ export async function runInvite(
     invitationId: result.invitation.id,
     status: result.invitation.status,
     acceptUrl: result.acceptUrl ?? null,
+    emailConfigured: result.emailConfigured ?? null,
   };
   if (opts.json) process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
   else {
     process.stdout.write(
       `Invited ${email} to ${workspace} as ${role} (${result.invitation.status}).\n`,
     );
-    if (result.acceptUrl) {
+    if (result.emailConfigured === true) {
+      process.stdout.write(`Invitation emailed to ${email}.\n`);
+    } else if (result.emailConfigured === false) {
       process.stdout.write(
-        `Accept link (share if email isn't configured):\n  ${result.acceptUrl}\n`,
+        "Email isn't configured on this install — share the accept link yourself.\n",
       );
+    }
+    if (result.acceptUrl) {
+      const label =
+        result.emailConfigured === true
+          ? "Accept link (backup)"
+          : result.emailConfigured === false
+            ? "Accept link"
+            : "Accept link (share if email isn't configured)";
+      process.stdout.write(`${label}:\n  ${result.acceptUrl}\n`);
     }
     process.stdout.write("They accept, then run: uploads login\n");
   }


### PR DESCRIPTION
Self-hosted operators had no way to tell whether a workspace invite actually emailed the invitee. The auth worker sends invite emails fire-and-forget: when the `EMAIL` binding is missing it only logs the accept link to worker logs, and the invite response carried no signal either way. So the web UI said "Invite created" unconditionally and the CLI hedged with "share if email isn't configured" for everyone — including cloud users whose email works fine.

## What changed

**Auth worker** — both invite responses (new and idempotent-existing) now include `emailConfigured: boolean`, reflecting whether the `EMAIL` binding is present. This is deliberately named for what it is: binding presence, not delivery confirmation (the send stays fire-and-forget).

**Web invite form** — the status line now reads "Invitation emailed to X." when the install can send email, or "Invite created for X — email isn't configured on this install, so share the accept link below yourself." when it can't.

**CLI `uploads invite create`** — same split: "Invitation emailed" plus an "Accept link (backup)" label, or an explicit share-it-yourself line. `emailConfigured` is included in `--json` output. Changeset included (patch).

**Compatibility** — the API's `/me/workspaces/:name/invites` proxy already spreads the auth payload through, so no API change was needed. Web and CLI treat a missing field (older auth worker) as unknown and keep the previous hedged copy.

## How to try it

- With `EMAIL` configured: invite from `/account/workspaces` → "Invitation emailed to …".
- Without it (local dev / self-host): the same form says email isn't configured and points at the accept link.
- `uploads invite create --email x@y.com --workspace foo --json` → payload includes `emailConfigured`.
