### PR TITLE
feat(web): nest workspaces in the account sidebar

### DIFF
--- a/apps/api/src/slug-policy.test.ts
+++ b/apps/api/src/slug-policy.test.ts
@@ -26,6 +26,7 @@ describe("validateSlug", () => {
       "usage",
       "health",
       "admin-ui",
+      "new",
     ]) {
       expect(validateSlug(s)).toEqual({ ok: false, code: "reserved_workspace_name" });
     }

--- a/apps/api/src/slug-policy.ts
+++ b/apps/api/src/slug-policy.ts
@@ -26,6 +26,8 @@ export const RESERVED_WORKSPACE_NAMES: ReadonlySet<string> = new Set([
   "usage",
   "health",
   "admin-ui",
+  // Account UI route: /account/workspaces/new
+  "new",
 ]);
 
 export type SlugVerdict =

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -18,7 +18,7 @@ interface Props {
   hasPublicUrl: boolean;
   /** Folder prefix to open on mount (from `?path=`). */
   initialPrefix?: string;
-  /** Fired on folder navigation for `?ws=&path=` URL sync. */
+  /** Fired on folder navigation for `/account/workspaces/:name?path=` URL sync. */
   onPrefixChange?: (prefix: string) => void;
 }
 

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -2,6 +2,9 @@
 /**
  * Shared shell for /account and /account/* — sidebar nav with real paths
  * (file-based routing), session gate chrome, and sign-out.
+ *
+ * Workspaces nest under the Workspaces parent: each membership is a
+ * client-filled sidebar link, plus a static "New workspace" action.
  */
 import { env } from "cloudflare:workers";
 import {
@@ -20,9 +23,15 @@ export type AccountSection = "overview" | "workspaces" | "profile" | "developers
 
 interface Props {
   section: AccountSection;
+  /** Active workspace slug on /account/workspaces/:name */
+  workspace?: string;
+  /** True on /account/workspaces/new */
+  creating?: boolean;
+  /** Optional document title override (e.g. workspace name). */
+  title?: string;
 }
 
-const { section } = Astro.props;
+const { section, workspace = "", creating = false, title } = Astro.props;
 
 const titles: Record<AccountSection, string> = {
   overview: "Account",
@@ -30,19 +39,16 @@ const titles: Record<AccountSection, string> = {
   profile: "Account",
   developers: "Developers",
 };
-const docTitle = `${titles[section]} · uploads.sh`;
+const pageHeading = title ?? (workspace || titles[section]);
+const docTitle = `${pageHeading} · uploads.sh`;
 
 const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 
-const nav: { href: string; section: AccountSection; label: string }[] = [
-  { href: "/account", section: "overview", label: "Overview" },
-  { href: "/account/workspaces", section: "workspaces", label: "Workspaces" },
-  { href: "/account/profile", section: "profile", label: "Account" },
-  { href: "/account/developers", section: "developers", label: "Developers" },
-];
+const workspacesActive = section === "workspaces";
+const workspacesParentCurrent = workspacesActive && !workspace && !creating;
 ---
 
 <html lang="en">
@@ -52,7 +58,7 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
 </head>
 <body>
 <div class="shell">
-  <h1 class="sr-only">{titles[section]}</h1>
+  <h1 class="sr-only">{pageHeading}</h1>
   <div id="checking" class="ul-callout status" role="status">Checking your session…</div>
 
   <div id="signed-out" hidden>
@@ -75,14 +81,48 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
 
     <div class="layout">
       <nav class="side" aria-label="Account sections">
-        {nav.map((item) => (
+        <a
+          href="/account"
+          aria-current={section === "overview" ? "page" : undefined}
+        >
+          Overview
+        </a>
+
+        <div class="side-group">
           <a
-            href={item.href}
-            aria-current={item.section === section ? "page" : undefined}
+            href="/account/workspaces"
+            class="side-parent"
+            aria-current={workspacesParentCurrent ? "page" : undefined}
           >
-            {item.label}
+            Workspaces
           </a>
-        ))}
+          <div class="side-nested">
+            <div id="workspaces-nav-list" class="side-nested-list" aria-label="Your workspaces">
+              {/* Filled client-side after session + /me/workspaces. */}
+            </div>
+            <a
+              href="/account/workspaces/new"
+              class="side-nested-item side-new"
+              aria-current={creating ? "page" : undefined}
+            >
+              + New workspace
+            </a>
+          </div>
+        </div>
+
+        <a
+          href="/account/profile"
+          aria-current={section === "profile" ? "page" : undefined}
+        >
+          Account
+        </a>
+        <a
+          href="/account/developers"
+          aria-current={section === "developers" ? "page" : undefined}
+        >
+          Developers
+        </a>
+
         <div class="side-foot">
           {showConsoleLinks ? <a href="/console">console →</a> : null}
           <a href="/admin" id="admin-link" hidden>admin →</a>
@@ -123,9 +163,10 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
   })();
 </script>
 
