### PR TITLE
fix(api): reserve upload budget atomically before paid work

### DIFF
--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -6,6 +6,7 @@
  * without redeploying. Omit a field (or set null via the script) for unlimited.
  */
 
+import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
 import type { WorkspaceUsage } from "./usage";
 
 /** Cumulative caps from the workspace registry record. */
@@ -42,6 +43,35 @@ export function resolveBudgetLimits(record: WorkspaceBudgetLimits): {
   };
 }
 
+/** The 429 monthly-upload-budget denial, shared by the read-side check and
+ * the atomic reservation path (usage.ts reserveUploads) so both reject with
+ * identical shape. */
+export function uploadBudgetDenial(
+  usage: WorkspaceUsage,
+  maxUploadsPerPeriod: number,
+): BudgetDenial {
+  return {
+    code: "upload_budget_exceeded",
+    status: 429,
+    message: `upload budget exceeded (${usage.uploadsInPeriod}/${maxUploadsPerPeriod} this period)`,
+    detail: {
+      uploadsInPeriod: usage.uploadsInPeriod,
+      maxUploadsPerPeriod,
+      periodStart: usage.periodStart,
+    },
+  };
+}
+
+/** Map a denial to the thrown error type: 507 storage, 429 upload budget. */
+export function budgetDenialError(
+  denial: BudgetDenial,
+): InsufficientStorageError | RateLimitedError {
+  const options = { code: denial.code, details: denial.detail };
+  return denial.status === 507
+    ? new InsufficientStorageError(denial.message, options)
+    : new RateLimitedError(denial.message, options);
+}
+
 /**
  * Whether a put that would apply `delta` is allowed under the workspace limits.
  * `delta.bytes` is the net storage change (newSize − previousSize for overwrites).
@@ -56,16 +86,7 @@ export function checkPutBudget(
 
   if (maxUploadsPerPeriod !== undefined && delta.uploads > 0) {
     if (usage.uploadsInPeriod + delta.uploads > maxUploadsPerPeriod) {
-      return {
-        code: "upload_budget_exceeded",
-        status: 429,
-        message: `upload budget exceeded (${usage.uploadsInPeriod}/${maxUploadsPerPeriod} this period)`,
-        detail: {
-          uploadsInPeriod: usage.uploadsInPeriod,
-          maxUploadsPerPeriod,
-          periodStart: usage.periodStart,
-        },
-      };
+      return uploadBudgetDenial(usage, maxUploadsPerPeriod);
     }
   }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -5,14 +5,14 @@
  * from `@uploads/errors`; REST serializes via `respondError`, MCP surfaces
  * `message` in the tool error.
  */
-import {
-  InsufficientStorageError,
-  NotFoundError,
-  RateLimitedError,
-  ValidationError,
-} from "@uploads/errors";
+import { NotFoundError, ValidationError } from "@uploads/errors";
 import type { Files } from "@uploads/storage";
-import { checkPutBudget } from "./budget";
+import {
+  budgetDenialError,
+  checkPutBudget,
+  resolveBudgetLimits,
+  uploadBudgetDenial,
+} from "./budget";
 import { deleteFileMetadata, replaceFileMetadata, validateMetadataEntries } from "./file-metadata";
 import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
@@ -23,7 +23,7 @@ import {
   type ProvenanceMap,
 } from "./provenance";
 import { objectPublicUrls, storage, storageConfig } from "./storage";
