### PR TITLE
feat(auth): migrate CLI device-flow login to a managed official OAuth client (#251)

### DIFF
--- a/apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql
+++ b/apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql
@@ -5,6 +5,13 @@
 -- except: grant_types carries the RFC 8628 device grant, redirect_uris is
 -- empty (device flow has no redirects), and metadata marks it official.
 -- Idempotent: INSERT OR IGNORE keys off the client_id UNIQUE constraint.
+-- skip_consent is seeded as 1: this is a first-party official client, and the
+-- oauth-client-reaper (apps/auth/src/oauth-client-reaper.ts) exempts
+-- skip_consent clients from its stale-client sweep. The device-authorization
+-- plugin never consults skip_consent, so this is semantically a no-op for the
+-- device flow itself but keeps this row from being reaped once it goes stale
+-- (it has user_id NULL and will never accrue oauth_consent/oauth_access_token
+-- rows, since device-flow logins issue Better Auth sessions, not tokens).
 INSERT OR IGNORE INTO oauth_client (
   id, client_id, client_secret, name, redirect_uris, scopes,
   grant_types, response_types, token_endpoint_auth_method, type,
@@ -21,7 +28,7 @@ INSERT OR IGNORE INTO oauth_client (
   '[]',
   'none',
   'web',
-  1, 1, 0, 0,
+  1, 1, 0, 1,
   NULL,
   '{"official":true}',
   CAST(strftime('%s','now') AS INTEGER) * 1000,

--- a/apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql
+++ b/apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql
@@ -1,0 +1,29 @@
+-- Issue #251: the CLI's device-flow client becomes a managed oauth_client
+-- registration instead of a string-allowlisted static id. The client_id stays
+-- 'uploads-cli' so already-configured CLIs keep working. Shape mirrors the
+-- admin panel's POST /internal/oauth-clients insert (public PKCE, no secret),
+-- except: grant_types carries the RFC 8628 device grant, redirect_uris is
+-- empty (device flow has no redirects), and metadata marks it official.
+-- Idempotent: INSERT OR IGNORE keys off the client_id UNIQUE constraint.
+INSERT OR IGNORE INTO oauth_client (
+  id, client_id, client_secret, name, redirect_uris, scopes,
+  grant_types, response_types, token_endpoint_auth_method, type,
+  public, require_pkce, disabled, skip_consent, user_id, metadata,
+  created_at, updated_at
+) VALUES (
+  'oc_uploads_cli_seed',
+  'uploads-cli',
+  NULL,
+  'Uploads CLI',
+  '[]',
+  '["files:read","files:write","files:delete"]',
+  '["urn:ietf:params:oauth:grant-type:device_code"]',
+  '[]',
+  'none',
+  'web',
+  1, 1, 0, 0,
+  NULL,
+  '{"official":true}',
+  CAST(strftime('%s','now') AS INTEGER) * 1000,
+  CAST(strftime('%s','now') AS INTEGER) * 1000
+);

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -37,14 +37,30 @@ import {
 } from "./secrets";
 
 /**
- * Static OAuth client id for the CLI's device flow (plan D5/Phase 4). The
- * `deviceAuthorization` plugin accepts ANY `client_id` unless `validateClient`
- * is supplied, so this is the sole allowlisted id — the CLI
- * (`@buildinternet/uploads`) sends the same literal when starting a device
- * flow. The full `oauthProvider` plugin (dynamic third-party clients) is out
- * of scope for v1 (D3); when it lands, this stays the CLI's reserved id.
+ * RFC 8628 device-flow client gate (issue #251). The CLI's client id
+ * (`uploads-cli`, seeded by migration 20260719000000 as a managed official
+ * oauth_client row) is no longer a string allowlist: any registered, enabled
+ * client whose grant_types include the device-code grant may start a device
+ * flow. Fail-closed — a missing row, a disabled toggle (admin panel
+ * /admin/oauth), or an absent grant type all reject. Exported for direct unit
+ * testing (device.test.ts).
  */
-export const UPLOADS_CLI_CLIENT_ID = "uploads-cli";
+export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+export async function isDeviceFlowClientAllowed(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  clientId: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({
+      disabled: schema.oauthClient.disabled,
+      grantTypes: schema.oauthClient.grantTypes,
+    })
+    .from(schema.oauthClient)
+    .where(eq(schema.oauthClient.clientId, clientId))
+    .limit(1);
+  if (!row || row.disabled) return false;
+  return Array.isArray(row.grantTypes) && row.grantTypes.includes(DEVICE_CODE_GRANT);
+}
 
 /** CLI device-flow User-Agent — keep in sync with apps/web `CLI_USER_AGENT_RE`. */
 export function isCliSessionUserAgent(ua?: string | null): boolean {
@@ -307,10 +323,11 @@ function buildAuth(
       // `.uploads.sh`-scoped (crossSubDomainCookies below) so it rides across
       // the two subdomains.
       //
-      // validateClient is a fail-closed allowlist: only the static CLI client
-      // id may start a device flow or exchange a code. Without it the plugin
-      // accepts ANY client_id — an unknown id could never obtain a token
-      // (approval is interactive) but the allowlist is defense in depth.
+      // validateClient is fail-closed against the oauth_client table: the id
+      // must be registered, enabled, and carry the device-code grant type
+      // (issue #251 — the CLI's `uploads-cli` id is a seeded managed row, so
+      // the admin panel's disable toggle now actually gates the device flow).
+      // Without validateClient the plugin accepts ANY client_id.
       //
       // No `schema: {}` workaround needed: better-auth 1.6.23 declares the
       // plugin's `schema` option as `.optional()`, which zod 4.4.3 accepts when
@@ -318,7 +335,7 @@ function buildAuth(
       // build whose `schema` field lacked `.optional()`).
       deviceAuthorization({
         verificationUri: `${webOrigin}/device`,
-        validateClient: (clientId) => clientId === UPLOADS_CLI_CLIENT_ID,
+        validateClient: (clientId) => isDeviceFlowClientAllowed(db, clientId),
       }),
       // Issue #231 (auth side): POST /oauth2/workspace-choice, letting a
       // signed-in multi-workspace user record which workspace an OAuth grant

--- a/apps/auth/src/device.test.ts
+++ b/apps/auth/src/device.test.ts
@@ -249,5 +249,9 @@ describe("seeded CLI oauth client (issue #251)", () => {
     expect(row.clientSecret).toBeNull();
     expect(row.grantTypes).toEqual(["urn:ietf:params:oauth:grant-type:device_code"]);
     expect(row.metadata).toEqual({ official: true });
+    // skipConsent is seeded true so the oauth-client-reaper's first-party
+    // exemption applies to this row and it is never swept as stale (see
+    // apps/auth/src/oauth-client-reaper.ts and the seed migration comment).
+    expect(row.skipConsent).toBe(true);
   });
 });

--- a/apps/auth/src/device.test.ts
+++ b/apps/auth/src/device.test.ts
@@ -86,32 +86,63 @@ describe("device/code validateClient allowlist", () => {
   });
 });
 
-describe("device flow end-to-end (claim → approve → token)", () => {
-  /** Seed a user + an active session, returning the raw session token to present as a bearer. */
-  async function seedSignedInUser(env: AuthEnv): Promise<string> {
-    const orm = drizzle(env.DB, { schema });
-    const userId = crypto.randomUUID();
-    await orm.insert(schema.user).values({
-      id: userId,
-      name: "Ada Lovelace",
-      email: `ada-${userId}@example.com`,
-      emailVerified: true,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      role: "user",
-    });
-    const token = `sess-${crypto.randomUUID()}`;
-    await orm.insert(schema.session).values({
-      id: crypto.randomUUID(),
-      userId,
-      token,
-      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
-    return token;
-  }
+/** Seed a user + an active session, returning the raw session token to present as a bearer. */
+async function seedSignedInUser(env: AuthEnv): Promise<string> {
+  const orm = drizzle(env.DB, { schema });
+  const userId = crypto.randomUUID();
+  await orm.insert(schema.user).values({
+    id: userId,
+    name: "Ada Lovelace",
+    email: `ada-${userId}@example.com`,
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    role: "user",
+  });
+  const token = `sess-${crypto.randomUUID()}`;
+  await orm.insert(schema.session).values({
+    id: crypto.randomUUID(),
+    userId,
+    token,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return token;
+}
 
+/**
+ * Claim + approve a device code for CLI_CLIENT_ID while the client is still
+ * valid, returning the device_code for a subsequent /device/token exchange.
+ */
+async function claimAndApproveDeviceCode(env: AuthEnv): Promise<string> {
+  const sessionToken = await seedSignedInUser(env);
+  const codeRes = await requestDeviceCode(env, { client_id: CLI_CLIENT_ID });
+  expect(codeRes.status).toBe(200);
+  const { device_code, user_code } = (await codeRes.json()) as {
+    device_code: string;
+    user_code: string;
+  };
+  const verifyRes = await app.request(
+    `/api/auth/device?user_code=${encodeURIComponent(user_code)}`,
+    { headers: { Authorization: `Bearer ${sessionToken}` } },
+    env,
+  );
+  expect(verifyRes.status).toBe(200);
+  const approveRes = await app.request(
+    "/api/auth/device/approve",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${sessionToken}` },
+      body: JSON.stringify({ userCode: user_code }),
+    },
+    env,
+  );
+  expect(approveRes.status).toBe(200);
+  return device_code;
+}
+
+describe("device flow end-to-end (claim → approve → token)", () => {
   it("claims a code, approves it, and exchanges it for a session access token", async () => {
     // One env (one fake D1) reused across every request in the flow.
     const env = dbEnv();
@@ -230,6 +261,68 @@ describe("validateClient DB lookup (issue #251)", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error?: string };
     expect(body.error).toBe("invalid_client");
+  });
+
+  it("rejects device/token for a client disabled after the device code was approved", async () => {
+    const env = dbEnv();
+    // Obtain an approved device code FIRST, while the client is still valid.
+    const device_code = await claimAndApproveDeviceCode(env);
+
+    // Now disable the client.
+    const db = drizzle(env.DB, { schema });
+    await db
+      .update(schema.oauthClient)
+      .set({ disabled: true })
+      .where(eq(schema.oauthClient.clientId, CLI_CLIENT_ID));
+
+    const tokenRes = await app.request(
+      "/api/auth/device/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code,
+          client_id: CLI_CLIENT_ID,
+        }),
+      },
+      env,
+    );
+    // better-auth's device-authorization token endpoint returns "invalid_grant"
+    // (not "invalid_client") when validateClient fails — see
+    // node_modules/better-auth/dist/plugins/device-authorization/routes.mjs:181-186.
+    expect(tokenRes.status).toBe(400);
+    const body = (await tokenRes.json()) as { error?: string };
+    expect(body.error).toBe("invalid_grant");
+  });
+
+  it("rejects device/token for a client whose grant types no longer include the device-code grant", async () => {
+    const env = dbEnv();
+    const device_code = await claimAndApproveDeviceCode(env);
+
+    // Remove the device-code grant from the (still enabled) client.
+    const db = drizzle(env.DB, { schema });
+    await db
+      .update(schema.oauthClient)
+      .set({ grantTypes: ["authorization_code", "refresh_token"] })
+      .where(eq(schema.oauthClient.clientId, CLI_CLIENT_ID));
+
+    const tokenRes = await app.request(
+      "/api/auth/device/token",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          device_code,
+          client_id: CLI_CLIENT_ID,
+        }),
+      },
+      env,
+    );
+    expect(tokenRes.status).toBe(400);
+    const body = (await tokenRes.json()) as { error?: string };
+    expect(body.error).toBe("invalid_grant");
   });
 });
 

--- a/apps/auth/src/device.test.ts
+++ b/apps/auth/src/device.test.ts
@@ -7,6 +7,7 @@
  * `consumeOne`/`incrementOne` (RETURNING + `WHERE id IN (SELECT …)`) SQL.
  */
 import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { app } from "./index";
 import { UPLOADS_CLI_CLIENT_ID, type AuthEnv } from "./auth";
@@ -188,5 +189,24 @@ describe("device flow end-to-end (claim → approve → token)", () => {
     expect((await tokenRes.json()) as { error?: string }).toMatchObject({
       error: "authorization_pending",
     });
+  });
+});
+
+describe("seeded CLI oauth client (issue #251)", () => {
+  it("migrations seed an official, enabled uploads-cli client", async () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    const [row] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, "uploads-cli"))
+      .limit(1);
+    expect(row).toBeDefined();
+    expect(row.disabled).toBe(false);
+    expect(row.public).toBe(true);
+    expect(row.requirePKCE).toBe(true);
+    expect(row.clientSecret).toBeNull();
+    expect(row.grantTypes).toEqual(["urn:ietf:params:oauth:grant-type:device_code"]);
+    expect(row.metadata).toEqual({ official: true });
   });
 });

--- a/apps/auth/src/device.test.ts
+++ b/apps/auth/src/device.test.ts
@@ -10,9 +10,11 @@ import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { app } from "./index";
-import { UPLOADS_CLI_CLIENT_ID, type AuthEnv } from "./auth";
+import type { AuthEnv } from "./auth";
 import * as schema from "./schema";
 import { createFakeD1 } from "./test/fake-d1";
+
+const CLI_CLIENT_ID = "uploads-cli";
 
 function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
   return {
@@ -39,7 +41,7 @@ function requestDeviceCode(env: AuthEnv, body: Record<string, unknown>) {
 
 describe("device/code validateClient allowlist", () => {
   it("issues a device + user code for the allowlisted CLI client id", async () => {
-    const res = await requestDeviceCode(dbEnv(), { client_id: UPLOADS_CLI_CLIENT_ID });
+    const res = await requestDeviceCode(dbEnv(), { client_id: CLI_CLIENT_ID });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       device_code?: string;
@@ -116,7 +118,7 @@ describe("device flow end-to-end (claim → approve → token)", () => {
     const sessionToken = await seedSignedInUser(env);
 
     // 1. CLI starts the flow (no session).
-    const codeRes = await requestDeviceCode(env, { client_id: UPLOADS_CLI_CLIENT_ID });
+    const codeRes = await requestDeviceCode(env, { client_id: CLI_CLIENT_ID });
     expect(codeRes.status).toBe(200);
     const { device_code, user_code } = (await codeRes.json()) as {
       device_code: string;
@@ -156,7 +158,7 @@ describe("device flow end-to-end (claim → approve → token)", () => {
         body: JSON.stringify({
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
           device_code,
-          client_id: UPLOADS_CLI_CLIENT_ID,
+          client_id: CLI_CLIENT_ID,
         }),
       },
       env,
@@ -169,7 +171,7 @@ describe("device flow end-to-end (claim → approve → token)", () => {
 
   it("returns authorization_pending until the code is approved", async () => {
     const env = dbEnv();
-    const codeRes = await requestDeviceCode(env, { client_id: UPLOADS_CLI_CLIENT_ID });
+    const codeRes = await requestDeviceCode(env, { client_id: CLI_CLIENT_ID });
     const { device_code } = (await codeRes.json()) as { device_code: string };
 
     const tokenRes = await app.request(
@@ -180,7 +182,7 @@ describe("device flow end-to-end (claim → approve → token)", () => {
         body: JSON.stringify({
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
           device_code,
-          client_id: UPLOADS_CLI_CLIENT_ID,
+          client_id: CLI_CLIENT_ID,
         }),
       },
       env,
@@ -189,6 +191,45 @@ describe("device flow end-to-end (claim → approve → token)", () => {
     expect((await tokenRes.json()) as { error?: string }).toMatchObject({
       error: "authorization_pending",
     });
+  });
+});
+
+describe("validateClient DB lookup (issue #251)", () => {
+  it("rejects device/code for a disabled client", async () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await db
+      .update(schema.oauthClient)
+      .set({ disabled: true })
+      .where(eq(schema.oauthClient.clientId, CLI_CLIENT_ID));
+    const res = await requestDeviceCode(env, { client_id: CLI_CLIENT_ID });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("rejects device/code for a registered client without the device-code grant", async () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await db.insert(schema.oauthClient).values({
+      id: "oc_authcode_only",
+      clientId: "authcode-only",
+      redirectUris: ["https://example.com/cb"],
+      scopes: ["files:read"],
+      grantTypes: ["authorization_code", "refresh_token"],
+      responseTypes: ["code"],
+      tokenEndpointAuthMethod: "none",
+      public: true,
+      requirePKCE: true,
+      disabled: false,
+      skipConsent: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const res = await requestDeviceCode(env, { client_id: "authcode-only" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("invalid_client");
   });
 });
 

--- a/apps/auth/src/internal-oauth-clients.test.ts
+++ b/apps/auth/src/internal-oauth-clients.test.ts
@@ -148,9 +148,12 @@ describe("GET /internal/oauth-clients", () => {
     const res = await jsonReq("GET", "/internal/oauth-clients");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { clients: Array<{ clientId: string; name: string }> };
-    expect(body.clients).toHaveLength(2);
-    expect(body.clients[0].clientId).toBe(secondBody.clientId);
-    expect(body.clients[1].clientId).toBe(firstBody.clientId);
+    // Issue #251 seeds an "uploads-cli" oauth_client row via migration, so a
+    // clean DB has that row plus these two, not just these two.
+    const created = body.clients.filter((c) => c.clientId !== "uploads-cli");
+    expect(created).toHaveLength(2);
+    expect(created[0].clientId).toBe(secondBody.clientId);
+    expect(created[1].clientId).toBe(firstBody.clientId);
   });
 });
 

--- a/apps/auth/src/oauth-client-reaper.test.ts
+++ b/apps/auth/src/oauth-client-reaper.test.ts
@@ -48,8 +48,10 @@ describe("sweepOauthClients", () => {
     expect(result.reapable).toBe(1);
     expect(result.deleted).toBe(0);
 
+    // Issue #251 seeds a recent, non-stale "uploads-cli" oauth_client row via
+    // migration, so a clean DB has that row plus stale-1.
     const remaining = await drizzle(db, { schema }).select().from(schema.oauthClient);
-    expect(remaining).toHaveLength(1);
+    expect(remaining).toHaveLength(2);
   });
 
   it("deletes stale anonymous unused clients when OAUTH_CLIENT_REAPER_ENABLED=true", async () => {
@@ -61,8 +63,9 @@ describe("sweepOauthClients", () => {
     expect(result.mode).toBe("delete");
     expect(result.deleted).toBe(1);
 
+    // The seeded "uploads-cli" row (issue #251) is recent and survives the sweep.
     const remaining = await drizzle(db, { schema }).select().from(schema.oauthClient);
-    expect(remaining).toHaveLength(0);
+    expect(remaining).toHaveLength(1);
   });
 
   it("never sweeps a recent client, a session-owned client, or a trusted (skip_consent) client", async () => {
@@ -77,8 +80,9 @@ describe("sweepOauthClients", () => {
     expect(result.candidates).toBe(0);
     expect(result.deleted).toBe(0);
 
+    // Plus the seeded "uploads-cli" row (issue #251), which is also recent.
     const remaining = await drizzle(db, { schema }).select().from(schema.oauthClient);
-    expect(remaining).toHaveLength(3);
+    expect(remaining).toHaveLength(4);
   });
 
   it("never sweeps a client with a consent row, even if stale and anonymous", async () => {

--- a/apps/auth/src/oauth-client-reaper.test.ts
+++ b/apps/auth/src/oauth-client-reaper.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { AuthEnv } from "./auth";
@@ -104,5 +105,29 @@ describe("sweepOauthClients", () => {
     expect(result.candidates).toBe(1);
     expect(result.reapable).toBe(0);
     expect(result.deleted).toBe(0);
+  });
+
+  it("never sweeps a stale seeded uploads-cli client (issue #251 skip_consent exemption)", async () => {
+    // The migration seeds "uploads-cli" as skip_consent=1 specifically so a
+    // stale-but-never-consented row (device-flow logins never create
+    // oauth_consent/oauth_access_token rows) isn't reaped. Backdate the
+    // seeded row's created_at past the cutoff and confirm it's excluded.
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await drizzle(db, { schema })
+      .update(schema.oauthClient)
+      .set({ createdAt: old, updatedAt: old })
+      .where(eq(schema.oauthClient.clientId, "uploads-cli"));
+
+    const result = await sweepOauthClients({ ...env, OAUTH_CLIENT_REAPER_ENABLED: "true" });
+
+    expect(result.candidates).toBe(0);
+    expect(result.reapable).toBe(0);
+    expect(result.deleted).toBe(0);
+
+    const remaining = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, "uploads-cli"));
+    expect(remaining).toHaveLength(1);
   });
 });

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -33,6 +33,10 @@ uploads login --workspace acme
 
 The CLI authenticates as the managed official OAuth client `uploads-cli`,
 visible and toggleable by operators in the admin panel at `/admin/oauth`.
+Operators should disable it there rather than hard-deleting it: the seed
+migration only runs once (`INSERT OR IGNORE`, journaled as applied), so a
+deleted `uploads-cli` client is not automatically re-seeded and would break
+CLI login fleet-wide until manually re-inserted.
 
 On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
 `UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -31,6 +31,9 @@ Pass `--workspace <name>` if your account can access more than one workspace:
 uploads login --workspace acme
 ```
 
+The CLI authenticates as the managed official OAuth client `uploads-cli`,
+visible and toggleable by operators in the admin panel at `/admin/oauth`.
+
 On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
 `UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never
 prints the raw workspace token. Use `--force` only when intentionally
@@ -141,3 +144,8 @@ Better Auth's session/organization/device-code tables that back
 the default onboarding path today. Direct token minting (`/admin/tokens`) is
 reserved for CI and break-glass administration. Rotate legacy routine-agent
 tokens to login-issued tokens gradually, then revoke the old hashes.
+
+Migration `20260719000000_seed_cli_oauth_client.sql` seeds the managed
+`uploads-cli` OAuth client row and must be applied (`pnpm migrate:d1` in
+`apps/auth`) before deploying an auth worker that includes the DB-backed
+`validateClient` — the device flow fails closed without the row.

--- a/docs/superpowers/plans/2026-07-18-cli-managed-oauth-client.md
+++ b/docs/superpowers/plans/2026-07-18-cli-managed-oauth-client.md
@@ -1,0 +1,311 @@
+# CLI Managed OAuth Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the CLI device-flow login from a hardcoded static client id to a seeded, managed `oauth_client` registration (public PKCE, `official: true`), and replace the string-equality special case in the authorization server with a real DB lookup (issue #251).
+
+**Architecture:** Keep the client id literal `uploads-cli` (so already-configured CLIs keep working — nothing changes on the wire), but seed it as a real row in the auth worker's `oauth_client` table via an idempotent D1 migration. The `deviceAuthorization` plugin's `validateClient` hook (which supports `Promise<boolean>`, verified in better-auth 1.6.23 `dist/plugins/device-authorization/routes.mjs:87-92,181-186`) switches from `clientId === "uploads-cli"` to a Drizzle lookup that requires the row to exist, be enabled, and carry the device-code grant type. The seeded row then appears in the `/admin/oauth` panel with the official badge and a working disable toggle.
+
+**Tech Stack:** Cloudflare Workers, D1 (raw SQL migrations in `apps/auth/migrations/`), Drizzle ORM, better-auth 1.6.23 `deviceAuthorization` plugin, Vitest with in-memory fake D1 (`apps/auth/src/test/fake-d1.ts` — `applyMigrations()` globs the migrations dir, so the seed row appears in tests automatically).
+
+## Global Constraints
+
+- Client id stays exactly `uploads-cli` — the CLI (`packages/uploads/src/client.ts:313` `DEVICE_CLIENT_ID`) is NOT changed; no CLI-side code changes in this plan.
+- Migration file naming: `YYYYMMDDHHMMSS_description.sql` in `apps/auth/migrations/`; must be idempotent (`INSERT OR IGNORE`) so re-applies and pre-seeded environments are safe.
+- The seeded row mirrors the admin-panel creation shape (`apps/auth/src/internal-routes.ts:731-752`): `client_secret NULL`, `token_endpoint_auth_method 'none'`, `public 1`, `require_pkce 1`, `disabled 0`, `skip_consent 0`, `user_id NULL` — except `grant_types` is `["urn:ietf:params:oauth:grant-type:device_code"]`, `redirect_uris` is `[]` (device flow has no redirects), and `metadata` is `{"official":true}`.
+- Fail-closed posture must be preserved: unknown client ids, disabled clients, and registered clients WITHOUT the device-code grant type must all be rejected on both `/api/auth/device/code` and `/api/auth/device/token`.
+- Tests: run from `apps/auth` with `pnpm vitest run src/device.test.ts` (plain vitest + fake D1; no pool-workers).
+- Commit messages: conventional commits, no sensational adjectives.
+- Deploy ordering (PR description note, not code): `pnpm migrate:d1` in `apps/auth` must run before or with the worker deploy — the new `validateClient` fails closed if the row is missing.
+
+## File Structure
+
+- Create: `apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql` — idempotent seed of the `uploads-cli` client row.
+- Modify: `apps/auth/src/auth.ts` — remove `UPLOADS_CLI_CLIENT_ID` export + its comment block (lines 39-47); replace `validateClient` (line 321) with a DB lookup; add exported helper `isDeviceFlowClientAllowed`; update the comment block at lines 310-314.
+- Modify: `apps/auth/src/device.test.ts` — drop the `UPLOADS_CLI_CLIENT_ID` import (use a local `CLI_CLIENT_ID = "uploads-cli"` constant); add negative tests (disabled client, registered-but-no-device-grant client) and a seed-row assertion.
+- Modify: `packages/uploads/src/client.ts` — doc comment only (lines ~305-313) describing the managed registration.
+- Modify: `docs/enrollment.md` — device-flow section + migration notes mention the managed client.
+
+---
+
+### Task 1: Seed migration for the `uploads-cli` client
+
+**Files:**
+
+- Create: `apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql`
+- Test: `apps/auth/src/device.test.ts` (new test appended)
+
+**Interfaces:**
+
+- Produces: an `oauth_client` row with `client_id = 'uploads-cli'`, `disabled = 0`, `grant_types = '["urn:ietf:params:oauth:grant-type:device_code"]'`, `metadata = '{"official":true}'` — Task 2's `validateClient` lookup depends on exactly these values.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/auth/src/device.test.ts` (reuse the existing `dbEnv()` helper and drizzle imports already in the file; add `oauthClient` to the existing schema import if not present):
+
+```ts
+describe("seeded CLI oauth client (issue #251)", () => {
+  it("migrations seed an official, enabled uploads-cli client", async () => {
+    const { env } = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    const [row] = await db
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, "uploads-cli"))
+      .limit(1);
+    expect(row).toBeDefined();
+    expect(row.disabled).toBe(false);
+    expect(row.public).toBe(true);
+    expect(row.requirePKCE).toBe(true);
+    expect(row.clientSecret).toBeNull();
+    expect(row.grantTypes).toEqual(["urn:ietf:params:oauth:grant-type:device_code"]);
+    expect(row.metadata).toEqual({ official: true });
+  });
+});
+```
+
+(Adapt the exact `dbEnv()`/drizzle call shape to what the top of the file already does — the file already constructs a drizzle instance for `seedSignedInUser`; follow that pattern verbatim. If the drizzle JSON columns come back as strings in this test context, match the file's existing deserialization behavior rather than fighting it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `apps/auth`): `pnpm vitest run src/device.test.ts -t "seeded"`
+Expected: FAIL — `row` is undefined (no seed migration yet).
+
+- [ ] **Step 3: Write the migration**
+
+Create `apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql`:
+
+```sql
+-- Issue #251: the CLI's device-flow client becomes a managed oauth_client
+-- registration instead of a string-allowlisted static id. The client_id stays
+-- 'uploads-cli' so already-configured CLIs keep working. Shape mirrors the
+-- admin panel's POST /internal/oauth-clients insert (public PKCE, no secret),
+-- except: grant_types carries the RFC 8628 device grant, redirect_uris is
+-- empty (device flow has no redirects), and metadata marks it official.
+-- Idempotent: INSERT OR IGNORE keys off the client_id UNIQUE constraint.
+INSERT OR IGNORE INTO oauth_client (
+  id, client_id, client_secret, name, redirect_uris, scopes,
+  grant_types, response_types, token_endpoint_auth_method, type,
+  public, require_pkce, disabled, skip_consent, user_id, metadata,
+  created_at, updated_at
+) VALUES (
+  'oc_uploads_cli_seed',
+  'uploads-cli',
+  NULL,
+  'Uploads CLI',
+  '[]',
+  '["files:read","files:write","files:delete"]',
+  '["urn:ietf:params:oauth:grant-type:device_code"]',
+  '[]',
+  'none',
+  'web',
+  1, 1, 0, 0,
+  NULL,
+  '{"official":true}',
+  CAST(strftime('%s','now') AS INTEGER) * 1000,
+  CAST(strftime('%s','now') AS INTEGER) * 1000
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/device.test.ts -t "seeded"`
+Expected: PASS. Then run the full file — `pnpm vitest run src/device.test.ts` — expected: all existing tests still pass (the seed row is inert while `validateClient` is still the string check).
+
+Also run `pnpm vitest run src/internal-oauth-clients.test.ts` — the admin CRUD tests must still pass with the extra seeded row present (if a test asserts an exact list length from a clean DB, adjust that test to account for the seeded row, and say so in the report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql apps/auth/src/device.test.ts
+git commit -m "feat(auth): seed uploads-cli as a managed official oauth_client (#251)"
+```
+
+---
+
+### Task 2: Replace the static-id allowlist with a DB lookup
+
+**Files:**
+
+- Modify: `apps/auth/src/auth.ts` (remove lines 39-47 constant+comment; replace `validateClient` at line 321; revise comment block at lines 310-314)
+- Modify/Test: `apps/auth/src/device.test.ts`
+
+**Interfaces:**
+
+- Consumes: the seeded row from Task 1 (`client_id = 'uploads-cli'`, `disabled`, `grantTypes` JSON including `urn:ietf:params:oauth:grant-type:device_code`).
+- Produces: exported `async function isDeviceFlowClientAllowed(db, clientId): Promise<boolean>` in `apps/auth/src/auth.ts` (exported for direct unit testing, same rationale as the existing `resolveWorkspaceClaims` export). `UPLOADS_CLI_CLIENT_ID` no longer exists — nothing else in the repo imports it except `device.test.ts` (verified in exploration).
+
+- [ ] **Step 1: Update tests first**
+
+In `apps/auth/src/device.test.ts`:
+
+1. Remove `UPLOADS_CLI_CLIENT_ID` from the `./auth` import; add a file-local `const CLI_CLIENT_ID = "uploads-cli";` and substitute it at the former usage sites (previously lines 41, 118, 158, 171, 182).
+2. Add new tests (reuse `dbEnv()` and the file's request-driving pattern against the real Hono `app` — mirror the existing "unknown client id" negative tests at lines ~66-83):
+
+```ts
+describe("validateClient DB lookup (issue #251)", () => {
+  it("rejects device/code for a disabled client", async () => {
+    const { env } = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await db
+      .update(schema.oauthClient)
+      .set({ disabled: true })
+      .where(eq(schema.oauthClient.clientId, CLI_CLIENT_ID));
+    const res = await postDeviceCode(env, CLI_CLIENT_ID); // use the file's existing request helper/pattern
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+
+  it("rejects device/code for a registered client without the device-code grant", async () => {
+    const { env } = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await db.insert(schema.oauthClient).values({
+      id: "oc_authcode_only",
+      clientId: "authcode-only",
+      redirectUris: ["https://example.com/cb"],
+      scopes: ["files:read"],
+      grantTypes: ["authorization_code", "refresh_token"],
+      responseTypes: ["code"],
+      tokenEndpointAuthMethod: "none",
+      public: true,
+      requirePKCE: true,
+      disabled: false,
+      skipConsent: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const res = await postDeviceCode(env, "authcode-only");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client");
+  });
+});
+```
+
+(`postDeviceCode` stands for however the existing tests POST `/api/auth/device/code` — reuse that exact mechanism; do not invent a new helper if an inline pattern exists, but extracting a tiny local helper to avoid triplicating the fetch is fine.)
+
+The existing "unknown client id → invalid_client / invalid_grant" tests stay as-is — they now exercise the lookup path instead of the string compare.
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm vitest run src/device.test.ts`
+Expected: the two new tests FAIL (disabled/no-grant clients are currently accepted or rejected for the wrong reason — the string check rejects `authcode-only` today with the right error, so specifically the "disabled client" test must fail; if the no-grant test passes trivially under the old code, that's expected and it becomes meaningful after Step 3).
+
+- [ ] **Step 3: Implement the lookup**
+
+In `apps/auth/src/auth.ts`:
+
+Delete lines 39-47 (the comment block and `export const UPLOADS_CLI_CLIENT_ID = "uploads-cli";`). In their place add:
+
+```ts
+/**
+ * RFC 8628 device-flow client gate (issue #251). The CLI's client id
+ * (`uploads-cli`, seeded by migration 20260719000000 as a managed official
+ * oauth_client row) is no longer a string allowlist: any registered, enabled
+ * client whose grant_types include the device-code grant may start a device
+ * flow. Fail-closed — a missing row, a disabled toggle (admin panel
+ * /admin/oauth), or an absent grant type all reject. Exported for direct unit
+ * testing (device.test.ts).
+ */
+export const DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+export async function isDeviceFlowClientAllowed(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  clientId: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({
+      disabled: schema.oauthClient.disabled,
+      grantTypes: schema.oauthClient.grantTypes,
+    })
+    .from(schema.oauthClient)
+    .where(eq(schema.oauthClient.clientId, clientId))
+    .limit(1);
+  if (!row || row.disabled) return false;
+  return Array.isArray(row.grantTypes) && row.grantTypes.includes(DEVICE_CODE_GRANT);
+}
+```
+
+(If `schema.oauthClient.grantTypes` deserializes to a string rather than an array in this Drizzle config, parse it with a try/catch `JSON.parse` and treat unparseable as `false` — check `apps/auth/src/schema.ts:278-313` for the column mode and match `internal-routes.ts`'s handling.)
+
+Then replace line 321:
+
+```ts
+        validateClient: (clientId) => clientId === UPLOADS_CLI_CLIENT_ID,
+```
+
+with:
+
+```ts
+        validateClient: (clientId) => isDeviceFlowClientAllowed(db, clientId),
+```
+
+And rewrite the comment block at lines 310-314 to:
+
+```ts
+// validateClient is fail-closed against the oauth_client table: the id
+// must be registered, enabled, and carry the device-code grant type
+// (issue #251 — the CLI's `uploads-cli` id is a seeded managed row, so
+// the admin panel's disable toggle now actually gates the device flow).
+// Without validateClient the plugin accepts ANY client_id.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/device.test.ts`
+Expected: PASS, all tests including the pre-existing happy-path device flow (which now passes via the seeded row) and both negative suites.
+
+Then run the worker's full suite from `apps/auth`: `pnpm test` (or the package's test script) — expected: PASS. Also run `pnpm typecheck` if the package has it (a removed export must not break other imports; exploration found none outside device.test.ts, verify with `grep -rn "UPLOADS_CLI_CLIENT_ID" --include="*.ts" .` from the repo root — expect zero hits after this step).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/auth/src/auth.ts apps/auth/src/device.test.ts
+git commit -m "feat(auth): gate device flow on registered oauth_client rows (#251)"
+```
+
+---
+
+### Task 3: Documentation and in-code comment updates
+
+**Files:**
+
+- Modify: `packages/uploads/src/client.ts` (doc comment above `DEVICE_CLIENT_ID`, ~lines 305-313 — comment only, no code change)
+- Modify: `docs/enrollment.md`
+
+**Interfaces:**
+
+- Consumes: the design shipped in Tasks 1-2 (seeded managed client, DB-lookup gate). No produced interfaces.
+
+- [ ] **Step 1: Update the CLI-side doc comment**
+
+In `packages/uploads/src/client.ts`, replace the doc comment immediately above `export const DEVICE_CLIENT_ID = "uploads-cli";` with (keep the constant itself unchanged):
+
+```ts
+/**
+ * OAuth client id for the device flow. Registered server-side as a managed
+ * official `oauth_client` row (seeded by apps/auth migration
+ * 20260719000000_seed_cli_oauth_client.sql — issue #251): public PKCE client,
+ * no secret, device-code grant only. The auth worker's device endpoints
+ * validate this id against that table, so operators can disable it from
+ * /admin/oauth. The literal must match the seeded row's client_id.
+ */
+```
+
+(Adapt the replacement to whatever the current comment's exact text is — the intent: it must no longer describe a "static allowlisted id" design.)
+
+- [ ] **Step 2: Update docs/enrollment.md**
+
+In the "Everyday login (device flow)" section, add one sentence noting the CLI authenticates as the managed official OAuth client `uploads-cli`, visible and toggleable in the operator admin panel at `/admin/oauth`. In the "Migration notes" section (lines ~130-143), note that migration `20260719000000_seed_cli_oauth_client.sql` seeds this client and must be applied (`pnpm migrate:d1` in `apps/auth`) before deploying an auth worker that includes the DB-backed `validateClient` — the device flow fails closed without the row.
+
+- [ ] **Step 3: Verify no stale references**
+
+Run from repo root: `grep -rn "static.*client id\|allowlisted id" docs packages/uploads/src apps/auth/src --include="*.ts" --include="*.md" | grep -iv node_modules`
+Expected: no remaining descriptions of the old static-allowlist design (test fixtures using the literal `uploads-cli` are fine).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/uploads/src/client.ts docs/enrollment.md
+git commit -m "docs: describe managed uploads-cli oauth client registration (#251)"
+```

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -309,7 +309,14 @@ export function createEnrollment(
 // `application/json` bodies, NOT the RFC's form-encoding — the JSON shapes
 // below are what the worker expects.
 
-/** Static OAuth client id allowlisted by the auth worker's `validateClient`. */
+/**
+ * OAuth client id for the device flow. Registered server-side as a managed
+ * official `oauth_client` row (seeded by apps/auth migration
+ * 20260719000000_seed_cli_oauth_client.sql — issue #251): public PKCE client,
+ * no secret, device-code grant only. The auth worker's device endpoints
+ * validate this id against that table, so operators can disable it from
+ * /admin/oauth. The literal must match the seeded row's client_id.
+ */
 export const DEVICE_CLIENT_ID = "uploads-cli";
 
 /**


### PR DESCRIPTION
Closes #251.

## What

The CLI's device-flow login no longer relies on a string-allowlisted static client id. `uploads-cli` is now a managed `oauth_client` registration:

- **Seed migration** `apps/auth/migrations/20260719000000_seed_cli_oauth_client.sql` — idempotent (`INSERT OR IGNORE`) insert of an official public-PKCE client: no secret, `grant_types` = device-code grant only, `metadata.official: true`, `skip_consent: 1` (exempts it from the stale-client reaper, whose predicate skips `skip_consent` rows).
- **DB-backed validation** — `deviceAuthorization`'s `validateClient` now calls `isDeviceFlowClientAllowed(db, clientId)`: the row must exist, be enabled, and carry `urn:ietf:params:oauth:grant-type:device_code`. Fail-closed on unknown ids, disabled clients, and registered clients without the device grant, on both `/device/code` and `/device/token`. The `UPLOADS_CLI_CLIENT_ID` static allowlist and its special-case comments are removed.
- **Admin panel** — the client now appears in `/admin/oauth` with the official badge, consent/token stats, and a working disable toggle.
- **Docs** — `docs/enrollment.md` covers the managed client, the disable-don't-delete guidance, and deploy ordering.

## Backward compatibility

The client id literal stays `uploads-cli`, so already-configured CLIs are unaffected — nothing changes on the wire, and no CLI-side code changes. Exploration confirmed no existing `oauth_refresh_token`/`oauth_access_token` rows reference the id (the device flow issues Better Auth sessions, not AS tokens), so there is no data backfill. Hosted-MCP dynamic-registration clients are deliberately untouched.

## Deploy note

`pnpm migrate:d1` in `apps/auth` must run before or with the worker deploy (the package's `deploy` script already orders it this way) — the new `validateClient` fails closed if the seeded row is missing.

## Tests

`apps/auth` suite 144/144 green, typecheck clean. New coverage: seeded-row shape assertion, disabled-client rejection, registered-client-without-device-grant rejection, and a reaper test proving a stale seeded row is never a reap candidate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a managed OAuth client for CLI device-flow authentication.
  * Device authorization now respects the client’s enabled status and supported grant types.
  * Administrators can disable the CLI login client through OAuth client management.

* **Documentation**
  * Added migration and deployment guidance for the managed CLI OAuth client.
  * Documented how to manage and disable the client safely.

* **Bug Fixes**
  * Device authorization now fails safely when the required client registration is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->