### PR TITLE
feat(web): full-width site header with avatar menu

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -1,73 +1,339 @@
 ---
-// Persistent signed-in indicator for the top nav area of pages that don't
-// already have their own session UI. Signed out -> "sign in" link to
-// /login. Signed in -> the user's email, linking to /account. Reserves a
-// fixed-height slot so the async session check causes no layout shift; the
-// slot shows a muted "…" placeholder until getSession resolves.
+/**
+ * Header auth control for SiteHeader.
+ *
+ * - Signed out → solid primary "Sign in" CTA
+ * - Signed in  → avatar placeholder (initials) + dropdown to account sections
+ *
+ * Reserves a fixed-size slot so the async session check does not reflow the
+ * header. Optimistic paint uses the same sessionStorage cache as the account
+ * shells when present.
+ */
 export interface Props {
   authOrigin: string;
 }
 
 const { authOrigin } = Astro.props;
+
+const MENU_ITEMS = [
+  { href: "/account", label: "Overview" },
+  { href: "/account/workspaces", label: "Workspaces" },
+  { href: "/account/profile", label: "Account" },
+  { href: "/account/developers", label: "Developers" },
+] as const;
 ---
 
-<span class="auth-indicator">
-  <span id="auth-indicator-slot" class="slot">…</span>
-</span>
-<script define:vars={{ authOrigin }}>
-  // Multiple instances/pages may set this; first one wins, all read the same value.
+<div class="auth-indicator" data-auth-indicator>
+  <div class="auth-indicator__slot" data-slot aria-live="polite">
+    <span class="auth-indicator__skeleton" aria-hidden="true"></span>
+  </div>
+</div>
+
+<script define:vars={{ authOrigin, menuItems: MENU_ITEMS }}>
   window.__UPLOADS_AUTH_ORIGIN__ = window.__UPLOADS_AUTH_ORIGIN__ || authOrigin;
+  window.__UPLOADS_AUTH_MENU_ITEMS__ = menuItems;
 </script>
 <script>
-  import { getSession } from "../lib/auth-client";
+  import { getSession, signOut, type SessionUser } from "../lib/auth-client";
+  import {
+    clearCachedSessionUser,
+    readCachedSessionUser,
+    writeCachedSessionUser,
+  } from "../lib/account-shell";
 
