### PR TITLE
feat: OAuth resource-server discovery so agents can find how to authenticate

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./workspace": "./src/workspace.ts",
+    "./well-known": "./src/well-known.ts",
     "./storage": "./src/storage.ts",
     "./files": "./src/files-core.ts",
     "./file-metadata": "./src/file-metadata.ts",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,7 @@ import { publicFiles } from "./routes/public-files";
 import { telemetry } from "./routes/telemetry";
 import { reports } from "./routes/reports";
 import { render } from "./routes/render";
+import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
 // authenticated endpoints. CORS is not the security boundary — bearer tokens
@@ -54,6 +55,20 @@ const adminUiCors = cors({
 /** Hono app — also re-exported for vitest (`app.request`). */
 export const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
+  // RFC 9728 discovery: this API is an OAuth resource server (workspace bearer
+  // tokens with `files:*` scopes). Public, uncached-cross-origin so browser
+  // agents can read it. See src/well-known.ts.
+  .get("/.well-known/oauth-protected-resource", (c) =>
+    c.json(
+      protectedResourceMetadata({
+        resource: requestOrigin(c.req.url),
+        resourceName: "uploads.sh REST API",
+        webOrigin: c.env.WEB_ORIGIN || "https://uploads.sh",
+      }),
+      200,
+      { "Cache-Control": "public, max-age=300", "Access-Control-Allow-Origin": "*" },
+    ),
+  )
   .use("/admin/*", consoleCors)
   .use("/admin-ui/*", adminUiCors)
   .use("/me/*", adminUiCors)

--- a/apps/api/src/well-known.test.ts
+++ b/apps/api/src/well-known.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { app } from "./index";
+
+// The route reads only c.env.WEB_ORIGIN (with a fallback), no bindings.
+const env = {} as unknown as Env;
+
+describe("GET /.well-known/oauth-protected-resource", () => {
+  it("advertises the API as an OAuth resource server (RFC 9728)", async () => {
+    const response = await app.request(
+      "https://api.uploads.sh/.well-known/oauth-protected-resource",
+      { method: "GET" },
+      env,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Cache-Control")).toContain("max-age=300");
+
+    const body = (await response.json()) as {
+      resource: string;
+      resource_name: string;
+      scopes_supported: string[];
+      bearer_methods_supported: string[];
+      resource_documentation: string;
+      authorization_servers?: unknown;
+    };
+    // resource is keyed to the request origin so preview URLs describe themselves.
+    expect(body.resource).toBe("https://api.uploads.sh");
+    expect(body.scopes_supported).toEqual(["files:read", "files:write", "files:delete"]);
+    expect(body.bearer_methods_supported).toEqual(["header"]);
+    expect(body.resource_documentation).toBe("https://uploads.sh/auth.md");
+    // No public authorization server for third-party clients (see well-known.ts).
+    expect(body.authorization_servers).toBeUndefined();
+  });
+});

--- a/apps/api/src/well-known.ts
+++ b/apps/api/src/well-known.ts
@@ -1,0 +1,50 @@
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ *
+ * uploads.sh's API and hosted MCP server are OAuth *resource servers*: they
+ * accept opaque per-workspace bearer tokens (`Authorization: Bearer up_<ws>_…`)
+ * with `files:*` scopes. This document lets an agent discover that scheme
+ * programmatically. It is served at `/.well-known/oauth-protected-resource`
+ * on each resource origin (api.uploads.sh, agents.uploads.sh).
+ *
+ * `authorization_servers` is deliberately omitted. There is no public OAuth
+ * authorization server for third-party clients — tokens are minted out-of-band
+ * via `uploads login` (a first-party device flow) and the token-mint endpoint,
+ * all described in `resource_documentation` (auth.md). Advertising an
+ * `authorization_servers` entry would point RFC 9728 clients at an
+ * authorization-server metadata document that we intentionally do not publish,
+ * so we leave it out rather than dangle a broken reference. See auth.md's
+ * "What we deliberately do not publish".
+ */
+import { FILE_SCOPES } from "./auth-db";
+
+export interface ProtectedResourceMetadata {
+  /** RFC 9728 resource identifier — the resource server this document describes. */
+  resource: string;
+  resource_name: string;
+  /** Only `files:*` scopes carried by workspace tokens; single source of truth is FILE_SCOPES. */
+  scopes_supported: string[];
+  /** We only read the `Authorization` header — never a form body or query param. */
+  bearer_methods_supported: string[];
+  /** Human/agent-readable acquisition + usage docs (auth.md). */
+  resource_documentation: string;
+}
+
+export function protectedResourceMetadata(opts: {
+  resource: string;
+  resourceName: string;
+  webOrigin: string;
+}): ProtectedResourceMetadata {
+  return {
+    resource: opts.resource,
+    resource_name: opts.resourceName,
+    scopes_supported: [...FILE_SCOPES],
+    bearer_methods_supported: ["header"],
+    resource_documentation: `${opts.webOrigin.replace(/\/$/, "")}/auth.md`,
+  };
+}
+
+/** Scheme + host of the incoming request — the resource identifier we advertise. */
+export function requestOrigin(url: string): string {
+  return new URL(url).origin;
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -11,6 +11,7 @@
 import { createMcpServer } from "@buildinternet/uploads/mcp";
 import { AppError, isAppError, MethodNotAllowedError, NotFoundError } from "@uploads/errors";
 import { tokenWorkspaceAuth, workspaceAuth, type WorkspaceVars } from "@uploads/api/workspace";
+import { protectedResourceMetadata, requestOrigin } from "@uploads/api/well-known";
 import { Hono, type Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import pkg from "../package.json";
@@ -82,10 +83,31 @@ function mcpServerCard() {
   };
 }
 
+/** RFC 9728 metadata for the MCP endpoint, keyed to the request host. */
+function respondProtectedResource(c: Context<WorkspaceVars>): Response {
+  return c.json(
+    protectedResourceMetadata({
+      // The protected resource is the `/mcp` endpoint itself (matches the
+      // server-card transport endpoint and the RFC 8707 resource an MCP
+      // client indicates when requesting a token).
+      resource: `${requestOrigin(c.req.url)}/mcp`,
+      resourceName: "uploads.sh MCP server",
+      webOrigin: c.env.WEB_ORIGIN || "https://uploads.sh",
+    }),
+    200,
+    { "Cache-Control": "public, max-age=300", "Access-Control-Allow-Origin": "*" },
+  );
+}
+
 const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
   // Public discovery — registered before /:workspace/* so ".well-known" is not a tenant.
   .get("/.well-known/mcp/server-card.json", (c) => c.json(mcpServerCard()))
+  // OAuth Protected Resource Metadata (RFC 9728). Served at both the origin
+  // root (where scanners probe) and the RFC path-suffixed location a strict
+  // client derives from `resource` = `<origin>/mcp`.
+  .get("/.well-known/oauth-protected-resource", respondProtectedResource)
+  .get("/.well-known/oauth-protected-resource/mcp", respondProtectedResource)
   // Primary endpoint: the workspace is inferred from the bearer token
   // (up_<workspace>_…), so clients only need the URL and the token.
   .post("/mcp", tokenWorkspaceAuth, handleMcp)

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -375,6 +375,35 @@ describe("mcp worker", () => {
     expect(body.authentication.required).toBe(true);
   });
 
+  it("serves OAuth Protected Resource Metadata (RFC 9728) for the MCP endpoint", async () => {
+    const { env } = await makeEnv();
+    for (const path of [
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/mcp",
+    ]) {
+      const response = await app.request(
+        `https://agents.uploads.sh${path}`,
+        { method: "GET" },
+        env,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      const body = (await response.json()) as {
+        resource: string;
+        scopes_supported: string[];
+        bearer_methods_supported: string[];
+        resource_documentation: string;
+        authorization_servers?: unknown;
+      };
+      expect(body.resource).toBe("https://agents.uploads.sh/mcp");
+      expect(body.scopes_supported).toEqual(["files:read", "files:write", "files:delete"]);
+      expect(body.bearer_methods_supported).toEqual(["header"]);
+      expect(body.resource_documentation).toBe("https://uploads.sh/auth.md");
+      // No public authorization server for third-party clients — must not dangle a reference.
+      expect(body.authorization_servers).toBeUndefined();
+    }
+  });
+
   it("rejects a wrong token with a uniform 401 before any MCP handling", async () => {
     const { env } = await makeEnv();
     const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, "wrong");

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -7,6 +7,8 @@
   Link: </auth.md>; rel="describedby"; type="text/markdown"
   Link: </.well-known/mcp/server-card.json>; rel="alternate"; type="application/json"
   Link: </.well-known/agent-skills/index.json>; rel="alternate"; type="application/json"
+  Link: <https://api.uploads.sh/.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"
+  Link: <https://agents.uploads.sh/.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"
   Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
   X-Content-Type-Options: nosniff
 


### PR DESCRIPTION
## In plain terms

An agent-readiness scan flagged that uploads.sh publishes no OAuth discovery metadata, so an agent has no machine-readable way to learn how to authenticate against our APIs. This adds the standard document that says "these endpoints take bearer tokens with these scopes, and here's where to read about getting one."

Our API and hosted MCP server are OAuth **resource servers** (they *accept* tokens), not an authorization server (we don't issue tokens to third-party clients — `uploads login`'s device flow is first-party only). So this publishes exactly the honest half: **OAuth Protected Resource Metadata (RFC 9728)**, and nothing that would imply an OAuth registration surface we don't offer.

## What it does

- Serves `/.well-known/oauth-protected-resource` on **api.uploads.sh** and **agents.uploads.sh** (the MCP worker also serves the RFC path-suffixed `/mcp` variant). The doc reports the resource identifier (keyed to the request origin), `scopes_supported` (`files:read/write/delete`), `bearer_methods_supported: ["header"]`, and `resource_documentation` → the existing `auth.md`.
- Advertises both resource-server docs from the **apex** (`uploads.sh`) via RFC 8288 `Link` headers, so an agent landing on the root domain can discover them.
- One shared helper is the single source of truth for both workers, so the shape can't drift; scopes reuse `FILE_SCOPES`.

## What it is not

- **No `authorization_servers` field.** There is no public authorization server for third-party clients; listing one would point clients at an `/.well-known/oauth-authorization-server` doc we deliberately don't publish. Token acquisition stays documented out-of-band in `auth.md` (linked as `resource_documentation`).
- **No `openid-configuration`** — there's no OIDC/JWKS/id_tokens here; publishing it would be false.
- **`auth.md` unchanged.** It only ever disclaimed `openid-configuration` and `oauth-authorization-server`, so nothing there is now contradicted.
- No changeset: these are the private `@uploads/api` / hosted-MCP workers, not the published `@buildinternet/uploads` package.

## Technical notes

- Helper: `apps/api/src/well-known.ts`, exported as `@uploads/api/well-known`.
- Routes: `apps/api/src/index.ts`, `apps/mcp/src/index.ts`. Registered before the `/:workspace/*` guard so `.well-known` isn't treated as a tenant. Public, `Cache-Control: public, max-age=300`, `Access-Control-Allow-Origin: *`.

## Test plan

- [x] `apps/api` suite (adds `well-known.test.ts`) — 434 passing
- [x] `apps/mcp` suite (adds PRM test covering both paths) — 41 passing
- [x] `pnpm --filter @uploads/api typecheck` clean; `pnpm check` (oxlint + oxfmt) clean
- [ ] Post-deploy: `curl https://api.uploads.sh/.well-known/oauth-protected-resource` and `https://agents.uploads.sh/.well-known/oauth-protected-resource`; re-run the agent-readiness scan
