### PR TITLE
feat(cli): styled command help, meta examples, whoami/logout

### DIFF
--- a/.changeset/cli-command-help-style.md
+++ b/.changeset/cli-command-help-style.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Style command-level --help like the root overview; add --meta examples to essentials help

--- a/.changeset/cli-command-help-style.md
+++ b/.changeset/cli-command-help-style.md
@@ -1,5 +1,5 @@
 ---
-"@buildinternet/uploads": patch
+"@buildinternet/uploads": minor
 ---
 
-Style command-level --help like the root overview; add --meta examples to essentials help
+Style command-level --help like the root overview; add --meta examples; add whoami/status and logout

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -139,6 +139,15 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     essential: true,
   },
   {
+    name: "whoami",
+    summary: "Show active workspace and token (alias: status)",
+    essential: true,
+  },
+  {
+    name: "logout",
+    summary: "Remove the saved UPLOADS_TOKEN from the config file",
+  },
+  {
     name: "invite",
     summary: "Invite a teammate to a workspace (workspace admin; device login)",
   },

--- a/packages/uploads/src/cli-help.ts
+++ b/packages/uploads/src/cli-help.ts
@@ -17,7 +17,16 @@ function toRow(c: (typeof ROOT_COMMANDS)[number]): CmdRow {
 }
 
 /** Preferred order for the short essentials help (subset of ROOT_COMMANDS). */
-const ESSENTIAL_ORDER = ["put", "attach", "login", "list", "delete", "doctor", "install"] as const;
+const ESSENTIAL_ORDER = [
+  "put",
+  "attach",
+  "login",
+  "whoami",
+  "list",
+  "delete",
+  "doctor",
+  "install",
+] as const;
 
 /** Day-to-day commands shown on bare `uploads` / `uploads help`. */
 const ESSENTIALS: CmdRow[] = ESSENTIAL_ORDER.map((name) => {
@@ -117,6 +126,7 @@ ${section(style, "Globals (before command):")}
 
 ${section(style, "Examples:")}
   ${style.command("uploads login")}
+  ${style.command("uploads whoami")}
   ${style.command("uploads put")} ./shot.png --pr 123 --name hero.png
   ${style.command("uploads put")} ./after.png --pr 123 --comment
   ${style.command("uploads put")} ./bug.png --issue 45
@@ -126,6 +136,7 @@ ${section(style, "Examples:")}
   ${style.command("uploads attach")} ./shot.png --meta app=myapp --meta page=settings
   ${style.command("uploads doctor")}
   ${style.command("uploads install")}
+  ${style.command("uploads logout")}
 `;
 }
 
@@ -165,6 +176,7 @@ ${section(style, "Update hints")} ${style.muted("(stderr, once/day):")} silence 
 
 ${section(style, "Examples:")}
   ${style.command("uploads login")}
+  ${style.command("uploads whoami")}
   ${style.command("uploads put")} ./shot.png --pr 123 --name hero.png
   ${style.command("uploads put")} ./after.png --pr 123 --comment
   ${style.command("uploads put")} ./bug.png --issue 45 --repo myorg/myapp
@@ -176,6 +188,7 @@ ${section(style, "Examples:")}
   ${style.command("uploads attach")} ./shot.png --meta app=myapp --meta page=settings
   ${style.command("uploads gallery")} create --title "Release screenshots"
   ${style.command("uploads doctor")}
+  ${style.command("uploads logout")}
   ${style.command("uploads --version")}
 
 ${section(style, "Agent/MCP:")} ${style.body("`uploads install` sets up the agent skill and the hosted MCP server")}

--- a/packages/uploads/src/cli-help.ts
+++ b/packages/uploads/src/cli-help.ts
@@ -120,8 +120,10 @@ ${section(style, "Examples:")}
   ${style.command("uploads put")} ./shot.png --pr 123 --name hero.png
   ${style.command("uploads put")} ./after.png --pr 123 --comment
   ${style.command("uploads put")} ./bug.png --issue 45
+  ${style.command("uploads put")} ./shot.png --meta app=myapp --meta page=settings
   ${style.command("uploads attach")} ./before.png ./after.png
   ${style.command("uploads attach")} ./shot.png --pr 123 --repo myorg/myapp
+  ${style.command("uploads attach")} ./shot.png --meta app=myapp --meta page=settings
   ${style.command("uploads doctor")}
   ${style.command("uploads install")}
 `;
@@ -167,9 +169,11 @@ ${section(style, "Examples:")}
   ${style.command("uploads put")} ./after.png --pr 123 --comment
   ${style.command("uploads put")} ./bug.png --issue 45 --repo myorg/myapp
   ${style.command("uploads put")} ./shot.png --dry-run --format url
+  ${style.command("uploads put")} ./shot.png --meta app=myapp --meta page=settings
   ${style.command("uploads attach")} ./before.png ./after.png
   ${style.command("uploads attach")} ./shot.png --pr 123 --repo myorg/myapp
   ${style.command("uploads attach")} ./artifact.zip --issue 45 --no-comment
+  ${style.command("uploads attach")} ./shot.png --meta app=myapp --meta page=settings
   ${style.command("uploads gallery")} create --title "Release screenshots"
   ${style.command("uploads doctor")}
   ${style.command("uploads --version")}

--- a/packages/uploads/src/cli-style.ts
+++ b/packages/uploads/src/cli-style.ts
@@ -137,8 +137,6 @@ export function formatCommandHelp(
       return `${indent}${style.command(cmd)}${style.body(rest)}`;
     }
 
-    // Indented continuation / option prose → body; top-level prose → muted-ish body
-    if (line.startsWith("  ") || line.startsWith("\t")) return style.body(line);
     return style.body(line);
   });
 

--- a/packages/uploads/src/cli-style.ts
+++ b/packages/uploads/src/cli-style.ts
@@ -89,3 +89,68 @@ export function padCmd(name: string, width: number, style: CliStyle): string {
   const pad = Math.max(0, width - name.length);
   return style.command(name) + " ".repeat(pad);
 }