-  const escapeHtml = (value: string) =>
-    value.replace(/[&<>"']/g, (ch) =>
-      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
-    );
+  const root = document.querySelector<HTMLElement>("[data-auth-indicator]");
+  const slot = root?.querySelector<HTMLElement>("[data-slot]");
+  if (!root || !slot) {
+    // Not on a page that mounted the indicator.
+  } else {
+    const origin =
+      (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__ ||
+      "https://auth.uploads.sh";
+    const menuItems =
+      (
+        window as unknown as {
+          __UPLOADS_AUTH_MENU_ITEMS__: ReadonlyArray<{ href: string; label: string }>;
+        }
+      ).__UPLOADS_AUTH_MENU_ITEMS__ ?? [];
 
-  const origin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
-  const slot = document.getElementById("auth-indicator-slot");
+    const escapeHtml = (value: string) =>
+      value.replace(/[&<>"']/g, (ch) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+      );
 
-  getSession(origin).then((result) => {
-    if (!slot) return;
-    if (result.kind === "unavailable") {
-      slot.textContent = "auth unavailable";
-      return;
-    }
-    if (result.kind !== "signed_in") {
-      slot.innerHTML = '<a href="/login">sign in</a>';
-      return;
-    }
-    slot.innerHTML = `<a href="/account">${escapeHtml(result.session.user.email)}</a>`;
-  });
+    const initialsFor = (user: SessionUser): string => {
+      const source = (user.name || user.email || "?").trim();
+      if (!source) return "?";
+      if (source.includes("@")) {
+        const local = source.split("@")[0] ?? source;
+        const parts = local.split(/[._\-\s]+/).filter(Boolean);
+        if (parts.length >= 2) {
+          return `${parts[0]![0] ?? ""}${parts[1]![0] ?? ""}`.toUpperCase();
+        }
+        return local.slice(0, 2).toUpperCase();
+      }
+      const words = source.split(/\s+/).filter(Boolean);
+      if (words.length >= 2) {
+        return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
+      }
+      return source.slice(0, 2).toUpperCase();
+    };
+
+    const paintSignedOut = () => {
+      slot.innerHTML =
+        '<a class="ul-btn ul-btn--solid ul-btn--sm auth-indicator__signin" href="/login">Sign in</a>';
+    };
+
+    const paintUnavailable = () => {
+      slot.innerHTML = '<span class="auth-indicator__muted">auth unavailable</span>';
+    };
+
+    let menuListeners: AbortController | null = null;
+
+    const paintUser = (user: SessionUser) => {
+      const initials = escapeHtml(initialsFor(user));
+      const email = escapeHtml(user.email);
+      const label = escapeHtml(user.name || user.email || "Account");
+      const adminItem =
+        user.role === "admin"
+          ? `<a class="auth-menu__item" href="/admin" role="menuitem">Admin</a>`
+          : "";
+
+      const links = menuItems
+        .map(
+          (item) =>
+            `<a class="auth-menu__item" href="${escapeHtml(item.href)}" role="menuitem">${escapeHtml(item.label)}</a>`,
+        )
+        .join("");
+
+      // Drop prior document listeners before replacing the menu DOM.
+      menuListeners?.abort();
+      menuListeners = new AbortController();
+      const { signal } = menuListeners;
+
+      slot.innerHTML = `
+        <div class="auth-menu" data-auth-menu>
+          <button
+            type="button"
+            class="auth-menu__trigger"
+            data-auth-menu-trigger
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-label="${label}"
+          >
+            <span class="auth-menu__avatar" aria-hidden="true">${initials}</span>
+          </button>
+          <div class="auth-menu__panel" data-auth-menu-panel hidden role="menu" aria-label="Account">
+            <div class="auth-menu__meta">
+              <span class="auth-menu__email">${email}</span>
+            </div>
+            <div class="auth-menu__list">
+              ${links}
+              ${adminItem}
+            </div>
+            <div class="auth-menu__foot">
+              <button type="button" class="auth-menu__item auth-menu__signout" data-auth-signout role="menuitem">
+                Sign out
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+
+      const menu = slot.querySelector<HTMLElement>("[data-auth-menu]");
+      const trigger = slot.querySelector<HTMLButtonElement>("[data-auth-menu-trigger]");
+      const panel = slot.querySelector<HTMLElement>("[data-auth-menu-panel]");
+      const signOutBtn = slot.querySelector<HTMLButtonElement>("[data-auth-signout]");
+      if (!menu || !trigger || !panel) return;
+
+      const setOpen = (open: boolean) => {
+        panel.hidden = !open;
+        trigger.setAttribute("aria-expanded", open ? "true" : "false");
+      };
+
+      trigger.addEventListener(
+        "click",
+        (event) => {
+          event.stopPropagation();
+          setOpen(panel.hidden);
+        },
+        { signal },
+      );
+
+      signOutBtn?.addEventListener(
+        "click",
+        () => {
+          clearCachedSessionUser();
+          void signOut(origin).then(() => {
+            location.href = "/login";
+          });
+        },
+        { signal },
+      );
+
+      document.addEventListener(
+        "pointerdown",
+        (event) => {
+          if (!menu.contains(event.target as Node)) setOpen(false);
+        },
+        { signal },
+      );
+      document.addEventListener(
+        "keydown",
+        (event) => {
+          if (event.key === "Escape") {
+            setOpen(false);
+            trigger.focus();
+          }
+        },
+        { signal },
+      );
+    };
+
+    // Optimistic: same cache key as account/admin shells.
+    const cached = readCachedSessionUser();
+    if (cached) paintUser(cached);
+
+    void getSession(origin).then((result) => {
+      if (result.kind === "unavailable") {
+        paintUnavailable();
+        return;
+      }
+      if (result.kind !== "signed_in") {
+        clearCachedSessionUser();
+        paintSignedOut();
+        return;
+      }
+      writeCachedSessionUser(result.session.user);
+      paintUser(result.session.user);
+    });
+  }
 </script>
 
 <style>
   .auth-indicator {
     display: inline-flex;
     align-items: center;
-    font-size: 12.5px;
-    font-family: "Geist Mono Variable", ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
-    color: var(--muted, #7d7d77);
-    /* Reserves horizontal space so "…" -> "sign in" / email causes no
-       reflow of anything to its right. */
-    min-width: 3.5em;
-    text-align: right;
+    position: relative;
+  }
+  .auth-indicator__slot {
+    display: inline-flex;
+    align-items: center;
+    min-height: 32px;
+  }
+  .auth-indicator__skeleton {
+    display: block;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: var(--panel, #121214);
+    border: 1px solid var(--line, #232327);
+  }
+  .auth-indicator__muted {
+    font: 12px var(--mono, ui-monospace, monospace);
+    color: var(--muted, #8a8a83);
+  }
+  .auth-indicator :global(.auth-indicator__signin) {
+    text-decoration: none;
     white-space: nowrap;
   }
-  .auth-indicator .slot {
+
+  .auth-indicator :global(.auth-menu) {
+    position: relative;
+  }
+  .auth-indicator :global(.auth-menu__trigger) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    border-radius: 999px;
+  }
+  .auth-indicator :global(.auth-menu__trigger:focus-visible) {
+    outline: 2px solid var(--accent, #c27eff);
+    outline-offset: 2px;
+  }
+  .auth-indicator :global(.auth-menu__avatar) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: var(--panel, #121214);
+    border: 1px solid var(--line, #232327);
+    color: var(--accent, #c27eff);
+    font: 600 11px/1 var(--mono, ui-monospace, monospace);
+    letter-spacing: 0.04em;
+    user-select: none;
+  }
+  .auth-indicator :global(.auth-menu__trigger:hover .auth-menu__avatar),
+  .auth-indicator :global(.auth-menu__trigger[aria-expanded="true"] .auth-menu__avatar) {
+    border-color: var(--accent, #c27eff);
+  }
+  .auth-indicator :global(.auth-menu__panel) {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: 40;
+    min-width: 200px;
+    padding: 6px;
+    background: var(--panel, #121214);
+    border: 1px solid var(--line, #232327);
+    border-radius: var(--radius-md, 8px);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  }
+  .auth-indicator :global(.auth-menu__meta) {
+    padding: 8px 10px 10px;
+    border-bottom: 1px solid var(--line, #232327);
+    margin-bottom: 4px;
+  }
+  .auth-indicator :global(.auth-menu__email) {
+    display: block;
+    font: 12px var(--mono, ui-monospace, monospace);
+    color: var(--muted, #8a8a83);
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
     max-width: 220px;
   }
-  .auth-indicator :global(a) {
-    color: var(--muted, #7d7d77);
-    text-decoration: none;
+  .auth-indicator :global(.auth-menu__list),
+  .auth-indicator :global(.auth-menu__foot) {
+    display: grid;
+    gap: 1px;
   }
-  .auth-indicator :global(a:hover),
-  .auth-indicator :global(a:focus-visible) {
+  .auth-indicator :global(.auth-menu__foot) {
+    margin-top: 4px;
+    padding-top: 4px;
+    border-top: 1px solid var(--line, #232327);
+  }
+  .auth-indicator :global(.auth-menu__item) {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 10px;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    color: var(--fg, #ececea);
+    font: 13px var(--sans, system-ui, sans-serif);
+    text-decoration: none;
+    cursor: pointer;
+  }
+  .auth-indicator :global(.auth-menu__item:hover),
+  .auth-indicator :global(.auth-menu__item:focus-visible) {
+    background: color-mix(in srgb, var(--accent, #c27eff) 12%, transparent);
     color: var(--accent, #c27eff);
     outline: none;
+  }
+  .auth-indicator :global(.auth-menu__signout) {
+    color: var(--muted, #8a8a83);
+  }
+  .auth-indicator :global(.auth-menu__signout:hover),
+  .auth-indicator :global(.auth-menu__signout:focus-visible) {
+    color: var(--red, #d98a9c);
+    background: color-mix(in srgb, var(--red, #d98a9c) 10%, transparent);
   }
 </style>

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -1,12 +1,14 @@
 ---
 /**
- * Canonical top-of-page header for content pages (landing, docs, guides):
- * <Brand /> on the left, optional GitHub star CTA + <AuthIndicator /> on the
- * right. Single source of truth so the star SVG and the header row aren't
- * duplicated per page — mirrors how <Footer /> standardizes the bottom.
+ * Canonical site header — full-viewport bar used across layouts (landing,
+ * docs, legal, signed-in account/admin, errors). Matches the releases/either
+ * pattern: the chrome spans the viewport edge-to-edge with a bottom border;
+ * page content below keeps its own max-width column.
  *
- * Centered-card pages (login, errors) keep their own `.brandbar` treatment;
- * signed-in shells (account/admin/console) keep their session headers.
+ * Left: <Brand /> + optional badge. Right: optional GitHub star +
+ * <AuthIndicator /> (solid Sign in CTA, or avatar menu when signed in).
+ *
+ * Centered auth cards (login, device, invite, consent) omit this header.
  */
 import AuthIndicator from "./AuthIndicator.astro";
 import Brand from "./Brand.astro";
@@ -14,29 +16,40 @@ import Brand from "./Brand.astro";
 interface Props {
   /** Show the "Star on GitHub" CTA with the live star count. */
   star?: boolean;
-  /** Render the sign-in/session indicator (requires the auth origin). */
+  /** Render the sign-in CTA / avatar menu (requires the auth origin). */
   authOrigin?: string;
+  /** Small pill next to the brand (e.g. "admin", "console"). */
+  badge?: string;
 }
 
-const { star = false, authOrigin } = Astro.props;
+const { star = false, authOrigin, badge } = Astro.props;
 const REPO = "https://github.com/buildinternet/uploads";
 ---
 
-<div class:list={["site-header", { "no-star": !star }]}>
-  <Brand />
-  {
-    star && (
-      <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-        </svg>
-        Star on GitHub
-        <span class="count" id="star-count" />
-      </a>
-    )
-  }
-  {authOrigin && <AuthIndicator authOrigin={authOrigin} />}
-</div>
+<header class="site-header">
+  <div class="site-header__inner">
+    <div class="site-header__start">
+      <Brand />
+      {badge ? <span class="site-header__badge">{badge}</span> : null}
+    </div>
+
+    <div class="site-header__end">
+      {
+        star && (
+          <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+              <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+            </svg>
+            Star on GitHub
+            <span class="count" id="star-count" />
+          </a>
+        )
+      }
+      {authOrigin ? <AuthIndicator authOrigin={authOrigin} /> : null}
+      <slot name="end" />
+    </div>
+  </div>
+</header>
 
 {
   star && (
@@ -69,29 +82,61 @@ const REPO = "https://github.com/buildinternet/uploads";
 }
 
 <style>
+  /* Full-bleed bar: sits outside page max-width columns (releases/either). */
   .site-header {
+    width: 100%;
+    border-bottom: 1px solid var(--line, #232327);
+    background: var(--bg, #0c0c0e);
+  }
+  .site-header__inner {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    width: 100%;
+    padding: 14px 24px;
+    box-sizing: border-box;
+  }
+  .site-header__start {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+  }
+  .site-header__end {
+    display: inline-flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 12px;
-    margin-bottom: 6px;
+    margin-left: auto;
+  }
+  .site-header__badge {
+    display: inline-block;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent, #c27eff);
+    border: 1px solid var(--line, #232327);
+    border-radius: 99px;
+    padding: 2px 9px;
+    background: var(--bg, #0c0c0e);
   }
   .star-cta {
-    margin-left: auto;
     display: inline-flex;
     align-items: center;
     gap: 7px;
-    color: var(--fg);
+    color: var(--fg, #e8e8e3);
     text-decoration: none;
-    font: 12.5px var(--mono);
-    border: 1px solid var(--line);
-    border-radius: var(--radius-sm);
+    font: 12.5px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
+    border: 1px solid var(--line, #232327);
+    border-radius: var(--radius-sm, 6px);
     padding: 6px 11px;
-    background: var(--panel);
+    background: var(--panel, #121214);
   }
   .star-cta:hover,
   .star-cta:focus-visible {
-    border-color: var(--accent);
+    border-color: var(--accent, #c27eff);
     outline: none;
   }
   .star-cta svg {
@@ -100,19 +145,18 @@ const REPO = "https://github.com/buildinternet/uploads";
     fill: currentColor;
   }
   .star-cta .count {
-    color: var(--muted);
-    border-left: 1px solid var(--line);
+    color: var(--muted, #7d7d77);
+    border-left: 1px solid var(--line, #232327);
     padding-left: 7px;
     font-variant-numeric: tabular-nums;
   }
   .star-cta .count:empty {
     display: none;
   }
-  /* When the star CTA is absent, the auth indicator holds the right edge. */
-  .site-header.no-star > :global(.auth-indicator) {
-    margin-left: auto;
-  }
   @media (max-width: 420px) {
+    .site-header__inner {
+      padding: 12px 16px;
+    }
     .star-cta .count {
       display: none;
     }

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -14,8 +14,8 @@ import {
   signedInCsp,
 } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
-import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
+import SiteHeader from "../components/SiteHeader.astro";
 import "../styles/signed-in-shell.css";
 import "../styles/account-content.css";
 
@@ -57,16 +57,17 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
   <title>{docTitle}</title>
 </head>
 <body>
-<div class="shell">
   <h1 class="sr-only">{pageHeading}</h1>
-  <div id="checking" class="ul-callout status" role="status">Checking your session…</div>
+  <div id="checking" class="shell-status">
+    <div class="ul-callout status" role="status">Checking your session…</div>
+  </div>
 
-  <div id="signed-out" hidden>
+  <div id="signed-out" class="shell-status" hidden>
     <div class="ul-callout status" data-state="error" role="alert">You're not signed in.</div>
     <a class="button" href="/login">Sign in</a>
   </div>
 
-  <div id="auth-unavailable" hidden>
+  <div id="auth-unavailable" class="shell-status" hidden>
     <div class="status" data-state="denied" role="alert">
       Authentication is temporarily unavailable. Check the local stack or try again.
     </div>
@@ -74,70 +75,68 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
   </div>
 
   <div id="app" hidden>
-    <header class="top">
-      <Brand />
-      <span class="who" id="who"></span>
-    </header>
+    <SiteHeader authOrigin={authOrigin} />
 
-    <div class="layout">
-      <nav class="side" aria-label="Account sections">
-        <a
-          href="/account"
-          aria-current={section === "overview" ? "page" : undefined}
-        >
-          Overview
-        </a>
-
-        <div class="side-group">
+    <div class="shell">
+      <div class="layout">
+        <nav class="side" aria-label="Account sections">
           <a
-            href="/account/workspaces"
-            class="side-parent"
-            aria-current={workspacesParentCurrent ? "page" : undefined}
+            href="/account"
+            aria-current={section === "overview" ? "page" : undefined}
           >
-            Workspaces
+            Overview
           </a>
-          <div class="side-nested">
-            <div id="workspaces-nav-list" class="side-nested-list" aria-label="Your workspaces">
-              {/* Filled client-side after session + /me/workspaces. */}
-            </div>
+
+          <div class="side-group">
             <a
-              href="/account/workspaces/new"
-              class="side-nested-item side-new"
-              aria-current={creating ? "page" : undefined}
+              href="/account/workspaces"
+              class="side-parent"
+              aria-current={workspacesParentCurrent ? "page" : undefined}
             >
-              + New workspace
+              Workspaces
             </a>
+            <div class="side-nested">
+              <div id="workspaces-nav-list" class="side-nested-list" aria-label="Your workspaces">
+                {/* Filled client-side after session + /me/workspaces. */}
+              </div>
+              <a
+                href="/account/workspaces/new"
+                class="side-nested-item side-new"
+                aria-current={creating ? "page" : undefined}
+              >
+                + New workspace
+              </a>
+            </div>
           </div>
+
+          <a
+            href="/account/profile"
+            aria-current={section === "profile" ? "page" : undefined}
+          >
+            Account
+          </a>
+          <a
+            href="/account/developers"
+            aria-current={section === "developers" ? "page" : undefined}
+          >
+            Developers
+          </a>
+
+          <div class="side-foot">
+            {showConsoleLinks ? <a href="/console">console →</a> : null}
+            <a href="/admin" id="admin-link" hidden>admin →</a>
+            <button type="button" id="sign-out-btn">Sign out</button>
+          </div>
+        </nav>
+
+        <div class="content">
+          <slot />
         </div>
-
-        <a
-          href="/account/profile"
-          aria-current={section === "profile" ? "page" : undefined}
-        >
-          Account
-        </a>
-        <a
-          href="/account/developers"
-          aria-current={section === "developers" ? "page" : undefined}
-        >
-          Developers
-        </a>
-
-        <div class="side-foot">
-          {showConsoleLinks ? <a href="/console">console →</a> : null}
-          <a href="/admin" id="admin-link" hidden>admin →</a>
-          <button type="button" id="sign-out-btn">Sign out</button>
-        </div>
-      </nav>
-
-      <div class="content">
-        <slot />
       </div>
-    </div>
 
-    <Footer />
+      <Footer />
+    </div>
   </div>
-</div>
 
 {/* Sync optimistic paint: show the shell before deferred modules run so
     /account → /account/workspaces does not flash "Checking your session…".
@@ -152,11 +151,9 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
       if (!user || !user.email) return;
       var checking = document.getElementById("checking");
       var app = document.getElementById("app");
-      var who = document.getElementById("who");
       var adminLink = document.getElementById("admin-link");
       if (checking) checking.hidden = true;
       if (app) app.hidden = false;
-      if (who) who.textContent = user.email;
       if (adminLink && user.role === "admin") adminLink.hidden = false;
       window.__uploadsSessionUser = user;
     } catch (e) {}
@@ -197,7 +194,6 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
     denied: requireElement<HTMLElement>("#signed-out", "account"),
     unavailable: requireElement<HTMLElement>("#auth-unavailable", "account"),
     app: requireElement<HTMLElement>("#app", "account"),
-    who: requireElement<HTMLElement>("#who", "account"),
   }).then((result) => {
     requireElement<HTMLElement>("#admin-link", "account").hidden =
       result?.user.role !== "admin";

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -12,8 +12,8 @@ import {
   signedInCsp,
 } from "../lib/signed-in-page";
 import BaseHead from "../components/BaseHead.astro";
-import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
+import SiteHeader from "../components/SiteHeader.astro";
 import "../styles/signed-in-shell.css";
 
 export type AdminSection = "workspaces" | "users";
@@ -47,16 +47,17 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
   <title>{docTitle}</title>
 </head>
 <body>
-<div class="shell">
   <h1 class="sr-only">{titles[section]}</h1>
-  <div id="checking" class="ul-callout status" role="status">Checking your session…</div>
+  <div id="checking" class="shell-status">
+    <div class="ul-callout status" role="status">Checking your session…</div>
+  </div>
 
-  <div id="denied" hidden>
+  <div id="denied" class="shell-status" hidden>
     <div class="ul-callout status" data-state="error" role="alert">You need admin access to view this page.</div>
     <a class="button" href="/login">Sign in</a>
   </div>
 
-  <div id="auth-unavailable" hidden>
+  <div id="auth-unavailable" class="shell-status" hidden>
     <div class="status" data-state="denied" role="alert">
       Authentication is temporarily unavailable. Check the local stack or try again.
     </div>
@@ -71,36 +72,34 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
     over the AUTH service binding on every request.
   -->
   <div id="dashboard" hidden>
-    <header class="top">
-      <div class="lockup"><Brand /><span class="pill">admin</span></div>
-      <span class="who" id="who"></span>
-    </header>
+    <SiteHeader badge="admin" authOrigin={authOrigin} />
 
-    <div class="layout">
-      <nav class="side" aria-label="Admin sections">
-        {nav.map((item) => (
-          <a
-            href={item.href}
-            aria-current={item.section === section ? "page" : undefined}
-          >
-            {item.label}
-          </a>
-        ))}
-        <div class="side-foot">
-          <a href="/account">← account</a>
-          {showConsoleLinks ? <a href="/console">console →</a> : null}
-          <button type="button" id="sign-out-btn">Sign out</button>
+    <div class="shell">
+      <div class="layout">
+        <nav class="side" aria-label="Admin sections">
+          {nav.map((item) => (
+            <a
+              href={item.href}
+              aria-current={item.section === section ? "page" : undefined}
+            >
+              {item.label}
+            </a>
+          ))}
+          <div class="side-foot">
+            <a href="/account">← account</a>
+            {showConsoleLinks ? <a href="/console">console →</a> : null}
+            <button type="button" id="sign-out-btn">Sign out</button>
+          </div>
+        </nav>
+
+        <div class="content">
+          <slot />
         </div>
-      </nav>
-
-      <div class="content">
-        <slot />
       </div>
-    </div>
 
-    <Footer />
+      <Footer />
+    </div>
   </div>
-</div>
 
 {/* Sync optimistic paint for admins only — same cache key as account-shell. */}
 <script is:inline>
@@ -112,10 +111,8 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
       if (!user || !user.email || user.role !== "admin") return;
       var checking = document.getElementById("checking");
       var app = document.getElementById("dashboard");
-      var who = document.getElementById("who");
       if (checking) checking.hidden = true;
       if (app) app.hidden = false;
-      if (who) who.textContent = user.email;
       window.__uploadsSessionUser = user;
     } catch (e) {}
   })();
@@ -145,7 +142,6 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
     denied: requireElement<HTMLElement>("#denied", "admin"),
     unavailable: requireElement<HTMLElement>("#auth-unavailable", "admin"),
     app: requireElement<HTMLElement>("#dashboard", "admin"),
-    who: requireElement<HTMLElement>("#who", "admin"),
     requireRole: "admin",
   });
 

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -82,19 +82,23 @@ const fullTitle = `${title} · uploads.sh`;
         color: var(--fg);
         font: 15.5px/1.7 var(--sans);
         padding: 0;
+        display: flex;
+        flex-direction: column;
       }
 
-      /* ---------- shell + three-column grid ---------- */
+      /* ---------- shell + three-column grid ----------
+         SiteHeader is full-bleed above; content column is constrained. */
       .docs-shell {
         width: min(1120px, 100%);
         margin: 0 auto;
-        padding: 40px 24px 64px;
+        padding: 32px 24px 64px;
+        flex: 1;
       }
       .docs-grid {
         display: flex;
         align-items: flex-start;
         gap: 44px;
-        margin-top: 28px;
+        margin-top: 8px;
       }
       main.docs-main { flex: 1 1 auto; min-width: 0; max-width: 720px; }
       main.docs-main > h1 {
@@ -462,9 +466,9 @@ const fullTitle = `${title} · uploads.sh`;
     </style>
   </head>
   <body>
-    <div class="docs-shell">
-      <SiteHeader star authOrigin={authOrigin} />
+    <SiteHeader star authOrigin={authOrigin} />
 
+    <div class="docs-shell">
       <div class="docs-grid">
         <nav class="docs-side" aria-label="Docs navigation">
           {

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -1,11 +1,12 @@
 ---
 /**
  * Shared shell for Astro status pages (404 missing route, 500 application error).
- * Same flat panel + titlebar treatment as the landing terminal.
+ * Full-bleed SiteHeader + centered card body (same panel + titlebar treatment
+ * as the landing terminal).
  */
 import BaseHead from "../components/BaseHead.astro";
-import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
+import SiteHeader from "../components/SiteHeader.astro";
 
 interface Props {
   status: number;
@@ -32,12 +33,18 @@ const { status, title, message, hint } = Astro.props;
         background: var(--bg);
         color: var(--fg);
         font: 14.5px/1.65 var(--mono);
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        flex: 1;
         display: grid;
         place-items: center;
         padding: 28px;
+        width: 100%;
+        box-sizing: border-box;
       }
-      main { width: min(var(--width-card, 480px), 100%); }
-      .brandbar { display: flex; justify-content: center; margin-bottom: 18px; }
+      .card-wrap { width: min(var(--width-card, 480px), 100%); }
       .card {
         background: var(--panel);
         border: 1px solid var(--line);
@@ -80,23 +87,11 @@ const { status, title, message, hint } = Astro.props;
       }
       .actions {
         margin-top: 22px;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 10px;
       }
-      a {
-        color: var(--fg);
-        text-decoration: underline;
-        text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
-        text-underline-offset: 3px;
-      }
-      a:hover,
-      a:focus-visible { color: var(--accent); outline: none; }
       .home {
         display: inline-block;
-        font: 12.5px var(--mono);
-        letter-spacing: 0.04em;
-        color: var(--fg);
+        font: 12px var(--mono);
+        color: var(--muted);
         background: var(--bg);
         border: 1px solid var(--line);
         border-radius: var(--radius-sm);
@@ -112,24 +107,26 @@ const { status, title, message, hint } = Astro.props;
     </style>
   </head>
   <body>
+    <SiteHeader />
     <main>
-      <div class="brandbar"><Brand /></div>
-      <section class="card" aria-labelledby="error-title">
-        <div class="titlebar" aria-hidden="true">
-          <span>uploads.sh — error</span>
-          <span>{status}</span>
-        </div>
-        <div class="body">
-          <p class="status" aria-hidden="true">{status}</p>
-          <h1 id="error-title">{title}</h1>
-          <p>{message}</p>
-          {hint ? <p class="hint">{hint}</p> : null}
-          <div class="actions">
-            <a class="home" href="/">← home</a>
+      <div class="card-wrap">
+        <section class="card" aria-labelledby="error-title">
+          <div class="titlebar" aria-hidden="true">
+            <span>uploads.sh — error</span>
+            <span>{status}</span>
           </div>
-        </div>
-      </section>
-      <Footer compact />
+          <div class="body">
+            <p class="status" aria-hidden="true">{status}</p>
+            <h1 id="error-title">{title}</h1>
+            <p>{message}</p>
+            {hint ? <p class="hint">{hint}</p> : null}
+            <div class="actions">
+              <a class="home" href="/">← home</a>
+            </div>
+          </div>
+        </section>
+        <Footer compact />
+      </div>
     </main>
   </body>
 </html>

--- a/apps/web/src/layouts/LegalLayout.astro
+++ b/apps/web/src/layouts/LegalLayout.astro
@@ -1,9 +1,10 @@
 ---
 // Shared shell for the static legal pages (/terms, /privacy). Same flat dark
 // palette and Geist type as the landing page, tuned for long-form prose.
+// Full-bleed SiteHeader (releases/either pattern); article column is constrained.
 import BaseHead from "../components/BaseHead.astro";
-import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
+import SiteHeader from "../components/SiteHeader.astro";
 
 interface Props {
 	title: string;
@@ -11,6 +12,9 @@ interface Props {
 	path: string;
 }
 const { title, description, path } = Astro.props;
+
+// Static page — auth origin is baked at build time (see src/lib/auth-client.ts).
+const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
 ---
 
 <html lang="en">
@@ -27,16 +31,22 @@ const { title, description, path } = Astro.props;
         background: var(--bg);
         color: var(--fg);
         font: 15.5px/1.7 var(--sans);
-        padding: 40px 24px 64px;
+        display: flex;
+        flex-direction: column;
       }
-      main { width: min(var(--width-content, 720px), 100%); margin: 0 auto; }
-      .brandbar { margin-bottom: 30px; }
+      main {
+        width: min(var(--width-content, 720px), 100%);
+        margin: 0 auto;
+        padding: 32px 24px 64px;
+        flex: 1;
+        box-sizing: border-box;
+      }
       h1 {
         font-size: clamp(26px, 5vw, 34px);
         font-weight: 600;
         letter-spacing: -0.015em;
         line-height: 1.25;
-        margin: 20px 0 4px;
+        margin: 8px 0 4px;
       }
       .effective { color: var(--muted); font-size: 13px; margin: 0 0 36px; }
       article h2 {
@@ -71,8 +81,8 @@ const { title, description, path } = Astro.props;
     </style>
   </head>
   <body>
+    <SiteHeader authOrigin={authOrigin} />
     <main>
-      <div class="brandbar"><Brand /></div>
       <article>
         <slot />
       </article>

--- a/apps/web/src/lib/account-shell.test.ts
+++ b/apps/web/src/lib/account-shell.test.ts
@@ -112,7 +112,30 @@ describe("resolveSessionGate", () => {
     );
     expect(values.get("uploads:sessionUser")).toContain(session.user.email);
     expect(options.app.hidden).toBe(false);
+    // Optional #who email paint (legacy); avatar menu no longer needs it.
     expect(options.who.textContent).toBe(session.user.email);
     expect(window.dispatchEvent).toHaveBeenCalledOnce();
+  });
+
+  it("shows the app without a who node when the header owns session UI", async () => {
+    installBrowser();
+    const options = {
+      authOrigin: "http://127.0.0.1:8788",
+      checking: element(),
+      denied: element(),
+      unavailable: element(),
+      app: element(),
+    };
+    auth.getSession.mockResolvedValue({
+      kind: "signed_in",
+      session: {
+        session: {},
+        user: { id: "user", email: "user@example.com", name: "User", role: "user" },
+      },
+    });
+
+    await expect(resolveSessionGate(options)).resolves.not.toBeNull();
+    expect(options.app.hidden).toBe(false);
+    expect(options.checking.hidden).toBe(true);
   });
 });

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -64,14 +64,19 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         background: var(--bg);
         color: var(--fg);
         font: 14.5px/1.65 var(--mono);
-        display: grid;
-        justify-items: center;
-        padding: 40px 24px 64px;
+        display: flex;
+        flex-direction: column;
+        padding: 0;
       }
+      /* SiteHeader is full-bleed; main keeps the reading column. */
       main {
         width: min(var(--width-content, 720px), 100%);
+        margin: 0 auto;
+        padding: 32px 24px 64px;
         display: grid;
         gap: 18px;
+        box-sizing: border-box;
+        flex: 1;
       }
       .hidden { visibility: hidden; }
       @media (prefers-reduced-motion: reduce) {
@@ -443,9 +448,8 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     </style>
   </head>
   <body>
+    <SiteHeader star authOrigin={authOrigin} />
     <main>
-      <SiteHeader star authOrigin={authOrigin} />
-
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
       <p class="lede">
         GitHub has no real way for an agent to show their work. <code>uploads attach</code> puts

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -42,10 +42,20 @@ code {
   display: none !important;
 }
 
-/* Sticky footer (signed-in shells only): body/shell are flex columns;
-   #app / #dashboard grow; .layout takes free space so content stays top-
-   aligned and the footer sits at the viewport bottom when the page is short.
-   When content is taller than the viewport, the footer scrolls after it. */
+/* Sticky footer (signed-in shells only): body is a flex column; #app /
+   #dashboard grow as full-width columns. SiteHeader is full-bleed at the
+   top; .shell is the constrained content column below it. .layout takes
+   free space so content stays top-aligned and the footer sits at the
+   viewport bottom when the page is short. When content is taller than the
+   viewport, the footer scrolls after it. */
+#app,
+#dashboard {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+}
 .shell {
   flex: 1;
   display: flex;
@@ -56,31 +66,18 @@ code {
   padding: 28px 20px 28px;
   box-sizing: border-box;
 }
-#app,
-#dashboard {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+/* Pre-auth status blocks (checking / signed-out / denied) stay in a
+   narrow centered column so they don't stretch edge-to-edge. */
+.shell-status {
+  width: 100%;
+  max-width: var(--width-shell, 960px);
+  margin: 0 auto;
+  padding: 28px 20px;
+  box-sizing: border-box;
 }
-#app > .layout,
-#dashboard > .layout {
+#app > .shell > .layout,
+#dashboard > .shell > .layout {
   flex: 1 0 auto;
-}
-header.top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 22px;
-}
-header.top .lockup {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
-}
-header.top .who {
-  color: var(--muted);
-  font-size: 12px;
 }
 /* Status blocks render as .ul-callout (DS); .status is the JS hook only. */
 .sr-only {


### PR DESCRIPTION
## In plain terms

The site header now spans the full viewport on the main page shells (like releases.sh / either), instead of living inside each page’s narrow content column. When you’re signed in, the email string is replaced by an avatar menu with links into account settings; when you’re signed out, Sign in is a solid primary button.

## What it does

- Makes `SiteHeader` a full-bleed bar with a bottom border across landing, docs, legal, account, admin, and error layouts
- Keeps page content in its existing max-width columns under the bar
- Replaces the logged-in email with an initials avatar + dropdown (Overview, Workspaces, Account, Developers, Admin when applicable, Sign out)
- Uses a solid primary **Sign in** CTA when signed out
- Leaves OAuth/login/device/invite/consent cards without the site header (centered brand only)

## What it is not

- Not a change to auth/session security — still cookie + server checks; the header is chrome only
- Does not restyle the centered auth cards

## How to try it

```bash
pnpm dev:web
```

Visit `/`, `/docs`, `/account`, and `/login`. Compare the header width and the avatar / Sign in control.

## Test plan

- [x] `pnpm --filter @uploads/web test` (127 passed)
- [ ] Visual check: full-bleed header on docs / landing / account
- [ ] Signed out: solid Sign in CTA opens `/login`
- [ ] Signed in: avatar menu reaches account sections and Sign out
- [ ] Login / OAuth consent still have no full site header