### PR TITLE
feat(api,auth,web): operator admin panel for OAuth client registrations

### DIFF
--- a/apps/api/src/routes/admin-ui-oauth-clients.test.ts
+++ b/apps/api/src/routes/admin-ui-oauth-clients.test.ts
@@ -1,0 +1,201 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { adminUi } from "./admin-ui";
+
+const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
+const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+const CANNED_CLIENT = {
+  clientId: "c-1",
+  name: "My App",
+  type: "web",
+  public: true,
+  disabled: false,
+  official: false,
+  redirectUris: ["https://example.com/callback"],
+  scopes: ["files:read"],
+  uri: null,
+  icon: null,
+  userId: null,
+  skipConsent: false,
+  createdAt: 1737000000000,
+  updatedAt: 1737000000000,
+  consentCount: 0,
+  activeTokenCount: 0,
+  lastConsentAt: null,
+};
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** A single stub that answers get-session with `user`, and everything else via `onInternal`. */
+function stubEnv(
+  user: typeof ADMIN_USER | null,
+  onInternal: (path: string, req: Request) => Response | Promise<Response>,
+): Env {
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+    }
+    return onInternal(url.pathname, req);
+  });
+  return { AUTH: auth, REGISTRY: fakeKv([]) } as unknown as Env;
+}
+
+function fakeKv(names: string[]): Pick<KVNamespace, "list"> {
+  return {
+    list: (async () => ({
+      keys: names.map((name) => ({ name: `ws:${name}` })),
+      list_complete: true,
+      cacheStatus: null,
+    })) as unknown as KVNamespace["list"],
+  };
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/admin-ui", adminUi)
+    .onError((err, c) => respondError(c, err));
+}
+
+describe("/admin-ui/oauth-clients auth gate", () => {
+  it("401s with no session", async () => {
+    const env = stubEnv(null, () => new Response("{}"));
+    const res = await app().request("/admin-ui/oauth-clients", {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const env = stubEnv(NON_ADMIN_USER, () => new Response("{}"));
+    const res = await app().request("/admin-ui/oauth-clients", {}, env);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /admin-ui/oauth-clients", () => {
+  it("passes through the list from the internal endpoint", async () => {
+    const env = stubEnv(ADMIN_USER, (path, req) => {
+      if (path === "/internal/oauth-clients") {
+        expect(req.headers.get("x-uploads-internal")).toBe("1");
+        return Response.json({ clients: [CANNED_CLIENT] });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/oauth-clients", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ clients: [CANNED_CLIENT] });
+  });
+});
+
+describe("POST /admin-ui/oauth-clients", () => {
+  it("passes through a create request body and 201 response", async () => {
+    const env = stubEnv(ADMIN_USER, (path, req) => {
+      if (path === "/internal/oauth-clients") {
+        expect(req.headers.get("x-uploads-internal")).toBe("1");
+        expect(req.headers.get("content-type")).toBe("application/json");
+        return Response.json(CANNED_CLIENT, { status: 201 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request(
+      "/admin-ui/oauth-clients",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "My App", redirectUris: ["https://example.com/callback"] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual(CANNED_CLIENT);
+  });
+});
+
+describe("GET /admin-ui/oauth-clients/:clientId", () => {
+  it("passes through a detail response", async () => {
+    const env = stubEnv(ADMIN_USER, (path) => {
+      if (path === "/internal/oauth-clients/c-1") return Response.json(CANNED_CLIENT);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/oauth-clients/c-1", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(CANNED_CLIENT);
+  });
+
+  it("passes through a 404", async () => {
+    const env = stubEnv(ADMIN_USER, (path) => {
+      if (path === "/internal/oauth-clients/missing") {
+        return Response.json({ error: "not_found" }, { status: 404 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/oauth-clients/missing", {}, env);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not_found" });
+  });
+});
+
+describe("PATCH /admin-ui/oauth-clients/:clientId", () => {
+  it("passes through the patch body and response", async () => {
+    const env = stubEnv(ADMIN_USER, (path, req) => {
+      if (path === "/internal/oauth-clients/c-1") {
+        expect(req.method).toBe("PATCH");
+        expect(req.headers.get("x-uploads-internal")).toBe("1");
+        return Response.json({ ...CANNED_CLIENT, disabled: true });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request(
+      "/admin-ui/oauth-clients/c-1",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ disabled: true }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ...CANNED_CLIENT, disabled: true });
+  });
+});
+
+describe("DELETE /admin-ui/oauth-clients/:clientId", () => {
+  it("passes through a delete response", async () => {
+    const env = stubEnv(ADMIN_USER, (path, req) => {
+      if (path === "/internal/oauth-clients/c-1") {
+        expect(req.method).toBe("DELETE");
+        return Response.json({ ok: true });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/oauth-clients/c-1", { method: "DELETE" }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
+describe("AUTH binding outage", () => {
+  it("503s when the AUTH binding throws", async () => {
+    const auth: Pick<Fetcher, "fetch"> = {
+      fetch: (async (input: RequestInfo | URL) => {
+        const req = input instanceof Request ? input : new Request(input);
+        const url = new URL(req.url);
+        if (url.pathname === "/api/auth/get-session") {
+          return new Response(JSON.stringify({ session: {}, user: ADMIN_USER }), { status: 200 });
+        }
+        throw new Error("binding unavailable");
+      }) as Fetcher["fetch"],
+    };
+    const env = { AUTH: auth, REGISTRY: fakeKv([]) } as unknown as Env;
+    const res = await app().request("/admin-ui/oauth-clients", {}, env);
+    expect(res.status).toBe(503);
+  });
+});

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -5,7 +5,12 @@
  * the ops/CI `/admin` surface stays untouched. Backs the /admin page's
  * Workspaces slot on apps/web.
  */
-import { NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
+import {
+  NotFoundError,
+  RateLimitedError,
+  ServiceUnavailableError,
+  ValidationError,
+} from "@uploads/errors";
 import { Hono } from "hono";
 import {
   DEFAULT_ENROLLMENT_SECONDS,
@@ -50,6 +55,45 @@ async function orgSummaryForWorkspace(env: Env, name: string): Promise<OrgSummar
   );
   if (!response.ok) return null;
   return (await response.json().catch(() => null)) as OrgSummary | null;
+}
+
+/**
+ * Proxies a request to `path` over the AUTH service binding (Lane 1's
+ * `/internal/oauth-clients*` routes) and passes the status code + JSON body
+ * straight through — the auth worker owns validation of these payloads, this
+ * layer only adds the session/admin gate. A binding-level failure (thrown
+ * fetch, unparseable response) surfaces as a 503 rather than masquerading as
+ * whatever status the caller happened to be checking for.
+ */
+async function proxyOauthClients(
+  env: Env,
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<Response> {
+  let response: Response;
+  try {
+    response = await env.AUTH.fetch(`https://auth.internal${path}`, {
+      method: init?.method ?? "GET",
+      headers: {
+        "x-uploads-internal": "1",
+        ...(init?.body !== undefined ? { "content-type": "application/json" } : {}),
+      },
+      body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+    });
+  } catch (err) {
+    throw new ServiceUnavailableError("auth service is unavailable", {
+      code: "auth_service_unavailable",
+      cause: err,
+    });
+  }
+  const payload = await response.json().catch(() => null);
+  if (payload === null && response.status >= 500) {
+    throw new ServiceUnavailableError("auth service returned a malformed response", {
+      code: "auth_service_unavailable",
+      details: { status: response.status },
+    });
+  }
+  return Response.json(payload, { status: response.status });
 }
 
 export const adminUi = new Hono<SessionVars>()
@@ -212,4 +256,35 @@ export const adminUi = new Hono<SessionVars>()
       },
       201,
     );
+  })
+
+  // OAuth client registrations — proxied 1:1 to Lane 1's internal routes
+  // (see .context/2026-07-18-oauth-admin-panel-contract.md). Never re-validate
+  // beyond parsing JSON; the auth worker owns validation.
+  .get("/oauth-clients", async (c) => proxyOauthClients(c.env, "/internal/oauth-clients"))
+
+  .get("/oauth-clients/:clientId", async (c) => {
+    const clientId = c.req.param("clientId");
+    return proxyOauthClients(c.env, `/internal/oauth-clients/${encodeURIComponent(clientId)}`);
+  })
+
+  .post("/oauth-clients", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    return proxyOauthClients(c.env, "/internal/oauth-clients", { method: "POST", body });
+  })
+
+  .patch("/oauth-clients/:clientId", async (c) => {
+    const clientId = c.req.param("clientId");
+    const body = await c.req.json().catch(() => ({}));
+    return proxyOauthClients(c.env, `/internal/oauth-clients/${encodeURIComponent(clientId)}`, {
+      method: "PATCH",
+      body,
+    });
+  })
+
+  .delete("/oauth-clients/:clientId", async (c) => {
+    const clientId = c.req.param("clientId");
+    return proxyOauthClients(c.env, `/internal/oauth-clients/${encodeURIComponent(clientId)}`, {
+      method: "DELETE",
+    });
   });

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -57,7 +57,7 @@ export function isCliSessionUserAgent(ua?: string | null): boolean {
  * dependency on that package. Keep in lockstep with `FILE_SCOPES` in
  * `apps/api/src/auth-db.ts`.
  */
-const OAUTH_SCOPES = ["files:read", "files:write", "files:delete"] as const;
+export const OAUTH_SCOPES = ["files:read", "files:write", "files:delete"] as const;
 
 /** Default scopes granted to a dynamically registered client that requests none. */
 const OAUTH_CLIENT_REGISTRATION_DEFAULT_SCOPES = ["files:read", "files:write"] as const;

--- a/apps/auth/src/internal-oauth-clients.test.ts
+++ b/apps/auth/src/internal-oauth-clients.test.ts
@@ -121,6 +121,15 @@ describe("POST /internal/oauth-clients", () => {
     });
     expect(bad.status).toBe(400);
   });
+
+  it("400s on a redirect URI containing a fragment (RFC 6749 §3.1.2)", async () => {
+    const res = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      redirectUris: ["https://example.com/callback#fragment"],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "invalid_request" });
+  });
 });
 
 describe("GET /internal/oauth-clients", () => {
@@ -312,6 +321,19 @@ describe("PATCH /internal/oauth-clients/:clientId", () => {
       .where(eqClientId(clientId));
     expect(rowAfterUnset.metadata).toMatchObject({ someOtherKey: "keep-me" });
     expect((rowAfterUnset.metadata as Record<string, unknown>).official).toBeUndefined();
+  });
+
+  it("clears uri when patched with null", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      uri: "https://example.com",
+    });
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const res = await jsonReq("PATCH", `/internal/oauth-clients/${clientId}`, { uri: null });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { uri: string | null };
+    expect(body.uri).toBeNull();
   });
 });
 

--- a/apps/auth/src/internal-oauth-clients.test.ts
+++ b/apps/auth/src/internal-oauth-clients.test.ts
@@ -1,0 +1,400 @@
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { internal } from "./internal-routes";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+/**
+ * Lane 1 coverage for the operator OAuth-client CRUD routes
+ * (.context/2026-07-18-oauth-admin-panel-contract.md) against the fake D1
+ * harness: real migrations, real drizzle queries.
+ */
+
+let db: FakeD1Database;
+let env: AuthEnv;
+
+beforeEach(() => {
+  db = createFakeD1();
+  env = { DB: db, WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
+});
+
+function app() {
+  return new Hono<{ Bindings: AuthEnv }>().route("/internal", internal);
+}
+
+async function jsonReq(method: string, path: string, body?: unknown) {
+  return app().request(
+    path,
+    {
+      method,
+      headers: body === undefined ? {} : { "content-type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+const validCreateBody = {
+  name: "My App",
+  redirectUris: ["https://example.com/callback"],
+  scopes: ["files:read", "files:write"],
+};
+
+describe("POST /internal/oauth-clients", () => {
+  it("creates a public PKCE client and never returns clientSecret", async () => {
+    const res = await jsonReq("POST", "/internal/oauth-clients", validCreateBody);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("clientSecret");
+    expect(body).toMatchObject({
+      name: "My App",
+      type: "web",
+      public: true,
+      disabled: false,
+      official: false,
+      redirectUris: ["https://example.com/callback"],
+      scopes: ["files:read", "files:write"],
+      uri: null,
+      icon: null,
+      userId: null,
+      skipConsent: false,
+      consentCount: 0,
+      activeTokenCount: 0,
+      lastConsentAt: null,
+    });
+    expect(typeof body.clientId).toBe("string");
+    expect(typeof body.createdAt).toBe("number");
+    expect(typeof body.updatedAt).toBe("number");
+  });
+
+  it("stores official:true in metadata and sets userId null", async () => {
+    const res = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      official: true,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.official).toBe(true);
+    expect(body.userId).toBeNull();
+  });
+
+  it("400s on empty name", async () => {
+    const res = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      name: "  ",
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "invalid_request" });
+  });
+
+  it("400s on a javascript: redirect URI", async () => {
+    const res = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      redirectUris: ["javascript:alert(1)"],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "invalid_request" });
+  });
+
+  it("400s on a scope outside OAUTH_SCOPES", async () => {
+    const res = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      scopes: ["files:read", "admin:everything"],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "invalid_request" });
+  });
+
+  it("accepts http loopback redirect URIs but rejects other http URIs", async () => {
+    const ok = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      redirectUris: ["http://localhost:5173/callback", "http://127.0.0.1:5173/callback"],
+    });
+    expect(ok.status).toBe(201);
+
+    const bad = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      redirectUris: ["http://example.com/callback"],
+    });
+    expect(bad.status).toBe(400);
+  });
+});
+
+describe("GET /internal/oauth-clients", () => {
+  it("lists clients ordered createdAt desc", async () => {
+    const first = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      name: "First",
+    });
+    const firstBody = (await first.json()) as { clientId: string };
+    const second = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      name: "Second",
+    });
+    const secondBody = (await second.json()) as { clientId: string };
+
+    const res = await jsonReq("GET", "/internal/oauth-clients");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { clients: Array<{ clientId: string; name: string }> };
+    expect(body.clients).toHaveLength(2);
+    expect(body.clients[0].clientId).toBe(secondBody.clientId);
+    expect(body.clients[1].clientId).toBe(firstBody.clientId);
+  });
+});
+
+describe("GET /internal/oauth-clients/:clientId", () => {
+  it("404s for an unknown client", async () => {
+    const res = await jsonReq("GET", "/internal/oauth-clients/does-not-exist");
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "not_found" });
+  });
+
+  it("computes consent/token stats", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", validCreateBody);
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const now = new Date();
+    const later = new Date(now.getTime() + 1000);
+    await drizzle(db, { schema })
+      .insert(schema.oauthConsent)
+      .values([
+        {
+          id: "consent-1",
+          userId: "user-1",
+          clientId,
+          scopes: ["files:read"],
+          createdAt: now,
+          updatedAt: now,
+        },
+        {
+          id: "consent-2",
+          userId: "user-2",
+          clientId,
+          scopes: ["files:read"],
+          createdAt: later,
+          updatedAt: later,
+        },
+        // Second consent row for user-1: consentCount is DISTINCT so this
+        // shouldn't bump the count above 2.
+        {
+          id: "consent-3",
+          userId: "user-1",
+          clientId,
+          scopes: ["files:write"],
+          createdAt: now,
+          updatedAt: now,
+        },
+      ]);
+
+    const activeExpiry = new Date(Date.now() + 1000 * 60 * 60);
+    const expiredExpiry = new Date(Date.now() - 1000 * 60 * 60);
+    await drizzle(db, { schema })
+      .insert(schema.oauthRefreshToken)
+      .values([
+        {
+          id: "rt-active",
+          token: "tok-active",
+          clientId,
+          userId: "user-1",
+          scopes: ["files:read"],
+          createdAt: now,
+          expiresAt: activeExpiry,
+        },
+        {
+          id: "rt-revoked",
+          token: "tok-revoked",
+          clientId,
+          userId: "user-1",
+          scopes: ["files:read"],
+          revoked: now,
+          createdAt: now,
+          expiresAt: activeExpiry,
+        },
+        {
+          id: "rt-expired",
+          token: "tok-expired",
+          clientId,
+          userId: "user-1",
+          scopes: ["files:read"],
+          createdAt: now,
+          expiresAt: expiredExpiry,
+        },
+      ]);
+
+    const res = await jsonReq("GET", `/internal/oauth-clients/${clientId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      consentCount: number;
+      activeTokenCount: number;
+      lastConsentAt: number;
+    };
+    expect(body.consentCount).toBe(2);
+    expect(body.activeTokenCount).toBe(1);
+    // D1's integer timestamp mode stores second precision, so compare at
+    // second granularity rather than exact epoch-ms equality.
+    expect(Math.floor(body.lastConsentAt / 1000)).toBe(Math.floor(later.getTime() / 1000));
+  });
+});
+
+describe("PATCH /internal/oauth-clients/:clientId", () => {
+  it("404s for an unknown client", async () => {
+    const res = await jsonReq("PATCH", "/internal/oauth-clients/does-not-exist", {
+      disabled: true,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("updates fields and toggles disabled", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", validCreateBody);
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const res = await jsonReq("PATCH", `/internal/oauth-clients/${clientId}`, {
+      name: "Renamed",
+      disabled: true,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { name: string; disabled: boolean };
+    expect(body.name).toBe("Renamed");
+    expect(body.disabled).toBe(true);
+  });
+
+  it("400s on an invalid patch value without mutating the row", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", validCreateBody);
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const res = await jsonReq("PATCH", `/internal/oauth-clients/${clientId}`, {
+      redirectUris: ["javascript:alert(1)"],
+    });
+    expect(res.status).toBe(400);
+
+    const check = await jsonReq("GET", `/internal/oauth-clients/${clientId}`);
+    const body = (await check.json()) as { redirectUris: string[] };
+    expect(body.redirectUris).toEqual(validCreateBody.redirectUris);
+  });
+
+  it("toggles official in metadata while preserving other metadata keys", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", validCreateBody);
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    // Seed an unrelated metadata key directly, simulating a client that
+    // already carries other metadata alongside the official flag.
+    await drizzle(db, { schema })
+      .update(schema.oauthClient)
+      .set({ metadata: { someOtherKey: "keep-me" } })
+      .where(eqClientId(clientId));
+
+    const setOfficial = await jsonReq("PATCH", `/internal/oauth-clients/${clientId}`, {
+      official: true,
+    });
+    expect(setOfficial.status).toBe(200);
+    const setBody = (await setOfficial.json()) as { official: boolean };
+    expect(setBody.official).toBe(true);
+
+    const [rowAfterSet] = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eqClientId(clientId));
+    expect(rowAfterSet.metadata).toMatchObject({ official: true, someOtherKey: "keep-me" });
+
+    const unsetOfficial = await jsonReq("PATCH", `/internal/oauth-clients/${clientId}`, {
+      official: false,
+    });
+    expect(unsetOfficial.status).toBe(200);
+    const unsetBody = (await unsetOfficial.json()) as { official: boolean };
+    expect(unsetBody.official).toBe(false);
+
+    const [rowAfterUnset] = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eqClientId(clientId));
+    expect(rowAfterUnset.metadata).toMatchObject({ someOtherKey: "keep-me" });
+    expect((rowAfterUnset.metadata as Record<string, unknown>).official).toBeUndefined();
+  });
+});
+
+describe("DELETE /internal/oauth-clients/:clientId", () => {
+  it("404s for an unknown client", async () => {
+    const res = await jsonReq("DELETE", "/internal/oauth-clients/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+
+  it("hard deletes the client and its dependent token/consent rows", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", validCreateBody);
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const now = new Date();
+    await drizzle(db, { schema })
+      .insert(schema.oauthConsent)
+      .values({
+        id: "consent-1",
+        userId: "user-1",
+        clientId,
+        scopes: ["files:read"],
+        createdAt: now,
+        updatedAt: now,
+      });
+    await drizzle(db, { schema })
+      .insert(schema.oauthRefreshToken)
+      .values({
+        id: "rt-1",
+        token: "tok-1",
+        clientId,
+        userId: "user-1",
+        scopes: ["files:read"],
+        createdAt: now,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      });
+    await drizzle(db, { schema })
+      .insert(schema.oauthAccessToken)
+      .values({
+        id: "at-1",
+        token: "atok-1",
+        clientId,
+        userId: "user-1",
+        scopes: ["files:read"],
+        createdAt: now,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      });
+
+    const res = await jsonReq("DELETE", `/internal/oauth-clients/${clientId}`);
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean }).toMatchObject({ ok: true });
+
+    const remainingClients = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eqClientId(clientId));
+    expect(remainingClients).toHaveLength(0);
+    const remainingConsent = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthConsent)
+      .where(eqClientIdConsent(clientId));
+    expect(remainingConsent).toHaveLength(0);
+    const remainingRefresh = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthRefreshToken)
+      .where(eqClientIdRefresh(clientId));
+    expect(remainingRefresh).toHaveLength(0);
+    const remainingAccess = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthAccessToken)
+      .where(eqClientIdAccess(clientId));
+    expect(remainingAccess).toHaveLength(0);
+  });
+});
+
+function eqClientId(clientId: string) {
+  return eq(schema.oauthClient.clientId, clientId);
+}
+function eqClientIdConsent(clientId: string) {
+  return eq(schema.oauthConsent.clientId, clientId);
+}
+function eqClientIdRefresh(clientId: string) {
+  return eq(schema.oauthRefreshToken.clientId, clientId);
+}
+function eqClientIdAccess(clientId: string) {
+  return eq(schema.oauthAccessToken.clientId, clientId);
+}

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -4,14 +4,144 @@
  * applied in src/index.ts before this router is even reached).
  */
 import { drizzle } from "drizzle-orm/d1";
-import { and, eq } from "drizzle-orm";
+import { and, count, countDistinct, eq, gt, isNull, max } from "drizzle-orm";
 import { Hono } from "hono";
-import type { AuthEnv } from "./auth";
+import { OAUTH_SCOPES, type AuthEnv } from "./auth";
 import { sendAuthEmail } from "./email";
 import * as schema from "./schema";
 
 function errorJson(code: string, message: string) {
   return { error: { code, message } } as const;
+}
+
+// Lane 1 (operator OAuth admin panel contract, .context/2026-07-18-oauth-admin-panel-contract.md):
+// validation error shape differs from the rest of this file's errorJson —
+// the contract locks in `{error:"invalid_request", message}` for these routes.
+function invalidRequest(message: string) {
+  return { error: "invalid_request", message } as const;
+}
+
+const REDIRECT_SCHEME_ALLOWLIST = new Set(["https:", "http:"]);
+
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
+}
+
+/** Validates a redirect/homepage/icon URL per the contract's scheme allowlist. */
+function isAllowedUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (!REDIRECT_SCHEME_ALLOWLIST.has(url.protocol)) return false;
+  if (url.protocol === "http:" && !isLoopbackHost(url.hostname)) return false;
+  return true;
+}
+
+type OauthClientRow = typeof schema.oauthClient.$inferSelect;
+
+/** Reads the `official` flag out of the client's metadata JSON blob. */
+function isOfficial(row: OauthClientRow): boolean {
+  const metadata = row.metadata as Record<string, unknown> | null;
+  return Boolean(metadata && metadata.official === true);
+}
+
+function toEpochMs(value: Date | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  return value instanceof Date ? value.getTime() : value;
+}
+
+type OauthClientStats = {
+  consentCount: number;
+  activeTokenCount: number;
+  lastConsentAt: number | null;
+};
+
+async function statsForClient(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  clientId: string,
+): Promise<OauthClientStats> {
+  const [consentRow] = await db
+    .select({
+      consentCount: countDistinct(schema.oauthConsent.userId),
+      lastConsentAt: max(schema.oauthConsent.createdAt),
+    })
+    .from(schema.oauthConsent)
+    .where(eq(schema.oauthConsent.clientId, clientId));
+  const [tokenRow] = await db
+    .select({ activeTokenCount: count() })
+    .from(schema.oauthRefreshToken)
+    .where(
+      and(
+        eq(schema.oauthRefreshToken.clientId, clientId),
+        isNull(schema.oauthRefreshToken.revoked),
+        gt(schema.oauthRefreshToken.expiresAt, new Date()),
+      ),
+    );
+  return {
+    consentCount: consentRow?.consentCount ?? 0,
+    activeTokenCount: tokenRow?.activeTokenCount ?? 0,
+    lastConsentAt: toEpochMs(consentRow?.lastConsentAt ?? null),
+  };
+}
+
+function serializeClient(row: OauthClientRow, stats: OauthClientStats) {
+  return {
+    clientId: row.clientId,
+    name: row.name,
+    type: row.type,
+    public: Boolean(row.public),
+    disabled: Boolean(row.disabled),
+    official: isOfficial(row),
+    redirectUris: row.redirectUris ?? [],
+    scopes: row.scopes ?? [],
+    uri: row.uri,
+    icon: row.icon,
+    userId: row.userId,
+    skipConsent: Boolean(row.skipConsent),
+    createdAt: toEpochMs(row.createdAt),
+    updatedAt: toEpochMs(row.updatedAt),
+    ...stats,
+  };
+}
+
+function validateName(name: unknown): string | null {
+  if (typeof name !== "string") return null;
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.length > 200) return null;
+  return trimmed;
+}
+
+function validateRedirectUris(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 20) return null;
+  const uris: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !isAllowedUrl(entry)) return null;
+    uris.push(entry);
+  }
+  return uris;
+}
+
+function validateScopes(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const scopes: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || !(OAUTH_SCOPES as readonly string[]).includes(entry)) {
+      return null;
+    }
+    scopes.push(entry);
+  }
+  return scopes;
+}
+
+/** Optional https(-or-loopback) URL field (uri/icon). Undefined = "not provided". */
+function validateOptionalUrl(value: unknown): { ok: true; value: string | null } | { ok: false } {
+  if (value === undefined) return { ok: true, value: null };
+  if (value === null) return { ok: true, value: null };
+  if (typeof value !== "string" || !isAllowedUrl(value)) return { ok: false };
+  return { ok: true, value };
 }
 
 export const internal = new Hono<{ Bindings: AuthEnv }>()
@@ -497,4 +627,207 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       ok: true,
       user: { id: updated.id, email: updated.email, role: updated.role },
     });
+  })
+  // Lane 1 (operator OAuth admin panel contract): operator CRUD over
+  // Better Auth's oauth-provider tables. Always creates/keeps a public PKCE
+  // client — no client-secret handling anywhere in this file.
+  .get("/oauth-clients", async (c) => {
+    const db = drizzle(c.env.DB, { schema });
+    const rows = await db.select().from(schema.oauthClient).orderBy(schema.oauthClient.createdAt);
+    // orderBy asc by default; contract wants createdAt desc.
+    rows.reverse();
+    const clients = await Promise.all(
+      rows.map(async (row) => serializeClient(row, await statsForClient(db, row.clientId))),
+    );
+    return c.json({ clients });
+  })
+  .get("/oauth-clients/:clientId", async (c) => {
+    const clientId = c.req.param("clientId");
+    const db = drizzle(c.env.DB, { schema });
+    const [row] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, clientId))
+      .limit(1);
+    if (!row) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    const stats = await statsForClient(db, clientId);
+    return c.json(serializeClient(row, stats));
+  })
+  .post("/oauth-clients", async (c) => {
+    const body = await c.req.json().catch(() => ({}) as Record<string, unknown>);
+
+    const name = validateName(body.name);
+    if (!name) {
+      return c.json(invalidRequest("name is required and must be ≤ 200 characters"), 400);
+    }
+    const redirectUris = validateRedirectUris(body.redirectUris);
+    if (!redirectUris) {
+      return c.json(
+        invalidRequest("redirectUris must be 1-20 valid http(s) URLs (http only for loopback)"),
+        400,
+      );
+    }
+    const scopes = validateScopes(body.scopes);
+    if (!scopes) {
+      return c.json(invalidRequest("scopes must be a non-empty subset of OAUTH_SCOPES"), 400);
+    }
+    const uriResult = validateOptionalUrl(body.uri);
+    if (!uriResult.ok) {
+      return c.json(invalidRequest("uri must be a valid https (or loopback http) URL"), 400);
+    }
+    const iconResult = validateOptionalUrl(body.icon);
+    if (!iconResult.ok) {
+      return c.json(invalidRequest("icon must be a valid https (or loopback http) URL"), 400);
+    }
+    const type = typeof body.type === "string" && body.type ? body.type : "web";
+    const official = body.official === true;
+
+    const db = drizzle(c.env.DB, { schema });
+    const clientId = crypto.randomUUID();
+    const now = new Date();
+    await db.insert(schema.oauthClient).values({
+      id: crypto.randomUUID(),
+      clientId,
+      clientSecret: null,
+      name,
+      icon: iconResult.value,
+      uri: uriResult.value,
+      redirectUris,
+      scopes,
+      grantTypes: ["authorization_code", "refresh_token"],
+      responseTypes: ["code"],
+      tokenEndpointAuthMethod: "none",
+      type,
+      public: true,
+      requirePKCE: true,
+      disabled: false,
+      skipConsent: false,
+      userId: null,
+      metadata: official ? { official: true } : null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const [row] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, clientId))
+      .limit(1);
+    const stats = await statsForClient(db, clientId);
+    return c.json(serializeClient(row, stats), 201);
+  })
+  .patch("/oauth-clients/:clientId", async (c) => {
+    const clientId = c.req.param("clientId");
+    const db = drizzle(c.env.DB, { schema });
+    const [existing] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, clientId))
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "not_found" }, 404);
+    }
+
+    const body = await c.req.json().catch(() => ({}) as Record<string, unknown>);
+    const updates: Partial<OauthClientRow> = {};
+
+    if ("name" in body) {
+      const name = validateName(body.name);
+      if (!name) {
+        return c.json(invalidRequest("name is required and must be ≤ 200 characters"), 400);
+      }
+      updates.name = name;
+    }
+    if ("redirectUris" in body) {
+      const redirectUris = validateRedirectUris(body.redirectUris);
+      if (!redirectUris) {
+        return c.json(
+          invalidRequest("redirectUris must be 1-20 valid http(s) URLs (http only for loopback)"),
+          400,
+        );
+      }
+      updates.redirectUris = redirectUris;
+    }
+    if ("scopes" in body) {
+      const scopes = validateScopes(body.scopes);
+      if (!scopes) {
+        return c.json(invalidRequest("scopes must be a non-empty subset of OAUTH_SCOPES"), 400);
+      }
+      updates.scopes = scopes;
+    }
+    if ("uri" in body) {
+      const uriResult = validateOptionalUrl(body.uri);
+      if (!uriResult.ok) {
+        return c.json(invalidRequest("uri must be a valid https (or loopback http) URL"), 400);
+      }
+      updates.uri = uriResult.value;
+    }
+    if ("icon" in body) {
+      const iconResult = validateOptionalUrl(body.icon);
+      if (!iconResult.ok) {
+        return c.json(invalidRequest("icon must be a valid https (or loopback http) URL"), 400);
+      }
+      updates.icon = iconResult.value;
+    }
+    if ("disabled" in body) {
+      if (typeof body.disabled !== "boolean") {
+        return c.json(invalidRequest("disabled must be a boolean"), 400);
+      }
+      updates.disabled = body.disabled;
+    }
+    if ("skipConsent" in body) {
+      if (typeof body.skipConsent !== "boolean") {
+        return c.json(invalidRequest("skipConsent must be a boolean"), 400);
+      }
+      updates.skipConsent = body.skipConsent;
+    }
+    if ("official" in body) {
+      if (typeof body.official !== "boolean") {
+        return c.json(invalidRequest("official must be a boolean"), 400);
+      }
+      const metadata = { ...(existing.metadata as Record<string, unknown> | null) };
+      if (body.official) {
+        metadata.official = true;
+      } else {
+        delete metadata.official;
+      }
+      updates.metadata = Object.keys(metadata).length > 0 ? metadata : null;
+    }
+
+    updates.updatedAt = new Date();
+    await db
+      .update(schema.oauthClient)
+      .set(updates)
+      .where(eq(schema.oauthClient.clientId, clientId));
+
+    const [row] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, clientId))
+      .limit(1);
+    const stats = await statsForClient(db, clientId);
+    return c.json(serializeClient(row, stats));
+  })
+  .delete("/oauth-clients/:clientId", async (c) => {
+    const clientId = c.req.param("clientId");
+    const db = drizzle(c.env.DB, { schema });
+    const [existing] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, clientId))
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "not_found" }, 404);
+    }
+
+    await db.delete(schema.oauthAccessToken).where(eq(schema.oauthAccessToken.clientId, clientId));
+    await db
+      .delete(schema.oauthRefreshToken)
+      .where(eq(schema.oauthRefreshToken.clientId, clientId));
+    await db.delete(schema.oauthConsent).where(eq(schema.oauthConsent.clientId, clientId));
+    await db.delete(schema.oauthClient).where(eq(schema.oauthClient.clientId, clientId));
+
+    return c.json({ ok: true });
   });

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -40,6 +40,13 @@ function isAllowedUrl(value: string): boolean {
   return true;
 }
 
+/** Redirect URIs additionally forbid a fragment component (RFC 6749 §3.1.2). */
+function isAllowedRedirectUrl(value: string): boolean {
+  if (!isAllowedUrl(value)) return false;
+  const url = new URL(value);
+  return url.hash === "";
+}
+
 type OauthClientRow = typeof schema.oauthClient.$inferSelect;
 
 /** Reads the `official` flag out of the client's metadata JSON blob. */
@@ -118,7 +125,7 @@ function validateRedirectUris(value: unknown): string[] | null {
   if (!Array.isArray(value) || value.length === 0 || value.length > 20) return null;
   const uris: string[] = [];
   for (const entry of value) {
-    if (typeof entry !== "string" || !isAllowedUrl(entry)) return null;
+    if (typeof entry !== "string" || !isAllowedRedirectUrl(entry)) return null;
     uris.push(entry);
   }
   return uris;
@@ -636,9 +643,43 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     const rows = await db.select().from(schema.oauthClient).orderBy(schema.oauthClient.createdAt);
     // orderBy asc by default; contract wants createdAt desc.
     rows.reverse();
-    const clients = await Promise.all(
-      rows.map(async (row) => serializeClient(row, await statsForClient(db, row.clientId))),
-    );
+
+    // Two grouped aggregate queries instead of one statsForClient() call per
+    // row — avoids an N+1 (2N) query fan-out on the list endpoint.
+    const consentRows = await db
+      .select({
+        clientId: schema.oauthConsent.clientId,
+        consentCount: countDistinct(schema.oauthConsent.userId),
+        lastConsentAt: max(schema.oauthConsent.createdAt),
+      })
+      .from(schema.oauthConsent)
+      .groupBy(schema.oauthConsent.clientId);
+    const consentByClient = new Map(consentRows.map((row) => [row.clientId, row]));
+
+    const tokenRows = await db
+      .select({
+        clientId: schema.oauthRefreshToken.clientId,
+        activeTokenCount: count(),
+      })
+      .from(schema.oauthRefreshToken)
+      .where(
+        and(
+          isNull(schema.oauthRefreshToken.revoked),
+          gt(schema.oauthRefreshToken.expiresAt, new Date()),
+        ),
+      )
+      .groupBy(schema.oauthRefreshToken.clientId);
+    const tokensByClient = new Map(tokenRows.map((row) => [row.clientId, row.activeTokenCount]));
+
+    const clients = rows.map((row) => {
+      const consent = consentByClient.get(row.clientId);
+      const stats: OauthClientStats = {
+        consentCount: consent?.consentCount ?? 0,
+        activeTokenCount: tokensByClient.get(row.clientId) ?? 0,
+        lastConsentAt: toEpochMs(consent?.lastConsentAt ?? null),
+      };
+      return serializeClient(row, stats);
+    });
     return c.json({ clients });
   })
   .get("/oauth-clients/:clientId", async (c) => {
@@ -822,12 +863,14 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       return c.json({ error: "not_found" }, 404);
     }
 
-    await db.delete(schema.oauthAccessToken).where(eq(schema.oauthAccessToken.clientId, clientId));
-    await db
-      .delete(schema.oauthRefreshToken)
-      .where(eq(schema.oauthRefreshToken.clientId, clientId));
-    await db.delete(schema.oauthConsent).where(eq(schema.oauthConsent.clientId, clientId));
-    await db.delete(schema.oauthClient).where(eq(schema.oauthClient.clientId, clientId));
+    // Atomic via D1 batch — a partial failure must not leave tokens/consents
+    // orphaned against a deleted client (or vice versa).
+    await db.batch([
+      db.delete(schema.oauthAccessToken).where(eq(schema.oauthAccessToken.clientId, clientId)),
+      db.delete(schema.oauthRefreshToken).where(eq(schema.oauthRefreshToken.clientId, clientId)),
+      db.delete(schema.oauthConsent).where(eq(schema.oauthConsent.clientId, clientId)),
+      db.delete(schema.oauthClient).where(eq(schema.oauthClient.clientId, clientId)),
+    ]);
 
     return c.json({ ok: true });
   });

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -20,7 +20,7 @@ import SiteHeader from "../components/SiteHeader.astro";
 import ViewTransitions from "../components/ViewTransitions.astro";
 import "../styles/signed-in-shell.css";
 
-export type AdminSection = "workspaces" | "users";
+export type AdminSection = "workspaces" | "users" | "oauth";
 
 interface Props {
   section: AdminSection;
@@ -31,6 +31,7 @@ const { section } = Astro.props;
 const titles: Record<AdminSection, string> = {
   workspaces: "Admin",
   users: "Users · Admin",
+  oauth: "OAuth apps · Admin",
 };
 const docTitle = `${titles[section]} · uploads.sh`;
 
@@ -42,6 +43,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 const nav: { href: string; section: AdminSection; label: string }[] = [
   { href: "/admin", section: "workspaces", label: "Workspaces" },
   { href: "/admin/users", section: "users", label: "Users" },
+  { href: "/admin/oauth", section: "oauth", label: "OAuth apps" },
 ];
 ---
 

--- a/apps/web/src/pages/admin/oauth.astro
+++ b/apps/web/src/pages/admin/oauth.astro
@@ -1,0 +1,266 @@
+---
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-workspaces.css";
+import "../../styles/admin-oauth.css";
+
+export const prerender = false;
+---
+
+<AdminLayout section="oauth">
+  <section class="card">
+    <h2>OAuth apps</h2>
+    <p>
+      Registered OAuth client applications. All clients are public PKCE
+      clients — there is no client secret to manage.
+    </p>
+    <div id="oauth-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+    <div id="oauth-list"></div>
+  </section>
+
+  <section class="card">
+    <h2>New OAuth app</h2>
+    <form id="oauth-create-form" class="oauth-form">
+      <label>
+        Name
+        <input type="text" id="oauth-create-name" required maxlength="200" placeholder="My app" />
+      </label>
+      <label>
+        Redirect URIs (one per line)
+        <textarea
+          id="oauth-create-redirects"
+          required
+          rows="3"
+          placeholder="https://example.com/callback"
+        ></textarea>
+      </label>
+      <fieldset class="oauth-scopes">
+        <legend>Scopes</legend>
+        <label class="oauth-scope-check">
+          <input type="checkbox" name="oauth-create-scope" value="files:read" checked />
+          files:read
+        </label>
+        <label class="oauth-scope-check">
+          <input type="checkbox" name="oauth-create-scope" value="files:write" checked />
+          files:write
+        </label>
+        <label class="oauth-scope-check">
+          <input type="checkbox" name="oauth-create-scope" value="files:delete" />
+          files:delete
+        </label>
+      </fieldset>
+      <label>
+        Homepage URL (optional)
+        <input type="url" id="oauth-create-uri" placeholder="https://example.com" />
+      </label>
+      <label class="oauth-scope-check">
+        <input type="checkbox" id="oauth-create-official" />
+        Official app
+      </label>
+      <button type="submit">Create app</button>
+    </form>
+    <div id="oauth-create-status" role="status" hidden></div>
+    <div id="oauth-create-result" hidden>
+      <p class="muted">New client ID (copy it now):</p>
+      <div class="oauth-copy-row">
+        <input type="text" id="oauth-create-client-id" readonly aria-label="New client ID" />
+        <button type="button" id="oauth-create-copy">Copy</button>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("oauth-list")) return;
+
+      const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
+
+      const oauthStatus = requireElement<HTMLElement>("#oauth-status", "admin oauth");
+      const oauthList = requireElement<HTMLElement>("#oauth-list", "admin oauth");
+
+      interface OAuthClient {
+        clientId: string;
+        name: string;
+        type: string;
+        public: boolean;
+        disabled: boolean;
+        official: boolean;
+        redirectUris: string[];
+        scopes: string[];
+        uri: string | null;
+        icon: string | null;
+        userId: string | null;
+        skipConsent: boolean;
+        createdAt: number;
+        updatedAt: number;
+        consentCount: number;
+        activeTokenCount: number;
+        lastConsentAt: number | null;
+      }
+
+      function escapeHtml(value: string): string {
+        return value.replace(/[&<>"']/g, (ch) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+        );
+      }
+
+      async function apiGet<T>(path: string): Promise<T> {
+        const res = await fetch(`${apiOrigin}${path}`, { credentials: "include", cache: "no-store" });
+        if (!res.ok) throw new Error(`request failed: ${res.status}`);
+        return (await res.json()) as T;
+      }
+
+      function badges(client: OAuthClient): string {
+        const parts: string[] = [];
+        if (client.official) parts.push(`<span class="pill oauth-badge-official">Official</span>`);
+        if (client.disabled) parts.push(`<span class="pill oauth-badge-disabled">Disabled</span>`);
+        if (client.userId === null && !client.official)
+          parts.push(`<span class="pill oauth-badge-dcr">DCR</span>`);
+        return parts.join(" ");
+      }
+
+      function renderClient(client: OAuthClient): HTMLElement {
+        const row = document.createElement("a");
+        row.className = "oauth-row";
+        row.href = `/admin/oauth/${encodeURIComponent(client.clientId)}`;
+        row.innerHTML = `
+          <div class="oauth-row-main">
+            <span class="name">${escapeHtml(client.name)}</span>
+            ${badges(client)}
+          </div>
+          <div class="oauth-row-meta">
+            <code class="oauth-client-id">${escapeHtml(client.clientId)}</code>
+            <span class="muted">${client.scopes.map(escapeHtml).join(", ")}</span>
+            <span class="muted">created ${new Date(client.createdAt).toLocaleDateString()}</span>
+            <span class="muted">${client.consentCount} consent${client.consentCount === 1 ? "" : "s"}</span>
+          </div>
+        `;
+        return row;
+      }
+
+      async function loadClients() {
+        try {
+          const { clients } = await apiGet<{ clients: OAuthClient[] }>("/admin-ui/oauth-clients");
+          oauthStatus.hidden = true;
+          oauthList.innerHTML = "";
+          if (!clients.length) {
+            oauthStatus.hidden = false;
+            oauthStatus.textContent = "No OAuth apps yet.";
+            return;
+          }
+          for (const client of clients) oauthList.appendChild(renderClient(client));
+        } catch {
+          oauthStatus.hidden = false;
+          oauthStatus.textContent = "Failed to load OAuth apps.";
+        }
+      }
+
+      const createForm = requireElement<HTMLFormElement>("#oauth-create-form", "admin oauth");
+      const createStatus = requireElement<HTMLElement>("#oauth-create-status", "admin oauth");
+      const createResult = requireElement<HTMLElement>("#oauth-create-result", "admin oauth");
+      const createClientIdInput = requireElement<HTMLInputElement>(
+        "#oauth-create-client-id",
+        "admin oauth",
+      );
+      const createCopyBtn = requireElement<HTMLButtonElement>("#oauth-create-copy", "admin oauth");
+
+      createForm.addEventListener("submit", (event) => {
+        void (async () => {
+          event.preventDefault();
+          const nameInput = requireElement<HTMLInputElement>("#oauth-create-name", "admin oauth");
+          const redirectsInput = requireElement<HTMLTextAreaElement>(
+            "#oauth-create-redirects",
+            "admin oauth",
+          );
+          const uriInput = requireElement<HTMLInputElement>("#oauth-create-uri", "admin oauth");
+          const officialInput = requireElement<HTMLInputElement>(
+            "#oauth-create-official",
+            "admin oauth",
+          );
+          const scopeInputs = Array.from(
+            createForm.querySelectorAll<HTMLInputElement>('input[name="oauth-create-scope"]:checked'),
+          );
+
+          const name = nameInput.value.trim();
+          const redirectUris = redirectsInput.value
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean);
+          const scopes = scopeInputs.map((input) => input.value);
+          const uri = uriInput.value.trim();
+
+          const submitBtn = createForm.querySelector<HTMLButtonElement>("button[type=submit]");
+          if (submitBtn) submitBtn.disabled = true;
+          createStatus.hidden = true;
+          createResult.hidden = true;
+
+          try {
+            const res = await fetch(`${apiOrigin}/admin-ui/oauth-clients`, {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                name,
+                redirectUris,
+                scopes,
+                uri: uri || undefined,
+                official: officialInput.checked,
+              }),
+            });
+            if (!res.ok) {
+              const payload = (await res.json().catch(() => null)) as
+                | { error?: { message?: string } | string; message?: string }
+                | null;
+              const message =
+                (typeof payload?.error === "object" ? payload?.error?.message : undefined) ||
+                payload?.message ||
+                `create failed: ${res.status}`;
+              throw new Error(message);
+            }
+            const client = (await res.json()) as OAuthClient;
+
+            createClientIdInput.value = client.clientId;
+            createResult.hidden = false;
+            createForm.reset();
+            // Re-check the default scopes after reset.
+            const readCheck = createForm.querySelector<HTMLInputElement>(
+              'input[name="oauth-create-scope"][value="files:read"]',
+            );
+            const writeCheck = createForm.querySelector<HTMLInputElement>(
+              'input[name="oauth-create-scope"][value="files:write"]',
+            );
+            if (readCheck) readCheck.checked = true;
+            if (writeCheck) writeCheck.checked = true;
+
+            void loadClients();
+          } catch (err) {
+            createStatus.dataset.state = "error";
+            createStatus.textContent =
+              err instanceof Error && err.message ? err.message : "Couldn't create the OAuth app.";
+            createStatus.hidden = false;
+          } finally {
+            if (submitBtn) submitBtn.disabled = false;
+          }
+        })();
+      });
+
+      createCopyBtn.addEventListener("click", () => {
+        void (async () => {
+          if (!createClientIdInput.value) return;
+          try {
+            await navigator.clipboard.writeText(createClientIdInput.value);
+          } catch {
+            createClientIdInput.focus();
+            createClientIdInput.select();
+          }
+        })();
+      });
+
+      onSession(() => {
+        void loadClients();
+      });
+    });
+  </script>
+</AdminLayout>

--- a/apps/web/src/pages/admin/oauth.astro
+++ b/apps/web/src/pages/admin/oauth.astro
@@ -116,8 +116,6 @@ export const prerender = false;
         const parts: string[] = [];
         if (client.official) parts.push(`<span class="pill oauth-badge-official">Official</span>`);
         if (client.disabled) parts.push(`<span class="pill oauth-badge-disabled">Disabled</span>`);
-        if (client.userId === null && !client.official)
-          parts.push(`<span class="pill oauth-badge-dcr">DCR</span>`);
         return parts.join(" ");
       }
 

--- a/apps/web/src/pages/admin/oauth/[clientId].astro
+++ b/apps/web/src/pages/admin/oauth/[clientId].astro
@@ -1,0 +1,397 @@
+---
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import "../../../styles/admin-workspaces.css";
+import "../../../styles/admin-oauth.css";
+
+export const prerender = false;
+
+const clientId = Astro.params.clientId ?? "";
+if (!clientId) return Astro.redirect("/admin/oauth");
+---
+
+<AdminLayout section="oauth">
+  <section class="card">
+    <a href="/admin/oauth" class="oauth-back">&larr; OAuth apps</a>
+    <div id="oauth-detail-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+
+    <div id="oauth-detail" hidden>
+      <div class="oauth-detail-header">
+        <h2 id="oauth-detail-name"></h2>
+        <div id="oauth-detail-badges" class="oauth-detail-badges"></div>
+      </div>
+
+      <dl class="oauth-detail-grid">
+        <div>
+          <dt>Client ID</dt>
+          <dd><code id="oauth-detail-client-id"></code></dd>
+        </div>
+        <div>
+          <dt>Homepage</dt>
+          <dd id="oauth-detail-uri"></dd>
+        </div>
+        <div>
+          <dt>Redirect URIs</dt>
+          <dd id="oauth-detail-redirects"></dd>
+        </div>
+        <div>
+          <dt>Scopes</dt>
+          <dd id="oauth-detail-scopes"></dd>
+        </div>
+        <div>
+          <dt>Consents</dt>
+          <dd id="oauth-detail-consent-count"></dd>
+        </div>
+        <div>
+          <dt>Active tokens</dt>
+          <dd id="oauth-detail-active-tokens"></dd>
+        </div>
+        <div>
+          <dt>Last consent</dt>
+          <dd id="oauth-detail-last-consent"></dd>
+        </div>
+        <div>
+          <dt>Created</dt>
+          <dd id="oauth-detail-created"></dd>
+        </div>
+      </dl>
+
+      <div class="oauth-detail-actions">
+        <button type="button" id="oauth-edit-toggle">Edit</button>
+        <button type="button" id="oauth-disable-toggle"></button>
+        <button type="button" id="oauth-delete" class="oauth-danger">Delete</button>
+      </div>
+      <div id="oauth-action-status" role="status" hidden></div>
+
+      <form id="oauth-edit-form" class="oauth-form" hidden>
+        <label>
+          Name
+          <input type="text" id="oauth-edit-name" required maxlength="200" />
+        </label>
+        <label>
+          Redirect URIs (one per line)
+          <textarea id="oauth-edit-redirects" required rows="3"></textarea>
+        </label>
+        <fieldset class="oauth-scopes">
+          <legend>Scopes</legend>
+          <label class="oauth-scope-check">
+            <input type="checkbox" name="oauth-edit-scope" value="files:read" />
+            files:read
+          </label>
+          <label class="oauth-scope-check">
+            <input type="checkbox" name="oauth-edit-scope" value="files:write" />
+            files:write
+          </label>
+          <label class="oauth-scope-check">
+            <input type="checkbox" name="oauth-edit-scope" value="files:delete" />
+            files:delete
+          </label>
+        </fieldset>
+        <label>
+          Homepage URL (optional)
+          <input type="url" id="oauth-edit-uri" />
+        </label>
+        <label class="oauth-scope-check">
+          <input type="checkbox" id="oauth-edit-official" />
+          Official app
+        </label>
+        <div class="oauth-form-actions">
+          <button type="submit">Save changes</button>
+          <button type="button" id="oauth-edit-cancel">Cancel</button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <script>
+    import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
+
+    onAstroPageLoad(() => {
+      const detailEl = document.getElementById("oauth-detail");
+      if (!detailEl) return;
+
+      const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
+      const clientId = decodeURIComponent(location.pathname.split("/").pop() ?? "");
+
+      interface OAuthClient {
+        clientId: string;
+        name: string;
+        type: string;
+        public: boolean;
+        disabled: boolean;
+        official: boolean;
+        redirectUris: string[];
+        scopes: string[];
+        uri: string | null;
+        icon: string | null;
+        userId: string | null;
+        skipConsent: boolean;
+        createdAt: number;
+        updatedAt: number;
+        consentCount: number;
+        activeTokenCount: number;
+        lastConsentAt: number | null;
+      }
+
+      function escapeHtml(value: string): string {
+        return value.replace(/[&<>"']/g, (ch) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+        );
+      }
+
+      function errorMessage(payload: unknown, fallback: string): string {
+        if (payload && typeof payload === "object") {
+          const p = payload as { error?: { message?: string } | string; message?: string };
+          if (typeof p.error === "object" && p.error?.message) return p.error.message;
+          if (p.message) return p.message;
+        }
+        return fallback;
+      }
+
+      const statusEl = requireElement<HTMLElement>("#oauth-detail-status", "admin oauth detail");
+      const detail = requireElement<HTMLElement>("#oauth-detail", "admin oauth detail");
+      const nameEl = requireElement<HTMLElement>("#oauth-detail-name", "admin oauth detail");
+      const badgesEl = requireElement<HTMLElement>("#oauth-detail-badges", "admin oauth detail");
+      const clientIdEl = requireElement<HTMLElement>("#oauth-detail-client-id", "admin oauth detail");
+      const uriEl = requireElement<HTMLElement>("#oauth-detail-uri", "admin oauth detail");
+      const redirectsEl = requireElement<HTMLElement>("#oauth-detail-redirects", "admin oauth detail");
+      const scopesEl = requireElement<HTMLElement>("#oauth-detail-scopes", "admin oauth detail");
+      const consentCountEl = requireElement<HTMLElement>(
+        "#oauth-detail-consent-count",
+        "admin oauth detail",
+      );
+      const activeTokensEl = requireElement<HTMLElement>(
+        "#oauth-detail-active-tokens",
+        "admin oauth detail",
+      );
+      const lastConsentEl = requireElement<HTMLElement>(
+        "#oauth-detail-last-consent",
+        "admin oauth detail",
+      );
+      const createdEl = requireElement<HTMLElement>("#oauth-detail-created", "admin oauth detail");
+      const editToggleBtn = requireElement<HTMLButtonElement>(
+        "#oauth-edit-toggle",
+        "admin oauth detail",
+      );
+      const disableToggleBtn = requireElement<HTMLButtonElement>(
+        "#oauth-disable-toggle",
+        "admin oauth detail",
+      );
+      const deleteBtn = requireElement<HTMLButtonElement>("#oauth-delete", "admin oauth detail");
+      const actionStatus = requireElement<HTMLElement>("#oauth-action-status", "admin oauth detail");
+      const editForm = requireElement<HTMLFormElement>("#oauth-edit-form", "admin oauth detail");
+      const editCancelBtn = requireElement<HTMLButtonElement>(
+        "#oauth-edit-cancel",
+        "admin oauth detail",
+      );
+
+      let current: OAuthClient | null = null;
+
+      function badges(client: OAuthClient): string {
+        const parts: string[] = [];
+        if (client.official) parts.push(`<span class="pill oauth-badge-official">Official</span>`);
+        if (client.disabled) parts.push(`<span class="pill oauth-badge-disabled">Disabled</span>`);
+        if (client.userId === null && !client.official)
+          parts.push(`<span class="pill oauth-badge-dcr">DCR</span>`);
+        return parts.join(" ");
+      }
+
+      function render(client: OAuthClient): void {
+        current = client;
+        document.title = `${client.name} · OAuth apps · Admin · uploads.sh`;
+        nameEl.textContent = client.name;
+        badgesEl.innerHTML = badges(client);
+        clientIdEl.textContent = client.clientId;
+        uriEl.textContent = client.uri || "—";
+        redirectsEl.innerHTML = client.redirectUris.length
+          ? `<ul class="oauth-uri-list">${client.redirectUris.map((u) => `<li>${escapeHtml(u)}</li>`).join("")}</ul>`
+          : "—";
+        scopesEl.textContent = client.scopes.join(", ") || "—";
+        consentCountEl.textContent = String(client.consentCount);
+        activeTokensEl.textContent = String(client.activeTokenCount);
+        lastConsentEl.textContent = client.lastConsentAt
+          ? new Date(client.lastConsentAt).toLocaleString()
+          : "Never";
+        createdEl.textContent = new Date(client.createdAt).toLocaleString();
+        disableToggleBtn.textContent = client.disabled ? "Enable" : "Disable";
+
+        const nameInput = requireElement<HTMLInputElement>("#oauth-edit-name", "admin oauth detail");
+        const redirectsInput = requireElement<HTMLTextAreaElement>(
+          "#oauth-edit-redirects",
+          "admin oauth detail",
+        );
+        const uriInput = requireElement<HTMLInputElement>("#oauth-edit-uri", "admin oauth detail");
+        const officialInput = requireElement<HTMLInputElement>(
+          "#oauth-edit-official",
+          "admin oauth detail",
+        );
+        nameInput.value = client.name;
+        redirectsInput.value = client.redirectUris.join("\n");
+        uriInput.value = client.uri ?? "";
+        officialInput.checked = client.official;
+        for (const input of Array.from(
+          editForm.querySelectorAll<HTMLInputElement>('input[name="oauth-edit-scope"]'),
+        )) {
+          input.checked = client.scopes.includes(input.value);
+        }
+      }
+
+      async function loadClient(): Promise<void> {
+        statusEl.hidden = false;
+        statusEl.textContent = "Loading…";
+        detail.hidden = true;
+        try {
+          const res = await fetch(
+            `${apiOrigin}/admin-ui/oauth-clients/${encodeURIComponent(clientId)}`,
+            { credentials: "include", cache: "no-store" },
+          );
+          if (res.status === 404) {
+            statusEl.textContent = "OAuth app not found.";
+            return;
+          }
+          if (!res.ok) throw new Error(`request failed: ${res.status}`);
+          const client = (await res.json()) as OAuthClient;
+          statusEl.hidden = true;
+          detail.hidden = false;
+          render(client);
+        } catch {
+          statusEl.hidden = false;
+          statusEl.textContent = "Failed to load this OAuth app.";
+        }
+      }
+
+      editToggleBtn.addEventListener("click", () => {
+        editForm.hidden = !editForm.hidden;
+      });
+      editCancelBtn.addEventListener("click", () => {
+        editForm.hidden = true;
+        if (current) render(current);
+      });
+
+      editForm.addEventListener("submit", (event) => {
+        void (async () => {
+          event.preventDefault();
+          if (!current) return;
+          const nameInput = requireElement<HTMLInputElement>("#oauth-edit-name", "admin oauth detail");
+          const redirectsInput = requireElement<HTMLTextAreaElement>(
+            "#oauth-edit-redirects",
+            "admin oauth detail",
+          );
+          const uriInput = requireElement<HTMLInputElement>("#oauth-edit-uri", "admin oauth detail");
+          const officialInput = requireElement<HTMLInputElement>(
+            "#oauth-edit-official",
+            "admin oauth detail",
+          );
+          const scopeInputs = Array.from(
+            editForm.querySelectorAll<HTMLInputElement>('input[name="oauth-edit-scope"]:checked'),
+          );
+
+          const submitBtn = editForm.querySelector<HTMLButtonElement>("button[type=submit]");
+          if (submitBtn) submitBtn.disabled = true;
+          actionStatus.hidden = true;
+
+          try {
+            const res = await fetch(
+              `${apiOrigin}/admin-ui/oauth-clients/${encodeURIComponent(current.clientId)}`,
+              {
+                method: "PATCH",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  name: nameInput.value.trim(),
+                  redirectUris: redirectsInput.value
+                    .split("\n")
+                    .map((line) => line.trim())
+                    .filter(Boolean),
+                  scopes: scopeInputs.map((input) => input.value),
+                  uri: uriInput.value.trim() || undefined,
+                  official: officialInput.checked,
+                }),
+              },
+            );
+            if (!res.ok) {
+              const payload = await res.json().catch(() => null);
+              throw new Error(errorMessage(payload, `save failed: ${res.status}`));
+            }
+            const client = (await res.json()) as OAuthClient;
+            render(client);
+            editForm.hidden = true;
+            actionStatus.dataset.state = "ready";
+            actionStatus.textContent = "Saved.";
+            actionStatus.hidden = false;
+          } catch (err) {
+            actionStatus.dataset.state = "error";
+            actionStatus.textContent =
+              err instanceof Error && err.message ? err.message : "Couldn't save changes.";
+            actionStatus.hidden = false;
+          } finally {
+            if (submitBtn) submitBtn.disabled = false;
+          }
+        })();
+      });
+
+      disableToggleBtn.addEventListener("click", () => {
+        void (async () => {
+          if (!current) return;
+          disableToggleBtn.disabled = true;
+          actionStatus.hidden = true;
+          try {
+            const res = await fetch(
+              `${apiOrigin}/admin-ui/oauth-clients/${encodeURIComponent(current.clientId)}`,
+              {
+                method: "PATCH",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ disabled: !current.disabled }),
+              },
+            );
+            if (!res.ok) {
+              const payload = await res.json().catch(() => null);
+              throw new Error(errorMessage(payload, `update failed: ${res.status}`));
+            }
+            const client = (await res.json()) as OAuthClient;
+            render(client);
+          } catch (err) {
+            actionStatus.dataset.state = "error";
+            actionStatus.textContent =
+              err instanceof Error && err.message ? err.message : "Couldn't update this app.";
+            actionStatus.hidden = false;
+          } finally {
+            disableToggleBtn.disabled = false;
+          }
+        })();
+      });
+
+      deleteBtn.addEventListener("click", () => {
+        void (async () => {
+          if (!current) return;
+          if (!confirm(`Delete "${current.name}"? This revokes all its tokens and cannot be undone.`))
+            return;
+          deleteBtn.disabled = true;
+          actionStatus.hidden = true;
+          try {
+            const res = await fetch(
+              `${apiOrigin}/admin-ui/oauth-clients/${encodeURIComponent(current.clientId)}`,
+              { method: "DELETE", credentials: "include" },
+            );
+            if (!res.ok) {
+              const payload = await res.json().catch(() => null);
+              throw new Error(errorMessage(payload, `delete failed: ${res.status}`));
+            }
+            location.href = "/admin/oauth";
+          } catch (err) {
+            actionStatus.dataset.state = "error";
+            actionStatus.textContent =
+              err instanceof Error && err.message ? err.message : "Couldn't delete this app.";
+            actionStatus.hidden = false;
+            deleteBtn.disabled = false;
+          }
+        })();
+      });
+
+      onSession(() => {
+        void loadClient();
+      });
+    });
+  </script>
+</AdminLayout>

--- a/apps/web/src/pages/admin/oauth/[clientId].astro
+++ b/apps/web/src/pages/admin/oauth/[clientId].astro
@@ -191,8 +191,6 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         const parts: string[] = [];
         if (client.official) parts.push(`<span class="pill oauth-badge-official">Official</span>`);
         if (client.disabled) parts.push(`<span class="pill oauth-badge-disabled">Disabled</span>`);
-        if (client.userId === null && !client.official)
-          parts.push(`<span class="pill oauth-badge-dcr">DCR</span>`);
         return parts.join(" ");
       }
 
@@ -304,7 +302,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
                     .map((line) => line.trim())
                     .filter(Boolean),
                   scopes: scopeInputs.map((input) => input.value),
-                  uri: uriInput.value.trim() || undefined,
+                  uri: uriInput.value.trim() || null,
                   official: officialInput.checked,
                 }),
               },

--- a/apps/web/src/styles/admin-oauth.css
+++ b/apps/web/src/styles/admin-oauth.css
@@ -1,0 +1,234 @@
+/* Admin OAuth apps on /admin/oauth and /admin/oauth/[clientId] (JS-injected markup). */
+#oauth-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+.oauth-row {
+  display: block;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg);
+  text-decoration: none;
+  color: inherit;
+}
+.oauth-row:hover,
+.oauth-row:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.oauth-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.oauth-row-main .name {
+  color: var(--fg);
+  font-weight: 600;
+  font-size: 13px;
+}
+.oauth-row-meta {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+.oauth-client-id {
+  color: var(--body);
+  font: 11px var(--mono);
+}
+
+.pill.oauth-badge-official {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.pill.oauth-badge-disabled {
+  color: var(--red);
+  border-color: var(--red);
+}
+.pill.oauth-badge-dcr {
+  color: var(--muted);
+}
+
+.oauth-form {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+  max-width: 480px;
+}
+.oauth-form label {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.oauth-form input[type="text"],
+.oauth-form input[type="url"],
+.oauth-form textarea {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 7px 9px;
+  font: 12px var(--mono);
+  text-transform: none;
+  letter-spacing: normal;
+}
+.oauth-form textarea {
+  resize: vertical;
+}
+.oauth-scopes {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  display: grid;
+  gap: 6px;
+}
+.oauth-scopes legend {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0 4px;
+}
+.oauth-scope-check {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center;
+  gap: 6px;
+  text-transform: none !important;
+  letter-spacing: normal !important;
+  color: var(--body) !important;
+  font-size: 12px !important;
+}
+.oauth-form button,
+.oauth-detail-actions button,
+.oauth-form-actions button {
+  font: 11px var(--mono);
+  color: var(--accent);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 7px 12px;
+  cursor: pointer;
+  width: fit-content;
+}
+.oauth-form button:hover,
+.oauth-form button:focus-visible,
+.oauth-detail-actions button:hover,
+.oauth-detail-actions button:focus-visible,
+.oauth-form-actions button:hover,
+.oauth-form-actions button:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.oauth-danger {
+  color: var(--red) !important;
+}
+
+#oauth-create-status,
+#oauth-action-status {
+  font-size: 12px;
+  margin-top: 8px;
+}
+#oauth-create-status[data-state="error"],
+#oauth-action-status[data-state="error"] {
+  color: var(--red);
+}
+#oauth-create-status[data-state="ready"],
+#oauth-action-status[data-state="ready"] {
+  color: var(--accent);
+}
+
+#oauth-create-result {
+  margin-top: 12px;
+}
+.oauth-copy-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.oauth-copy-row input {
+  flex: 1;
+  min-width: 200px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 7px 9px;
+  font: 11px var(--mono);
+}
+
+.oauth-back {
+  font-size: 12px;
+  color: var(--muted);
+  text-decoration: none;
+}
+.oauth-back:hover,
+.oauth-back:focus-visible {
+  color: var(--accent);
+}
+
+.oauth-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+.oauth-detail-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.oauth-detail-grid {
+  margin: 16px 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px 20px;
+}
+.oauth-detail-grid dt {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.oauth-detail-grid dd {
+  margin: 4px 0 0;
+  color: var(--body);
+  font-size: 13px;
+  word-break: break-word;
+}
+.oauth-detail-grid code {
+  font: 12px var(--mono);
+}
+.oauth-uri-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+  font: 12px var(--mono);
+}
+
+.oauth-detail-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+
+.oauth-form-actions {
+  display: flex;
+  gap: 8px;
+}

--- a/apps/web/src/styles/admin-oauth.css
+++ b/apps/web/src/styles/admin-oauth.css
@@ -205,7 +205,7 @@
   margin: 4px 0 0;
   color: var(--body);
   font-size: 13px;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .oauth-detail-grid code {
   font: 12px var(--mono);


### PR DESCRIPTION
## Summary

Adds an operator admin panel for managing OAuth client registrations:

- auth-worker: `/internal/oauth-clients` CRUD routes
- api-worker: session + admin-gated `/admin-ui/oauth-clients` proxy in front of the auth-worker routes
- web: `/admin/oauth` and `/admin/oauth/[clientId]` pages under `AdminLayout`

## Design decisions

- Public PKCE clients only — no client secrets are issued or stored
- `official` is a flag stored in client metadata JSON, not a schema column
- Clients can be disabled without deleting them
- Delete is hard delete, with cleanup of the client's tokens and consent records
- Per-client stats (tokens issued, active consents, etc.) are read from the consent/token tables
- Scope input is validated against `OAUTH_SCOPES`
- Redirect URIs are checked against a scheme allowlist, with an exception for `http` loopback addresses (localhost dev clients)

## Motivation

This is a prerequisite for shipping official first-party OAuth apps (e.g. a GitHub integration and the CLI), which need registered public clients with an `official` flag. Modeled on the equivalent OAuth client admin panels in the either and sunny repos.

## Test plan

- [x] Unified suite: 1354/1354 passing
- [x] New coverage: `apps/api/src/routes/admin-ui-oauth-clients.test.ts`, `apps/auth/src/internal-oauth-clients.test.ts`
- [x] No D1 migrations needed — reuses the oauth-provider tables added in #226

## Screenshots

| List | Detail |
| --- | --- |
| ![OAuth apps list, showing an Official-badged client and a plain client, plus the create form](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/245/oauth-list-2026-07-18T17-25-51-056Z.webp) | ![OAuth app detail page with stats and edit/disable/delete controls](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/245/oauth-detail-2026-07-18T17-26-08-611Z.webp) |

Post-create state (copyable client ID):

![Post-create state showing the new client ID field with a Copy button](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/245/oauth-create-result-2026-07-18T17-25-24-143Z.webp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin OAuth apps section for viewing, creating, editing, enabling/disabling, and deleting OAuth applications.
  * OAuth app details now include redirect URLs, scopes, status, consent counts, token activity, and timestamps.
  * Added validation for app names, redirect URLs, scopes, and optional homepage/icon URLs.
  * Added navigation links and dedicated detail views for OAuth apps.

* **Bug Fixes**
  * Improved handling of unauthorized access, missing apps, invalid requests, and service outages.

* **Tests**
  * Added comprehensive coverage for OAuth administration, validation, statistics, and CRUD operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
