### PR TITLE
fix(web): ClientRouter workspace access + quieter account settings

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -29,10 +29,13 @@ const MENU_ITEMS = [
   </div>
 </div>
 
-<script is:inline data-astro-rerun define:vars={{ authOrigin, menuItems: MENU_ITEMS }}>
-  window.__UPLOADS_AUTH_ORIGIN__ = window.__UPLOADS_AUTH_ORIGIN__ || authOrigin;
-  window.__UPLOADS_AUTH_MENU_ITEMS__ = menuItems;
-</script>
+{/* Window assigns only — define:vars injects top-level const, which breaks
+    data-astro-rerun under ClientRouter (redeclaration on sibling navigations). */}
+<script
+  is:inline
+  data-astro-rerun
+  set:html={`window.__UPLOADS_AUTH_ORIGIN__=window.__UPLOADS_AUTH_ORIGIN__||${JSON.stringify(authOrigin)};window.__UPLOADS_AUTH_MENU_ITEMS__=${JSON.stringify(MENU_ITEMS)};`}
+></script>
 <script>
   import { getSession, signOut, type SessionUser } from "../lib/auth-client";
   import {

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -166,12 +166,14 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
   })();
 </script>
 
-<script is:inline data-astro-rerun define:vars={{ authOrigin, apiOrigin, workspace, workspacePage }}>
-  window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
-  window.__UPLOADS_API_ORIGIN__ = apiOrigin;
-  window.__UPLOADS_ACTIVE_WORKSPACE__ = workspace;
-  window.__UPLOADS_WORKSPACE_PAGE__ = workspacePage;
-</script>
+{/* Assign to window only — no `define:vars` `const`s. ClientRouter re-runs
+    this after every body swap; top-level const would throw "already declared"
+    and leave stale __UPLOADS_ACTIVE_WORKSPACE__ (access denied after sibling nav). */}
+<script
+  is:inline
+  data-astro-rerun
+  set:html={`window.__UPLOADS_AUTH_ORIGIN__=${JSON.stringify(authOrigin)};window.__UPLOADS_API_ORIGIN__=${JSON.stringify(apiOrigin)};window.__UPLOADS_ACTIVE_WORKSPACE__=${JSON.stringify(workspace)};window.__UPLOADS_WORKSPACE_PAGE__=${JSON.stringify(workspacePage)};`}
+></script>
 <script>
   import {
     initSignOut,
@@ -179,6 +181,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
     requireElement,
     resolveSessionGate,
   } from "../lib/account-shell";
