### PR TITLE
feat: parallel multi-file attach with partial failures

### DIFF
--- a/.changeset/attach-parallel-partial.md
+++ b/.changeset/attach-parallel-partial.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Parallel multi-file `attach` (CLI + MCP) with partial-failure `uploads`/`failures` results

--- a/packages/uploads/src/async.ts
+++ b/packages/uploads/src/async.ts
@@ -1,0 +1,23 @@
+/**
+ * Run `fn` over `values` with bounded concurrency, preserving input order
+ * in the returned array. Used by multi-file attach (and similar fan-outs).
+ */
+export async function mapBounded<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  fn: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (values.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, values.length));
+  const result = Array.from<R>({ length: values.length });
+  let next = 0;
+  async function worker() {
+    for (;;) {
+      const index = next++;
+      if (index >= values.length) return;
+      result[index] = await fn(values[index]!, index);
+    }
+  }
+  await Promise.all(Array.from({ length: limit }, worker));
+  return result;
+}

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
-import { createUploadsClient, type GalleryItem, type UploadsClient } from "./client.js";
+import { mapBounded } from "./async.js";
+import {
+  createUploadsClient,
+  type GalleryItem,
+  type PutResult,
+  type UploadsClient,
+} from "./client.js";
 import {
   parseCommandArgs,
   flagString,
@@ -53,6 +59,9 @@ import { formatUsageHuman } from "./format-usage.js";
 import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
 import { colorEnabled, writeCommandHelp } from "./cli-style.js";
+
+/** Parallel fan-out for multi-file attach (matches files-sdk bulk default). */
+export const ATTACH_CONCURRENCY = 8;
 
 export { formatUsageHuman } from "./format-usage.js";
 
@@ -221,7 +230,13 @@ export function optimizeOptionsFromFlags(
   };
 }
 
