### PR TITLE
fix(web): polish account shell — nav, surfaces, and local React load

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -2,6 +2,19 @@ import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 
+/**
+ * Vite 8 / Rolldown + @vitejs/plugin-react injects Fast Refresh helpers
+ * (`$RefreshSig$`, `/@react-refresh`) into every `.tsx` file. Under the
+ * Cloudflare local adapter those helpers often fail to evaluate (missing
+ * virtual module, or TDZ/`$RefreshSig$ is not defined`), which aborts any
+ * page script that imports a React component — e.g. the workspace page
+ * stuck on “Loading workspace…”.
+ *
+ * We don't need component-level HMR for the account file browser (it mounts
+ * via createRoot after a session fetch). Disabling Vite HMR turns off the
+ * Fast Refresh transform entirely (`skipFastRefresh`); CSS/full reloads
+ * still work via the browser refresh. Production builds already skip this.
+ */
 export default defineConfig({
   site: "https://uploads.sh",
   adapter: cloudflare({ imageService: "compile" }),
@@ -13,5 +26,10 @@ export default defineConfig({
   },
   build: {
     format: "file",
+  },
+  vite: {
+    server: {
+      hmr: false,
+    },
   },
 });

--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -284,6 +284,8 @@ const MENU_ITEMS = [
     border: 1px solid var(--line, #232327);
     border-radius: var(--radius-md, 8px);
     box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+    /* Clip hover/active item fills to the panel radius (esp. first/last rows). */
+    overflow: hidden;
   }
   .auth-indicator :global(.auth-menu__meta) {
     padding: 8px 10px 10px;
@@ -311,12 +313,13 @@ const MENU_ITEMS = [
   }
   .auth-indicator :global(.auth-menu__item) {
     display: block;
+    box-sizing: border-box;
     width: 100%;
     text-align: left;
     padding: 8px 10px;
     border: none;
     border-radius: 6px;
-    background: none;
+    background: transparent;
     color: var(--fg, #ececea);
     font: 13px var(--sans, system-ui, sans-serif);
     text-decoration: none;
@@ -326,6 +329,7 @@ const MENU_ITEMS = [
   .auth-indicator :global(.auth-menu__item:focus-visible) {
     background: color-mix(in srgb, var(--accent, #c27eff) 12%, transparent);
     color: var(--accent, #c27eff);
+    text-decoration: none;
     outline: none;
   }
   .auth-indicator :global(.auth-menu__signout) {

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -87,6 +87,8 @@ const REPO = "https://github.com/buildinternet/uploads";
     width: 100%;
     border-bottom: 1px solid var(--line, #232327);
     background: var(--bg, #0c0c0e);
+    /* Avatar menu is position:absolute — never clip its panel. */
+    overflow: visible;
   }
   .site-header__inner {
     display: flex;
@@ -97,6 +99,7 @@ const REPO = "https://github.com/buildinternet/uploads";
     width: 100%;
     padding: 14px 24px;
     box-sizing: border-box;
+    overflow: visible;
   }
   .site-header__start {
     display: inline-flex;
@@ -110,6 +113,7 @@ const REPO = "https://github.com/buildinternet/uploads";
     flex-wrap: wrap;
     gap: 12px;
     margin-left: auto;
+    overflow: visible;
   }
   .site-header__badge {
     display: inline-block;

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -3,8 +3,8 @@
  * Shared shell for /account and /account/* — sidebar nav with real paths
  * (file-based routing), session gate chrome, and sign-out.
  *
- * Workspaces nest under the Workspaces parent: each membership is a
- * client-filled sidebar link, plus a static "New workspace" action.
+ * Workspaces is a section label (not a link). Each membership nests under it,
+ * with per-workspace sub-pages (e.g. Invite) when that workspace is active.
  */
 import { env } from "cloudflare:workers";
 import {
@@ -20,18 +20,27 @@ import "../styles/signed-in-shell.css";
 import "../styles/account-content.css";
 
 export type AccountSection = "overview" | "workspaces" | "profile" | "developers";
+export type WorkspacePage = "overview" | "invite";
 
 interface Props {
   section: AccountSection;
-  /** Active workspace slug on /account/workspaces/:name */
+  /** Active workspace slug on /account/workspaces/:name[/*] */
   workspace?: string;
+  /** Nested page under an active workspace (default overview). */
+  workspacePage?: WorkspacePage;
   /** True on /account/workspaces/new */
   creating?: boolean;
   /** Optional document title override (e.g. workspace name). */
   title?: string;
 }
 
-const { section, workspace = "", creating = false, title } = Astro.props;
+const {
+  section,
+  workspace = "",
+  workspacePage = "overview",
+  creating = false,
+  title,
+} = Astro.props;
 
 const titles: Record<AccountSection, string> = {
   overview: "Account",
@@ -46,9 +55,6 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
-
-const workspacesActive = section === "workspaces";
-const workspacesParentCurrent = workspacesActive && !workspace && !creating;
 ---
 
 <html lang="en">
@@ -88,16 +94,10 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
           </a>
 
           <div class="side-group">
-            <a
-              href="/account/workspaces"
-              class="side-parent"
-              aria-current={workspacesParentCurrent ? "page" : undefined}
-            >
-              Workspaces
-            </a>
-            <div class="side-nested">
+            <div class="side-label" id="workspaces-nav-label">Workspaces</div>
+            <div class="side-nested" role="group" aria-labelledby="workspaces-nav-label">
               <div id="workspaces-nav-list" class="side-nested-list" aria-label="Your workspaces">
-                {/* Filled client-side after session + /me/workspaces. */}
+                {/* Filled client-side after session + /me/workspaces (cached for paint). */}
               </div>
               <a
                 href="/account/workspaces/new"
@@ -160,10 +160,11 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
   })();
 </script>
 
-<script define:vars={{ authOrigin, apiOrigin, workspace }}>
+<script define:vars={{ authOrigin, apiOrigin, workspace, workspacePage }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
   window.__UPLOADS_ACTIVE_WORKSPACE__ = workspace;
+  window.__UPLOADS_WORKSPACE_PAGE__ = workspacePage;
 </script>
 <script>
   import {
@@ -171,22 +172,22 @@ const workspacesParentCurrent = workspacesActive && !workspace && !creating;
     requireElement,
     resolveSessionGate,
   } from "../lib/account-shell";
-  import { initWorkspacesNav } from "../lib/workspaces-nav";
+  import { initWorkspacesNav, type WorkspaceNavPage } from "../lib/workspaces-nav";
 
   const w = window as unknown as {
     __UPLOADS_AUTH_ORIGIN__: string;
     __UPLOADS_API_ORIGIN__: string;
     __UPLOADS_ACTIVE_WORKSPACE__: string;
+    __UPLOADS_WORKSPACE_PAGE__: WorkspaceNavPage;
   };
   const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
   const apiOrigin = w.__UPLOADS_API_ORIGIN__;
 
   initSignOut(authOrigin);
-  initWorkspacesNav(
-    apiOrigin,
-    requireElement<HTMLElement>("#workspaces-nav-list", "account"),
-    w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
-  );
+  initWorkspacesNav(apiOrigin, requireElement<HTMLElement>("#workspaces-nav-list", "account"), {
+    active: w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+    page: w.__UPLOADS_WORKSPACE_PAGE__ || "overview",
+  });
 
   void resolveSessionGate({
     authOrigin,

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -49,6 +49,8 @@ export function writeCachedSessionUser(user: SessionUser): void {
 export function clearCachedSessionUser(): void {
   try {
     sessionStorage.removeItem(SESSION_CACHE_KEY);
+    // Membership list is also a session-scoped UX cache — drop it with the user.
+    sessionStorage.removeItem("uploads:myWorkspaces");
   } catch {
     // ignore
   }

--- a/apps/web/src/lib/workspace-browse-url.test.ts
+++ b/apps/web/src/lib/workspace-browse-url.test.ts
@@ -29,6 +29,13 @@ describe("workspaceFromPathname", () => {
     expect(workspaceFromPathname("/account/workspaces/buildinternet/")).toBe("buildinternet");
   });
 
+  it("reads the workspace slug from nested workspace pages", () => {
+    expect(workspaceFromPathname("/account/workspaces/buildinternet/invite")).toBe("buildinternet");
+    expect(workspaceFromPathname("/account/workspaces/buildinternet/invite/")).toBe(
+      "buildinternet",
+    );
+  });
+
   it("ignores index, create, and invalid slugs", () => {
     expect(workspaceFromPathname("/account/workspaces")).toBe("");
     expect(workspaceFromPathname("/account/workspaces/new")).toBe("");

--- a/apps/web/src/lib/workspace-browse-url.ts
+++ b/apps/web/src/lib/workspace-browse-url.ts
@@ -28,11 +28,12 @@ export function isBrowseWorkspace(value: string): boolean {
 }
 
 /**
- * Extract a workspace slug from `/account/workspaces/:name` (not `/new`).
- * Returns "" when the path is the index, create page, or unrelated.
+ * Extract a workspace slug from `/account/workspaces/:name` or a nested page
+ * under it (`…/:name/invite`). Returns "" for the index, create page, or
+ * unrelated paths.
  */
 export function workspaceFromPathname(pathname: string): string {
-  const match = pathname.match(/^\/account\/workspaces\/([^/]+)\/?$/);
+  const match = pathname.match(/^\/account\/workspaces\/([^/]+)(?:\/|$)/);
   if (!match) return "";
   const slug = decodeURIComponent(match[1] ?? "");
   return isBrowseWorkspace(slug) ? slug : "";

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearCachedWorkspaces,
+  readCachedWorkspaces,
+  renderWorkspacesNavHtml,
+  writeCachedWorkspaces,
+  WORKSPACES_CACHE_KEY,
+} from "./workspaces-nav";
+import type { MyWorkspace } from "./api-client";
+
+function installStorage() {
+  const values = new Map<string, string>();
+  vi.stubGlobal("sessionStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  });
+  return values;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const sample: MyWorkspace[] = [
+  {
+    workspace: "buildinternet",
+    organization: { id: "1", slug: "buildinternet", name: "buildinternet" },
+    role: "admin",
+    communal: false,
+    hasPublicUrl: true,
+  },
+  {
+    workspace: "side",
+    organization: { id: "2", slug: "side", name: "Side Project" },
+    role: "member",
+    communal: false,
+    hasPublicUrl: false,
+  },
+];
+
+describe("workspaces cache", () => {
+  it("round-trips a membership list through sessionStorage", () => {
+    installStorage();
+    writeCachedWorkspaces(sample);
+    expect(readCachedWorkspaces()).toEqual(sample);
+    clearCachedWorkspaces();
+    expect(readCachedWorkspaces()).toBeNull();
+    expect(sessionStorage.getItem(WORKSPACES_CACHE_KEY)).toBeNull();
+  });
+
+  it("drops malformed cache payloads", () => {
+    const values = installStorage();
+    values.set(WORKSPACES_CACHE_KEY, "{not-json");
+    expect(readCachedWorkspaces()).toBeNull();
+    values.set(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces: "nope" }));
+    expect(readCachedWorkspaces()).toBeNull();
+  });
+});
+
+describe("renderWorkspacesNavHtml", () => {
+  it("marks the active workspace and nests Invite for admins", () => {
+    const html = renderWorkspacesNavHtml(sample, {
+      active: "buildinternet",
+      page: "overview",
+    });
+    expect(html).toContain('href="/account/workspaces/buildinternet"');
+    expect(html).toContain('aria-current="page"');
+    expect(html).toContain('href="/account/workspaces/buildinternet/invite"');
+    expect(html).toContain(">Invite<");
+    // Non-active memberships do not get an Invite sub-link.
+    expect(html).not.toContain("/account/workspaces/side/invite");
+  });
+
+  it("marks Invite as the current page and the workspace as location-current", () => {
+    const html = renderWorkspacesNavHtml(sample, {
+      active: "buildinternet",
+      page: "invite",
+    });
+    expect(html).toMatch(/href="\/account\/workspaces\/buildinternet"[^>]*aria-current="true"/);
+    expect(html).toMatch(
+      /href="\/account\/workspaces\/buildinternet\/invite"[^>]*aria-current="page"/,
+    );
+  });
+
+  it("does not offer Invite for non-admin memberships", () => {
+    const html = renderWorkspacesNavHtml(sample, { active: "side", page: "overview" });
+    expect(html).toContain('href="/account/workspaces/side"');
+    expect(html).not.toContain("/account/workspaces/side/invite");
+  });
+});

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -1,23 +1,130 @@
 /**
  * Nested workspaces list in the account sidebar.
  * Fills `#workspaces-nav-list` after session + GET /me/workspaces.
+ *
+ * Caches the last successful list in sessionStorage (same idea as the session
+ * user cache) so navigations can paint memberships immediately and revalidate
+ * in the background — avoids the empty-nested-list flash while logged in.
  */
-import { getMyWorkspaces } from "./api-client";
+import { getMyWorkspaces, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
-import { escapeHtml } from "./workspace-ui";
+import { escapeHtml, isWorkspaceAdminRole } from "./workspace-ui";
 
-export function initWorkspacesNav(apiOrigin: string, listEl: HTMLElement, active = ""): void {
+/** sessionStorage key — UX only; membership is still enforced server-side. */
+export const WORKSPACES_CACHE_KEY = "uploads:myWorkspaces";
+
+export type WorkspaceNavPage = "overview" | "invite";
+
+export type WorkspacesNavOptions = {
+  /** Active workspace slug (from the layout). */
+  active?: string;
+  /** Nested page under the active workspace (invite, etc.). */
+  page?: WorkspaceNavPage;
+};
+
+type CachePayload = { workspaces: MyWorkspace[] };
+
+export function readCachedWorkspaces(): MyWorkspace[] | null {
+  try {
+    const raw = sessionStorage.getItem(WORKSPACES_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CachePayload;
+    if (!parsed || !Array.isArray(parsed.workspaces)) return null;
+    return parsed.workspaces.filter(
+      (ws) =>
+        ws &&
+        typeof ws.workspace === "string" &&
+        typeof ws.role === "string" &&
+        ws.organization &&
+        typeof ws.organization.name === "string",
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedWorkspaces(workspaces: MyWorkspace[]): void {
+  try {
+    sessionStorage.setItem(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces }));
+  } catch {
+    // Private mode / quota — nav still works without the cache.
+  }
+}
+
+export function clearCachedWorkspaces(): void {
+  try {
+    sessionStorage.removeItem(WORKSPACES_CACHE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Render one workspace row (+ Invite sub-link when active and admin). */
+export function renderWorkspacesNavHtml(
+  workspaces: MyWorkspace[],
+  options: WorkspacesNavOptions = {},
+): string {
+  const active = options.active ?? "";
+  const page = options.page ?? "overview";
+
+  return workspaces
+    .map((ws) => {
+      const label = ws.organization.name || ws.workspace;
+      const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
+      const isActive = active === ws.workspace;
+      const current =
+        isActive && page === "overview"
+          ? ' aria-current="page"'
+          : isActive
+            ? ' aria-current="true"'
+            : "";
+      const inviteHref = `${href}/invite`;
+      const showInvite = isActive && isWorkspaceAdminRole(ws.role);
+      const inviteCurrent = page === "invite" ? ' aria-current="page"' : "";
+
+      const inviteBlock = showInvite
+        ? `<div class="side-nested-sub">
+            <a href="${escapeHtml(inviteHref)}" class="side-nested-item side-nested-subitem"${inviteCurrent}>Invite</a>
+          </div>`
+        : "";
+
+      return `<div class="side-workspace">
+        <a href="${escapeHtml(href)}" class="side-nested-item"${current}>${escapeHtml(label)}</a>
+        ${inviteBlock}
+      </div>`;
+    })
+    .join("");
+}
+
+function paint(
+  listEl: HTMLElement,
+  workspaces: MyWorkspace[],
+  options: WorkspacesNavOptions,
+): void {
+  listEl.innerHTML = renderWorkspacesNavHtml(workspaces, options);
+}
+
+/**
+ * Optimistic paint from cache, then revalidate after session.
+ * Call once per account shell mount.
+ */
+export function initWorkspacesNav(
+  apiOrigin: string,
+  listEl: HTMLElement,
+  options: WorkspacesNavOptions | string = {},
+): void {
+  // Back-compat: older call sites passed the active slug as a string.
+  const opts: WorkspacesNavOptions =
+    typeof options === "string" ? { active: options } : (options ?? {});
+
+  const cached = readCachedWorkspaces();
+  if (cached?.length) paint(listEl, cached, opts);
+
   onSession(() => {
     void getMyWorkspaces(apiOrigin).then((result) => {
       if (result.kind !== "success") return;
-      listEl.innerHTML = result.workspaces
-        .map((ws) => {
-          const label = ws.organization.name || ws.workspace;
-          const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
-          const current = active === ws.workspace ? ' aria-current="page"' : "";
-          return `<a href="${escapeHtml(href)}" class="side-nested-item"${current}>${escapeHtml(label)}</a>`;
-        })
-        .join("");
+      writeCachedWorkspaces(result.workspaces);
+      paint(listEl, result.workspaces, opts);
     });
   });
 }

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -39,6 +39,10 @@ describe.each([
   { path: "/account/workspaces", title: "Workspaces · uploads.sh" },
   { path: "/account/workspaces/new", title: "New workspace · uploads.sh" },
   { path: "/account/workspaces/buildinternet", title: "buildinternet · uploads.sh" },
+  {
+    path: "/account/workspaces/buildinternet/invite",
+    title: "Invite · buildinternet · uploads.sh",
+  },
   { path: "/account/profile", title: "Account · uploads.sh" },
   { path: "/account/developers", title: "Developers · uploads.sh" },
   { path: "/console", title: "uploads.sh console" },

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -9,25 +9,26 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
 ---
 
 <AccountLayout section="developers">
-  <section class="card">
+  <section class="card dev-page">
     <h2>Developers</h2>
-    <p>
-      Most people just need <code>uploads login</code> from the
-      <a href="/account#cli-setup">account overview</a>. These are for API and CI use.
+    <p class="dev-lead">
+      Most people just need <code>uploads login</code> from the{" "}
+      <a href="/account#cli-setup">account overview</a>. These are for API and CI
+      use.
     </p>
-    <ul class="plain">
+    <ul class="dev-links">
       {showConsoleLinks ? (
         <li>
-          <span><a href="/console">Console</a></span>
+          <a href="/console">Console</a>
           <span class="slug">usage, files, invites — bring a token</span>
         </li>
       ) : null}
       <li>
-        <span><a href="/docs">API docs</a></span>
+        <a href="/docs">API docs</a>
         <span class="slug">endpoints &amp; auth</span>
       </li>
       <li>
-        <span><a href="https://github.com/buildinternet/uploads">GitHub</a></span>
+        <a href="https://github.com/buildinternet/uploads">GitHub</a>
         <span class="slug">source &amp; issues</span>
       </li>
     </ul>

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -35,6 +35,7 @@ if (isBrowseWorkspace(legacyWs)) {
   <script>
     import { onSession, requireElement } from "../../lib/account-shell";
     import { getMyWorkspaces } from "../../lib/api-client";
+    import { writeCachedWorkspaces } from "../../lib/workspaces-nav";
     import { escapeHtml } from "../../lib/workspace-ui";
 
     const apiOrigin = (window as unknown as { __UPLOADS_API_ORIGIN__: string })
@@ -59,6 +60,8 @@ if (isBrowseWorkspace(legacyWs)) {
       }
 
       const { workspaces } = result;
+      writeCachedWorkspaces(workspaces);
+
       if (!workspaces.length) {
         status.innerHTML =
           'No workspaces yet — <a href="/account/workspaces/new">create one</a>, or accept an invite.';

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -1,6 +1,7 @@
 ---
 /**
- * Dedicated workspace page: header · files · galleries · invite · operator.
+ * Workspace overview: header · files · galleries.
+ * Invite / operator enrollment live on `…/invite`.
  */
 import AccountLayout from "../../../layouts/AccountLayout.astro";
 import { isBrowseWorkspace } from "../../../lib/workspace-browse-url";
@@ -12,12 +13,18 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 ---
 
-<AccountLayout section="workspaces" workspace={workspace} title={workspace}>
+<AccountLayout
+  section="workspaces"
+  workspace={workspace}
+  workspacePage="overview"
+  title={workspace}
+>
   <div id="ws-status" class="ul-callout status" role="status">Loading workspace…</div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 
   <div id="ws-app" hidden>
-    <section class="card">
+    {/* One surface: header · files · galleries as stacked blocks, not nested cards. */}
+    <section class="card ws-page-card">
       <div class="ws-page-header">
         <div class="ws-title-block">
           <h2 id="ws-name"></h2>
@@ -26,56 +33,22 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         <span class="pill ws-role" id="ws-role" hidden></span>
         <div class="usage" id="ws-usage">Loading usage…</div>
       </div>
-    </section>
 
-    <section class="card" id="ws-communal" hidden>
-      <h2>Shared space</h2>
-      <p class="ws-note">
-        Shared, public space — world-readable at <code>storage.uploads.sh</code>.
-        Browse and upload with the CLI.
-      </p>
-    </section>
-
-    <section class="card" id="ws-files-card" hidden>
-      <h2 class="ws-section-head">Files</h2>
-      <div id="ws-files"></div>
-    </section>
-
-    <section class="card" id="ws-galleries-card" hidden>
-      <h2 class="ws-section-head">Galleries</h2>
-      <div id="ws-galleries"><p class="ws-empty">Loading…</p></div>
-    </section>
-
-    <section class="card" id="ws-invite-card" hidden>
-      <h2>Invite a teammate</h2>
-      <p class="ws-lead">They open the accept link, then run <code>uploads login</code>.</p>
-      <form class="ws-form" id="ws-invite-form">
-        <div class="input-group">
-          <label class="input-group__field">
-            <span class="sr-only">Email</span>
-            <input
-              type="email"
-              name="email"
-              required
-              autocomplete="email"
-              placeholder="teammate@example.com"
-            />
-          </label>
-          <button type="submit" class="input-group__action">Invite</button>
-        </div>
-      </form>
-      <div class="ws-messages">
-        <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
-        <p class="muted cli-note" id="ws-invite-link" hidden></p>
+      <div class="ws-block" id="ws-communal" hidden>
+        <h2 class="ws-section-head">Shared space</h2>
+        <p class="ws-note">
+          Shared, public space — world-readable at <code>storage.uploads.sh</code>.
+          Browse and upload with the CLI.
+        </p>
       </div>
-    </section>
 
-    <section class="card" id="ws-operator-card" hidden>
-      <h2>Operator enrollment code</h2>
-      <p class="muted"><code>ADMIN_TOKEN</code> only — not for everyday invites.</p>
-      <div class="command">
-        <code id="ws-operator-cmd"></code>
-        <button type="button" id="ws-operator-copy" aria-live="polite">copy</button>
+      <div class="ws-block" id="ws-files-card" hidden>
+        <div id="ws-files"></div>
+      </div>
+
+      <div class="ws-block" id="ws-galleries-card" hidden>
+        <h2 class="ws-section-head">Galleries</h2>
+        <div id="ws-galleries"><p class="ws-empty">Loading…</p></div>
       </div>
     </section>
   </div>
@@ -86,24 +59,24 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       getMyWorkspaces,
       getMyWorkspaceUsage,
       getMyWorkspaceGalleries,
-      inviteToWorkspace,
       type GallerySummary,
     } from "../../../lib/api-client";
-    import { WorkspaceFiles } from "../../../components/WorkspaceFiles";
+    import { writeCachedWorkspaces } from "../../../lib/workspaces-nav";
     import {
       readBrowseLocation,
       replaceBrowseLocation,
     } from "../../../lib/workspace-browse-url";
     import { readSearchFilters } from "../../../lib/workspace-search-url";
-    import {
-      bindCopyButtons,
-      escapeHtml,
-      isWorkspaceAdminRole,
-      operatorInviteCommand,
-      renderUsageHtml,
-    } from "../../../lib/workspace-ui";
+    import { escapeHtml, renderUsageHtml } from "../../../lib/workspace-ui";
     import { createElement } from "react";
     import { createRoot } from "react-dom/client";
+
+    // Lazy so a Fast Refresh / HMR glitch in the file browser does not
+    // block the whole page script (header, galleries, usage).
+    async function loadWorkspaceFiles() {
+      const { WorkspaceFiles } = await import("../../../components/WorkspaceFiles");
+      return WorkspaceFiles;
+    }
 
     const page = "workspace page";
     const w = window as unknown as {
@@ -125,16 +98,9 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     const communalCard = requireElement<HTMLElement>("#ws-communal", page);
     const filesCard = requireElement<HTMLElement>("#ws-files-card", page);
     const galleriesCard = requireElement<HTMLElement>("#ws-galleries-card", page);
-    const inviteCard = requireElement<HTMLElement>("#ws-invite-card", page);
-    const operatorCard = requireElement<HTMLElement>("#ws-operator-card", page);
     const filesEl = requireElement<HTMLElement>("#ws-files", page);
     const galleriesEl = requireElement<HTMLElement>("#ws-galleries", page);
-    const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
-    const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
-    const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
-    const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
 
-    let sessionRole: string | null | undefined;
     let filesRoot: ReturnType<typeof createRoot> | null = null;
 
     function showError(message: string, retry = true): void {
@@ -171,6 +137,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         return;
       }
 
+      writeCachedWorkspaces(result.workspaces);
+
       const ws = result.workspaces.find((item) => item.workspace === workspaceName);
       if (!ws) {
         showError("You don’t have access to this workspace.", false);
@@ -195,85 +163,40 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       communalCard.hidden = !ws.communal;
       filesCard.hidden = ws.communal;
       galleriesCard.hidden = ws.communal;
-      inviteCard.hidden = !isWorkspaceAdminRole(ws.role);
 
       if (!ws.communal) {
-        if (!filesRoot) filesRoot = createRoot(filesEl);
-        filesRoot.render(
-          createElement(WorkspaceFiles, {
-            apiOrigin,
-            workspace: ws.workspace,
-            hasPublicUrl: ws.hasPublicUrl,
-            initialPrefix:
-              !browseOnLoad.workspace || browseOnLoad.workspace === ws.workspace
-                ? browseOnLoad.path
-                : "",
-            initialFilters: searchFiltersOnLoad,
-            onPrefixChange: (path: string) => {
-              replaceBrowseLocation({ workspace: ws.workspace, path });
-            },
-          }),
-        );
         void getMyWorkspaceGalleries(apiOrigin, ws.workspace).then(renderGalleries);
-      }
-
-      const isOperator = sessionRole === "admin";
-      operatorCard.hidden = !isOperator;
-      if (isOperator) {
-        const cmd = operatorInviteCommand(ws.workspace);
-        operatorCmd.textContent = cmd;
-        operatorCopy.dataset.copy = cmd;
+        void loadWorkspaceFiles()
+          .then((WorkspaceFiles) => {
+            if (!filesRoot) filesRoot = createRoot(filesEl);
+            filesRoot.render(
+              createElement(WorkspaceFiles, {
+                apiOrigin,
+                workspace: ws.workspace,
+                hasPublicUrl: ws.hasPublicUrl,
+                initialPrefix:
+                  !browseOnLoad.workspace || browseOnLoad.workspace === ws.workspace
+                    ? browseOnLoad.path
+                    : "",
+                initialFilters: searchFiltersOnLoad,
+                onPrefixChange: (path: string) => {
+                  replaceBrowseLocation({ workspace: ws.workspace, path });
+                },
+              }),
+            );
+          })
+          .catch(() => {
+            filesEl.innerHTML =
+              `<p class="ws-empty" role="alert">File browser failed to load. Refresh the page.</p>`;
+          });
       }
     }
-
-    bindCopyButtons(document);
-
-    requireElement<HTMLFormElement>("#ws-invite-form", page).addEventListener("submit", (event) => {
-      void (async () => {
-        event.preventDefault();
-        const form = event.currentTarget as HTMLFormElement;
-        const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
-        const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
-        const email = emailInput?.value.trim() ?? "";
-        if (!email || !submit) return;
-
-        inviteStatus.hidden = false;
-        inviteStatus.textContent = "Creating invite…";
-        inviteLink.hidden = true;
-        inviteLink.textContent = "";
-        submit.disabled = true;
-        const result = await inviteToWorkspace(apiOrigin, workspaceName, email);
-        submit.disabled = false;
-
-        if (result.kind === "ok") {
-          inviteStatus.textContent =
-            result.emailConfigured === true
-              ? `Invitation emailed to ${email}.`
-              : result.emailConfigured === false
-                ? `Invite created for ${email} — share the accept link below.`
-                : `Invite created for ${email}.`;
-          if (emailInput) emailInput.value = "";
-          if (result.acceptUrl) {
-            inviteLink.hidden = false;
-            inviteLink.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
-          }
-          return;
-        }
-        inviteStatus.textContent =
-          result.reason === "forbidden"
-            ? "You need workspace admin access to invite."
-            : result.reason === "invalid"
-              ? "That email doesn’t look valid."
-              : "Couldn’t create the invite. Try again.";
-      })();
-    });
 
     retryBtn.addEventListener("click", () => {
       void loadWorkspace();
     });
 
-    onSession((user) => {
-      sessionRole = user.role;
+    onSession(() => {
       void loadWorkspace();
     });
   </script>

--- a/apps/web/src/pages/account/workspaces/[name]/invite.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/invite.astro
@@ -1,0 +1,205 @@
+---
+/**
+ * Workspace invite page — session-authed teammate invites, plus the
+ * operator-only ADMIN_TOKEN enrollment command for site admins.
+ */
+import AccountLayout from "../../../../layouts/AccountLayout.astro";
+import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+
+export const prerender = false;
+
+const nameParam = Astro.params.name ?? "";
+const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
+if (!workspace) return Astro.redirect("/account/workspaces");
+---
+
+<AccountLayout
+  section="workspaces"
+  workspace={workspace}
+  workspacePage="invite"
+  title={`Invite · ${workspace}`}
+>
+  <div id="ws-status" class="ul-callout status" role="status">Loading…</div>
+  <button id="ws-retry" type="button" hidden>Try again</button>
+
+  <div id="ws-app" hidden>
+    <section class="card">
+      <div class="ws-page-header">
+        <div class="ws-title-block">
+          <h2>Invite a teammate</h2>
+          <p class="muted" id="ws-slug"></p>
+        </div>
+        <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+      </div>
+      <p class="ws-lead">They open the accept link, then run <code>uploads login</code>.</p>
+      <form class="ws-form" id="ws-invite-form">
+        <div class="input-group">
+          <label class="input-group__field">
+            <span class="sr-only">Email</span>
+            <input
+              type="email"
+              name="email"
+              required
+              autocomplete="email"
+              placeholder="teammate@example.com"
+            />
+          </label>
+          <button type="submit" class="input-group__action">Invite</button>
+        </div>
+      </form>
+      <div class="ws-messages">
+        <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
+        <p class="muted cli-note" id="ws-invite-link" hidden></p>
+      </div>
+    </section>
+
+    <section class="card" id="ws-operator-card" hidden>
+      <h2>Operator enrollment code</h2>
+      <p class="muted"><code>ADMIN_TOKEN</code> only — not for everyday invites.</p>
+      <div class="command">
+        <code id="ws-operator-cmd"></code>
+        <button type="button" id="ws-operator-copy" aria-live="polite">copy</button>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    import { onSession, requireElement } from "../../../../lib/account-shell";
+    import { getMyWorkspaces, inviteToWorkspace } from "../../../../lib/api-client";
+    import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
+    import {
+      bindCopyButtons,
+      escapeHtml,
+      isWorkspaceAdminRole,
+      operatorInviteCommand,
+    } from "../../../../lib/workspace-ui";
+
+    const page = "workspace invite";
+    const w = window as unknown as {
+      __UPLOADS_API_ORIGIN__: string;
+      __UPLOADS_ACTIVE_WORKSPACE__: string;
+    };
+    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+    const workspaceName = w.__UPLOADS_ACTIVE_WORKSPACE__;
+
+    const statusEl = requireElement<HTMLElement>("#ws-status", page);
+    const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
+    const appEl = requireElement<HTMLElement>("#ws-app", page);
+    const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+    const operatorCard = requireElement<HTMLElement>("#ws-operator-card", page);
+    const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
+    const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
+    const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
+    const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
+    const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
+
+    let sessionRole: string | null | undefined;
+
+    function showError(message: string, retry = true): void {
+      statusEl.hidden = false;
+      statusEl.textContent = message;
+      statusEl.dataset.state = "error";
+      appEl.hidden = true;
+      retryBtn.hidden = !retry;
+    }
+
+    async function loadInvitePage(): Promise<void> {
+      statusEl.hidden = false;
+      statusEl.textContent = "Loading…";
+      statusEl.removeAttribute("data-state");
+      retryBtn.hidden = true;
+      appEl.hidden = true;
+
+      const result = await getMyWorkspaces(apiOrigin);
+      if (result.kind === "unavailable") {
+        showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
+        return;
+      }
+
+      writeCachedWorkspaces(result.workspaces);
+
+      const ws = result.workspaces.find((item) => item.workspace === workspaceName);
+      if (!ws) {
+        showError("You don’t have access to this workspace.", false);
+        return;
+      }
+
+      if (!isWorkspaceAdminRole(ws.role) && sessionRole !== "admin") {
+        showError("You need workspace admin access to invite teammates.", false);
+        return;
+      }
+
+      // Non-admins who somehow deep-linked should not use the form (site
+      // operators may still open the page for the ADMIN_TOKEN command).
+      if (!isWorkspaceAdminRole(ws.role)) {
+        inviteForm.hidden = true;
+      }
+
+      statusEl.hidden = true;
+      appEl.hidden = false;
+
+      const displayName = ws.organization.name || ws.workspace;
+      slugEl.textContent = displayName === ws.workspace ? ws.workspace : `${displayName} · ${ws.workspace}`;
+      document.title = `Invite · ${displayName} · uploads.sh`;
+
+      const isOperator = sessionRole === "admin";
+      operatorCard.hidden = !isOperator;
+      if (isOperator) {
+        const cmd = operatorInviteCommand(ws.workspace);
+        operatorCmd.textContent = cmd;
+        operatorCopy.dataset.copy = cmd;
+      }
+    }
+
+    bindCopyButtons(document);
+
+    inviteForm.addEventListener("submit", (event) => {
+      void (async () => {
+        event.preventDefault();
+        const form = event.currentTarget as HTMLFormElement;
+        const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
+        const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+        const email = emailInput?.value.trim() ?? "";
+        if (!email || !submit) return;
+
+        inviteStatus.hidden = false;
+        inviteStatus.textContent = "Creating invite…";
+        inviteLink.hidden = true;
+        inviteLink.textContent = "";
+        submit.disabled = true;
+        const result = await inviteToWorkspace(apiOrigin, workspaceName, email);
+        submit.disabled = false;
+
+        if (result.kind === "ok") {
+          inviteStatus.textContent =
+            result.emailConfigured === true
+              ? `Invitation emailed to ${email}.`
+              : result.emailConfigured === false
+                ? `Invite created for ${email} — share the accept link below.`
+                : `Invite created for ${email}.`;
+          if (emailInput) emailInput.value = "";
+          if (result.acceptUrl) {
+            inviteLink.hidden = false;
+            inviteLink.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
+          }
+          return;
+        }
+        inviteStatus.textContent =
+          result.reason === "forbidden"
+            ? "You need workspace admin access to invite."
+            : result.reason === "invalid"
+              ? "That email doesn’t look valid."
+              : "Couldn’t create the invite. Try again.";
+      })();
+    });
+
+    retryBtn.addEventListener("click", () => {
+      void loadInvitePage();
+    });
+
+    onSession((user) => {
+      sessionRole = user.role;
+      void loadInvitePage();
+    });
+  </script>
+</AccountLayout>

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -69,6 +69,7 @@ export const prerender = false;
     import { onSession, requireElement } from "../../../lib/account-shell";
     import { linkGitHub, listAccounts } from "../../../lib/auth-client";
     import { createWorkspace } from "../../../lib/api-client";
+    import { clearCachedWorkspaces } from "../../../lib/workspaces-nav";
     import {
       bindCopyButtons,
       createErrorCopy,
@@ -135,6 +136,9 @@ export const prerender = false;
         const result = await createWorkspace(apiOrigin, name);
         if (submit) submit.disabled = false;
         if (result.kind === "created") {
+          // Drop the sidebar membership cache so the next paint includes this
+          // workspace (revalidated on the destination page's /me/workspaces).
+          clearCachedWorkspaces();
           // Interrupted-flow return (OAuth consent): skip the CLI-setup card
           // and go straight back — the user's goal is the pending authorize
           // request, not terminal setup.

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -427,14 +427,16 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         outline: none;
       }
       .cta-note { color: var(--muted); font-size: 12.5px; }
-      a {
+      /* Scope to main so header auth menu hover/active paint is not overridden
+         (global `a` styles were bleeding into the avatar dropdown). */
+      main a {
         color: var(--fg);
         text-decoration: underline;
         text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
         text-underline-offset: 3px;
       }
-      a:hover,
-      a:focus-visible { color: var(--accent); outline: none; }
+      main a:hover,
+      main a:focus-visible { color: var(--accent); outline: none; }
       @media (max-width: 560px) {
         .cmdrow { grid-template-columns: 1fr auto; }
         .cmdrow .tag { grid-column: 1 / -1; }

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1,4 +1,54 @@
 /* Content styles for /account/* cards (profile kv, workspace list, developer list). */
+
+/* Developers — one card; links as flat hairline rows, not nested mini-panels. */
+section.card.dev-page {
+  padding: 22px 22px 10px;
+}
+section.card.dev-page h2 {
+  margin: 0 0 8px;
+}
+section.card.dev-page .dev-lead {
+  margin: 0 0 18px;
+  max-width: 36rem;
+  text-wrap: pretty;
+}
+ul.dev-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0;
+}
+ul.dev-links li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px 14px;
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+  background: none;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  border-radius: 0;
+  font-size: 13px;
+}
+ul.dev-links a {
+  color: var(--fg);
+  text-decoration: none;
+  font-weight: 500;
+}
+ul.dev-links a:hover,
+ul.dev-links a:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+ul.dev-links .slug {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .kv {
   display: grid;
   grid-template-columns: max-content 1fr;
@@ -368,19 +418,28 @@ ul.detail-list .detail-current {
   letter-spacing: 0.04em;
 }
 
-/* Dedicated workspace page (/account/workspaces/:name) ────────────────── */
+/* Dedicated workspace page (/account/workspaces/:name) ──────────────────
+   One card surface; header / files / galleries are blocks with hairlines
+   and vertical rhythm — not a stack of nested panels. */
 
+.ws-page-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 22px 22px 24px;
+}
 .ws-page-header {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 10px 16px;
+  gap: 12px 16px;
+  padding-bottom: 4px;
 }
 .ws-page-header .ws-title-block {
   min-width: 0;
   display: grid;
-  gap: 4px;
+  gap: 6px;
 }
 .ws-page-header h2 {
   margin: 0;
@@ -396,9 +455,9 @@ ul.detail-list .detail-current {
   color: var(--muted);
   font-size: 12px;
   display: grid;
-  gap: 6px;
+  gap: 10px;
   min-height: 1.2em;
-  margin-top: 4px;
+  margin-top: 10px;
 }
 .ws-page-header .usage .usage-text,
 .ws-page-header .usage .usage-meta {
@@ -408,31 +467,62 @@ ul.detail-list .detail-current {
   font-size: 11px;
   opacity: 0.9;
 }
+/* Stacked regions inside the single card. */
+.ws-page-card > .ws-block {
+  margin-top: 22px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 14px;
+}
+.ws-page-card > .ws-block[hidden] {
+  display: none;
+}
+.ws-page-card .ws-section-head,
 section.card .ws-section-head {
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
-  margin: 0 0 10px;
+  margin: 0;
 }
+.ws-page-card .ws-files,
+section.card .ws-files {
+  display: grid;
+  gap: 14px;
+}
+.ws-page-card .ws-items,
 section.card .ws-items {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 5px;
+  gap: 8px;
 }
+.ws-page-card .ws-items li,
 section.card .ws-items li {
   font-size: 13px;
 }
+.ws-page-card .ws-empty,
+.ws-page-card .ws-note,
 section.card .ws-empty,
 section.card .ws-note {
   color: var(--muted);
   font-size: 13px;
   margin: 0;
 }
+.ws-page-card .ws-note,
 section.card .ws-note {
   color: var(--body);
+}
+/* Search bar breathing room above the file list. */
+.ws-page-card .ws-search-bar {
+  margin: 0;
+  gap: 10px;
+}
+.ws-page-card .ws-search-error,
+.ws-page-card .ws-search-chips {
+  margin: 0;
 }
 /* Workspace page copy + joined input group ────────────────────────────── */
 
@@ -541,10 +631,15 @@ section.card .ws-note {
 .ws-messages .ul-callout .cli-note {
   margin-top: 10px;
 }
-/* Operator / create-success command rows sit under copy, not in .cli-steps. */
+/* Operator / create-success command rows sit under copy, not in .cli-steps
+   (those use grid gap). */
+section.card > .command,
+section.card > p + .command,
+section.card > .muted + .command {
+  margin-top: 12px;
+}
 section.card .command + .command,
-section.card .ws-messages .command,
-section.card #ws-operator-card .command {
+section.card .ws-messages .command {
   margin-top: 10px;
 }
 /* Workspace file browser: metadata search entry + results ─────────────── */

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -136,15 +136,24 @@ nav.side a[aria-current="page"] {
   background: var(--panel);
   border-color: var(--line);
 }
-/* Nested workspaces under the Workspaces parent. */
+/* Nested workspaces under the Workspaces section label. */
 nav.side .side-group {
   display: grid;
   gap: 2px;
 }
+nav.side .side-label {
+  display: block;
+  padding: 8px 12px 4px;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  user-select: none;
+}
 nav.side .side-nested {
   display: grid;
   gap: 2px;
-  margin: 2px 0 2px 12px;
+  margin: 0 0 2px 12px;
   padding-left: 10px;
   border-left: 1px solid var(--line);
 }
@@ -152,6 +161,17 @@ nav.side .side-nested-list {
   display: grid;
   gap: 2px;
   min-height: 0;
+}
+nav.side .side-workspace {
+  display: grid;
+  gap: 2px;
+}
+nav.side .side-nested-sub {
+  display: grid;
+  gap: 2px;
+  margin: 0 0 2px 10px;
+  padding-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--line) 80%, transparent);
 }
 nav.side .side-nested-item {
   display: block;
@@ -168,10 +188,15 @@ nav.side .side-nested-item {
 nav.side .side-nested-item:hover {
   color: var(--fg);
 }
-nav.side .side-nested-item[aria-current="page"] {
+nav.side .side-nested-item[aria-current="page"],
+nav.side .side-nested-item[aria-current="true"] {
   color: var(--accent);
   background: var(--panel);
   border-color: var(--line);
+}
+nav.side .side-nested-item.side-nested-subitem {
+  font-size: 11px;
+  padding: 5px 9px;
 }
 nav.side .side-nested-item.side-new {
   color: color-mix(in srgb, var(--muted) 85%, var(--accent));
@@ -209,7 +234,7 @@ nav.side button:focus-visible {
 
 .content {
   display: grid;
-  gap: 16px;
+  gap: 20px;
   min-width: 0;
 }
 section.card {
@@ -219,13 +244,13 @@ section.card {
   padding: 18px 20px;
 }
 section.card h2 {
-  margin: 0 0 4px;
+  margin: 0 0 6px;
   font-size: 0.95rem;
   font-weight: 600;
 }
 section.card p {
   color: var(--body);
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   font-size: 13px;
 }
 p.muted,
@@ -257,6 +282,9 @@ span.muted {
   nav.side .side-group {
     grid-column: 1 / -1;
   }
+  nav.side .side-label {
+    padding: 4px 8px 2px;
+  }
   nav.side .side-nested {
     margin-left: 8px;
     display: flex;
@@ -267,6 +295,15 @@ span.muted {
   }
   nav.side .side-nested-list {
     display: contents;
+  }
+  nav.side .side-workspace {
+    display: contents;
+  }
+  nav.side .side-nested-sub {
+    display: contents;
+    margin: 0;
+    padding: 0;
+    border: 0;
   }
   nav.side .side-foot {
     grid-column: 1 / -1;

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -67,7 +67,7 @@ Workspace access also comes from an **organization invitation**, not a code
 you redeem. Someone who already **admins that workspace** (org role
 admin/owner) invites your email:
 
-- **Account UI** — `/account/workspaces` → “Invite a teammate”
+- **Account UI** — `/account/workspaces/<name>/invite` → “Invite a teammate”
 - **CLI** — `uploads invite create --email you@example.com --workspace <name>`
   (device login as the inviter; no `ADMIN_TOKEN`)
 - **Site operators** can also invite from `/admin` (global admin session)

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -100,8 +100,8 @@ this at production while testing.
 People with org role **admin** or **owner** on a workspace invite teammates
 without `ADMIN_TOKEN` or a global site-admin role:
 
-- **Web:** `/account/workspaces` → “Invite a teammate” (session cookie →
-  `POST /me/workspaces/:name/invites`)
+- **Web:** `/account/workspaces/<name>/invite` → “Invite a teammate” (session
+  cookie → `POST /me/workspaces/:name/invites`)
 - **CLI:** `uploads invite create --email teammate@example.com --workspace <name>`
   (device login as the inviter, then the same `/me/…/invites` API)
 


### PR DESCRIPTION
## In plain terms

The signed-in account shell was cluttered (stacked cards, invite mixed into the workspace page) and the sidebar memberships flashed empty on every navigation. Locally the workspace page could also stick on “Loading…” because React Fast Refresh broke under the Cloudflare Vite adapter. This cleans up the layout, moves invite to a nested route, caches the sidebar list, and makes local dev load the React file browser reliably.

## What it does

- **Sidebar:** “Workspaces” is a section label (not a link). Memberships paint from `sessionStorage` then revalidate; invite appears as a nested item under the active workspace when you can invite.
- **Routes:** Workspace overview is header / files / galleries only. Invite + operator enrollment live at `/account/workspaces/<name>/invite`.
- **Surfaces:** Workspace and Developers use one card with internal blocks/hairlines instead of nested mini-panels.
- **Home avatar menu:** Scope landing link styles to `main` and clip menu hover fills so purple hover no longer bleeds on the homepage.
- **Local dev:** Disable Vite HMR so Fast Refresh cannot inject broken `$RefreshSig$` / `/@react-refresh` into account React mounts (production already skips this).

## What it is not

- No API/auth contract changes.
- No invite capability changes (still session-authed for workspace admins; `ADMIN_TOKEN` CLI remains operator-only).
- Component-level HMR is off in local web dev by design; full page refresh still works.

## How to try it

```bash
pnpm dev:stack
# open http://127.0.0.1:4321/account/workspaces/dev-demo
# invite: /account/workspaces/dev-demo/invite
# developers: /account/developers
# homepage avatar menu hover
```

## Test plan

- [x] `pnpm --filter @uploads/web test` (134 tests)
- [x] Local stack: workspace overview loads files/usage/galleries
- [ ] Sidebar memberships do not flash empty on navigate
- [ ] Nested Invite only for workspace admin/owner
- [ ] Developers list is flat hairline rows
- [ ] Homepage avatar menu hover stays inside the panel