### PR TITLE
feat(cli): human-readable usage meters and briefer telemetry notice

### DIFF
--- a/.changeset/cli-usage-human.md
+++ b/.changeset/cli-usage-human.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Make `uploads usage` human-readable: formatted sizes/counts, local-timezone timestamps, and terminal progress bars (with web-matching % and high/full thresholds). Also shortens the first-run telemetry notice to a brief non-PII opt-out FYI.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -49,9 +49,12 @@ import {
 import { applyFrame, resolveFrameId, type FrameResult } from "./frame.js";
 import { buildCliProvenance } from "./provenance.js";
 import { formatByteSize } from "./format-bytes.js";
+import { formatUsageHuman } from "./format-usage.js";
 import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
-import { writeCommandHelp } from "./cli-style.js";
+import { colorEnabled, writeCommandHelp } from "./cli-style.js";
+
+export { formatUsageHuman } from "./format-usage.js";
 
 export interface CliContext {
   config: ResolvedConfig;
@@ -1261,12 +1264,21 @@ export async function runComment(
 
 const USAGE_HELP = `uploads usage [--workspace <name>]
 
-Show workspace storage and monthly upload counters (and limits when set).
+Show workspace storage and monthly upload counters.
+
+When the API reports workspace quotas (typical on uploads.sh cloud /
+self-serve plans), human output includes progress bars toward those caps.
+Self-hosted or unlimited operator workspaces get usage totals only, plus a
+short unmetered note — no invented limits.
 
 Examples:
   uploads --env-file .env usage
   uploads usage --json
 `;
+
+function formatCount(n: number): string {
+  return Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : String(n);
+}
 
 export async function runUsage(ctx: CliContext, args: string[], help = false): Promise<number> {
   if (help || parseCommandArgs(args).help) {
@@ -1278,14 +1290,9 @@ export async function runUsage(ctx: CliContext, args: string[], help = false): P
     await writeJson(result);
     return 0;
   }
-  const lines = [
-    `workspace: ${result.workspace}`,
-    `bytes:     ${result.bytes}${result.maxStorageBytes != null ? ` / ${result.maxStorageBytes} (${result.storageRemainingBytes} remaining)` : ""}`,
-    `objects:   ${result.objects}`,
-    `uploads:   ${result.uploadsInPeriod} this period (${result.periodStart})${result.maxUploadsPerPeriod != null ? ` / ${result.maxUploadsPerPeriod} (${result.uploadsRemaining} remaining)` : ""}`,
-    `updated:   ${result.updatedAt}`,
-  ];
-  await writeStdout(lines.join("\n") + "\n");
+  await writeStdout(
+    formatUsageHuman(result, { color: colorEnabled(process.stdout) }).join("\n") + "\n",
+  );
   return 0;
 }
 
@@ -1512,7 +1519,7 @@ export async function runDoctor(ctx: CliContext, args: string[], help = false): 
   if (report.usage) {
     lines.push(
       report.usage.ok
-        ? `usage:     ${report.usage.bytes} bytes, ${report.usage.objects} objects, ${report.usage.uploadsInPeriod} uploads this period`
+        ? `usage:     ${formatByteSize(report.usage.bytes ?? 0)}, ${formatCount(report.usage.objects ?? 0)} objects, ${formatCount(report.usage.uploadsInPeriod ?? 0)} uploads this period`
         : `usage:     failed — ${report.usage.error ?? "unknown"}`,
     );
   }

--- a/packages/uploads/src/commands/telemetry.ts
+++ b/packages/uploads/src/commands/telemetry.ts
@@ -63,13 +63,8 @@ export async function runTelemetry(
       process.stdout.write(`Anon ID:   ${s.anonId}\n`);
       process.stdout.write(`Kind:      ${s.clientKind}${s.agentName ? ` (${s.agentName})` : ""}\n`);
       process.stdout.write(`Endpoint:  ${s.endpoint}\n`);
-      process.stdout.write(
-        "\nCollected: command name, version, OS/arch, runtime, exit code, duration,\n",
-      );
-      process.stdout.write(
-        "           client kind, anonymous id, optional allowlisted error code.\n",
-      );
-      process.stdout.write("Never:     arguments, paths, tokens, workspace names, or content.\n");
+      process.stdout.write("\nAnonymous non-PII usage only (no paths, tokens, or content).\n");
+      process.stdout.write("See `uploads telemetry --help` for what is sent and how to opt out.\n");
       return 0;
     }
     case "enable": {

--- a/packages/uploads/src/format-usage.ts
+++ b/packages/uploads/src/format-usage.ts
@@ -1,0 +1,164 @@
+/**
+ * Human formatting for `uploads usage` — sizes, progress bars (mirrors web
+ * account meters when workspace quotas exist), and local timestamps.
+ *
+ * Metered vs unmetered is derived from the usage payload: cloud / self-serve
+ * workspaces ship with `maxStorageBytes` / `maxUploadsPerPeriod`; self-host
+ * and operator workspaces usually omit them (unlimited). Progress bars only
+ * appear for fields that have a positive cap — never invent a budget.
+ */
+import { formatByteSize } from "./format-bytes.js";
+import { BRAND, type Rgb } from "./cli-brand.js";
+
+export type UsageSnapshotLike = {
+  workspace: string;
+  bytes: number;
+  objects: number;
+  uploadsInPeriod: number;
+  periodStart: string;
+  updatedAt: string;
+  maxStorageBytes?: number;
+  storageRemainingBytes?: number;
+  maxUploadsPerPeriod?: number;
+  uploadsRemaining?: number;
+};
+
+export type FormatUsageOptions = {
+  /** IANA zone or undefined for the host local zone. */
+  timeZone?: string;
+  /** Color the bar fill (TTY / FORCE_COLOR). Default false. */
+  color?: boolean;
+  /** Progress track width in cells. Default 20. */
+  barWidth?: number;
+};
+
+/** True when the API reported any cumulative workspace quota. */
+export function isUsageMetered(result: UsageSnapshotLike): boolean {
+  return (
+    usagePct(result.bytes, result.maxStorageBytes) !== null ||
+    usagePct(result.uploadsInPeriod, result.maxUploadsPerPeriod) !== null
+  );
+}
+
+/** 0–100, one decimal. Missing/invalid caps → no bar. Matches web `usagePct`. */
+export function usagePct(value: number, max: number | undefined): number | null {
+  if (typeof max !== "number" || !(max > 0) || !Number.isFinite(value)) return null;
+  return Math.min(100, Math.max(0, Math.round((value / max) * 1000) / 10));
+}
+
+/** Web thresholds: high ≥85, full ≥100. */
+export function usageLevel(pct: number): "normal" | "high" | "full" {
+  if (pct >= 100) return "full";
+  if (pct >= 85) return "high";
+  return "normal";
+}
+
+/**
+ * Terminal meter: `[████░░░░░░░░░░░░░░░░]  20%`
+ * At least one filled cell when pct > 0 so tiny usage is still visible.
+ */
+export function formatProgressBar(
+  pct: number,
+  opts: { width?: number; color?: boolean } = {},
+): string {
+  const width = opts.width ?? 20;
+  const clamped = Math.min(100, Math.max(0, pct));
+  let filled = Math.round((clamped / 100) * width);
+  if (clamped > 0 && filled === 0) filled = 1;
+  if (clamped >= 100) filled = width;
+  filled = Math.min(width, Math.max(0, filled));
+
+  const fillChar = "█";
+  const emptyChar = "░";
+  const body = fillChar.repeat(filled) + emptyChar.repeat(width - filled);
+  const bar = opts.color ? colorizeBar(body, filled, usageLevel(clamped)) : body;
+  const label = formatPctLabel(clamped);
+  return `[${bar}] ${label.padStart(5)}`;
+}
+
+function formatPctLabel(pct: number): string {
+  if (Number.isInteger(pct)) return `${pct}%`;
+  return `${pct.toFixed(1)}%`;
+}
+
+function colorizeBar(body: string, filled: number, level: "normal" | "high" | "full"): string {
+  if (filled <= 0) return paint(body, BRAND.muted);
+  const fill = body.slice(0, filled);
+  const empty = body.slice(filled);
+  const tone = level === "full" ? BRAND.accent : level === "high" ? BRAND.body : BRAND.green;
+  return paint(fill, tone) + paint(empty, BRAND.muted);
+}
+
+function paint(text: string, c: Rgb): string {
+  return `\u001b[38;2;${c.r};${c.g};${c.b}m${text}\u001b[0m`;
+}
+
+function formatCount(n: number): string {
+  return Number.isFinite(n) ? Math.trunc(n).toLocaleString("en-US") : String(n);
+}
+
+/** Host-local time by default; pass `timeZone` for stable tests. */
+export function formatUsageTimestamp(iso: string, timeZone?: string): string {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return iso;
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "short",
+      ...(timeZone ? { timeZone } : {}),
+    }).format(new Date(ms));
+  } catch {
+    return iso;
+  }
+}
+
+/** Human-readable lines for `uploads usage` (not JSON). */
+export function formatUsageHuman(
+  result: UsageSnapshotLike,
+  opts: FormatUsageOptions = {},
+): string[] {
+  const width = opts.barWidth ?? 20;
+  const color = opts.color === true;
+  const metered = isUsageMetered(result);
+  const lines: string[] = [`workspace: ${result.workspace}`];
+
+  const storagePct = usagePct(result.bytes, result.maxStorageBytes);
+  if (storagePct !== null && result.maxStorageBytes != null) {
+    const detail =
+      `${formatByteSize(result.bytes)} / ${formatByteSize(result.maxStorageBytes)}` +
+      (result.storageRemainingBytes != null
+        ? ` (${formatByteSize(result.storageRemainingBytes)} free)`
+        : "");
+    const bar = formatProgressBar(storagePct, { width, color });
+    lines.push(`storage:   ${bar}  ${detail}`);
+  } else {
+    lines.push(`storage:   ${formatByteSize(result.bytes)}`);
+  }
+
+  lines.push(`objects:   ${formatCount(result.objects)}`);
+
+  const uploadsPct = usagePct(result.uploadsInPeriod, result.maxUploadsPerPeriod);
+  if (uploadsPct !== null && result.maxUploadsPerPeriod != null) {
+    const detail = `${formatCount(result.uploadsInPeriod)} / ${formatCount(result.maxUploadsPerPeriod)} this period (${result.periodStart})`;
+    const bar = formatProgressBar(uploadsPct, { width, color });
+    lines.push(`uploads:   ${bar}  ${detail}`);
+  } else {
+    // Unmetered (or no upload cap): period counter only — not a quota fraction.
+    lines.push(
+      `uploads:   ${formatCount(result.uploadsInPeriod)} this period (${result.periodStart})`,
+    );
+  }
+
+  lines.push(`updated:   ${formatUsageTimestamp(result.updatedAt, opts.timeZone)}`);
+
+  if (!metered) {
+    // Self-host / operator unlimited: report usage without implying a plan.
+    lines.push("note:      unmetered — no storage or upload quotas on this workspace");
+  }
+
+  return lines;
+}

--- a/packages/uploads/src/telemetry.ts
+++ b/packages/uploads/src/telemetry.ts
@@ -229,14 +229,9 @@ export function maybeShowFirstRunNotice(
 
   const write = opts.write ?? ((t: string) => process.stderr.write(t));
   write(
-    [
-      "",
-      "uploads collects anonymous usage data: command name, version, OS/arch,",
-      "runtime, exit code, duration, client kind, anonymous id, optional error code.",
-      "No arguments, paths, tokens, or file content are sent. Opt out with:",
-      "  uploads telemetry disable   # or set UPLOADS_TELEMETRY_DISABLED=1",
-      "",
-    ].join("\n"),
+    "\n" +
+      "Note: uploads collects anonymous non-PII usage data. " +
+      "Opt out with `uploads telemetry disable` or UPLOADS_TELEMETRY_DISABLED=1.\n\n",
   );
   safeWrite(marker, new Date().toISOString());
 }

--- a/packages/uploads/test/commands-usage.test.ts
+++ b/packages/uploads/test/commands-usage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UploadsClient } from "../src/client.js";
 import { runUsage, runReconcile, runPurgeExpired, type CliContext } from "../src/commands.js";
 
