### PR TITLE
feat: multi-file put and richer MCP batch failures

### DIFF
--- a/.changeset/put-multi-batch-errors.md
+++ b/.changeset/put-multi-batch-errors.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Multi-file `put` (CLI + stdio MCP) with partial failures; MCP total-failure keeps structured `failures[]`

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -74,7 +74,7 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
   },
   {
     name: "put",
-    usage: "put <file>",
+    usage: "put <file...>",
     summary: "Upload (+ URL + markdown for GitHub)",
     essential: true,
   },

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -60,8 +60,10 @@ import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
 import { colorEnabled, writeCommandHelp } from "./cli-style.js";
 
-/** Parallel fan-out for multi-file attach (matches files-sdk bulk default). */
-export const ATTACH_CONCURRENCY = 8;
+/** Parallel fan-out for multi-file put/attach (matches files-sdk bulk default). */
+export const UPLOAD_BATCH_CONCURRENCY = 8;
+/** @deprecated Use UPLOAD_BATCH_CONCURRENCY. */
+export const ATTACH_CONCURRENCY = UPLOAD_BATCH_CONCURRENCY;
 
 export { formatUsageHuman } from "./format-usage.js";
 
@@ -87,9 +89,13 @@ export function readFileArg(fileArg: string): Uint8Array {
 
 // --- put ---
 
-const PUT_HELP = `uploads put <file> [options]
+const PUT_HELP = `uploads put <file...> [options]
 
-Upload an image for GitHub embeds. Use "-" for stdin.
+Upload one or more images for GitHub embeds. Use "-" for stdin (single file only).
+
+Multiple files upload in parallel (bounded concurrency). One bad file does not
+block the rest; multi-file JSON is { uploads, failures } (exit 1 when any failed).
+Single-file JSON stays a flat object (back-compat).
 
 Still images (PNG/JPEG/…) are optimized to WebP by default (long edge capped,
 high quality; EXIF stripped) so GitHub embeds stay lean. Original bytes are kept
@@ -112,13 +118,13 @@ Human/json output includes durable url and (when dual-host applies) embedUrl.
 MARKDOWN prefers embedUrl for GitHub. Override: UPLOADS_EMBED_PUBLIC_BASE_URL.
 
 Options:
-  --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>)
-  --name <leaf>         Clean key leaf + default alt (no '/'); keeps --pr/default path. Not with --key
+  --key <key>           Object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>). Single file only
+  --name <leaf>         Clean key leaf + default alt (no '/'); keeps --pr/default path. Single file only. Not with --key
   --destination <id>    Typed root: screenshots | gh | f (sets --prefix)
   --prefix <path>       Key prefix (default: screenshots, or UPLOADS_DEFAULT_PREFIX)
   --repo <owner/repo>   Repo segment (default: git remote, or UPLOADS_DEFAULT_REPO)
   --ref <id>            PR/issue/branch segment (default: today, or UPLOADS_DEFAULT_REF)
