### PR TITLE
fix(web): hide console footer link and fix landing CTA hover

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -28,7 +28,6 @@ const COLUMNS: FooterColumn[] = [
     links: [
       { label: "Docs", href: "/docs" },
       { label: "Agent guide", href: "/github-screenshots" },
-      { label: "Console", href: "/console" },
       { label: "Sign in", href: "/login" },
     ],
   },

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -419,13 +419,6 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         padding: 10px 16px;
         text-decoration: none;
       }
-      .cta-solid:hover,
-      .cta-solid:focus-visible {
-        color: var(--bg);
-        background: color-mix(in srgb, var(--accent) 88%, #fff);
-        border-color: color-mix(in srgb, var(--accent) 88%, #fff);
-        outline: none;
-      }
       .cta-note { color: var(--muted); font-size: 12.5px; }
       /* Scope to main so header auth menu hover/active paint is not overridden
          (global `a` styles were bleeding into the avatar dropdown). */
@@ -437,6 +430,19 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       }
       main a:hover,
       main a:focus-visible { color: var(--accent); outline: none; }
+      /* Beat `main a:hover` so the solid CTA keeps dark text on a lighter fill
+         (otherwise accent-on-accent is nearly unreadable). */
+      main a.cta-solid {
+        color: var(--bg);
+        text-decoration: none;
+      }
+      main a.cta-solid:hover,
+      main a.cta-solid:focus-visible {
+        color: var(--bg);
+        background: color-mix(in srgb, var(--accent) 82%, #fff);
+        border-color: color-mix(in srgb, var(--accent) 82%, #fff);
+        outline: none;
+      }
       @media (max-width: 560px) {
         .cmdrow { grid-template-columns: 1fr auto; }
         .cmdrow .tag { grid-column: 1 / -1; }


### PR DESCRIPTION
## In plain terms

The site footer was advertising `/console`, which is still an operator-only surface and should not show up as a public nav link. The bottom “sign in with GitHub” button on the landing page also became nearly unreadable on hover — light purple text on a light purple fill.

## What it does

- Removes the **Console** entry from the public footer Product column
- Fixes landing CTA hover so dark text stays on a slightly lighter accent fill (beats the more general `main a:hover` color rule)

## What it is not

- Does not remove `/console` itself or operator-gated console links in account/admin shells
- Not a design system overhaul — just the footer link and the landing solid CTA hover specificity

## How to try it

1. Open the homepage and hover the bottom **sign in with GitHub** button — label should stay dark and readable
2. Check the footer Product column — **Console** should be gone; Docs / Agent guide / Sign in remain

## Test plan

- [x] Diff reviewed for footer link removal and CTA hover specificity
- [ ] Homepage hover check in a browser after deploy/preview
- [ ] Footer no longer lists Console on docs/legal/content pages that share `Footer.astro`