### PR TITLE
feat(cli): uploads login --create provisions the workspace during login

### DIFF
--- a/.changeset/login-create-workspace.md
+++ b/.changeset/login-create-workspace.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads login --workspace <name> --create` provisions the workspace during login when the account doesn't have it yet, so scripted and agent logins can self-onboard without an interactive prompt (device approval in a browser is still required once). The zero-workspace non-interactive error now points at the flag.

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -49,7 +49,10 @@ admins a workspace, or an **enrollment code** shared out-of-band.
 Any signed-in user with a **GitHub-linked account** can create a workspace
 without an invitation or `ADMIN_TOKEN` — `/account/workspaces` has a "Create a
 workspace" form, and `uploads login` offers the same prompt when your account
-has no workspaces yet. You become the owner of a new organization and a
+has no workspaces yet. Scripted or agent logins can skip the prompt with
+`uploads login --workspace <name> --create`, which provisions the workspace
+during login when the account doesn't already have it (browser device
+approval is still required once). You become the owner of a new organization and a
 `<name>/` prefix on the shared bucket, capped at 3 self-serve workspaces per
 user and with tighter default limits than an operator-provisioned workspace.
 See [workspaces.md#self-serve-workspaces](workspaces.md#self-serve-workspaces)

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -30,6 +30,9 @@ code only if you were given one from before device login (fallback path).
 Options:
   --workspace <name>  Workspace to mint a token for (device flow; required if
                       your account can access more than one)
+  --create            With --workspace: create the workspace first if your
+                      account doesn't have it yet (device flow only) — lets
+                      scripted/agent logins provision without a prompt
   --scopes <list>     Comma-separated scopes (default: files:read,files:write)
   --label <text>      Token label (default: this machine's hostname)
   --auth-url <url>    Auth base (default: https://auth.uploads.sh)
@@ -46,6 +49,7 @@ Options:
 Examples:
   uploads login
   uploads login --workspace acme
+  uploads login --workspace acme --create         # provision if it doesn't exist
   uploads login --code upe_… --force              # fallback: pre-existing invite
   printf '%s' upe_… | uploads login --code-stdin --non-interactive
 `;
@@ -247,7 +251,13 @@ async function runDeviceLogin(
   );
   const accessToken = await obtainDeviceAccessToken(opts.authUrl, { noOpen: opts.noOpen }, io);
 
-  const workspace = await resolveMintWorkspace(opts.apiUrl, accessToken, requestedWorkspace, io);
+  const workspace = await resolveMintWorkspace(
+    opts.apiUrl,
+    accessToken,
+    requestedWorkspace,
+    io,
+    flagBool(parsed.flags, "--create"),
+  );
   const minted = await mintWorkspaceToken(opts.apiUrl, accessToken, { workspace, scopes, label });
   return { workspace: minted.workspace, token: minted.token, apiUrl: opts.apiUrl };
 }
