### PR TITLE
feat(web): client-side routing to reduce shell flicker

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -29,7 +29,7 @@ const MENU_ITEMS = [
   </div>
 </div>
 
-<script define:vars={{ authOrigin, menuItems: MENU_ITEMS }}>
+<script is:inline data-astro-rerun define:vars={{ authOrigin, menuItems: MENU_ITEMS }}>
   window.__UPLOADS_AUTH_ORIGIN__ = window.__UPLOADS_AUTH_ORIGIN__ || authOrigin;
   window.__UPLOADS_AUTH_MENU_ITEMS__ = menuItems;
 </script>
@@ -37,15 +37,19 @@ const MENU_ITEMS = [
   import { getSession, signOut, type SessionUser } from "../lib/auth-client";
   import {
     clearCachedSessionUser,
+    onAstroPageLoad,
     readCachedSessionUser,
     writeCachedSessionUser,
   } from "../lib/account-shell";
 
-  const root = document.querySelector<HTMLElement>("[data-auth-indicator]");
-  const slot = root?.querySelector<HTMLElement>("[data-slot]");
-  if (!root || !slot) {
-    // Not on a page that mounted the indicator.
-  } else {
+  function bootAuthIndicator(): void {
+    const root = document.querySelector<HTMLElement>("[data-auth-indicator]");
+    const slot = root?.querySelector<HTMLElement>("[data-slot]");
+    // Skip when absent, or when this DOM node was already wired (avoids
+    // double-boot when ClientRouter fires page-load after the first eager run).
+    if (!root || !slot || root.dataset.booted === "1") return;
+    root.dataset.booted = "1";
+
     const origin =
       (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__ ||
       "https://auth.uploads.sh";
@@ -155,7 +159,7 @@ const MENU_ITEMS = [
         "click",
         (event) => {
           event.stopPropagation();
-          setOpen(panel.hidden);
+          setOpen(Boolean(panel.hidden));
         },
         { signal },
       );
@@ -195,6 +199,8 @@ const MENU_ITEMS = [
     if (cached) paintUser(cached);
 
     void getSession(origin).then((result) => {
+      // Ignore if this indicator was swapped out mid-flight.
+      if (root.dataset.booted !== "1" || !document.contains(root)) return;
       if (result.kind === "unavailable") {
         paintUnavailable();
         return;
@@ -208,6 +214,12 @@ const MENU_ITEMS = [
       paintUser(result.session.user);
     });
   }
+
+  // Eager boot for pages without ClientRouter (landing, legal, login chrome).
+  // With ClientRouter, the data-booted guard skips the duplicate page-load call
+  // on first paint; body swaps get a fresh node and re-boot on page-load.
+  bootAuthIndicator();
+  onAstroPageLoad(bootAuthIndicator);
 </script>
 
 <style>

--- a/apps/web/src/components/ViewTransitions.astro
+++ b/apps/web/src/components/ViewTransitions.astro
@@ -1,0 +1,16 @@
+---
+/**
+ * Client-side routing for multi-page shells (account, admin, docs).
+ *
+ * We use Astro’s ClientRouter to hold the current view while the next route
+ * HTML is fetched, then swap — which removes the blank-page flicker of full
+ * reloads. Animations are intentionally off (`fallback="swap"` here; layouts
+ * also set `transition:animate="none"` on `<html>`).
+ *
+ * Layout and page scripts that attach listeners or fill dynamic UI must re-run
+ * on `astro:page-load` (bundled modules only execute once per session).
+ */
+import { ClientRouter } from "astro:transitions";
+---
+
+<ClientRouter fallback="swap" />

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -5,6 +5,9 @@
  *
  * Workspaces is a section label (not a link). Each membership nests under it,
  * with per-workspace sub-pages (e.g. Invite) when that workspace is active.
+ *
+ * ClientRouter holds the current view while the next account route loads
+ * (no blank-page flicker). Scripts re-boot on `astro:page-load`.
  */
 import { env } from "cloudflare:workers";
 import {
@@ -16,6 +19,7 @@ import {
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import ViewTransitions from "../components/ViewTransitions.astro";
 import "../styles/signed-in-shell.css";
 import "../styles/account-content.css";
 
@@ -57,9 +61,10 @@ const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
 ---
 
-<html lang="en">
+<html lang="en" transition:animate="none">
 <head>
   <BaseHead />
+  <ViewTransitions />
   <title>{docTitle}</title>
 </head>
 <body>
@@ -141,8 +146,9 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 {/* Sync optimistic paint: show the shell before deferred modules run so
     /account → /account/workspaces does not flash "Checking your session…".
     Key must match SESSION_CACHE_KEY in account-shell.ts. Not a security
-    boundary — revalidated by resolveSessionGate immediately after. */}
-<script is:inline>
+    boundary — revalidated by resolveSessionGate immediately after.
+    data-astro-rerun: ClientRouter must re-apply this after every body swap. */}
+<script is:inline data-astro-rerun>
   (function () {
     try {
       var raw = sessionStorage.getItem("uploads:sessionUser");
@@ -160,7 +166,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
   })();
 </script>
 
-<script define:vars={{ authOrigin, apiOrigin, workspace, workspacePage }}>
+<script is:inline data-astro-rerun define:vars={{ authOrigin, apiOrigin, workspace, workspacePage }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
   window.__UPLOADS_ACTIVE_WORKSPACE__ = workspace;
@@ -169,39 +175,48 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 <script>
   import {
     initSignOut,
+    onAstroPageLoad,
     requireElement,
     resolveSessionGate,
   } from "../lib/account-shell";
   import { initWorkspacesNav, type WorkspaceNavPage } from "../lib/workspaces-nav";
 
-  const w = window as unknown as {
-    __UPLOADS_AUTH_ORIGIN__: string;
-    __UPLOADS_API_ORIGIN__: string;
-    __UPLOADS_ACTIVE_WORKSPACE__: string;
-    __UPLOADS_WORKSPACE_PAGE__: WorkspaceNavPage;
-  };
-  const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
-  const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+  onAstroPageLoad(() => {
+    if (!document.getElementById("app")) return;
 
-  initSignOut(authOrigin);
-  initWorkspacesNav(apiOrigin, requireElement<HTMLElement>("#workspaces-nav-list", "account"), {
-    active: w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
-    page: w.__UPLOADS_WORKSPACE_PAGE__ || "overview",
-  });
+    const w = window as unknown as {
+      __UPLOADS_AUTH_ORIGIN__: string;
+      __UPLOADS_API_ORIGIN__: string;
+      __UPLOADS_ACTIVE_WORKSPACE__: string;
+      __UPLOADS_WORKSPACE_PAGE__: WorkspaceNavPage;
+    };
+    const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
 
-  void resolveSessionGate({
-    authOrigin,
-    checking: requireElement<HTMLElement>("#checking", "account"),
-    denied: requireElement<HTMLElement>("#signed-out", "account"),
-    unavailable: requireElement<HTMLElement>("#auth-unavailable", "account"),
-    app: requireElement<HTMLElement>("#app", "account"),
-  }).then((result) => {
-    requireElement<HTMLElement>("#admin-link", "account").hidden =
-      result?.user.role !== "admin";
-  });
+    initSignOut(authOrigin);
+    initWorkspacesNav(apiOrigin, requireElement<HTMLElement>("#workspaces-nav-list", "account"), {
+      active: w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+      page: w.__UPLOADS_WORKSPACE_PAGE__ || "overview",
+    });
 
-  requireElement<HTMLButtonElement>("#session-retry", "account").addEventListener("click", () => {
-    location.reload();
+    void resolveSessionGate({
+      authOrigin,
+      checking: requireElement<HTMLElement>("#checking", "account"),
+      denied: requireElement<HTMLElement>("#signed-out", "account"),
+      unavailable: requireElement<HTMLElement>("#auth-unavailable", "account"),
+      app: requireElement<HTMLElement>("#app", "account"),
+    }).then((result) => {
+      requireElement<HTMLElement>("#admin-link", "account").hidden =
+        result?.user.role !== "admin";
+    });
+
+    const retry = document.querySelector<HTMLButtonElement>("#session-retry");
+    if (retry && retry.dataset.bound !== "1") {
+      retry.dataset.bound = "1";
+      retry.addEventListener("click", () => {
+        location.reload();
+      });
+    }
   });
 </script>
 </body>

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -3,6 +3,9 @@
  * Shared shell for /admin and /admin/* — sidebar nav with real paths.
  * Client-side gating is a UX affordance only; /admin-ui/* enforces admin
  * server-side.
+ *
+ * ClientRouter holds the current view while the next admin route loads
+ * (no blank-page flicker). Scripts re-boot on `astro:page-load`.
  */
 import { env } from "cloudflare:workers";
 import {
@@ -14,6 +17,7 @@ import {
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import ViewTransitions from "../components/ViewTransitions.astro";
 import "../styles/signed-in-shell.css";
 
 export type AdminSection = "workspaces" | "users";
@@ -41,9 +45,10 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
 ];
 ---
 
-<html lang="en">
+<html lang="en" transition:animate="none">
 <head>
   <BaseHead />
+  <ViewTransitions />
   <title>{docTitle}</title>
 </head>
 <body>
@@ -101,8 +106,9 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
     </div>
   </div>
 
-{/* Sync optimistic paint for admins only — same cache key as account-shell. */}
-<script is:inline>
+{/* Sync optimistic paint for admins only — same cache key as account-shell.
+    data-astro-rerun: ClientRouter must re-apply this after every body swap. */}
+<script is:inline data-astro-rerun>
   (function () {
     try {
       var raw = sessionStorage.getItem("uploads:sessionUser");
@@ -118,35 +124,44 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
   })();
 </script>
 
-<script define:vars={{ authOrigin, apiOrigin }}>
+<script is:inline data-astro-rerun define:vars={{ authOrigin, apiOrigin }}>
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
   window.__UPLOADS_API_ORIGIN__ = apiOrigin;
 </script>
 <script>
   import {
     initSignOut,
+    onAstroPageLoad,
     requireElement,
     resolveSessionGate,
   } from "../lib/account-shell";
 
-  const w = window as unknown as {
-    __UPLOADS_AUTH_ORIGIN__: string;
-  };
-  const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
+  onAstroPageLoad(() => {
+    if (!document.getElementById("dashboard")) return;
 
-  initSignOut(authOrigin);
+    const w = window as unknown as {
+      __UPLOADS_AUTH_ORIGIN__: string;
+    };
+    const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
 
-  void resolveSessionGate({
-    authOrigin,
-    checking: requireElement<HTMLElement>("#checking", "admin"),
-    denied: requireElement<HTMLElement>("#denied", "admin"),
-    unavailable: requireElement<HTMLElement>("#auth-unavailable", "admin"),
-    app: requireElement<HTMLElement>("#dashboard", "admin"),
-    requireRole: "admin",
-  });
+    initSignOut(authOrigin);
 
-  requireElement<HTMLButtonElement>("#session-retry", "admin").addEventListener("click", () => {
-    location.reload();
+    void resolveSessionGate({
+      authOrigin,
+      checking: requireElement<HTMLElement>("#checking", "admin"),
+      denied: requireElement<HTMLElement>("#denied", "admin"),
+      unavailable: requireElement<HTMLElement>("#auth-unavailable", "admin"),
+      app: requireElement<HTMLElement>("#dashboard", "admin"),
+      requireRole: "admin",
+    });
+
+    const retry = document.querySelector<HTMLButtonElement>("#session-retry");
+    if (retry && retry.dataset.bound !== "1") {
+      retry.dataset.bound = "1";
+      retry.addEventListener("click", () => {
+        location.reload();
+      });
+    }
   });
 </script>
 </body>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -12,6 +12,7 @@
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import ViewTransitions from "../components/ViewTransitions.astro";
 
 interface TocEntry {
   id: string;
@@ -54,9 +55,10 @@ const currentLabel =
 const fullTitle = `${title} · uploads.sh`;
 ---
 
-<html lang="en">
+<html lang="en" transition:animate="none">
   <head>
     <BaseHead preloadSans />
+    <ViewTransitions />
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={`https://uploads.sh${path}`} />

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -95,13 +95,26 @@ function showUnavailable(
 /** Wire `#sign-out-btn` to end the session and return to /login. */
 export function initSignOut(authOrigin: string): void {
   const button = document.querySelector<HTMLButtonElement>("#sign-out-btn");
-  if (!button) return;
+  if (!button || button.dataset.bound === "1") return;
+  button.dataset.bound = "1";
   button.addEventListener("click", () => {
     clearCachedSessionUser();
     void signOut(authOrigin).then(() => {
       location.href = "/login";
     });
   });
+}
+
+/**
+ * Run after every Astro ClientRouter navigation (and the initial load when
+ * `<ClientRouter />` is present). Bundled module scripts only execute once per
+ * session — page/layout boot that queries the DOM must register here so it
+ * re-attaches after body swap.
+ *
+ * Prefer this over top-level side effects in account/admin page scripts.
+ */
+export function onAstroPageLoad(callback: () => void): void {
+  document.addEventListener("astro:page-load", callback);
 }
 
 export type SessionGateOptions = {

--- a/apps/web/src/pages/account/index.astro
+++ b/apps/web/src/pages/account/index.astro
@@ -59,71 +59,75 @@ export const prerender = false;
   </section>
 
   <script>
-    import { onSession, requireElement } from "../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { listSessions } from "../../lib/auth-client";
     import { resolveCliSetupState } from "../../lib/cli-setup-state";
 
-    const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
-      .__UPLOADS_AUTH_ORIGIN__;
+    onAstroPageLoad(() => {
+      if (!document.getElementById("cli-setup")) return;
 
-    requireElement<HTMLElement>("#cli-setup", "account overview").addEventListener(
-      "click",
-      (event) => {
-        void (async () => {
-          const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
-            "button[data-copy]",
-          );
-          if (!button) return;
-          try {
-            await navigator.clipboard.writeText(button.dataset.copy ?? "");
-            const previous = button.textContent;
-            button.textContent = "copied ✓";
-            setTimeout(() => {
-              button.textContent = previous;
-            }, 1500);
-          } catch {
-            // Clipboard blocked — leave the label.
-          }
-        })();
-      },
-    );
+      const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+        .__UPLOADS_AUTH_ORIGIN__;
 
-    function applyCliSetup(
-      sessions: Awaited<ReturnType<typeof listSessions>>,
-      cliOnboardedAt: string | Date | null | undefined,
-      loaded: boolean,
-    ): void {
-      const { kind, statusText, statusState } = resolveCliSetupState({
-        sessions,
-        cliOnboardedAt,
-        loaded,
-      });
-      const status = requireElement<HTMLElement>("#cli-setup-status", "account overview");
-      const card = requireElement<HTMLElement>("#cli-setup", "account overview");
-      const steps = requireElement<HTMLElement>("#cli-steps", "account overview");
-      const installCmd = requireElement<HTMLElement>("#cli-install-cmd", "account overview");
-      const note = requireElement<HTMLElement>("#cli-setup-note", "account overview");
+      requireElement<HTMLElement>("#cli-setup", "account overview").addEventListener(
+        "click",
+        (event) => {
+          void (async () => {
+            const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+              "button[data-copy]",
+            );
+            if (!button) return;
+            try {
+              await navigator.clipboard.writeText(button.dataset.copy ?? "");
+              const previous = button.textContent;
+              button.textContent = "copied ✓";
+              setTimeout(() => {
+                button.textContent = previous;
+              }, 1500);
+            } catch {
+              // Clipboard blocked — leave the label.
+            }
+          })();
+        },
+      );
 
-      card.dataset.setup = kind;
-      card.classList.toggle("is-pending", kind === "checking" || kind === "setup");
-      if (statusState) status.dataset.state = statusState;
-      else delete status.dataset.state;
-      status.textContent = statusText;
+      function applyCliSetup(
+        sessions: Awaited<ReturnType<typeof listSessions>>,
+        cliOnboardedAt: string | Date | null | undefined,
+        loaded: boolean,
+      ): void {
+        const { kind, statusText, statusState } = resolveCliSetupState({
+          sessions,
+          cliOnboardedAt,
+          loaded,
+        });
+        const status = requireElement<HTMLElement>("#cli-setup-status", "account overview");
+        const card = requireElement<HTMLElement>("#cli-setup", "account overview");
+        const steps = requireElement<HTMLElement>("#cli-steps", "account overview");
+        const installCmd = requireElement<HTMLElement>("#cli-install-cmd", "account overview");
+        const note = requireElement<HTMLElement>("#cli-setup-note", "account overview");
 
-      // ready: hide commands; reconnect: login only; setup/checking: full install.
-      steps.hidden = kind === "ready";
-      installCmd.hidden = kind === "reconnect";
-      note.hidden = kind === "ready" || kind === "reconnect";
-    }
+        card.dataset.setup = kind;
+        card.classList.toggle("is-pending", kind === "checking" || kind === "setup");
+        if (statusState) status.dataset.state = statusState;
+        else delete status.dataset.state;
+        status.textContent = statusText;
 
-    onSession((user) => {
-      requireElement<HTMLElement>("#hello-name", "account overview").textContent = user.name
-        ? `, ${user.name}`
-        : "";
+        // ready: hide commands; reconnect: login only; setup/checking: full install.
+        steps.hidden = kind === "ready";
+        installCmd.hidden = kind === "reconnect";
+        note.hidden = kind === "ready" || kind === "reconnect";
+      }
 
-      applyCliSetup(null, user.cliOnboardedAt, false);
-      void listSessions(authOrigin).then((sessions) => {
-        applyCliSetup(sessions, user.cliOnboardedAt, true);
+      onSession((user) => {
+        requireElement<HTMLElement>("#hello-name", "account overview").textContent = user.name
+          ? `, ${user.name}`
+          : "";
+
+        applyCliSetup(null, user.cliOnboardedAt, false);
+        void listSessions(authOrigin).then((sessions) => {
+          applyCliSetup(sessions, user.cliOnboardedAt, true);
+        });
       });
     });
   </script>

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -54,7 +54,7 @@ export const prerender = false;
   </section>
 
   <script>
-    import { onSession, requireElement } from "../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import {
       getAccountInfo,
       getSession,
@@ -68,6 +68,9 @@ export const prerender = false;
     import { getMyWorkspaces } from "../../lib/api-client";
     import { githubMarkSvg } from "../../lib/brand-icons";
     import { deviceLabel, formatSessionTime, isCliUserAgent } from "../../lib/session-device";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("acct-email")) return;
 
     const w = window as unknown as {
       __UPLOADS_AUTH_ORIGIN__: string;
@@ -396,6 +399,7 @@ export const prerender = false;
       void loadAccounts();
       void loadWorkspaceAccess();
       void loadSessions();
+    });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -33,69 +33,73 @@ if (isBrowseWorkspace(legacyWs)) {
   </section>
 
   <script>
-    import { onSession, requireElement } from "../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { getMyWorkspaces } from "../../lib/api-client";
     import { writeCachedWorkspaces } from "../../lib/workspaces-nav";
     import { escapeHtml } from "../../lib/workspace-ui";
 
-    const apiOrigin = (window as unknown as { __UPLOADS_API_ORIGIN__: string })
-      .__UPLOADS_API_ORIGIN__;
-    const page = "workspaces index";
-    const status = requireElement<HTMLElement>("#orgs-status", page);
-    const list = requireElement<HTMLUListElement>("#orgs-list", page);
-    const retry = requireElement<HTMLButtonElement>("#orgs-retry", page);
+    onAstroPageLoad(() => {
+      if (!document.getElementById("orgs-status")) return;
 
-    async function loadIndex(): Promise<void> {
-      status.hidden = false;
-      list.hidden = true;
-      retry.hidden = true;
-      status.textContent = "Loading…";
+      const apiOrigin = (window as unknown as { __UPLOADS_API_ORIGIN__: string })
+        .__UPLOADS_API_ORIGIN__;
+      const page = "workspaces index";
+      const status = requireElement<HTMLElement>("#orgs-status", page);
+      const list = requireElement<HTMLUListElement>("#orgs-list", page);
+      const retry = requireElement<HTMLButtonElement>("#orgs-retry", page);
 
-      const result = await getMyWorkspaces(apiOrigin);
-      if (result.kind === "unavailable") {
-        status.textContent =
-          "Workspaces are temporarily unavailable. Check the local stack or try again.";
-        retry.hidden = false;
-        return;
-      }
+      async function loadIndex(): Promise<void> {
+        status.hidden = false;
+        list.hidden = true;
+        retry.hidden = true;
+        status.textContent = "Loading…";
 
-      const { workspaces } = result;
-      writeCachedWorkspaces(workspaces);
+        const result = await getMyWorkspaces(apiOrigin);
+        if (result.kind === "unavailable") {
+          status.textContent =
+            "Workspaces are temporarily unavailable. Check the local stack or try again.";
+          retry.hidden = false;
+          return;
+        }
 
-      if (!workspaces.length) {
-        status.innerHTML =
-          'No workspaces yet — <a href="/account/workspaces/new">create one</a>, or accept an invite.';
-        return;
-      }
+        const { workspaces } = result;
+        writeCachedWorkspaces(workspaces);
 
-      if (workspaces.length === 1) {
-        const only = workspaces[0]!;
-        status.textContent = `Opening ${only.organization.name || only.workspace}…`;
-        location.replace(`/account/workspaces/${encodeURIComponent(only.workspace)}`);
-        return;
-      }
+        if (!workspaces.length) {
+          status.innerHTML =
+            'No workspaces yet — <a href="/account/workspaces/new">create one</a>, or accept an invite.';
+          return;
+        }
 
-      status.hidden = true;
-      list.hidden = false;
-      list.innerHTML = workspaces
-        .map((ws) => {
-          const name = ws.organization.name || ws.workspace;
-          const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
-          return `<li>
+        if (workspaces.length === 1) {
+          const only = workspaces[0]!;
+          status.textContent = `Opening ${only.organization.name || only.workspace}…`;
+          location.replace(`/account/workspaces/${encodeURIComponent(only.workspace)}`);
+          return;
+        }
+
+        status.hidden = true;
+        list.hidden = false;
+        list.innerHTML = workspaces
+          .map((ws) => {
+            const name = ws.organization.name || ws.workspace;
+            const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
+            return `<li>
             <div class="row">
               <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>
               <span class="slug">${escapeHtml(ws.role)}</span>
             </div>
           </li>`;
-        })
-        .join("");
-    }
+          })
+          .join("");
+      }
 
-    retry.addEventListener("click", () => {
-      void loadIndex();
-    });
-    onSession(() => {
-      void loadIndex();
+      retry.addEventListener("click", () => {
+        void loadIndex();
+      });
+      onSession(() => {
+        void loadIndex();
+      });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -54,7 +54,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
   </div>
 
   <script>
-    import { onSession, requireElement } from "../../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
     import {
       getMyWorkspaces,
       getMyWorkspaceUsage,
@@ -77,6 +77,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const { WorkspaceFiles } = await import("../../../components/WorkspaceFiles");
       return WorkspaceFiles;
     }
+
+    onAstroPageLoad(() => {
+      // Invite page also uses #ws-status/#ws-app — require the files mount.
+      if (!document.getElementById("ws-files")) return;
 
     const page = "workspace page";
     const w = window as unknown as {
@@ -198,6 +202,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
     onSession(() => {
       void loadWorkspace();
+    });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces/[name]/invite.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/invite.astro
@@ -64,7 +64,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
   </div>
 
   <script>
-    import { onSession, requireElement } from "../../../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../../../lib/account-shell";
     import { getMyWorkspaces, inviteToWorkspace } from "../../../../lib/api-client";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import {
@@ -73,6 +73,9 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       isWorkspaceAdminRole,
       operatorInviteCommand,
     } from "../../../../lib/workspace-ui";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("ws-invite-form")) return;
 
     const page = "workspace invite";
     const w = window as unknown as {
@@ -200,6 +203,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     onSession((user) => {
       sessionRole = user.role;
       void loadInvitePage();
+    });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -66,7 +66,7 @@ export const prerender = false;
   </section>
 
   <script>
-    import { onSession, requireElement } from "../../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
     import { linkGitHub, listAccounts } from "../../../lib/auth-client";
     import { createWorkspace } from "../../../lib/api-client";
     import { clearCachedWorkspaces } from "../../../lib/workspaces-nav";
@@ -76,6 +76,9 @@ export const prerender = false;
       safeSameOriginPath,
       suggestedWorkspaceName,
     } from "../../../lib/workspace-ui";
+
+    onAstroPageLoad(() => {
+      if (!document.querySelector("[data-create-form]")) return;
 
     const w = window as unknown as {
       __UPLOADS_API_ORIGIN__: string;
@@ -171,6 +174,7 @@ export const prerender = false;
         const suggestion = suggestedWorkspaceName(user.email);
         if (suggestion) input.value = suggestion;
       }
+    });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -17,7 +17,10 @@ export const prerender = false;
   </section>
 
   <script>
-    import { onSession, requireElement } from "../../lib/account-shell";
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("workspaces-list")) return;
 
     const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
     const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
@@ -273,6 +276,7 @@ export const prerender = false;
 
     onSession(() => {
       void loadWorkspaces();
+    });
     });
   </script>
 </AdminLayout>


### PR DESCRIPTION
## In plain terms

Moving around the account, admin, and docs shells used to do a full page reload every time, which left a blank flash (and sometimes a brief “Checking your session…” beat) even when the chrome barely changed. This turns those navigations into Astro client-side route swaps so the current view stays up until the next page is ready.

## What it does

- Adds Astro’s `ClientRouter` on account, admin, and docs layouts
- Keeps animations off (`transition:animate="none"`, `fallback="swap"`) — the goal is continuity, not motion
- Re-boots shell and page scripts on `astro:page-load` after body swap (modules only run once)
- Re-runs optimistic session paint scripts with `data-astro-rerun` so the signed-in chrome doesn’t re-flash the checking state

## What it is not

- Not a visual redesign or fancy transition library
- Login, legal, and other one-off pages still full-reload
- No CLI/package version change (no changeset)

## How to try it

```bash
pnpm --filter @uploads/web dev
```

Sign in, then click between Overview / Account / workspaces in the sidebar. The shell should stay continuous instead of blanking between states.

## Technical notes

- Shared wrapper: `apps/web/src/components/ViewTransitions.astro`
- `onAstroPageLoad` helper in `account-shell.ts` for layout/page boot
- Auth indicator still boots eagerly for pages without the router; `data-booted` avoids double-init when ClientRouter is present

## Test plan

- [x] `pnpm --filter @uploads/web test` (146 passed)
- [x] `pnpm --filter @uploads/web exec astro check` (0 errors)
- [ ] Manually click through `/account/*` and `/admin/*` with a signed-in session
- [ ] Docs left-nav navigations feel continuous without blank flash