### PR TITLE
feat(cli,api): uploads screenshot command with local and remote render backends

### DIFF
--- a/.changeset/cli-screenshot-command.md
+++ b/.changeset/cli-screenshot-command.md
@@ -1,0 +1,14 @@
+---
+"@buildinternet/uploads": minor
+---
+
+New `uploads screenshot <url|file.html>` command: capture a URL or a local
+`.html` file and host it in one step, sharing the `put` upload pipeline
+(`--frame`, optimize-by-default, `--pr`/`--issue` attachment + `--comment`).
+Two capture backends selected by `--via auto|local|remote` (default `auto`,
+or `UPLOADS_SCREENSHOT_VIA`): `local` drives an already-installed
+Chrome/Chromium via `playwright-core` (an optional dependency — no browser
+download), while `remote` renders server-side through a new uploads.sh
+render endpoint. `auto` prefers local when a browser is found, else falls
+back to remote; localhost/private-network targets and `.html` files stay
+local-only. Also available as an MCP tool and reported in `uploads doctor`.

--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -175,32 +175,58 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
 }
 
 /**
- * Per-workspace rate limit for mutating requests. Keyed by workspace name so
- * one tenant's traffic can't exhaust another's budget. The window and quota are
- * fixed in wrangler.jsonc (`WRITE_LIMITER`, a fixed sliding window); it's
- * per-colo rather than globally exact — enough to blunt abuse, not billing.
- * Fails open when the binding is absent (some local/dev setups, tests).
+ * Builds a per-workspace rate-limit guard on top of a named `RateLimit`
+ * binding: a Hono middleware that 429s when the limit is exceeded, plus the
+ * standalone `allow` check for non-route callers. Keyed by workspace name so
+ * one tenant's traffic can't exhaust another's budget. Fails open when the
+ * binding is absent (some local/dev setups, tests) — the window/quota
+ * themselves are fixed per-binding in wrangler.jsonc (fixed sliding windows,
+ * per-colo rather than globally exact — enough to blunt abuse, not billing).
  */
-export const writeRateLimit: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
-  if (!(await allowWrite(c.env, c.get("workspaceName")))) {
-    throw new RateLimitedError("rate limit exceeded");
-  }
-  await next();
-};
+function makeRateLimitGuard<BindingKey extends keyof Env>(
+  bindingKey: BindingKey,
+  message: string,
+): {
+  middleware: MiddlewareHandler<WorkspaceVars>;
+  allow: (env: { [K in BindingKey]?: Env[BindingKey] }, workspaceName: string) => Promise<boolean>;
+} {
+  const allow = async (
+    env: { [K in BindingKey]?: Env[BindingKey] },
+    workspaceName: string,
+  ): Promise<boolean> => {
+    const limiter = env[bindingKey] as unknown as RateLimit | undefined;
+    if (!limiter) return true;
+    const { success } = await limiter.limit({ key: workspaceName });
+    return success;
+  };
+
+  const middleware: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
+    if (!(await allow(c.env, c.get("workspaceName")))) {
+      throw new RateLimitedError(message);
+    }
+    await next();
+  };
+
+  return { middleware, allow };
+}
 
 /**
- * The check behind writeRateLimit, for non-route callers (the MCP worker's
- * put/delete tools). False = over budget; fails open without the binding.
+ * Per-workspace rate limit for mutating requests (`WRITE_LIMITER`), used by
+ * the file put/delete routes and the MCP worker's put/delete tools.
  */
-export async function allowWrite(
-  env: { WRITE_LIMITER?: Env["WRITE_LIMITER"] },
-  workspaceName: string,
-): Promise<boolean> {
-  const limiter = env.WRITE_LIMITER;
-  if (!limiter) return true;
-  const { success } = await limiter.limit({ key: workspaceName });
-  return success;
-}
+const writeRateLimitGuard = makeRateLimitGuard("WRITE_LIMITER", "rate limit exceeded");
+export const writeRateLimit = writeRateLimitGuard.middleware;
+export const allowWrite = writeRateLimitGuard.allow;
+
+/**
+ * Burst rate limit for POST /v1/render (`RENDER_LIMITER`) — browser-hours
+ * bill to our account, so this guards against a hot loop hammering the
+ * endpoint independent of the monthly upload-budget check (`checkPutBudget`,
+ * reused for renders in routes/render.ts).
+ */
+const renderRateLimitGuard = makeRateLimitGuard("RENDER_LIMITER", "render rate limit exceeded");
+export const renderRateLimit = renderRateLimitGuard.middleware;
+export const allowRender = renderRateLimitGuard.allow;
 
 /**
  * Strict per-user rate limit for self-serve workspace creation. Kept separate

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,6 +17,7 @@ import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";
 import { telemetry } from "./routes/telemetry";
 import { reports } from "./routes/reports";
+import { render } from "./routes/render";
 
 // Lets the browser console on the web origin (and local dev) call the token-
 // authenticated endpoints. CORS is not the security boundary — bearer tokens
@@ -75,6 +76,12 @@ export const app = new Hono<WorkspaceVars>()
   .route("/v1/telemetry", telemetry)
   // Explicit opt-in diagnostic reports (message + optional log) — no auth.
   .route("/v1/reports", reports)
+  // Screenshot render (phase 1, POST /v1/render). Brings its own auth
+  // (tokenWorkspaceAuth resolves the workspace from the token, not the path)
+  // so — like /v1/tokens — it must be registered before the `/v1/:workspace/*`
+  // guard: that pattern requires a trailing segment and never matches this
+  // route. See src/routes/render.ts.
+  .route("/v1/render", render)
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/galleries", galleries)
   .route("/v1/:workspace/files", files)

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -1,0 +1,384 @@
+/**
+ * POST /v1/render (phase 1): renders a URL or raw HTML to a PNG via the
+ * Cloudflare Browser Run binding and returns the bytes directly — no R2
+ * write. See `.context/2026-07-16-render-endpoint-brief.md` for the full
+ * spec and `.context/2026-07-16-cli-screenshot-render-pipeline.md` for the
+ * surrounding CLI pipeline this feeds.
+ *
+ * This module owns two things kept deliberately separate:
+ *  - request validation (`parseRenderRequest`): pure, no bindings, easy to
+ *    unit test without a Worker environment.
+ *  - the `Renderer` seam (`browserRenderer`): wraps `env.BROWSER.quickAction`.
+ *    Routes depend on the `Renderer` interface, never on `BrowserRun`
+ *    directly, so tests can substitute a `FakeBrowser` — quickAction has no
+ *    Miniflare/local simulation (it requires `"remote": true` and proxies to
+ *    the real metered service), so this seam is required, not a nicety.
+ */
+import { AppError, PayloadTooLargeError, RateLimitedError, ValidationError } from "@uploads/errors";
+
+/** Max size of a raw `html` body. Declared separately from the outer request
+ * body cap (`routes/render.ts`) so the two limits can't silently drift. */
+export const MAX_RENDER_HTML_BYTES = 2 * 1024 * 1024; // 2 MiB
+
+const MIN_VIEWPORT_DIMENSION = 16;
+const MAX_VIEWPORT_DIMENSION = 4096;
+const MIN_DEVICE_SCALE_FACTOR = 1;
+const MAX_DEVICE_SCALE_FACTOR = 3;
+
+/** Navigation timeout handed to Browser Run — below its 60s ceiling. */
+const NAVIGATION_TIMEOUT_MS = 30_000;
+/** Safety margin above `NAVIGATION_TIMEOUT_MS` for the local handler-side race,
+ * in case Browser Run hangs without ever resolving `quickAction`'s promise. */
+const HANDLER_TIMEOUT_MS = 35_000;
+
+export interface RenderViewport {
+  width: number;
+  height: number;
+  deviceScaleFactor?: number;
+}
+
+export interface RenderInput {
+  url?: string;
+  html?: string;
+  viewport?: RenderViewport;
+  selector?: string;
+  fullPage?: boolean;
+  colorScheme?: "dark" | "light";
+  waitUntil?: "load" | "domcontentloaded" | "networkidle";
+}
+
+export interface RenderResult {
+  png: Uint8Array;
+  contentType: string;
+}
+
+export interface Renderer {
+  screenshot(input: RenderInput): Promise<RenderResult>;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * True for hostnames that resolve (by literal form, not DNS) to a private,
+ * loopback, or link-local network, plus the conventional `.internal`/`.local`
+ * TLDs. DNS-rebinding-grade resolution is out of scope — Cloudflare's browser
+ * runs isolated from our infra, so the risk here is "don't hand an agent a
+ * pivot into our own network," not a full SSRF hardening pass.
+ */
+/** Parses a dotted-quad IPv4 literal into its four octets, or `null`. */
+function parseIpv4(host: string): [number, number, number, number] | null {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!m) return null;
+  const octets = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+  if (octets.some((o) => o > 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+/**
+ * Parses the trailing 32 bits of an IPv4-mapped IPv6 address (the part after
+ * `::ffff:`) into dotted-quad octets. Accepts both forms the wire can carry:
+ * the dotted form (`127.0.0.1`) and the hex-group form (`7f00:1`) that `URL`
+ * normalizes dotted IPv4-mapped addresses into (verified:
+ * `new URL("http://[::ffff:127.0.0.1]/").hostname` → `[::ffff:7f00:1]`).
+ */
+function parseIpv4MappedTail(tail: string): [number, number, number, number] | null {
+  const dotted = parseIpv4(tail);
+  if (dotted) return dotted;
+
+  const hexParts = tail.split(":");
+  if (hexParts.length !== 2 || hexParts.some((p) => !/^[0-9a-f]{1,4}$/.test(p))) return null;
+  const hi = Number.parseInt(hexParts[0], 16);
+  const lo = Number.parseInt(hexParts[1], 16);
+  const value = (hi << 16) | lo;
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
+}
+
+/** True for the private/loopback/link-local IPv4 ranges we block. */
+function isPrivateIpv4([a, b]: [number, number, number, number]): boolean {
+  if (a === 0) return true; // 0.0.0.0/8 ("this network" / unspecified)
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 (incl. cloud metadata)
+  return false;
+}
+
+export function isPrivateRenderTarget(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host.endsWith(".internal") || host.endsWith(".local")) return true;
+  if (host === "::1") return true;
+
+  const ipv4 = parseIpv4(host);
+  if (ipv4) return isPrivateIpv4(ipv4);
+
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d or its ::ffff:xxxx:yyyy hex-normalized
+  // form) — decode the trailing 32 bits and re-run the IPv4 range checks.
+  const mapped = /^::ffff:(.+)$/.exec(host);
+  if (mapped) {
+    const tail = parseIpv4MappedTail(mapped[1]);
+    if (tail) return isPrivateIpv4(tail);
+  }
+
+  if (/^f[cd][0-9a-f]{2}:/i.test(host)) return true; // fc00::/7 unique local
+  if (/^fe[89ab][0-9a-f]:/i.test(host)) return true; // fe80::/10 link-local
+
+  return false;
+}
+
+/**
+ * Validates a parsed JSON body into a `RenderInput`. Throws `ValidationError`
+ * (code `invalid_request`) or `PayloadTooLargeError` (code `upload_too_large`,
+ * matching the existing oversized-payload convention in guards.ts) on any
+ * malformed input.
+ */
+export function parseRenderRequest(parsed: unknown): RenderInput {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ValidationError("request body must be a JSON object", { code: "invalid_request" });
+  }
+  const body = parsed as Record<string, unknown>;
+
+  const hasUrl = typeof body.url === "string" && body.url.length > 0;
+  const hasHtml = typeof body.html === "string" && body.html.length > 0;
+  if (hasUrl === hasHtml) {
+    throw new ValidationError("exactly one of url or html is required", {
+      code: "invalid_request",
+    });
+  }
+
+  const input: RenderInput = {};
+
+  if (hasUrl) {
+    const rawUrl = body.url as string;
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(rawUrl);
+    } catch {
+      throw new ValidationError("url must be a valid absolute URL", { code: "invalid_request" });
+    }
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      throw new ValidationError("url must be http or https", { code: "invalid_request" });
+    }
+    if (isPrivateRenderTarget(parsedUrl.hostname)) {
+      throw new ValidationError("url targets a private or internal network", {
+        code: "invalid_request",
+      });
+    }
+    input.url = rawUrl;
+  } else {
+    const html = body.html as string;
+    const byteLength = new TextEncoder().encode(html).byteLength;
+    if (byteLength > MAX_RENDER_HTML_BYTES) {
+      throw new PayloadTooLargeError("html body too large", {
+        code: "upload_too_large",
+        details: { maxBytes: MAX_RENDER_HTML_BYTES },
+      });
+    }
+    input.html = html;
+  }
+
+  if (body.viewport !== undefined) {
+    if (
+      typeof body.viewport !== "object" ||
+      body.viewport === null ||
+      Array.isArray(body.viewport)
+    ) {
+      throw new ValidationError("viewport must be an object", { code: "invalid_request" });
+    }
+    const v = body.viewport as Record<string, unknown>;
+    if (typeof v.width !== "number" || typeof v.height !== "number") {
+      throw new ValidationError("viewport.width and viewport.height must be numbers", {
+        code: "invalid_request",
+      });
+    }
+    const viewport: RenderViewport = {
+      width: clamp(Math.round(v.width), MIN_VIEWPORT_DIMENSION, MAX_VIEWPORT_DIMENSION),
+      height: clamp(Math.round(v.height), MIN_VIEWPORT_DIMENSION, MAX_VIEWPORT_DIMENSION),
+    };
+    if (v.deviceScaleFactor !== undefined) {
+      if (typeof v.deviceScaleFactor !== "number") {
+        throw new ValidationError("viewport.deviceScaleFactor must be a number", {
+          code: "invalid_request",
+        });
+      }
+      viewport.deviceScaleFactor = clamp(
+        v.deviceScaleFactor,
+        MIN_DEVICE_SCALE_FACTOR,
+        MAX_DEVICE_SCALE_FACTOR,
+      );
+    }
+    input.viewport = viewport;
+  }
+
+  if (body.selector !== undefined) {
+    if (typeof body.selector !== "string" || body.selector.length === 0) {
+      throw new ValidationError("selector must be a non-empty string", { code: "invalid_request" });
+    }
+    input.selector = body.selector;
+  }
+
+  if (body.fullPage !== undefined) {
+    if (typeof body.fullPage !== "boolean") {
+      throw new ValidationError("fullPage must be a boolean", { code: "invalid_request" });
+    }
+    input.fullPage = body.fullPage;
+  }
+
+  if (body.colorScheme !== undefined) {
+    if (body.colorScheme !== "dark" && body.colorScheme !== "light") {
+      throw new ValidationError('colorScheme must be "dark" or "light"', {
+        code: "invalid_request",
+      });
+    }
+    input.colorScheme = body.colorScheme;
+  }
+
+  if (body.waitUntil !== undefined) {
+    if (
+      body.waitUntil !== "load" &&
+      body.waitUntil !== "domcontentloaded" &&
+      body.waitUntil !== "networkidle"
+    ) {
+      throw new ValidationError('waitUntil must be "load", "domcontentloaded", or "networkidle"', {
+        code: "invalid_request",
+      });
+    }
+    input.waitUntil = body.waitUntil;
+  }
+
+  return input;
+}
+
+function toBrowserRunOptions(input: RenderInput): BrowserRunScreenshotOptions {
+  const base = (input.url !== undefined ? { url: input.url } : { html: input.html as string }) as
+    | { url: string }
+    | { html: string };
+
+  // Cloudflare's own lifecycle events are the puppeteer set
+  // (load/domcontentloaded/networkidle0/networkidle2); our wire contract
+  // exposes "load" (default), "domcontentloaded" (passed straight through —
+  // it's already a Browser Run/puppeteer lifecycle value), and "networkidle".
+  // "networkidle2" (<=2 in-flight connections for 500ms) is the closer match
+  // to "networkidle" as commonly understood than the stricter networkidle0 —
+  // CF's docs note ~4.5s effective cap on top of gotoOptions.timeout
+  // regardless. Numeric waits stay unsupported server-side (the CLI rejects
+  // them client-side for remote renders).
+  const waitUntil: BrowserRunLifecycleEvent =
+    input.waitUntil === "networkidle"
+      ? "networkidle2"
+      : input.waitUntil === "domcontentloaded"
+        ? "domcontentloaded"
+        : "load";
+
+  const options: BrowserRunScreenshotOptions = {
+    ...base,
+    gotoOptions: { timeout: NAVIGATION_TIMEOUT_MS, waitUntil },
+    screenshotOptions: { type: "png", fullPage: input.fullPage ?? false },
+  } as BrowserRunScreenshotOptions;
+
+  if (input.selector !== undefined) options.selector = input.selector;
+  if (input.viewport !== undefined) {
+    options.viewport = {
+      width: input.viewport.width,
+      height: input.viewport.height,
+      ...(input.viewport.deviceScaleFactor !== undefined
+        ? { deviceScaleFactor: input.viewport.deviceScaleFactor }
+        : {}),
+    };
+  }
+  if (input.colorScheme !== undefined) {
+    // DEVIATION (see RESULT.md): quickAction's typed surface has no
+    // prefers-color-scheme / emulateMediaFeatures option — only
+    // `emulateMediaType` (screen/print). We inject a `color-scheme` CSS
+    // property as a best effort, which affects native form controls and
+    // scrollbars but can NOT force a page's own `prefers-color-scheme` media
+    // query to match (that reflects the browser's OS-level signal, which an
+    // injected stylesheet cannot spoof). Good enough for our own
+    // `screenshots/` templated-card use case; documented as a known gap for
+    // arbitrary third-party pages.
+    options.addStyleTag = [{ content: `:root{color-scheme:${input.colorScheme};}` }];
+  }
+
+  return options;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new AppError({
+          type: "unavailable",
+          code: "render_failed",
+          message: "render timed out",
+          status: 504,
+        }),
+      );
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Wraps the Browser Run `BROWSER` binding behind the `Renderer` seam. */
+export function browserRenderer(browser: BrowserRun): Renderer {
+  return {
+    async screenshot(input) {
+      const options = toBrowserRunOptions(input);
+      let response: Response;
+      try {
+        response = await withTimeout(
+          browser.quickAction("screenshot", options),
+          HANDLER_TIMEOUT_MS,
+        );
+      } catch (err) {
+        if (err instanceof AppError) throw err;
+        throw new AppError({
+          type: "unavailable",
+          code: "render_failed",
+          message: "render failed",
+          status: 502,
+          cause: err,
+        });
+      }
+
+      if (!response.ok) {
+        let detail: unknown;
+        try {
+          detail = await response.clone().json();
+        } catch {
+          detail = undefined;
+        }
+        if (response.status === 429) {
+          throw new RateLimitedError("browser render rate limited upstream", {
+            code: "rate_limited",
+            details: detail,
+          });
+        }
+        if (response.status === 400 || response.status === 422) {
+          throw new ValidationError("render request rejected by the browser", {
+            code: "render_failed",
+            details: detail,
+          });
+        }
+        throw new AppError({
+          type: "unavailable",
+          code: "render_failed",
+          message: "render failed",
+          status: 502,
+          details: detail,
+        });
+      }
+
+      const contentType = response.headers.get("content-type") ?? "image/png";
+      const png = new Uint8Array(await response.arrayBuffer());
+      return { png, contentType };
+    },
+  };
+}

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -27,6 +27,9 @@ const MAX_DEVICE_SCALE_FACTOR = 3;
 
 /** Navigation timeout handed to Browser Run — below its 60s ceiling. */
 const NAVIGATION_TIMEOUT_MS = 30_000;
+/** Upstream cap on the post-load action (screenshot) so Browser Run can't
+ *  keep a billed session running after the handler's own window lapses. */
+const ACTION_TIMEOUT_MS = 30_000;
 /** Safety margin above `NAVIGATION_TIMEOUT_MS` for the local handler-side race,
  * in case Browser Run hangs without ever resolving `quickAction`'s promise. */
 const HANDLER_TIMEOUT_MS = 35_000;
