### PR TITLE
feat(plugin): ship a Claude Code plugin for uploads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "uploads",
+  "owner": {
+    "name": "Build Internet",
+    "url": "https://uploads.sh"
+  },
+  "description": "Host screenshots, GIFs, recordings, and files on uploads.sh and embed them in GitHub PRs and issues.",
+  "plugins": [
+    {
+      "name": "uploads",
+      "source": "./",
+      "description": "Get screenshots, GIFs, recordings, and files into GitHub PRs and issues via uploads.sh. Bundles the github-screenshots + uploads-cli skills, a local MCP server, and the /uploads:attach command.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Build Internet"
+      },
+      "homepage": "https://uploads.sh",
+      "repository": "https://github.com/buildinternet/uploads",
+      "license": "MIT",
+      "keywords": ["uploads", "screenshots", "github", "file-hosting", "images", "mcp"],
+      "strict": false,
+      "skills": ["./skills/github-screenshots", "./skills/uploads-cli"],
+      "commands": "./plugins/claude/uploads/commands",
+      "mcpServers": "./plugins/claude/uploads/.mcp.json"
+    }
+  ]
+}

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -9,7 +9,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, get a URL for any file, capture a screenshot
-- [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server
+- [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
 - [Auth for agents](https://uploads.sh/auth.md): invitation enrollment and bearer tokens
@@ -31,6 +31,13 @@ Remote MCP (HTTP):
 
 ```bash
 claude mcp add --transport http uploads https://agents.uploads.sh/mcp
+```
+
+Claude Code plugin (bundles the skills, the hosted MCP server, and the /uploads:attach command):
+
+```text
+/plugin marketplace add buildinternet/uploads
+/plugin install uploads@uploads
 ```
 
 ## Endpoints

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -279,6 +279,9 @@ const fullTitle = `${title} · uploads.sh`;
         scrollbar-width: none;
       }
       .doc .cmd .text::before { content: "$ "; color: var(--accent); }
+      /* slash commands are typed into Claude Code, not a shell: no "$ " prompt —
+         the command's own leading "/" stands in for it */
+      .doc .cmd.slash .text::before { content: ""; }
       .doc .cmd .text .url { color: var(--body); }
       .doc .cmd .text .cm { color: var(--muted); }
       .doc .cmd button {

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -33,6 +33,29 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
     </div>
   </section>
 
+  <section id="plugin">
+    <h2>Claude Code plugin <a class="anchor" href="#plugin" aria-label="Link to this section">#</a></h2>
+    <p>
+      On Claude Code you can install everything as one plugin — both agent skills, an
+      MCP server, and an <code>/uploads:attach</code> command — from the uploads
+      marketplace. Add the marketplace, then install:
+    </p>
+    <div class="cmd slash">
+      <span class="text">/plugin marketplace add buildinternet/uploads</span>
+      <button type="button" data-copy="/plugin marketplace add buildinternet/uploads" aria-live="polite">copy</button>
+    </div>
+    <div class="cmd slash">
+      <span class="text">/plugin install uploads@uploads</span>
+      <button type="button" data-copy="/plugin install uploads@uploads" aria-live="polite">copy</button>
+    </div>
+    <p>
+      The bundled MCP server runs the local <code>uploads mcp</code> over stdio and
+      reads the token <code>uploads login</code> already stored, so once you've signed
+      in there's nothing else to wire up — just make sure the <code>uploads</code> CLI
+      is on your <code>PATH</code>.
+    </p>
+  </section>
+
   <section id="skill-vs-mcp">
     <h2>Skill vs. MCP <a class="anchor" href="#skill-vs-mcp" aria-label="Link to this section">#</a></h2>
     <p>

--- a/plugins/claude/uploads/.mcp.json
+++ b/plugins/claude/uploads/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "uploads": {
+    "command": "uploads",
+    "args": ["mcp"]
+  }
+}

--- a/plugins/claude/uploads/README.md
+++ b/plugins/claude/uploads/README.md
@@ -1,0 +1,60 @@
+# uploads plugin
+
+Get screenshots, GIFs, recordings, and files into GitHub PRs and issues via
+[uploads.sh](https://uploads.sh) — workspace-scoped hosting built for showing
+your work.
+
+This directory holds the Claude Code plugin's tool-specific config. The plugin
+itself is declared inline in [`.claude-plugin/marketplace.json`](../../../.claude-plugin/marketplace.json)
+with `source: "./"`, so the whole repo is a one-plugin marketplace.
+
+## What it bundles
+
+| Component                | Invocation                    | Purpose                                                                           |
+| ------------------------ | ----------------------------- | --------------------------------------------------------------------------------- |
+| github-screenshots skill | `/uploads:github-screenshots` | Capture + host + embed a visual in a PR/issue with a stable per-target key        |
+| uploads-cli skill        | `/uploads:uploads-cli`        | Full `uploads` CLI reference — `put`, `attach`, `screenshot`, galleries, metadata |
+| attach command           | `/uploads:attach`             | Explicit entry point for hosting a file or attaching to a PR/issue                |
+| uploads MCP server       | (tools)                       | Local stdio `uploads mcp` — `put`, `list`, `attach`, galleries                    |
+
+Plugin skills and commands are namespaced by the plugin name (`uploads`), so
+they appear as `/uploads:…`.
+
+## Install
+
+```
+/plugin marketplace add buildinternet/uploads
+/plugin install uploads@uploads
+```
+
+## MCP auth
+
+The bundled MCP server runs the local CLI over stdio (`uploads mcp`). It reads
+your workspace token from the config file `uploads login` writes
+(`~/.config/buildinternet/config`), so once you've signed in there's nothing
+else to set up:
+
+```
+npm install -g @buildinternet/uploads   # if the CLI isn't already installed
+uploads login                            # device flow → stores the token
+```
+
+The CLI must be on your `PATH` for the bundled server to launch. Tokens carry
+`files:read` + `files:write` by default and are scoped to a single workspace.
+See <https://uploads.sh/auth.md> for the full credential model.
+
+### Why not the hosted endpoint?
+
+The hosted MCP at `https://agents.uploads.sh/mcp` authenticates with a bearer
+token, but a static plugin manifest can't inject a per-user token. `uploads
+login` stores the token in a config file, **not** an environment variable, so a
+`${UPLOADS_TOKEN}` header would be empty for a normally signed-in user. Until
+`agents.uploads.sh` exposes an OAuth authorization server that Claude Code can
+complete interactively, the local stdio server is the one that works without
+manual token wiring. To use the hosted endpoint anyway, register it yourself
+with the token baked in (this is what `uploads install` does):
+
+```
+claude mcp add --transport http uploads https://agents.uploads.sh/mcp \
+  --header "Authorization: Bearer up_<workspace>_…"
+```

--- a/plugins/claude/uploads/commands/attach.md
+++ b/plugins/claude/uploads/commands/attach.md
@@ -1,0 +1,41 @@
+---
+description: Host a screenshot, GIF, or file on uploads.sh and attach it to a GitHub PR/issue (or just get a public URL)
+argument-hint: <file-or-description> [PR#/issue#]
+---
+
+# /uploads:attach
+
+Host a screenshot, GIF, recording, or file on [uploads.sh](https://uploads.sh)
+and embed it in a GitHub PR or issue — or just get back a public URL.
+
+## Usage
+
+```
+/uploads:attach <file-or-description> [target]
+```
+
+- **file-or-description**: A local path to host, or a description of what to
+  capture/attach (e.g. "the failing test output", "before/after of the header").
+- **target**: An optional GitHub PR or issue (e.g. `#142`) to embed the image in.
+
+## Examples
+
+```
+/uploads:attach ./out/report.png
+/uploads:attach screenshot of the new homepage, attach to #198
+/uploads:attach before/after GIF of the footer refresh, add to PR #206
+/uploads:attach give me a public link for docs/diagram.svg
+```
+
+## How it works
+
+1. For anything visual that belongs in a **GitHub PR or issue**, follow the
+   `uploads:github-screenshots` skill — it captures (or takes a given file),
+   hosts it on uploads.sh with a stable per-PR/issue key, and embeds the URL in
+   the description, body, or a comment.
+2. For a plain **public link** to an existing file, or for exact CLI flags
+   (keys, galleries, metadata, `put`/`attach`/`screenshot`), follow the
+   `uploads:uploads-cli` skill.
+3. Hosting and lookups can also go through the bundled **uploads MCP server**
+   (`put`, `list`, `attach`, galleries), which runs the local `uploads mcp` and
+   reuses your `uploads login` session — see this plugin's README for setup.


### PR DESCRIPTION
## In plain terms

You can now install uploads into Claude Code as a single plugin. Adding the
marketplace and installing the plugin pulls in both agent skills, an MCP server,
and a `/uploads:attach` command in one step — no hand-wiring `npx skills add`
and `claude mcp add` separately. The site's "Set up your agent" docs gain a
third install path alongside `uploads install` and the manual setup.

## Screenshot

The new section on `/docs/agents` (slash commands render without a shell `$`
prompt via a small `.cmd.slash` style):

<img width="700" alt="New Claude Code plugin section on the /docs/agents page" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/225/plugin-section.webp">

## What it does / what it is not

- Adds a one-plugin marketplace at `.claude-plugin/marketplace.json`
  (`source: "./"`), mirroring the `releases-cli` layout: skills stay at the repo
  root `skills/`, and the plugin's MCP + command live under
  `plugins/claude/uploads/`.
- Bundles the existing `github-screenshots` and `uploads-cli` skills (namespaced
  as `/uploads:…`), a `/uploads:attach` command, and an MCP server.
- The bundled MCP is the **local stdio** server (`uploads mcp`), not the hosted
  endpoint. `uploads login` stores the token in a config file, not an
  environment variable, so a static `${UPLOADS_TOKEN}` header would be empty for
  a signed-in user. The stdio server reuses that same config, so it works right
  after `uploads login` (with the `uploads` CLI on `PATH`).
- Proper OAuth for the hosted `agents.uploads.sh/mcp` — which would drop the CLI
  dependency entirely — is deliberately deferred and tracked in #224.
- Docs-only web change otherwise: a "Claude Code plugin" section on
  `/docs/agents`, a small `.cmd.slash` style so slash commands render without a
  `$` shell prompt, and a plugin entry in `llms.txt`. No package/runtime code
  changed, so no changeset.

## How to try it

```
/plugin marketplace add buildinternet/uploads
/plugin install uploads@uploads
```

Then, once the CLI is set up (`npm i -g @buildinternet/uploads && uploads login`):

```
/uploads:attach   # host a file / attach a screenshot to a PR or issue
```

## Technical notes

- `claude plugin validate .` passes against Claude Code 2.1.211.
- Install resolves as `plugin-name@marketplace-name` → `uploads@uploads`.
- `.mcp.json` is `{ "uploads": { "command": "uploads", "args": ["mcp"] } }`; the
  hosted-HTTP + baked-token form is documented in the plugin README as the
  alternative `uploads install` already uses.

## Test plan

- [x] `claude plugin validate .` — passes
- [x] `/docs/agents` renders the new section; slash rows show no `$` prompt
      (verified computed `::before` is empty); no console/server errors
- [x] oxfmt clean (JSON + Markdown); pre-commit `pnpm types` passed
- [ ] Post-merge: `/plugin marketplace add buildinternet/uploads` +
      `/plugin install uploads@uploads` against `main` from a clean machine
