### PR TITLE
feat: OAuth 2.1 authorization server for the hosted MCP

### DIFF
--- a/apps/api/src/well-known.test.ts
+++ b/apps/api/src/well-known.test.ts
@@ -28,7 +28,9 @@ describe("GET /.well-known/oauth-protected-resource", () => {
     expect(body.scopes_supported).toEqual(["files:read", "files:write", "files:delete"]);
     expect(body.bearer_methods_supported).toEqual(["header"]);
     expect(body.resource_documentation).toBe("https://uploads.sh/auth.md");
-    // No public authorization server for third-party clients (see well-known.ts).
+    // apps/api's own call site deliberately doesn't pass `authorizationServers`
+    // (see well-known.ts) — only apps/mcp does (issue #224). Not that the
+    // field is unsupported; index.ts just never opts in.
     expect(body.authorization_servers).toBeUndefined();
   });
 });

--- a/apps/api/src/well-known.ts
+++ b/apps/api/src/well-known.ts
@@ -7,14 +7,16 @@
  * programmatically. It is served at `/.well-known/oauth-protected-resource`
  * on each resource origin (api.uploads.sh, agents.uploads.sh).
  *
- * `authorization_servers` is deliberately omitted. There is no public OAuth
- * authorization server for third-party clients — tokens are minted out-of-band
- * via `uploads login` (a first-party device flow) and the token-mint endpoint,
- * all described in `resource_documentation` (auth.md). Advertising an
- * `authorization_servers` entry would point RFC 9728 clients at an
- * authorization-server metadata document that we intentionally do not publish,
- * so we leave it out rather than dangle a broken reference. See auth.md's
- * "What we deliberately do not publish".
+ * `authorization_servers` is opt-in per caller via `authorizationServers`
+ * (issue #224). Only apps/mcp passes it — it's the only resource server that
+ * verifies the uploads-auth OAuth JWTs (v1 is MCP-only; see
+ * docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md).
+ * apps/api's own usage keeps omitting it: tokens for the REST API are still
+ * minted out-of-band via `uploads login` / the token-mint endpoint (described
+ * in `resource_documentation`), and advertising an authorization server here
+ * would point RFC 9728 clients at an AS that doesn't accept api.uploads.sh
+ * audiences — a dangling, misleading reference. See auth.md's "What we
+ * deliberately do not publish".
  */
 import { FILE_SCOPES } from "./auth-db";
 
@@ -28,12 +30,16 @@ export interface ProtectedResourceMetadata {
   bearer_methods_supported: string[];
   /** Human/agent-readable acquisition + usage docs (auth.md). */
   resource_documentation: string;
+  /** Issuer URL(s) of the authorization server(s) that issue tokens for this resource. Omitted when the caller doesn't pass `authorizationServers`. */
+  authorization_servers?: string[];
 }
 
 export function protectedResourceMetadata(opts: {
   resource: string;
   resourceName: string;
   webOrigin: string;
+  /** Issuer(s) whose access tokens this resource server accepts. Leave unset to omit `authorization_servers` (the honest default — see module doc). */
+  authorizationServers?: string[];
 }): ProtectedResourceMetadata {
   return {
     resource: opts.resource,
@@ -41,6 +47,7 @@ export function protectedResourceMetadata(opts: {
     scopes_supported: [...FILE_SCOPES],
     bearer_methods_supported: ["header"],
     resource_documentation: `${opts.webOrigin.replace(/\/$/, "")}/auth.md`,
+    ...(opts.authorizationServers ? { authorization_servers: opts.authorizationServers } : {}),
   };
 }
 

--- a/apps/auth/migrations/20260717000000_oauth_provider.sql
+++ b/apps/auth/migrations/20260717000000_oauth_provider.sql
@@ -1,0 +1,93 @@
+-- OAuth 2.1 authorization server (issue #224, Lane A): `jwt()` +
+-- `oauthProvider()` plugins (see src/auth.ts). Paired with `jwks` /
+-- oauthClient / oauthAccessToken / oauthRefreshToken / oauthConsent in
+-- src/schema.ts. string[] columns are JSON text; timestamps are integer
+-- epoch ms (Better Auth Drizzle / SQLite shape). Shape mirrors
+-- ~/Code/sunny/apps/auth/src/schema.ts:239-336 and its paired migration
+-- (apps/api/migrations/20260715064623_oauth_provider.sql).
+
+CREATE TABLE jwks (
+  id TEXT PRIMARY KEY,
+  public_key TEXT NOT NULL,
+  private_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER
+);
+
+CREATE TABLE oauth_client (
+  id TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL UNIQUE,
+  client_secret TEXT,
+  name TEXT,
+  icon TEXT,
+  uri TEXT,
+  redirect_uris TEXT NOT NULL,
+  post_logout_redirect_uris TEXT,
+  scopes TEXT NOT NULL,
+  grant_types TEXT,
+  response_types TEXT,
+  contacts TEXT,
+  token_endpoint_auth_method TEXT,
+  type TEXT,
+  public INTEGER,
+  require_pkce INTEGER,
+  disabled INTEGER,
+  skip_consent INTEGER,
+  enable_end_session INTEGER,
+  subject_type TEXT,
+  tos TEXT,
+  policy TEXT,
+  software_id TEXT,
+  software_version TEXT,
+  software_statement TEXT,
+  user_id TEXT,
+  reference_id TEXT,
+  metadata TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_oauth_client_client_id ON oauth_client (client_id);
+
+CREATE TABLE oauth_access_token (
+  id TEXT PRIMARY KEY,
+  token TEXT NOT NULL UNIQUE,
+  client_id TEXT NOT NULL REFERENCES oauth_client (client_id),
+  session_id TEXT REFERENCES session (id) ON DELETE SET NULL,
+  refresh_id TEXT,
+  user_id TEXT,
+  reference_id TEXT,
+  scopes TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+CREATE INDEX idx_oauth_access_token_token ON oauth_access_token (token);
+CREATE INDEX idx_oauth_access_client_id ON oauth_access_token (client_id);
+CREATE INDEX idx_oauth_access_session_id ON oauth_access_token (session_id);
+
+CREATE TABLE oauth_refresh_token (
+  id TEXT PRIMARY KEY,
+  token TEXT NOT NULL UNIQUE,
+  client_id TEXT NOT NULL REFERENCES oauth_client (client_id),
+  session_id TEXT REFERENCES session (id) ON DELETE SET NULL,
+  user_id TEXT NOT NULL,
+  reference_id TEXT,
+  scopes TEXT NOT NULL,
+  revoked INTEGER, -- epoch ms; NULL = not revoked
+  auth_time INTEGER,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+CREATE INDEX idx_oauth_refresh_token_token ON oauth_refresh_token (token);
+CREATE INDEX idx_oauth_refresh_client_id ON oauth_refresh_token (client_id);
+CREATE INDEX idx_oauth_refresh_session_id ON oauth_refresh_token (session_id);
+
+CREATE TABLE oauth_consent (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  client_id TEXT NOT NULL,
+  reference_id TEXT,
+  scopes TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_oauth_consent_user_client ON oauth_consent (user_id, client_id);

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@better-auth/infra": "^0.3.6",
+    "@better-auth/oauth-provider": "^1.6.23",
     "@uploads/email": "workspace:^",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -6,11 +6,19 @@
  * serves a stale instance.
  */
 import { dash } from "@better-auth/infra";
+import { oauthProvider } from "@better-auth/oauth-provider";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { admin, bearer, deviceAuthorization, magicLink, organization } from "better-auth/plugins";
+import {
+  admin,
+  bearer,
+  deviceAuthorization,
+  jwt,
+  magicLink,
+  organization,
+} from "better-auth/plugins";
 import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import * as schema from "./schema";
@@ -36,6 +44,50 @@ export const UPLOADS_CLI_CLIENT_ID = "uploads-cli";
 /** CLI device-flow User-Agent — keep in sync with apps/web `CLI_USER_AGENT_RE`. */
 export function isCliSessionUserAgent(ua?: string | null): boolean {
   return Boolean(ua && /@buildinternet\/uploads(?:\/[\w.-]+)?/i.test(ua));
+}
+
+/**
+ * OAuth 2.1 authorization server scopes (issue #224, Lane A). Duplicated
+ * literally rather than imported from `@uploads/api` — this worker has no
+ * dependency on that package. Keep in lockstep with `FILE_SCOPES` in
+ * `apps/api/src/auth-db.ts`.
+ */
+const OAUTH_SCOPES = ["files:read", "files:write", "files:delete"] as const;
+
+/** Default scopes granted to a dynamically registered client that requests none. */
+const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = ["files:read", "files:write"] as const;
+
+/**
+ * Resource servers that accept this AS's JWT access tokens (design doc:
+ * "Accepted audiences"). Mirrored into apps/mcp's JWT verification config —
+ * keep both in lockstep.
+ */
+const OAUTH_VALID_AUDIENCES = ["https://agents.uploads.sh/mcp", "https://mcp.uploads.sh/mcp"];
+
+/**
+ * Workspace claims embedded in every OAuth access-token JWT
+ * (`customAccessTokenClaims` below): the oldest org membership's slug as the
+ * primary `workspace`, plus every slug the user belongs to. Queries the same
+ * D1 the rest of this worker uses (member ⋈ organization). Defensive:
+ * missing user or zero memberships still returns a shape MCP can consume
+ * (`workspace: null`) rather than throwing — a token must always issue.
+ *
+ * Exported for direct unit testing (see auth.test.ts) since driving the full
+ * authorize→consent→token flow through the plugin is comparatively heavy.
+ */
+export async function resolveWorkspaceClaims(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  userId: string | undefined,
+): Promise<{ workspace: string | null; workspaces: string[] }> {
+  if (!userId) return { workspace: null, workspaces: [] };
+  const rows = await db
+    .select({ slug: schema.organization.slug })
+    .from(schema.member)
+    .innerJoin(schema.organization, eq(schema.member.organizationId, schema.organization.id))
+    .where(eq(schema.member.userId, userId))
+    .orderBy(asc(schema.member.createdAt));
+  const workspaces = rows.map((r) => r.slug);
+  return { workspace: workspaces[0] ?? null, workspaces };
 }
 
 export type AuthEnv = GitHubCredentialsEnv &
@@ -101,6 +153,11 @@ function buildAuth(
     baseURL: betterAuthUrl,
     basePath: "/api/auth",
     secret: signingSecret,
+    // `schema` (the whole module) is passed through as before — the adapter
+    // discovers tables by matching each export's camelCase name to the
+    // plugin's model name, so adding `jwks`/`oauthClient`/`oauthAccessToken`/
+    // `oauthRefreshToken`/`oauthConsent` exports to schema.ts (issue #224,
+    // Lane A) is sufficient; no explicit map needed here.
     database: drizzleAdapter(db, {
       provider: "sqlite",
       schema,
@@ -170,6 +227,39 @@ function buildAuth(
             });
           },
         },
+      }),
+      // Issue #224, Lane A: signs the OAuth provider's access tokens as JWTs
+      // and serves JWKS at /api/auth/jwks. MUST precede oauthProvider() below
+      // — the plugin looks up the jwt() config at registration time.
+      jwt(),
+      // Issue #224, Lane A: OAuth 2.1 authorization server for
+      // agents.uploads.sh/mcp (see docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md).
+      // loginPage/consentPage MUST be absolute URLs on the WEB origin — same
+      // rule as deviceAuthorization's verificationUri above; the /login and
+      // /oauth/consent pages are served by apps/web, not this worker.
+      // DCR is on and unauthenticated (agent/MCP clients self-register before
+      // any user has logged in); the stale-client reaper (oauth-client-reaper.ts)
+      // sweeps abandoned anonymous registrations from the cron below.
+      oauthProvider({
+        loginPage: `${webOrigin}/login`,
+        consentPage: `${webOrigin}/oauth/consent`,
+        scopes: [...OAUTH_SCOPES],
+        clientRegistrationDefaultScopes: [...OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES],
+        validAudiences: OAUTH_VALID_AUDIENCES,
+        // Root /.well-known aliases are served by src/index.ts.
+        silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+        allowDynamicClientRegistration: true,
+        allowUnauthenticatedClientRegistration: true,
+        // Explicit abuse ceiling on the public /oauth2/register endpoint —
+        // pinned here rather than the plugin's library default so it's
+        // auditable and can't silently drift. Enforced only when Better
+        // Auth's core rate limiter is on (see rateLimit below).
+        rateLimit: { register: { window: 60, max: 5 } },
+        // member ⋈ organization, oldest membership wins for `workspace`; all
+        // slugs ride along in `workspaces` for a future workspace picker
+        // (design doc: "deferred"). Zero memberships still issues a token
+        // (workspace: null) — the MCP worker is responsible for the 403.
+        customAccessTokenClaims: async ({ user }) => resolveWorkspaceClaims(db, user?.id),
       }),
       // D5/Phase 4: bearer() lets the CLI present the device-flow session token
       // as `Authorization: Bearer <token>` so apps/api's session verification

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -85,7 +85,9 @@ export async function resolveWorkspaceClaims(
     .from(schema.member)
     .innerJoin(schema.organization, eq(schema.member.organizationId, schema.organization.id))
     .where(eq(schema.member.userId, userId))
-    .orderBy(asc(schema.member.createdAt));
+    // Secondary sort on id: memberships created in the same millisecond must
+    // still yield the same primary workspace on every token issuance.
+    .orderBy(asc(schema.member.createdAt), asc(schema.member.id));
   const workspaces = rows.map((r) => r.slug);
   return { workspace: workspaces[0] ?? null, workspaces };
 }

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -6,6 +6,7 @@ import { isInternalRequest } from "./internal";
 import { LOCAL_STACK_WEB_ORIGIN, localDemoEnabled } from "./local-demo";
 import { isTrustedOrigin } from "./trusted-origins";
 import { runAuthRetentionSweep } from "./retention-sweep";
+import { sweepOauthClients } from "./oauth-client-reaper";
 
 // Credentialed CORS for the web origin (+ dev origins), scoped to /api/auth/*
 // only — this worker has no other public surface (D1: "CORS becomes trivial").
@@ -17,8 +18,48 @@ const authCors = cors({
   maxAge: 86400,
 });
 
+/**
+ * Rewrite the request path to `pathname` and run it through the Better Auth
+ * handler, stamping `Access-Control-Allow-Origin: *` on the response — issue
+ * #224, Lane A's root `/.well-known/*` discovery aliases below. Clients that
+ * discover from the issuer origin (not `/api/auth`) hit these; this rewrites
+ * to the plugin's actual paths under the basePath. Public metadata only, so
+ * CORS is wide open (unlike the credentialed `authCors` on `/api/auth/*`).
+ * Mirrors `~/Code/sunny/apps/auth/src/index.ts`'s `runBetterAuth`.
+ */
+async function discoveryAlias(
+  c: { env: AuthEnv; req: { raw: Request } },
+  pathname: string,
+): Promise<Response> {
+  const auth = await createAuth(c.env);
+  if (!auth) {
+    return Response.json(
+      { error: { code: "auth_unavailable", message: "Auth is not configured yet." } },
+      { status: 503 },
+    );
+  }
+  const url = new URL(c.req.raw.url);
+  url.pathname = pathname;
+  const res = await auth.handler(new Request(url.toString(), c.req.raw));
+  const headers = new Headers(res.headers);
+  headers.set("Access-Control-Allow-Origin", "*");
+  return new Response(res.body, { status: res.status, headers });
+}
+
 export const app = new Hono<{ Bindings: AuthEnv }>()
   .get("/health", (c) => c.json({ ok: true }))
+  // RFC 8414 path-inserted form: /.well-known/oauth-authorization-server{issuer-path}.
+  // Issuer is `${BETTER_AUTH_URL}/api/auth`, so both the bare and `/*` forms
+  // rewrite to the same plugin path.
+  .get("/.well-known/oauth-authorization-server", (c) =>
+    discoveryAlias(c, "/api/auth/.well-known/oauth-authorization-server"),
+  )
+  .get("/.well-known/oauth-authorization-server/*", (c) =>
+    discoveryAlias(c, "/api/auth/.well-known/oauth-authorization-server"),
+  )
+  .get("/.well-known/openid-configuration", (c) =>
+    discoveryAlias(c, "/api/auth/.well-known/openid-configuration"),
+  )
   // Service-binding-only API (D1/D9): 404 rather than 403 for non-internal
   // callers so the route's existence isn't leaked to public probing.
   .use("/internal/*", async (c, next) => {
@@ -73,6 +114,19 @@ export default {
         console.error(
           JSON.stringify({
             message: "auth_retention_sweep_failed",
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }),
+    );
+    // Issue #224, Lane A: nightly sweep of stale, never-used dynamically
+    // registered OAuth clients. Observe-only until OAUTH_CLIENT_REAPER_ENABLED
+    // is set (see src/oauth-client-reaper.ts).
+    ctx.waitUntil(
+      sweepOauthClients(env).catch((err) => {
+        console.error(
+          JSON.stringify({
+            message: "oauth_client_reaper_failed",
             error: err instanceof Error ? err.message : String(err),
           }),
         );

--- a/apps/auth/src/oauth-client-reaper.test.ts
+++ b/apps/auth/src/oauth-client-reaper.test.ts
@@ -1,0 +1,104 @@
+import { drizzle } from "drizzle-orm/d1";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { sweepOauthClients } from "./oauth-client-reaper";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+let db: FakeD1Database;
+let env: AuthEnv;
+
+beforeEach(() => {
+  db = createFakeD1();
+  env = { DB: db, WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
+});
+
+function seedClient(
+  id: string,
+  overrides: Partial<{
+    clientId: string;
+    createdAt: Date;
+    userId: string | null;
+    skipConsent: boolean | null;
+  }> = {},
+) {
+  return drizzle(db, { schema })
+    .insert(schema.oauthClient)
+    .values({
+      id,
+      clientId: overrides.clientId ?? `client-${id}`,
+      redirectUris: ["https://client.example.com/callback"],
+      scopes: ["files:read"],
+      userId: overrides.userId ?? null,
+      skipConsent: overrides.skipConsent ?? null,
+      createdAt: overrides.createdAt ?? new Date(),
+      updatedAt: overrides.createdAt ?? new Date(),
+    });
+}
+
+describe("sweepOauthClients", () => {
+  it("observes (does not delete) stale anonymous unused clients by default", async () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await seedClient("stale-1", { createdAt: old });
+
+    const result = await sweepOauthClients(env);
+
+    expect(result.mode).toBe("observe");
+    expect(result.candidates).toBe(1);
+    expect(result.reapable).toBe(1);
+    expect(result.deleted).toBe(0);
+
+    const remaining = await drizzle(db, { schema }).select().from(schema.oauthClient);
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("deletes stale anonymous unused clients when OAUTH_CLIENT_REAPER_ENABLED=true", async () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await seedClient("stale-1", { createdAt: old });
+
+    const result = await sweepOauthClients({ ...env, OAUTH_CLIENT_REAPER_ENABLED: "true" });
+
+    expect(result.mode).toBe("delete");
+    expect(result.deleted).toBe(1);
+
+    const remaining = await drizzle(db, { schema }).select().from(schema.oauthClient);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("never sweeps a recent client, a session-owned client, or a trusted (skip_consent) client", async () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    const recent = new Date();
+    await seedClient("recent", { createdAt: recent });
+    await seedClient("owned", { createdAt: old, userId: "user-1" });
+    await seedClient("trusted", { createdAt: old, skipConsent: true });
+
+    const result = await sweepOauthClients({ ...env, OAUTH_CLIENT_REAPER_ENABLED: "true" });
+
+    expect(result.candidates).toBe(0);
+    expect(result.deleted).toBe(0);
+
+    const remaining = await drizzle(db, { schema }).select().from(schema.oauthClient);
+    expect(remaining).toHaveLength(3);
+  });
+
+  it("never sweeps a client with a consent row, even if stale and anonymous", async () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await seedClient("consented", { createdAt: old });
+    await drizzle(db, { schema })
+      .insert(schema.oauthConsent)
+      .values({
+        id: "consent-1",
+        userId: "user-1",
+        clientId: "client-consented",
+        scopes: ["files:read"],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+    const result = await sweepOauthClients({ ...env, OAUTH_CLIENT_REAPER_ENABLED: "true" });
+
+    expect(result.candidates).toBe(1);
+    expect(result.reapable).toBe(0);
+    expect(result.deleted).toBe(0);
+  });
+});

--- a/apps/auth/src/oauth-client-reaper.ts
+++ b/apps/auth/src/oauth-client-reaper.ts
@@ -1,0 +1,176 @@
+/**
+ * Nightly stale OAuth-client reaper (issue #224, Lane A DCR follow-up).
+ *
+ * Dynamic client registration lets anyone self-register at the public
+ * `/api/auth/oauth2/register` endpoint (see src/auth.ts's
+ * `allowUnauthenticatedClientRegistration`), so abandoned registrations
+ * (a probe, MCP Inspector, or an agent that registered but never completed
+ * auth) accumulate as `oauth_client` rows. This sweep purges them.
+ *
+ * A client is REAPABLE only when ALL hold:
+ *   - older than the retention window (default 30d,
+ *     `OAUTH_CLIENT_REAPER_RETENTION_DAYS`),
+ *   - anonymous (`user_id` null) — this repo has no admin-provisioned
+ *     `oauth2/create-client` path yet, but the guard is cheap insurance if
+ *     one is added later,
+ *   - NOT trusted (`skip_consent` ≠ true) — a future first-party
+ *     skip-consent client should never be swept,
+ *   - zero `oauth_consent` rows AND zero token rows — no user ever
+ *     authorized it.
+ *
+ * Gated by `OAUTH_CLIENT_REAPER_ENABLED` (default **off** = OBSERVE-ONLY):
+ * candidates are computed and logged; nothing is deleted until the env var
+ * is set to `"true"`. Prior art: `~/Code/sunny/apps/auth/src/oauth-client-reaper.ts`
+ * (this repo has no Flagship binding, so the gate is a plain env var).
+ *
+ * Called from the existing `15 6 * * *` cron alongside the retention sweep
+ * (see src/index.ts's `scheduled` handler).
+ */
+import { and, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import type { AuthEnv } from "./auth";
+import * as schema from "./schema";
+
+export const DEFAULT_RETENTION_DAYS = 30;
+/** Cap the client_id sample logged per run so the audit line stays lean. */
+const CLIENT_ID_LOG_SAMPLE = 50;
+/** D1 allows ≤100 bound params per statement; chunk id-lists well under that. */
+const DELETE_CHUNK = 90;
+
+export type OauthClientReaperEnv = AuthEnv & {
+  OAUTH_CLIENT_REAPER_ENABLED?: string;
+  OAUTH_CLIENT_REAPER_RETENTION_DAYS?: string;
+  /** TEST-ONLY: pin wall-clock so retention cutoffs don't rot as real time advances. */
+  _now?: Date;
+  /** TEST-ONLY: inject a store so unit tests need no real D1. */
+  _store?: OauthClientReaperStore;
+};
+
+export type OauthClientCandidate = { id: string; clientId: string };
+
+/** Storage seam — production uses Drizzle/D1; tests inject an in-memory fake. */
+export interface OauthClientReaperStore {
+  listCandidates(cutoff: Date): Promise<OauthClientCandidate[]>;
+  collectInUseClientIds(): Promise<Set<string>>;
+  deleteByIds(ids: string[]): Promise<number>;
+}
+
+export function parseRetentionDays(raw: string | undefined): number {
+  const n = Number(raw ?? DEFAULT_RETENTION_DAYS);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_RETENTION_DAYS;
+}
+
+/** Pure filter: candidates that have never been used. */
+export function filterReapable(
+  candidates: OauthClientCandidate[],
+  inUse: ReadonlySet<string>,
+): OauthClientCandidate[] {
+  return candidates.filter((c) => !inUse.has(c.clientId));
+}
+
+export function drizzleOauthClientReaperStore(db: D1Database): OauthClientReaperStore {
+  const d = drizzle(db, { schema });
+  return {
+    async listCandidates(cutoff) {
+      // Anonymous DCR only (user_id null) + not trusted (skip_consent).
+      return d
+        .select({ id: schema.oauthClient.id, clientId: schema.oauthClient.clientId })
+        .from(schema.oauthClient)
+        .where(
+          and(
+            lt(schema.oauthClient.createdAt, cutoff),
+            isNull(schema.oauthClient.userId),
+            or(isNull(schema.oauthClient.skipConsent), eq(schema.oauthClient.skipConsent, false)),
+          ),
+        );
+    },
+    async collectInUseClientIds() {
+      const inUse = new Set<string>();
+      for (const table of [
+        schema.oauthConsent,
+        schema.oauthAccessToken,
+        schema.oauthRefreshToken,
+      ] as const) {
+        // Sequential: three small distinct lookups; NOT IN (subquery) is
+        // messier with SQLite nulls and harder to test.
+        // oxlint-disable-next-line no-await-in-loop -- intentional sequential reads
+        const rows = await d.select({ clientId: table.clientId }).from(table);
+        for (const r of rows) inUse.add(r.clientId);
+      }
+      return inUse;
+    },
+    async deleteByIds(ids) {
+      if (ids.length === 0) return 0;
+      let deleted = 0;
+      for (let i = 0; i < ids.length; i += DELETE_CHUNK) {
+        const chunk = ids.slice(i, i + DELETE_CHUNK);
+        // oxlint-disable-next-line no-await-in-loop -- chunked under D1 bind cap
+        const res = await d
+          .delete(schema.oauthClient)
+          .where(inArray(schema.oauthClient.id, chunk))
+          .returning({ id: schema.oauthClient.id });
+        deleted += res.length;
+      }
+      return deleted;
+    },
+  };
+}
+
+export type SweepOauthClientsResult = {
+  mode: "observe" | "delete";
+  retentionDays: number;
+  candidates: number;
+  reapable: number;
+  deleted: number;
+  clientIds: string[];
+  notes: string;
+};
+
+/**
+ * Run one reaper pass. Never throws for business logic; DB failures propagate
+ * so the Workers scheduled handler can surface them.
+ */
+export async function sweepOauthClients(
+  env: OauthClientReaperEnv,
+): Promise<SweepOauthClientsResult> {
+  const now = env._now ?? new Date();
+  const retentionDays = parseRetentionDays(env.OAUTH_CLIENT_REAPER_RETENTION_DAYS);
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+  const deleteEnabled = env.OAUTH_CLIENT_REAPER_ENABLED === "true";
+
+  const store = env._store ?? drizzleOauthClientReaperStore(env.DB);
+  const candidates = await store.listCandidates(cutoff);
+  const inUse = await store.collectInUseClientIds();
+  const reapable = filterReapable(candidates, inUse);
+
+  let deleted = 0;
+  if (deleteEnabled && reapable.length > 0) {
+    deleted = await store.deleteByIds(reapable.map((c) => c.id));
+  }
+
+  const mode = deleteEnabled ? "delete" : "observe";
+  const clientIds = reapable.slice(0, CLIENT_ID_LOG_SAMPLE).map((c) => c.clientId);
+  const notes = `mode=${mode} candidates=${candidates.length} reapable=${reapable.length} deleted=${deleted} (anonymous, no consent/tokens, older than ${retentionDays}d)`;
+
+  console.log(
+    JSON.stringify({
+      message: "oauth_client_reaper",
+      mode,
+      retentionDays,
+      candidates: candidates.length,
+      reapable: reapable.length,
+      deleted,
+      clientIds,
+    }),
+  );
+
+  return {
+    mode,
+    retentionDays,
+    candidates: candidates.length,
+    reapable: reapable.length,
+    deleted,
+    clientIds,
+    notes,
+  };
+}

--- a/apps/auth/src/oauth-client-reaper.ts
+++ b/apps/auth/src/oauth-client-reaper.ts
@@ -26,7 +26,7 @@
  * Called from the existing `15 6 * * *` cron alongside the retention sweep
  * (see src/index.ts's `scheduled` handler).
  */
-import { and, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import { and, eq, isNull, lt, notExists, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { AuthEnv } from "./auth";
 import * as schema from "./schema";
@@ -34,8 +34,6 @@ import * as schema from "./schema";
 export const DEFAULT_RETENTION_DAYS = 30;
 /** Cap the client_id sample logged per run so the audit line stays lean. */
 const CLIENT_ID_LOG_SAMPLE = 50;
-/** D1 allows ≤100 bound params per statement; chunk id-lists well under that. */
-const DELETE_CHUNK = 90;
 
 export type OauthClientReaperEnv = AuthEnv & {
   OAUTH_CLIENT_REAPER_ENABLED?: string;
@@ -48,11 +46,14 @@ export type OauthClientReaperEnv = AuthEnv & {
 
 export type OauthClientCandidate = { id: string; clientId: string };
 
-/** Storage seam — production uses Drizzle/D1; tests inject an in-memory fake. */
+/** Storage seam — production uses Drizzle/D1; tests run the real store over fake D1. */
 export interface OauthClientReaperStore {
+  /** Age/anonymous/untrusted candidates, before the never-used check (observability). */
   listCandidates(cutoff: Date): Promise<OauthClientCandidate[]>;
-  collectInUseClientIds(): Promise<Set<string>>;
-  deleteByIds(ids: string[]): Promise<number>;
+  /** Candidates that additionally have no consent/token rows (observe mode). */
+  listReapable(cutoff: Date): Promise<OauthClientCandidate[]>;
+  /** Delete reapable clients, re-checking EVERY predicate at statement time. */
+  deleteReapable(cutoff: Date): Promise<OauthClientCandidate[]>;
 }
 
 export function parseRetentionDays(raw: string | undefined): number {
@@ -60,58 +61,48 @@ export function parseRetentionDays(raw: string | undefined): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_RETENTION_DAYS;
 }
 
-/** Pure filter: candidates that have never been used. */
-export function filterReapable(
-  candidates: OauthClientCandidate[],
-  inUse: ReadonlySet<string>,
-): OauthClientCandidate[] {
-  return candidates.filter((c) => !inUse.has(c.clientId));
-}
-
 export function drizzleOauthClientReaperStore(db: D1Database): OauthClientReaperStore {
   const d = drizzle(db, { schema });
+  // Anonymous DCR only (user_id null) + not trusted (skip_consent) + stale.
+  const candidateWhere = (cutoff: Date) =>
+    and(
+      lt(schema.oauthClient.createdAt, cutoff),
+      isNull(schema.oauthClient.userId),
+      or(isNull(schema.oauthClient.skipConsent), eq(schema.oauthClient.skipConsent, false)),
+    );
+  // Never used: correlated NOT EXISTS per usage table, evaluated inside the
+  // SAME statement as the read/delete it guards — a consent or token created
+  // between a separate "collect ids" read and the delete could otherwise be
+  // orphaned (or trip the token tables' FKs). Also keeps usage checks in SQL
+  // instead of loading every historical consent/token client_id into memory.
+  const neverUsed = () =>
+    and(
+      ...([schema.oauthConsent, schema.oauthAccessToken, schema.oauthRefreshToken] as const).map(
+        (table) =>
+          notExists(
+            d
+              .select({ one: sql`1` })
+              .from(table)
+              .where(eq(table.clientId, schema.oauthClient.clientId)),
+          ),
+      ),
+    );
+  const projection = { id: schema.oauthClient.id, clientId: schema.oauthClient.clientId };
   return {
     async listCandidates(cutoff) {
-      // Anonymous DCR only (user_id null) + not trusted (skip_consent).
+      return d.select(projection).from(schema.oauthClient).where(candidateWhere(cutoff));
+    },
+    async listReapable(cutoff) {
       return d
-        .select({ id: schema.oauthClient.id, clientId: schema.oauthClient.clientId })
+        .select(projection)
         .from(schema.oauthClient)
-        .where(
-          and(
-            lt(schema.oauthClient.createdAt, cutoff),
-            isNull(schema.oauthClient.userId),
-            or(isNull(schema.oauthClient.skipConsent), eq(schema.oauthClient.skipConsent, false)),
-          ),
-        );
+        .where(and(candidateWhere(cutoff), neverUsed()));
     },
-    async collectInUseClientIds() {
-      const inUse = new Set<string>();
-      for (const table of [
-        schema.oauthConsent,
-        schema.oauthAccessToken,
-        schema.oauthRefreshToken,
-      ] as const) {
-        // Sequential: three small distinct lookups; NOT IN (subquery) is
-        // messier with SQLite nulls and harder to test.
-        // oxlint-disable-next-line no-await-in-loop -- intentional sequential reads
-        const rows = await d.select({ clientId: table.clientId }).from(table);
-        for (const r of rows) inUse.add(r.clientId);
-      }
-      return inUse;
-    },
-    async deleteByIds(ids) {
-      if (ids.length === 0) return 0;
-      let deleted = 0;
-      for (let i = 0; i < ids.length; i += DELETE_CHUNK) {
-        const chunk = ids.slice(i, i + DELETE_CHUNK);
-        // oxlint-disable-next-line no-await-in-loop -- chunked under D1 bind cap
-        const res = await d
-          .delete(schema.oauthClient)
-          .where(inArray(schema.oauthClient.id, chunk))
-          .returning({ id: schema.oauthClient.id });
-        deleted += res.length;
-      }
-      return deleted;
+    async deleteReapable(cutoff) {
+      return d
+        .delete(schema.oauthClient)
+        .where(and(candidateWhere(cutoff), neverUsed()))
+        .returning(projection);
     },
   };
 }
@@ -140,13 +131,12 @@ export async function sweepOauthClients(
 
   const store = env._store ?? drizzleOauthClientReaperStore(env.DB);
   const candidates = await store.listCandidates(cutoff);
-  const inUse = await store.collectInUseClientIds();
-  const reapable = filterReapable(candidates, inUse);
-
-  let deleted = 0;
-  if (deleteEnabled && reapable.length > 0) {
-    deleted = await store.deleteByIds(reapable.map((c) => c.id));
-  }
+  // Delete mode never trusts a prior read: deleteReapable re-evaluates every
+  // predicate (incl. never-used) in the delete statement itself.
+  const reapable = deleteEnabled
+    ? await store.deleteReapable(cutoff)
+    : await store.listReapable(cutoff);
+  const deleted = deleteEnabled ? reapable.length : 0;
 
   const mode = deleteEnabled ? "delete" : "observe";
   const clientIds = reapable.slice(0, CLIENT_ID_LOG_SAMPLE).map((c) => c.clientId);

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -1,0 +1,188 @@
+/**
+ * OAuth 2.1 authorization server (issue #224, Lane A): migration/schema
+ * parity, dynamic client registration, JWKS, workspace-claim mapping, and
+ * the root `/.well-known/*` discovery aliases. Driven against the real
+ * Better Auth handler (via src/index.ts's `app`) and the fake-D1 harness, so
+ * migration drift between src/schema.ts and migrations/*.sql is caught here
+ * — see src/test/fake-d1.ts.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resolveWorkspaceClaims, type AuthEnv } from "./auth";
+import { app } from "./index";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://auth.uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+describe("oauth-provider migration/schema parity", () => {
+  it("creates the jwks + oauth_* tables the migration defines", () => {
+    const db = createFakeD1();
+    const tables = db.__sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all()
+      .map((r) => (r as { name: string }).name);
+    for (const table of [
+      "jwks",
+      "oauth_client",
+      "oauth_access_token",
+      "oauth_refresh_token",
+      "oauth_consent",
+    ]) {
+      expect(tables).toContain(table);
+    }
+  });
+});
+
+describe("dynamic client registration", () => {
+  it("registers a client via POST /api/auth/oauth2/register (unauthenticated)", async () => {
+    const res = await app.request(
+      "/api/auth/oauth2/register",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "Test MCP Client",
+          redirect_uris: ["https://client.example.com/callback"],
+        }),
+      },
+      dbEnv(),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { client_id?: string; redirect_uris?: string[] };
+    expect(typeof body.client_id).toBe("string");
+    expect(body.redirect_uris).toEqual(["https://client.example.com/callback"]);
+  });
+});
+
+describe("JWKS endpoint", () => {
+  it("serves a key set at /api/auth/jwks", async () => {
+    const res = await app.request("/api/auth/jwks", {}, dbEnv());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { keys?: unknown[] };
+    expect(Array.isArray(body.keys)).toBe(true);
+    expect(body.keys?.length).toBeGreaterThan(0);
+  });
+});
+
+describe("root discovery aliases", () => {
+  it("serves /.well-known/oauth-authorization-server with issuer ending /api/auth and CORS *", async () => {
+    const res = await app.request("/.well-known/oauth-authorization-server", {}, dbEnv());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    const body = (await res.json()) as { issuer?: string };
+    expect(body.issuer).toBe("https://auth.uploads.sh/api/auth");
+  });
+
+  it("serves the RFC 8414 path-inserted form", async () => {
+    const res = await app.request(
+      "/.well-known/oauth-authorization-server/some/issuer/path",
+      {},
+      dbEnv(),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    const body = (await res.json()) as { issuer?: string };
+    expect(body.issuer).toBe("https://auth.uploads.sh/api/auth");
+  });
+
+  it("forwards /.well-known/openid-configuration with CORS * (404: no `openid` scope, no OIDC id_token — honest metadata)", async () => {
+    const res = await app.request("/.well-known/openid-configuration", {}, dbEnv());
+    // The oauth-provider plugin 404s this endpoint unless "openid" is in its
+    // configured `scopes` — this AS issues only files:* scopes and no
+    // id_token, so this is the correct, honest response, not a bug. The
+    // assertion that matters here is that the alias forwards to the plugin
+    // (not a routing 404) and still stamps CORS.
+    expect(res.status).toBe(404);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+});
+
+describe("resolveWorkspaceClaims", () => {
+  let db: FakeD1Database;
+  let orm: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeEach(() => {
+    db = createFakeD1();
+    orm = drizzle(db, { schema });
+  });
+
+  it("returns null workspace and empty workspaces for an undefined user", async () => {
+    expect(await resolveWorkspaceClaims(orm, undefined)).toEqual({
+      workspace: null,
+      workspaces: [],
+    });
+  });
+
+  it("returns null workspace and empty workspaces for a user with no memberships", async () => {
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.user).values({
+      id: userId,
+      name: "No Org",
+      email: `no-org-${userId}@example.com`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    expect(await resolveWorkspaceClaims(orm, userId)).toEqual({
+      workspace: null,
+      workspaces: [],
+    });
+  });
+
+  it("returns the oldest membership's slug as primary, all slugs in workspaces", async () => {
+    const userId = crypto.randomUUID();
+    await orm.insert(schema.user).values({
+      id: userId,
+      name: "Multi Org",
+      email: `multi-org-${userId}@example.com`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const orgs = [
+      { id: crypto.randomUUID(), slug: "newer-org" },
+      { id: crypto.randomUUID(), slug: "older-org" },
+    ];
+    for (const org of orgs) {
+      await orm.insert(schema.organization).values({
+        id: org.id,
+        name: org.slug,
+        slug: org.slug,
+        createdAt: new Date(),
+      });
+    }
+
+    // Insert the "older" membership second but with an earlier createdAt, so
+    // ordering by createdAt (not insertion order) is what's exercised.
+    await orm.insert(schema.member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgs[0]!.id,
+      userId,
+      role: "member",
+      createdAt: new Date("2026-02-01T00:00:00Z"),
+    });
+    await orm.insert(schema.member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgs[1]!.id,
+      userId,
+      role: "member",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const claims = await resolveWorkspaceClaims(orm, userId);
+    expect(claims.workspace).toBe("older-org");
+    expect(new Set(claims.workspaces)).toEqual(new Set(["older-org", "newer-org"]));
+    expect(claims.workspaces).toHaveLength(2);
+  });
+});

--- a/apps/auth/src/oauth.test.ts
+++ b/apps/auth/src/oauth.test.ts
@@ -84,11 +84,9 @@ describe("root discovery aliases", () => {
   });
 
   it("serves the RFC 8414 path-inserted form", async () => {
-    const res = await app.request(
-      "/.well-known/oauth-authorization-server/some/issuer/path",
-      {},
-      dbEnv(),
-    );
+    // The path a client actually derives from our issuer
+    // (https://auth.uploads.sh/api/auth) per RFC 8414 §3.1.
+    const res = await app.request("/.well-known/oauth-authorization-server/api/auth", {}, dbEnv());
     expect(res.status).toBe(200);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
     const body = (await res.json()) as { issuer?: string };

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -251,6 +251,130 @@ export const deviceCode = sqliteTable(
 );
 
 /**
+ * `jwt()` plugin keyset (issue #224, Lane A): the signing keypair for OAuth
+ * access-token JWTs, encrypted at rest under the Better Auth secret. Model
+ * name is fixed at "jwks" by the plugin. `expiresAt` is optional (key
+ * rotation, unused for now).
+ *
+ * Paired migration: `migrations/20260717000000_oauth_provider.sql`.
+ */
+export const jwks = sqliteTable("jwks", {
+  id: text("id").primaryKey(),
+  publicKey: text("public_key").notNull(),
+  privateKey: text("private_key").notNull(),
+  createdAt: timestampCol("created_at"),
+  expiresAt: integer("expires_at", { mode: "timestamp" }),
+});
+
+/**
+ * `@better-auth/oauth-provider` tables (issue #224, Lane A: OAuth 2.1
+ * authorization server). Adapter keys must match the plugin's model names;
+ * SQL is snake_case. `string[]` columns are JSON text (drizzle `mode: "json"`)
+ * — mirrors `~/Code/sunny/apps/auth/src/schema.ts:239-336`, itself reconciled
+ * against `npx @better-auth/cli generate` output for this plugin.
+ *
+ * Paired migration: `migrations/20260717000000_oauth_provider.sql`.
+ */
+export const oauthClient = sqliteTable(
+  "oauth_client",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id").notNull().unique(),
+    clientSecret: text("client_secret"),
+    name: text("name"),
+    icon: text("icon"),
+    uri: text("uri"),
+    redirectUris: text("redirect_uris", { mode: "json" }).$type<string[]>().notNull(),
+    postLogoutRedirectUris: text("post_logout_redirect_uris", { mode: "json" }).$type<string[]>(),
+    scopes: text("scopes", { mode: "json" }).$type<string[]>().notNull(),
+    grantTypes: text("grant_types", { mode: "json" }).$type<string[]>(),
+    responseTypes: text("response_types", { mode: "json" }).$type<string[]>(),
+    contacts: text("contacts", { mode: "json" }).$type<string[]>(),
+    tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
+    type: text("type"),
+    public: integer("public", { mode: "boolean" }),
+    requirePKCE: integer("require_pkce", { mode: "boolean" }),
+    disabled: integer("disabled", { mode: "boolean" }),
+    skipConsent: integer("skip_consent", { mode: "boolean" }),
+    enableEndSession: integer("enable_end_session", { mode: "boolean" }),
+    subjectType: text("subject_type"),
+    tos: text("tos"),
+    policy: text("policy"),
+    softwareId: text("software_id"),
+    softwareVersion: text("software_version"),
+    softwareStatement: text("software_statement"),
+    userId: text("user_id"),
+    referenceId: text("reference_id"),
+    metadata: text("metadata", { mode: "json" }),
+    createdAt: timestampCol("created_at"),
+    updatedAt: timestampCol("updated_at"),
+  },
+  (t) => [index("idx_oauth_client_client_id").on(t.clientId)],
+);
+
+export const oauthAccessToken = sqliteTable(
+  "oauth_access_token",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").notNull().unique(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId),
+    sessionId: text("session_id").references(() => session.id, { onDelete: "set null" }),
+    refreshId: text("refresh_id"),
+    userId: text("user_id"),
+    referenceId: text("reference_id"),
+    scopes: text("scopes", { mode: "json" }).$type<string[]>().notNull(),
+    createdAt: timestampCol("created_at"),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [
+    index("idx_oauth_access_token_token").on(t.token),
+    index("idx_oauth_access_client_id").on(t.clientId),
+    index("idx_oauth_access_session_id").on(t.sessionId),
+  ],
+);
+
+export const oauthRefreshToken = sqliteTable(
+  "oauth_refresh_token",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").notNull().unique(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId),
+    sessionId: text("session_id").references(() => session.id, { onDelete: "set null" }),
+    userId: text("user_id").notNull(),
+    referenceId: text("reference_id"),
+    scopes: text("scopes", { mode: "json" }).$type<string[]>().notNull(),
+    // Revocation timestamp, not a boolean: a Date when revoked, null while active.
+    revoked: integer("revoked", { mode: "timestamp" }),
+    authTime: integer("auth_time", { mode: "timestamp" }),
+    createdAt: timestampCol("created_at"),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  },
+  (t) => [
+    index("idx_oauth_refresh_token_token").on(t.token),
+    index("idx_oauth_refresh_client_id").on(t.clientId),
+    index("idx_oauth_refresh_session_id").on(t.sessionId),
+  ],
+);
+
+export const oauthConsent = sqliteTable(
+  "oauth_consent",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id").notNull(),
+    clientId: text("client_id").notNull(),
+    referenceId: text("reference_id"),
+    scopes: text("scopes", { mode: "json" }).$type<string[]>().notNull(),
+    createdAt: timestampCol("created_at"),
+    updatedAt: timestampCol("updated_at"),
+  },
+  (t) => [index("idx_oauth_consent_user_client").on(t.userId, t.clientId)],
+);
+
+/**
  * Drizzle relations for Better Auth `experimental.joins` (adapter needs these
  * on the same schema object as the tables). No SQL/migration impact.
  *
@@ -326,3 +450,4 @@ export type AuthOrganization = typeof organization.$inferSelect;
 export type AuthMember = typeof member.$inferSelect;
 export type AuthInvitation = typeof invitation.$inferSelect;
 export type AuthDeviceCode = typeof deviceCode.$inferSelect;
+export type AuthOauthClient = typeof oauthClient.$inferSelect;

--- a/apps/mcp/.dev.vars.example
+++ b/apps/mcp/.dev.vars.example
@@ -1,0 +1,9 @@
+# Copy to apps/mcp/.dev.vars for local `wrangler dev` (gitignored).
+
+# The Cloudflare adapter inherits the top-level (production) wrangler var
+# from wrangler.jsonc, so without this override the OAuth JWT path (src/
+# oauth.ts) verifies against https://auth.uploads.sh instead of a local
+# auth worker. 127.0.0.1, not localhost — matches apps/auth's pinned dev
+# port and apps/web's UPLOADS_AUTH_ORIGIN convention (cookies/redirect_uri
+# treat the two as different sites).
+AUTH_ORIGIN=http://127.0.0.1:8788

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -19,7 +19,8 @@
     "@uploads/api": "workspace:^",
     "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",
-    "hono": "^4.12.28"
+    "hono": "^4.12.28",
+    "jose": "^6.2.3"
   },
   "devDependencies": {
     "@types/node": "^26.1.0",

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -9,13 +9,118 @@
  * `createMcpServer`, shared verbatim.
  */
 import { createMcpServer } from "@buildinternet/uploads/mcp";
-import { AppError, isAppError, MethodNotAllowedError, NotFoundError } from "@uploads/errors";
-import { tokenWorkspaceAuth, workspaceAuth, type WorkspaceVars } from "@uploads/api/workspace";
+import {
+  AppError,
+  ForbiddenError,
+  isAppError,
+  MethodNotAllowedError,
+  NotFoundError,
+  UnauthorizedError,
+} from "@uploads/errors";
+import {
+  loadWorkspaceRecord,
+  tokenWorkspaceAuth,
+  workspaceAuth,
+  type WorkspaceVars,
+} from "@uploads/api/workspace";
 import { protectedResourceMetadata, requestOrigin } from "@uploads/api/well-known";
-import { Hono, type Context } from "hono";
+import { Hono, type Context, type Next } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import pkg from "../package.json";
 import { createRemoteTools } from "./tools";
+import { invalidTokenChallenge, isJwtShaped, missingTokenChallenge, verifyOAuthJwt } from "./oauth";
+
+/**
+ * Both prod hostnames this worker answers on (see wrangler.jsonc routes) are
+ * accepted as `aud` — mirrored into the AS's own audience allow-list (parallel
+ * lane). A JWT minted against either resource works on either route.
+ */
+const OAUTH_AUDIENCES = ["https://agents.uploads.sh/mcp", "https://mcp.uploads.sh/mcp"];
+
+function authOriginOf(env: Env): string {
+  return (env.AUTH_ORIGIN || "https://auth.uploads.sh").replace(/\/+$/, "");
+}
+
+function bearerFrom(header: string | undefined): string {
+  return header?.startsWith("Bearer ") ? header.slice(7) : "";
+}
+
+/** Actionable 403 for a token whose user has no workspace yet (`workspace: null`). */
+function noWorkspaceError(): ForbiddenError {
+  return new ForbiddenError(
+    "This account has no workspace yet. Create one at https://uploads.sh, then reconnect.",
+    { code: "workspace_required" },
+  );
+}
+
+/**
+ * Verifies a JWT-shaped bearer against the AS JWKS and, on success, sets the
+ * same context vars `tokenWorkspaceAuth`/`workspaceAuth` set (workspace
+ * record, name, scopes) so downstream tool handlers don't need to know which
+ * auth lane ran. `pathWorkspace` is set only for the `/:workspace/mcp` route,
+ * where the token must additionally list that workspace in its `workspaces`
+ * claim — otherwise this is the token-inferred `/mcp` route, which uses the
+ * token's primary `workspace` claim.
+ */
+async function oauthAuth(
+  c: Context<WorkspaceVars>,
+  token: string,
+  pathWorkspace: string | undefined,
+): Promise<Response | null> {
+  const verified = await verifyOAuthJwt(token, {
+    issuer: `${authOriginOf(c.env)}/api/auth`,
+    audience: OAUTH_AUDIENCES,
+  });
+  if (!verified) return invalidTokenChallenge(c.req.url);
+
+  const workspaceName = pathWorkspace ?? verified.workspace ?? undefined;
+  if (pathWorkspace) {
+    // Path-based route: the presented JWT must grant access to THIS workspace.
+    // A uniform 401 (not the invalid_token challenge, which is only for a bad
+    // credential) — mirrors the existing up_ token behavior for a workspace
+    // mismatch (see mcp.test.ts "rejects the same token against a different
+    // workspace path").
+    if (!verified.workspaces.includes(pathWorkspace)) throw new UnauthorizedError();
+  } else if (verified.workspace === null) {
+    throw noWorkspaceError();
+  }
+
+  const record = workspaceName ? await loadWorkspaceRecord(c.env, workspaceName) : null;
+  // Token claims a workspace slug that no longer exists (deleted after
+  // issuance, or a claims/registry desync) — treat like any other credential
+  // that doesn't resolve, rather than inventing a third error shape.
+  if (!record || !workspaceName) throw new UnauthorizedError();
+
+  c.set("workspace", record);
+  c.set("workspaceName", workspaceName);
+  c.set("authScopes", verified.scopes);
+  return null;
+}
+
+/** POST /mcp: JWT-shaped bearer → OAuth verification; everything else → the existing up_ token path. */
+async function mcpBearerAuth(c: Context<WorkspaceVars>, next: Next): Promise<Response | void> {
+  const token = bearerFrom(c.req.header("Authorization"));
+  // No credential at all → 401 with the RFC 9728 discovery challenge; MCP
+  // clients start the OAuth flow from this response's `resource_metadata`.
+  if (!token) return missingTokenChallenge(c.req.url);
+  if (isJwtShaped(token)) {
+    const response = await oauthAuth(c, token, undefined);
+    if (response) return response;
+    return next();
+  }
+  return tokenWorkspaceAuth(c, next);
+}
+
+/** /:workspace/mcp: JWT-shaped bearer → OAuth verification scoped to the path workspace; everything else → the existing up_ token path. */
+async function workspacePathAuth(c: Context<WorkspaceVars>, next: Next): Promise<Response | void> {
+  const token = bearerFrom(c.req.header("Authorization"));
+  if (isJwtShaped(token)) {
+    const response = await oauthAuth(c, token, c.req.param("workspace"));
+    if (response) return response;
+    return next();
+  }
+  return workspaceAuth(c, next);
+}
 
 async function handleMcp(c: Context<WorkspaceVars>): Promise<Response> {
   const body = await c.req.text();
@@ -76,9 +181,9 @@ function mcpServerCard() {
     },
     authentication: {
       required: true,
-      schemes: ["bearer"],
+      schemes: ["bearer", "oauth2"],
       description:
-        "Per-workspace bearer token (Authorization: Bearer up_<workspace>_…). Obtain via invitation + `uploads login`. See https://uploads.sh/auth.md",
+        "Bearer token — either a per-workspace token (Authorization: Bearer up_<workspace>_…, via invitation + `uploads login`) or an OAuth 2.1 access token from the uploads-auth authorization server (browser consent flow; see /.well-known/oauth-protected-resource). See https://uploads.sh/auth.md",
     },
   };
 }
@@ -93,6 +198,11 @@ function respondProtectedResource(c: Context<WorkspaceVars>): Response {
       resource: `${requestOrigin(c.req.url)}/mcp`,
       resourceName: "uploads.sh MCP server",
       webOrigin: c.env.WEB_ORIGIN || "https://uploads.sh",
+      // Only this worker advertises an AS — it's the only resource server
+      // that verifies uploads-auth OAuth JWTs (v1 is MCP-only). The issuer,
+      // not a well-known URL: clients apply RFC 8414 path-insertion for
+      // discovery.
+      authorizationServers: [`${authOriginOf(c.env)}/api/auth`],
     }),
     200,
     { "Cache-Control": "public, max-age=300", "Access-Control-Allow-Origin": "*" },
@@ -109,11 +219,12 @@ const app = new Hono<WorkspaceVars>()
   .get("/.well-known/oauth-protected-resource", respondProtectedResource)
   .get("/.well-known/oauth-protected-resource/mcp", respondProtectedResource)
   // Primary endpoint: the workspace is inferred from the bearer token
-  // (up_<workspace>_…), so clients only need the URL and the token.
-  .post("/mcp", tokenWorkspaceAuth, handleMcp)
+  // (up_<workspace>_…) or, for a JWT-shaped bearer, the OAuth token's
+  // `workspace` claim — so clients only need the URL and the token.
+  .post("/mcp", mcpBearerAuth, handleMcp)
   .on(["GET", "DELETE"], "/mcp", methodNotAllowed)
   // Workspace-prefixed alternate, kept for existing clients.
-  .use("/:workspace/*", workspaceAuth)
+  .use("/:workspace/*", workspacePathAuth)
   .post("/:workspace/mcp", handleMcp)
   .on(["GET", "DELETE"], "/:workspace/mcp", methodNotAllowed)
   .onError((err, c) => respondError(c, err))

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -42,7 +42,8 @@ function authOriginOf(env: Env): string {
 }
 
 function bearerFrom(header: string | undefined): string {
-  return header?.startsWith("Bearer ") ? header.slice(7) : "";
+  // RFC 9110 §11.1: auth scheme names are case-insensitive.
+  return header?.match(/^Bearer +(.+)$/i)?.[1] ?? "";
 }
 
 /** Actionable 403 for a token whose user has no workspace yet (`workspace: null`). */

--- a/apps/mcp/src/oauth.ts
+++ b/apps/mcp/src/oauth.ts
@@ -1,0 +1,228 @@
+/**
+ * Resource-server verification of OAuth 2.1 access tokens minted by the
+ * uploads-auth authorization server (issue #224). The MCP worker has no
+ * service binding to apps/auth — it verifies JWTs locally with `jose`
+ * against the AS's public JWKS, fetched over plain `fetch` and cached
+ * in-isolate for a few minutes (mirrors sunny/apps/api/src/oauth-resource.ts,
+ * adapted from a service-binding fetch to a real HTTP fetch since there's no
+ * binding here).
+ *
+ * Token shape (see docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md):
+ * issuer `${AUTH_ORIGIN}/api/auth`, `workspace` (primary slug, or null for a
+ * user with none) and `workspaces` (all slugs) custom claims, and scopes in
+ * the standard `scope` claim — handled defensively in case better-auth's
+ * oauth-provider emits a `scopes` array instead (unverified at write time).
+ */
+import { createLocalJWKSet, jwtVerify, type JSONWebKeySet, type JWTPayload } from "jose";
+
+/**
+ * The existing FILE_SCOPES ladder (apps/api/src/auth-db.ts), duplicated as a
+ * literal here — same tradeoff the AS lane makes in apps/auth: this worker
+ * doesn't otherwise need @uploads/api's auth-db module, and scopes are stable
+ * enough that a values-only duplication (with a type-level cross-check) beats
+ * pulling in the extra import surface.
+ */
+export const FILE_SCOPES = ["files:read", "files:write", "files:delete"] as const;
+export type FileScope = (typeof FILE_SCOPES)[number];
+
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type JwksCache = { jwks: JSONWebKeySet; expiresAt: number };
+let jwksCache: JwksCache | null = null;
+
+/** Test-only: drop the per-isolate JWKS cache so a fresh fetcher re-resolves. */
+export function resetOAuthJwksCacheForTests(): void {
+  jwksCache = null;
+}
+
+/** Fetches a JWKS document from a URL. Overridable in tests to avoid network. */
+export type JwksFetcher = (jwksUrl: string) => Promise<JSONWebKeySet>;
+
+const defaultJwksFetcher: JwksFetcher = async (jwksUrl) => {
+  const res = await fetch(jwksUrl);
+  if (!res.ok) throw new Error(`jwks fetch failed: ${res.status}`);
+  const body = (await res.json()) as JSONWebKeySet;
+  if (!body || !Array.isArray(body.keys)) throw new Error("malformed jwks document");
+  return body;
+};
+
+async function loadJwks(jwksUrl: string, fetcher: JwksFetcher): Promise<JSONWebKeySet | null> {
+  const now = Date.now();
+  if (jwksCache && now < jwksCache.expiresAt) return jwksCache.jwks;
+  try {
+    const jwks = await fetcher(jwksUrl);
+    jwksCache = { jwks, expiresAt: now + JWKS_CACHE_TTL_MS };
+    return jwks;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cheap routing check: does the credential look like a compact JWS (three
+ * non-empty base64url segments)? `up_<workspace>_…` tokens never match (no
+ * dots), so this decides the auth lane without validating the token.
+ */
+export function isJwtShaped(raw: string): boolean {
+  const parts = raw.split(".");
+  if (parts.length !== 3) return false;
+  return parts.every((p) => p.length > 0 && /^[A-Za-z0-9_-]+$/.test(p));
+}
+
+/**
+ * Extract FILE_SCOPES-ladder scopes from a verified payload. The AS emits a
+ * space-delimited `scope` string per RFC 6749, but better-auth's
+ * oauth-provider plugin behavior for `scope` vs. an array `scopes` claim
+ * wasn't independently confirmed against a running 1.6.23 instance at write
+ * time, so both shapes are read defensively; unknown scope strings are
+ * dropped rather than passed through.
+ */
+export function extractFileScopes(payload: JWTPayload): FileScope[] {
+  const record = payload as Record<string, unknown>;
+  const raw = record.scope ?? record.scopes;
+  let tokens: string[];
+  if (typeof raw === "string") {
+    tokens = raw.split(/\s+/).filter(Boolean);
+  } else if (Array.isArray(raw)) {
+    tokens = raw.filter((s): s is string => typeof s === "string");
+  } else {
+    tokens = [];
+  }
+  const seen = new Set<FileScope>();
+  for (const t of tokens) {
+    if ((FILE_SCOPES as readonly string[]).includes(t)) seen.add(t as FileScope);
+  }
+  return [...seen];
+}
+
+/** `workspace` (primary slug or null) and `workspaces` (all slugs) custom claims. */
+function extractWorkspaceClaims(payload: JWTPayload): {
+  workspace: string | null;
+  workspaces: string[];
+} {
+  const record = payload as Record<string, unknown>;
+  const workspace = typeof record.workspace === "string" ? record.workspace : null;
+  const workspaces = Array.isArray(record.workspaces)
+    ? record.workspaces.filter((w): w is string => typeof w === "string")
+    : [];
+  return { workspace, workspaces };
+}
+
+/** A successfully verified OAuth access token, projected to what MCP auth needs. */
+export interface VerifiedOAuthToken {
+  /** Primary workspace slug, or null when the user has no workspace yet. */
+  workspace: string | null;
+  /** All workspace slugs the token's user belongs to. */
+  workspaces: string[];
+  /** FILE_SCOPES-ladder scopes carried by the token. */
+  scopes: FileScope[];
+  /** The full verified payload, for callers that need other claims. */
+  raw: JWTPayload;
+}
+
+export interface OAuthJwtConfig {
+  /** Expected `iss` — `${AUTH_ORIGIN}/api/auth`. jose does an exact match. */
+  issuer: string;
+  /** Acceptable `aud` values — this resource's canonical URIs. */
+  audience: string[];
+  /** JWKS endpoint. Defaults to `${issuer origin}/api/auth/jwks`. */
+  jwksUrl?: string;
+  /** Test seam: skip the network fetch and cache, verify against this fetcher. */
+  jwksFetcher?: JwksFetcher;
+}
+
+function defaultJwksUrl(issuer: string): string {
+  return new URL("/api/auth/jwks", issuer).href;
+}
+
+/**
+ * Verify an OAuth access-token JWT against the AS JWKS. Checks signature,
+ * `iss`, `aud` (any of the configured audiences), and `exp` (jose enforces
+ * expiry). Returns the projected token on success, `null` on ANY failure —
+ * callers treat null exactly like an invalid opaque token. Never throws.
+ */
+export async function verifyOAuthJwt(
+  token: string,
+  config: OAuthJwtConfig,
+): Promise<VerifiedOAuthToken | null> {
+  try {
+    const jwksUrl = config.jwksUrl ?? defaultJwksUrl(config.issuer);
+    const fetcher = config.jwksFetcher ?? defaultJwksFetcher;
+    const jwks = await loadJwks(jwksUrl, fetcher);
+    if (!jwks) return null;
+    const { payload } = await jwtVerify(token, createLocalJWKSet(jwks), {
+      issuer: config.issuer,
+      audience: config.audience,
+    });
+    const { workspace, workspaces } = extractWorkspaceClaims(payload);
+    return {
+      workspace,
+      workspaces,
+      scopes: extractFileScopes(payload),
+      raw: payload,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Origin (`scheme://host[:port]`) of a request URL — used to build the discovery challenge. */
+function requestOriginOf(requestUrl: string): string {
+  return new URL(requestUrl).origin;
+}
+
+/**
+ * RFC 9728 §5.1 `WWW-Authenticate` challenge for an invalid/expired OAuth
+ * JWT, pointing the client at this resource's protected-resource metadata so
+ * a compliant MCP client can discover the AS and re-authenticate.
+ */
+export function wwwAuthenticateChallenge(requestUrl: string): string {
+  const origin = requestOriginOf(requestUrl);
+  return `Bearer error="invalid_token", resource_metadata="${origin}/.well-known/oauth-protected-resource"`;
+}
+
+/**
+ * 401 for a request that presented no bearer credential at all. Per RFC 9728
+ * §5.1 the challenge carries `resource_metadata` but NO `error` attribute
+ * (RFC 6750 §3.1: `invalid_token` is only for a bad credential, not a missing
+ * one). This is the response MCP clients bootstrap OAuth discovery from.
+ */
+export function missingTokenChallenge(requestUrl: string): Response {
+  const origin = requestOriginOf(requestUrl);
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "unauthorized",
+        type: "unauthorized",
+        message: "Authentication required.",
+      },
+    }),
+    {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+        "WWW-Authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+      },
+    },
+  );
+}
+
+/** 401 JSON response carrying the RFC 9728 discovery challenge for a bad JWT. */
+export function invalidTokenChallenge(requestUrl: string): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "invalid_token",
+        type: "unauthorized",
+        message: "The access token is invalid or expired.",
+      },
+    }),
+    {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+        "WWW-Authenticate": wwwAuthenticateChallenge(requestUrl),
+      },
+    },
+  );
+}

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1,12 +1,18 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { exportJWK, generateKeyPair, SignJWT, type JWK } from "jose";
 import app from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
 import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
+import { resetOAuthJwksCacheForTests } from "../src/oauth";
 import { GalleryFakeD1 } from "./gallery-fake-d1";
 
 const TOKEN = "up_test-ws_legacy-token-value";
 const ALPHA_TOKEN = "up_alpha_gallery-test";
 const BETA_TOKEN = "up_beta_gallery-test";
+
+const OAUTH_ISSUER = "https://auth.uploads.sh/api/auth";
+const OAUTH_AUDIENCE = "https://agents.uploads.sh/mcp";
+const OAUTH_KID = "test-key";
 
 const workspace: WorkspaceRecord = {
   provider: "r2",
@@ -29,6 +35,59 @@ beforeAll(() => {
     });
   }
 });
+
+/**
+ * OAuth JWT test fixtures (issue #224): one RS256 key pair for the whole
+ * suite, its public half served as the fake AS JWKS. `resetOAuthJwksCacheForTests`
+ * runs between tests so the module-level 5-min cache in src/oauth.ts never
+ * leaks a stale (or wrong-suite) key set across tests, and `fetch` is stubbed
+ * per-test to return it instead of hitting the network — the test seam the
+ * design calls for is `jwksFetcher`, but nothing in src/index.ts threads one
+ * through, so stubbing global fetch (the thing src/oauth.ts's default
+ * fetcher calls) exercises the real code path end-to-end.
+ */
+let oauthKeyPair: CryptoKeyPair;
+let oauthJwks: { keys: JWK[] };
+
+beforeAll(async () => {
+  oauthKeyPair = await generateKeyPair("RS256");
+  const publicJwk = await exportJWK(oauthKeyPair.publicKey);
+  oauthJwks = { keys: [{ ...publicJwk, kid: OAUTH_KID, alg: "RS256", use: "sig" }] };
+});
+
+beforeEach(() => {
+  resetOAuthJwksCacheForTests();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url === `${OAUTH_ISSUER}/jwks`) {
+        return new Response(JSON.stringify(oauthJwks), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function signOAuthToken(
+  claims: Record<string, unknown>,
+  opts: { issuer?: string; audience?: string; expiresIn?: string } = {},
+): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: OAUTH_KID })
+    .setIssuedAt()
+    .setIssuer(opts.issuer ?? OAUTH_ISSUER)
+    .setAudience(opts.audience ?? OAUTH_AUDIENCE)
+    .setExpirationTime(opts.expiresIn ?? "5m")
+    .sign(oauthKeyPair.privateKey);
+}
 
 /**
  * Fake bindings following apps/api/test/routes-auth.test.ts: KV returns the
@@ -399,8 +458,10 @@ describe("mcp worker", () => {
       expect(body.scopes_supported).toEqual(["files:read", "files:write", "files:delete"]);
       expect(body.bearer_methods_supported).toEqual(["header"]);
       expect(body.resource_documentation).toBe("https://uploads.sh/auth.md");
-      // No public authorization server for third-party clients — must not dangle a reference.
-      expect(body.authorization_servers).toBeUndefined();
+      // Only apps/mcp advertises an AS (issue #224) — it's the only resource
+      // server that verifies uploads-auth OAuth JWTs. Defaults to the prod
+      // issuer when AUTH_ORIGIN isn't set on the test env.
+      expect(body.authorization_servers).toEqual(["https://auth.uploads.sh/api/auth"]);
     }
   });
 
@@ -1113,5 +1174,201 @@ describe("token-inferred /mcp endpoint", () => {
       );
       expect(response.status).toBe(405);
     }
+  });
+});
+
+describe("OAuth JWT bearer (issue #224)", () => {
+  it("accepts a valid JWT at the token-inferred /mcp endpoint, scoped to its granted scopes", async () => {
+    const { env, bucket } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "test-ws",
+      workspaces: ["test-ws"],
+      scope: "files:read files:write",
+    });
+    const result = await callTool(
+      env,
+      "put",
+      { contentBase64: PNG_B64, filename: "shot.png", key: "shots/shot.png" },
+      jwt,
+      "/mcp",
+    );
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({ workspace: "test-ws", key: "shots/shot.png" });
+    expect(bucket.store.has("shots/shot.png")).toBe(true);
+  });
+
+  it("accepts a valid JWT at the path-based /:workspace/mcp endpoint when the path workspace is in `workspaces`", async () => {
+    const { env, bucket } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "test-ws",
+      workspaces: ["test-ws", "other-ws"],
+      scope: "files:read files:write",
+    });
+    const result = await callTool(
+      env,
+      "put",
+      { contentBase64: PNG_B64, filename: "shot.png", key: "shots/shot.png" },
+      jwt,
+      "/test-ws/mcp",
+    );
+    expect(result.isError).toBe(false);
+    expect(bucket.store.has("shots/shot.png")).toBe(true);
+  });
+
+  it("rejects a JWT at /:workspace/mcp when the path workspace isn't in `workspaces`", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "other-ws",
+      workspaces: ["other-ws"],
+      scope: "files:read files:write",
+    });
+    const response = await rpc(
+      env,
+      { jsonrpc: "2.0", id: 1, method: "initialize" },
+      jwt,
+      "/test-ws/mcp",
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("enforces the JWT's granted scopes inside tool handlers", async () => {
+    const { env, bucket } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "test-ws",
+      workspaces: ["test-ws"],
+      scope: "files:read",
+    });
+    const result = await callTool(
+      env,
+      "put",
+      { contentBase64: PNG_B64, filename: "shot.png" },
+      jwt,
+      "/mcp",
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: "forbidden: requires files:write scope" },
+    ]);
+    expect(bucket.store.size).toBe(0);
+  });
+
+  it("also accepts a `scopes` array claim (defensive against the AS emitting either shape)", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "test-ws",
+      workspaces: ["test-ws"],
+      scopes: ["files:read"],
+    });
+    const result = await callTool(env, "list", {}, jwt, "/mcp");
+    expect(result.isError).toBe(false);
+  });
+
+  it("responds 403 with an actionable message when the token's user has no workspace", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: null,
+      workspaces: [],
+      scope: "files:read files:write",
+    });
+    const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, jwt, "/mcp");
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("workspace_required");
+    expect(body.error.message).toContain("uploads.sh");
+  });
+
+  it("401s with a discovery challenge (no error attribute) when no credential is presented", async () => {
+    const { env } = await makeEnv();
+    const response = await app.request(
+      "https://agents.uploads.sh/mcp",
+      { method: "POST", body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }) },
+      env,
+    );
+    expect(response.status).toBe(401);
+    // RFC 6750 §3.1: a request with NO credential must not get `invalid_token`.
+    expect(response.headers.get("WWW-Authenticate")).toBe(
+      'Bearer resource_metadata="https://agents.uploads.sh/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("401s with an RFC 9728 discovery challenge for a bad-issuer JWT", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { issuer: "https://evil.example.com/api/auth" },
+    );
+    const response = await rpc(
+      env,
+      { jsonrpc: "2.0", id: 1, method: "initialize" },
+      jwt,
+      "https://agents.uploads.sh/mcp",
+    );
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toBe(
+      'Bearer error="invalid_token", resource_metadata="https://agents.uploads.sh/.well-known/oauth-protected-resource"',
+    );
+  });
+
+  it("401s with a discovery challenge for a bad-audience JWT", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { audience: "https://not-uploads.example.com/mcp" },
+    );
+    const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, jwt, "/mcp");
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain('error="invalid_token"');
+  });
+
+  it("401s with a discovery challenge for an expired JWT", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { expiresIn: "-1s" },
+    );
+    const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, jwt, "/mcp");
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain('error="invalid_token"');
+  });
+
+  it("401s for a JWT naming a workspace the registry no longer has", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "deleted-ws",
+      workspaces: ["deleted-ws"],
+      scope: "files:read",
+    });
+    const response = await rpc(env, { jsonrpc: "2.0", id: 1, method: "initialize" }, jwt, "/mcp");
+    expect(response.status).toBe(401);
+  });
+
+  it("accepts the mcp.uploads.sh alternate audience too", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken(
+      { sub: "user-1", workspace: "test-ws", workspaces: ["test-ws"], scope: "files:read" },
+      { audience: "https://mcp.uploads.sh/mcp" },
+    );
+    const result = await callTool(env, "list", {}, jwt, "/mcp");
+    expect(result.isError).toBe(false);
+  });
+
+  it("still authenticates the legacy up_ token path unaffected by the JWT lane", async () => {
+    const { env, bucket } = await makeEnv();
+    const result = await callTool(
+      env,
+      "put",
+      { contentBase64: PNG_B64, filename: "shot.png", key: "shots/legacy.png" },
+      TOKEN,
+      "/mcp",
+    );
+    expect(result.isError).toBe(false);
+    expect(bucket.store.has("shots/legacy.png")).toBe(true);
   });
 });

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1198,6 +1198,26 @@ describe("OAuth JWT bearer (issue #224)", () => {
     expect(bucket.store.has("shots/shot.png")).toBe(true);
   });
 
+  it("accepts a lowercase `bearer` authentication scheme (RFC 9110: schemes are case-insensitive)", async () => {
+    const { env } = await makeEnv();
+    const jwt = await signOAuthToken({
+      sub: "user-1",
+      workspace: "test-ws",
+      workspaces: ["test-ws"],
+      scope: "files:read",
+    });
+    const response = await app.request(
+      "https://agents.uploads.sh/mcp",
+      {
+        method: "POST",
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+        headers: { Authorization: `bearer ${jwt}` },
+      },
+      env,
+    );
+    expect(response.status).toBe(200);
+  });
+
   it("accepts a valid JWT at the path-based /:workspace/mcp endpoint when the path workspace is in `workspaces`", async () => {
     const { env, bucket } = await makeEnv();
     const jwt = await signOAuthToken({

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -6,6 +6,12 @@
   "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "WEB_ORIGIN": "https://uploads.sh",
+    // OAuth 2.1 authorization server this worker verifies access-token JWTs
+    // against (issue #224) — issuer is `${AUTH_ORIGIN}/api/auth`, JWKS at
+    // `${AUTH_ORIGIN}/api/auth/jwks`. See src/oauth.ts. Override locally via
+    // .dev.vars (AUTH_ORIGIN=http://127.0.0.1:8788, matching apps/auth's
+    // pinned dev port).
+    "AUTH_ORIGIN": "https://auth.uploads.sh",
   },
   "routes": [
     // Primary domain; mcp.uploads.sh is kept as a working alternate.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,7 +24,7 @@ public/_headers                      Per-path response headers (Link, robots, ty
 public/robots.txt                    Crawl policy + Content Signals + AI bot rules
 public/sitemap.xml                   Public URL list (landing only)
 public/llms.txt                      Agent-oriented product summary
-public/auth.md                       Agent enrollment / bearer auth (not OAuth)
+public/auth.md                       Agent enrollment / bearer auth + hosted-MCP OAuth
 public/.well-known/api-catalog       RFC 9727 linkset
 public/.well-known/openapi.json      Summary OpenAPI for the REST API
 public/.well-known/mcp/              MCP server card (points at agents.uploads.sh)
@@ -61,15 +61,15 @@ rules there.
 
 ## Agent discovery (easy wins)
 
-| Check           | Location                                 |
-| --------------- | ---------------------------------------- |
-| robots.txt      | `/robots.txt`                            |
-| sitemap         | `/sitemap.xml` (referenced from robots)  |
-| Link headers    | homepage `/` via `_headers`              |
-| API catalog     | `/.well-known/api-catalog`               |
-| MCP server card | `/.well-known/mcp/server-card.json`      |
-| Agent skills    | `/.well-known/agent-skills/index.json`   |
-| Auth for agents | `/auth.md` (bearer / invite — not OAuth) |
+| Check           | Location                                                             |
+| --------------- | -------------------------------------------------------------------- |
+| robots.txt      | `/robots.txt`                                                        |
+| sitemap         | `/sitemap.xml` (referenced from robots)                              |
+| Link headers    | homepage `/` via `_headers`                                          |
+| API catalog     | `/.well-known/api-catalog`                                           |
+| MCP server card | `/.well-known/mcp/server-card.json`                                  |
+| Agent skills    | `/.well-known/agent-skills/index.json`                               |
+| Auth for agents | `/auth.md` (bearer / invite; also documents the hosted-MCP OAuth AS) |
 
 ### Agent skills — always track GitHub `main`
 
@@ -118,11 +118,11 @@ converted responses matches `robots.txt` (`search=yes`, `ai-input=yes`,
 
 ### Intentionally not implemented (yet)
 
-| Item                            | Why                                                                |
-| ------------------------------- | ------------------------------------------------------------------ |
-| OAuth/OIDC well-known + PRM     | Auth is invitation bearer tokens, not OAuth                        |
-| DNS-AID SVCB records            | DNS / DNSSEC operator work, not this deployable                    |
-| WebMCP `navigator.modelContext` | Experimental browser API; no product tools on the landing page yet |
+| Item                                  | Why                                                                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| OAuth/OIDC well-known on `uploads.sh` | Discovery lives on the auth worker (`https://auth.uploads.sh/.well-known/oauth-authorization-server`), not this origin |
+| DNS-AID SVCB records                  | DNS / DNSSEC operator work, not this deployable                                                                        |
+| WebMCP `navigator.modelContext`       | Experimental browser API; no product tools on the landing page yet                                                     |
 
 ## Error pages
 

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -73,14 +73,28 @@ inferred from the `up_<workspace>_…` token form).
 | API health             | https://api.uploads.sh/health                                  |
 | MCP health             | https://agents.uploads.sh/health                               |
 
-## What we deliberately do not publish
+## OAuth for the hosted MCP
 
-There is **no** public OAuth authorization server for third-party clients
-today. `uploads login`'s device flow talks to our own dedicated auth worker
-with a fixed CLI client id — it is not a general-purpose OAuth client
-registration surface. `/.well-known/openid-configuration` and
-`/.well-known/oauth-authorization-server` are intentionally absent. Do not
-invent OAuth client registration against this origin.
+`https://agents.uploads.sh/mcp` also accepts OAuth 2.1 bearer tokens issued by
+our authorization server at `https://auth.uploads.sh` (issuer
+`https://auth.uploads.sh/api/auth`). It supports PKCE and dynamic client
+registration (RFC 7591) — an MCP client can register itself, no manual setup.
+Discovery:
+
+```bash
+curl -s https://auth.uploads.sh/.well-known/oauth-authorization-server
+curl -s https://auth.uploads.sh/.well-known/openid-configuration
+```
+
+Scopes are the same three as the workspace-token table above: `files:read`,
+`files:write`, `files:delete`. A human authorizing a client signs in and
+grants scopes at `https://uploads.sh/oauth/consent`. This is the auth surface
+for third-party OAuth clients against the hosted MCP; `uploads login`'s device
+flow (above) is unrelated and still the way to mint a long-lived
+`up_<workspace>_…` workspace token for CLI/agent use.
+
+`api.uploads.sh` does not accept OAuth tokens in v1 — only the hosted MCP
+does.
 
 ## Operator note
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -12,7 +12,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
-- [Auth for agents](https://uploads.sh/auth.md): invitation enrollment and bearer tokens
+- [Auth for agents](https://uploads.sh/auth.md): invitation enrollment, bearer tokens, and the hosted-MCP OAuth authorization server
 - [Source & docs](https://github.com/buildinternet/uploads): repository, roadmap, and operator docs
 - [Enrollment](https://github.com/buildinternet/uploads/blob/main/docs/enrollment.md): how `uploads login` works
 - [API](https://github.com/buildinternet/uploads/blob/main/docs/api.md): REST surface for workspace-scoped files

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -236,11 +236,11 @@ describe("linkGitHub", () => {
   });
 });
 
-describe("sendMagicLink oauth resume", () => {
-  function stubLocation(search: string) {
-    vi.stubGlobal("location", { search });
-  }
+function stubLocation(search: string) {
+  vi.stubGlobal("location", { search });
+}
 
+describe("sendMagicLink oauth resume", () => {
   it("injects oauth_query when location.search carries a signed sig= param", async () => {
     stubLocation("?client_id=abc&sig=deadbeef");
     const fetcher = vi.fn(async () => new Response(null, { status: 200 }));

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getAccountInfo,
+  getOAuthPublicClient,
   getSession,
   linkGitHub,
   listAccounts,
   listSessions,
   revokeSession,
+  sendMagicLink,
   startLocalDemoSession,
+  submitOAuthConsent,
 } from "./auth-client";
 import { BROWSER_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "./request";
 
@@ -230,6 +233,100 @@ describe("linkGitHub", () => {
     await expect(
       linkGitHub("https://auth.uploads.sh", "https://uploads.sh/account/profile"),
     ).resolves.toBe(false);
+  });
+});
+
+describe("sendMagicLink oauth resume", () => {
+  function stubLocation(search: string) {
+    vi.stubGlobal("location", { search });
+  }
+
+  it("injects oauth_query when location.search carries a signed sig= param", async () => {
+    stubLocation("?client_id=abc&sig=deadbeef");
+    const fetcher = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await sendMagicLink("https://auth.uploads.sh", "a@example.com", "https://uploads.sh/account");
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/sign-in/magic-link",
+      expect.objectContaining({
+        body: JSON.stringify({
+          email: "a@example.com",
+          callbackURL: "https://uploads.sh/account",
+          oauth_query: "client_id=abc&sig=deadbeef",
+        }),
+      }),
+    );
+  });
+
+  it("omits oauth_query when there is no signed query", async () => {
+    stubLocation("");
+    const fetcher = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await sendMagicLink("https://auth.uploads.sh", "a@example.com", "https://uploads.sh/account");
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/sign-in/magic-link",
+      expect.objectContaining({
+        body: JSON.stringify({
+          email: "a@example.com",
+          callbackURL: "https://uploads.sh/account",
+        }),
+      }),
+    );
+  });
+});
+
+describe("getOAuthPublicClient", () => {
+  it("returns the client on success and null on failure or malformed body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ client_id: "c1", client_name: "Agent App" })),
+    );
+    await expect(getOAuthPublicClient("https://auth.uploads.sh", "c1")).resolves.toEqual({
+      client_id: "c1",
+      client_name: "Agent App",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+    await expect(getOAuthPublicClient("https://auth.uploads.sh", "c1")).resolves.toBeNull();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({})),
+    );
+    await expect(getOAuthPublicClient("https://auth.uploads.sh", "c1")).resolves.toBeNull();
+  });
+});
+
+describe("submitOAuthConsent", () => {
+  it("returns the redirect on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ redirect_uri: "https://client.example/callback?code=1" })),
+    );
+    await expect(
+      submitOAuthConsent("https://auth.uploads.sh", {
+        accept: true,
+        scope: "files:read",
+        oauthQuery: "client_id=c1&sig=x",
+      }),
+    ).resolves.toEqual({ ok: true, redirectUri: "https://client.example/callback?code=1" });
+  });
+
+  it("surfaces the AS error description on rejection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ error_description: "expired request" }, { status: 400 })),
+    );
+    await expect(
+      submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
+    ).resolves.toEqual({ ok: false, error: "expired request" });
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -169,11 +169,12 @@ async function redirectToGitHubOAuth(
   }
 }
 
-/** Start GitHub sign-in (unauthenticated). */
+/** Start GitHub sign-in (unauthenticated). Carries the OAuth resume query, see oauthResumeBody. */
 export async function signInWithGitHub(origin: string, callbackURL: string): Promise<boolean> {
   return redirectToGitHubOAuth(origin, "/api/auth/sign-in/social", {
     provider: "github",
     callbackURL,
+    ...oauthResumeBody(),
   });
 }
 
@@ -190,6 +191,22 @@ export async function linkGitHub(origin: string, callbackURL: string): Promise<b
   });
 }
 
+/**
+ * OAuth AS resume support (issue #224, Lane B). When the AS sends an
+ * unauthenticated user to `/login?<signed authorize query>`, the server only
+ * resumes the authorize flow if the sign-in POST body carries `oauth_query` =
+ * `location.search` with the leading "?" stripped. Mirrors the official
+ * oauth-provider client plugin's fetch hook, which injects this whenever
+ * `location.search` contains `sig=` — that param only appears on a signed
+ * query, so its presence is the trigger.
+ */
+function oauthResumeBody(): { oauth_query: string } | Record<string, never> {
+  if (typeof location === "undefined") return {};
+  const search = location.search;
+  if (!search || !new URLSearchParams(search).has("sig")) return {};
+  return { oauth_query: search.slice(1) };
+}
+
 /** POST /api/auth/sign-in/magic-link. Returns true when the auth worker accepted the request. */
 export async function sendMagicLink(
   origin: string,
@@ -200,7 +217,7 @@ export async function sendMagicLink(
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, callbackURL }),
+    body: JSON.stringify({ email, callbackURL, ...oauthResumeBody() }),
   });
   return res.ok;
 }
@@ -467,5 +484,85 @@ export async function revokeSession(origin: string, token: string): Promise<bool
     return res.ok;
   } catch {
     return false;
+  }
+}
+
+/**
+ * OAuth AS client metadata (issue #224, Lane B): fields the `/oauth/consent`
+ * page reads off `@better-auth/oauth-provider`'s public-client response.
+ * `client_uri`/`logo_uri` are attacker-controlled (any registered DCR
+ * client) — callers must scheme-check before rendering them as links/images.
+ */
+export interface OAuthPublicClient {
+  client_id: string;
+  client_name?: string;
+  client_uri?: string;
+  logo_uri?: string;
+}
+
+/**
+ * GET /api/auth/oauth2/public-client?client_id=. Session-gated (credentialed
+ * fetch). Returns null on any failure, malformed body, or missing session —
+ * the consent page falls back to displaying the raw client_id.
+ */
+export async function getOAuthPublicClient(
+  origin: string,
+  clientId: string,
+): Promise<OAuthPublicClient | null> {
+  try {
+    const res = await fetch(
+      `${authOrigin(origin)}/api/auth/oauth2/public-client?client_id=${encodeURIComponent(clientId)}`,
+      { credentials: "include", cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as OAuthPublicClient | null;
+    return body && typeof body.client_id === "string" ? body : null;
+  } catch {
+    return null;
+  }
+}
+
+export type OAuthConsentResult = { ok: true; redirectUri: string } | { ok: false; error: string };
+
+/**
+ * POST /api/auth/oauth2/consent. `oauthQuery` is `location.search` with the
+ * leading "?" stripped (the signed consent query the AS handed the browser) —
+ * required so the AS can resolve which pending authorize request this is.
+ * `scope` is the space-delimited set of scopes the user is granting; omit on
+ * deny. Response carries `redirect_uri` on success, `error_description` /
+ * `message` on rejection (expired/invalid signed query, unknown client, …).
+ */
+export async function submitOAuthConsent(
+  origin: string,
+  opts: { accept: boolean; scope?: string; oauthQuery: string },
+): Promise<OAuthConsentResult> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/oauth2/consent`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        accept: opts.accept,
+        ...(opts.scope !== undefined ? { scope: opts.scope } : {}),
+        oauth_query: opts.oauthQuery,
+      }),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      redirect_uri?: string;
+      error_description?: string;
+      message?: string;
+    } | null;
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: body?.error_description ?? body?.message ?? "Something went wrong. Try again.",
+      };
+    }
+    if (!body?.redirect_uri) {
+      return { ok: false, error: "The authorization server didn't return a redirect." };
+    }
+    return { ok: true, redirectUri: body.redirect_uri };
+  } catch {
+    return { ok: false, error: "Couldn't reach the authorization server. Try again." };
   }
 }

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -88,10 +88,6 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     <div class="ul-callout status" data-state="ready" role="status">Redirecting…</div>
   </div>
 
-  <div id="denied" hidden>
-    <div class="ul-callout status" role="status">Request denied. You can close this page.</div>
-  </div>
-
   <Footer compact />
 </main>
 <script define:vars={{ authOrigin }}>
@@ -125,7 +121,6 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const denyBtn = requireElement<HTMLButtonElement>("#deny-btn");
   const confirmError = requireElement<HTMLElement>("#confirm-error");
   const redirecting = requireElement<HTMLElement>("#redirecting");
-  const denied = requireElement<HTMLElement>("#denied");
 
   // Human copy for the scopes this AS issues (see docs/superpowers/specs/
   // 2026-07-17-oauth-authorization-server-design.md — files:read/write/delete).
@@ -142,7 +137,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const oauthQuery = location.search.replace(/^\?/, "");
 
   function hideAll() {
-    for (const el of [checking, authUnavailable, noRequest, signedOut, confirmBox, redirecting, denied]) {
+    for (const el of [checking, authUnavailable, noRequest, signedOut, confirmBox, redirecting]) {
       el.hidden = true;
     }
   }
@@ -243,11 +238,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       confirmError.hidden = false;
       return;
     }
-    if (!accept) {
-      hideAll();
-      denied.hidden = false;
-      return;
-    }
+    // Deny redirects too: the AS's redirect_uri carries `error=access_denied`
+    // (+ state) back to the initiating client so its flow can finish cleanly.
     hideAll();
     redirecting.hidden = false;
     location.href = result.redirectUri;

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -1,0 +1,265 @@
+---
+import { env } from "cloudflare:workers";
+import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page";
+import BaseHead from "../../components/BaseHead.astro";
+import Brand from "../../components/Brand.astro";
+import Footer from "../../components/Footer.astro";
+
+export const prerender = false;
+
+const authOrigin =
+  env.UPLOADS_AUTH_ORIGIN ??
+  import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
+  "https://auth.uploads.sh";
+
+// Header (not meta): frame-ancestors is ignored on meta CSP.
+applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
+---
+
+<html lang="en">
+<head>
+  <BaseHead />
+  <title>Authorize application · uploads.sh</title>
+  <style>
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100dvh;display:grid;place-items:center;padding:28px;background:var(--bg);color:var(--fg);font:14.5px/1.65 var(--mono)}
+    main{width:min(var(--width-card, 480px),100%);background:var(--panel);border:1px solid var(--line);border-radius:var(--radius-lg);padding:clamp(24px,6vw,40px)}
+    .brandbar{display:flex;justify-content:center;margin-bottom:24px}
+    h1{margin:0 0 8px;font-size:clamp(21px,5vw,26px);font-weight:600;letter-spacing:-.015em;line-height:1.25}
+    p{color:var(--body);margin:0 0 20px}
+    .status{margin:16px 0}
+    .client-host{color:var(--muted);font-size:12.5px;margin:-14px 0 20px;word-break:break-all}
+    .client-host a{color:inherit}
+    .scopes{list-style:none;margin:0 0 22px;padding:0;display:grid;gap:10px}
+    .scopes li{display:flex;align-items:baseline;gap:10px;padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-md)}
+    .scopes .dot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none;margin-top:6px}
+    .scopes .desc{color:var(--fg)}
+    .scopes .id{display:block;color:var(--muted);font-size:11px;letter-spacing:.02em}
+    .actions{display:flex;gap:10px}
+    button.primary,button.secondary{flex:1;font:12px var(--mono);letter-spacing:.04em;color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-sm);padding:11px 13px;cursor:pointer}
+    button.secondary{color:var(--muted)}
+    button.primary:hover,button.primary:focus-visible{border-color:var(--accent);outline:none}
+    button.secondary:hover,button.secondary:focus-visible{border-color:var(--red);color:var(--red);outline:none}
+    button:disabled{opacity:.6;cursor:default}
+    a.linklike{color:var(--accent)}
+    [hidden]{display:none!important}
+  </style>
+</head>
+<body>
+<main>
+  <div class="brandbar"><Brand /></div>
+  <h1>Authorize application</h1>
+
+  <div id="checking" class="ul-callout status" role="status">Checking…</div>
+
+  <div id="auth-unavailable" hidden>
+    <div class="status" data-state="error" role="alert">
+      Authentication is temporarily unavailable. Check the local stack or try again.
+    </div>
+    <button type="button" id="session-retry">Try again</button>
+  </div>
+
+  <div id="no-request" hidden>
+    <div class="ul-callout status" role="status">
+      No pending authorization request. Start again from the application you were using.
+    </div>
+  </div>
+
+  <div id="signed-out" hidden>
+    <p>
+      Sign in to review this request. <a class="linklike" id="signin-link" href="/login">Sign in</a>
+    </p>
+  </div>
+
+  <div id="confirm" hidden>
+    <p>
+      <strong id="client-name"></strong> wants to access your uploads.sh account.
+    </p>
+    <div class="client-host" id="client-host" hidden></div>
+    <ul class="scopes" id="scope-list"></ul>
+    <div class="actions">
+      <button type="button" class="primary" id="allow-btn">Allow</button>
+      <button type="button" class="secondary" id="deny-btn">Deny</button>
+    </div>
+    <div class="ul-callout status" id="confirm-error" data-state="error" role="alert" hidden></div>
+  </div>
+
+  <div id="redirecting" hidden>
+    <div class="ul-callout status" data-state="ready" role="status">Redirecting…</div>
+  </div>
+
+  <div id="denied" hidden>
+    <div class="ul-callout status" role="status">Request denied. You can close this page.</div>
+  </div>
+
+  <Footer compact />
+</main>
+<script define:vars={{ authOrigin }}>
+  window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
+</script>
+<script>
+  import {
+    getOAuthPublicClient,
+    getSession,
+    submitOAuthConsent,
+  } from "../../lib/auth-client";
+
+  const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
+
+  function requireElement<T extends Element>(selector: string): T {
+    const element = document.querySelector<T>(selector);
+    if (!element) throw new Error(`consent page is missing ${selector}`);
+    return element as T;
+  }
+
+  const checking = requireElement<HTMLElement>("#checking");
+  const authUnavailable = requireElement<HTMLElement>("#auth-unavailable");
+  const noRequest = requireElement<HTMLElement>("#no-request");
+  const signedOut = requireElement<HTMLElement>("#signed-out");
+  const signinLink = requireElement<HTMLAnchorElement>("#signin-link");
+  const confirmBox = requireElement<HTMLElement>("#confirm");
+  const clientName = requireElement<HTMLElement>("#client-name");
+  const clientHost = requireElement<HTMLElement>("#client-host");
+  const scopeList = requireElement<HTMLUListElement>("#scope-list");
+  const allowBtn = requireElement<HTMLButtonElement>("#allow-btn");
+  const denyBtn = requireElement<HTMLButtonElement>("#deny-btn");
+  const confirmError = requireElement<HTMLElement>("#confirm-error");
+  const redirecting = requireElement<HTMLElement>("#redirecting");
+  const denied = requireElement<HTMLElement>("#denied");
+
+  // Human copy for the scopes this AS issues (see docs/superpowers/specs/
+  // 2026-07-17-oauth-authorization-server-design.md — files:read/write/delete).
+  // Unrecognized scopes fall back to the raw identifier.
+  const SCOPE_DESCRIPTIONS: Record<string, string> = {
+    "files:read": "Read your files",
+    "files:write": "Upload and modify files",
+    "files:delete": "Delete files",
+  };
+
+  const params = new URLSearchParams(location.search);
+  const clientId = params.get("client_id")?.trim() ?? "";
+  const requestedScopes = (params.get("scope") ?? "").split(/\s+/).filter(Boolean);
+  const oauthQuery = location.search.replace(/^\?/, "");
+
+  function hideAll() {
+    for (const el of [checking, authUnavailable, noRequest, signedOut, confirmBox, redirecting, denied]) {
+      el.hidden = true;
+    }
+  }
+
+  // appendChild, not append(): worker-configuration.d.ts's HTMLRewriter
+  // `Element` ambiently redeclares `append()` with an incompatible
+  // (non-Node) signature, which typecheck resolves against DOM elements too.
+  function renderScopes() {
+    scopeList.replaceChildren();
+    for (const scope of requestedScopes) {
+      const li = document.createElement("li");
+      const dot = document.createElement("span");
+      dot.className = "dot";
+      const text = document.createElement("span");
+      const desc = document.createElement("span");
+      desc.className = "desc";
+      desc.textContent = SCOPE_DESCRIPTIONS[scope] ?? scope;
+      const id = document.createElement("span");
+      id.className = "id";
+      id.textContent = scope;
+      text.appendChild(desc);
+      text.appendChild(id);
+      li.appendChild(dot);
+      li.appendChild(text);
+      scopeList.appendChild(li);
+    }
+  }
+
+  // A registered client (DCR) fully controls client_uri/logo_uri — only
+  // render it as a link if it's actually http(s), never javascript:/data:/etc.
+  function safeHttpUrl(value: string | undefined): URL | null {
+    if (!value) return null;
+    try {
+      const url = new URL(value);
+      return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function proceed() {
+    hideAll();
+    checking.hidden = false;
+
+    if (!clientId) {
+      hideAll();
+      noRequest.hidden = false;
+      return;
+    }
+
+    const session = await getSession(authOrigin);
+    if (session.kind === "unavailable") {
+      hideAll();
+      authUnavailable.hidden = false;
+      return;
+    }
+    if (session.kind !== "signed_in") {
+      hideAll();
+      signinLink.href = `/login?callbackURL=${encodeURIComponent(location.href)}`;
+      signedOut.hidden = false;
+      return;
+    }
+
+    const client = await getOAuthPublicClient(authOrigin, clientId);
+    hideAll();
+
+    clientName.textContent = client?.client_name || clientId;
+    const host = safeHttpUrl(client?.client_uri);
+    if (host) {
+      clientHost.replaceChildren();
+      const a = document.createElement("a");
+      a.href = host.href;
+      a.target = "_blank";
+      a.rel = "noreferrer";
+      a.textContent = host.host;
+      clientHost.appendChild(a);
+      clientHost.hidden = false;
+    } else {
+      clientHost.hidden = true;
+    }
+    renderScopes();
+    confirmBox.hidden = false;
+  }
+
+  async function decide(accept: boolean) {
+    confirmError.hidden = true;
+    allowBtn.disabled = true;
+    denyBtn.disabled = true;
+    const result = await submitOAuthConsent(authOrigin, {
+      accept,
+      scope: accept ? requestedScopes.join(" ") : undefined,
+      oauthQuery,
+    });
+    if (!result.ok) {
+      allowBtn.disabled = false;
+      denyBtn.disabled = false;
+      confirmError.textContent = result.error;
+      confirmError.hidden = false;
+      return;
+    }
+    if (!accept) {
+      hideAll();
+      denied.hidden = false;
+      return;
+    }
+    hideAll();
+    redirecting.hidden = false;
+    location.href = result.redirectUri;
+  }
+
+  requireElement<HTMLButtonElement>("#session-retry").addEventListener("click", () => {
+    void proceed();
+  });
+  allowBtn.addEventListener("click", () => void decide(true));
+  denyBtn.addEventListener("click", () => void decide(false));
+
+  void proceed();
+</script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md
+++ b/docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md
@@ -1,0 +1,97 @@
+# OAuth 2.1 authorization server for agents.uploads.sh (issue #224)
+
+Status: approved design, implementing on `claude/oauth-agents-implementation-0fefce`.
+
+## Goal
+
+Stand up an OAuth 2.1 authorization server on the existing `uploads-auth` worker
+(`auth.uploads.sh`) so the hosted MCP server at `agents.uploads.sh/mcp` can
+authenticate through a browser flow — no env var, no baked token, no local CLI.
+Acceptance (from #224): a fresh Claude Code user installs the plugin and the
+hosted MCP authenticates via OAuth; the bundled `.mcp.json` switches back to the
+hosted HTTP endpoint.
+
+## Approach
+
+Follow the pattern proven in the sibling repos (`~/Code/releases`,
+`~/Code/sunny`), both on Better Auth 1.6.23 with `@better-auth/oauth-provider`:
+
+- **AS**: `jwt()` + `oauthProvider()` plugins added to the existing
+  `betterAuth()` config in `apps/auth/src/auth.ts` (jwt registered **before**
+  oauthProvider — it signs access tokens and serves JWKS at
+  `/api/auth/jwks`). Issuer is `${BETTER_AUTH_URL}/api/auth`
+  (`https://auth.uploads.sh/api/auth`).
+- **Tokens**: JWT access tokens verified **statelessly** by resource servers
+  against the AS JWKS — no AUTH service binding added to `apps/mcp`. This is
+  the JWKS path the Better Auth introduction plan (D1, lines 108–110) already
+  reserved.
+- **Workspace mapping**: `customAccessTokenClaims` queries the auth D1
+  (`member` ⋈ `organization`, same database) and embeds the user's workspace
+  slugs: `workspaces: [...]` plus a primary `workspace` (oldest membership) the
+  MCP worker uses. Zero workspaces → claims still issue; the MCP worker
+  responds 403 with a create-a-workspace message.
+- **Scopes**: the existing `FILE_SCOPES` — `files:read`, `files:write`,
+  `files:delete` (duplicated as a literal in `apps/auth`; no dependency on
+  `@uploads/api`). DCR default scopes: `files:read files:write`.
+- **DCR**: `allowDynamicClientRegistration` + unauthenticated registration on,
+  rate-limited (5/min, D1-backed), with a stale-client reaper added to the
+  existing `15 6 * * *` cron (copy `sunny/apps/auth/src/oauth-client-reaper.ts`).
+- **Discovery**: root aliases on the auth worker —
+  `/.well-known/oauth-authorization-server` (+ `/*` path-inserted form, RFC
+  8414) and `/.well-known/openid-configuration` — rewritten to the Better Auth
+  handler, `Access-Control-Allow-Origin: *`.
+- **RFC 9728**: `protectedResourceMetadata` in `apps/api/src/well-known.ts`
+  gains an `authorizationServers` option. Only `apps/mcp` advertises it (it's
+  the only origin that accepts the JWTs in v1); `apps/api` keeps omitting it —
+  honest metadata. Tests updated accordingly.
+- **Resource server** (`apps/mcp`): bearer path multiplexes credential types —
+  JWT-shaped tokens (two dots) verify via `jose` against
+  `https://auth.uploads.sh/api/auth/jwks` (issuer + audience checked, JWKS
+  cached ~5 min in-isolate), everything else falls through to the existing
+  `up_` workspace-token path. Valid JWT → same context vars
+  (workspace/scopes) the existing auth sets. Invalid → 401 +
+  `WWW-Authenticate: Bearer error="invalid_token", resource_metadata="…"`.
+  Accepted audiences: `https://agents.uploads.sh/mcp`,
+  `https://mcp.uploads.sh/mcp` (mirrored into the AS `validAudiences`).
+- **Web UI** (`apps/web`, Astro, dependency-free client):
+  - `/oauth/consent` page modeled on `device.astro`: fetches
+    `/api/auth/oauth2/public-client?client_id=…`, shows scopes, POSTs
+    `/api/auth/oauth2/consent` with `accept` + `oauth_query`
+    (= `location.search` minus `?`), follows `redirect_uri`.
+  - Login resume: the plugin sends unauthenticated users to
+    `login?<signed query>`. The client contract is simply to inject
+    `oauth_query` into sign-in POST bodies when `location.search` carries
+    `sig=` — added to `auth-client.ts`; the server resumes the authorize flow
+    (including through magic-link and GitHub redirects).
+- **Plugin**: `plugins/claude/uploads/.mcp.json` switches back to the hosted
+  HTTP endpoint `https://agents.uploads.sh/mcp`.
+- **Docs**: `apps/web/public/auth.md` + web README lose the "no public OAuth
+  AS" claim and document the new AS.
+
+## Out of scope / deferred
+
+- OAuth JWT acceptance on `api.uploads.sh` (v1 is MCP-only).
+- A workspace picker at consent for multi-workspace users (v1: oldest
+  membership wins; all slugs are in the token for a future picker).
+- Third-party client management UI. DCR + consent is the only client surface.
+- The `uploads-cli` device flow is untouched.
+
+## Data / migrations
+
+New tables in the `uploads-auth` D1, hand-synced schema + timestamped SQL
+migration (repo convention, fake-D1 tests apply real migrations):
+`oauth_client`, `oauth_access_token`, `oauth_refresh_token`, `oauth_consent`,
+`jwks` — copied from `sunny/apps/auth/src/schema.ts:239-336` and its
+`oauth_provider` migration. Post-merge operational step: `wrangler d1
+migrations apply DB --remote` for `uploads-auth`.
+
+## Testing
+
+- `apps/auth`: fake-D1 tests — discovery metadata served at root aliases, DCR
+  registers a client, authorize→consent→token round-trip issues a JWT carrying
+  workspace claims, JWKS endpoint serves keys.
+- `apps/mcp`: sign a JWT with a test key, serve a fake JWKS, assert the MCP
+  auth path accepts it (and rejects bad iss/aud/exp) and that
+  `oauth-protected-resource` now advertises `authorization_servers`.
+- `apps/api`: `well-known.test.ts` keeps asserting the API resource omits
+  `authorization_servers`.

--- a/docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md
+++ b/docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md
@@ -37,8 +37,7 @@ Follow the pattern proven in the sibling repos (`~/Code/releases`,
   rate-limited (5/min, D1-backed), with a stale-client reaper added to the
   existing `15 6 * * *` cron (copy `sunny/apps/auth/src/oauth-client-reaper.ts`).
 - **Discovery**: root aliases on the auth worker —
-  `/.well-known/oauth-authorization-server` (+ `/*` path-inserted form, RFC
-  8414) and `/.well-known/openid-configuration` — rewritten to the Better Auth
+  `/.well-known/oauth-authorization-server` (+ `/*` path-inserted form, RFC 8414) and `/.well-known/openid-configuration` — rewritten to the Better Auth
   handler, `Access-Control-Allow-Origin: *`.
 - **RFC 9728**: `protectedResourceMetadata` in `apps/api/src/well-known.ts`
   gains an `authorizationServers` option. Only `apps/mcp` advertises it (it's

--- a/plugins/claude/uploads/.mcp.json
+++ b/plugins/claude/uploads/.mcp.json
@@ -1,6 +1,6 @@
 {
   "uploads": {
-    "command": "uploads",
-    "args": ["mcp"]
+    "type": "http",
+    "url": "https://agents.uploads.sh/mcp"
   }
 }

--- a/plugins/claude/uploads/README.md
+++ b/plugins/claude/uploads/README.md
@@ -15,7 +15,7 @@ with `source: "./"`, so the whole repo is a one-plugin marketplace.
 | github-screenshots skill | `/uploads:github-screenshots` | Capture + host + embed a visual in a PR/issue with a stable per-target key        |
 | uploads-cli skill        | `/uploads:uploads-cli`        | Full `uploads` CLI reference — `put`, `attach`, `screenshot`, galleries, metadata |
 | attach command           | `/uploads:attach`             | Explicit entry point for hosting a file or attaching to a PR/issue                |
-| uploads MCP server       | (tools)                       | Local stdio `uploads mcp` — `put`, `list`, `attach`, galleries                    |
+| uploads MCP server       | (tools)                       | Hosted `https://agents.uploads.sh/mcp` — `put`, `list`, `attach`, galleries       |
 
 Plugin skills and commands are namespaced by the plugin name (`uploads`), so
 they appear as `/uploads:…`.
@@ -29,30 +29,20 @@ they appear as `/uploads:…`.
 
 ## MCP auth
 
-The bundled MCP server runs the local CLI over stdio (`uploads mcp`). It reads
-your workspace token from the config file `uploads login` writes
-(`~/.config/buildinternet/config`), so once you've signed in there's nothing
-else to set up:
+The bundled MCP server points at the hosted endpoint,
+`https://agents.uploads.sh/mcp`. On first use, Claude Code opens a browser to
+the uploads.sh OAuth consent screen — sign in, approve access, and Claude Code
+stores the resulting access token for you. No CLI install, no config file, no
+environment variable to wire up.
 
-```
-npm install -g @buildinternet/uploads   # if the CLI isn't already installed
-uploads login                            # device flow → stores the token
-```
+Tokens carry `files:read` + `files:write` by default and are scoped to your
+primary workspace (a fresh account with no workspace is prompted to create one
+at <https://uploads.sh> before the tools will work). See
+<https://uploads.sh/auth.md> for the full credential model.
 
-The CLI must be on your `PATH` for the bundled server to launch. Tokens carry
-`files:read` + `files:write` by default and are scoped to a single workspace.
-See <https://uploads.sh/auth.md> for the full credential model.
-
-### Why not the hosted endpoint?
-
-The hosted MCP at `https://agents.uploads.sh/mcp` authenticates with a bearer
-token, but a static plugin manifest can't inject a per-user token. `uploads
-login` stores the token in a config file, **not** an environment variable, so a
-`${UPLOADS_TOKEN}` header would be empty for a normally signed-in user. Until
-`agents.uploads.sh` exposes an OAuth authorization server that Claude Code can
-complete interactively, the local stdio server is the one that works without
-manual token wiring. To use the hosted endpoint anyway, register it yourself
-with the token baked in (this is what `uploads install` does):
+If you'd rather use a long-lived per-workspace token instead of the OAuth
+flow (e.g. for CI or a non-interactive agent), register the endpoint yourself
+with the token baked in:
 
 ```
 claude mcp add --transport http uploads https://agents.uploads.sh/mcp \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@better-auth/infra':
         specifier: ^0.3.6
         version: 0.3.6(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(zod@4.4.3)
+      '@better-auth/oauth-provider':
+        specifier: ^1.6.23
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
       '@uploads/email':
         specifier: workspace:^
         version: link:../../packages/email
@@ -115,6 +118,9 @@ importers:
       hono:
         specifier: ^4.12.28
         version: 4.12.28
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
     devDependencies:
       '@types/node':
         specifier: ^26.1.0
@@ -656,6 +662,15 @@ packages:
     peerDependenciesMeta:
       mongodb:
         optional: true
+
+  '@better-auth/oauth-provider@1.6.23':
+    resolution: {integrity: sha512-1sDN+N4Sztmpk8ziCU3MXicxOTfvYoHvHvhJMQ7PSfr+pLXnYN+dJFI9S3zBRwstmTeJx/OhRIZWrwFJ0TgBnA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: ^1.6.23
+      better-call: 1.3.7
 
   '@better-auth/prisma-adapter@1.6.23':
     resolution: {integrity: sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==}
@@ -5299,6 +5314,16 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
+
+  '@better-auth/oauth-provider@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)))
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      zod: 4.4.3
 
   '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:


### PR DESCRIPTION
Closes #224.

Stands up an OAuth 2.1 authorization server on the existing `uploads-auth` worker so the hosted MCP at `agents.uploads.sh/mcp` authenticates through a browser flow — no env var, no baked token, no local CLI dependency. The bundled Claude Code plugin points back at the hosted HTTP endpoint.

Design doc: `docs/superpowers/specs/2026-07-17-oauth-authorization-server-design.md`. Pattern follows the proven sibling implementations (releases.sh, sunny) on Better Auth 1.6.23 + `@better-auth/oauth-provider`.

## What's in here

**apps/auth — the authorization server**
- `jwt()` + `oauthProvider()` added to the existing `betterAuth()` config (jwt first — it signs access tokens and serves JWKS at `/api/auth/jwks`). Issuer: `https://auth.uploads.sh/api/auth`.
- Five new D1 tables (`oauth_client`, `oauth_access_token`, `oauth_refresh_token`, `oauth_consent`, `jwks`) as hand-synced schema + migration `20260717000000_oauth_provider.sql`.
- `customAccessTokenClaims` embeds workspace claims from org memberships (`workspace`: oldest membership's slug, `workspaces`: all slugs). Zero-workspace users still get a token; the resource server owns the 403.
- Dynamic client registration on (unauthenticated, 5/min rate limit) with a stale-client reaper wired into the existing cron (default observe-only via `OAUTH_CLIENT_REAPER_ENABLED`).
- RFC 8414 discovery aliases at the issuer root (`/.well-known/oauth-authorization-server[/*]`), CORS `*`.
- Scopes are the existing `FILE_SCOPES` (`files:read` / `files:write` / `files:delete`); DCR default grants read+write.

**apps/mcp — the resource server**
- JWT-shaped bearers verify via `jose` against the AS JWKS (5-min in-isolate cache, no service binding); non-JWT bearers use the existing `up_` path untouched.
- Valid token → same context (`workspace`/`authScopes`) as today, so tools are unchanged downstream. `workspace: null` → actionable 403. Bad/expired token → 401 + `WWW-Authenticate: Bearer error="invalid_token", resource_metadata=…`; **no credential at all** → 401 + the RFC 9728 discovery challenge (this is the response MCP clients bootstrap OAuth from).
- `oauth-protected-resource` metadata now advertises `authorization_servers: ["https://auth.uploads.sh/api/auth"]` (MCP origins only — `api.uploads.sh` keeps omitting it since it doesn't accept these JWTs yet).

**apps/web — the human surface**
- New `/oauth/consent` page (Astro, dependency-free, `authPageCsp`, all `textContent` sinks, sanitized client URIs).
- `auth-client.ts` injects `oauth_query` into sign-in POSTs when the page carries the AS's signed authorize query, which is how the flow resumes through login (verified against the plugin source).
- `auth.md` / README / llms.txt updated — the "no public OAuth AS" claim is gone.

**plugins/claude** — `.mcp.json` switches from the local stdio workaround back to `{"type":"http","url":"https://agents.uploads.sh/mcp"}`.

## Notes

- Access tokens are JWTs **only when the client sends an RFC 8707 `resource` param** matching `validAudiences` (plugin behavior); MCP clients per the 2025-06 spec always do. A client that omits it gets an opaque token the MCP worker rejects — acceptable for v1.
- `openid-configuration` correctly 404s: this AS issues no OIDC scopes.
- Multi-workspace users get their oldest workspace in v1; all slugs ride in the token for a future consent-time picker (deferred, see design doc).

## Verification

- 1278/1278 tests pass repo-wide, including new suites: auth (DCR, JWKS, discovery aliases, workspace claims, reaper), mcp (signed test JWTs: happy path, both `scope` shapes, bad iss/aud/exp, deleted workspace, no-workspace 403, no-credential challenge, `up_` path regression), web (oauth_query injection).
- Typecheck clean for auth/api; the 2 mcp errors and 1 web error reproduce identically on `main` (pre-existing `worker-configuration.d.ts` drift, spun off separately).

## Post-merge ops

1. `wrangler d1 migrations apply DB --remote` in `apps/auth` (uploads-auth database).
2. Deploy `uploads-auth`, `uploads-mcp`, `uploads-web`.
3. End-to-end prod check: fresh `claude mcp add --transport http uploads https://agents.uploads.sh/mcp` → browser consent → tool call; then re-run the discovery scan from #216.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.1 authorization for the hosted MCP server, including JWT bearer authentication, scopes, workspace claims, discovery, dynamic client registration, and consent approval.
  * Added OAuth login-resume support for GitHub and magic-link authentication.
  * Hosted MCP integrations now connect through `https://agents.uploads.sh/mcp` with interactive browser authorization.

* **Bug Fixes**
  * Improved OAuth metadata and authentication error responses, including standards-compliant discovery challenges.

* **Documentation**
  * Updated agent authentication, OAuth, and hosted MCP setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->