@@ -276,6 +279,10 @@ function toBrowserRunOptions(input: RenderInput): BrowserRunScreenshotOptions {
   const options: BrowserRunScreenshotOptions = {
     ...base,
     gotoOptions: { timeout: NAVIGATION_TIMEOUT_MS, waitUntil },
+    // Bound the post-load action upstream too: withTimeout() only stops the
+    // handler waiting — without this, Browser Run keeps the (billed) action
+    // running past our window.
+    actionTimeout: ACTION_TIMEOUT_MS,
     screenshotOptions: { type: "png", fullPage: input.fullPage ?? false },
   } as BrowserRunScreenshotOptions;
 

--- a/apps/api/src/routes/render.ts
+++ b/apps/api/src/routes/render.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /v1/render (phase 1, see .context/2026-07-16-render-endpoint-brief.md):
+ * renders a URL or raw HTML to a PNG via the Browser Run binding and returns
+ * the bytes directly (no R2 write — the CLI uploads through the existing put
+ * path). Registered before the `/v1/:workspace/*` guard in src/index.ts, so
+ * (like /v1/tokens and /v1/workspaces) it brings its own auth — here,
+ * `tokenWorkspaceAuth`, which resolves the workspace from the token itself
+ * rather than a path segment.
+ *
+ * Quota: renders draw against the *existing* monthly upload budget
+ * (`maxUploadsPerPeriod` / `checkPutBudget`) with a zero-byte delta — no new
+ * ledger. A burst limiter (`RENDER_LIMITER`) additionally guards against a
+ * hot loop within a single window, independent of the monthly cap.
+ */
+import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
+import { Hono } from "hono";
+import { checkPutBudget } from "../budget";
+import { readJsonObjectBody } from "../cli-intake";
+import { renderRateLimit } from "../guards";
+import { browserRenderer, MAX_RENDER_HTML_BYTES, parseRenderRequest } from "../render";
+import { getWorkspaceUsage, recordUsageSafe } from "../usage";
+import { requireScope, tokenWorkspaceAuth, type WorkspaceVars } from "../workspace";
+
+// Headroom over the 2 MiB `html` cap for JSON-encoding overhead (escaped
+// backslashes/unicode, the surrounding object). Checked (via
+// readJsonObjectBody's declared-Content-Length short-circuit and buffered-size
+// check) before JSON.parse so an oversized payload never reaches the parser —
+// same shape as the body-size guard the other CLI/MCP intake routes use
+// (`/v1/telemetry`, `/v1/reports`). The exact 2 MiB `html` field cap is
+// re-checked inside `parseRenderRequest`.
+const MAX_BODY_BYTES = MAX_RENDER_HTML_BYTES + 1024 * 1024;
+
+export const render = new Hono<WorkspaceVars>().post(
+  "/",
+  tokenWorkspaceAuth,
+  requireScope("files:write"),
+  renderRateLimit,
+  async (c) => {
+    const parsed = await readJsonObjectBody(c.req.raw, MAX_BODY_BYTES);
+    const input = parseRenderRequest(parsed);
+
+    const workspaceName = c.get("workspaceName");
+    const ws = c.get("workspace");
+
+    // Renders never move stored bytes, so the delta is uploads-only — this
+    // deliberately reuses the existing monthly upload budget (not a
+    // render-specific ledger): checkPutBudget's storage-cap branch only
+    // triggers on delta.bytes > 0, so a zero-byte delta here can only ever
+    // trip maxUploadsPerPeriod.
+    const usage = await getWorkspaceUsage(c.env.DB, workspaceName);
+    const denial = checkPutBudget(usage, ws, { bytes: 0, uploads: 1 });
+    if (denial) {
+      if (denial.status === 507) {
+        throw new InsufficientStorageError(denial.message, {
+          code: denial.code,
+          details: denial.detail,
+        });
+      }
+      throw new RateLimitedError(denial.message, {
+        code: denial.code,
+        details: denial.detail,
+      });
+    }
+
+    const renderer = browserRenderer(c.env.BROWSER);
+    const result = await renderer.screenshot(input);
+
+    await recordUsageSafe(c.env.DB, workspaceName, { bytes: 0, objects: 0, uploads: 1 });
+
+    return new Response(result.png, {
+      status: 200,
+      headers: { "Content-Type": result.contentType || "image/png" },
+    });
+  },
+);

--- a/apps/api/test/fake-browser.ts
+++ b/apps/api/test/fake-browser.ts
@@ -1,0 +1,37 @@
+/**
+ * Minimal stand-in for the `BROWSER` (Browser Run) binding. quickAction has no
+ * Miniflare/local simulation — `"remote": true` always proxies to the real
+ * metered service — so route tests substitute this instead, mirroring how
+ * `FakeR2Bucket` fakes R2.
+ */
+export class FakeBrowser {
+  calls: Array<{ action: string; options: unknown }> = [];
+  private response: () => Response;
+
+  constructor(response: () => Response) {
+    this.response = response;
+  }
+
+  async quickAction(action: string, options: unknown): Promise<Response> {
+    this.calls.push({ action, options });
+    return this.response();
+  }
+
+  /** A successful `screenshot` action returning the given PNG bytes. */
+  static pngResponse(png: Uint8Array): FakeBrowser {
+    return new FakeBrowser(
+      () => new Response(png, { status: 200, headers: { "content-type": "image/png" } }),
+    );
+  }
+
+  /** A Browser Run `BrowserRunErrorResponse` at the given status. */
+  static errorResponse(status: number, message = "browser run error"): FakeBrowser {
+    return new FakeBrowser(
+      () =>
+        new Response(JSON.stringify({ success: false, errors: [{ message }] }), {
+          status,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+  }
+}

--- a/apps/api/test/routes-render.test.ts
+++ b/apps/api/test/routes-render.test.ts
@@ -1,0 +1,358 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeBrowser } from "./fake-browser";
+import { UsageFakeD1 } from "./usage-fake-d1";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+
+// tokenWorkspaceAuth (unlike the path-based workspaceAuth used by /v1/:workspace/*)
+// resolves the workspace name from the token itself (`up_<name>_…`), so every
+// token here must encode "default" to match the fake REGISTRY record below.
+const TOKEN = "up_default_rendertoken";
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+/** Extends UsageFakeD1 (real workspace_usage ledger) with an optional
+ * D1-backed scoped auth token, so scope-enforcement tests can exercise a
+ * token with fewer than the full FILE_SCOPES set — the legacy tokenHash path
+ * (used by every other test here) always grants all scopes. */
+class RenderFakeD1 extends UsageFakeD1 {
+  constructor(authToken?: { tokenHash: string; scopes: string }) {
+    super();
+    const base = this.prepare;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.prepare = ((sql: string): any => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      if (normalized.includes("FROM auth_tokens") && authToken) {
+        let args: unknown[] = [];
+        const stmt = {
+          bind: (...v: unknown[]) => {
+            args = v;
+            return stmt;
+          },
+          first: async () => {
+            const hash = args[1] as string;
+            if (hash === authToken.tokenHash) {
+              return {
+                id: "token-id",
+                workspace: "default",
+                token_hash: authToken.tokenHash,
+                label: null,
+                scopes: authToken.scopes,
+                created_at: "2026-07-16T00:00:00.000Z",
+                expires_at: null,
+                revoked_at: null,
+                minting_user_id: null,
+              };
+            }
+            return null;
+          },
+          all: async () => ({ success: true, results: [] }),
+          run: async () => ({ success: true, meta: { changes: 0 }, results: [] }),
+        };
+        return stmt;
+      }
+      return base(sql);
+    }) as typeof this.prepare;
+  }
+}
+
+async function makeEnv(
+  opts: {
+    overrides?: Partial<WorkspaceRecord>;
+    browser?: FakeBrowser;
+    rateLimitOk?: boolean;
+    scopedToken?: { rawToken: string; scopes: string[] };
+  } = {},
+) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...opts.overrides,
+  };
+  const db = new RenderFakeD1(
+    opts.scopedToken
+      ? {
+          tokenHash: await sha256Hex(opts.scopedToken.rawToken),
+          scopes: JSON.stringify(opts.scopedToken.scopes),
+        }
+      : undefined,
+  );
+  const browser = opts.browser ?? FakeBrowser.pngResponse(PNG);
+  const env = {
+    REGISTRY: { get: async () => record, put: async () => undefined },
+    DB: db,
+    BROWSER: browser,
+    RENDER_LIMITER: { limit: async () => ({ success: opts.rateLimitOk ?? true }) },
+  };
+  return { env, db, browser };
+}
+
+function renderReq(env: unknown, body: unknown, token = TOKEN) {
+  return app.request(
+    "/v1/render",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env as never,
+  );
+}
+
+describe("POST /v1/render happy path", () => {
+  it("renders a url and returns PNG bytes with the right content-type", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect([...new Uint8Array(await res.arrayBuffer())]).toEqual([...PNG]);
+    expect(browser.calls).toHaveLength(1);
+    expect(browser.calls[0].action).toBe("screenshot");
+    expect(browser.calls[0].options).toMatchObject({ url: "https://example.com" });
+  });
+
+  it("renders raw html", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, { html: "<!doctype html><h1>hi</h1>" });
+    expect(res.status).toBe(200);
+    expect(browser.calls[0].options).toMatchObject({ html: "<!doctype html><h1>hi</h1>" });
+  });
+
+  it("passes viewport, selector, fullPage and waitUntil through to Browser Run", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, {
+      url: "https://example.com",
+      viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+      selector: "main",
+      fullPage: true,
+      waitUntil: "networkidle",
+    });
+    expect(res.status).toBe(200);
+    expect(browser.calls[0].options).toMatchObject({
+      selector: "main",
+      viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+      screenshotOptions: { type: "png", fullPage: true },
+      gotoOptions: { waitUntil: "networkidle2" },
+    });
+  });
+
+  it('passes waitUntil "domcontentloaded" straight through to Browser Run', async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, {
+      url: "https://example.com",
+      waitUntil: "domcontentloaded",
+    });
+    expect(res.status).toBe(200);
+    expect(browser.calls[0].options).toMatchObject({
+      gotoOptions: { waitUntil: "domcontentloaded" },
+    });
+  });
+
+  it("clamps out-of-range viewport and deviceScaleFactor values", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, {
+      url: "https://example.com",
+      viewport: { width: 99999, height: 1, deviceScaleFactor: 10 },
+    });
+    expect(res.status).toBe(200);
+    expect(browser.calls[0].options).toMatchObject({
+      viewport: { width: 4096, height: 16, deviceScaleFactor: 3 },
+    });
+  });
+
+  it("increments uploads_in_period on a successful render (shares the monthly upload budget)", async () => {
+    const { env, db } = await makeEnv();
+    await renderReq(env, { url: "https://example.com" });
+    expect(db.usage.get("default")?.uploads_in_period).toBe(1);
+  });
+});
+
+describe("POST /v1/render auth + scope", () => {
+  it("401s with no bearer token", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/render",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://example.com" }),
+      },
+      env as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("401s an unknown/garbage token", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com" }, "up_default_wrong-token");
+    expect(res.status).toBe(401);
+  });
+
+  it("403s a read-only-scoped token (insufficient_scope), no render performed", async () => {
+    const READ_TOKEN = "up_default_readonlytoken";
+    const { env, browser } = await makeEnv({
+      scopedToken: { rawToken: READ_TOKEN, scopes: ["files:read"] },
+    });
+    const res = await renderReq(env, { url: "https://example.com" }, READ_TOKEN);
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe("insufficient_scope");
+    expect(browser.calls).toHaveLength(0);
+  });
+});
+
+describe("POST /v1/render validation", () => {
+  it("rejects a body with neither url nor html", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, {});
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a body with both url and html", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com", html: "<p>x</p>" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects malformed JSON", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/render",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+        body: "{not json",
+      },
+      env as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an oversized html body with 413 (upload_too_large, from parseRenderRequest's exact 2 MiB field check)", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { html: "x".repeat(2 * 1024 * 1024 + 1) });
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("upload_too_large");
+  });
+
+  it("rejects a request body over the outer cap with 413 (payload_too_large, from readJsonObjectBody)", async () => {
+    const { env } = await makeEnv();
+    // Well past MAX_RENDER_HTML_BYTES + 1 MiB headroom, so readJsonObjectBody's
+    // buffered-size check rejects it before parseRenderRequest ever runs.
+    const res = await renderReq(env, { html: "x".repeat(4 * 1024 * 1024) });
+    expect(res.status).toBe(413);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("payload_too_large");
+  });
+
+  it("rejects a non-http(s) url", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { url: "file:///etc/passwd" });
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    "http://localhost/",
+    "http://127.0.0.1/",
+    "http://10.0.0.5/",
+    "http://172.16.0.1/",
+    "http://192.168.1.1/",
+    "http://169.254.169.254/",
+    "http://foo.internal/",
+    "http://foo.local/",
+    "http://[::1]/",
+    "http://0.0.0.0/",
+    "http://[::ffff:127.0.0.1]/",
+    "http://[::ffff:7f00:1]/",
+    "http://[fc00::1]/",
+    "http://[fd12::1]/",
+    "http://[fe80::1]/",
+  ])("rejects a private/internal render target: %s", async (url) => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, { url });
+    expect(res.status).toBe(400);
+    expect(browser.calls).toHaveLength(0);
+  });
+
+  it("rejects an invalid colorScheme", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com", colorScheme: "blue" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an invalid waitUntil", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com", waitUntil: "eventually" });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /v1/render quota + rate limiting", () => {
+  it("429s when the burst RENDER_LIMITER denies", async () => {
+    const { env, browser } = await makeEnv({ rateLimitOk: false });
+    const res = await renderReq(env, { url: "https://example.com" });
+    expect(res.status).toBe(429);
+    expect(browser.calls).toHaveLength(0);
+  });
+
+  it("429s with upload_budget_exceeded once the monthly upload cap is hit, and does not call the renderer", async () => {
+    const { env, browser } = await makeEnv({ overrides: { maxUploadsPerPeriod: 1 } });
+    const first = await renderReq(env, { url: "https://example.com" });
+    expect(first.status).toBe(200);
+
+    const second = await renderReq(env, { url: "https://example.com" });
+    expect(second.status).toBe(429);
+    const json = (await second.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("upload_budget_exceeded");
+    expect(browser.calls).toHaveLength(1); // only the first (successful) render
+  });
+});
+
+describe("POST /v1/render Browser Run error passthrough", () => {
+  it("maps a Browser Run 429 to our rate_limited error", async () => {
+    const { env, db } = await makeEnv({ browser: FakeBrowser.errorResponse(429) });
+    const res = await renderReq(env, { url: "https://example.com" });
+    expect(res.status).toBe(429);
+    const json = (await res.json()) as { error: { type: string } };
+    expect(json.error.type).toBe("rate_limited");
+    // A failed render must not consume the monthly upload budget.
+    expect(db.usage.get("default")?.uploads_in_period ?? 0).toBe(0);
+  });
+
+  it("maps a Browser Run 422 to a render_failed validation error", async () => {
+    const { env } = await makeEnv({ browser: FakeBrowser.errorResponse(422, "bad selector") });
+    const res = await renderReq(env, { url: "https://example.com" });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { type: string; code: string } };
+    expect(json.error.type).toBe("validation");
+    expect(json.error.code).toBe("render_failed");
+  });
+
+  it("maps a Browser Run 500 to a render_failed service error", async () => {
+    const { env } = await makeEnv({ browser: FakeBrowser.errorResponse(500) });
+    const res = await renderReq(env, { url: "https://example.com" });
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("render_failed");
+  });
+});

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -40,6 +40,14 @@
       "id": "808bc1c3a86a4675b134e11b6dca303d",
     },
   ],
+  // Browser Run binding (POST /v1/render, phase 1). "remote": true is
+  // required — quickAction has no Miniflare/local simulation and always
+  // proxies to the real metered service, even under `wrangler dev`. Unit
+  // tests substitute a `Renderer`/FakeBrowser (see src/render.ts) instead.
+  "browser": {
+    "binding": "BROWSER",
+    "remote": true,
+  },
   "d1_databases": [
     {
       "binding": "DB",
@@ -88,6 +96,18 @@
         "namespace_id": "1003",
         "simple": {
           "limit": 3,
+          "period": 60,
+        },
+      },
+      {
+        // POST /v1/render burst guard, keyed by workspace. Independent of the
+        // monthly upload-budget check (checkPutBudget) that also gates
+        // renders — this one blunts a hot loop within a single period.
+        "name": "RENDER_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1004",
+        "simple": {
+          "limit": 10,
           "period": 60,
         },
       },

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -64,6 +64,9 @@ export const ERROR_CODES = [
   "file_metadata_duplicate_filter",
   "file_metadata_too_many_filters",
 
+  // Render (POST /v1/render)
+  "render_failed",
+
   // Admin
   "invalid_workspace",
   "workspace_not_found",

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -64,5 +64,8 @@
   },
   "dependencies": {
     "sharp": "^0.35.3"
+  },
+  "optionalDependencies": {
+    "playwright-core": "^1.61.1"
   }
 }

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -54,6 +54,52 @@ export const PUT_LIKE_FLAGS: readonly string[] = [
   "-h",
 ];
 
