### PR TITLE
chore: fix typecheck on main (apps/mcp + apps/web)

### DIFF
--- a/apps/api/src/guards.ts
+++ b/apps/api/src/guards.ts
@@ -183,25 +183,28 @@ export function inspectUpload(bytes: Uint8Array, policy: UploadPolicy): UploadIn
  * themselves are fixed per-binding in wrangler.jsonc (fixed sliding windows,
  * per-colo rather than globally exact — enough to blunt abuse, not billing).
  */
-function makeRateLimitGuard<BindingKey extends keyof Env>(
+function makeRateLimitGuard<BindingKey extends string>(
   bindingKey: BindingKey,
   message: string,
 ): {
   middleware: MiddlewareHandler<WorkspaceVars>;
-  allow: (env: { [K in BindingKey]?: Env[BindingKey] }, workspaceName: string) => Promise<boolean>;
+  allow: (env: Partial<Record<BindingKey, RateLimit>>, workspaceName: string) => Promise<boolean>;
 } {
   const allow = async (
-    env: { [K in BindingKey]?: Env[BindingKey] },
+    env: Partial<Record<BindingKey, RateLimit>>,
     workspaceName: string,
   ): Promise<boolean> => {
-    const limiter = env[bindingKey] as unknown as RateLimit | undefined;
+    const limiter = env[bindingKey];
     if (!limiter) return true;
     const { success } = await limiter.limit({ key: workspaceName });
     return success;
   };
 
   const middleware: MiddlewareHandler<WorkspaceVars> = async (c, next) => {
-    if (!(await allow(c.env, c.get("workspaceName")))) {
+    // `c.env` is the worker's full Env; narrowed here since this guard only
+    // ever reads the single `bindingKey` binding off of it.
+    const env = c.env as unknown as Partial<Record<BindingKey, RateLimit>>;
+    if (!(await allow(env, c.get("workspaceName")))) {
       throw new RateLimitedError(message);
     }
     await next();
@@ -236,7 +239,7 @@ export const allowRender = renderRateLimitGuard.allow;
  * local/dev setups, tests).
  */
 export async function allowWorkspaceCreate(
-  env: { WS_CREATE_LIMITER?: Env["WS_CREATE_LIMITER"] },
+  env: { WS_CREATE_LIMITER?: RateLimit },
   userId: string,
 ): Promise<boolean> {
   const limiter = env.WS_CREATE_LIMITER;


### PR DESCRIPTION
## Summary

Confirmed and fixed the pre-existing typecheck errors from #232.

**apps/mcp (2 errors, now fixed here):** `apps/api/src/guards.ts`'s
`makeRateLimitGuard` helper was generically constrained to
`BindingKey extends keyof Env`, and `allowWorkspaceCreate` indexed
`Env["WS_CREATE_LIMITER"]` — both against the *global ambient* `Env`
interface. apps/mcp imports and typechecks this file directly (it reuses
the guard helpers for its own put/delete rate limiting), so under mcp's
own generated `worker-configuration.d.ts` — which declares `WRITE_LIMITER`
but not `RENDER_LIMITER`/`WS_CREATE_LIMITER` (those are api-only bindings)
— the indexed types didn't resolve.

Fix: decouple the guard's env parameter from the global `Env` entirely.
It now takes a structural `Partial<Record<BindingKey, RateLimit>>`, since
all the helper ever does is read one named `RateLimit` binding off
whatever env object it's handed. Runtime behavior is unchanged — same
binding key, same fail-open-when-absent semantics, same limiter call.

**apps/web (was in the issue, already fixed on main):** the
`HTMLRewriter`-ambient-types clash in
`src/pages/account/workspaces/new.astro` was already resolved by #234
(`bindCopyButtons` widened to `Node`) before this branch was cut. Verified
`apps/web` typechecks clean with 0 errors; no changes needed here.

## Root causes
- mcp: cross-package typecheck of shared api code resolving a generic
  bound against the *consuming* package's ambient `Env`, not the
  declaring package's.
- web: already fixed by #234 (not touched in this PR).

## Test plan
- [x] `pnpm --filter @uploads/mcp run typecheck` — 0 errors
- [x] `pnpm --filter @uploads/api run typecheck` — 0 errors
- [x] `pnpm --filter @uploads/web run typecheck` — 0 errors
- [x] `pnpm --filter @uploads/auth run typecheck` — 0 errors
- [x] `pnpm test` — 121 files / 1323 tests passed
- [x] `pnpm check` (oxfmt) — clean

Closes #232