+  import { resolveActiveWorkspace } from "../lib/workspace-browse-url";
   import { initWorkspacesNav, type WorkspaceNavPage } from "../lib/workspaces-nav";
 
   onAstroPageLoad(() => {
@@ -193,10 +196,18 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
     const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
     const apiOrigin = w.__UPLOADS_API_ORIGIN__;
 
+    // Pathname wins when the boot global is empty/stale after ClientRouter nav.
+    const activeWorkspace = resolveActiveWorkspace(
+      location.pathname,
+      w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+    );
+    const workspacePage: WorkspaceNavPage =
+      /\/invite\/?$/.test(location.pathname) ? "invite" : w.__UPLOADS_WORKSPACE_PAGE__ || "overview";
+
     initSignOut(authOrigin);
     initWorkspacesNav(apiOrigin, requireElement<HTMLElement>("#workspaces-nav-list", "account"), {
-      active: w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
-      page: w.__UPLOADS_WORKSPACE_PAGE__ || "overview",
+      active: activeWorkspace,
+      page: workspacePage,
     });
 
     void resolveSessionGate({

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -126,10 +126,12 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
   })();
 </script>
 
-<script is:inline data-astro-rerun define:vars={{ authOrigin, apiOrigin }}>
-  window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
-  window.__UPLOADS_API_ORIGIN__ = apiOrigin;
-</script>
+{/* Window assigns only — see AccountLayout (define:vars const breaks data-astro-rerun). */}
+<script
+  is:inline
+  data-astro-rerun
+  set:html={`window.__UPLOADS_AUTH_ORIGIN__=${JSON.stringify(authOrigin)};window.__UPLOADS_API_ORIGIN__=${JSON.stringify(apiOrigin)};`}
+></script>
 <script>
   import {
     initSignOut,

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -15,6 +15,9 @@ import {
   type SessionResponse,
   type SessionUser,
 } from "./auth-client";
+import { markPageLoad } from "./page-visit";
+
+export { getPageVisit, isCurrentPageVisit } from "./page-visit";
 
 const SESSION_EVENT = "uploads:session";
 
@@ -105,15 +108,27 @@ export function initSignOut(authOrigin: string): void {
   });
 }
 
+let pageVisitTrackingInstalled = false;
+
 /**
  * Run after every Astro ClientRouter navigation (and the initial load when
  * `<ClientRouter />` is present). Bundled module scripts only execute once per
  * session — page/layout boot that queries the DOM must register here so it
  * re-attaches after body swap.
  *
+ * Also bumps the shared page-visit id (see `page-visit.ts`) once per event so
+ * async handlers can drop stale results after the user navigates away.
+ *
  * Prefer this over top-level side effects in account/admin page scripts.
  */
 export function onAstroPageLoad(callback: () => void): void {
+  if (!pageVisitTrackingInstalled) {
+    pageVisitTrackingInstalled = true;
+    // Register before page callbacks so they observe the bumped id.
+    document.addEventListener("astro:page-load", () => {
+      markPageLoad();
+    });
+  }
   document.addEventListener("astro:page-load", callback);
 }
 

--- a/apps/web/src/lib/client-router-boot.test.ts
+++ b/apps/web/src/lib/client-router-boot.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Locks in ClientRouter boot invariants that already burned us once:
+ * `define:vars` + `data-astro-rerun` injects top-level `const` and throws on
+ * the second account navigation, leaving stale __UPLOADS_* globals.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function readSrc(rel: string): string {
+  return readFileSync(join(root, rel), "utf8");
+}
+
+describe("ClientRouter boot scripts", () => {
+  const bootFiles = [
+    "layouts/AccountLayout.astro",
+    "layouts/AdminLayout.astro",
+    "components/AuthIndicator.astro",
+  ] as const;
+
+  it.each(bootFiles)("%s does not combine define:vars with data-astro-rerun", (rel) => {
+    const src = readSrc(rel);
+    // Must re-run after body swap…
+    expect(src).toContain("data-astro-rerun");
+    // Attribute form only — comments may still warn about the pitfall.
+    // `define:vars` injects top-level const and throws on the second nav.
+    expect(src).not.toMatch(/define:vars\s*=/);
+  });
+
+  it("account layout assigns boot globals via set:html window assigns", () => {
+    const src = readSrc("layouts/AccountLayout.astro");
+    expect(src).toContain("__UPLOADS_ACTIVE_WORKSPACE__");
+    expect(src).toContain("set:html=");
+    expect(src).toContain("JSON.stringify");
+  });
+});

--- a/apps/web/src/lib/page-visit.test.ts
+++ b/apps/web/src/lib/page-visit.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getPageVisit,
+  isCurrentPageVisit,
+  markPageLoad,
+  resetPageVisitForTests,
+} from "./page-visit";
+
+afterEach(() => {
+  resetPageVisitForTests();
+});
+
+describe("page visit generation", () => {
+  it("starts at 0 and is not a current visit", () => {
+    expect(getPageVisit()).toBe(0);
+    expect(isCurrentPageVisit(0)).toBe(false);
+  });
+
+  it("marks prior visits stale after another page-load", () => {
+    const first = markPageLoad();
+    expect(first).toBe(1);
+    expect(isCurrentPageVisit(first)).toBe(true);
+
+    const second = markPageLoad();
+    expect(second).toBe(2);
+    expect(isCurrentPageVisit(first)).toBe(false);
+    expect(isCurrentPageVisit(second)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/page-visit.ts
+++ b/apps/web/src/lib/page-visit.ts
@@ -1,0 +1,32 @@
+/**
+ * ClientRouter visit generation for account/admin shells.
+ *
+ * Module scripts register `astro:page-load` once and keep firing after every
+ * body swap. Async fetches started on visit N must not paint into visit N+1
+ * (workspace A → profile → workspace B races). Call {@link markPageLoad} once
+ * per `astro:page-load` (see `onAstroPageLoad`), then capture the id and check
+ * {@link isCurrentPageVisit} before DOM writes.
+ */
+
+let pageVisit = 0;
+
+/** Bump the visit id. Returns the new id. */
+export function markPageLoad(): number {
+  pageVisit += 1;
+  return pageVisit;
+}
+
+/** Current visit id (0 before the first page-load). */
+export function getPageVisit(): number {
+  return pageVisit;
+}
+
+/** True when `visit` is still the active ClientRouter page. */
+export function isCurrentPageVisit(visit: number): boolean {
+  return visit === pageVisit && visit > 0;
+}
+
+/** Test helper — do not use in app code. */
+export function resetPageVisitForTests(): void {
+  pageVisit = 0;
+}

--- a/apps/web/src/lib/workspace-browse-url.test.ts
+++ b/apps/web/src/lib/workspace-browse-url.test.ts
@@ -4,6 +4,7 @@ import {
   isBrowseWorkspace,
   normalizeBrowsePath,
   readBrowseLocation,
+  resolveActiveWorkspace,
   workspaceFromPathname,
 } from "./workspace-browse-url";
 
@@ -41,6 +42,22 @@ describe("workspaceFromPathname", () => {
     expect(workspaceFromPathname("/account/workspaces/new")).toBe("");
     expect(workspaceFromPathname("/account/workspaces/Not_Valid")).toBe("");
     expect(workspaceFromPathname("/account")).toBe("");
+  });
+});
+
+describe("resolveActiveWorkspace", () => {
+  it("prefers the pathname over a stale ClientRouter boot global", () => {
+    // Sibling nav left __UPLOADS_ACTIVE_WORKSPACE__ empty after define:vars const
+    // redeclaration — URL is still the source of truth.
+    expect(resolveActiveWorkspace("/account/workspaces/buildinternet", "")).toBe("buildinternet");
+    expect(resolveActiveWorkspace("/account/workspaces/buildinternet/invite", "other")).toBe(
+      "buildinternet",
+    );
+  });
+
+  it("falls back to the boot global only when the path has no workspace", () => {
+    expect(resolveActiveWorkspace("/account/profile", "buildinternet")).toBe("buildinternet");
+    expect(resolveActiveWorkspace("/account", "")).toBe("");
   });
 });
 

--- a/apps/web/src/lib/workspace-browse-url.ts
+++ b/apps/web/src/lib/workspace-browse-url.ts
@@ -39,6 +39,17 @@ export function workspaceFromPathname(pathname: string): string {
   return isBrowseWorkspace(slug) ? slug : "";
 }
 
+/**
+ * Active workspace for ClientRouter account pages.
+ *
+ * Prefer the URL (always correct after a body swap) over the layout boot
+ * global (`window.__UPLOADS_ACTIVE_WORKSPACE__`), which can lag when the
+ * inline boot script fails to re-apply — the sibling-nav access error in #239.
+ */
+export function resolveActiveWorkspace(pathname: string, bootGlobal = ""): string {
+  return workspaceFromPathname(pathname) || bootGlobal || "";
+}
+
 function hasControlChars(value: string): boolean {
   for (let i = 0; i < value.length; i++) {
     const code = value.charCodeAt(i);

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { orderOrgsOldestFirst, safeSameOriginPath } from "./workspace-ui";
+import { orderOrgsOldestFirst, renderUsageHtml, safeSameOriginPath } from "./workspace-ui";
 
 describe("safeSameOriginPath", () => {
   it("accepts an absolute in-app path with query and hash", () => {
@@ -19,6 +19,37 @@ describe("safeSameOriginPath", () => {
     // Defense in depth: a raw embedded scheme is rejected even inside the
     // query — legitimate producers percent-encode (the consent page does).
     expect(safeSameOriginPath("/ok?u=https://evil.example")).toBeNull();
+  });
+});
+
+describe("renderUsageHtml", () => {
+  it("falls back to plain text when no quota caps are set", () => {
+    const html = renderUsageHtml({
+      bytes: 8_388_608,
+      objects: 64,
+      uploadsInPeriod: 1,
+    });
+    expect(html).toContain("usage-text");
+    expect(html).toContain("8 MB");
+    expect(html).toContain("64 objects");
+    expect(html).toContain("1 uploads this month");
+    expect(html).not.toContain("ul-progress");
+  });
+
+  it("renders labeled progress meters when storage and upload caps exist", () => {
+    const html = renderUsageHtml({
+      bytes: 500,
+      objects: 3,
+      uploadsInPeriod: 2,
+      maxStorageBytes: 1000,
+      maxUploadsPerPeriod: 10,
+    });
+    expect(html).toContain('class="ul-progress"');
+    expect(html).toContain("Storage");
+    expect(html).toContain("Uploads this month");
+    expect(html).toContain('aria-valuenow="50"');
+    expect(html).toContain("3 objects");
+    expect(html).not.toContain("usage-text");
   });
 });
 

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -9,28 +9,29 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
 ---
 
 <AccountLayout section="developers">
-  <section class="card dev-page">
-    <h2>Developers</h2>
-    <p class="dev-lead">
-      Most people just need <code>uploads login</code> from the{" "}
-      <a href="/account#cli-setup">account overview</a>. These are for API and CI
-      use.
-    </p>
-    <ul class="dev-links">
-      {showConsoleLinks ? (
+  <section class="card settings-page dev-page">
+    <div class="settings-section">
+      <h2>Developers</h2>
+      <p class="settings-note muted">
+        API and CI. Day to day: <code>uploads login</code> from the{" "}
+        <a href="/account#cli-setup">overview</a>.
+      </p>
+      <ul class="dev-links">
+        {showConsoleLinks ? (
+          <li>
+            <a href="/console">Console</a>
+            <span class="slug">token-based ops</span>
+          </li>
+        ) : null}
         <li>
-          <a href="/console">Console</a>
-          <span class="slug">usage, files, invites — bring a token</span>
+          <a href="/docs">API docs</a>
+          <span class="slug">endpoints &amp; auth</span>
         </li>
-      ) : null}
-      <li>
-        <a href="/docs">API docs</a>
-        <span class="slug">endpoints &amp; auth</span>
-      </li>
-      <li>
-        <a href="https://github.com/buildinternet/uploads">GitHub</a>
-        <span class="slug">source &amp; issues</span>
-      </li>
-    </ul>
+        <li>
+          <a href="https://github.com/buildinternet/uploads">GitHub</a>
+          <span class="slug">source &amp; issues</span>
+        </li>
+      </ul>
+    </div>
   </section>
 </AccountLayout>

--- a/apps/web/src/pages/account/index.astro
+++ b/apps/web/src/pages/account/index.astro
@@ -13,10 +13,9 @@ export const prerender = false;
   -->
   <section class="card is-pending" id="cli-setup" data-setup="checking">
     <h2>Set up the CLI</h2>
-    <p>
-      Most of uploads is used from the terminal. Install once, run
-      <code>uploads login</code>, then <code>uploads attach</code> /
-      <code>uploads put</code> against this account’s workspaces.
+    <p class="settings-note">
+      Install once, then <code>uploads login</code> and
+      <code>uploads put</code> / <code>uploads attach</code>.
     </p>
     <div id="cli-setup-status" class="ul-callout" data-state="muted" role="status">
       Checking for a CLI sign-in…
@@ -32,14 +31,11 @@ export const prerender = false;
       </div>
     </div>
     <p class="muted cli-note" id="cli-setup-note">
-      Prefer no global install? <code>npx @buildinternet/uploads login</code>.
-      Full walkthrough in the <a href="/docs#install">docs</a>.
+      Or <code>npx @buildinternet/uploads login</code> —
+      <a href="/docs#install">docs</a>.
     </p>
     <div id="cli-agents">
-      <p class="muted cli-note">
-        Using a coding agent? One more command adds the uploads skill and MCP
-        server to Claude Code, so agents attach screenshots on their own:
-      </p>
+      <p class="muted cli-note">Agents (skill + MCP for Claude Code):</p>
       <div class="cli-steps cli-steps--solo">
         <div class="command">
           <code>uploads install</code>
@@ -51,10 +47,8 @@ export const prerender = false;
 
   <section class="card">
     <h2>Welcome back<span id="hello-name"></span></h2>
-    <p>
-      uploads.sh hosts files you want to link to — PR screenshots, agent
-      artifacts, quick shares. Workspaces and account details are in the
-      sidebar.
+    <p class="settings-note">
+      Host PR screenshots and shares — workspaces are in the sidebar.
     </p>
   </section>
 

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -5,52 +5,41 @@ export const prerender = false;
 ---
 
 <AccountLayout section="profile">
-  <section class="card">
-    <h2>Account</h2>
-    <dl class="kv">
-      <dt>Email</dt><dd id="acct-email"></dd>
-      <dt>Name</dt><dd id="acct-name"></dd>
-      <dt>Role</dt><dd id="acct-role"></dd>
-    </dl>
-    <p class="muted" style="margin-top:14px">
-      Name and avatar come from your sign-in provider. Nothing to edit here yet.
-    </p>
-  </section>
-
-  <section class="card">
-    <h2>Sign-in methods</h2>
-    <p class="muted">How you sign in to the web app and approve <code>uploads login</code>.</p>
-    <div id="accounts-status" class="muted detail-status">Loading…</div>
-    <ul class="detail-list" id="accounts-list" hidden></ul>
-    <p id="accounts-error" class="detail-error" role="alert" hidden></p>
-  </section>
-
-  <section class="card">
-    <h2>Workspace access</h2>
-    <p class="muted">
-      Workspaces this account can use. Membership expands as you’re invited;
-      open a workspace to browse files.
-    </p>
-    <div id="access-status" class="muted detail-status">Loading…</div>
-    <ul class="detail-list" id="access-list" hidden></ul>
-  </section>
-
-  <section class="card">
-    <h2>Active sessions</h2>
-    <p class="muted">
-      Browsers and CLI devices signed in to this account. Revoking a CLI session
-      doesn’t remove workspace tokens already saved on that machine.
-    </p>
-    <div id="sessions-status" class="muted detail-status">Loading…</div>
-    <ul class="detail-list" id="sessions-list" hidden></ul>
-    <div id="sessions-recover" class="sessions-recover" hidden>
-      <p class="muted">
-        Couldn’t load the session list. Sign in again to refresh it — browsing
-        still works with your current session.
-      </p>
-      <a class="text-btn" id="sessions-reauth" href="/login">Sign in again</a>
+  {/* One surface, hairline sections — avoids stacked cards + nested list boxes. */}
+  <section class="card settings-page">
+    <div class="settings-section">
+      <h2>Account</h2>
+      <dl class="kv">
+        <dt>Email</dt><dd id="acct-email"></dd>
+        <dt>Name</dt><dd id="acct-name"></dd>
+        <dt>Role</dt><dd id="acct-role"></dd>
+      </dl>
+      <p class="muted settings-note">From your sign-in provider.</p>
     </div>
-    <p id="sessions-error" class="detail-error" role="alert" hidden></p>
+
+    <div class="settings-section">
+      <h2>Sign-in methods</h2>
+      <div id="accounts-status" class="muted detail-status">Loading…</div>
+      <ul class="detail-list" id="accounts-list" hidden></ul>
+      <p id="accounts-error" class="detail-error" role="alert" hidden></p>
+    </div>
+
+    <div class="settings-section">
+      <h2>Workspaces</h2>
+      <div id="access-status" class="muted detail-status">Loading…</div>
+      <ul class="detail-list" id="access-list" hidden></ul>
+    </div>
+
+    <div class="settings-section">
+      <h2>Sessions</h2>
+      <div id="sessions-status" class="muted detail-status">Loading…</div>
+      <ul class="detail-list" id="sessions-list" hidden></ul>
+      <div id="sessions-recover" class="sessions-recover" hidden>
+        <p class="muted">Couldn’t load sessions — sign in again to refresh.</p>
+        <a class="text-btn" id="sessions-reauth" href="/login">Sign in again</a>
+      </div>
+      <p id="sessions-error" class="detail-error" role="alert" hidden></p>
+    </div>
   </section>
 
   <script>
@@ -174,7 +163,7 @@ export const prerender = false;
       if (!github) {
         rows.push({
           title: "GitHub",
-          detail: "Not connected — connect it to sign in with GitHub next time.",
+          detail: "Not connected",
           ok: false,
           icon: GITHUB_ICON,
           connectGithub: true,

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -21,15 +21,17 @@ if (isBrowseWorkspace(legacyWs)) {
 ---
 
 <AccountLayout section="workspaces">
-  <section class="card">
-    <h2>Workspaces</h2>
-    <p class="ws-lead">
-      Choose one from the sidebar, or
-      <a href="/account/workspaces/new">create a new workspace</a>.
-    </p>
-    <div id="orgs-status" class="ws-status muted">Loading…</div>
-    <button id="orgs-retry" type="button" hidden>Try again</button>
-    <ul class="plain" id="orgs-list" hidden></ul>
+  <section class="card settings-page">
+    <div class="settings-section">
+      <h2>Workspaces</h2>
+      <p class="settings-note muted">
+        Pick one in the sidebar, or
+        <a href="/account/workspaces/new">create one</a>.
+      </p>
+      <div id="orgs-status" class="ws-status muted">Loading…</div>
+      <button id="orgs-retry" type="button" hidden>Try again</button>
+      <ul class="plain" id="orgs-list" hidden></ul>
+    </div>
   </section>
 
   <script>

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -54,7 +54,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
   </div>
 
   <script>
-    import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
+    import {
+      getPageVisit,
+      isCurrentPageVisit,
+      onAstroPageLoad,
+      onSession,
+      requireElement,
+    } from "../../../lib/account-shell";
     import {
       getMyWorkspaces,
       getMyWorkspaceUsage,
@@ -65,11 +71,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     import {
       readBrowseLocation,
       replaceBrowseLocation,
+      resolveActiveWorkspace,
     } from "../../../lib/workspace-browse-url";
     import { readSearchFilters } from "../../../lib/workspace-search-url";
     import { escapeHtml, renderUsageHtml } from "../../../lib/workspace-ui";
     import { createElement } from "react";
-    import { createRoot } from "react-dom/client";
+    import { createRoot, type Root } from "react-dom/client";
 
     // Lazy so a Fast Refresh / HMR glitch in the file browser does not
     // block the whole page script (header, galleries, usage).
@@ -82,127 +89,162 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       // Invite page also uses #ws-status/#ws-app — require the files mount.
       if (!document.getElementById("ws-files")) return;
 
-    const page = "workspace page";
-    const w = window as unknown as {
-      __UPLOADS_API_ORIGIN__: string;
-      __UPLOADS_ACTIVE_WORKSPACE__: string;
-    };
-    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
-    const workspaceName = w.__UPLOADS_ACTIVE_WORKSPACE__;
-    const browseOnLoad = readBrowseLocation(window.location.search, window.location.pathname);
-    const searchFiltersOnLoad = readSearchFilters(window.location.search);
+      const page = "workspace page";
+      const visit = getPageVisit();
+      const w = window as unknown as {
+        __UPLOADS_API_ORIGIN__: string;
+        __UPLOADS_ACTIVE_WORKSPACE__: string;
+      };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+      // Prefer the URL — ClientRouter sibling nav can leave the layout global
+      // stale if the boot script failed to re-apply. Pathname is always current.
+      const workspaceName = resolveActiveWorkspace(
+        window.location.pathname,
+        w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+      );
+      const browseOnLoad = readBrowseLocation(window.location.search, window.location.pathname);
+      const searchFiltersOnLoad = readSearchFilters(window.location.search);
 
-    const statusEl = requireElement<HTMLElement>("#ws-status", page);
-    const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
-    const appEl = requireElement<HTMLElement>("#ws-app", page);
-    const nameEl = requireElement<HTMLElement>("#ws-name", page);
-    const slugEl = requireElement<HTMLElement>("#ws-slug", page);
-    const roleEl = requireElement<HTMLElement>("#ws-role", page);
-    const usageEl = requireElement<HTMLElement>("#ws-usage", page);
-    const communalCard = requireElement<HTMLElement>("#ws-communal", page);
-    const filesCard = requireElement<HTMLElement>("#ws-files-card", page);
-    const galleriesCard = requireElement<HTMLElement>("#ws-galleries-card", page);
-    const filesEl = requireElement<HTMLElement>("#ws-files", page);
-    const galleriesEl = requireElement<HTMLElement>("#ws-galleries", page);
+      const statusEl = requireElement<HTMLElement>("#ws-status", page);
+      const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
+      const appEl = requireElement<HTMLElement>("#ws-app", page);
+      const nameEl = requireElement<HTMLElement>("#ws-name", page);
+      const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+      const roleEl = requireElement<HTMLElement>("#ws-role", page);
+      const usageEl = requireElement<HTMLElement>("#ws-usage", page);
+      const communalCard = requireElement<HTMLElement>("#ws-communal", page);
+      const filesCard = requireElement<HTMLElement>("#ws-files-card", page);
+      const galleriesCard = requireElement<HTMLElement>("#ws-galleries-card", page);
+      const filesEl = requireElement<HTMLElement>("#ws-files", page);
+      const galleriesEl = requireElement<HTMLElement>("#ws-galleries", page);
 
-    let filesRoot: ReturnType<typeof createRoot> | null = null;
+      let filesRoot: Root | null = null;
 
-    function showError(message: string, retry = true): void {
-      statusEl.hidden = false;
-      statusEl.textContent = message;
-      statusEl.dataset.state = "error";
-      appEl.hidden = true;
-      retryBtn.hidden = !retry;
-    }
+      const stillHere = (): boolean => isCurrentPageVisit(visit);
 
-    function renderGalleries(galleries: GallerySummary[]): void {
-      if (!galleries.length) {
-        galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet.</p>`;
-        return;
-      }
-      galleriesEl.innerHTML = `<ul class="ws-items">${galleries
-        .map(
-          (g) =>
-            `<li><a href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a></li>`,
-        )
-        .join("")}</ul>`;
-    }
+      const tearDownFiles = (): void => {
+        if (!filesRoot) return;
+        try {
+          filesRoot.unmount();
+        } catch {
+          // Container may already be gone after a body swap.
+        }
+        filesRoot = null;
+      };
 
-    async function loadWorkspace(): Promise<void> {
-      statusEl.hidden = false;
-      statusEl.textContent = "Loading workspace…";
-      statusEl.removeAttribute("data-state");
-      retryBtn.hidden = true;
-      appEl.hidden = true;
+      // Unmount React before ClientRouter swaps the body away.
+      document.addEventListener(
+        "astro:before-swap",
+        () => {
+          tearDownFiles();
+        },
+        { once: true },
+      );
 
-      const result = await getMyWorkspaces(apiOrigin);
-      if (result.kind === "unavailable") {
-        showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
-        return;
-      }
-
-      writeCachedWorkspaces(result.workspaces);
-
-      const ws = result.workspaces.find((item) => item.workspace === workspaceName);
-      if (!ws) {
-        showError("You don’t have access to this workspace.", false);
-        return;
+      function showError(message: string, retry = true): void {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = message;
+        statusEl.dataset.state = "error";
+        appEl.hidden = true;
+        retryBtn.hidden = !retry;
       }
 
-      statusEl.hidden = true;
-      appEl.hidden = false;
+      function renderGalleries(galleries: GallerySummary[]): void {
+        if (!stillHere()) return;
+        if (!galleries.length) {
+          galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet.</p>`;
+          return;
+        }
+        galleriesEl.innerHTML = `<ul class="ws-items">${galleries
+          .map(
+            (g) =>
+              `<li><a href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a></li>`,
+          )
+          .join("")}</ul>`;
+      }
 
-      const displayName = ws.organization.name || ws.workspace;
-      nameEl.textContent = displayName;
-      slugEl.textContent = ws.workspace;
-      slugEl.hidden = ws.workspace === displayName;
-      roleEl.textContent = ws.role;
-      roleEl.hidden = false;
-      document.title = `${displayName} · uploads.sh`;
+      async function loadWorkspace(): Promise<void> {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = "Loading workspace…";
+        statusEl.removeAttribute("data-state");
+        retryBtn.hidden = true;
+        appEl.hidden = true;
 
-      void getMyWorkspaceUsage(apiOrigin, ws.workspace).then((usage) => {
-        usageEl.innerHTML = usage ? renderUsageHtml(usage) : "Usage unavailable.";
+        const result = await getMyWorkspaces(apiOrigin);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
+          return;
+        }
+
+        writeCachedWorkspaces(result.workspaces);
+
+        const ws = result.workspaces.find((item) => item.workspace === workspaceName);
+        if (!ws) {
+          showError("You don’t have access to this workspace.", false);
+          return;
+        }
+
+        statusEl.hidden = true;
+        appEl.hidden = false;
+
+        const displayName = ws.organization.name || ws.workspace;
+        nameEl.textContent = displayName;
+        slugEl.textContent = ws.workspace;
+        slugEl.hidden = ws.workspace === displayName;
+        roleEl.textContent = ws.role;
+        roleEl.hidden = false;
+        document.title = `${displayName} · uploads.sh`;
+
+        void getMyWorkspaceUsage(apiOrigin, ws.workspace).then((usage) => {
+          if (!stillHere()) return;
+          usageEl.innerHTML = usage ? renderUsageHtml(usage) : "Usage unavailable.";
+        });
+
+        communalCard.hidden = !ws.communal;
+        filesCard.hidden = ws.communal;
+        galleriesCard.hidden = ws.communal;
+
+        if (!ws.communal) {
+          void getMyWorkspaceGalleries(apiOrigin, ws.workspace).then(renderGalleries);
+          void loadWorkspaceFiles()
+            .then((WorkspaceFiles) => {
+              if (!stillHere() || !document.contains(filesEl)) return;
+              if (!filesRoot) filesRoot = createRoot(filesEl);
+              filesRoot.render(
+                createElement(WorkspaceFiles, {
+                  apiOrigin,
+                  workspace: ws.workspace,
+                  hasPublicUrl: ws.hasPublicUrl,
+                  initialPrefix:
+                    !browseOnLoad.workspace || browseOnLoad.workspace === ws.workspace
+                      ? browseOnLoad.path
+                      : "",
+                  initialFilters: searchFiltersOnLoad,
+                  onPrefixChange: (path: string) => {
+                    if (!stillHere()) return;
+                    replaceBrowseLocation({ workspace: ws.workspace, path });
+                  },
+                }),
+              );
+            })
+            .catch(() => {
+              if (!stillHere()) return;
+              filesEl.innerHTML =
+                `<p class="ws-empty" role="alert">File browser failed to load. Refresh the page.</p>`;
+            });
+        }
+      }
+
+      retryBtn.addEventListener("click", () => {
+        void loadWorkspace();
       });
 
-      communalCard.hidden = !ws.communal;
-      filesCard.hidden = ws.communal;
-      galleriesCard.hidden = ws.communal;
-
-      if (!ws.communal) {
-        void getMyWorkspaceGalleries(apiOrigin, ws.workspace).then(renderGalleries);
-        void loadWorkspaceFiles()
-          .then((WorkspaceFiles) => {
-            if (!filesRoot) filesRoot = createRoot(filesEl);
-            filesRoot.render(
-              createElement(WorkspaceFiles, {
-                apiOrigin,
-                workspace: ws.workspace,
-                hasPublicUrl: ws.hasPublicUrl,
-                initialPrefix:
-                  !browseOnLoad.workspace || browseOnLoad.workspace === ws.workspace
-                    ? browseOnLoad.path
-                    : "",
-                initialFilters: searchFiltersOnLoad,
-                onPrefixChange: (path: string) => {
-                  replaceBrowseLocation({ workspace: ws.workspace, path });
-                },
-              }),
-            );
-          })
-          .catch(() => {
-            filesEl.innerHTML =
-              `<p class="ws-empty" role="alert">File browser failed to load. Refresh the page.</p>`;
-          });
-      }
-    }
-
-    retryBtn.addEventListener("click", () => {
-      void loadWorkspace();
-    });
-
-    onSession(() => {
-      void loadWorkspace();
-    });
+      onSession(() => {
+        void loadWorkspace();
+      });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces/[name]/invite.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/invite.astro
@@ -23,50 +23,59 @@ if (!workspace) return Astro.redirect("/account/workspaces");
   <button id="ws-retry" type="button" hidden>Try again</button>
 
   <div id="ws-app" hidden>
-    <section class="card">
-      <div class="ws-page-header">
-        <div class="ws-title-block">
-          <h2>Invite a teammate</h2>
-          <p class="muted" id="ws-slug"></p>
+    <section class="card settings-page">
+      <div class="settings-section">
+        <div class="ws-page-header">
+          <div class="ws-title-block">
+            <h2>Invite</h2>
+            <p class="muted" id="ws-slug"></p>
+          </div>
+          <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
         </div>
-        <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
-      </div>
-      <p class="ws-lead">They open the accept link, then run <code>uploads login</code>.</p>
-      <form class="ws-form" id="ws-invite-form">
-        <div class="input-group">
-          <label class="input-group__field">
-            <span class="sr-only">Email</span>
-            <input
-              type="email"
-              name="email"
-              required
-              autocomplete="email"
-              placeholder="teammate@example.com"
-            />
-          </label>
-          <button type="submit" class="input-group__action">Invite</button>
+        <p class="settings-note muted">Accept link, then <code>uploads login</code>.</p>
+        <form class="ws-form" id="ws-invite-form">
+          <div class="input-group">
+            <label class="input-group__field">
+              <span class="sr-only">Email</span>
+              <input
+                type="email"
+                name="email"
+                required
+                autocomplete="email"
+                placeholder="teammate@example.com"
+              />
+            </label>
+            <button type="submit" class="input-group__action">Invite</button>
+          </div>
+        </form>
+        <div class="ws-messages">
+          <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
+          <p class="muted cli-note" id="ws-invite-link" hidden></p>
         </div>
-      </form>
-      <div class="ws-messages">
-        <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
-        <p class="muted cli-note" id="ws-invite-link" hidden></p>
       </div>
-    </section>
 
-    <section class="card" id="ws-operator-card" hidden>
-      <h2>Operator enrollment code</h2>
-      <p class="muted"><code>ADMIN_TOKEN</code> only — not for everyday invites.</p>
-      <div class="command">
-        <code id="ws-operator-cmd"></code>
-        <button type="button" id="ws-operator-copy" aria-live="polite">copy</button>
+      <div class="settings-section" id="ws-operator-card" hidden>
+        <h2>Operator enrollment</h2>
+        <p class="settings-note muted"><code>ADMIN_TOKEN</code> only.</p>
+        <div class="command">
+          <code id="ws-operator-cmd"></code>
+          <button type="button" id="ws-operator-copy" aria-live="polite">copy</button>
+        </div>
       </div>
     </section>
   </div>
 
   <script>
-    import { onAstroPageLoad, onSession, requireElement } from "../../../../lib/account-shell";
+    import {
+      getPageVisit,
+      isCurrentPageVisit,
+      onAstroPageLoad,
+      onSession,
+      requireElement,
+    } from "../../../../lib/account-shell";
     import { getMyWorkspaces, inviteToWorkspace } from "../../../../lib/api-client";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
+    import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import {
       bindCopyButtons,
       escapeHtml,
@@ -77,133 +86,145 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     onAstroPageLoad(() => {
       if (!document.getElementById("ws-invite-form")) return;
 
-    const page = "workspace invite";
-    const w = window as unknown as {
-      __UPLOADS_API_ORIGIN__: string;
-      __UPLOADS_ACTIVE_WORKSPACE__: string;
-    };
-    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
-    const workspaceName = w.__UPLOADS_ACTIVE_WORKSPACE__;
+      const page = "workspace invite";
+      const visit = getPageVisit();
+      const stillHere = (): boolean => isCurrentPageVisit(visit);
+      const w = window as unknown as {
+        __UPLOADS_API_ORIGIN__: string;
+        __UPLOADS_ACTIVE_WORKSPACE__: string;
+      };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+      // Prefer the URL over the layout global (ClientRouter sibling-nav safety).
+      const workspaceName = resolveActiveWorkspace(
+        window.location.pathname,
+        w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+      );
 
-    const statusEl = requireElement<HTMLElement>("#ws-status", page);
-    const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
-    const appEl = requireElement<HTMLElement>("#ws-app", page);
-    const slugEl = requireElement<HTMLElement>("#ws-slug", page);
-    const operatorCard = requireElement<HTMLElement>("#ws-operator-card", page);
-    const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
-    const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
-    const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
-    const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
-    const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
+      const statusEl = requireElement<HTMLElement>("#ws-status", page);
+      const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
+      const appEl = requireElement<HTMLElement>("#ws-app", page);
+      const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+      const operatorCard = requireElement<HTMLElement>("#ws-operator-card", page);
+      const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
+      const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
+      const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
+      const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
+      const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
 
-    let sessionRole: string | null | undefined;
+      let sessionRole: string | null | undefined;
 
-    function showError(message: string, retry = true): void {
-      statusEl.hidden = false;
-      statusEl.textContent = message;
-      statusEl.dataset.state = "error";
-      appEl.hidden = true;
-      retryBtn.hidden = !retry;
-    }
-
-    async function loadInvitePage(): Promise<void> {
-      statusEl.hidden = false;
-      statusEl.textContent = "Loading…";
-      statusEl.removeAttribute("data-state");
-      retryBtn.hidden = true;
-      appEl.hidden = true;
-
-      const result = await getMyWorkspaces(apiOrigin);
-      if (result.kind === "unavailable") {
-        showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
-        return;
+      function showError(message: string, retry = true): void {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = message;
+        statusEl.dataset.state = "error";
+        appEl.hidden = true;
+        retryBtn.hidden = !retry;
       }
 
-      writeCachedWorkspaces(result.workspaces);
+      async function loadInvitePage(): Promise<void> {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = "Loading…";
+        statusEl.removeAttribute("data-state");
+        retryBtn.hidden = true;
+        appEl.hidden = true;
 
-      const ws = result.workspaces.find((item) => item.workspace === workspaceName);
-      if (!ws) {
-        showError("You don’t have access to this workspace.", false);
-        return;
-      }
-
-      if (!isWorkspaceAdminRole(ws.role) && sessionRole !== "admin") {
-        showError("You need workspace admin access to invite teammates.", false);
-        return;
-      }
-
-      // Non-admins who somehow deep-linked should not use the form (site
-      // operators may still open the page for the ADMIN_TOKEN command).
-      if (!isWorkspaceAdminRole(ws.role)) {
-        inviteForm.hidden = true;
-      }
-
-      statusEl.hidden = true;
-      appEl.hidden = false;
-
-      const displayName = ws.organization.name || ws.workspace;
-      slugEl.textContent = displayName === ws.workspace ? ws.workspace : `${displayName} · ${ws.workspace}`;
-      document.title = `Invite · ${displayName} · uploads.sh`;
-
-      const isOperator = sessionRole === "admin";
-      operatorCard.hidden = !isOperator;
-      if (isOperator) {
-        const cmd = operatorInviteCommand(ws.workspace);
-        operatorCmd.textContent = cmd;
-        operatorCopy.dataset.copy = cmd;
-      }
-    }
-
-    bindCopyButtons(document);
-
-    inviteForm.addEventListener("submit", (event) => {
-      void (async () => {
-        event.preventDefault();
-        const form = event.currentTarget as HTMLFormElement;
-        const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
-        const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
-        const email = emailInput?.value.trim() ?? "";
-        if (!email || !submit) return;
-
-        inviteStatus.hidden = false;
-        inviteStatus.textContent = "Creating invite…";
-        inviteLink.hidden = true;
-        inviteLink.textContent = "";
-        submit.disabled = true;
-        const result = await inviteToWorkspace(apiOrigin, workspaceName, email);
-        submit.disabled = false;
-
-        if (result.kind === "ok") {
-          inviteStatus.textContent =
-            result.emailConfigured === true
-              ? `Invitation emailed to ${email}.`
-              : result.emailConfigured === false
-                ? `Invite created for ${email} — share the accept link below.`
-                : `Invite created for ${email}.`;
-          if (emailInput) emailInput.value = "";
-          if (result.acceptUrl) {
-            inviteLink.hidden = false;
-            inviteLink.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
-          }
+        const result = await getMyWorkspaces(apiOrigin);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
           return;
         }
-        inviteStatus.textContent =
-          result.reason === "forbidden"
-            ? "You need workspace admin access to invite."
-            : result.reason === "invalid"
-              ? "That email doesn’t look valid."
-              : "Couldn’t create the invite. Try again.";
-      })();
-    });
 
-    retryBtn.addEventListener("click", () => {
-      void loadInvitePage();
-    });
+        writeCachedWorkspaces(result.workspaces);
 
-    onSession((user) => {
-      sessionRole = user.role;
-      void loadInvitePage();
-    });
+        const ws = result.workspaces.find((item) => item.workspace === workspaceName);
+        if (!ws) {
+          showError("You don’t have access to this workspace.", false);
+          return;
+        }
+
+        if (!isWorkspaceAdminRole(ws.role) && sessionRole !== "admin") {
+          showError("You need workspace admin access to invite teammates.", false);
+          return;
+        }
+
+        // Non-admins who somehow deep-linked should not use the form (site
+        // operators may still open the page for the ADMIN_TOKEN command).
+        if (!isWorkspaceAdminRole(ws.role)) {
+          inviteForm.hidden = true;
+        }
+
+        statusEl.hidden = true;
+        appEl.hidden = false;
+
+        const displayName = ws.organization.name || ws.workspace;
+        slugEl.textContent =
+          displayName === ws.workspace ? ws.workspace : `${displayName} · ${ws.workspace}`;
+        document.title = `Invite · ${displayName} · uploads.sh`;
+
+        const isOperator = sessionRole === "admin";
+        operatorCard.hidden = !isOperator;
+        if (isOperator) {
+          const cmd = operatorInviteCommand(ws.workspace);
+          operatorCmd.textContent = cmd;
+          operatorCopy.dataset.copy = cmd;
+        }
+      }
+
+      bindCopyButtons(document);
+
+      inviteForm.addEventListener("submit", (event) => {
+        void (async () => {
+          event.preventDefault();
+          if (!stillHere()) return;
+          const form = event.currentTarget as HTMLFormElement;
+          const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]');
+          const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]');
+          const email = emailInput?.value.trim() ?? "";
+          if (!email || !submit) return;
+
+          inviteStatus.hidden = false;
+          inviteStatus.textContent = "Creating invite…";
+          inviteLink.hidden = true;
+          inviteLink.textContent = "";
+          submit.disabled = true;
+          const result = await inviteToWorkspace(apiOrigin, workspaceName, email);
+          if (!stillHere()) return;
+          submit.disabled = false;
+
+          if (result.kind === "ok") {
+            inviteStatus.textContent =
+              result.emailConfigured === true
+                ? `Invitation emailed to ${email}.`
+                : result.emailConfigured === false
+                  ? `Invite created for ${email} — share the accept link below.`
+                  : `Invite created for ${email}.`;
+            if (emailInput) emailInput.value = "";
+            if (result.acceptUrl) {
+              inviteLink.hidden = false;
+              inviteLink.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
+            }
+            return;
+          }
+          inviteStatus.textContent =
+            result.reason === "forbidden"
+              ? "You need workspace admin access to invite."
+              : result.reason === "invalid"
+                ? "That email doesn’t look valid."
+                : "Couldn’t create the invite. Try again.";
+        })();
+      });
+
+      retryBtn.addEventListener("click", () => {
+        void loadInvitePage();
+      });
+
+      onSession((user) => {
+        sessionRole = user.role;
+        void loadInvitePage();
+      });
     });
   </script>
 </AccountLayout>

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -5,12 +5,12 @@ export const prerender = false;
 ---
 
 <AccountLayout section="workspaces" creating title="New workspace">
-  <section class="card" id="create">
-    <h2>Create a workspace</h2>
-    <p class="ws-lead">
-      Public folder on the shared bucket — unguessable URLs under
-      <code>storage.uploads.sh/&lt;name&gt;/…</code> for PR embeds.
-      Free: 1&nbsp;GB · 25&nbsp;MB per file.
+  <section class="card settings-page" id="create">
+    <div class="settings-section">
+    <h2>New workspace</h2>
+    <p class="settings-note muted">
+      Shared bucket · 1&nbsp;GB · 25&nbsp;MB/file ·
+      <code>storage.uploads.sh/&lt;name&gt;/…</code>
     </p>
 
     <form class="ws-form" data-create-form>
@@ -62,6 +62,7 @@ export const prerender = false;
         GitHub linking isn't available —
         <a href="/account/profile">try from your profile</a>.
       </p>
+    </div>
     </div>
   </section>
 

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1,20 +1,40 @@
 /* Content styles for /account/* cards (profile kv, workspace list, developer list). */
 
-/* Developers — one card; links as flat hairline rows, not nested mini-panels. */
-section.card.dev-page {
-  padding: 22px 22px 10px;
+/* Settings pages: one card, hairline sections — no stacked cards / nested boxes. */
+section.card.settings-page {
+  padding: 20px 22px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
-section.card.dev-page h2 {
-  margin: 0 0 8px;
+.settings-section {
+  padding: 4px 0 20px;
 }
-section.card.dev-page .dev-lead {
-  margin: 0 0 18px;
+.settings-section + .settings-section {
+  margin-top: 4px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line);
+}
+section.card.settings-page h2 {
+  margin: 0 0 10px;
+}
+.settings-note {
+  margin: 0 0 12px;
   max-width: 36rem;
+  font-size: 13px;
   text-wrap: pretty;
+}
+.settings-section > .settings-note:last-child {
+  margin-bottom: 0;
+}
+
+/* Developers — flat hairline rows inside the settings surface. */
+section.card.dev-page {
+  padding-bottom: 4px;
 }
 ul.dev-links {
   list-style: none;
-  margin: 0;
+  margin: 4px 0 0;
   padding: 0;
   display: grid;
   gap: 0;
@@ -25,7 +45,7 @@ ul.dev-links li {
   align-items: baseline;
   justify-content: space-between;
   gap: 6px 14px;
-  padding: 14px 0;
+  padding: 12px 0;
   border-top: 1px solid var(--line);
   background: none;
   border-left: 0;
@@ -53,8 +73,11 @@ ul.dev-links .slug {
   display: grid;
   grid-template-columns: max-content 1fr;
   gap: 6px 18px;
-  margin-top: 12px;
+  margin: 0;
   font-size: 13px;
+}
+.settings-section .kv + .settings-note {
+  margin-top: 12px;
 }
 .kv dt {
   color: var(--muted);
@@ -259,6 +282,13 @@ section.card.is-pending {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
 }
+section.card .settings-note {
+  margin: 6px 0 0;
+  max-width: 36rem;
+  font-size: 13px;
+  text-wrap: pretty;
+  color: var(--body);
+}
 #cli-setup-status {
   margin-top: 14px;
 }
@@ -324,7 +354,7 @@ section.card .cli-note {
 }
 
 .detail-status {
-  margin-top: 12px;
+  margin-top: 4px;
   font-size: 13px;
 }
 .detail-error {
@@ -332,21 +362,22 @@ section.card .cli-note {
   font-size: 12px;
   color: var(--red);
 }
+/* Flat rows — no nested panel inside the settings card. */
 ul.detail-list {
   list-style: none;
-  margin: 12px 0 0;
+  margin: 4px 0 0;
   padding: 0;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--bg);
-  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  overflow: visible;
 }
 ul.detail-list li {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 11px 12px;
+  padding: 11px 0;
   font-size: 13px;
 }
 ul.detail-list li + li {
@@ -536,8 +567,17 @@ section.card .ws-note {
   font-size: 13px;
 }
 .ws-form {
-  margin-top: 16px;
+  margin-top: 12px;
   max-width: 28rem;
+}
+.settings-section .ws-form {
+  margin-top: 4px;
+}
+.settings-section .ws-page-header {
+  padding-bottom: 0;
+}
+.settings-section .command {
+  margin-top: 8px;
 }
 /* Joined control: one outer border, hairline between input and action. */
 .input-group {


### PR DESCRIPTION
## In plain terms

Account settings navigations after ClientRouter (#239) could show **“You don’t have access to this workspace”** even for workspaces you own — a hard refresh fixed it. This restores reliable client-side routing, stops stale async paints after leaving a workspace page, and simplifies busy settings layouts.

## What it does

- **Fix workspace access on sibling nav:** stop using `define:vars` on `data-astro-rerun` boot scripts (top-level `const` redeclares and aborts the script). Assign boot globals with `JSON.stringify` window writes instead.
- **Prefer the URL** for the active workspace (`resolveActiveWorkspace`) so a stale `__UPLOADS_ACTIVE_WORKSPACE__` cannot deny access.
- **Stale async guards:** page-visit generation so usage / galleries / membership loads drop after ClientRouter navigates away.
- **Unmount** the file-browser React root on `astro:before-swap`.
- **Quieter settings UI:** one surface with hairline sections on profile and related account pages; shorter bylines.
- **Regression tests** for boot script shape, pathname preference, and page-visit staleness.

## What it is not

- Not a change to API auth or membership enforcement.
- Progress meters still only appear when a workspace has storage/upload caps (uncapped BYO stays plain totals).

## How to try it

1. Sign in at `https://uploads.sh/account`.
2. Open **Account** (profile), then click **buildinternet** in the sidebar — it should load without the access error (no full reload).
3. Navigate workspace → profile → workspace again; usage and files should stay coherent.
4. Profile should be one card with sections, not four stacked panels.

## Technical notes

- Layouts touched: `AccountLayout`, `AdminLayout`, `AuthIndicator`.
- New: `apps/web/src/lib/page-visit.ts`, `resolveActiveWorkspace` in `workspace-browse-url.ts`.
- Tests: `pnpm --filter @uploads/web test` (156).

## Test plan

- [x] `pnpm --filter @uploads/web test`
- [ ] Manual: account sibling nav into a workspace (access OK)
- [ ] Manual: profile/settings look quieter
- [ ] Manual: leave a workspace mid-load (no wrong paint)