+/**
+ * All flags `uploads screenshot` actually reads (verified against
+ * commands/screenshot.ts) — kept as its own explicit list rather than
+ * spreading PUT_LIKE_FLAGS, which includes `--name`/`--no-comment` that
+ * screenshot never parses.
+ */
+export const SCREENSHOT_FLAGS: readonly string[] = [
+  "--via",
+  "--browser",
+  "--cdp",
+  "--viewport",
+  "--selector",
+  "--full-page",
+  "--dark",
+  "--light",
+  "--wait",
+  "--out",
+  "--no-upload",
+  "--destination",
+  "--prefix",
+  "--repo",
+  "--ref",
+  "--key",
+  "--alt",
+  "--width",
+  "--frame",
+  "--frame-url",
+  "--frame-fit",
+  "--no-optimize",
+  "--optimize-max-edge",
+  "--optimize-quality",
+  "--keep-exif",
+  "--no-git",
+  "--pr",
+  "--issue",
+  "--comment",
+  "--gallery",
+  "--meta",
+  "--dry-run",
+  "--format",
+  "--workspace",
+  "-w",
+  "--help",
+  "-h",
+];
+
 export const LIST_LIKE_FLAGS: readonly string[] = [
   "--prefix",
   "--limit",
@@ -76,6 +122,12 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     name: "put",
     usage: "put <file...>",
     summary: "Upload (+ URL + markdown for GitHub)",
+    essential: true,
+  },
+  {
+    name: "screenshot",
+    usage: "screenshot <target>",
+    summary: "Capture a URL or .html file and host it (local browser or remote render)",
     essential: true,
   },
   {

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -38,6 +38,7 @@ import { runCompletion } from "./commands/completion.js";
 import { runLogout, runWhoami } from "./commands/session.js";
 import { runTelemetry } from "./commands/telemetry.js";
 import { runReport } from "./commands/report.js";
+import { runScreenshot } from "./commands/screenshot.js";
 import { packageVersion } from "./package-version.js";
 import { checkForUpdate, maybeHintUpdate } from "./update-check.js";
 import {
@@ -116,7 +117,12 @@ function exitCode(err: unknown): number {
       case "STORAGE_QUOTA":
       case "UPLOAD_BUDGET":
         return 3;
+      case "BROWSER_NOT_FOUND":
+        return 2;
       case "NETWORK":
+      // Transient — same "retry, don't reconfigure" family as a network
+      // hiccup, not an auth/policy/budget denial (those are exit 3).
+      case "RATE_LIMITED":
         return 4;
       default:
         return 1;
@@ -146,6 +152,9 @@ const ERROR_HINTS: Partial<Record<UploadsError["code"], string>> = {
     "hint: use a typed destination (`--destination screenshots|gh`) or an allowed prefix; operators set allowlists with `pnpm workspace:limits --allowed-prefixes`\n",
   UNAUTHORIZED:
     "hint: token rejected — run `uploads login` to sign in again, or check UPLOADS_TOKEN / --token\n",
+  BROWSER_NOT_FOUND:
+    "hint: no local browser found; try --via remote, or install Chrome / npx playwright install chromium\n",
+  RATE_LIMITED: "hint: transient rate limit — wait ~60s and retry\n",
 };
 
 function errorOut(err: unknown, format: OutputFormat): void {
@@ -328,6 +337,7 @@ export async function runCli(argv: string[]): Promise<number> {
         break;
       case "attach":
       case "put":
+      case "screenshot":
       case "gallery":
       case "list":
       case "find":
@@ -345,6 +355,9 @@ export async function runCli(argv: string[]): Promise<number> {
             break;
           case "put":
             code = await runPut(ctx, cmdArgs, showHelp);
+            break;
+          case "screenshot":
+            code = await runScreenshot(ctx, cmdArgs, showHelp);
             break;
           case "gallery":
             code = await runGallery(ctx, cmdArgs, showHelp);

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -623,7 +623,7 @@ export async function parseErrorEnvelope(
 }
 
 async function parseErrorResponse(res: Response): Promise<UploadsError> {
-  const { message, code } = await parseErrorEnvelope(res, "request failed");
+  const { message, code } = await parseErrorEnvelope(res, res.statusText || "request failed");
   return mapApiError(res.status, message, code);
 }
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -585,15 +585,20 @@ function mapApiError(status: number, error: string, code?: string): UploadsError
 /**
  * Parse API error bodies. Prefers the nested envelope
  * `{ error: { code, type, message, details? } }`; still accepts the legacy
- * flat `{ error: string, code?: string }` shape.
+ * flat `{ error: string, code?: string }` shape. Exported so other backends
+ * (e.g. the screenshot render endpoint) share this parsing instead of
+ * duplicating it — each caller supplies its own `fallback` message.
  */
-function extractErrorFields(body: unknown): { message: string; code?: string } {
+export function extractErrorFields(
+  body: unknown,
+  fallback = "request failed",
+): { message: string; code?: string } {
   if (typeof body === "object" && body && "error" in body) {
     const err = (body as { error: unknown }).error;
     if (typeof err === "object" && err && "message" in err) {
       const nested = err as { message?: unknown; code?: unknown };
       return {
-        message: typeof nested.message === "string" ? nested.message : "request failed",
+        message: typeof nested.message === "string" ? nested.message : fallback,
         code: typeof nested.code === "string" ? nested.code : undefined,
       };
     }
@@ -605,13 +610,21 @@ function extractErrorFields(body: unknown): { message: string; code?: string } {
       return { message: err, code };
     }
   }
-  return { message: "request failed" };
+  return { message: fallback };
+}
+
+/** Fetch + parse an error-response body via {@link extractErrorFields}. */
+export async function parseErrorEnvelope(
+  res: Response,
+  fallback = "request failed",
+): Promise<{ message: string; code?: string }> {
+  const body = await res.json().catch(() => ({}));
+  return extractErrorFields(body, fallback);
 }
 
 async function parseErrorResponse(res: Response): Promise<UploadsError> {
-  const body = await res.json().catch(() => ({}));
-  const { message, code } = extractErrorFields(body);
-  return mapApiError(res.status, message || res.statusText || "request failed", code);
+  const { message, code } = await parseErrorEnvelope(res, "request failed");
+  return mapApiError(res.status, message, code);
 }
 
 export function createUploadsClient(config: UploadsClientConfig) {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -58,6 +58,7 @@ import { formatByteSize } from "./format-bytes.js";
 import { formatUsageHuman } from "./format-usage.js";
 import { packageVersion } from "./package-version.js";
 import type { PutDefaults } from "./config-file.js";
+import type { DetectRoots } from "./screenshot-local.js";
 import { colorEnabled, writeCommandHelp } from "./cli-style.js";
 
 /** Parallel fan-out for multi-file put/attach (matches files-sdk bulk default). */
@@ -183,7 +184,10 @@ export function makeGhTarget(
 }
 
 /** Reads --pr/--issue (+ --repo) into a GhTarget; undefined when neither flag is present. */
-function ghTargetFromFlags(flags: CommandFlags["flags"], run: CommandRunner): GhTarget | undefined {
+export function ghTargetFromFlags(
+  flags: CommandFlags["flags"],
+  run: CommandRunner,
+): GhTarget | undefined {
   return makeGhTarget(
     flagInt(flags, "--pr", "--pr"),
     flagInt(flags, "--issue", "--issue"),
@@ -303,7 +307,89 @@ export async function prepareImageForUpload(
   return { ...optimized, frame: frameMeta };
 }
 
-function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
+export interface UploadPreparedImageOptions {
+  frame: {
+    frameId?: string;
+    frameUrl?: string;
+    frameFit?: "cover" | "contain";
+  };
+  optimize: OptimizeImageOptions;
+  /** gh attachment key wins over `key` when both are set (matches every call site). */
+  ghTarget?: GhTarget;
+  key?: string;
+  prefix?: string;
+  repo?: string;
+  ref?: string;
+  deriveRepoFromGit?: boolean;
+  contentType?: string;
+  dryRun?: boolean;
+  metadata?: Record<string, string>;
+  provenanceClient?: string;
+  /**
+   * Alt text for the markdown. Takes the prepared result so callers whose
+   * default depends on the post-frame/optimize filename can use it — each
+   * call site's existing default is preserved verbatim (see
+   * .context/2026-07-16-screenshot-command-RESULT.md, "Simplify pass").
+   */
+  alt: (prepared: PreparedUpload) => string;
+  width?: number;
+}
+
+export interface UploadPreparedImageResult {
+  result: PutResult;
+  prepared: PreparedUpload;
+  markdown: string;
+}
+
+/**
+ * Shared bytes-oriented upload tail: frame + optimize the bytes, resolve the
+ * object key (gh attachment key wins over an explicit key; extension
+ * rewritten post-optimize), put, and build the GitHub embed markdown. Used by
+ * the screenshot CLI command, the MCP screenshot tool, and the MCP put
+ * tool's contentBase64 path — the three in-memory-bytes call sites.
+ * uploadPuts/uploadAttachments loop over file paths with their own bounded
+ * concurrency and delegate here per item.
+ */
+export async function uploadPreparedImage(
+  client: UploadsClient,
+  bytes: Uint8Array,
+  sourceName: string,
+  opts: UploadPreparedImageOptions,
+): Promise<UploadPreparedImageResult> {
+  const prepared = await prepareImageForUpload(bytes, sourceName, {
+    frameId: opts.frame.frameId,
+    frameUrl: opts.frame.frameUrl,
+    frameFit: opts.frame.frameFit,
+    optimize: opts.optimize,
+  });
+  let key = opts.ghTarget ? ghAttachmentKey(opts.ghTarget, prepared.filename) : opts.key;
+  if (key && prepared.optimized) key = rewriteKeyExtension(key, prepared.filename);
+  const result = await client.put(prepared.bytes, {
+    filename: prepared.filename,
+    key,
+    prefix: opts.prefix,
+    repo: opts.repo,
+    ref: opts.ref,
+    contentType: prepared.optimized ? prepared.contentType : opts.contentType,
+    deriveRepoFromGit: opts.deriveRepoFromGit,
+    dryRun: opts.dryRun,
+    provenance: buildCliProvenance({
+      sourceName,
+      client: opts.provenanceClient,
+      optimized: prepared.optimized,
+      frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
+      keepExif: opts.optimize.keepExif === true,
+    }),
+    metadata: opts.metadata,
+  });
+  const markdown = buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+    alt: opts.alt(prepared),
+    width: opts.width,
+  });
+  return { result, prepared, markdown };
+}
+
+export function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
   frameId?: string;
   frameUrl?: string;
   frameFit?: "cover" | "contain";
@@ -612,42 +698,33 @@ export async function uploadPuts(opts: {
               ? basename(opts.explicitKey)
               : "stdin.bin"
             : basename(file));
-        const prepared = await prepareImageForUpload(readFileArg(file), sourceName, {
-          ...opts.frame,
-          optimize: opts.optimize,
-        });
-        let key = opts.ghTarget
-          ? ghAttachmentKey(opts.ghTarget, prepared.filename)
-          : opts.explicitKey;
-        if (key && prepared.optimized) key = rewriteKeyExtension(key, prepared.filename);
-        const result = await opts.client.put(prepared.bytes, {
-          filename: prepared.filename,
-          key,
-          prefix: opts.prefix,
-          repo: opts.repo,
-          ref: opts.ref,
-          contentType: prepared.optimized ? prepared.contentType : opts.contentType,
-          deriveRepoFromGit: opts.deriveRepoFromGit,
-          dryRun: opts.dryRun,
-          provenance: buildCliProvenance({
-            sourceName,
-            client: opts.provenanceClient,
-            optimized: prepared.optimized,
-            frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
-            keepExif: opts.optimize.keepExif === true,
-          }),
-          metadata: opts.metadata,
-        });
-        const alt = opts.alt ?? basename(sourceName);
+        const { result, prepared, markdown } = await uploadPreparedImage(
+          opts.client,
+          readFileArg(file),
+          sourceName,
+          {
+            frame: opts.frame,
+            optimize: opts.optimize,
+            ghTarget: opts.ghTarget,
+            key: opts.explicitKey,
+            prefix: opts.prefix,
+            repo: opts.repo,
+            ref: opts.ref,
+            deriveRepoFromGit: opts.deriveRepoFromGit,
+            contentType: opts.contentType,
+            dryRun: opts.dryRun,
+            metadata: opts.metadata,
+            provenanceClient: opts.provenanceClient,
+            alt: () => opts.alt ?? basename(sourceName),
+            width: opts.width,
+          },
+        );
         return {
           ok: true,
           upload: {
             ...result,
             file,
-            markdown: buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
-              alt,
-              width: opts.width,
-            }),
+            markdown,
             optimize: {
               optimized: prepared.optimized,
               skippedReason: prepared.skippedReason,
@@ -1734,12 +1811,69 @@ export interface DoctorReport {
   /** Workspace/token mismatch warning (also present in hints). */
   warning?: string;
   hints: string[];
+  /** `screenshot`'s local-browser detection (fs scans only — never launches a browser). */
+  browser: {
+    /** false when this runtime has no Node fs/process (e.g. the apps/mcp Worker). */
+    supported: boolean;
+    found: boolean;
+    /** Which backend `uploads screenshot --via auto` would pick right now. */
+    autoBackend: "local" | "remote";
+    candidates: { source: string; kind: string; executablePath: string }[];
+    /** The best candidate by rank (may differ from candidates[0], which is scan order). */
+    winner?: { source: string; kind: string; executablePath: string };
+    note?: string;
+  };
+}
+
+/**
+ * Best-effort local-browser detection for doctor. fs scans only, no browser
+ * launch. Guarded for non-Node runtimes as a precaution for any future
+ * non-Node consumer of this module — apps/mcp today only imports
+ * `buildMarkdown`/`buildScreenshotKey` from the package root, not
+ * `buildDoctorReport`, so this guard isn't exercised on that path currently.
+ */
+async function detectBrowserForDoctor(detectRoots?: DetectRoots): Promise<DoctorReport["browser"]> {
+  if (typeof process === "undefined" || !process.versions?.node) {
+    return {
+      supported: false,
+      found: false,
+      autoBackend: "remote",
+      candidates: [],
+      note: "browser detection is not supported in this runtime",
+    };
+  }
+  try {
+    const { detectLocalBrowser } = await import("./screenshot-local.js");
+    const { candidates, winner } = detectLocalBrowser(detectRoots);
+    return {
+      supported: true,
+      found: Boolean(winner),
+      autoBackend: winner ? "local" : "remote",
+      candidates: candidates.map((c) => ({
+        source: c.source,
+        kind: c.kind,
+        executablePath: c.executablePath,
+      })),
+      winner: winner
+        ? { source: winner.source, kind: winner.kind, executablePath: winner.executablePath }
+        : undefined,
+    };
+  } catch (err) {
+    return {
+      supported: true,
+      found: false,
+      autoBackend: "remote",
+      candidates: [],
+      note: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 /** Doctor's health + auth + workspace checks, shared by the CLI and the MCP tool. */
 export async function buildDoctorReport(
   config: ResolvedConfig,
   client: UploadsClient,
+  detectRoots?: DetectRoots,
 ): Promise<DoctorReport> {
   const mismatch = workspaceMismatch(config);
   const hints: string[] = [];
@@ -1747,8 +1881,13 @@ export async function buildDoctorReport(
   if (config.apiUrl.includes("localhost") || config.apiUrl.includes("127.0.0.1")) {
     hints.push("local API uses dev KV — prod tokens won't work unless minted with --local");
   }
+  // Independent checks — fs-based browser detection doesn't depend on the
+  // network health probe (or vice versa).
+  const [browser, health] = await Promise.all([
+    detectBrowserForDoctor(detectRoots),
+    client.health(),
+  ]);
 
-  const health = await client.health();
   let authOk = false;
   let authError: string | undefined;
   try {
@@ -1807,6 +1946,7 @@ export async function buildDoctorReport(
     usage,
     warning: mismatch,
     hints,
+    browser,
   };
 }
 
@@ -1836,6 +1976,15 @@ export async function runDoctor(ctx: CliContext, args: string[], help = false): 
         ? `usage:     ${formatByteSize(report.usage.bytes ?? 0)}, ${formatCount(report.usage.objects ?? 0)} objects, ${formatCount(report.usage.uploadsInPeriod ?? 0)} uploads this period`
         : `usage:     failed — ${report.usage.error ?? "unknown"}`,
     );
+  }
+  if (report.browser.supported) {
+    lines.push(
+      report.browser.found
+        ? `browser:   found (${report.browser.winner?.source}/${report.browser.winner?.kind}) — screenshot --via auto uses local`
+        : `browser:   none found — screenshot --via auto uses remote`,
+    );
+  } else {
+    lines.push(`browser:   ${report.browser.note ?? "not supported in this runtime"}`);
   }
   if (report.warning) lines.push(`warning:   ${report.warning}`);
   for (const h of report.hints) if (h !== report.warning) lines.push(`hint:      ${h}`);

--- a/packages/uploads/src/commands/completion.ts
+++ b/packages/uploads/src/commands/completion.ts
@@ -4,6 +4,7 @@ import {
   GLOBAL_FLAGS,
   LIST_LIKE_FLAGS,
   PUT_LIKE_FLAGS,
+  SCREENSHOT_FLAGS,
   ROOT_COMMANDS,
   isCompletionShell,
   type CompletionShell,
@@ -38,6 +39,7 @@ function bashScript(): string {
   const globals = GLOBAL_FLAGS.map((g) => g.flag).join(" ");
   const putFlags = PUT_LIKE_FLAGS.join(" ");
   const listFlags = LIST_LIKE_FLAGS.join(" ");
+  const screenshotFlags = SCREENSHOT_FLAGS.join(" ");
 
   const subMaps = ROOT_COMMANDS.filter((c) => c.subcommands?.length).map((c) => {
     const names = c.subcommands!.map((s) => s.name).join(" ");
@@ -64,6 +66,7 @@ _uploads() {
   local -a globals=(${globals})
   local -a put_flags=(${putFlags})
   local -a list_flags=(${listFlags})
+  local -a screenshot_flags=(${screenshotFlags})
 
   # Find the first non-global positional (the subcommand).
   local cmd="" i=1
@@ -114,6 +117,9 @@ ${subMaps.join("\n")}
       put|attach)
         COMPREPLY=( $(compgen -W "\${put_flags[*]}" -- "$cur") )
         ;;
+      screenshot)
+        COMPREPLY=( $(compgen -W "\${screenshot_flags[*]}" -- "$cur") )
+        ;;
       list|find)
         COMPREPLY=( $(compgen -W "\${list_flags[*]}" -- "$cur") )
         ;;
@@ -126,7 +132,7 @@ ${subMaps.join("\n")}
 
   # File paths for upload-style commands.
   case "$cmd" in
-    put|attach)
+    put|attach|screenshot)
       COMPREPLY=( $(compgen -f -- "$cur") )
       ;;
   esac
@@ -201,7 +207,7 @@ ${globalArgs} \\
     args)
       case $line[1] in
 ${subCases}
-      put|attach)
+      put|attach|screenshot)
         _files
         ;;
       esac
@@ -260,6 +266,12 @@ function fishScript(): string {
       `complete -c uploads -n '__fish_seen_subcommand_from put attach' -l ${flag.slice(2)}`,
     );
   }
+  for (const flag of SCREENSHOT_FLAGS) {
+    if (!flag.startsWith("--")) continue;
+    lines.push(
+      `complete -c uploads -n '__fish_seen_subcommand_from screenshot' -l ${flag.slice(2)}`,
+    );
+  }
   for (const flag of LIST_LIKE_FLAGS) {
     if (!flag.startsWith("--")) continue;
     lines.push(
@@ -267,8 +279,8 @@ function fishScript(): string {
     );
   }
 
-  // File completion for put/attach
-  lines.push(`complete -c uploads -n '__fish_seen_subcommand_from put attach' -F`);
+  // File completion for put/attach/screenshot
+  lines.push(`complete -c uploads -n '__fish_seen_subcommand_from put attach screenshot' -F`);
 
   return lines.join("\n") + "\n";
 }

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -1,0 +1,358 @@
+import { writeFileSync } from "node:fs";
+import { basename } from "node:path";
+import {
+  flagBool,
+  flagInt,
+  flagString,
+  flagValues,
+  parseCommandArgs,
+  UsageError,
+} from "../cli-args.js";
+import { writeCommandHelp } from "../cli-style.js";
+import {
+  frameOptionsFromFlags,
+  ghTargetFromFlags,
+  optimizeOptionsFromFlags,
+  syncAttachmentsComment,
+  uploadPreparedImage,
+  type CliContext,
+} from "../commands.js";
+import { resolvePutDefaults } from "../config.js";
+import { loadDefaultsRaw, resolveScreenshotDefaults } from "../config-file.js";
+import { resolvePutPrefix } from "../destinations.js";
+import { ghMetadataFromTarget } from "../github.js";
+import { execRunner, type CommandRunner } from "../github-gh.js";
+import { parseMetaFlags, validateMetaMap } from "../metadata.js";
+import { writeJson, writeStdout } from "../io.js";
+import {
+  captureScreenshot,
+  parseViewport,
+  parseWaitUntil,
+  type ScreenshotBackend,
+} from "../screenshot.js";
+
+const SCREENSHOT_HELP = `uploads screenshot <target> [options]
+
+Capture a URL or a local .html file and host it — a hosted, PR-embeddable
+image in one step. target is an http(s) URL or a path to an .html file.
+
+Two capture backends: "local" drives an already-installed Chrome/Chromium via
+playwright-core (no browser download); "remote" renders server-side via the
+uploads.sh render endpoint (no local browser needed, counts against the
+workspace's monthly upload budget). Default --via auto prefers local when a
+browser is found, else remote.
+
+localhost/private-network URLs and .html files are reachable only by the
+local backend — with --via remote (or auto falling back to remote) these
+fail fast with a clear error instead of sending a doomed request.
+
+After capture, screenshots share the put upload pipeline: optional --frame,
+optimize-by-default, --pr/--issue attachment + --comment, --gallery, --meta.
+
+Options:
+  --via auto|local|remote   Capture backend (default: auto, or UPLOADS_SCREENSHOT_VIA)
+  --browser <path>          Explicit local browser executable (or UPLOADS_CHROME_PATH / CHROME_PATH)
+  --cdp <endpoint>          Attach to a running Chrome via CDP (http://host:port or ws://…)
+  --viewport <WxH[@Sx]>     Size + device scale factor (default: 1280x800@2)
+  --selector <css>          Capture one element instead of the viewport
+  --full-page               Capture the full scrollable page
+  --dark / --light          Emulate prefers-color-scheme (full media-query emulation on --via local
+                            only; --via remote just sets the CSS color-scheme property, so a page's
+                            own prefers-color-scheme queries won't flip)
+  --wait <load|domcontentloaded|networkidle|ms>  Settle strategy (default: load); a millisecond
+                            count is local-only — use --via local
+  --out <file>              Also write the PNG to a local file
+  --no-upload                Skip hosting; requires --out (local file only)
+  --destination <id>        Typed root: screenshots | gh | f
+  --prefix <path>           Key prefix (default: screenshots, or UPLOADS_DEFAULT_PREFIX)
+  --repo <owner/repo>       Repo segment (default: git remote, or UPLOADS_DEFAULT_REPO)
+  --ref <id>                PR/issue/branch segment (default: today, or UPLOADS_DEFAULT_REF)
+  --key <key>               Explicit object key; cannot combine with --pr/--issue
+  --alt <text>              Alt text (default: derived filename)
+  --width <px>              <img width=…> markdown
+  --frame <id>              Device/browser frame before optimize (phone|browser|iphone-16-pro)
+  --frame-url <url>         Address bar text for --frame browser
+  --frame-fit cover|contain How the shot fills the screen (default: cover)
+  --no-optimize             Skip client-side image optimization
+  --optimize-max-edge <px>  Max long edge when optimizing (default: 2400)
+  --optimize-quality <1-100> WebP quality (default: 85)
+  --keep-exif               Keep EXIF/XMP/ICC when optimizing
+  --pr <num>                Attach to a pull request (stable URL, no hash)
+  --issue <num>             Attach to an issue
+  --comment                 With --pr/--issue: update the managed attachments comment
+  --gallery <id>            Add the uploaded object to this public gallery
+  --meta <k=v>              Queryable custom metadata (repeatable)
+  --workspace, -w <name>    Override workspace
+  --dry-run                 Capture + resolve key/URL without uploading
+  --format human|url|markdown|json
+
+Exit codes: 0 ok · 2 usage/no browser found/file · 3 auth/policy/budget · 4 network · 1 other.
+
+Examples:
+  uploads screenshot https://uploads.sh
+  uploads screenshot ./card.html --out ./card.png
+  uploads screenshot https://app.example/settings --selector main --dark
+  uploads screenshot http://localhost:3000 --via local --full-page
+  uploads screenshot https://uploads.sh --pr 128 --comment
+  uploads screenshot ./card.html --no-upload --out ./card.png
+`;
+
+function colorSchemeFromFlags(
+  flags: ReturnType<typeof parseCommandArgs>["flags"],
+): "dark" | "light" | undefined {
+  const dark = flagBool(flags, "--dark");
+  const light = flagBool(flags, "--light");
+  if (dark && light) throw new UsageError("--dark and --light are mutually exclusive");
+  if (dark) return "dark";
+  if (light) return "light";
+  return undefined;
+}
+
+function viaFromFlags(
+  flags: ReturnType<typeof parseCommandArgs>["flags"],
+  fallback: ScreenshotBackend,
+): ScreenshotBackend {
+  const raw = flagString(flags, "--via");
+  if (!raw) return fallback;
+  if (raw === "auto" || raw === "local" || raw === "remote") return raw;
+  throw new UsageError(`invalid --via: ${raw} (use auto, local, or remote)`);
+}
+
+export async function runScreenshot(
+  ctx: CliContext,
+  args: string[],
+  help = false,
+  run: CommandRunner = execRunner,
+  /** Injectable for tests — avoids launching a real browser or hitting the network. */
+  captureImpl: typeof captureScreenshot = captureScreenshot,
+): Promise<number> {
+  if (help) {
+    writeCommandHelp(SCREENSHOT_HELP);
+    return 0;
+  }
+  const parsed = parseCommandArgs(args);
+  if (parsed.help) {
+    writeCommandHelp(SCREENSHOT_HELP);
+    return 0;
+  }
+
+  const target = parsed.positionals[0];
+  if (!target) {
+    writeCommandHelp(SCREENSHOT_HELP);
+    return 2;
+  }
+  if (parsed.positionals.length > 1) {
+    throw new UsageError("screenshot takes exactly one target");
+  }
+
+  // Read the on-disk config once and share it between the screenshot and
+  // put-style default resolvers (both would otherwise read the same file).
+  const rawDefaults = loadDefaultsRaw({ envFile: ctx.envFile });
+  const screenshotDefaults = resolveScreenshotDefaults({ envFile: ctx.envFile }, rawDefaults);
+  const via = viaFromFlags(parsed.flags, screenshotDefaults.via ?? "auto");
+  const browserPath = flagString(parsed.flags, "--browser");
+  const cdp = flagString(parsed.flags, "--cdp");
+  const viewport = parseViewport(flagString(parsed.flags, "--viewport"));
+  const selector = flagString(parsed.flags, "--selector");
+  const fullPage = flagBool(parsed.flags, "--full-page");
+  const colorScheme = colorSchemeFromFlags(parsed.flags);
+  const waitUntil = parseWaitUntil(flagString(parsed.flags, "--wait"));
+  const outFile = flagString(parsed.flags, "--out");
+  const noUpload = flagBool(parsed.flags, "--no-upload");
+  if (noUpload && !outFile) throw new UsageError("--no-upload requires --out");
+
+  const keyHint = flagString(parsed.flags, "--key");
+  const destFlag = flagString(parsed.flags, "--destination");
+  const prefixFlag = flagString(parsed.flags, "--prefix");
+  const ghTarget = ghTargetFromFlags(parsed.flags, run);
+  const wantComment = parsed.flags.has("--comment");
+  const galleryId = flagString(parsed.flags, "--gallery");
+  const dryRun = flagBool(parsed.flags, "--dry-run");
+
+  if (wantComment && !ghTarget) throw new UsageError("--comment requires --pr or --issue");
+  if (ghTarget) {
+    if (keyHint) throw new UsageError("--key cannot be combined with --pr/--issue");
+    if (flagString(parsed.flags, "--ref"))
+      throw new UsageError("--ref cannot be combined with --pr/--issue");
+    if (prefixFlag) throw new UsageError("--prefix cannot be combined with --pr/--issue");
+  }
+  if (dryRun) {
+    if (wantComment) throw new UsageError("--dry-run cannot be combined with --comment");
+    if (galleryId) throw new UsageError("--dry-run cannot be combined with --gallery");
+    if (noUpload) throw new UsageError("--dry-run cannot be combined with --no-upload");
+  }
+
+  let resolvedPrefix: string | undefined;
+  try {
+    resolvedPrefix = resolvePutPrefix({
+      destination: destFlag,
+      prefix: prefixFlag,
+      key: keyHint,
+      ghAttachment: Boolean(ghTarget),
+    });
+  } catch (err) {
+    throw new UsageError(err instanceof Error ? err.message : String(err));
+  }
+
+  const format = ctx.json
+    ? "json"
+    : (() => {
+        const raw = flagString(parsed.flags, "--format");
+        if (!raw || raw === "human") return "human" as const;
+        if (raw === "url" || raw === "markdown" || raw === "json") return raw;
+        throw new UsageError(`invalid --format: ${raw}`);
+      })();
+
+  const putDefaults = resolvePutDefaults({ envFile: ctx.envFile }, rawDefaults);
+  const optimizeOpts = optimizeOptionsFromFlags(parsed.flags, putDefaults);
+  const frameOpts = frameOptionsFromFlags(parsed.flags);
+  const altFlag = flagString(parsed.flags, "--alt");
+  const width = flagInt(parsed.flags, "--width", "--width") ?? putDefaults.width;
+
+  const metaExtras = parseMetaFlags(flagValues(parsed.flags, "--meta"));
+  let metadata: Record<string, string> | undefined = metaExtras;
+  if (ghTarget) {
+    metadata = { ...metaExtras, ...ghMetadataFromTarget(ghTarget) };
+    validateMetaMap(metadata);
+  } else if (Object.keys(metaExtras).length > 0) {
+    validateMetaMap(metaExtras);
+  }
+
+  const logHuman = !ctx.quiet && format === "human";
+  if (logHuman) process.stderr.write(`>> capturing ${target}\n`);
+
+  const captured = await captureImpl({
+    target,
+    via,
+    browserPath,
+    cdp,
+    viewport,
+    selector,
+    fullPage,
+    colorScheme,
+    waitUntil,
+    apiUrl: ctx.config.apiUrl,
+    token: ctx.config.token,
+  });
+
+  if (logHuman) process.stderr.write(`>> captured via ${captured.backend} backend\n`);
+
+  if (outFile) {
+    writeFileSync(outFile, captured.png);
+    if (logHuman) process.stderr.write(`>> wrote ${outFile}\n`);
+  }
+
+  if (noUpload) {
+    if (ctx.json) {
+      await writeJson({ file: outFile, backend: captured.backend, size: captured.png.byteLength });
+    } else {
+      await writeStdout(`FILE: ${outFile}\n`);
+    }
+    return 0;
+  }
+
+  const repo = flagString(parsed.flags, "--repo") ?? putDefaults.repo;
+  const ref = flagString(parsed.flags, "--ref") ?? putDefaults.ref;
+
+  const alt = altFlag ?? basename(captured.filename);
+  const { result, prepared, markdown } = await uploadPreparedImage(
+    ctx.client,
+    captured.png,
+    captured.filename,
+    {
+      frame: frameOpts,
+      optimize: optimizeOpts,
+      ghTarget,
+      key: keyHint,
+      prefix: resolvedPrefix ?? putDefaults.prefix,
+      repo,
+      ref,
+      deriveRepoFromGit: !(flagBool(parsed.flags, "--no-git") || putDefaults.noGit === true),
+      dryRun,
+      metadata,
+      provenanceClient: "uploads-cli-screenshot",
+      alt: () => alt,
+      width,
+    },
+  );
+
+  let gallery: { id: string; url?: string; error?: string } | undefined;
+  if (galleryId) {
+    try {
+      const current = await ctx.client.getGallery(galleryId);
+      const item = await ctx.client.addGalleryItem(galleryId, result.key, {
+        expectedVersion: current.version,
+        altText: alt,
+      });
+      gallery = { id: galleryId, url: current.url };
+      void item;
+    } catch (err) {
+      gallery = { id: galleryId, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+  let commentError: string | undefined;
+  if (wantComment && ghTarget) {
+    try {
+      comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
+      if (logHuman) process.stderr.write(`>> attachments comment ${comment.action}\n`);
+    } catch (err) {
+      commentError = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `warning: upload succeeded but the GitHub comment failed (is gh installed and authenticated?): ${commentError}\n`,
+      );
+    }
+  }
+
+  if (logHuman) {
+    if (prepared.frame?.framed) process.stderr.write(`>> framed with ${prepared.frame.frameId}\n`);
+    if (prepared.optimized) {
+      process.stderr.write(
+        `>> optimized ${prepared.originalBytes} → ${prepared.outputBytes} bytes\n`,
+      );
+    }
+    process.stderr.write(`>> key: ${result.key}${dryRun ? " (dry run — not uploaded)" : ""}\n\n`);
+  }
+
+  switch (format) {
+    case "json":
+      await writeJson({
+        workspace: result.workspace,
+        key: result.key,
+        url: result.url,
+        embedUrl: result.embedUrl,
+        size: result.size,
+        contentType: result.contentType,
+        replaced: result.replaced,
+        markdown,
+        backend: captured.backend,
+        gallery,
+        ...(dryRun ? { dryRun: true } : {}),
+      });
+      break;
+    case "url":
+      await writeStdout(`${result.url}\n`);
+      break;
+    case "markdown":
+      await writeStdout(`${markdown}\n`);
+      break;
+    default: {
+      const embedLine = result.embedUrl ? `EMBED: ${result.embedUrl}\n` : "";
+      await writeStdout(
+        `URL: ${result.url}\n${embedLine}MARKDOWN: ${markdown}${gallery?.url ? `\nGALLERY: ${gallery.url}` : ""}\n`,
+      );
+    }
+  }
+
+  if (gallery?.error) {
+    process.stderr.write(
+      `warning: upload succeeded but adding it to gallery ${gallery.id} failed: ${gallery.error}\n`,
+    );
+  }
+  if (commentError && ctx.json) {
+    // already reported to stderr above; json output stays upload-focused.
+  }
+
+  return gallery?.error ? 1 : 0;
+}

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -42,7 +42,9 @@ uploads.sh render endpoint (no local browser needed, counts against the
 workspace's monthly upload budget). Default --via auto prefers local when a
 browser is found, else remote.
 
-localhost/private-network URLs and .html files are reachable only by the
+.html files work on both backends (sent inline to remote, ≤ 2 MiB; anything
+they reference via file:// or relative paths only resolves with --via local).
+localhost/private-network URLs are reachable only by the
 local backend — with --via remote (or auto falling back to remote) these
 fail fast with a clear error instead of sending a doomed request.
 

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -15,6 +15,7 @@ export const UPLOADS_CONFIG_KEYS = [
   "UPLOADS_NO_OPTIMIZE",
   "UPLOADS_KEEP_EXIF",
   "UPLOADS_NO_AUTO_META",
+  "UPLOADS_SCREENSHOT_VIA",
 ] as const;
 
 export type UploadsConfigKey = (typeof UPLOADS_CONFIG_KEYS)[number];
@@ -162,14 +163,77 @@ export function mergePutDefaults(...layers: PutDefaults[]): PutDefaults {
   return out;
 }
 
+/** Raw `--env-file` / user-config-file contents, keyed the way both `resolve*Defaults` need. */
+export interface RawDefaultsConfig {
+  fromEnvFile: UploadsConfigValues;
+  fromUser: UploadsConfigValues;
+}
+
+/**
+ * Read the on-disk config once (`--env-file` when given, else the user
+ * config file) so callers that need both put-style and screenshot-style
+ * defaults from the same invocation (e.g. `runScreenshot`) don't each read
+ * the file separately. Pass the result to `resolvePutDefaults` /
+ * `resolveScreenshotDefaults` as their second argument.
+ */
+export function loadDefaultsRaw(flags?: { envFile?: string }): RawDefaultsConfig {
+  const fromEnvFile = flags?.envFile ? loadConfigFile(flags.envFile) : {};
+  const fromUser = flags?.envFile ? {} : loadConfigFile(resolveConfigPath(flags));
+  return { fromEnvFile, fromUser };
+}
+
 /** Put defaults from env, optional env-file, and user config (same precedence as client config). */
-export function resolvePutDefaults(flags?: { envFile?: string }): PutDefaults {
+export function resolvePutDefaults(
+  flags?: { envFile?: string },
+  preloaded?: RawDefaultsConfig,
+): PutDefaults {
   const fromEnv = parsePutDefaultsFromEnv();
-  const fromEnvFile = flags?.envFile ? parsePutDefaultsFromRaw(loadConfigFile(flags.envFile)) : {};
-  const fromUser = flags?.envFile
-    ? {}
-    : parsePutDefaultsFromRaw(loadConfigFile(resolveConfigPath(flags)));
-  return mergePutDefaults(fromUser, fromEnvFile, fromEnv);
+  const { fromEnvFile, fromUser } = preloaded ?? loadDefaultsRaw(flags);
+  return mergePutDefaults(
+    parsePutDefaultsFromRaw(fromUser),
+    parsePutDefaultsFromRaw(fromEnvFile),
+    fromEnv,
+  );
+}
+
+export type ScreenshotBackendPref = "auto" | "local" | "remote";
+
+export interface ScreenshotDefaults {
+  via?: ScreenshotBackendPref;
+}
+
+function isScreenshotBackendPref(value: string | undefined): value is ScreenshotBackendPref {
+  return value === "auto" || value === "local" || value === "remote";
+}
+
+function parseScreenshotDefaultsFromRaw(raw: UploadsConfigValues): ScreenshotDefaults {
+  const out: ScreenshotDefaults = {};
+  if (isScreenshotBackendPref(raw.UPLOADS_SCREENSHOT_VIA)) out.via = raw.UPLOADS_SCREENSHOT_VIA;
+  return out;
+}
+
+function parseScreenshotDefaultsFromEnv(): ScreenshotDefaults {
+  const raw: UploadsConfigValues = {};
+  if (process.env.UPLOADS_SCREENSHOT_VIA)
+    raw.UPLOADS_SCREENSHOT_VIA = process.env.UPLOADS_SCREENSHOT_VIA;
+  return parseScreenshotDefaultsFromRaw(raw);
+}
+
+/**
+ * `screenshot --via` default: flag (applied by the caller) > env >
+ * --env-file > user config file > "auto" (the caller's own fallback).
+ */
+export function resolveScreenshotDefaults(
+  flags?: { envFile?: string },
+  preloaded?: RawDefaultsConfig,
+): ScreenshotDefaults {
+  const fromEnv = parseScreenshotDefaultsFromEnv();
+  const { fromEnvFile, fromUser } = preloaded ?? loadDefaultsRaw(flags);
+  return {
+    ...parseScreenshotDefaultsFromRaw(fromUser),
+    ...parseScreenshotDefaultsFromRaw(fromEnvFile),
+    ...fromEnv,
+  };
 }
 
 export function redactToken(token: string | undefined): string {

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -13,10 +13,13 @@ export {
   putDefaultsToConfigValues,
   resolvePutDefaults,
   mergePutDefaults,
+  resolveScreenshotDefaults,
   UPLOADS_CONFIG_KEYS,
   type UploadsConfigKey,
   type UploadsConfigValues,
   type PutDefaults,
+  type ScreenshotDefaults,
+  type ScreenshotBackendPref,
 } from "./config-file.js";
 
 export interface UploadsClientConfig {

--- a/packages/uploads/src/errors.ts
+++ b/packages/uploads/src/errors.ts
@@ -11,7 +11,10 @@ export type UploadsErrorCode =
   | "GITHUB_REQUIRED"
   | "API_ERROR"
   | "NETWORK"
-  | "USAGE";
+  | "USAGE"
+  | "BROWSER_NOT_FOUND"
+  | "RENDER_FAILED"
+  | "RATE_LIMITED";
 
 export class UploadsError extends Error {
   readonly code: UploadsErrorCode;

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -672,6 +672,7 @@ export function createUploadsMcpTools(opts: {
           optimizeQuality: { type: "number", description: "WebP quality 1-100 when optimizing." },
           keepExif: { type: "boolean", description: "Keep EXIF/XMP/ICC when optimizing." },
           ...frameProps,
+          noGit: { type: "boolean", description: "Don't derive the repo segment from git." },
           comment: {
             type: "boolean",
             description:

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -5,16 +5,14 @@
  * per-call `workspace` argument behaves like the CLI's --workspace flag, and
  * a missing token surfaces as a tool error rather than a startup failure.
  */
-import { basename } from "node:path";
 import type { GlobalFlags } from "../cli-args.js";
 import { createUploadsClient, type UploadsClient } from "../client.js";
 import {
   buildDoctorReport,
   makeGhTarget,
-  prepareImageForUpload,
-  readFileArg,
   syncAttachmentsComment,
   uploadAttachments,
+  uploadPreparedImage,
   uploadPuts,
 } from "../commands.js";
 import { resolveFrameId } from "../frame.js";
@@ -24,13 +22,10 @@ import {
   type ResolvedConfig,
   type UploadsClientConfig,
 } from "../config.js";
-import { buildMarkdown } from "../embed.js";
-import { urlForGithubEmbed } from "../public-urls.js";
 import { resolvePutPrefix } from "../destinations.js";
-import { ghAttachmentKey, ghKeyPrefix, ghMetadataFromTarget, type GhTarget } from "../github.js";
+import { ghKeyPrefix, ghMetadataFromTarget, type GhTarget } from "../github.js";
 import { validateMetaMap } from "../metadata.js";
-import { rewriteKeyExtension, type OptimizeImageOptions } from "../optimize.js";
-import { buildCliProvenance } from "../provenance.js";
+import { type OptimizeImageOptions } from "../optimize.js";
 import {
   execRunner,
   resolveCurrentPullRequest,
@@ -524,35 +519,27 @@ export function createUploadsMcpTools(opts: {
         if (contentBase64 !== undefined) {
           const sourceName = filenameArg!;
           const bytes = new Uint8Array(Buffer.from(contentBase64, "base64"));
-          const prepared = await prepareImageForUpload(bytes, sourceName, {
-            ...frameOpts,
-            optimize: optimizeOpts,
-          });
-          const filename = prepared.filename;
-          let key = target ? ghAttachmentKey(target, filename) : keyArg;
-          if (key && prepared.optimized) key = rewriteKeyExtension(key, filename);
-          const result = await client.put(prepared.bytes, {
-            filename,
-            key,
-            prefix: resolvedPrefix ?? defaults.prefix,
-            repo: optString(args, "repo") ?? defaults.repo,
-            ref: refArg ?? defaults.ref,
-            contentType: prepared.optimized ? prepared.contentType : contentType,
-            deriveRepoFromGit: !noGit,
-            dryRun,
-            provenance: buildCliProvenance({
-              sourceName,
-              client: "uploads-mcp",
-              optimized: prepared.optimized,
-              frameId: prepared.frame?.framed ? prepared.frame.frameId : undefined,
-              keepExif: optimizeOpts.keepExif === true,
-            }),
-            metadata,
-          });
-          const markdown = buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
-            alt: alt ?? sourceName,
-            width,
-          });
+          const { result, prepared, markdown } = await uploadPreparedImage(
+            client,
+            bytes,
+            sourceName,
+            {
+              frame: frameOpts,
+              optimize: optimizeOpts,
+              ghTarget: target,
+              key: keyArg,
+              prefix: resolvedPrefix ?? defaults.prefix,
+              repo: optString(args, "repo") ?? defaults.repo,
+              ref: refArg ?? defaults.ref,
+              contentType,
+              deriveRepoFromGit: !noGit,
+              dryRun,
+              metadata,
+              provenanceClient: "uploads-mcp",
+              alt: () => alt ?? sourceName,
+              width,
+            },
+          );
           const optimize = {
             optimized: prepared.optimized,
             skippedReason: prepared.skippedReason,
@@ -594,6 +581,260 @@ export function createUploadsMcpTools(opts: {
           markdown: u.markdown,
           optimize: u.optimize,
           frame: u.frame,
+          ...(dryRun ? { dryRun: true } : {}),
+        };
+        if (wantComment && target) {
+          const { comment, commentError } = await syncComment(client, target);
+          return { ...flat, comment, commentError };
+        }
+        return flat;
+      },
+    },
+    {
+      name: "screenshot",
+      description:
+        "Capture a URL or a local .html file and host it — a hosted, PR-embeddable image in one call. Backend `local` drives an already-installed Chrome/Chromium (dynamically loaded; unavailable in some runtimes); `remote` renders server-side via the workspace's render endpoint and counts against the monthly upload budget. Default via=auto prefers local when found, else remote. localhost/private-network URLs and .html files are local-only — via=remote (or auto falling back to remote) fails fast instead of a doomed request. Shares the put upload pipeline: optional frame, optimize-by-default, pr/issue attachment + comment, gallery, metadata. Uploads are public.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          target: {
+            type: "string",
+            description: "http(s) URL, or a path to a local .html file.",
+          },
+          via: {
+            type: "string",
+            description: "Capture backend: auto (default) | local | remote.",
+          },
+          browser: {
+            type: "string",
+            description: "Explicit local browser executable path (local backend only).",
+          },
+          cdp: {
+            type: "string",
+            description:
+              "Attach to a running Chrome via CDP instead of launching one (local backend only).",
+          },
+          viewport: {
+            type: "string",
+            description: "WIDTHxHEIGHT[@SCALEx], e.g. 1280x800@2x (default: 1280x800@2).",
+          },
+          selector: { type: "string", description: "Capture one element instead of the viewport." },
+          fullPage: { type: "boolean", description: "Capture the full scrollable page." },
+          colorScheme: {
+            type: "string",
+            description:
+              "Emulate prefers-color-scheme: dark | light. Full media-query emulation requires via: \"local\" — the remote backend only sets the CSS color-scheme property and won't flip a page's own prefers-color-scheme queries.",
+          },
+          wait: {
+            type: "string",
+            description:
+              'Settle strategy: load (default) | domcontentloaded | networkidle | a millisecond count (millisecond counts are local-only — via: "local").',
+          },
+          key: {
+            type: "string",
+            description:
+              "Explicit object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.png). Cannot be combined with pr/issue.",
+          },
+          destination: {
+            type: "string",
+            description:
+              "Typed destination root: screenshots | gh | f. With pr/issue must be gh or omitted.",
+          },
+          prefix: {
+            type: "string",
+            description: "Key prefix (default: screenshots, or UPLOADS_DEFAULT_PREFIX).",
+          },
+          ...ghTargetProps("Attach to"),
+          repo: {
+            type: "string",
+            description: "owner/name repo segment (default: git remote, or UPLOADS_DEFAULT_REPO).",
+          },
+          ref: {
+            type: "string",
+            description: "PR/issue/branch key segment (default: today, or UPLOADS_DEFAULT_REF).",
+          },
+          alt: {
+            type: "string",
+            description: "Alt text for the markdown (default: derived filename).",
+          },
+          width: {
+            type: "number",
+            description: "Emit <img width=…> markdown instead of a plain embed.",
+          },
+          noOptimize: {
+            type: "boolean",
+            description: "Skip client-side image optimization (default: optimize to WebP).",
+          },
+          optimizeMaxEdge: {
+            type: "number",
+            description: "Max long edge in pixels when optimizing.",
+          },
+          optimizeQuality: { type: "number", description: "WebP quality 1-100 when optimizing." },
+          keepExif: { type: "boolean", description: "Keep EXIF/XMP/ICC when optimizing." },
+          ...frameProps,
+          comment: {
+            type: "boolean",
+            description:
+              "With pr/issue: create/update the managed attachments comment (best-effort).",
+          },
+          galleryId: {
+            type: "string",
+            description: "Add the uploaded object to this public gallery.",
+          },
+          dryRun: {
+            type: "boolean",
+            description:
+              "Capture + resolve key/URL without uploading. Not with comment or galleryId.",
+          },
+          metadata: metadataProp,
+          workspace: workspaceProp,
+        },
+        required: ["target"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const targetArg = optString(args, "target");
+        if (!targetArg) usage("target is required");
+        const viaArg = optString(args, "via") ?? "auto";
+        if (viaArg !== "auto" && viaArg !== "local" && viaArg !== "remote") {
+          usage("via must be auto, local, or remote");
+        }
+        const colorSchemeArg = optString(args, "colorScheme");
+        if (colorSchemeArg && colorSchemeArg !== "dark" && colorSchemeArg !== "light") {
+          usage("colorScheme must be dark or light");
+        }
+
+        const target = ghTargetFromArgs(args, run);
+        const wantComment = optBool(args, "comment");
+        const dryRun = optBool(args, "dryRun");
+        const keyArg = optString(args, "key");
+        const destArg = optString(args, "destination");
+        const prefixArg = optString(args, "prefix");
+        const refArg = optString(args, "ref");
+        const galleryIdArg = optString(args, "galleryId");
+        if (wantComment && !target) usage("comment requires pr or issue");
+        if (dryRun && wantComment) usage("dryRun cannot be combined with comment");
+        if (dryRun && galleryIdArg) usage("dryRun cannot be combined with galleryId");
+        if (target) {
+          if (keyArg) usage("key cannot be combined with pr/issue");
+          if (refArg) usage("ref cannot be combined with pr/issue");
+          if (prefixArg) usage("prefix cannot be combined with pr/issue");
+        }
+        const metadata = optStringRecord(args, "metadata");
+        if (metadata) validateMetaMap(metadata);
+        let resolvedPrefix: string | undefined;
+        try {
+          resolvedPrefix = resolvePutPrefix({
+            destination: destArg,
+            prefix: prefixArg,
+            key: keyArg,
+            ghAttachment: Boolean(target),
+          });
+        } catch (err) {
+          usage(err instanceof Error ? err.message : String(err));
+        }
+
+        const { config, client } = clientFor(args);
+        const defaults = resolvePutDefaults({ envFile: globals.envFile });
+        const frameOpts = mcpFrameOptions(args);
+        const optimizeOpts = mcpOptimizeOptions(args, defaults);
+        const noGit = optBool(args, "noGit") || defaults.noGit === true;
+        const alt = optString(args, "alt");
+        const width = optPosInt(args, "width") ?? defaults.width;
+
+        // Dynamic import only: keeps mcp/tools.ts (and therefore anything
+        // that statically imports it) free of a static reference to the
+        // local-backend chain. If this fails, the runtime can't do Node-side
+        // capture at all — point the caller at the remote backend instead.
+        let screenshotModule: typeof import("../screenshot.js");
+        try {
+          screenshotModule = await import("../screenshot.js");
+        } catch (err) {
+          usage(
+            `screenshot capture is unavailable in this runtime; try via: "remote" instead (${
+              err instanceof Error ? err.message : String(err)
+            })`,
+          );
+        }
+
+        let captured: Awaited<ReturnType<typeof screenshotModule.captureScreenshot>>;
+        try {
+          captured = await screenshotModule.captureScreenshot({
+            target: targetArg!,
+            via: viaArg,
+            browserPath: optString(args, "browser"),
+            cdp: optString(args, "cdp"),
+            viewport: screenshotModule.parseViewport(optString(args, "viewport")),
+            selector: optString(args, "selector"),
+            fullPage: optBool(args, "fullPage"),
+            colorScheme: colorSchemeArg as "dark" | "light" | undefined,
+            waitUntil: screenshotModule.parseWaitUntil(optString(args, "wait")),
+            apiUrl: config.apiUrl,
+            token: config.token,
+          });
+        } catch (err) {
+          if (
+            err instanceof Error &&
+            "code" in err &&
+            (err as { code?: string }).code === "BROWSER_NOT_FOUND" &&
+            viaArg === "local"
+          ) {
+            usage(`${err.message} — try via: "remote" instead`);
+          }
+          throw err;
+        }
+
+        const { result, prepared, markdown } = await uploadPreparedImage(
+          client,
+          captured.png,
+          captured.filename,
+          {
+            frame: frameOpts,
+            optimize: optimizeOpts,
+            ghTarget: target,
+            key: keyArg,
+            prefix: resolvedPrefix ?? defaults.prefix,
+            repo: optString(args, "repo") ?? defaults.repo,
+            ref: refArg ?? defaults.ref,
+            deriveRepoFromGit: !noGit,
+            dryRun,
+            metadata,
+            provenanceClient: "uploads-mcp-screenshot",
+            alt: (p) => alt ?? p.filename,
+            width,
+          },
+        );
+
+        let gallery: { id: string; url?: string; error?: string } | undefined;
+        if (galleryIdArg) {
+          try {
+            const current = await client.getGallery(galleryIdArg);
+            await client.addGalleryItem(galleryIdArg, result.key, {
+              expectedVersion: current.version,
+              altText: alt ?? prepared.filename,
+            });
+            gallery = { id: galleryIdArg, url: current.url };
+          } catch (err) {
+            gallery = {
+              id: galleryIdArg,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+
+        const flat = {
+          ...result,
+          markdown,
+          backend: captured.backend,
+          optimize: {
+            optimized: prepared.optimized,
+            skippedReason: prepared.skippedReason,
+            originalBytes: prepared.originalBytes,
+            outputBytes: prepared.outputBytes,
+            filename: prepared.filename,
+          },
+          frame: prepared.frame,
+          gallery,
           ...(dryRun ? { dryRun: true } : {}),
         };
         if (wantComment && target) {

--- a/packages/uploads/src/screenshot-local.ts
+++ b/packages/uploads/src/screenshot-local.ts
@@ -1,0 +1,431 @@
+/**
+ * Local screenshot backend — drives an already-installed Chrome/Chromium via
+ * `playwright-core` (no browser download; ~12 MB of JS).
+ *
+ * IMPORTANT: `playwright-core` must never be statically imported. This module
+ * is Node-only and is itself only ever reached via dynamic `await import()`
+ * from callers (never from index.ts / agent.ts / mcp/server.ts) so the
+ * apps/mcp Cloudflare Worker — which bundles those three entry points — never
+ * pulls this file (or playwright-core) into its bundle.
+ */
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { UploadsError } from "./errors.js";
+
+export type BrowserCandidateSource = "env" | "system" | "playwright-cache" | "puppeteer-cache";
+
+export interface BrowserCandidate {
+  source: BrowserCandidateSource;
+  /** e.g. "chrome", "chromium", "chromium_headless_shell", "edge". */
+  kind: string;
+  executablePath: string;
+  /** Cache revision/build string, when applicable. */
+  revision?: string;
+}
+
+export interface DetectRoots {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  playwrightCacheDir?: string;
+  puppeteerCacheDir?: string;
+  /** Injectable for tests: overrides the fixed system-install paths. */
+  systemCandidates?: readonly { kind: string; path: string }[];
+  /** Injectable for tests: replaces fs.existsSync. */
+  exists?: (path: string) => boolean;
+  /** Injectable for tests: replaces fs.readdirSync. */
+  readdir?: (path: string) => string[];
+}
+
+export interface DetectResult {
+  /** Explicit --browser / UPLOADS_CHROME_PATH / CHROME_PATH override, if any. */
+  envOverride?: string;
+  candidates: BrowserCandidate[];
+  /** Best candidate by the documented ranking, or undefined if none found. */
+  winner?: BrowserCandidate;
+}
+
+function defaultPlaywrightCacheDir(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  if (env.PLAYWRIGHT_BROWSERS_PATH) return env.PLAYWRIGHT_BROWSERS_PATH;
+  if (platform === "darwin") return join(homedir(), "Library", "Caches", "ms-playwright");
+  if (platform === "win32") return join(homedir(), "AppData", "Local", "ms-playwright");
+  return join(homedir(), ".cache", "ms-playwright");
+}
+
+function defaultPuppeteerCacheDir(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  if (env.PUPPETEER_CACHE_DIR) return env.PUPPETEER_CACHE_DIR;
+  if (platform === "win32") return join(homedir(), "AppData", "Local", "puppeteer", "cache");
+  return join(homedir(), ".cache", "puppeteer");
+}
+
+function defaultSystemCandidates(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): { kind: string; path: string }[] {
+  if (platform === "darwin") {
+    return [
+      { kind: "chrome", path: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" },
+      { kind: "edge", path: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" },
+      { kind: "chromium", path: "/Applications/Chromium.app/Contents/MacOS/Chromium" },
+      { kind: "brave", path: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser" },
+    ];
+  }
+  if (platform === "linux") {
+    return [
+      { kind: "chrome", path: "/usr/bin/google-chrome" },
+      { kind: "chrome", path: "/usr/bin/google-chrome-stable" },
+      { kind: "chromium", path: "/usr/bin/chromium-browser" },
+      { kind: "chromium", path: "/usr/bin/chromium" },
+      { kind: "edge", path: "/usr/bin/microsoft-edge" },
+    ];
+  }
+  if (platform === "win32") {
+    const pf = env.PROGRAMFILES ?? "C:\\Program Files";
+    const pf86 = env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)";
+    return [
+      { kind: "chrome", path: join(pf, "Google", "Chrome", "Application", "chrome.exe") },
+      { kind: "chrome", path: join(pf86, "Google", "Chrome", "Application", "chrome.exe") },
+      { kind: "edge", path: join(pf, "Microsoft", "Edge", "Application", "msedge.exe") },
+      { kind: "edge", path: join(pf86, "Microsoft", "Edge", "Application", "msedge.exe") },
+    ];
+  }
+  return [];
+}
+
+/** Executable subpath inside a Playwright chromium/chromium_headless_shell revision dir. */
+function playwrightExecutable(
+  revisionDir: string,
+  kind: "chromium" | "chromium_headless_shell",
+  platform: NodeJS.Platform,
+  exists: (p: string) => boolean,
+): string | undefined {
+  const layouts: string[] =
+    kind === "chromium"
+      ? platform === "darwin"
+        ? [
+            join(
+              revisionDir,
+              "chrome-mac-arm64",
+              "Google Chrome for Testing.app",
+              "Contents",
+              "MacOS",
+              "Google Chrome for Testing",
+            ),
+            join(revisionDir, "chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium"),
+          ]
+        : platform === "linux"
+          ? [join(revisionDir, "chrome-linux", "chrome")]
+          : platform === "win32"
+            ? [join(revisionDir, "chrome-win", "chrome.exe")]
+            : []
+      : platform === "darwin"
+        ? [join(revisionDir, "chrome-headless-shell-mac-arm64", "chrome-headless-shell")]
+        : platform === "linux"
+          ? [join(revisionDir, "chrome-headless-shell-linux", "chrome-headless-shell")]
+          : platform === "win32"
+            ? [join(revisionDir, "chrome-headless-shell-win", "chrome-headless-shell.exe")]
+            : [];
+  return layouts.find((p) => exists(p));
+}
+
+function scanPlaywrightCache(
+  dir: string,
+  platform: NodeJS.Platform,
+  exists: (p: string) => boolean,
+  readdir: (p: string) => string[],
+): BrowserCandidate[] {
+  if (!exists(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdir(dir);
+  } catch {
+    return [];
+  }
+  const out: BrowserCandidate[] = [];
+  for (const kind of ["chromium", "chromium_headless_shell"] as const) {
+    const matches = entries
+      .filter((e) => e.startsWith(`${kind}-`))
+      .map((e) => ({ name: e, rev: Number.parseInt(e.slice(kind.length + 1), 10) || 0 }))
+      .toSorted((a, b) => b.rev - a.rev); // newest revision first
+    for (const m of matches) {
+      const exe = playwrightExecutable(join(dir, m.name), kind, platform, exists);
+      if (exe)
+        out.push({
+          source: "playwright-cache",
+          kind,
+          executablePath: exe,
+          revision: String(m.rev),
+        });
+    }
+  }
+  return out;
+}
+
+function puppeteerExecutable(
+  buildDir: string,
+  kind: "chrome" | "chrome-headless-shell",
+  platform: NodeJS.Platform,
+  exists: (p: string) => boolean,
+): string | undefined {
+  let sub: string;
+  if (platform === "darwin")
+    sub = kind === "chrome" ? "chrome-mac-arm64" : "chrome-headless-shell-mac-arm64";
+  else if (platform === "win32")
+    sub = kind === "chrome" ? "chrome-win64" : "chrome-headless-shell-win64";
+  else sub = kind === "chrome" ? "chrome-linux64" : "chrome-headless-shell-linux64";
+
+  let exe: string;
+  if (kind === "chrome") {
+    exe =
+      platform === "darwin"
+        ? join(
+            buildDir,
+            sub,
+            "Google Chrome for Testing.app",
+            "Contents",
+            "MacOS",
+            "Google Chrome for Testing",
+          )
+        : platform === "win32"
+          ? join(buildDir, sub, "chrome.exe")
+          : join(buildDir, sub, "chrome");
+  } else {
+    exe = join(
+      buildDir,
+      sub,
+      platform === "win32" ? "chrome-headless-shell.exe" : "chrome-headless-shell",
+    );
+  }
+  return exists(exe) ? exe : undefined;
+}
+
+function scanPuppeteerCache(
+  dir: string,
+  platform: NodeJS.Platform,
+  exists: (p: string) => boolean,
+  readdir: (p: string) => string[],
+): BrowserCandidate[] {
+  const out: BrowserCandidate[] = [];
+  for (const kind of ["chrome", "chrome-headless-shell"] as const) {
+    const kindDir = join(dir, kind);
+    if (!exists(kindDir)) continue;
+    let builds: string[];
+    try {
+      builds = readdir(kindDir);
+    } catch {
+      continue;
+    }
+    builds = builds
+      .filter((b) => exists(join(kindDir, b)))
+      .sort((a, b) => {
+        const va = (a.match(/[\d.]+$/) ?? ["0"])[0]!;
+        const vb = (b.match(/[\d.]+$/) ?? ["0"])[0]!;
+        return vb.localeCompare(va, undefined, { numeric: true });
+      });
+    for (const b of builds) {
+      const exe = puppeteerExecutable(join(kindDir, b), kind, platform, exists);
+      if (exe) out.push({ source: "puppeteer-cache", kind, executablePath: exe, revision: b });
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan for a usable local Chromium-family executable. Pure fs/env — never
+ * launches a browser. Roots are injectable so tests can fake a cache layout.
+ */
+export function detectLocalBrowser(roots: DetectRoots = {}): DetectResult {
+  const platform = roots.platform ?? process.platform;
+  const env = roots.env ?? process.env;
+  const exists = roots.exists ?? existsSync;
+  const readdir = roots.readdir ?? ((p: string) => readdirSync(p) as string[]);
+
+  const envOverride = env.UPLOADS_CHROME_PATH || env.CHROME_PATH || undefined;
+  const candidates: BrowserCandidate[] = [];
+  if (envOverride && exists(envOverride)) {
+    candidates.push({ source: "env", kind: "env-override", executablePath: envOverride });
+  }
+
+  const systemCandidates = roots.systemCandidates ?? defaultSystemCandidates(platform, env);
+  for (const c of systemCandidates) {
+    if (exists(c.path)) candidates.push({ source: "system", kind: c.kind, executablePath: c.path });
+  }
+
+  candidates.push(
+    ...scanPlaywrightCache(
+      roots.playwrightCacheDir ?? defaultPlaywrightCacheDir(env, platform),
+      platform,
+      exists,
+      readdir,
+    ),
+  );
+  candidates.push(
+    ...scanPuppeteerCache(
+      roots.puppeteerCacheDir ?? defaultPuppeteerCacheDir(env, platform),
+      platform,
+      exists,
+      readdir,
+    ),
+  );
+
+  // Ranking: env override > system Chrome (channel:'chrome' launch target,
+  // preferred default) > playwright cache chromium > puppeteer cache chrome >
+  // any other system browser > headless-shell builds last (see brief).
+  const rank = (c: BrowserCandidate): number => {
+    if (c.source === "env") return 0;
+    if (c.source === "system" && c.kind === "chrome") return 1;
+    if (c.source === "playwright-cache" && c.kind === "chromium") return 2;
+    if (c.source === "puppeteer-cache" && c.kind === "chrome") return 3;
+    if (c.source === "system") return 4;
+    if (c.source === "playwright-cache" && c.kind === "chromium_headless_shell") return 5;
+    if (c.source === "puppeteer-cache" && c.kind === "chrome-headless-shell") return 6;
+    return 9;
+  };
+  const winner = [...candidates].toSorted((a, b) => rank(a) - rank(b))[0];
+  return { envOverride, candidates, winner };
+}
+
+export interface LocalCaptureOptions {
+  /** URL to navigate to, or a `file://` URL for local .html targets. */
+  url: string;
+  /** Explicit browser executable (--browser / UPLOADS_CHROME_PATH / CHROME_PATH). */
+  browserPath?: string;
+  /** Attach to a running Chrome instead of launching one. */
+  cdp?: string;
+  viewport: { width: number; height: number; deviceScaleFactor: number };
+  selector?: string;
+  fullPage?: boolean;
+  colorScheme?: "dark" | "light";
+  /** "load" | "domcontentloaded" | "networkidle", or a millisecond settle delay. */
+  waitUntil: "load" | "domcontentloaded" | "networkidle" | number;
+  timeoutMs?: number;
+  detectRoots?: DetectRoots;
+  /**
+   * Pre-computed detection result from a caller that already scanned the
+   * filesystem (e.g. `auto`-routing's probe) — avoids re-running
+   * `detectLocalBrowser` a second time for the same capture.
+   */
+  detectResult?: DetectResult;
+}
+
+type PlaywrightCoreModule = typeof import("playwright-core");
+
+async function loadPlaywrightCore(): Promise<PlaywrightCoreModule> {
+  try {
+    // Dynamic import only — never hoist this to a static `import` statement.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    return (await import("playwright-core")) as PlaywrightCoreModule;
+  } catch (err) {
+    throw new UploadsError(
+      `no local browser runtime available (playwright-core failed to load: ${
+        err instanceof Error ? err.message : String(err)
+      })`,
+      "BROWSER_NOT_FOUND",
+    );
+  }
+}
+
+/** Launch a browser per the documented detection order. Never throws BROWSER_NOT_FOUND for a bad candidate — falls through to the next. */
+async function launchLocalBrowser(
+  chromium: PlaywrightCoreModule["chromium"],
+  opts: LocalCaptureOptions,
+): Promise<import("playwright-core").Browser> {
+  if (opts.browserPath) {
+    return chromium.launch({ executablePath: opts.browserPath, headless: true });
+  }
+
+  const detected = opts.detectResult ?? detectLocalBrowser(opts.detectRoots);
+  if (detected.envOverride) {
+    try {
+      return await chromium.launch({ executablePath: detected.envOverride, headless: true });
+    } catch {
+      // fall through
+    }
+  }
+
+  // Preferred default: let playwright-core resolve system Chrome itself.
+  try {
+    return await chromium.launch({ channel: "chrome", headless: true });
+  } catch {
+    // fall through
+  }
+  try {
+    return await chromium.launch({ channel: "msedge", headless: true });
+  } catch {
+    // fall through
+  }
+
+  for (const candidate of detected.candidates) {
+    if (candidate.source === "env") continue; // already tried above
+    try {
+      return await chromium.launch({ executablePath: candidate.executablePath, headless: true });
+    } catch {
+      // try the next candidate
+    }
+  }
+
+  throw new UploadsError(
+    "no local browser found — install Chrome, or run `npx playwright install chromium`",
+    "BROWSER_NOT_FOUND",
+  );
+}
+
+/** Capture a PNG screenshot using a local (already-installed) browser. */
+export async function captureLocal(opts: LocalCaptureOptions): Promise<Uint8Array> {
+  const { chromium } = await loadPlaywrightCore();
+
+  let browser: import("playwright-core").Browser;
+  let usingCdp = false;
+  if (opts.cdp) {
+    try {
+      browser = await chromium.connectOverCDP(opts.cdp);
+      usingCdp = true;
+    } catch (err) {
+      throw new UploadsError(
+        `could not connect to CDP endpoint ${opts.cdp}: ${err instanceof Error ? err.message : String(err)}`,
+        "BROWSER_NOT_FOUND",
+      );
+    }
+  } else {
+    try {
+      browser = await launchLocalBrowser(chromium, opts);
+    } catch (err) {
+      if (err instanceof UploadsError) throw err;
+      throw new UploadsError(
+        `could not launch a local browser: ${err instanceof Error ? err.message : String(err)}`,
+        "BROWSER_NOT_FOUND",
+      );
+    }
+  }
+
+  try {
+    // deviceScaleFactor cannot be set on an existing CDP context — the Chrome
+    // process itself must have been launched with --force-device-scale-factor.
+    const context = usingCdp
+      ? (browser.contexts()[0] ?? (await browser.newContext()))
+      : await browser.newContext({
+          viewport: { width: opts.viewport.width, height: opts.viewport.height },
+          deviceScaleFactor: opts.viewport.deviceScaleFactor,
+          colorScheme: opts.colorScheme,
+        });
+    const page = usingCdp
+      ? await context.newPage()
+      : (context.pages()[0] ?? (await context.newPage()));
+    if (usingCdp) {
+      await page.setViewportSize({ width: opts.viewport.width, height: opts.viewport.height });
+      if (opts.colorScheme) await page.emulateMedia({ colorScheme: opts.colorScheme });
+    }
+
+    const waitUntil = typeof opts.waitUntil === "string" ? opts.waitUntil : "load";
+    await page.goto(opts.url, { waitUntil, timeout: opts.timeoutMs ?? 30_000 });
+    if (typeof opts.waitUntil === "number") await page.waitForTimeout(opts.waitUntil);
+
+    const png = opts.selector
+      ? await page.locator(opts.selector).screenshot({ timeout: opts.timeoutMs ?? 30_000 })
+      : await page.screenshot({ fullPage: opts.fullPage === true });
+    // Buffer extends Uint8Array — return it as-is rather than copying.
+    return png;
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/uploads/src/screenshot-remote.ts
+++ b/packages/uploads/src/screenshot-remote.ts
@@ -1,0 +1,101 @@
+/**
+ * Remote screenshot backend — POSTs to the workspace-authed render endpoint
+ * and gets raw PNG bytes back. No local browser required. Network-only; safe
+ * to import statically anywhere (no native/optional deps).
+ */
+import { parseErrorEnvelope } from "./client.js";
+import { UploadsError } from "./errors.js";
+
+const POST_TIMEOUT_MS = 30_000;
+/** Matches the brief's remote-backend cap for inline HTML bodies. */
+export const MAX_REMOTE_HTML_BYTES = 2 * 1024 * 1024;
+
+export interface RemoteRenderRequest {
+  url?: string;
+  html?: string;
+  viewport: { width: number; height: number; deviceScaleFactor: number };
+  selector?: string;
+  fullPage?: boolean;
+  colorScheme?: "dark" | "light";
+  waitUntil?: "load" | "domcontentloaded" | "networkidle" | number;
+}
+
+export interface RemoteRenderOptions {
+  apiUrl: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+/**
+ * Maps the render endpoint's error codes onto CLI error codes. Mirrors
+ * client.ts's mapApiError conventions: `render_failed` -> RENDER_FAILED;
+ * render-budget denials arrive as the EXISTING `upload_budget_exceeded` code
+ * (renders draw from the monthly upload budget — no separate RENDER_BUDGET
+ * code), so they fall into the shared UPLOAD_BUDGET mapping/hints. The
+ * server's burst limiter reports `rate_limited` explicitly; a bare 429 with
+ * no body code is also treated as a throttle (more likely than a budget
+ * denial), both mapping to RATE_LIMITED — checked before the generic 429
+ * fallback so an explicit `upload_budget_exceeded` on a 429 still wins.
+ */
+function mapRenderError(status: number, message: string, code?: string): UploadsError {
+  if (status === 401 || code === "unauthorized")
+    return new UploadsError(message, "UNAUTHORIZED", status);
+  if (code === "upload_budget_exceeded") return new UploadsError(message, "UPLOAD_BUDGET", status);
+  if (code === "render_failed") return new UploadsError(message, "RENDER_FAILED", status);
+  if (code === "rate_limited") return new UploadsError(message, "RATE_LIMITED", status);
+  if (status === 429) return new UploadsError(message, "RATE_LIMITED", status);
+  return new UploadsError(message, "API_ERROR", status);
+}
+
+/** POST the render request; resolves with raw PNG bytes on 200. */
+export async function captureRemote(
+  body: RemoteRenderRequest,
+  opts: RemoteRenderOptions,
+): Promise<Uint8Array> {
+  if (body.html !== undefined) {
+    const htmlBytes = new TextEncoder().encode(body.html).byteLength;
+    if (htmlBytes > MAX_REMOTE_HTML_BYTES) {
+      throw new UploadsError(
+        `html body exceeds the remote backend's ${MAX_REMOTE_HTML_BYTES} byte limit (use --via local instead)`,
+        "USAGE",
+      );
+    }
+  }
+
+  const base = opts.apiUrl.replace(/\/$/, "");
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? POST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetchImpl(`${base}/v1/render`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${opts.token}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "network request failed";
+    throw new UploadsError(
+      message.includes("abort") ? "render request timed out" : message,
+      "NETWORK",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    const { message, code } = await parseErrorEnvelope(res, "render failed");
+    throw mapRenderError(res.status, message, code);
+  }
+
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  if (bytes.byteLength === 0) {
+    throw new UploadsError("render endpoint returned an empty response", "RENDER_FAILED");
+  }
+  return bytes;
+}

--- a/packages/uploads/src/screenshot-remote.ts
+++ b/packages/uploads/src/screenshot-remote.ts
@@ -67,9 +67,11 @@ export async function captureRemote(
   const fetchImpl = opts.fetchImpl ?? fetch;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? POST_TIMEOUT_MS);
-  let res: Response;
+  // The body reads stay inside the abort-guarded scope: the timer must cover
+  // the full response (a server stalling mid-stream would otherwise hang
+  // res.arrayBuffer() forever once the headers had arrived).
   try {
-    res = await fetchImpl(`${base}/v1/render`, {
+    const res = await fetchImpl(`${base}/v1/render`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -78,7 +80,19 @@ export async function captureRemote(
       body: JSON.stringify(body),
       signal: controller.signal,
     });
+
+    if (!res.ok) {
+      const { message, code } = await parseErrorEnvelope(res, "render failed");
+      throw mapRenderError(res.status, message, code);
+    }
+
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength === 0) {
+      throw new UploadsError("render endpoint returned an empty response", "RENDER_FAILED");
+    }
+    return bytes;
   } catch (err) {
+    if (err instanceof UploadsError) throw err;
     const message = err instanceof Error ? err.message : "network request failed";
     throw new UploadsError(
       message.includes("abort") ? "render request timed out" : message,
@@ -87,15 +101,4 @@ export async function captureRemote(
   } finally {
     clearTimeout(timer);
   }
-
-  if (!res.ok) {
-    const { message, code } = await parseErrorEnvelope(res, "render failed");
-    throw mapRenderError(res.status, message, code);
-  }
-
-  const bytes = new Uint8Array(await res.arrayBuffer());
-  if (bytes.byteLength === 0) {
-    throw new UploadsError("render endpoint returned an empty response", "RENDER_FAILED");
-  }
-  return bytes;
 }

--- a/packages/uploads/src/screenshot.ts
+++ b/packages/uploads/src/screenshot.ts
@@ -1,0 +1,321 @@
+/**
+ * Shared screenshot capture core: target classification, backend selection,
+ * and dispatch to the local (playwright-core, dynamic import) or remote
+ * (render endpoint) backend. Used by both the CLI command and the MCP tool.
+ *
+ * Deliberately NOT re-exported from index.ts/agent.ts — this module is safe
+ * to import statically (it never touches playwright-core itself), but
+ * keeping it out of the public entry points keeps the Worker-bundle
+ * constraint obvious and easy to audit with a grep.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+import { UploadsError } from "./errors.js";
+import { captureRemote, MAX_REMOTE_HTML_BYTES } from "./screenshot-remote.js";
+import type { DetectRoots } from "./screenshot-local.js";
+
+export type ScreenshotBackend = "auto" | "local" | "remote";
+export type WaitUntil = "load" | "domcontentloaded" | "networkidle" | number;
+
+export interface ScreenshotViewport {
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+}
+
+export const DEFAULT_SCREENSHOT_VIEWPORT: ScreenshotViewport = {
+  width: 1280,
+  height: 800,
+  deviceScaleFactor: 2,
+};
+
+/** Parses `WIDTHxHEIGHT[@SCALEx]`, e.g. "1280x800", "1280x800@2x", "1280x800@2". */
+export function parseViewport(raw: string | undefined): ScreenshotViewport {
+  if (!raw) return DEFAULT_SCREENSHOT_VIEWPORT;
+  const match = /^(\d+)x(\d+)(?:@(\d+(?:\.\d+)?)x?)?$/.exec(raw.trim());
+  if (!match) {
+    throw new UploadsError(
+      `invalid viewport: ${raw} (expected WIDTHxHEIGHT[@SCALEx], e.g. 1280x800@2x)`,
+      "USAGE",
+    );
+  }
+  const width = Number.parseInt(match[1]!, 10);
+  const height = Number.parseInt(match[2]!, 10);
+  const deviceScaleFactor = match[3] ? Number.parseFloat(match[3]) : 1;
+  if (width <= 0 || height <= 0 || deviceScaleFactor <= 0) {
+    throw new UploadsError(`invalid viewport: ${raw} (values must be positive)`, "USAGE");
+  }
+  return { width, height, deviceScaleFactor };
+}
+
+/** Parses `--wait`: "load" | "domcontentloaded" | "networkidle" | a millisecond count. */
+export function parseWaitUntil(raw: string | undefined): WaitUntil {
+  if (!raw) return "load";
+  if (raw === "load" || raw === "domcontentloaded" || raw === "networkidle") return raw;
+  if (/^\d+$/.test(raw)) return Number.parseInt(raw, 10);
+  throw new UploadsError(
+    `invalid wait strategy: ${raw} (use load, domcontentloaded, networkidle, or a millisecond count)`,
+    "USAGE",
+  );
+}
+
+export type ScreenshotTarget =
+  | { kind: "url"; url: string; localOnly: boolean }
+  | { kind: "html-file"; path: string; html: string };
+
+/** IPv4 loopback/private/link-local ranges. Mirrors the server's isPrivateRenderTarget. */
+const PRIVATE_IPV4_RE =
+  /^(127\.\d+\.\d+\.\d+|0\.0\.0\.0|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|169\.254\.\d+\.\d+)$/;
+
+/** Hostname forms treated as local/private regardless of DNS resolution. */
+const PRIVATE_HOSTNAME_RE = /^((.+\.)?localhost|.+\.local|.+\.internal)$/i;
+
+/** IPv6 unique local addresses, fc00::/7 (RFC 4193). */
+const IPV6_ULA_RE = /^f[cd][0-9a-f]{2}:/i;
+
+/** IPv6 link-local addresses, fe80::/10. */
+const IPV6_LINK_LOCAL_RE = /^fe[89ab][0-9a-f]:/i;
+
+function isPrivateIPv4(host: string): boolean {
+  return PRIVATE_IPV4_RE.test(host);
+}
+
+/**
+ * True for localhost / private-network / link-local hosts — only reachable
+ * by the local backend. Accepts a bare hostname or an IPv6 literal with its
+ * brackets still attached (as returned by `new URL(...).hostname`, e.g.
+ * `"[::1]"`). Mirrors the server's `isPrivateRenderTarget` so `--via remote`
+ * fails fast for the same targets the render endpoint itself would reject.
+ */
+export function isPrivateOrLocalHost(hostname: string): boolean {
+  const host = /^\[.+\]$/.test(hostname) ? hostname.slice(1, -1) : hostname;
+
+  if (isPrivateIPv4(host)) return true;
+  if (PRIVATE_HOSTNAME_RE.test(host)) return true;
+  if (host === "::1" || host === "::") return true;
+  if (IPV6_ULA_RE.test(host)) return true;
+  if (IPV6_LINK_LOCAL_RE.test(host)) return true;
+
+  // IPv4-mapped IPv6, e.g. "::ffff:10.0.0.1" or "::ffff:a00:1" — private iff
+  // the mapped IPv4 quad is private.
+  const mapped = /^::ffff:(.+)$/i.exec(host);
+  if (mapped) {
+    const rest = mapped[1]!;
+    if (isPrivateIPv4(rest)) return true;
+    const hex = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(rest);
+    if (hex) {
+      const hi = Number.parseInt(hex[1]!, 16);
+      const lo = Number.parseInt(hex[2]!, 16);
+      const a = (hi >> 8) & 0xff;
+      const b = hi & 0xff;
+      const c = (lo >> 8) & 0xff;
+      const d = lo & 0xff;
+      if (isPrivateIPv4(`${a}.${b}.${c}.${d}`)) return true;
+    }
+  }
+
+  return false;
+}
+
+/** Classifies a CLI target: http(s) URL, or a path to a local .html file. */
+export function classifyTarget(target: string): ScreenshotTarget {
+  if (/^https?:\/\//i.test(target)) {
+    let hostname: string;
+    try {
+      hostname = new URL(target).hostname;
+    } catch {
+      throw new UploadsError(`invalid target URL: ${target}`, "USAGE");
+    }
+    return { kind: "url", url: target, localOnly: isPrivateOrLocalHost(hostname) };
+  }
+
+  const abs = resolvePath(target);
+  if (!existsSync(abs)) {
+    throw new UploadsError(
+      `target not found: ${target} (expected a URL or an .html file)`,
+      "USAGE",
+    );
+  }
+  if (!statSync(abs).isFile() || !/\.html?$/i.test(abs)) {
+    throw new UploadsError(
+      `target must be an http(s) URL or an .html file (got ${target})`,
+      "USAGE",
+    );
+  }
+  return { kind: "html-file", path: abs, html: readFileSync(abs, "utf8") };
+}
+
+export interface CaptureScreenshotOptions {
+  target: string;
+  via: ScreenshotBackend;
+  browserPath?: string;
+  cdp?: string;
+  viewport?: ScreenshotViewport;
+  selector?: string;
+  fullPage?: boolean;
+  colorScheme?: "dark" | "light";
+  waitUntil?: WaitUntil;
+  apiUrl: string;
+  token: string;
+  /** Injectable for tests; forwarded to detectLocalBrowser. */
+  detectRoots?: DetectRoots;
+  /** Injectable for tests: replaces the local capture implementation. */
+  captureLocalImpl?: (opts: {
+    url: string;
+    browserPath?: string;
+    cdp?: string;
+    viewport: ScreenshotViewport;
+    selector?: string;
+    fullPage?: boolean;
+    colorScheme?: "dark" | "light";
+    waitUntil: WaitUntil;
+    detectRoots?: DetectRoots;
+    /** Pre-computed detection result from auto-routing, to avoid a second fs scan. */
+    detectResult?: import("./screenshot-local.js").DetectResult;
+  }) => Promise<Uint8Array>;
+  /** Injectable for tests: replaces the remote capture implementation. */
+  captureRemoteImpl?: typeof captureRemote;
+}
+
+export interface CaptureScreenshotResult {
+  png: Uint8Array;
+  filename: string;
+  backend: "local" | "remote";
+}
+
+/** Derives a filename from a URL (host+path) or the source .html filename. */
+function deriveFilename(target: ScreenshotTarget): string {
+  if (target.kind === "html-file") {
+    const stem = basename(target.path).replace(/\.html?$/i, "");
+    return `${stem || "screenshot"}.png`;
+  }
+  const url = new URL(target.url);
+  const pathPart = url.pathname
+    .replace(/\/+$/, "")
+    .replace(/^\/+/, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-");
+  const stem = [url.hostname, pathPart].filter(Boolean).join("-");
+  return `${stem || "screenshot"}.png`;
+}
+
+/**
+ * Best-effort local-browser probe used only to decide `auto` routing. Never
+ * throws — any failure (e.g. optional playwright-core not installed) means
+ * "no local browser available". Returns the full detection result (not just
+ * a boolean) so callers that go on to launch locally can reuse it instead of
+ * re-scanning the filesystem a second time.
+ */
+async function probeLocalBrowser(
+  detectRoots: DetectRoots | undefined,
+): Promise<import("./screenshot-local.js").DetectResult | undefined> {
+  try {
+    const { detectLocalBrowser } = await import("./screenshot-local.js");
+    return detectLocalBrowser(detectRoots);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve target + options into PNG bytes via the local or remote backend.
+ * Shared by the CLI `screenshot` command and the MCP `screenshot` tool.
+ */
+export async function captureScreenshot(
+  opts: CaptureScreenshotOptions,
+): Promise<CaptureScreenshotResult> {
+  const target = classifyTarget(opts.target);
+  const viewport = opts.viewport ?? DEFAULT_SCREENSHOT_VIEWPORT;
+  const waitUntil = opts.waitUntil ?? "load";
+  const filename = deriveFilename(target);
+
+  const localOnly = target.kind === "html-file" || target.localOnly;
+
+  // Populated only when auto-routing actually probes the filesystem, so it
+  // can be threaded into captureLocalImpl below to avoid a second scan.
+  let detected: import("./screenshot-local.js").DetectResult | undefined;
+
+  let backend: "local" | "remote";
+  if (opts.via === "local") {
+    backend = "local";
+  } else if (opts.via === "remote") {
+    if (localOnly) {
+      throw new UploadsError(
+        `${opts.target} is only reachable by the local backend (localhost/private network, or a local file) — use --via local`,
+        "USAGE",
+      );
+    }
+    backend = "remote";
+  } else {
+    // auto
+    detected = await probeLocalBrowser(opts.detectRoots);
+    const available = Boolean(detected?.winner);
+    if (localOnly) {
+      if (!available) {
+        throw new UploadsError(
+          `${opts.target} is only reachable by the local backend, but no local browser was found — install Chrome or run \`npx playwright install chromium\``,
+          "BROWSER_NOT_FOUND",
+        );
+      }
+      backend = "local";
+    } else {
+      backend = available ? "local" : "remote";
+    }
+  }
+
+  // Numeric --wait is a fixed post-load settle delay the local Playwright
+  // page can honor directly; the remote render endpoint only understands the
+  // named strategies, so fail fast instead of silently ignoring the delay.
+  if (backend === "remote" && typeof waitUntil === "number") {
+    throw new UploadsError(
+      `numeric --wait (${waitUntil}ms) is local-only — use --via local, or one of load/domcontentloaded/networkidle for the remote backend`,
+      "USAGE",
+    );
+  }
+
+  if (backend === "local") {
+    const captureLocalImpl =
+      opts.captureLocalImpl ??
+      (async (localOpts) => {
+        const { captureLocal } = await import("./screenshot-local.js");
+        return captureLocal(localOpts);
+      });
+    const png = await captureLocalImpl({
+      url: target.kind === "html-file" ? pathToFileURL(target.path).href : target.url,
+      browserPath: opts.browserPath,
+      cdp: opts.cdp,
+      viewport,
+      selector: opts.selector,
+      fullPage: opts.fullPage,
+      colorScheme: opts.colorScheme,
+      waitUntil,
+      detectRoots: opts.detectRoots,
+      detectResult: detected,
+    });
+    return { png, filename, backend };
+  }
+
+  if (target.kind === "html-file") {
+    const bytes = new TextEncoder().encode(target.html).byteLength;
+    if (bytes > MAX_REMOTE_HTML_BYTES) {
+      throw new UploadsError(
+        `${opts.target} is ${bytes} bytes, over the remote backend's ${MAX_REMOTE_HTML_BYTES} byte limit — use --via local`,
+        "USAGE",
+      );
+    }
+  }
+
+  const captureRemoteImpl = opts.captureRemoteImpl ?? captureRemote;
+  const png = await captureRemoteImpl(
+    {
+      ...(target.kind === "html-file" ? { html: target.html } : { url: target.url }),
+      viewport,
+      selector: opts.selector,
+      fullPage: opts.fullPage,
+      colorScheme: opts.colorScheme,
+      waitUntil,
+    },
+    { apiUrl: opts.apiUrl, token: opts.token },
+  );
+  return { png, filename, backend };
+}

--- a/packages/uploads/src/screenshot.ts
+++ b/packages/uploads/src/screenshot.ts
@@ -229,7 +229,10 @@ export async function captureScreenshot(
   const waitUntil = opts.waitUntil ?? "load";
   const filename = deriveFilename(target);
 
-  const localOnly = target.kind === "html-file" || target.localOnly;
+  // Only private-network URLs are truly unreachable remotely; an .html file
+  // is sent to the remote backend as an inline `html` body (though anything
+  // it references via file:// or relative paths won't resolve there).
+  const localOnly = target.kind === "url" && target.localOnly;
 
   // Populated only when auto-routing actually probes the filesystem, so it
   // can be threaded into captureLocalImpl below to avoid a second scan.

--- a/packages/uploads/test/cli-completion.test.ts
+++ b/packages/uploads/test/cli-completion.test.ts
@@ -24,7 +24,7 @@ describe("generateCompletionScript", () => {
   it("bash script registers complete -F and lists root commands", () => {
     const script = generateCompletionScript("bash");
     expect(script).toMatch(/complete -o default -F _uploads uploads/);
-    expect(script).toMatch(/local -a root_cmds=\(attach put gallery/);
+    expect(script).toMatch(/local -a root_cmds=\(attach put screenshot gallery/);
     for (const cmd of ROOT_COMMANDS) {
       expect(script).toContain(cmd.name);
     }
@@ -47,6 +47,25 @@ describe("generateCompletionScript", () => {
       /complete -c uploads -n '__fish_seen_subcommand_from gallery' -a 'create'/,
     );
     expect(script).toMatch(/__fish_seen_subcommand_from put attach/);
+  });
+
+  it("screenshot completions use their own explicit flag list, not put's --name/--no-comment", () => {
+    const bash = generateCompletionScript("bash");
+    const screenshotVarMatch = /local -a screenshot_flags=\(([^)]*)\)/.exec(bash);
+    expect(screenshotVarMatch).not.toBeNull();
+    const screenshotFlags = screenshotVarMatch![1]!.split(" ");
+    expect(screenshotFlags).toContain("--key");
+    expect(screenshotFlags).toContain("--via");
+    expect(screenshotFlags).not.toContain("--name");
+    expect(screenshotFlags).not.toContain("--no-comment");
+
+    const fish = generateCompletionScript("fish");
+    expect(fish).toMatch(/complete -c uploads -n '__fish_seen_subcommand_from screenshot' -l key/);
+    expect(fish).not.toMatch(
+      /complete -c uploads -n '__fish_seen_subcommand_from screenshot' -l name/,
+    );
+    // put/attach still get their own flags, without screenshot in that group.
+    expect(fish).toMatch(/__fish_seen_subcommand_from put attach' -l name/);
   });
 });
 

--- a/packages/uploads/test/commands-doctor.test.ts
+++ b/packages/uploads/test/commands-doctor.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { UploadsClient } from "../src/client.js";
+import { buildDoctorReport } from "../src/commands.js";
+import type { ResolvedConfig } from "../src/config.js";
+
+function fakeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    apiUrl: "https://x.test",
+    workspace: "test",
+    token: "up_test_x",
+    workspaceSource: "override",
+    configPath: "/tmp/uploads-test-config",
+    configExists: false,
+    ...overrides,
+  };
+}
+
+function fakeClient(): UploadsClient {
+  return {
+    list: async () => ({ items: [], cursor: null }),
+    health: async () => ({ ok: true }),
+    usage: async () => ({ bytes: 0, objects: 0, uploadsInPeriod: 0 }),
+  } as unknown as UploadsClient;
+}
+
+describe("buildDoctorReport browser section", () => {
+  it("reports a browser section (fs scans only — never launches a browser)", async () => {
+    const report = await buildDoctorReport(fakeConfig(), fakeClient());
+    expect(report.browser).toBeDefined();
+    // On Node (which is what runs vitest), detection is supported even if no
+    // browser happens to be installed on the CI/dev machine.
+    expect(report.browser.supported).toBe(true);
+    expect(report.browser.autoBackend === "local" || report.browser.autoBackend === "remote").toBe(
+      true,
+    );
+    expect(Array.isArray(report.browser.candidates)).toBe(true);
+  });
+
+  it("prints the ranked winner, not the first candidate found in scan order", async () => {
+    // System browsers are scanned before the playwright cache, so a system
+    // Edge install would be candidates[0] — but a playwright-cache chromium
+    // outranks any non-Chrome system browser. Doctor must report the winner
+    // by rank, not by scan order.
+    const cacheDir = "/home/.cache/ms-playwright";
+    const edgePath = "/usr/bin/microsoft-edge";
+    const chromium = `${cacheDir}/chromium-1200/chrome-linux/chrome`;
+    const paths = new Set([edgePath, chromium]);
+    const exists = (p: string) => paths.has(p) || [...paths].some((f) => f.startsWith(`${p}/`));
+    const readdir = (dir: string): string[] => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      const names = new Set<string>();
+      for (const p of paths) {
+        if (!p.startsWith(prefix)) continue;
+        const first = p.slice(prefix.length).split("/")[0];
+        if (first) names.add(first);
+      }
+      return [...names];
+    };
+
+    const report = await buildDoctorReport(fakeConfig(), fakeClient(), {
+      platform: "linux",
+      env: {},
+      systemCandidates: [{ kind: "edge", path: edgePath }],
+      playwrightCacheDir: cacheDir,
+      puppeteerCacheDir: "/home/.cache/puppeteer",
+      exists,
+      readdir,
+    });
+
+    // Scan order puts the system Edge candidate first...
+    expect(report.browser.candidates[0]?.kind).toBe("edge");
+    // ...but the playwright-cache chromium outranks it and must win.
+    expect(report.browser.winner?.source).toBe("playwright-cache");
+    expect(report.browser.winner?.kind).toBe("chromium");
+    expect(report.browser.autoBackend).toBe("local");
+  });
+});

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -1,0 +1,278 @@
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { UsageError } from "../src/cli-args.js";
+import type { UploadsClient } from "../src/client.js";
+import type { CliContext } from "../src/commands.js";
+import { runScreenshot } from "../src/commands/screenshot.js";
+import type { CommandRunner } from "../src/github-gh.js";
+import type { CaptureScreenshotResult } from "../src/screenshot.js";
+
+/** Fake client capturing put() calls; other methods throw if reached. */
+function fakeClient() {
+  const puts: {
+    key?: string;
+    filename: string;
+    prefix?: string;
+    dryRun?: boolean;
+    body: Uint8Array;
+    metadata?: Record<string, string>;
+  }[] = [];
+  const client = {
+    put: async (
+      body: Uint8Array,
+      opts: {
+        filename: string;
+        key?: string;
+        prefix?: string;
+        dryRun?: boolean;
+        metadata?: Record<string, string>;
+      },
+    ) => {
+      puts.push({
+        key: opts.key,
+        filename: opts.filename,
+        prefix: opts.prefix,
+        dryRun: opts.dryRun,
+        body,
+        metadata: opts.metadata,
+      });
+      return {
+        workspace: "test",
+        key: opts.key ?? "screenshots/misc/generated.png",
+        url: `https://x.test/${opts.key ?? "screenshots/misc/generated.png"}`,
+        embedUrl: null,
+        size: body.byteLength,
+        contentType: "image/png",
+      };
+    },
+    list: async () => ({ items: [], cursor: null }),
+    health: async () => ({ ok: true }),
+  } as unknown as UploadsClient;
+  return { client, puts };
+}
+
+function ctxWith(client: UploadsClient, overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    config: {
+      apiUrl: "https://x.test",
+      workspace: "test",
+      token: "up_test_x",
+      workspaceSource: "override",
+      configPath: "/tmp/uploads-test-config",
+      configExists: false,
+    },
+    client,
+    json: false,
+    quiet: true,
+    ...overrides,
+  };
+}
+
+const noRun: CommandRunner = () => {
+  throw new Error("runner should not be called");
+};
+
+const png = new Uint8Array([137, 80, 78, 71]); // fake PNG magic-ish bytes
+
+function fakeCapture(
+  backend: "local" | "remote" = "remote",
+): (opts: unknown) => Promise<CaptureScreenshotResult> {
+  return async () => ({ png, filename: "example-com.png", backend });
+}
+
+describe("runScreenshot flag validation", () => {
+  it("--no-upload requires --out", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runScreenshot(
+        ctxWith(client),
+        ["https://example.com", "--no-upload"],
+        false,
+        noRun,
+        fakeCapture(),
+      ),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("rejects an invalid --via value", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runScreenshot(
+        ctxWith(client),
+        ["https://example.com", "--via", "carrier-pigeon"],
+        false,
+        noRun,
+        fakeCapture(),
+      ),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("rejects --dark combined with --light", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runScreenshot(
+        ctxWith(client),
+        ["https://example.com", "--dark", "--light"],
+        false,
+        noRun,
+        fakeCapture(),
+      ),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("rejects an invalid --viewport", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runScreenshot(
+        ctxWith(client),
+        ["https://example.com", "--viewport", "huge"],
+        false,
+        noRun,
+        fakeCapture(),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("rejects --dry-run combined with --no-upload", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const out = join(dir, "shot.png");
+    await expect(
+      runScreenshot(
+        ctxWith(client),
+        ["https://example.com", "--dry-run", "--no-upload", "--out", out],
+        false,
+        noRun,
+        fakeCapture(),
+      ),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("shows help without capturing or uploading", async () => {
+    const { client, puts } = fakeClient();
+    let captured = false;
+    const code = await runScreenshot(ctxWith(client), ["--help"], false, noRun, async () => {
+      captured = true;
+      return { png, filename: "x.png", backend: "remote" };
+    });
+    expect(code).toBe(0);
+    expect(captured).toBe(false);
+    expect(puts).toEqual([]);
+  });
+});
+
+describe("runScreenshot upload tail", () => {
+  it("captures and uploads, printing URL/EMBED/MARKDOWN", async () => {
+    const { client, puts } = fakeClient();
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      const code = await runScreenshot(
+        ctxWith(client),
+        ["https://example.com"],
+        false,
+        noRun,
+        fakeCapture("remote"),
+      );
+      expect(code).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(puts).toHaveLength(1);
+    expect(puts[0]?.filename).toBe("example-com.png");
+    // No --destination/--prefix given: prefix stays undefined here (buildScreenshotKey
+    // applies the "screenshots" default server-side, same as put's own default path).
+    expect(puts[0]?.prefix).toBeUndefined();
+    const out = chunks.join("");
+    expect(out).toContain("URL: https://x.test/");
+    expect(out).toContain("MARKDOWN:");
+  });
+
+  it("--dry-run captures but does not persist the object", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--dry-run"],
+      false,
+      noRun,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts).toHaveLength(1);
+    expect(puts[0]?.dryRun).toBe(true);
+  });
+
+  it("--out writes the PNG locally in addition to uploading", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const out = join(dir, "shot.png");
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--out", out],
+      false,
+      noRun,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out)).toEqual(Buffer.from(png));
+  });
+
+  it("--no-upload with --out skips hosting entirely", async () => {
+    const { client, puts } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const out = join(dir, "shot.png");
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--no-upload", "--out", out],
+      false,
+      noRun,
+      fakeCapture("local"),
+    );
+    expect(code).toBe(0);
+    expect(puts).toEqual([]);
+    expect(existsSync(out)).toBe(true);
+  });
+
+  it("--destination screenshots sets the key prefix", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--destination", "screenshots"],
+      false,
+      noRun,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts[0]?.prefix).toBe("screenshots");
+  });
+
+  it("writes JSON output with --format json", async () => {
+    const { client } = fakeClient();
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      const code = await runScreenshot(
+        ctxWith(client, { json: true }),
+        ["https://example.com"],
+        false,
+        noRun,
+        fakeCapture("local"),
+      );
+      expect(code).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    const payload = JSON.parse(chunks.join("")) as { url: string; backend: string };
+    expect(payload.backend).toBe("local");
+    expect(payload.url).toContain("https://x.test/");
+  });
+});

--- a/packages/uploads/test/config-screenshot-defaults.test.ts
+++ b/packages/uploads/test/config-screenshot-defaults.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveScreenshotDefaults } from "../src/config-file.js";
+
+describe("resolveScreenshotDefaults", () => {
+  const prev = process.env.UPLOADS_SCREENSHOT_VIA;
+  const prevBic = process.env.BUILDINTERNET_CONFIG;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.UPLOADS_SCREENSHOT_VIA;
+    else process.env.UPLOADS_SCREENSHOT_VIA = prev;
+    if (prevBic === undefined) delete process.env.BUILDINTERNET_CONFIG;
+    else process.env.BUILDINTERNET_CONFIG = prevBic;
+  });
+
+  it("is undefined by default (caller falls back to auto)", () => {
+    delete process.env.UPLOADS_SCREENSHOT_VIA;
+    process.env.BUILDINTERNET_CONFIG = "/nonexistent/uploads-config";
+    expect(resolveScreenshotDefaults({}).via).toBeUndefined();
+  });
+
+  it("reads a valid value from env", () => {
+    process.env.UPLOADS_SCREENSHOT_VIA = "local";
+    process.env.BUILDINTERNET_CONFIG = "/nonexistent/uploads-config";
+    expect(resolveScreenshotDefaults({}).via).toBe("local");
+  });
+
+  it("ignores an invalid value from env", () => {
+    process.env.UPLOADS_SCREENSHOT_VIA = "carrier-pigeon";
+    process.env.BUILDINTERNET_CONFIG = "/nonexistent/uploads-config";
+    expect(resolveScreenshotDefaults({}).via).toBeUndefined();
+  });
+
+  it("env wins over --env-file, which wins over the user config file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-config-"));
+    const userConfig = join(dir, "user-config");
+    const envFile = join(dir, "env-file");
+    writeFileSync(userConfig, "UPLOADS_SCREENSHOT_VIA=remote\n");
+    writeFileSync(envFile, "UPLOADS_SCREENSHOT_VIA=local\n");
+    process.env.BUILDINTERNET_CONFIG = userConfig;
+
+    delete process.env.UPLOADS_SCREENSHOT_VIA;
+    expect(resolveScreenshotDefaults({}).via).toBe("remote");
+    expect(resolveScreenshotDefaults({ envFile }).via).toBe("local");
+
+    process.env.UPLOADS_SCREENSHOT_VIA = "auto";
+    expect(resolveScreenshotDefaults({ envFile }).via).toBe("auto");
+  });
+});

--- a/packages/uploads/test/mcp-screenshot.test.ts
+++ b/packages/uploads/test/mcp-screenshot.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UploadsClient } from "../src/client.js";
+import type { UploadsClientConfig } from "../src/config.js";
+import { createMcpServer, type McpServer } from "../src/mcp/server.js";
+import { createUploadsMcpTools } from "../src/mcp/tools.js";
+
+// The screenshot tool dynamically imports "../screenshot.js" from inside its
+// handler (by design — keeps mcp/tools.ts free of a static reference to the
+// local-backend chain). Mock captureScreenshot there so this test never
+// launches a browser or hits the network, while keeping the real parsers.
+vi.mock("../src/screenshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/screenshot.js")>();
+  return {
+    ...actual,
+    captureScreenshot: vi.fn(async () => ({
+      png: new Uint8Array([1, 2, 3]),
+      filename: "example-com.png",
+      backend: "remote" as const,
+    })),
+  };
+});
+
+function fakeClient(): UploadsClient {
+  return {
+    put: async (body: Uint8Array, opts: { filename: string; key?: string }) => ({
+      workspace: "test",
+      key: opts.key ?? "screenshots/misc/generated.png",
+      url: `https://x.test/${opts.key ?? "screenshots/misc/generated.png"}`,
+      embedUrl: null,
+      size: body.byteLength,
+      contentType: "image/png",
+    }),
+    list: async () => ({ items: [], cursor: null }),
+    health: async () => ({ ok: true }),
+  } as unknown as UploadsClient;
+}
+
+function serverWith() {
+  const client = fakeClient();
+  const server = createMcpServer({
+    serverInfo: { name: "uploads", version: "0.0.0-test" },
+    tools: createUploadsMcpTools({
+      globals: { apiUrl: "https://x.test", token: "up_test_x" },
+      clientFactory: (_config: UploadsClientConfig) => client,
+    }),
+  });
+  return { server };
+}
+
+async function rpc(server: McpServer, method: string, params?: unknown, id: number | string = 1) {
+  const raw = await server.handleLine(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+  return raw === undefined ? undefined : JSON.parse(raw);
+}
+
+describe("mcp screenshot tool", () => {
+  it("is listed in tools/list", async () => {
+    const { server } = serverWith();
+    const res = await rpc(server, "tools/list");
+    // oxlint-disable-next-line no-explicit-any
+    const tools = res.result.tools as Array<any>;
+    expect(tools.some((t) => t.name === "screenshot")).toBe(true);
+  });
+
+  it("captures (mocked) and uploads, returning url + markdown", async () => {
+    const { server } = serverWith();
+    const res = await rpc(server, "tools/call", {
+      name: "screenshot",
+      arguments: { target: "https://example.com" },
+    });
+    expect(res.result.isError).toBe(false);
+    const content = res.result.structuredContent as {
+      url: string;
+      markdown: string;
+      backend: string;
+    };
+    expect(content.backend).toBe("remote");
+    expect(content.url).toContain("https://x.test/");
+    expect(content.markdown).toContain("![");
+  });
+
+  it("rejects a missing target as a tool error", async () => {
+    const { server } = serverWith();
+    const res = await rpc(server, "tools/call", { name: "screenshot", arguments: {} });
+    expect(res.result.isError).toBe(true);
+  });
+
+  it("rejects an invalid via value", async () => {
+    const { server } = serverWith();
+    const res = await rpc(server, "tools/call", {
+      name: "screenshot",
+      arguments: { target: "https://example.com", via: "carrier-pigeon" },
+    });
+    expect(res.result.isError).toBe(true);
+  });
+});

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -316,6 +316,7 @@ describe("tools/list", () => {
       "gallery_link",
       "gallery_find_by_reference",
       "put",
+      "screenshot",
       "attach",
       "list",
       "delete",

--- a/packages/uploads/test/screenshot-local.test.ts
+++ b/packages/uploads/test/screenshot-local.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { detectLocalBrowser, type DetectRoots } from "../src/screenshot-local.js";
+
+/** Builds a fake fs (exists + readdir) over an in-memory tree of paths. */
+function fakeFs(paths: readonly string[]) {
+  const set = new Set(paths);
+  // A path "exists" if it's a leaf file we listed, or a directory that
+  // contains one of those leaves (mirrors real fs semantics well enough for
+  // the detection scan, which only calls existsSync on dirs and leaf files).
+  const exists = (p: string) => set.has(p) || [...set].some((f) => f.startsWith(`${p}/`));
+  const readdir = (dir: string): string[] => {
+    const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+    const names = new Set<string>();
+    for (const p of set) {
+      if (!p.startsWith(prefix)) continue;
+      const rest = p.slice(prefix.length);
+      const first = rest.split("/")[0];
+      if (first) names.add(first);
+    }
+    return [...names];
+  };
+  return { exists, readdir };
+}
+
+describe("detectLocalBrowser", () => {
+  it("finds nothing when no candidate paths exist", () => {
+    const { exists, readdir } = fakeFs([]);
+    const result = detectLocalBrowser({
+      platform: "darwin",
+      env: {},
+      exists,
+      readdir,
+      systemCandidates: [],
+      playwrightCacheDir: "/home/.cache/ms-playwright",
+      puppeteerCacheDir: "/home/.cache/puppeteer",
+    });
+    expect(result.candidates).toEqual([]);
+    expect(result.winner).toBeUndefined();
+  });
+
+  it("prefers an env override above every other candidate", () => {
+    const roots: DetectRoots = {
+      platform: "darwin",
+      env: { UPLOADS_CHROME_PATH: "/opt/my-chrome" },
+      systemCandidates: [{ kind: "chrome", path: "/Applications/Google Chrome.app/x" }],
+      playwrightCacheDir: "/home/.cache/ms-playwright",
+      puppeteerCacheDir: "/home/.cache/puppeteer",
+      ...fakeFs(["/opt/my-chrome", "/Applications/Google Chrome.app/x"]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.envOverride).toBe("/opt/my-chrome");
+    expect(result.winner).toEqual({
+      source: "env",
+      kind: "env-override",
+      executablePath: "/opt/my-chrome",
+    });
+  });
+
+  it("falls back to CHROME_PATH when UPLOADS_CHROME_PATH is unset", () => {
+    const roots: DetectRoots = {
+      platform: "linux",
+      env: { CHROME_PATH: "/usr/local/bin/chrome" },
+      systemCandidates: [],
+      playwrightCacheDir: "/home/.cache/ms-playwright",
+      puppeteerCacheDir: "/home/.cache/puppeteer",
+      ...fakeFs(["/usr/local/bin/chrome"]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.winner?.executablePath).toBe("/usr/local/bin/chrome");
+  });
+
+  it("prefers system Chrome over playwright/puppeteer caches", () => {
+    const cacheDir = "/home/.cache/ms-playwright";
+    const puppeteerDir = "/home/.cache/puppeteer";
+    const systemChrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+    const pwChromium = `${cacheDir}/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`;
+    const roots: DetectRoots = {
+      platform: "darwin",
+      env: {},
+      systemCandidates: [{ kind: "chrome", path: systemChrome }],
+      playwrightCacheDir: cacheDir,
+      puppeteerCacheDir: puppeteerDir,
+      ...fakeFs([systemChrome, pwChromium]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.winner?.source).toBe("system");
+    expect(result.winner?.executablePath).toBe(systemChrome);
+    expect(result.candidates.some((c) => c.executablePath === pwChromium)).toBe(true);
+  });
+
+  it("finds the newest-revision chromium in the modern chrome-mac-arm64 layout", () => {
+    const cacheDir = "/home/.cache/ms-playwright";
+    const older = `${cacheDir}/chromium-1100/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`;
+    const newer = `${cacheDir}/chromium-1200/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`;
+    const roots: DetectRoots = {
+      platform: "darwin",
+      env: {},
+      systemCandidates: [],
+      playwrightCacheDir: cacheDir,
+      puppeteerCacheDir: "/home/.cache/puppeteer",
+      ...fakeFs([older, newer]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.winner?.source).toBe("playwright-cache");
+    expect(result.winner?.kind).toBe("chromium");
+    expect(result.winner?.executablePath).toBe(newer);
+    expect(result.winner?.revision).toBe("1200");
+  });
+
+  it("finds chromium in the legacy chrome-mac/Chromium.app layout", () => {
+    const cacheDir = "/home/.cache/ms-playwright";
+    const legacy = `${cacheDir}/chromium-900/chrome-mac/Chromium.app/Contents/MacOS/Chromium`;
+    const roots: DetectRoots = {
+      platform: "darwin",
+      env: {},
+      systemCandidates: [],
+      playwrightCacheDir: cacheDir,
+      puppeteerCacheDir: "/home/.cache/puppeteer",
+      ...fakeFs([legacy]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.winner?.executablePath).toBe(legacy);
+  });
+
+  it("falls back to the puppeteer cache when no playwright cache or system browser exists", () => {
+    const puppeteerDir = "/home/.cache/puppeteer";
+    const chromeBuild = `${puppeteerDir}/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`;
+    const roots: DetectRoots = {
+      platform: "darwin",
+      env: {},
+      systemCandidates: [],
+      playwrightCacheDir: "/home/.cache/ms-playwright",
+      puppeteerCacheDir: puppeteerDir,
+      ...fakeFs([chromeBuild]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.winner?.source).toBe("puppeteer-cache");
+    expect(result.winner?.executablePath).toBe(chromeBuild);
+  });
+
+  it("ranks headless-shell builds last, behind every other kind", () => {
+    const cacheDir = "/home/.cache/ms-playwright";
+    const shell = `${cacheDir}/chromium_headless_shell-1200/chrome-headless-shell-mac-arm64/chrome-headless-shell`;
+    const puppeteerDir = "/home/.cache/puppeteer";
+    const chromeBuild = `${puppeteerDir}/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`;
+    const roots: DetectRoots = {
+      platform: "darwin",
+      env: {},
+      systemCandidates: [],
+      playwrightCacheDir: cacheDir,
+      puppeteerCacheDir: puppeteerDir,
+      ...fakeFs([shell, chromeBuild]),
+    };
+    const result = detectLocalBrowser(roots);
+    expect(result.winner?.executablePath).toBe(chromeBuild);
+    expect(result.candidates.some((c) => c.executablePath === shell)).toBe(true);
+  });
+});

--- a/packages/uploads/test/screenshot-remote.test.ts
+++ b/packages/uploads/test/screenshot-remote.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { UploadsError } from "../src/errors.js";
+import { captureRemote, MAX_REMOTE_HTML_BYTES } from "../src/screenshot-remote.js";
+
+function fakeFetch(handler: (input: unknown, init?: RequestInit) => Response) {
+  return (async (input: unknown, init?: RequestInit) => handler(input, init)) as typeof fetch;
+}
+
+describe("captureRemote", () => {
+  it("resolves with raw PNG bytes on a 200 response", async () => {
+    const png = new Uint8Array([1, 2, 3, 4]);
+    let seenUrl: string | undefined;
+    let seenAuth: string | null | undefined;
+    const fetchImpl = fakeFetch((input, init) => {
+      seenUrl = String(input);
+      seenAuth = (init?.headers as Record<string, string> | undefined)?.authorization;
+      return new Response(png, { status: 200, headers: { "content-type": "image/png" } });
+    });
+
+    const bytes = await captureRemote(
+      { url: "https://example.com", viewport: { width: 1280, height: 800, deviceScaleFactor: 2 } },
+      { apiUrl: "https://api.uploads.sh", token: "up_default_test", fetchImpl },
+    );
+
+    expect(seenUrl).toBe("https://api.uploads.sh/v1/render");
+    expect(seenAuth).toBe("Bearer up_default_test");
+    expect(new Uint8Array(bytes)).toEqual(png);
+  });
+
+  it("maps render_failed to RENDER_FAILED", async () => {
+    const fetchImpl = fakeFetch(
+      () =>
+        new Response(
+          JSON.stringify({ error: { message: "render timed out", code: "render_failed" } }),
+          {
+            status: 502,
+          },
+        ),
+    );
+    await expect(
+      captureRemote(
+        {
+          url: "https://example.com",
+          viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+        },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: "RENDER_FAILED" });
+  });
+
+  it("maps upload_budget_exceeded (429) to the existing UPLOAD_BUDGET code", async () => {
+    const fetchImpl = fakeFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: { message: "monthly upload budget exceeded", code: "upload_budget_exceeded" },
+          }),
+          { status: 429 },
+        ),
+    );
+    await expect(
+      captureRemote(
+        {
+          url: "https://example.com",
+          viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+        },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: "UPLOAD_BUDGET", status: 429 });
+  });
+
+  it("maps the server's rate_limited code to RATE_LIMITED", async () => {
+    const fetchImpl = fakeFetch(
+      () =>
+        new Response(
+          JSON.stringify({ error: { message: "too many renders", code: "rate_limited" } }),
+          { status: 429 },
+        ),
+    );
+    await expect(
+      captureRemote(
+        {
+          url: "https://example.com",
+          viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+        },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: "RATE_LIMITED", status: 429 });
+  });
+
+  it("maps a bare 429 (no body code) to RATE_LIMITED — a throttle is more likely than a budget denial", async () => {
+    const fetchImpl = fakeFetch(() => new Response(JSON.stringify({}), { status: 429 }));
+    await expect(
+      captureRemote(
+        {
+          url: "https://example.com",
+          viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+        },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: "RATE_LIMITED" });
+  });
+
+  it("maps 401 to UNAUTHORIZED", async () => {
+    const fetchImpl = fakeFetch(
+      () => new Response(JSON.stringify({ error: { message: "bad token" } }), { status: 401 }),
+    );
+    await expect(
+      captureRemote(
+        {
+          url: "https://example.com",
+          viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+        },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED", status: 401 });
+  });
+
+  it("rejects an oversized html body before making any request", async () => {
+    let called = false;
+    const fetchImpl = fakeFetch(() => {
+      called = true;
+      return new Response(null, { status: 200 });
+    });
+    const html = "x".repeat(MAX_REMOTE_HTML_BYTES + 1);
+    await expect(
+      captureRemote(
+        { html, viewport: { width: 1280, height: 800, deviceScaleFactor: 2 } },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toBeInstanceOf(UploadsError);
+    expect(called).toBe(false);
+  });
+
+  it("maps a network failure to NETWORK", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("getaddrinfo ENOTFOUND");
+    }) as typeof fetch;
+    await expect(
+      captureRemote(
+        {
+          url: "https://example.com",
+          viewport: { width: 1280, height: 800, deviceScaleFactor: 2 },
+        },
+        { apiUrl: "https://api.uploads.sh", token: "t", fetchImpl },
+      ),
+    ).rejects.toMatchObject({ code: "NETWORK" });
+  });
+});

--- a/packages/uploads/test/screenshot.test.ts
+++ b/packages/uploads/test/screenshot.test.ts
@@ -193,18 +193,43 @@ describe("captureScreenshot backend selection", () => {
     expect(usedRemote).toBe(false);
   });
 
-  it("--via remote on an .html file target fails fast", async () => {
+  it("--via remote on an .html file POSTs its contents as inline html", async () => {
     const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
     const file = join(dir, "card.html");
-    writeFileSync(file, "<html></html>");
+    writeFileSync(file, "<html><body>hi</body></html>");
+    let sentHtml: string | undefined;
+    const result = await captureScreenshot({
+      target: file,
+      via: "remote",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureRemoteImpl: async (body) => {
+        sentHtml = (body as { html?: string }).html;
+        return png;
+      },
+    });
+    expect(sentHtml).toBe("<html><body>hi</body></html>");
+    expect(result.backend).toBe("remote");
+  });
+
+  it("--via remote rejects an .html file over the 2 MiB inline limit", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const file = join(dir, "big.html");
+    writeFileSync(file, `<html>${"x".repeat(2 * 1024 * 1024)}</html>`);
+    let usedRemote = false;
     await expect(
       captureScreenshot({
         target: file,
         via: "remote",
         apiUrl: "https://api.uploads.sh",
         token: "t",
+        captureRemoteImpl: async () => {
+          usedRemote = true;
+          return png;
+        },
       }),
-    ).rejects.toThrow(UploadsError);
+    ).rejects.toMatchObject({ code: "USAGE" });
+    expect(usedRemote).toBe(false);
   });
 
   it("auto falls back to remote when no local browser is detected", async () => {

--- a/packages/uploads/test/screenshot.test.ts
+++ b/packages/uploads/test/screenshot.test.ts
@@ -1,0 +1,359 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { UploadsError } from "../src/errors.js";
+import {
+  captureScreenshot,
+  classifyTarget,
+  isPrivateOrLocalHost,
+  parseViewport,
+  parseWaitUntil,
+} from "../src/screenshot.js";
+
+describe("parseViewport", () => {
+  it("defaults to 1280x800@2", () => {
+    expect(parseViewport(undefined)).toEqual({ width: 1280, height: 800, deviceScaleFactor: 2 });
+  });
+
+  it("parses WIDTHxHEIGHT with no scale (defaults to 1x)", () => {
+    expect(parseViewport("1000x700")).toEqual({ width: 1000, height: 700, deviceScaleFactor: 1 });
+  });
+
+  it("parses an explicit @Nx scale", () => {
+    expect(parseViewport("1280x800@2x")).toEqual({
+      width: 1280,
+      height: 800,
+      deviceScaleFactor: 2,
+    });
+    expect(parseViewport("1280x800@1.5x")).toEqual({
+      width: 1280,
+      height: 800,
+      deviceScaleFactor: 1.5,
+    });
+    expect(parseViewport("1280x800@3")).toEqual({ width: 1280, height: 800, deviceScaleFactor: 3 });
+  });
+
+  it("rejects malformed input", () => {
+    expect(() => parseViewport("garbage")).toThrow(UploadsError);
+    expect(() => parseViewport("0x0")).toThrow(UploadsError);
+    expect(() => parseViewport("1280x")).toThrow(UploadsError);
+  });
+});
+
+describe("parseWaitUntil", () => {
+  it("defaults to load", () => {
+    expect(parseWaitUntil(undefined)).toBe("load");
+  });
+  it("accepts the known strategies", () => {
+    expect(parseWaitUntil("networkidle")).toBe("networkidle");
+    expect(parseWaitUntil("domcontentloaded")).toBe("domcontentloaded");
+  });
+  it("accepts a millisecond count", () => {
+    expect(parseWaitUntil("500")).toBe(500);
+  });
+  it("rejects anything else", () => {
+    expect(() => parseWaitUntil("whenever")).toThrow(UploadsError);
+  });
+});
+
+describe("isPrivateOrLocalHost", () => {
+  it("flags localhost/private ranges", () => {
+    for (const host of [
+      "localhost",
+      "127.0.0.1",
+      "192.168.1.5",
+      "10.0.0.4",
+      "172.16.0.1",
+      "foo.local",
+    ]) {
+      expect(isPrivateOrLocalHost(host)).toBe(true);
+    }
+  });
+  it("does not flag public hosts", () => {
+    for (const host of ["example.com", "uploads.sh", "8.8.8.8"]) {
+      expect(isPrivateOrLocalHost(host)).toBe(false);
+    }
+  });
+
+  it("strips IPv6 brackets before testing, as new URL(...).hostname returns them", () => {
+    expect(isPrivateOrLocalHost("[::1]")).toBe(true);
+    expect(isPrivateOrLocalHost("::1")).toBe(true);
+  });
+
+  it("flags 169.254.0.0/16 link-local", () => {
+    expect(isPrivateOrLocalHost("169.254.1.2")).toBe(true);
+  });
+
+  it("flags .internal and .localhost subdomains, not just bare localhost", () => {
+    expect(isPrivateOrLocalHost("api.internal")).toBe(true);
+    expect(isPrivateOrLocalHost("foo.localhost")).toBe(true);
+    expect(isPrivateOrLocalHost("localhost")).toBe(true);
+  });
+
+  it("flags IPv6 ULA (fc00::/7) and link-local (fe80::/10)", () => {
+    expect(isPrivateOrLocalHost("fc00::1")).toBe(true);
+    expect(isPrivateOrLocalHost("fd12:3456::1")).toBe(true);
+    expect(isPrivateOrLocalHost("fe80::1")).toBe(true);
+    expect(isPrivateOrLocalHost("[fe80::1]")).toBe(true);
+  });
+
+  it("does not flag unrelated IPv6 addresses", () => {
+    expect(isPrivateOrLocalHost("2001:4860:4860::8888")).toBe(false);
+  });
+
+  it("flags IPv4-mapped IPv6 addresses when the mapped quad is private", () => {
+    expect(isPrivateOrLocalHost("::ffff:10.0.0.1")).toBe(true);
+    expect(isPrivateOrLocalHost("::ffff:192.168.1.1")).toBe(true);
+    // hex form: ::ffff:a00:1 -> 10.0.0.1
+    expect(isPrivateOrLocalHost("::ffff:a00:1")).toBe(true);
+  });
+
+  it("does not flag an IPv4-mapped IPv6 address when the mapped quad is public", () => {
+    expect(isPrivateOrLocalHost("::ffff:8.8.8.8")).toBe(false);
+  });
+});
+
+describe("classifyTarget", () => {
+  it("classifies a public http(s) URL as non-local-only", () => {
+    const t = classifyTarget("https://example.com/path");
+    expect(t).toEqual({ kind: "url", url: "https://example.com/path", localOnly: false });
+  });
+
+  it("classifies a localhost URL as local-only", () => {
+    const t = classifyTarget("http://localhost:3000");
+    expect(t.kind).toBe("url");
+    if (t.kind === "url") expect(t.localOnly).toBe(true);
+  });
+
+  it("reads an existing .html file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const file = join(dir, "card.html");
+    writeFileSync(file, "<html><body>hi</body></html>");
+    const t = classifyTarget(file);
+    expect(t.kind).toBe("html-file");
+    if (t.kind === "html-file") expect(t.html).toContain("hi");
+  });
+
+  it("throws USAGE for a missing target", () => {
+    expect(() => classifyTarget("./definitely-missing.html")).toThrow(UploadsError);
+  });
+});
+
+describe("captureScreenshot backend selection", () => {
+  const png = new Uint8Array([9, 9, 9]);
+
+  it("uses local when --via local is requested", async () => {
+    let usedLocal = false;
+    const result = await captureScreenshot({
+      target: "https://example.com",
+      via: "local",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async () => {
+        usedLocal = true;
+        return png;
+      },
+    });
+    expect(usedLocal).toBe(true);
+    expect(result.backend).toBe("local");
+    expect(result.png).toEqual(png);
+  });
+
+  it("uses remote when --via remote is requested for a public URL", async () => {
+    let usedRemote = false;
+    const result = await captureScreenshot({
+      target: "https://example.com",
+      via: "remote",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureRemoteImpl: async () => {
+        usedRemote = true;
+        return png;
+      },
+    });
+    expect(usedRemote).toBe(true);
+    expect(result.backend).toBe("remote");
+  });
+
+  it("--via remote on a localhost target fails fast instead of sending a doomed request", async () => {
+    let usedRemote = false;
+    await expect(
+      captureScreenshot({
+        target: "http://localhost:4000",
+        via: "remote",
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        captureRemoteImpl: async () => {
+          usedRemote = true;
+          return png;
+        },
+      }),
+    ).rejects.toThrow(UploadsError);
+    expect(usedRemote).toBe(false);
+  });
+
+  it("--via remote on an .html file target fails fast", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const file = join(dir, "card.html");
+    writeFileSync(file, "<html></html>");
+    await expect(
+      captureScreenshot({
+        target: file,
+        via: "remote",
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+      }),
+    ).rejects.toThrow(UploadsError);
+  });
+
+  it("auto falls back to remote when no local browser is detected", async () => {
+    let usedRemote = false;
+    const result = await captureScreenshot({
+      target: "https://example.com",
+      via: "auto",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      // Force detectLocalBrowser to find nothing, regardless of what's
+      // actually installed on the machine running this test.
+      detectRoots: {
+        env: {},
+        systemCandidates: [],
+        playwrightCacheDir: "/nonexistent/ms-playwright",
+        puppeteerCacheDir: "/nonexistent/puppeteer",
+      },
+      captureRemoteImpl: async () => {
+        usedRemote = true;
+        return png;
+      },
+    });
+    expect(usedRemote).toBe(true);
+    expect(result.backend).toBe("remote");
+  });
+
+  it("auto uses local when a local browser is detected", async () => {
+    let usedLocal = false;
+    let seenDetectResult: unknown;
+    const systemChrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+    const result = await captureScreenshot({
+      target: "https://example.com",
+      via: "auto",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      detectRoots: {
+        env: {},
+        systemCandidates: [{ kind: "chrome", path: systemChrome }],
+        exists: (p: string) => p === systemChrome,
+        playwrightCacheDir: "/nonexistent/ms-playwright",
+        puppeteerCacheDir: "/nonexistent/puppeteer",
+      },
+      captureLocalImpl: async (opts) => {
+        usedLocal = true;
+        seenDetectResult = opts.detectResult;
+        return png;
+      },
+    });
+    expect(usedLocal).toBe(true);
+    expect(result.backend).toBe("local");
+    // auto-routing's probe result is threaded through so the local capture
+    // doesn't have to re-scan the filesystem a second time.
+    expect(seenDetectResult).toMatchObject({ winner: { executablePath: systemChrome } });
+  });
+
+  it("--via local (no auto-probe) does not pre-populate detectResult — capture scans once itself", async () => {
+    let seenDetectResult: unknown = "unset";
+    await captureScreenshot({
+      target: "https://example.com",
+      via: "local",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async (opts) => {
+        seenDetectResult = opts.detectResult;
+        return png;
+      },
+    });
+    expect(seenDetectResult).toBeUndefined();
+  });
+
+  it("rejects a numeric --wait on --via remote before making any request", async () => {
+    let usedRemote = false;
+    await expect(
+      captureScreenshot({
+        target: "https://example.com",
+        via: "remote",
+        waitUntil: 500,
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        captureRemoteImpl: async () => {
+          usedRemote = true;
+          return png;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "USAGE" });
+    expect(usedRemote).toBe(false);
+  });
+
+  it("rejects a numeric --wait when auto resolves to remote (no local browser)", async () => {
+    let usedRemote = false;
+    await expect(
+      captureScreenshot({
+        target: "https://example.com",
+        via: "auto",
+        waitUntil: 250,
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        detectRoots: {
+          env: {},
+          systemCandidates: [],
+          playwrightCacheDir: "/nonexistent/ms-playwright",
+          puppeteerCacheDir: "/nonexistent/puppeteer",
+        },
+        captureRemoteImpl: async () => {
+          usedRemote = true;
+          return png;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "USAGE" });
+    expect(usedRemote).toBe(false);
+  });
+
+  it("allows a numeric --wait on --via local", async () => {
+    let seenWait: unknown;
+    const result = await captureScreenshot({
+      target: "https://example.com",
+      via: "local",
+      waitUntil: 500,
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async (opts) => {
+        seenWait = opts.waitUntil;
+        return png;
+      },
+    });
+    expect(seenWait).toBe(500);
+    expect(result.backend).toBe("local");
+  });
+
+  it("auto on a localhost target errors clearly when no local browser is found (no doomed remote request)", async () => {
+    let usedRemote = false;
+    await expect(
+      captureScreenshot({
+        target: "http://localhost:4000",
+        via: "auto",
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        detectRoots: {
+          env: {},
+          systemCandidates: [],
+          playwrightCacheDir: "/nonexistent/ms-playwright",
+          puppeteerCacheDir: "/nonexistent/puppeteer",
+        },
+        captureRemoteImpl: async () => {
+          usedRemote = true;
+          return png;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "BROWSER_NOT_FOUND" });
+    expect(usedRemote).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,10 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
+    optionalDependencies:
+      playwright-core:
+        specifier: ^1.61.1
+        version: 1.61.1
 
 packages:
 
@@ -3849,6 +3853,11 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -7959,6 +7968,9 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.61.1:
+    optional: true
 
   postcss-load-config@6.0.1(postcss@8.5.16)(yaml@2.9.0):
     dependencies:

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -36,6 +36,10 @@ file:
 - An OS screenshot or screen recording the user already made.
 - Any existing image, GIF, or diagram file.
 
+No browser tool on hand? `uploads screenshot <url|file.html>` captures
+**and** hosts in one step — it drives an installed Chrome itself, or falls
+back to a server-side render when none is found. See the uploads-cli skill.
+
 GIFs and video upload as-is — the client-side optimizer only rewrites still
 images (PNG/JPEG → WebP). No special flags needed for motion.
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -2,9 +2,10 @@
 name: uploads-cli
 description: >-
   Reference for the uploads CLI — host files on uploads.sh and manage them.
-  Covers put and attach, stable PR/issue keys, the managed attachments
-  comment, metadata and search, galleries, config defaults, login/doctor, and
-  output formats. Use when driving the `uploads` CLI or its MCP tools, when
+  Covers put and attach, screenshot capture (local browser or server-side
+  render), stable PR/issue keys, the managed attachments comment, metadata
+  and search, galleries, config defaults, login/doctor, and output formats.
+  Use when driving the `uploads` CLI or its MCP tools, when
   you need a public URL for a local file ("upload this", "host this image",
   "give me a public URL for this file"), or when you need exact flags, key
   layouts, or setup and auth details. For the when-and-how of getting a
@@ -215,6 +216,75 @@ uploads put ./shot.png --format markdown   # just the ![]()/<img> snippet
 uploads put ./shot.png --json              # {workspace,key,url,size,markdown}
 ```
 
+## Capturing a screenshot: `uploads screenshot`
+
+Capture a URL or a local `.html` file and host it — no separate screenshot
+tool needed, and no browser install required for the default path:
+
+```bash
+uploads screenshot https://uploads.sh --pr 128 --comment
+uploads screenshot ./card.html --out ./card.png
+uploads screenshot ./card.html --no-upload --out ./card.png
+```
+
+After capture, a screenshot shares the exact `put` upload pipeline described
+above: optional `--frame`, optimize-by-default, `--pr`/`--issue` attachment +
+`--comment`, `--gallery`, `--meta`, and the same output formats. It also
+ships as an MCP tool (`screenshot`) alongside the CLI command.
+
+**Two capture backends**, selected with `--via`:
+
+| Backend  | What it is                                                        | Needs                                                               |
+| -------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `local`  | Drives an already-installed Chrome/Chromium via `playwright-core` | A discoverable browser on disk, or `--cdp`                          |
+| `remote` | Renders server-side via the uploads.sh render endpoint            | Nothing local; counts against the workspace's monthly upload budget |
+
+`--via auto` (the default) prefers local when a usable browser is found,
+else falls back to remote. Set a persistent default with
+`UPLOADS_SCREENSHOT_VIA=auto|local|remote` (env, `--env-file`, or the user
+config file — see "Config commands"); the `--via` flag always wins.
+
+**localhost/private-network targets and local `.html` files are local-only.**
+With `--via remote` (or `auto` falling back to remote) these fail fast with a
+clear error instead of sending a request that could never work. A numeric
+`--wait <ms>` (fixed settle delay after load) is also local-only; use
+`--wait load|domcontentloaded|networkidle` for a backend-agnostic wait.
+
+Use `--cdp <endpoint>` to attach to a Chrome that's already running
+(`http://host:port` or `ws://…`) instead of launching a new one — handy when
+an agent already has a Playwright MCP or `agent-browser` session open.
+`--browser <path>` (or `UPLOADS_CHROME_PATH` / `CHROME_PATH`) points at an
+explicit executable.
+
+Key options (`uploads screenshot --help` for all):
+
+| Flag                                                 | Purpose                                                                                                                                                                                                  |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--via auto\|local\|remote`                          | Capture backend (default: `auto`, or `UPLOADS_SCREENSHOT_VIA`).                                                                                                                                          |
+| `--browser <path>`                                   | Explicit local browser executable (or `UPLOADS_CHROME_PATH` / `CHROME_PATH`).                                                                                                                            |
+| `--cdp <endpoint>`                                   | Attach to a running Chrome via CDP instead of launching one (local backend only).                                                                                                                        |
+| `--viewport <WxH[@Sx]>`                              | Size + device scale factor (default: `1280x800@2`).                                                                                                                                                      |
+| `--selector <css>`                                   | Capture one element instead of the viewport.                                                                                                                                                             |
+| `--full-page`                                        | Capture the full scrollable page.                                                                                                                                                                        |
+| `--dark` / `--light`                                 | Emulate `prefers-color-scheme` (full media-query emulation on `--via local` only — `--via remote` only sets the CSS `color-scheme` property, so a page's own `prefers-color-scheme` queries won't flip). |
+| `--wait <load\|domcontentloaded\|networkidle\|ms>`   | Settle strategy (default: `load`); a millisecond count is local-only.                                                                                                                                    |
+| `--out <file>`                                       | Also write the PNG to a local file.                                                                                                                                                                      |
+| `--no-upload`                                        | Skip hosting; requires `--out` (local file only).                                                                                                                                                        |
+| `--key` / `--pr` / `--issue` / `--comment`           | Same destination and attachment options as `put` (see above); `--pr`/`--issue` also give a stable, hash-free key.                                                                                        |
+| `--frame` / `--no-optimize` / `--gallery` / `--meta` | Same as `put` — reused from the shared upload pipeline.                                                                                                                                                  |
+
+**Errors and hints:** a local capture with no usable browser fails with
+`BROWSER_NOT_FOUND` (exit `2`) — hint: try `--via remote`, or install a
+browser (`npx playwright install chromium`). A remote render that the server
+can't complete returns `RENDER_FAILED`. A burst rate limit on the render
+endpoint returns `RATE_LIMITED` (exit `4`) — hint: wait ~60s and retry. A
+remote render over the workspace's monthly upload budget surfaces the usual
+`UPLOAD_BUDGET` code and hint (`uploads usage`, then delete objects or raise
+limits) — renders and puts share one monthly counter.
+
+`uploads doctor` reports which local browser (if any) was detected and which
+backend `--via auto` would currently pick.
+
 ## Custom metadata & search
 
 Every object can carry queryable key-value metadata (distinct from optimize/frame
@@ -405,7 +475,7 @@ uploads config init --api-url http://localhost:8787 --workspace default --token 
 Recognized keys: `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, `UPLOADS_TOKEN`,
 `UPLOADS_DEFAULT_PREFIX`, `UPLOADS_DEFAULT_REPO`, `UPLOADS_DEFAULT_REF`,
 `UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`, `UPLOADS_NO_OPTIMIZE`, `UPLOADS_KEEP_EXIF`,
-`UPLOADS_NO_AUTO_META`.
+`UPLOADS_NO_AUTO_META`, `UPLOADS_SCREENSHOT_VIA`.
 Also read (env only, not config-file keys): `UPLOADS_EMBED_PUBLIC_BASE_URL`.
 
 ## Local development

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -244,9 +244,12 @@ else falls back to remote. Set a persistent default with
 `UPLOADS_SCREENSHOT_VIA=auto|local|remote` (env, `--env-file`, or the user
 config file — see "Config commands"); the `--via` flag always wins.
 
-**localhost/private-network targets and local `.html` files are local-only.**
-With `--via remote` (or `auto` falling back to remote) these fail fast with a
-clear error instead of sending a request that could never work. A numeric
+**localhost/private-network targets are local-only.** With `--via remote`
+(or `auto` falling back to remote) these fail fast with a clear error instead
+of sending a request that could never work. Local `.html` files work on both
+backends — the remote backend receives the file's contents inline (≤ 2 MiB),
+so anything the page references via `file://` or relative paths only resolves
+with `--via local`. A numeric
 `--wait <ms>` (fixed settle delay after load) is also local-only; use
 `--wait load|domcontentloaded|networkidle` for a backend-agnostic wait.
 


### PR DESCRIPTION
## In plain terms

Agents attaching visuals to PRs currently need their own browser tooling to produce the image before `uploads` can host it. This adds `uploads screenshot <url|file.html>`: capture and host in one command. When a Chrome/Chromium already exists on the machine it drives that (no browser download); when none exists it falls back to a new uploads.sh render endpoint backed by Cloudflare Browser Run — so the command works everywhere from a laptop with Chrome to a bare CI container.

Captured with the new command, uploaded by the new command — this is the repo's own `@uploads/ui` design system (Panel, Badge, Progress, Callout, Button with the real Geist fonts and tokens), rendered to static HTML and screenshotted via the local backend:

![@uploads/ui components rendered and captured with uploads screenshot](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/202/ui-demo.webp)

A URL-target example (the live uploads.sh homepage) is in the attachments comment below; both were attached with `--pr 202 --comment`, exercising the managed-comment sync end to end.

## What it does / what it is not

- `uploads screenshot <target>` accepts an http(s) URL or a local `.html` file, then reuses the exact `put` tail: optimize, `--frame`, `screenshots/` keys, `--pr/--issue --comment` attach, markdown output.
- `--via auto|local|remote` (config: `UPLOADS_SCREENSHOT_VIA`; default `auto` = local-first for speed and zero metered browser-hours). `--via local` and `--via remote` force a backend; localhost/private targets are local-only and fail fast with a clear error rather than sending a doomed remote request. `.html` files work on both backends — sent inline (≤ 2 MiB) to the remote one, where `file://`/relative references won't resolve.
- Local backend: `playwright-core` (optionalDependency, ~12 MB, ships no browser) drives an existing browser — env override, `--browser <path>`, `--cdp <endpoint>` to attach to an already-running Chrome, system Chrome via channel, then Playwright/Puppeteer caches. `uploads doctor` reports what was detected and which backend `auto` picks.
- Remote backend: new authenticated `POST /v1/render` (url XOR html ≤ 2 MiB, viewport/selector/fullPage/colorScheme/waitUntil) using the Browser Run `quickAction` binding behind an injectable `Renderer` seam; returns PNG bytes, private/internal targets blocked (incl. IPv4-mapped IPv6 and IPv6 ULA/link-local). Renders draw from the existing monthly upload budget plus a per-workspace burst limiter — no new quota knobs.
- Also exposed as a `screenshot` MCP tool on the stdio server; the remote `apps/mcp` Worker bundle stays free of playwright-core (verified by wrangler dry-run bundle grep).
- Not in this PR (planned follow-ups in the pipeline plan): rendering React components/Storybook stories to images, server-side `store:true` persistence, MDX input, template cards.
- Honest caveat, documented in help: `--dark/--light` fully emulates `prefers-color-scheme` on the local backend; the remote backend can only set the CSS `color-scheme` property.

## How to try it

```
uploads screenshot https://uploads.sh --pr 123 --comment
uploads screenshot ./report.html --dark --selector "main"
uploads screenshot ./card.html --no-upload --out card.png   # local file only
```

## Technical notes

- CLI: `screenshot.ts` (backend selection + target classification), `screenshot-local.ts` (detection + capture; sole home of the dynamic `playwright-core` import), `screenshot-remote.ts` (render client), shared `uploadPreparedImage()` tail now used by `put`, `screenshot`, and both MCP tool paths.
- API: `routes/render.ts` + `render.ts` (`tokenWorkspaceAuth`, `files:write`, `readJsonObjectBody`, rate-limit guard factory, `FakeBrowser` test double). New error codes: `render_failed` (server), `BROWSER_NOT_FOUND`/`RENDER_FAILED`/`RATE_LIMITED` (CLI).
- `wrangler.jsonc`: `browser` binding (`remote: true` — `quickAction` has no local simulation) + `RENDER_LIMITER`.
- Skills updated: `uploads-cli` (full command reference), `github-screenshots` (no-browser capture path).

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test` — 489 passing (45 files)
- [x] `pnpm --filter uploads-api test` — 424 passing (41 files)
- [x] `pnpm --filter @uploads/errors test` — 15 passing
- [x] typecheck + build + `check-pack.mjs` + apps/mcp bundle dry-run (no playwright-core in Worker bundle)
- [x] End-to-end smoke on macOS: local backend detected system Chrome; captured `file://` HTML with CSS grid at 2x, element capture via `--selector`, dark-scheme emulation verified visually; full capture→optimize→upload path produced the hosted image embedded above
- [x] `--via remote` smoke against the branch-preview deployment of `/v1/render` (Workers Builds deployed the `BROWSER` binding on this branch): POSTed the self-contained design-system HTML, Browser Run returned the rendered PNG at 2x — this also caught and fixed a bug where `.html` targets were wrongly classified local-only, making the remote html path unreachable
