### PR TITLE
docs: document uploads screenshot in the README and website docs

### DIFF
--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -321,6 +321,7 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
           <li><a href="#install">Install &amp; sign in</a></li>
           <li><a href="#attach">Attach files to a PR</a></li>
           <li><a href="#put">Get a URL for any file</a></li>
+          <li><a href="#screenshot">Capture a screenshot</a></li>
           <li><a href="#agents">Set up your agent</a></li>
           <li><a href="#manage">Manage what you uploaded</a></li>
           <li><a href="#good-to-know">Good to know</a></li>
@@ -496,6 +497,43 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
           By default, images are re-encoded to WebP (capped size, high quality) so GitHub embeds
           stay fast, and <strong>EXIF metadata is stripped</strong>. Use <code>--keep-exif</code>&#32;
           to keep metadata, or <code>--no-optimize</code> to skip all processing.
+        </p>
+      </section>
+
+      <section id="screenshot">
+        <h2>Capture a screenshot <a class="anchor" href="#screenshot" aria-label="Link to this section">#</a></h2>
+        <p>
+          Don't have the image yet? <code>screenshot</code> renders a URL or a local
+          <code>.html</code> file and hosts the result in one step, with no browser
+          install required.
+        </p>
+        <div class="cmd">
+          <span class="text">uploads screenshot https://app.example --pr 123 --comment</span>
+          <button type="button" data-copy="uploads screenshot https://app.example --pr 123 --comment" aria-live="polite">copy</button>
+        </div>
+        <div class="block" aria-label="Example output">
+          <pre>&gt;&gt; capturing https://app.example
+&gt;&gt; captured via local backend
+&gt;&gt; optimized 29.3 KB → 13.4 KB (app.example.webp)
+&gt;&gt; key: gh/app/example/pull/123/app.example.webp
+
+URL: <span class="v">https://storage.uploads.sh/gh/app/example/pull/123/app.example.webp</span>
+MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.example.webp)</pre>
+        </div>
+        <p>A few useful variations:</p>
+        <div class="cmd">
+          <span class="text">uploads screenshot ./report.html --dark --selector "main" <span class="cm"># dark scheme</span></span>
+          <button type="button" data-copy='uploads screenshot ./report.html --dark --selector "main"' aria-live="polite">copy</button>
+        </div>
+        <div class="cmd">
+          <span class="text">uploads screenshot ./card.html --no-upload --out ./card.png <span class="cm"># no hosting</span></span>
+          <button type="button" data-copy="uploads screenshot ./card.html --no-upload --out ./card.png" aria-live="polite">copy</button>
+        </div>
+        <p>
+          If a Chrome or Chromium is already on the machine, <code>screenshot</code> drives it
+          directly (nothing to download); otherwise it renders on uploads.sh servers. Force
+          either side with <code>--via local</code> or <code>--via remote</code>. Note that
+          <code>localhost</code> URLs are only reachable locally.
         </p>
       </section>
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -15,6 +15,8 @@ npx @buildinternet/uploads --help
 uploads setup
 uploads --version
 uploads attach ./before.png ./after.png
+uploads screenshot https://app.example --pr 123 --comment   # capture + host in one step
+uploads screenshot ./report.html --dark --selector "main"
 uploads put ./shot.png
 uploads put ./shot.png --destination screenshots
 uploads put ./shot.png --no-optimize
@@ -37,7 +39,7 @@ Inside this monorepo only, `pnpm uploads …` builds the package first so you pi
 up local source; product docs and PR “how to try it” examples should use the
 global `uploads` form above.
 
-Commands: `attach`, `put`, `gallery`, `comment`, `list`, `find`, `meta`, `delete`, `usage`,
+Commands: `attach`, `put`, `screenshot`, `gallery`, `comment`, `list`, `find`, `meta`, `delete`, `usage`,
 `reconcile`, `purge-expired`, `setup`, `install`, `login`, `whoami` (alias `status`),
 `logout`, `invite`, `admin`, `config`, `telemetry`, `report`, `doctor`, `health`, `mcp`,
 `completion`.
@@ -80,6 +82,15 @@ previews the key + public URL without uploading.
 infers the pull request for the current branch via `gh`, uploads stable URLs, and creates
 or updates one marker-owned GitHub comment. It keeps loose `gh/...` attachments and linked public galleries in distinct sections, shows up to three available gallery images inline, and updates that same comment in place on every sync. Use `--pr`, `--issue`, and `--repo` to select
 the target explicitly, or `--no-comment` to upload without changing GitHub comments.
+
+**Screenshot capture:** `uploads screenshot <url|file.html>` renders a page to a
+hosted image in one step — no separate browser tooling needed. `--via auto`
+(default) drives a Chrome/Chromium already on the machine (`playwright-core`
+ships no browser; `--browser <path>`, `--cdp <endpoint>`, or the Playwright/
+Puppeteer caches all work), and falls back to server-side rendering when none
+is found. localhost/private URLs are local-only; `.html` files work on both
+backends. After capture it joins the same pipeline as `put` (optimize, frames,
+`--pr`/`--issue` comments, galleries). See `uploads screenshot --help`.
 
 **Keys / destinations:** default put uses the `screenshots` layout. Typed destinations
 (`--destination screenshots|gh|f`, MCP `destination`) set the root; `--pr`/`--issue`


### PR DESCRIPTION
## In plain terms

PR #202 shipped `uploads screenshot`, but the two places people actually discover commands — the npm README and the uploads.sh docs page — still didn't mention it. This fills that gap.

## What it does

- `packages/uploads/README.md`: two `screenshot` lines in the quick-start example block, the command added to the command list, and a short "Screenshot capture" paragraph alongside the existing keys/optimization/frames notes.
- `apps/web/src/pages/docs.astro`: a new "Capture a screenshot" section between "Get a URL for any file" and "Set up your agent", with copyable command rows and example output matching the page's existing patterns, plus the nav entry.
- No changeset: the README rides along with the pending minor release from #202; the web app isn't versioned.

Rendered section (captured from the local dev server with `uploads screenshot http://localhost:4321/docs --selector "#screenshot"`, naturally):

![docs-screenshot-section.png](https://embed.uploads.sh/default/screenshots/buildinternet-uploads/docs-screenshot-command/docs-screenshot-section-af89ed.webp)

## Test plan

- [x] Verified the section renders on the local dev server (nav anchor, copy rows, example output block) — the embed above is that render
- [x] Copy matches the shipped flag surface (`--via`, `--dark`, `--selector`, `--no-upload --out`)