-import { getWorkspaceUsage, recordUsageSafe } from "./usage";
+import { getWorkspaceUsage, recordUsageSafe, releaseUploadsSafe, reserveUploads } from "./usage";
 import { objectVisibility, VISIBILITY_META_KEY, type Visibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
 
@@ -162,17 +162,18 @@ export async function putObject(
 
   const usage = await getWorkspaceUsage(env.DB, workspaceName);
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
-  if (denial) {
-    if (denial.status === 507) {
-      throw new InsufficientStorageError(denial.message, {
-        code: denial.code,
-        details: denial.detail,
-      });
-    }
-    throw new RateLimitedError(denial.message, {
-      code: denial.code,
-      details: denial.detail,
-    });
+  if (denial) throw budgetDenialError(denial);
+
+  // The read-side check above handles the storage cap and rejects
+  // obviously-spent budgets cheaply, but it races with concurrent puts at the
+  // upload-cap boundary. Reserve the upload atomically (guarded D1 increment)
+  // before the R2 write; the reservation IS the upload count, so the post-put
+  // recordUsageSafe below must not count it again, and a failed write
+  // releases it.
+  const { maxUploadsPerPeriod } = resolveBudgetLimits(ws);
+  const reservation = await reserveUploads(env.DB, workspaceName, 1, maxUploadsPerPeriod);
+  if (!reservation.ok) {
+    throw budgetDenialError(uploadBudgetDenial(reservation.usage, reservation.maxUploadsPerPeriod));
   }
 
   // Client headers first; always attach content-sha256 of the final stored body
@@ -190,20 +191,27 @@ export async function putObject(
     ...(storedVisibility ? { [VISIBILITY_META_KEY]: storedVisibility } : {}),
   };
 
-  await store.upload(finalKey, bytes, {
-    contentType: inspection.contentType,
-    cacheControl: UPLOAD_CACHE_CONTROL,
-    metadata: storageMetadata,
-  });
+  try {
+    await store.upload(finalKey, bytes, {
+      contentType: inspection.contentType,
+      cacheControl: UPLOAD_CACHE_CONTROL,
+      metadata: storageMetadata,
+    });
+  } catch (err) {
+    // Nothing was stored, so the reserved upload goes back to the budget.
+    await releaseUploadsSafe(env.DB, workspaceName, 1);
+    throw err;
+  }
 
   // Usage accounting first: the object is already durably stored above, so
   // the ledger must be updated regardless of whether the metadata batch
   // below succeeds — otherwise a metadata failure leaves bytes/objects
-  // stored but under-counted (recordUsageSafe never throws).
+  // stored but under-counted (recordUsageSafe never throws). The upload
+  // itself was already counted by reserveUploads, hence `uploads: 0`.
   await recordUsageSafe(env.DB, workspaceName, {
     bytes: deltaBytes,
     objects: replaced ? 0 : 1,
-    uploads: 1,
+    uploads: 0,
   });
 
   if (opts?.metadata) {

--- a/apps/api/src/routes/render.ts
+++ b/apps/api/src/routes/render.ts
@@ -8,17 +8,19 @@
  * rather than a path segment.
  *
  * Quota: renders draw against the *existing* monthly upload budget
- * (`maxUploadsPerPeriod` / `checkPutBudget`) with a zero-byte delta — no new
- * ledger. A burst limiter (`RENDER_LIMITER`) additionally guards against a
- * hot loop within a single window, independent of the monthly cap.
+ * (`maxUploadsPerPeriod`) — no new ledger. The upload is reserved atomically
+ * in D1 (`reserveUploads`) BEFORE the paid Browser Run call and released if
+ * the render fails, so concurrent requests at the cap boundary cannot all
+ * pass a read-then-check and overshoot the cap. A burst limiter
+ * (`RENDER_LIMITER`) additionally guards against a hot loop within a single
+ * window, independent of the monthly cap.
  */
-import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
 import { Hono } from "hono";
-import { checkPutBudget } from "../budget";
+import { budgetDenialError, resolveBudgetLimits, uploadBudgetDenial } from "../budget";
 import { readJsonObjectBody } from "../cli-intake";
 import { renderRateLimit } from "../guards";
 import { browserRenderer, MAX_RENDER_HTML_BYTES, parseRenderRequest } from "../render";
-import { getWorkspaceUsage, recordUsageSafe } from "../usage";
+import { releaseUploadsSafe, reserveUploads } from "../usage";
 import { requireScope, tokenWorkspaceAuth, type WorkspaceVars } from "../workspace";
 
 // Headroom over the 2 MiB `html` cap for JSON-encoding overhead (escaped
@@ -42,30 +44,26 @@ export const render = new Hono<WorkspaceVars>().post(
     const workspaceName = c.get("workspaceName");
     const ws = c.get("workspace");
 
-    // Renders never move stored bytes, so the delta is uploads-only — this
-    // deliberately reuses the existing monthly upload budget (not a
-    // render-specific ledger): checkPutBudget's storage-cap branch only
-    // triggers on delta.bytes > 0, so a zero-byte delta here can only ever
-    // trip maxUploadsPerPeriod.
-    const usage = await getWorkspaceUsage(c.env.DB, workspaceName);
-    const denial = checkPutBudget(usage, ws, { bytes: 0, uploads: 1 });
-    if (denial) {
-      if (denial.status === 507) {
-        throw new InsufficientStorageError(denial.message, {
-          code: denial.code,
-          details: denial.detail,
-        });
-      }
-      throw new RateLimitedError(denial.message, {
-        code: denial.code,
-        details: denial.detail,
-      });
+    // Renders never move stored bytes, so only the monthly upload budget
+    // applies (this deliberately reuses the put budget, not a render-specific
+    // ledger). Reserve the upload atomically before the metered Browser Run
+    // call; the reservation IS the count, so success records nothing further
+    // and failure releases it.
+    const { maxUploadsPerPeriod } = resolveBudgetLimits(ws);
+    const reservation = await reserveUploads(c.env.DB, workspaceName, 1, maxUploadsPerPeriod);
+    if (!reservation.ok) {
+      throw budgetDenialError(
+        uploadBudgetDenial(reservation.usage, reservation.maxUploadsPerPeriod),
+      );
     }
 
-    const renderer = browserRenderer(c.env.BROWSER);
-    const result = await renderer.screenshot(input);
-
-    await recordUsageSafe(c.env.DB, workspaceName, { bytes: 0, objects: 0, uploads: 1 });
+    let result;
+    try {
+      result = await browserRenderer(c.env.BROWSER).screenshot(input);
+    } catch (err) {
+      await releaseUploadsSafe(c.env.DB, workspaceName, 1);
+      throw err;
+    }
 
     return new Response(result.png, {
       status: 200,

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -130,6 +130,108 @@ export async function applyUsageDelta(
   ]);
 }
 
+export type UploadReservation =
+  | { ok: true }
+  | { ok: false; usage: WorkspaceUsage; maxUploadsPerPeriod: number };
+
+/**
+ * Atomically reserve `count` uploads against the monthly budget BEFORE the
+ * paid work (Browser Run render / R2 put) happens. A guarded UPDATE increments
+ * `uploads_in_period` only while the workspace stays within
+ * `maxUploadsPerPeriod`, so concurrent requests at the cap boundary cannot all
+ * pass a read-then-check and overshoot the cap. Callers must
+ * `releaseUploadsSafe` the reservation if the work fails, and must NOT count
+ * the upload again in their post-work `recordUsageSafe` delta.
+ *
+ * Unlike recordUsageSafe this throws on D1 failure — the budget gate is a
+ * precondition of the work, not best-effort metering.
+ */
+export async function reserveUploads(
+  db: D1Database,
+  workspace: string,
+  count: number,
+  maxUploadsPerPeriod: number | undefined,
+  now = new Date(),
+): Promise<UploadReservation> {
+  if (maxUploadsPerPeriod === undefined) {
+    // Unlimited: still count at reservation time so failure/release semantics
+    // stay uniform with capped workspaces.
+    await applyUsageDelta(db, workspace, { bytes: 0, objects: 0, uploads: count }, now);
+    return { ok: true };
+  }
+
+  const period = usagePeriodStart(now);
+  const updatedAt = now.toISOString();
+
+  // Ensure row, then a conditional increment: the WHERE clause re-derives the
+  // current period's upload count (a stale period_start means the month rolled
+  // over, so it counts as 0) and only matches while the guarded increment
+  // stays within the cap. `meta.changes === 0` means the budget is spent.
+  const results = await db.batch([
+    db
+      .prepare(
+        `INSERT OR IGNORE INTO workspace_usage
+           (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+         VALUES (?, 0, 0, 0, ?, ?)`,
+      )
+      .bind(workspace, period, updatedAt),
+    db
+      .prepare(
+        `UPDATE workspace_usage SET
+           uploads_in_period = (CASE WHEN period_start = ? THEN uploads_in_period ELSE 0 END) + ?,
+           period_start = ?,
+           updated_at = ?
+         WHERE workspace = ?
+           AND (CASE WHEN period_start = ? THEN uploads_in_period ELSE 0 END) + ? <= ?`,
+      )
+      .bind(period, count, period, updatedAt, workspace, period, count, maxUploadsPerPeriod),
+  ]);
+
+  const changes = results[1]?.meta?.changes ?? 0;
+  if (changes > 0) return { ok: true };
+  return { ok: false, usage: await getWorkspaceUsage(db, workspace, now), maxUploadsPerPeriod };
+}
+
+/**
+ * Return a reservation taken by `reserveUploads` after the reserved work
+ * failed. Best-effort like recordUsageSafe: the reservation is already spent
+ * budget, so a failed release only over-counts (never under-counts). A release
+ * that lands after the month rolled over is a deliberate no-op — the
+ * reservation belonged to the old period.
+ */
+export async function releaseUploadsSafe(
+  db: D1Database,
+  workspace: string,
+  count: number,
+  now = new Date(),
+): Promise<void> {
+  const period = usagePeriodStart(now);
+  try {
+    await db
+      .prepare(
+        `UPDATE workspace_usage SET
+           uploads_in_period = CASE
+             WHEN period_start = ? THEN MAX(0, uploads_in_period - ?)
+             ELSE uploads_in_period
+           END,
+           updated_at = ?
+         WHERE workspace = ?`,
+      )
+      .bind(period, count, now.toISOString(), workspace)
+      .run();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "upload reservation release failed",
+        workspace,
+        count,
+        error: message,
+      }),
+    );
+  }
+}
+
 /** Best-effort metering: log and continue if D1 fails. */
 export async function recordUsageSafe(
   db: D1Database,

--- a/apps/api/test/routes-budget.test.ts
+++ b/apps/api/test/routes-budget.test.ts
@@ -84,6 +84,45 @@ describe("workspace budget enforcement", () => {
     expect(body.error.type).toBe("rate_limited");
   });
 
+  it("admits exactly the remaining budget under concurrent puts at the cap boundary", async () => {
+    // Five simultaneous puts against a cap of 2: the atomic D1 reservation in
+    // putObject must admit exactly 2 — a read-then-check would let all five
+    // pass the check before any of them recorded an upload.
+    const { env, db } = await makeEnv({ maxUploadsPerPeriod: 2 });
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => put(env, `concurrent-${i}.png`)),
+    );
+
+    const statuses = responses.map((r) => r.status);
+    expect(statuses.filter((s) => s === 201)).toHaveLength(2);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(3);
+
+    const denied = responses.find((r) => r.status === 429)!;
+    const body = (await denied.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("upload_budget_exceeded");
+
+    expect(db.usage.get("default")?.uploads_in_period).toBe(2);
+  });
+
+  it("releases the reserved upload when the storage write fails", async () => {
+    const { env, db } = await makeEnv({ maxUploadsPerPeriod: 1 });
+    const bucket = (env as { UPLOADS_DEFAULT: FakeR2Bucket }).UPLOADS_DEFAULT;
+    const realPut = bucket.put.bind(bucket);
+    bucket.put = async () => {
+      throw new Error("simulated R2 outage");
+    };
+
+    const failed = await put(env, "a.png");
+    expect(failed.status).toBeGreaterThanOrEqual(500);
+    // The failed put must not consume the monthly budget…
+    expect(db.usage.get("default")?.uploads_in_period ?? 0).toBe(0);
+
+    // …so a retry still fits under maxUploadsPerPeriod: 1.
+    bucket.put = realPut;
+    expect((await put(env, "a.png")).status).toBe(201);
+    expect(db.usage.get("default")?.uploads_in_period).toBe(1);
+  });
+
   it("surfaces limits on GET /usage", async () => {
     const { env } = await makeEnv({
       maxStorageBytes: 10_000,

--- a/apps/api/test/routes-render.test.ts
+++ b/apps/api/test/routes-render.test.ts
@@ -326,6 +326,29 @@ describe("POST /v1/render quota + rate limiting", () => {
     expect(json.error.code).toBe("upload_budget_exceeded");
     expect(browser.calls).toHaveLength(1); // only the first (successful) render
   });
+
+  it("admits exactly the remaining budget under concurrent renders at the cap boundary", async () => {
+    // Five simultaneous renders against a cap of 2: the atomic D1 reservation
+    // (reserveUploads) must admit exactly 2 — a read-then-check would let all
+    // five pass the check before any of them recorded an upload.
+    const { env, db, browser } = await makeEnv({ overrides: { maxUploadsPerPeriod: 2 } });
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () => renderReq(env, { url: "https://example.com" })),
+    );
+
+    const statuses = responses.map((r) => r.status);
+    expect(statuses.filter((s) => s === 200)).toHaveLength(2);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(3);
+
+    const denied = responses.find((r) => r.status === 429)!;
+    const json = (await denied.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("upload_budget_exceeded");
+
+    // Only the admitted renders reached the metered Browser Run call, and the
+    // ledger never overshoots the cap.
+    expect(browser.calls).toHaveLength(2);
+    expect(db.usage.get("default")?.uploads_in_period).toBe(2);
+  });
 });
 
 describe("POST /v1/render Browser Run error passthrough", () => {

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -85,6 +85,55 @@ export class UsageFakeD1 {
           return { success: true as const, meta: { changes: 1 }, results: [] };
         }
         if (normalized.startsWith("UPDATE workspace_usage SET")) {
+          // Guarded reservation from reserveUploads: increments
+          // uploads_in_period only while within the cap; changes: 0 signals
+          // a spent budget. Atomic within a single run(), like D1's UPDATE.
+          if (normalized.includes("<= ?")) {
+            const [period, count, periodSet, updatedAt, workspace, , , max] = values as [
+              string,
+              number,
+              string,
+              string,
+              string,
+              string,
+              number,
+              number,
+            ];
+            const row = this.usage.get(workspace);
+            if (!row) throw new Error(`update before insert for ${workspace}`);
+            const current = row.period_start === period ? row.uploads_in_period : 0;
+            if (current + count > max) {
+              return { success: true as const, meta: { changes: 0 }, results: [] };
+            }
+            this.usage.set(workspace, {
+              ...row,
+              uploads_in_period: current + count,
+              period_start: periodSet,
+              updated_at: updatedAt,
+            });
+            return { success: true as const, meta: { changes: 1 }, results: [] };
+          }
+          // Reservation release from releaseUploadsSafe: same-period
+          // decrement clamped at zero; a rolled-over period is a no-op.
+          if (normalized.includes("MAX(0, uploads_in_period - ?)")) {
+            const [period, count, updatedAt, workspace] = values as [
+              string,
+              number,
+              string,
+              string,
+            ];
+            const row = this.usage.get(workspace);
+            if (!row) return { success: true as const, meta: { changes: 0 }, results: [] };
+            this.usage.set(workspace, {
+              ...row,
+              uploads_in_period:
+                row.period_start === period
+                  ? Math.max(0, row.uploads_in_period - count)
+                  : row.uploads_in_period,
+              updated_at: updatedAt,
+            });
+            return { success: true as const, meta: { changes: 1 }, results: [] };
+          }
           // Absolute totals from setUsageTotals: bytes, objects, updated_at, workspace
           if (
             normalized.includes("bytes = ?") &&

--- a/apps/api/test/usage.test.ts
+++ b/apps/api/test/usage.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { applyUsageDelta, emptyUsage, getWorkspaceUsage, usagePeriodStart } from "../src/usage";
+import {
+  applyUsageDelta,
+  emptyUsage,
+  getWorkspaceUsage,
+  releaseUploadsSafe,
+  reserveUploads,
+  usagePeriodStart,
+} from "../src/usage";
 import { UsageFakeD1 } from "./usage-fake-d1";
 
 describe("usagePeriodStart", () => {
@@ -78,5 +85,71 @@ describe("workspace usage ledger", () => {
 
     await applyUsageDelta(db, "acme", { bytes: -999, objects: -5, uploads: 0 }, now);
     expect(await getWorkspaceUsage(db, "acme", now)).toMatchObject({ bytes: 0, objects: 0 });
+  });
+});
+
+describe("upload reservations", () => {
+  const now = new Date("2026-07-10T00:00:00Z");
+
+  it("reserves up to the cap, then denies with a usage snapshot", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    expect((await reserveUploads(db, "acme", 1, 2, now)).ok).toBe(true);
+    expect((await reserveUploads(db, "acme", 1, 2, now)).ok).toBe(true);
+
+    const denied = await reserveUploads(db, "acme", 1, 2, now);
+    expect(denied.ok).toBe(false);
+    if (!denied.ok) {
+      expect(denied.usage.uploadsInPeriod).toBe(2);
+      expect(denied.maxUploadsPerPeriod).toBe(2);
+    }
+    expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(2);
+  });
+
+  it("counts uploads at reservation time when unlimited", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    expect((await reserveUploads(db, "acme", 1, undefined, now)).ok).toBe(true);
+    expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(1);
+  });
+
+  it("treats a rolled-over period as zero uploads", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    await applyUsageDelta(db, "acme", { bytes: 0, objects: 0, uploads: 2 }, now);
+
+    const august = new Date("2026-08-01T00:00:00Z");
+    const res = await reserveUploads(db, "acme", 1, 2, august);
+    expect(res.ok).toBe(true);
+    expect(await getWorkspaceUsage(db, "acme", august)).toMatchObject({
+      uploadsInPeriod: 1,
+      periodStart: "2026-08",
+    });
+  });
+
+  it("release returns a same-period reservation, clamped at zero", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    await reserveUploads(db, "acme", 1, 2, now);
+    await releaseUploadsSafe(db, "acme", 1, now);
+    expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(0);
+
+    // Over-release never goes negative.
+    await releaseUploadsSafe(db, "acme", 1, now);
+    expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(0);
+  });
+
+  it("release after a period rollover is a no-op", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    await reserveUploads(db, "acme", 1, 2, now);
+
+    await releaseUploadsSafe(db, "acme", 1, new Date("2026-08-01T00:00:00Z"));
+    // The stored row still holds July's count untouched.
+    expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(1);
+  });
+
+  it("only admits the cap under concurrent reservations", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => reserveUploads(db, "acme", 1, 2, now)),
+    );
+    expect(results.filter((r) => r.ok)).toHaveLength(2);
+    expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #202, addressing the unresolved CodeRabbit finding (comment [3597447765](https://github.com/buildinternet/uploads/pull/202#discussion_r3597447765)): both `POST /v1/render` and `putObject` used a check-then-record pattern (`getWorkspaceUsage` + `checkPutBudget`, then `recordUsageSafe` after the work), so concurrent requests at the cap boundary could all pass the check and exceed `maxUploadsPerPeriod`. `RENDER_LIMITER` can't serialize this — Cloudflare rate-limit counters are per-location and permissive.

## Changes

- **`reserveUploads` (usage.ts)**: takes the upload with a conditional D1 increment — `UPDATE workspace_usage ... WHERE uploads_in_period + 1 <= max` (period-rollover aware) — *before* the paid work (Browser Run render / R2 put). `meta.changes === 0` means the budget is spent. Unlimited workspaces still count at reservation time so failure semantics stay uniform.
- **`releaseUploadsSafe` (usage.ts)**: returns the reservation if the work fails (best-effort, clamped at zero, no-op across a period rollover).
- **Render route + `putObject`** both reserve before the metered call and release on failure; their post-work `recordUsageSafe` delta no longer counts the upload. `putObject` keeps the read-side `checkPutBudget` for the storage-bytes cap and cheap early rejection.
- **Error mapping preserved**: shared `uploadBudgetDenial` / `budgetDenialError` helpers keep the exact `upload_budget_exceeded` (429) / `storage_quota_exceeded` (507) shapes.

## Tests

- Concurrent cap-boundary tests for both surfaces: 5 simultaneous renders/puts against a cap of 2 must admit exactly 2 (fake-D1 models the guarded UPDATE atomically).
- Release-on-failure: a failed R2 write / Browser Run error does not consume the budget, and a retry still fits.
- Unit coverage for reserve/release: cap denial with usage snapshot, unlimited path, period rollover, zero clamp.

All 433 apps/api tests pass; full monorepo suite green.