-  --alt <text>          Alt text (default: filename)
+  --alt <text>          Alt text (default: each file's name; with multiple files applies to all)
   --width <px>          <img width=…> markdown (or UPLOADS_DEFAULT_WIDTH)
   --content-type <mime> Override Content-Type (ignored when optimize rewrites the body)
   --frame <id>          Device/browser frame before optimize (phone|browser|iphone-16-pro)
@@ -136,18 +142,19 @@ Options:
   --pr <num>            Attach to a pull request: key gh/<owner>/<repo>/pull/<num>/<name> (stable URL, no hash)
   --issue <num>         Attach to an issue: key gh/<owner>/<repo>/issues/<num>/<name>
   --comment             With --pr/--issue: update one managed comment with attachments and linked galleries via local gh auth
-  --gallery <id>         Add the uploaded object to this public gallery
+  --gallery <id>         Add the uploaded object(s) to this public gallery
   --meta <k=v>          Queryable custom metadata (repeatable; value may contain "="): key ^[a-z][a-z0-9._-]{0,63}$, value 1-512 printable ASCII, max 24 pairs
                         Re-uploading to an existing key WITH --meta replaces that file's
                         entire metadata set; without --meta the existing metadata is
                         preserved. Use "uploads meta set" to edit individual keys.
   --dry-run             Print key + public URL without uploading; reports if the key would replace an existing object. Not with --comment/--gallery
 
-Exit codes: 0 ok · 2 usage/token/file · 3 auth/policy · 4 network · 1 other.
+Exit codes: 0 ok · 2 usage/token/file · 3 auth/policy · 4 network · 1 other (incl. partial multi-file failure).
 Scripted formats (json|url|markdown) also print failures on stdout.
 
 Examples:
   uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New cards" --width 700
+  uploads put ./before.png ./after.png
   uploads put ./mobile.png --frame phone
   uploads put ./ui.png --frame browser --frame-url "https://app.example/settings"
   uploads put ./shot.png --destination screenshots
@@ -479,7 +486,7 @@ export async function uploadAttachments(opts: {
 
   const slots = await mapBounded(
     opts.files,
-    opts.concurrency ?? ATTACH_CONCURRENCY,
+    opts.concurrency ?? UPLOAD_BATCH_CONCURRENCY,
     async (file): Promise<Slot> => {
       try {
         const sourceName = basename(file);
@@ -541,6 +548,133 @@ function errorDetail(err: unknown): { message: string; code?: string; status?: n
   if (err instanceof UploadsError)
     return { message: err.message, code: err.code, status: err.status };
   return { message: err instanceof Error ? err.message : String(err) };
+}
+
+export type PutUploadItem = PutResult & {
+  file: string;
+  markdown: string;
+  optimize: AttachUploadItem["optimize"];
+  frame?: PreparedUpload["frame"];
+};
+
+/**
+ * Prepare + put each path with put-style key resolution and bounded concurrency.
+ * Same partial-failure shape as uploadAttachments.
+ */
+export async function uploadPuts(opts: {
+  client: UploadsClient;
+  files: readonly string[];
+  /** Single-file --name leaf override. */
+  nameOverride?: string;
+  /** Single-file --key. */
+  explicitKey?: string;
+  ghTarget?: GhTarget;
+  prefix?: string;
+  repo?: string;
+  ref?: string;
+  deriveRepoFromGit?: boolean;
+  contentType?: string;
+  dryRun?: boolean;
+  optimize: OptimizeImageOptions;
+  frame: {
+    frameId?: string;
+    frameUrl?: string;
+    frameFit?: "cover" | "contain";
+  };
+  metadata?: Record<string, string>;
+  provenanceClient?: string;
+  /** When set, used as alt for every file; else each file's basename. */
+  alt?: string;
+  width?: number;
+  concurrency?: number;
+}): Promise<{ uploads: PutUploadItem[]; failures: AttachFailure[]; firstError?: unknown }> {
+  if (opts.files.length > 1 && opts.files.some((f) => f === "-")) {
+    throw new UsageError("stdin (-) cannot be combined with multiple file arguments");
+  }
+  if (opts.files.length > 1 && opts.explicitKey) {
+    throw new UsageError("--key cannot be combined with multiple files");
+  }
+  if (opts.files.length > 1 && opts.nameOverride) {
+    throw new UsageError("--name cannot be combined with multiple files");
+  }
+
+  type Slot = { ok: true; upload: PutUploadItem } | { ok: false; file: string; err: unknown };
+
+  const slots = await mapBounded(
+    opts.files,
+    opts.concurrency ?? UPLOAD_BATCH_CONCURRENCY,
+    async (file): Promise<Slot> => {
+      try {
+        const sourceName =
+          opts.nameOverride ??
+          (file === "-"
+            ? opts.explicitKey
+              ? basename(opts.explicitKey)
+              : "stdin.bin"
+            : basename(file));
+        const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
+          ...opts.frame,
+          optimize: opts.optimize,
+        });
+        let key = opts.ghTarget
+          ? ghAttachmentKey(opts.ghTarget, prepared.filename)
+          : opts.explicitKey;
+        if (key && prepared.optimized) key = rewriteKeyExtension(key, prepared.filename);
+        const result = await opts.client.put(prepared.bytes, {
+          filename: prepared.filename,
+          key,
+          prefix: opts.prefix,
+          repo: opts.repo,
+          ref: opts.ref,
+          contentType: prepared.optimized ? prepared.contentType : opts.contentType,
+          deriveRepoFromGit: opts.deriveRepoFromGit,
+          dryRun: opts.dryRun,
+          provenance: buildCliProvenance({
+            sourceName,
+            client: opts.provenanceClient,
+            optimized: prepared.optimized,
+            frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+            keepExif: opts.optimize.keepExif === true,
+          }),
+          metadata: opts.metadata,
+        });
+        const alt = opts.alt ?? basename(sourceName);
+        return {
+          ok: true,
+          upload: {
+            ...result,
+            file,
+            markdown: buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+              alt,
+              width: opts.width,
+            }),
+            optimize: {
+              optimized: prepared.optimized,
+              skippedReason: prepared.skippedReason,
+              originalBytes: prepared.originalBytes,
+              outputBytes: prepared.outputBytes,
+              filename: prepared.filename,
+            },
+            frame: prepared.frame,
+          },
+        };
+      } catch (err) {
+        return { ok: false, file, err };
+      }
+    },
+  );
+
+  const uploads: PutUploadItem[] = [];
+  const failures: AttachFailure[] = [];
+  let firstError: unknown;
+  for (const slot of slots) {
+    if (slot.ok) uploads.push(slot.upload);
+    else {
+      firstError ??= slot.err;
+      failures.push({ file: slot.file, error: errorDetail(slot.err) });
+    }
+  }
+  return { uploads, failures, firstError };
 }
 
 export async function runAttach(
@@ -659,11 +793,12 @@ export async function runPut(
     return 0;
   }
 
-  const fileArg = parsed.positionals[0];
-  if (!fileArg) {
+  const files = parsed.positionals;
+  if (files.length === 0) {
     writeCommandHelp(PUT_HELP);
     return 2;
   }
+  const multi = files.length > 1;
 
   const keyHint = flagString(parsed.flags, "--key");
   const destFlag = flagString(parsed.flags, "--destination");
@@ -688,6 +823,14 @@ export async function runPut(
     throw new UsageError("--no-auto takes no value");
   }
   if (wantComment && !ghTarget) throw new UsageError("--comment requires --pr or --issue");
+  if (multi) {
+    if (keyHint) throw new UsageError("--key cannot be combined with multiple files");
+    if (nameFlag !== undefined)
+      throw new UsageError("--name cannot be combined with multiple files");
+    if (files.some((f) => f === "-")) {
+      throw new UsageError("stdin (-) cannot be combined with multiple file arguments");
+    }
+  }
   if (ghTarget) {
     if (keyHint) {
       throw new UsageError(
@@ -720,9 +863,6 @@ export async function runPut(
   } catch (err) {
     throw new UsageError(err instanceof Error ? err.message : String(err));
   }
-  const bytes = readFileArg(fileArg);
-  const sourceName =
-    nameFlag ?? (fileArg === "-" ? (keyHint ? basename(keyHint) : "stdin.bin") : basename(fileArg));
 
   const format = ctx.json
     ? "json"
@@ -736,14 +876,8 @@ export async function runPut(
   const defaults = resolvePutDefaults({ envFile: ctx.envFile });
   const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, defaults);
   const frameOpts = frameOptionsFromFlags(parsed.flags);
-  // Optimize even on --dry-run so the preview key extension/hash match a real put.
-  const prepared = await prepareImageForUpload(bytes, sourceName, {
-    ...frameOpts,
-    optimize: optimizeOpts,
-  });
-  const filename = prepared.filename;
   const contentTypeOverride = flagString(parsed.flags, "--content-type");
-  const alt = flagString(parsed.flags, "--alt") ?? basename(sourceName);
+  const altFlag = flagString(parsed.flags, "--alt");
   const widthRaw = flagString(parsed.flags, "--width");
   const width =
     widthRaw && /^\d+$/.test(widthRaw) && Number(widthRaw) > 0
@@ -753,15 +887,6 @@ export async function runPut(
             throw new UsageError(`invalid --width: ${widthRaw}`);
           })()
         : defaults.width;
-
-  if (!ctx.quiet && format === "human") {
-    process.stderr.write(
-      `>> ${dryRun ? "dry run" : "uploading"} ${fileArg === "-" ? "stdin" : fileArg}\n`,
-    );
-    if (prepared.frame?.framed) process.stderr.write(`>> framed with ${prepared.frame.frameId}\n`);
-    const note = formatOptimizeNote(prepared);
-    if (note) process.stderr.write(`>> ${note}\n`);
-  }
 
   const noGit = flagBool(parsed.flags, "--no-git") || defaults.noGit === true;
   // gh.* metadata: explicit --pr/--issue target wins over --meta; otherwise
@@ -801,73 +926,162 @@ export async function runPut(
       }
     }
   }
-  if (attachedRef && !ctx.quiet && format === "human") {
-    process.stderr.write(`>> attached to ${attachedRef}\n`);
+
+  const logHuman = !ctx.quiet && format === "human";
+  if (logHuman) {
+    if (multi) {
+      process.stderr.write(`>> ${dryRun ? "dry run for" : "uploading"} ${files.length} files\n`);
+    } else {
+      const fileArg = files[0]!;
+      process.stderr.write(
+        `>> ${dryRun ? "dry run" : "uploading"} ${fileArg === "-" ? "stdin" : fileArg}\n`,
+      );
+    }
+    if (attachedRef) process.stderr.write(`>> attached to ${attachedRef}\n`);
   }
-  let key = ghTarget ? ghAttachmentKey(ghTarget, filename) : keyHint;
-  if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
-  const result = await ctx.client.put(prepared.bytes, {
-    filename,
-    key,
+
+  const { uploads, failures, firstError } = await uploadPuts({
+    client: ctx.client,
+    files,
+    nameOverride: nameFlag,
+    explicitKey: keyHint,
+    ghTarget,
     prefix: resolvedPrefix ?? defaults.prefix,
     repo: flagString(parsed.flags, "--repo") ?? defaults.repo,
     ref: flagString(parsed.flags, "--ref") ?? defaults.ref,
-    contentType: prepared.optimized ? prepared.contentType : contentTypeOverride,
     deriveRepoFromGit: !noGit,
+    contentType: contentTypeOverride,
     dryRun,
-    provenance: buildCliProvenance({
-      sourceName,
-      optimized: prepared.optimized,
-      frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
-      keepExif: optimizeOpts.keepExif === true,
-    }),
+    optimize: optimizeOpts,
+    frame: frameOpts,
     metadata,
+    alt: altFlag,
+    width,
   });
-  if (format === "human") writeReplacedNote(result.replaced, ctx.quiet, dryRun);
 
-  const embedSrc = urlForGithubEmbed(result.url, result.embedUrl)!;
-  const markdown = buildMarkdown(embedSrc, { alt, width });
-  let gallery:
-    | {
-        id: string;
-        url?: string;
-        item?: GalleryItem;
-        error?: { message: string; code?: string; status?: number };
+  // Single-file total failure: rethrow so CLI exit codes stay auth/network-aware.
+  if (uploads.length === 0 && failures.length > 0 && !multi) {
+    throw firstError instanceof Error ? firstError : new Error(String(firstError));
+  }
+
+  type GalleryOutcome = {
+    id: string;
+    url?: string;
+    item?: GalleryItem;
+    error?: { message: string; code?: string; status?: number };
+  };
+  const galleriesByKey = new Map<string, GalleryOutcome>();
+  let galleryHadError = false;
+  if (galleryId && uploads.length > 0) {
+    for (const upload of uploads) {
+      const alt = altFlag ?? basename(upload.file === "-" ? upload.optimize.filename : upload.file);
+      try {
+        // Gallery mutations use optimistic versions. Re-fetch before each add.
+        const current = await ctx.client.getGallery(galleryId);
+        const item = await ctx.client.addGalleryItem(galleryId, upload.key, {
+          expectedVersion: current.version,
+          altText: alt,
+        });
+        galleriesByKey.set(upload.key, { id: galleryId, url: current.url, item });
+      } catch (err) {
+        galleryHadError = true;
+        galleriesByKey.set(upload.key, { id: galleryId, error: errorDetail(err) });
       }
-    | undefined;
-  if (galleryId) {
-    try {
-      // Gallery mutations use optimistic versions. Fetch immediately before this
-      // mutation so `put --gallery` composes safely with other CLI writers.
-      const current = await ctx.client.getGallery(galleryId);
-      const item = await ctx.client.addGalleryItem(galleryId, result.key, {
-        expectedVersion: current.version,
-        altText: alt,
-      });
-      gallery = { id: galleryId, url: current.url, item };
-    } catch (err) {
-      gallery = { id: galleryId, error: errorDetail(err) };
     }
   }
-  const optimizeMeta = {
-    optimized: prepared.optimized,
-    skippedReason: prepared.skippedReason,
-    originalBytes: prepared.originalBytes,
-    outputBytes: prepared.outputBytes,
-    filename: prepared.filename,
-  };
 
-  if (!ctx.quiet && format === "human") {
+  let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+  let commentError: string | undefined;
+  if (wantComment && ghTarget && uploads.length > 0) {
+    try {
+      comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
+      if (logHuman) process.stderr.write(`>> attachments comment ${comment.action}\n`);
+    } catch (err) {
+      commentError = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `warning: upload succeeded but the GitHub comment failed (is gh installed and authenticated?): ${commentError}\n`,
+      );
+    }
+  }
+
+  // --- multi-file output ---
+  if (multi) {
+    if (format === "json") {
+      await writeJson({
+        uploads: uploads.map((u) => ({
+          ...u,
+          gallery: galleriesByKey.get(u.key),
+          ...(dryRun ? { dryRun: true } : {}),
+        })),
+        failures,
+        comment,
+        commentError,
+      });
+    } else {
+      for (const result of uploads) {
+        if (logHuman) {
+          if (result.frame?.framed) {
+            process.stderr.write(
+              `>> ${basename(result.file)}: framed with ${result.frame.frameId}\n`,
+            );
+          }
+          const note = formatOptimizeNote(result.optimize);
+          if (note) process.stderr.write(`>> ${basename(result.file)}: ${note}\n`);
+          writeReplacedNote(result.replaced, false, dryRun);
+          process.stderr.write(
+            `>> key: ${result.key}${dryRun ? " (dry run — not uploaded)" : ""}\n`,
+          );
+        }
+        const gallery = galleriesByKey.get(result.key);
+        if (format === "url") await writeStdout(`${result.url}\n`);
+        else if (format === "markdown") await writeStdout(`${result.markdown}\n`);
+        else {
+          const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
+          await writeStdout(
+            `URL: ${result.url}\n${embedLine}MARKDOWN: ${result.markdown}${gallery?.url ? `\nGALLERY: ${gallery.url}` : ""}\n`,
+          );
+        }
+        if (gallery?.error) {
+          process.stderr.write(
+            `warning: upload succeeded but adding ${result.key} to gallery ${gallery.id} failed: ${gallery.error.message}\n`,
+          );
+        }
+      }
+      for (const failure of failures) {
+        process.stderr.write(
+          `warning: could not upload ${failure.file}: ${failure.error.message}\n`,
+        );
+      }
+    }
+    return failures.length === 0 && !galleryHadError ? 0 : 1;
+  }
+
+  // --- single-file output (flat JSON shape, back-compat) ---
+  const result = uploads[0]!;
+  const gallery = galleriesByKey.get(result.key);
+  if (logHuman) {
+    if (result.frame?.framed) {
+      process.stderr.write(`>> framed with ${result.frame.frameId}\n`);
+    }
+    const note = formatOptimizeNote(result.optimize);
+    if (note) process.stderr.write(`>> ${note}\n`);
+    writeReplacedNote(result.replaced, ctx.quiet, dryRun);
     process.stderr.write(`>> key: ${result.key}${dryRun ? " (dry run — not uploaded)" : ""}\n\n`);
   }
 
   switch (format) {
     case "json":
       await writeJson({
-        ...result,
-        markdown,
-        optimize: optimizeMeta,
-        frame: prepared.frame,
+        workspace: result.workspace,
+        key: result.key,
+        url: result.url,
+        embedUrl: result.embedUrl,
+        size: result.size,
+        contentType: result.contentType,
+        replaced: result.replaced,
+        markdown: result.markdown,
+        optimize: result.optimize,
+        frame: result.frame,
         gallery,
         ...(dryRun ? { dryRun: true } : {}),
       });
@@ -876,12 +1090,12 @@ export async function runPut(
       await writeStdout(`${result.url}\n`);
       break;
     case "markdown":
-      await writeStdout(`${markdown}\n`);
+      await writeStdout(`${result.markdown}\n`);
       break;
     default: {
       const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
       await writeStdout(
-        `URL: ${result.url}\n${embedLine}MARKDOWN: ${markdown}${gallery?.url ? `\nGALLERY: ${gallery.url}` : ""}\n`,
+        `URL: ${result.url}\n${embedLine}MARKDOWN: ${result.markdown}${gallery?.url ? `\nGALLERY: ${gallery.url}` : ""}\n`,
       );
     }
   }
@@ -889,25 +1103,10 @@ export async function runPut(
   if (gallery?.url && format !== "human") {
     process.stderr.write(`gallery: ${gallery.url}\n`);
   }
-
   if (gallery?.error) {
     process.stderr.write(
       `warning: upload succeeded but adding it to gallery ${gallery.id} failed: ${gallery.error.message}\n`,
     );
-  }
-
-  if (wantComment && ghTarget) {
-    try {
-      const sync = await syncAttachmentsComment(ctx.client, ghTarget, run);
-      if (!ctx.quiet && format === "human") {
-        process.stderr.write(`>> attachments comment ${sync.action}\n`);
-      }
-    } catch (err) {
-      // Upload already succeeded; the comment is best-effort by design.
-      process.stderr.write(
-        `warning: upload succeeded but the GitHub comment failed (is gh installed and authenticated?): ${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
   }
 
   return gallery?.error ? 1 : 0;

--- a/packages/uploads/src/mcp/batch-error.ts
+++ b/packages/uploads/src/mcp/batch-error.ts
@@ -1,0 +1,27 @@
+/**
+ * Tool handler failure that still carries structuredContent (e.g. multi-file
+ * total failure with a `failures` array). The MCP server maps this to
+ * isError: true while preserving structuredContent for agents.
+ */
+export class ToolBatchError extends Error {
+  readonly structuredContent: unknown;
+
+  constructor(message: string, structuredContent: unknown) {
+    super(message);
+    this.name = "ToolBatchError";
+    this.structuredContent = structuredContent;
+  }
+}
+
+/** One-line summary of a multi-file failure list. */
+export function batchFailureMessage(
+  failures: readonly { file: string; error: { message: string } }[],
+): string {
+  if (failures.length === 0) return "upload failed";
+  if (failures.length === 1) {
+    const f = failures[0]!;
+    return `${f.file}: ${f.error.message}`;
+  }
+  const lines = failures.map((f) => `  ${f.file}: ${f.error.message}`);
+  return `${failures.length} uploads failed:\n${lines.join("\n")}`;
+}

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -9,6 +9,7 @@
  */
 import { UploadsError } from "../errors.js";
 import { errorCodeFromUnknown, recordEvent } from "../telemetry.js";
+import { ToolBatchError } from "./batch-error.js";
 
 export {
   METADATA_DESCRIPTION,
@@ -20,6 +21,7 @@ export {
   usage,
   type ToolArgs,
 } from "./args.js";
+export { ToolBatchError, batchFailureMessage } from "./batch-error.js";
 
 export interface McpTool {
   name: string;
@@ -98,6 +100,20 @@ export function createMcpServer(opts: {
         },
         { apiUrl },
       );
+      // Multi-file total failure: keep structuredContent so agents see every
+      // per-file error, not only the first message string.
+      if (err instanceof ToolBatchError) {
+        return response(id, {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(err.structuredContent, null, 2),
+            },
+          ],
+          structuredContent: err.structuredContent,
+          isError: true,
+        });
+      }
       return response(id, {
         content: [{ type: "text", text: toolErrorText(err) }],
         isError: true,

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -15,6 +15,7 @@ import {
   readFileArg,
   syncAttachmentsComment,
   uploadAttachments,
+  uploadPuts,
 } from "../commands.js";
 import { resolveFrameId } from "../frame.js";
 import {
@@ -46,7 +47,7 @@ import {
   usage,
   type ToolArgs,
 } from "./args.js";
-import type { McpTool } from "./server.js";
+import { batchFailureMessage, ToolBatchError, type McpTool } from "./server.js";
 import {
   attachmentFromText,
   buildReportPayload,
@@ -330,14 +331,20 @@ export function createUploadsMcpTools(opts: {
     {
       name: "put",
       description:
-        "Upload a file to uploads.sh and get a public URL plus GitHub-ready embed markdown. Returns `url` (durable CDN) and `embedUrl` (same object, freshness-oriented host for GitHub Camo — prefer this in PR/issue markdown). The returned `markdown` already uses embedUrl when available. Pass `file` or `contentBase64` + `filename`; with `pr`/`issue` the key is stable and `comment` syncs the managed attachments comment. All uploads are public; pr/issue keys are predictable, so upload only non-sensitive media.",
+        "Upload one or more files to uploads.sh and get public URL(s) plus GitHub-ready embed markdown. Single-file: pass `file` or `contentBase64`+`filename` (flat result with `url`/`embedUrl`/`markdown`). Multi-file: pass `files` (paths; parallel; returns `uploads`+`failures`). Prefer `embedUrl` in PR/issue markdown. With `pr`/`issue` keys are stable and `comment` syncs the managed attachments comment. All uploads are public; pr/issue keys are predictable — upload only non-sensitive media.",
       inputSchema: {
         type: "object",
         properties: {
           file: {
             type: "string",
             description:
-              "Path of the file to upload. Exactly one of file or contentBase64 is required.",
+              "Path of a single file to upload. Exactly one of file, files, or contentBase64 is required.",
+          },
+          files: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Paths of multiple files to upload in parallel. Returns { uploads, failures }. Cannot combine with file, contentBase64, key, or filename.",
           },
           contentBase64: {
             type: "string",
@@ -346,12 +353,12 @@ export function createUploadsMcpTools(opts: {
           filename: {
             type: "string",
             description:
-              "Filename for contentBase64 content (drives the key and content type). With `file`, overrides the key's leaf (clean name) while keeping the pr/default path.",
+              "Filename for contentBase64 content (drives the key and content type). With single `file`, overrides the key's leaf (clean name) while keeping the pr/default path.",
           },
           key: {
             type: "string",
             description:
-              "Explicit object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>). Cannot be combined with pr/issue.",
+              "Explicit object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>). Single file only; cannot be combined with pr/issue.",
           },
           destination: {
             type: "string",
@@ -374,7 +381,11 @@ export function createUploadsMcpTools(opts: {
             description:
               "PR/issue/branch key segment (default: today, or UPLOADS_DEFAULT_REF). Cannot be combined with pr/issue.",
           },
-          alt: { type: "string", description: "Alt text for the markdown (default: filename)." },
+          alt: {
+            type: "string",
+            description:
+              "Alt text for the markdown (default: each file's name; with multiple files applies to all).",
+          },
           width: {
             type: "number",
             description: "Emit <img width=…> markdown instead of a plain image embed.",
@@ -419,14 +430,23 @@ export function createUploadsMcpTools(opts: {
       },
       async handler(args) {
         const file = optString(args, "file");
+        const filesArg = optStringArray(args, "files");
         const contentBase64 = optString(args, "contentBase64");
-        if ((file === undefined) === (contentBase64 === undefined)) {
-          usage("exactly one of file or contentBase64 is required");
+        if (filesArg !== undefined && filesArg.length === 0) {
+          usage("files must be a non-empty array of paths");
         }
+        const multi = filesArg !== undefined;
+        const sources = [file !== undefined, multi, contentBase64 !== undefined];
+        if (sources.filter(Boolean).length !== 1) {
+          usage("exactly one of file, files, or contentBase64 is required");
+        }
+
         const filenameArg = optString(args, "filename");
         if (contentBase64 !== undefined && !filenameArg) {
           usage("filename is required with contentBase64");
         }
+        if (multi && filenameArg) usage("filename cannot be combined with files");
+        if (multi && optString(args, "key")) usage("key cannot be combined with files");
 
         const target = ghTargetFromArgs(args, run);
         const wantComment = optBool(args, "comment");
@@ -460,64 +480,127 @@ export function createUploadsMcpTools(opts: {
         }
 
         const { client } = clientFor(args);
-        const bytes =
-          file !== undefined
-            ? readFileArg(file)
-            : new Uint8Array(Buffer.from(contentBase64!, "base64"));
-        const sourceName = file !== undefined ? (filenameArg ?? basename(file)) : filenameArg!;
-
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
         const frameOpts = mcpFrameOptions(args);
         const optimizeOpts = mcpOptimizeOptions(args, defaults);
-        const prepared = await prepareImageForUpload(bytes, sourceName, {
-          ...frameOpts,
-          optimize: optimizeOpts,
-        });
-        const filename = prepared.filename;
-        let key = target ? ghAttachmentKey(target, filename) : keyArg;
-        if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
         const noGit = optBool(args, "noGit") || defaults.noGit === true;
-        const result = await client.put(prepared.bytes, {
-          filename,
-          key,
+        const alt = optString(args, "alt");
+        const width = optPosInt(args, "width") ?? defaults.width;
+        const contentType = optString(args, "contentType");
+        const putShared = {
+          client,
+          ghTarget: target,
           prefix: resolvedPrefix ?? defaults.prefix,
           repo: optString(args, "repo") ?? defaults.repo,
           ref: refArg ?? defaults.ref,
-          contentType: prepared.optimized ? prepared.contentType : optString(args, "contentType"),
           deriveRepoFromGit: !noGit,
+          contentType,
           dryRun,
-          provenance: buildCliProvenance({
-            sourceName,
-            client: "uploads-mcp",
-            optimized: prepared.optimized,
-            frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
-            keepExif: optimizeOpts.keepExif === true,
-          }),
+          optimize: optimizeOpts,
+          frame: frameOpts,
           metadata,
-        });
-        const markdown = buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
-          alt: optString(args, "alt") ?? sourceName,
-          width: optPosInt(args, "width") ?? defaults.width,
-        });
-        const optimize = {
-          optimized: prepared.optimized,
-          skippedReason: prepared.skippedReason,
-          originalBytes: prepared.originalBytes,
-          outputBytes: prepared.outputBytes,
-          filename: prepared.filename,
+          provenanceClient: "uploads-mcp" as const,
+          alt,
+          width,
         };
 
-        if (wantComment && target) {
-          const { comment, commentError } = await syncComment(client, target);
-          return { ...result, markdown, optimize, frame: prepared.frame, comment, commentError };
+        // Multi-file path (paths only — no base64 batch).
+        if (multi) {
+          const { uploads, failures } = await uploadPuts({
+            ...putShared,
+            files: filesArg!,
+          });
+          if (uploads.length === 0 && failures.length > 0) {
+            throw new ToolBatchError(batchFailureMessage(failures), { uploads, failures });
+          }
+          if (wantComment && target && uploads.length > 0) {
+            const { comment, commentError } = await syncComment(client, target);
+            return { uploads, failures, comment, commentError };
+          }
+          return { uploads, failures };
         }
-        return {
-          ...result,
-          markdown,
-          optimize,
-          frame: prepared.frame,
+
+        // Single-file: contentBase64 still supported; paths go through uploadPuts.
+        if (contentBase64 !== undefined) {
+          const sourceName = filenameArg!;
+          const bytes = new Uint8Array(Buffer.from(contentBase64, "base64"));
+          const prepared = await prepareImageForUpload(bytes, sourceName, {
+            ...frameOpts,
+            optimize: optimizeOpts,
+          });
+          const filename = prepared.filename;
+          let key = target ? ghAttachmentKey(target, filename) : keyArg;
+          if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
+          const result = await client.put(prepared.bytes, {
+            filename,
+            key,
+            prefix: resolvedPrefix ?? defaults.prefix,
+            repo: optString(args, "repo") ?? defaults.repo,
+            ref: refArg ?? defaults.ref,
+            contentType: prepared.optimized ? prepared.contentType : contentType,
+            deriveRepoFromGit: !noGit,
+            dryRun,
+            provenance: buildCliProvenance({
+              sourceName,
+              client: "uploads-mcp",
+              optimized: prepared.optimized,
+              frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+              keepExif: optimizeOpts.keepExif === true,
+            }),
+            metadata,
+          });
+          const markdown = buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+            alt: alt ?? sourceName,
+            width,
+          });
+          const optimize = {
+            optimized: prepared.optimized,
+            skippedReason: prepared.skippedReason,
+            originalBytes: prepared.originalBytes,
+            outputBytes: prepared.outputBytes,
+            filename: prepared.filename,
+          };
+          if (wantComment && target) {
+            const { comment, commentError } = await syncComment(client, target);
+            return { ...result, markdown, optimize, frame: prepared.frame, comment, commentError };
+          }
+          return {
+            ...result,
+            markdown,
+            optimize,
+            frame: prepared.frame,
+            ...(dryRun ? { dryRun: true } : {}),
+          };
+        }
+
+        const { uploads, failures, firstError } = await uploadPuts({
+          ...putShared,
+          files: [file!],
+          nameOverride: filenameArg,
+          explicitKey: keyArg,
+        });
+        if (uploads.length === 0 && failures.length > 0) {
+          throw firstError instanceof Error ? firstError : new Error(String(firstError));
+        }
+        const u = uploads[0]!;
+        const flat = {
+          workspace: u.workspace,
+          key: u.key,
+          url: u.url,
+          embedUrl: u.embedUrl,
+          size: u.size,
+          contentType: u.contentType,
+          replaced: u.replaced,
+          markdown: u.markdown,
+          optimize: u.optimize,
+          frame: u.frame,
           ...(dryRun ? { dryRun: true } : {}),
         };
+        if (wantComment && target) {
+          const { comment, commentError } = await syncComment(client, target);
+          return { ...flat, comment, commentError };
+        }
+        return flat;
       },
     },
     {
@@ -595,7 +678,7 @@ export function createUploadsMcpTools(opts: {
         const metadata = { ...metaExtras, ...ghMetadataFromTarget(target) };
         if (Object.keys(metadata).length > 0) validateMetaMap(metadata);
 
-        const { uploads, failures, firstError } = await uploadAttachments({
+        const { uploads, failures } = await uploadAttachments({
           client,
           target,
           files,
@@ -606,9 +689,13 @@ export function createUploadsMcpTools(opts: {
           provenanceClient: "uploads-mcp",
         });
 
-        // Total failure → tool error (isError) so agents notice.
+        // Total failure → isError with full failures[] for agents.
         if (uploads.length === 0 && failures.length > 0) {
-          throw firstError instanceof Error ? firstError : new Error(String(firstError));
+          throw new ToolBatchError(batchFailureMessage(failures), {
+            target,
+            uploads,
+            failures,
+          });
         }
 
         if (optBool(args, "noComment")) return { target, uploads, failures };

--- a/packages/uploads/test/cli-help.test.ts
+++ b/packages/uploads/test/cli-help.test.ts
@@ -25,7 +25,7 @@ describe("formatRootHelp", () => {
   it("shows essentials by default without the full catalog", () => {
     const text = formatRootHelp({ color: false });
     expect(text).toMatch(/Essentials:/);
-    expect(text).toMatch(/put <file>/);
+    expect(text).toMatch(/put <file\.\.\.>/);
     expect(text).toMatch(/attach <file\.\.\.>/);
     expect(text).toMatch(/uploads help --all/);
     // install ships multiple agent skills — keep catalog/help plural (#189 drift).

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -183,6 +183,31 @@ describe("runAttach", () => {
     });
   });
 
+  it("returns exit 1 with failures when every multi-file upload fails", async () => {
+    const { client, puts } = fakeClient({
+      failLeaf: () => new UploadsError("nope", "API_ERROR", 500),
+    });
+    const { run } = ghRunner();
+    const ctx = { ...ctxWith(client), json: true };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runAttach(ctx, files("a.png", "b.png"), false, run)).toBe(1);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(puts).toEqual([]);
+    const payload = JSON.parse(chunks.join("")) as {
+      uploads: unknown[];
+      failures: { file: string }[];
+    };
+    expect(payload.uploads).toEqual([]);
+    expect(payload.failures).toHaveLength(2);
+  });
+
   it("supports an explicit issue and skips the managed comment with --no-comment", async () => {
     const { client, puts } = fakeClient();
     const { run, calls } = ghRunner();

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -85,6 +85,88 @@ const noRun: CommandRunner = () => {
   throw new Error("runner should not be called");
 };
 
+function tmpFiles(...names: string[]): string[] {
+  const dir = mkdtempSync(join(tmpdir(), "uploads-put-multi-"));
+  return names.map((name) => {
+    const path = join(dir, name);
+    writeFileSync(path, name);
+    return path;
+  });
+}
+
+describe("runPut multi-file", () => {
+  it("uploads multiple files and returns batch JSON", async () => {
+    const { client, puts } = fakeClient();
+    const paths = tmpFiles("a.png", "b.png");
+    const ctx = { ...ctxWith(client), json: true };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runPut(ctx, paths, false, noRun)).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(puts.map((p) => p.filename).sort()).toEqual(["a.png", "b.png"]);
+    const payload = JSON.parse(chunks.join("")) as {
+      uploads: { file: string; url: string }[];
+      failures: unknown[];
+    };
+    expect(payload.uploads).toHaveLength(2);
+    expect(payload.failures).toEqual([]);
+  });
+
+  it("continues after a per-file failure (exit 1)", async () => {
+    const puts: string[] = [];
+    const client = {
+      put: async (_body: Uint8Array, opts: { filename: string; key?: string }) => {
+        if (opts.filename === "bad.png") {
+          throw new UploadsError("forced", "API_ERROR", 500);
+        }
+        puts.push(opts.filename);
+        return {
+          workspace: "test",
+          key: opts.key ?? `generated/${opts.filename}`,
+          url: `https://x.test/${opts.filename}`,
+          embedUrl: null,
+          size: 3,
+          contentType: "image/png",
+        };
+      },
+      list: async () => ({ items: [], cursor: null }),
+    } as unknown as UploadsClient;
+    const paths = tmpFiles("good.png", "bad.png");
+    const ctx = { ...ctxWith(client), json: true };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runPut(ctx, paths, false, noRun)).toBe(1);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(puts).toEqual(["good.png"]);
+    const payload = JSON.parse(chunks.join("")) as {
+      uploads: { optimize: { filename: string } }[];
+      failures: { file: string; error: { code?: string } }[];
+    };
+    expect(payload.uploads).toHaveLength(1);
+    expect(payload.failures).toHaveLength(1);
+    expect(payload.failures[0]!.error.code).toBe("API_ERROR");
+  });
+
+  it("rejects --key with multiple files", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runPut(ctxWith(client), [...tmpFiles("a.png", "b.png"), "--key", "x/y.png"], false, noRun),
+    ).rejects.toThrow(UsageError);
+  });
+});
+
 describe("runPut --pr/--issue", () => {
   it("builds a stable PR key with no hash", async () => {
     const { client, puts } = fakeClient();

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -458,11 +458,77 @@ describe("tools/call put", () => {
     expect(res.result.content[0].text).toContain("mutually exclusive");
   });
 
-  it("requires exactly one of file and contentBase64", async () => {
+  it("requires exactly one of file, files, or contentBase64", async () => {
     const { server } = serverWith();
     const res = await rpc(server, "tools/call", { name: "put", arguments: {} });
     expect(res.result.isError).toBe(true);
-    expect(res.result.content[0].text).toContain("file or contentBase64");
+    expect(res.result.content[0].text).toContain("file, files, or contentBase64");
+  });
+
+  it("uploads multiple files in parallel and returns uploads + failures", async () => {
+    const { UploadsError } = await import("../src/errors.js");
+    const { server } = serverWith({
+      factory: () =>
+        ({
+          put: async (_body: Uint8Array, opts: { key: string; filename: string }) => {
+            if (opts.filename === "bad.png") {
+              throw new UploadsError("forced fail", "API_ERROR", 500);
+            }
+            return {
+              workspace: "test",
+              key: opts.key ?? `generated/${opts.filename}`,
+              url: `https://x.test/${opts.filename}`,
+              embedUrl: null,
+              size: 3,
+              contentType: "image/png",
+            };
+          },
+          listAll: async () => [],
+          findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+          getGallery: async () => ({ items: [] }),
+        }) as never,
+    });
+    const dir = mkdtempSync(join(tmpdir(), "uploads-mcp-put-"));
+    const good = join(dir, "good.png");
+    const bad = join(dir, "bad.png");
+    writeFileSync(good, "png");
+    writeFileSync(bad, "png");
+
+    const res = await rpc(server, "tools/call", {
+      name: "put",
+      arguments: { files: [good, bad], noGit: true },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent.uploads).toHaveLength(1);
+    expect(res.result.structuredContent.failures).toHaveLength(1);
+    expect(res.result.structuredContent.failures[0].file).toContain("bad.png");
+  });
+
+  it("surfaces all failures with isError when every multi-file put fails", async () => {
+    const { UploadsError } = await import("../src/errors.js");
+    const { server } = serverWith({
+      factory: () =>
+        ({
+          put: async () => {
+            throw new UploadsError("forced fail", "API_ERROR", 500);
+          },
+        }) as never,
+    });
+    const dir = mkdtempSync(join(tmpdir(), "uploads-mcp-put-"));
+    const a = join(dir, "a.png");
+    const b = join(dir, "b.png");
+    writeFileSync(a, "png");
+    writeFileSync(b, "png");
+
+    const res = await rpc(server, "tools/call", {
+      name: "put",
+      arguments: { files: [a, b], noGit: true },
+    });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.structuredContent.uploads).toEqual([]);
+    expect(res.result.structuredContent.failures).toHaveLength(2);
+    expect(res.result.content[0].text).toContain("a.png");
+    expect(res.result.content[0].text).toContain("b.png");
   });
 
   it("passes custom metadata through to the client", async () => {
@@ -572,6 +638,39 @@ describe("tools/call attach", () => {
     expect(res.result.structuredContent.failures).toHaveLength(1);
     expect(res.result.structuredContent.failures[0].file).toContain("bad.png");
     expect(putCalls.some((k) => k.includes("good.png"))).toBe(true);
+  });
+
+  it("on total multi-file failure returns isError with every failure in structuredContent", async () => {
+    const { run } = ghRunner();
+    const { UploadsError } = await import("../src/errors.js");
+    const { server } = serverWith({
+      runner: run,
+      factory: () =>
+        ({
+          put: async () => {
+            throw new UploadsError("forced fail", "API_ERROR", 500);
+          },
+          listAll: async () => [],
+          findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+          getGallery: async () => ({ items: [] }),
+        }) as never,
+    });
+    const dir = mkdtempSync(join(tmpdir(), "uploads-mcp-test-"));
+    const a = join(dir, "a.png");
+    const b = join(dir, "b.png");
+    writeFileSync(a, "png");
+    writeFileSync(b, "png");
+
+    const res = await rpc(server, "tools/call", {
+      name: "attach",
+      arguments: { files: [a, b], noComment: true },
+    });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.structuredContent.uploads).toEqual([]);
+    expect(res.result.structuredContent.failures).toHaveLength(2);
+    expect(res.result.structuredContent.failures[0].file).toContain("a.png");
+    expect(res.result.content[0].text).toContain("a.png");
+    expect(res.result.content[0].text).toContain("b.png");
   });
 
   it("rejects an empty files array", async () => {

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -137,10 +137,13 @@ commands" for setting put defaults
 
 ## Core workflow: `uploads put`
 
-Upload a file and get back a URL plus ready-to-paste markdown:
+Upload one or more files and get back URL(s) plus ready-to-paste markdown.
+Multiple paths upload in parallel; multi-file JSON is `{ uploads, failures }`
+(exit `1` when any failed). Single-file JSON stays a flat object.
 
 ```bash
 uploads put ./shot.png --repo myorg/myapp --ref 1722 --alt "New live feed cards" --width 700
+uploads put ./before.png ./after.png
 ```
 
 Human output goes to stderr; the URL and markdown to stdout, so you can pipe or


### PR DESCRIPTION
## In plain terms

Agents can now upload several non-PR files in one `put` (CLI or stdio MCP), with the same parallel + partial-failure behavior as `attach`. When every file in an MCP batch fails, the tool error still includes the full `failures` list so nothing is lost after the first error.

## What it does

- **Multi-file `put`** (`uploads put a.png b.png`): bounded concurrency, `{ uploads, failures }` for multi-file JSON; single-file JSON stays flat
- **Stdio MCP `put`**: optional `files: string[]` (paths); same batch shape
- **MCP total failure**: `ToolBatchError` → `isError: true` **with** `structuredContent.failures` (attach + multi put)
- Single-file total failure still throws for CLI exit-code mapping
- Skill + catalog usage updated

## What it is not

- Remote/hosted MCP multi-item upload — tracked in #196
- New REST batch API
- Breaking single-file `put` JSON shape

## How to try it

```bash
uploads put ./before.png ./after.png
uploads --json put ./a.png ./b.png --destination screenshots
```

Stdio MCP: `put` with `{ "files": ["./a.png", "./b.png"] }`.

## Test plan

- [x] Unit: multi-file put success/partial/reject `--key`
- [x] Unit: attach multi total-failure exit 1
- [x] MCP: multi put partial + total failure structuredContent
- [x] MCP: attach total failure structuredContent
- [x] Smoke: prod multi-file put returned both URLs + empty `failures`
- [ ] CI

Related: #196 (remote MCP multi-item)