### PR TITLE
feat(web): default the invite page to the code-stdin login flow

### DIFF
--- a/apps/web/src/pages/invite.astro
+++ b/apps/web/src/pages/invite.astro
@@ -25,9 +25,10 @@ import Footer from "../components/Footer.astro";
     <ol>
       <li>Install<div class="command"><code>npm install --global @buildinternet/uploads</code><button data-copy="npm install --global @buildinternet/uploads" aria-live="polite">copy</button></div></li>
       <li>Log in<div class="command"><code id="login-cmd">uploads login</code><button id="login-copy" data-copy="uploads login" aria-live="polite">copy</button></div></li>
+      <li id="code-step" hidden>Paste your code at the prompt<div class="command"><code id="code-value"></code><button id="code-copy" aria-live="polite">copy</button></div></li>
     </ol>
   </section>
-  <p class="security">Treat this link like a password — it's single-use and stops working once you log in.</p>
+  <p class="security">Treat this link like a password — it's single-use and stops working once you log in. Pasting the code at the prompt keeps it out of your shell history.</p>
   <Footer compact />
 </main>
 <script>
@@ -50,9 +51,15 @@ import Footer from "../components/Footer.astro";
   if (url.hash) history.replaceState(null, "", url.pathname + url.search);
 
   if (/^upe_[A-Za-z0-9_-]{20,}$/.test(code)) {
-    const command = `uploads login --code ${code}`;
+    // --code-stdin keeps the code out of shell history: the command itself
+    // carries no secret, and the code is pasted at the CLI's stdin prompt.
+    const command = "uploads login --code-stdin";
     loginCmd.textContent = command;
     loginCopy.dataset.copy = command;
+    const codeStep = requireElement<HTMLElement>("#code-step");
+    requireElement<HTMLElement>("#code-value").textContent = code;
+    requireElement<HTMLButtonElement>("#code-copy").dataset.copy = code;
+    codeStep.hidden = false;
   }
 
   async function checkInvitation() {


### PR DESCRIPTION
Last of the onboarding-walkthrough hygiene items (after #176/#177/#179/#181). The /invite page baked the one-time `upe_` enrollment code into the copyable login command, so redeeming an invite put a password-equivalent secret into the user's shell history.

## What changed

When the page has a code in the URL fragment, the login step is now the secret-free `uploads login --code-stdin`, and the code becomes its own copyable step ("Paste your code at the prompt"). The CLI already reads the code from stdin in this mode, so nothing secret ever appears on a command line. The security note now explains why.

Note on the alternative: a `printf '%s' upe_… | uploads login --code-stdin` one-liner was rejected because the code would still land in shell history — the paste-at-prompt flow is the only genuinely history-safe shape.

No behavior change when the fragment carries no code (the plain `uploads login` row stays). Fragment scrubbing from the address bar is unchanged.

## Verified

Loaded /invite with a synthetic fragment code in the dev server: login row reads `uploads login --code-stdin` with matching copy payload, the code step is visible with the code as its copy payload, and `location.hash` is scrubbed.
