### PR TITLE
feat: CLI telemetry and opt-in diagnostic reports

### DIFF
--- a/.changeset/cli-telemetry.md
+++ b/.changeset/cli-telemetry.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Anonymous, opt-out usage telemetry for the CLI and MCP server (command name, version, OS/arch, exit code, duration, optional error code — never paths or tokens). Opt out with `UPLOADS_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, or `uploads telemetry disable`.
+
+Also adds explicit opt-in diagnostic reports: `uploads report` and the MCP `report` tool can send a short message plus an optional text log/trace (max 256 KiB) when the user asks — never automatic.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Client-side settings for talking to the uploads API from scripts, skills,
 # and tests. Copy to .env (gitignored) and fill in.
 #
+# Anonymous CLI usage telemetry (command names only) is on by default.
+# Opt out: UPLOADS_TELEMETRY_DISABLED=1  (or DO_NOT_TRACK=1)
+#
 # For personal CLI defaults, prefer the shared buildinternet config instead:
 #   ~/.config/buildinternet/config   (see packages/uploads/config.example)
 #   uploads login

--- a/apps/api/migrations/20260715120000_uploads_cli_observability.sql
+++ b/apps/api/migrations/20260715120000_uploads_cli_observability.sql
@@ -1,0 +1,50 @@
+-- CLI/MCP observability on the shared uploads D1 (same binding as auth/galleries).
+-- Two tables, one database:
+--   uploads_telemetry_events  — automatic command-name pings (high volume, no free text)
+--   uploads_cli_reports       — explicit opt-in messages (+ optional R2 log attachment)
+--
+-- Why D1 (not KV): append + aggregate (counts by command/error/day). KV is a poor fit
+-- for "list recent / group by". Report blobs stay in R2; only metadata is here.
+
+CREATE TABLE uploads_telemetry_events (
+  id          TEXT PRIMARY KEY NOT NULL,
+  anon_id     TEXT NOT NULL,
+  timestamp   INTEGER NOT NULL,
+  surface     TEXT NOT NULL,
+  client_kind TEXT NOT NULL,
+  agent_name  TEXT,
+  command     TEXT NOT NULL,
+  exit_code   INTEGER,
+  duration_ms INTEGER,
+  error_code  TEXT,
+  cli_version TEXT NOT NULL,
+  os          TEXT,
+  arch        TEXT,
+  runtime     TEXT,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX uploads_telemetry_events_ts_idx ON uploads_telemetry_events (timestamp);
+CREATE INDEX uploads_telemetry_events_cmd_idx ON uploads_telemetry_events (command);
+
+CREATE TABLE uploads_cli_reports (
+  id                   TEXT PRIMARY KEY NOT NULL,
+  created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  message              TEXT NOT NULL,
+  type                 TEXT NOT NULL,
+  contact              TEXT,
+  surface              TEXT NOT NULL,
+  client_kind          TEXT,
+  anon_id              TEXT,
+  cli_version          TEXT,
+  os                   TEXT,
+  arch                 TEXT,
+  runtime              TEXT,
+  command              TEXT,
+  error_code           TEXT,
+  attachment_key       TEXT,
+  attachment_filename  TEXT,
+  attachment_bytes     INTEGER
+);
+
+CREATE INDEX uploads_cli_reports_created_idx ON uploads_cli_reports (created_at);

--- a/apps/api/src/cli-intake.ts
+++ b/apps/api/src/cli-intake.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared helpers for CLI/MCP intake routes (`/v1/telemetry`, `/v1/reports`).
+ * Keep field allowlists and sanitizers in one place.
+ */
+
+export const MAX_STRING = 200;
+export const MAX_COMMAND = 120;
+export const MAX_VERSION = 32;
+export const MAX_ANON_ID = 64;
+export const MAX_ERROR_CODE = 64;
+export const MAX_ATTACHMENT_BYTES = 256 * 1024;
+
+export const SURFACES = new Set(["cli", "mcp"]);
+export const CLIENT_KINDS = new Set(["external", "ci", "agent"]);
+export const REPORT_TYPES = new Set(["bug", "error", "idea", "other"]);
+
+/** Allowlisted CLI error codes. Unknown values are dropped (never free-form). */
+export const ERROR_CODES = new Set([
+  "MISSING_TOKEN",
+  "NO_PUBLIC_URL",
+  "FILE_NOT_FOUND",
+  "NOT_FOUND",
+  "UNAUTHORIZED",
+  "INVALID_KEY",
+  "KEY_POLICY",
+  "STORAGE_QUOTA",
+  "UPLOAD_BUDGET",
+  "GITHUB_REQUIRED",
+  "API_ERROR",
+  "NETWORK",
+  "USAGE",
+]);
+
+export function sanitizeString(value: unknown, max: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, max);
+}
+
+export function sanitizeInt(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return Math.trunc(n);
+  }
+  return null;
+}
+
+/** Drop C0 controls except tab/LF/CR (terminal-safe stored text). */
+export function stripControl(value: string): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    if (code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127)) out += ch;
+  }
+  return out;
+}
+
+export function pickSurface(value: unknown, fallback = "cli"): string {
+  const s = sanitizeString(value, 16) ?? fallback;
+  return SURFACES.has(s) ? s : fallback;
+}
+
+export function pickClientKind(value: unknown): string {
+  const s = sanitizeString(value, 32) ?? "external";
+  return CLIENT_KINDS.has(s) ? s : "external";
+}
+
+export function pickErrorCode(value: unknown): string | null {
+  const raw = sanitizeString(value, MAX_ERROR_CODE);
+  return raw && ERROR_CODES.has(raw) ? raw : null;
+}
+
+export function pickReportType(value: unknown): string {
+  const raw = sanitizeString(value, 32) ?? "other";
+  return REPORT_TYPES.has(raw) ? raw : "other";
+}
+
+export function safeFilename(raw: string | null): string {
+  const base = (raw ?? "attachment.txt")
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()!
+    .replace(/[^\w.\-+=@]+/g, "_")
+    .slice(0, 120);
+  return base.length > 0 ? base : "attachment.txt";
+}
+
+export function envFlagOn(value: string | undefined): boolean {
+  return value === "1" || value === "true";
+}
+
+export function newId(prefix: "tel" | "rpt"): string {
+  return `${prefix}_${crypto.randomUUID().replace(/-/g, "")}`;
+}

--- a/apps/api/src/cli-intake.ts
+++ b/apps/api/src/cli-intake.ts
@@ -2,6 +2,7 @@
  * Shared helpers for CLI/MCP intake routes (`/v1/telemetry`, `/v1/reports`).
  * Keep field allowlists and sanitizers in one place.
  */
+import { PayloadTooLargeError, ValidationError } from "@uploads/errors";
 
 export const MAX_STRING = 200;
 export const MAX_COMMAND = 120;
@@ -9,6 +10,10 @@ export const MAX_VERSION = 32;
 export const MAX_ANON_ID = 64;
 export const MAX_ERROR_CODE = 64;
 export const MAX_ATTACHMENT_BYTES = 256 * 1024;
+/** Telemetry JSON is tiny (no free text). */
+export const MAX_TELEMETRY_BODY_BYTES = 8 * 1024;
+/** Report JSON = short message + optional 256 KiB text attachment. */
+export const MAX_REPORT_BODY_BYTES = MAX_ATTACHMENT_BYTES + 8 * 1024;
 
 export const SURFACES = new Set(["cli", "mcp"]);
 export const CLIENT_KINDS = new Set(["external", "ci", "agent"]);
@@ -38,13 +43,53 @@ export function sanitizeString(value: unknown, max: number): string | null {
   return trimmed.slice(0, max);
 }
 
+/**
+ * Parse a finite integer within JavaScript's safe integer range.
+ * Returns null for invalid / non-safe values (callers apply field ranges).
+ */
 export function sanitizeInt(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value);
-  if (typeof value === "string" && value.trim() !== "") {
-    const n = Number(value);
-    if (Number.isFinite(n)) return Math.trunc(n);
+  let n: number | null = null;
+  if (typeof value === "number" && Number.isFinite(value)) n = Math.trunc(value);
+  else if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) n = Math.trunc(parsed);
   }
-  return null;
+  if (n === null || !Number.isSafeInteger(n)) return null;
+  return n;
+}
+
+/** Keep only when in [min, max] inclusive. */
+export function clampInt(value: number | null, min: number, max: number): number | null {
+  if (value === null || value < min || value > max) return null;
+  return value;
+}
+
+/**
+ * Read and parse a JSON object body with Content-Length + buffer size caps.
+ * Rejects null, arrays, and non-objects.
+ */
+export async function readJsonObjectBody(
+  req: Request,
+  maxBytes: number,
+): Promise<Record<string, unknown>> {
+  const declared = Number(req.headers.get("Content-Length") ?? 0);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new PayloadTooLargeError(`request body exceeds ${maxBytes} bytes`);
+  }
+  const bytes = await req.arrayBuffer();
+  if (bytes.byteLength > maxBytes) {
+    throw new PayloadTooLargeError(`request body exceeds ${maxBytes} bytes`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new ValidationError("invalid JSON body");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new ValidationError("invalid JSON body");
+  }
+  return parsed as Record<string, unknown>;
 }
 
 /** Drop C0 controls except tab/LF/CR (terminal-safe stored text). */

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -14,4 +14,14 @@ interface Env {
    * storage/store.uploads.sh; empty = never emit embedUrl; URL = self-host.
    */
   EMBED_PUBLIC_BASE_URL?: string;
+  /**
+   * Kill switch for anonymous CLI/MCP telemetry intake (`POST /v1/telemetry`).
+   * Set to "1" or "true" to accept and drop events without writing D1.
+   */
+  TELEMETRY_DISABLED?: string;
+  /**
+   * Kill switch for explicit diagnostic reports (`POST /v1/reports`).
+   * Set to "1" or "true" to reject new reports.
+   */
+  REPORTS_DISABLED?: string;
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,8 @@ import { runRetentionSweep } from "./retention-sweep";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";
+import { telemetry } from "./routes/telemetry";
+import { reports } from "./routes/reports";
 
 // Lets the browser console on the web origin (and local dev) call the token-
 // authenticated endpoints. CORS is not the security boundary — bearer tokens
@@ -69,6 +71,10 @@ export const app = new Hono<WorkspaceVars>()
   // brings its own session auth. See routes/tokens.ts.
   .route("/v1/tokens", tokens)
   .route("/v1/workspaces", workspaces)
+  // Anonymous CLI/MCP usage pings — no auth, before workspace guard.
+  .route("/v1/telemetry", telemetry)
+  // Explicit opt-in diagnostic reports (message + optional log) — no auth.
+  .route("/v1/reports", reports)
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/galleries", galleries)
   .route("/v1/:workspace/files", files)

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,149 @@
+/**
+ * Explicit diagnostic reports → D1 `uploads_cli_reports` (+ optional R2 log).
+ * Never automatic — requires `uploads report` / MCP `report`.
+ */
+import { PayloadTooLargeError, RateLimitedError, ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import {
+  MAX_ANON_ID,
+  MAX_ATTACHMENT_BYTES,
+  MAX_COMMAND,
+  MAX_STRING,
+  MAX_VERSION,
+  envFlagOn,
+  newId,
+  pickClientKind,
+  pickErrorCode,
+  pickReportType,
+  pickSurface,
+  safeFilename,
+  sanitizeString,
+  stripControl,
+} from "../cli-intake";
+import type { WorkspaceVars } from "../workspace";
+
+export { MAX_ATTACHMENT_BYTES };
+
+export const reports = new Hono<WorkspaceVars>();
+
+reports.post("/", async (c) => {
+  if (envFlagOn(c.env.REPORTS_DISABLED)) {
+    throw new ValidationError("report intake is disabled", { code: "reports_disabled" });
+  }
+
+  const limiter = c.env.INVITE_LIMITER;
+  if (limiter) {
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    const { success } = await limiter.limit({ key: `cli-report:${ip}` });
+    if (!success) {
+      c.header("Retry-After", "60");
+      throw new RateLimitedError("too many reports; retry shortly");
+    }
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await c.req.json()) as Record<string, unknown>;
+  } catch {
+    throw new ValidationError("invalid JSON body");
+  }
+
+  const rawMessage = sanitizeString(body.message, 4000);
+  const message = rawMessage ? stripControl(rawMessage).trim() : null;
+  if (!message || message.length < 5) {
+    throw new ValidationError("message must be 5–4000 characters", { code: "bad_request" });
+  }
+
+  const type = pickReportType(body.type);
+  const contactRaw = sanitizeString(body.contact, 200);
+  const contact = contactRaw ? stripControl(contactRaw).trim() || null : null;
+  const surface = pickSurface(body.surface);
+  const clientKind = pickClientKind(body.clientKind);
+  const id = newId("rpt");
+
+  let attachmentKey: string | null = null;
+  let attachmentFilename: string | null = null;
+  let attachmentBytes: number | null = null;
+
+  if (body.attachment != null) {
+    if (typeof body.attachment !== "object" || Array.isArray(body.attachment)) {
+      throw new ValidationError("attachment must be an object", { code: "bad_request" });
+    }
+    const att = body.attachment as Record<string, unknown>;
+    if (typeof att.body !== "string" || !att.body) {
+      throw new ValidationError("attachment.body is required", { code: "bad_request" });
+    }
+    const bytes = new TextEncoder().encode(att.body);
+    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+      throw new PayloadTooLargeError(`attachment exceeds ${MAX_ATTACHMENT_BYTES} bytes`, {
+        code: "attachment_too_large",
+      });
+    }
+    const contentType = sanitizeString(att.contentType, 100) ?? "text/plain; charset=utf-8";
+    if (
+      !contentType.startsWith("text/") &&
+      contentType !== "application/json" &&
+      contentType !== "application/x-ndjson" &&
+      !contentType.startsWith("application/json")
+    ) {
+      throw new ValidationError("attachment content type must be text or json", {
+        code: "unsupported_attachment_type",
+      });
+    }
+    const r2 = c.env.UPLOADS_DEFAULT;
+    if (!r2) {
+      throw new ValidationError("report attachments unavailable (no R2 binding)", {
+        code: "attachment_unavailable",
+      });
+    }
+    const filename = safeFilename(sanitizeString(att.filename, 120));
+    attachmentKey = `_internal/uploads-cli-reports/${id}/${filename}`;
+    attachmentFilename = filename;
+    attachmentBytes = bytes.byteLength;
+    await r2.put(attachmentKey, bytes, {
+      httpMetadata: { contentType },
+      customMetadata: { reportId: id, surface, type },
+    });
+  }
+
+  if (c.env.DB) {
+    try {
+      await c.env.DB.prepare(
+        `INSERT INTO uploads_cli_reports (
+          id, message, type, contact, surface, client_kind, anon_id,
+          cli_version, os, arch, runtime, command, error_code,
+          attachment_key, attachment_filename, attachment_bytes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          id,
+          message,
+          type,
+          contact,
+          surface,
+          clientKind,
+          sanitizeString(body.anonId, MAX_ANON_ID),
+          sanitizeString(body.cliVersion, MAX_VERSION),
+          sanitizeString(body.os, MAX_STRING),
+          sanitizeString(body.arch, MAX_STRING),
+          sanitizeString(body.runtime, MAX_STRING),
+          sanitizeString(body.command, MAX_COMMAND),
+          pickErrorCode(body.errorCode),
+          attachmentKey,
+          attachmentFilename,
+          attachmentBytes,
+        )
+        .run();
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          message: "uploads_cli_reports insert failed",
+          error: err instanceof Error ? err.message : String(err),
+          id,
+        }),
+      );
+    }
+  }
+
+  return c.json({ ok: true, id, hasAttachment: Boolean(attachmentKey) }, 202);
+});

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -2,12 +2,19 @@
  * Explicit diagnostic reports → D1 `uploads_cli_reports` (+ optional R2 log).
  * Never automatic — requires `uploads report` / MCP `report`.
  */
