### PR TITLE
chore: drop orphaned @uploads/web changeset blocking releases

### DIFF
--- a/.changeset/robots-allow-ai-train.md
+++ b/.changeset/robots-allow-ai-train.md
@@ -1,5 +1,0 @@
----
-"@uploads/web": patch
----
-
-Allow AI training in `robots.txt` — flip the `Content-Signal` `ai-train` preference from `no` to `yes` across the wildcard and every named AI crawler block. Search and RAG signals are unchanged, and the `/invite`, `/console`, `/404`, `/500` disallow rules stay in place.


### PR DESCRIPTION
## Why

The npm publish of `0.13.0` (which ships `uploads screenshot`, #221/#219) failed. Root cause is **not** in that PR — it's a pre-existing poison changeset.

`.changeset/robots-allow-ai-train.md` (from #215) targets `@uploads/web`, which is in the changesets **`ignore`** list (the web app deploys via Workers Builds, not npm). So `changeset version` consumes it but produces no versionable diff, leaving `changeset-release/main` identical to `main`. `changesets/action` then fails creating the version PR:

```
Validation Failed: No commits between main and changeset-release/main
```

That step has no `continue-on-error`, so the job aborts **before** the publish step (`if: hasChangesets == 'false'`). Net effect: `main` is at `0.13.0` but npm is stuck at `0.12.1`, and this has silently blocked every release since #215.

## Fix

Remove the inert changeset. The robots.txt change itself already shipped via Workers Builds; a changeset for an ignored package can never produce a release. With it gone, the next Release run sees zero changesets → `hasChangesets=false` → the publish step runs and pushes `0.13.0`.

## After merge

The `Release` workflow fires on the merge and should publish `0.13.0` to npm. (Optional hardening, not in this PR: add `continue-on-error: true` to the "Create Release PR" step so a future ignored-package changeset can't abort publishing.)