### PR TITLE
chore(web): allow AI training in robots.txt content signal

### DIFF
--- a/.changeset/robots-allow-ai-train.md
+++ b/.changeset/robots-allow-ai-train.md
@@ -1,0 +1,5 @@
+---
+"@uploads/web": patch
+---
+
+Allow AI training in `robots.txt` — flip the `Content-Signal` `ai-train` preference from `no` to `yes` across the wildcard and every named AI crawler block. Search and RAG signals are unchanged, and the `/invite`, `/console`, `/404`, `/500` disallow rules stay in place.

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -3,10 +3,10 @@
 #
 # Content Signals (https://contentsignals.org/): preferences for how collected
 # content may be used. search = indexing/snippets; ai-input = RAG/grounding;
-# ai-train = model training/fine-tuning.
+# ai-train = model training/fine-tuning (yes = training is permitted).
 
 User-agent: *
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -17,7 +17,7 @@ Disallow: /500
 # expect named User-agent blocks, not only the wildcard).
 
 User-agent: GPTBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -25,7 +25,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: OAI-SearchBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -33,7 +33,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: Claude-Web
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -41,7 +41,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: ClaudeBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -49,7 +49,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: anthropic-ai
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -57,7 +57,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: Google-Extended
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -65,7 +65,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: Amazonbot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -73,7 +73,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: Applebot-Extended
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -81,7 +81,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: Bytespider
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console
@@ -89,7 +89,7 @@ Disallow: /404
 Disallow: /500
 
 User-agent: CCBot
-Content-Signal: search=yes, ai-input=yes, ai-train=no
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 Disallow: /invite
 Disallow: /console


### PR DESCRIPTION
## What

Flip the `robots.txt` `Content-Signal` `ai-train` preference from `no` to `yes` so AI model training is permitted on the public marketing content.

Applies across the wildcard `User-agent: *` block and every named AI crawler block (GPTBot, OAI-SearchBot, Claude-Web, ClaudeBot, anthropic-ai, Google-Extended, Amazonbot, Applebot-Extended, Bytespider, CCBot).

## Details

- `Content-Signal` is the [Content Signals](https://contentsignals.org/) preference standard: `search`, `ai-input` (RAG/grounding), and `ai-train` (model training/fine-tuning). Only `ai-train` changes here — `search=yes` and `ai-input=yes` are unchanged.
- The `Allow` / `Disallow` access rules are untouched: `/invite`, `/console`, `/404`, and `/500` remain non-crawlable. Training is permitted on the public surface, not on invite magic-links or the operator console.

## Test plan

- [ ] `robots.txt` served from `apps/web/public/` shows `ai-train=yes` in each block
