### PR TITLE
feat(mcp): multi-file put on the remote MCP worker

### DIFF
--- a/.changeset/remote-mcp-multi-put.md
+++ b/.changeset/remote-mcp-multi-put.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Export `mapBounded` from the `/mcp` entry so runtime-agnostic MCP tool sets (like the hosted worker's multi-file `put`) can share the SDK's bounded-concurrency batch helper.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -474,7 +474,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           usage("key cannot be combined with prefix/repo/ref");
         }
 
-        const maxBytes = resolveUploadPolicy(workspace).maxBytes;
+        const policy = resolveUploadPolicy(workspace);
+        // Pre-decode gate uses the policy ceiling (video caps can exceed
+        // maxBytes); putObject's inspectUpload enforces the content-specific
+        // limit after sniffing, so an over-cap image still fails per item.
+        const maxBytes = Math.max(policy.maxBytes, policy.maxVideoBytes);
         const alt = optString(args, "alt");
         const width = optPosInt(args, "width");
         const putOpts = metadata !== undefined ? { metadata } : undefined;
@@ -492,23 +496,42 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               );
             }
           });
+          // Keys are deterministic (sanitized name + content hash), so two
+          // items can collide — e.g. the same file listed twice. Reject
+          // before any write: concurrent same-key puts would double-count
+          // the usage ledger and report more uploads than stored objects.
+          const keys = await Promise.all(
+            decoded.map((bytes, i) =>
+              buildScreenshotKey({
+                filename: items[i]!.filename,
+                fileBytes: bytes,
+                prefix,
+                repo,
+                ref,
+                deriveRepoFromGit: false,
+              }),
+            ),
+          );
+          const firstIndexByKey = new Map<string, number>();
+          keys.forEach((key, i) => {
+            const first = firstIndexByKey.get(key);
+            if (first === undefined) {
+              firstIndexByKey.set(key, i);
+              return;
+            }
+            usage(
+              `files[${i}] (${items[i]!.filename}) resolves to the same key as files[${first}] (${items[first]!.filename}): ${key}`,
+            );
+          });
           type Slot =
             | { ok: true; upload: Record<string, unknown> }
             | { ok: false; file: string; err: unknown };
           const slots: Slot[] = await mapBounded(items, PUT_CONCURRENCY, async (item, i) => {
             try {
-              const key = await buildScreenshotKey({
-                filename: item.filename,
-                fileBytes: decoded[i]!,
-                prefix,
-                repo,
-                ref,
-                deriveRepoFromGit: false,
-              });
               const result = await putObject(
                 env,
                 workspace,
-                key,
+                keys[i]!,
                 decoded[i]!,
                 workspaceName,
                 putOpts,

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -8,6 +8,9 @@
 import { buildMarkdown, buildScreenshotKey } from "@buildinternet/uploads";
 import {
   METADATA_DESCRIPTION,
+  ToolBatchError,
+  batchFailureMessage,
+  mapBounded,
   metadataProp,
   optPosInt,
   optString,
@@ -16,7 +19,7 @@ import {
   usage,
   type McpTool,
 } from "@buildinternet/uploads/mcp";
-import { NotFoundError } from "@uploads/errors";
+import { AppError, NotFoundError } from "@uploads/errors";
 import { badKey } from "@uploads/api/files";
 import {
   findObjectsByMetadata,
@@ -74,6 +77,58 @@ function decodeBase64(value: string, maxBytes: number): Uint8Array {
   return Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
 }
 
+/** Max items per multi-file put call — bounds decoded bytes held in isolate memory. */
+export const MAX_PUT_FILES = 20;
+/** Bounded parallelism for batch writes (each is a D1 budget check + R2 put). */
+const PUT_CONCURRENCY = 5;
+
+interface PutFileItem {
+  filename: string;
+  contentBase64: string;
+  alt?: string;
+}
+
+/** Validate the multi-file `files` argument shape (content, not paths — no filesystem here). */
+function optPutFileItems(args: Record<string, unknown>): PutFileItem[] | undefined {
+  const v = args.files;
+  if (v === undefined || v === null) return undefined;
+  if (!Array.isArray(v)) usage("files must be an array of { filename, contentBase64 } objects");
+  return v.map((entry, i) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      usage(`files[${i}] must be an object with filename and contentBase64`);
+    }
+    const rec = entry as Record<string, unknown>;
+    for (const key of Object.keys(rec)) {
+      if (!["filename", "contentBase64", "alt"].includes(key)) {
+        usage(`files[${i}].${key} is not a valid property`);
+      }
+    }
+    const { filename, contentBase64, alt } = rec;
+    if (typeof filename !== "string" || !filename) usage(`files[${i}].filename is required`);
+    if (typeof contentBase64 !== "string" || !contentBase64) {
+      usage(`files[${i}].contentBase64 is required`);
+    }
+    if (alt !== undefined && typeof alt !== "string") usage(`files[${i}].alt must be a string`);
+    return {
+      filename,
+      contentBase64,
+      ...(typeof alt === "string" ? { alt } : {}),
+    };
+  });
+}
+
+/** Per-item failure detail, same shape as the CLI/stdio `failures[]` entries. */
+function errorDetail(err: unknown): {
+  message: string;
+  code?: string;
+  status?: number;
+} {
+  if (err instanceof AppError) {
+    return { message: err.message, code: String(err.code), status: err.status };
+  }
+  return { message: err instanceof Error ? err.message : String(err) };
+}
+
 export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
   const { env, workspace, workspaceName } = ctx;
 
@@ -122,8 +177,14 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       inputSchema: {
         type: "object",
         properties: {
-          title: { type: "string", description: "Gallery title (1–120 characters)." },
-          description: { type: "string", description: "Optional public gallery description." },
+          title: {
+            type: "string",
+            description: "Gallery title (1–120 characters).",
+          },
+          description: {
+            type: "string",
+            description: "Optional public gallery description.",
+          },
         },
         required: ["title"],
         additionalProperties: false,
@@ -147,7 +208,9 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         "Get a workspace-owned gallery, including its ordered media and canonical public URL. Gallery media is public to anyone with the URL.",
       inputSchema: {
         type: "object",
-        properties: { galleryId: { type: "string", description: "Opaque gallery ID." } },
+        properties: {
+          galleryId: { type: "string", description: "Opaque gallery ID." },
+        },
         required: ["galleryId"],
         additionalProperties: false,
       },
@@ -164,7 +227,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         type: "object",
         properties: {
           galleryId: { type: "string", description: "Opaque gallery ID." },
-          objectKey: { type: "string", description: "Existing public object key to add." },
+          objectKey: {
+            type: "string",
+            description: "Existing public object key to add.",
+          },
           caption: { type: "string", description: "Optional public caption." },
           altText: { type: "string", description: "Optional public alt text." },
         },
@@ -224,7 +290,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         type: "object",
         properties: {
           galleryId: { type: "string", description: "Opaque gallery ID." },
-          provider: { type: "string", description: "External provider (currently github)." },
+          provider: {
+            type: "string",
+            description: "External provider (currently github).",
+          },
           coordinate: {
             type: "string",
             description: "Provider-native external reference coordinate.",
@@ -257,12 +326,18 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       inputSchema: {
         type: "object",
         properties: {
-          provider: { type: "string", description: "External provider (currently github)." },
+          provider: {
+            type: "string",
+            description: "External provider (currently github).",
+          },
           coordinate: {
             type: "string",
             description: "Provider-native external reference coordinate.",
           },
-          limit: { type: "number", description: "Page size (default 50, max 100)." },
+          limit: {
+            type: "number",
+            description: "Page size (default 50, max 100).",
+          },
         },
         required: ["provider", "coordinate"],
         additionalProperties: false,
@@ -288,17 +363,42 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "put",
       description:
-        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead. Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
+        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
       inputSchema: {
         type: "object",
         properties: {
           contentBase64: {
             type: "string",
-            description: "Base64-encoded file content to upload (must be non-empty).",
+            description:
+              "Base64-encoded file content to upload (must be non-empty). Exactly one of contentBase64 or files is required.",
           },
           filename: {
             type: "string",
             description: "Filename for the content (drives the key and content type).",
+          },
+          files: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                filename: {
+                  type: "string",
+                  description: "Filename for this item (drives the key and content type).",
+                },
+                contentBase64: {
+                  type: "string",
+                  description: "Base64-encoded content for this item (must be non-empty).",
+                },
+                alt: {
+                  type: "string",
+                  description:
+                    "Per-item alt text override (default: top-level alt, then filename).",
+                },
+              },
+              required: ["filename", "contentBase64"],
+              additionalProperties: false,
+            },
+            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/width/metadata apply to every item. Returns { uploads, failures } with per-item results.`,
           },
           key: {
             type: "string",
@@ -317,7 +417,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             type: "string",
             description: "PR/issue/branch key segment for the default key layout (default: today).",
           },
-          alt: { type: "string", description: "Alt text for the markdown (default: filename)." },
+          alt: {
+            type: "string",
+            description: "Alt text for the markdown (default: filename).",
+          },
           width: {
             type: "number",
             description: "Emit <img width=…> markdown instead of a plain image embed.",
@@ -329,16 +432,30 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               "Queryable custom metadata (key→value), separate from provenance. Omit to leave any metadata already stored for this key untouched; pass an object (even {}) to fully replace it. Keys: lowercase, ^[a-z][a-z0-9._-]{0,63}$. Values: 1-512 printable ASCII characters. Caps: at most 24 keys, at most 8192 total key+value bytes. Suggested keys: app, url, page, device, resolution, commit, branch. `gh.*` is reserved by convention for GitHub PR/issue attachment context (repo/kind/number/ref), normally system-managed by the attach flow.",
           },
         },
-        required: ["contentBase64", "filename"],
         additionalProperties: false,
       },
       async handler(args) {
         requireScope("files:write");
+        // One limiter hit per tool call, single or batch — the batch's cost
+        // ceiling is bounded by MAX_PUT_FILES instead.
         await requireWriteBudget();
         const contentBase64 = optString(args, "contentBase64");
         const filename = optString(args, "filename");
-        if (!contentBase64) usage("contentBase64 is required");
-        if (!filename) usage("filename is required");
+        const items = optPutFileItems(args);
+        const multi = items !== undefined;
+        if (multi) {
+          if (contentBase64 !== undefined || filename !== undefined) {
+            usage("contentBase64/filename cannot be combined with files");
+          }
+          if (items.length === 0) usage("files must be a non-empty array");
+          if (items.length > MAX_PUT_FILES) {
+            usage(`files supports at most ${MAX_PUT_FILES} items per call`);
+          }
+          if (optString(args, "key")) usage("key cannot be combined with files");
+        } else {
+          if (!contentBase64) usage("contentBase64 is required");
+          if (!filename) usage("filename is required");
+        }
 
         const metadata = optStringRecord(args, "metadata");
         if (metadata) {
@@ -357,13 +474,82 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           usage("key cannot be combined with prefix/repo/ref");
         }
 
-        const bytes = decodeBase64(contentBase64, resolveUploadPolicy(workspace).maxBytes);
+        const maxBytes = resolveUploadPolicy(workspace).maxBytes;
+        const alt = optString(args, "alt");
+        const width = optPosInt(args, "width");
+        const putOpts = metadata !== undefined ? { metadata } : undefined;
+
+        if (multi) {
+          // Decode (and size-gate) every item before any write, so a
+          // structurally invalid batch fails whole with a usage error
+          // instead of leaving partial writes behind.
+          const decoded = items.map((item, i) => {
+            try {
+              return decodeBase64(item.contentBase64, maxBytes);
+            } catch (err) {
+              usage(
+                `files[${i}] (${item.filename}): ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          });
+          type Slot =
+            | { ok: true; upload: Record<string, unknown> }
+            | { ok: false; file: string; err: unknown };
+          const slots: Slot[] = await mapBounded(items, PUT_CONCURRENCY, async (item, i) => {
+            try {
+              const key = await buildScreenshotKey({
+                filename: item.filename,
+                fileBytes: decoded[i]!,
+                prefix,
+                repo,
+                ref,
+                deriveRepoFromGit: false,
+              });
+              const result = await putObject(
+                env,
+                workspace,
+                key,
+                decoded[i]!,
+                workspaceName,
+                putOpts,
+              );
+              const markdown =
+                result.url === null
+                  ? undefined
+                  : buildMarkdown(result.url, {
+                      alt: item.alt ?? alt ?? item.filename,
+                      width,
+                    });
+              return {
+                ok: true,
+                upload: { file: item.filename, ...result, markdown },
+              };
+            } catch (err) {
+              return { ok: false, file: item.filename, err };
+            }
+          });
+          const uploads = slots.flatMap((slot) => (slot.ok ? [slot.upload] : []));
+          const failures = slots.flatMap((slot) =>
+            slot.ok ? [] : [{ file: slot.file, error: errorDetail(slot.err) }],
+          );
+          if (uploads.length === 0 && failures.length > 0) {
+            // Total failure → isError with structuredContent, same as stdio.
+            throw new ToolBatchError(batchFailureMessage(failures), {
+              workspace: workspaceName,
+              uploads,
+              failures,
+            });
+          }
+          return { workspace: workspaceName, uploads, failures };
+        }
+
+        const bytes = decodeBase64(contentBase64!, maxBytes);
 
         const key =
           explicitKey ??
           // deriveRepoFromGit: false — no git (or child_process) on a worker.
           (await buildScreenshotKey({
-            filename,
+            filename: filename!,
             fileBytes: bytes,
             prefix,
             repo,
@@ -375,20 +561,13 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         // shared with the REST API — the stored content type is sniffed there.
         // metadata is undefined when omitted (leave existing D1 rows
         // untouched); passing opts only when defined preserves that.
-        const result = await putObject(
-          env,
-          workspace,
-          key,
-          bytes,
-          workspaceName,
-          metadata !== undefined ? { metadata } : undefined,
-        );
+        const result = await putObject(env, workspace, key, bytes, workspaceName, putOpts);
         const markdown =
           result.url === null
             ? undefined
             : buildMarkdown(result.url, {
-                alt: optString(args, "alt") ?? filename,
-                width: optPosInt(args, "width"),
+                alt: alt ?? filename!,
+                width,
               });
         return { workspace: workspaceName, ...result, markdown };
       },
@@ -401,8 +580,14 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         type: "object",
         properties: {
           prefix: { type: "string", description: "Key prefix filter." },
-          limit: { type: "number", description: "Page size (default 100, max 1000)." },
-          cursor: { type: "string", description: "Pagination cursor from a previous call." },
+          limit: {
+            type: "number",
+            description: "Page size (default 100, max 1000).",
+          },
+          cursor: {
+            type: "string",
+            description: "Pagination cursor from a previous call.",
+          },
         },
         additionalProperties: false,
       },
@@ -462,7 +647,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         type: "object",
         properties: {
           key: { type: "string", description: "Object key to update." },
-          set: { ...metadataProp, description: "Keys to set/overwrite. " + METADATA_DESCRIPTION },
+          set: {
+            ...metadataProp,
+            description: "Keys to set/overwrite. " + METADATA_DESCRIPTION,
+          },
           delete: {
             type: "array",
             items: { type: "string" },
@@ -497,8 +685,14 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             ...metadataProp,
             description: "Metadata equality filters (at least one pair). " + METADATA_DESCRIPTION,
           },
-          prefix: { type: "string", description: "Key prefix filter, combinable with filters." },
-          limit: { type: "number", description: "Page size (default 50, max 500)." },
+          prefix: {
+            type: "string",
+            description: "Key prefix filter, combinable with filters.",
+          },
+          limit: {
+            type: "number",
+            description: "Page size (default 50, max 500).",
+          },
         },
         required: ["filters"],
         additionalProperties: false,
@@ -532,7 +726,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       name: "usage",
       description:
         "Workspace storage and monthly upload counters (and remaining headroom when budgets are configured).",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
       async handler() {
         requireScope("files:read");
         const snapshot = await getWorkspaceUsage(env.DB, workspaceName);
@@ -543,7 +741,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       name: "reconcile",
       description:
         "Rebuild usage ledger bytes/objects from storage (source of truth). Preserves the monthly upload counter. Requires files:write.",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
       async handler() {
         requireScope("files:write");
         await requireWriteBudget();
@@ -558,7 +760,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       name: "purge_expired",
       description:
         "Delete objects older than the workspace retentionDays setting, then reconcile. Skips if retention is unset. Requires files:delete.",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
       async handler() {
         requireScope("files:delete");
         await requireWriteBudget();
@@ -576,7 +782,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "health",
       description: "Check uploads.sh MCP server liveness. No scope required.",
-      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
       async handler() {
         return { ok: true };
       },

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -42,6 +42,7 @@ async function makeEnv(
   options: {
     d1?: { tokenHash: string; scopes: string };
     rateLimitOk?: boolean;
+    record?: Partial<WorkspaceRecord>;
   } = {},
 ): Promise<{
   env: Env;
@@ -51,6 +52,7 @@ async function makeEnv(
   const record: WorkspaceRecord = {
     ...workspace,
     tokenHash: await sha256Hex(TOKEN),
+    ...options.record,
   };
   const bucket = new FakeR2Bucket();
   // Keyed by `${workspace} ${objectKey}` -> ordered meta_key -> meta_value,
@@ -572,6 +574,44 @@ describe("mcp worker", () => {
     };
     expect(body.uploads).toEqual([]);
     expect(body.failures.map((f) => f.file)).toEqual(["a.txt", "b.txt"]);
+    expect(bucket.store.size).toBe(0);
+  });
+
+  it("multi-file put rejects duplicate generated keys before any write", async () => {
+    const { env, bucket } = await makeEnv();
+    // Same filename + same content → same sanitized-name/content-hash key.
+    const result = await callTool(env, "put", {
+      files: [
+        { filename: "shot.png", contentBase64: PNG_B64 },
+        { filename: "shot.png", contentBase64: PNG_B64 },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(
+      /^files\[1\] \(shot\.png\) resolves to the same key as files\[0\] \(shot\.png\): /,
+    );
+    expect(bucket.store.size).toBe(0);
+  });
+
+  it("multi-file put pre-decode gate uses the video cap ceiling; per-item limits still apply", async () => {
+    // Image cap below the 11-byte PNG, video cap above it: the batch must
+    // decode (ceiling gate), then fail the PNG per item — not whole-batch.
+    const { env, bucket } = await makeEnv({
+      record: { maxUploadBytes: 8, maxVideoUploadBytes: 4096 },
+    });
+    const result = await callTool(env, "put", {
+      files: [{ filename: "big.png", contentBase64: PNG_B64 }],
+    });
+    expect(result.isError).toBe(true);
+    const body = result.structuredContent as {
+      uploads: unknown[];
+      failures: Array<{ file: string; error: { status?: number } }>;
+    };
+    expect(body.uploads).toEqual([]);
+    expect(body.failures).toHaveLength(1);
+    expect(body.failures[0].file).toBe("big.png");
+    expect(body.failures[0].error.status).toBe(413);
     expect(bucket.store.size).toBe(0);
   });
 

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -39,9 +39,19 @@ beforeAll(() => {
  * path (mirrors apps/api/test/routes-files.test.ts).
  */
 async function makeEnv(
-  options: { d1?: { tokenHash: string; scopes: string }; rateLimitOk?: boolean } = {},
-): Promise<{ env: Env; bucket: FakeR2Bucket; metadata: Map<string, Map<string, string>> }> {
-  const record: WorkspaceRecord = { ...workspace, tokenHash: await sha256Hex(TOKEN) };
+  options: {
+    d1?: { tokenHash: string; scopes: string };
+    rateLimitOk?: boolean;
+  } = {},
+): Promise<{
+  env: Env;
+  bucket: FakeR2Bucket;
+  metadata: Map<string, Map<string, string>>;
+}> {
+  const record: WorkspaceRecord = {
+    ...workspace,
+    tokenHash: await sha256Hex(TOKEN),
+  };
   const bucket = new FakeR2Bucket();
   // Keyed by `${workspace} ${objectKey}` -> ordered meta_key -> meta_value,
   // real enough to exercise putObject's file_metadata read/write/delete path
@@ -145,8 +155,11 @@ async function makeEnv(
               normalized.startsWith("SELECT object_key, meta_key, meta_value FROM file_metadata")
             ) {
               const [ws, ...keys] = values as string[];
-              const results: Array<{ object_key: string; meta_key: string; meta_value: string }> =
-                [];
+              const results: Array<{
+                object_key: string;
+                meta_key: string;
+                meta_value: string;
+              }> = [];
               for (const objectKey of keys) {
                 const map = metadata.get(scopeKey(ws, objectKey));
                 if (!map) continue;
@@ -167,7 +180,11 @@ async function makeEnv(
     UPLOADS: bucket,
     ...(options.rateLimitOk === undefined
       ? {}
-      : { WRITE_LIMITER: { limit: async () => ({ success: options.rateLimitOk }) } }),
+      : {
+          WRITE_LIMITER: {
+            limit: async () => ({ success: options.rateLimitOk }),
+          },
+        }),
   } as unknown as Env;
   return { env, bucket, metadata };
 }
@@ -229,13 +246,22 @@ async function callTool(
 ) {
   const response = await rpc(
     env,
-    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
     token,
     path,
   );
   expect(response.status).toBe(200);
   const body = (await response.json()) as {
-    result: { isError: boolean; structuredContent?: Record<string, unknown>; content: unknown[] };
+    result: {
+      isError: boolean;
+      structuredContent?: Record<string, unknown>;
+      content: unknown[];
+    };
   };
   return body.result;
 }
@@ -259,7 +285,11 @@ describe("hosted gallery tenant isolation", () => {
       alphaPath,
     );
     expect(created.isError).toBe(false);
-    const gallery = created.structuredContent as { id: string; url: string; version: number };
+    const gallery = created.structuredContent as {
+      id: string;
+      url: string;
+      version: number;
+    };
     expect(gallery.url).toBe("https://uploads.test/g/" + gallery.id);
 
     const added = await callTool(
@@ -319,7 +349,10 @@ describe("hosted gallery tenant isolation", () => {
       BETA_TOKEN,
       betaPath,
     );
-    expect(betaFound.structuredContent).toEqual({ galleries: [], nextCursor: null });
+    expect(betaFound.structuredContent).toEqual({
+      galleries: [],
+      nextCursor: null,
+    });
   });
 });
 
@@ -372,8 +405,14 @@ describe("mcp worker", () => {
 
   it("lists exactly the remote tools", async () => {
     const { env } = await makeEnv();
-    const response = await rpc(env, { jsonrpc: "2.0", id: 2, method: "tools/list" });
-    const body = (await response.json()) as { result: { tools: { name: string }[] } };
+    const response = await rpc(env, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    const body = (await response.json()) as {
+      result: { tools: { name: string }[] };
+    };
     expect(body.result.tools.map((tool) => tool.name).sort()).toEqual([
       "delete",
       "find_files",
@@ -463,6 +502,134 @@ describe("mcp worker", () => {
     expect(bucket.store.size).toBe(0);
   });
 
+  it("uploads multiple files in one call with per-item results", async () => {
+    const { env, bucket } = await makeEnv();
+    const result = await callTool(env, "put", {
+      files: [
+        { filename: "one.png", contentBase64: PNG_B64 },
+        { filename: "two.png", contentBase64: PNG_B64, alt: "second shot" },
+      ],
+      prefix: "shots",
+      repo: "acme/app",
+      ref: "42",
+    });
+    expect(result.isError).toBe(false);
+    const body = result.structuredContent as {
+      workspace: string;
+      uploads: Array<{
+        file: string;
+        key: string;
+        url: string;
+        markdown: string;
+      }>;
+      failures: unknown[];
+    };
+    expect(body.workspace).toBe("test-ws");
+    expect(body.failures).toEqual([]);
+    expect(body.uploads).toHaveLength(2);
+    expect(body.uploads[0].file).toBe("one.png");
+    expect(body.uploads[0].key).toMatch(/^shots\/acme-app\/42\/one-/);
+    expect(body.uploads[0].markdown).toContain("![one.png](");
+    expect(body.uploads[1].markdown).toContain("![second shot](");
+    expect(bucket.store.size).toBe(2);
+  });
+
+  it("multi-file put returns partial failures without aborting the batch", async () => {
+    const { env, bucket } = await makeEnv();
+    const textB64 = btoa("not an image");
+    const result = await callTool(env, "put", {
+      files: [
+        { filename: "good.png", contentBase64: PNG_B64 },
+        { filename: "bad.txt", contentBase64: textB64 },
+      ],
+    });
+    expect(result.isError).toBe(false);
+    const body = result.structuredContent as {
+      uploads: Array<{ file: string }>;
+      failures: Array<{ file: string; error: { message: string } }>;
+    };
+    expect(body.uploads).toHaveLength(1);
+    expect(body.uploads[0].file).toBe("good.png");
+    expect(body.failures).toHaveLength(1);
+    expect(body.failures[0].file).toBe("bad.txt");
+    expect(body.failures[0].error.message).toBeTruthy();
+    expect(bucket.store.size).toBe(1);
+  });
+
+  it("multi-file total failure is isError with structured failures", async () => {
+    const { env, bucket } = await makeEnv();
+    const textB64 = btoa("not an image");
+    const result = await callTool(env, "put", {
+      files: [
+        { filename: "a.txt", contentBase64: textB64 },
+        { filename: "b.txt", contentBase64: textB64 },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    const body = result.structuredContent as {
+      uploads: unknown[];
+      failures: Array<{ file: string }>;
+    };
+    expect(body.uploads).toEqual([]);
+    expect(body.failures.map((f) => f.file)).toEqual(["a.txt", "b.txt"]);
+    expect(bucket.store.size).toBe(0);
+  });
+
+  it("multi-file put rejects invalid combinations and shapes before writing", async () => {
+    const { env, bucket } = await makeEnv();
+    const combined = await callTool(env, "put", {
+      files: [{ filename: "one.png", contentBase64: PNG_B64 }],
+      contentBase64: PNG_B64,
+      filename: "extra.png",
+    });
+    expect(combined.isError).toBe(true);
+    expect(combined.content).toEqual([
+      {
+        type: "text",
+        text: "contentBase64/filename cannot be combined with files (USAGE)",
+      },
+    ]);
+
+    const withKey = await callTool(env, "put", {
+      files: [{ filename: "one.png", contentBase64: PNG_B64 }],
+      key: "shots/one.png",
+    });
+    expect(withKey.isError).toBe(true);
+    expect(withKey.content).toEqual([
+      { type: "text", text: "key cannot be combined with files (USAGE)" },
+    ]);
+
+    const overCap = await callTool(env, "put", {
+      files: Array.from({ length: 21 }, (_, i) => ({
+        filename: `f${i}.png`,
+        contentBase64: PNG_B64,
+      })),
+    });
+    expect(overCap.isError).toBe(true);
+    expect(overCap.content).toEqual([
+      {
+        type: "text",
+        text: "files supports at most 20 items per call (USAGE)",
+      },
+    ]);
+
+    // One bad base64 item fails the whole batch before any write.
+    const badBase64 = await callTool(env, "put", {
+      files: [
+        { filename: "one.png", contentBase64: PNG_B64 },
+        { filename: "two.png", contentBase64: "%%%" },
+      ],
+    });
+    expect(badBase64.isError).toBe(true);
+    expect(badBase64.content).toEqual([
+      {
+        type: "text",
+        text: "files[1] (two.png): contentBase64 must be valid base64 (USAGE)",
+      },
+    ]);
+    expect(bucket.store.size).toBe(0);
+  });
+
   it("get_metadata returns stored pairs, empty map, or not-found", async () => {
     const { env } = await makeEnv();
     await callTool(env, "put", {
@@ -477,24 +644,33 @@ describe("mcp worker", () => {
       key: "shots/plain.png",
     });
 
-    const tagged = await callTool(env, "get_metadata", { key: "shots/tagged.png" });
+    const tagged = await callTool(env, "get_metadata", {
+      key: "shots/tagged.png",
+    });
     expect(tagged.isError).toBe(false);
     expect(tagged.structuredContent).toEqual({
       metadata: { app: "myapp", page: "/checkout" },
     });
 
-    const plain = await callTool(env, "get_metadata", { key: "shots/plain.png" });
+    const plain = await callTool(env, "get_metadata", {
+      key: "shots/plain.png",
+    });
     expect(plain.isError).toBe(false);
     expect(plain.structuredContent).toEqual({ metadata: {} });
 
-    const missing = await callTool(env, "get_metadata", { key: "shots/missing.png" });
+    const missing = await callTool(env, "get_metadata", {
+      key: "shots/missing.png",
+    });
     expect(missing.isError).toBe(true);
   });
 
   it("get_metadata enforces files:read scope", async () => {
     const token = "up_test-ws_write-only-token";
     const { env } = await makeEnv({
-      d1: { tokenHash: await sha256Hex(token), scopes: JSON.stringify(["files:write"]) },
+      d1: {
+        tokenHash: await sha256Hex(token),
+        scopes: JSON.stringify(["files:write"]),
+      },
     });
     const result = await callTool(env, "get_metadata", { key: "shots/x.png" }, token);
     expect(result.isError).toBe(true);
@@ -531,7 +707,9 @@ describe("mcp worker", () => {
       filename: "shot.png",
       key: "shots/tagged.png",
     });
-    const result = await callTool(env, "set_metadata", { key: "shots/tagged.png" });
+    const result = await callTool(env, "set_metadata", {
+      key: "shots/tagged.png",
+    });
     expect(result.isError).toBe(true);
     expect(result.content).toEqual([
       { type: "text", text: "set_metadata requires set and/or delete (USAGE)" },
@@ -565,7 +743,10 @@ describe("mcp worker", () => {
   it("set_metadata enforces files:write scope", async () => {
     const token = "up_test-ws_read-only-token";
     const { env } = await makeEnv({
-      d1: { tokenHash: await sha256Hex(token), scopes: JSON.stringify(["files:read"]) },
+      d1: {
+        tokenHash: await sha256Hex(token),
+        scopes: JSON.stringify(["files:read"]),
+      },
     });
     const result = await callTool(
       env,
@@ -643,21 +824,30 @@ describe("mcp worker", () => {
 
     const listed = await callTool(env, "list", { prefix: "shots/" });
     expect(listed.isError).toBe(false);
-    const items = listed.structuredContent?.items as { key: string; url: string }[];
+    const items = listed.structuredContent?.items as {
+      key: string;
+      url: string;
+    }[];
     expect(items).toHaveLength(1);
     expect(items[0].key).toBe("shots/shot.png");
     expect(items[0].url).toBe("https://storage.example.com/shots/shot.png");
 
     const deleted = await callTool(env, "delete", { key: "shots/shot.png" });
     expect(deleted.isError).toBe(false);
-    expect(deleted.structuredContent).toEqual({ key: "shots/shot.png", deleted: true });
+    expect(deleted.structuredContent).toEqual({
+      key: "shots/shot.png",
+      deleted: true,
+    });
     expect(bucket.store.size).toBe(0);
   });
 
   it("enforces token scopes inside tool handlers", async () => {
     const token = "up_test-ws_read-only-token";
     const { env, bucket } = await makeEnv({
-      d1: { tokenHash: await sha256Hex(token), scopes: JSON.stringify(["files:read"]) },
+      d1: {
+        tokenHash: await sha256Hex(token),
+        scopes: JSON.stringify(["files:read"]),
+      },
     });
     const result = await callTool(
       env,
@@ -746,7 +936,10 @@ describe("mcp worker", () => {
 
   it("returns 202 with an empty body for notifications", async () => {
     const { env } = await makeEnv();
-    const response = await rpc(env, { jsonrpc: "2.0", method: "notifications/initialized" });
+    const response = await rpc(env, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
     expect(response.status).toBe(202);
     expect(await response.text()).toBe("");
   });
@@ -791,7 +984,11 @@ describe("token-inferred /mcp endpoint", () => {
           method: "tools/call",
           params: {
             name: "put",
-            arguments: { contentBase64: PNG_B64, filename: "shot.png", key: "shots/shot.png" },
+            arguments: {
+              contentBase64: PNG_B64,
+              filename: "shot.png",
+              key: "shots/shot.png",
+            },
           },
         },
         TOKEN,
@@ -799,7 +996,10 @@ describe("token-inferred /mcp endpoint", () => {
       );
       expect(response.status).toBe(200);
       return (await response.json()) as {
-        result: { isError: boolean; structuredContent?: Record<string, unknown> };
+        result: {
+          isError: boolean;
+          structuredContent?: Record<string, unknown>;
+        };
       };
     })();
     expect(result.result.isError).toBe(false);

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -22,6 +22,7 @@ export {
   type ToolArgs,
 } from "./args.js";
 export { ToolBatchError, batchFailureMessage } from "./batch-error.js";
+export { mapBounded } from "../async.js";
 
 export interface McpTool {
   name: string;
@@ -155,7 +156,11 @@ export function createMcpServer(opts: {
             const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.has(requested)
               ? requested
               : LATEST_PROTOCOL_VERSION;
-            return response(id, { protocolVersion, capabilities: { tools: {} }, serverInfo });
+            return response(id, {
+              protocolVersion,
+              capabilities: { tools: {} },
+              serverInfo,
+            });
           }
           case "ping":
             return response(id, {});

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -514,7 +514,10 @@ uploads --api-url http://localhost:8787 doctor
   `--file ./trace.log`. Never auto-send logs. MCP tool: `report`.
 - **MCP:** `uploads mcp` (stdio) mirrors CLI tools; hosted MCP at
   `https://agents.uploads.sh/mcp`. Metadata: `get_metadata` / `set_metadata` /
-  `find_files` (same as `meta get` / `meta set` / `find`). `uploads install` sets
+  `find_files` (same as `meta get` / `meta set` / `find`). Both support
+  multi-file `put` in one call — stdio takes `files` as paths, hosted takes
+  `files: [{ filename, contentBase64 }]` (max 20/call) — returning
+  `{ uploads, failures }` with per-item results. `uploads install` sets
   up this skill + hosted MCP (short progress; `--verbose` / `--dry-run` available).
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -516,8 +516,9 @@ uploads --api-url http://localhost:8787 doctor
   `https://agents.uploads.sh/mcp`. Metadata: `get_metadata` / `set_metadata` /
   `find_files` (same as `meta get` / `meta set` / `find`). Both support
   multi-file `put` in one call — stdio takes `files` as paths, hosted takes
-  `files: [{ filename, contentBase64 }]` (max 20/call) — returning
-  `{ uploads, failures }` with per-item results. `uploads install` sets
+  `files: [{ filename, contentBase64, alt? }]` (max 20/call; per-item `alt`
+  overrides the top-level one) — returning `{ uploads, failures }` with
+  per-item results. `uploads install` sets
   up this skill + hosted MCP (short progress; `--verbose` / `--dry-run` available).
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing


### PR DESCRIPTION
Closes #196.

The hosted MCP (`agents.uploads.sh`) `put` tool now accepts `files: [{ filename, contentBase64, alt? }]` for uploading multiple files in one tool call, mirroring the CLI/stdio multi-file contract.

## What changed

- **`put` batch path** (`apps/mcp/src/tools.ts`): up to 20 items per call. Every item is decoded and size-gated against the workspace upload policy *before any write*, so a structurally invalid batch (bad base64, oversized item, over-cap count, bad shape) fails whole with a clear usage error and no partial writes. Shared `prefix`/`repo`/`ref`/`width`/`metadata` apply to every item; `alt` can be set per item or once for all. `key`/`contentBase64`/`filename` cannot combine with `files`.
- **Partial failure**: uploads run with bounded concurrency (5); one bad item doesn't abort the rest. The result is `{ workspace, uploads, failures }` with per-item `url`/`markdown` and typed failure details (`message`/`code`/`status`). Total failure maps to `isError: true` with `structuredContent` preserved, via the SDK's existing `ToolBatchError` handling in the shared MCP server core — no transport changes needed.
- **Rate limits**: one `WRITE_LIMITER` hit per tool call (single or batch); the batch's cost ceiling is bounded by the 20-item cap instead. Monthly upload budget stays enforced per object inside `putObject`, same as REST.
- **SDK** (`@buildinternet/uploads/mcp`): re-exports `mapBounded` so runtime-agnostic tool sets can share the bounded-concurrency helper (changeset: minor).
- **Docs**: `uploads-cli` skill notes the hosted multi-file `put` contract.

Single-file `put` behavior is unchanged.

## Tests

- `@uploads/mcp`: 38 passed (4 new: batch success with per-item markdown/alt, partial failure, total failure → `isError` + structured `failures`, and pre-write validation of combinations/cap/bad base64 with an empty bucket asserted).
- `@buildinternet/uploads`: 493 passed; typecheck clean. (The two `guards.ts` typecheck errors under `apps/mcp` are pre-existing on `main` — stale `worker-configuration.d.ts`.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-file uploads through MCP, supporting up to 20 files per request.
  * Upload batches now report successful uploads and individual failures without stopping the entire operation.
  * Added detailed validation for file formats, size limits, and conflicting request options.
  * Expanded MCP tool descriptions and input guidance.

* **Documentation**
  * Clarified multi-file upload request formats, limits, responses, and metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->