### PR TITLE
feat(web): first-run workspace interstitial on consent + OAuth-aware login callbacks

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -337,21 +337,22 @@ export interface OrganizationSummary {
 
 /**
  * GET /api/auth/organization/list — the signed-in user's organizations
- * (Better Auth organization plugin). Returns [] on any failure — the
- * /account page treats "no orgs" and "couldn't load" the same way visually,
- * with copy that covers both.
+ * (Better Auth organization plugin). Returns null when the list couldn't be
+ * loaded (outage, network) so callers can tell "no orgs" from "don't know" —
+ * the consent page routes genuinely org-less users into workspace creation
+ * and must not misroute users on a transient failure.
  */
-export async function listOrganizations(origin: string): Promise<OrganizationSummary[]> {
+export async function listOrganizations(origin: string): Promise<OrganizationSummary[] | null> {
   try {
     const res = await fetch(`${authOrigin(origin)}/api/auth/organization/list`, {
       credentials: "include",
       cache: "no-store",
     });
-    if (!res.ok) return [];
+    if (!res.ok) return null;
     const body = (await res.json().catch(() => null)) as OrganizationSummary[] | null;
-    return Array.isArray(body) ? body : [];
+    return Array.isArray(body) ? body : null;
   } catch {
-    return [];
+    return null;
   }
 }
 

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { safeSameOriginPath } from "./workspace-ui";
+
+describe("safeSameOriginPath", () => {
+  it("accepts an absolute in-app path with query and hash", () => {
+    expect(safeSameOriginPath("/oauth/consent?client_id=c1&sig=x#top")).toBe(
+      "/oauth/consent?client_id=c1&sig=x#top",
+    );
+  });
+
+  it("rejects everything that could navigate off-origin", () => {
+    expect(safeSameOriginPath(undefined)).toBeNull();
+    expect(safeSameOriginPath("")).toBeNull();
+    expect(safeSameOriginPath("relative/path")).toBeNull();
+    expect(safeSameOriginPath("https://evil.example/x")).toBeNull();
+    // Protocol-relative and the backslash variant browsers normalize to it.
+    expect(safeSameOriginPath("//evil.example")).toBeNull();
+    expect(safeSameOriginPath("/\\evil.example")).toBeNull();
+    // Defense in depth: a raw embedded scheme is rejected even inside the
+    // query — legitimate producers percent-encode (the consent page does).
+    expect(safeSameOriginPath("/ok?u=https://evil.example")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -105,6 +105,20 @@ export function suggestedWorkspaceName(email: string | undefined): string {
   return WORKSPACE_NAME_RE.test(sanitized) ? sanitized : "";
 }
 
+/**
+ * Sanitize a `?next=` return path to a same-origin absolute path (with
+ * optional query/hash). Rejects anything that could navigate off-origin:
+ * absolute URLs, protocol-relative `//host`, and the backslash variant
+ * `/\host` browsers normalize to `//host`. Returns null when unusable so
+ * callers fall back to their default destination.
+ */
+export function safeSameOriginPath(raw: string | null | undefined): string | null {
+  if (!raw || raw[0] !== "/") return null;
+  if (raw[1] === "/" || raw[1] === "\\") return null;
+  if (raw.includes("://")) return null;
+  return raw;
+}
+
 export function createErrorCopy(code: string): string {
   switch (code) {
     case "invalid_workspace_name":

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -72,6 +72,7 @@ export const prerender = false;
     import {
       bindCopyButtons,
       createErrorCopy,
+      safeSameOriginPath,
       suggestedWorkspaceName,
     } from "../../../lib/workspace-ui";
 
@@ -94,6 +95,11 @@ export const prerender = false;
     const input = form.elements.namedItem("name") as HTMLInputElement;
     const submit = form.querySelector<HTMLButtonElement>("button[type='submit']");
 
+    // `?next=` (same-origin path) returns the user to an interrupted flow —
+    // the OAuth consent page sends `/oauth/consent?<signed query>` so a
+    // workspace-less user can create one mid-authorization and resume.
+    const nextPath = safeSameOriginPath(new URLSearchParams(location.search).get("next"));
+
     void listAccounts(authOrigin).then((accounts) => {
       if (accounts && !accounts.some((a) => a.providerId === "github")) githubEl.hidden = false;
     });
@@ -105,7 +111,12 @@ export const prerender = false;
         githubError.hidden = true;
         connectBtn.disabled = true;
         connectBtn.textContent = "Redirecting…";
-        if (!(await linkGitHub(authOrigin, `${location.origin}/account/workspaces/new`))) {
+        // Thread `next` through the GitHub redirect hop so the return trip
+        // still knows where the user was headed.
+        const returnTo = nextPath
+          ? `${location.origin}/account/workspaces/new?next=${encodeURIComponent(nextPath)}`
+          : `${location.origin}/account/workspaces/new`;
+        if (!(await linkGitHub(authOrigin, returnTo))) {
           connectBtn.disabled = false;
           connectBtn.textContent = "Connect GitHub";
           githubError.hidden = false;
@@ -124,6 +135,13 @@ export const prerender = false;
         const result = await createWorkspace(apiOrigin, name);
         if (submit) submit.disabled = false;
         if (result.kind === "created") {
+          // Interrupted-flow return (OAuth consent): skip the CLI-setup card
+          // and go straight back — the user's goal is the pending authorize
+          // request, not terminal setup.
+          if (nextPath) {
+            location.href = nextPath;
+            return;
+          }
           input.value = "";
           createdName.textContent = name;
           openLink.href = `/account/workspaces/${encodeURIComponent(name)}`;

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -100,9 +100,17 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const emailInput = requireElement<HTMLInputElement>("#email");
 
   // Default: CLI setup card. Same-origin ?callbackURL= allowed (session recovery).
-  const defaultCallback = `${location.origin}/account#cli-setup`;
+  // Mid-OAuth exception (#228): a signed authorize query (`sig=`) means the AS
+  // sent the user here to sign in — route the post-auth hop (magic-link email
+  // click, GitHub redirect) to the consent page carrying the same signed
+  // query, instead of stranding the pending authorize request at /account.
+  // The consent endpoint re-validates the signature server-side.
+  const params = new URLSearchParams(location.search);
+  const defaultCallback = params.has("sig")
+    ? `${location.origin}/oauth/consent${location.search}`
+    : `${location.origin}/account#cli-setup`;
   let callbackURL = defaultCallback;
-  const rawCallback = new URLSearchParams(location.search).get("callbackURL");
+  const rawCallback = params.get("callbackURL");
   if (rawCallback) {
     try {
       const url = new URL(rawCallback, location.origin);

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -36,6 +36,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     .scopes :global(.desc){color:var(--fg)}
     .scopes :global(.id){display:block;color:var(--muted);font-size:11px;letter-spacing:.02em}
     .actions{display:flex;gap:10px}
+    a.linkbtn{display:block;text-align:center;text-decoration:none;font:12px var(--mono);letter-spacing:.04em;color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-sm);padding:11px 13px}
+    a.linkbtn:hover,a.linkbtn:focus-visible{border-color:var(--accent);outline:none}
     button.primary,button.secondary{flex:1;font:12px var(--mono);letter-spacing:.04em;color:var(--accent);background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-sm);padding:11px 13px;cursor:pointer}
     button.secondary{color:var(--muted)}
     button.primary:hover,button.primary:focus-visible{border-color:var(--accent);outline:none}
@@ -71,6 +73,22 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     </p>
   </div>
 
+  <div id="no-workspace" hidden>
+    <p>
+      <strong id="nw-client-name"></strong> stores files in a workspace, and your account doesn't
+      have one yet.
+    </p>
+    <p>
+      Create one (takes a minute — needs a linked GitHub account), and you'll be brought back here
+      to finish authorizing.
+    </p>
+    <div class="actions">
+      <a class="primary linkbtn" id="create-workspace-link" href="/account/workspaces/new">
+        Create a workspace
+      </a>
+    </div>
+  </div>
+
   <div id="confirm" hidden>
     <p>
       <strong id="client-name"></strong> wants to access your uploads.sh account.
@@ -97,6 +115,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   import {
     getOAuthPublicClient,
     getSession,
+    listOrganizations,
     submitOAuthConsent,
   } from "../../lib/auth-client";
 
@@ -113,6 +132,9 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const noRequest = requireElement<HTMLElement>("#no-request");
   const signedOut = requireElement<HTMLElement>("#signed-out");
   const signinLink = requireElement<HTMLAnchorElement>("#signin-link");
+  const noWorkspace = requireElement<HTMLElement>("#no-workspace");
+  const nwClientName = requireElement<HTMLElement>("#nw-client-name");
+  const createWorkspaceLink = requireElement<HTMLAnchorElement>("#create-workspace-link");
   const confirmBox = requireElement<HTMLElement>("#confirm");
   const clientName = requireElement<HTMLElement>("#client-name");
   const clientHost = requireElement<HTMLElement>("#client-host");
@@ -137,7 +159,8 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const oauthQuery = location.search.replace(/^\?/, "");
 
   function hideAll() {
-    for (const el of [checking, authUnavailable, noRequest, signedOut, confirmBox, redirecting]) {
+    const panels = [checking, authUnavailable, noRequest, signedOut, noWorkspace, confirmBox, redirecting];
+    for (const el of panels) {
       el.hidden = true;
     }
   }
@@ -201,8 +224,26 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       return;
     }
 
+    // Access-token claims are baked at issuance: a token minted for a
+    // workspace-less user stays `workspace: null` for its full lifetime, so
+    // the only useful place to fix "no workspace yet" is HERE, before the
+    // user can approve. Send them through the creation page with a `next`
+    // return to this exact consent URL (signed query included — the AS
+    // re-validates it on the way back).
+    const orgs = await listOrganizations(authOrigin);
     const client = await getOAuthPublicClient(authOrigin, clientId);
     hideAll();
+
+    // null = list unavailable, NOT "no orgs" — fail open to the normal
+    // consent card (server-side enforcement still yields the workspace 403
+    // at worst) rather than misrouting a workspace-having user.
+    if (orgs !== null && orgs.length === 0) {
+      nwClientName.textContent = client?.client_name || clientId;
+      const next = encodeURIComponent(`/oauth/consent${location.search}`);
+      createWorkspaceLink.href = `/account/workspaces/new?next=${next}`;
+      noWorkspace.hidden = false;
+      return;
+    }
 
     clientName.textContent = client?.client_name || clientId;
     const host = safeHttpUrl(client?.client_uri);


### PR DESCRIPTION
Closes #228. Follow-up to #226/#227, smoothing the two first-run gaps the live e2e exposed.

**Why before issuance:** access-token claims are baked when the token is minted — a workspace-less user who completes consent holds a `workspace: null` token for its full hour lifetime, and creating a workspace afterward doesn't help until the client re-authenticates. So the funnel is fixed inside the browser flow, before Allow.

## Changes

**Consent interstitial** — a signed-in user with zero organizations sees a create-a-workspace card (client name + explanation) instead of the Allow/Deny actions, linking to `/account/workspaces/new?next=<this consent URL>`. `listOrganizations` now returns `null` on couldn't-load vs `[]` for genuinely none — a transient outage fails open to the normal consent card (worst case is the existing server-side 403) instead of misrouting a workspace-having user.

**Creation page `next=` return** — sanitized to a same-origin path (`safeSameOriginPath`, unit-tested against protocol-relative/backslash/embedded-scheme escapes), threaded through the GitHub-connect redirect hop, and auto-returns on successful creation (skipping the CLI-setup card — the user's goal is the pending authorize request). No auto-provisioning: the GitHub gate, 3-workspace cap, and user-chosen slug all stay intact.

**Login resume (#228)** — when the login page's query carries a signed OAuth request (`sig=`), the default magic-link/GitHub `callbackURL` becomes `/oauth/consent?<signed query>` instead of `/account#cli-setup`, so the email hop lands back in the flow (the consent endpoint re-validates the signature server-side). An explicit same-origin `?callbackURL=` still wins. Signed requests expire (~10 min), so a stale email link degrades to the consent page's start-again error rather than a dead end.

## Verification

Web suite 15 files / 126 tests passing (new `safeSameOriginPath` suite). Typecheck unchanged — the 1 pre-existing `new.astro` HTMLRewriter-ambient error is tracked separately. Full-flow check owed post-deploy: fresh account → authorize → magic link → consent shows interstitial → create workspace → return → Allow → working token.