### PR TITLE
docs(web): unify guide into the docs shell, rename attach slug

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -7,6 +7,10 @@ export default defineConfig({
   adapter: cloudflare({ imageService: "compile" }),
   integrations: [react()],
   trailingSlash: "never",
+  redirects: {
+    // Renamed for a more recognizable slug; keep the old path working.
+    "/docs/attach": "/docs/attach-pull-request-images",
+  },
   build: {
     format: "file",
   },

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -8,7 +8,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
-- [Docs: attach & share](https://uploads.sh/docs/attach): attach media to PRs/issues, get a URL for any file, capture a screenshot
+- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, get a URL for any file, capture a screenshot
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -11,7 +11,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://uploads.sh/docs/attach</loc>
+    <loc>https://uploads.sh/docs/attach-pull-request-images</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -1,6 +1,6 @@
 ---
 // Shared shell for the /docs pages: a hub (/docs) plus focused subject pages
-// (/docs/attach, /docs/agents, /docs/reference). Three-column docs layout —
+// (/docs/attach-pull-request-images, /docs/agents, /docs/reference). Three-column layout —
 // a persistent left nav sidebar, the article, and an optional right "on this
 // page" TOC rail — modeled on the releases.sh docs layout. Below the wide
 // breakpoint the TOC rail drops, then the left nav collapses to a dropdown.
@@ -20,13 +20,14 @@ interface TocEntry {
 interface Props {
   title: string;
   description: string;
-  path: string; // canonical path, e.g. "/docs/attach"
+  path: string; // canonical path, e.g. "/docs/attach-pull-request-images"
   heading: string;
   tagline: string;
   active: string; // slug of the current page, matched against DOCS_NAV
   toc?: TocEntry[];
+  ogType?: string; // "website" for the subject pages, "article" for the guide
 }
-const { title, description, path, heading, tagline, active, toc } = Astro.props;
+const { title, description, path, heading, tagline, active, toc, ogType = "website" } = Astro.props;
 
 // Static page (no `prerender = false`) — auth origin is baked at build time,
 // not read from request-time env. See src/lib/auth-client.ts.
@@ -38,7 +39,7 @@ const DOCS_NAV = [
     title: "Docs",
     items: [
       { slug: "overview", href: "/docs", label: "Overview" },
-      { slug: "attach", href: "/docs/attach", label: "Attach & share" },
+      { slug: "attach", href: "/docs/attach-pull-request-images", label: "Attach & share" },
       { slug: "agents", href: "/docs/agents", label: "Set up your agent" },
       { slug: "reference", href: "/docs/reference", label: "Reference" },
     ],
@@ -60,13 +61,14 @@ const fullTitle = `${title} · uploads.sh`;
     <meta name="description" content={description} />
     <link rel="canonical" href={`https://uploads.sh${path}`} />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={`https://uploads.sh${path}`} />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
+    <slot name="head" />
     <style is:global>
       * { box-sizing: border-box; }
       html { scroll-behavior: smooth; }
@@ -92,7 +94,7 @@ const fullTitle = `${title} · uploads.sh`;
         display: flex;
         align-items: flex-start;
         gap: 44px;
-        margin-top: 8px;
+        margin-top: 28px;
       }
       main.docs-main { flex: 1 1 auto; min-width: 0; max-width: 720px; }
       main.docs-main > h1 {
@@ -239,8 +241,14 @@ const fullTitle = `${title} · uploads.sh`;
       .doc section h2 .anchor:focus-visible { color: var(--accent); background: none; }
       /* the first section shouldn't add a rule directly under the page title */
       .doc section.lead h2 { border-top: none; padding-top: 0; margin-top: 22px; }
+      .doc h3 { font: 600 15px/1.4 var(--sans); margin: 22px 0 6px; color: var(--fg); }
       .doc p, .doc li { color: var(--body); }
       .doc strong { color: var(--fg); }
+
+      /* FAQ definition list (used by the agent guide) */
+      .doc .faq { margin: 0; }
+      .doc .faq dt { color: var(--fg); font-weight: 600; margin-top: 18px; }
+      .doc .faq dd { margin: 6px 0 0; color: var(--body); }
       .doc ul { padding-left: 22px; }
       .doc li { margin: 8px 0; }
       .doc code {

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -70,7 +70,7 @@ const REPO = "https://github.com/buildinternet/uploads";
   <section id="explore">
     <h2>Explore the docs <a class="anchor" href="#explore" aria-label="Link to this section">#</a></h2>
     <div class="cards">
-      <a class="card" href="/docs/attach">
+      <a class="card" href="/docs/attach-pull-request-images">
         <h3>Attach &amp; share <span class="go">→</span></h3>
         <p>Post files to a PR or issue, get a URL for any file, and capture a screenshot.</p>
       </a>

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -53,7 +53,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   </section>
 
   <nav class="page-nav" aria-label="More docs">
-    <a class="prev" href="/docs/attach"><span class="dir">← Back</span>Attach &amp; share</a>
+    <a class="prev" href="/docs/attach-pull-request-images"><span class="dir">← Back</span>Attach &amp; share</a>
     <a class="next" href="/docs/reference"><span class="dir">Next →</span>Reference</a>
   </nav>
 </DocsLayout>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -14,7 +14,7 @@ const TOC = [
 <DocsLayout
   title="Attach & share"
   description="Attach screenshots and video to GitHub PRs and issues, get a public URL for any file, and capture a screenshot in one step with the uploads CLI."
-  path="/docs/attach"
+  path="/docs/attach-pull-request-images"
   heading="Attach & share"
   tagline="The three commands that get media onto a PR, an issue, or a plain URL."
   active="attach"

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -2,15 +2,22 @@
 // uploads.sh — discovery/landing page for the core use case: getting coding
 // agents (Claude Code, Codex, CI jobs, scripts) to upload screenshots and
 // video to GitHub PRs and issues. Prose targets the search question directly;
-// FAQ JSON-LD mirrors the on-page answers.
-import BaseHead from "../components/BaseHead.astro";
-import Footer from "../components/Footer.astro";
-import SiteHeader from "../components/SiteHeader.astro";
+// FAQ JSON-LD mirrors the on-page answers. Rendered in the shared DocsLayout
+// shell so it matches the /docs pages (left nav, "on this page" rail); the
+// FAQ structured data and article og:type ride along via the layout's head
+// slot and `ogType` prop.
+import DocsLayout from "../layouts/DocsLayout.astro";
 
 const REPO = "https://github.com/buildinternet/uploads";
-// Static page (no `prerender = false`) — auth origin is baked at build time,
-// not read from request-time env. See src/lib/auth-client.ts.
-const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
+
+const TOC = [
+	{ id: "problem", label: "The problem" },
+	{ id: "setup", label: "Install & sign in" },
+	{ id: "agents", label: "Teach your agent" },
+	{ id: "attach", label: "Attach media" },
+	{ id: "video", label: "Video & everything else" },
+	{ id: "faq", label: "FAQ" },
+];
 
 const FAQ = [
 	{
@@ -46,337 +53,167 @@ const FAQ_JSON_LD = JSON.stringify({
 });
 ---
 
-<html lang="en">
-  <head>
-    <BaseHead preloadSans />
-    <title>How to get agents to upload screenshots &amp; video to GitHub · uploads.sh</title>
-    <meta
-      name="description"
-      content="Agents can't drag-and-drop into GitHub comments. Give Claude Code, CI jobs, and scripts one command that posts screenshots and video to PRs and issues."
-    />
-    <link rel="canonical" href="https://uploads.sh/github-screenshots" />
-    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://uploads.sh/github-screenshots" />
-    <meta property="og:title" content="How to get agents to upload screenshots & video to GitHub" />
-    <meta
-      property="og:description"
-      content="Agents can't drag-and-drop into GitHub comments. Give Claude Code, CI jobs, and scripts one command that posts screenshots and video to PRs and issues."
-    />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="How to get agents to upload screenshots & video to GitHub" />
-    <meta
-      name="twitter:description"
-      content="Agents can't drag-and-drop into GitHub comments. Give them one command that hosts media at stable URLs and posts it to PRs and issues."
-    />
-    <script type="application/ld+json" set:html={FAQ_JSON_LD} />
-    <style>
-      * { box-sizing: border-box; }
-      html { scroll-behavior: smooth; }
-      @media (prefers-reduced-motion: reduce) {
-        html { scroll-behavior: auto; }
-      }
-      body {
-        margin: 0;
-        min-height: 100dvh;
-        background: var(--bg);
-        color: var(--fg);
-        font: 15.5px/1.7 var(--sans);
-        padding: 40px 24px 64px;
-      }
-      main { width: min(var(--width-content, 720px), 100%); margin: 0 auto; }
+<DocsLayout
+  title="How to get agents to upload screenshots & video to GitHub"
+  description="Agents can't drag-and-drop into GitHub comments. Give Claude Code, CI jobs, and scripts one command that posts screenshots and video to PRs and issues."
+  path="/github-screenshots"
+  heading="How to get agents to upload screenshots & video to GitHub"
+  tagline="Claude Code, CI jobs, review bots, plain scripts: anything without a browser."
+  active="walkthrough"
+  ogType="article"
+  toc={TOC}
+>
+  <script type="application/ld+json" slot="head" set:html={FAQ_JSON_LD} />
 
-      h1 {
-        font: 600 clamp(25px, 5vw, 34px)/1.22 var(--sans);
-        letter-spacing: -0.015em;
-        margin: 26px 0 8px;
-      }
-      .tagline { color: var(--muted); margin: 0 0 30px; }
-      h2 {
-        font: 600 20px/1.35 var(--sans);
-        letter-spacing: -0.01em;
-        margin: 42px 0 10px;
-        padding-top: 22px;
-        border-top: 1px solid var(--line);
-        scroll-margin-top: 24px;
-      }
-      h3 { font: 600 15px/1.4 var(--sans); margin: 22px 0 6px; }
-      p, li { color: var(--body); }
-      strong { color: var(--fg); }
-      ul, ol { padding-left: 22px; }
-      li { margin: 8px 0; }
-      a {
-        color: var(--fg);
-        text-decoration: underline;
-        text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
-        text-underline-offset: 3px;
-      }
-      a:hover, a:focus-visible { color: var(--accent); outline: none; }
-      code {
-        font: 0.88em var(--mono);
-        background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: 5px;
-        padding: 1px 6px;
-      }
+  <section class="lead" id="problem">
+    <h2>The problem: no drag-and-drop from a terminal <a class="anchor" href="#problem" aria-label="Link to this section">#</a></h2>
+    <p>
+      You put a screenshot on a pull request by dragging the file into the comment box.
+      GitHub then hosts it at <code>github.com/user-attachments/…</code>. That only works
+      in a signed-in browser. There is no <code>gh</code> command and no API for it.
+    </p>
+    <p>
+      So an agent that just changed your UI can't show its work. The usual workarounds
+      all hurt:
+    </p>
+    <ul>
+      <li><strong>Committing images to the repo</strong> bloats it forever, for a screenshot that matters once.</li>
+      <li><strong>Random image hosts</strong> give you random URLs, expiring links, or need a browser anyway.</li>
+      <li><strong>A hand-rolled S3 script</strong> works fine until you want stable URLs, image optimization, and comment cleanup.</li>
+    </ul>
+    <p>
+      The fix: host the file at a public URL the agent can create itself, then write
+      plain Markdown. That's what&#32;
+      <a href="/">uploads.sh</a> does.
+    </p>
+  </section>
 
-      /* copyable command rows */
-      .cmd {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        align-items: center;
-        gap: 12px;
-        background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: var(--radius-md);
-        padding: 10px 12px;
-        margin: 12px 0;
-        font: 13px var(--mono);
-      }
-      .cmd .text {
-        color: var(--fg);
-        overflow-x: auto;
-        white-space: nowrap;
-        scrollbar-width: none;
-      }
-      .cmd .text::before { content: "$ "; color: var(--accent); }
-      .cmd .text .cm { color: var(--muted); }
-      .cmd button {
-        font: 11px var(--mono);
-        letter-spacing: 0.06em;
-        color: var(--accent);
-        background: none;
-        border: 1px solid var(--line);
-        border-radius: 6px;
-        padding: 5px 10px;
-        cursor: pointer;
-      }
-      .cmd button:hover, .cmd button:focus-visible { border-color: var(--accent); outline: none; }
-      .cmd button.done { color: var(--green); border-color: var(--green); }
+  <section id="setup">
+    <h2>Step 1: install the CLI and sign in (once) <a class="anchor" href="#setup" aria-label="Link to this section">#</a></h2>
+    <div class="cmd">
+      <span class="text">npm install -g @buildinternet/uploads</span>
+      <button type="button" data-copy="npm install -g @buildinternet/uploads" aria-live="polite">copy</button>
+    </div>
+    <div class="cmd">
+      <span class="text">uploads login</span>
+      <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
+    </div>
+    <p>
+      <code>uploads login</code> trades an invite code for a workspace token and saves it.
+      You do this once per machine. Access is invite-only for now; ask via&#32;
+      <a href={REPO}>the GitHub repo</a>. Check your setup with <code>uploads doctor</code>.
+    </p>
+  </section>
 
-      /* multi-line output block (not copyable) */
-      .block {
-        background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: var(--radius-md);
-        padding: 12px 14px;
-        margin: 12px 0;
-        font: 12.5px/1.6 var(--mono);
-        color: var(--muted);
-        overflow-x: auto;
-      }
-      .block .ok { color: var(--green); }
-      .block .v { color: var(--body); }
-      .block pre { margin: 0; white-space: pre; }
+  <section id="agents">
+    <h2>Step 2: teach your agent <a class="anchor" href="#agents" aria-label="Link to this section">#</a></h2>
+    <p>One command sets up Claude Code:</p>
+    <div class="cmd">
+      <span class="text">uploads install</span>
+      <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
+    </div>
+    <ul>
+      <li>
+        The <strong>agent skill</strong> teaches the agent when to attach screenshots,
+        like before/after shots on a PR it just opened.
+      </li>
+      <li>
+        The <strong>MCP server</strong> offers the same tools
+        (<code>put</code>, <code>attach</code>, <code>list</code>, <code>delete</code>, …)
+        for runtimes that prefer MCP.
+      </li>
+    </ul>
+    <p>Or set up each piece yourself, for other agent runtimes:</p>
+    <div class="cmd">
+      <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
+      <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli" aria-live="polite">copy</button>
+    </div>
+    <div class="cmd">
+      <span class="text">claude mcp add --transport http uploads <span class="url">https://agents.uploads.sh/mcp</span></span>
+      <button type="button" data-copy="claude mcp add --transport http uploads https://agents.uploads.sh/mcp" aria-live="polite">copy</button>
+    </div>
+  </section>
 
-      .note {
-        margin: 20px 0 0;
-        color: var(--muted);
-        font-size: 14px;
-      }
-      .note a { color: var(--muted); }
-
-      /* faq */
-      .faq dt { color: var(--fg); font-weight: 600; margin-top: 18px; }
-      .faq dd { margin: 6px 0 0; color: var(--body); }
-
-      /* Geist Mono merges " --" into a joined dash via calt - keep CLI flags literal.
-         Declared last: the font shorthand in earlier rules resets feature settings. */
-      code, pre, .cmd, .block, .screen, .cmdtext, .cmdrow, .terminal, .feature h3 {
-        font-variant-ligatures: none;
-        font-feature-settings: "calt" 0, "liga" 0;
-      }
-    </style>
-  </head>
-  <body>
-    <main>
-      <SiteHeader star authOrigin={authOrigin} />
-
-      <h1>How to get agents to upload screenshots &amp; video to GitHub</h1>
-      <p class="tagline">
-        Claude Code, CI jobs, review bots, plain scripts: anything without a browser.
-      </p>
-
-      <section id="problem">
-        <h2>The problem: no drag-and-drop from a terminal</h2>
-        <p>
-          You put a screenshot on a pull request by dragging the file into the comment box.
-          GitHub then hosts it at <code>github.com/user-attachments/…</code>. That only works
-          in a signed-in browser. There is no <code>gh</code> command and no API for it.
-        </p>
-        <p>
-          So an agent that just changed your UI can't show its work. The usual workarounds
-          all hurt:
-        </p>
-        <ul>
-          <li><strong>Committing images to the repo</strong> bloats it forever, for a screenshot that matters once.</li>
-          <li><strong>Random image hosts</strong> give you random URLs, expiring links, or need a browser anyway.</li>
-          <li><strong>A hand-rolled S3 script</strong> works fine until you want stable URLs, image optimization, and comment cleanup.</li>
-        </ul>
-        <p>
-          The fix: host the file at a public URL the agent can create itself, then write
-          plain Markdown. That's what&#32;
-          <a href="/">uploads.sh</a> does.
-        </p>
-      </section>
-
-      <section id="setup">
-        <h2>Step 1: install the CLI and sign in (once)</h2>
-        <div class="cmd">
-          <span class="text">npm install -g @buildinternet/uploads</span>
-          <button type="button" data-copy="npm install -g @buildinternet/uploads">copy</button>
-        </div>
-        <div class="cmd">
-          <span class="text">uploads login</span>
-          <button type="button" data-copy="uploads login">copy</button>
-        </div>
-        <p>
-          <code>uploads login</code> trades an invite code for a workspace token and saves it.
-          You do this once per machine. Access is invite-only for now; ask via&#32;
-          <a href={REPO}>the GitHub repo</a>. Check your setup with <code>uploads doctor</code>.
-        </p>
-      </section>
-
-      <section id="agents">
-        <h2>Step 2: teach your agent</h2>
-        <p>One command sets up Claude Code:</p>
-        <div class="cmd">
-          <span class="text">uploads install</span>
-          <button type="button" data-copy="uploads install">copy</button>
-        </div>
-        <ul>
-          <li>
-            The <strong>agent skill</strong> teaches the agent when to attach screenshots,
-            like before/after shots on a PR it just opened.
-          </li>
-          <li>
-            The <strong>MCP server</strong> offers the same tools
-            (<code>put</code>, <code>attach</code>, <code>list</code>, <code>delete</code>, …)
-            for runtimes that prefer MCP.
-          </li>
-        </ul>
-        <p>Or set up each piece yourself, for other agent runtimes:</p>
-        <div class="cmd">
-          <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
-          <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli">copy</button>
-        </div>
-        <div class="cmd">
-          <span class="text">claude mcp add --transport http uploads https://agents.uploads.sh/mcp</span>
-          <button type="button" data-copy="claude mcp add --transport http uploads https://agents.uploads.sh/mcp">copy</button>
-        </div>
-      </section>
-
-      <section id="attach">
-        <h2>Step 3: the agent attaches media with one command</h2>
-        <p>
-          From a branch with an open pull request, <code>attach</code> only needs the files.
-          It finds the PR through <code>gh</code>, uploads each file to a stable URL, and
-          keeps one managed comment:
-        </p>
-        <div class="cmd">
-          <span class="text">uploads attach ./before.png ./after.png</span>
-          <button type="button" data-copy="uploads attach ./before.png ./after.png">copy</button>
-        </div>
-        <div class="block" aria-label="Example output">
-          <pre># optimizes each image, then keeps one comment on the PR up to date
+  <section id="attach">
+    <h2>Step 3: the agent attaches media with one command <a class="anchor" href="#attach" aria-label="Link to this section">#</a></h2>
+    <p>
+      From a branch with an open pull request, <code>attach</code> only needs the files.
+      It finds the PR through <code>gh</code>, uploads each file to a stable URL, and
+      keeps one managed comment:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads attach ./before.png ./after.png</span>
+      <button type="button" data-copy="uploads attach ./before.png ./after.png" aria-live="polite">copy</button>
+    </div>
+    <div class="block" aria-label="Example output">
+      <pre># optimizes each image, then keeps one comment on the PR up to date
 &gt;&gt; uploading ./before.png
 &gt;&gt; uploading ./after.png
 <span class="ok">&gt;&gt; attachments comment updated</span></pre>
-        </div>
-        <p>Not on a PR branch? Point it somewhere:</p>
-        <div class="cmd">
-          <span class="text">uploads attach ./repro.gif --issue 45</span>
-          <button type="button" data-copy="uploads attach ./repro.gif --issue 45">copy</button>
-        </div>
-        <div class="cmd">
-          <span class="text">uploads attach ./shot.png --repo owner/name --pr 123</span>
-          <button type="button" data-copy="uploads attach ./shot.png --repo owner/name --pr 123">copy</button>
-        </div>
-        <p>
-          Want to place the image yourself, in a PR description or README?&#32;
-          <code>--no-comment</code> prints the URL and Markdown without posting anything.&#32;
-          <code>uploads put</code> gives full control over naming and output.
-        </p>
-        <h3>Why the URLs matter</h3>
-        <p>
-          Attachments get <strong>stable keys</strong>, like&#32;
-          <code>gh/owner/repo/pull/123/shot.webp</code>. Upload the same filename again and
-          the PR shows the new image at the same URL within a minute. No stale screenshots.
-        </p>
-      </section>
+    </div>
+    <p>Not on a PR branch? Point it somewhere:</p>
+    <div class="cmd">
+      <span class="text">uploads attach ./repro.gif --issue 45</span>
+      <button type="button" data-copy="uploads attach ./repro.gif --issue 45" aria-live="polite">copy</button>
+    </div>
+    <div class="cmd">
+      <span class="text">uploads attach ./shot.png --repo owner/name --pr 123</span>
+      <button type="button" data-copy="uploads attach ./shot.png --repo owner/name --pr 123" aria-live="polite">copy</button>
+    </div>
+    <p>
+      Want to place the image yourself, in a PR description or README?&#32;
+      <code>--no-comment</code> prints the URL and Markdown without posting anything.&#32;
+      <code>uploads put</code> gives full control over naming and output.
+    </p>
+    <h3>Why the URLs matter</h3>
+    <p>
+      Attachments get <strong>stable keys</strong>, like&#32;
+      <code>gh/owner/repo/pull/123/shot.webp</code>. Upload the same filename again and
+      the PR shows the new image at the same URL within a minute. No stale screenshots.
+    </p>
+  </section>
 
-      <section id="video">
-        <h2>Video and everything else</h2>
-        <p>
-          A short screen recording is often the best proof that a change works. MP4, WebM,
-          GIFs, zips, logs all upload as-is:
-        </p>
-        <div class="cmd">
-          <span class="text">uploads attach ./demo.mp4 <span class="cm"># linked from the comment</span></span>
-          <button type="button" data-copy="uploads attach ./demo.mp4">copy</button>
-        </div>
-        <p>
-          One caveat: GitHub only plays videos it hosts itself. Outside video shows up as a&#32;
-          <strong>link, not a player</strong>. GIFs embed like images.
-        </p>
-        <p>
-          Images are optimized by default: re-encoded to WebP, size capped, and&#32;
-          <strong>EXIF stripped</strong> so they load fast and leak nothing. Opt out with&#32;
-          <code>--no-optimize</code> or <code>--keep-exif</code>. Add device chrome with&#32;
-          <code>--frame phone|browser|iphone-16-pro</code>.
-        </p>
-      </section>
+  <section id="video">
+    <h2>Video and everything else <a class="anchor" href="#video" aria-label="Link to this section">#</a></h2>
+    <p>
+      A short screen recording is often the best proof that a change works. MP4, WebM,
+      GIFs, zips, logs all upload as-is:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads attach ./demo.mp4 <span class="cm"># linked from the comment</span></span>
+      <button type="button" data-copy="uploads attach ./demo.mp4" aria-live="polite">copy</button>
+    </div>
+    <p>
+      One caveat: GitHub only plays videos it hosts itself. Outside video shows up as a&#32;
+      <strong>link, not a player</strong>. GIFs embed like images.
+    </p>
+    <p>
+      Images are optimized by default: re-encoded to WebP, size capped, and&#32;
+      <strong>EXIF stripped</strong> so they load fast and leak nothing. Opt out with&#32;
+      <code>--no-optimize</code> or <code>--keep-exif</code>. Add device chrome with&#32;
+      <code>--frame phone|browser|iphone-16-pro</code>.
+    </p>
+  </section>
 
-      <section id="faq">
-        <h2>FAQ</h2>
-        <dl class="faq">
-          {FAQ.map((item) => (
-            <>
-              <dt>{item.q}</dt>
-              <dd>{item.a}</dd>
-            </>
-          ))}
-        </dl>
-        <p class="note">
-          Every command and flag is in the <a href="/docs">docs</a>. Agents can read&#32;
-          <a href="/llms.txt">/llms.txt</a>. If this saved you a hand-rolled upload script,&#32;
-          <a href={REPO}>a star on GitHub</a> helps others find it.
-        </p>
-      </section>
+  <section id="faq">
+    <h2>FAQ <a class="anchor" href="#faq" aria-label="Link to this section">#</a></h2>
+    <dl class="faq">
+      {FAQ.map((item) => (
+        <>
+          <dt>{item.q}</dt>
+          <dd>{item.a}</dd>
+        </>
+      ))}
+    </dl>
+    <p class="note">
+      Every command and flag is in the <a href="/docs">docs</a>. Agents can read&#32;
+      <a href="/llms.txt">/llms.txt</a>. If this saved you a hand-rolled upload script,&#32;
+      <a href={REPO}>a star on GitHub</a> helps others find it.
+    </p>
+  </section>
 
-      <Footer />
-    </main>
-
-    <script>
-      for (const btn of document.querySelectorAll(".cmd button")) {
-        btn.addEventListener("click", async () => {
-          const text = btn.getAttribute("data-copy") ?? "";
-          let ok = false;
-          try {
-            await navigator.clipboard.writeText(text);
-            ok = true;
-          } catch {
-            const ta = document.createElement("textarea");
-            ta.value = text;
-            ta.style.position = "fixed";
-            ta.style.opacity = "0";
-            document.body.appendChild(ta);
-            ta.select();
-            try {
-              ok = document.execCommand("copy");
-            } catch {
-              ok = false;
-            }
-            ta.remove();
-          }
-          btn.textContent = ok ? "copied ✓" : "copy failed";
-          btn.classList.toggle("done", ok);
-          setTimeout(() => {
-            btn.textContent = "copy";
-            btn.classList.remove("done");
-          }, 1500);
-        });
-      }
-    </script>
-  </body>
-</html>
+  <nav class="page-nav" aria-label="More docs">
+    <a class="prev" href="/docs/agents"><span class="dir">← Back</span>Set up your agent</a>
+    <a class="next" href="/docs"><span class="dir">Next →</span>Docs overview</a>
+  </nav>
+</DocsLayout>


### PR DESCRIPTION
Follow-up to the /docs split (#218): make the agent guide match the other docs pages and give the attach page a more recognizable slug.

## What changed

**Guide now uses the shared docs shell.** `/github-screenshots` (the "Agent walkthrough" guide, linked from the docs sidebar) had its own standalone layout, so clicking into it from the sidebar landed on a page that looked different. It now renders through `DocsLayout`, so it gets the same `SiteHeader`, three-column grid (left nav + "on this page" rail), and content styling as the `/docs` subject pages.

To keep its SEO intact through the shared layout, `DocsLayout` gained:
- an `ogType` prop (defaults to `website`; the guide passes `article`),
- a named `head` slot so the guide can inject its **FAQPage JSON-LD**,
- `.doc h3` and `.doc .faq` styles the guide's content needs.

**Renamed `/docs/attach` to `/docs/attach-pull-request-images`** for a more recognizable slug. Updated every reference — the nav in `DocsLayout`, the hub card in `docs.astro`, the prev-nav in `agents.astro`, plus `sitemap.xml` and `llms.txt` — and added a **301 redirect** from the old path in `astro.config.mjs` so existing links don't break. The internal `slug`/`active` identifier stayed `attach` (only the public URL changed).

**Header/content spacing.** Bumped the docs grid `margin-top` from `8px` to `28px` so the header row isn't crowding the content. Applies to every `/docs` page.

## Verification

Ran the dev server and checked in-browser:
- Guide renders in the docs shell; nav highlights "Agent walkthrough"; TOC rail populated; no console errors.
- SEO preserved: `FAQPage` JSON-LD present in `<head>`, `og:type=article`, canonical still `/github-screenshots`.
- New slug serves `200`; old `/docs/attach` returns `301` to the new path; sidebar/canonical links point to the new slug.