### PR TITLE
feat: workspace deletion path (admin-gated, v1)

### DIFF
--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -217,6 +217,14 @@ export async function deleteFileMetadata(
     .run();
 }
 
+/** Deletes every metadata row for a workspace being torn down. */
+export async function deleteFileMetadataForWorkspace(
+  db: D1Database,
+  workspace: string,
+): Promise<void> {
+  await db.prepare(`DELETE FROM file_metadata WHERE workspace = ?`).bind(workspace).run();
+}
+
 /**
  * Fully replaces an object's metadata: validates `metadata` once (there's no
  * prior state to merge against, so unlike `setFileMetadata` there's nothing

--- a/apps/api/src/galleries.ts
+++ b/apps/api/src/galleries.ts
@@ -315,6 +315,37 @@ export async function updateGallery(
   };
 }
 
+/**
+ * Hard-deletes every gallery (and its items/external references) for a
+ * workspace being torn down. Unlike `softDeleteGallery`, this is a permanent,
+ * unversioned wipe — only for workspace deletion, never a member-facing
+ * route. Explicit child deletes first rather than relying on the schema's
+ * `ON DELETE CASCADE` so this stays correct even if D1's FK enforcement
+ * config ever changes.
+ */
+export async function deleteGalleriesForWorkspace(
+  db: D1Database,
+  workspace: string,
+): Promise<{ galleries: number }> {
+  await db
+    .prepare(
+      `DELETE FROM gallery_items WHERE gallery_id IN (SELECT id FROM galleries WHERE workspace = ?)`,
+    )
+    .bind(workspace)
+    .run();
+  await db
+    .prepare(
+      `DELETE FROM gallery_external_references WHERE gallery_id IN (SELECT id FROM galleries WHERE workspace = ?)`,
+    )
+    .bind(workspace)
+    .run();
+  const result = await db
+    .prepare(`DELETE FROM galleries WHERE workspace = ?`)
+    .bind(workspace)
+    .run();
+  return { galleries: result.meta.changes ?? 0 };
+}
+
 export async function softDeleteGallery(
   db: D1Database,
   workspace: string,

--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -1,0 +1,190 @@
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it } from "vitest";
+import { FakeR2Bucket } from "../../test/fake-r2";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { respondError } from "../error-response";
+import { createGallery } from "../galleries";
+import { admin } from "./admin";
+
+const ADMIN_TOKEN = "test-admin-token";
+const MIGRATIONS = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260713210559_file_metadata.sql",
+];
+
+beforeAll(() => {
+  if (typeof crypto.subtle.timingSafeEqual !== "function") {
+    (
+      crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+    ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+      a.length === b.length && a.every((byte, i) => byte === b[i]);
+  }
+});
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+const RECORD = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "UPLOADS_DEFAULT",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+function fakeKv(records: Record<string, unknown>) {
+  const store = new Map(Object.entries(records));
+  return {
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    delete: (async (key: string) => {
+      store.delete(key);
+    }) as unknown as KVNamespace["delete"],
+    __store: store,
+  };
+}
+
+function appWith(opts: {
+  kvRecords?: Record<string, unknown>;
+  onDeleteOrg?: (slug: string) => void;
+  bucket?: FakeR2Bucket;
+  db?: SqliteD1;
+  defaultWorkspace?: string;
+}) {
+  const { kvRecords = {}, onDeleteOrg, bucket = new FakeR2Bucket(), db, defaultWorkspace } = opts;
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (req.method === "DELETE" && url.pathname.startsWith("/internal/orgs/")) {
+      onDeleteOrg?.(decodeURIComponent(url.pathname.slice("/internal/orgs/".length)));
+      return new Response(null, { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  });
+  const registry = fakeKv(kvRecords);
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/admin", admin)
+    .onError((err, c) => respondError(c, err));
+  const env = {
+    ADMIN_TOKEN,
+    AUTH: auth,
+    REGISTRY: registry,
+    UPLOADS_DEFAULT: bucket,
+    DB: db ? database(db) : undefined,
+    ...(defaultWorkspace ? { DEFAULT_WORKSPACE: defaultWorkspace } : {}),
+  } as unknown as Env;
+  return { app, env, registry, bucket };
+}
+
+function deleteRequest(name: string, opts?: { force?: boolean }) {
+  const url = new URL(`https://api.uploads.sh/admin/workspaces/${name}`);
+  if (opts?.force) url.searchParams.set("force", "1");
+  return new Request(url, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
+describe("DELETE /admin/workspaces/:name", () => {
+  it("401s without a valid admin token", async () => {
+    const { app, env } = appWith({});
+    const req = new Request("https://api.uploads.sh/admin/workspaces/acme", { method: "DELETE" });
+    const res = await app.request(req, {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("404s for an unknown workspace", async () => {
+    const { app, env } = appWith({});
+    const res = await app.request(deleteRequest("acme"), {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses to delete the communal/protected workspace", async () => {
+    const { app, env } = appWith({
+      kvRecords: { "ws:default": RECORD },
+      defaultWorkspace: "default",
+    });
+    const res = await app.request(deleteRequest("default"), {}, env);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("protected_workspace");
+  });
+
+  it("409s a non-empty workspace without ?force=1, reporting the object count", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
+    const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD }, bucket });
+    const res = await app.request(deleteRequest("acme"), {}, env);
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      error: { code: string; details?: { objectCount?: number } };
+    };
+    expect(body.error.code).toBe("workspace_not_empty");
+    expect(body.error.details?.objectCount).toBe(1);
+    // Nothing was touched.
+    expect(bucket.store.has("acme/f/one.png")).toBe(true);
+  });
+
+  it("cascades a forced delete: R2 objects, D1 rows, auth org, then the KV record", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
+    await bucket.put("acme/f/two.png", new Uint8Array([4, 5, 6, 7]));
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await createGallery(database(sqlite), { workspace: "acme", title: "Gallery" });
+      await createGallery(database(sqlite), { workspace: "beta", title: "Other" });
+
+      let deletedOrgSlug: string | undefined;
+      const {
+        app,
+        env,
+        registry,
+        bucket: envBucket,
+      } = appWith({
+        kvRecords: { "ws:acme": RECORD },
+        bucket,
+        db: sqlite,
+        onDeleteOrg: (slug) => {
+          deletedOrgSlug = slug;
+        },
+      });
+
+      const res = await app.request(deleteRequest("acme", { force: true }), {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        workspace: string;
+        deleted: boolean;
+        forced: boolean;
+        objectsDeleted: number;
+        galleriesDeleted: number;
+      };
+      expect(body).toMatchObject({
+        workspace: "acme",
+        deleted: true,
+        forced: true,
+        objectsDeleted: 2,
+        galleriesDeleted: 1,
+      });
+
+      // R2 objects gone.
+      expect(envBucket.store.size).toBe(0);
+      // Galleries gone for acme, untouched for beta.
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS count FROM galleries WHERE workspace = 'acme'").get(),
+      ).toMatchObject({ count: 0 });
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS count FROM galleries WHERE workspace = 'beta'").get(),
+      ).toMatchObject({ count: 1 });
+      // Auth-side org delete was invoked for the right slug.
+      expect(deletedOrgSlug).toBe("acme");
+      // KV record removed last.
+      expect(registry.__store.has("ws:acme")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,5 +1,11 @@
 import { renderEnrollmentInvitationEmail } from "@uploads/email";
-import { ConflictError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitedError,
+  ValidationError,
+} from "@uploads/errors";
 import { Hono } from "hono";
 import { adminAuth } from "../admin";
 import {
@@ -14,9 +20,18 @@ import {
   revokeToken,
   validateScopes,
 } from "../auth-db";
+import { deleteFileMetadataForWorkspace } from "../file-metadata";
+import { deleteGalleriesForWorkspace } from "../galleries";
 import { deriveWebOrigin, inviteLinkUrl as inviteMagicLink } from "../invite-links";
+import { deleteOrg } from "../org-workspaces";
 import { reencryptRegistryCredentials } from "../reencrypt-registry";
+import { isCommunal } from "./me";
+import { storage } from "../storage";
 import type { WorkspaceRecord } from "../workspace";
+
+// files-sdk bulk-delete batch size — mirrors retention.ts's DELETE_BATCH
+// (stays under R2/S3's 1000-key DeleteObjects cap while bounding memory).
+const R2_DELETE_BATCH = 500;
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 const HASH_PREFIX_LEN = 8;
@@ -426,4 +441,93 @@ export const admin = new Hono<{ Bindings: Env }>()
       const message = err instanceof Error ? err.message : String(err);
       throw new ValidationError(message, { cause: err });
     }
+  })
+
+  /**
+   * Admin-gated workspace teardown (v1 — see issue #241). Session-authed
+   * self-serve delete is deliberately out of scope here; this is the
+   * ops/CI break-glass path, same as `/tokens` and `/enrollments` above.
+   *
+   * Order (fail-safe: the KV record — the thing that actually grants
+   * storage access — is deleted last, so a failure partway through leaves
+   * the workspace inert rather than half-deleted-but-still-reachable):
+   *   1. 404 unknown workspace; 403 the communal/protected workspace.
+   *   2. Non-empty workspaces 409 with the object count unless `?force=1`;
+   *      with force, paginated list+delete of every R2 object under the
+   *      workspace's prefix.
+   *   3. Hard-delete file_metadata + galleries (+ items/references) rows.
+   *   4. Best-effort delete of the auth-side org + memberships.
+   *   5. Delete the `ws:<name>` KV record.
+   */
+  .delete("/workspaces/:name", async (c) => {
+    const name = c.req.param("name");
+    requireWorkspaceName(name);
+
+    if (isCommunal(c.env, name)) {
+      throw new ForbiddenError("cannot delete the communal workspace", {
+        code: "protected_workspace",
+      });
+    }
+
+    const record = await workspace(c, name);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const force = c.req.query("force") === "1" || c.req.query("force") === "true";
+
+    const store = await storage(c.env, record);
+    let objectCount = 0;
+    let freedBytes = 0;
+    let batch: string[] = [];
+    for await (const item of store.listAll()) {
+      objectCount += 1;
+      freedBytes += item.size ?? 0;
+      if (force) {
+        batch.push(item.key);
+        if (batch.length >= R2_DELETE_BATCH) {
+          await store.delete(batch);
+          batch = [];
+        }
+      }
+    }
+    if (!force && objectCount > 0) {
+      throw new ConflictError(
+        `workspace has ${objectCount} object(s); retry with ?force=1 to delete them too`,
+        { code: "workspace_not_empty", details: { objectCount } },
+      );
+    }
+    if (batch.length > 0) await store.delete(batch);
+
+    const { galleries } = await deleteGalleriesForWorkspace(c.env.DB, name);
+    await deleteFileMetadataForWorkspace(c.env.DB, name);
+
+    // Best-effort, like the self-serve rollback path in routes/workspaces.ts
+    // — an org left behind after this point is orphaned (no KV record means
+    // no storage access) and safe to clean up later.
+    await deleteOrg(c.env, name).catch((err) =>
+      console.error("workspace delete: org cleanup failed for", name, "may be orphaned", err),
+    );
+
+    await c.env.REGISTRY.delete(`ws:${name}`);
+
+    console.log(
+      JSON.stringify({
+        event: "workspace_deleted",
+        workspace: name,
+        forced: force,
+        objectsDeleted: force ? objectCount : 0,
+        freedBytes: force ? freedBytes : 0,
+        galleriesDeleted: galleries,
+      }),
+    );
+
+    return c.json({
+      workspace: name,
+      deleted: true,
+      forced: force,
+      objectsDeleted: force ? objectCount : 0,
+      freedBytes: force ? freedBytes : 0,
+      galleriesDeleted: galleries,
+    });
   });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -41,7 +41,7 @@ interface MyWorkspace {
  * mark it). Configurable via the `DEFAULT_WORKSPACE` var; defaults to
  * "default". Member surfaces skip the personal galleries/files browser for it.
  */
-function isCommunal(env: Env, name: string): boolean {
+export function isCommunal(env: Env, name: string): boolean {
   return name === (env.DEFAULT_WORKSPACE || "default");
 }
 

--- a/apps/api/test/file-metadata-sqlite.test.ts
+++ b/apps/api/test/file-metadata-sqlite.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   META_MAX_KEYS,
   deleteFileMetadata,
+  deleteFileMetadataForWorkspace,
   findObjectsByMetadata,
   getFileMetadata,
   replaceFileMetadata,
@@ -309,6 +310,27 @@ describe("file metadata persistence against SQLite", () => {
         // Rolled back: the DELETE + INSERT from the failed batch never committed.
         await expect(getFileMetadata(database(sqlite), "alpha", "f/one.png")).resolves.toEqual({
           app: "screenshots",
+        });
+      } finally {
+        sqlite.close();
+      }
+    });
+  });
+
+  describe("deleteFileMetadataForWorkspace", () => {
+    it("wipes every row for a workspace, leaving other workspaces untouched", async () => {
+      const sqlite = new SqliteD1(MIGRATION);
+      try {
+        await setFileMetadata(database(sqlite), "alpha", "f/one.png", { app: "screenshots" });
+        await setFileMetadata(database(sqlite), "alpha", "f/two.png", { app: "screenshots" });
+        await setFileMetadata(database(sqlite), "beta", "f/one.png", { app: "other" });
+
+        await deleteFileMetadataForWorkspace(database(sqlite), "alpha");
+
+        await expect(getFileMetadata(database(sqlite), "alpha", "f/one.png")).resolves.toEqual({});
+        await expect(getFileMetadata(database(sqlite), "alpha", "f/two.png")).resolves.toEqual({});
+        await expect(getFileMetadata(database(sqlite), "beta", "f/one.png")).resolves.toEqual({
+          app: "other",
         });
       } finally {
         sqlite.close();

--- a/apps/api/test/galleries-sqlite.test.ts
+++ b/apps/api/test/galleries-sqlite.test.ts
@@ -7,6 +7,7 @@ import {
   addExternalReference,
   addGalleryItem,
   createGallery,
+  deleteGalleriesForWorkspace,
   getGallery,
   listExternalReferences,
   listGalleryItems,
@@ -238,6 +239,50 @@ describe("gallery persistence against SQLite", () => {
       );
       await expect(getGallery(database(sqlite), "alpha", created.id)).resolves.toMatchObject({
         version: 2,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deleteGalleriesForWorkspace hard-deletes a workspace's galleries, items, and references, leaving others intact", async () => {
+    const sqlite = newSqliteD1();
+    try {
+      const alpha = await gallery(sqlite, "alpha");
+      await addGalleryItem(database(sqlite), "alpha", alpha.id, {
+        expectedVersion: 1,
+        objectKey: "screenshots/one.png",
+      });
+      await addExternalReference(database(sqlite), "alpha", alpha.id, {
+        expectedVersion: 2,
+        provider: "github",
+        resourceType: "item",
+        normalizedKey: "github:item:buildinternet/uploads#123",
+        locator: { owner: "buildinternet", repository: "uploads", number: 123 },
+        canonicalUrl: "https://github.com/buildinternet/uploads/issues/123",
+      });
+      const beta = await gallery(sqlite, "beta");
+      await addGalleryItem(database(sqlite), "beta", beta.id, {
+        expectedVersion: 1,
+        objectKey: "screenshots/two.png",
+      });
+
+      const result = await deleteGalleriesForWorkspace(database(sqlite), "alpha");
+      expect(result).toEqual({ galleries: 1 });
+
+      expect(
+        sqlite.db
+          .prepare("SELECT COUNT(*) AS count FROM galleries WHERE workspace = 'alpha'")
+          .get(),
+      ).toMatchObject({ count: 0 });
+      expect(sqlite.db.prepare("SELECT COUNT(*) AS count FROM gallery_items").get()).toMatchObject({
+        count: 1,
+      });
+      expect(
+        sqlite.db.prepare("SELECT COUNT(*) AS count FROM gallery_external_references").get(),
+      ).toMatchObject({ count: 0 });
+      await expect(getGallery(database(sqlite), "beta", beta.id)).resolves.toMatchObject({
+        id: beta.id,
       });
     } finally {
       sqlite.close();


### PR DESCRIPTION
## Summary

Adds a way to delete a workspace. Today there is none — no self-serve
endpoint, no `/admin` route, only the internal provisioning-rollback
helper `deleteOrg()`. Surfaced by a leftover `picker-e2e-tmp` workspace
from the OAuth picker e2e, which still counts toward the self-serve cap
of 3.

## Endpoint

`DELETE /admin/workspaces/:name` on the existing `ADMIN_TOKEN`-gated
`/admin` router (`apps/api/src/routes/admin.ts`) — ops/CI only, same
surface as `/tokens` and `/enrollments` on that router. A session-authed
self-serve delete (owner-initiated, with confirmation) is deliberately
**out of scope** for this pass — noted as follow-up.

### Contract

- `404 workspace_not_found` — no `ws:<name>` KV record.
- `403 protected_workspace` — the communal workspace (`DEFAULT_WORKSPACE`,
  default `"default"`; reuses `isCommunal`, now exported from
  `routes/me.ts`).
- `409 workspace_not_empty` (with `details.objectCount`) — the workspace
  has R2 objects and the request didn't pass `?force=1`.
- `?force=1` — cascades: paginated list+delete of every R2 object under
  the workspace's prefix (files-sdk `listAll()` + bulk `delete()`,
  mirroring `retention.ts`'s purge-expired pattern), then hard-deletes
  `file_metadata` rows and `galleries` (+ items + external references —
  explicit child deletes rather than relying on `ON DELETE CASCADE`),
  then best-effort deletes the auth-side org via the existing
  `deleteOrg()`, then finally deletes the `ws:<name>` KV record.
- Response: `{ workspace, deleted, forced, objectsDeleted, freedBytes, galleriesDeleted }`.
  Logs a structured `workspace_deleted` event.

Cleanup order is fail-safe: the KV record — the thing that actually
grants storage access — is deleted last, so a failure partway through
leaves the workspace inert rather than half-deleted-but-still-reachable.

## New helpers

- `deleteFileMetadataForWorkspace` (`src/file-metadata.ts`)
- `deleteGalleriesForWorkspace` (`src/galleries.ts`)
- `isCommunal` exported from `src/routes/me.ts` (was route-local)

## Out of scope / follow-ups

- Session-authed self-serve delete (owner-initiated with confirmation).
- Cleaning up `workspace_usage`/token rows — the workspace becomes
  unreachable once the KV record is gone, so these are orphaned but
  harmless; left for a follow-up if it matters.
- The leftover `picker-e2e-tmp` workspace on prod is the intended first
  use of this endpoint, **after** merge — not touched by this PR.

## Test plan

- [x] New tests: 404 unknown, 409 non-empty without force (reports
      count, touches nothing), forced cascade happy path (R2 + D1 +
      auth-org + KV, leaves other workspaces alone), protected-workspace
      refusal, admin-token gating (`src/routes/admin-workspace-delete.test.ts`)
- [x] Unit tests for the two new D1 helpers against real SQLite
      (`test/galleries-sqlite.test.ts`, `test/file-metadata-sqlite.test.ts`)
- [x] `pnpm --filter @uploads/api run typecheck` — 0 errors
- [x] `pnpm test` — 122 files / 1330 tests passed
- [x] `pnpm check` (oxfmt) — clean

Closes #241