### PR TITLE
feat(cli,api): ship uploads screenshot + agent-friendly capture flags (#219)

### DIFF
--- a/.changeset/screenshot-command.md
+++ b/.changeset/screenshot-command.md
@@ -3,3 +3,5 @@
 ---
 
 Publish the `uploads screenshot` command (added in #202 but never released). Captures a URL or local HTML file and hosts it in one call, with local Chrome and server-side `/v1/render` backends. Supports `--viewport WxH@Nx`, `--wait`, `--selector`, `--full-page`, `--dark`/`--light`, `--via local|remote`, and `--out <file>` (with `--no-upload` for file-only).
+
+Adds agent-friendly capture controls: `--hide <css>` (repeatable) hides overlays before capture and localhost/private targets auto-hide known framework dev toolbars (opt out with `--no-hide-dev-tools`); `--reduced-motion` settles animations; and `--eval <js>` / `--init-script <file>` run setup JS before capture (local backend only).

--- a/.changeset/screenshot-command.md
+++ b/.changeset/screenshot-command.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Publish the `uploads screenshot` command (added in #202 but never released). Captures a URL or local HTML file and hosts it in one call, with local Chrome and server-side `/v1/render` backends. Supports `--viewport WxH@Nx`, `--wait`, `--selector`, `--full-page`, `--dark`/`--light`, `--via local|remote`, and `--out <file>` (with `--no-upload` for file-only).

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -282,8 +282,10 @@ export function parseRenderRequest(parsed: unknown): RenderInput {
     }
     for (const sel of body.hide) {
       // Non-empty, and can't break out of the generated `sel{display:none}`
-      // rule or inject markup via the addStyleTag content.
-      if (typeof sel !== "string" || sel.length === 0 || /[{}<>]/.test(sel)) {
+      // rule or inject markup via the addStyleTag content. `@` is rejected so a
+      // leading at-rule (`@import url(...);*`) can't smuggle an `@import` into
+      // the injected stylesheet — mirrors assertHideSelector in the SDK.
+      if (typeof sel !== "string" || sel.length === 0 || /[@{}<>]/.test(sel)) {
         throw new ValidationError("each hide selector must be a plain CSS selector string", {
           code: "invalid_request",
         });

--- a/apps/api/src/render.ts
+++ b/apps/api/src/render.ts
@@ -40,6 +40,21 @@ export interface RenderViewport {
   deviceScaleFactor?: number;
 }
 
+/** Cap on `hide` selectors — a screenshot never needs many, and it bounds the
+ * injected-stylesheet size. */
+const MAX_HIDE_SELECTORS = 50;
+
+/**
+ * Neutralizes CSS/JS animations and transitions so a page settles to its
+ * finished state deterministically. Browser Run's typed surface has no
+ * prefers-reduced-motion / emulateMediaFeatures option (only emulateMediaType +
+ * addStyleTag), so `reducedMotion` is a documented best-effort here — the same
+ * kind of gap as `colorScheme`. It forces end-state rather than honoring a
+ * page's own reduced-motion rules, which is what our screenshot use case wants.
+ */
+const REDUCED_MOTION_CSS =
+  "*,*::before,*::after{animation-duration:0s !important;animation-delay:0s !important;animation-iteration-count:1 !important;transition-duration:0s !important;transition-delay:0s !important;scroll-behavior:auto !important}";
+
 export interface RenderInput {
   url?: string;
   html?: string;
@@ -48,6 +63,8 @@ export interface RenderInput {
   fullPage?: boolean;
   colorScheme?: "dark" | "light";
   waitUntil?: "load" | "domcontentloaded" | "networkidle";
+  hide?: string[];
+  reducedMotion?: boolean;
 }
 
 export interface RenderResult {
@@ -252,6 +269,36 @@ export function parseRenderRequest(parsed: unknown): RenderInput {
     input.waitUntil = body.waitUntil;
   }
 
+  if (body.hide !== undefined) {
+    if (!Array.isArray(body.hide)) {
+      throw new ValidationError("hide must be an array of CSS selectors", {
+        code: "invalid_request",
+      });
+    }
+    if (body.hide.length > MAX_HIDE_SELECTORS) {
+      throw new ValidationError(`hide accepts at most ${MAX_HIDE_SELECTORS} selectors`, {
+        code: "invalid_request",
+      });
+    }
+    for (const sel of body.hide) {
+      // Non-empty, and can't break out of the generated `sel{display:none}`
+      // rule or inject markup via the addStyleTag content.
+      if (typeof sel !== "string" || sel.length === 0 || /[{}<>]/.test(sel)) {
+        throw new ValidationError("each hide selector must be a plain CSS selector string", {
+          code: "invalid_request",
+        });
+      }
+    }
+    input.hide = body.hide as string[];
+  }
+
+  if (body.reducedMotion !== undefined) {
+    if (typeof body.reducedMotion !== "boolean") {
+      throw new ValidationError("reducedMotion must be a boolean", { code: "invalid_request" });
+    }
+    input.reducedMotion = body.reducedMotion;
+  }
+
   return input;
 }
 
@@ -296,6 +343,10 @@ function toBrowserRunOptions(input: RenderInput): BrowserRunScreenshotOptions {
         : {}),
     };
   }
+  // Browser Run's typed surface only exposes `addStyleTag` (+ emulateMediaType)
+  // for media/appearance control, so colorScheme, hide, and reduced-motion all
+  // flow through injected stylesheets. Accumulate into one array.
+  const styleTags: { content: string }[] = [];
   if (input.colorScheme !== undefined) {
     // DEVIATION (see RESULT.md): quickAction's typed surface has no
     // prefers-color-scheme / emulateMediaFeatures option — only
@@ -306,8 +357,15 @@ function toBrowserRunOptions(input: RenderInput): BrowserRunScreenshotOptions {
     // injected stylesheet cannot spoof). Good enough for our own
     // `screenshots/` templated-card use case; documented as a known gap for
     // arbitrary third-party pages.
-    options.addStyleTag = [{ content: `:root{color-scheme:${input.colorScheme};}` }];
+    styleTags.push({ content: `:root{color-scheme:${input.colorScheme};}` });
   }
+  if (input.hide !== undefined && input.hide.length > 0) {
+    styleTags.push({ content: `${input.hide.join(",")}{display:none !important}` });
+  }
+  if (input.reducedMotion) {
+    styleTags.push({ content: REDUCED_MOTION_CSS });
+  }
+  if (styleTags.length > 0) options.addStyleTag = styleTags;
 
   return options;
 }

--- a/apps/api/test/routes-render.test.ts
+++ b/apps/api/test/routes-render.test.ts
@@ -179,6 +179,28 @@ describe("POST /v1/render happy path", () => {
     });
   });
 
+  it("injects hide, reducedMotion, and colorScheme as combined addStyleTag entries", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, {
+      url: "https://example.com",
+      colorScheme: "dark",
+      hide: ["astro-dev-toolbar", ".cookie-banner"],
+      reducedMotion: true,
+    });
+    expect(res.status).toBe(200);
+    const tags = (browser.calls[0].options as { addStyleTag: { content: string }[] }).addStyleTag;
+    const joined = tags.map((t) => t.content).join("\n");
+    expect(joined).toContain("color-scheme:dark");
+    expect(joined).toContain("astro-dev-toolbar,.cookie-banner{display:none !important}");
+    expect(joined).toContain("animation-duration:0s");
+  });
+
+  it("omits addStyleTag entirely when no appearance options are set", async () => {
+    const { env, browser } = await makeEnv();
+    await renderReq(env, { url: "https://example.com" });
+    expect(browser.calls[0].options).not.toHaveProperty("addStyleTag");
+  });
+
   it("increments uploads_in_period on a successful render (shares the monthly upload budget)", async () => {
     const { env, db } = await makeEnv();
     await renderReq(env, { url: "https://example.com" });
@@ -303,6 +325,29 @@ describe("POST /v1/render validation", () => {
   it("rejects an invalid waitUntil", async () => {
     const { env } = await makeEnv();
     const res = await renderReq(env, { url: "https://example.com", waitUntil: "eventually" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-array hide", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com", hide: "astro-dev-toolbar" });
+    expect(res.status).toBe(400);
+    expect(browser.calls).toHaveLength(0);
+  });
+
+  it("rejects a hide selector that could break out of the injected rule", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, {
+      url: "https://example.com",
+      hide: ["ok", "evil}{body{display:block"],
+    });
+    expect(res.status).toBe(400);
+    expect(browser.calls).toHaveLength(0);
+  });
+
+  it("rejects a non-boolean reducedMotion", async () => {
+    const { env } = await makeEnv();
+    const res = await renderReq(env, { url: "https://example.com", reducedMotion: "yes" });
     expect(res.status).toBe(400);
   });
 });

--- a/apps/api/test/routes-render.test.ts
+++ b/apps/api/test/routes-render.test.ts
@@ -345,6 +345,16 @@ describe("POST /v1/render validation", () => {
     expect(browser.calls).toHaveLength(0);
   });
 
+  it("rejects a hide at-rule that would smuggle an @import (no braces needed)", async () => {
+    const { env, browser } = await makeEnv();
+    const res = await renderReq(env, {
+      url: "https://example.com",
+      hide: ["@import url(http://127.0.0.1);*"],
+    });
+    expect(res.status).toBe(400);
+    expect(browser.calls).toHaveLength(0);
+  });
+
   it("rejects a non-boolean reducedMotion", async () => {
     const { env } = await makeEnv();
     const res = await renderReq(env, { url: "https://example.com", reducedMotion: "yes" });

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -154,11 +154,22 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
       <span class="text">uploads screenshot ./card.html --no-upload --out ./card.png <span class="cm"># no hosting</span></span>
       <button type="button" data-copy="uploads screenshot ./card.html --no-upload --out ./card.png" aria-live="polite">copy</button>
     </div>
+    <div class="cmd">
+      <span class="text">uploads screenshot http://localhost:4321 --reduced-motion <span class="cm"># clean dev-server shot</span></span>
+      <button type="button" data-copy="uploads screenshot http://localhost:4321 --reduced-motion" aria-live="polite">copy</button>
+    </div>
     <p>
       If a Chrome or Chromium is already on the machine, <code>screenshot</code> drives it
       directly (nothing to download); otherwise it renders on uploads.sh servers. Force
       either side with <code>--via local</code> or <code>--via remote</code>. Note that
       <code>localhost</code> URLs are only reachable locally.
+    </p>
+    <p>
+      Shooting your own dev server, it hides known framework dev toolbars
+      (Astro, Next, Nuxt, Vite) automatically and takes <code>--reduced-motion</code> to
+      settle animations. Hide any other overlay with <code>--hide &lt;selector&gt;</code>
+      (repeatable), or run setup JS first with <code>--eval &lt;js&gt;</code> /
+      <code>--init-script &lt;file&gt;</code> (local backend).
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -166,7 +166,8 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
     </p>
     <p>
       Shooting your own dev server, it hides known framework dev toolbars
-      (Astro, Next, Nuxt, Vite) automatically and takes <code>--reduced-motion</code> to
+      (Astro, Next, Nuxt, Vite) automatically (opt out with
+      <code>--no-hide-dev-tools</code>) and takes <code>--reduced-motion</code> to
       settle animations. Hide any other overlay with <code>--hide &lt;selector&gt;</code>
       (repeatable), or run setup JS first with <code>--eval &lt;js&gt;</code> /
       <code>--init-script &lt;file&gt;</code> (local backend).

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { basename } from "node:path";
 import {
   flagBool,
@@ -63,6 +63,12 @@ Options:
                             own prefers-color-scheme queries won't flip)
   --wait <load|domcontentloaded|networkidle|ms>  Settle strategy (default: load); a millisecond
                             count is local-only — use --via local
+  --hide <css>              Hide matching elements before capture (repeatable)
+  --no-hide-dev-tools       Don't auto-hide framework dev toolbars (auto-hidden on localhost/private)
+  --reduced-motion          Emulate prefers-reduced-motion: reduce so animations settle (best-effort
+                            on --via remote — neutralizes animations via injected CSS)
+  --eval <js>               Run JS in the page after settle, before capture (--via local only)
+  --init-script <file>      Inject a JS file before navigation (--via local only)
   --out <file>              Also write the PNG to a local file
   --no-upload                Skip hosting; requires --out (local file only)
   --destination <id>        Typed root: screenshots | gh | f
@@ -159,6 +165,30 @@ export async function runScreenshot(
   const fullPage = flagBool(parsed.flags, "--full-page");
   const colorScheme = colorSchemeFromFlags(parsed.flags);
   const waitUntil = parseWaitUntil(flagString(parsed.flags, "--wait"));
+
+  const hide = flagValues(parsed.flags, "--hide");
+  for (const sel of hide) {
+    if (sel.length === 0 || /[{}<>]/.test(sel)) {
+      throw new UsageError(`invalid --hide selector: ${JSON.stringify(sel)} (a CSS selector)`);
+    }
+  }
+  // --no-hide-dev-tools opts out of auto-hiding framework toolbars; undefined
+  // lets captureScreenshot apply its localhost-aware default.
+  const hideDevTools = flagBool(parsed.flags, "--no-hide-dev-tools") ? false : undefined;
+  const reducedMotion = flagBool(parsed.flags, "--reduced-motion");
+  const evalJs = flagString(parsed.flags, "--eval");
+  const initScriptPath = flagString(parsed.flags, "--init-script");
+  let initScript: string | undefined;
+  if (initScriptPath !== undefined) {
+    try {
+      initScript = readFileSync(initScriptPath, "utf8");
+    } catch (err) {
+      throw new UsageError(
+        `could not read --init-script ${initScriptPath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   const outFile = flagString(parsed.flags, "--out");
   const noUpload = flagBool(parsed.flags, "--no-upload");
   if (noUpload && !outFile) throw new UsageError("--no-upload requires --out");
@@ -233,6 +263,11 @@ export async function runScreenshot(
     fullPage,
     colorScheme,
     waitUntil,
+    hide,
+    hideDevTools,
+    reducedMotion,
+    evalJs,
+    initScript,
     apiUrl: ctx.config.apiUrl,
     token: ctx.config.token,
   });

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -25,6 +25,7 @@ import { execRunner, type CommandRunner } from "../github-gh.js";
 import { parseMetaFlags, validateMetaMap } from "../metadata.js";
 import { writeJson, writeStdout } from "../io.js";
 import {
+  assertHideSelector,
   captureScreenshot,
   parseViewport,
   parseWaitUntil,
@@ -167,11 +168,9 @@ export async function runScreenshot(
   const waitUntil = parseWaitUntil(flagString(parsed.flags, "--wait"));
 
   const hide = flagValues(parsed.flags, "--hide");
-  for (const sel of hide) {
-    if (sel.length === 0 || /[{}<>]/.test(sel)) {
-      throw new UsageError(`invalid --hide selector: ${JSON.stringify(sel)} (a CSS selector)`);
-    }
-  }
+  // Fail fast before capture, using the shared policy (throws UploadsError
+  // code USAGE → exit 2, same as UsageError) so there's one source of truth.
+  for (const sel of hide) assertHideSelector(sel);
   // --no-hide-dev-tools opts out of auto-hiding framework toolbars; undefined
   // lets captureScreenshot apply its localhost-aware default.
   const hideDevTools = flagBool(parsed.flags, "--no-hide-dev-tools") ? false : undefined;

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -630,6 +630,22 @@ export function createUploadsMcpTools(opts: {
             description:
               'Settle strategy: load (default) | domcontentloaded | networkidle | a millisecond count (millisecond counts are local-only — via: "local").',
           },
+          hide: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "CSS selectors to hide (display:none) before capture. Works on both backends.",
+          },
+          noHideDevTools: {
+            type: "boolean",
+            description:
+              "Don't auto-hide framework dev toolbars (Astro/Next/Nuxt/Vite), which are hidden by default for localhost/private-network targets.",
+          },
+          reducedMotion: {
+            type: "boolean",
+            description:
+              'Emulate prefers-reduced-motion: reduce so animations settle. Best-effort on via: "remote" (neutralizes animations via injected CSS).',
+          },
           key: {
             type: "string",
             description:
@@ -770,6 +786,9 @@ export function createUploadsMcpTools(opts: {
             fullPage: optBool(args, "fullPage"),
             colorScheme: colorSchemeArg as "dark" | "light" | undefined,
             waitUntil: screenshotModule.parseWaitUntil(optString(args, "wait")),
+            hide: optStringArray(args, "hide"),
+            hideDevTools: optBool(args, "noHideDevTools") ? false : undefined,
+            reducedMotion: optBool(args, "reducedMotion"),
             apiUrl: config.apiUrl,
             token: config.token,
           });

--- a/packages/uploads/src/screenshot-local.ts
+++ b/packages/uploads/src/screenshot-local.ts
@@ -298,6 +298,14 @@ export interface LocalCaptureOptions {
   colorScheme?: "dark" | "light";
   /** "load" | "domcontentloaded" | "networkidle", or a millisecond settle delay. */
   waitUntil: "load" | "domcontentloaded" | "networkidle" | number;
+  /** CSS selectors hidden (display:none) just before capture. */
+  hide?: string[];
+  /** Emulate prefers-reduced-motion: reduce so animations settle deterministically. */
+  reducedMotion?: boolean;
+  /** JS run via page.evaluate after settle, before capture. */
+  evalJs?: string;
+  /** JS injected via addInitScript before navigation. */
+  initScript?: string;
   timeoutMs?: number;
   detectRoots?: DetectRoots;
   /**
@@ -407,18 +415,36 @@ export async function captureLocal(opts: LocalCaptureOptions): Promise<Uint8Arra
           viewport: { width: opts.viewport.width, height: opts.viewport.height },
           deviceScaleFactor: opts.viewport.deviceScaleFactor,
           colorScheme: opts.colorScheme,
+          reducedMotion: opts.reducedMotion ? "reduce" : undefined,
         });
+    // Runs before every navigation on this context — must be registered before
+    // the goto below so it's present when the page's own scripts first run.
+    if (opts.initScript) await context.addInitScript({ content: opts.initScript });
     const page = usingCdp
       ? await context.newPage()
       : (context.pages()[0] ?? (await context.newPage()));
     if (usingCdp) {
       await page.setViewportSize({ width: opts.viewport.width, height: opts.viewport.height });
-      if (opts.colorScheme) await page.emulateMedia({ colorScheme: opts.colorScheme });
+      // deviceScaleFactor + reducedMotion can't be set on an already-launched
+      // CDP context, but emulateMedia (colorScheme + reduced-motion) still can.
+      if (opts.colorScheme || opts.reducedMotion) {
+        await page.emulateMedia({
+          colorScheme: opts.colorScheme,
+          reducedMotion: opts.reducedMotion ? "reduce" : undefined,
+        });
+      }
     }
 
     const waitUntil = typeof opts.waitUntil === "string" ? opts.waitUntil : "load";
     await page.goto(opts.url, { waitUntil, timeout: opts.timeoutMs ?? 30_000 });
     if (typeof opts.waitUntil === "number") await page.waitForTimeout(opts.waitUntil);
+
+    // Hide overlays first, then run any user eval (which may depend on, or
+    // deliberately override, the hidden state).
+    if (opts.hide && opts.hide.length > 0) {
+      await page.addStyleTag({ content: `${opts.hide.join(",")}{display:none !important}` });
+    }
+    if (opts.evalJs) await page.evaluate(opts.evalJs);
 
     const png = opts.selector
       ? await page.locator(opts.selector).screenshot({ timeout: opts.timeoutMs ?? 30_000 })

--- a/packages/uploads/src/screenshot-remote.ts
+++ b/packages/uploads/src/screenshot-remote.ts
@@ -18,6 +18,14 @@ export interface RemoteRenderRequest {
   fullPage?: boolean;
   colorScheme?: "dark" | "light";
   waitUntil?: "load" | "domcontentloaded" | "networkidle" | number;
+  /** CSS selectors hidden (display:none) server-side before capture. */
+  hide?: string[];
+  /**
+   * Best-effort reduced-motion on the remote backend: the render endpoint has
+   * no true media-feature emulation, so it neutralizes animations/transitions
+   * with an injected stylesheet (documented gap, like colorScheme).
+   */
+  reducedMotion?: boolean;
 }
 
 export interface RemoteRenderOptions {

--- a/packages/uploads/src/screenshot.ts
+++ b/packages/uploads/src/screenshot.ts
@@ -39,11 +39,14 @@ export const DEV_TOOLBAR_SELECTORS: readonly string[] = [
  * Reject a `--hide` selector that could break out of the generated
  * `selector{display:none}` rule (or inject markup server-side). The selectors
  * are the caller's own, so this guards against footguns, not a trust boundary.
+ * `@` is rejected too: a leading at-rule (e.g. `@import url(...);*`) needs no
+ * braces to smuggle an `@import` into the injected stylesheet — and `@` is
+ * never valid in a CSS selector anyway.
  */
 export function assertHideSelector(selector: string): void {
-  if (selector.length === 0 || /[{}<>]/.test(selector)) {
+  if (selector.length === 0 || /[@{}<>]/.test(selector)) {
     throw new UploadsError(
-      `invalid hide selector: ${JSON.stringify(selector)} (a CSS selector, no {, }, <, or >)`,
+      `invalid hide selector: ${JSON.stringify(selector)} (a CSS selector, no @, {, }, <, or >)`,
       "USAGE",
     );
   }

--- a/packages/uploads/src/screenshot.ts
+++ b/packages/uploads/src/screenshot.ts
@@ -18,6 +18,37 @@ import type { DetectRoots } from "./screenshot-local.js";
 export type ScreenshotBackend = "auto" | "local" | "remote";
 export type WaitUntil = "load" | "domcontentloaded" | "networkidle" | number;
 
+/**
+ * Host selectors for framework dev toolbars/overlays that otherwise pollute a
+ * screenshot of a running dev server. Hidden (display:none) automatically when
+ * the target is a localhost/private URL, unless `--no-hide-dev-tools`. Hiding
+ * the custom-element host also hides its shadow-DOM contents, so a single
+ * host-level rule is enough for the web-component toolbars.
+ */
+export const DEV_TOOLBAR_SELECTORS: readonly string[] = [
+  "astro-dev-toolbar", // Astro
+  "#__next-build-watcher", // Next.js (legacy build-activity indicator)
+  "nextjs-portal", // Next.js dev overlay / indicators (App Router)
+  "#nuxt-devtools-anchor", // Nuxt DevTools launcher
+  "#nuxt-devtools-container",
+  "vite-plugin-checker-error-overlay", // vite-plugin-checker overlay
+  "vite-error-overlay", // Vite HMR error overlay
+];
+
+/**
+ * Reject a `--hide` selector that could break out of the generated
+ * `selector{display:none}` rule (or inject markup server-side). The selectors
+ * are the caller's own, so this guards against footguns, not a trust boundary.
+ */
+export function assertHideSelector(selector: string): void {
+  if (selector.length === 0 || /[{}<>]/.test(selector)) {
+    throw new UploadsError(
+      `invalid hide selector: ${JSON.stringify(selector)} (a CSS selector, no {, }, <, or >)`,
+      "USAGE",
+    );
+  }
+}
+
 export interface ScreenshotViewport {
   width: number;
   height: number;
@@ -156,6 +187,19 @@ export interface CaptureScreenshotOptions {
   fullPage?: boolean;
   colorScheme?: "dark" | "light";
   waitUntil?: WaitUntil;
+  /** Extra CSS selectors to hide (display:none) before capture. */
+  hide?: string[];
+  /**
+   * Auto-hide known framework dev toolbars. Defaults to on for localhost/
+   * private-network targets and off otherwise; pass `false` to opt out.
+   */
+  hideDevTools?: boolean;
+  /** Emulate prefers-reduced-motion: reduce so CSS/JS animations settle. */
+  reducedMotion?: boolean;
+  /** Run this JS in the page after settle, before capture (local backend only). */
+  evalJs?: string;
+  /** Inject this JS as an init script before navigation (local backend only). */
+  initScript?: string;
   apiUrl: string;
   token: string;
   /** Injectable for tests; forwarded to detectLocalBrowser. */
@@ -170,6 +214,10 @@ export interface CaptureScreenshotOptions {
     fullPage?: boolean;
     colorScheme?: "dark" | "light";
     waitUntil: WaitUntil;
+    hide?: string[];
+    reducedMotion?: boolean;
+    evalJs?: string;
+    initScript?: string;
     detectRoots?: DetectRoots;
     /** Pre-computed detection result from auto-routing, to avoid a second fs scan. */
     detectResult?: import("./screenshot-local.js").DetectResult;
@@ -234,6 +282,13 @@ export async function captureScreenshot(
   // it references via file:// or relative paths won't resolve there).
   const localOnly = target.kind === "url" && target.localOnly;
 
+  // Auto-hide framework dev toolbars only makes sense for a running dev server
+  // (a localhost/private URL); default off elsewhere. Combine with any
+  // explicit --hide selectors into one list shared by both backends.
+  const autoHideDevTools = opts.hideDevTools ?? localOnly;
+  for (const sel of opts.hide ?? []) assertHideSelector(sel);
+  const hide = [...(opts.hide ?? []), ...(autoHideDevTools ? DEV_TOOLBAR_SELECTORS : [])];
+
   // Populated only when auto-routing actually probes the filesystem, so it
   // can be threaded into captureLocalImpl below to avoid a second scan.
   let detected: import("./screenshot-local.js").DetectResult | undefined;
@@ -276,6 +331,13 @@ export async function captureScreenshot(
     );
   }
 
+  // Arbitrary pre-capture JS runs only on the local backend — the shared
+  // remote renderer intentionally has no eval escape hatch (different security
+  // posture). Fail fast rather than silently dropping it.
+  if (backend === "remote" && (opts.evalJs !== undefined || opts.initScript !== undefined)) {
+    throw new UploadsError("--eval and --init-script are local-only — use --via local", "USAGE");
+  }
+
   if (backend === "local") {
     const captureLocalImpl =
       opts.captureLocalImpl ??
@@ -292,6 +354,10 @@ export async function captureScreenshot(
       fullPage: opts.fullPage,
       colorScheme: opts.colorScheme,
       waitUntil,
+      hide,
+      reducedMotion: opts.reducedMotion,
+      evalJs: opts.evalJs,
+      initScript: opts.initScript,
       detectRoots: opts.detectRoots,
       detectResult: detected,
     });
@@ -317,6 +383,8 @@ export async function captureScreenshot(
       fullPage: opts.fullPage,
       colorScheme: opts.colorScheme,
       waitUntil,
+      ...(hide.length > 0 ? { hide } : {}),
+      ...(opts.reducedMotion ? { reducedMotion: true } : {}),
     },
     { apiUrl: opts.apiUrl, token: opts.token },
   );

--- a/packages/uploads/test/screenshot.test.ts
+++ b/packages/uploads/test/screenshot.test.ts
@@ -6,6 +6,7 @@ import { UploadsError } from "../src/errors.js";
 import {
   captureScreenshot,
   classifyTarget,
+  DEV_TOOLBAR_SELECTORS,
   isPrivateOrLocalHost,
   parseViewport,
   parseWaitUntil,
@@ -357,6 +358,117 @@ describe("captureScreenshot backend selection", () => {
     });
     expect(seenWait).toBe(500);
     expect(result.backend).toBe("local");
+  });
+
+  it("auto-hides dev toolbars on a localhost target, passing them to the local backend", async () => {
+    let seenHide: string[] | undefined;
+    await captureScreenshot({
+      target: "http://localhost:3000",
+      via: "local",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async (opts) => {
+        seenHide = opts.hide;
+        return png;
+      },
+    });
+    expect(seenHide).toEqual([...DEV_TOOLBAR_SELECTORS]);
+  });
+
+  it("does not auto-hide dev toolbars on a public target", async () => {
+    let seenHide: string[] | undefined;
+    await captureScreenshot({
+      target: "https://example.com",
+      via: "local",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async (opts) => {
+        seenHide = opts.hide;
+        return png;
+      },
+    });
+    expect(seenHide).toEqual([]);
+  });
+
+  it("--no-hide-dev-tools (hideDevTools:false) suppresses auto-hide but keeps explicit --hide", async () => {
+    let seenHide: string[] | undefined;
+    await captureScreenshot({
+      target: "http://localhost:3000",
+      via: "local",
+      hide: [".banner"],
+      hideDevTools: false,
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async (opts) => {
+        seenHide = opts.hide;
+        return png;
+      },
+    });
+    expect(seenHide).toEqual([".banner"]);
+  });
+
+  it("combines explicit --hide with auto-hidden dev toolbars", async () => {
+    let seenHide: string[] | undefined;
+    await captureScreenshot({
+      target: "http://localhost:3000",
+      via: "local",
+      hide: [".banner"],
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureLocalImpl: async (opts) => {
+        seenHide = opts.hide;
+        return png;
+      },
+    });
+    expect(seenHide).toEqual([".banner", ...DEV_TOOLBAR_SELECTORS]);
+  });
+
+  it("rejects a --hide selector that could break out of the injected rule", async () => {
+    await expect(
+      captureScreenshot({
+        target: "https://example.com",
+        via: "local",
+        hide: ["ok", "evil}{body{display:none"],
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        captureLocalImpl: async () => png,
+      }),
+    ).rejects.toMatchObject({ code: "USAGE" });
+  });
+
+  it("forwards reducedMotion and hide to the remote backend body", async () => {
+    let sentBody: Record<string, unknown> | undefined;
+    await captureScreenshot({
+      target: "https://example.com",
+      via: "remote",
+      hide: [".banner"],
+      reducedMotion: true,
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureRemoteImpl: async (body) => {
+        sentBody = body as unknown as Record<string, unknown>;
+        return png;
+      },
+    });
+    expect(sentBody).toMatchObject({ hide: [".banner"], reducedMotion: true });
+  });
+
+  it("rejects --eval on the remote backend (local-only) before any request", async () => {
+    let usedRemote = false;
+    await expect(
+      captureScreenshot({
+        target: "https://example.com",
+        via: "remote",
+        evalJs: "document.title = 'x'",
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        captureRemoteImpl: async () => {
+          usedRemote = true;
+          return png;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "USAGE" });
+    expect(usedRemote).toBe(false);
   });
 
   it("auto on a localhost target errors clearly when no local browser is found (no doomed remote request)", async () => {

--- a/packages/uploads/test/screenshot.test.ts
+++ b/packages/uploads/test/screenshot.test.ts
@@ -436,6 +436,19 @@ describe("captureScreenshot backend selection", () => {
     ).rejects.toMatchObject({ code: "USAGE" });
   });
 
+  it("rejects a --hide at-rule that would smuggle an @import (no braces needed)", async () => {
+    await expect(
+      captureScreenshot({
+        target: "https://example.com",
+        via: "local",
+        hide: ["@import url(http://127.0.0.1);*"],
+        apiUrl: "https://api.uploads.sh",
+        token: "t",
+        captureLocalImpl: async () => png,
+      }),
+    ).rejects.toMatchObject({ code: "USAGE" });
+  });
+
   it("forwards reducedMotion and hide to the remote backend body", async () => {
     let sentBody: Record<string, unknown> | undefined;
     await captureScreenshot({

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -26,22 +26,28 @@ already point at something publicly hosted. The **`uploads` CLI** provides
 that: it hosts the file on uploads.sh and returns a stable public URL plus
 ready-to-paste markdown.
 
-## Step 1 — Get the visual (any tool)
+## Step 1 — Capture the visual
 
-Capture is tool-agnostic. Use whatever this environment has and save a local
-file:
+**Prefer `uploads screenshot <url|file.html>`** — it captures **and** hosts in
+one step (drives a local Chrome, or falls back to a server-side render), so you
+skip a separate host call. It takes `--viewport WxH@Nx`, `--wait`, `--selector`,
+`--full-page`, and `--out <file>` (to also save the PNG).
 
-- The agent harness's own browser tools (screenshot the preview pane).
-- A Playwright/browser MCP, `agent-browser`, or similar automation.
-- An OS screenshot or screen recording the user already made.
-- Any existing image, GIF, or diagram file.
+Capturing your **own dev server**? It hides known framework dev toolbars
+(Astro/Next/Nuxt/Vite) automatically and takes `--reduced-motion` to settle
+animations — no manual DOM surgery. Use `--hide <selector>` for any other
+overlay (repeatable), and `--eval <js>` / `--init-script <file>` (local backend)
+as an escape hatch to dismiss a banner or freeze a specific animation.
 
-No browser tool on hand? `uploads screenshot <url|file.html>` captures
-**and** hosts in one step — it drives an installed Chrome itself, or falls
-back to a server-side render when none is found. See the uploads-cli skill.
+```bash
+uploads screenshot http://localhost:4321 --viewport 1520x960@1x --out home.png --reduced-motion
+uploads screenshot https://uploads.sh --selector main --dark
+```
 
-GIFs and video upload as-is — the client-side optimizer only rewrites still
-images (PNG/JPEG → WebP). No special flags needed for motion.
+Only reach for your harness's browser tools / Playwright / an existing file when
+`uploads screenshot` can't reach the target (e.g. a flow that needs auth or
+interaction first). GIFs and video: capture with any tool and upload as-is — the
+optimizer only rewrites still images (PNG/JPEG → WebP).
 
 ## Step 2 — Host and embed
 

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -34,10 +34,11 @@ skip a separate host call. It takes `--viewport WxH@Nx`, `--wait`, `--selector`,
 `--full-page`, and `--out <file>` (to also save the PNG).
 
 Capturing your **own dev server**? It hides known framework dev toolbars
-(Astro/Next/Nuxt/Vite) automatically and takes `--reduced-motion` to settle
-animations — no manual DOM surgery. Use `--hide <selector>` for any other
-overlay (repeatable), and `--eval <js>` / `--init-script <file>` (local backend)
-as an escape hatch to dismiss a banner or freeze a specific animation.
+(Astro/Next/Nuxt/Vite) automatically (opt out with `--no-hide-dev-tools`) and
+takes `--reduced-motion` to settle animations — no manual DOM surgery. Use
+`--hide <selector>` for any other overlay (repeatable), and `--eval <js>` /
+`--init-script <file>` (local backend) as an escape hatch to dismiss a banner or
+freeze a specific animation.
 
 ```bash
 uploads screenshot http://localhost:4321 --viewport 1520x960@1x --out home.png --reduced-motion


### PR DESCRIPTION
## What & why

`uploads screenshot` shipped in #202 but was **never released** — the PR merged without a changeset, so the published CLI stayed at `0.12.1` and reports `unknown command: screenshot`. Agents that install the CLI and follow the docs hit that wall and detour to hand-rolled Playwright, which is exactly what #219 documents.

This PR cuts the release **and** closes the capture gaps from #219 so agents can stay on the product's own primitive.

Closes #219.

## Changes

- **Release** — adds the changeset for the #202 work (minor bump), so the next release publishes `screenshot`.
- **`--hide <css>`** (repeatable) — hide matching elements before capture, on both backends. localhost/private targets also **auto-hide known framework dev toolbars** (Astro/Next/Nuxt/Vite); opt out with `--no-hide-dev-tools`.
- **`--reduced-motion`** — emulate `prefers-reduced-motion: reduce` so animations settle. True media emulation on the local backend; best-effort injected CSS on the remote `/v1/render` path (same documented gap as `colorScheme`, since Browser Run exposes no media-feature emulation).
- **`--eval <js>` / `--init-script <file>`** — run setup JS before capture (dismiss a banner, freeze an animation). **Local backend only** — the shared remote renderer keeps no eval escape hatch.
- Skill (`github-screenshots`) Step 1 and the web docs now lead with `uploads screenshot` instead of listing it as a fallback.

Wiring spans the shared core, local + remote backends, the render endpoint (validated: 50-selector cap, injection-safe selectors), the CLI, and the MCP tool (`hide`/`noHideDevTools`/`reducedMotion`; `eval` stays CLI-only).

## Verification

All three flags exercised end-to-end through the real local backend (drives system Chrome). Same synthetic page, captured without flags (before) and with `--hide ".toast" --reduced-motion --eval "…='eval ran'"` (after):

- **before:** red "DEV TOOLBAR" overlay present, text reads "hi"
- **after:** overlay hidden, text reads "eval ran", animation settled

_(images below)_

| Before (`uploads screenshot card.html`) | After (`--hide ".toast" --reduced-motion --eval …`) |
| --- | --- |
| <img width="420" alt="Before: dev toolbar visible, text 'hi'" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/221/before.webp"> | <img width="420" alt="After: toolbar hidden, text 'eval ran'" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/221/after.webp"> |

- `pnpm test` — 1245 passing (added routing/validation/backend tests)
- typecheck (`@buildinternet/uploads`, `@uploads/api`) + oxlint + oxfmt clean

## Follow-ups (not in this PR)

Cutting the release still requires merging + the release PR to publish to npm. The remaining #219 item — `uploads doctor` reporting screenshot-backend availability — was already shipped previously and is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded screenshot capture controls with reduced-motion support, element hiding, custom JavaScript evaluation, and initialization scripts.
  * Automatically hides common development toolbars for local captures, with an option to disable this behavior.
  * Added corresponding options to the screenshot CLI and MCP tool.
  * Remote rendering now supports element hiding and reduced-motion handling.

* **Documentation**
  * Added guidance and examples for the new screenshot options and workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->