@@ -303,8 +313,9 @@ export async function pollForDeviceToken(
 }
 
 /**
- * Pick the workspace to mint for. An explicit --workspace wins; otherwise, if
- * the account can access exactly one workspace, use it — and if it can access
+ * Pick the workspace to mint for. An explicit --workspace wins (with --create,
+ * it's provisioned first when the account doesn't have it); otherwise, if the
+ * account can access exactly one workspace, use it — and if it can access
  * several, require the flag rather than guessing.
  */
 async function resolveMintWorkspace(
@@ -312,14 +323,25 @@ async function resolveMintWorkspace(
   accessToken: string,
   requested: string | undefined,
   io: DeviceLoginIo,
+  create = false,
 ): Promise<string> {
-  if (requested) return requested;
+  if (requested) {
+    if (!create) return requested;
+    // Idempotent from the caller's view: an existing membership just mints.
+    const { workspaces } = await listMintWorkspaces(apiUrl, accessToken);
+    if (workspaces.some((w) => w.workspace === requested)) return requested;
+    const created = await createWorkspaceRequest(apiUrl, accessToken, requested);
+    io.write(
+      `created workspace "${created.name}" — files will get public URLs under ${created.publicBaseUrl}/\n`,
+    );
+    return created.name;
+  }
   const { workspaces } = await listMintWorkspaces(apiUrl, accessToken);
   if (workspaces.length === 1) return workspaces[0]!.workspace;
   if (workspaces.length === 0) {
     if (!io.isTTY) {
       throw new UsageError(
-        "your account has no workspace access yet — create one with a name, or ask an administrator for an invitation. Run `uploads login` interactively to create one.",
+        "your account has no workspace access yet — pass `--workspace <name> --create` to provision one, run `uploads login` interactively, or ask an administrator for an invitation",
       );
     }
     const name = (await io.promptWorkspaceName()).trim();
@@ -356,8 +378,13 @@ export async function runLogin(
       "UPLOADS_TOKEN is already set in the environment; unset it or use --force",
     );
 
+  if (flagBool(parsed.flags, "--create") && !flagString(parsed.flags, "--workspace"))
+    throw new UsageError("--create requires --workspace <name>");
+
   let result: LoginResult;
   if (hasEnrollmentSource(parsed)) {
+    if (flagBool(parsed.flags, "--create"))
+      throw new UsageError("--create is device-flow only; enrollment codes are workspace-bound");
     const code = await resolveEnrollmentCode(parsed);
     result = await exchangeEnrollment(apiUrl, code);
   } else {

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -291,7 +291,115 @@ describe("runLogin device flow", () => {
         ...silentIo,
         isTTY: false,
       }),
-    ).rejects.toThrow(/no workspace access yet.*create one with a name.*uploads login/s);
+    ).rejects.toThrow(/no workspace access yet.*--workspace <name> --create.*uploads login/s);
+  });
+
+  it("provisions the workspace with --workspace --create when the account lacks it", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const token = "up_newteam_abcdefghijklmnopqrstuvwxyz";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode())
+      .mockResolvedValueOnce(
+        response({ access_token: "sess-tok", token_type: "Bearer", expires_in: 3600, scope: "" }),
+      )
+      .mockResolvedValueOnce(response({ workspaces: [] })) // GET /v1/tokens
+      .mockResolvedValueOnce(
+        response(
+          {
+            workspace: {
+              name: "newteam",
+              publicBaseUrl: "https://storage.uploads.sh/newteam",
+              selfServe: true,
+            },
+          },
+          201,
+        ),
+      ) // POST /v1/workspaces
+      .mockResolvedValueOnce(
+        response(
+          {
+            token,
+            workspace: "newteam",
+            scopes: ["files:read", "files:write"],
+            label: "host",
+            expiresAt: null,
+          },
+          201,
+        ),
+      ); // POST /v1/tokens
+
+    // Non-interactive io: --create must work without any prompt.
+    expect(
+      await runLogin(
+        ["--path", path, "--workspace", "newteam", "--create", "--no-check"],
+        { json: true },
+        false,
+        { ...silentIo, isTTY: false },
+      ),
+    ).toBe(0);
+
+    const createCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith("/v1/workspaces"));
+    expect(createCall).toBeTruthy();
+    expect(JSON.parse(String((createCall![1] as RequestInit).body))).toEqual({ name: "newteam" });
+    expect(loadConfigFile(path).UPLOADS_WORKSPACE).toBe("newteam");
+  });
+
+  it("skips provisioning with --create when the workspace already exists", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const token = "up_acme_abcdefghijklmnopqrstuvwxyz";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(deviceCode())
+      .mockResolvedValueOnce(
+        response({ access_token: "sess-tok", token_type: "Bearer", expires_in: 3600, scope: "" }),
+      )
+      .mockResolvedValueOnce(response({ workspaces: [{ workspace: "acme", role: "owner" }] }))
+      .mockResolvedValueOnce(
+        response(
+          {
+            token,
+            workspace: "acme",
+            scopes: ["files:read", "files:write"],
+            label: "host",
+            expiresAt: null,
+          },
+          201,
+        ),
+      ); // POST /v1/tokens
+
+    expect(
+      await runLogin(
+        ["--path", path, "--workspace", "acme", "--create", "--no-check"],
+        { json: true },
+        false,
+        silentIo,
+      ),
+    ).toBe(0);
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith("/v1/workspaces"))).toBe(false);
+  });
+
+  it("rejects --create without --workspace", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(
+      runLogin(["--path", path, "--create"], { json: true }, false, silentIo),
+    ).rejects.toThrow(/--create requires --workspace/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects --create combined with an enrollment code", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-login-")), "config");
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(
+      runLogin(
+        ["--path", path, "--workspace", "acme", "--create", "--code", `upe_${"a".repeat(24)}`],
+        { json: true },
+        false,
+        silentIo,
+      ),
+    ).rejects.toThrow(/--create is device-flow only/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("prompts to create a workspace when zero exist and interactive, then mints for it", async () => {


### PR DESCRIPTION
Agents and CI runners could not self-onboard: `uploads login` with zero workspaces and no TTY was a hard error, because workspace creation only existed behind an interactive prompt. This closes the last provisioning dead end from the onboarding walkthrough (follow-up to #176/#177).

## What changed

`uploads login --workspace <name> --create` provisions the workspace during login when the account doesn't already have it, using the same session-authed `POST /v1/workspaces` endpoint as the interactive prompt and the web form. No server changes — all existing gates (GitHub-linked account, 3-workspace cap, slug policy, rate limit) apply unchanged.

Semantics:

- **Existing membership** → no create call, just mints the token. Re-running the same command is safe.
- **Missing workspace** → created, then the token is minted for it. Works without a TTY.
- `--create` without `--workspace` is a usage error, and `--create` is rejected on the enrollment-code path (codes are already workspace-bound).
- The zero-workspace non-interactive error now points at the flag instead of only suggesting an interactive run.

The browser device approval is still required once — that's inherent to the device flow, not a provisioning gap.

Docs: enrollment.md self-serve section mentions the flag. Changeset included (patch).

## Tests

Five new cases: provisions when missing (non-interactive), skips the create call when the workspace exists, rejects `--create` without `--workspace`, rejects it with `--code`, and the updated zero-workspace error copy. 354 pass.

## How to try it

```bash
uploads login --workspace my-team --create --force
# approve in the browser once; workspace is created if needed and the token saved
```
