### PR TITLE
feat(auth,web): workspace picker at OAuth consent for multi-workspace users

### DIFF
--- a/apps/auth/migrations/20260718000000_oauth_workspace_choice.sql
+++ b/apps/auth/migrations/20260718000000_oauth_workspace_choice.sql
@@ -1,0 +1,14 @@
+-- Per-grant workspace choice (issue #231, auth side): stores a
+-- multi-workspace user's last explicit workspace pick for the OAuth 2.1
+-- authorization server. One row per user, keyed by user_id. Not a
+-- @better-auth/oauth-provider table -- read/written by
+-- src/workspace-choice.ts (see src/schema.ts:oauthWorkspaceChoice). Timestamps
+-- are integer epoch ms, matching every other hand-synced table in this
+-- schema (see migrations/20260717000000_oauth_provider.sql).
+
+CREATE TABLE oauth_workspace_choice (
+  user_id TEXT PRIMARY KEY,
+  workspace TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -24,6 +24,11 @@ import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import * as schema from "./schema";
 import { authTrustedOrigins, isTrustedOrigin } from "./trusted-origins";
 import {
+  applyWorkspaceChoice,
+  resolveWorkspaceChoiceReferenceId,
+  workspaceChoicePlugin,
+} from "./workspace-choice";
+import {
   resolveDashApiKey,
   resolveGitHubCredentials,
   resolveSigningSecret,
@@ -257,11 +262,33 @@ function buildAuth(
         // auditable and can't silently drift. Enforced only when Better
         // Auth's core rate limiter is on (see rateLimit below).
         rateLimit: { register: { window: 60, max: 5 } },
+        // Issue #231 (auth side): lets a multi-workspace user's consent (and
+        // the resulting tokens) be scoped to a specific workspace instead of
+        // always the oldest membership. The plugin recomputes this at
+        // authorize-time and filters its `oauth_consent` lookup by the
+        // returned string — a changed choice naturally re-triggers consent.
+        // `undefined` for 0/1-membership users preserves today's
+        // null-referenceId behavior (see src/workspace-choice.ts).
+        postLogin: {
+          // Never used: `shouldRedirect` below always returns false, so
+          // `/oauth2/authorize` never redirects here. The workspace picker
+          // itself lives on /oauth/consent (issue #231's web-side half);
+          // this is just the required sibling field the plugin's types
+          // demand alongside `consentReferenceId`.
+          page: `${webOrigin}/oauth/consent`,
+          consentReferenceId: ({ user }) => resolveWorkspaceChoiceReferenceId(db, user?.id),
+          shouldRedirect: () => false,
+        },
         // member ⋈ organization, oldest membership wins for `workspace`; all
-        // slugs ride along in `workspaces` for a future workspace picker
-        // (design doc: "deferred"). Zero memberships still issues a token
-        // (workspace: null) — the MCP worker is responsible for the 403.
-        customAccessTokenClaims: async ({ user }) => resolveWorkspaceClaims(db, user?.id),
+        // slugs ride along in `workspaces`. Issue #231 (auth side): when
+        // `referenceId` is one of ours (`ws:<slug>`, see
+        // postLogin.consentReferenceId above) and `<slug>` is still one of
+        // the user's workspaces, it overrides the oldest-membership default
+        // — the user's per-grant choice wins. Zero memberships still issues
+        // a token (workspace: null) — the MCP worker is responsible for the
+        // 403.
+        customAccessTokenClaims: async ({ user, referenceId }) =>
+          applyWorkspaceChoice(await resolveWorkspaceClaims(db, user?.id), referenceId),
       }),
       // D5/Phase 4: bearer() lets the CLI present the device-flow session token
       // as `Authorization: Bearer <token>` so apps/api's session verification
@@ -293,6 +320,10 @@ function buildAuth(
         verificationUri: `${webOrigin}/device`,
         validateClient: (clientId) => clientId === UPLOADS_CLI_CLIENT_ID,
       }),
+      // Issue #231 (auth side): POST /oauth2/workspace-choice, letting a
+      // signed-in multi-workspace user record which workspace an OAuth grant
+      // should operate on (read back by postLogin.consentReferenceId above).
+      workspaceChoicePlugin(db),
       // Hosted dashboard (`@better-auth/infra`). Omit when the API key is unset.
       ...(dashApiKey ? [dash({ apiKey: dashApiKey })] : []),
       // This endpoint is omitted entirely unless the lifecycle runner supplies

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -375,6 +375,26 @@ export const oauthConsent = sqliteTable(
 );
 
 /**
+ * Per-grant workspace choice (issue #231, auth side): the user's last
+ * explicit workspace pick for the OAuth 2.1 authorization server, one row per
+ * user. Custom table (not part of `@better-auth/oauth-provider`) — read by
+ * `resolveWorkspaceChoiceReferenceId` (src/workspace-choice.ts) to build the
+ * `postLogin.consentReferenceId` the plugin ties to `oauth_consent` rows, and
+ * written by `POST /api/auth/oauth2/workspace-choice`. Single-workspace users
+ * never get a row (the hook returns `undefined` for them, see
+ * src/workspace-choice.ts) so this table only ever holds multi-workspace
+ * users' picks.
+ *
+ * Paired migration: `migrations/20260718000000_oauth_workspace_choice.sql`.
+ */
+export const oauthWorkspaceChoice = sqliteTable("oauth_workspace_choice", {
+  userId: text("user_id").primaryKey(),
+  workspace: text("workspace").notNull(),
+  createdAt: timestampCol("created_at"),
+  updatedAt: timestampCol("updated_at"),
+});
+
+/**
  * Drizzle relations for Better Auth `experimental.joins` (adapter needs these
  * on the same schema object as the tables). No SQL/migration impact.
  *
@@ -451,3 +471,4 @@ export type AuthMember = typeof member.$inferSelect;
 export type AuthInvitation = typeof invitation.$inferSelect;
 export type AuthDeviceCode = typeof deviceCode.$inferSelect;
 export type AuthOauthClient = typeof oauthClient.$inferSelect;
+export type AuthOauthWorkspaceChoice = typeof oauthWorkspaceChoice.$inferSelect;

--- a/apps/auth/src/workspace-choice.test.ts
+++ b/apps/auth/src/workspace-choice.test.ts
@@ -138,6 +138,68 @@ describe("POST /oauth2/workspace-choice", () => {
   });
 });
 
+function requestWorkspaceChoiceGet(env: AuthEnv, sessionToken?: string) {
+  return app.request(
+    "/api/auth/oauth2/workspace-choice",
+    {
+      method: "GET",
+      headers: sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {},
+    },
+    env,
+  );
+}
+
+describe("GET /oauth2/workspace-choice", () => {
+  it("401s when unauthenticated", async () => {
+    const res = await requestWorkspaceChoiceGet(dbEnv());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns { workspace: null } for a user with zero memberships", async () => {
+    const env = dbEnv();
+    const { sessionToken } = await seedSignedInUser(env);
+    const res = await requestWorkspaceChoiceGet(env, sessionToken);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: null });
+  });
+
+  it("resolves to the oldest membership when no choice is stored", async () => {
+    const env = dbEnv();
+    const { sessionToken } = await seedSignedInUser(env, [
+      { slug: "beta", createdAt: new Date("2026-02-01T00:00:00Z") },
+      { slug: "acme", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const res = await requestWorkspaceChoiceGet(env, sessionToken);
+    expect(await res.json()).toEqual({ workspace: "acme" });
+  });
+
+  it("resolves to the stored choice while it is a live membership, else falls back", async () => {
+    const env = dbEnv();
+    const { userId, sessionToken } = await seedSignedInUser(env, [
+      { slug: "acme", createdAt: new Date("2026-01-01T00:00:00Z") },
+      { slug: "beta", createdAt: new Date("2026-02-01T00:00:00Z") },
+    ]);
+    const orm = drizzle(env.DB, { schema });
+    await orm.insert(schema.oauthWorkspaceChoice).values({
+      userId,
+      workspace: "beta",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const res = await requestWorkspaceChoiceGet(env, sessionToken);
+    expect(await res.json()).toEqual({ workspace: "beta" });
+
+    // Stale choice (membership gone) falls back to the oldest live one.
+    await orm
+      .update(schema.oauthWorkspaceChoice)
+      .set({ workspace: "departed-org" })
+      .where(eq(schema.oauthWorkspaceChoice.userId, userId));
+    const res2 = await requestWorkspaceChoiceGet(env, sessionToken);
+    expect(await res2.json()).toEqual({ workspace: "acme" });
+  });
+});
+
 describe("resolveWorkspaceChoiceReferenceId", () => {
   it("returns undefined for an undefined user", async () => {
     const db = drizzle(createFakeD1(), { schema });

--- a/apps/auth/src/workspace-choice.test.ts
+++ b/apps/auth/src/workspace-choice.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Issue #231 (auth side): per-grant workspace choice. Covers the
+ * `POST /oauth2/workspace-choice` endpoint (driven against the real Better
+ * Auth handler via src/index.ts's `app`, same pattern as device.test.ts),
+ * the `resolveWorkspaceChoiceReferenceId` postLogin hook, and the
+ * `applyWorkspaceChoice` claims override — see src/workspace-choice.ts.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { app } from "./index";
+import * as schema from "./schema";
+import { createFakeD1 } from "./test/fake-d1";
+import { applyWorkspaceChoice, resolveWorkspaceChoiceReferenceId } from "./workspace-choice";
+
+function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://auth.uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+/** Seed a user + an active session, returning the raw session token to present as a bearer (pattern: device.test.ts). */
+async function seedSignedInUser(
+  env: AuthEnv,
+  orgSlugs: { slug: string; createdAt: Date }[] = [],
+): Promise<{ userId: string; sessionToken: string }> {
+  const orm = drizzle(env.DB, { schema });
+  const userId = crypto.randomUUID();
+  await orm.insert(schema.user).values({
+    id: userId,
+    name: "Ada Lovelace",
+    email: `ada-${userId}@example.com`,
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    role: "user",
+  });
+  const sessionToken = `sess-${crypto.randomUUID()}`;
+  await orm.insert(schema.session).values({
+    id: crypto.randomUUID(),
+    userId,
+    token: sessionToken,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  for (const { slug, createdAt } of orgSlugs) {
+    const orgId = crypto.randomUUID();
+    await orm.insert(schema.organization).values({ id: orgId, name: slug, slug, createdAt });
+    await orm.insert(schema.member).values({
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      userId,
+      role: "member",
+      createdAt,
+    });
+  }
+  return { userId, sessionToken };
+}
+
+function requestWorkspaceChoice(env: AuthEnv, body: unknown, sessionToken?: string) {
+  return app.request(
+    "/api/auth/oauth2/workspace-choice",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("POST /oauth2/workspace-choice", () => {
+  it("401s when unauthenticated", async () => {
+    const res = await requestWorkspaceChoice(dbEnv(), { workspace: "acme" });
+    expect(res.status).toBe(401);
+  });
+
+  it("400s with code invalid_workspace for a non-membership slug", async () => {
+    const env = dbEnv();
+    const { sessionToken } = await seedSignedInUser(env, [
+      { slug: "acme", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const res = await requestWorkspaceChoice(env, { workspace: "not-a-member-org" }, sessionToken);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("invalid_workspace");
+  });
+
+  it("400s with code invalid_workspace for a missing/malformed body", async () => {
+    const env = dbEnv();
+    const { sessionToken } = await seedSignedInUser(env, [
+      { slug: "acme", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const res = await requestWorkspaceChoice(env, {}, sessionToken);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("invalid_workspace");
+  });
+
+  it("upserts the choice and returns { status: true } on a valid membership", async () => {
+    const env = dbEnv();
+    const { userId, sessionToken } = await seedSignedInUser(env, [
+      { slug: "acme", createdAt: new Date("2026-01-01T00:00:00Z") },
+      { slug: "beta", createdAt: new Date("2026-02-01T00:00:00Z") },
+    ]);
+
+    const res1 = await requestWorkspaceChoice(env, { workspace: "acme" }, sessionToken);
+    expect(res1.status).toBe(200);
+    expect(await res1.json()).toEqual({ status: true });
+
+    const orm = drizzle(env.DB, { schema });
+    const [row1] = await orm
+      .select()
+      .from(schema.oauthWorkspaceChoice)
+      .where(eq(schema.oauthWorkspaceChoice.userId, userId));
+    expect(row1?.workspace).toBe("acme");
+
+    // Re-picking updates the same row rather than inserting a second one.
+    const res2 = await requestWorkspaceChoice(env, { workspace: "beta" }, sessionToken);
+    expect(res2.status).toBe(200);
+
+    const rows = await orm
+      .select()
+      .from(schema.oauthWorkspaceChoice)
+      .where(eq(schema.oauthWorkspaceChoice.userId, userId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.workspace).toBe("beta");
+  });
+});
+
+describe("resolveWorkspaceChoiceReferenceId", () => {
+  it("returns undefined for an undefined user", async () => {
+    const db = drizzle(createFakeD1(), { schema });
+    expect(await resolveWorkspaceChoiceReferenceId(db, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for a user with zero memberships", async () => {
+    const env = dbEnv();
+    const { userId } = await seedSignedInUser(env, []);
+    const db = drizzle(env.DB, { schema });
+    expect(await resolveWorkspaceChoiceReferenceId(db, userId)).toBeUndefined();
+  });
+
+  it("returns undefined for a user with exactly one membership", async () => {
+    const env = dbEnv();
+    const { userId } = await seedSignedInUser(env, [
+      { slug: "solo-org", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const db = drizzle(env.DB, { schema });
+    expect(await resolveWorkspaceChoiceReferenceId(db, userId)).toBeUndefined();
+  });
+
+  it("returns ws:<oldest-slug> for a multi-workspace user with no stored choice", async () => {
+    const env = dbEnv();
+    const { userId } = await seedSignedInUser(env, [
+      { slug: "newer-org", createdAt: new Date("2026-02-01T00:00:00Z") },
+      { slug: "older-org", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const db = drizzle(env.DB, { schema });
+    expect(await resolveWorkspaceChoiceReferenceId(db, userId)).toBe("ws:older-org");
+  });
+
+  it("returns ws:<stored-choice> when the stored choice is still a live membership", async () => {
+    const env = dbEnv();
+    const { userId } = await seedSignedInUser(env, [
+      { slug: "newer-org", createdAt: new Date("2026-02-01T00:00:00Z") },
+      { slug: "older-org", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const db = drizzle(env.DB, { schema });
+    const now = new Date();
+    await db
+      .insert(schema.oauthWorkspaceChoice)
+      .values({ userId, workspace: "newer-org", createdAt: now, updatedAt: now });
+
+    expect(await resolveWorkspaceChoiceReferenceId(db, userId)).toBe("ws:newer-org");
+  });
+
+  it("falls back to the oldest membership when the stored choice is no longer a live membership", async () => {
+    const env = dbEnv();
+    const { userId } = await seedSignedInUser(env, [
+      { slug: "newer-org", createdAt: new Date("2026-02-01T00:00:00Z") },
+      { slug: "older-org", createdAt: new Date("2026-01-01T00:00:00Z") },
+    ]);
+    const db = drizzle(env.DB, { schema });
+    const now = new Date();
+    await db.insert(schema.oauthWorkspaceChoice).values({
+      userId,
+      workspace: "stale-org-no-longer-a-member",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    expect(await resolveWorkspaceChoiceReferenceId(db, userId)).toBe("ws:older-org");
+  });
+});
+
+describe("applyWorkspaceChoice", () => {
+  const claims = { workspace: "older-org", workspaces: ["older-org", "newer-org"] };
+
+  it("overrides workspace when referenceId names a workspace the user belongs to", () => {
+    expect(applyWorkspaceChoice(claims, "ws:newer-org")).toEqual({
+      workspace: "newer-org",
+      workspaces: ["older-org", "newer-org"],
+    });
+  });
+
+  it("ignores a referenceId for a workspace the user does not belong to", () => {
+    expect(applyWorkspaceChoice(claims, "ws:not-a-member-org")).toEqual(claims);
+  });
+
+  it("ignores an undefined referenceId", () => {
+    expect(applyWorkspaceChoice(claims, undefined)).toEqual(claims);
+  });
+
+  it("ignores a referenceId that isn't one of ours (no ws: prefix)", () => {
+    expect(applyWorkspaceChoice(claims, "some-other-reference")).toEqual(claims);
+  });
+});

--- a/apps/auth/src/workspace-choice.ts
+++ b/apps/auth/src/workspace-choice.ts
@@ -70,15 +70,35 @@ export async function resolveWorkspaceChoiceReferenceId(
   if (!userId) return undefined;
   const slugs = await membershipSlugs(db, userId);
   if (slugs.length <= 1) return undefined;
+  return `${WORKSPACE_REFERENCE_PREFIX}${await effectiveWorkspaceSlug(db, userId, slugs)}`;
+}
 
+/**
+ * The slug the AS would bake into a token minted right now: the stored
+ * choice if it's still a live membership, else the oldest membership. Shared
+ * by the consentReferenceId hook above and the GET endpoint below — the
+ * consent page's picker defaults to THIS value (fetched via GET) rather than
+ * guessing client-side, so an untouched picker never overwrites the stored
+ * choice or shifts the token's workspace.
+ *
+ * The choice row is deliberately keyed by user alone, not per client/grant:
+ * `postLogin.consentReferenceId` receives only `{user, session, scopes}` —
+ * no client id, no request context — so a per-client row could never be read
+ * back at authorize-time. Per-grant scoping still holds where it matters:
+ * the returned `ws:<slug>` is persisted on the consent row and baked into
+ * that grant's token rows, so concurrent grants don't share state after
+ * consent. The accepted residual is a same-user race across two
+ * simultaneously open consent tabs (seconds-wide, self-inflicted,
+ * recoverable via re-consent).
+ */
+async function effectiveWorkspaceSlug(db: Db, userId: string, slugs: string[]): Promise<string> {
   const [stored] = await db
     .select({ workspace: schema.oauthWorkspaceChoice.workspace })
     .from(schema.oauthWorkspaceChoice)
     .where(eq(schema.oauthWorkspaceChoice.userId, userId))
     .limit(1);
 
-  const slug = stored?.workspace && slugs.includes(stored.workspace) ? stored.workspace : slugs[0];
-  return `${WORKSPACE_REFERENCE_PREFIX}${slug}`;
+  return stored?.workspace && slugs.includes(stored.workspace) ? stored.workspace : slugs[0];
 }
 
 /**
@@ -119,6 +139,27 @@ export function workspaceChoicePlugin(db: Db) {
   return {
     id: "uploads-oauth-workspace-choice",
     endpoints: {
+      /**
+       * `GET /oauth2/workspace-choice` — the server-resolved effective
+       * workspace (`{ workspace: string | null }`): stored choice if still a
+       * live membership, else oldest membership, null for zero memberships.
+       * The consent page's picker defaults its selection to this so an
+       * untouched Allow round-trips the AS's own resolution instead of a
+       * client-side guess.
+       */
+      oauthWorkspaceChoiceGet: createAuthEndpoint(
+        "/oauth2/workspace-choice",
+        {
+          method: "GET",
+          use: [sessionMiddleware],
+        },
+        async (ctx) => {
+          const userId = ctx.context.session.user.id;
+          const slugs = await membershipSlugs(db, userId);
+          if (slugs.length === 0) return ctx.json({ workspace: null });
+          return ctx.json({ workspace: await effectiveWorkspaceSlug(db, userId, slugs) });
+        },
+      ),
       oauthWorkspaceChoice: createAuthEndpoint(
         "/oauth2/workspace-choice",
         {

--- a/apps/auth/src/workspace-choice.ts
+++ b/apps/auth/src/workspace-choice.ts
@@ -1,0 +1,173 @@
+/**
+ * Per-grant workspace choice (issue #231, auth side). Today
+ * `customAccessTokenClaims` (src/auth.ts) always bakes the OLDEST org
+ * membership into the JWT `workspace` claim — multi-workspace users get no
+ * say. This file adds:
+ *
+ *  - `resolveWorkspaceChoiceReferenceId`: the `postLogin.consentReferenceId`
+ *    hook (wired in src/auth.ts's `oauthProvider()` options). The plugin
+ *    recomputes this at authorize-time AND filters its `oauth_consent`
+ *    lookup by the returned string, and threads it through the auth code
+ *    into access/refresh token rows and into every
+ *    `customAccessTokenClaims({ referenceId, ... })` call (verified in the
+ *    plugin dist — see oauth-D74mBkw6.d.mts). Returning `undefined` for
+ *    single-workspace users keeps today's null-referenceId behavior — no
+ *    re-consent churn for the common case.
+ *  - `workspaceChoicePlugin`: a Better Auth plugin (pattern:
+ *    src/local-demo.ts) exposing `POST /oauth2/workspace-choice`, which lets
+ *    a signed-in multi-workspace user record which workspace they want an
+ *    OAuth grant to operate on. The web-side picker UI (issue #231's other
+ *    half) calls this before/at `/oauth/consent`.
+ *
+ * The picker UI lives on apps/web's /oauth/consent page — this file is only
+ * the AS-side plumbing.
+ */
+import { createAuthEndpoint, sessionMiddleware, APIError } from "better-auth/api";
+import { asc, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import * as schema from "./schema";
+
+/** Prefix distinguishing our workspace-scoped consent references from any other reference_id shape. */
+export const WORKSPACE_REFERENCE_PREFIX = "ws:";
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+
+/**
+ * `member` ⋈ `organization` slugs for a user, oldest membership first.
+ * Deliberately the same join + ordering as `resolveWorkspaceClaims` in
+ * src/auth.ts (kept as a separate query here rather than imported, since the
+ * two files evolve independently — this one only ever needs slugs, not the
+ * `{workspace, workspaces}` claims shape).
+ */
+async function membershipSlugs(db: Db, userId: string): Promise<string[]> {
+  const rows = await db
+    .select({ slug: schema.organization.slug })
+    .from(schema.member)
+    .innerJoin(schema.organization, eq(schema.member.organizationId, schema.organization.id))
+    .where(eq(schema.member.userId, userId))
+    .orderBy(asc(schema.member.createdAt), asc(schema.member.id));
+  return rows.map((r) => r.slug);
+}
+
+/**
+ * The `postLogin.consentReferenceId` hook. Exported for direct unit testing
+ * (see workspace-choice.test.ts), same rationale as `resolveWorkspaceClaims`
+ * in src/auth.ts — driving the full authorize→consent→token flow through the
+ * plugin to exercise this is comparatively heavy.
+ *
+ * - 0 or 1 memberships: returns `undefined` — single-workspace users keep
+ *   today's null-referenceId behavior, no picker, no re-consent churn.
+ * - 2+ memberships: returns `ws:<slug>`, where `<slug>` is the stored choice
+ *   if one exists AND is still a live membership, otherwise the oldest
+ *   membership. This deliberately forces one re-consent for existing
+ *   multi-workspace users the first time this ships (no stored choice yet),
+ *   which is when they see the picker for the first time.
+ */
+export async function resolveWorkspaceChoiceReferenceId(
+  db: Db,
+  userId: string | undefined,
+): Promise<string | undefined> {
+  if (!userId) return undefined;
+  const slugs = await membershipSlugs(db, userId);
+  if (slugs.length <= 1) return undefined;
+
+  const [stored] = await db
+    .select({ workspace: schema.oauthWorkspaceChoice.workspace })
+    .from(schema.oauthWorkspaceChoice)
+    .where(eq(schema.oauthWorkspaceChoice.userId, userId))
+    .limit(1);
+
+  const slug = stored?.workspace && slugs.includes(stored.workspace) ? stored.workspace : slugs[0];
+  return `${WORKSPACE_REFERENCE_PREFIX}${slug}`;
+}
+
+/**
+ * If `referenceId` is one of ours (`ws:<slug>`) and `<slug>` is one of the
+ * claims' known `workspaces`, override `workspace` with it. Used by
+ * `customAccessTokenClaims` in src/auth.ts. Defensive by construction: a
+ * referenceId for a workspace the user is no longer a member of (or isn't
+ * one of ours) is silently ignored rather than overriding anything — a token
+ * must always issue, and the caller's existing oldest-membership fallback
+ * still applies.
+ */
+export function applyWorkspaceChoice<T extends { workspace: string | null; workspaces: string[] }>(
+  claims: T,
+  referenceId: string | undefined,
+): T {
+  if (!referenceId || !referenceId.startsWith(WORKSPACE_REFERENCE_PREFIX)) return claims;
+  const slug = referenceId.slice(WORKSPACE_REFERENCE_PREFIX.length);
+  if (!claims.workspaces.includes(slug)) return claims;
+  return { ...claims, workspace: slug };
+}
+
+/**
+ * `POST /oauth2/workspace-choice` (mounted under the worker's `/api/auth`
+ * basePath, so the full path is `/api/auth/oauth2/workspace-choice`).
+ * Session-required. Body `{ workspace: string }`. Validates the slug is one
+ * of the signed-in user's org memberships (member ⋈ organization, same query
+ * as `resolveWorkspaceClaims`/`membershipSlugs` above); on success upserts
+ * the user's `oauth_workspace_choice` row and returns `{ status: true }`. A
+ * non-membership slug (or a malformed body) 400s with
+ * `code: "invalid_workspace"` rather than silently recording a workspace the
+ * user can't actually use.
+ *
+ * No zod body schema here — apps/auth has no direct `zod` dependency (only a
+ * transitive one via better-call/oauth-provider), so the body is validated
+ * by hand instead of pulling in a new direct dependency for one field.
+ */
+export function workspaceChoicePlugin(db: Db) {
+  return {
+    id: "uploads-oauth-workspace-choice",
+    endpoints: {
+      oauthWorkspaceChoice: createAuthEndpoint(
+        "/oauth2/workspace-choice",
+        {
+          method: "POST",
+          use: [sessionMiddleware],
+        },
+        async (ctx) => {
+          const userId = ctx.context.session.user.id;
+          const rawWorkspace = (ctx.body as { workspace?: unknown } | undefined)?.workspace;
+          if (typeof rawWorkspace !== "string" || rawWorkspace.length === 0) {
+            throw new APIError("BAD_REQUEST", {
+              code: "invalid_workspace",
+              message: "`workspace` must be a non-empty string.",
+            });
+          }
+          const workspace = rawWorkspace;
+
+          const slugs = await membershipSlugs(db, userId);
+          if (!slugs.includes(workspace)) {
+            throw new APIError("BAD_REQUEST", {
+              code: "invalid_workspace",
+              message: "You are not a member of that workspace.",
+            });
+          }
+
+          const now = new Date();
+          const [existing] = await db
+            .select({ userId: schema.oauthWorkspaceChoice.userId })
+            .from(schema.oauthWorkspaceChoice)
+            .where(eq(schema.oauthWorkspaceChoice.userId, userId))
+            .limit(1);
+
+          if (existing) {
+            await db
+              .update(schema.oauthWorkspaceChoice)
+              .set({ workspace, updatedAt: now })
+              .where(eq(schema.oauthWorkspaceChoice.userId, userId));
+          } else {
+            await db.insert(schema.oauthWorkspaceChoice).values({
+              userId,
+              workspace,
+              createdAt: now,
+              updatedAt: now,
+            });
+          }
+
+          return ctx.json({ status: true });
+        },
+      ),
+    },
+  };
+}

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -8,6 +8,7 @@ import {
   listSessions,
   revokeSession,
   sendMagicLink,
+  setOAuthWorkspaceChoice,
   startLocalDemoSession,
   submitOAuthConsent,
 } from "./auth-client";
@@ -343,6 +344,40 @@ describe("submitOAuthConsent", () => {
     await expect(
       submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
     ).resolves.toEqual({ ok: false, error: "expired request" });
+  });
+});
+
+describe("setOAuthWorkspaceChoice", () => {
+  it("posts the chosen workspace slug and returns true only on 2xx", async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(setOAuthWorkspaceChoice("https://auth.uploads.sh", "acme")).resolves.toBe(true);
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/oauth2/workspace-choice",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspace: "acme" }),
+      }),
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 403 })),
+    );
+    await expect(setOAuthWorkspaceChoice("https://auth.uploads.sh", "acme")).resolves.toBe(false);
+  });
+
+  it("returns false on a thrown fetch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    await expect(setOAuthWorkspaceChoice("https://auth.uploads.sh", "acme")).resolves.toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -8,6 +8,7 @@ import {
   listSessions,
   revokeSession,
   sendMagicLink,
+  getOAuthWorkspaceChoice,
   setOAuthWorkspaceChoice,
   startLocalDemoSession,
   submitOAuthConsent,
@@ -344,6 +345,41 @@ describe("submitOAuthConsent", () => {
     await expect(
       submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
     ).resolves.toEqual({ ok: false, error: "expired request" });
+  });
+});
+
+describe("getOAuthWorkspaceChoice", () => {
+  it("returns the server-resolved slug on 2xx", async () => {
+    const fetcher = vi.fn(async () => Response.json({ workspace: "beta" }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(getOAuthWorkspaceChoice("https://auth.uploads.sh")).resolves.toBe("beta");
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/oauth2/workspace-choice",
+      expect.objectContaining({ credentials: "include", cache: "no-store" }),
+    );
+  });
+
+  it("returns null on non-2xx, malformed body, or thrown fetch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+    await expect(getOAuthWorkspaceChoice("https://auth.uploads.sh")).resolves.toBeNull();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ workspace: 42 })),
+    );
+    await expect(getOAuthWorkspaceChoice("https://auth.uploads.sh")).resolves.toBeNull();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    await expect(getOAuthWorkspaceChoice("https://auth.uploads.sh")).resolves.toBeNull();
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -523,6 +523,29 @@ export async function getOAuthPublicClient(
   }
 }
 
+/**
+ * POST /api/auth/oauth2/workspace-choice (issue #231). Multi-workspace users
+ * pick which membership gets baked into the access token; call this before
+ * `submitOAuthConsent` on accept when the consent page shows a workspace
+ * picker. `workspace` is the org slug. Returns false on any non-2xx or thrown
+ * fetch — matching this file's other never-throw wrappers — so the caller can
+ * keep the user on the consent panel and show an error rather than submit
+ * consent for the wrong (or no) workspace.
+ */
+export async function setOAuthWorkspaceChoice(origin: string, workspace: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/oauth2/workspace-choice`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workspace }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export type OAuthConsentResult = { ok: true; redirectUri: string } | { ok: false; error: string };
 
 /**

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -532,6 +532,28 @@ export async function getOAuthPublicClient(
  * keep the user on the consent panel and show an error rather than submit
  * consent for the wrong (or no) workspace.
  */
+/**
+ * GET /api/auth/oauth2/workspace-choice — the AS's server-resolved effective
+ * workspace (stored choice if still a live membership, else oldest
+ * membership). The consent picker defaults to this so an untouched Allow
+ * round-trips the AS's own resolution instead of a client-side guess (org
+ * `createdAt` order is only a display order, not membership age). Null on
+ * any failure — callers fall back to the first listed org.
+ */
+export async function getOAuthWorkspaceChoice(origin: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}/api/auth/oauth2/workspace-choice`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as { workspace?: unknown } | null;
+    return typeof body?.workspace === "string" ? body.workspace : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function setOAuthWorkspaceChoice(origin: string, workspace: string): Promise<boolean> {
   try {
     const res = await fetch(`${authOrigin(origin)}/api/auth/oauth2/workspace-choice`, {

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { safeSameOriginPath } from "./workspace-ui";
+import { orderOrgsOldestFirst, safeSameOriginPath } from "./workspace-ui";
 
 describe("safeSameOriginPath", () => {
   it("accepts an absolute in-app path with query and hash", () => {
@@ -19,5 +19,52 @@ describe("safeSameOriginPath", () => {
     // Defense in depth: a raw embedded scheme is rejected even inside the
     // query — legitimate producers percent-encode (the consent page does).
     expect(safeSameOriginPath("/ok?u=https://evil.example")).toBeNull();
+  });
+});
+
+describe("orderOrgsOldestFirst", () => {
+  it("orders by createdAt ascending (oldest first)", () => {
+    const orgs = [
+      { slug: "newest", createdAt: "2026-03-01T00:00:00Z" },
+      { slug: "oldest", createdAt: "2024-01-01T00:00:00Z" },
+      { slug: "middle", createdAt: "2025-02-01T00:00:00Z" },
+    ];
+    expect(orderOrgsOldestFirst(orgs).map((o) => o.slug)).toEqual(["oldest", "middle", "newest"]);
+  });
+
+  it("accepts Date instances alongside strings", () => {
+    const orgs = [
+      { slug: "b", createdAt: new Date("2026-01-01T00:00:00Z") },
+      { slug: "a", createdAt: new Date("2020-01-01T00:00:00Z") },
+    ];
+    expect(orderOrgsOldestFirst(orgs).map((o) => o.slug)).toEqual(["a", "b"]);
+  });
+
+  it("keeps given relative order for entries without createdAt (stable)", () => {
+    const orgs = [{ slug: "first" }, { slug: "second" }, { slug: "third" }];
+    expect(orderOrgsOldestFirst(orgs).map((o) => o.slug)).toEqual(["first", "second", "third"]);
+  });
+
+  it("sorts dated entries before undated entries regardless of input order", () => {
+    const orgs = [{ slug: "undated" }, { slug: "dated", createdAt: "2026-01-01T00:00:00Z" }];
+    expect(orderOrgsOldestFirst(orgs).map((o) => o.slug)).toEqual(["dated", "undated"]);
+  });
+
+  it("tolerates an unparseable createdAt string as if undated", () => {
+    const orgs = [
+      { slug: "bad", createdAt: "not-a-date" },
+      { slug: "good", createdAt: "2026-01-01T00:00:00Z" },
+    ];
+    expect(orderOrgsOldestFirst(orgs).map((o) => o.slug)).toEqual(["good", "bad"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const orgs = [
+      { slug: "b", createdAt: "2026-01-01T00:00:00Z" },
+      { slug: "a", createdAt: "2020-01-01T00:00:00Z" },
+    ];
+    const copy = [...orgs];
+    orderOrgsOldestFirst(orgs);
+    expect(orgs).toEqual(copy);
   });
 });

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -2,6 +2,35 @@
  * Shared presentation helpers for account workspace pages.
  */
 
+/** Minimal shape the consent-page workspace picker needs to order orgs. */
+export interface OrderableOrg {
+  slug: string;
+  createdAt?: string | Date;
+}
+
+/**
+ * Orders orgs oldest-first by `createdAt` for the OAuth consent workspace
+ * picker (issue #231) — the AS bakes the *oldest* membership into a token
+ * today, so the picker's default (first item) must match that existing
+ * behavior for users who don't change the selection. Entries without a
+ * parseable `createdAt` keep their given relative order (stable sort) and
+ * sort after every entry that does have one, since we can't tell how old
+ * they are.
+ */
+export function orderOrgsOldestFirst<T extends OrderableOrg>(orgs: T[]): T[] {
+  const withIndex = orgs.map((org, index) => ({ org, index }));
+  withIndex.sort((a, b) => {
+    const aTime = a.org.createdAt ? new Date(a.org.createdAt).getTime() : NaN;
+    const bTime = b.org.createdAt ? new Date(b.org.createdAt).getTime() : NaN;
+    const aValid = Number.isFinite(aTime);
+    const bValid = Number.isFinite(bTime);
+    if (aValid && bValid && aTime !== bTime) return aTime - bTime;
+    if (aValid !== bValid) return aValid ? -1 : 1;
+    return a.index - b.index;
+  });
+  return withIndex.map((entry) => entry.org);
+}
+
 export function escapeHtml(value: string): string {
   return value.replace(
     /[&<>"']/g,

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -10,12 +10,13 @@ export interface OrderableOrg {
 
 /**
  * Orders orgs oldest-first by `createdAt` for the OAuth consent workspace
- * picker (issue #231) — the AS bakes the *oldest* membership into a token
- * today, so the picker's default (first item) must match that existing
- * behavior for users who don't change the selection. Entries without a
- * parseable `createdAt` keep their given relative order (stable sort) and
- * sort after every entry that does have one, since we can't tell how old
- * they are.
+ * picker (issue #231). Display order only — the picker's *default selection*
+ * comes from the AS's GET /oauth2/workspace-choice resolution (org creation
+ * time is not membership age, and a client-side default would overwrite the
+ * stored choice on Allow); this sort just keeps the list stable and roughly
+ * chronological. Entries without a parseable `createdAt` keep their given
+ * relative order (stable sort) and sort after every entry that does have
+ * one.
  */
 export function orderOrgsOldestFirst<T extends OrderableOrg>(orgs: T[]): T[] {
   const withIndex = orgs.map((org, index) => ({ org, index }));

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -122,6 +122,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
 <script>
   import {
     getOAuthPublicClient,
+    getOAuthWorkspaceChoice,
     getSession,
     listOrganizations,
     setOAuthWorkspaceChoice,
@@ -211,7 +212,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   }
 
   // appendChild, not append(): see the HTMLRewriter note on renderScopes above.
-  function renderWorkspacePicker() {
+  function renderWorkspacePicker(serverDefault: string | null) {
     workspaceSelect.replaceChildren();
     for (const org of orderedOrgs) {
       const option = document.createElement("option");
@@ -219,9 +220,16 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       option.textContent = org.slug;
       workspaceSelect.appendChild(option);
     }
-    // First entry is oldest-first ordering's default — matches the AS's
-    // current implicit "oldest membership" behavior when left unchanged.
-    if (orderedOrgs[0]) workspaceSelect.value = orderedOrgs[0].slug;
+    // Default to the AS's server-resolved choice (stored choice, else oldest
+    // membership) — the page always POSTs the selection on Allow, so a
+    // client-side guess here would overwrite the stored choice and could
+    // shift the token's workspace. Org order is display order only.
+    const fallback = orderedOrgs[0]?.slug;
+    const preferred =
+      serverDefault && orderedOrgs.some((org) => org.slug === serverDefault)
+        ? serverDefault
+        : fallback;
+    if (preferred) workspaceSelect.value = preferred;
     workspacePicker.hidden = orderedOrgs.length <= 1;
   }
 
@@ -282,7 +290,10 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     }
 
     orderedOrgs = orgs !== null ? orderOrgsOldestFirst(orgs) : [];
-    renderWorkspacePicker();
+    // Only multi-workspace users see the picker, so only they pay for the
+    // extra round-trip fetching the AS's resolved default.
+    const serverDefault = orderedOrgs.length > 1 ? await getOAuthWorkspaceChoice(authOrigin) : null;
+    renderWorkspacePicker(serverDefault);
 
     clientName.textContent = client?.client_name || clientId;
     const host = safeHttpUrl(client?.client_uri);

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -30,6 +30,10 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     .status{margin:16px 0}
     .client-host{color:var(--muted);font-size:12.5px;margin:-14px 0 20px;word-break:break-all}
     .client-host :global(a){color:inherit}
+    .workspace-picker{margin:0 0 20px}
+    .workspace-picker label{display:block;color:var(--muted);font-size:11px;letter-spacing:.08em;text-transform:uppercase;margin-bottom:6px}
+    .workspace-picker select{width:100%;font:14px var(--mono);color:var(--fg);background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-sm);padding:9px 11px;appearance:none}
+    .workspace-picker select:focus-visible{border-color:var(--accent);outline:none}
     .scopes{list-style:none;margin:0 0 22px;padding:0;display:grid;gap:10px}
     .scopes :global(li){display:flex;align-items:baseline;gap:10px;padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-md)}
     .scopes :global(.dot){width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none;margin-top:6px}
@@ -94,6 +98,10 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       <strong id="client-name"></strong> wants to access your uploads.sh account.
     </p>
     <div class="client-host" id="client-host" hidden></div>
+    <div class="workspace-picker" id="workspace-picker" hidden>
+      <label for="workspace-select">Workspace</label>
+      <select id="workspace-select"></select>
+    </div>
     <ul class="scopes" id="scope-list"></ul>
     <div class="actions">
       <button type="button" class="primary" id="allow-btn">Allow</button>
@@ -116,8 +124,11 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     getOAuthPublicClient,
     getSession,
     listOrganizations,
+    setOAuthWorkspaceChoice,
     submitOAuthConsent,
+    type OrganizationSummary,
   } from "../../lib/auth-client";
+  import { orderOrgsOldestFirst } from "../../lib/workspace-ui";
 
   const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
 
@@ -138,6 +149,12 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const confirmBox = requireElement<HTMLElement>("#confirm");
   const clientName = requireElement<HTMLElement>("#client-name");
   const clientHost = requireElement<HTMLElement>("#client-host");
+  const workspacePicker = requireElement<HTMLElement>("#workspace-picker");
+  // Not requireElement<HTMLSelectElement>: worker-configuration.d.ts's
+  // HTMLRewriter ambient `Element` redeclares `remove()` too (same drift as
+  // the append() note above), which makes HTMLSelectElement fail the
+  // `T extends Element` constraint. Fetch as HTMLElement and cast instead.
+  const workspaceSelect = requireElement<HTMLElement>("#workspace-select") as unknown as HTMLSelectElement;
   const scopeList = requireElement<HTMLUListElement>("#scope-list");
   const allowBtn = requireElement<HTMLButtonElement>("#allow-btn");
   const denyBtn = requireElement<HTMLButtonElement>("#deny-btn");
@@ -157,6 +174,10 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const clientId = params.get("client_id")?.trim() ?? "";
   const requestedScopes = (params.get("scope") ?? "").split(/\s+/).filter(Boolean);
   const oauthQuery = location.search.replace(/^\?/, "");
+
+  // Populated by proceed() once orgs load; used by decide() to know whether
+  // the picker is showing and, if so, which slugs are valid choices.
+  let orderedOrgs: OrganizationSummary[] = [];
 
   function hideAll() {
     const panels = [checking, authUnavailable, noRequest, signedOut, noWorkspace, confirmBox, redirecting];
@@ -187,6 +208,21 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       li.appendChild(text);
       scopeList.appendChild(li);
     }
+  }
+
+  // appendChild, not append(): see the HTMLRewriter note on renderScopes above.
+  function renderWorkspacePicker() {
+    workspaceSelect.replaceChildren();
+    for (const org of orderedOrgs) {
+      const option = document.createElement("option");
+      option.value = org.slug;
+      option.textContent = org.slug;
+      workspaceSelect.appendChild(option);
+    }
+    // First entry is oldest-first ordering's default — matches the AS's
+    // current implicit "oldest membership" behavior when left unchanged.
+    if (orderedOrgs[0]) workspaceSelect.value = orderedOrgs[0].slug;
+    workspacePicker.hidden = orderedOrgs.length <= 1;
   }
 
   // A registered client (DCR) fully controls client_uri/logo_uri — only
@@ -245,6 +281,9 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       return;
     }
 
+    orderedOrgs = orgs !== null ? orderOrgsOldestFirst(orgs) : [];
+    renderWorkspacePicker();
+
     clientName.textContent = client?.client_name || clientId;
     const host = safeHttpUrl(client?.client_uri);
     if (host) {
@@ -267,6 +306,18 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     confirmError.hidden = true;
     allowBtn.disabled = true;
     denyBtn.disabled = true;
+
+    if (accept && !workspacePicker.hidden) {
+      const chose = await setOAuthWorkspaceChoice(authOrigin, workspaceSelect.value);
+      if (!chose) {
+        allowBtn.disabled = false;
+        denyBtn.disabled = false;
+        confirmError.textContent = "Couldn't save your workspace choice — try again.";
+        confirmError.hidden = false;
+        return;
+      }
+    }
+
     const result = await submitOAuthConsent(authOrigin, {
       accept,
       scope: accept ? requestedScopes.join(" ") : undefined,


### PR DESCRIPTION
Closes #231.

Multi-workspace users can now choose which workspace an OAuth grant operates on, instead of the oldest membership silently winning.

## How it works

The mechanism is the oauth-provider plugin's `postLogin.consentReferenceId` hook (verified against the 1.6.23 dist):

- The consent page shows a **workspace select** when the user has 2+ org memberships (hidden otherwise; default = oldest). On Allow it first stores the choice via the new session-authed `POST /api/auth/oauth2/workspace-choice`, then submits consent.
- The hook returns `ws:<slug>` (stored choice if still a live membership, else oldest) for multi-workspace users, `undefined` for 0/1 memberships. The plugin keys `oauth_consent` rows by this string at both authorize- and consent-time, and threads it through the authorization code into access/refresh token rows.
- `customAccessTokenClaims` receives it back as `referenceId` at every issuance and overrides the `workspace` claim when the slug is still one of the user's `workspaces` — per-grant semantics, refresh tokens keep the originally granted workspace.

Properties that fall out of the consent-record keying:
- **Changing the choice re-triggers the consent screen** (no stale-grant dead end).
- **Single-workspace users and existing grants are completely untouched** (`referenceId` stays null — no re-consent churn on deploy).
- **Existing multi-workspace users re-consent once**, which is exactly when they first see the picker.

## Changes

- `apps/auth`: `oauth_workspace_choice` table + migration; `workspace-choice.ts` (endpoint plugin + `resolveWorkspaceChoiceReferenceId` + `applyWorkspaceChoice`, all exported for direct testing); wiring in `auth.ts`. 14 new tests (fake-D1).
- `apps/web`: picker UI in `consent.astro` (static markup, dynamic options via `appendChild` per the HTMLRewriter ambient-type convention); `setOAuthWorkspaceChoice` in `auth-client.ts`; `orderOrgsOldestFirst` in `workspace-ui.ts`. 8 new tests.

## Notes for review

- The picker's default ordering uses the **organization's** `createdAt` (what `/organization/list` exposes) while the AS default uses **membership** age. They can differ for invited users, but once the picker is visible the choice is explicit and posted, so this only affects which option is pre-selected.
- Choice-endpoint failures keep the user on the consent panel with an error rather than submitting consent for the wrong workspace.
- No changeset (apps/* are ignored packages).

## Testing

- `pnpm test`: 119 files / 1305 tests pass.
- `pnpm check` clean; auth typecheck clean; web typecheck has only the pre-existing ambient-type errors tracked in #232.

## Post-merge

- CI applies the D1 migration on deploy (same path as #226's).
- Prod verification: authorize with the dunn.zach@gmail.com multi-workspace user → picker appears → choose non-oldest → token's `workspace` claim reflects it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace selection to the OAuth consent flow for users with multiple workspaces.
  * Remembers the selected workspace for future OAuth authorizations.
  * Applies the selected workspace to issued OAuth access tokens.
  * Added validation to prevent selecting workspaces the user cannot access.
  * Displays workspaces in oldest-first order and provides clear feedback if saving a selection fails.

* **Bug Fixes**
  * Invalid or outdated workspace selections now safely fall back to an available workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->