-function formatOptimizeNote(opt: OptimizeImageResult): string | undefined {
+function formatOptimizeNote(opt: {
+  optimized: boolean;
+  skippedReason?: OptimizeImageResult["skippedReason"];
+  originalBytes: number;
+  outputBytes: number;
+  filename: string;
+}): string | undefined {
   if (opt.optimized) {
     return `optimized ${formatByteSize(opt.originalBytes)} → ${formatByteSize(opt.outputBytes)} (${opt.filename})`;
   }
@@ -374,6 +389,9 @@ const ATTACH_HELP = `uploads attach <file...> [options]
 Upload one or more stable PR/issue attachments and maintain a single GitHub
 comment. With no target, uses the pull request for the current branch.
 
+Multiple files upload in parallel (bounded concurrency). One bad file does not
+block the rest; JSON includes uploads + failures (exit 1 when any failed).
+
 Attachments are public and their repo/number/filename keys are predictable.
 Private/internal GitHub repository visibility does not restrict access; upload
 only media that is safe at a public URL.
@@ -414,6 +432,117 @@ Examples:
   uploads attach ./shot.png --meta app=myapp --meta page=settings
 `;
 
+export type AttachUploadItem = PutResult & {
+  file: string;
+  markdown: string;
+  optimize: {
+    optimized: boolean;
+    skippedReason?: OptimizeImageResult["skippedReason"];
+    originalBytes: number;
+    outputBytes: number;
+    filename: string;
+  };
+  frame?: PreparedUpload["frame"];
+};
+
+export type AttachFailure = {
+  file: string;
+  error: { message: string; code?: string; status?: number };
+};
+
+/**
+ * Prepare + put each path as a PR/issue attachment with bounded concurrency.
+ * Per-file errors collect in `failures` (does not throw). `firstError` is the
+ * original cause of the first failure — for rethrowing single-file CLI paths.
+ */
+export async function uploadAttachments(opts: {
+  client: UploadsClient;
+  target: GhTarget;
+  files: readonly string[];
+  contentType?: string;
+  optimize: OptimizeImageOptions;
+  frame: {
+    frameId?: string;
+    frameUrl?: string;
+    frameFit?: "cover" | "contain";
+  };
+  metadata?: Record<string, string>;
+  /** Provenance `client` field (default uploads-cli). */
+  provenanceClient?: string;
+  concurrency?: number;
+}): Promise<{ uploads: AttachUploadItem[]; failures: AttachFailure[]; firstError?: unknown }> {
+  if (opts.files.some((f) => f === "-")) {
+    throw new UsageError("attach does not support stdin; pass one or more file paths");
+  }
+
+  type Slot = { ok: true; upload: AttachUploadItem } | { ok: false; file: string; err: unknown };
+
+  const slots = await mapBounded(
+    opts.files,
+    opts.concurrency ?? ATTACH_CONCURRENCY,
+    async (file): Promise<Slot> => {
+      try {
+        const sourceName = basename(file);
+        const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
+          ...opts.frame,
+          optimize: opts.optimize,
+        });
+        const result = await opts.client.put(prepared.bytes, {
+          filename: prepared.filename,
+          key: ghAttachmentKey(opts.target, prepared.filename),
+          contentType: prepared.optimized ? prepared.contentType : opts.contentType,
+          provenance: buildCliProvenance({
+            sourceName,
+            client: opts.provenanceClient,
+            optimized: prepared.optimized,
+            frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+            keepExif: opts.optimize.keepExif === true,
+          }),
+          metadata: opts.metadata,
+        });
+        return {
+          ok: true,
+          upload: {
+            ...result,
+            file,
+            markdown: buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+              alt: sourceName,
+            }),
+            optimize: {
+              optimized: prepared.optimized,
+              skippedReason: prepared.skippedReason,
+              originalBytes: prepared.originalBytes,
+              outputBytes: prepared.outputBytes,
+              filename: prepared.filename,
+            },
+            frame: prepared.frame,
+          },
+        };
+      } catch (err) {
+        return { ok: false, file, err };
+      }
+    },
+  );
+
+  const uploads: AttachUploadItem[] = [];
+  const failures: AttachFailure[] = [];
+  let firstError: unknown;
+  for (const slot of slots) {
+    if (slot.ok) uploads.push(slot.upload);
+    else {
+      firstError ??= slot.err;
+      failures.push({ file: slot.file, error: errorDetail(slot.err) });
+    }
+  }
+  return { uploads, failures, firstError };
+}
+
+function errorDetail(err: unknown): { message: string; code?: string; status?: number } {
+  if (err instanceof UploadsError)
+    return { message: err.message, code: err.code, status: err.status };
+  return { message: err instanceof Error ? err.message : String(err) };
+}
+
 export async function runAttach(
   ctx: CliContext,
   args: string[],
@@ -449,52 +578,32 @@ export async function runAttach(
   const metaExtras = parseMetaFlags(flagValues(parsed.flags, "--meta"));
   const metadata = { ...metaExtras, ...ghMetadataFromTarget(target) };
   if (Object.keys(metadata).length > 0) validateMetaMap(metadata);
-  const results = [];
-  for (const file of parsed.positionals) {
-    if (file === "-")
-      throw new UsageError("attach does not support stdin; pass one or more file paths");
-    const sourceName = basename(file);
-    if (!ctx.quiet && !ctx.json) process.stderr.write(`>> uploading ${file}\n`);
-    const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
-      ...frameOpts,
-      optimize: optimizeOpts,
-    });
-    if (prepared.frame?.framed && !ctx.quiet && !ctx.json) {
-      process.stderr.write(`>> framed with ${prepared.frame.frameId}\n`);
-    }
-    const note = formatOptimizeNote(prepared);
-    if (note && !ctx.quiet && !ctx.json) process.stderr.write(`>> ${note}\n`);
-    const result = await ctx.client.put(prepared.bytes, {
-      filename: prepared.filename,
-      key: ghAttachmentKey(target, prepared.filename),
-      contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
-      provenance: buildCliProvenance({
-        sourceName,
-        optimized: prepared.optimized,
-        frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
-        keepExif: optimizeOpts.keepExif === true,
-      }),
-      metadata,
-    });
-    writeReplacedNote(result.replaced, ctx.quiet || ctx.json);
-    const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
-    results.push({
-      ...result,
-      markdown: buildMarkdown(embedSrc, { alt: sourceName }),
-      optimize: {
-        optimized: prepared.optimized,
-        skippedReason: prepared.skippedReason,
-        originalBytes: prepared.originalBytes,
-        outputBytes: prepared.outputBytes,
-        filename: prepared.filename,
-      },
-      frame: prepared.frame,
-    });
+
+  const logHuman = !ctx.quiet && !ctx.json;
+  if (logHuman) {
+    const n = parsed.positionals.length;
+    process.stderr.write(`>> uploading ${n} file${n === 1 ? "" : "s"}\n`);
+  }
+
+  const { uploads, failures, firstError } = await uploadAttachments({
+    client: ctx.client,
+    target,
+    files: parsed.positionals,
+    contentType: contentTypeOverride,
+    optimize: optimizeOpts,
+    frame: frameOpts,
+    metadata,
+  });
+
+  // Single-file total failure: rethrow so CLI exit codes stay auth/network-aware.
+  if (uploads.length === 0 && failures.length === 1 && parsed.positionals.length === 1) {
+    throw firstError instanceof Error ? firstError : new Error(String(firstError));
   }
 
   let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
   let commentError: string | undefined;
-  if (!parsed.flags.has("--no-comment")) {
+  // Skip comment refresh when every upload failed — nothing new from this batch.
+  if (!parsed.flags.has("--no-comment") && uploads.length > 0) {
     try {
       comment = await syncAttachmentsComment(ctx.client, target, run);
     } catch (err) {
@@ -506,20 +615,32 @@ export async function runAttach(
   }
 
   if (ctx.json) {
-    await writeJson({ target, uploads: results, comment, commentError });
+    await writeJson({ target, uploads, failures, comment, commentError });
   } else {
-    for (const result of results) {
+    for (const result of uploads) {
+      if (logHuman) {
+        if (result.frame?.framed) {
+          process.stderr.write(
+            `>> ${basename(result.file)}: framed with ${result.frame.frameId}\n`,
+          );
+        }
+        const note = formatOptimizeNote(result.optimize);
+        if (note) process.stderr.write(`>> ${basename(result.file)}: ${note}\n`);
+        writeReplacedNote(result.replaced, false);
+      }
       const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
       await writeStdout(`URL: ${result.url}\n${embedLine}MARKDOWN: ${result.markdown}\n`);
     }
+    for (const failure of failures) {
+      process.stderr.write(`warning: could not upload ${failure.file}: ${failure.error.message}\n`);
+    }
     if (!ctx.quiet && comment) process.stderr.write(`>> attachments comment ${comment.action}\n`);
-    // attach auto-writes gh.* metadata; point the user at how to find it later.
-    if (!ctx.quiet) {
+    if (!ctx.quiet && uploads.length > 0) {
       const ref = ghMetadataFromTarget(target)["gh.ref"];
       process.stderr.write(`>> find these later: uploads find gh.ref=${ref}\n`);
     }
   }
-  return 0;
+  return failures.length === 0 ? 0 : 1;
 }
 
 export async function runPut(
@@ -725,7 +846,7 @@ export async function runPut(
       });
       gallery = { id: galleryId, url: current.url, item };
     } catch (err) {
-      gallery = { id: galleryId, error: galleryError(err) };
+      gallery = { id: galleryId, error: errorDetail(err) };
     }
   }
   const optimizeMeta = {
@@ -790,12 +911,6 @@ export async function runPut(
   }
 
   return gallery?.error ? 1 : 0;
-}
-
-function galleryError(err: unknown): { message: string; code?: string; status?: number } {
-  if (err instanceof UploadsError)
-    return { message: err.message, code: err.code, status: err.status };
-  return { message: err instanceof Error ? err.message : String(err) };
 }
 
 // --- galleries ---
@@ -982,7 +1097,7 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
             }),
           );
         } catch (err) {
-          failures.push({ objectKey, error: galleryError(err) });
+          failures.push({ objectKey, error: errorDetail(err) });
         }
       }
       const output = { galleryId: id, galleryUrl: galleryUrl ?? null, added, failures };

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -14,6 +14,7 @@ import {
   prepareImageForUpload,
   readFileArg,
   syncAttachmentsComment,
+  uploadAttachments,
 } from "../commands.js";
 import { resolveFrameId } from "../frame.js";
 import {
@@ -522,7 +523,7 @@ export function createUploadsMcpTools(opts: {
     {
       name: "attach",
       description:
-        "Upload one or more files as stable PR/issue attachments and maintain a single managed GitHub comment listing them. Each upload returns `url`, `embedUrl` (when dual-host applies), and `markdown` (uses embedUrl for GitHub). With no pr/issue, targets the pull request for the current branch. Attachments are public and keys are predictable; upload only non-sensitive media.",
+        "Upload one or more files as stable PR/issue attachments (in parallel) and maintain a managed GitHub comment. Returns `uploads` and `failures` (one bad file does not abort the batch). Each success has `url`, `embedUrl`, and `markdown` (prefer embedUrl for GitHub). With no pr/issue, targets the current branch PR. Attachments are public and keys are predictable; upload only non-sensitive media.",
       inputSchema: {
         type: "object",
         properties: {
@@ -594,45 +595,25 @@ export function createUploadsMcpTools(opts: {
         const metadata = { ...metaExtras, ...ghMetadataFromTarget(target) };
         if (Object.keys(metadata).length > 0) validateMetaMap(metadata);
 
-        const uploads = [];
-        for (const file of files) {
-          const sourceName = basename(file);
-          const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
-            ...frameOpts,
-            optimize: optimizeOpts,
-          });
-          const result = await client.put(prepared.bytes, {
-            filename: prepared.filename,
-            key: ghAttachmentKey(target, prepared.filename),
-            contentType: prepared.optimized ? prepared.contentType : contentType,
-            provenance: buildCliProvenance({
-              sourceName,
-              client: "uploads-mcp",
-              optimized: prepared.optimized,
-              frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
-              keepExif: optimizeOpts.keepExif === true,
-            }),
-            metadata,
-          });
-          uploads.push({
-            ...result,
-            markdown: buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
-              alt: sourceName,
-            }),
-            frame: prepared.frame,
-            optimize: {
-              optimized: prepared.optimized,
-              skippedReason: prepared.skippedReason,
-              originalBytes: prepared.originalBytes,
-              outputBytes: prepared.outputBytes,
-              filename: prepared.filename,
-            },
-          });
+        const { uploads, failures, firstError } = await uploadAttachments({
+          client,
+          target,
+          files,
+          contentType,
+          optimize: optimizeOpts,
+          frame: frameOpts,
+          metadata,
+          provenanceClient: "uploads-mcp",
+        });
+
+        // Total failure → tool error (isError) so agents notice.
+        if (uploads.length === 0 && failures.length > 0) {
+          throw firstError instanceof Error ? firstError : new Error(String(firstError));
         }
 
-        if (optBool(args, "noComment")) return { target, uploads };
+        if (optBool(args, "noComment")) return { target, uploads, failures };
         const { comment, commentError } = await syncComment(client, target);
-        return { target, uploads, comment, commentError };
+        return { target, uploads, failures, comment, commentError };
       },
     },
     {

--- a/packages/uploads/test/async.test.ts
+++ b/packages/uploads/test/async.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { mapBounded } from "../src/async.js";
+
+describe("mapBounded", () => {
+  it("preserves input order under concurrency", async () => {
+    const delays = [30, 5, 15, 1];
+    const started: number[] = [];
+    const result = await mapBounded(delays, 2, async (ms, index) => {
+      started.push(index);
+      await new Promise((r) => setTimeout(r, ms));
+      return index * 10;
+    });
+    expect(result).toEqual([0, 10, 20, 30]);
+    // With concurrency 2, the first two indices start before later ones finish.
+    expect(started.slice(0, 2).sort()).toEqual([0, 1]);
+  });
+
+  it("handles empty input", async () => {
+    expect(await mapBounded([], 4, async (v) => v)).toEqual([]);
+  });
+
+  it("caps concurrency at the input length", async () => {
+    let max = 0;
+    let inFlight = 0;
+    await mapBounded([1, 2, 3], 100, async (v) => {
+      inFlight += 1;
+      max = Math.max(max, inFlight);
+      await Promise.resolve();
+      inFlight -= 1;
+      return v;
+    });
+    expect(max).toBe(3);
+  });
+});

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
 import type { UploadsClient } from "../src/client.js";
 import { runAttach, type CliContext } from "../src/commands.js";
+import { UploadsError } from "../src/errors.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
 function files(...names: string[]): string[] {
@@ -16,7 +17,10 @@ function files(...names: string[]): string[] {
   });
 }
 
-function fakeClient() {
+function fakeClient(opts?: {
+  /** Reject put for keys whose leaf matches this predicate. */
+  failLeaf?: (leaf: string) => boolean | Error;
+}) {
   const puts: string[] = [];
   const metadataByKey: Record<string, Record<string, string> | undefined> = {};
   const list = async ({ prefix }: { prefix?: string } = {}) => ({
@@ -26,20 +30,29 @@ function fakeClient() {
     cursor: null,
   });
   const client = {
-    put: async (_body: Uint8Array, opts: { key: string; metadata?: Record<string, string> }) => {
-      puts.push(opts.key);
-      metadataByKey[opts.key] = opts.metadata;
+    put: async (_body: Uint8Array, putOpts: { key: string; metadata?: Record<string, string> }) => {
+      const leaf = putOpts.key.split("/").at(-1) ?? putOpts.key;
+      if (opts?.failLeaf) {
+        const fail = opts.failLeaf(leaf);
+        if (fail) {
+          throw fail instanceof Error
+            ? fail
+            : new UploadsError(`forced fail: ${leaf}`, "API_ERROR", 500);
+        }
+      }
+      puts.push(putOpts.key);
+      metadataByKey[putOpts.key] = putOpts.metadata;
       return {
         workspace: "test",
-        key: opts.key,
-        url: `https://x.test/${opts.key}`,
+        key: putOpts.key,
+        url: `https://x.test/${putOpts.key}`,
         embedUrl: null,
         size: 3,
         contentType: "image/png",
       };
     },
     list,
-    listAll: async (opts: { prefix?: string } = {}) => (await list(opts)).items,
+    listAll: async (listOpts: { prefix?: string } = {}) => (await list(listOpts)).items,
     findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
     getGallery: async () => ({ items: [] }),
   } as unknown as UploadsClient;
@@ -84,14 +97,90 @@ describe("runAttach", () => {
     const { client, puts } = fakeClient();
     const { run, calls } = ghRunner();
     expect(await runAttach(ctxWith(client), files("before.png", "after.png"), false, run)).toBe(0);
-    expect(puts).toEqual([
-      "gh/buildinternet/uploads/pull/123/before.png",
-      "gh/buildinternet/uploads/pull/123/after.png",
-    ]);
+    expect(puts.sort()).toEqual(
+      [
+        "gh/buildinternet/uploads/pull/123/before.png",
+        "gh/buildinternet/uploads/pull/123/after.png",
+      ].sort(),
+    );
     expect(calls.some((call) => call[1] === "pr" && call[2] === "view")).toBe(true);
     expect(
       calls.some((call) => call.includes("repos/buildinternet/uploads/issues/123/comments")),
     ).toBe(true);
+  });
+
+  it("uploads multiple files with bounded concurrency", async () => {
+    const { client, puts } = fakeClient();
+    const { run } = ghRunner();
+    // Count overlap at the put boundary (after prepare). Hold each put open so
+    // concurrent workers can stack before any resolves.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const originalPut = client.put.bind(client);
+    client.put = async (body, opts) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 40));
+      inFlight -= 1;
+      return originalPut(body, opts);
+    };
+    const paths = files("a.png", "b.png", "c.png", "d.png");
+    expect(await runAttach(ctxWith(client), [...paths, "--no-comment"], false, run)).toBe(0);
+    expect(puts).toHaveLength(4);
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it("continues after a per-file failure and reports failures (exit 1)", async () => {
+    const { client, puts } = fakeClient({
+      failLeaf: (leaf) => leaf === "bad.png",
+    });
+    const { run, calls } = ghRunner();
+    const paths = files("good.png", "bad.png", "also-good.png");
+    const ctx = { ...ctxWith(client), json: true };
+    const jsonChunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      jsonChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runAttach(ctx, paths, false, run)).toBe(1);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(puts.sort()).toEqual(
+      [
+        "gh/buildinternet/uploads/pull/123/good.png",
+        "gh/buildinternet/uploads/pull/123/also-good.png",
+      ].sort(),
+    );
+    const payload = JSON.parse(jsonChunks.join("")) as {
+      uploads: { key: string }[];
+      failures: { file: string; error: { message: string; code?: string } }[];
+    };
+    expect(payload.uploads.map((u) => u.key).sort()).toEqual(
+      [
+        "gh/buildinternet/uploads/pull/123/good.png",
+        "gh/buildinternet/uploads/pull/123/also-good.png",
+      ].sort(),
+    );
+    expect(payload.failures).toHaveLength(1);
+    expect(payload.failures[0]!.file).toContain("bad.png");
+    expect(payload.failures[0]!.error.code).toBe("API_ERROR");
+    // Partial success still refreshes the managed comment.
+    expect(
+      calls.some((call) => call.includes("repos/buildinternet/uploads/issues/123/comments")),
+    ).toBe(true);
+  });
+
+  it("rethrows a single-file total failure for exit-code mapping", async () => {
+    const { client } = fakeClient({
+      failLeaf: () => new UploadsError("nope", "UNAUTHORIZED", 401),
+    });
+    const { run } = ghRunner();
+    await expect(runAttach(ctxWith(client), files("only.png"), false, run)).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      status: 401,
+    });
   });
 
   it("supports an explicit issue and skips the managed comment with --no-comment", async () => {

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -524,8 +524,54 @@ describe("tools/call attach", () => {
       num: 123,
     });
     expect(res.result.structuredContent.uploads[0].markdown).toContain("before.png");
+    expect(res.result.structuredContent.failures).toEqual([]);
     expect(res.result.structuredContent.comment).toEqual({ action: "created", count: 1 });
     expect(calls.some((call) => call[1] === "pr" && call[2] === "view")).toBe(true);
+  });
+
+  it("uploads multiple files and reports per-file failures without aborting the batch", async () => {
+    const { run } = ghRunner();
+    const { UploadsError } = await import("../src/errors.js");
+    const putCalls: string[] = [];
+    const { server } = serverWith({
+      runner: run,
+      factory: () =>
+        ({
+          put: async (_body: Uint8Array, opts: { key: string; filename: string }) => {
+            putCalls.push(opts.key);
+            if (opts.filename === "bad.png") {
+              throw new UploadsError("forced fail", "API_ERROR", 500);
+            }
+            return {
+              workspace: "test",
+              key: opts.key,
+              url: `https://x.test/${opts.key}`,
+              embedUrl: null,
+              size: 3,
+              contentType: "image/png",
+            };
+          },
+          listAll: async () => [],
+          findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+          getGallery: async () => ({ items: [] }),
+        }) as never,
+    });
+    const dir = mkdtempSync(join(tmpdir(), "uploads-mcp-test-"));
+    const good = join(dir, "good.png");
+    const bad = join(dir, "bad.png");
+    writeFileSync(good, "png");
+    writeFileSync(bad, "png");
+
+    const res = await rpc(server, "tools/call", {
+      name: "attach",
+      arguments: { files: [good, bad], noComment: true },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent.uploads).toHaveLength(1);
+    expect(res.result.structuredContent.uploads[0].key).toContain("good.png");
+    expect(res.result.structuredContent.failures).toHaveLength(1);
+    expect(res.result.structuredContent.failures[0].file).toContain("bad.png");
+    expect(putCalls.some((k) => k.includes("good.png"))).toBe(true);
   });
 
   it("rejects an empty files array", async () => {

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -42,8 +42,9 @@ images (PNG/JPEG → WebP). No special flags needed for motion.
 ## Step 2 — Host and embed
 
 For the common case — files attached to the current branch's PR — use
-`uploads attach`. It infers the PR, uploads under stable keys, and maintains
-a single managed "attachments" comment:
+`uploads attach`. It infers the PR, uploads under stable keys in parallel, and
+maintains a single managed "attachments" comment. Multi-file runs keep going if
+one path fails (`failures` in `--json`; exit `1` when any failed):
 
 ```bash
 uploads attach ./before.png ./after.png

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -28,8 +28,9 @@ also create and maintain a single "attachments" comment for you via your local
 `gh` auth.
 
 For the common case, use `uploads attach <file...>`. It infers the current branch's
-PR, uploads every file under stable attachment keys, and maintains the comment by
-default:
+PR, uploads every file under stable attachment keys (in parallel), and maintains
+the comment by default. One bad file does not block the rest — JSON includes
+`uploads` and `failures` (exit `1` when any failed):
 
 ```bash
 uploads attach ./before.png ./after.png


### PR DESCRIPTION
## In plain terms

When an agent attaches several screenshots at once, `uploads attach` no longer uploads them one-by-one and no longer aborts the whole batch if a single file fails. Files go up in parallel, and results report what succeeded and what did not.

## What it does

- Bounded concurrent prepare+put for multi-file `attach` (CLI and MCP; concurrency 8)
- Structured partial failure: `uploads` + `failures` (JSON / MCP); exit `1` when any failed
- Single-file total failure still throws so CLI auth/network exit codes stay useful
- Managed attachments comment still refreshes when anything landed
- Skill docs note the new behavior

## What it is not

- Not a new batch REST API or files-sdk storage bulk path — still one PUT per object
- Does not change `put` (still one file per invocation)

## How to try it

```bash
uploads attach ./before.png ./after.png --no-comment
uploads --json attach ./a.png ./b.png --pr 123 --no-comment
```

Inspect `failures` in JSON when one path is bad; successful URLs still print.

## Test plan

- [x] Unit: concurrency, partial failure, single-file rethrow, MCP multi-file
- [x] `mapBounded` tests
- [x] Smoke: monorepo `pnpm uploads attach` two PNGs to prod (`--pr 194 --no-comment`) — both URLs returned
- [ ] CI on this PR