### PR TITLE
feat(web): homepage layout tweaks and columned site footer

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -1,27 +1,95 @@
 ---
 /**
- * Canonical site footer: attribution + the standing links (source, docs, legal).
- * Single source of truth so every page's footer is identical — mirrors how
- * <Brand /> standardizes the header lockup.
+ * Canonical site footer. The default (non-compact) variant is the columned
+ * treatment shared by content pages: brand blurb, link columns, and a family
+ * bar with the maintainer credit + a cross-link to the sibling Build Internet
+ * tool (releases.sh links back to us the same way).
  *
- * `compact` trims the top spacing for the centered auth/error cards; the default
- * is the full-width content-page treatment (the style docs/legal already used).
+ * `compact` keeps the original one-liner for the centered auth/error cards.
  */
 interface Props {
   compact?: boolean;
 }
 const { compact = false } = Astro.props;
 const REPO = "https://github.com/buildinternet/uploads";
+
+// Sibling tool in the Build Internet family — a registry of release notes.
+// rel omits "noreferrer" so releases.sh sees the referral traffic (mirrors
+// how its footer links to uploads.sh).
+const RELEASES_URL = "https://releases.sh";
+
+type FooterLink = { label: string; href: string };
+type FooterColumn = { title: string; links: FooterLink[] };
+
+// Adding a future link is a one-line edit here — no markup changes needed.
+const COLUMNS: FooterColumn[] = [
+  {
+    title: "Product",
+    links: [
+      { label: "Docs", href: "/docs" },
+      { label: "Agent guide", href: "/github-screenshots" },
+      { label: "Console", href: "/console" },
+      { label: "Sign in", href: "/login" },
+    ],
+  },
+  {
+    title: "Project",
+    links: [
+      { label: "GitHub", href: REPO },
+      { label: "Terms", href: "/terms" },
+      { label: "Privacy", href: "/privacy" },
+    ],
+  },
+];
 ---
 
