### PR TITLE
feat: ship github-screenshots as a first-party skill installed by uploads install

### DIFF
--- a/.changeset/install-github-screenshots-skill.md
+++ b/.changeset/install-github-screenshots-skill.md
@@ -1,0 +1,8 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads install` now installs two agent skills: the new `github-screenshots`
+workflow skill (when and how to get screenshots, GIFs, and recordings into
+GitHub PRs and issues) alongside the existing `uploads-cli` CLI reference.
+Skill steps are reported separately in human and `--json` output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,17 @@ packages/errors     @uploads/errors — typed AppError hierarchy + nested wire e
 packages/storage    @uploads/storage — files-sdk adapter factory
 packages/uploads    @buildinternet/uploads — CLI + client for GitHub image embeds
                     (also ships `uploads mcp`, a stdio MCP server mirroring the CLI commands)
-skills/uploads-cli  Agent skill for driving the CLI (host a file → embed in a PR/issue)
+skills/github-screenshots  Workflow skill — screenshots/recordings into PRs, issues, share links
+skills/uploads-cli  Agent skill for driving the CLI (full reference: commands, flags, keys)
 ```
 
-The `uploads-cli` skill in `skills/uploads-cli/SKILL.md` is checked in at the repo
-root so it's installable via the `npx skills add` convention (`--skill uploads-cli`),
-and is the API-backed successor to the `github-screenshots` skill's bundled R2
-scripts. Keep it in sync when the CLI's commands or flags change.
+Two agent skills are checked in at the repo root so they're installable via
+the `npx skills add` convention (and by `uploads install`):
+`skills/github-screenshots` is the thin workflow skill (when a screenshot or
+recording should go into a PR/issue or be shared as a link — the in-repo
+successor to the external `github-screenshots` skill's bundled R2 scripts),
+and `skills/uploads-cli` is the full CLI reference it defers to. Keep both in
+sync when the CLI's commands or flags change.
 
 Keep API and web separate deployables. All storage access goes through
 `createStorage()` in `packages/storage` — never import files-sdk adapters or

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -13,7 +13,7 @@ Developers and the coding agents that work alongside them. The core workflow is
 CLI- and agent-first: one command takes a local file — a PR screenshot, an agent
 artifact, a quick share — and returns a stable, embeddable URL, usually landing in
 a GitHub PR or issue. Agents are first-class users, not an afterthought: they reach
-the product through the CLI, the agent skill, and the MCP server, and they can't
+the product through the CLI, the agent skills, and the MCP server, and they can't
 drag-and-drop into GitHub the way a human can.
 
 The web surfaces serve two moments: deciding (a landing page and docs that explain

--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ workspace token — see [enrollment](docs/enrollment.md). Hosted files are
 public, including media attached to private repositories. Do not upload
 secrets or sensitive UI.
 
-**Agent skill** — an auto-triggering playbook for the CLI, installable into
-any agent runtime without checking out anything:
+**Agent skills** — auto-triggering playbooks, installable into any agent
+runtime without checking out anything (`uploads install` runs these for you):
 
 ```bash
-npx skills add buildinternet/uploads --skill uploads-cli
+npx skills add buildinternet/uploads --skill github-screenshots   # visuals → PRs/issues
+npx skills add buildinternet/uploads --skill uploads-cli          # full CLI reference
 ```
 
 Full CLI usage — key conventions, stable PR/issue attachments, managed
@@ -94,16 +95,17 @@ routes are in [docs/api.md](docs/api.md).
 
 ## What's in this repo
 
-| Path                  | What                                                      |
-| --------------------- | --------------------------------------------------------- |
-| `apps/api/`           | Hono worker — REST API, deploys to `api.uploads.sh`       |
-| `apps/auth/`          | Better Auth worker — sessions, enrollment, device flow    |
-| `apps/mcp/`           | Remote MCP server                                         |
-| `apps/web/`           | Astro site — uploads.sh, account and admin UI             |
-| `packages/storage/`   | `@uploads/storage` — files-sdk adapter factory            |
-| `packages/uploads/`   | `@buildinternet/uploads` — CLI + client, publishes to npm |
-| `packages/ui/`        | `@uploads/ui` — shared design system                      |
-| `skills/uploads-cli/` | Agent skill for driving the CLI                           |
+| Path                         | What                                                      |
+| ---------------------------- | --------------------------------------------------------- |
+| `apps/api/`                  | Hono worker — REST API, deploys to `api.uploads.sh`       |
+| `apps/auth/`                 | Better Auth worker — sessions, enrollment, device flow    |
+| `apps/mcp/`                  | Remote MCP server                                         |
+| `apps/web/`                  | Astro site — uploads.sh, account and admin UI             |
+| `packages/storage/`          | `@uploads/storage` — files-sdk adapter factory            |
+| `packages/uploads/`          | `@buildinternet/uploads` — CLI + client, publishes to npm |
+| `packages/ui/`               | `@uploads/ui` — shared design system                      |
+| `skills/github-screenshots/` | Workflow skill — visuals into PRs/issues/share links      |
+| `skills/uploads-cli/`        | Agent skill for driving the CLI                           |
 
 The workers and web app are separate deployables. All storage access goes
 through `createStorage()` in `packages/storage` — adding a provider is one new

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ the storage layer is provider-agnostic (R2 today; any files-sdk adapter later).
 </p>
 
 <p>
+  <a href="https://skills.sh/buildinternet/uploads"><img alt="skills.sh" src="https://skills.sh/b/buildinternet/uploads"></a>
   <a href="https://github.com/buildinternet/uploads/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/buildinternet/uploads/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/@buildinternet/uploads"><img alt="npm (CLI)" src="https://img.shields.io/npm/v/@buildinternet/uploads?color=cb3837&label=%40buildinternet%2Fuploads&logo=npm"></a>
   <a href="https://deepwiki.com/buildinternet/uploads"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
@@ -85,9 +86,11 @@ secrets or sensitive UI.
 runtime without checking out anything (`uploads install` runs these for you):
 
 ```bash
-npx skills add buildinternet/uploads --skill github-screenshots   # visuals → PRs/issues
-npx skills add buildinternet/uploads --skill uploads-cli          # full CLI reference
+npx skills add buildinternet/uploads
 ```
+
+That installs both: `github-screenshots` (visuals → PRs/issues) and
+`uploads-cli` (full CLI reference).
 
 Full CLI usage — key conventions, stable PR/issue attachments, managed
 comments, and public galleries — lives in [docs/cli.md](docs/cli.md). REST

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ and exit codes, run `uploads help --all` or see
 ```bash
 uploads login          # sign in via browser; saves your workspace token, then runs doctor
 uploads whoami         # show the active workspace + token (alias: uploads status)
-uploads install        # install the agent skill + register the hosted MCP server
+uploads install        # install the agent skills + register the hosted MCP server
 uploads put ./shot.png # stdout: public URL + ready-to-paste markdown; stderr: human summary
 ```
 
@@ -29,23 +29,23 @@ with `uploads setup --token <token>` or into `.env` / user config.
 
 ## Command overview
 
-| Command                 | What it does                                             |
-| ----------------------- | -------------------------------------------------------- |
-| `attach <file…>`        | Attach media to the current PR (stable URLs + comment)   |
-| `put <file>`            | Upload one file → public URL + GitHub markdown           |
-| `comment`               | Create/update a PR/issue attachments comment (via `gh`)  |
-| `list` / `find k=v`     | List objects, optionally filtered by queryable metadata  |
-| `meta get` / `meta set` | Read or merge-set an object's queryable metadata         |
-| `gallery …`             | Create and organize public media galleries               |
-| `delete <key>`          | Delete an object                                         |
-| `usage`                 | Workspace storage / upload counters                      |
-| `install`               | Install the agent skill + register the remote MCP server |
-| `login` / `logout`      | Sign in (browser or enrollment code) / clear saved token |
-| `whoami` (`status`)     | Show the active workspace and token                      |
-| `invite`                | Invite a teammate to a workspace (workspace admin)       |
-| `doctor` / `health`     | Health + auth + workspace checks / API liveness          |
-| `setup` / `config`      | Inspect and configure CLI settings                       |
-| `mcp`                   | Serve MCP over stdio (tools mirror the CLI)              |
+| Command                 | What it does                                              |
+| ----------------------- | --------------------------------------------------------- |
+| `attach <file…>`        | Attach media to the current PR (stable URLs + comment)    |
+| `put <file>`            | Upload one file → public URL + GitHub markdown            |
+| `comment`               | Create/update a PR/issue attachments comment (via `gh`)   |
+| `list` / `find k=v`     | List objects, optionally filtered by queryable metadata   |
+| `meta get` / `meta set` | Read or merge-set an object's queryable metadata          |
+| `gallery …`             | Create and organize public media galleries                |
+| `delete <key>`          | Delete an object                                          |
+| `usage`                 | Workspace storage / upload counters                       |
+| `install`               | Install the agent skills + register the remote MCP server |
+| `login` / `logout`      | Sign in (browser or enrollment code) / clear saved token  |
+| `whoami` (`status`)     | Show the active workspace and token                       |
+| `invite`                | Invite a teammate to a workspace (workspace admin)        |
+| `doctor` / `health`     | Health + auth + workspace checks / API liveness           |
+| `setup` / `config`      | Inspect and configure CLI settings                        |
+| `mcp`                   | Serve MCP over stdio (tools mirror the CLI)               |
 
 Run `uploads <command> --help` for per-command flags.
 
@@ -176,13 +176,17 @@ does not change gallery identity or visibility.
 > GitHub or repository visibility. Removing or deleting a gallery does not
 > delete its uploaded media or exempt it from retention.
 
-## Agent skill
+## Agent skills
 
-For agent runtimes, install the checked-in skill as well:
+For agent runtimes, install the checked-in skills as well (`uploads install`
+does this for you):
 
 ```bash
+npx skills add buildinternet/uploads --skill github-screenshots
 npx skills add buildinternet/uploads --skill uploads-cli
 ```
 
-See [`skills/uploads-cli/SKILL.md`](../skills/uploads-cli/SKILL.md) for
-agent-oriented usage and [api.md](api.md) for REST routes.
+[`skills/github-screenshots/SKILL.md`](../skills/github-screenshots/SKILL.md)
+is the workflow skill (screenshots/recordings into PRs and issues);
+[`skills/uploads-cli/SKILL.md`](../skills/uploads-cli/SKILL.md) is the full
+CLI reference it defers to. See [api.md](api.md) for REST routes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,8 +182,7 @@ For agent runtimes, install the checked-in skills as well (`uploads install`
 does this for you):
 
 ```bash
-npx skills add buildinternet/uploads --skill github-screenshots
-npx skills add buildinternet/uploads --skill uploads-cli
+npx skills add buildinternet/uploads
 ```
 
 [`skills/github-screenshots/SKILL.md`](../skills/github-screenshots/SKILL.md)

--- a/docs/superpowers/plans/2026-07-15-github-screenshots-skill.md
+++ b/docs/superpowers/plans/2026-07-15-github-screenshots-skill.md
@@ -1,0 +1,605 @@
+# In-repo `github-screenshots` Workflow Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a thin `github-screenshots` workflow skill inside this repo (screenshots/recordings → PRs, issues, share links), trim the `uploads-cli` skill's trigger surface to CLI mechanics, and make `uploads install` install both skills.
+
+**Architecture:** Two SKILL.md files split by altitude — a workflow skill that owns the "get this visual into a PR/issue/in front of a person" moment and defers to the CLI-reference skill, plus a list-driven change to `packages/uploads/src/commands/install.ts` so the skill step runs `npx skills add` once per skill and reports each step separately.
+
+**Tech Stack:** Markdown skills (`npx skills add` convention), TypeScript CLI (`packages/uploads`), Vitest, Changesets.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-github-screenshots-skill-design.md`
+
+## Global Constraints
+
+- No capture implementation: no `uploads shot`, no bundled Playwright/capture scripts. Capture stays tool-agnostic.
+- The new skill must NOT claim capture phrasings like "screenshot this page" in its description.
+- No changes to the external `buildinternet/skills` repo in this plan.
+- New skill body target: well under 150 lines.
+- Repo commit style: conventional commits, no sensational adjectives.
+- Product-facing examples use the global `uploads …` binary, never `pnpm uploads …`.
+- Test command: `pnpm --filter @buildinternet/uploads test` (vitest); typecheck: `pnpm --filter @buildinternet/uploads typecheck`.
+- A husky pre-commit hook runs wrangler types + lint-staged; it is slow but normal — do not bypass it.
+
+---
+
+### Task 1: Create the `github-screenshots` workflow skill
+
+**Files:**
+
+- Create: `skills/github-screenshots/SKILL.md`
+
+**Interfaces:**
+
+- Consumes: nothing (pure content).
+- Produces: a skill named `github-screenshots` installable as `npx skills add buildinternet/uploads --skill github-screenshots`. Task 3 hardcodes this name; Task 4 links this path.
+
+- [ ] **Step 1: Write the skill file**
+
+Create `skills/github-screenshots/SKILL.md` with exactly this content:
+
+````markdown
+---
+name: github-screenshots
+description: >-
+  Embed screenshots, images, diagrams, GIFs, and screen recordings in GitHub
+  PRs and issues — or get a durable public link to share a visual with a
+  person. Use this whenever a visual needs to end up in a PR description,
+  issue body, or PR/issue comment, or in front of a teammate. Triggers include
+  "attach a screenshot to the PR", "add a before/after to the issue", "include
+  a screenshot of …", "share a GIF of the flow", "record the bug and put it in
+  the issue", "get me a link I can paste in Slack", or having just captured or
+  changed something visual that a shot would make clearer. Reach for this
+  instead of drag-and-drop or github.com/user-attachments (agents can't upload
+  there) and instead of hand-rolling cloud-storage uploads. Capture the visual
+  with whatever browser or screenshot tooling you have; this skill covers
+  hosting and embedding it.
+---
+
+# Screenshots and recordings in GitHub PRs and issues
+
+## Why this exists
+
+GitHub's native image hosting (`github.com/user-attachments/…`) only works
+from an authenticated browser session — there is no `gh` CLI or REST endpoint
+for it. Any image URL in a PR/issue body written with `gh … --body-file` must
+already point at something publicly hosted. The **`uploads` CLI** provides
+that: it hosts the file on uploads.sh and returns a stable public URL plus
+ready-to-paste markdown.
+
+## Step 1 — Get the visual (any tool)
+
+Capture is tool-agnostic. Use whatever this environment has and save a local
+file:
+
+- The agent harness's own browser tools (screenshot the preview pane).
+- A Playwright/browser MCP, `agent-browser`, or similar automation.
+- An OS screenshot or screen recording the user already made.
+- Any existing image, GIF, or diagram file.
+
+GIFs and video upload as-is — the client-side optimizer only rewrites still
+images (PNG/JPEG → WebP). No special flags needed for motion.
+
+## Step 2 — Host and embed
+
+For the common case — files attached to the current branch's PR — use
+`uploads attach`. It infers the PR, uploads under stable keys, and maintains
+a single managed "attachments" comment:
+
+```bash
+uploads attach ./before.png ./after.png
+uploads attach ./flow.gif --issue 45 --repo myorg/myapp
+uploads attach ./shot.png --no-comment      # stable URLs only, no comment
+```
+
+For a URL you'll hard-code in a PR/issue body (re-uploads overwrite in place,
+URL never changes):
+
+```bash
+uploads put ./after.png --pr 123 --alt "Dashboard after" --width 700
+```
+
+For a durable public link to share anywhere (Slack, docs, a teammate):
+
+```bash
+uploads put ./demo.gif --format url
+```
+
+Always embed the returned **markdown** (or `embedUrl`) in GitHub — it uses the
+no-cache host so overwrites propagate. Don't hand-build storage URLs.
+
+## Step 3 — Embed well
+
+- **Meaningful alt text**, always (`--alt`).
+- **Constrain width** on large shots with `--width` (emits sized `<img>`).
+- **Before/after** reads best side by side:
+
+  ```markdown
+  | Before                               | After                               |
+  | ------------------------------------ | ----------------------------------- |
+  | <img width="380" src="…/before.png"> | <img width="380" src="…/after.png"> |
+  ```
+
+- **Motion:** GitHub markdown won't autoplay MP4 URLs — prefer a GIF, or a
+  still image that links to the video URL.
+- Write bodies to a file and use `gh pr edit --body-file` / `gh issue comment
+--body-file` rather than inline HEREDOCs.
+
+## Setup and escalation
+
+- CLI missing? `npm install --global @buildinternet/uploads`
+- Not authenticated? `uploads login` (one-time, opens a browser), then
+  `uploads doctor` to verify.
+- Everything deeper — flags, key layouts, metadata and search, galleries,
+  config defaults, output formats, exit codes — lives in the **uploads-cli**
+  skill and `uploads <command> --help`.
+
+## Cautions
+
+- **Uploads are public and effectively permanent** until deleted. GitHub repo
+  visibility is not an access control, and `gh/<owner>/<repo>/pull/<num>/…`
+  keys are predictable. Never upload secrets, tokens, or customer PII —
+  crop/redact first.
+````
+
+- [ ] **Step 2: Verify frontmatter parses and the capture-phrase constraint holds**
+
+Run:
+
+```bash
+node -e '
+const fs = require("fs");
+const s = fs.readFileSync("skills/github-screenshots/SKILL.md", "utf8");
+const m = s.match(/^---\n([\s\S]*?)\n---\n/);
+if (!m) throw new Error("no frontmatter");
+if (!/name: github-screenshots/.test(m[1])) throw new Error("bad name");
+if (/screenshot this page/i.test(m[1])) throw new Error("claims capture trigger");
+console.log("ok, body lines:", s.split("\n").length);
+'
+```
+
+Expected: `ok, body lines:` followed by a number under 150.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/github-screenshots/SKILL.md
+git commit -m "feat(skills): add github-screenshots workflow skill"
+```
+
+---
+
+### Task 2: Trim the `uploads-cli` skill description to CLI mechanics
+
+**Files:**
+
+- Modify: `skills/uploads-cli/SKILL.md:1-14` (frontmatter only; body unchanged)
+
+**Interfaces:**
+
+- Consumes: the `github-screenshots` skill name from Task 1 (referenced in the description).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Replace the frontmatter description**
+
+In `skills/uploads-cli/SKILL.md`, replace the entire frontmatter block (lines 1–14, from the opening `---` through the closing `---`) with:
+
+```yaml
+---
+name: uploads-cli
+description: >-
+  Reference for the uploads CLI — host files on uploads.sh and manage them.
+  Covers put and attach, stable PR/issue keys, the managed attachments
+  comment, metadata and search, galleries, config defaults, login/doctor, and
+  output formats. Use when driving the `uploads` CLI or its MCP tools, when
+  you need a public URL for a local file ("upload this", "host this image",
+  "give me a public URL for this file"), or when you need exact flags, key
+  layouts, or setup and auth details. For the when-and-how of getting a
+  screenshot or recording into a GitHub PR or issue, start with the
+  github-screenshots skill — it defers here for CLI detail.
+---
+```
+
+Do not change anything below the closing `---`.
+
+- [ ] **Step 2: Verify only the frontmatter changed**
+
+Run: `git diff --stat skills/uploads-cli/SKILL.md && git diff skills/uploads-cli/SKILL.md | grep '^+' | grep -v '^+++' | grep -cv 'description\|name:\|^+---\|^+  '`
+
+Expected: 1 file changed; the count is `0` (no body lines added).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/uploads-cli/SKILL.md
+git commit -m "docs(skills): scope uploads-cli skill description to CLI reference"
+```
+
+---
+
+### Task 3: `uploads install` installs both skills
+
+**Files:**
+
+- Modify: `packages/uploads/src/commands/install.ts`
+- Test: `packages/uploads/test/install.test.ts`
+
+**Interfaces:**
+
+- Consumes: skill names `uploads-cli` and `github-screenshots` (Task 1).
+- Produces: result-record keys `skill:uploads-cli`, `skill:github-screenshots`, `mcp` in both human and `--json` output. Human success footer says `Done — skills and mcp ready.`; the partial-failure nudge says `Skills are installed.`
+
+- [ ] **Step 1: Update the tests to the two-skill contract (failing first)**
+
+In `packages/uploads/test/install.test.ts`, make these changes:
+
+Replace the body of the first test (`runs both steps by default…`) `expect(calls)` with:
+
+```ts
+expect(calls).toEqual([
+  [
+    "npx",
+    "-y",
+    "skills",
+    "add",
+    "buildinternet/uploads",
+    "--skill",
+    "uploads-cli",
+    "-g",
+    "-y",
+    "-a",
+    "*",
+  ],
+  [
+    "npx",
+    "-y",
+    "skills",
+    "add",
+    "buildinternet/uploads",
+    "--skill",
+    "github-screenshots",
+    "-g",
+    "-y",
+    "-a",
+    "*",
+  ],
+  [
+    "claude",
+    "mcp",
+    "add",
+    "--transport",
+    "http",
+    "uploads",
+    DEFAULT_MCP_URL,
+    "--header",
+    "Authorization: Bearer up_acme_secret",
+  ],
+]);
+```
+
+In the test `prints step progress and suppresses child output on success`, replace:
+
+```ts
+expect(printed).toContain("Installing skill…");
+expect(printed).toMatch(/skill: ok/);
+```
+
+with:
+
+```ts
+expect(printed).toContain("Installing skills…");
+expect(printed).toMatch(/skill:uploads-cli: ok/);
+expect(printed).toMatch(/skill:github-screenshots: ok/);
+```
+
+In the test `install skill runs only the skills step`, replace the two assertions after the `runInstall` call with:
+
+```ts
+expect(calls).toHaveLength(2);
+expect(calls.every((c) => c[0] === "npx")).toBe(true);
+```
+
+In the test `install all without a token still installs the skill, then nudges login for MCP`, replace:
+
+```ts
+expect(calls).toHaveLength(1);
+expect(calls[0][0]).toBe("npx");
+expect(out.join("")).toMatch(/skill: ok/);
+```
+
+with:
+
+```ts
+expect(calls).toHaveLength(2);
+expect(calls.every((c) => c[0] === "npx")).toBe(true);
+expect(out.join("")).toMatch(/skill:uploads-cli: ok/);
+expect(out.join("")).toMatch(/skill:github-screenshots: ok/);
+```
+
+and replace `expect(out.join("")).toMatch(/Skill is installed/);` with `expect(out.join("")).toMatch(/Skills are installed/);`.
+
+Add this new test inside the `describe` block:
+
+```ts
+it("--json reports each skill step under its own key", async () => {
+  const { run } = fakeRunner();
+  const { out } = captureStreams();
+  const code = await runInstall(["skill"], { globals: GLOBALS, json: true, runner: run });
+  expect(code).toBe(0);
+  const parsed = JSON.parse(out.join(""));
+  expect(parsed.ok).toBe(true);
+  expect(Object.keys(parsed.steps)).toEqual(["skill:uploads-cli", "skill:github-screenshots"]);
+});
+```
+
+- [ ] **Step 2: Run the install tests to verify they fail**
+
+Run: `pnpm --filter @buildinternet/uploads test -- test/install.test.ts`
+
+Expected: FAIL — the default-run test sees 2 calls instead of 3, progress-text assertions miss.
+
+- [ ] **Step 3: Implement the list-driven skill step**
+
+In `packages/uploads/src/commands/install.ts`:
+
+Replace line 14 (`const SKILL_NAME = "uploads-cli";`) with:
+
+```ts
+const SKILL_NAMES = ["uploads-cli", "github-screenshots"];
+```
+
+Replace the `INSTALL_HELP` intro paragraph and the two blocks under it so the help reads:
+
+```ts
+const INSTALL_HELP = `uploads install — set up agent integrations (skills + remote MCP)
+
+Installs the github-screenshots and uploads-cli agent skills and registers
+the hosted MCP server with Claude Code. The remote MCP endpoint infers your
+workspace from the bearer token, so only the token is needed.
+
+Usage:
+  uploads install [skill|mcp|all]     (default: all)
+
+What it does:
+  skill   Agent skills (via npx skills) — github-screenshots: visuals into
+          PRs/issues; uploads-cli: full CLI reference
+  mcp     Hosted MCP server in Claude Code — put, list, attach, galleries
+
+What runs under the hood:
+  skill   npx -y skills add ${SKILL_SOURCE} --skill <name> -g -y -a '*'
+          (once per skill: ${SKILL_NAMES.join(", ")})
+  mcp     claude mcp add --transport http uploads ${DEFAULT_MCP_URL} \\
+            --header "Authorization: Bearer <token>"
+
+Options:
+  --url <endpoint>    Remote MCP endpoint (default: ${DEFAULT_MCP_URL})
+  --name <name>       MCP server name in the client (default: uploads)
+  --dry-run           Print the plan without running anything
+  --verbose           Show underlying command output (default: errors only)
+
+Examples:
+  uploads install
+  uploads install skill
+  uploads install mcp
+  uploads install --dry-run
+`;
+```
+
+Replace `skillCommand()`:
+
+```ts
+function skillCommand(skill: string): string[] {
+  // -g global, -y non-interactive, -a '*' every agent (skips the multi-select TUI)
+  return ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", skill, "-g", "-y", "-a", "*"];
+}
+```
+
+Replace the skill branch in `runInstall`:
+
+```ts
+if (target === "skill" || target === "all") {
+  if (human) process.stdout.write("Installing skills…\n");
+  for (const skill of SKILL_NAMES) {
+    const command = skillCommand(skill);
+    results[`skill:${skill}`] = dryRun
+      ? { command, ok: true, skipped: "dry-run" }
+      : runStep(run, command);
+  }
+}
+```
+
+Replace the success-footer call and the partial-failure branch at the bottom of `runInstall` (currently `printSuccessFooter(Object.keys(results), signedIn);` and the `else if` that checks `results.skill?.ok`):
+
+```ts
+const skillResults = Object.entries(results)
+  .filter(([step]) => step.startsWith("skill:"))
+  .map(([, r]) => r);
+const skillsOk = skillResults.length > 0 && skillResults.every((r) => r.ok);
+
+if (!failed && !dryRun) {
+  const stepLabels = [
+    ...new Set(Object.keys(results).map((k) => (k.startsWith("skill:") ? "skills" : k))),
+  ];
+  printSuccessFooter(stepLabels, signedIn);
+} else if (failed && !dryRun && skillsOk && results.mcp && !results.mcp.ok) {
+  const next =
+    results.mcp.skipped === "sign-in"
+      ? "Sign in with `uploads login`, then re-run `uploads install mcp`."
+      : "Fix the MCP step above, then re-run `uploads install mcp`.";
+  process.stdout.write(`\nSkills are installed. ${next}\n`);
+}
+```
+
+- [ ] **Step 4: Run the install tests to verify they pass**
+
+Run: `pnpm --filter @buildinternet/uploads test -- test/install.test.ts`
+
+Expected: PASS (all tests, including the new `--json` one).
+
+- [ ] **Step 5: Typecheck and full package tests**
+
+Run: `pnpm --filter @buildinternet/uploads typecheck && pnpm --filter @buildinternet/uploads test`
+
+Expected: both PASS. (The help-snapshot tests in `cli-help.test.ts` / `cli-style-help.test.ts` may assert on install help text — if one fails on the new wording, update its expected string to match the new `INSTALL_HELP` verbatim.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/uploads/src/commands/install.ts packages/uploads/test/install.test.ts
+git commit -m "feat(cli): uploads install adds the github-screenshots skill"
+```
+
+---
+
+### Task 4: Update repo docs for the two-skill split
+
+**Files:**
+
+- Modify: `AGENTS.md` (layout block + skill paragraph)
+- Modify: `README.md:85-89` (install snippet) and `README.md:106` (repo table)
+- Modify: `docs/cli.md:17,42,178-186` (install mentions + Agent skill section)
+
+**Interfaces:**
+
+- Consumes: skill names/paths from Tasks 1–3.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: AGENTS.md**
+
+In the layout block, replace:
+
+```
+skills/uploads-cli  Agent skill for driving the CLI (host a file → embed in a PR/issue)
+```
+
+with:
+
+```
+skills/github-screenshots  Workflow skill — screenshots/recordings into PRs, issues, share links
+skills/uploads-cli  Agent skill for driving the CLI (full reference: commands, flags, keys)
+```
+
+Replace the paragraph starting `The `uploads-cli`skill in`skills/uploads-cli/SKILL.md` is checked in…` with:
+
+```markdown
+Two agent skills are checked in at the repo root so they're installable via
+the `npx skills add` convention (and by `uploads install`):
+`skills/github-screenshots` is the thin workflow skill (when a screenshot or
+recording should go into a PR/issue or be shared as a link — the in-repo
+successor to the external `github-screenshots` skill's bundled R2 scripts),
+and `skills/uploads-cli` is the full CLI reference it defers to. Keep both in
+sync when the CLI's commands or flags change.
+```
+
+- [ ] **Step 2: README.md**
+
+Replace the agent-skill snippet (currently the single `npx skills add buildinternet/uploads --skill uploads-cli` fence and its intro sentence) with:
+
+````markdown
+**Agent skills** — auto-triggering playbooks, installable into any agent
+runtime without checking out anything (`uploads install` runs these for you):
+
+```bash
+npx skills add buildinternet/uploads --skill github-screenshots   # visuals → PRs/issues
+npx skills add buildinternet/uploads --skill uploads-cli          # full CLI reference
+```
+````
+
+In the "What's in this repo" table, replace the `skills/uploads-cli/` row with:
+
+```markdown
+| `skills/github-screenshots/` | Workflow skill — visuals into PRs/issues/share links |
+| `skills/uploads-cli/` | Agent skill for driving the CLI |
+```
+
+(Re-align the table's column padding to match the surrounding rows.)
+
+- [ ] **Step 3: docs/cli.md**
+
+Line 17: change `# install the agent skill + register the hosted MCP server` to `# install the agent skills + register the hosted MCP server`.
+
+Line 42 (command table): change `Install the agent skill + register the remote MCP server` to `Install the agent skills + register the remote MCP server`.
+
+Replace the "Agent skill" section (heading and body around lines 178–186) with:
+
+````markdown
+## Agent skills
+
+For agent runtimes, install the checked-in skills as well (`uploads install`
+does this for you):
+
+```bash
+npx skills add buildinternet/uploads --skill github-screenshots
+npx skills add buildinternet/uploads --skill uploads-cli
+```
+
+[`skills/github-screenshots/SKILL.md`](../skills/github-screenshots/SKILL.md)
+is the workflow skill (screenshots/recordings into PRs and issues);
+[`skills/uploads-cli/SKILL.md`](../skills/uploads-cli/SKILL.md) is the full
+CLI reference it defers to. See [api.md](api.md) for REST routes.
+````
+
+- [ ] **Step 4: Verify no stale single-skill references remain**
+
+Run: `grep -rn "the agent skill\b\|--skill uploads-cli" README.md AGENTS.md docs/cli.md | grep -v "github-screenshots"`
+
+Expected: only lines that intentionally install `uploads-cli` alongside the new skill (the paired `npx skills add … --skill uploads-cli` lines); no prose describing a single skill.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md README.md docs/cli.md
+git commit -m "docs: describe the github-screenshots + uploads-cli skill split"
+```
+
+---
+
+### Task 5: Changeset and final verification
+
+**Files:**
+
+- Create: `.changeset/install-github-screenshots-skill.md`
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: release notes for the next `@buildinternet/uploads` version.
+
+- [ ] **Step 1: Write the changeset**
+
+Create `.changeset/install-github-screenshots-skill.md`:
+
+```markdown
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads install` now installs two agent skills: the new `github-screenshots`
+workflow skill (when and how to get screenshots, GIFs, and recordings into
+GitHub PRs and issues) alongside the existing `uploads-cli` CLI reference.
+Skill steps are reported separately in human and `--json` output.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `pnpm --filter @buildinternet/uploads typecheck && pnpm --filter @buildinternet/uploads test`
+
+Expected: PASS.
+
+Run: `node packages/uploads/bin/uploads.js install --dry-run --json 2>/dev/null || pnpm uploads install --dry-run --json`
+
+Expected: JSON with `steps["skill:uploads-cli"]`, `steps["skill:github-screenshots"]` (both `skipped: "dry-run"`), and an `mcp` step; no token visible.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/install-github-screenshots-skill.md
+git commit -m "chore: changeset for two-skill uploads install"
+```
+
+---
+
+## Manual follow-up checks (post-merge, not tasks)
+
+- Fresh-agent trigger check: "attach this screenshot to the PR" routes to `github-screenshots`; "what flags does uploads put take" routes to `uploads-cli`.
+- Retirement path (separate effort, per spec follow-ups): tombstone `buildinternet/skills/github-screenshots`, update external CLAUDE.md references, consider `uploads shot`.

--- a/docs/superpowers/specs/2026-07-15-github-screenshots-skill-design.md
+++ b/docs/superpowers/specs/2026-07-15-github-screenshots-skill-design.md
@@ -1,0 +1,124 @@
+# In-repo `github-screenshots` workflow skill
+
+**Date:** 2026-07-15
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+The skill that activates when someone wants to put a screenshot or recording
+into a GitHub PR/issue lives outside this repo, in
+`buildinternet/skills/github-screenshots`. It predates uploads.sh: it bundles
+MVP shell scripts (Playwright capture, direct-R2 upload) that the CLI has since
+superseded, and it merely _prefers_ the uploads CLI when configured. Anyone who
+installs the uploads CLI or the `uploads-cli` skill today still has to discover
+and install that secondary external skill before the common "attach a
+screenshot to the PR" moment reliably routes to uploads.
+
+Goal: installing uploads (`uploads install`) should make the
+screenshot-into-GitHub workflow work out of the box, with no external skill.
+
+## Non-goals (deliberate follow-ups, not this change)
+
+- **No capture implementation.** No `uploads shot` CLI command, no bundled
+  Playwright script. Capture stays tool-agnostic: agents use whatever
+  browser/screenshot tooling their environment has.
+- **No changes to the external skill yet.** Tombstoning
+  `buildinternet/skills/github-screenshots` (and updating references to it,
+  e.g. in user CLAUDE.md files) happens after this skill ships and proves out.
+  Note: the new skill reuses the same name, so once both are installed the
+  names collide — the external one should be uninstalled/tombstoned promptly.
+- **No R2-fallback migration.** The direct-R2 path is the legacy the CLI
+  replaced; it stays behind in the external skill and dies with it.
+
+## Design
+
+Two skills in this repo, split by altitude, both installed by
+`uploads install`:
+
+### 1. New: `skills/github-screenshots/SKILL.md` — the workflow skill
+
+Owns the _moment_: "I have (or am about to have) an image or recording that
+needs to end up in a PR, an issue, or in front of a person." Thin — it teaches
+when and how to use uploads for this job and defers CLI detail to the
+`uploads-cli` skill.
+
+**Frontmatter description (trigger surface)** claims:
+
+- Screenshots/images/diagrams destined for a PR description, issue body, or
+  comment ("attach a screenshot to the PR", "add a before/after to the
+  issue", "include a screenshot of …").
+- Recordings and motion: GIFs and screen recordings of an interaction
+  ("share a GIF of the flow", "record the bug and put it in the issue").
+- The post-capture moment: user or agent just captured something visual and
+  it needs to be shared.
+- Sharing visuals with people generally: "get me a link I can paste in
+  Slack / send to a teammate" (durable public URL).
+- Steers away from drag-and-drop / `github.com/user-attachments` (not
+  scriptable) and hand-rolled cloud-storage uploads.
+
+It does **not** claim capture phrasings like "screenshot this page" — those
+remain with the environment's browser tooling (and, for now, the external
+skill).
+
+**Body outline** (short — target well under 150 lines):
+
+1. _Why_: GitHub's native image hosting is browser-session-only; `gh
+… --body-file` needs an already-public URL. uploads.sh provides it.
+2. _Get the visual_ (tool-agnostic): use the harness browser tools,
+   Playwright MCP, OS screenshot, or an existing file; save locally. GIFs
+   and video upload as-is (the optimizer only rewrites still images).
+3. _Host + embed_: `uploads attach <files…>` for the common PR/issue case
+   (managed comment, stable keys); `uploads put --pr/--issue` for URLs to
+   hard-code in bodies; plain `uploads put` for a durable share link.
+   Always use the returned `markdown`/`embedUrl` for GitHub embeds.
+4. _Etiquette_: meaningful alt text, `--width` on large shots,
+   before/after side-by-side table, GIF-vs-MP4 (GitHub markdown won't
+   autoplay MP4 — prefer GIF or a still linking to the video URL).
+5. _Setup + escalation_: not installed → `npm i -g @buildinternet/uploads`;
+   not authed → `uploads login`; anything deeper (flags, keys, metadata,
+   galleries, config) → see the `uploads-cli` skill / `uploads --help`.
+6. _Cautions_: uploads are public; predictable `gh/…` keys; redact secrets.
+
+### 2. Existing: `skills/uploads-cli/SKILL.md` — the CLI reference
+
+Body unchanged. Frontmatter description trimmed to hosting/CLI mechanics
+("upload this", "host this image", "public URL for this file", driving the
+`uploads` CLI) so the two descriptions don't compete for the workflow
+phrasings the new skill now owns. Keep enough overlap that either skill
+resolving still leads to the same commands.
+
+### 3. `uploads install` installs both
+
+`packages/uploads/src/commands/install.ts` currently hardcodes one skill
+(`SKILL_NAME = "uploads-cli"`). Change to a list
+(`["uploads-cli", "github-screenshots"]`), one `npx skills add` step per
+skill (the `skills` CLI takes one `--skill` per invocation), reported
+separately in human and `--json` output (e.g. keyed results or an array),
+same continue-on-failure semantics as today. Help text and dry-run output
+updated to show both.
+
+### 4. Docs
+
+- `AGENTS.md` layout table: add `skills/github-screenshots` and describe the
+  split (workflow skill vs CLI reference); note both are kept in sync with
+  the CLI.
+- `docs/cli.md` / README mention of `uploads install`: reflect that it
+  installs two skills, if they enumerate.
+
+## Testing
+
+- Existing install-command tests updated for the two-skill list (command
+  construction, `--json` shape, dry-run).
+- `uploads install --dry-run` shows both `npx skills add … --skill …` steps.
+- Skill lint/review pass on the new SKILL.md (description length, triggers).
+- Manual: fresh-agent trigger check — "attach this screenshot to the PR"
+  routes to the new skill; "what flags does uploads put take" routes to
+  `uploads-cli`.
+
+## Follow-ups (out of scope, tracked for the retirement path)
+
+1. Tombstone `buildinternet/skills/github-screenshots` (pointer to
+   `npm i -g @buildinternet/uploads && uploads install`), or delete it.
+2. Update external references to the old skill (global CLAUDE.md files).
+3. Optional: `uploads shot <url>` capture subcommand (Playwright resolved
+   on demand), at which point the new skill can claim capture triggers too.

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -136,7 +136,7 @@ Config layers (first match wins): CLI flags → env vars → `--env-file` → `~
 
 Or with `UPLOADS_TOKEN`/`UPLOADS_WORKSPACE` in the environment or user config. Claude Code: `claude mcp add uploads -- uploads --env-file /path/to/.env mcp`.
 
-For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. The hosted `put` also accepts a `metadata` param. `uploads install` registers the skill + hosted MCP (short progress; `--verbose` for underlying output). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
+For HTTP clients there's also a hosted variant at `https://agents.uploads.sh/mcp` — the workspace is inferred from the bearer token, so only the URL and token are needed (`https://agents.uploads.sh/<workspace>/mcp` and the `mcp.uploads.sh` hostname also work). Tools: file operations plus `gallery_create`, `gallery_get`, `gallery_add`, `gallery_link`, and `gallery_find_by_reference`; all use the same bearer-token workspace scopes and gallery URLs come from the API — see `apps/mcp` in the repo. The hosted `put` also accepts a `metadata` param. `uploads install` registers the skills + hosted MCP (short progress; `--verbose` for underlying output). Its `put` takes no content type: the stored type is sniffed server-side from the bytes and checked against the workspace allowlist, and writes are rate limited per workspace.
 
 ## Programmatic use
 
@@ -173,4 +173,4 @@ pnpm pack:check   # verify the npm tarball contents
 
 Maintainer release instructions: [`docs/releasing.md`](../../docs/releasing.md).
 
-Agent-oriented usage: [`skills/uploads-cli/SKILL.md`](../../skills/uploads-cli/SKILL.md). REST details: [`docs/api.md`](../../docs/api.md).
+Agent-oriented usage: [`skills/uploads-cli/SKILL.md`](../../skills/uploads-cli/SKILL.md) (full CLI reference) and [`skills/github-screenshots/SKILL.md`](../../skills/github-screenshots/SKILL.md) (visuals into PRs/issues). REST details: [`docs/api.md`](../../docs/api.md).

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -125,12 +125,12 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
   { name: "setup", summary: "Inspect/configure advanced CLI settings" },
   {
     name: "install",
-    summary: "Install the agent skill + register the remote MCP server",
+    summary: "Install the agent skills + register the remote MCP server",
     essential: true,
     subcommands: [
-      { name: "skill", summary: "Install the agent skill only" },
+      { name: "skill", summary: "Install the agent skills only" },
       { name: "mcp", summary: "Register the remote MCP server only" },
-      { name: "all", summary: "Install skill and MCP (default)" },
+      { name: "all", summary: "Install skills and MCP (default)" },
     ],
   },
   {

--- a/packages/uploads/src/cli-help.ts
+++ b/packages/uploads/src/cli-help.ts
@@ -191,7 +191,7 @@ ${section(style, "Examples:")}
   ${style.command("uploads logout")}
   ${style.command("uploads --version")}
 
-${section(style, "Agent/MCP:")} ${style.body("`uploads install` sets up the agent skill and the hosted MCP server")}
+${section(style, "Agent/MCP:")} ${style.body("`uploads install` sets up the agent skills and the hosted MCP server")}
 ${style.body("(https://agents.uploads.sh/mcp, workspace inferred from the token). Run")}
 ${style.body("`uploads mcp` for local stdio, or use createUploadsWorkerFileTools()")}
 ${style.body("from @buildinternet/uploads/agent on the Worker.")}

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -11,23 +11,25 @@ import { writeCommandHelp } from "../cli-style.js";
 
 export const DEFAULT_MCP_URL = "https://agents.uploads.sh/mcp";
 const SKILL_SOURCE = "buildinternet/uploads";
-const SKILL_NAME = "uploads-cli";
+const SKILL_NAMES = ["uploads-cli", "github-screenshots"];
 
-const INSTALL_HELP = `uploads install — set up agent integrations (skill + remote MCP)
+const INSTALL_HELP = `uploads install — set up agent integrations (skills + remote MCP)
 
-Installs the uploads-cli agent skill and registers the hosted MCP server
-with Claude Code. The remote MCP endpoint infers your workspace from the
-bearer token, so only the token is needed.
+Installs the github-screenshots and uploads-cli agent skills and registers
+the hosted MCP server with Claude Code. The remote MCP endpoint infers your
+workspace from the bearer token, so only the token is needed.
 
 Usage:
   uploads install [skill|mcp|all]     (default: all)
 
 What it does:
-  skill   Agent skill (via npx skills) — when to host files / embed in PRs
+  skill   Agent skills (via npx skills) — github-screenshots: visuals into
+          PRs/issues; uploads-cli: full CLI reference
   mcp     Hosted MCP server in Claude Code — put, list, attach, galleries
 
 What runs under the hood:
-  skill   npx -y skills add ${SKILL_SOURCE} --skill ${SKILL_NAME} -g -y -a '*'
+  skill   npx -y skills add ${SKILL_SOURCE} --skill <name> -g -y -a '*'
+          (once per skill: ${SKILL_NAMES.join(", ")})
   mcp     claude mcp add --transport http uploads ${DEFAULT_MCP_URL} \\
             --header "Authorization: Bearer <token>"
 
@@ -75,9 +77,9 @@ function runStep(run: CommandRunner, command: string[]): StepResult {
   }
 }
 
-function skillCommand(): string[] {
+function skillCommand(skill: string): string[] {
   // -g global, -y non-interactive, -a '*' every agent (skips the multi-select TUI)
-  return ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", SKILL_NAME, "-g", "-y", "-a", "*"];
+  return ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", skill, "-g", "-y", "-a", "*"];
 }
 
 function mcpCommand(name: string, url: string, bearer: string): string[] {
@@ -176,9 +178,13 @@ export async function runInstall(
   const results: Record<string, StepResult> = {};
 
   if (target === "skill" || target === "all") {
-    const command = skillCommand();
-    if (human) process.stdout.write("Installing skill…\n");
-    results.skill = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
+    if (human) process.stdout.write("Installing skills…\n");
+    for (const skill of SKILL_NAMES) {
+      const command = skillCommand(skill);
+      results[`skill:${skill}`] = dryRun
+        ? { command, ok: true, skipped: "dry-run" }
+        : runStep(run, command);
+    }
   }
 
   if (target === "mcp" || target === "all") {
@@ -217,14 +223,22 @@ export async function runInstall(
 
   printHumanSteps(results, redact, verbose);
 
+  const skillResults = Object.entries(results)
+    .filter(([step]) => step.startsWith("skill:"))
+    .map(([, r]) => r);
+  const skillsOk = skillResults.length > 0 && skillResults.every((r) => r.ok);
+
   if (!failed && !dryRun) {
-    printSuccessFooter(Object.keys(results), signedIn);
-  } else if (failed && !dryRun && results.skill?.ok && results.mcp && !results.mcp.ok) {
+    const stepLabels = [
+      ...new Set(Object.keys(results).map((k) => (k.startsWith("skill:") ? "skills" : k))),
+    ];
+    printSuccessFooter(stepLabels, signedIn);
+  } else if (failed && !dryRun && skillsOk && results.mcp && !results.mcp.ok) {
     const next =
       results.mcp.skipped === "sign-in"
         ? "Sign in with `uploads login`, then re-run `uploads install mcp`."
         : "Fix the MCP step above, then re-run `uploads install mcp`.";
-    process.stdout.write(`\nSkill is installed. ${next}\n`);
+    process.stdout.write(`\nSkills are installed. ${next}\n`);
   }
 
   return failed ? 1 : 0;

--- a/packages/uploads/test/install.test.ts
+++ b/packages/uploads/test/install.test.ts
@@ -59,6 +59,19 @@ describe("uploads install", () => {
         "*",
       ],
       [
+        "npx",
+        "-y",
+        "skills",
+        "add",
+        "buildinternet/uploads",
+        "--skill",
+        "github-screenshots",
+        "-g",
+        "-y",
+        "-a",
+        "*",
+      ],
+      [
         "claude",
         "mcp",
         "add",
@@ -78,9 +91,10 @@ describe("uploads install", () => {
     const code = await runInstall([], { globals: GLOBALS, runner: run });
     expect(code).toBe(0);
     const printed = out.join("");
-    expect(printed).toContain("Installing skill…");
+    expect(printed).toContain("Installing skills…");
     expect(printed).toContain("Installing MCP server…");
-    expect(printed).toMatch(/skill: ok/);
+    expect(printed).toMatch(/skill:uploads-cli: ok/);
+    expect(printed).toMatch(/skill:github-screenshots: ok/);
     expect(printed).toMatch(/mcp: ok/);
     // Child process noise stays out of the happy path.
     expect(printed).not.toContain("multi-line child output");
@@ -100,8 +114,8 @@ describe("uploads install", () => {
   it("install skill runs only the skills step", async () => {
     const { run, calls } = fakeRunner();
     expect(await runInstall(["skill"], { globals: GLOBALS, runner: run })).toBe(0);
-    expect(calls).toHaveLength(1);
-    expect(calls[0][0]).toBe("npx");
+    expect(calls).toHaveLength(2);
+    expect(calls.every((c) => c[0] === "npx")).toBe(true);
   });
 
   it("skill-only success still nudges login when unsigned", async () => {
@@ -159,13 +173,14 @@ describe("uploads install", () => {
       runner: run,
     });
     expect(code).toBe(1);
-    expect(calls).toHaveLength(1);
-    expect(calls[0][0]).toBe("npx");
-    expect(out.join("")).toMatch(/skill: ok/);
+    expect(calls).toHaveLength(2);
+    expect(calls.every((c) => c[0] === "npx")).toBe(true);
+    expect(out.join("")).toMatch(/skill:uploads-cli: ok/);
+    expect(out.join("")).toMatch(/skill:github-screenshots: ok/);
     expect(out.join("")).toMatch(/mcp: skipped/);
     expect(out.join("")).not.toMatch(/mcp: failed/);
     expect(out.join("")).toMatch(/uploads login/);
-    expect(out.join("")).toMatch(/Skill is installed/);
+    expect(out.join("")).toMatch(/Skills are installed/);
     expect(err.join("")).not.toMatch(/error:/i);
   });
 
@@ -190,5 +205,15 @@ describe("uploads install", () => {
     await expect(runInstall(["nope"], { globals: GLOBALS, runner: run })).rejects.toThrow(
       /unknown install target/,
     );
+  });
+
+  it("--json reports each skill step under its own key", async () => {
+    const { run } = fakeRunner();
+    const { out } = captureStreams();
+    const code = await runInstall(["skill"], { globals: GLOBALS, json: true, runner: run });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.ok).toBe(true);
+    expect(Object.keys(parsed.steps)).toEqual(["skill:uploads-cli", "skill:github-screenshots"]);
   });
 });

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "GitHub screenshots & file hosting",
+      "description": "Start with github-screenshots — it gets screenshots, GIFs, and recordings into PRs and issues. uploads-cli is the full CLI reference it defers to.",
+      "skills": ["github-screenshots", "uploads-cli"]
+    }
+  ]
+}

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: github-screenshots
+description: >-
+  Embed screenshots, images, diagrams, GIFs, and screen recordings in GitHub
+  PRs and issues — or get a durable public link to share a visual with a
+  person. Use this whenever a visual needs to end up in a PR description,
+  issue body, or PR/issue comment, or in front of a teammate. Triggers include
+  "attach a screenshot to the PR", "add a before/after to the issue", "include
+  a screenshot of …", "share a GIF of the flow", "record the bug and put it in
+  the issue", "get me a link I can paste in Slack", or having just captured or
+  changed something visual that a shot would make clearer. Reach for this
+  instead of drag-and-drop or github.com/user-attachments (agents can't upload
+  there) and instead of hand-rolling cloud-storage uploads. Capture the visual
+  with whatever browser or screenshot tooling you have; this skill covers
+  hosting and embedding it.
+---
+
+# Screenshots and recordings in GitHub PRs and issues
+
+## Why this exists
+
+GitHub's native image hosting (`github.com/user-attachments/…`) only works
+from an authenticated browser session — there is no `gh` CLI or REST endpoint
+for it. Any image URL in a PR/issue body written with `gh … --body-file` must
+already point at something publicly hosted. The **`uploads` CLI** provides
+that: it hosts the file on uploads.sh and returns a stable public URL plus
+ready-to-paste markdown.
+
+## Step 1 — Get the visual (any tool)
+
+Capture is tool-agnostic. Use whatever this environment has and save a local
+file:
+
+- The agent harness's own browser tools (screenshot the preview pane).
+- A Playwright/browser MCP, `agent-browser`, or similar automation.
+- An OS screenshot or screen recording the user already made.
+- Any existing image, GIF, or diagram file.
+
+GIFs and video upload as-is — the client-side optimizer only rewrites still
+images (PNG/JPEG → WebP). No special flags needed for motion.
+
+## Step 2 — Host and embed
+
+For the common case — files attached to the current branch's PR — use
+`uploads attach`. It infers the PR, uploads under stable keys, and maintains
+a single managed "attachments" comment:
+
+```bash
+uploads attach ./before.png ./after.png
+uploads attach ./flow.gif --issue 45 --repo myorg/myapp
+uploads attach ./shot.png --no-comment      # stable URLs only, no comment
+```
+
+For a URL you'll hard-code in a PR/issue body (re-uploads overwrite in place,
+URL never changes):
+
+```bash
+uploads put ./after.png --pr 123 --alt "Dashboard after" --width 700
+```
+
+For a durable public link to share anywhere (Slack, docs, a teammate):
+
+```bash
+uploads put ./demo.gif --format url
+```
+
+Always embed the returned **markdown** (or `embedUrl`) in GitHub — it uses the
+no-cache host so overwrites propagate. Don't hand-build storage URLs.
+
+## Step 3 — Embed well
+
+- **Meaningful alt text**, always (`--alt`).
+- **Constrain width** on large shots with `--width` (emits sized `<img>`).
+- **Before/after** reads best side by side:
+
+  ```markdown
+  | Before                               | After                               |
+  | ------------------------------------ | ----------------------------------- |
+  | <img width="380" src="…/before.png"> | <img width="380" src="…/after.png"> |
+  ```
+
+- **Motion:** GitHub markdown won't autoplay MP4 URLs — prefer a GIF, or a
+  still image that links to the video URL.
+- Write bodies to a file and use `gh pr edit --body-file` / `gh issue comment
+--body-file` rather than inline HEREDOCs.
+
+## Setup and escalation
+
+- CLI missing? `npm install --global @buildinternet/uploads`
+- Not authenticated? `uploads login` (one-time, opens a browser), then
+  `uploads doctor` to verify.
+- Everything deeper — flags, key layouts, metadata and search, galleries,
+  config defaults, output formats, exit codes — lives in the **uploads-cli**
+  skill and `uploads <command> --help`.
+
+## Cautions
+
+- **Uploads are public and effectively permanent** until deleted. GitHub repo
+  visibility is not an access control, and `gh/<owner>/<repo>/pull/<num>/…`
+  keys are predictable. Never upload secrets, tokens, or customer PII —
+  crop/redact first.

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: uploads-cli
 description: >-
-  Host a file on uploads.sh and get a stable, public URL — then embed it in a
-  GitHub PR or issue. Use this whenever you want to put a screenshot, diagram,
-  before/after image, GIF, or any binary into a PR description, issue body, or
-  PR/issue comment, or whenever you just need a durable public link to a local
-  file. Triggers include "upload this", "host this image", "attach a screenshot
-  to the PR", "add a before/after to the issue", "give me a public URL for this
-  file", "put this in the PR comment", or having just built/changed something
-  visual that a shot would make clearer. Reach for this instead of drag-and-drop
-  or the GitHub API (an agent can't upload to github.com/user-attachments) and
-  instead of hand-rolling cloud storage uploads.
+  Reference for the uploads CLI — host files on uploads.sh and manage them.
+  Covers put and attach, stable PR/issue keys, the managed attachments
+  comment, metadata and search, galleries, config defaults, login/doctor, and
+  output formats. Use when driving the `uploads` CLI or its MCP tools, when
+  you need a public URL for a local file ("upload this", "host this image",
+  "give me a public URL for this file"), or when you need exact flags, key
+  layouts, or setup and auth details. For the when-and-how of getting a
+  screenshot or recording into a GitHub PR or issue, start with the
+  github-screenshots skill — it defers here for CLI detail.
 ---
 
 # Uploading files to uploads.sh and embedding in GitHub


### PR DESCRIPTION
## What

Ships the GitHub-screenshots workflow as a first-party skill so `uploads install` makes the "attach a screenshot to the PR" moment work out of the box — no external `buildinternet/skills/github-screenshots` install required.

- **New `skills/github-screenshots`** — thin workflow skill owning the moment a screenshot, GIF, or recording needs to end up in a PR description, issue body, comment, or in front of a person. Capture stays tool-agnostic (harness browser tools, Playwright MCP, OS screenshot, existing file); hosting/embedding goes through `uploads attach` / `uploads put`, with embedding etiquette (alt text, width, before/after tables, GIF-vs-MP4). Defers CLI depth to `uploads-cli`.
- **`skills/uploads-cli` rescoped** — frontmatter description trimmed to CLI-reference/hosting mechanics so the two skills don't compete for workflow phrasings; body unchanged.
- **`uploads install` installs both skills** — the skill step is now list-driven (`uploads-cli`, `github-screenshots`), one `npx skills add` per skill, reported separately as `skill:<name>` steps in human and `--json` output. Redaction, dry-run, sign-in skip, and continue-on-failure semantics preserved.
- **Docs aligned** — AGENTS.md, README.md, docs/cli.md, packages/uploads README, PRODUCT.md, and the CLI help catalog now describe the two-skill split (several "the agent skill" singular strings were stale in shipped `uploads help` output).
- Changeset (minor) + design spec + implementation plan included.

## Why

The skill that activated on "put this screenshot in the PR" lived outside this repo and predates uploads.sh (MVP shell scripts, direct-R2 fallback). Installing the uploads CLI should be sufficient on its own. Deliberate non-goals for this PR: no capture command (`uploads shot` is a possible follow-up) and no changes to the external skill yet — tombstoning it is the follow-up once this ships (same skill name, so it should be uninstalled promptly wherever both are present).

## Testing

- `pnpm --filter @buildinternet/uploads typecheck` — clean.
- `pnpm --filter @buildinternet/uploads test` — 36 files, 392/392 passing (install tests updated to the two-skill contract, new `--json` step-key test).
- `uploads install --dry-run --json` verified: `skill:uploads-cli` + `skill:github-screenshots` + `mcp` steps, token redacted.

## How to try it

```bash
npm install --global @buildinternet/uploads
uploads install --dry-run   # shows both skills add steps + mcp registration
```

Known minor (left as-is, pre-existing pattern): when one skill installs and the other fails under `install all`, the per-step failure prints but no closing guidance line does.
