### PR TITLE
ci: reject changesets targeting ignored packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Oxfmt
         run: pnpm format:check
 
+      # A changeset for an ignored package yields an empty version PR and blocks
+      # the npm publish — reject it here before it can merge.
+      - name: Changeset lint
+        run: pnpm changeset:lint
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "preuploads": "pnpm --filter @buildinternet/uploads run build",
     "uploads": "pnpm exec uploads",
     "changeset": "changeset",
+    "changeset:lint": "node scripts/changeset-lint.mjs",
     "changeset:version": "changeset version && pnpm install --lockfile-only",
     "changeset:publish": "changeset publish",
     "prepare": "husky"

--- a/scripts/changeset-lint.mjs
+++ b/scripts/changeset-lint.mjs
@@ -1,0 +1,47 @@
+/**
+ * Fail if any changeset targets a package in the changesets `ignore` list.
+ *
+ * Such a changeset can never produce a release (the package is versioned out of
+ * band — Workers Builds, not npm), yet it makes `changeset version` yield an
+ * empty diff. The Release workflow's changesets/action then dies creating the
+ * version PR ("No commits between main and changeset-release/main") *before*
+ * the publish step, silently blocking every npm publish. This guard keeps such
+ * a changeset from ever landing. See the uploads-release-changeset-poison note.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const changesetDir = join(dirname(fileURLToPath(import.meta.url)), "..", ".changeset");
+const config = JSON.parse(readFileSync(join(changesetDir, "config.json"), "utf8"));
+const ignored = new Set(config.ignore ?? []);
+
+const files = readdirSync(changesetDir).filter(
+  (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+);
+
+const offenders = [];
+for (const file of files) {
+  const text = readFileSync(join(changesetDir, file), "utf8");
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text);
+  if (!frontmatter) continue;
+  for (const line of frontmatter[1].split(/\r?\n/)) {
+    // Frontmatter entries look like: "@uploads/web": patch
+    const match = /^\s*["']?(@?[\w./-]+)["']?\s*:/.exec(line);
+    if (match && ignored.has(match[1])) offenders.push({ file, pkg: match[1] });
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    "changeset-lint: changeset(s) target packages in the changesets `ignore` list.\n" +
+      "These can never be released (they deploy via Workers Builds, not npm) and\n" +
+      "will BLOCK the npm publish — the version PR comes out empty and the Release\n" +
+      'workflow fails with "No commits between main and changeset-release/main".\n' +
+      "Remove the changeset(s) below (the underlying change ships on its own):\n",
+  );
+  for (const { file, pkg } of offenders) console.error(`  - .changeset/${file} → ${pkg}`);
+  process.exit(1);
+}
+
+console.log(`changeset-lint: ${files.length} changeset(s) OK — none target ignored packages.`);


### PR DESCRIPTION
## Why

Follow-up to the `0.13.0` publish incident (#221 → #222). A changeset for a package in the changesets **`ignore`** list (`@uploads/api`, `@uploads/mcp`, `@uploads/web`, `@uploads/storage`, `@uploads/auth` — they deploy via Workers Builds, not npm) can never be released, yet it makes `changeset version` produce an **empty version PR**. The Release workflow's `changesets/action` then fails:

```
Validation Failed: No commits between main and changeset-release/main
```

…**before** the publish step, silently blocking every npm publish. That's exactly how a stray `@uploads/web` changeset (from #215) held `0.13.0` back with `main` bumped but npm stuck at `0.12.1`.

## Why not just `continue-on-error`

The tempting one-liner — `continue-on-error: true` on the "Create Release PR" step — does **not** fix it. An ignored-package changeset still makes `steps.changesets.outputs.hasChangesets == 'true'`, so the publish steps (gated on `== 'false'`) skip anyway. The fix has to be **prevention at PR time**.

## What

- `scripts/changeset-lint.mjs` — reads the `ignore` list from `.changeset/config.json` and fails if any changeset's frontmatter names an ignored package, with a message pointing at the offending file.
- `pnpm changeset:lint` script.
- Wired into the CI **Lint & Format** job, so such a changeset can't merge.

## Verification

```
# clean tree
changeset-lint: 0 changeset(s) OK — none target ignored packages.   (exit 0)

# poison (@uploads/web)
changeset-lint: changeset(s) target packages in the changesets `ignore` list.
  - .changeset/__poison-test.md → @uploads/web                       (exit 1)

# valid (@buildinternet/uploads)
changeset-lint: 1 changeset(s) OK — none target ignored packages.   (exit 0)
```

Reproduces and catches the exact `robots-allow-ai-train.md` case from #222.