-<footer class:list={["site-footer", { compact }]}>
-  {compact ? null : <Fragment>uploads.sh · </Fragment>}a <a href="https://buildinternet.com">Build Internet</a> project · <a href={REPO}>source</a> · <a href="/docs">docs</a> · <a href="/terms">terms</a> · <a href="/privacy">privacy</a>
-</footer>
+{
+  compact ? (
+    <footer class="site-footer compact">
+      a <a href="https://buildinternet.com">Build Internet</a> project · <a href={REPO}>source</a>{" "}
+      · <a href="/docs">docs</a> · <a href="/terms">terms</a> · <a href="/privacy">privacy</a>
+    </footer>
+  ) : (
+    <footer class="site-footer">
+      <div class="cols">
+        <div class="brand">
+          <a class="wordmark" href="/">
+            uploads.sh
+          </a>
+          <p>Screenshots &amp; recordings for agent PRs.</p>
+        </div>
+        {COLUMNS.map((column) => (
+          <nav aria-label={column.title}>
+            <div class="col-title">{column.title}</div>
+            <ul>
+              {column.links.map((link) => (
+                <li>
+                  <a href={link.href}>{link.label}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ))}
+      </div>
+      <div class="family">
+        <p>
+          Maintained by <a href="https://zachdunn.com">Zach Dunn</a> /{" "}
+          <a href="https://buildinternet.com">Build Internet</a>.
+        </p>
+        <p>
+          Release notes for the tools you use —{" "}
+          <a href={RELEASES_URL} rel="noopener">
+            releases.sh →
+          </a>
+        </p>
+      </div>
+    </footer>
+  )
+}
 
 <style>
   .site-footer {
     margin-top: 56px;
-    padding-top: 20px;
     border-top: 1px solid var(--line, #232327);
     color: var(--muted, #7d7d77);
     font: 12px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
@@ -41,5 +109,62 @@ const REPO = "https://github.com/buildinternet/uploads";
   .site-footer a:focus-visible {
     color: var(--accent, #c27eff);
     outline: none;
+  }
+
+  /* ---- columned (default) variant ---- */
+  .cols {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr;
+    gap: 24px 32px;
+    padding: 24px 0 10px;
+  }
+  .wordmark {
+    font-weight: 600;
+    color: var(--fg, #e8e8e3);
+  }
+  .site-footer a.wordmark { color: var(--fg, #e8e8e3); }
+  .site-footer a.wordmark:hover,
+  .site-footer a.wordmark:focus-visible { color: var(--accent, #c27eff); }
+  .brand p {
+    margin: 4px 0 0;
+    max-width: 30ch;
+  }
+  .col-title {
+    font-size: 10.5px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+  .cols ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 3px;
+  }
+  .family {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 4px 24px;
+    border-top: 1px solid var(--line, #232327);
+    margin-top: 14px;
+    padding: 12px 0 0;
+    font-size: 11.5px;
+  }
+  .family p {
+    margin: 0;
+  }
+  @media (max-width: 560px) {
+    .cols {
+      grid-template-columns: 1fr 1fr;
+      gap: 20px 24px;
+    }
+    .brand {
+      grid-column: 1 / -1;
+    }
+    .family {
+      flex-direction: column;
+    }
   }
 </style>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -61,13 +61,13 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
         font: 600 clamp(24px, 5vw, 32px)/1.25 var(--sans);
         letter-spacing: -0.015em;
         margin: 6px 0 0;
+        text-wrap: balance;
       }
       h1 .nb { white-space: nowrap; }
       .lede {
         font: 15px/1.65 var(--sans);
         color: var(--body);
         margin: 0 0 8px;
-        max-width: 58ch;
       }
       .lede code {
         font: 0.9em var(--mono);
@@ -254,6 +254,24 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
         .features .grid { grid-template-columns: 1fr; gap: 18px; }
       }
 
+      /* Full-width worked examples under the grid — slim, titlebar-less takes
+         on the hero terminal. */
+      .examples { display: grid; gap: 14px; margin-top: 24px; }
+      .example { margin: 0; }
+      .example-cap {
+        font: 12.5px/1.5 var(--sans);
+        color: var(--muted);
+        margin: 0 0 6px 2px;
+      }
+      .example-cap .arrow { color: var(--accent); }
+      .example-screen {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: var(--radius-md);
+        padding: 12px 14px;
+        font-size: 12.5px;
+      }
+
       /* ---------- guide callout ---------- */
       .guide {
         font: 13.5px/1.6 var(--sans);
@@ -381,7 +399,7 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
       }
       /* Geist Mono merges " --" into a joined dash via calt - keep CLI flags literal.
          Declared last: the font shorthand in earlier rules resets feature settings. */
-      code, pre, .cmd, .block, .screen, .cmdtext, .cmdrow, .terminal, .feature h3 {
+      code, pre, .cmd, .block, .screen, .example-screen, .cmdtext, .cmdrow, .terminal, .feature h3 {
         font-variant-ligatures: none;
         font-feature-settings: "calt" 0, "liga" 0;
       }
@@ -500,6 +518,21 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
             </p>
           </div>
           <div class="feature">
+            <h3>queryable metadata</h3>
+            <p>
+              Tag any upload with <code>--meta path=/settings</code> and query it back with
+              <code>uploads find</code>. <code>attach</code> stamps <code>gh.repo</code> and PR
+              context automatically.
+            </p>
+          </div>
+          <div class="feature">
+            <h3>one-command screenshots</h3>
+            <p>
+              <code>uploads screenshot &lt;url&gt;</code> captures and hosts in one step — your
+              local browser if you have one, remote render if you don't.
+            </p>
+          </div>
+          <div class="feature">
             <h3>shareable galleries</h3>
             <p>
               Group uploads into a public gallery page at <code>uploads.sh/g/…</code> — one
@@ -513,6 +546,30 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
               rules. Nothing is shared between them.
             </p>
           </div>
+        </div>
+
+        <div class="examples">
+          <figure class="example">
+            <figcaption class="example-cap">
+              <span class="arrow">▸</span> tag uploads as you attach them
+            </figcaption>
+            <div class="example-screen">
+              <p class="line"><span class="prompt">$</span> <span class="cmd">uploads attach ./settings.png --meta path=/settings --meta app=web</span></p>
+              <p class="line out">&gt;&gt; uploading ./settings.png</p>
+              <p class="line out">&gt;&gt; optimized 402.3 KB → 91.7 KB (settings.webp)</p>
+              <p class="line out"><span class="ok">&gt;&gt; attachments comment updated</span></p>
+              <p class="line out">&gt;&gt; find these later: <span class="v">uploads find gh.ref=pull/123</span></p>
+            </div>
+          </figure>
+          <figure class="example">
+            <figcaption class="example-cap">
+              <span class="arrow">▸</span> find them later, and see exactly where they're attached
+            </figcaption>
+            <div class="example-screen">
+              <p class="line"><span class="prompt">$</span> <span class="cmd">uploads find path=/settings</span></p>
+              <p class="line out"><span class="v">gh/you/app/pull/123/settings.webp</span>&#32;&#32;app=web gh.number=123 gh.repo=you/app path=/settings</p>
+            </div>
+          </figure>
         </div>
       </section>
 

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -520,7 +520,7 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
           <div class="feature">
             <h3>queryable metadata</h3>
             <p>
-              Tag any upload with <code>--meta path=/settings</code> and query it back with
+              Tag any upload with <code>--meta path=/settings</code> and query it back with&#32;
               <code>uploads find</code>. <code>attach</code> stamps <code>gh.repo</code> and PR
               context automatically.
             </p>

--- a/docs/superpowers/specs/2026-07-16-homepage-tweaks-design.md
+++ b/docs/superpowers/specs/2026-07-16-homepage-tweaks-design.md
@@ -1,0 +1,80 @@
+# Homepage tweaks: headline balance, lede width, feature examples, columned footer
+
+Approved design, 2026-07-16. Four small changes to `apps/web` — three on
+`src/pages/index.astro`, one to the shared `src/components/Footer.astro`.
+
+## 1. Headline text balance
+
+Add `text-wrap: balance` to the `h1` rule. Keep the `.nb` nowrap span around
+"pull requests, too." unless it visibly fights the balancer at narrow widths,
+in which case drop the nowrap and let `balance` own the line breaks.
+
+## 2. Lede wraps too early
+
+`.lede` caps at `max-width: 58ch`, which at 15px sans is ~490px inside the
+720px content column — the visible "early wrap". Remove the `max-width` so the
+paragraph fills the column like every other block.
+
+## 3. "What else it does" — concrete examples
+
+Two changes to the features section:
+
+**New grid cells (6 → 8, grid stays even):**
+
+- `queryable metadata` — tag uploads with `--meta path=/settings`, find them
+  later with `uploads find`; `attach` auto-stamps `gh.repo`/`gh.pr` so every
+  file knows where it's attached.
+- `screenshot command` — `uploads screenshot <url>` captures and hosts in one
+  step; local browser if one is installed, remote render if not.
+
+**Two full-width example blocks below the grid**, styled as slim versions of
+the hero terminal (no titlebar; small caption line above each). Output lines
+mirror what the CLI actually prints:
+
+Example A — tag it when you attach it:
+
+```
+$ uploads attach ./settings.png --meta path=/settings --meta app=web
+>> uploading ./settings.png
+>> optimized 402.3 KB → 91.7 KB (settings.webp)
+>> attachments comment updated
+>> find these later: uploads find gh.ref=pull/123
+```
+
+Example B — find it later, and see where it landed:
+
+```
+$ uploads find path=/settings
+gh/you/app/pull/123/settings.webp  app=web gh.number=123 gh.repo=you/app path=/settings
+```
+
+The `find these later` line in A is real `attach` output (commands.ts) and
+bridges into B. B's line shape matches `runFindFiles` human output
+(`key  meta-pairs`, sorted), with the URL column omitted for width.
+
+## 4. Columned footer (shared, all pages)
+
+Rework the non-compact variant of `Footer.astro` into the releases.sh footer
+shape, sized for lighter content. The `compact` variant (auth/error cards)
+keeps today's one-liner.
+
+- **Brand column:** "uploads.sh" + one-liner: "Screenshots & recordings for
+  agent PRs."
+- **Product column:** Docs (`/docs`), Agent guide (`/github-screenshots`),
+  Console (`/console`), Sign in (`/login`)
+- **Project column:** GitHub (repo), Terms, Privacy
+- **Family bar** below a divider: left, "Maintained by Zach Dunn / Build
+  Internet" (links to zachdunn.com / buildinternet.com); right, "Release notes
+  for the tools you use — releases.sh →" with `rel="noopener"` only (no
+  `noreferrer`), mirroring how releases.sh links back to uploads.sh.
+
+Styling stays in-system: mono 12px, `var(--line)` borders, muted links with
+accent hover, uppercase 11px column titles echoing `.sect-head`. Grid
+`1.4fr 1fr 1fr`, stacking on mobile (~560px). Links defined as a data array so
+future links are one-line edits (mirrors releases' footer.tsx).
+
+## Verification
+
+Astro dev server; check desktop + mobile widths; confirm headline balance,
+full-width lede, example blocks, and footer on `/` plus one non-compact page
+(`/docs`) and one compact page (`/login`); screenshot.


### PR DESCRIPTION
Homepage layout and content tweaks, plus a columned site footer.

## What changed

**Headline & lede** (`apps/web/src/pages/index.astro`)

- `text-wrap: balance` on the hero headline so the two lines break evenly.
- Dropped the `max-width: 58ch` cap on the intro paragraph — it was folding
  the text at ~490px inside the 720px column, which read as a premature wrap.
  It now fills the content column.

**"What else it does" section**

- Two new feature cells: **queryable metadata** (`--meta` tags +
  `uploads find`) and **one-command screenshots** (`uploads screenshot`,
  shipped in #202 but previously absent from the page). Grid stays even at 8.
- Two full-width worked examples under the grid, styled as slim titlebar-less
  takes on the hero terminal: tagging with `--meta` on `attach`, then querying
  with `uploads find`. Output lines mirror what the CLI actually prints —
  including the real `>> find these later: uploads find gh.ref=pull/123`
  hint, which bridges the two blocks.

**Footer** (`apps/web/src/components/Footer.astro`)

- The default variant is now the columned treatment used by releases.sh:
  brand blurb, Product/Project link columns (data-driven, one-line edits to
  extend), and a family bar with the maintainer credit and a cross-promo link
  to releases.sh (`rel="noopener"` only, so the referral is visible — mirrors
  how releases.sh links back here).
- The `compact` variant (auth/error cards) is unchanged.
- All non-compact pages (docs, agent guide, gallery/file pages) pick the
  columns up automatically via the shared component.

Design spec: `docs/superpowers/specs/2026-07-16-homepage-tweaks-design.md`.

## Reviewer notes

- Verified at desktop and 375px mobile: no horizontal overflow; footer
  columns stack (brand full-width, two link columns side by side, family bar
  stacked).
- `@uploads/web` tests pass (112/112); pre-commit types hook green.
- Screenshots below are from the local dev server, so the header shows the
  dev-only "auth unavailable" badge.

## Screenshots

**Hero — balanced headline, full-width lede**

<img width="700" alt="Homepage hero: balanced headline, full-width lede, install row, terminal demo" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/206/hero.webp">

**"What else it does" — new cells + worked examples**

<img width="700" alt="What else it does: 8-cell feature grid plus two worked metadata examples" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/206/features.webp">

**Footer — columns + family bar**

<img width="700" alt="Columned footer: brand blurb, Product and Project columns, family bar with releases.sh cross-link" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/206/footer.webp">
