### PR TITLE
docs: align CLI examples with real output

### DIFF
--- a/.changeset/cli-docs-consistency.md
+++ b/.changeset/cli-docs-consistency.md
@@ -1,0 +1,8 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Docs: correct CLI examples to match real output. Optimize notes now show human
+sizes (`411.5 KB → 94.2 KB`) instead of raw bytes, `--pr` example keys reflect
+the WebP extension rewrite, and the README command list includes `login`,
+`whoami`/`status`, `logout`, `invite`, and `admin`.

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -346,9 +346,9 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
         </div>
         <div class="block" aria-label="Example output">
           <pre>&gt;&gt; uploading ./before.png
-&gt;&gt; optimized 421337 → 96412 bytes (before.webp)
+&gt;&gt; optimized 411.5 KB → 94.2 KB (before.webp)
 &gt;&gt; uploading ./after.png
-&gt;&gt; optimized 407190 → 91205 bytes (after.webp)
+&gt;&gt; optimized 397.6 KB → 89.1 KB (after.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/before.webp</span>
 MARKDOWN: ![before.png](https://storage.uploads.sh/gh/you/app/pull/123/before.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</span>
@@ -478,7 +478,7 @@ MARKDOWN: ![after.png](https://storage.uploads.sh/gh/you/app/pull/123/after.webp
         </div>
         <div class="block" aria-label="Example output">
           <pre>&gt;&gt; uploading ./shot.png
-&gt;&gt; optimized 421337 → 96412 bytes (shot.webp)
+&gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
 &gt;&gt; key: screenshots/app/2026-07-12/shot-9f2c1a.webp
 
 URL: <span class="v">https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp</span>

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -308,9 +308,9 @@ const FAQ_JSON_LD = JSON.stringify({
         </div>
         <div class="block" aria-label="Example output">
           <pre>&gt;&gt; uploading ./before.png
-&gt;&gt; optimized 421337 → 96412 bytes (before.webp)
+&gt;&gt; optimized 411.5 KB → 94.2 KB (before.webp)
 &gt;&gt; uploading ./after.png
-&gt;&gt; optimized 407190 → 91205 bytes (after.webp)
+&gt;&gt; optimized 397.6 KB → 89.1 KB (after.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/before.webp</span>
 MARKDOWN: ![before.png](https://storage.uploads.sh/gh/you/app/pull/123/before.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/pull/123/after.webp</span>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,25 +1,53 @@
 # CLI guide
 
 The `@buildinternet/uploads` package wraps the API for scripting and GitHub
-image embeds. Examples use the global `uploads` binary (same as after
-`npm install -g @buildinternet/uploads`).
+image embeds. Examples use the global `uploads` binary; install it with
+`npm install -g @buildinternet/uploads`. Inside this monorepo only,
+`pnpm uploads …` builds the package first so you pick up local source.
+
+This guide covers the everyday flows. For the exhaustive command list, globals,
+and exit codes, run `uploads help --all` or see
+[`packages/uploads/README.md`](../packages/uploads/README.md).
+
+## Getting started
 
 ```bash
-uploads put ./shot.png
-# stdout: public URL + ready-to-paste markdown; stderr: human summary
+uploads login          # sign in via browser; saves your workspace token, then runs doctor
+uploads whoami         # show the active workspace + token (alias: uploads status)
+uploads install        # install the agent skill + register the hosted MCP server
+uploads put ./shot.png # stdout: public URL + ready-to-paste markdown; stderr: human summary
 ```
 
-Inside this monorepo only, `pnpm uploads …` builds the package first so you
-pick up local source.
-
-## Tokens
-
-An uploads.sh administrator invites your email to a workspace; `uploads login`
-opens a browser to sign in (GitHub or a magic link) and saves the resulting
-workspace token. For local development, `pnpm workspace:add` prints a bearer
-token once — save it with `uploads setup --token <token>` or into `.env` /
-user config. Routine agents never receive or need `ADMIN_TOKEN`. See
+An uploads.sh administrator invites your email to a workspace first; `login`
+trades that invite for a saved workspace token (GitHub or a magic link) and
+`logout` removes it. `uploads doctor` checks health, auth, and workspace access
+when something's off. Routine agents never receive or need `ADMIN_TOKEN`. See
 [enrollment](enrollment.md).
+
+For local development, `pnpm workspace:add` prints a bearer token once — save it
+with `uploads setup --token <token>` or into `.env` / user config.
+
+## Command overview
+
+| Command                 | What it does                                             |
+| ----------------------- | -------------------------------------------------------- |
+| `attach <file…>`        | Attach media to the current PR (stable URLs + comment)   |
+| `put <file>`            | Upload one file → public URL + GitHub markdown           |
+| `comment`               | Create/update a PR/issue attachments comment (via `gh`)  |
+| `list` / `find k=v`     | List objects, optionally filtered by queryable metadata  |
+| `meta get` / `meta set` | Read or merge-set an object's queryable metadata         |
+| `gallery …`             | Create and organize public media galleries               |
+| `delete <key>`          | Delete an object                                         |
+| `usage`                 | Workspace storage / upload counters                      |
+| `install`               | Install the agent skill + register the remote MCP server |
+| `login` / `logout`      | Sign in (browser or enrollment code) / clear saved token |
+| `whoami` (`status`)     | Show the active workspace and token                      |
+| `invite`                | Invite a teammate to a workspace (workspace admin)       |
+| `doctor` / `health`     | Health + auth + workspace checks / API liveness          |
+| `setup` / `config`      | Inspect and configure CLI settings                       |
+| `mcp`                   | Serve MCP over stdio (tools mirror the CLI)              |
+
+Run `uploads <command> --help` for per-command flags.
 
 ## How keys work
 
@@ -38,8 +66,8 @@ uploads --version
 uploads doctor
 ```
 
-See [`packages/uploads/README.md`](../packages/uploads/README.md) for globals
-(`--version`, update hints, quiet/json) and the full command list.
+Globals like `--json`, `--quiet`, and update hints are covered in
+[`packages/uploads/README.md`](../packages/uploads/README.md).
 
 ## GitHub embeds
 
@@ -52,7 +80,7 @@ re-uploading the same filename overwrites in place and the URL never changes:
 
 ```bash
 uploads put ./after.png --pr 123 --alt "Dashboard after"
-# key: gh/<owner>/<repo>/pull/123/after.png
+# key: gh/<owner>/<repo>/pull/123/after.webp  (PNG optimized to WebP; extension follows the output)
 ```
 
 **Managed attachments comment** (`--comment`, requires local `gh` auth)

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -38,8 +38,8 @@ up local source; product docs and PR “how to try it” examples should use the
 global `uploads` form above.
 
 Commands: `attach`, `put`, `gallery`, `comment`, `list`, `find`, `meta`, `delete`, `usage`,
-`reconcile`, `purge-expired`, `setup`, `install`, `config`, `doctor`, `health`, `mcp`,
-`completion`.
+`reconcile`, `purge-expired`, `setup`, `install`, `login`, `whoami` (alias `status`),
+`logout`, `invite`, `admin`, `config`, `doctor`, `health`, `mcp`, `completion`.
 
 **Help:** bare `uploads` / `uploads help` / `--help` shows essentials; use
 `uploads help --all` (or `--help --all`) for the full command list. Per-command:

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -298,7 +298,7 @@ URL is safe to hard-code in a PR body you'll edit later:
 
 ```bash
 uploads put ./after.png --pr 123 --alt "Dashboard after"
-# key: gh/<owner>/<repo>/pull/123/after.png  → stable public URL
+# key: gh/<owner>/<repo>/pull/123/after.webp  → stable public URL (PNG optimized to WebP)
 ```
 
 `--issue <num>` does the same under `.../issues/<num>/`. The `<owner>/<repo>` comes


### PR DESCRIPTION
## What

A documentation pass focused on making the CLI examples consistent with the CLI's real output — and filling gaps where recently-added commands weren't documented.

## Why

The home-page terminal was already updated to show the CLI's real, human-readable output, but the **inner site pages and reference docs still showed the old format**. This aligns everything (home, `/docs`, `/github-screenshots`, `docs/cli.md`, the package README, and the agent skill) against the actual CLI source.

## Changes

**Output format consistency (the main fix)**
- `apps/web/src/pages/docs.astro` and `apps/web/src/pages/github-screenshots.astro`: optimize notes now show human sizes (`optimized 411.5 KB → 94.2 KB`) instead of raw bytes (`421337 → 96412 bytes`), matching the home page and the real CLI. Verified against `packages/uploads/src/format-bytes.ts` — those byte values format to exactly these KB figures.

**Example accuracy**
- `docs/cli.md`, `skills/uploads-cli/SKILL.md`: `--pr` example resulting keys now show the `.webp` extension the optimizer rewrites to (the web pages already showed this).

**Coverage gaps**
- `packages/uploads/README.md`: command list now includes `login`, `whoami`/`status`, `logout`, `invite`, and `admin` (were missing).
- `docs/cli.md`: added a **Getting started** flow (`login` → `whoami` → `install` → `put`) and a **Command overview** table, so `install`/`whoami`/`logout` are documented rather than absent.

## Verification

Ran the web dev server and grepped the live-rendered HTML of both inner pages: both now emit `411.5 KB → 94.2 KB` / `397.6 KB → 89.1 KB`, with zero stale `bytes (` occurrences remaining anywhere in the web app.

## Notes

- Historical `docs/superpowers/{plans,specs}` design records were left untouched (dated records, not live docs).
- Kept the CLI guide as one restructured page rather than splitting into multiple files, to avoid cross-link churn.
