### PR TITLE
fix(api,web): unbreak self-serve workspace CORS + magic-link consent resume

### DIFF
--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -1,0 +1,47 @@
+/**
+ * CORS mounting on the root app. The subtle one is `/v1/workspaces`: it is
+ * the only `/v1/*` route authenticated by session COOKIE (self-serve creation
+ * from the signed-in console at WEB_ORIGIN), so its preflight must be
+ * credentialed — without `Access-Control-Allow-Credentials` the browser
+ * drops the request entirely ("Failed to fetch") and self-serve creation
+ * silently breaks in prod. The rest of `/v1/*` is bearer-token-authenticated
+ * and deliberately stays uncredentialed.
+ */
+import { describe, expect, it } from "vitest";
+import { app } from "./index";
+
+const env = {} as unknown as Env;
+
+function preflight(path: string) {
+  return app.request(
+    `https://api.uploads.sh${path}`,
+    {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://uploads.sh",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type",
+      },
+    },
+    env,
+  );
+}
+
+describe("CORS preflights from the web origin", () => {
+  it("credentials the cookie-authenticated /v1/workspaces route", async () => {
+    const res = await preflight("/v1/workspaces");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("keeps bearer-token /v1 routes uncredentialed", async () => {
+    const res = await preflight("/v1/tokens");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+  });
+
+  it("keeps the cookie-authenticated /me surface credentialed", async () => {
+    const res = await preflight("/me/workspaces");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -72,7 +72,13 @@ export const app = new Hono<WorkspaceVars>()
   .use("/admin/*", consoleCors)
   .use("/admin-ui/*", adminUiCors)
   .use("/me/*", adminUiCors)
-  .use("/v1/*", consoleCors)
+  // `/v1/workspaces` is the one `/v1/*` route authenticated by session COOKIE
+  // (self-serve creation from the signed-in console), so its CORS must be
+  // credentialed like /me/* — the uncredentialed consoleCors preflight makes
+  // the browser drop the request entirely ("Failed to fetch"), which silently
+  // broke self-serve workspace creation from uploads.sh. Everything else
+  // under /v1/* stays uncredentialed: bearer tokens are the boundary there.
+  .use("/v1/*", (c, next) => (c.req.path === "/v1/workspaces" ? adminUiCors : consoleCors)(c, next))
   .route("/admin", admin)
   .route("/admin-ui", adminUi)
   .route("/me", me)

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -9,6 +9,7 @@ import {
   revokeSession,
   sendMagicLink,
   getOAuthWorkspaceChoice,
+  repairOAuthQuery,
   setOAuthWorkspaceChoice,
   startLocalDemoSession,
   submitOAuthConsent,
@@ -345,6 +346,21 @@ describe("submitOAuthConsent", () => {
     await expect(
       submitOAuthConsent("https://auth.uploads.sh", { accept: false, oauthQuery: "sig=x" }),
     ).resolves.toEqual({ ok: false, error: "expired request" });
+  });
+});
+
+describe("repairOAuthQuery", () => {
+  it("re-encodes literal + inside the sig param only", () => {
+    expect(repairOAuthQuery("?client_id=c1&scope=files%3Aread+files%3Awrite&sig=aB+cD/eF=")).toBe(
+      "client_id=c1&scope=files%3Aread+files%3Awrite&sig=aB%2BcD/eF=",
+    );
+  });
+
+  it("is a no-op for a cleanly encoded signed query", () => {
+    const clean = "client_id=c1&state=x-_y&sig=aB%2BcD%2FeF%3D";
+    expect(repairOAuthQuery(`?${clean}`)).toBe(clean);
+    expect(repairOAuthQuery("?client_id=c1")).toBe("client_id=c1");
+    expect(repairOAuthQuery("")).toBe("");
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -568,6 +568,29 @@ export async function setOAuthWorkspaceChoice(origin: string, workspace: string)
   }
 }
 
+/**
+ * location.search → the `oauth_query` string the AS's consent endpoint
+ * expects, repairing a specific corruption: better-auth 1.6.23's magic-link
+ * verify decodes its callbackURL one time too many, so a signed OAuth query
+ * that round-tripped through a sign-in email lands with the sig param's
+ * base64 `%2B` collapsed to a literal `+` — which query parsing then folds
+ * into a space, and the AS rejects the whole request with
+ * `invalid_signature`. A literal `+` can never legitimately appear in `sig`
+ * (base64 has no spaces to encode), so re-encoding it is a no-op for clean
+ * queries and repairs corrupted ones regardless of which hop dropped the
+ * encoding. The double-decode is lossless for sig's other specials (`%2F`→
+ * `/`, `%3D`→`=` survive parsing) and for the remaining signed params, whose
+ * values (URLs, base64url state/code_challenge) contain no encoded `+`.
+ */
+export function repairOAuthQuery(search: string): string {
+  return search
+    .replace(/^\?/, "")
+    .replace(
+      /(^|&)(sig=)([^&]*)/,
+      (_m, sep: string, key: string, value: string) => `${sep}${key}${value.replace(/\+/g, "%2B")}`,
+    );
+}
+
 export type OAuthConsentResult = { ok: true; redirectUri: string } | { ok: false; error: string };
 
 /**

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -125,6 +125,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     getOAuthWorkspaceChoice,
     getSession,
     listOrganizations,
+    repairOAuthQuery,
     setOAuthWorkspaceChoice,
     submitOAuthConsent,
     type OrganizationSummary,
@@ -174,7 +175,9 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   const params = new URLSearchParams(location.search);
   const clientId = params.get("client_id")?.trim() ?? "";
   const requestedScopes = (params.get("scope") ?? "").split(/\s+/).filter(Boolean);
-  const oauthQuery = location.search.replace(/^\?/, "");
+  // repairOAuthQuery, not a bare strip: a magic-link round trip can land here
+  // with the sig param's `%2B` collapsed to literal `+` (see auth-client.ts).
+  const oauthQuery = repairOAuthQuery(location.search);
 
   // Populated by proceed() once orgs load; used by decide() to know whether
   // the picker is showing and, if so, which slugs are valid choices.


### PR DESCRIPTION
Two prod bugs surfaced by the live e2e of the #236 workspace picker.

## 1. Self-serve workspace creation from the console has been broken since #171

`POST /v1/workspaces` authenticates by **session cookie**, but sat under the uncredentialed `consoleCors` mounted on all of `/v1/*`. The preflight response therefore lacked `Access-Control-Allow-Credentials`, the browser dropped the request (`Failed to fetch`), and the create-workspace form showed "The API is unreachable right now" for every signed-in user on uploads.sh. (#171's owed prod signup-flow verification would have caught this — it just got caught now instead, live.)

Fix: `/v1/workspaces` gets the credentialed `adminUiCors` treatment via a conditional mount; every other `/v1/*` route stays uncredentialed (bearer tokens are the boundary there). New `cors.test.ts` pins the three cases (workspaces credentialed, tokens not, /me still credentialed).

## 2. Magic-link OAuth resume fails `invalid_signature` for most sig values

better-auth 1.6.23's magic-link verify decodes its `callbackURL` one time too many. A signed OAuth query round-tripping through a sign-in email (the #229 resume path) lands on `/oauth/consent` with the `sig` param's base64 `%2B` collapsed to a literal `+` — query parsing folds that into a space and the AS rejects the consent POST with `invalid_signature`. Any sig containing `+` (~50% of HMACs) breaks; `%2F`→`/` and `%3D`→`=` survive parsing losslessly, as do the other signed params (URLs and base64url values contain no encoded `+`).

Fix: `repairOAuthQuery` in auth-client.ts re-encodes literal `+` **inside the sig param only** before the consent POST — a no-op for cleanly encoded queries, and independent of which hop dropped the encoding (so it stays correct if better-auth fixes the double-decode later). Unit tests cover the corrupted and clean cases.

Verified locally: 121 files / 1323 tests pass, format clean.

Post-merge: re-run the live flow — self-serve create from uploads.sh, and a fresh magic-link → consent → Allow round trip.