### PR TITLE
fix(cli): infer PR from current branch by passing a branch selector

### DIFF
--- a/.changeset/pr-inference-branch-selector.md
+++ b/.changeset/pr-inference-branch-selector.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Fix PR inference from the current branch: `gh pr view --repo` requires an explicit selector, so pass the current branch name. `uploads attach`/`put` from a branch with an open PR now resolve it instead of erroring.

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -50,9 +50,14 @@ export function resolveRepo(explicit: string | undefined, run: CommandRunner = e
 /** Resolve the pull request associated with the current branch. */
 export function resolveCurrentPullRequest(repo: string, run: CommandRunner = execRunner): GhTarget {
   try {
+    // `gh pr view --repo` requires an explicit selector (it refuses to infer
+    // from the current branch), so pass the branch name as the selector.
+    const branch = run("git", ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+    if (branch === "" || branch === "HEAD") throw new Error("detached HEAD");
     const out = run("gh", [
       "pr",
       "view",
+      branch,
       "--repo",
       repo,
       "--json",

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -534,6 +534,7 @@ describe("runPut gh.* metadata (explicit target)", () => {
 /** Fake gh: answers `gh pr view` (branch→PR) and `gh api` (classify). */
 function ghRunner(opts: { pr?: number; classify?: "pull" | "issue" }): CommandRunner {
   return (cmd, args) => {
+    if (cmd === "git" && args[0] === "rev-parse") return "feature/thing\n"; // current branch
     if (cmd === "gh" && args[0] === "repo") return "o/r\n"; // resolveRepo fallback
     if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
       if (opts.pr) return `${opts.pr}\n`;

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -3,6 +3,7 @@ import { UsageError } from "../src/cli-args.js";
 import { ATTACHMENTS_MARKER, type GhTarget } from "../src/github.js";
 import {
   classifyGhNumber,
+  resolveCurrentPullRequest,
   resolveRepo,
   upsertAttachmentsComment,
   type CommandRunner,
@@ -51,6 +52,54 @@ describe("resolveRepo", () => {
   it("throws UsageError when nothing resolves", () => {
     const { run } = fakeRunner({});
     expect(() => resolveRepo(undefined, run)).toThrow(UsageError);
+  });
+});
+
+describe("resolveCurrentPullRequest", () => {
+  it("passes the current branch as the selector so --repo stays honored", () => {
+    const { run, calls } = fakeRunner({
+      git: (args) => {
+        expect(args).toEqual(["rev-parse", "--abbrev-ref", "HEAD"]);
+        return "feature/thing\n";
+      },
+      gh: () => "208\n",
+    });
+    expect(resolveCurrentPullRequest("buildinternet/uploads", run)).toEqual({
+      repo: "buildinternet/uploads",
+      kind: "pull",
+      num: 208,
+    });
+    const gh = calls.find((c) => c.cmd === "gh");
+    expect(gh?.args).toEqual([
+      "pr",
+      "view",
+      "feature/thing",
+      "--repo",
+      "buildinternet/uploads",
+      "--json",
+      "number",
+      "--jq",
+      ".number",
+    ]);
+  });
+
+  it("throws UsageError on a detached HEAD instead of calling gh", () => {
+    const { run, calls } = fakeRunner({
+      git: () => "HEAD\n",
+      gh: () => "1\n",
+    });
+    expect(() => resolveCurrentPullRequest("o/r", run)).toThrow(UsageError);
+    expect(calls.some((c) => c.cmd === "gh")).toBe(false);
+  });
+
+  it("throws UsageError when gh finds no PR for the branch", () => {
+    const { run } = fakeRunner({
+      git: () => "feature/thing\n",
+      gh: () => {
+        throw new Error("no pull requests found for branch");
+      },
+    });
+    expect(() => resolveCurrentPullRequest("o/r", run)).toThrow(/could not infer a pull request/);
   });
 });
 


### PR DESCRIPTION
## Summary

`uploads attach`/`put` from a branch with an open PR always failed with "could not infer a pull request for the current branch" because `resolveCurrentPullRequest` ran `gh pr view --repo <owner/name>` with no selector — and `gh pr view` refuses to infer from the current branch when `--repo` is passed.

Fixes #209

## Changes

- `resolveCurrentPullRequest` now resolves the current branch via `git rev-parse --abbrev-ref HEAD` and passes it as the selector, keeping `--repo` honored (matters for forks/explicit `--repo`).
- Detached HEAD (or empty output) short-circuits to the existing UsageError without calling gh.
- Regression tests assert the exact argv shape of the gh invocation, plus detached-HEAD and no-PR paths; the `commands-put` stub runner now answers `git rev-parse`.

## Verification

- All 493 package tests pass; typecheck clean.
- Live check of the invocation shape against the case from the issue: `gh pr view claude/landing-page-updates-bbdf6f --repo buildinternet/uploads --json number --jq .number` → `208`.
