### PR TITLE
test: run the whole suite in one vitest process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,12 @@ jobs:
       - name: Generate Wrangler types
         run: pnpm types
 
+      # Single-process Vitest across every workspace project (see vitest.config.ts).
+      # The root `pretest` builds @buildinternet/uploads first — apps/mcp imports
+      # it from dist. Replaces the former serial `pnpm --filter … test` chain and
+      # adds apps/web, packages/email, and packages/errors to CI coverage.
       - name: Run tests
-        run: pnpm --filter @uploads/api test && pnpm --filter @uploads/mcp test && pnpm --filter @uploads/auth test && pnpm --filter @uploads/storage test && pnpm --filter @buildinternet/uploads test
+        run: pnpm test
 
       - name: Verify npm package
         run: pnpm --filter @buildinternet/uploads run build && pnpm --filter @buildinternet/uploads run pack:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ pnpm install
 pnpm dev                 # API on :8787 (local R2 + KV + D1 simulation)
 pnpm dev:web             # Astro site
 pnpm typecheck           # wrangler types + tsc across workspaces
+pnpm test                # whole suite in one vitest process (all packages); CI's Test job runs this
+pnpm --filter @uploads/api test   # single package still works (uses vitest defaults, not the root config)
 pnpm run deploy          # all workers; or deploy:api / deploy:web / deploy:mcp
 pnpm workspace:add <name> [--bucket <bucket>] [--binding X] [--local] \
   [--no-default-limits] [--max-storage …]   # shared/agent limit template by default

--- a/apps/api/test/helpers/sqlite-d1.ts
+++ b/apps/api/test/helpers/sqlite-d1.ts
@@ -8,7 +8,14 @@
  */
 
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+
+// Resolve migration paths against apps/api rather than process.cwd(), so the
+// helper works under both per-package vitest (cwd = apps/api) and the unified
+// root runner (cwd = repo root). Absolute paths pass through resolve() unchanged.
+const API_ROOT = fileURLToPath(new NodeURL("../../", import.meta.url));
 
 type SqliteValue = string | number | bigint | null | Uint8Array;
 
@@ -63,7 +70,7 @@ export class SqliteD1 {
   constructor(migrationPaths: string | string[], pragmas: string[] = []) {
     for (const pragma of pragmas) this.db.exec(pragma);
     const paths = Array.isArray(migrationPaths) ? migrationPaths : [migrationPaths];
-    for (const path of paths) this.db.exec(readFileSync(path, "utf8"));
+    for (const path of paths) this.db.exec(readFileSync(resolve(API_ROOT, path), "utf8"));
   }
 
   prepare(sql: string) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "format:check": "oxfmt --check",
     "check": "pnpm run lint && pnpm run format:check",
     "typecheck": "pnpm --filter @buildinternet/uploads run build && pnpm -r typecheck",
+    "pretest": "pnpm --filter @buildinternet/uploads run build",
+    "test": "vitest run --config vitest.projects.ts",
     "workspace:add": "pnpm --filter @uploads/api run workspace:add",
     "workspace:limits": "pnpm --filter @uploads/api run workspace:limits",
     "workspace:reencrypt-secrets": "pnpm --filter @uploads/api run workspace:reencrypt-secrets",
@@ -49,7 +51,8 @@
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
     "oxlint-tsgolint": "^0.24.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
   apps/api:
     dependencies:

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vitest/config";
+
+// Unified test runner for the whole monorepo. Each workspace package is a
+// Vitest "project" so the entire suite runs in a single process with one shared
+// worker pool — instead of N serial `pnpm --filter … test` invocations, each
+// paying its own pnpm-resolution + Vitest cold-start. The glob auto-discovers
+// any package that gains tests, so new suites can't silently fall out of CI the
+// way apps/web, packages/email, and packages/errors previously did.
+//
+// Filename is deliberately NOT `vitest.config.ts`: Vitest searches parent
+// directories for a config, so a root `vitest.config.ts` would hijack every
+// per-package `pnpm --filter <pkg> test` run (documented in AGENTS.md) and try
+// to resolve these repo-root globs against the package's cwd. Only `pnpm test`
+// at the root loads this file, via `--config vitest.projects.ts`; per-package
+// runs are unaffected and keep using Vitest defaults, as before.
+//
+// Packages carry no per-package Vitest config and rely on defaults (node
+// environment, TS via esbuild); resolving each project against its own root
+// keeps workspace-package imports (e.g. `@uploads/api/workspace`) working.
+//
+// Note: `apps/mcp` imports `@buildinternet/uploads` from its built `dist/`, so
+// the root `pretest` script builds that package before this runner starts.
+export default defineConfig({
+  test: {
+    // Negation excludes stray files (e.g. `apps/README.md`) that the directory
+    // globs would otherwise match — Vitest treats a matched *file* as a project
+    // config and errors when it isn't one.
+    projects: ["apps/*", "packages/*", "!**/*.md"],
+  },
+});


### PR DESCRIPTION
## In plain terms

Our CI test job ran the suites one package at a time, as a chain of five separate `pnpm --filter … test` calls. Each call restarts pnpm and vitest from cold, so most of the wall-clock time was process startup, not actual testing — and three packages (`apps/web`, `packages/email`, `packages/errors`) were quietly left out of CI entirely.

This runs the whole monorepo as a single vitest process instead. It's about **2.8× faster** on the test command (~9–11s → ~3–4s locally) **and** now covers those three previously-skipped packages — 115 files / 1233 tests in one shot.

This started as a check against a sibling repo's 4× test speedup ([either#835](https://github.com/buildinternet/either/issues/835)). That win came from `@cloudflare/vitest-pool-workers` booting a fresh workerd isolate per file — a cost we don't have here (we test the Hono app in-process against fakes). So the fix is different: collapse the redundant per-package process startups, not the isolate boot.

## What it does / what it is not

- **One runner:** `pnpm test` runs every package as a vitest "project" in one shared worker pool. CI's Test job now runs just `pnpm test`.
- **Per-package runs still work.** `pnpm --filter @uploads/api test` behaves exactly as before. The root config is deliberately named `vitest.projects.ts`, *not* `vitest.config.ts` — vitest searches parent directories for a config, so a root `vitest.config.ts` would hijack every per-package run. Only `pnpm test` loads it, via `--config`.
- **Not a logic change.** No product source changes; `@buildinternet/uploads` is untouched, so no changeset.
- **Coverage note:** `apps/web`, `packages/email`, and `packages/errors` are now in CI for the first time. They already passed locally; they pass here too.

## Technical notes

- Root `pretest` builds `@buildinternet/uploads` before the run (apps/mcp imports it from `dist/`). `vitest` added as a root devDependency.
- `apps/api/test/helpers/sqlite-d1.ts` now resolves migration paths against `apps/api` via `import.meta.url` instead of `process.cwd()`, so it works whether cwd is the package or the repo root. `path.resolve` leaves absolute paths (as passed by `routes-galleries.test.ts`, `me.test.ts`) untouched.
- Branch-protection heads up: if a required check is named `Test` (single job), nothing changes. This does not split or rename jobs.

## Test plan

- [x] `pnpm test` — 115 files / 1233 tests pass
- [x] `pnpm --filter @uploads/api test` and `pnpm --filter @buildinternet/uploads test` — per-package runs unchanged
- [x] `pnpm lint` (exit 0), `oxfmt --check`, `apps/api` typecheck — all clean
- [x] Fair timing A/B (build pre-done for both): old serial chain ~9–11s vs unified ~3–4s
