### PR TITLE
fix(web): unbreak web typecheck on main (bindCopyButtons ParentNode drift)

### DIFF
--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -134,8 +134,15 @@ export function createErrorCopy(code: string): string {
   }
 }
 
-/** Copy-to-clipboard for `button[data-copy]` under `root`. */
-export function bindCopyButtons(root: ParentNode): void {
+/**
+ * Copy-to-clipboard for `button[data-copy]` under `root`.
+ *
+ * `Node`, not `ParentNode`: this only needs `addEventListener`/`contains`
+ * (both on `Node`), and worker-configuration.d.ts's HTMLRewriter `Element`
+ * ambiently redeclares `append()`, which makes DOM elements unassignable to
+ * `ParentNode`. Same wrangler-types drift worked around in oauth/consent.astro.
+ */
+export function bindCopyButtons(root: Node): void {
   root.addEventListener("click", (event) => {
     void (async () => {
       const button = (event.target as HTMLElement).closest<HTMLButtonElement>("button[data-copy]");


### PR DESCRIPTION
## Problem

`pnpm --filter @uploads/web typecheck` fails on `main`:

```
src/pages/account/workspaces/new.astro:163:21 - error ts(2345):
  Argument of type 'HTMLElement' is not assignable to parameter of type 'ParentNode'.
    Types of property 'append' are incompatible.
```

`worker-configuration.d.ts` (regenerated by `wrangler types`) ambiently redeclares the HTMLRewriter `Element` interface with an `append(content, options): Element` signature. That merges into the global `Element`, poisoning DOM `HTMLElement.append`, so `HTMLElement` is no longer assignable to `ParentNode` (conflicting `append` signatures). The `bindCopyButtons(requireElement<HTMLElement>("#create", page))` call site trips this.

A related instance of this drift was already worked around in `oauth/consent.astro` (switched to `appendChild`).

## Fix

Widen `bindCopyButtons`'s parameter from `ParentNode` to `Node`. The function only calls `addEventListener` and `contains` — both are `Node` members, never `ParentNode`-specific ones — and `Node` has no `append`, so it sidesteps the poisoned signature entirely. No per-call-site casts needed, and both callers stay valid:

- `bindCopyButtons(document)` in `workspaces/[name].astro`
- `bindCopyButtons(requireElement<HTMLElement>("#create", page))` in `workspaces/new.astro`

## Verification

`pnpm --filter @uploads/web typecheck` → **0 errors** (was 1).

No changeset: `@uploads/web` is in `.changeset/config.json`'s ignore list.
