### PR TITLE
feat(api): soft-delete workspaces with grace window + deletion policy doc (#247)

### DIFF
--- a/apps/api/src/retention-sweep.ts
+++ b/apps/api/src/retention-sweep.ts
@@ -1,9 +1,13 @@
 /**
  * Daily retention sweep: every REGISTRY workspace with retentionDays set runs
- * purgeExpiredObjects. Invoked from the Worker scheduled handler.
+ * purgeExpiredObjects. Also finalizes soft-deleted workspaces (#247) whose
+ * grace window (`purgeAt`) has passed — full hard teardown, then a permanent
+ * purged tombstone so the slug stays reserved. Invoked from the Worker
+ * scheduled handler.
  */
 import { purgeExpiredObjects } from "./retention";
-import type { WorkspaceRecord } from "./workspace";
+import { teardownWorkspace } from "./workspace-teardown";
+import { isPurgedTombstone, type PurgedTombstone, type WorkspaceRecord } from "./workspace";
 
 export interface SweepResult {
   workspacesScanned: number;
@@ -15,6 +19,13 @@ export interface SweepResult {
     skipped?: boolean;
     error?: string;
   }>;
+  workspacesFinalized: Array<{
+    workspace: string;
+    objectsDeleted: number;
+    freedBytes: number;
+    galleriesDeleted: number;
+    error?: string;
+  }>;
 }
 
 export async function runRetentionSweep(env: Env): Promise<SweepResult> {
@@ -22,6 +33,7 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
   let workspacesScanned = 0;
   let workspacesWithRetention = 0;
   const purged: SweepResult["purged"] = [];
+  const workspacesFinalized: SweepResult["workspacesFinalized"] = [];
 
   do {
     const page = await env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
@@ -30,9 +42,9 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
       const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
       if (!name) continue;
 
-      let record: WorkspaceRecord | null = null;
+      let record: WorkspaceRecord | PurgedTombstone | null = null;
       try {
-        record = await env.REGISTRY.get<WorkspaceRecord>(entry.name, "json");
+        record = await env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(entry.name, "json");
       } catch (err) {
         purged.push({
           workspace: name,
@@ -43,6 +55,47 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
         continue;
       }
       if (!record) continue;
+      // Already-finalized tombstone — nothing to do, skip harmlessly.
+      if (isPurgedTombstone(record)) continue;
+
+      if (record.deletedAt) {
+        // Soft-deleted: skip normal retention purge; finalize once the grace
+        // window has elapsed.
+        if (!record.purgeAt || Date.now() < Date.parse(record.purgeAt)) continue;
+
+        try {
+          const result = await teardownWorkspace(env, name, record, {
+            reason: "grace_period_expired",
+            force: true,
+            replaceWithTombstone: true,
+          });
+          workspacesFinalized.push({
+            workspace: name,
+            objectsDeleted: result.objectsDeleted,
+            freedBytes: result.freedBytes,
+            galleriesDeleted: result.galleriesDeleted,
+          });
+          console.log(
+            JSON.stringify({
+              event: "workspace_purged",
+              workspace: name,
+              objectsDeleted: result.objectsDeleted,
+              freedBytes: result.freedBytes,
+              galleriesDeleted: result.galleriesDeleted,
+            }),
+          );
+        } catch (err) {
+          workspacesFinalized.push({
+            workspace: name,
+            objectsDeleted: 0,
+            freedBytes: 0,
+            galleriesDeleted: 0,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        continue;
+      }
+
       if (typeof record.retentionDays !== "number" || record.retentionDays <= 0) continue;
 
       workspacesWithRetention += 1;
@@ -75,7 +128,8 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
       workspacesScanned,
       workspacesWithRetention,
       purged,
+      workspacesFinalized,
     }),
   );
-  return { workspacesScanned, workspacesWithRetention, purged };
+  return { workspacesScanned, workspacesWithRetention, purged, workspacesFinalized };
 }

--- a/apps/api/src/retention-sweep.ts
+++ b/apps/api/src/retention-sweep.ts
@@ -60,8 +60,22 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
 
       if (record.deletedAt) {
         // Soft-deleted: skip normal retention purge; finalize once the grace
-        // window has elapsed.
-        if (!record.purgeAt || Date.now() < Date.parse(record.purgeAt)) continue;
+        // window has elapsed. A missing or unparseable purgeAt must never
+        // fall through to teardown (NaN comparisons are false, which would
+        // otherwise read as "grace elapsed") — surface it as an error instead.
+        if (!record.purgeAt) continue;
+        const purgeAtMs = Date.parse(record.purgeAt);
+        if (!Number.isFinite(purgeAtMs)) {
+          workspacesFinalized.push({
+            workspace: name,
+            objectsDeleted: 0,
+            freedBytes: 0,
+            galleriesDeleted: 0,
+            error: `unparseable purgeAt: ${record.purgeAt}`,
+          });
+          continue;
+        }
+        if (Date.now() < purgeAtMs) continue;
 
         try {
           const result = await teardownWorkspace(env, name, record, {

--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -42,6 +42,9 @@ function fakeKv(records: Record<string, unknown>) {
   const store = new Map(Object.entries(records));
   return {
     get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    put: (async (key: string, value: string) => {
+      store.set(key, JSON.parse(value));
+    }) as unknown as KVNamespace["put"],
     delete: (async (key: string) => {
       store.delete(key);
     }) as unknown as KVNamespace["delete"],
@@ -80,11 +83,19 @@ function appWith(opts: {
   return { app, env, registry, bucket };
 }
 
-function deleteRequest(name: string, opts?: { force?: boolean }) {
+function deleteRequest(name: string, opts?: { force?: boolean; hard?: boolean }) {
   const url = new URL(`https://api.uploads.sh/admin/workspaces/${name}`);
   if (opts?.force) url.searchParams.set("force", "1");
+  if (opts?.hard) url.searchParams.set("hard", "1");
   return new Request(url, {
     method: "DELETE",
+    headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
+function restoreRequest(name: string) {
+  return new Request(`https://api.uploads.sh/admin/workspaces/${name}/restore`, {
+    method: "POST",
     headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
   });
 }
@@ -114,11 +125,11 @@ describe("DELETE /admin/workspaces/:name", () => {
     expect(body.error.code).toBe("protected_workspace");
   });
 
-  it("409s a non-empty workspace without ?force=1, reporting the object count", async () => {
+  it("409s a non-empty workspace on ?hard=1 without ?force=1, reporting the object count", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
     const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD }, bucket });
-    const res = await app.request(deleteRequest("acme"), {}, env);
+    const res = await app.request(deleteRequest("acme", { hard: true }), {}, env);
     expect(res.status).toBe(409);
     const body = (await res.json()) as {
       error: { code: string; details?: { objectCount?: number } };
@@ -129,7 +140,18 @@ describe("DELETE /admin/workspaces/:name", () => {
     expect(bucket.store.has("acme/f/one.png")).toBe(true);
   });
 
-  it("cascades a forced delete: R2 objects, D1 rows, auth org, then the KV record", async () => {
+  it("refuses to delete the communal/protected workspace on ?hard=1 too", async () => {
+    const { app, env } = appWith({
+      kvRecords: { "ws:default": RECORD },
+      defaultWorkspace: "default",
+    });
+    const res = await app.request(deleteRequest("default", { hard: true }), {}, env);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("protected_workspace");
+  });
+
+  it("cascades a forced hard delete: R2 objects, D1 rows, auth org, then the KV record (slug freed)", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
     await bucket.put("acme/f/two.png", new Uint8Array([4, 5, 6, 7]));
@@ -153,17 +175,21 @@ describe("DELETE /admin/workspaces/:name", () => {
         },
       });
 
-      const res = await app.request(deleteRequest("acme", { force: true }), {}, env);
+      const res = await app.request(deleteRequest("acme", { force: true, hard: true }), {}, env);
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
+        ok: boolean;
         workspace: string;
+        mode: string;
         deleted: boolean;
         forced: boolean;
         objectsDeleted: number;
         galleriesDeleted: number;
       };
       expect(body).toMatchObject({
+        ok: true,
         workspace: "acme",
+        mode: "hard",
         deleted: true,
         forced: true,
         objectsDeleted: 2,
@@ -181,10 +207,94 @@ describe("DELETE /admin/workspaces/:name", () => {
       ).toMatchObject({ count: 1 });
       // Auth-side org delete was invoked for the right slug.
       expect(deletedOrgSlug).toBe("acme");
-      // KV record removed last.
+      // KV record removed outright — the slug is freed.
       expect(registry.__store.has("ws:acme")).toBe(false);
     } finally {
       sqlite.close();
     }
+  });
+
+  describe("soft delete (default)", () => {
+    it("sets deletedAt/purgeAt, leaves data untouched, R2 intact", async () => {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
+      const { app, env, registry } = appWith({ kvRecords: { "ws:acme": RECORD }, bucket });
+
+      const res = await app.request(deleteRequest("acme"), {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        ok: boolean;
+        mode: string;
+        deletedAt: string;
+        purgeAt: string;
+      };
+      expect(body.ok).toBe(true);
+      expect(body.mode).toBe("soft");
+      expect(new Date(body.purgeAt).getTime() - new Date(body.deletedAt).getTime()).toBe(
+        14 * 24 * 60 * 60 * 1000,
+      );
+
+      const stored = registry.__store.get("ws:acme") as { deletedAt?: string; purgeAt?: string };
+      expect(stored.deletedAt).toBe(body.deletedAt);
+      expect(stored.purgeAt).toBe(body.purgeAt);
+      // Data untouched.
+      expect(bucket.store.has("acme/f/one.png")).toBe(true);
+    });
+
+    it("a second delete 409s already_deleted with the existing purgeAt", async () => {
+      const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD } });
+      const first = await app.request(deleteRequest("acme"), {}, env);
+      const firstBody = (await first.json()) as { purgeAt: string };
+
+      const second = await app.request(deleteRequest("acme"), {}, env);
+      expect(second.status).toBe(409);
+      const body = (await second.json()) as {
+        error: { code: string; details?: { purgeAt?: string } };
+      };
+      expect(body.error.code).toBe("already_deleted");
+      expect(body.error.details?.purgeAt).toBe(firstBody.purgeAt);
+    });
+  });
+
+  describe("POST /admin/workspaces/:name/restore", () => {
+    it("404s for an unknown workspace", async () => {
+      const { app, env } = appWith({});
+      const res = await app.request(restoreRequest("acme"), {}, env);
+      expect(res.status).toBe(404);
+    });
+
+    it("409s not_deleted for a workspace that isn't soft-deleted", async () => {
+      const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD } });
+      const res = await app.request(restoreRequest("acme"), {}, env);
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("not_deleted");
+    });
+
+    it("restores within the grace window, clearing deletedAt/purgeAt", async () => {
+      const { app, env, registry } = appWith({ kvRecords: { "ws:acme": RECORD } });
+      await app.request(deleteRequest("acme"), {}, env);
+
+      const res = await app.request(restoreRequest("acme"), {}, env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, workspace: "acme" });
+
+      const stored = registry.__store.get("ws:acme") as { deletedAt?: string; purgeAt?: string };
+      expect(stored.deletedAt).toBeUndefined();
+      expect(stored.purgeAt).toBeUndefined();
+    });
+
+    it("410s grace_expired once purgeAt has passed", async () => {
+      const expired = {
+        ...RECORD,
+        deletedAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
+        purgeAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      const { app, env } = appWith({ kvRecords: { "ws:acme": expired } });
+      const res = await app.request(restoreRequest("acme"), {}, env);
+      expect(res.status).toBe(410);
+      const body = (await res.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("grace_expired");
+    });
   });
 });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,5 +1,6 @@
 import { renderEnrollmentInvitationEmail } from "@uploads/email";
 import {
+  AppError,
   ConflictError,
   ForbiddenError,
   NotFoundError,
@@ -20,18 +21,17 @@ import {
   revokeToken,
   validateScopes,
 } from "../auth-db";
-import { deleteFileMetadataForWorkspace } from "../file-metadata";
-import { deleteGalleriesForWorkspace } from "../galleries";
 import { deriveWebOrigin, inviteLinkUrl as inviteMagicLink } from "../invite-links";
-import { deleteOrg } from "../org-workspaces";
 import { reencryptRegistryCredentials } from "../reencrypt-registry";
 import { isCommunal } from "./me";
 import { storage } from "../storage";
-import type { WorkspaceRecord } from "../workspace";
-
-// files-sdk bulk-delete batch size — mirrors retention.ts's DELETE_BATCH
-// (stays under R2/S3's 1000-key DeleteObjects cap while bounding memory).
-const R2_DELETE_BATCH = 500;
+import { teardownWorkspace } from "../workspace-teardown";
+import {
+  isPurgedTombstone,
+  loadWorkspaceRecordRaw,
+  WORKSPACE_DELETE_GRACE_DAYS,
+  type WorkspaceRecord,
+} from "../workspace";
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 const HASH_PREFIX_LEN = 8;
@@ -444,20 +444,24 @@ export const admin = new Hono<{ Bindings: Env }>()
   })
 
   /**
-   * Admin-gated workspace teardown (v1 — see issue #241). Session-authed
-   * self-serve delete is deliberately out of scope here; this is the
-   * ops/CI break-glass path, same as `/tokens` and `/enrollments` above.
+   * Admin-gated workspace teardown (v1 — see issue #241; soft-by-default —
+   * see #247). Session-authed self-serve delete is deliberately out of scope
+   * here; this is the ops/CI break-glass path, same as `/tokens` and
+   * `/enrollments` above.
    *
-   * Order (fail-safe: the KV record — the thing that actually grants
-   * storage access — is deleted last, so a failure partway through leaves
-   * the workspace inert rather than half-deleted-but-still-reachable):
-   *   1. 404 unknown workspace; 403 the communal/protected workspace.
-   *   2. Non-empty workspaces 409 with the object count unless `?force=1`;
-   *      with force, paginated list+delete of every R2 object under the
-   *      workspace's prefix.
-   *   3. Hard-delete file_metadata + galleries (+ items/references) rows.
-   *   4. Best-effort delete of the auth-side org + memberships.
-   *   5. Delete the `ws:<name>` KV record.
+   * Default (no `?hard=1`): **soft delete**. Stamps `deletedAt`/`purgeAt`
+   * (14-day grace window) on the record and puts it back — access denies
+   * immediately (`loadWorkspaceRecord` treats a `deletedAt` record as not
+   * found), data untouched. Deleting an already-soft-deleted workspace 409s.
+   * The daily retention sweep finalizes (full hard teardown + permanent
+   * purged tombstone) once `purgeAt` passes.
+   *
+   * `?hard=1`: immediate permanent teardown via `teardownWorkspace` — R2
+   * objects, file_metadata + galleries rows, best-effort auth org, then the
+   * `ws:<name>` KV key is deleted outright (the only path that frees the
+   * slug). Non-empty workspaces still require `?force=1` on top.
+   *
+   * The communal/protected-workspace guard applies to both modes.
    */
   .delete("/workspaces/:name", async (c) => {
     const name = c.req.param("name");
@@ -469,65 +473,100 @@ export const admin = new Hono<{ Bindings: Env }>()
       });
     }
 
-    const record = await workspace(c, name);
-    if (!record) {
+    const raw = await loadWorkspaceRecordRaw(c.env, name);
+    if (!raw || isPurgedTombstone(raw)) {
       throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
     }
+    const record = raw;
 
+    const hard = c.req.query("hard") === "1" || c.req.query("hard") === "true";
     const force = c.req.query("force") === "1" || c.req.query("force") === "true";
 
-    const store = await storage(c.env, record);
-    let objectCount = 0;
-    let freedBytes = 0;
-    let batch: string[] = [];
-    for await (const item of store.listAll()) {
-      objectCount += 1;
-      freedBytes += item.size ?? 0;
-      if (force) {
-        batch.push(item.key);
-        if (batch.length >= R2_DELETE_BATCH) {
-          await store.delete(batch);
-          batch = [];
-        }
+    if (!hard) {
+      if (record.deletedAt) {
+        throw new ConflictError("workspace is already soft-deleted", {
+          code: "already_deleted",
+          details: { deletedAt: record.deletedAt, purgeAt: record.purgeAt },
+        });
+      }
+
+      const now = new Date();
+      const deletedAt = now.toISOString();
+      const purgeAt = new Date(
+        now.getTime() + WORKSPACE_DELETE_GRACE_DAYS * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const updated: WorkspaceRecord = { ...record, deletedAt, purgeAt };
+      await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(updated));
+
+      console.log(
+        JSON.stringify({ event: "workspace_deleted", workspace: name, mode: "soft", purgeAt }),
+      );
+
+      return c.json({ ok: true, workspace: name, mode: "soft", deletedAt, purgeAt });
+    }
+
+    // Hard path: count objects up front so the not-empty guard still applies
+    // without force, mirroring the previous behavior.
+    if (!force) {
+      const store = await storage(c.env, record);
+      let objectCount = 0;
+      for await (const _item of store.listAll()) objectCount += 1;
+      if (objectCount > 0) {
+        throw new ConflictError(
+          `workspace has ${objectCount} object(s); retry with ?force=1 to delete them too`,
+          { code: "workspace_not_empty", details: { objectCount } },
+        );
       }
     }
-    if (!force && objectCount > 0) {
-      throw new ConflictError(
-        `workspace has ${objectCount} object(s); retry with ?force=1 to delete them too`,
-        { code: "workspace_not_empty", details: { objectCount } },
-      );
-    }
-    if (batch.length > 0) await store.delete(batch);
 
-    const { galleries } = await deleteGalleriesForWorkspace(c.env.DB, name);
-    await deleteFileMetadataForWorkspace(c.env.DB, name);
-
-    // Best-effort, like the self-serve rollback path in routes/workspaces.ts
-    // — an org left behind after this point is orphaned (no KV record means
-    // no storage access) and safe to clean up later.
-    await deleteOrg(c.env, name).catch((err) =>
-      console.error("workspace delete: org cleanup failed for", name, "may be orphaned", err),
-    );
-
-    await c.env.REGISTRY.delete(`ws:${name}`);
-
-    console.log(
-      JSON.stringify({
-        event: "workspace_deleted",
-        workspace: name,
-        forced: force,
-        objectsDeleted: force ? objectCount : 0,
-        freedBytes: force ? freedBytes : 0,
-        galleriesDeleted: galleries,
-      }),
-    );
+    const result = await teardownWorkspace(c.env, name, record, {
+      reason: "admin_hard_delete",
+      force: true,
+    });
 
     return c.json({
+      ok: true,
       workspace: name,
+      mode: "hard",
       deleted: true,
       forced: force,
-      objectsDeleted: force ? objectCount : 0,
-      freedBytes: force ? freedBytes : 0,
-      galleriesDeleted: galleries,
+      objectsDeleted: result.objectsDeleted,
+      freedBytes: result.freedBytes,
+      galleriesDeleted: result.galleriesDeleted,
     });
+  })
+
+  /**
+   * Undelete a soft-deleted workspace within its grace window. 404 if the
+   * workspace never existed or is already a purged tombstone; 409
+   * `not_deleted` if it isn't currently soft-deleted; 410 `grace_expired`
+   * once `purgeAt` has passed (even if the sweep hasn't finalized it yet —
+   * restorability must not depend on cron timing).
+   */
+  .post("/workspaces/:name/restore", async (c) => {
+    const name = c.req.param("name");
+    requireWorkspaceName(name);
+
+    const raw = await loadWorkspaceRecordRaw(c.env, name);
+    if (!raw || isPurgedTombstone(raw)) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+    if (!raw.deletedAt) {
+      throw new ConflictError("workspace is not deleted", { code: "not_deleted" });
+    }
+    if (raw.purgeAt && Date.now() >= Date.parse(raw.purgeAt)) {
+      throw new AppError({
+        type: "conflict",
+        code: "grace_expired",
+        message: "grace period has expired",
+        status: 410,
+      });
+    }
+
+    const { deletedAt: _deletedAt, purgeAt: _purgeAt, ...rest } = raw;
+    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(rest));
+
+    console.log(JSON.stringify({ event: "workspace_restored", workspace: name }));
+
+    return c.json({ ok: true, workspace: name });
   });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -450,9 +450,10 @@ export const admin = new Hono<{ Bindings: Env }>()
    * `/enrollments` above.
    *
    * Default (no `?hard=1`): **soft delete**. Stamps `deletedAt`/`purgeAt`
-   * (14-day grace window) on the record and puts it back — access denies
-   * immediately (`loadWorkspaceRecord` treats a `deletedAt` record as not
-   * found), data untouched. Deleting an already-soft-deleted workspace 409s.
+   * (14-day grace window) on the record and puts it back — access denies at
+   * the record layer (`loadWorkspaceRecord` treats a `deletedAt` record as
+   * not found; its 60s KV cacheTtl means auth may trail up to a minute),
+   * data untouched. Deleting an already-soft-deleted workspace 409s.
    * The daily retention sweep finalizes (full hard teardown + permanent
    * purged tombstone) once `purgeAt` passes.
    *
@@ -517,6 +518,18 @@ export const admin = new Hono<{ Bindings: Env }>()
           { code: "workspace_not_empty", details: { objectCount } },
         );
       }
+    }
+
+    // Stamp the record non-serving before any destructive step: if teardown
+    // crashes partway, the workspace denies access instead of serving a
+    // half-wiped state, and the retention sweep finalizes it (purgeAt is
+    // already past) on its next run. Skip if already soft-deleted.
+    if (!record.deletedAt) {
+      const now = new Date().toISOString();
+      await c.env.REGISTRY.put(
+        `ws:${name}`,
+        JSON.stringify({ ...record, deletedAt: now, purgeAt: now }),
+      );
     }
 
     const result = await teardownWorkspace(c.env, name, record, {

--- a/apps/api/src/workspace-teardown.ts
+++ b/apps/api/src/workspace-teardown.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared hard-teardown sequence for a workspace: R2 objects, D1 rows (file
+ * metadata + galleries), best-effort auth org, then the `ws:<name>` KV
+ * record. Used by the admin hard-delete path (`DELETE
+ * /admin/workspaces/:name?hard=1`) and by the retention sweep's finalization
+ * of an expired soft delete (`apps/api/src/retention-sweep.ts`).
+ *
+ * Ordering is fail-safe: the KV record — the thing that actually grants
+ * storage access — is written/deleted last, so a failure partway through
+ * leaves the workspace inert rather than half-deleted-but-still-reachable.
+ */
+import { deleteFileMetadataForWorkspace } from "./file-metadata";
+import { deleteGalleriesForWorkspace } from "./galleries";
+import { deleteOrg } from "./org-workspaces";
+import { storage } from "./storage";
+import type { PurgedTombstone, WorkspaceRecord } from "./workspace";
+
+// files-sdk bulk-delete batch size — mirrors retention.ts's DELETE_BATCH
+// (stays under R2/S3's 1000-key DeleteObjects cap while bounding memory).
+const R2_DELETE_BATCH = 500;
+
+export interface TeardownOptions {
+  /** Structured-log `event` field / reason tag (e.g. "admin_hard_delete", "grace_period_expired"). */
+  reason: string;
+  /**
+   * Skip listing/deleting R2 objects even if the workspace is non-empty
+   * (force semantics) — the caller has already decided teardown proceeds
+   * regardless of object count. Defaults to true (delete unconditionally).
+   */
+  force?: boolean;
+  /**
+   * When true, replace the KV record with a minimal permanent purged
+   * tombstone instead of deleting the key outright — keeps the slug
+   * reserved. When false/omitted, the key is deleted (frees the slug).
+   */
+  replaceWithTombstone?: boolean;
+}
+
+export interface TeardownResult {
+  objectsDeleted: number;
+  freedBytes: number;
+  galleriesDeleted: number;
+}
+
+export async function teardownWorkspace(
+  env: Env,
+  name: string,
+  record: WorkspaceRecord,
+  opts: TeardownOptions,
+): Promise<TeardownResult> {
+  const force = opts.force ?? true;
+
+  const store = await storage(env, record);
+  let objectCount = 0;
+  let freedBytes = 0;
+  let batch: string[] = [];
+  for await (const item of store.listAll()) {
+    objectCount += 1;
+    freedBytes += item.size ?? 0;
+    if (force) {
+      batch.push(item.key);
+      if (batch.length >= R2_DELETE_BATCH) {
+        await store.delete(batch);
+        batch = [];
+      }
+    }
+  }
+  if (batch.length > 0) await store.delete(batch);
+
+  const { galleries } = await deleteGalleriesForWorkspace(env.DB, name);
+  await deleteFileMetadataForWorkspace(env.DB, name);
+
+  // Best-effort, like the self-serve rollback path in routes/workspaces.ts
+  // — an org left behind after this point is orphaned (no KV record means
+  // no storage access) and safe to clean up later.
+  await deleteOrg(env, name).catch((err) =>
+    console.error("workspace teardown: org cleanup failed for", name, "may be orphaned", err),
+  );
+
+  if (opts.replaceWithTombstone) {
+    const tombstone: PurgedTombstone = {
+      status: "purged",
+      name,
+      purgedAt: new Date().toISOString(),
+      deletedAt: record.deletedAt,
+    };
+    await env.REGISTRY.put(`ws:${name}`, JSON.stringify(tombstone));
+  } else {
+    await env.REGISTRY.delete(`ws:${name}`);
+  }
+
+  console.log(
+    JSON.stringify({
+      event: "workspace_deleted",
+      reason: opts.reason,
+      workspace: name,
+      forced: force,
+      objectsDeleted: objectCount,
+      freedBytes,
+      galleriesDeleted: galleries,
+    }),
+  );
+
+  return { objectsDeleted: objectCount, freedBytes, galleriesDeleted: galleries };
+}

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPurgedTombstone,
+  loadWorkspaceRecord,
+  loadWorkspaceRecordRaw,
+  WORKSPACE_DELETE_GRACE_DAYS,
+  type PurgedTombstone,
+  type WorkspaceRecord,
+} from "./workspace";
+
+const RECORD: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "UPLOADS_DEFAULT",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+function fakeRegistry(records: Record<string, unknown>): Env["REGISTRY"] {
+  const store = new Map(Object.entries(records));
+  return {
+    get: (async (key: string) => store.get(key) ?? null) as unknown,
+  } as Env["REGISTRY"];
+}
+
+describe("loadWorkspaceRecord (#247 soft-delete filtering)", () => {
+  it("returns the record for a normal workspace", async () => {
+    const env = { REGISTRY: fakeRegistry({ "ws:acme": RECORD }) } as unknown as Env;
+    expect(await loadWorkspaceRecord(env, "acme")).toEqual(RECORD);
+  });
+
+  it("returns null for a soft-deleted workspace (auth path denies like unknown)", async () => {
+    const softDeleted: WorkspaceRecord = {
+      ...RECORD,
+      deletedAt: "2026-07-01T00:00:00.000Z",
+      purgeAt: "2026-07-15T00:00:00.000Z",
+    };
+    const env = { REGISTRY: fakeRegistry({ "ws:acme": softDeleted }) } as unknown as Env;
+    expect(await loadWorkspaceRecord(env, "acme")).toBeNull();
+    // But the raw read (used by admin routes / the sweep) still sees it.
+    expect(await loadWorkspaceRecordRaw(env, "acme")).toEqual(softDeleted);
+  });
+
+  it("returns null for a purged tombstone", async () => {
+    const tombstone: PurgedTombstone = {
+      status: "purged",
+      name: "acme",
+      purgedAt: "2026-07-15T00:00:00.000Z",
+    };
+    const env = { REGISTRY: fakeRegistry({ "ws:acme": tombstone }) } as unknown as Env;
+    expect(await loadWorkspaceRecord(env, "acme")).toBeNull();
+    expect(isPurgedTombstone(await loadWorkspaceRecordRaw(env, "acme"))).toBe(true);
+  });
+
+  it("returns null for an unknown workspace", async () => {
+    const env = { REGISTRY: fakeRegistry({}) } as unknown as Env;
+    expect(await loadWorkspaceRecord(env, "acme")).toBeNull();
+  });
+
+  it("registration's raw KV existence check still sees soft-deleted/purged records as taken", async () => {
+    // Mirrors routes/workspaces.ts:80 — a direct `REGISTRY.get` (no filtering)
+    // is what registration uses to reject an already-registered name; both
+    // soft-deleted records and purged tombstones must still read non-null.
+    const softDeleted: WorkspaceRecord = { ...RECORD, deletedAt: "2026-07-01T00:00:00.000Z" };
+    const tombstone: PurgedTombstone = {
+      status: "purged",
+      name: "acme",
+      purgedAt: "2026-07-15T00:00:00.000Z",
+    };
+    const registry = fakeRegistry({ "ws:soft": softDeleted, "ws:purged": tombstone });
+    expect(await registry.get("ws:soft")).not.toBeNull();
+    expect(await registry.get("ws:purged")).not.toBeNull();
+  });
+
+  it("grace window constant is 14 days", () => {
+    expect(WORKSPACE_DELETE_GRACE_DAYS).toBe(14);
+  });
+});

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -71,6 +71,33 @@ export interface WorkspaceRecord {
   createdByUserId?: string;
   /** ISO timestamp of self-serve creation. */
   createdAt?: string;
+  /** Set by `DELETE /admin/workspaces/:name` (default/soft mode). Present → the workspace is soft-deleted. */
+  deletedAt?: string;
+  /** `deletedAt` + the grace window (`WORKSPACE_DELETE_GRACE_DAYS`); the retention sweep finalizes at/after this. */
+  purgeAt?: string;
+}
+
+/** Days a soft-deleted workspace's data is retained before the retention sweep finalizes it. */
+export const WORKSPACE_DELETE_GRACE_DAYS = 14;
+
+/**
+ * Minimal permanent tombstone left under `ws:<name>` once a soft-deleted
+ * workspace is finalized (or hard-deleted with `replaceWithTombstone`) —
+ * intentionally not a full `WorkspaceRecord`. Its mere presence is what keeps
+ * a slug reserved for registration checks; see `apps/api/src/workspace-teardown.ts`.
+ */
+export interface PurgedTombstone {
+  status: "purged";
+  name: string;
+  purgedAt: string;
+  deletedAt?: string;
+}
+
+/** True for a purged tombstone written after finalization. */
+export function isPurgedTombstone(
+  record: WorkspaceRecord | PurgedTombstone | null,
+): record is PurgedTombstone {
+  return record !== null && (record as PurgedTombstone).status === "purged";
 }
 
 export type WorkspaceVars = {
@@ -133,7 +160,29 @@ export async function loadWorkspaceRecord(
   name: string | undefined,
 ): Promise<WorkspaceRecord | null> {
   if (!name || !WS_NAME_RE.test(name)) return null;
-  return env.REGISTRY.get<WorkspaceRecord>(`ws:${name}`, { type: "json", cacheTtl: 60 });
+  const record = await env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(`ws:${name}`, {
+    type: "json",
+    cacheTtl: 60,
+  });
+  // Soft-deleted and purged-tombstone records deny access exactly like an
+  // unknown workspace (uniform 404/401 across every auth/serving path) while
+  // still occupying the KV key, so the slug can't be re-registered.
+  if (!record || isPurgedTombstone(record) || record.deletedAt) return null;
+  return record;
+}
+
+/**
+ * Unfiltered read of `ws:<name>` — used by admin routes and the retention
+ * sweep, which need to see soft-deleted records and purged tombstones rather
+ * than have them collapsed to "not found". No `cacheTtl`: these callers act
+ * on the record (restore, finalize) and can't tolerate a stale hit.
+ */
+export async function loadWorkspaceRecordRaw(
+  env: Env,
+  name: string | undefined,
+): Promise<WorkspaceRecord | PurgedTombstone | null> {
+  if (!name || !WS_NAME_RE.test(name)) return null;
+  return env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(`ws:${name}`, { type: "json" });
 }
 
 function workspaceAuthWith(

--- a/apps/api/test/retention-sweep.test.ts
+++ b/apps/api/test/retention-sweep.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { runRetentionSweep } from "../src/retention-sweep";
+import type { PurgedTombstone, WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260710140000_workspace_usage.sql",
+];
+
+const RECORD: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "BUCKET",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+/** Fake REGISTRY: paginated `ws:` list plus get/put/delete over an in-memory Map. */
+function fakeRegistry(records: Record<string, unknown>) {
+  const store = new Map(Object.entries(records));
+  return {
+    store,
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    put: (async (key: string, value: string) => {
+      store.set(key, JSON.parse(value));
+    }) as unknown as KVNamespace["put"],
+    delete: (async (key: string) => {
+      store.delete(key);
+    }) as unknown as KVNamespace["delete"],
+    list: (async ({ prefix }: { prefix?: string }) => ({
+      keys: [...store.keys()]
+        .filter((k) => !prefix || k.startsWith(prefix))
+        .map((name) => ({ name })),
+      list_complete: true,
+      cursor: undefined,
+    })) as unknown as KVNamespace["list"],
+  };
+}
+
+function makeEnv(opts: {
+  kvRecords: Record<string, unknown>;
+  bucket?: FakeR2Bucket;
+  db: SqliteD1;
+}) {
+  const { kvRecords, bucket = new FakeR2Bucket(), db } = opts;
+  const registry = fakeRegistry(kvRecords);
+  const env = {
+    REGISTRY: registry,
+    BUCKET: bucket,
+    DB: database(db),
+  } as unknown as Env;
+  return { env, registry, bucket };
+}
+
+describe("runRetentionSweep — soft-delete finalization (#247)", () => {
+  it("fully tears down a past-purgeAt workspace and writes a purged tombstone", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("f/one.png", new Uint8Array([1, 2, 3]));
+      const record: WorkspaceRecord = {
+        ...RECORD,
+        deletedAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
+        purgeAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      const { env, registry } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesFinalized).toHaveLength(1);
+      expect(result.workspacesFinalized[0]).toMatchObject({ workspace: "acme", objectsDeleted: 1 });
+      expect(bucket.store.size).toBe(0);
+
+      const stored = registry.store.get("ws:acme") as PurgedTombstone;
+      expect(stored.status).toBe("purged");
+      expect(stored.name).toBe("acme");
+      expect(stored.deletedAt).toBe(record.deletedAt);
+      // Slug still "taken" — the key is non-null.
+      expect(registry.store.has("ws:acme")).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("leaves a not-yet-due soft-deleted workspace untouched", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("f/one.png", new Uint8Array([1, 2, 3]));
+      const record: WorkspaceRecord = {
+        ...RECORD,
+        deletedAt: new Date().toISOString(),
+        purgeAt: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      const { env, registry } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesFinalized).toHaveLength(0);
+      expect(bucket.store.has("f/one.png")).toBe(true);
+      expect(registry.store.get("ws:acme")).toEqual(record);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("skips a purged tombstone harmlessly on a later sweep", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const tombstone: PurgedTombstone = {
+        status: "purged",
+        name: "acme",
+        purgedAt: new Date().toISOString(),
+      };
+      const { env, registry } = makeEnv({ kvRecords: { "ws:acme": tombstone }, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesFinalized).toHaveLength(0);
+      expect(result.purged).toHaveLength(0);
+      expect(registry.store.get("ws:acme")).toEqual(tombstone);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still runs the normal retentionDays purge for workspaces without deletedAt", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("old.png", new Uint8Array([1, 2, 3]), {
+        httpMetadata: { contentType: "image/png" },
+      });
+      bucket.setUploaded("old.png", new Date("2020-01-01T00:00:00Z"));
+      const record: WorkspaceRecord = { ...RECORD, retentionDays: 30 };
+      const { env } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesWithRetention).toBe(1);
+      expect(result.purged).toEqual([{ workspace: "acme", deleted: 1, freedBytes: 3 }]);
+      expect(bucket.store.has("old.png")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/retention-sweep.test.ts
+++ b/apps/api/test/retention-sweep.test.ts
@@ -106,6 +106,29 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
     }
   });
 
+  it("refuses to finalize a workspace whose purgeAt is unparseable", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("f/one.png", new Uint8Array([1, 2, 3]));
+      const record: WorkspaceRecord = {
+        ...RECORD,
+        deletedAt: new Date().toISOString(),
+        purgeAt: "not-a-timestamp",
+      };
+      const { env, registry } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesFinalized).toHaveLength(1);
+      expect(result.workspacesFinalized[0]?.error).toMatch(/unparseable purgeAt/);
+      expect(bucket.store.has("f/one.png")).toBe(true);
+      expect(registry.store.get("ws:acme")).toEqual(record);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("skips a purged tombstone harmlessly on a later sweep", async () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {

--- a/docs/deletion.md
+++ b/docs/deletion.md
@@ -1,0 +1,51 @@
+# Deletion policy
+
+How deletions behave across uploads.sh, per surface: which are soft (recoverable
+for a grace window), which are hard (immediate and permanent), and why.
+Follow-up to the admin workspace delete (#244) and the soft-delete evaluation
+(#247).
+
+## The rule
+
+**Member-facing deletes are soft; break-glass and finalization are hard.**
+
+Anything a workspace member (or admin acting routinely) can trigger should be
+reversible for a grace window. Hard deletion happens only as an explicit
+break-glass action or as the automated finalization of an already-expired soft
+delete.
+
+## Per-surface policy
+
+| Surface                                               | Mode                              | Notes                                                                                                                                                                                                                                                                                                                                             |
+| ----------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Workspace deletion (`DELETE /admin/workspaces/:name`) | **Soft** by default, 14-day grace | Tombstones the `ws:<name>` KV record; access denied immediately; data (R2, metadata, galleries) retained; `POST /admin/workspaces/:name/restore` undeletes within the window. The daily retention cron finalizes past `purgeAt` with the full hard teardown.                                                                                      |
+| Workspace deletion, break-glass (`?hard=1`)           | **Hard**                          | Immediate permanent teardown (R2 objects, file_metadata, galleries, auth org, KV record). Non-empty workspaces additionally require `force=1`. The only path that frees a slug.                                                                                                                                                                   |
+| Slug reuse                                            | **Never freed**                   | After finalization the `ws:<name>` key retains a permanent `{ status: "purged" }` tombstone, so registration keeps rejecting the name. This closes the squatting vector where old public `storage.uploads.sh/<name>/…` URLs embedded in merged PRs could be re-registered by a different owner. Admin hard delete is the deliberate escape hatch. |
+| Galleries (`DELETE /v1/:ws/galleries/:id`)            | **Soft** (`deleted_at`)           | Existing behavior; all reads filter `deleted_at IS NULL`. Workspace teardown hard-deletes galleries via `deleteGalleriesForWorkspace` — that is finalization, consistent with the rule.                                                                                                                                                           |
+| File deletion (`files:delete` via API/MCP)            | **Hard**                          | Object-storage semantics; kept intentionally. No trash tier.                                                                                                                                                                                                                                                                                      |
+| Retention purge (per-workspace `retentionDays`)       | **Hard**                          | Automated expiry is finalization by definition.                                                                                                                                                                                                                                                                                                   |
+| Auth org deletion                                     | **Hard, best-effort**             | Runs during workspace teardown; multi-member orgs are left behind (logged as orphaned) and are inert without a KV record. An orphan sweep is tracked separately.                                                                                                                                                                                  |
+
+## Grace window mechanics
+
+- Soft delete stamps `deletedAt` and `purgeAt = deletedAt + 14 days` on the
+  workspace KV record.
+- Access denial is immediate at the record layer (lookups treat soft-deleted
+  workspaces as not found), subject to two propagation tails:
+  - workspace record reads use a 60s KV `cacheTtl`, so token auth may succeed
+    for up to a minute after deletion;
+  - already-cached public bytes can keep serving from the edge/Camo for up to
+    the cache window (app-pinned 60s; R2 custom-domain default is 4h for
+    objects served before the pin). Deletion of any kind — soft, hard, or
+    per-file — does not purge edge caches.
+- Restore is available until `purgeAt`; after that the restore endpoint returns
+  410 even if the sweep hasn't finalized yet, so recoverability never depends
+  on cron timing.
+- Finalization runs in the daily retention sweep (06:00 UTC): full hard
+  teardown, then the permanent purged tombstone.
+
+## What this means for self-serve deletion
+
+Self-serve workspace deletion (follow-up to #244) must build on this model:
+soft delete + grace window only, never direct hard teardown, and no ability to
+free a slug.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -86,8 +86,10 @@ into the sweep's `workspacesFinalized` field.
 
 `DELETE /admin/workspaces/:name` is **soft by default** (#247): it stamps
 `deletedAt`/`purgeAt` (14-day grace window, `WORKSPACE_DELETE_GRACE_DAYS`) on
-the KV record and puts it back. Access denies immediately — every
-auth/serving path treats a `deletedAt` record as not found — but R2 objects,
+the KV record and puts it back. Access denies at the record layer — every
+auth/serving path treats a `deletedAt` record as not found — subject to the
+60-second KV `cacheTtl` on workspace reads, so token auth may keep succeeding
+for up to a minute after deletion (see `docs/deletion.md`). R2 objects,
 file metadata, and galleries are untouched. Deleting an already-soft-deleted
 workspace 409s `already_deleted` with the existing `purgeAt`.
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -76,6 +76,51 @@ uploads purge-expired      # needs retentionDays
 
 The API worker also runs a **daily cron** (`0 6 * * *` UTC) that purges every workspace with `retentionDays` set. Logs: `retention_sweep` JSON.
 
+The same sweep also finalizes soft-deleted workspaces (see below): once a
+workspace's grace window elapses, the sweep runs the full hard teardown and
+replaces its `ws:<name>` KV record with a permanent purged tombstone. That
+work is logged separately per workspace as `workspace_purged` and rolled up
+into the sweep's `workspacesFinalized` field.
+
+## Workspace deletion, restore, and finalization
+
+`DELETE /admin/workspaces/:name` is **soft by default** (#247): it stamps
+`deletedAt`/`purgeAt` (14-day grace window, `WORKSPACE_DELETE_GRACE_DAYS`) on
+the KV record and puts it back. Access denies immediately — every
+auth/serving path treats a `deletedAt` record as not found — but R2 objects,
+file metadata, and galleries are untouched. Deleting an already-soft-deleted
+workspace 409s `already_deleted` with the existing `purgeAt`.
+
+```bash
+curl -X DELETE https://api.uploads.sh/admin/workspaces/acme \
+  -H "authorization: Bearer $ADMIN_TOKEN"
+# → { "ok": true, "workspace": "acme", "mode": "soft", "deletedAt": "…", "purgeAt": "…" }
+```
+
+**Restore** within the grace window clears `deletedAt`/`purgeAt`:
+
+```bash
+curl -X POST https://api.uploads.sh/admin/workspaces/acme/restore \
+  -H "authorization: Bearer $ADMIN_TOKEN"
+```
+
+404s if the workspace never existed or was already finalized (purged
+tombstone), 409 `not_deleted` if it isn't currently soft-deleted, and 410
+`grace_expired` once `purgeAt` has passed — restorability never depends on
+whether the sweep has actually run yet.
+
+**Break-glass hard delete** (`?hard=1`) skips the grace period entirely:
+immediate permanent teardown (R2 objects, `file_metadata` + galleries rows,
+best-effort auth-org delete, then the KV key removed outright). Non-empty
+workspaces still need `?force=1` on top, same as before. This is the only
+path that frees a slug for reuse — every other path (soft delete → grace
+period → sweep finalization) leaves a permanent `{ status: "purged" }`
+tombstone under `ws:<name>` so the name can never be re-registered. The
+communal/protected-workspace guard applies to both modes.
+
+See [docs/deletion.md](deletion.md) for the full cross-surface deletion
+policy and rationale.
+
 ## Backfill gh metadata
 
 One-time script for objects uploaded under `gh/...` before per-file metadata


### PR DESCRIPTION
Closes #247.

## Policy (new `docs/deletion.md`)

The rule: **member-facing deletes are soft; break-glass and finalization are hard.** Per surface:

- **Workspace deletion** — soft by default with a 14-day grace window; break-glass hard path retained.
- **Slug reuse** — never freed: a permanent `{ status: "purged" }` tombstone stays under `ws:<name>` after finalization, so old public `storage.uploads.sh/<name>/…` URLs in merged PRs can't be squatted. Admin hard delete is the only escape hatch.
- **Files** — stay hard (object-storage semantics); the edge-cache stale-serve tail is documented.
- **Galleries** — soft for members (existing `deleted_at`), hard only in teardown (finalization).
- **Auth orgs** — best-effort as today; orphan sweep tracked in a follow-up issue.

## Implementation

- `DELETE /admin/workspaces/:name` (default) → soft delete: stamps `deletedAt`/`purgeAt` on the KV record. Access denies immediately (`loadWorkspaceRecord` treats soft-deleted/purged records as not found across every auth/serving path); R2/D1 data untouched. Repeat delete → 409 `already_deleted`.
- `?hard=1[&force=1]` → the previous immediate teardown, now via a shared `teardownWorkspace()` helper (same fail-safe ordering, KV last); deletes the KV key outright.
- `POST /admin/workspaces/:name/restore` → undelete within the window; 409 `not_deleted`, 410 `grace_expired` (restorability doesn't depend on cron timing), 404 for unknown/purged.
- Daily retention sweep finalizes soft deletes past `purgeAt`: full teardown, then the permanent purged tombstone; skips soft-deleted workspaces for normal retention purges and skips tombstones.
- Registration keeps rejecting tombstoned slugs for free (it checks raw KV existence).

No D1 migrations (workspace state lives in KV). `@uploads/api` is changeset-ignored, so no changeset.

## Follow-ups (filed separately)

- Self-serve workspace deletion (#244 follow-up) — must build on this soft-delete model.
- Orphaned auth-org sweep.

## Tests

`pnpm test`: 124 files, 1347 tests passing (new coverage for soft delete, restore edge cases, hard path, sweep finalization, tombstone slug reservation). Typecheck and oxfmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added soft-delete support for workspaces with a 14-day recovery window.
  * Added workspace restoration during the grace period.
  * Added optional immediate hard deletion with force protection for non-empty workspaces.
  * Automatically finalizes expired soft-deleted workspaces during daily retention sweeps.
  * Added deletion metrics and permanent purged-state tracking.

* **Documentation**
  * Added workspace deletion policy and operations guidance.

* **Bug Fixes**
  * Soft-deleted and permanently purged workspaces are no longer accessible through normal workspace loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->