+
+/** Section labels used across command --help blocks. */
+const SECTION_RE =
+  /^(Options|Examples|Commands|Subcommands|Keys|Shells|Usage|What it does|What runs under the hood|Exit codes|Config|Workspace):\s*$/;
+
+/** Flag column: `  --pr <num>   …` or `  --workspace, -w <name>  …`. */
+const FLAG_RE = /^(\s+)(-[\w-]+(?:,\s*-[\w-]+)?(?:\s+<[^>]+>)?)(\s{2,})(.*)$/;
+
+/** Example / invocation line starting with the CLI name. */
+const EXAMPLE_RE = /^(\s*)(uploads(?:\s+\S+)*)(.*)$/;
+
+/**
+ * Apply root-help visual hierarchy to a plain multi-line command help string:
+ * accent section headers, green flags/commands, muted body.
+ * No-op when color is disabled (returns text unchanged aside from trailing newline).
+ */
+export function formatCommandHelp(
+  text: string,
+  style: CliStyle = createStyle(colorEnabled(process.stderr)),
+): string {
+  const normalized = text.endsWith("\n") ? text.slice(0, -1) : text;
+  if (!style.enabled) return `${normalized}\n`;
+
+  const lines = normalized.split("\n");
+  let firstContent = true;
+  const out = lines.map((line) => {
+    if (line.trim() === "") return line;
+
+    // Synopsis line (first non-empty): high emphasis
+    if (firstContent) {
+      firstContent = false;
+      return style.title(line);
+    }
+
+    if (SECTION_RE.test(line)) return style.heading(line);
+
+    const flag = FLAG_RE.exec(line);
+    if (flag) {
+      const [, indent, name, gap, desc] = flag;
+      return `${indent}${style.command(name)}${gap}${style.body(desc)}`;
+    }
+
+    const example = EXAMPLE_RE.exec(line);
+    if (example && line.trimStart().startsWith("uploads")) {
+      const [, indent, cmd, rest] = example;
+      return `${indent}${style.command(cmd)}${style.body(rest)}`;
+    }
+
+    // Indented continuation / option prose → body; top-level prose → muted-ish body
+    if (line.startsWith("  ") || line.startsWith("\t")) return style.body(line);
+    return style.body(line);
+  });
+
+  return `${out.join("\n")}\n`;
+}
+
+/** Write styled command help to stderr (or a custom writer). */
+export function writeCommandHelp(
+  text: string,
+  write: (chunk: string) => void = (c) => {
+    process.stderr.write(c);
+  },
+): void {
+  write(formatCommandHelp(text));
+}

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -35,6 +35,7 @@ import { runAdmin } from "./commands/admin-enrollment.js";
 import { runMcp } from "./commands/mcp.js";
 import { runInstall } from "./commands/install.js";
 import { runCompletion } from "./commands/completion.js";
+import { runLogout, runWhoami } from "./commands/session.js";
 import { packageVersion } from "./package-version.js";
 import { checkForUpdate, maybeHintUpdate } from "./update-check.js";
 
