### PR TITLE
fix(web): clarify releases.sh footer as agent registry

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -77,7 +77,7 @@ const COLUMNS: FooterColumn[] = [
           <a href="https://buildinternet.com">Build Internet</a>.
         </p>
         <p>
-          Release notes for the tools you use —{" "}
+          Release notes registry for agents —{" "}
           <a href={RELEASES_URL} rel="noopener">
             releases.sh →
           </a>

--- a/docs/superpowers/specs/2026-07-16-homepage-tweaks-design.md
+++ b/docs/superpowers/specs/2026-07-16-homepage-tweaks-design.md
@@ -65,7 +65,7 @@ keeps today's one-liner.
 - **Project column:** GitHub (repo), Terms, Privacy
 - **Family bar** below a divider: left, "Maintained by Zach Dunn / Build
   Internet" (links to zachdunn.com / buildinternet.com); right, "Release notes
-  for the tools you use — releases.sh →" with `rel="noopener"` only (no
+  registry for agents — releases.sh →" with `rel="noopener"` only (no
   `noreferrer`), mirroring how releases.sh links back to uploads.sh.
 
 Styling stays in-system: mono 12px, `var(--line)` borders, muted links with


### PR DESCRIPTION
## In plain terms

The site footer link to releases.sh now says what that product is: a release notes registry for agents, not a generic “tools you use” line.

## What it does

- Updates the family-bar copy to: **Release notes registry for agents — releases.sh →**
- Aligns the homepage-tweaks design spec with the same wording

## What it is not

- No layout, link target, or `rel` changes

## Test plan

- [x] Diff-only copy change in `Footer.astro`
- [ ] Spot-check footer on a non-compact page (e.g. `/` or `/docs`) after deploy or local `pnpm dev:web`