### PR TITLE
feat(web): oEmbed for public file and gallery pages

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,7 +19,8 @@ From the repo root: `pnpm dev:web` / `pnpm run deploy:web`.
 ```
 src/layouts/                         Shared shells (error pages)
 src/pages/                           Astro pages; g/[id].astro is the on-demand public gallery
-src/lib/                             Public gallery API schema/fetch boundary
+src/pages/oembed.ts                  oEmbed 1.0 JSON endpoint for shareable /f and /g pages
+src/lib/                             Public gallery/file fetch + oEmbed resolution
 public/_headers                      Per-path response headers (Link, robots, types)
 public/robots.txt                    Crawl policy + Content Signals + AI bot rules
 public/sitemap.xml                   Public URL list (landing only)
@@ -70,6 +71,7 @@ rules there.
 | MCP server card | `/.well-known/mcp/server-card.json`                                  |
 | Agent skills    | `/.well-known/agent-skills/index.json`                               |
 | Auth for agents | `/auth.md` (bearer / invite; also documents the hosted-MCP OAuth AS) |
+| oEmbed          | `/oembed?url=…` for public `/f/…` and `/g/…` pages (JSON only)       |
 
 ### Agent skills — always track GitHub `main`
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -46,6 +46,7 @@ Claude Code plugin (bundles the skills, the hosted MCP server, and the /uploads:
 - API: https://api.uploads.sh
 - Agents / MCP: https://agents.uploads.sh/mcp
 - Public storage: https://storage.uploads.sh
+- oEmbed (share pages `/f/…`, `/g/…`): https://uploads.sh/oembed?url=<page-url>&format=json
 
 ## Machine-readable discovery
 

--- a/apps/web/src/lib/oembed.test.ts
+++ b/apps/web/src/lib/oembed.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ABSOLUTE_MAX_EDGE,
+  DEFAULT_PHOTO_SIZE,
+  DEFAULT_VIDEO_HEIGHT,
+  DEFAULT_VIDEO_WIDTH,
+  fitDimensions,
+  oembedDiscoveryHref,
+  oembedHttpResponse,
+  parsePositiveInt,
+  parseShareableUrl,
+  resolveOEmbed,
+  sharePageUrl,
+} from "./oembed";
+
+const SITE = "https://uploads.sh";
+const API = "https://api.uploads.sh";
+const GALLERY_ID = "gal_abcdefghijklmnopqrstuv";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const publicFile = {
+  workspace: "acme",
+  key: "screenshots/shot.png",
+  url: "https://storage.uploads.sh/acme/screenshots/shot.png",
+  embedUrl: "https://embed.uploads.sh/acme/screenshots/shot.png",
+  size: 20480,
+  contentType: "image/png",
+  uploaded: "2026-07-13T12:00:00.000Z",
+};
+
+const publicVideo = {
+  ...publicFile,
+  key: "clips/demo.mp4",
+  url: "https://storage.uploads.sh/acme/clips/demo.mp4",
+  embedUrl: null,
+  contentType: "video/mp4",
+};
+
+const publicGallery = {
+  id: GALLERY_ID,
+  title: "PR screenshots",
+  description: "Before/after",
+  visibility: "public" as const,
+  coverItemId: "item_cover",
+  version: 1,
+  createdAt: "2026-07-13T12:00:00.000Z",
+  updatedAt: "2026-07-13T13:00:00.000Z",
+  items: [
+    {
+      id: "item_cover",
+      filename: "before.png",
+      position: 1,
+      caption: null,
+      altText: null,
+      status: "available" as const,
+      url: "https://storage.uploads.sh/acme/before.png",
+      embedUrl: "https://embed.uploads.sh/acme/before.png",
+      contentType: "image/png",
+    },
+    {
+      id: "item_two",
+      filename: "notes.txt",
+      position: 2,
+      caption: null,
+      altText: null,
+      status: "available" as const,
+      url: "https://storage.uploads.sh/acme/notes.txt",
+      embedUrl: null,
+      contentType: "text/plain",
+    },
+  ],
+  references: [],
+};
+
+describe("parseShareableUrl", () => {
+  it("parses file, gallery, and gallery-item paths on the request origin", () => {
+    expect(parseShareableUrl(`${SITE}/f/acme/screenshots/shot.png`, SITE)).toEqual({
+      kind: "file",
+      workspace: "acme",
+      key: "screenshots/shot.png",
+    });
+    expect(parseShareableUrl(`${SITE}/g/${GALLERY_ID}`, SITE)).toEqual({
+      kind: "gallery",
+      id: GALLERY_ID,
+    });
+    expect(parseShareableUrl(`${SITE}/g/${GALLERY_ID}/item_cover`, SITE)).toEqual({
+      kind: "gallery-item",
+      id: GALLERY_ID,
+      itemId: "item_cover",
+    });
+  });
+
+  it("decodes path segments and rejects traversal / foreign origins", () => {
+    expect(parseShareableUrl(`${SITE}/f/acme/My%20Shot%231.png`, SITE)).toEqual({
+      kind: "file",
+      workspace: "acme",
+      key: "My Shot#1.png",
+    });
+    // Encoded slash keeps `..` inside a path segment through URL parsing; after
+    // decode, isSafeKey rejects `..` components.
+    expect(parseShareableUrl(`${SITE}/f/acme/..%2fetc%2fpasswd`, SITE)).toBeNull();
+    // Bare / percent-encoded `../` path segments are collapsed by the URL
+    // parser into a different path (not a client-controlled key under acme).
+    expect(parseShareableUrl(`${SITE}/f/acme/../etc/passwd`, SITE)).toEqual({
+      kind: "file",
+      workspace: "etc",
+      key: "passwd",
+    });
+    expect(parseShareableUrl(`https://evil.example/f/acme/shot.png`, SITE)).toBeNull();
+    expect(parseShareableUrl(`${SITE}/docs`, SITE)).toBeNull();
+    expect(parseShareableUrl(`${SITE}/g/not-a-gallery-id`, SITE)).toBeNull();
+  });
+});
+
+describe("fitDimensions / parsePositiveInt", () => {
+  it("clamps to maxwidth/maxheight preserving aspect ratio", () => {
+    expect(fitDimensions(2000, 1000, 1000)).toEqual({ width: 1000, height: 500 });
+    expect(fitDimensions(1000, 2000, undefined, 500)).toEqual({ width: 250, height: 500 });
+    expect(fitDimensions(100, 100, 50, 50)).toEqual({ width: 50, height: 50 });
+  });
+
+  it("parses positive integer query params and caps the absolute max edge", () => {
+    expect(parsePositiveInt("800")).toBe(800);
+    expect(parsePositiveInt("0")).toBeUndefined();
+    expect(parsePositiveInt("-1")).toBeUndefined();
+    expect(parsePositiveInt("12.5")).toBeUndefined();
+    expect(parsePositiveInt(String(ABSOLUTE_MAX_EDGE + 10))).toBe(ABSOLUTE_MAX_EDGE);
+  });
+});
+
+describe("oembedDiscoveryHref / sharePageUrl", () => {
+  it("builds a discovery href with url + format=json", () => {
+    const page = sharePageUrl(SITE, {
+      kind: "file",
+      workspace: "acme",
+      key: "screenshots/shot.png",
+    });
+    const href = oembedDiscoveryHref(page, SITE);
+    const parsed = new URL(href);
+    expect(parsed.origin).toBe(SITE);
+    expect(parsed.pathname).toBe("/oembed");
+    expect(parsed.searchParams.get("url")).toBe(page);
+    expect(parsed.searchParams.get("format")).toBe("json");
+  });
+});
+
+describe("resolveOEmbed", () => {
+  it("returns a photo response for an image file page", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const href = String(input);
+      expect(href).toContain("/public/files/acme/screenshots/shot.png");
+      return jsonResponse(publicFile);
+    });
+
+    const page = sharePageUrl(SITE, {
+      kind: "file",
+      workspace: "acme",
+      key: "screenshots/shot.png",
+    });
+    const result = await resolveOEmbed({
+      url: page,
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: fetchMock as typeof fetch,
+      maxwidth: 600,
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.body).toMatchObject({
+      version: "1.0",
+      type: "photo",
+      provider_name: "uploads.sh",
+      provider_url: SITE,
+      title: "shot.png",
+      url: publicFile.url,
+      width: 600,
+      height: 600,
+    });
+  });
+
+  it("returns a video response with escaped HTML for a video file", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(publicVideo));
+    const page = sharePageUrl(SITE, {
+      kind: "file",
+      workspace: "acme",
+      key: "clips/demo.mp4",
+    });
+    const result = await resolveOEmbed({
+      url: page,
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: fetchMock as typeof fetch,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.body.type).toBe("video");
+    if (result.body.type !== "video") return;
+    expect(result.body.width).toBe(DEFAULT_VIDEO_WIDTH);
+    expect(result.body.height).toBe(DEFAULT_VIDEO_HEIGHT);
+    expect(result.body.html).toContain(`src="${publicVideo.url}"`);
+    expect(result.body.html).toContain("controls");
+  });
+
+  it("returns link + thumbnail for a gallery index", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(publicGallery));
+    const page = sharePageUrl(SITE, { kind: "gallery", id: GALLERY_ID });
+    const result = await resolveOEmbed({
+      url: page,
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: fetchMock as typeof fetch,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.body).toMatchObject({
+      type: "link",
+      title: "PR screenshots",
+      thumbnail_url: publicGallery.items[0]!.url,
+      thumbnail_width: DEFAULT_PHOTO_SIZE,
+      thumbnail_height: DEFAULT_PHOTO_SIZE,
+    });
+  });
+
+  it("returns photo for a gallery item image", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(publicGallery));
+    const page = sharePageUrl(SITE, {
+      kind: "gallery-item",
+      id: GALLERY_ID,
+      itemId: "item_cover",
+    });
+    const result = await resolveOEmbed({
+      url: page,
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: fetchMock as typeof fetch,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.body).toMatchObject({
+      type: "photo",
+      title: "before.png",
+      url: publicGallery.items[0]!.url,
+    });
+  });
+
+  it("maps missing/private files and bad input to the right statuses", async () => {
+    const notFound = await resolveOEmbed({
+      url: sharePageUrl(SITE, { kind: "file", workspace: "acme", key: "missing.png" }),
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: (async () => jsonResponse({ error: "nope" }, 404)) as typeof fetch,
+    });
+    expect(notFound.status).toBe("not_found");
+
+    const authRequired = await resolveOEmbed({
+      url: sharePageUrl(SITE, { kind: "file", workspace: "acme", key: "private.png" }),
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: (async () =>
+        jsonResponse(
+          { error: { code: "auth_required", message: "Sign in required" } },
+          401,
+        )) as typeof fetch,
+    });
+    expect(authRequired.status).toBe("not_found");
+
+    const bad = await resolveOEmbed({
+      url: "",
+      requestOrigin: SITE,
+      apiOrigin: API,
+    });
+    expect(bad).toEqual({ status: "bad_request", message: "Missing or invalid url parameter." });
+
+    const xml = await resolveOEmbed({
+      url: sharePageUrl(SITE, { kind: "file", workspace: "acme", key: "shot.png" }),
+      requestOrigin: SITE,
+      apiOrigin: API,
+      format: "xml",
+    });
+    expect(xml.status).toBe("not_implemented");
+
+    const foreign = await resolveOEmbed({
+      url: "https://evil.example/f/acme/shot.png",
+      requestOrigin: SITE,
+      apiOrigin: API,
+    });
+    expect(foreign.status).toBe("not_found");
+  });
+
+  it("surfaces API outages as unavailable", async () => {
+    const result = await resolveOEmbed({
+      url: sharePageUrl(SITE, { kind: "file", workspace: "acme", key: "shot.png" }),
+      requestOrigin: SITE,
+      apiOrigin: API,
+      fetch: (async () => jsonResponse({ error: "boom" }, 500)) as typeof fetch,
+    });
+    expect(result.status).toBe("unavailable");
+  });
+});
+
+describe("oembedHttpResponse", () => {
+  it("returns JSON + CORS on success and structured errors otherwise", async () => {
+    const ok = oembedHttpResponse({
+      status: "ok",
+      body: {
+        version: "1.0",
+        type: "link",
+        title: "x",
+        provider_name: "uploads.sh",
+        provider_url: SITE,
+        cache_age: 300,
+      },
+    });
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(ok.headers.get("Content-Type")).toContain("application/json");
+    expect(ok.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect(await ok.json()).toMatchObject({ type: "link", title: "x" });
+
+    expect(oembedHttpResponse({ status: "not_found" }).status).toBe(404);
+    expect(
+      oembedHttpResponse({ status: "bad_request", message: "Missing or invalid url parameter." })
+        .status,
+    ).toBe(400);
+    expect(
+      oembedHttpResponse({ status: "not_implemented", message: "Only format=json is supported." })
+        .status,
+    ).toBe(501);
+    expect(oembedHttpResponse({ status: "unavailable" }).status).toBe(503);
+  });
+});

--- a/apps/web/src/lib/oembed.ts
+++ b/apps/web/src/lib/oembed.ts
@@ -1,0 +1,405 @@
+/**
+ * oEmbed 1.0 for public shareable pages (`/f/…`, `/g/…`).
+ *
+ * Pages advertise discovery via
+ *   <link rel="alternate" type="application/json+oembed" href="/oembed?url=…">
+ * The endpoint re-fetches the public API so private/missing objects never leak.
+ * Pages set `X-Frame-Options: DENY`, so responses never iframe the page —
+ * images use `photo`, videos use an inline `<video>` snippet, else `link`.
+ */
+
+import { fetchPublicFile, fileKind, filePath, isSafeKey } from "./public-file";
+import {
+  fetchPublicGallery,
+  galleryItemPath,
+  galleryPath,
+  mediaKind as galleryMediaKind,
+  type PublicGallery,
+  type PublicGalleryItem,
+} from "./public-gallery";
+
+export const OEMBED_VERSION = "1.0" as const;
+export const OEMBED_PROVIDER_NAME = "uploads.sh";
+export const OEMBED_PROVIDER_URL = "https://uploads.sh";
+
+/** Default photo edge when dimensions are unknown. */
+export const DEFAULT_PHOTO_SIZE = 1200;
+/** Default video frame when dimensions are unknown. */
+export const DEFAULT_VIDEO_WIDTH = 1280;
+export const DEFAULT_VIDEO_HEIGHT = 720;
+/** Cap when the consumer omits maxwidth / maxheight. */
+export const ABSOLUTE_MAX_EDGE = 4096;
+
+const WORKSPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const GALLERY_ID_PATTERN = /^gal_[A-Za-z0-9_-]{22}$/;
+/** Opaque item ids (UUIDs in production; tests use short tokens). */
+const ITEM_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export type ShareTarget =
+  | { kind: "file"; workspace: string; key: string }
+  | { kind: "gallery"; id: string }
+  | { kind: "gallery-item"; id: string; itemId: string };
+
+export type OEmbedType = "photo" | "video" | "link";
+
+export interface OEmbedBase {
+  version: typeof OEMBED_VERSION;
+  type: OEmbedType;
+  title?: string;
+  provider_name: typeof OEMBED_PROVIDER_NAME;
+  provider_url: typeof OEMBED_PROVIDER_URL;
+  cache_age?: number;
+  thumbnail_url?: string;
+  thumbnail_width?: number;
+  thumbnail_height?: number;
+}
+
+export interface OEmbedPhoto extends OEmbedBase {
+  type: "photo";
+  url: string;
+  width: number;
+  height: number;
+}
+
+export interface OEmbedVideo extends OEmbedBase {
+  type: "video";
+  html: string;
+  width: number;
+  height: number;
+}
+
+export interface OEmbedLink extends OEmbedBase {
+  type: "link";
+}
+
+export type OEmbedResponse = OEmbedPhoto | OEmbedVideo | OEmbedLink;
+
+export type OEmbedResult =
+  | { status: "ok"; body: OEmbedResponse }
+  | { status: "bad_request"; message: string }
+  | { status: "not_found" }
+  | { status: "unavailable" }
+  | { status: "not_implemented"; message: string };
+
+export interface OEmbedRequest {
+  /** Absolute shareable page URL from the `url` query param. */
+  url: string;
+  /** Origin of the oEmbed request (must match the share page origin). */
+  requestOrigin: string;
+  /** API origin used to resolve public file/gallery DTOs. */
+  apiOrigin: string;
+  maxwidth?: number;
+  maxheight?: number;
+  /** Only `json` is supported; omit or `json` is fine. */
+  format?: string;
+  fetch?: typeof globalThis.fetch;
+  timeoutMs?: number;
+}
+
+/** Absolute discovery href for a shareable page's canonical URL. */
+export function oembedDiscoveryHref(pageUrl: string, siteOrigin: string): string {
+  const endpoint = new URL("/oembed", siteOrigin);
+  endpoint.searchParams.set("url", pageUrl);
+  endpoint.searchParams.set("format", "json");
+  return endpoint.href;
+}
+
+/** Positive integer query param; rejects non-integers and non-positives. */
+export function parsePositiveInt(raw: string | null | undefined): number | undefined {
+  if (raw == null || raw === "" || !/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n <= 0) return undefined;
+  return Math.min(n, ABSOLUTE_MAX_EDGE);
+}
+
+/**
+ * Parse a shareable page URL into a target when its origin matches
+ * `requestOrigin` (blocks using this endpoint as an open proxy).
+ */
+export function parseShareableUrl(rawUrl: string, requestOrigin: string): ShareTarget | null {
+  let page: URL;
+  let expected: URL;
+  try {
+    page = new URL(rawUrl);
+    expected = new URL(requestOrigin);
+  } catch {
+    return null;
+  }
+  if (page.origin !== expected.origin) return null;
+  if (page.protocol !== "https:" && page.protocol !== "http:") return null;
+
+  const parts: string[] = [];
+  for (const segment of page.pathname.split("/").filter(Boolean)) {
+    try {
+      parts.push(decodeURIComponent(segment));
+    } catch {
+      return null;
+    }
+  }
+
+  if (parts[0] === "f" && parts.length >= 3) {
+    const workspace = parts[1]!;
+    const key = parts.slice(2).join("/");
+    if (!WORKSPACE_PATTERN.test(workspace) || !isSafeKey(key)) return null;
+    return { kind: "file", workspace, key };
+  }
+
+  if (parts[0] === "g" && parts.length === 2) {
+    const id = parts[1]!;
+    if (!GALLERY_ID_PATTERN.test(id)) return null;
+    return { kind: "gallery", id };
+  }
+
+  if (parts[0] === "g" && parts.length === 3) {
+    const id = parts[1]!;
+    const itemId = parts[2]!;
+    if (!GALLERY_ID_PATTERN.test(id) || !ITEM_ID_PATTERN.test(itemId)) return null;
+    return { kind: "gallery-item", id, itemId };
+  }
+
+  return null;
+}
+
+/** Fit a natural box into optional maxwidth/maxheight, preserving aspect ratio. */
+export function fitDimensions(
+  naturalWidth: number,
+  naturalHeight: number,
+  maxwidth?: number,
+  maxheight?: number,
+): { width: number; height: number } {
+  const width = Math.max(1, Math.round(naturalWidth));
+  const height = Math.max(1, Math.round(naturalHeight));
+  const scale = Math.min(
+    1,
+    (maxwidth ?? ABSOLUTE_MAX_EDGE) / width,
+    (maxheight ?? ABSOLUTE_MAX_EDGE) / height,
+  );
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+function escapeHtmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function provider(
+  title?: string,
+): Pick<OEmbedBase, "version" | "provider_name" | "provider_url" | "title" | "cache_age"> {
+  return {
+    version: OEMBED_VERSION,
+    provider_name: OEMBED_PROVIDER_NAME,
+    provider_url: OEMBED_PROVIDER_URL,
+    cache_age: 300,
+    ...(title ? { title } : {}),
+  };
+}
+
+function forMedia(
+  kind: "image" | "video" | "file" | "unsupported",
+  mediaUrl: string,
+  title: string,
+  maxwidth?: number,
+  maxheight?: number,
+): OEmbedResponse {
+  if (kind === "image") {
+    const { width, height } = fitDimensions(
+      DEFAULT_PHOTO_SIZE,
+      DEFAULT_PHOTO_SIZE,
+      maxwidth,
+      maxheight,
+    );
+    return { ...provider(title), type: "photo", url: mediaUrl, width, height };
+  }
+  if (kind === "video") {
+    const { width, height } = fitDimensions(
+      DEFAULT_VIDEO_WIDTH,
+      DEFAULT_VIDEO_HEIGHT,
+      maxwidth,
+      maxheight,
+    );
+    return {
+      ...provider(title),
+      type: "video",
+      width,
+      height,
+      html: `<video src="${escapeHtmlAttr(mediaUrl)}" width="${width}" height="${height}" controls playsinline preload="metadata" style="max-width:100%;height:auto"></video>`,
+    };
+  }
+  return { ...provider(title), type: "link" };
+}
+
+function filenameFromKey(key: string): string {
+  const slash = key.lastIndexOf("/");
+  return slash === -1 ? key : key.slice(slash + 1) || key;
+}
+
+function coverThumbnail(
+  gallery: PublicGallery,
+  maxwidth?: number,
+  maxheight?: number,
+): Pick<OEmbedLink, "thumbnail_url" | "thumbnail_width" | "thumbnail_height"> | undefined {
+  const items = gallery.items.toSorted(
+    (a, b) => a.position - b.position || a.id.localeCompare(b.id),
+  );
+  const prefer = gallery.coverItemId
+    ? items.find((item) => item.id === gallery.coverItemId)
+    : undefined;
+  const cover: PublicGalleryItem | undefined =
+    prefer && galleryMediaKind(prefer) === "image" && prefer.url
+      ? prefer
+      : items.find((item) => galleryMediaKind(item) === "image" && item.url);
+  if (!cover?.url) return undefined;
+  const { width, height } = fitDimensions(
+    DEFAULT_PHOTO_SIZE,
+    DEFAULT_PHOTO_SIZE,
+    maxwidth,
+    maxheight,
+  );
+  return { thumbnail_url: cover.url, thumbnail_width: width, thumbnail_height: height };
+}
+
+function fromFetchFailure(
+  status: "not_found" | "auth_required" | "unavailable",
+): Extract<OEmbedResult, { status: "not_found" | "unavailable" }> {
+  return status === "unavailable" ? { status: "unavailable" } : { status: "not_found" };
+}
+
+async function resolveTarget(target: ShareTarget, options: OEmbedRequest): Promise<OEmbedResult> {
+  const api = {
+    origin: options.apiOrigin,
+    fetch: options.fetch,
+    timeoutMs: options.timeoutMs,
+  };
+  const { maxwidth, maxheight } = options;
+
+  if (target.kind === "file") {
+    const result = await fetchPublicFile(target.workspace, target.key, api);
+    if (result.status !== "ok") return fromFetchFailure(result.status);
+    const file = result.file;
+    return {
+      status: "ok",
+      body: forMedia(
+        fileKind(file.contentType),
+        file.url,
+        filenameFromKey(file.key),
+        maxwidth,
+        maxheight,
+      ),
+    };
+  }
+
+  const result = await fetchPublicGallery(target.id, api);
+  if (result.status !== "ok") return fromFetchFailure(result.status);
+  const gallery = result.gallery;
+
+  if (target.kind === "gallery") {
+    return {
+      status: "ok",
+      body: {
+        ...provider(gallery.title),
+        type: "link",
+        ...coverThumbnail(gallery, maxwidth, maxheight),
+      },
+    };
+  }
+
+  const item = gallery.items.find((entry) => entry.id === target.itemId);
+  if (!item) return { status: "not_found" };
+  const kind = galleryMediaKind(item);
+  if (kind === "missing" || !item.url) {
+    return { status: "ok", body: { ...provider(item.filename), type: "link" } };
+  }
+  return {
+    status: "ok",
+    body: forMedia(kind, item.url, item.filename, maxwidth, maxheight),
+  };
+}
+
+/** Validate format + share URL, fetch public data, return a typed result. */
+export async function resolveOEmbed(options: OEmbedRequest): Promise<OEmbedResult> {
+  if ((options.format ?? "json").toLowerCase() !== "json") {
+    return { status: "not_implemented", message: "Only format=json is supported." };
+  }
+  if (!options.url || options.url.length > 4096) {
+    return { status: "bad_request", message: "Missing or invalid url parameter." };
+  }
+  const target = parseShareableUrl(options.url, options.requestOrigin);
+  if (!target) return { status: "not_found" };
+  return resolveTarget(target, options);
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Accept",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "no-referrer",
+} as const;
+
+/** Map an {@link OEmbedResult} to JSON + CORS. */
+export function oembedHttpResponse(result: OEmbedResult): Response {
+  if (result.status === "ok") {
+    return new Response(JSON.stringify(result.body), {
+      status: 200,
+      headers: {
+        ...CORS,
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "public, max-age=300",
+      },
+    });
+  }
+
+  const status =
+    result.status === "bad_request"
+      ? 400
+      : result.status === "not_implemented"
+        ? 501
+        : result.status === "unavailable"
+          ? 503
+          : 404;
+  const error =
+    result.status === "bad_request" || result.status === "not_implemented"
+      ? result.message
+      : result.status === "unavailable"
+        ? "Service unavailable"
+        : "Not found";
+
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: {
+      ...CORS,
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/** OPTIONS preflight for cross-origin oEmbed consumers. */
+export function oembedOptionsResponse(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Accept",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+}
+
+/** Canonical absolute URL for a share target — used by tests and callers. */
+export function sharePageUrl(siteOrigin: string, target: ShareTarget): string {
+  const path =
+    target.kind === "file"
+      ? filePath(target.workspace, target.key)
+      : target.kind === "gallery"
+        ? galleryPath(target.id)
+        : galleryItemPath(target.id, target.itemId);
+  return new URL(path, siteOrigin).href;
+}

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -126,6 +126,12 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
       stay fast, and <strong>EXIF metadata is stripped</strong>. Use <code>--keep-exif</code>&#32;
       to keep metadata, or <code>--no-optimize</code> to skip all processing.
     </p>
+    <p>
+      Each file also gets a shareable page on uploads.sh (under <code>/f/…</code>) that
+      supports <a href="https://oembed.com/">oEmbed</a> — so chat apps, notes tools, and
+      other unfurlers can embed the image when you paste the page link. Details are in
+      <a href="/docs/reference#good-to-know">Reference</a>.
+    </p>
   </section>
 
   <section id="screenshot">

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -42,6 +42,13 @@ const REPO = "https://github.com/buildinternet/uploads";
         media attached to private repositories. Don't upload secrets or sensitive UI.
       </li>
       <li>
+        <strong>Share pages support embeds.</strong> Every public file and gallery has a
+        page at <code>/f/…</code> or <code>/g/…</code> with
+        <a href="https://oembed.com/">oEmbed</a> discovery, so tools that unfurl links can
+        show the media. The endpoint is
+        <code>GET /oembed?url=&lt;page-url&gt;&amp;format=json</code>.
+      </li>
+      <li>
         <strong>Access is by invitation.</strong> There's no self-serve signup right now. If
         you'd like in, reach out via <a href={REPO}>the GitHub repo</a>.
       </li>

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -14,6 +14,7 @@ import {
   filePath,
   formatBytes,
 } from "../../../lib/public-file";
+import { oembedDiscoveryHref } from "../../../lib/oembed";
 import { env } from "cloudflare:workers";
 
 export const prerender = false;
@@ -67,6 +68,9 @@ const title = file
   : result.status === "auth_required"
     ? "Sign in to view · uploads.sh"
     : "File unavailable · uploads.sh";
+// oEmbed discovery only when the public object is fully resolved — private /
+// missing pages must not advertise an endpoint that would 404 or leak existence.
+const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : null;
 ---
 
 <!doctype html>
@@ -82,6 +86,14 @@ const title = file
     <meta property="og:description" content="Public file hosted by uploads.sh." />
     <meta property="og:url" content={canonical} />
     {file && kind(file.contentType) === "image" && <meta property="og:image" content={file.url} />}
+    {oembedHref && (
+      <link
+        rel="alternate"
+        type="application/json+oembed"
+        href={oembedHref}
+        title={`${filename} oEmbed Profile`}
+      />
+    )}
     <style>
       * { box-sizing:border-box; }
       body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }

--- a/apps/web/src/pages/g/[id].astro
+++ b/apps/web/src/pages/g/[id].astro
@@ -11,6 +11,7 @@ import {
   mediaKind as kind,
   type PublicGalleryItem,
 } from "../../lib/public-gallery";
+import { oembedDiscoveryHref } from "../../lib/oembed";
 import { env } from "cloudflare:workers";
 
 export const prerender = false;
@@ -29,6 +30,7 @@ if (result.status === "unavailable") Astro.response.status = 503;
 const gallery = result.status === "ok" ? result.gallery : null;
 const canonical = new URL(galleryPath(id), Astro.url.origin).href;
 const itemPage = (item: PublicGalleryItem) => galleryItemPath(id, item.id);
+const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : null;
 ---
 
 <!doctype html>
@@ -43,6 +45,14 @@ const itemPage = (item: PublicGalleryItem) => galleryItemPath(id, item.id);
     <meta property="og:title" content={gallery?.title ?? "Gallery unavailable"} />
     <meta property="og:description" content={gallery?.description ?? "A public media gallery hosted by uploads.sh."} />
     <meta property="og:url" content={canonical} />
+    {oembedHref && gallery && (
+      <link
+        rel="alternate"
+        type="application/json+oembed"
+        href={oembedHref}
+        title={`${gallery.title} oEmbed Profile`}
+      />
+    )}
     <style>
       * { box-sizing:border-box; }
       body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -14,6 +14,7 @@ import {
   mediaKind as kind,
   type PublicGalleryItem,
 } from "../../../lib/public-gallery";
+import { oembedDiscoveryHref } from "../../../lib/oembed";
 import { env } from "cloudflare:workers";
 
 export const prerender = false;
@@ -56,6 +57,8 @@ const embedFormats: EmbedFormatOption[] =
     : [];
 const downloadUrl =
   item && item.status === "available" ? galleryItemDownloadUrl(origin, id, item.id) : null;
+const oembedHref =
+  gallery && item ? oembedDiscoveryHref(canonical, Astro.url.origin) : null;
 ---
 
 <!doctype html>
@@ -71,6 +74,14 @@ const downloadUrl =
     <meta property="og:description" content={item?.caption ?? gallery?.description ?? "Public media hosted by uploads.sh."} />
     <meta property="og:url" content={canonical} />
     {item && kind(item) === "image" && <meta property="og:image" content={item.url!} />}
+    {oembedHref && item && (
+      <link
+        rel="alternate"
+        type="application/json+oembed"
+        href={oembedHref}
+        title={`${item.filename} oEmbed Profile`}
+      />
+    )}
     <style>
       * { box-sizing:border-box; }
       body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }

--- a/apps/web/src/pages/oembed.ts
+++ b/apps/web/src/pages/oembed.ts
@@ -1,0 +1,36 @@
+/**
+ * oEmbed 1.0 endpoint for public shareable pages.
+ *
+ *   GET /oembed?url=<absolute page url>&format=json&maxwidth=&maxheight=
+ *
+ * Discovery links on `/f/…` and `/g/…` point here. Only same-origin shareable
+ * page URLs are accepted (no open-proxy). See `src/lib/oembed.ts`.
+ */
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import {
+  oembedHttpResponse,
+  oembedOptionsResponse,
+  parsePositiveInt,
+  resolveOEmbed,
+} from "../lib/oembed";
+
+export const prerender = false;
+
+export const OPTIONS: APIRoute = () => oembedOptionsResponse();
+
+export const GET: APIRoute = async ({ url }) => {
+  const apiOrigin =
+    env.UPLOADS_API_ORIGIN ?? import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ?? "https://api.uploads.sh";
+
+  const result = await resolveOEmbed({
+    url: url.searchParams.get("url") ?? "",
+    requestOrigin: url.origin,
+    apiOrigin,
+    maxwidth: parsePositiveInt(url.searchParams.get("maxwidth")),
+    maxheight: parsePositiveInt(url.searchParams.get("maxheight")),
+    format: url.searchParams.get("format") ?? "json",
+  });
+
+  return oembedHttpResponse(result);
+};


### PR DESCRIPTION
## In plain terms

Public share pages for files and galleries can now be unfurled by tools that speak oEmbed. Paste a `/f/…` or `/g/…` link into a chat app, notes tool, or other embed consumer and it can resolve media cleanly instead of only seeing a bare URL.

## What it does

- Adds `GET /oembed?url=…&format=json` on the web app (optional `maxwidth` / `maxheight`, CORS-enabled)
- Advertises discovery via `<link rel="alternate" type="application/json+oembed">` on public file and gallery pages (only when the object is fully public)
- Response shapes: images → `photo`, videos → `video` with an inline player snippet, galleries/other → `link` (with cover thumbnail when available)
- Re-resolves through the existing public API so private / missing objects never leak through oEmbed
- Same-origin URL allowlist only (no open-proxy)
- Brief docs: Attach & share, Reference, and `/llms.txt`

## What it is not

- Not an iframe of the HTML page (pages stay `X-Frame-Options: DENY`)
- Not XML oEmbed (`format=xml` → 501)
- Not a change to storage URLs or the API worker

## How to try it

After deploy:

```bash
# discovery on a public file page
curl -sS https://uploads.sh/f/<workspace>/<key> | grep oembed

# resolve oEmbed JSON
curl -sS "https://uploads.sh/oembed?url=https%3A%2F%2Fuploads.sh%2Ff%2F…&format=json"
```

## Technical notes

- Logic lives in `apps/web/src/lib/oembed.ts`; route at `apps/web/src/pages/oembed.ts`
- Reuses `fetchPublicFile` / `fetchPublicGallery` + `isSafeKey`
- Unit coverage in `oembed.test.ts` (parsing, dimensions, photo/video/gallery, auth → 404, HTTP mapping)

## Test plan

- [x] `pnpm --filter @uploads/web test` (158 tests)
- [x] Pre-commit oxlint + oxfmt
- [ ] Manual: load a public `/f/` image page and confirm discovery link + `/oembed` photo response
- [ ] Manual: gallery index returns `link` + thumbnail when a cover image exists