-<script define:vars={{ authOrigin, apiOrigin }}>
+<script define:vars={{ authOrigin, apiOrigin, workspace }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
+  window.__UPLOADS_ACTIVE_WORKSPACE__ = workspace;
 </script>
 <script>
   import {
@@ -133,13 +174,22 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
     requireElement,
     resolveSessionGate,
   } from "../lib/account-shell";
+  import { initWorkspacesNav } from "../lib/workspaces-nav";
 
   const w = window as unknown as {
     __UPLOADS_AUTH_ORIGIN__: string;
+    __UPLOADS_API_ORIGIN__: string;
+    __UPLOADS_ACTIVE_WORKSPACE__: string;
   };
   const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+  const apiOrigin = w.__UPLOADS_API_ORIGIN__;
 
   initSignOut(authOrigin);
+  initWorkspacesNav(
+    apiOrigin,
+    requireElement<HTMLElement>("#workspaces-nav-list", "account"),
+    w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+  );
 
   void resolveSessionGate({
     authOrigin,
@@ -149,8 +199,8 @@ const nav: { href: string; section: AccountSection; label: string }[] = [
     app: requireElement<HTMLElement>("#app", "account"),
     who: requireElement<HTMLElement>("#who", "account"),
   }).then((result) => {
-    const adminLink = requireElement<HTMLElement>("#admin-link", "account");
-    adminLink.hidden = result?.user.role !== "admin";
+    requireElement<HTMLElement>("#admin-link", "account").hidden =
+      result?.user.role !== "admin";
   });
 
   requireElement<HTMLButtonElement>("#session-retry", "account").addEventListener("click", () => {

--- a/apps/web/src/lib/workspace-browse-url.test.ts
+++ b/apps/web/src/lib/workspace-browse-url.test.ts
@@ -4,6 +4,7 @@ import {
   isBrowseWorkspace,
   normalizeBrowsePath,
   readBrowseLocation,
+  workspaceFromPathname,
 } from "./workspace-browse-url";
 
 describe("normalizeBrowsePath", () => {
@@ -22,8 +23,31 @@ describe("normalizeBrowsePath", () => {
   });
 });
 
+describe("workspaceFromPathname", () => {
+  it("reads the workspace slug from the dedicated route", () => {
+    expect(workspaceFromPathname("/account/workspaces/buildinternet")).toBe("buildinternet");
+    expect(workspaceFromPathname("/account/workspaces/buildinternet/")).toBe("buildinternet");
+  });
+
+  it("ignores index, create, and invalid slugs", () => {
+    expect(workspaceFromPathname("/account/workspaces")).toBe("");
+    expect(workspaceFromPathname("/account/workspaces/new")).toBe("");
+    expect(workspaceFromPathname("/account/workspaces/Not_Valid")).toBe("");
+    expect(workspaceFromPathname("/account")).toBe("");
+  });
+});
+
 describe("readBrowseLocation", () => {
-  it("parses ws + path and ignores invalid workspace slugs", () => {
+  it("parses path-based workspace + path query", () => {
+    expect(
+      readBrowseLocation("?path=screenshots/releases", "/account/workspaces/buildinternet"),
+    ).toEqual({
+      workspace: "buildinternet",
+      path: "screenshots/releases/",
+    });
+  });
+
+  it("falls back to legacy ?ws= when pathname has no slug", () => {
     expect(readBrowseLocation("?ws=buildinternet&path=screenshots/releases")).toEqual({
       workspace: "buildinternet",
       path: "screenshots/releases/",
@@ -40,13 +64,14 @@ describe("readBrowseLocation", () => {
 });
 
 describe("applyBrowseLocation", () => {
-  it("sets and clears query params without clobbering other search keys", () => {
+  it("writes path-based workspace routes and keeps other search keys", () => {
     const base = new URL("https://uploads.sh/account/workspaces?tab=1");
     const withPath = applyBrowseLocation(base, {
       workspace: "buildinternet",
       path: "screenshots/",
     });
-    expect(withPath.searchParams.get("ws")).toBe("buildinternet");
+    expect(withPath.pathname).toBe("/account/workspaces/buildinternet");
+    expect(withPath.searchParams.get("ws")).toBeNull();
     expect(withPath.searchParams.get("path")).toBe("screenshots/");
     expect(withPath.searchParams.get("tab")).toBe("1");
 
@@ -55,13 +80,24 @@ describe("applyBrowseLocation", () => {
     expect(cleared.searchParams.get("path")).toBeNull();
     expect(cleared.searchParams.get("tab")).toBe("1");
   });
+
+  it("updates path only when already on the workspace page", () => {
+    const base = new URL("https://uploads.sh/account/workspaces/buildinternet?path=old/");
+    const next = applyBrowseLocation(base, {
+      workspace: "buildinternet",
+      path: "screenshots/",
+    });
+    expect(next.pathname).toBe("/account/workspaces/buildinternet");
+    expect(next.searchParams.get("path")).toBe("screenshots/");
+  });
 });
 
 describe("isBrowseWorkspace", () => {
-  it("matches the API workspace name shape", () => {
+  it("matches the API workspace name shape and excludes route reserved names", () => {
     expect(isBrowseWorkspace("buildinternet")).toBe(true);
     expect(isBrowseWorkspace("ab")).toBe(true);
     expect(isBrowseWorkspace("a")).toBe(false);
     expect(isBrowseWorkspace("BuildInternet")).toBe(false);
+    expect(isBrowseWorkspace("new")).toBe(false);
   });
 });

--- a/apps/web/src/lib/workspace-browse-url.ts
+++ b/apps/web/src/lib/workspace-browse-url.ts
@@ -1,6 +1,9 @@
 /**
- * Query-param deep links for the account file browser:
- *   /account/workspaces?ws=<workspace>&path=screenshots/releases/
+ * Deep links for the account file browser:
+ *   /account/workspaces/<workspace>?path=screenshots/releases/
+ *
+ * Legacy query form (`?ws=`) is still parsed so old links and profile
+ * bookmarks keep working; new writes prefer the path-based route.
  *
  * files-sdk's FileBrowser owns navigation in React state and only offers
  * `initialPrefix` / `onSelect` — no URL sync — so the account shell wires
@@ -10,6 +13,9 @@
 /** Workspace slug shape used by the API (`apps/api` WS_NAME_RE). */
 const WS_SLUG_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 
+/** Static segments under /account/workspaces that are not workspace slugs. */
+const WORKSPACE_ROUTE_RESERVED = new Set(["new"]);
+
 export interface BrowseLocation {
   workspace: string;
   /** Folder prefix with trailing `/`, or `""` for workspace root. */
@@ -18,7 +24,18 @@ export interface BrowseLocation {
 
 /** True when `value` is a valid workspace name for query use. */
 export function isBrowseWorkspace(value: string): boolean {
-  return WS_SLUG_RE.test(value);
+  return WS_SLUG_RE.test(value) && !WORKSPACE_ROUTE_RESERVED.has(value);
+}
+
+/**
+ * Extract a workspace slug from `/account/workspaces/:name` (not `/new`).
+ * Returns "" when the path is the index, create page, or unrelated.
+ */
+export function workspaceFromPathname(pathname: string): string {
+  const match = pathname.match(/^\/account\/workspaces\/([^/]+)\/?$/);
+  if (!match) return "";
+  const slug = decodeURIComponent(match[1] ?? "");
+  return isBrowseWorkspace(slug) ? slug : "";
 }
 
 function hasControlChars(value: string): boolean {
@@ -47,26 +64,41 @@ export function normalizeBrowsePath(path: string): string {
   return `${segments.join("/")}/`;
 }
 
-/** Read `ws` + `path` from a query string or full search (`?…`). */
-export function readBrowseLocation(search: string): BrowseLocation {
+/**
+ * Read workspace + folder path from the current location.
+ * Prefers the path-based workspace slug; falls back to `?ws=`.
+ * Pass `pathname` when not reading from `window` (tests / SSR).
+ */
+export function readBrowseLocation(search: string, pathname = ""): BrowseLocation {
   const raw = search.startsWith("?") ? search.slice(1) : search;
   const params = new URLSearchParams(raw);
-  const workspaceRaw = (params.get("ws") ?? "").trim();
+  const fromPath = pathname ? workspaceFromPathname(pathname) : "";
+  const workspaceRaw = fromPath || (params.get("ws") ?? "").trim();
   const workspace = isBrowseWorkspace(workspaceRaw) ? workspaceRaw : "";
   const path = workspace ? normalizeBrowsePath(params.get("path") ?? "") : "";
   return { workspace, path };
 }
 
 /**
- * Apply browse location onto a URL (mutates a copy). Clears params when
- * workspace is empty. Returns the new URL for `history.replaceState`.
+ * Apply browse location onto a URL. When already under
+ * `/account/workspaces/:name` (or navigating to one), the workspace lives in
+ * the pathname and `ws` is stripped from the query. Returns a new URL for
+ * `history.replaceState`.
  */
 export function applyBrowseLocation(current: URL, location: BrowseLocation): URL {
   const next = new URL(current.href);
   const workspace = isBrowseWorkspace(location.workspace) ? location.workspace : "";
   const path = workspace ? normalizeBrowsePath(location.path) : "";
-  if (workspace) next.searchParams.set("ws", workspace);
-  else next.searchParams.delete("ws");
+  const pathWorkspace = workspaceFromPathname(next.pathname);
+
+  if (workspace) {
+    if (pathWorkspace !== workspace) {
+      next.pathname = `/account/workspaces/${encodeURIComponent(workspace)}`;
+    }
+    next.searchParams.delete("ws");
+  } else {
+    next.searchParams.delete("ws");
+  }
   if (path) next.searchParams.set("path", path);
   else next.searchParams.delete("path");
   return next;

--- a/apps/web/src/lib/workspace-search-url.ts
+++ b/apps/web/src/lib/workspace-search-url.ts
@@ -1,12 +1,12 @@
 /**
  * Query-param sync for the account file browser's metadata search mode:
- *   /account/workspaces?ws=<workspace>&meta.gh.repo=owner/name&meta.app=web
+ *   /account/workspaces/<workspace>?meta.gh.repo=owner/name&meta.app=web
  *
- * Sibling to workspace-browse-url.ts (which owns `ws` + `path`). Search mode
+ * Sibling to workspace-browse-url.ts (which owns folder `path`). Search mode
  * replaces `path` with one or more `meta.*` pairs. Validation mirrors the
  * API's META_KEY_RE / META_VALUE_MAX so bad input is caught before a request.
  */
-import { isBrowseWorkspace } from "./workspace-browse-url";
+import { isBrowseWorkspace, workspaceFromPathname } from "./workspace-browse-url";
 
 export interface MetaFilter {
   key: string;
@@ -58,9 +58,10 @@ export function buildSearchQuery(filters: MetaFilter[]): string {
 }
 
 /**
- * Write `ws` + `meta.*` into the address bar (no history entry). Clears
- * `path` (search and folder-browse are mutually exclusive) and all prior
- * `meta.*` params. Empty filters + empty workspace clears search entirely.
+ * Write `meta.*` into the address bar (no history entry). Clears `path`
+ * (search and folder-browse are mutually exclusive) and all prior `meta.*`
+ * params. Workspace identity prefers the path-based route; legacy `?ws=` is
+ * stripped when the pathname already carries the slug.
  */
 export function replaceSearchLocation(workspace: string, filters: MetaFilter[]): void {
   if (typeof window === "undefined") return;
@@ -70,8 +71,14 @@ export function replaceSearchLocation(workspace: string, filters: MetaFilter[]):
   }
   next.searchParams.delete("path");
   const ws = isBrowseWorkspace(workspace) ? workspace : "";
-  if (ws) next.searchParams.set("ws", ws);
-  else next.searchParams.delete("ws");
+  if (ws) {
+    if (workspaceFromPathname(next.pathname) !== ws) {
+      next.pathname = `/account/workspaces/${encodeURIComponent(ws)}`;
+    }
+    next.searchParams.delete("ws");
+  } else {
+    next.searchParams.delete("ws");
+  }
   for (const { key, value } of filters) {
     if (isValidMetaKey(key) && isValidMetaValue(value)) next.searchParams.set(`meta.${key}`, value);
   }

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared presentation helpers for account workspace pages.
+ */
+
+export function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+  );
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
+}
+
+export type UsageSnapshot = {
+  bytes: number;
+  objects: number;
+  uploadsInPeriod: number;
+  maxStorageBytes?: number;
+  maxUploadsPerPeriod?: number;
+};
+
+function formatUsagePlain(usage: UsageSnapshot): string {
+  const parts = [
+    formatBytes(usage.bytes),
+    `${usage.objects} object${usage.objects === 1 ? "" : "s"}`,
+  ];
+  if (usage.uploadsInPeriod > 0) parts.push(`${usage.uploadsInPeriod} uploads this month`);
+  return parts.join(" · ");
+}
+
+/** 0–100, one decimal. Missing/invalid caps → no bar. */
+function usagePct(value: number, max: number | undefined): number | null {
+  if (typeof max !== "number" || !(max > 0) || !Number.isFinite(value)) return null;
+  return Math.min(100, Math.max(0, Math.round((value / max) * 1000) / 10));
+}
+
+/** One labeled meter — keep markup in sync with `Progress` in @uploads/ui. */
+function progressRowHtml(label: string, detail: string, pct: number): string {
+  let levelAttr = "";
+  if (pct >= 100) levelAttr = ' data-level="full"';
+  else if (pct >= 85) levelAttr = ' data-level="high"';
+  return `<div class="ul-progress__row">
+    <div class="ul-progress__head">
+      <span class="ul-progress__label">${escapeHtml(label)}</span>
+      <span class="ul-progress__value">${escapeHtml(detail)}</span>
+    </div>
+    <div class="ul-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(pct)}" aria-label="${escapeHtml(label)}">
+      <div class="ul-progress__fill"${levelAttr} style="width:${pct}%"></div>
+    </div>
+  </div>`;
+}
+
+export function renderUsageHtml(usage: UsageSnapshot): string {
+  const meters: { label: string; detail: string; pct: number }[] = [];
+  const storagePct = usagePct(usage.bytes, usage.maxStorageBytes);
+  if (storagePct !== null && usage.maxStorageBytes) {
+    meters.push({
+      label: "Storage",
+      detail: `${formatBytes(usage.bytes)} of ${formatBytes(usage.maxStorageBytes)}`,
+      pct: storagePct,
+    });
+  }
+  const uploadsPct = usagePct(usage.uploadsInPeriod, usage.maxUploadsPerPeriod);
+  if (uploadsPct !== null && usage.maxUploadsPerPeriod) {
+    meters.push({
+      label: "Uploads this month",
+      detail: `${usage.uploadsInPeriod} of ${usage.maxUploadsPerPeriod}`,
+      pct: uploadsPct,
+    });
+  }
+  if (!meters.length) {
+    return `<div class="usage-text">${escapeHtml(formatUsagePlain(usage))}</div>`;
+  }
+  const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
+  return `<div class="ul-progress">${meters.map((m) => progressRowHtml(m.label, m.detail, m.pct)).join("")}</div><div class="usage-meta">${escapeHtml(objects)}</div>`;
+}
+
+export function isWorkspaceAdminRole(role: string): boolean {
+  return role === "admin" || role === "owner";
+}
+
+export function operatorInviteCommand(workspace: string): string {
+  return `uploads admin invite create --workspace ${workspace} --email teammate@example.com`;
+}
+
+const WORKSPACE_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
+
+export function suggestedWorkspaceName(email: string | undefined): string {
+  const local = (email ?? "").split("@")[0] ?? "";
+  const sanitized = local
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63);
+  return WORKSPACE_NAME_RE.test(sanitized) ? sanitized : "";
+}
+
+export function createErrorCopy(code: string): string {
+  switch (code) {
+    case "invalid_workspace_name":
+      return "Use 2–63 lowercase letters, digits, or hyphens.";
+    case "reserved_workspace_name":
+      return "That name is reserved — pick another.";
+    case "workspace_name_taken":
+      return "That name is taken — pick another.";
+    case "workspace_cap_reached":
+      return "You've reached the workspace limit for this account.";
+    default:
+      return "Workspace creation failed — try again.";
+  }
+}
+
+/** Copy-to-clipboard for `button[data-copy]` under `root`. */
+export function bindCopyButtons(root: ParentNode): void {
+  root.addEventListener("click", (event) => {
+    void (async () => {
+      const button = (event.target as HTMLElement).closest<HTMLButtonElement>("button[data-copy]");
+      if (!button || !root.contains(button)) return;
+      try {
+        await navigator.clipboard.writeText(button.dataset.copy ?? "");
+        const previous = button.textContent;
+        button.textContent = "copied ✓";
+        setTimeout(() => {
+          button.textContent = previous;
+        }, 1500);
+      } catch {
+        // Clipboard blocked — leave the label.
+      }
+    })();
+  });
+}

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -1,0 +1,23 @@
+/**
+ * Nested workspaces list in the account sidebar.
+ * Fills `#workspaces-nav-list` after session + GET /me/workspaces.
+ */
+import { getMyWorkspaces } from "./api-client";
+import { onSession } from "./account-shell";
+import { escapeHtml } from "./workspace-ui";
+
+export function initWorkspacesNav(apiOrigin: string, listEl: HTMLElement, active = ""): void {
+  onSession(() => {
+    void getMyWorkspaces(apiOrigin).then((result) => {
+      if (result.kind !== "success") return;
+      listEl.innerHTML = result.workspaces
+        .map((ws) => {
+          const label = ws.organization.name || ws.workspace;
+          const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
+          const current = active === ws.workspace ? ' aria-current="page"' : "";
+          return `<a href="${escapeHtml(href)}" class="side-nested-item"${current}>${escapeHtml(label)}</a>`;
+        })
+        .join("");
+    });
+  });
+}

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -37,6 +37,8 @@ describe.each([
   { path: "/accept-invitation/upi_abc123", title: "Accept invitation · uploads.sh" },
   { path: "/account", title: "Account · uploads.sh" },
   { path: "/account/workspaces", title: "Workspaces · uploads.sh" },
+  { path: "/account/workspaces/new", title: "New workspace · uploads.sh" },
+  { path: "/account/workspaces/buildinternet", title: "buildinternet · uploads.sh" },
   { path: "/account/profile", title: "Account · uploads.sh" },
   { path: "/account/developers", title: "Developers · uploads.sh" },
   { path: "/console", title: "uploads.sh console" },

--- a/apps/web/src/pages/account/index.astro
+++ b/apps/web/src/pages/account/index.astro
@@ -40,9 +40,11 @@ export const prerender = false;
         Using a coding agent? One more command adds the uploads skill and MCP
         server to Claude Code, so agents attach screenshots on their own:
       </p>
-      <div class="command">
-        <code>uploads install</code>
-        <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
+      <div class="cli-steps cli-steps--solo">
+        <div class="command">
+          <code>uploads install</code>
+          <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
+        </div>
       </div>
     </div>
   </section>

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -220,7 +220,7 @@ export const prerender = false;
       if (!workspaces.length) {
         showStatus(
           status,
-          'No workspaces yet — <a href="/account/workspaces#create">create one</a> or accept an invite.',
+          'No workspaces yet — <a href="/account/workspaces/new">create one</a> or accept an invite.',
           { html: true },
         );
         return;
@@ -231,7 +231,7 @@ export const prerender = false;
       list.innerHTML = workspaces
         .map((ws) => {
           const name = ws.organization.name || ws.workspace;
-          const href = `/account/workspaces?ws=${encodeURIComponent(ws.workspace)}`;
+          const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
           const meta = [
             ws.workspace !== name ? ws.workspace : null,
             ws.role,

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -1,551 +1,98 @@
 ---
+/**
+ * Workspaces index.
+ * Legacy `?ws=` deep links redirect to `/account/workspaces/<name>`.
+ * Single membership auto-opens that workspace; otherwise pick from the list/sidebar.
+ */
 import AccountLayout from "../../layouts/AccountLayout.astro";
+import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
 
 export const prerender = false;
+
+const legacyWs = (Astro.url.searchParams.get("ws") ?? "").trim();
+if (isBrowseWorkspace(legacyWs)) {
+  const dest = new URL(`/account/workspaces/${encodeURIComponent(legacyWs)}`, Astro.url);
+  dest.search = "";
+  for (const [key, value] of Astro.url.searchParams) {
+    if (key !== "ws") dest.searchParams.append(key, value);
+  }
+  return Astro.redirect(`${dest.pathname}${dest.search}${dest.hash}`);
+}
 ---
 
 <AccountLayout section="workspaces">
   <section class="card">
     <h2>Workspaces</h2>
-    <p>Workspaces group your files and tokens. You belong to these:</p>
-    <div id="orgs-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+    <p class="ws-lead">
+      Choose one from the sidebar, or
+      <a href="/account/workspaces/new">create a new workspace</a>.
+    </p>
+    <div id="orgs-status" class="ws-status muted">Loading…</div>
     <button id="orgs-retry" type="button" hidden>Try again</button>
     <ul class="plain" id="orgs-list" hidden></ul>
   </section>
 
-  <section class="card" id="create" data-create-workspace hidden>
-    <h2>Create a workspace</h2>
-    <p>
-      Workspaces get a folder in the shared uploads bucket. Files you upload get
-      <strong>public, unguessable URLs</strong> under <code>storage.uploads.sh/&lt;name&gt;/…</code> —
-      made for embedding in PRs and issues. Free workspaces start at 1&nbsp;GB storage, 25&nbsp;MB per
-      file.
-    </p>
-    <form class="invite-form" data-create-form>
-      <label class="invite-label">
-        <span class="sr-only">Workspace name</span>
-        <input
-          name="name"
-          required
-          pattern="[a-z0-9][a-z0-9-]{1,62}"
-          placeholder="workspace-name"
-          autocomplete="off"
-        />
-      </label>
-      <button type="submit">Create workspace</button>
-    </form>
-    <div class="ul-callout" data-create-success role="status" hidden>
-      <p>
-        Workspace <strong data-created-name></strong> is ready. Uploading happens
-        from the terminal; run these to get your first file URL:
-      </p>
-      <div class="command">
-        <code>npm install -g @buildinternet/uploads</code>
-        <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite">copy</button>
-      </div>
-      <div class="command">
-        <code>uploads login</code>
-        <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
-      </div>
-      <div class="command">
-        <code>uploads put ./screenshot.png</code>
-        <button type="button" data-copy="uploads put ./screenshot.png" aria-live="polite">copy</button>
-      </div>
-      <p class="muted cli-note">
-        Using a coding agent? <code>uploads install</code> adds the uploads skill
-        and MCP server to Claude Code, so agents attach screenshots on their own.
-      </p>
-    </div>
-    <p class="muted cli-note" data-create-error role="alert" hidden></p>
-    <p class="muted cli-note" data-create-github role="status" hidden>
-      Creating a workspace requires a linked GitHub account.
-      <button type="button" class="text-btn" data-connect-github>Connect GitHub</button>
-      — you'll come right back here.
-    </p>
-    <p class="muted cli-note" data-github-error role="alert" hidden>
-      GitHub linking isn't available right now —
-      <a href="/account/profile">try from your profile</a>.
-    </p>
-  </section>
-
   <script>
     import { onSession, requireElement } from "../../lib/account-shell";
-    import { linkGitHub, listAccounts } from "../../lib/auth-client";
-    import {
-      getMyWorkspaces,
-      getMyWorkspaceUsage,
-      getMyWorkspaceGalleries,
-      inviteToWorkspace,
-      createWorkspace,
-      type GallerySummary,
-    } from "../../lib/api-client";
-    import { WorkspaceFiles } from "../../components/WorkspaceFiles";
-    import {
-      readBrowseLocation,
-      replaceBrowseLocation,
-    } from "../../lib/workspace-browse-url";
-    import { readSearchFilters } from "../../lib/workspace-search-url";
-    import { createElement } from "react";
-    import { createRoot } from "react-dom/client";
+    import { getMyWorkspaces } from "../../lib/api-client";
+    import { escapeHtml } from "../../lib/workspace-ui";
 
-    const w = window as unknown as {
-      __UPLOADS_API_ORIGIN__: string;
-      __UPLOADS_AUTH_ORIGIN__: string;
-    };
-    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
-    const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
-    // Deep-link restore: ?ws=<name>&path=screenshots/releases/
-    const browseOnLoad = readBrowseLocation(window.location.search);
-    // Deep-link restore: ?ws=<name>&meta.gh.repo=owner/name&…
-    const searchFiltersOnLoad = readSearchFilters(window.location.search);
+    const apiOrigin = (window as unknown as { __UPLOADS_API_ORIGIN__: string })
+      .__UPLOADS_API_ORIGIN__;
+    const page = "workspaces index";
+    const status = requireElement<HTMLElement>("#orgs-status", page);
+    const list = requireElement<HTMLUListElement>("#orgs-list", page);
+    const retry = requireElement<HTMLButtonElement>("#orgs-retry", page);
 
-    const escapeHtml = (value: string) =>
-      value.replace(/[&<>"']/g, (ch) =>
-        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
-      );
-
-    // Workspace names are already restricted to [a-z0-9-] on the API, but
-    // escape defensively for the attribute-selector lookup below regardless.
-    const cssEscape = (value: string) =>
-      typeof CSS !== "undefined" && CSS.escape
-        ? CSS.escape(value)
-        : value.replace(/["\\]/g, "\\$&");
-
-    function formatBytes(bytes: number): string {
-      if (bytes < 1024) return `${bytes} B`;
-      const units = ["KB", "MB", "GB", "TB"];
-      let value = bytes / 1024;
-      let unit = 0;
-      while (value >= 1024 && unit < units.length - 1) {
-        value /= 1024;
-        unit += 1;
-      }
-      return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
-    }
-
-    type UsageSnapshot = {
-      bytes: number;
-      objects: number;
-      uploadsInPeriod: number;
-      maxStorageBytes?: number;
-      maxUploadsPerPeriod?: number;
-    };
-
-    /** Plain one-liner when no cumulative caps are set (no bars to attach labels to). */
-    function formatUsagePlain(usage: UsageSnapshot): string {
-      const size = formatBytes(usage.bytes);
-      const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
-      const parts = [size, objects];
-      if (usage.uploadsInPeriod > 0) {
-        parts.push(`${usage.uploadsInPeriod} uploads this month`);
-      }
-      return parts.join(" · ");
-    }
-
-    /** 0–100, one decimal. Missing/invalid caps → no bar. */
-    function usagePct(value: number, max: number | undefined): number | null {
-      if (typeof max !== "number" || !(max > 0) || !Number.isFinite(value)) return null;
-      return Math.min(100, Math.max(0, Math.round((value / max) * 1000) / 10));
-    }
-
-    /**
-     * One labeled meter: label + detail above the bar.
-     * Keep markup in sync with `Progress` in @uploads/ui.
-     */
-    function progressRowHtml(label: string, detail: string, pct: number): string {
-      let levelAttr = "";
-      if (pct >= 100) levelAttr = ' data-level="full"';
-      else if (pct >= 85) levelAttr = ' data-level="high"';
-      return `<div class="ul-progress__row">
-        <div class="ul-progress__head">
-          <span class="ul-progress__label">${escapeHtml(label)}</span>
-          <span class="ul-progress__value">${escapeHtml(detail)}</span>
-        </div>
-        <div class="ul-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(pct)}" aria-label="${escapeHtml(label)}">
-          <div class="ul-progress__fill"${levelAttr} style="width:${pct}%"></div>
-        </div>
-      </div>`;
-    }
-
-    function renderUsageHtml(usage: UsageSnapshot): string {
-      const meters: { label: string; detail: string; pct: number }[] = [];
-      const storagePct = usagePct(usage.bytes, usage.maxStorageBytes);
-      if (storagePct !== null && usage.maxStorageBytes) {
-        const detail = `${formatBytes(usage.bytes)} of ${formatBytes(usage.maxStorageBytes)}`;
-        meters.push({ label: "Storage", detail, pct: storagePct });
-      }
-      const uploadsPct = usagePct(usage.uploadsInPeriod, usage.maxUploadsPerPeriod);
-      if (uploadsPct !== null && usage.maxUploadsPerPeriod) {
-        meters.push({
-          label: "Uploads this month",
-          detail: `${usage.uploadsInPeriod} of ${usage.maxUploadsPerPeriod}`,
-          pct: uploadsPct,
-        });
-      }
-      if (!meters.length) {
-        return `<div class="usage-text">${escapeHtml(formatUsagePlain(usage))}</div>`;
-      }
-      // Object count is informational (no quota) — keep it as a quiet footer.
-      const objects = `${usage.objects} object${usage.objects === 1 ? "" : "s"}`;
-      const rows = meters.map((m) => progressRowHtml(m.label, m.detail, m.pct)).join("");
-      return `<div class="ul-progress">${rows}</div><div class="usage-meta">${escapeHtml(objects)}</div>`;
-    }
-
-    // Operator enrollment CLI — site-wide ADMIN_TOKEN only (not workspace role).
-    const operatorInviteCommand = (workspace: string) =>
-      `uploads admin invite create --workspace ${workspace} --email teammate@example.com`;
-
-    const isWorkspaceAdminRole = (role: string) => role === "admin" || role === "owner";
-
-    // Captured from onSession so the operator CLI block can gate on global role.
-    let sessionUser: { role?: string | null; email?: string } | null = null;
-
-    const createSection = document.querySelector<HTMLElement>("[data-create-workspace]");
-    const createForm = document.querySelector<HTMLFormElement>("[data-create-form]");
-    const createError = document.querySelector<HTMLElement>("[data-create-error]");
-    const createGithub = document.querySelector<HTMLElement>("[data-create-github]");
-    const createSuccess = document.querySelector<HTMLElement>("[data-create-success]");
-    const createdName = document.querySelector<HTMLElement>("[data-created-name]");
-    const githubError = document.querySelector<HTMLElement>("[data-github-error]");
-    const connectGithubBtn = document.querySelector<HTMLButtonElement>("[data-connect-github]");
-
-    function showCreateSection(prefill?: string): void {
-      if (!createSection) return;
-      createSection.hidden = false;
-      const input = createForm?.elements.namedItem("name") as HTMLInputElement | null;
-      if (input && prefill && !input.value) input.value = prefill;
-      // Surface the GitHub requirement before the user types a name and gets a
-      // 403 — link status comes from the auth worker, so best-effort only (a
-      // null/failed lookup stays quiet and the submit path still catches it).
-      void listAccounts(authOrigin).then((accounts) => {
-        if (!accounts || !createGithub) return;
-        if (!accounts.some((a) => a.providerId === "github")) createGithub.hidden = false;
-      });
-    }
-
-    connectGithubBtn?.addEventListener("click", () => {
-      void (async () => {
-        if (githubError) githubError.hidden = true;
-        connectGithubBtn.disabled = true;
-        connectGithubBtn.textContent = "Redirecting…";
-        // Round-trips through GitHub OAuth and lands back on this form.
-        const returnTo = `${location.origin}/account/workspaces#create`;
-        if (!(await linkGitHub(authOrigin, returnTo))) {
-          connectGithubBtn.disabled = false;
-          connectGithubBtn.textContent = "Connect GitHub";
-          if (githubError) githubError.hidden = false;
-        }
-      })();
-    });
-
-    // Better Auth link-social failures redirect back with ?error=.
-    if (new URLSearchParams(location.search).get("error") && githubError) {
-      githubError.hidden = false;
-    }
-
-    // Matches the API's workspace-name pattern (see apps/api slug-policy):
-    // 2–63 lowercase letters/digits/hyphens, starting with a letter or digit.
-    const WORKSPACE_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
-
-    function suggestedWorkspaceName(email: string | undefined): string {
-      const local = (email ?? "").split("@")[0] ?? "";
-      const sanitized = local
-        .toLowerCase()
-        .replace(/[^a-z0-9-]/g, "-")
-        .replace(/^-+|-+$/g, "")
-        .slice(0, 63);
-      // Guarantee validity or nothing at all — an all-symbol localpart (or a
-      // 1-char one) can sanitize down to something too short/empty to pass
-      // the API's pattern. Don't prefill garbage; let the user type their own.
-      return WORKSPACE_NAME_RE.test(sanitized) ? sanitized : "";
-    }
-
-    function createErrorCopy(code: string): string {
-      switch (code) {
-        case "invalid_workspace_name":
-          return "That name isn't available. Use 2–63 lowercase letters, digits, or hyphens, and try a different word.";
-        case "reserved_workspace_name":
-          return "That name is reserved — pick another.";
-        case "workspace_name_taken":
-          return "That name is taken — pick another.";
-        case "workspace_cap_reached":
-          return "You've reached the workspace limit for this account.";
-        default:
-          return "Workspace creation failed — try again.";
-      }
-    }
-
-    createForm?.addEventListener("submit", (event) => {
-      event.preventDefault();
-      void (async () => {
-        if (createError) createError.hidden = true;
-        if (createGithub) createGithub.hidden = true;
-        if (createSuccess) createSuccess.hidden = true;
-        const input = createForm.elements.namedItem("name") as HTMLInputElement;
-        const name = input.value.trim();
-        const button = createForm.querySelector("button");
-        if (button) button.disabled = true;
-        const result = await createWorkspace(apiOrigin, name);
-        if (button) button.disabled = false;
-        if (result.kind === "created") {
-          input.value = "";
-          // Hand off to the terminal: the web can create a workspace but not
-          // upload to it, so surface the exact next commands right here.
-          if (createdName) createdName.textContent = name;
-          if (createSuccess) createSuccess.hidden = false;
-          await loadWorkspaces();
-          return;
-        }
-        if (result.kind === "error" && result.code === "github_required") {
-          if (createGithub) createGithub.hidden = false;
-          return;
-        }
-        if (createError) {
-          createError.textContent =
-            result.kind === "unavailable"
-              ? "The API is unreachable right now — try again shortly."
-              : createErrorCopy(result.code);
-          createError.hidden = false;
-        }
-      })();
-    });
-
-    function renderGalleries(container: HTMLElement, galleries: GallerySummary[]): void {
-      const head = `<div class="ws-section-head">Galleries${galleries.length ? ` (${galleries.length})` : ""}</div>`;
-      if (!galleries.length) {
-        container.innerHTML = `${head}<p class="ws-empty">No galleries yet.</p>`;
-        return;
-      }
-      const items = galleries
-        .map(
-          (g) =>
-            `<li><a href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a></li>`,
-        )
-        .join("");
-      container.innerHTML = `${head}<ul class="ws-items">${items}</ul>`;
-    }
-
-    async function loadWorkspaces(): Promise<void> {
-      const orgsStatus = requireElement<HTMLElement>("#orgs-status", "account workspaces");
-      const orgsList = requireElement<HTMLUListElement>("#orgs-list", "account workspaces");
-      const retry = requireElement<HTMLButtonElement>("#orgs-retry", "account workspaces");
-      orgsStatus.hidden = false;
-      orgsList.hidden = true;
+    async function loadIndex(): Promise<void> {
+      status.hidden = false;
+      list.hidden = true;
       retry.hidden = true;
-      orgsStatus.textContent = "Loading…";
+      status.textContent = "Loading…";
+
       const result = await getMyWorkspaces(apiOrigin);
       if (result.kind === "unavailable") {
-        orgsStatus.textContent = "Workspaces are temporarily unavailable. Check the local stack or try again.";
+        status.textContent =
+          "Workspaces are temporarily unavailable. Check the local stack or try again.";
         retry.hidden = false;
         return;
       }
+
       const { workspaces } = result;
       if (!workspaces.length) {
-        orgsStatus.textContent =
-          "No workspaces yet — create one below, or accept an invite to join an existing one.";
-        showCreateSection(suggestedWorkspaceName(sessionUser?.email));
+        status.innerHTML =
+          'No workspaces yet — <a href="/account/workspaces/new">create one</a>, or accept an invite.';
         return;
       }
-      showCreateSection();
-      orgsStatus.hidden = true;
-      orgsList.hidden = false;
-      // Global Better Auth role (site operator), not workspace membership role.
-      // Only operators hold ADMIN_TOKEN and should see the enrollment CLI snippet.
-      const isSiteOperator = sessionUser?.role === "admin";
-      orgsList.innerHTML = workspaces
+
+      if (workspaces.length === 1) {
+        const only = workspaces[0]!;
+        status.textContent = `Opening ${only.organization.name || only.workspace}…`;
+        location.replace(`/account/workspaces/${encodeURIComponent(only.workspace)}`);
+        return;
+      }
+
+      status.hidden = true;
+      list.hidden = false;
+      list.innerHTML = workspaces
         .map((ws) => {
-          // Communal workspace = the shared, world-readable dumping ground; it
-          // gets a short note instead of the personal galleries/files browser.
-          const body = ws.communal
-            ? `<p class="ws-note">This is the shared, public space — anything here is world-readable at <code>storage.uploads.sh</code>. Browse and upload with the CLI.</p>`
-            : `<div class="ws-section" data-galleries><div class="ws-section-head">Galleries</div><p class="ws-empty">Loading&#32;…</p></div>
-               <div class="ws-section" data-files><div class="ws-section-head">Files</div><p class="ws-empty">Loading&#32;…</p></div>`;
-          // Workspace org admin|owner: invite by email (session). Accept URL is
-          // always returned so installs without outbound email still work.
-          const memberInvite = isWorkspaceAdminRole(ws.role)
-            ? `<div class="ws-section" data-invite>
-                 <div class="ws-section-head">Invite a teammate</div>
-                 <form class="invite-form" data-workspace="${escapeHtml(ws.workspace)}">
-                   <label class="invite-label">
-                     <span class="sr-only">Email</span>
-                     <input type="email" name="email" required autocomplete="email" placeholder="teammate@example.com" />
-                   </label>
-                   <button type="submit">Invite</button>
-                 </form>
-                 <p class="muted cli-note" data-invite-status role="status"></p>
-                 <p class="muted cli-note" data-invite-link hidden></p>
-                 <p class="muted cli-note">They open the accept link, then run <code>uploads login</code>.</p>
-               </div>`
-            : "";
-          // Site operators only: enrollment codes need ADMIN_TOKEN (separate product path).
-          const cmd = operatorInviteCommand(ws.workspace);
-          const operatorInvite = isSiteOperator
-            ? `<div class="ws-section">
-                 <div class="ws-section-head">Operator enrollment code</div>
-                 <div class="command"><code>${escapeHtml(cmd)}</code><button type="button" aria-live="polite" data-copy="${escapeHtml(cmd)}">copy</button></div>
-                 <p class="muted cli-note"><code>ADMIN_TOKEN</code> only — not for everyday teammate invites.</p>
-               </div>`
-            : "";
-          return `<li data-workspace="${escapeHtml(ws.workspace)}">
-              <div class="row">
-                <span>${escapeHtml(ws.organization.name)}</span>
-                <span class="slug">${escapeHtml(ws.role)}</span>
-              </div>
-              <div class="usage">Loading usage&#32;…</div>
-              <div class="ws-detail">${body}${memberInvite}${operatorInvite}</div>
-            </li>`;
+          const name = ws.organization.name || ws.workspace;
+          const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
+          return `<li>
+            <div class="row">
+              <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>
+              <span class="slug">${escapeHtml(ws.role)}</span>
+            </div>
+          </li>`;
         })
         .join("");
-
-      // Usage, galleries, and files are fetched per workspace, concurrently,
-      // after the list renders, so a slow or failing call for one workspace (or
-      // one surface) never blocks the others. Communal workspaces skip the
-      // galleries/files fetch entirely — the API returns them empty anyway.
-      await Promise.all(
-        workspaces.map(async (ws) => {
-          const li = orgsList.querySelector<HTMLElement>(
-            `li[data-workspace="${cssEscape(ws.workspace)}"]`,
-          );
-          if (!li) return;
-          const tasks: Promise<void>[] = [];
-          const usageEl = li.querySelector<HTMLElement>(".usage");
-          if (usageEl) {
-            tasks.push(
-              getMyWorkspaceUsage(apiOrigin, ws.workspace).then((usage) => {
-                if (!usage) {
-                  usageEl.textContent = "Usage unavailable.";
-                  return;
-                }
-                usageEl.innerHTML = renderUsageHtml(usage);
-              }),
-            );
-          }
-          if (!ws.communal) {
-            const galleriesEl = li.querySelector<HTMLElement>("[data-galleries]");
-            if (galleriesEl) {
-              tasks.push(
-                getMyWorkspaceGalleries(apiOrigin, ws.workspace).then((galleries) => {
-                  renderGalleries(galleriesEl, galleries);
-                }),
-              );
-            }
-            const filesEl = li.querySelector<HTMLElement>("[data-files]");
-            if (filesEl) {
-              const isDeepLinked = browseOnLoad.workspace === ws.workspace;
-              // Mount lazily near the viewport; deep-linked workspaces mount now
-              // so `?path=` restores before the user scrolls.
-              const mount = () => {
-                createRoot(filesEl).render(
-                  createElement(WorkspaceFiles, {
-                    apiOrigin,
-                    workspace: ws.workspace,
-                    hasPublicUrl: ws.hasPublicUrl,
-                    initialPrefix: isDeepLinked ? browseOnLoad.path : "",
-                    initialFilters: isDeepLinked ? searchFiltersOnLoad : [],
-                    onPrefixChange: (path: string) => {
-                      replaceBrowseLocation({ workspace: ws.workspace, path });
-                    },
-                  }),
-                );
-              };
-              if (isDeepLinked || typeof IntersectionObserver === "undefined") {
-                mount();
-                if (isDeepLinked) {
-                  requestAnimationFrame(() => {
-                    li.scrollIntoView({ block: "start", behavior: "smooth" });
-                  });
-                }
-              } else {
-                const observer = new IntersectionObserver(
-                  (entries) => {
-                    if (!entries.some((entry) => entry.isIntersecting)) return;
-                    observer.disconnect();
-                    mount();
-                  },
-                  { rootMargin: "200px" },
-                );
-                observer.observe(filesEl);
-              }
-            }
-          }
-          await Promise.all(tasks);
-        }),
-      );
     }
 
-    // Delegated handlers for copy buttons + workspace invite forms.
-    const orgsListEl = requireElement<HTMLUListElement>("#orgs-list", "account workspaces");
-    const handleCopyClick = (event: Event) => {
-      void (async () => {
-        const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
-          "button[data-copy]",
-        );
-        if (!button) return;
-        try {
-          await navigator.clipboard.writeText(button.dataset.copy ?? "");
-          const previous = button.textContent;
-          button.textContent = "copied ✓";
-          setTimeout(() => (button.textContent = previous), 1500);
-        } catch {
-          // Clipboard blocked (permissions/insecure context) — leave the label.
-        }
-      })();
-    };
-    orgsListEl.addEventListener("click", handleCopyClick);
-    createSection?.addEventListener("click", handleCopyClick);
-    orgsListEl.addEventListener("submit", (event) => {
-      void (async () => {
-        const form = (event.target as HTMLElement).closest<HTMLFormElement>("form.invite-form");
-        if (!form) return;
-        event.preventDefault();
-        const workspace = form.dataset.workspace;
-        if (!workspace) return;
-        const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
-        const status = form.parentElement?.querySelector<HTMLElement>("[data-invite-status]");
-        const linkEl = form.parentElement?.querySelector<HTMLElement>("[data-invite-link]");
-        const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
-        const email = emailInput?.value.trim() ?? "";
-        if (!email || !status || !submit) return;
-        status.textContent = "Creating invite…";
-        if (linkEl) {
-          linkEl.hidden = true;
-          linkEl.textContent = "";
-        }
-        submit.disabled = true;
-        const result = await inviteToWorkspace(apiOrigin, workspace, email);
-        submit.disabled = false;
-        if (result.kind === "ok") {
-          // emailConfigured is binding presence on the auth worker; undefined
-          // means an older worker that doesn't report it — keep neutral copy.
-          status.textContent =
-            result.emailConfigured === true
-              ? `Invitation emailed to ${email}.`
-              : result.emailConfigured === false
-                ? `Invite created for ${email} — email isn't configured on this install, so share the accept link below yourself.`
-                : `Invite created for ${email}.`;
-          if (emailInput) emailInput.value = "";
-          if (linkEl && result.acceptUrl) {
-            linkEl.hidden = false;
-            linkEl.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
-          }
-          return;
-        }
-        status.textContent =
-          result.reason === "forbidden"
-            ? "You need workspace admin access to invite."
-            : result.reason === "invalid"
-              ? "That email doesn’t look valid."
-              : "Couldn’t create the invite. Try again.";
-      })();
+    retry.addEventListener("click", () => {
+      void loadIndex();
     });
-
-    requireElement<HTMLButtonElement>("#orgs-retry", "account workspaces").addEventListener("click", () => {
-      void loadWorkspaces();
-    });
-
-    onSession((user) => {
-      sessionUser = user;
-      void loadWorkspaces();
+    onSession(() => {
+      void loadIndex();
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -1,0 +1,280 @@
+---
+/**
+ * Dedicated workspace page: header · files · galleries · invite · operator.
+ */
+import AccountLayout from "../../../layouts/AccountLayout.astro";
+import { isBrowseWorkspace } from "../../../lib/workspace-browse-url";
+
+export const prerender = false;
+
+const nameParam = Astro.params.name ?? "";
+const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
+if (!workspace) return Astro.redirect("/account/workspaces");
+---
+
+<AccountLayout section="workspaces" workspace={workspace} title={workspace}>
+  <div id="ws-status" class="ul-callout status" role="status">Loading workspace…</div>
+  <button id="ws-retry" type="button" hidden>Try again</button>
+
+  <div id="ws-app" hidden>
+    <section class="card">
+      <div class="ws-page-header">
+        <div class="ws-title-block">
+          <h2 id="ws-name"></h2>
+          <p class="muted" id="ws-slug" hidden></p>
+        </div>
+        <span class="pill ws-role" id="ws-role" hidden></span>
+        <div class="usage" id="ws-usage">Loading usage…</div>
+      </div>
+    </section>
+
+    <section class="card" id="ws-communal" hidden>
+      <h2>Shared space</h2>
+      <p class="ws-note">
+        Shared, public space — world-readable at <code>storage.uploads.sh</code>.
+        Browse and upload with the CLI.
+      </p>
+    </section>
+
+    <section class="card" id="ws-files-card" hidden>
+      <h2 class="ws-section-head">Files</h2>
+      <div id="ws-files"></div>
+    </section>
+
+    <section class="card" id="ws-galleries-card" hidden>
+      <h2 class="ws-section-head">Galleries</h2>
+      <div id="ws-galleries"><p class="ws-empty">Loading…</p></div>
+    </section>
+
+    <section class="card" id="ws-invite-card" hidden>
+      <h2>Invite a teammate</h2>
+      <p class="ws-lead">They open the accept link, then run <code>uploads login</code>.</p>
+      <form class="ws-form" id="ws-invite-form">
+        <div class="input-group">
+          <label class="input-group__field">
+            <span class="sr-only">Email</span>
+            <input
+              type="email"
+              name="email"
+              required
+              autocomplete="email"
+              placeholder="teammate@example.com"
+            />
+          </label>
+          <button type="submit" class="input-group__action">Invite</button>
+        </div>
+      </form>
+      <div class="ws-messages">
+        <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
+        <p class="muted cli-note" id="ws-invite-link" hidden></p>
+      </div>
+    </section>
+
+    <section class="card" id="ws-operator-card" hidden>
+      <h2>Operator enrollment code</h2>
+      <p class="muted"><code>ADMIN_TOKEN</code> only — not for everyday invites.</p>
+      <div class="command">
+        <code id="ws-operator-cmd"></code>
+        <button type="button" id="ws-operator-copy" aria-live="polite">copy</button>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    import { onSession, requireElement } from "../../../lib/account-shell";
+    import {
+      getMyWorkspaces,
+      getMyWorkspaceUsage,
+      getMyWorkspaceGalleries,
+      inviteToWorkspace,
+      type GallerySummary,
+    } from "../../../lib/api-client";
+    import { WorkspaceFiles } from "../../../components/WorkspaceFiles";
+    import {
+      readBrowseLocation,
+      replaceBrowseLocation,
+    } from "../../../lib/workspace-browse-url";
+    import { readSearchFilters } from "../../../lib/workspace-search-url";
+    import {
+      bindCopyButtons,
+      escapeHtml,
+      isWorkspaceAdminRole,
+      operatorInviteCommand,
+      renderUsageHtml,
+    } from "../../../lib/workspace-ui";
+    import { createElement } from "react";
+    import { createRoot } from "react-dom/client";
+
+    const page = "workspace page";
+    const w = window as unknown as {
+      __UPLOADS_API_ORIGIN__: string;
+      __UPLOADS_ACTIVE_WORKSPACE__: string;
+    };
+    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+    const workspaceName = w.__UPLOADS_ACTIVE_WORKSPACE__;
+    const browseOnLoad = readBrowseLocation(window.location.search, window.location.pathname);
+    const searchFiltersOnLoad = readSearchFilters(window.location.search);
+
+    const statusEl = requireElement<HTMLElement>("#ws-status", page);
+    const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
+    const appEl = requireElement<HTMLElement>("#ws-app", page);
+    const nameEl = requireElement<HTMLElement>("#ws-name", page);
+    const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+    const roleEl = requireElement<HTMLElement>("#ws-role", page);
+    const usageEl = requireElement<HTMLElement>("#ws-usage", page);
+    const communalCard = requireElement<HTMLElement>("#ws-communal", page);
+    const filesCard = requireElement<HTMLElement>("#ws-files-card", page);
+    const galleriesCard = requireElement<HTMLElement>("#ws-galleries-card", page);
+    const inviteCard = requireElement<HTMLElement>("#ws-invite-card", page);
+    const operatorCard = requireElement<HTMLElement>("#ws-operator-card", page);
+    const filesEl = requireElement<HTMLElement>("#ws-files", page);
+    const galleriesEl = requireElement<HTMLElement>("#ws-galleries", page);
+    const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
+    const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
+    const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
+    const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
+
+    let sessionRole: string | null | undefined;
+    let filesRoot: ReturnType<typeof createRoot> | null = null;
+
+    function showError(message: string, retry = true): void {
+      statusEl.hidden = false;
+      statusEl.textContent = message;
+      statusEl.dataset.state = "error";
+      appEl.hidden = true;
+      retryBtn.hidden = !retry;
+    }
+
+    function renderGalleries(galleries: GallerySummary[]): void {
+      if (!galleries.length) {
+        galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet.</p>`;
+        return;
+      }
+      galleriesEl.innerHTML = `<ul class="ws-items">${galleries
+        .map(
+          (g) =>
+            `<li><a href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a></li>`,
+        )
+        .join("")}</ul>`;
+    }
+
+    async function loadWorkspace(): Promise<void> {
+      statusEl.hidden = false;
+      statusEl.textContent = "Loading workspace…";
+      statusEl.removeAttribute("data-state");
+      retryBtn.hidden = true;
+      appEl.hidden = true;
+
+      const result = await getMyWorkspaces(apiOrigin);
+      if (result.kind === "unavailable") {
+        showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
+        return;
+      }
+
+      const ws = result.workspaces.find((item) => item.workspace === workspaceName);
+      if (!ws) {
+        showError("You don’t have access to this workspace.", false);
+        return;
+      }
+
+      statusEl.hidden = true;
+      appEl.hidden = false;
+
+      const displayName = ws.organization.name || ws.workspace;
+      nameEl.textContent = displayName;
+      slugEl.textContent = ws.workspace;
+      slugEl.hidden = ws.workspace === displayName;
+      roleEl.textContent = ws.role;
+      roleEl.hidden = false;
+      document.title = `${displayName} · uploads.sh`;
+
+      void getMyWorkspaceUsage(apiOrigin, ws.workspace).then((usage) => {
+        usageEl.innerHTML = usage ? renderUsageHtml(usage) : "Usage unavailable.";
+      });
+
+      communalCard.hidden = !ws.communal;
+      filesCard.hidden = ws.communal;
+      galleriesCard.hidden = ws.communal;
+      inviteCard.hidden = !isWorkspaceAdminRole(ws.role);
+
+      if (!ws.communal) {
+        if (!filesRoot) filesRoot = createRoot(filesEl);
+        filesRoot.render(
+          createElement(WorkspaceFiles, {
+            apiOrigin,
+            workspace: ws.workspace,
+            hasPublicUrl: ws.hasPublicUrl,
+            initialPrefix:
+              !browseOnLoad.workspace || browseOnLoad.workspace === ws.workspace
+                ? browseOnLoad.path
+                : "",
+            initialFilters: searchFiltersOnLoad,
+            onPrefixChange: (path: string) => {
+              replaceBrowseLocation({ workspace: ws.workspace, path });
+            },
+          }),
+        );
+        void getMyWorkspaceGalleries(apiOrigin, ws.workspace).then(renderGalleries);
+      }
+
+      const isOperator = sessionRole === "admin";
+      operatorCard.hidden = !isOperator;
+      if (isOperator) {
+        const cmd = operatorInviteCommand(ws.workspace);
+        operatorCmd.textContent = cmd;
+        operatorCopy.dataset.copy = cmd;
+      }
+    }
+
+    bindCopyButtons(document);
+
+    requireElement<HTMLFormElement>("#ws-invite-form", page).addEventListener("submit", (event) => {
+      void (async () => {
+        event.preventDefault();
+        const form = event.currentTarget as HTMLFormElement;
+        const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
+        const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+        const email = emailInput?.value.trim() ?? "";
+        if (!email || !submit) return;
+
+        inviteStatus.hidden = false;
+        inviteStatus.textContent = "Creating invite…";
+        inviteLink.hidden = true;
+        inviteLink.textContent = "";
+        submit.disabled = true;
+        const result = await inviteToWorkspace(apiOrigin, workspaceName, email);
+        submit.disabled = false;
+
+        if (result.kind === "ok") {
+          inviteStatus.textContent =
+            result.emailConfigured === true
+              ? `Invitation emailed to ${email}.`
+              : result.emailConfigured === false
+                ? `Invite created for ${email} — share the accept link below.`
+                : `Invite created for ${email}.`;
+          if (emailInput) emailInput.value = "";
+          if (result.acceptUrl) {
+            inviteLink.hidden = false;
+            inviteLink.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
+          }
+          return;
+        }
+        inviteStatus.textContent =
+          result.reason === "forbidden"
+            ? "You need workspace admin access to invite."
+            : result.reason === "invalid"
+              ? "That email doesn’t look valid."
+              : "Couldn’t create the invite. Try again.";
+      })();
+    });
+
+    retryBtn.addEventListener("click", () => {
+      void loadWorkspace();
+    });
+
+    onSession((user) => {
+      sessionRole = user.role;
+      void loadWorkspace();
+    });
+  </script>
+</AccountLayout>

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -1,0 +1,154 @@
+---
+import AccountLayout from "../../../layouts/AccountLayout.astro";
+
+export const prerender = false;
+---
+
+<AccountLayout section="workspaces" creating title="New workspace">
+  <section class="card" id="create">
+    <h2>Create a workspace</h2>
+    <p class="ws-lead">
+      Public folder on the shared bucket — unguessable URLs under
+      <code>storage.uploads.sh/&lt;name&gt;/…</code> for PR embeds.
+      Free: 1&nbsp;GB · 25&nbsp;MB per file.
+    </p>
+
+    <form class="ws-form" data-create-form>
+      <div class="input-group">
+        <label class="input-group__field">
+          <span class="sr-only">Workspace name</span>
+          <input
+            name="name"
+            required
+            pattern="[a-z0-9][a-z0-9-]{1,62}"
+            placeholder="workspace-name"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </label>
+        <button type="submit" class="input-group__action">Create</button>
+      </div>
+      <p class="ws-hint muted">2–63 chars · lowercase letters, digits, hyphens</p>
+    </form>
+
+    <div class="ws-messages">
+      <div class="ul-callout" data-create-success role="status" hidden>
+        <p><strong data-created-name></strong> is ready. Upload from the terminal:</p>
+        <div class="command">
+          <code>npm install -g @buildinternet/uploads</code>
+          <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite">copy</button>
+        </div>
+        <div class="command">
+          <code>uploads login</code>
+          <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
+        </div>
+        <div class="command">
+          <code>uploads put ./screenshot.png</code>
+          <button type="button" data-copy="uploads put ./screenshot.png" aria-live="polite">copy</button>
+        </div>
+        <p class="muted cli-note">
+          Agents: <code>uploads install</code> adds the skill + MCP.
+        </p>
+        <p class="muted cli-note">
+          <a data-open-workspace href="/account/workspaces">Open this workspace →</a>
+        </p>
+      </div>
+      <p class="muted cli-note" data-create-error role="alert" hidden></p>
+      <p class="muted cli-note" data-create-github role="status" hidden>
+        Requires a linked GitHub account.
+        <button type="button" class="text-btn" data-connect-github>Connect GitHub</button>
+      </p>
+      <p class="muted cli-note" data-github-error role="alert" hidden>
+        GitHub linking isn't available —
+        <a href="/account/profile">try from your profile</a>.
+      </p>
+    </div>
+  </section>
+
+  <script>
+    import { onSession, requireElement } from "../../../lib/account-shell";
+    import { linkGitHub, listAccounts } from "../../../lib/auth-client";
+    import { createWorkspace } from "../../../lib/api-client";
+    import {
+      bindCopyButtons,
+      createErrorCopy,
+      suggestedWorkspaceName,
+    } from "../../../lib/workspace-ui";
+
+    const w = window as unknown as {
+      __UPLOADS_API_ORIGIN__: string;
+      __UPLOADS_AUTH_ORIGIN__: string;
+    };
+    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+    const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+    const page = "create workspace";
+
+    const form = requireElement<HTMLFormElement>("[data-create-form]", page);
+    const errorEl = requireElement<HTMLElement>("[data-create-error]", page);
+    const githubEl = requireElement<HTMLElement>("[data-create-github]", page);
+    const successEl = requireElement<HTMLElement>("[data-create-success]", page);
+    const createdName = requireElement<HTMLElement>("[data-created-name]", page);
+    const githubError = requireElement<HTMLElement>("[data-github-error]", page);
+    const connectBtn = requireElement<HTMLButtonElement>("[data-connect-github]", page);
+    const openLink = requireElement<HTMLAnchorElement>("[data-open-workspace]", page);
+    const input = form.elements.namedItem("name") as HTMLInputElement;
+    const submit = form.querySelector<HTMLButtonElement>("button[type='submit']");
+
+    void listAccounts(authOrigin).then((accounts) => {
+      if (accounts && !accounts.some((a) => a.providerId === "github")) githubEl.hidden = false;
+    });
+
+    if (new URLSearchParams(location.search).get("error")) githubError.hidden = false;
+
+    connectBtn.addEventListener("click", () => {
+      void (async () => {
+        githubError.hidden = true;
+        connectBtn.disabled = true;
+        connectBtn.textContent = "Redirecting…";
+        if (!(await linkGitHub(authOrigin, `${location.origin}/account/workspaces/new`))) {
+          connectBtn.disabled = false;
+          connectBtn.textContent = "Connect GitHub";
+          githubError.hidden = false;
+        }
+      })();
+    });
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      void (async () => {
+        errorEl.hidden = true;
+        githubEl.hidden = true;
+        successEl.hidden = true;
+        const name = input.value.trim();
+        if (submit) submit.disabled = true;
+        const result = await createWorkspace(apiOrigin, name);
+        if (submit) submit.disabled = false;
+        if (result.kind === "created") {
+          input.value = "";
+          createdName.textContent = name;
+          openLink.href = `/account/workspaces/${encodeURIComponent(name)}`;
+          successEl.hidden = false;
+          return;
+        }
+        if (result.kind === "error" && result.code === "github_required") {
+          githubEl.hidden = false;
+          return;
+        }
+        errorEl.textContent =
+          result.kind === "unavailable"
+            ? "The API is unreachable right now — try again shortly."
+            : createErrorCopy(result.code);
+        errorEl.hidden = false;
+      })();
+    });
+
+    bindCopyButtons(requireElement<HTMLElement>("#create", page));
+
+    onSession((user) => {
+      if (!input.value) {
+        const suggestion = suggestedWorkspaceName(user.email);
+        if (suggestion) input.value = suggestion;
+      }
+    });
+  </script>
+</AccountLayout>

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -363,6 +363,219 @@ ul.detail-list .detail-current {
   letter-spacing: 0.04em;
 }
 
+/* Dedicated workspace page (/account/workspaces/:name) ────────────────── */
+
+.ws-page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px 16px;
+}
+.ws-page-header .ws-title-block {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+.ws-page-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  text-wrap: balance;
+}
+.ws-page-header .ws-role {
+  flex-shrink: 0;
+}
+.ws-page-header .usage {
+  width: 100%;
+  color: var(--muted);
+  font-size: 12px;
+  display: grid;
+  gap: 6px;
+  min-height: 1.2em;
+  margin-top: 4px;
+}
+.ws-page-header .usage .usage-text,
+.ws-page-header .usage .usage-meta {
+  line-height: 1.35;
+}
+.ws-page-header .usage .usage-meta {
+  font-size: 11px;
+  opacity: 0.9;
+}
+section.card .ws-section-head {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 10px;
+}
+section.card .ws-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 5px;
+}
+section.card .ws-items li {
+  font-size: 13px;
+}
+section.card .ws-empty,
+section.card .ws-note {
+  color: var(--muted);
+  font-size: 13px;
+  margin: 0;
+}
+section.card .ws-note {
+  color: var(--body);
+}
+/* Workspace page copy + joined input group ────────────────────────────── */
+
+.ws-lead {
+  margin: 8px 0 0;
+  max-width: 36rem;
+  text-wrap: pretty;
+}
+.ws-status {
+  margin-top: 12px;
+  font-size: 13px;
+}
+.ws-form {
+  margin-top: 16px;
+  max-width: 28rem;
+}
+/* Joined control: one outer border, hairline between input and action. */
+.input-group {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  overflow: hidden;
+}
+.input-group:focus-within {
+  border-color: var(--accent);
+}
+.input-group__field {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  display: block;
+}
+.input-group__field input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--fg);
+  padding: 10px 12px;
+  font: 13px var(--mono);
+  outline: none;
+}
+.input-group__field input::placeholder {
+  color: var(--muted);
+}
+.input-group__action {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  border: 0;
+  border-left: 1px solid var(--line);
+  border-radius: 0;
+  background: var(--panel);
+  color: var(--accent);
+  padding: 0 14px;
+  font: 12px var(--mono);
+  letter-spacing: 0.03em;
+  cursor: pointer;
+}
+.input-group:focus-within .input-group__action {
+  border-left-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+}
+.input-group__action:hover,
+.input-group__action:focus-visible {
+  background: color-mix(in srgb, var(--accent) 10%, var(--panel));
+  outline: none;
+}
+.input-group__action:active {
+  transform: scale(0.96);
+}
+.input-group__action:disabled {
+  opacity: 0.55;
+  cursor: default;
+  transform: none;
+}
+.ws-hint {
+  margin: 8px 0 0;
+  font-size: 11px;
+}
+.ws-messages {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+.ws-messages:not(:has(:not([hidden]))) {
+  display: none;
+  margin: 0;
+}
+.ws-messages .cli-note {
+  margin: 0;
+}
+.ws-messages .ul-callout p {
+  margin: 0;
+}
+.ws-messages .ul-callout .command {
+  margin-top: 8px;
+}
+.ws-messages .ul-callout .command + .command {
+  margin-top: 6px;
+}
+.ws-messages .ul-callout .cli-note {
+  margin-top: 10px;
+}
+section.card .command {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+section.card .command code {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow-x: auto;
+  display: block;
+  border: 0;
+  background: none;
+  padding: 0;
+  font-size: 12px;
+}
+section.card .command button {
+  flex-shrink: 0;
+  font: 11px var(--mono);
+  letter-spacing: 0.05em;
+  color: var(--accent);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 10px;
+  background: var(--panel);
+  cursor: pointer;
+}
+section.card .command button:hover,
+section.card .command button:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+section.card .cli-note {
+  margin: 10px 0 0;
+  font-size: 12px;
+}
 /* Workspace file browser: metadata search entry + results ─────────────── */
 
 .ws-search-bar {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -217,7 +217,12 @@ section.card.is-pending {
   gap: 8px;
   margin-top: 14px;
 }
-.cli-steps .command {
+/* Single-row follow-on under a note (e.g. uploads install). */
+.cli-steps--solo {
+  margin-top: 8px;
+}
+/* Shared copyable command row (CLI setup, workspace invite, create success). */
+section.card .command {
   display: flex;
   gap: 10px;
   align-items: center;
@@ -225,7 +230,7 @@ section.card.is-pending {
   border-radius: var(--radius-sm);
   background: var(--bg);
 }
-.cli-steps .command code {
+section.card .command code {
   flex: 1;
   min-width: 0;
   white-space: nowrap;
@@ -236,7 +241,7 @@ section.card.is-pending {
   padding: 0;
   font-size: 12px;
 }
-.cli-steps .command button {
+section.card .command button {
   flex-shrink: 0;
   font: 11px var(--mono);
   letter-spacing: 0.05em;
@@ -247,8 +252,8 @@ section.card.is-pending {
   background: var(--panel);
   cursor: pointer;
 }
-.cli-steps .command button:hover,
-.cli-steps .command button:focus-visible {
+section.card .command button:hover,
+section.card .command button:focus-visible {
   border-color: var(--accent);
   outline: none;
 }
@@ -536,45 +541,11 @@ section.card .ws-note {
 .ws-messages .ul-callout .cli-note {
   margin-top: 10px;
 }
-section.card .command {
-  display: flex;
-  gap: 10px;
-  align-items: center;
+/* Operator / create-success command rows sit under copy, not in .cli-steps. */
+section.card .command + .command,
+section.card .ws-messages .command,
+section.card #ws-operator-card .command {
   margin-top: 10px;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  background: var(--bg);
-}
-section.card .command code {
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow-x: auto;
-  display: block;
-  border: 0;
-  background: none;
-  padding: 0;
-  font-size: 12px;
-}
-section.card .command button {
-  flex-shrink: 0;
-  font: 11px var(--mono);
-  letter-spacing: 0.05em;
-  color: var(--accent);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 5px 10px;
-  background: var(--panel);
-  cursor: pointer;
-}
-section.card .command button:hover,
-section.card .command button:focus-visible {
-  border-color: var(--accent);
-  outline: none;
-}
-section.card .cli-note {
-  margin: 10px 0 0;
-  font-size: 12px;
 }
 /* Workspace file browser: metadata search entry + results ─────────────── */
 

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -139,6 +139,51 @@ nav.side a[aria-current="page"] {
   background: var(--panel);
   border-color: var(--line);
 }
+/* Nested workspaces under the Workspaces parent. */
+nav.side .side-group {
+  display: grid;
+  gap: 2px;
+}
+nav.side .side-nested {
+  display: grid;
+  gap: 2px;
+  margin: 2px 0 2px 12px;
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+}
+nav.side .side-nested-list {
+  display: grid;
+  gap: 2px;
+  min-height: 0;
+}
+nav.side .side-nested-item {
+  display: block;
+  padding: 6px 10px;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+nav.side .side-nested-item:hover {
+  color: var(--fg);
+}
+nav.side .side-nested-item[aria-current="page"] {
+  color: var(--accent);
+  background: var(--panel);
+  border-color: var(--line);
+}
+nav.side .side-nested-item.side-new {
+  color: color-mix(in srgb, var(--muted) 85%, var(--accent));
+}
+nav.side .side-nested-item.side-new:hover,
+nav.side .side-nested-item.side-new:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
 nav.side .side-foot {
   margin-top: 14px;
   padding-top: 14px;
@@ -210,6 +255,21 @@ span.muted {
     position: static;
     grid-template-columns: repeat(auto-fit, minmax(90px, max-content));
     gap: 6px;
+  }
+  /* Nested workspaces stay a vertical stack within the horizontal chip row. */
+  nav.side .side-group {
+    grid-column: 1 / -1;
+  }
+  nav.side .side-nested {
+    margin-left: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 6px;
+    border-left: 0;
+    padding-left: 0;
+  }
+  nav.side .side-nested-list {
+    display: contents;
   }
   nav.side .side-foot {
     grid-column: 1 / -1;

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -112,11 +112,12 @@ The prefix is applied in exactly one place — `createStorage()` in
 ## Self-serve workspaces
 
 Signed-in users with a **GitHub-linked account** can create their own
-workspace without an operator: `/account/workspaces` has a "Create a
-workspace" form (anchor `#create`), and `POST /v1/workspaces` (session-authed,
-no `ADMIN_TOKEN`) backs it. `uploads login` offers the same flow when the
-signed-in account has zero workspaces yet — interactively it prompts to
-create one; non-interactively it errors with guidance.
+workspace without an operator: `/account/workspaces/new` is the create form
+(also linked from the account sidebar), and `POST /v1/workspaces`
+(session-authed, no `ADMIN_TOKEN`) backs it. Each membership has a dedicated
+page at `/account/workspaces/<name>`. `uploads login` offers the same create
+flow when the signed-in account has zero workspaces yet — interactively it
+prompts to create one; non-interactively it errors with guidance.
 
 Creation provisions a Better Auth organization (the caller as owner) and a
 `ws:<name>` KV record in the shared `uploads-default` bucket, same as the

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -105,8 +105,8 @@ config file is written, every later `uploads` invocation — including from a
 non-interactive agent — just reads the saved token. Routine agents never need
 `ADMIN_TOKEN`.
 
-**Inviting a teammate** (workspace admin/owner only): `/account/workspaces` in the
-browser, or:
+**Inviting a teammate** (workspace admin/owner only): open the workspace under
+`/account/workspaces/<name>` in the browser, or:
 
 ```bash
 uploads invite create --email teammate@example.com --workspace acme


### PR DESCRIPTION
## In plain terms

The account Workspaces page used to dump every membership, file browser, invite form, and operator snippet into one long card. Workspaces now show as nested sidebar items, each with a dedicated page and a separate create flow, so the UI is easier to scan and manage.

## What it does

- Nested sidebar links under **Workspaces**, plus **+ New workspace**
- Dedicated page per workspace: header/usage, files, galleries, invite, operator (when relevant)
- Create flow at `/account/workspaces/new` with a joined name + Create control
- Index at `/account/workspaces` picks from a short list (or auto-opens when you only have one)
- Legacy `?ws=` deep links redirect to `/account/workspaces/<name>` and keep `path` / `meta.*`
- Reserves workspace slug `new` so it cannot collide with the create route

## What it is not

- No API auth/storage changes beyond reserving the `new` slug
- No CodeRabbit request (on-demand only)

## How to try it

1. Sign in and open `/account/workspaces`
2. Confirm memberships appear nested in the sidebar
3. Open a workspace — sections should feel separate, not one stacked wall
4. Use **+ New workspace** — joined input group + shorter copy
5. Hit an old link like `/account/workspaces?ws=buildinternet&path=screenshots/` and confirm it lands on the path-based page

## Technical notes

- Routes: `workspaces.astro` (index), `workspaces/new.astro`, `workspaces/[name].astro`
- Shared helpers: `workspace-ui.ts`, `workspaces-nav.ts`
- Browse/search URL helpers prefer path-based workspace identity

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run` (browse/search URL + reachability)
- [x] `pnpm --filter @uploads/api exec vitest run src/slug-policy.test.ts`
- [x] `pnpm --filter @uploads/web exec tsc --noEmit`
- [ ] Manual pass on signed-in shell (sidebar nest, create form, invite, operator block)