@@ -233,6 +234,23 @@ export async function runCli(argv: string[]): Promise<number> {
         break;
       case "login":
         code = await runLogin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        break;
+      case "whoami":
+      case "status":
+        code = await runWhoami(
+          cmdArgs,
+          {
+            json,
+            envFile: parsed.globals.envFile,
+            token: parsed.globals.token,
+            workspace: parsed.globals.workspace,
+            apiUrl: parsed.globals.apiUrl,
+          },
+          showHelp,
+        );
+        break;
+      case "logout":
+        code = await runLogout(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
         break;
       case "invite":
         code = await runInvite(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -51,6 +51,7 @@ import { buildCliProvenance } from "./provenance.js";
 import { formatByteSize } from "./format-bytes.js";
 import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
+import { writeCommandHelp } from "./cli-style.js";
 
 export interface CliContext {
   config: ResolvedConfig;
@@ -418,11 +419,11 @@ export async function runAttach(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(ATTACH_HELP);
+    writeCommandHelp(ATTACH_HELP);
     return 0;
   }
   if (parsed.positionals.length === 0) {
-    process.stderr.write(ATTACH_HELP);
+    writeCommandHelp(ATTACH_HELP);
     return 2;
   }
   if (parsed.flags.has("--no-comment") && typeof parsed.flags.get("--no-comment") === "string") {
@@ -525,18 +526,18 @@ export async function runPut(
   run: CommandRunner = execRunner,
 ): Promise<number> {
   if (help) {
-    process.stderr.write(PUT_HELP);
+    writeCommandHelp(PUT_HELP);
     return 0;
   }
   const parsed = parseCommandArgs(args);
   if (parsed.help) {
-    process.stderr.write(PUT_HELP);
+    writeCommandHelp(PUT_HELP);
     return 0;
   }
 
   const fileArg = parsed.positionals[0];
   if (!fileArg) {
-    process.stderr.write(PUT_HELP);
+    writeCommandHelp(PUT_HELP);
     return 2;
   }
 
@@ -837,7 +838,7 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
   const parsed = parseCommandArgs(args);
   const action = parsed.positionals[0];
   if (help || parsed.help || !action) {
-    process.stderr.write(GALLERY_HELP);
+    writeCommandHelp(GALLERY_HELP);
     return help || parsed.help ? 0 : 2;
   }
 
@@ -1051,7 +1052,7 @@ export async function runList(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(LIST_HELP);
+    writeCommandHelp(LIST_HELP);
     return 0;
   }
   const metaPairs = flagValues(parsed.flags, "--meta");
@@ -1110,11 +1111,11 @@ Examples:
 export async function runFind(ctx: CliContext, args: string[], help = false): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(FIND_HELP);
+    writeCommandHelp(FIND_HELP);
     return 0;
   }
   if (parsed.positionals.length === 0) {
-    process.stderr.write(FIND_HELP);
+    writeCommandHelp(FIND_HELP);
     return 2;
   }
   const filters = parseMetaFlags(parsed.positionals);
@@ -1142,7 +1143,7 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
   const parsed = parseCommandArgs(args);
   const action = parsed.positionals[0];
   if (help || parsed.help || !action) {
-    process.stderr.write(META_HELP);
+    writeCommandHelp(META_HELP);
     return help || parsed.help ? 0 : 2;
   }
 
@@ -1196,12 +1197,12 @@ Examples:
 export async function runDelete(ctx: CliContext, args: string[], help = false): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(DELETE_HELP);
+    writeCommandHelp(DELETE_HELP);
     return 0;
   }
   const key = parsed.positionals[0];
   if (!key) {
-    process.stderr.write(DELETE_HELP);
+    writeCommandHelp(DELETE_HELP);
     return 2;
   }
   if (flagBool(parsed.flags, "--dry-run")) {
@@ -1237,7 +1238,7 @@ export async function runComment(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(COMMENT_HELP);
+    writeCommandHelp(COMMENT_HELP);
     return 0;
   }
   const target = ghTargetFromFlags(parsed.flags, run);
@@ -1269,7 +1270,7 @@ Examples:
 
 export async function runUsage(ctx: CliContext, args: string[], help = false): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(USAGE_HELP);
+    writeCommandHelp(USAGE_HELP);
     return 0;
   }
   const result = await ctx.client.usage();
@@ -1299,7 +1300,7 @@ Examples:
 
 export async function runReconcile(ctx: CliContext, args: string[], help = false): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(RECONCILE_HELP);
+    writeCommandHelp(RECONCILE_HELP);
     return 0;
   }
   const result = await ctx.client.reconcile();
@@ -1330,7 +1331,7 @@ export async function runPurgeExpired(
   help = false,
 ): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(PURGE_HELP);
+    writeCommandHelp(PURGE_HELP);
     return 0;
   }
   const result = await ctx.client.purgeExpired();
@@ -1365,7 +1366,7 @@ export async function runHealth(
   help = false,
 ): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(HEALTH_HELP);
+    writeCommandHelp(HEALTH_HELP);
     return 0;
   }
   const result = await createUploadsClient({
@@ -1490,7 +1491,7 @@ export async function buildDoctorReport(
 
 export async function runDoctor(ctx: CliContext, args: string[], help = false): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(DOCTOR_HELP);
+    writeCommandHelp(DOCTOR_HELP);
     return 0;
   }
 

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -1,5 +1,6 @@
 import { createEnrollment } from "../client.js";
 import { flagBool, flagInt, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 const HELP = `uploads admin invite create [options]
 
@@ -74,7 +75,7 @@ export async function runAdmin(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(HELP);
+    writeCommandHelp(HELP);
     return 0;
   }
   if (

--- a/packages/uploads/src/commands/completion.ts
+++ b/packages/uploads/src/commands/completion.ts
@@ -8,6 +8,7 @@ import {
   isCompletionShell,
   type CompletionShell,
 } from "../cli-catalog.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 const HELP = `uploads completion <shell>
 
@@ -286,7 +287,7 @@ export function generateCompletionScript(shell: CompletionShell): string {
 export async function runCompletion(args: string[], help = false): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help || parsed.positionals.length === 0) {
-    process.stderr.write(HELP);
+    writeCommandHelp(HELP);
     return help || parsed.help ? 0 : 2;
   }
 

--- a/packages/uploads/src/commands/config.ts
+++ b/packages/uploads/src/commands/config.ts
@@ -12,6 +12,7 @@ import {
   type UploadsConfigKey,
 } from "../config.js";
 import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 const CONFIG_HELP = `uploads config — manage shared buildinternet config
 
@@ -61,7 +62,7 @@ export async function runConfig(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help || parsed.positionals.length === 0) {
-    process.stderr.write(CONFIG_HELP);
+    writeCommandHelp(CONFIG_HELP);
     return 0;
   }
 
@@ -79,7 +80,8 @@ export async function runConfig(
     case "set":
       return runConfigSet(rest, subArgs, opts, help);
     default:
-      process.stderr.write(`unknown config subcommand: ${sub}\n\n${CONFIG_HELP}`);
+      process.stderr.write(`unknown config subcommand: ${sub}\n\n`);
+      writeCommandHelp(CONFIG_HELP);
       return 2;
   }
 }
@@ -90,7 +92,7 @@ async function runConfigPath(
   help: boolean,
 ): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(`uploads config path\n\nPrint the resolved config file path.\n`);
+    writeCommandHelp(`uploads config path\n\nPrint the resolved config file path.\n`);
     return 0;
   }
   const path = resolveConfigPath({ envFile: opts.envFile });
@@ -106,7 +108,7 @@ async function runConfigShow(
   help: boolean,
 ): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(`uploads config show\n\nShow effective settings (token redacted).\n`);
+    writeCommandHelp(`uploads config show\n\nShow effective settings (token redacted).\n`);
     return 0;
   }
 
@@ -150,7 +152,7 @@ async function runConfigInit(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(`uploads config init [options]
+    writeCommandHelp(`uploads config init [options]
 
 Create or update UPLOADS_* keys in the shared config file.
 
@@ -210,7 +212,7 @@ async function runConfigSet(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(`uploads config set <key> <value> [--path <file>] [--force]
+    writeCommandHelp(`uploads config set <key> <value> [--path <file>] [--force]
 
 Examples:
   uploads config set UPLOADS_TOKEN up_default_…
@@ -222,7 +224,7 @@ Examples:
   const key = positionals[0] as UploadsConfigKey | undefined;
   const value = positionals[1];
   if (!key || !value) {
-    process.stderr.write(`uploads config set <key> <value>\n`);
+    writeCommandHelp(`uploads config set <key> <value>\n`);
     return 2;
   }
   if (!VALID_KEYS.has(key)) {

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -7,6 +7,7 @@ import {
 } from "../cli-args.js";
 import { resolveConfig } from "../config.js";
 import { execRunner, type CommandRunner } from "../github-gh.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 export const DEFAULT_MCP_URL = "https://agents.uploads.sh/mcp";
 const SKILL_SOURCE = "buildinternet/uploads";
@@ -153,7 +154,7 @@ export async function runInstall(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(INSTALL_HELP);
+    writeCommandHelp(INSTALL_HELP);
     return 0;
   }
 

--- a/packages/uploads/src/commands/invite.ts
+++ b/packages/uploads/src/commands/invite.ts
@@ -4,6 +4,7 @@
  */
 import { createWorkspaceInvite, listMintWorkspaces } from "../client.js";
 import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
 import {
   defaultDeviceIo,
   obtainDeviceAccessToken,
@@ -72,7 +73,7 @@ export async function runInvite(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(HELP);
+    writeCommandHelp(HELP);
     return 0;
   }
   if (parsed.positionals[0] !== "create") {

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -20,6 +20,7 @@ import {
 } from "../client.js";
 import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
 import { parseScopes } from "./admin-enrollment.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 const HELP = `uploads login [options]
 
@@ -364,7 +365,7 @@ export async function runLogin(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(HELP);
+    writeCommandHelp(HELP);
     return 0;
   }
   const apiUrl = flagString(parsed.flags, "--api-url") ?? opts.apiUrl ?? "https://api.uploads.sh";

--- a/packages/uploads/src/commands/mcp.ts
+++ b/packages/uploads/src/commands/mcp.ts
@@ -3,6 +3,7 @@ import { createMcpServer } from "../mcp/server.js";
 import { serveStdio } from "../mcp/stdio.js";
 import { createUploadsMcpTools } from "../mcp/tools.js";
 import { packageVersion } from "../package-version.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 const MCP_HELP = `uploads [globals] mcp
 
@@ -30,7 +31,7 @@ export async function runMcp(
   help = false,
 ): Promise<number> {
   if (help || parseCommandArgs(args).help) {
-    process.stderr.write(MCP_HELP);
+    writeCommandHelp(MCP_HELP);
     return 0;
   }
   const server = createMcpServer({

--- a/packages/uploads/src/commands/session.ts
+++ b/packages/uploads/src/commands/session.ts
@@ -1,0 +1,207 @@
+/**
+ * Session commands: whoami / status (show identity) and logout (clear token).
+ */
+import {
+  describeConfigSources,
+  loadConfigFile,
+  redactToken,
+  removeConfigKeys,
+  resolveConfig,
+  resolveConfigPath,
+  workspaceFromToken,
+} from "../config.js";
+import { flagBool, flagString, parseCommandArgs } from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
+import { writeJson } from "../io.js";
+
+const WHOAMI_HELP = `uploads whoami
+
+Show the active CLI identity: workspace, token (redacted), API URL, and where
+each value came from. Alias: uploads status.
+
+Does not call the API (offline). Use uploads doctor to verify the token works.
+
+Options:
+  --path <file>       Config file to inspect (default: shared buildinternet config)
+  --json              JSON on stdout
+
+Examples:
+  uploads whoami
+  uploads status --json
+  uploads whoami --path ./my.env
+`;
+
+const LOGOUT_HELP = `uploads logout
+
+Remove the saved UPLOADS_TOKEN from the shared config file so this machine is
+no longer signed in for the CLI. Does not revoke the token on the server.
+
+Environment variables (UPLOADS_TOKEN) are not unset — export them yourself if set.
+
+Options:
+  --path <file>       Config file to edit (default: shared buildinternet config)
+  --json              JSON on stdout
+
+Examples:
+  uploads logout
+  uploads logout --path ./my.env
+`;
+
+export interface WhoamiReport {
+  signedIn: boolean;
+  workspace: string;
+  workspaceSource: string;
+  workspaceFromToken: string | undefined;
+  token: string;
+  tokenSource: string;
+  /** True when a token is present only via process env (not config file). */
+  tokenFromEnv: boolean;
+  /** True when the config file holds UPLOADS_TOKEN. */
+  tokenInConfig: boolean;
+  apiUrl: string;
+  apiUrlSource: string;
+  configPath: string;
+  configExists: boolean;
+}
+
+export function buildWhoamiReport(opts: {
+  envFile?: string;
+  token?: string;
+  workspace?: string;
+  apiUrl?: string;
+}): WhoamiReport {
+  const config = resolveConfig({
+    envFile: opts.envFile,
+    token: opts.token,
+    workspace: opts.workspace,
+    apiUrl: opts.apiUrl,
+    requireToken: false,
+  });
+  const sources = describeConfigSources({
+    envFile: opts.envFile,
+    token: opts.token,
+    workspace: opts.workspace,
+    apiUrl: opts.apiUrl,
+  });
+  const fileRaw = loadConfigFile(config.configPath);
+  const tokenInConfig = Boolean(fileRaw.UPLOADS_TOKEN);
+  const tokenFromEnv = sources.token === "env" || sources.token === "env-file";
+
+  return {
+    signedIn: Boolean(config.token),
+    workspace: config.workspace,
+    workspaceSource: sources.workspace,
+    workspaceFromToken: config.token ? workspaceFromToken(config.token) : undefined,
+    token: redactToken(config.token || undefined),
+    tokenSource: sources.token,
+    tokenFromEnv: Boolean(config.token) && tokenFromEnv && !tokenInConfig,
+    tokenInConfig,
+    apiUrl: config.apiUrl,
+    apiUrlSource: sources.apiUrl,
+    configPath: config.configPath,
+    configExists: config.configExists,
+  };
+}
+
+function formatWhoami(report: WhoamiReport): string {
+  const lines: string[] = [];
+  if (!report.signedIn) {
+    lines.push("signed in:  no");
+    lines.push(`config:     ${report.configPath}${report.configExists ? "" : " (missing)"}`);
+    lines.push(`api:        ${report.apiUrl} (${report.apiUrlSource})`);
+    lines.push(`workspace:  ${report.workspace} (${report.workspaceSource})`);
+    lines.push("");
+    lines.push("hint: run uploads login to sign in");
+    return lines.join("\n") + "\n";
+  }
+
+  lines.push("signed in:  yes");
+  lines.push(`workspace:  ${report.workspace} (${report.workspaceSource})`);
+  if (report.workspaceFromToken && report.workspaceFromToken !== report.workspace) {
+    lines.push(`token ws:   ${report.workspaceFromToken} (encoded in token)`);
+  }
+  lines.push(`token:      ${report.token} (${report.tokenSource})`);
+  lines.push(`api:        ${report.apiUrl} (${report.apiUrlSource})`);
+  lines.push(`config:     ${report.configPath}${report.configExists ? "" : " (missing)"}`);
+  if (report.tokenFromEnv) {
+    lines.push("");
+    lines.push("note: token is from the environment, not the config file");
+    lines.push("      uploads logout only clears the config file");
+  }
+  return lines.join("\n") + "\n";
+}
+
+export async function runWhoami(
+  args: string[],
+  opts: { json?: boolean; envFile?: string; token?: string; workspace?: string; apiUrl?: string },
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(WHOAMI_HELP);
+    return 0;
+  }
+
+  const path = flagString(parsed.flags, "--path") ?? opts.envFile;
+  const report = buildWhoamiReport({
+    envFile: path,
+    token: opts.token,
+    workspace: opts.workspace,
+    apiUrl: opts.apiUrl,
+  });
+
+  if (opts.json || flagBool(parsed.flags, "--json")) {
+    await writeJson(report);
+  } else {
+    process.stdout.write(formatWhoami(report));
+  }
+  return report.signedIn ? 0 : 1;
+}
+
+export async function runLogout(
+  args: string[],
+  opts: { json?: boolean; envFile?: string },
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(LOGOUT_HELP);
+    return 0;
+  }
+
+  const path = flagString(parsed.flags, "--path") ?? resolveConfigPath({ envFile: opts.envFile });
+  const before = loadConfigFile(path);
+  const hadFileToken = Boolean(before.UPLOADS_TOKEN);
+  const envToken = Boolean(process.env.UPLOADS_TOKEN);
+
+  const result = removeConfigKeys(path, ["UPLOADS_TOKEN"]);
+
+  const payload = {
+    path: result.path,
+    removed: result.removed,
+    configExisted: result.existed,
+    hadTokenInConfig: hadFileToken,
+    envTokenStillSet: envToken,
+  };
+
+  if (opts.json || flagBool(parsed.flags, "--json")) {
+    await writeJson(payload);
+    return 0;
+  }
+
+  if (result.removed.includes("UPLOADS_TOKEN")) {
+    process.stdout.write(`signed out — removed UPLOADS_TOKEN from ${result.path}\n`);
+  } else if (!result.existed) {
+    process.stdout.write(`no config file at ${result.path} — already signed out\n`);
+  } else {
+    process.stdout.write(`no UPLOADS_TOKEN in ${result.path} — already signed out\n`);
+  }
+
+  if (envToken) {
+    process.stderr.write(
+      "note: UPLOADS_TOKEN is still set in the environment; unset it to fully sign out\n",
+    );
+  }
+
+  return 0;
+}

--- a/packages/uploads/src/commands/session.ts
+++ b/packages/uploads/src/commands/session.ts
@@ -54,8 +54,6 @@ export interface WhoamiReport {
   workspaceFromToken: string | undefined;
   token: string;
   tokenSource: string;
-  /** True when a token is present only via process env (not config file). */
-  tokenFromEnv: boolean;
   /** True when the config file holds UPLOADS_TOKEN. */
   tokenInConfig: boolean;
   apiUrl: string;
@@ -70,22 +68,15 @@ export function buildWhoamiReport(opts: {
   workspace?: string;
   apiUrl?: string;
 }): WhoamiReport {
-  const config = resolveConfig({
+  const flags = {
     envFile: opts.envFile,
     token: opts.token,
     workspace: opts.workspace,
     apiUrl: opts.apiUrl,
-    requireToken: false,
-  });
-  const sources = describeConfigSources({
-    envFile: opts.envFile,
-    token: opts.token,
-    workspace: opts.workspace,
-    apiUrl: opts.apiUrl,
-  });
-  const fileRaw = loadConfigFile(config.configPath);
-  const tokenInConfig = Boolean(fileRaw.UPLOADS_TOKEN);
-  const tokenFromEnv = sources.token === "env" || sources.token === "env-file";
+  };
+  const config = resolveConfig({ ...flags, requireToken: false });
+  const sources = describeConfigSources(flags);
+  const tokenInConfig = Boolean(loadConfigFile(config.configPath).UPLOADS_TOKEN);
 
   return {
     signedIn: Boolean(config.token),
@@ -94,7 +85,6 @@ export function buildWhoamiReport(opts: {
     workspaceFromToken: config.token ? workspaceFromToken(config.token) : undefined,
     token: redactToken(config.token || undefined),
     tokenSource: sources.token,
-    tokenFromEnv: Boolean(config.token) && tokenFromEnv && !tokenInConfig,
     tokenInConfig,
     apiUrl: config.apiUrl,
     apiUrlSource: sources.apiUrl,
@@ -104,31 +94,33 @@ export function buildWhoamiReport(opts: {
 }
 
 function formatWhoami(report: WhoamiReport): string {
-  const lines: string[] = [];
-  if (!report.signedIn) {
-    lines.push("signed in:  no");
-    lines.push(`config:     ${report.configPath}${report.configExists ? "" : " (missing)"}`);
-    lines.push(`api:        ${report.apiUrl} (${report.apiUrlSource})`);
-    lines.push(`workspace:  ${report.workspace} (${report.workspaceSource})`);
-    lines.push("");
-    lines.push("hint: run uploads login to sign in");
-    return lines.join("\n") + "\n";
-  }
-
-  lines.push("signed in:  yes");
-  lines.push(`workspace:  ${report.workspace} (${report.workspaceSource})`);
+  const cfg = `${report.configPath}${report.configExists ? "" : " (missing)"}`;
+  const lines = [
+    `signed in:  ${report.signedIn ? "yes" : "no"}`,
+    `workspace:  ${report.workspace} (${report.workspaceSource})`,
+  ];
   if (report.workspaceFromToken && report.workspaceFromToken !== report.workspace) {
     lines.push(`token ws:   ${report.workspaceFromToken} (encoded in token)`);
   }
-  lines.push(`token:      ${report.token} (${report.tokenSource})`);
+  if (report.signedIn) {
+    lines.push(`token:      ${report.token} (${report.tokenSource})`);
+  }
   lines.push(`api:        ${report.apiUrl} (${report.apiUrlSource})`);
-  lines.push(`config:     ${report.configPath}${report.configExists ? "" : " (missing)"}`);
-  if (report.tokenFromEnv) {
-    lines.push("");
-    lines.push("note: token is from the environment, not the config file");
-    lines.push("      uploads logout only clears the config file");
+  lines.push(`config:     ${cfg}`);
+  if (!report.signedIn) {
+    lines.push("", "hint: run uploads login to sign in");
+  } else if (report.tokenSource === "env" && !report.tokenInConfig) {
+    lines.push(
+      "",
+      "note: token is from the environment, not the config file",
+      "      uploads logout only clears the config file",
+    );
   }
   return lines.join("\n") + "\n";
+}
+
+function wantsJson(opts: { json?: boolean }, parsed: ReturnType<typeof parseCommandArgs>): boolean {
+  return Boolean(opts.json || flagBool(parsed.flags, "--json"));
 }
 
 export async function runWhoami(
@@ -142,19 +134,15 @@ export async function runWhoami(
     return 0;
   }
 
-  const path = flagString(parsed.flags, "--path") ?? opts.envFile;
   const report = buildWhoamiReport({
-    envFile: path,
+    envFile: flagString(parsed.flags, "--path") ?? opts.envFile,
     token: opts.token,
     workspace: opts.workspace,
     apiUrl: opts.apiUrl,
   });
 
-  if (opts.json || flagBool(parsed.flags, "--json")) {
-    await writeJson(report);
-  } else {
-    process.stdout.write(formatWhoami(report));
-  }
+  if (wantsJson(opts, parsed)) await writeJson(report);
+  else process.stdout.write(formatWhoami(report));
   return report.signedIn ? 0 : 1;
 }
 
@@ -170,10 +158,8 @@ export async function runLogout(
   }
 
   const path = flagString(parsed.flags, "--path") ?? resolveConfigPath({ envFile: opts.envFile });
-  const before = loadConfigFile(path);
-  const hadFileToken = Boolean(before.UPLOADS_TOKEN);
-  const envToken = Boolean(process.env.UPLOADS_TOKEN);
-
+  const hadFileToken = Boolean(loadConfigFile(path).UPLOADS_TOKEN);
+  const envTokenStillSet = Boolean(process.env.UPLOADS_TOKEN);
   const result = removeConfigKeys(path, ["UPLOADS_TOKEN"]);
 
   const payload = {
@@ -181,10 +167,10 @@ export async function runLogout(
     removed: result.removed,
     configExisted: result.existed,
     hadTokenInConfig: hadFileToken,
-    envTokenStillSet: envToken,
+    envTokenStillSet,
   };
 
-  if (opts.json || flagBool(parsed.flags, "--json")) {
+  if (wantsJson(opts, parsed)) {
     await writeJson(payload);
     return 0;
   }
@@ -197,11 +183,10 @@ export async function runLogout(
     process.stdout.write(`no UPLOADS_TOKEN in ${result.path} — already signed out\n`);
   }
 
-  if (envToken) {
+  if (envTokenStillSet) {
     process.stderr.write(
       "note: UPLOADS_TOKEN is still set in the environment; unset it to fully sign out\n",
     );
   }
-
   return 0;
 }

--- a/packages/uploads/src/commands/setup.ts
+++ b/packages/uploads/src/commands/setup.ts
@@ -15,6 +15,7 @@ import {
 } from "../config.js";
 import { flagBool, flagInt, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
 import { UploadsError } from "../errors.js";
+import { writeCommandHelp } from "../cli-style.js";
 
 const SETUP_HELP = `uploads setup — guided CLI configuration
 
@@ -133,7 +134,7 @@ export async function runSetup(
 ): Promise<number> {
   const parsed = parseCommandArgs(args);
   if (help || parsed.help) {
-    process.stderr.write(SETUP_HELP);
+    writeCommandHelp(SETUP_HELP);
     return 0;
   }
 

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -229,14 +229,7 @@ export function writeConfigKeys(
     }
   }
 
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, lines.join("\n").replace(/\n*$/, "\n"), { encoding: "utf8", mode: 0o600 });
-  renameSync(tmp, path);
-  try {
-    chmodSync(path, 0o600);
-  } catch {
-    /* Windows/filesystems may not support modes. */
-  }
+  writeConfigFileAtomic(path, lines.join("\n"));
   return { path, created: !existed, updated };
 }
 
@@ -263,11 +256,10 @@ export function removeConfigKeys(
   if (!existsSync(path)) return { path, removed: [], existed: false };
 
   const keySet = new Set(keys);
-  const lines = readFileSync(path, "utf8").split("\n");
   const removed: string[] = [];
   const kept: string[] = [];
 
-  for (const line of lines) {
+  for (const line of readFileSync(path, "utf8").split("\n")) {
     const parsed = parseEnvLine(line);
     if (parsed && keySet.has(parsed.key)) {
       if (!removed.includes(parsed.key)) removed.push(parsed.key);
@@ -278,25 +270,22 @@ export function removeConfigKeys(
 
   if (removed.length === 0) return { path, removed: [], existed: true };
 
-  // Collapse excess blank lines left by removals
-  const collapsed: string[] = [];
-  for (const line of kept) {
-    if (line === "" && collapsed.length > 0 && collapsed[collapsed.length - 1] === "") continue;
-    collapsed.push(line);
-  }
+  // Drop consecutive blank lines left by removals
+  const collapsed = kept.filter((line, i) => !(line === "" && i > 0 && kept[i - 1] === ""));
+  writeConfigFileAtomic(path, collapsed.join("\n"));
+  return { path, removed, existed: true };
+}
 
+/** Atomic write + mode 0o600 (best-effort on platforms without chmod). */
+function writeConfigFileAtomic(path: string, body: string): void {
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, collapsed.join("\n").replace(/\n*$/, "\n"), {
-    encoding: "utf8",
-    mode: 0o600,
-  });
+  writeFileSync(tmp, body.replace(/\n*$/, "\n"), { encoding: "utf8", mode: 0o600 });
   renameSync(tmp, path);
   try {
     chmodSync(path, 0o600);
   } catch {
     /* Windows/filesystems may not support modes. */
   }
-  return { path, removed, existed: true };
 }
 
 export { PUT_DEFAULT_KEY_MAP };

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -252,4 +252,51 @@ export function configValuesFromClient(
   return out;
 }
 
+/**
+ * Remove keys from the shared config file (e.g. logout clears UPLOADS_TOKEN).
+ * No-op for missing file/keys. Preserves other lines and comments.
+ */
+export function removeConfigKeys(
+  path: string,
+  keys: readonly string[],
+): { path: string; removed: string[]; existed: boolean } {
+  if (!existsSync(path)) return { path, removed: [], existed: false };
+
+  const keySet = new Set(keys);
+  const lines = readFileSync(path, "utf8").split("\n");
+  const removed: string[] = [];
+  const kept: string[] = [];
+
+  for (const line of lines) {
+    const parsed = parseEnvLine(line);
+    if (parsed && keySet.has(parsed.key)) {
+      if (!removed.includes(parsed.key)) removed.push(parsed.key);
+      continue;
+    }
+    kept.push(line);
+  }
+
+  if (removed.length === 0) return { path, removed: [], existed: true };
+
+  // Collapse excess blank lines left by removals
+  const collapsed: string[] = [];
+  for (const line of kept) {
+    if (line === "" && collapsed.length > 0 && collapsed[collapsed.length - 1] === "") continue;
+    collapsed.push(line);
+  }
+
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, collapsed.join("\n").replace(/\n*$/, "\n"), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(tmp, path);
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    /* Windows/filesystems may not support modes. */
+  }
+  return { path, removed, existed: true };
+}
+
 export { PUT_DEFAULT_KEY_MAP };

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -8,6 +8,7 @@ export {
   loadConfigFile,
   redactToken,
   writeConfigKeys,
+  removeConfigKeys,
   configValuesFromClient,
   putDefaultsToConfigValues,
   resolvePutDefaults,

--- a/packages/uploads/test/cli-style-help.test.ts
+++ b/packages/uploads/test/cli-style-help.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createStyle, formatCommandHelp } from "../src/cli-style.js";
+
+const SAMPLE = `uploads attach <file...> [options]
+
+Upload one or more stable PR/issue attachments.
+
+Options:
+  --pr <num>            Attach to this pull request
+  --issue <num>         Attach to this issue
+  --workspace, -w <name>  Override workspace
+
+Examples:
+  uploads attach ./before.png ./after.png
+  uploads attach ./shot.png --meta app=myapp --meta page=settings
+`;
+
+describe("formatCommandHelp", () => {
+  it("is a no-op for structure when color is off", () => {
+    const text = formatCommandHelp(SAMPLE, createStyle(false));
+    expect(text).toContain("Options:");
+    expect(text).toContain("--pr <num>");
+    expect(text).not.toContain("\u001b[");
+  });
+
+  it("colors synopsis, sections, flags, and examples when enabled", () => {
+    const text = formatCommandHelp(SAMPLE, createStyle(true));
+    // Accent headings
+    expect(text).toContain("\u001b[38;2;194;126;255m");
+    // Green commands/flags
+    expect(text).toContain("\u001b[38;2;143;174;98m");
+    expect(text).toMatch(/Options:/);
+    expect(text).toMatch(/--pr <num>/);
+    expect(text).toMatch(/uploads attach/);
+  });
+});

--- a/packages/uploads/test/commands-session.test.ts
+++ b/packages/uploads/test/commands-session.test.ts
@@ -76,6 +76,8 @@ describe("buildWhoamiReport / runWhoami", () => {
     expect(report.token).toMatch(/set \(/);
     expect(report.token).not.toContain("secrettokenvalue");
     expect(report.tokenInConfig).toBe(true);
+    // --path is resolved as env-file layer
+    expect(report.tokenSource).toBe("env-file");
   });
 
   it("exits 1 when signed out", async () => {

--- a/packages/uploads/test/commands-session.test.ts
+++ b/packages/uploads/test/commands-session.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildWhoamiReport, runLogout, runWhoami } from "../src/commands/session.js";
+import { loadConfigFile, removeConfigKeys, writeConfigKeys } from "../src/config-file.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.UPLOADS_TOKEN;
+  delete process.env.UPLOADS_WORKSPACE;
+  delete process.env.UPLOADS_API_URL;
+});
+
+function capture() {
+  let out = "";
+  let err = "";
+  vi.spyOn(process.stdout, "write").mockImplementation(((v: string | Uint8Array) => {
+    out += String(v);
+    return true;
+  }) as typeof process.stdout.write);
+  vi.spyOn(process.stderr, "write").mockImplementation(((v: string | Uint8Array) => {
+    err += String(v);
+    return true;
+  }) as typeof process.stderr.write);
+  return { out: () => out, err: () => err };
+}
+
+describe("removeConfigKeys", () => {
+  it("removes UPLOADS_TOKEN and preserves other keys", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-logout-"));
+    const path = join(dir, "config");
+    writeConfigKeys(path, {
+      UPLOADS_API_URL: "https://api.uploads.sh",
+      UPLOADS_WORKSPACE: "acme",
+      UPLOADS_TOKEN: "up_acme_secrettokenvalue",
+    });
+    const result = removeConfigKeys(path, ["UPLOADS_TOKEN"]);
+    expect(result.removed).toEqual(["UPLOADS_TOKEN"]);
+    const raw = loadConfigFile(path);
+    expect(raw.UPLOADS_TOKEN).toBeUndefined();
+    expect(raw.UPLOADS_WORKSPACE).toBe("acme");
+    expect(raw.UPLOADS_API_URL).toBe("https://api.uploads.sh");
+  });
+
+  it("is a no-op when the file is missing", () => {
+    const path = join(mkdtempSync(join(tmpdir(), "uploads-logout-")), "missing");
+    expect(removeConfigKeys(path, ["UPLOADS_TOKEN"])).toEqual({
+      path,
+      removed: [],
+      existed: false,
+    });
+  });
+});
+
+describe("buildWhoamiReport / runWhoami", () => {
+  it("reports signed out when no token", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-whoami-"));
+    const path = join(dir, "config");
+    writeFileSync(path, "UPLOADS_WORKSPACE=acme\n");
+    const report = buildWhoamiReport({ envFile: path });
+    expect(report.signedIn).toBe(false);
+    expect(report.workspace).toBe("acme");
+  });
+
+  it("reports signed in with redacted token", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-whoami-"));
+    const path = join(dir, "config");
+    writeConfigKeys(path, {
+      UPLOADS_TOKEN: "up_acme_secrettokenvalue",
+      UPLOADS_WORKSPACE: "acme",
+    });
+    const report = buildWhoamiReport({ envFile: path });
+    expect(report.signedIn).toBe(true);
+    expect(report.workspace).toBe("acme");
+    expect(report.token).toMatch(/set \(/);
+    expect(report.token).not.toContain("secrettokenvalue");
+    expect(report.tokenInConfig).toBe(true);
+  });
+
+  it("exits 1 when signed out", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-whoami-"));
+    const path = join(dir, "empty");
+    writeFileSync(path, "");
+    const io = capture();
+    const code = await runWhoami([], { envFile: path });
+    expect(code).toBe(1);
+    expect(io.out()).toMatch(/signed in:\s+no/);
+    expect(io.out()).toMatch(/uploads login/);
+  });
+
+  it("exits 0 and prints whoami when signed in", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-whoami-"));
+    const path = join(dir, "config");
+    writeConfigKeys(path, { UPLOADS_TOKEN: "up_acme_secrettokenvalue" });
+    const io = capture();
+    const code = await runWhoami([], { envFile: path });
+    expect(code).toBe(0);
+    expect(io.out()).toMatch(/signed in:\s+yes/);
+    expect(io.out()).toMatch(/workspace:/);
+  });
+
+  it("prints help", async () => {
+    const io = capture();
+    expect(await runWhoami([], {}, true)).toBe(0);
+    expect(io.err()).toMatch(/uploads whoami/);
+  });
+});
+
+describe("runLogout", () => {
+  it("removes the token from the config file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-logout-"));
+    const path = join(dir, "config");
+    writeConfigKeys(path, {
+      UPLOADS_TOKEN: "up_acme_secrettokenvalue",
+      UPLOADS_WORKSPACE: "acme",
+    });
+    const io = capture();
+    const code = await runLogout(["--path", path], {});
+    expect(code).toBe(0);
+    expect(io.out()).toMatch(/signed out/);
+    expect(loadConfigFile(path).UPLOADS_TOKEN).toBeUndefined();
+    expect(loadConfigFile(path).UPLOADS_WORKSPACE).toBe("acme");
+    // file still exists and is not empty of other keys
+    expect(readFileSync(path, "utf8")).toMatch(/UPLOADS_WORKSPACE/);
+  });
+
+  it("notes when env token remains", async () => {
+    process.env.UPLOADS_TOKEN = "up_env_only_token_value";
+    const dir = mkdtempSync(join(tmpdir(), "uploads-logout-"));
+    const path = join(dir, "config");
+    writeFileSync(path, "UPLOADS_WORKSPACE=acme\n");
+    const io = capture();
+    await runLogout(["--path", path], {});
+    expect(io.err()).toMatch(/environment/);
+  });
+
+  it("prints help", async () => {
+    const io = capture();
+    expect(await runLogout([], {}, true)).toBe(0);
+    expect(io.err()).toMatch(/uploads logout/);
+  });
+});


### PR DESCRIPTION
## In plain terms

Command-level help was plain while the root overview had brand hierarchy. This styles every command `--help` the same way, adds `--meta` to overview examples, and fills the session gap with **whoami/status** and **logout**.

## What it does

- Shared `formatCommandHelp` styles synopsis, section headings, flags, and example lines
- Overview examples include `--meta app=… --meta page=…` (put + attach)
- **`uploads whoami`** (alias **`status`**) — offline identity: workspace, redacted token, sources, config path; exit 1 when signed out
- **`uploads logout`** — removes `UPLOADS_TOKEN` from the config file; warns if env still sets a token
- `removeConfigKeys` + shared atomic config write helper

## What it is not

- Not multi-workspace profiles (tokens remain single-workspace). Tracked separately: https://github.com/buildinternet/uploads/issues/183
- Not a rewrite of help copy — styling is applied at print time

## How to try it

```bash
uploads attach --help
uploads whoami
uploads logout
uploads login
uploads whoami
```

## Follow-up

- Multi-workspace profiles / switch default: #183

## Test plan

- [x] Package tests (session, style-help, attach, help)
- [ ] Visual: `uploads attach --help` and `uploads whoami` in a TTY