### PR TITLE
fix(web): consent page follows better-auth's actual redirect shape

### DIFF
--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -319,6 +319,22 @@ describe("submitOAuthConsent", () => {
     ).resolves.toEqual({ ok: true, redirectUri: "https://client.example/callback?code=1" });
   });
 
+  it("returns the redirect from better-auth 1.6.23's `{ redirect, url }` shape (prod-verified)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ redirect: true, url: "https://client.example/callback?code=2" }),
+      ),
+    );
+    await expect(
+      submitOAuthConsent("https://auth.uploads.sh", {
+        accept: true,
+        scope: "files:read",
+        oauthQuery: "client_id=c1&sig=x",
+      }),
+    ).resolves.toEqual({ ok: true, redirectUri: "https://client.example/callback?code=2" });
+  });
+
   it("surfaces the AS error description on rejection", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -529,7 +529,8 @@ export type OAuthConsentResult = { ok: true; redirectUri: string } | { ok: false
  * leading "?" stripped (the signed consent query the AS handed the browser) —
  * required so the AS can resolve which pending authorize request this is.
  * `scope` is the space-delimited set of scopes the user is granting; omit on
- * deny. Response carries `redirect_uri` on success, `error_description` /
+ * deny. Response carries the redirect target (`url` on better-auth 1.6.23,
+ * `redirect_uri` in older builds) on success, `error_description` /
  * `message` on rejection (expired/invalid signed query, unknown client, …).
  */
 export async function submitOAuthConsent(
@@ -549,6 +550,7 @@ export async function submitOAuthConsent(
     });
     const body = (await res.json().catch(() => null)) as {
       redirect_uri?: string;
+      url?: string;
       error_description?: string;
       message?: string;
     } | null;
@@ -558,10 +560,13 @@ export async function submitOAuthConsent(
         error: body?.error_description ?? body?.message ?? "Something went wrong. Try again.",
       };
     }
-    if (!body?.redirect_uri) {
+    // better-auth 1.6.23 responds `{ redirect: true, url }` (prod-verified);
+    // `redirect_uri` is the shape older plugin builds documented. Accept both.
+    const redirectUri = body?.url ?? body?.redirect_uri;
+    if (!redirectUri) {
       return { ok: false, error: "The authorization server didn't return a redirect." };
     }
-    return { ok: true, redirectUri: body.redirect_uri };
+    return { ok: true, redirectUri };
   } catch {
     return { ok: false, error: "Couldn't reach the authorization server. Try again." };
   }

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -29,12 +29,12 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     p{color:var(--body);margin:0 0 20px}
     .status{margin:16px 0}
     .client-host{color:var(--muted);font-size:12.5px;margin:-14px 0 20px;word-break:break-all}
-    .client-host a{color:inherit}
+    .client-host :global(a){color:inherit}
     .scopes{list-style:none;margin:0 0 22px;padding:0;display:grid;gap:10px}
-    .scopes li{display:flex;align-items:baseline;gap:10px;padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-md)}
-    .scopes .dot{width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none;margin-top:6px}
-    .scopes .desc{color:var(--fg)}
-    .scopes .id{display:block;color:var(--muted);font-size:11px;letter-spacing:.02em}
+    .scopes :global(li){display:flex;align-items:baseline;gap:10px;padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-md)}
+    .scopes :global(.dot){width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none;margin-top:6px}
+    .scopes :global(.desc){color:var(--fg)}
+    .scopes :global(.id){display:block;color:var(--muted);font-size:11px;letter-spacing:.02em}
     .actions{display:flex;gap:10px}
     button.primary,button.secondary{flex:1;font:12px var(--mono);letter-spacing:.04em;color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-sm);padding:11px 13px;cursor:pointer}
     button.secondary{color:var(--muted)}


### PR DESCRIPTION
Two bugs surfaced by the live browser e2e of the OAuth flow shipped in #226 (issue #224):

1. **Consent redirect dropped (flow-blocking).** better-auth 1.6.23's `POST /oauth2/consent` responds `{ "redirect": true, "url": "…" }` — not the `{ "redirect_uri": … }` shape the form expected — so every consent ended in "The authorization server didn't return a redirect" and the issued authorization code was never delivered to the client. `submitOAuthConsent` now accepts both shapes (prod-verified against the deployed AS).

2. **Unstyled scope list (cosmetic).** The scope rows and client-host link are created with `document.createElement`, which never receives Astro's scoped-style attribute, so the `.desc`/`.id`/`li` rules silently missed and the description ran into the raw scope id ("Read your filesfiles:read"). The dynamic-element selectors now pierce with `:global()`.

Verification: new unit test for the `{ redirect, url }` shape; web suite 124/124, typecheck unchanged (the 1 pre-existing `new.astro` error is spun off separately).

E2e context: with these fixes the deployed flow completes end to end — DCR → authorize → login → consent → code → token → `agents.uploads.sh/mcp` accepting the JWKS-verified JWT (proven live; the test account got the designed `workspace_required` 403 since it has no org membership).