@@ -19,6 +19,10 @@ function ctxWith(client: Partial<UploadsClient>, json = false): CliContext {
 }
 
 describe("runUsage / runReconcile / runPurgeExpired", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("usage returns the snapshot", async () => {
     const snap = {
       workspace: "test",
@@ -28,6 +32,12 @@ describe("runUsage / runReconcile / runPurgeExpired", () => {
       periodStart: "2026-07",
       updatedAt: "2026-07-11T00:00:00.000Z",
     };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+
     const code = await runUsage(
       ctxWith({
         usage: async () => snap,
@@ -35,6 +45,8 @@ describe("runUsage / runReconcile / runPurgeExpired", () => {
       [],
     );
     expect(code).toBe(0);
+    expect(chunks.join("")).toContain("storage:   10 B");
+    expect(chunks.join("")).not.toContain("bytes:");
   });
 
   it("reconcile reports change", async () => {

--- a/packages/uploads/test/format-usage.test.ts
+++ b/packages/uploads/test/format-usage.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatProgressBar,
+  formatUsageHuman,
+  formatUsageTimestamp,
+  isUsageMetered,
+  usageLevel,
+  usagePct,
+} from "../src/format-usage.js";
+
+describe("usagePct / usageLevel", () => {
+  it("mirrors web 0–100 one-decimal math", () => {
+    expect(usagePct(1_590_024, 2_500_000_000)).toBe(0.1);
+    expect(usagePct(78, 10_000)).toBe(0.8);
+    expect(usagePct(850, 1000)).toBe(85);
+    expect(usagePct(1000, 1000)).toBe(100);
+    expect(usagePct(1200, 1000)).toBe(100);
+    expect(usagePct(10, undefined)).toBeNull();
+    expect(usagePct(10, 0)).toBeNull();
+  });
+
+  it("maps high / full thresholds like the web meters", () => {
+    expect(usageLevel(0)).toBe("normal");
+    expect(usageLevel(84.9)).toBe("normal");
+    expect(usageLevel(85)).toBe("high");
+    expect(usageLevel(99.9)).toBe("high");
+    expect(usageLevel(100)).toBe("full");
+  });
+});
+
+describe("formatProgressBar", () => {
+  it("renders a fixed-width track and percent label", () => {
+    expect(formatProgressBar(0, { width: 10 })).toBe("[░░░░░░░░░░]    0%");
+    expect(formatProgressBar(50, { width: 10 })).toBe("[█████░░░░░]   50%");
+    expect(formatProgressBar(100, { width: 10 })).toBe("[██████████]  100%");
+  });
+
+  it("shows at least one fill cell for tiny non-zero usage", () => {
+    expect(formatProgressBar(0.1, { width: 20 })).toBe("[█░░░░░░░░░░░░░░░░░░░]  0.1%");
+  });
+});
+
+describe("formatUsageTimestamp", () => {
+  it("formats in the requested zone with a short zone name", () => {
+    const s = formatUsageTimestamp("2026-07-15T12:16:51.147Z", "America/New_York");
+    expect(s).toMatch(/Jul 15, 2026/);
+    expect(s).toMatch(/8:16\s*AM/);
+    expect(s).toMatch(/EDT|EST|GMT-4|GMT-5/);
+  });
+
+  it("passes through unparseable input", () => {
+    expect(formatUsageTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("isUsageMetered", () => {
+  it("is true only when a positive cap is present", () => {
+    expect(
+      isUsageMetered({
+        workspace: "w",
+        bytes: 1,
+        objects: 1,
+        uploadsInPeriod: 1,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+        maxStorageBytes: 1000,
+      }),
+    ).toBe(true);
+    expect(
+      isUsageMetered({
+        workspace: "w",
+        bytes: 1,
+        objects: 1,
+        uploadsInPeriod: 1,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("formatUsageHuman", () => {
+  it("adds progress bars when limits are set (cloud / capped workspace)", () => {
+    const lines = formatUsageHuman(
+      {
+        workspace: "default",
+        bytes: 1_590_024,
+        objects: 63,
+        uploadsInPeriod: 78,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-15T12:16:51.147Z",
+        maxStorageBytes: 2_500_000_000,
+        storageRemainingBytes: 2_498_409_976,
+        maxUploadsPerPeriod: 10_000,
+        uploadsRemaining: 9_922,
+      },
+      { timeZone: "America/New_York" },
+    );
+    expect(lines[0]).toBe("workspace: default");
+    expect(lines[1]).toMatch(
+      /^storage:   \[█░░░░░░░░░░░░░░░░░░░\]\s+0\.1%\s+1\.5 MB \/ 2\.3 GB \(2\.3 GB free\)$/,
+    );
+    expect(lines[2]).toBe("objects:   63");
+    expect(lines[3]).toMatch(
+      /^uploads:   \[█░░░░░░░░░░░░░░░░░░░\]\s+0\.8%\s+78 \/ 10,000 this period \(2026-07\)$/,
+    );
+    expect(lines[4]).toMatch(/^updated:   Jul 15, 2026, 8:16 AM /);
+    expect(lines.some((l) => l.startsWith("note:"))).toBe(false);
+  });
+
+  it("meters only the capped dimensions (partial quotas)", () => {
+    const lines = formatUsageHuman(
+      {
+        workspace: "ops",
+        bytes: 500,
+        objects: 2,
+        uploadsInPeriod: 9,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+        maxStorageBytes: 1000,
+        storageRemainingBytes: 500,
+      },
+      { timeZone: "UTC" },
+    );
+    expect(lines.find((l) => l.startsWith("storage:"))).toMatch(/\[/);
+    expect(lines.find((l) => l.startsWith("uploads:"))).toBe("uploads:   9 this period (2026-07)");
+    expect(lines.some((l) => l.startsWith("note:"))).toBe(false);
+  });
+
+  it("omits bars and explains unmetered when no limits (self-host / unlimited)", () => {
+    const lines = formatUsageHuman(
+      {
+        workspace: "test",
+        bytes: 10,
+        objects: 1,
+        uploadsInPeriod: 2,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+      },
+      { timeZone: "UTC" },
+    );
+    expect(lines).toEqual([
+      "workspace: test",
+      "storage:   10 B",
+      "objects:   1",
+      "uploads:   2 this period (2026-07)",
+      "updated:   Jul 11, 2026, 12:00 AM UTC",
+      "note:      unmetered — no storage or upload quotas on this workspace",
+    ]);
+  });
+});

--- a/packages/uploads/test/telemetry.test.ts
+++ b/packages/uploads/test/telemetry.test.ts
@@ -230,7 +230,10 @@ describe("maybeShowFirstRunNotice", () => {
       interactive: true,
       write: (t) => lines.push(t),
     });
-    expect(lines.join("")).toMatch(/anonymous usage/);
+    const text = lines.join("");
+    expect(text).toMatch(/anonymous non-PII usage/);
+    expect(text).toMatch(/telemetry disable/);
+    expect(text).not.toMatch(/command name/);
     expect(existsSync(join(dir, "telemetry-notice-shown"))).toBe(true);
     const first = lines.length;
     maybeShowFirstRunNotice({


### PR DESCRIPTION
## In plain terms

`uploads usage` was dumping raw byte counters and ISO timestamps. Human mode now reads like a small dashboard when the workspace has quotas (cloud / self-serve), and stays deliberately unmetered for self-host or unlimited operator setups. The first-run telemetry notice is also shorter.

## What it does

- Formats storage with human sizes (`1.5 MB / 2.3 GB`) and free headroom
- Progress bars + % only when the API reports a positive quota (same high/full thresholds as the web account meters)
- Timestamps in the user’s local timezone (`Jul 15, 2026, 8:16 AM EDT`)
- Unmetered workspaces: usage totals only + `note: unmetered — no storage or upload quotas…`
- Briefer first-run telemetry notice (non-PII FYI + how to opt out; no field laundry list)
- Patch changeset for `@buildinternet/uploads`

## What it is not

- No API / JSON shape changes (`uploads usage --json` is the same payload)
- Does not invent quotas for self-host installs
- Does not change enforcement — only CLI presentation

## How to try it

```bash
uploads usage
uploads usage --json   # unchanged machine output
```

Cloud/capped workspace shows bars; a workspace with no `maxStorageBytes` / `maxUploadsPerPeriod` shows unmetered totals + note.

## Technical notes

- New `packages/uploads/src/format-usage.ts` (pure formatters + tests)
- Metered mode is derived from limit fields already returned by `GET …/usage`
- Bar color uses brand tokens when stdout is a TTY

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test` (format-usage + suite green)
- [ ] Spot-check `uploads usage` against a capped cloud workspace
- [ ] Spot-check unmetered/self-host style response (no max* fields)