-import { PayloadTooLargeError, RateLimitedError, ValidationError } from "@uploads/errors";
+import {
+  InternalError,
+  PayloadTooLargeError,
+  RateLimitedError,
+  ServiceUnavailableError,
+  ValidationError,
+} from "@uploads/errors";
 import { Hono } from "hono";
 import {
   MAX_ANON_ID,
   MAX_ATTACHMENT_BYTES,
   MAX_COMMAND,
+  MAX_REPORT_BODY_BYTES,
   MAX_STRING,
   MAX_VERSION,
   envFlagOn,
@@ -16,6 +23,7 @@ import {
   pickErrorCode,
   pickReportType,
   pickSurface,
+  readJsonObjectBody,
   safeFilename,
   sanitizeString,
   stripControl,
@@ -41,12 +49,11 @@ reports.post("/", async (c) => {
     }
   }
 
-  let body: Record<string, unknown>;
-  try {
-    body = (await c.req.json()) as Record<string, unknown>;
-  } catch {
-    throw new ValidationError("invalid JSON body");
+  if (!c.env.DB) {
+    throw new ServiceUnavailableError("report storage unavailable");
   }
+
+  const body = await readJsonObjectBody(c.req.raw, MAX_REPORT_BODY_BYTES);
 
   const rawMessage = sanitizeString(body.message, 4000);
   const message = rawMessage ? stripControl(rawMessage).trim() : null;
@@ -61,8 +68,10 @@ reports.post("/", async (c) => {
   const clientKind = pickClientKind(body.clientKind);
   const id = newId("rpt");
 
-  let attachmentKey: string | null = null;
+  let attachmentBytesPayload: Uint8Array | null = null;
   let attachmentFilename: string | null = null;
+  let attachmentContentType: string | null = null;
+  let attachmentKey: string | null = null;
   let attachmentBytes: number | null = null;
 
   if (body.attachment != null) {
@@ -90,8 +99,7 @@ reports.post("/", async (c) => {
         code: "unsupported_attachment_type",
       });
     }
-    const r2 = c.env.UPLOADS_DEFAULT;
-    if (!r2) {
+    if (!c.env.UPLOADS_DEFAULT) {
       throw new ValidationError("report attachments unavailable (no R2 binding)", {
         code: "attachment_unavailable",
       });
@@ -99,49 +107,72 @@ reports.post("/", async (c) => {
     const filename = safeFilename(sanitizeString(att.filename, 120));
     attachmentKey = `_internal/uploads-cli-reports/${id}/${filename}`;
     attachmentFilename = filename;
+    attachmentContentType = contentType;
     attachmentBytes = bytes.byteLength;
-    await r2.put(attachmentKey, bytes, {
-      httpMetadata: { contentType },
-      customMetadata: { reportId: id, surface, type },
-    });
+    attachmentBytesPayload = bytes;
   }
 
-  if (c.env.DB) {
-    try {
-      await c.env.DB.prepare(
-        `INSERT INTO uploads_cli_reports (
-          id, message, type, contact, surface, client_kind, anon_id,
-          cli_version, os, arch, runtime, command, error_code,
-          attachment_key, attachment_filename, attachment_bytes
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  // Persist metadata first so a successful response always has a D1 row.
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO uploads_cli_reports (
+        id, message, type, contact, surface, client_kind, anon_id,
+        cli_version, os, arch, runtime, command, error_code,
+        attachment_key, attachment_filename, attachment_bytes
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        id,
+        message,
+        type,
+        contact,
+        surface,
+        clientKind,
+        sanitizeString(body.anonId, MAX_ANON_ID),
+        sanitizeString(body.cliVersion, MAX_VERSION),
+        sanitizeString(body.os, MAX_STRING),
+        sanitizeString(body.arch, MAX_STRING),
+        sanitizeString(body.runtime, MAX_STRING),
+        sanitizeString(body.command, MAX_COMMAND),
+        pickErrorCode(body.errorCode),
+        attachmentKey,
+        attachmentFilename,
+        attachmentBytes,
       )
-        .bind(
-          id,
-          message,
-          type,
-          contact,
-          surface,
-          clientKind,
-          sanitizeString(body.anonId, MAX_ANON_ID),
-          sanitizeString(body.cliVersion, MAX_VERSION),
-          sanitizeString(body.os, MAX_STRING),
-          sanitizeString(body.arch, MAX_STRING),
-          sanitizeString(body.runtime, MAX_STRING),
-          sanitizeString(body.command, MAX_COMMAND),
-          pickErrorCode(body.errorCode),
-          attachmentKey,
-          attachmentFilename,
-          attachmentBytes,
-        )
-        .run();
+      .run();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "uploads_cli_reports insert failed",
+        error: err instanceof Error ? err.message : String(err),
+        id,
+      }),
+    );
+    throw new InternalError("failed to persist report");
+  }
+
+  // Attachment after D1 so failures don't orphan objects without a row.
+  // If R2 fails, delete the D1 row so we never report success without a complete write.
+  if (attachmentBytesPayload && attachmentKey && c.env.UPLOADS_DEFAULT) {
+    try {
+      await c.env.UPLOADS_DEFAULT.put(attachmentKey, attachmentBytesPayload, {
+        httpMetadata: { contentType: attachmentContentType ?? "text/plain; charset=utf-8" },
+        customMetadata: { reportId: id, surface, type },
+      });
     } catch (err) {
       console.error(
         JSON.stringify({
-          message: "uploads_cli_reports insert failed",
+          message: "report attachment put failed",
           error: err instanceof Error ? err.message : String(err),
           id,
         }),
       );
+      try {
+        await c.env.DB.prepare("DELETE FROM uploads_cli_reports WHERE id = ?").bind(id).run();
+      } catch {
+        // best-effort cleanup
+      }
+      throw new InternalError("failed to store report attachment");
     }
   }
 

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -2,18 +2,21 @@
  * Anonymous CLI / MCP usage pings → D1 `uploads_telemetry_events`.
  * PII-clean: command names, versions, OS, exit codes only.
  */
-import { ValidationError } from "@uploads/errors";
+import { RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import {
   MAX_ANON_ID,
   MAX_COMMAND,
   MAX_STRING,
+  MAX_TELEMETRY_BODY_BYTES,
   MAX_VERSION,
+  clampInt,
   envFlagOn,
   newId,
   pickClientKind,
   pickErrorCode,
   pickSurface,
+  readJsonObjectBody,
   sanitizeInt,
   sanitizeString,
   SURFACES,
@@ -22,18 +25,33 @@ import type { WorkspaceVars } from "../workspace";
 
 export const telemetry = new Hono<WorkspaceVars>();
 
+/** Exit codes observed from CLIs are small signed/unsigned ints. */
+const MAX_EXIT_CODE = 255;
+const MIN_EXIT_CODE = -128;
+/** Cap recorded duration at 24h (ms). */
+const MAX_DURATION_MS = 24 * 60 * 60 * 1000;
+/** Timestamps: unix ms within a reasonable window around "now". */
+const MAX_TS_SKEW_MS = 365 * 24 * 60 * 60 * 1000;
+
 telemetry.post("/", async (c) => {
   if (envFlagOn(c.env.TELEMETRY_DISABLED)) {
     return c.json({ ok: true, disabled: true }, 202);
   }
+
+  // IP rate limit via WRITE_LIMITER (anonymous key — no workspace on this route).
+  const limiter = c.env.WRITE_LIMITER;
+  if (limiter) {
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    const { success } = await limiter.limit({ key: `cli-telemetry:${ip}` });
+    if (!success) {
+      c.header("Retry-After", "60");
+      throw new RateLimitedError("too many telemetry events; retry shortly");
+    }
+  }
+
   if (!c.env.DB) return c.json({ ok: true }, 202);
 
-  let body: Record<string, unknown>;
-  try {
-    body = (await c.req.json()) as Record<string, unknown>;
-  } catch {
-    throw new ValidationError("invalid JSON body");
-  }
+  const body = await readJsonObjectBody(c.req.raw, MAX_TELEMETRY_BODY_BYTES);
 
   const surface = pickSurface(body.surface, "");
   const command = sanitizeString(body.command, MAX_COMMAND);
@@ -42,6 +60,12 @@ telemetry.post("/", async (c) => {
   if (!surface || !SURFACES.has(surface) || !command || !anonId || !cliVersion) {
     throw new ValidationError("missing or invalid telemetry fields");
   }
+
+  const now = Date.now();
+  const timestamp =
+    clampInt(sanitizeInt(body.timestamp), now - MAX_TS_SKEW_MS, now + MAX_TS_SKEW_MS) ?? now;
+  const exitCode = clampInt(sanitizeInt(body.exitCode), MIN_EXIT_CODE, MAX_EXIT_CODE);
+  const durationMs = clampInt(sanitizeInt(body.durationMs), 0, MAX_DURATION_MS);
 
   try {
     await c.env.DB.prepare(
@@ -54,13 +78,13 @@ telemetry.post("/", async (c) => {
       .bind(
         newId("tel"),
         anonId,
-        sanitizeInt(body.timestamp) ?? Date.now(),
+        timestamp,
         surface,
         pickClientKind(body.clientKind),
         sanitizeString(body.agentName, 64),
         command,
-        sanitizeInt(body.exitCode),
-        sanitizeInt(body.durationMs),
+        exitCode,
+        durationMs,
         pickErrorCode(body.errorCode),
         cliVersion,
         sanitizeString(body.os, MAX_STRING),

--- a/apps/api/src/routes/telemetry.ts
+++ b/apps/api/src/routes/telemetry.ts
@@ -1,0 +1,81 @@
+/**
+ * Anonymous CLI / MCP usage pings → D1 `uploads_telemetry_events`.
+ * PII-clean: command names, versions, OS, exit codes only.
+ */
+import { ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import {
+  MAX_ANON_ID,
+  MAX_COMMAND,
+  MAX_STRING,
+  MAX_VERSION,
+  envFlagOn,
+  newId,
+  pickClientKind,
+  pickErrorCode,
+  pickSurface,
+  sanitizeInt,
+  sanitizeString,
+  SURFACES,
+} from "../cli-intake";
+import type { WorkspaceVars } from "../workspace";
+
+export const telemetry = new Hono<WorkspaceVars>();
+
+telemetry.post("/", async (c) => {
+  if (envFlagOn(c.env.TELEMETRY_DISABLED)) {
+    return c.json({ ok: true, disabled: true }, 202);
+  }
+  if (!c.env.DB) return c.json({ ok: true }, 202);
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await c.req.json()) as Record<string, unknown>;
+  } catch {
+    throw new ValidationError("invalid JSON body");
+  }
+
+  const surface = pickSurface(body.surface, "");
+  const command = sanitizeString(body.command, MAX_COMMAND);
+  const anonId = sanitizeString(body.anonId, MAX_ANON_ID);
+  const cliVersion = sanitizeString(body.cliVersion, MAX_VERSION);
+  if (!surface || !SURFACES.has(surface) || !command || !anonId || !cliVersion) {
+    throw new ValidationError("missing or invalid telemetry fields");
+  }
+
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO uploads_telemetry_events (
+        id, anon_id, timestamp, surface, client_kind, agent_name,
+        command, exit_code, duration_ms, error_code, cli_version,
+        os, arch, runtime
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        newId("tel"),
+        anonId,
+        sanitizeInt(body.timestamp) ?? Date.now(),
+        surface,
+        pickClientKind(body.clientKind),
+        sanitizeString(body.agentName, 64),
+        command,
+        sanitizeInt(body.exitCode),
+        sanitizeInt(body.durationMs),
+        pickErrorCode(body.errorCode),
+        cliVersion,
+        sanitizeString(body.os, MAX_STRING),
+        sanitizeString(body.arch, MAX_STRING),
+        sanitizeString(body.runtime, MAX_STRING),
+      )
+      .run();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "uploads_telemetry_events insert failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+
+  return c.json({ ok: true }, 202);
+});

--- a/apps/api/test/reports.test.ts
+++ b/apps/api/test/reports.test.ts
@@ -1,0 +1,187 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+import { MAX_ATTACHMENT_BYTES } from "../src/routes/reports";
+
+const MIGRATION = "migrations/20260715120000_uploads_cli_observability.sql";
+
+function fakeR2() {
+  const objects = new Map<string, Uint8Array>();
+  return {
+    objects,
+    async put(key: string, value: ArrayBuffer | ArrayBufferView | string) {
+      const body =
+        typeof value === "string"
+          ? new TextEncoder().encode(value)
+          : value instanceof ArrayBuffer
+            ? new Uint8Array(value)
+            : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+      objects.set(key, body);
+      return { key } as R2Object;
+    },
+  };
+}
+
+function env(
+  options: {
+    db?: D1Database;
+    r2?: ReturnType<typeof fakeR2>;
+    reportsDisabled?: string;
+    inviteAllowed?: boolean;
+  } = {},
+) {
+  return {
+    DB: options.db,
+    UPLOADS_DEFAULT: options.r2,
+    REPORTS_DISABLED: options.reportsDisabled,
+    INVITE_LIMITER:
+      options.inviteAllowed === undefined
+        ? undefined
+        : { limit: async () => ({ success: options.inviteAllowed }) },
+    REGISTRY: { get: async () => null, put: async () => undefined },
+  } as unknown as Env;
+}
+
+describe("POST /v1/reports", () => {
+  it("stores metadata in uploads_cli_reports and log in R2", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    const r2 = fakeR2();
+    try {
+      const res = await app.request(
+        "http://localhost/v1/reports",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            message: "put fails with KEY_POLICY on custom prefixes",
+            type: "error",
+            contact: "dev@example.com",
+            surface: "cli",
+            command: "put",
+            errorCode: "KEY_POLICY",
+            cliVersion: "0.10.0",
+            attachment: {
+              filename: "trace.log",
+              contentType: "text/plain",
+              body: "Error: KEY_POLICY\n  at put\n",
+            },
+          }),
+        },
+        env({ db: database(sqlite), r2 }),
+      );
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as { ok: boolean; id: string; hasAttachment: boolean };
+      expect(json.ok).toBe(true);
+      expect(json.id).toMatch(/^rpt_/);
+      expect(json.hasAttachment).toBe(true);
+
+      const row = sqlite.db
+        .prepare("SELECT * FROM uploads_cli_reports WHERE id = ?")
+        .get(json.id) as Record<string, unknown>;
+      expect(row.type).toBe("error");
+      expect(row.error_code).toBe("KEY_POLICY");
+      expect(String(row.attachment_key)).toBe(`_internal/uploads-cli-reports/${json.id}/trace.log`);
+      expect(new TextDecoder().decode(r2.objects.get(String(row.attachment_key))!)).toMatch(
+        /KEY_POLICY/,
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects short messages, oversized attachments, kill switch, rate limit", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    const r2 = fakeR2();
+    try {
+      expect(
+        (
+          await app.request(
+            "http://localhost/v1/reports",
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ message: "hi" }),
+            },
+            env({ db: database(sqlite), r2 }),
+          )
+        ).status,
+      ).toBe(400);
+
+      expect(
+        (
+          await app.request(
+            "http://localhost/v1/reports",
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                message: "long enough message here",
+                attachment: { filename: "big.log", body: "x".repeat(MAX_ATTACHMENT_BYTES + 1) },
+              }),
+            },
+            env({ db: database(sqlite), r2 }),
+          )
+        ).status,
+      ).toBe(413);
+
+      expect(
+        (
+          await app.request(
+            "http://localhost/v1/reports",
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ message: "still long enough" }),
+            },
+            env({ db: database(sqlite), reportsDisabled: "1" }),
+          )
+        ).status,
+      ).toBe(400);
+
+      expect(
+        (
+          await app.request(
+            "http://localhost/v1/reports",
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ message: "still long enough" }),
+            },
+            env({ db: database(sqlite), inviteAllowed: false }),
+          )
+        ).status,
+      ).toBe(429);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("sanitizes path traversal in attachment filenames", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    const r2 = fakeR2();
+    try {
+      const res = await app.request(
+        "http://localhost/v1/reports",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            message: "path traversal attempt in filename",
+            attachment: { filename: "../../etc/passwd", body: "not real" },
+          }),
+        },
+        env({ db: database(sqlite), r2 }),
+      );
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as { id: string };
+      const row = sqlite.db
+        .prepare("SELECT attachment_key FROM uploads_cli_reports WHERE id = ?")
+        .get(json.id) as { attachment_key: string };
+      expect(row.attachment_key).toBe(`_internal/uploads-cli-reports/${json.id}/passwd`);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/reports.test.ts
+++ b/apps/api/test/reports.test.ts
@@ -158,6 +158,24 @@ describe("POST /v1/reports", () => {
     }
   });
 
+  it("fails when DB is absent (no orphan attachment success)", async () => {
+    const r2 = fakeR2();
+    const res = await app.request(
+      "http://localhost/v1/reports",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          message: "still long enough to send",
+          attachment: { filename: "trace.log", body: "log line" },
+        }),
+      },
+      env({ r2 }),
+    );
+    expect(res.status).toBe(503);
+    expect(r2.objects.size).toBe(0);
+  });
+
   it("sanitizes path traversal in attachment filenames", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     const r2 = fakeR2();

--- a/apps/api/test/telemetry.test.ts
+++ b/apps/api/test/telemetry.test.ts
@@ -1,0 +1,143 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260715120000_uploads_cli_observability.sql";
+
+function env(options: { db?: D1Database; telemetryDisabled?: string } = {}) {
+  return {
+    DB: options.db,
+    TELEMETRY_DISABLED: options.telemetryDisabled,
+    REGISTRY: { get: async () => null, put: async () => undefined },
+  } as unknown as Env;
+}
+
+describe("POST /v1/telemetry", () => {
+  it("stores a sanitized event in uploads_telemetry_events", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const res = await app.request(
+        "http://localhost/v1/telemetry",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            anonId: "11111111-2222-3333-4444-555555555555",
+            timestamp: 1_700_000_000_000,
+            surface: "cli",
+            clientKind: "external",
+            command: "put",
+            exitCode: 3,
+            durationMs: 120,
+            errorCode: "KEY_POLICY",
+            cliVersion: "0.10.0",
+            os: "darwin",
+            arch: "arm64",
+            runtime: "node-22.0.0",
+          }),
+        },
+        env({ db: database(sqlite) }),
+      );
+      expect(res.status).toBe(202);
+      expect(await res.json()).toEqual({ ok: true });
+
+      const row = sqlite.db
+        .prepare("SELECT * FROM uploads_telemetry_events WHERE command = ?")
+        .get("put") as Record<string, unknown>;
+      expect(row).toMatchObject({
+        anon_id: "11111111-2222-3333-4444-555555555555",
+        surface: "cli",
+        command: "put",
+        exit_code: 3,
+        error_code: "KEY_POLICY",
+        cli_version: "0.10.0",
+      });
+      expect(String(row.id)).toMatch(/^tel_/);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("drops unknown error codes", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const res = await app.request(
+        "http://localhost/v1/telemetry",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            anonId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            surface: "mcp",
+            clientKind: "not-a-kind",
+            command: "tool put",
+            errorCode: "HACKER_CODE",
+            cliVersion: "0.10.0",
+          }),
+        },
+        env({ db: database(sqlite) }),
+      );
+      expect(res.status).toBe(202);
+      const row = sqlite.db
+        .prepare("SELECT client_kind, error_code FROM uploads_telemetry_events LIMIT 1")
+        .get() as { client_kind: string; error_code: string | null };
+      expect(row.client_kind).toBe("external");
+      expect(row.error_code).toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects missing fields; honors kill switch; fails open without DB", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const bad = await app.request(
+        "http://localhost/v1/telemetry",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ command: "put" }),
+        },
+        env({ db: database(sqlite) }),
+      );
+      expect(bad.status).toBe(400);
+
+      const disabled = await app.request(
+        "http://localhost/v1/telemetry",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            anonId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            surface: "cli",
+            command: "put",
+            cliVersion: "0.10.0",
+          }),
+        },
+        env({ db: database(sqlite), telemetryDisabled: "1" }),
+      );
+      expect(disabled.status).toBe(202);
+      expect(await disabled.json()).toEqual({ ok: true, disabled: true });
+    } finally {
+      sqlite.close();
+    }
+
+    const noDb = await app.request(
+      "http://localhost/v1/telemetry",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          anonId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          surface: "cli",
+          command: "doctor",
+          cliVersion: "0.10.0",
+        }),
+      },
+      env({}),
+    );
+    expect(noDb.status).toBe(202);
+  });
+});

--- a/apps/api/test/telemetry.test.ts
+++ b/apps/api/test/telemetry.test.ts
@@ -90,7 +90,7 @@ describe("POST /v1/telemetry", () => {
     }
   });
 
-  it("rejects missing fields; honors kill switch; fails open without DB", async () => {
+  it("rejects missing fields, null JSON, and oversized bodies; honors kill switch", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
       const bad = await app.request(
@@ -103,6 +103,33 @@ describe("POST /v1/telemetry", () => {
         env({ db: database(sqlite) }),
       );
       expect(bad.status).toBe(400);
+
+      const nullBody = await app.request(
+        "http://localhost/v1/telemetry",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "null",
+        },
+        env({ db: database(sqlite) }),
+      );
+      expect(nullBody.status).toBe(400);
+
+      const oversized = await app.request(
+        "http://localhost/v1/telemetry",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json", "content-length": "99999" },
+          body: JSON.stringify({
+            anonId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            surface: "cli",
+            command: "put",
+            cliVersion: "0.10.0",
+          }),
+        },
+        env({ db: database(sqlite) }),
+      );
+      expect(oversized.status).toBe(413);
 
       const disabled = await app.request(
         "http://localhost/v1/telemetry",

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -333,7 +333,10 @@ wrangler d1 execute uploads-production --remote \
   --command "SELECT id, created_at, type, command, error_code, substr(message,1,80)
              FROM uploads_cli_reports ORDER BY created_at DESC LIMIT 20"
 
-wrangler r2 object get uploads-default/_internal/uploads-cli-reports/<id>/<file> \
+# Quote placeholders so shell redirection is not triggered by unquoted <…>.
+REPORT_ID="rpt_…"
+REPORT_FILE="trace.log"
+wrangler r2 object get "uploads-default/_internal/uploads-cli-reports/${REPORT_ID}/${REPORT_FILE}" \
   --file ./trace.log
 ```
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -295,6 +295,48 @@ Console visibility controls links, not security — the console is bearer-token 
 
 Resolution order (see apps/web `src/lib/console-mode.ts`): the Flagship `console-mode` flag (app "uploads", `FLAGS` binding) wins when present, so prod can flip modes without a redeploy — `wrangler flagship flags update <app-id> console-mode --default <mode>`. The `CONSOLE_MODE` var in apps/web `wrangler.jsonc` is the fallback. Self-hosters without Flagship: delete the `flagship` block from wrangler.jsonc and set the var.
 
+## CLI observability (telemetry + reports)
+
+Both live on the **existing** D1 binding (`uploads-production` / `DB`) — no new
+database. One migration creates two tables
+(`20260715120000_uploads_cli_observability.sql`):
+
+| Table                      | Role                                                     |
+| -------------------------- | -------------------------------------------------------- |
+| `uploads_telemetry_events` | Automatic command-name pings (high volume, no free text) |
+| `uploads_cli_reports`      | Explicit opt-in messages (+ optional log metadata)       |
+
+**Why D1, not KV:** we need append + aggregate (`GROUP BY command`, recent
+errors). KV is a key lookup store, not a query log. Report **blobs** use R2;
+only metadata is in D1.
+
+**Why two tables:** different volume, retention, and shape. Telemetry is
+fire-and-forget counters; reports are sparse free text with optional
+attachments. Sharing one polymorphic table would mostly add null columns.
+
+### Telemetry (`POST /v1/telemetry`)
+
+Command name, version, OS/arch, exit code, duration, allowlisted error code.
+Opt-out: `UPLOADS_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, or
+`uploads telemetry disable`. Kill switch: `TELEMETRY_DISABLED=1`.
+
+### Reports (`POST /v1/reports`)
+
+Explicit only (`uploads report` / MCP `report`). Message + optional text
+attachment (max 256 KiB) at
+`_internal/uploads-cli-reports/<rpt_id>/<file>` on `UPLOADS_DEFAULT`.
+Rate limit: `INVITE_LIMITER` key `cli-report:<ip>`. Kill switch:
+`REPORTS_DISABLED=1`.
+
+```bash
+wrangler d1 execute uploads-production --remote \
+  --command "SELECT id, created_at, type, command, error_code, substr(message,1,80)
+             FROM uploads_cli_reports ORDER BY created_at DESC LIMIT 20"
+
+wrangler r2 object get uploads-default/_internal/uploads-cli-reports/<id>/<file> \
+  --file ./trace.log
+```
+
 ## Deploys
 
 Code via Workers Builds / `pnpm run deploy`. D1 migrations on merge. npm CLI via changesets.

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -39,7 +39,8 @@ global `uploads` form above.
 
 Commands: `attach`, `put`, `gallery`, `comment`, `list`, `find`, `meta`, `delete`, `usage`,
 `reconcile`, `purge-expired`, `setup`, `install`, `login`, `whoami` (alias `status`),
-`logout`, `invite`, `admin`, `config`, `doctor`, `health`, `mcp`, `completion`.
+`logout`, `invite`, `admin`, `config`, `telemetry`, `report`, `doctor`, `health`, `mcp`,
+`completion`.
 
 **Help:** bare `uploads` / `uploads help` / `--help` shows essentials; use
 `uploads help --all` (or `--help --all`) for the full command list. Per-command:
@@ -56,6 +57,19 @@ stdout. Example (zsh): `uploads completion zsh > ~/.zsh/completions/_uploads`.
 newer npm release is available (at most once/day, `~/.cache/uploads/`). Silence
 with `--quiet`, `--json`, `UPLOADS_NO_UPDATE=1`, or `NO_UPDATE_NOTIFIER=1`. Not used
 for `uploads mcp`.
+
+**Telemetry:** the CLI and MCP server send anonymous usage pings (command name,
+version, OS/arch, exit code, duration, optional error code) to
+`POST /v1/telemetry` on the configured API. No arguments, paths, tokens, workspace
+names, or file content. Opt out with `UPLOADS_TELEMETRY_DISABLED=1`,
+`DO_NOT_TRACK=1`, or `uploads telemetry disable`. First interactive run prints a
+one-line notice.
+
+**Diagnostic reports (opt-in):** `uploads report "what broke"` sends a short
+message to the team. Attach a log with `--file ./trace.log`, or pipe:
+`uploads doctor --json 2>&1 | uploads report "doctor failed"`. Never automatic —
+also available as the MCP `report` tool when the user asks to submit feedback.
+Attachments are text-only (max 256 KiB) and stored under an unguessable R2 key.
 
 **Exit codes:** `0` ok, `2` usage/token/file, `3` auth/policy, `4` network, `1` other.
 Failures go to stderr; under `--format json|url|markdown` they also go to stdout so

--- a/packages/uploads/config.example
+++ b/packages/uploads/config.example
@@ -49,3 +49,8 @@ UPLOADS_DEFAULT_PREFIX=screenshots
 # Keep EXIF/XMP/ICC when optimizing (default: strip for privacy on public URLs).
 # Prefer for discussion-critical photo metadata; otherwise leave unset.
 # UPLOADS_KEEP_EXIF=1
+
+# --- Telemetry (optional) ---------------------------------------------------
+# Anonymous usage pings (command name, version, OS, exit code). No paths or
+# tokens. Also honored: DO_NOT_TRACK=1, or `uploads telemetry disable`.
+# UPLOADS_TELEMETRY_DISABLED=1

--- a/packages/uploads/config.example
+++ b/packages/uploads/config.example
@@ -51,6 +51,7 @@ UPLOADS_DEFAULT_PREFIX=screenshots
 # UPLOADS_KEEP_EXIF=1
 
 # --- Telemetry (optional) ---------------------------------------------------
-# Anonymous usage pings (command name, version, OS, exit code). No paths or
-# tokens. Also honored: DO_NOT_TRACK=1, or `uploads telemetry disable`.
+# Anonymous usage pings: command name, version, OS/arch, runtime, exit code,
+# duration, client kind, anonymous id, optional allowlisted error code.
+# No paths or tokens. Also honored: DO_NOT_TRACK=1, or `uploads telemetry disable`.
 # UPLOADS_TELEMETRY_DISABLED=1

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -170,6 +170,20 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     ],
   },
   {
+    name: "telemetry",
+    summary: "Manage anonymous usage telemetry (status / enable / disable)",
+    subcommands: [
+      { name: "status", summary: "Show whether telemetry is enabled" },
+      { name: "enable", summary: "Enable anonymous usage telemetry" },
+      { name: "disable", summary: "Disable anonymous usage telemetry" },
+    ],
+  },
+  {
+    name: "report",
+    usage: "report [message]",
+    summary: "Send a diagnostic report (optional log attachment; explicit opt-in)",
+  },
+  {
     name: "doctor",
     summary: "Health + auth + workspace checks",
     essential: true,

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -1,5 +1,5 @@
 import { createUploadsClient } from "./client.js";
-import { resolveApiUrl, resolveConfig } from "./config.js";
+import { DEFAULT_API_URL, resolveApiUrl, resolveConfig } from "./config.js";
 import { UploadsError } from "./errors.js";
 import {
   commandWorkspace,
@@ -204,6 +204,14 @@ function usageHint(argv: string[]): void {
 export async function runCli(argv: string[]): Promise<number> {
   const telemetryStart = Date.now();
   const telemetryCmd = telemetryCommandName(argv);
+  // Prefer --api-url from argv early so every exit path can pass it to telemetry.
+  let apiUrl = DEFAULT_API_URL;
+  try {
+    apiUrl = resolveApiUrl(parseArgv(argv).globals);
+  } catch {
+    // Usage errors while parsing globals fall through to the main try/catch.
+  }
+
   const skipTelemetry =
     argv.includes("--version") ||
     argv.includes("-V") ||
@@ -218,12 +226,12 @@ export async function runCli(argv: string[]): Promise<number> {
     maybeShowFirstRunNotice({ interactive: wantsQuiet ? false : undefined });
   }
 
-  const flushTelemetry = async (code: number, err?: unknown, apiUrl?: string): Promise<void> => {
+  const flushTelemetry = (code: number, err?: unknown): void => {
     if (skipTelemetry) return;
     // Long-lived MCP process: per-tool events come from the MCP server; skip
     // a process-level "mcp" ping so we don't double-count or hang exit.
     if (telemetryCmd === "mcp") return;
-    await recordEvent(
+    recordEvent(
       {
         surface: "cli",
         command: telemetryCmd,
@@ -239,7 +247,7 @@ export async function runCli(argv: string[]): Promise<number> {
     const parsed = parseArgv(argv);
     const json = parsed.globals.json ?? false;
     const quiet = parsed.globals.quiet ?? false;
-    const apiUrl = resolveApiUrl(parsed.globals);
+    apiUrl = resolveApiUrl(parsed.globals);
 
     if (parsed.globals.version) {
       process.stdout.write(`${packageVersion()}\n`);
@@ -258,7 +266,7 @@ export async function runCli(argv: string[]): Promise<number> {
       });
       // Explicit help exits 0; bare `uploads` is usage → 2.
       const code = parsed.help || isHelpCommand ? 0 : 2;
-      await flushTelemetry(code);
+      flushTelemetry(code);
       return code;
     }
 
@@ -379,7 +387,7 @@ export async function runCli(argv: string[]): Promise<number> {
           token: parsed.globals.token,
           envFile: parsed.globals.envFile,
         });
-        await flushTelemetry(2);
+        flushTelemetry(2);
         return 2;
       }
     }
@@ -388,14 +396,14 @@ export async function runCli(argv: string[]): Promise<number> {
     if (code === 0 && !showHelp) {
       await maybeHintUpdate({ quiet: quiet || json, command: parsed.command });
     }
-    await flushTelemetry(code, undefined, apiUrl);
+    flushTelemetry(code);
     return code;
   } catch (err) {
     const format = outputFormat(argv);
     errorOut(err, format);
     if (err instanceof UsageError && format !== "json") usageHint(argv);
     const code = exitCode(err);
-    await flushTelemetry(code, err);
+    flushTelemetry(code, err);
     return code;
   }
 }

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -36,8 +36,16 @@ import { runMcp } from "./commands/mcp.js";
 import { runInstall } from "./commands/install.js";
 import { runCompletion } from "./commands/completion.js";
 import { runLogout, runWhoami } from "./commands/session.js";
+import { runTelemetry } from "./commands/telemetry.js";
+import { runReport } from "./commands/report.js";
 import { packageVersion } from "./package-version.js";
 import { checkForUpdate, maybeHintUpdate } from "./update-check.js";
+import {
+  errorCodeFromUnknown,
+  maybeShowFirstRunNotice,
+  recordEvent,
+  telemetryCommandName,
+} from "./telemetry.js";
 
 async function writeRootHelp(
   options: {
@@ -194,10 +202,44 @@ function usageHint(argv: string[]): void {
 }
 
 export async function runCli(argv: string[]): Promise<number> {
+  const telemetryStart = Date.now();
+  const telemetryCmd = telemetryCommandName(argv);
+  const skipTelemetry =
+    argv.includes("--version") ||
+    argv.includes("-V") ||
+    telemetryCmd === "telemetry" ||
+    telemetryCmd.startsWith("telemetry ") ||
+    // Report is itself a deliberate submit; skip the automatic usage ping.
+    telemetryCmd === "report";
+
+  // One-time notice for interactive humans (never MCP / json / quiet).
+  if (!skipTelemetry) {
+    const wantsQuiet = argv.includes("--json") || argv.includes("--quiet") || argv[2] === "mcp";
+    maybeShowFirstRunNotice({ interactive: wantsQuiet ? false : undefined });
+  }
+
+  const flushTelemetry = async (code: number, err?: unknown, apiUrl?: string): Promise<void> => {
+    if (skipTelemetry) return;
+    // Long-lived MCP process: per-tool events come from the MCP server; skip
+    // a process-level "mcp" ping so we don't double-count or hang exit.
+    if (telemetryCmd === "mcp") return;
+    await recordEvent(
+      {
+        surface: "cli",
+        command: telemetryCmd,
+        exitCode: code,
+        durationMs: Date.now() - telemetryStart,
+        errorCode: err !== undefined ? errorCodeFromUnknown(err) : undefined,
+      },
+      { apiUrl },
+    );
+  };
+
   try {
     const parsed = parseArgv(argv);
     const json = parsed.globals.json ?? false;
     const quiet = parsed.globals.quiet ?? false;
+    const apiUrl = resolveApiUrl(parsed.globals);
 
     if (parsed.globals.version) {
       process.stdout.write(`${packageVersion()}\n`);
@@ -215,7 +257,9 @@ export async function runCli(argv: string[]): Promise<number> {
         envFile: parsed.globals.envFile,
       });
       // Explicit help exits 0; bare `uploads` is usage → 2.
-      return parsed.help || isHelpCommand ? 0 : 2;
+      const code = parsed.help || isHelpCommand ? 0 : 2;
+      await flushTelemetry(code);
+      return code;
     }
 
     const cmdArgs = parsed.rest.slice(1);
@@ -224,7 +268,7 @@ export async function runCli(argv: string[]): Promise<number> {
 
     switch (parsed.command) {
       case "health":
-        code = await runHealth({ apiUrl: resolveApiUrl(parsed.globals), json }, cmdArgs, showHelp);
+        code = await runHealth({ apiUrl, json }, cmdArgs, showHelp);
         break;
       case "config":
         code = await runConfig(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
@@ -233,7 +277,7 @@ export async function runCli(argv: string[]): Promise<number> {
         code = await runSetup(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
         break;
       case "login":
-        code = await runLogin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        code = await runLogin(cmdArgs, { json, apiUrl }, showHelp);
         break;
       case "whoami":
       case "status":
@@ -253,10 +297,16 @@ export async function runCli(argv: string[]): Promise<number> {
         code = await runLogout(cmdArgs, { json, envFile: parsed.globals.envFile }, showHelp);
         break;
       case "invite":
-        code = await runInvite(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        code = await runInvite(cmdArgs, { json, apiUrl }, showHelp);
         break;
       case "admin":
-        code = await runAdmin(cmdArgs, { json, apiUrl: resolveApiUrl(parsed.globals) }, showHelp);
+        code = await runAdmin(cmdArgs, { json, apiUrl }, showHelp);
+        break;
+      case "telemetry":
+        code = await runTelemetry(cmdArgs, { json, apiUrl }, showHelp);
+        break;
+      case "report":
+        code = await runReport(cmdArgs, { json, apiUrl }, showHelp);
         break;
       case "mcp":
         code = await runMcp(cmdArgs, { globals: parsed.globals }, showHelp);
@@ -329,6 +379,7 @@ export async function runCli(argv: string[]): Promise<number> {
           token: parsed.globals.token,
           envFile: parsed.globals.envFile,
         });
+        await flushTelemetry(2);
         return 2;
       }
     }
@@ -337,11 +388,14 @@ export async function runCli(argv: string[]): Promise<number> {
     if (code === 0 && !showHelp) {
       await maybeHintUpdate({ quiet: quiet || json, command: parsed.command });
     }
+    await flushTelemetry(code, undefined, apiUrl);
     return code;
   } catch (err) {
     const format = outputFormat(argv);
     errorOut(err, format);
     if (err instanceof UsageError && format !== "json") usageHint(argv);
-    return exitCode(err);
+    const code = exitCode(err);
+    await flushTelemetry(code, err);
+    return code;
   }
 }

--- a/packages/uploads/src/commands/mcp.ts
+++ b/packages/uploads/src/commands/mcp.ts
@@ -1,4 +1,5 @@
 import { parseCommandArgs, type GlobalFlags } from "../cli-args.js";
+import { resolveApiUrl } from "../config.js";
 import { createMcpServer } from "../mcp/server.js";
 import { serveStdio } from "../mcp/stdio.js";
 import { createUploadsMcpTools } from "../mcp/tools.js";
@@ -37,6 +38,7 @@ export async function runMcp(
   const server = createMcpServer({
     serverInfo: { name: "uploads", version: packageVersion() },
     tools: createUploadsMcpTools({ globals: opts.globals }),
+    apiUrl: resolveApiUrl(opts.globals),
   });
   await serveStdio(server);
   return 0;

--- a/packages/uploads/src/commands/report.ts
+++ b/packages/uploads/src/commands/report.ts
@@ -1,0 +1,153 @@
+/**
+ * `uploads report` — explicit opt-in diagnostic message (+ optional log).
+ */
+import { createInterface } from "node:readline/promises";
+import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
+import { writeJson } from "../io.js";
+import {
+  attachmentFromText,
+  buildReportPayload,
+  loadReportAttachment,
+  parseReportType,
+  reportFallbackHint,
+  REPORT_TYPES,
+  submitReport,
+  validateReportMessage,
+} from "../report.js";
+
+const REPORT_HELP = `uploads report [message] — send a diagnostic report (explicit opt-in)
+
+Nothing is sent unless you run this (or the MCP report tool).
+
+Options:
+  --file <path>         Attach a text log/trace (max 256 KiB)
+  --type <t>            bug | error | idea | other (default: other)
+  --contact <value>     Optional email/handle for follow-up
+  --command <name>      Command that failed (e.g. put) — no args/paths
+  --error-code <code>   Optional UploadsError code (e.g. KEY_POLICY)
+  --dry-run             Print the payload without sending
+  --json                JSON on stdout
+
+Examples:
+  uploads report "put fails with KEY_POLICY on custom prefixes"
+  uploads report --type bug --file ./trace.log "crash during optimize"
+  uploads doctor --json 2>&1 | uploads report "doctor failed"
+`;
+
+async function readStdinText(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function runReport(
+  args: string[],
+  opts: { json?: boolean; apiUrl?: string } = {},
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(REPORT_HELP);
+    return 0;
+  }
+
+  const typeFlag = flagString(parsed.flags, "--type");
+  if (typeFlag && !parseReportType(typeFlag)) {
+    throw new UsageError(`--type must be one of: ${REPORT_TYPES.join(", ")}`);
+  }
+
+  const type = parseReportType(typeFlag) ?? "other";
+  const dryRun = flagBool(parsed.flags, "--dry-run");
+  const json = opts.json || flagBool(parsed.flags, "--json");
+  const filePath = flagString(parsed.flags, "--file");
+  const positional = parsed.positionals.length > 0 ? parsed.positionals.join(" ") : undefined;
+  const piped = !process.stdin.isTTY ? await readStdinText() : "";
+  const pipedTrimmed = piped.trim();
+
+  let raw: string | null = null;
+  if (positional?.trim()) raw = positional;
+  else if (pipedTrimmed) raw = pipedTrimmed;
+  else if (process.stdin.isTTY) {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    try {
+      const answer = await rl.question("What's going wrong? (blank to cancel)\n> ");
+      raw = answer.trim() || null;
+    } finally {
+      rl.close();
+    }
+  }
+
+  if (raw === null) {
+    if (json) await writeJson({ ok: false, cancelled: true });
+    else process.stderr.write("Cancelled — no report sent.\n");
+    return 0;
+  }
+
+  const validated = validateReportMessage(raw);
+  if (!validated.ok) {
+    if (!positional && pipedTrimmed.length > 4000) {
+      throw new UsageError(
+        'piped input is too long for the message — use: `… | uploads report "summary"`',
+      );
+    }
+    throw new UsageError(validated.error);
+  }
+
+  let attachment;
+  try {
+    if (filePath) attachment = loadReportAttachment(filePath);
+    else if (positional?.trim() && pipedTrimmed) {
+      attachment = attachmentFromText(piped, "stdin.log");
+    }
+  } catch (err) {
+    throw new UsageError(err instanceof Error ? err.message : String(err));
+  }
+
+  const payload = buildReportPayload(validated.message, {
+    type,
+    contact: flagString(parsed.flags, "--contact")?.trim() || undefined,
+    surface: "cli",
+    command: flagString(parsed.flags, "--command"),
+    errorCode: flagString(parsed.flags, "--error-code"),
+    attachment,
+  });
+
+  if (dryRun) {
+    const preview = {
+      ...payload,
+      attachment: payload.attachment
+        ? {
+            filename: payload.attachment.filename,
+            contentType: payload.attachment.contentType,
+            bytes: new TextEncoder().encode(payload.attachment.body).byteLength,
+            body: "[omitted in dry-run]",
+          }
+        : undefined,
+    };
+    if (json) await writeJson({ dryRun: true, payload: preview });
+    else process.stdout.write(`[dry-run] would POST:\n${JSON.stringify(preview, null, 2)}\n`);
+    return 0;
+  }
+
+  const result = await submitReport(payload, { apiUrl: opts.apiUrl });
+  if (result.ok) {
+    if (json) {
+      await writeJson({ ok: true, id: result.id, hasAttachment: result.hasAttachment });
+    } else {
+      process.stdout.write(
+        `Thanks — report received (id: ${result.id}${result.hasAttachment ? ", with attachment" : ""})\n`,
+      );
+    }
+    return 0;
+  }
+
+  if (json) await writeJson({ ok: false, error: result.error });
+  else {
+    process.stderr.write(`error: couldn't send report: ${result.error}\n`);
+    process.stderr.write(`hint: ${reportFallbackHint()}\n`);
+  }
+  return 1;
+}

--- a/packages/uploads/src/commands/report.ts
+++ b/packages/uploads/src/commands/report.ts
@@ -9,6 +9,8 @@ import {
   attachmentFromText,
   buildReportPayload,
   loadReportAttachment,
+  MAX_REPORT_ATTACHMENT_BYTES,
+  MAX_REPORT_MESSAGE,
   parseReportType,
   reportFallbackHint,
   REPORT_TYPES,
@@ -35,12 +37,26 @@ Examples:
   uploads doctor --json 2>&1 | uploads report "doctor failed"
 `;
 
-async function readStdinText(): Promise<string> {
+/**
+ * Bound stdin read. Stops once maxBytes is exceeded (returns what was read
+ * plus a flag so callers can reject oversized input).
+ */
+async function readStdinBounded(maxBytes: number): Promise<{ text: string; exceeded: boolean }> {
   const chunks: Buffer[] = [];
+  let total = 0;
+  let exceeded = false;
   for await (const chunk of process.stdin) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    total += buf.byteLength;
+    if (total > maxBytes) {
+      exceeded = true;
+      const keep = maxBytes - (total - buf.byteLength);
+      if (keep > 0) chunks.push(buf.subarray(0, keep));
+      break; // stop reading; peer close drains the rest
+    }
+    chunks.push(buf);
   }
-  return Buffer.concat(chunks).toString("utf8");
+  return { text: Buffer.concat(chunks).toString("utf8"), exceeded };
 }
 
 export async function runReport(
@@ -64,11 +80,25 @@ export async function runReport(
   const json = opts.json || flagBool(parsed.flags, "--json");
   const filePath = flagString(parsed.flags, "--file");
   const positional = parsed.positionals.length > 0 ? parsed.positionals.join(" ") : undefined;
-  const piped = !process.stdin.isTTY ? await readStdinText() : "";
+  const hasPositional = Boolean(positional?.trim());
+  const stdinIsPipe = !process.stdin.isTTY;
+
+  // Only consume stdin when we still need a message or a piped attachment.
+  // Skip when --file already supplies the log and a positional message exists.
+  const needStdinAsMessage = stdinIsPipe && !hasPositional;
+  const needStdinAsAttachment = stdinIsPipe && hasPositional && !filePath;
+  let piped = "";
+  let pipedExceeded = false;
+  if (needStdinAsMessage || needStdinAsAttachment) {
+    const max = needStdinAsAttachment ? MAX_REPORT_ATTACHMENT_BYTES : MAX_REPORT_MESSAGE + 1; // +1 so we can detect "too long"
+    const result = await readStdinBounded(max);
+    piped = result.text;
+    pipedExceeded = result.exceeded;
+  }
   const pipedTrimmed = piped.trim();
 
   let raw: string | null = null;
-  if (positional?.trim()) raw = positional;
+  if (hasPositional) raw = positional!;
   else if (pipedTrimmed) raw = pipedTrimmed;
   else if (process.stdin.isTTY) {
     const rl = createInterface({ input: process.stdin, output: process.stderr });
@@ -86,20 +116,22 @@ export async function runReport(
     return 0;
   }
 
-  const validated = validateReportMessage(raw);
-  if (!validated.ok) {
-    if (!positional && pipedTrimmed.length > 4000) {
-      throw new UsageError(
-        'piped input is too long for the message — use: `… | uploads report "summary"`',
-      );
-    }
-    throw new UsageError(validated.error);
+  if (needStdinAsMessage && (pipedExceeded || raw.length > MAX_REPORT_MESSAGE)) {
+    throw new UsageError(
+      'piped input is too long for the message — use: `… | uploads report "summary"`',
+    );
   }
+
+  const validated = validateReportMessage(raw);
+  if (!validated.ok) throw new UsageError(validated.error);
 
   let attachment;
   try {
     if (filePath) attachment = loadReportAttachment(filePath);
-    else if (positional?.trim() && pipedTrimmed) {
+    else if (needStdinAsAttachment && pipedTrimmed) {
+      if (pipedExceeded) {
+        throw new Error(`attachment exceeds ${MAX_REPORT_ATTACHMENT_BYTES} bytes`);
+      }
       attachment = attachmentFromText(piped, "stdin.log");
     }
   } catch (err) {

--- a/packages/uploads/src/commands/telemetry.ts
+++ b/packages/uploads/src/commands/telemetry.ts
@@ -1,0 +1,89 @@
+/**
+ * `uploads telemetry` — status / enable / disable for anonymous usage pings.
+ */
+import { flagBool, parseCommandArgs } from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
+import { writeJson } from "../io.js";
+import { setTelemetryEnabled, telemetryStatus, defaultTelemetryDataDir } from "../telemetry.js";
+
+const TELEMETRY_HELP = `uploads telemetry — manage anonymous usage telemetry
+
+Subcommands:
+  status     Show whether telemetry is enabled and where events go
+  enable     Enable anonymous usage telemetry
+  disable    Disable anonymous usage telemetry
+
+What is collected (when enabled):
+  command name, CLI version, OS/arch, runtime, exit code, duration,
+  optional error code (e.g. KEY_POLICY). Never arguments, paths, tokens,
+  workspace names, or file content.
+
+Opt out without this command:
+  UPLOADS_TELEMETRY_DISABLED=1
+  DO_NOT_TRACK=1
+
+Examples:
+  uploads telemetry status
+  uploads telemetry status --json
+  uploads telemetry disable
+  uploads telemetry enable
+`;
+
+export async function runTelemetry(
+  args: string[],
+  opts: { json?: boolean; apiUrl?: string } = {},
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help || parsed.positionals.length === 0) {
+    writeCommandHelp(TELEMETRY_HELP);
+    return 0;
+  }
+
+  const sub = parsed.positionals[0];
+  const json = opts.json || flagBool(parsed.flags, "--json");
+
+  switch (sub) {
+    case "status": {
+      const s = telemetryStatus({ apiUrl: opts.apiUrl });
+      if (json) {
+        await writeJson({
+          enabled: s.enabled,
+          reason: s.reason ?? null,
+          anonId: s.anonId,
+          clientKind: s.clientKind,
+          agentName: s.agentName ?? null,
+          endpoint: s.endpoint,
+          dataDir: defaultTelemetryDataDir(),
+        });
+        return 0;
+      }
+      process.stdout.write(`Telemetry: ${s.enabled ? "enabled" : "disabled"}\n`);
+      if (!s.enabled && s.reason) process.stdout.write(`Reason:    ${s.reason}\n`);
+      process.stdout.write(`Anon ID:   ${s.anonId}\n`);
+      process.stdout.write(`Kind:      ${s.clientKind}${s.agentName ? ` (${s.agentName})` : ""}\n`);
+      process.stdout.write(`Endpoint:  ${s.endpoint}\n`);
+      process.stdout.write(
+        "\nCollected: command name, version, OS/arch, runtime, exit code, duration, error code.\n",
+      );
+      process.stdout.write("Never:     arguments, paths, tokens, workspace names, or content.\n");
+      return 0;
+    }
+    case "enable": {
+      setTelemetryEnabled(true);
+      if (json) await writeJson({ enabled: true });
+      else process.stdout.write("Telemetry enabled.\n");
+      return 0;
+    }
+    case "disable": {
+      setTelemetryEnabled(false);
+      if (json) await writeJson({ enabled: false });
+      else process.stdout.write("Telemetry disabled.\n");
+      return 0;
+    }
+    default:
+      process.stderr.write(`error: unknown telemetry subcommand: ${sub}\n`);
+      process.stderr.write("hint: uploads telemetry --help\n");
+      return 2;
+  }
+}

--- a/packages/uploads/src/commands/telemetry.ts
+++ b/packages/uploads/src/commands/telemetry.ts
@@ -15,8 +15,8 @@ Subcommands:
 
 What is collected (when enabled):
   command name, CLI version, OS/arch, runtime, exit code, duration,
-  optional error code (e.g. KEY_POLICY). Never arguments, paths, tokens,
-  workspace names, or file content.
+  client kind/agent, anonymous id, optional allowlisted error code.
+  Never arguments, paths, tokens, workspace names, or file content.
 
 Opt out without this command:
   UPLOADS_TELEMETRY_DISABLED=1
@@ -64,15 +64,25 @@ export async function runTelemetry(
       process.stdout.write(`Kind:      ${s.clientKind}${s.agentName ? ` (${s.agentName})` : ""}\n`);
       process.stdout.write(`Endpoint:  ${s.endpoint}\n`);
       process.stdout.write(
-        "\nCollected: command name, version, OS/arch, runtime, exit code, duration, error code.\n",
+        "\nCollected: command name, version, OS/arch, runtime, exit code, duration,\n",
+      );
+      process.stdout.write(
+        "           client kind, anonymous id, optional allowlisted error code.\n",
       );
       process.stdout.write("Never:     arguments, paths, tokens, workspace names, or content.\n");
       return 0;
     }
     case "enable": {
       setTelemetryEnabled(true);
-      if (json) await writeJson({ enabled: true });
-      else process.stdout.write("Telemetry enabled.\n");
+      const s = telemetryStatus({ apiUrl: opts.apiUrl });
+      if (json) {
+        await writeJson({ enabled: s.enabled, reason: s.reason ?? null });
+      } else if (s.enabled) {
+        process.stdout.write("Telemetry enabled.\n");
+      } else {
+        process.stdout.write(`Telemetry still disabled (${s.reason ?? "opt-out active"}).\n`);
+        process.stdout.write("Cleared the local disable file; env opt-outs still apply.\n");
+      }
       return 0;
     }
     case "disable": {

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -56,8 +56,10 @@ function toolErrorText(err: unknown): string {
 export function createMcpServer(opts: {
   serverInfo: { name: string; version: string };
   tools: McpTool[];
+  /** API base for telemetry (honors uploads --api-url). */
+  apiUrl?: string;
 }): McpServer {
-  const { serverInfo, tools } = opts;
+  const { serverInfo, tools, apiUrl } = opts;
 
   async function callTool(id: JsonRpcId, params: Record<string, unknown>): Promise<string> {
     const name = params.name;
@@ -71,25 +73,31 @@ export function createMcpServer(opts: {
     const command = `tool ${tool.name}`.slice(0, 120);
     try {
       const result = await tool.handler(args as Record<string, unknown>);
-      void recordEvent({
-        surface: "mcp",
-        command,
-        exitCode: 0,
-        durationMs: Date.now() - start,
-      });
+      recordEvent(
+        {
+          surface: "mcp",
+          command,
+          exitCode: 0,
+          durationMs: Date.now() - start,
+        },
+        { apiUrl },
+      );
       return response(id, {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         structuredContent: result,
         isError: false,
       });
     } catch (err) {
-      void recordEvent({
-        surface: "mcp",
-        command,
-        exitCode: 1,
-        durationMs: Date.now() - start,
-        errorCode: errorCodeFromUnknown(err),
-      });
+      recordEvent(
+        {
+          surface: "mcp",
+          command,
+          exitCode: 1,
+          durationMs: Date.now() - start,
+          errorCode: errorCodeFromUnknown(err),
+        },
+        { apiUrl },
+      );
       return response(id, {
         content: [{ type: "text", text: toolErrorText(err) }],
         isError: true,

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -8,6 +8,7 @@
  * stdio transport lives in ./stdio.ts; logs must never go to stdout.
  */
 import { UploadsError } from "../errors.js";
+import { errorCodeFromUnknown, recordEvent } from "../telemetry.js";
 
 export {
   METADATA_DESCRIPTION,
@@ -66,14 +67,29 @@ export function createMcpServer(opts: {
     if (typeof args !== "object" || args === null || Array.isArray(args)) {
       return errorResponse(id, -32602, "tool arguments must be an object");
     }
+    const start = Date.now();
+    const command = `tool ${tool.name}`.slice(0, 120);
     try {
       const result = await tool.handler(args as Record<string, unknown>);
+      void recordEvent({
+        surface: "mcp",
+        command,
+        exitCode: 0,
+        durationMs: Date.now() - start,
+      });
       return response(id, {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         structuredContent: result,
         isError: false,
       });
     } catch (err) {
+      void recordEvent({
+        surface: "mcp",
+        command,
+        exitCode: 1,
+        durationMs: Date.now() - start,
+        errorCode: errorCodeFromUnknown(err),
+      });
       return response(id, {
         content: [{ type: "text", text: toolErrorText(err) }],
         isError: true,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -46,6 +46,15 @@ import {
   type ToolArgs,
 } from "./args.js";
 import type { McpTool } from "./server.js";
+import {
+  attachmentFromText,
+  buildReportPayload,
+  parseReportType,
+  REPORT_TYPES,
+  submitReport,
+  validateReportMessage,
+} from "../report.js";
+import { resolveApiUrl } from "../config.js";
 
 function optBool(args: ToolArgs, name: string): boolean {
   const v = args[name];
@@ -839,6 +848,93 @@ export function createUploadsMcpTools(opts: {
       async handler(args) {
         const { config, client } = clientFor(args);
         return buildDoctorReport(config, client);
+      },
+    },
+    {
+      name: "report",
+      description:
+        "Send an explicit diagnostic report to the uploads team (message + optional text log). " +
+        "Only call this when the user asked to submit feedback, a bug report, or error logs — " +
+        "never automatically. Do not include tokens, secrets, or private file contents. " +
+        "Same as `uploads report`.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: {
+            type: "string",
+            description: "Short description of the problem (required, 5–4000 chars).",
+          },
+          type: {
+            type: "string",
+            description: `One of: ${REPORT_TYPES.join(", ")} (default: other).`,
+          },
+          contact: {
+            type: "string",
+            description: "Optional contact for follow-up (email or handle).",
+          },
+          command: {
+            type: "string",
+            description: "Command that failed (e.g. put) — name only, no paths or args.",
+          },
+          errorCode: {
+            type: "string",
+            description: "Optional UploadsError code (e.g. KEY_POLICY).",
+          },
+          attachmentText: {
+            type: "string",
+            description:
+              "Optional text log/trace body the user consented to send (max 256 KiB). Not a file path.",
+          },
+          attachmentFilename: {
+            type: "string",
+            description: "Filename label for attachmentText (default: trace.txt).",
+          },
+        },
+        required: ["message"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const messageRaw = optString(args, "message");
+        if (!messageRaw) usage("message is required");
+        const validated = validateReportMessage(messageRaw);
+        if (!validated.ok) usage(validated.error);
+
+        const typeRaw = optString(args, "type");
+        if (typeRaw && !parseReportType(typeRaw)) {
+          usage(`type must be one of: ${REPORT_TYPES.join(", ")}`);
+        }
+        const type = parseReportType(typeRaw) ?? "other";
+
+        let attachment;
+        const attachmentText = optString(args, "attachmentText");
+        if (attachmentText) {
+          try {
+            attachment = attachmentFromText(
+              attachmentText,
+              optString(args, "attachmentFilename") ?? "trace.txt",
+            );
+          } catch (err) {
+            usage(err instanceof Error ? err.message : String(err));
+          }
+        }
+
+        const payload = buildReportPayload(validated.message, {
+          type,
+          contact: optString(args, "contact"),
+          surface: "mcp",
+          command: optString(args, "command"),
+          errorCode: optString(args, "errorCode"),
+          attachment,
+        });
+
+        const apiUrl = resolveApiUrl(globals);
+        const result = await submitReport(payload, { apiUrl });
+        if (!result.ok) usage(`couldn't send report: ${result.error}`);
+        return {
+          ok: true,
+          id: result.id,
+          hasAttachment: result.hasAttachment,
+        };
       },
     },
   ];

--- a/packages/uploads/src/report.ts
+++ b/packages/uploads/src/report.ts
@@ -53,10 +53,6 @@ export interface ReportPayload {
 export interface SubmitReportOptions {
   apiUrl?: string;
   fetchImpl?: typeof fetch;
-  version?: string;
-  dataDir?: string;
-  /** Include anonId only when telemetry is enabled (default). */
-  includeAnonId?: boolean;
 }
 
 export type ValidateMessageResult = { ok: true; message: string } | { ok: false; error: string };

--- a/packages/uploads/src/report.ts
+++ b/packages/uploads/src/report.ts
@@ -1,0 +1,223 @@
+/**
+ * Explicit, permissioned diagnostic report submission.
+ *
+ * Unlike automatic telemetry, nothing is sent unless the user (or an agent
+ * they instructed) runs `uploads report` / the MCP `report` tool.
+ *
+ * Optional log/trace attachments are text-only, capped, and stored server-side
+ * in R2 under an unguessable key. Never auto-attaches files from disk.
+ */
+import { readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+import { DEFAULT_API_URL } from "./config.js";
+import { packageVersion } from "./package-version.js";
+import {
+  detectClientKind,
+  detectRuntime,
+  getOrCreateAnonId,
+  isTelemetryEnabled,
+} from "./telemetry.js";
+
+export const REPORT_TYPES = ["bug", "error", "idea", "other"] as const;
+export type ReportType = (typeof REPORT_TYPES)[number];
+
+export const MIN_REPORT_MESSAGE = 5;
+export const MAX_REPORT_MESSAGE = 4000;
+export const MAX_REPORT_ATTACHMENT_BYTES = 256 * 1024;
+const POST_TIMEOUT_MS = 15_000;
+const ISSUES_URL = "https://github.com/buildinternet/uploads/issues";
+
+export interface ReportAttachment {
+  filename: string;
+  contentType: string;
+  body: string;
+}
+
+export interface ReportPayload {
+  message: string;
+  type: ReportType;
+  contact?: string;
+  surface: "cli" | "mcp";
+  cliVersion: string;
+  clientKind: string;
+  agentName?: string;
+  anonId?: string;
+  os: string;
+  arch: string;
+  runtime: string;
+  command?: string;
+  errorCode?: string;
+  attachment?: ReportAttachment;
+}
+
+export interface SubmitReportOptions {
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+  version?: string;
+  dataDir?: string;
+  /** Include anonId only when telemetry is enabled (default). */
+  includeAnonId?: boolean;
+}
+
+export type ValidateMessageResult = { ok: true; message: string } | { ok: false; error: string };
+
+export function validateReportMessage(raw: string): ValidateMessageResult {
+  const message = raw.trim();
+  if (message.length < MIN_REPORT_MESSAGE) {
+    return { ok: false, error: "message is too short — add a sentence or two" };
+  }
+  if (message.length > MAX_REPORT_MESSAGE) {
+    return {
+      ok: false,
+      error: `message is too long (max ${MAX_REPORT_MESSAGE} chars)`,
+    };
+  }
+  return { ok: true, message };
+}
+
+export function parseReportType(raw: string | undefined): ReportType | undefined {
+  if (!raw) return undefined;
+  return (REPORT_TYPES as readonly string[]).includes(raw) ? (raw as ReportType) : undefined;
+}
+
+/**
+ * Load a local text file as an attachment. Rejects oversized / missing files.
+ * Callers must have obtained the path from explicit user input (`--file`).
+ */
+export function loadReportAttachment(path: string): ReportAttachment {
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      throw new Error(`file not found: ${path}`, { cause: err });
+    }
+    throw err;
+  }
+  if (size > MAX_REPORT_ATTACHMENT_BYTES) {
+    throw new Error(`attachment exceeds ${MAX_REPORT_ATTACHMENT_BYTES} bytes (got ${size})`);
+  }
+  const body = readFileSync(path, "utf8");
+  // Re-check UTF-8 byte length (stat is filesystem size).
+  const bytes = new TextEncoder().encode(body).byteLength;
+  if (bytes > MAX_REPORT_ATTACHMENT_BYTES) {
+    throw new Error(`attachment exceeds ${MAX_REPORT_ATTACHMENT_BYTES} bytes after read`);
+  }
+  const filename = basename(path) || "attachment.txt";
+  const lower = filename.toLowerCase();
+  const contentType =
+    lower.endsWith(".json") || lower.endsWith(".jsonl") || lower.endsWith(".ndjson")
+      ? "application/json"
+      : "text/plain; charset=utf-8";
+  return { filename, contentType, body };
+}
+
+/** Build attachment from an in-memory string (MCP / piped text). */
+export function attachmentFromText(
+  body: string,
+  filename = "trace.txt",
+  contentType = "text/plain; charset=utf-8",
+): ReportAttachment {
+  const bytes = new TextEncoder().encode(body).byteLength;
+  if (bytes > MAX_REPORT_ATTACHMENT_BYTES) {
+    throw new Error(`attachment exceeds ${MAX_REPORT_ATTACHMENT_BYTES} bytes`);
+  }
+  if (!body.trim()) throw new Error("attachment is empty");
+  return {
+    filename: basename(filename) || "trace.txt",
+    contentType,
+    body,
+  };
+}
+
+export function buildReportPayload(
+  message: string,
+  opts: {
+    type?: ReportType;
+    contact?: string;
+    surface?: "cli" | "mcp";
+    command?: string;
+    errorCode?: string;
+    attachment?: ReportAttachment;
+  } = {},
+  deps: {
+    version?: string;
+    dataDir?: string;
+    includeAnonId?: boolean;
+  } = {},
+): ReportPayload {
+  const ctx = detectClientKind();
+  const includeAnon = deps.includeAnonId ?? isTelemetryEnabled(deps.dataDir);
+  return {
+    message,
+    type: opts.type ?? "other",
+    contact: opts.contact?.trim() || undefined,
+    surface: opts.surface ?? "cli",
+    cliVersion: deps.version ?? packageVersion(),
+    clientKind: ctx.kind,
+    agentName: ctx.agentName,
+    anonId: includeAnon ? getOrCreateAnonId(deps.dataDir) : undefined,
+    os: process.platform,
+    arch: process.arch,
+    runtime: detectRuntime(),
+    command: opts.command?.trim().slice(0, 120) || undefined,
+    errorCode: opts.errorCode?.trim().slice(0, 64) || undefined,
+    attachment: opts.attachment,
+  };
+}
+
+export type SubmitReportResult =
+  | { ok: true; id: string; hasAttachment: boolean }
+  | { ok: false; error: string };
+
+export async function submitReport(
+  payload: ReportPayload,
+  opts: SubmitReportOptions = {},
+): Promise<SubmitReportResult> {
+  const base = (opts.apiUrl ?? process.env.UPLOADS_API_URL ?? DEFAULT_API_URL).replace(/\/$/, "");
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  try {
+    const res = await fetchImpl(`${base}/v1/reports`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": `uploads-cli/${payload.cliVersion}`,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      let detail = `server returned ${res.status}`;
+      try {
+        const errBody = (await res.json()) as { error?: { message?: string } };
+        if (errBody?.error?.message) detail = errBody.error.message;
+      } catch {
+        // ignore
+      }
+      return { ok: false, error: detail };
+    }
+    const json = (await res.json()) as {
+      ok?: boolean;
+      id?: string;
+      hasAttachment?: boolean;
+    };
+    if (!json.ok || !json.id) return { ok: false, error: "unexpected response" };
+    return {
+      ok: true,
+      id: json.id,
+      hasAttachment: Boolean(json.hasAttachment),
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("abort")) return { ok: false, error: "request timed out" };
+    return { ok: false, error: msg };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function reportFallbackHint(): string {
+  return `You can open an issue instead: ${ISSUES_URL}`;
+}

--- a/packages/uploads/src/telemetry.ts
+++ b/packages/uploads/src/telemetry.ts
@@ -21,6 +21,7 @@ const DISABLE_FILE = "telemetry-disabled";
 const NOTICE_FILE = "telemetry-notice-shown";
 const POST_TIMEOUT_MS = 1500;
 const MAX_COMMAND = 120;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** Known root commands that take a subcommand as the second positional. */
 const NESTED_COMMANDS = new Set([
@@ -32,6 +33,26 @@ const NESTED_COMMANDS = new Set([
   "install",
   "meta",
   "telemetry",
+]);
+
+/** Global flags that consume a following value (must not become command names). */
+const VALUE_GLOBALS = new Set(["--api-url", "--workspace", "-w", "--token", "--env-file"]);
+
+/** Allowlisted error codes sent to telemetry (mirror server ERROR_CODES). */
+const TELEMETRY_ERROR_CODES = new Set([
+  "MISSING_TOKEN",
+  "NO_PUBLIC_URL",
+  "FILE_NOT_FOUND",
+  "NOT_FOUND",
+  "UNAUTHORIZED",
+  "INVALID_KEY",
+  "KEY_POLICY",
+  "STORAGE_QUOTA",
+  "UPLOAD_BUDGET",
+  "GITHUB_REQUIRED",
+  "API_ERROR",
+  "NETWORK",
+  "USAGE",
 ]);
 
 export type TelemetrySurface = "cli" | "mcp";
@@ -94,7 +115,7 @@ function safeWrite(path: string, content: string, mode?: number): void {
 export function getOrCreateAnonId(dataDir?: string): string {
   const path = filePath(ANON_ID_FILE, dataDir);
   const existing = safeRead(path);
-  if (existing && existing.length > 0) return existing;
+  if (existing && UUID_RE.test(existing)) return existing;
   const id = randomUUID();
   safeWrite(path, id, 0o600);
   return id;
@@ -160,10 +181,26 @@ function endpoint(apiUrl?: string): string {
 
 /**
  * Build a safe command label from argv. Only the root command (+ subcommand
- * for known nested commands). Never includes file paths or flag values.
+ * for known nested commands). Skips global flag/value pairs so
+ * `--token up_… put` never records the token as the command.
  */
 export function telemetryCommandName(argv: string[]): string {
-  const positional = argv.slice(2).filter((a) => !a.startsWith("-"));
+  const args = argv.slice(2);
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--") {
+      positional.push(...args.slice(i + 1).filter((a) => !a.startsWith("-")));
+      break;
+    }
+    if (VALUE_GLOBALS.has(arg)) {
+      i += 1; // skip value
+      continue;
+    }
+    if (arg.startsWith("--") && arg.includes("=")) continue;
+    if (arg.startsWith("-")) continue;
+    positional.push(arg);
+  }
   const root = positional[0];
   if (!root) return "(root)";
   if (!NESTED_COMMANDS.has(root)) return root.slice(0, MAX_COMMAND);
@@ -194,7 +231,8 @@ export function maybeShowFirstRunNotice(
   write(
     [
       "",
-      "uploads collects anonymous usage data (command name, version, OS, exit code).",
+      "uploads collects anonymous usage data: command name, version, OS/arch,",
+      "runtime, exit code, duration, client kind, anonymous id, optional error code.",
       "No arguments, paths, tokens, or file content are sent. Opt out with:",
       "  uploads telemetry disable   # or set UPLOADS_TELEMETRY_DISABLED=1",
       "",
@@ -203,51 +241,50 @@ export function maybeShowFirstRunNotice(
   safeWrite(marker, new Date().toISOString());
 }
 
-export async function recordEvent(
-  input: TelemetryEventInput,
-  opts: RecordEventOptions = {},
-): Promise<void> {
+/**
+ * Fire-and-forget usage ping. Never throws; delivery runs in the background
+ * so CLI exit is not delayed by the network.
+ */
+export function recordEvent(input: TelemetryEventInput, opts: RecordEventOptions = {}): void {
   if (!isTelemetryEnabled(opts.dataDir)) return;
-  try {
-    const ctx = detectClientKind();
-    const command = input.command.trim().slice(0, MAX_COMMAND);
-    if (!command) return;
+  const command = input.command.trim().slice(0, MAX_COMMAND);
+  if (!command) return;
 
-    const body = {
-      anonId: getOrCreateAnonId(opts.dataDir),
-      timestamp: opts.now ?? Date.now(),
-      surface: input.surface,
-      clientKind: ctx.kind,
-      agentName: ctx.agentName ?? null,
-      command,
-      exitCode: input.exitCode ?? null,
-      durationMs: input.durationMs ?? null,
-      errorCode: input.errorCode ?? null,
-      cliVersion: opts.version ?? packageVersion(),
-      os: process.platform,
-      arch: process.arch,
-      runtime: detectRuntime(),
-    };
+  const ctx = detectClientKind();
+  const body = {
+    anonId: getOrCreateAnonId(opts.dataDir),
+    timestamp: opts.now ?? Date.now(),
+    surface: input.surface,
+    clientKind: ctx.kind,
+    agentName: ctx.agentName ?? null,
+    command,
+    exitCode: input.exitCode ?? null,
+    durationMs: input.durationMs ?? null,
+    errorCode: input.errorCode ?? null,
+    cliVersion: opts.version ?? packageVersion(),
+    os: process.platform,
+    arch: process.arch,
+    runtime: detectRuntime(),
+  };
 
-    const controller = new AbortController();
-    const t = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
-    const fetchImpl = opts.fetchImpl ?? fetch;
-    try {
-      await fetchImpl(`${endpoint(opts.apiUrl)}/v1/telemetry`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "user-agent": `uploads-cli/${body.cliVersion}`,
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-    } finally {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  void fetchImpl(`${endpoint(opts.apiUrl)}/v1/telemetry`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "user-agent": `uploads-cli/${body.cliVersion}`,
+    },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  })
+    .catch(() => {
+      // fire-and-forget
+    })
+    .finally(() => {
       clearTimeout(t);
-    }
-  } catch {
-    // fire-and-forget
-  }
+    });
 }
 
 export function telemetryStatus(opts: { dataDir?: string; apiUrl?: string } = {}): {
@@ -282,20 +319,19 @@ export function errorCodeFromUnknown(err: unknown): string | undefined {
   if (
     err &&
     typeof err === "object" &&
-    "code" in err &&
-    typeof (err as { code: unknown }).code === "string"
-  ) {
-    const code = (err as { code: string }).code;
-    // UploadsError codes + UsageError uses name USAGE via exit path
-    return code.slice(0, 64);
-  }
-  if (
-    err &&
-    typeof err === "object" &&
     "name" in err &&
     (err as { name: string }).name === "UsageError"
   ) {
     return "USAGE";
+  }
+  if (
+    err &&
+    typeof err === "object" &&
+    "code" in err &&
+    typeof (err as { code: unknown }).code === "string"
+  ) {
+    const code = (err as { code: string }).code.slice(0, 64);
+    return TELEMETRY_ERROR_CODES.has(code) ? code : undefined;
   }
   return undefined;
 }

--- a/packages/uploads/src/telemetry.ts
+++ b/packages/uploads/src/telemetry.ts
@@ -1,0 +1,301 @@
+/**
+ * Anonymous, opt-out usage telemetry for the CLI and MCP server.
+ *
+ * Sends command names, timing, exit codes, and optional error codes only —
+ * never arguments, paths, tokens, workspace names, or content.
+ *
+ * Opt out:
+ *   UPLOADS_TELEMETRY_DISABLED=1
+ *   DO_NOT_TRACK=1
+ *   uploads telemetry disable
+ */
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { DEFAULT_API_URL } from "./config.js";
+import { packageVersion } from "./package-version.js";
+
+const ANON_ID_FILE = "telemetry-id";
+const DISABLE_FILE = "telemetry-disabled";
+const NOTICE_FILE = "telemetry-notice-shown";
+const POST_TIMEOUT_MS = 1500;
+const MAX_COMMAND = 120;
+
+/** Known root commands that take a subcommand as the second positional. */
+const NESTED_COMMANDS = new Set([
+  "admin",
+  "completion",
+  "completions",
+  "config",
+  "gallery",
+  "install",
+  "meta",
+  "telemetry",
+]);
+
+export type TelemetrySurface = "cli" | "mcp";
+export type TelemetryClientKind = "external" | "ci" | "agent";
+
+export interface TelemetryEventInput {
+  surface: TelemetrySurface;
+  command: string;
+  exitCode?: number;
+  durationMs?: number;
+  /** UploadsError code or USAGE — never free-form messages. */
+  errorCode?: string;
+}
+
+export interface RecordEventOptions {
+  /** Override data directory (tests). */
+  dataDir?: string;
+  /** Override API base URL (tests / --api-url). */
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+  now?: number;
+  version?: string;
+}
+
+function truthyEnv(name: string): boolean {
+  const v = process.env[name];
+  if (!v) return false;
+  const lower = v.toLowerCase();
+  return lower !== "0" && lower !== "false" && lower !== "no";
+}
+
+/** XDG data dir for long-lived telemetry state (anon id, disable marker). */
+export function defaultTelemetryDataDir(): string {
+  const base = process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share");
+  return join(base, "uploads");
+}
+
+function filePath(name: string, dataDir?: string): string {
+  return join(dataDir ?? defaultTelemetryDataDir(), name);
+}
+
+function safeRead(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function safeWrite(path: string, content: string, mode?: number): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, "utf8");
+    if (mode !== undefined) chmodSync(path, mode);
+  } catch {
+    // Telemetry must never throw or break the CLI.
+  }
+}
+
+export function getOrCreateAnonId(dataDir?: string): string {
+  const path = filePath(ANON_ID_FILE, dataDir);
+  const existing = safeRead(path);
+  if (existing && existing.length > 0) return existing;
+  const id = randomUUID();
+  safeWrite(path, id, 0o600);
+  return id;
+}
+
+export function isTelemetryEnabled(dataDir?: string): boolean {
+  if (truthyEnv("UPLOADS_TELEMETRY_DISABLED")) return false;
+  if (process.env.DO_NOT_TRACK === "1") return false;
+  // Vitest sets VITEST=true — never open a network connection from other suites.
+  // Opt in for this package's own telemetry tests with UPLOADS_TELEMETRY_TEST=1.
+  if (process.env.VITEST && process.env.UPLOADS_TELEMETRY_TEST !== "1") return false;
+  if (existsSync(filePath(DISABLE_FILE, dataDir))) return false;
+  return true;
+}
+
+export function setTelemetryEnabled(enabled: boolean, dataDir?: string): void {
+  const path = filePath(DISABLE_FILE, dataDir);
+  if (enabled) {
+    try {
+      if (existsSync(path)) unlinkSync(path);
+    } catch {
+      // ignore
+    }
+  } else {
+    safeWrite(path, "disabled\n");
+  }
+}
+
+export function detectClientKind(): {
+  kind: TelemetryClientKind;
+  agentName?: string;
+} {
+  const envKind = process.env.UPLOADS_CLIENT_KIND;
+  if (envKind === "external" || envKind === "ci" || envKind === "agent") {
+    return { kind: envKind, agentName: process.env.UPLOADS_CLIENT_AGENT };
+  }
+  if (process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true") {
+    return { kind: "ci" };
+  }
+  // Coarse agent-host markers only (no PII).
+  if (process.env.CLAUDECODE || process.env.CLAUDE_CODE) {
+    return { kind: "agent", agentName: process.env.UPLOADS_CLIENT_AGENT ?? "claude" };
+  }
+  if (process.env.CURSOR_AGENT || process.env.CURSOR_TRACE_ID) {
+    return { kind: "agent", agentName: process.env.UPLOADS_CLIENT_AGENT ?? "cursor" };
+  }
+  return { kind: "external" };
+}
+
+export function detectRuntime(): string {
+  const bun = (globalThis as { Bun?: { version?: string } }).Bun;
+  if (bun?.version) return `bun-${bun.version}`;
+  if (typeof process !== "undefined" && process.versions?.node) {
+    return `node-${process.versions.node}`;
+  }
+  return "unknown";
+}
+
+function endpoint(apiUrl?: string): string {
+  const base = (apiUrl ?? process.env.UPLOADS_API_URL ?? DEFAULT_API_URL).replace(/\/$/, "");
+  return base;
+}
+
+/**
+ * Build a safe command label from argv. Only the root command (+ subcommand
+ * for known nested commands). Never includes file paths or flag values.
+ */
+export function telemetryCommandName(argv: string[]): string {
+  const positional = argv.slice(2).filter((a) => !a.startsWith("-"));
+  const root = positional[0];
+  if (!root) return "(root)";
+  if (!NESTED_COMMANDS.has(root)) return root.slice(0, MAX_COMMAND);
+  const sub = positional[1];
+  if (!sub) return root.slice(0, MAX_COMMAND);
+  return `${root} ${sub}`.slice(0, MAX_COMMAND);
+}
+
+/** One-time stderr notice for interactive external users. */
+export function maybeShowFirstRunNotice(
+  opts: {
+    dataDir?: string;
+    write?: (text: string) => void;
+    /** When false, skip (MCP stdio, --json, non-TTY). */
+    interactive?: boolean;
+  } = {},
+): void {
+  if (!isTelemetryEnabled(opts.dataDir)) return;
+  if (opts.interactive === false) return;
+  if (detectClientKind().kind !== "external") return;
+  // Default: only when stderr looks interactive.
+  if (opts.interactive === undefined && !process.stderr.isTTY) return;
+
+  const marker = filePath(NOTICE_FILE, opts.dataDir);
+  if (existsSync(marker)) return;
+
+  const write = opts.write ?? ((t: string) => process.stderr.write(t));
+  write(
+    [
+      "",
+      "uploads collects anonymous usage data (command name, version, OS, exit code).",
+      "No arguments, paths, tokens, or file content are sent. Opt out with:",
+      "  uploads telemetry disable   # or set UPLOADS_TELEMETRY_DISABLED=1",
+      "",
+    ].join("\n"),
+  );
+  safeWrite(marker, new Date().toISOString());
+}
+
+export async function recordEvent(
+  input: TelemetryEventInput,
+  opts: RecordEventOptions = {},
+): Promise<void> {
+  if (!isTelemetryEnabled(opts.dataDir)) return;
+  try {
+    const ctx = detectClientKind();
+    const command = input.command.trim().slice(0, MAX_COMMAND);
+    if (!command) return;
+
+    const body = {
+      anonId: getOrCreateAnonId(opts.dataDir),
+      timestamp: opts.now ?? Date.now(),
+      surface: input.surface,
+      clientKind: ctx.kind,
+      agentName: ctx.agentName ?? null,
+      command,
+      exitCode: input.exitCode ?? null,
+      durationMs: input.durationMs ?? null,
+      errorCode: input.errorCode ?? null,
+      cliVersion: opts.version ?? packageVersion(),
+      os: process.platform,
+      arch: process.arch,
+      runtime: detectRuntime(),
+    };
+
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+    const fetchImpl = opts.fetchImpl ?? fetch;
+    try {
+      await fetchImpl(`${endpoint(opts.apiUrl)}/v1/telemetry`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "user-agent": `uploads-cli/${body.cliVersion}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(t);
+    }
+  } catch {
+    // fire-and-forget
+  }
+}
+
+export function telemetryStatus(opts: { dataDir?: string; apiUrl?: string } = {}): {
+  enabled: boolean;
+  anonId: string;
+  clientKind: TelemetryClientKind;
+  agentName?: string;
+  endpoint: string;
+  reason?: string;
+} {
+  const dataDir = opts.dataDir;
+  const enabled = isTelemetryEnabled(dataDir);
+  let reason: string | undefined;
+  if (truthyEnv("UPLOADS_TELEMETRY_DISABLED")) reason = "UPLOADS_TELEMETRY_DISABLED=1";
+  else if (process.env.DO_NOT_TRACK === "1") reason = "DO_NOT_TRACK=1";
+  else if (existsSync(filePath(DISABLE_FILE, dataDir))) {
+    reason = `${filePath(DISABLE_FILE, dataDir)} present`;
+  }
+  const ctx = detectClientKind();
+  return {
+    enabled,
+    anonId: getOrCreateAnonId(dataDir),
+    clientKind: ctx.kind,
+    agentName: ctx.agentName,
+    endpoint: `${endpoint(opts.apiUrl)}/v1/telemetry`,
+    reason,
+  };
+}
+
+/** Map thrown CLI errors to a short, allowlisted code for telemetry. */
+export function errorCodeFromUnknown(err: unknown): string | undefined {
+  if (
+    err &&
+    typeof err === "object" &&
+    "code" in err &&
+    typeof (err as { code: unknown }).code === "string"
+  ) {
+    const code = (err as { code: string }).code;
+    // UploadsError codes + UsageError uses name USAGE via exit path
+    return code.slice(0, 64);
+  }
+  if (
+    err &&
+    typeof err === "object" &&
+    "name" in err &&
+    (err as { name: string }).name === "UsageError"
+  ) {
+    return "USAGE";
+  }
+  return undefined;
+}

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -751,6 +751,57 @@ describe("config resolution", () => {
     expect(res.result.structuredContent).toEqual({ ok: true, apiUrl: "https://x.test" });
   });
 
+  it("report rejects short messages", async () => {
+    const { server } = serverWith();
+    const res = await rpc(server, "tools/call", {
+      name: "report",
+      arguments: { message: "hi" },
+    });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toMatch(/too short/i);
+  });
+
+  it("report rejects oversized attachments", async () => {
+    const { server } = serverWith();
+    const res = await rpc(server, "tools/call", {
+      name: "report",
+      arguments: {
+        message: "log attached is too big",
+        attachmentText: "x".repeat(256 * 1024 + 1),
+      },
+    });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toMatch(/exceeds/i);
+  });
+
+  it("report submits successfully when the intake responds", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: true, id: "rpt_test", hasAttachment: false }), {
+        status: 202,
+      })) as typeof fetch;
+    try {
+      const { server } = serverWith();
+      const res = await rpc(server, "tools/call", {
+        name: "report",
+        arguments: {
+          message: "put fails with KEY_POLICY in tests",
+          type: "error",
+          command: "put",
+          errorCode: "KEY_POLICY",
+        },
+      });
+      expect(res.result.isError).toBe(false);
+      expect(res.result.structuredContent).toEqual({
+        ok: true,
+        id: "rpt_test",
+        hasAttachment: false,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("a per-call workspace argument overrides the globals", async () => {
     const { server, configs } = serverWith();
     await rpc(server, "tools/call", {

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -327,6 +327,7 @@ describe("tools/list", () => {
       "comment",
       "health",
       "doctor",
+      "report",
     ]);
     for (const tool of tools) {
       expect(tool.description.length).toBeGreaterThan(20);

--- a/packages/uploads/test/report.test.ts
+++ b/packages/uploads/test/report.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  attachmentFromText,
+  buildReportPayload,
+  loadReportAttachment,
+  MAX_REPORT_ATTACHMENT_BYTES,
+  parseReportType,
+  submitReport,
+  validateReportMessage,
+} from "../src/report.js";
+
+process.env.UPLOADS_TELEMETRY_TEST = "1";
+
+describe("validateReportMessage / parseReportType", () => {
+  it("enforces length bounds", () => {
+    expect(validateReportMessage("hi").ok).toBe(false);
+    expect(validateReportMessage("this is fine").ok).toBe(true);
+    expect(validateReportMessage("x".repeat(4001)).ok).toBe(false);
+  });
+
+  it("parses types", () => {
+    expect(parseReportType("bug")).toBe("bug");
+    expect(parseReportType("nope")).toBeUndefined();
+  });
+});
+
+describe("attachments", () => {
+  it("loads a text file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-report-"));
+    const path = join(dir, "trace.log");
+    writeFileSync(path, "line1\nline2\n");
+    const att = loadReportAttachment(path);
+    expect(att.filename).toBe("trace.log");
+    expect(att.body).toContain("line1");
+    expect(att.contentType).toMatch(/text\/plain/);
+  });
+
+  it("rejects oversized in-memory attachments", () => {
+    expect(() => attachmentFromText("x".repeat(MAX_REPORT_ATTACHMENT_BYTES + 1))).toThrow(
+      /exceeds/,
+    );
+  });
+});
+
+describe("buildReportPayload / submitReport", () => {
+  const prevDisabled = process.env.UPLOADS_TELEMETRY_DISABLED;
+  const prevDnt = process.env.DO_NOT_TRACK;
+
+  afterEach(() => {
+    if (prevDisabled === undefined) delete process.env.UPLOADS_TELEMETRY_DISABLED;
+    else process.env.UPLOADS_TELEMETRY_DISABLED = prevDisabled;
+    if (prevDnt === undefined) delete process.env.DO_NOT_TRACK;
+    else process.env.DO_NOT_TRACK = prevDnt;
+  });
+
+  it("omits anonId when telemetry is disabled", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-report-"));
+    process.env.UPLOADS_TELEMETRY_DISABLED = "1";
+    delete process.env.DO_NOT_TRACK;
+    const payload = buildReportPayload(
+      "something broke during put",
+      { type: "error", command: "put", errorCode: "KEY_POLICY" },
+      { dataDir: dir, version: "0.10.0" },
+    );
+    expect(payload.anonId).toBeUndefined();
+    expect(payload.command).toBe("put");
+    expect(payload.errorCode).toBe("KEY_POLICY");
+    expect(payload.cliVersion).toBe("0.10.0");
+  });
+
+  it("POSTs payload and returns id", async () => {
+    const result = await submitReport(
+      buildReportPayload("something broke during put", { type: "bug" }, { version: "0.10.0" }),
+      {
+        apiUrl: "https://api.example.test",
+        fetchImpl: async (input, init) => {
+          expect(String(input)).toBe("https://api.example.test/v1/reports");
+          const body = JSON.parse(String(init?.body)) as { message: string; type: string };
+          expect(body.message).toMatch(/broke/);
+          expect(body.type).toBe("bug");
+          return new Response(JSON.stringify({ ok: true, id: "rpt_abc", hasAttachment: false }), {
+            status: 202,
+          });
+        },
+      },
+    );
+    expect(result).toEqual({ ok: true, id: "rpt_abc", hasAttachment: false });
+  });
+});

--- a/packages/uploads/test/report.test.ts
+++ b/packages/uploads/test/report.test.ts
@@ -43,6 +43,13 @@ describe("attachments", () => {
       /exceeds/,
     );
   });
+
+  it("rejects oversized on-disk attachments", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-report-"));
+    const path = join(dir, "huge.log");
+    writeFileSync(path, "x".repeat(MAX_REPORT_ATTACHMENT_BYTES + 1));
+    expect(() => loadReportAttachment(path)).toThrow(/exceeds/);
+  });
 });
 
 describe("buildReportPayload / submitReport", () => {

--- a/packages/uploads/test/telemetry.test.ts
+++ b/packages/uploads/test/telemetry.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getOrCreateAnonId,
+  isTelemetryEnabled,
+  setTelemetryEnabled,
+  telemetryCommandName,
+  telemetryStatus,
+  recordEvent,
+  maybeShowFirstRunNotice,
+  errorCodeFromUnknown,
+} from "../src/telemetry.js";
+import { UploadsError } from "../src/errors.js";
+import { UsageError } from "../src/cli-args.js";
+
+// Allow isTelemetryEnabled / recordEvent during this file only.
+process.env.UPLOADS_TELEMETRY_TEST = "1";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "uploads-telemetry-"));
+}
+
+function clearOptOutEnv(): void {
+  delete process.env.UPLOADS_TELEMETRY_DISABLED;
+  delete process.env.DO_NOT_TRACK;
+  process.env.UPLOADS_CLIENT_KIND = "external";
+  delete process.env.CI;
+  delete process.env.GITHUB_ACTIONS;
+  delete process.env.CLAUDECODE;
+  delete process.env.CLAUDE_CODE;
+  delete process.env.CURSOR_AGENT;
+  delete process.env.CURSOR_TRACE_ID;
+}
+
+describe("telemetryCommandName", () => {
+  it("returns root for simple commands and ignores file args", () => {
+    expect(telemetryCommandName(["node", "uploads", "put", "./secret.png"])).toBe("put");
+    expect(telemetryCommandName(["node", "uploads", "attach", "a.png", "b.png"])).toBe("attach");
+  });
+
+  it("includes subcommand for nested commands only", () => {
+    expect(telemetryCommandName(["node", "uploads", "config", "set", "UPLOADS_TOKEN", "x"])).toBe(
+      "config set",
+    );
+    expect(telemetryCommandName(["node", "uploads", "gallery", "create", "--title", "x"])).toBe(
+      "gallery create",
+    );
+    expect(telemetryCommandName(["node", "uploads", "telemetry", "disable"])).toBe(
+      "telemetry disable",
+    );
+  });
+
+  it("handles root / flags-only", () => {
+    expect(telemetryCommandName(["node", "uploads"])).toBe("(root)");
+    expect(telemetryCommandName(["node", "uploads", "--json", "doctor"])).toBe("doctor");
+  });
+});
+
+describe("isTelemetryEnabled / setTelemetryEnabled", () => {
+  const prevDisabled = process.env.UPLOADS_TELEMETRY_DISABLED;
+  const prevDnt = process.env.DO_NOT_TRACK;
+
+  afterEach(() => {
+    if (prevDisabled === undefined) delete process.env.UPLOADS_TELEMETRY_DISABLED;
+    else process.env.UPLOADS_TELEMETRY_DISABLED = prevDisabled;
+    if (prevDnt === undefined) delete process.env.DO_NOT_TRACK;
+    else process.env.DO_NOT_TRACK = prevDnt;
+  });
+
+  it("opts out via UPLOADS_TELEMETRY_DISABLED", () => {
+    const dir = tempDir();
+    process.env.UPLOADS_TELEMETRY_DISABLED = "1";
+    delete process.env.DO_NOT_TRACK;
+    expect(isTelemetryEnabled(dir)).toBe(false);
+  });
+
+  it("opts out via DO_NOT_TRACK=1", () => {
+    const dir = tempDir();
+    delete process.env.UPLOADS_TELEMETRY_DISABLED;
+    process.env.DO_NOT_TRACK = "1";
+    expect(isTelemetryEnabled(dir)).toBe(false);
+  });
+
+  it("opts out via disable file", () => {
+    const dir = tempDir();
+    clearOptOutEnv();
+    expect(isTelemetryEnabled(dir)).toBe(true);
+    setTelemetryEnabled(false, dir);
+    expect(isTelemetryEnabled(dir)).toBe(false);
+    setTelemetryEnabled(true, dir);
+    expect(isTelemetryEnabled(dir)).toBe(true);
+  });
+});
+
+describe("getOrCreateAnonId", () => {
+  it("persists a stable UUID", () => {
+    const dir = tempDir();
+    const a = getOrCreateAnonId(dir);
+    const b = getOrCreateAnonId(dir);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(existsSync(join(dir, "telemetry-id"))).toBe(true);
+  });
+});
+
+describe("recordEvent", () => {
+  const prevDisabled = process.env.UPLOADS_TELEMETRY_DISABLED;
+  const prevDnt = process.env.DO_NOT_TRACK;
+
+  beforeEach(() => {
+    clearOptOutEnv();
+  });
+
+  afterEach(() => {
+    if (prevDisabled === undefined) delete process.env.UPLOADS_TELEMETRY_DISABLED;
+    else process.env.UPLOADS_TELEMETRY_DISABLED = prevDisabled;
+    if (prevDnt === undefined) delete process.env.DO_NOT_TRACK;
+    else process.env.DO_NOT_TRACK = prevDnt;
+  });
+
+  it("POSTs a PII-clean payload and skips when disabled", async () => {
+    const dir = tempDir();
+    clearOptOutEnv();
+    const bodies: unknown[] = [];
+    await recordEvent(
+      {
+        surface: "cli",
+        command: "put",
+        exitCode: 3,
+        durationMs: 42,
+        errorCode: "KEY_POLICY",
+      },
+      {
+        dataDir: dir,
+        apiUrl: "https://api.example.test",
+        version: "0.10.0",
+        now: 1_700_000_000_000,
+        fetchImpl: async (input, init) => {
+          expect(String(input)).toBe("https://api.example.test/v1/telemetry");
+          expect(init?.method).toBe("POST");
+          bodies.push(JSON.parse(String(init?.body)));
+          return new Response(JSON.stringify({ ok: true }), { status: 202 });
+        },
+      },
+    );
+
+    expect(bodies).toHaveLength(1);
+    const body = bodies[0] as Record<string, unknown>;
+    expect(body.command).toBe("put");
+    expect(body.surface).toBe("cli");
+    expect(body.exitCode).toBe(3);
+    expect(body.durationMs).toBe(42);
+    expect(body.errorCode).toBe("KEY_POLICY");
+    expect(body.cliVersion).toBe("0.10.0");
+    expect(body.anonId).toBeTruthy();
+    // Must never include path-like content in the envelope keys we control.
+    expect(JSON.stringify(body)).not.toMatch(/secret|\.png|token|up_/i);
+
+    setTelemetryEnabled(false, dir);
+    await recordEvent(
+      { surface: "cli", command: "put" },
+      {
+        dataDir: dir,
+        fetchImpl: async () => {
+          throw new Error("should not fetch");
+        },
+      },
+    );
+  });
+
+  it("never throws on network failure", async () => {
+    const dir = tempDir();
+    await expect(
+      recordEvent(
+        { surface: "cli", command: "doctor" },
+        {
+          dataDir: dir,
+          fetchImpl: async () => {
+            throw new Error("network down");
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("maybeShowFirstRunNotice", () => {
+  const prevDisabled = process.env.UPLOADS_TELEMETRY_DISABLED;
+
+  afterEach(() => {
+    if (prevDisabled === undefined) delete process.env.UPLOADS_TELEMETRY_DISABLED;
+    else process.env.UPLOADS_TELEMETRY_DISABLED = prevDisabled;
+  });
+
+  it("prints once then is silent", () => {
+    const dir = tempDir();
+    clearOptOutEnv();
+    const lines: string[] = [];
+    maybeShowFirstRunNotice({
+      dataDir: dir,
+      interactive: true,
+      write: (t) => lines.push(t),
+    });
+    expect(lines.join("")).toMatch(/anonymous usage/);
+    expect(existsSync(join(dir, "telemetry-notice-shown"))).toBe(true);
+    const first = lines.length;
+    maybeShowFirstRunNotice({
+      dataDir: dir,
+      interactive: true,
+      write: (t) => lines.push(t),
+    });
+    expect(lines.length).toBe(first);
+  });
+});
+
+describe("telemetryStatus / errorCodeFromUnknown", () => {
+  it("reports disable reason", () => {
+    const dir = tempDir();
+    setTelemetryEnabled(false, dir);
+    const s = telemetryStatus({ dataDir: dir, apiUrl: "https://api.uploads.sh" });
+    expect(s.enabled).toBe(false);
+    expect(s.reason).toMatch(/telemetry-disabled/);
+    expect(s.endpoint).toBe("https://api.uploads.sh/v1/telemetry");
+  });
+
+  it("maps known errors", () => {
+    expect(errorCodeFromUnknown(new UploadsError("nope", "UNAUTHORIZED", 401))).toBe(
+      "UNAUTHORIZED",
+    );
+    expect(errorCodeFromUnknown(new UsageError("bad"))).toBe("USAGE");
+    expect(errorCodeFromUnknown(new Error("boom"))).toBeUndefined();
+  });
+
+  it("writes disable marker content", () => {
+    const dir = tempDir();
+    setTelemetryEnabled(false, dir);
+    expect(readFileSync(join(dir, "telemetry-disabled"), "utf8")).toMatch(/disabled/);
+  });
+});

--- a/packages/uploads/test/telemetry.test.ts
+++ b/packages/uploads/test/telemetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -49,6 +49,24 @@ describe("telemetryCommandName", () => {
     );
     expect(telemetryCommandName(["node", "uploads", "telemetry", "disable"])).toBe(
       "telemetry disable",
+    );
+  });
+
+  it("skips value-bearing global flags and their values", () => {
+    expect(
+      telemetryCommandName([
+        "node",
+        "uploads",
+        "--token",
+        "up_secret_token",
+        "--api-url",
+        "https://api.example",
+        "put",
+        "./x.png",
+      ]),
+    ).toBe("put");
+    expect(telemetryCommandName(["node", "uploads", "--env-file", "/path/to/.env", "doctor"])).toBe(
+      "doctor",
     );
   });
 
@@ -124,7 +142,11 @@ describe("recordEvent", () => {
     const dir = tempDir();
     clearOptOutEnv();
     const bodies: unknown[] = [];
-    await recordEvent(
+    let resolvePosted!: () => void;
+    const posted = new Promise<void>((r) => {
+      resolvePosted = r;
+    });
+    recordEvent(
       {
         surface: "cli",
         command: "put",
@@ -141,10 +163,12 @@ describe("recordEvent", () => {
           expect(String(input)).toBe("https://api.example.test/v1/telemetry");
           expect(init?.method).toBe("POST");
           bodies.push(JSON.parse(String(init?.body)));
+          resolvePosted();
           return new Response(JSON.stringify({ ok: true }), { status: 202 });
         },
       },
     );
+    await posted;
 
     expect(bodies).toHaveLength(1);
     const body = bodies[0] as Record<string, unknown>;
@@ -159,20 +183,22 @@ describe("recordEvent", () => {
     expect(JSON.stringify(body)).not.toMatch(/secret|\.png|token|up_/i);
 
     setTelemetryEnabled(false, dir);
-    await recordEvent(
-      { surface: "cli", command: "put" },
-      {
-        dataDir: dir,
-        fetchImpl: async () => {
-          throw new Error("should not fetch");
+    expect(() =>
+      recordEvent(
+        { surface: "cli", command: "put" },
+        {
+          dataDir: dir,
+          fetchImpl: async () => {
+            throw new Error("should not fetch");
+          },
         },
-      },
-    );
+      ),
+    ).not.toThrow();
   });
 
   it("never throws on network failure", async () => {
     const dir = tempDir();
-    await expect(
+    expect(() =>
       recordEvent(
         { surface: "cli", command: "doctor" },
         {
@@ -182,7 +208,8 @@ describe("recordEvent", () => {
           },
         },
       ),
-    ).resolves.toBeUndefined();
+    ).not.toThrow();
+    await new Promise((r) => setTimeout(r, 10));
   });
 });
 
@@ -225,12 +252,23 @@ describe("telemetryStatus / errorCodeFromUnknown", () => {
     expect(s.endpoint).toBe("https://api.uploads.sh/v1/telemetry");
   });
 
-  it("maps known errors", () => {
+  it("maps allowlisted errors only", () => {
     expect(errorCodeFromUnknown(new UploadsError("nope", "UNAUTHORIZED", 401))).toBe(
       "UNAUTHORIZED",
     );
     expect(errorCodeFromUnknown(new UsageError("bad"))).toBe("USAGE");
     expect(errorCodeFromUnknown(new Error("boom"))).toBeUndefined();
+    expect(errorCodeFromUnknown(Object.assign(new Error("x"), { code: "SECRET_PATH" }))).toBe(
+      undefined,
+    );
+  });
+
+  it("rejects non-UUID anon ids and rewrites the file", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "telemetry-id"), "not-a-uuid\n");
+    const id = getOrCreateAnonId(dir);
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(getOrCreateAnonId(dir)).toBe(id);
   });
 
   it("writes disable marker content", () => {

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -432,6 +432,10 @@ uploads --api-url http://localhost:8787 doctor
   `hint: uploads <cmd> --help`.
 - **Update hints (stderr):** successful human runs may note a newer npm release
   (daily). Silence with `--quiet` / `--json` / `UPLOADS_NO_UPDATE=1`.
+- **Telemetry:** anonymous command-name pings (no paths/tokens). Opt out with
+  `UPLOADS_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, or `uploads telemetry disable`.
+- **Reports:** only when the user asks — `uploads report "what broke"` or
+  `--file ./trace.log`. Never auto-send logs. MCP tool: `report`.
 - **MCP:** `uploads mcp` (stdio) mirrors CLI tools; hosted MCP at
   `https://agents.uploads.sh/mcp`. `uploads install` sets up this skill + hosted MCP
   (short progress; `--verbose` / `--dry-run` available).


### PR DESCRIPTION
## In plain terms

The CLI (and MCP) can now send **anonymous usage pings** so we can see which commands people run and which errors show up — without collecting paths, tokens, or file content. Separately, users can **opt in** to send a short diagnostic report (and optional text log) when something breaks.

## What it does

- **Telemetry** (on by default, easy opt-out): after each command / MCP tool call, fire-and-forget `POST /v1/telemetry` with command name, version, OS/arch, exit code, duration, and allowlisted error codes only
  - Opt out: `UPLOADS_TELEMETRY_DISABLED=1`, `DO_NOT_TRACK=1`, or `uploads telemetry disable`
  - First interactive run prints a one-line notice
- **Reports** (never automatic): `uploads report "what broke"` and MCP `report` tool
  - Optional text attachment (`--file` or piped stdin with a message summary)
  - Max 256 KiB text/json
- **Storage** (existing D1, no new database):
  - `uploads_telemetry_events` — high-volume command pings
  - `uploads_cli_reports` — sparse free-text reports
  - Report blobs: R2 `_internal/uploads-cli-reports/<id>/…` (unguessable id; no public CDN URL returned)
- Kill switches: `TELEMETRY_DISABLED`, `REPORTS_DISABLED`
- Changeset: minor for `@buildinternet/uploads`

## What it is not

- Not a full analytics product or admin triage UI
- Does not auto-upload logs, env files, or directory listings
- Does not use KV for event storage (D1 for append + aggregate; R2 for report blobs)

## How to try it

```bash
uploads telemetry status
uploads telemetry disable   # or UPLOADS_TELEMETRY_DISABLED=1

uploads report "put fails with KEY_POLICY on custom prefixes"
uploads report --type bug --file ./trace.log "crash during optimize"
uploads doctor --json 2>&1 | uploads report "doctor failed"
uploads report --dry-run "preview without sending"
```

## Technical notes

- Shared API helpers in `apps/api/src/cli-intake.ts`
- Migration: `apps/api/migrations/20260715120000_uploads_cli_observability.sql` (applied on deploy via existing D1 migrate path)
- Operator queries: see `docs/ops.md` (CLI observability section)

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @uploads/api test` (telemetry + reports suites)
- [x] typecheck + pre-commit lint
- [x] CLI smoke: `telemetry status --json`, `report --dry-run --json`
- [ ] After merge: confirm D1 migration applies in prod; spot-check a local or staging `POST /v1/telemetry` and `POST /v1/reports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added anonymous, opt-out usage telemetry for CLI and MCP activity.
  - Added `uploads telemetry` commands to view, enable, or disable telemetry.
  - Added opt-in diagnostic reports through `uploads report` and the MCP `report` tool, with optional text attachments and dry-run previews.

- **Documentation**
  - Updated CLI, configuration, operations, and skill documentation with telemetry controls and reporting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->