### PR TITLE
fix(api): credential CORS for workspace lifecycle subroutes

### DIFF
--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -34,6 +34,25 @@ describe("CORS preflights from the web origin", () => {
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
   });
 
+  it("credentials the #249 lifecycle subroutes, DELETE included", async () => {
+    const del = await app.request(
+      "https://api.uploads.sh/v1/workspaces/acme",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://uploads.sh",
+          "Access-Control-Request-Method": "DELETE",
+        },
+      },
+      env,
+    );
+    expect(del.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(del.headers.get("Access-Control-Allow-Methods")).toContain("DELETE");
+
+    const restore = await preflight("/v1/workspaces/acme/restore");
+    expect(restore.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
   it("keeps bearer-token /v1 routes uncredentialed", async () => {
     const res = await preflight("/v1/tokens");
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -47,7 +47,7 @@ const adminUiCors = cors({
     return null;
   },
   credentials: true,
-  allowMethods: ["GET", "POST", "OPTIONS"],
+  allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
   allowHeaders: ["Content-Type"],
   maxAge: 86400,
 });
@@ -72,13 +72,18 @@ export const app = new Hono<WorkspaceVars>()
   .use("/admin/*", consoleCors)
   .use("/admin-ui/*", adminUiCors)
   .use("/me/*", adminUiCors)
-  // `/v1/workspaces` is the one `/v1/*` route authenticated by session COOKIE
-  // (self-serve creation from the signed-in console), so its CORS must be
-  // credentialed like /me/* — the uncredentialed consoleCors preflight makes
-  // the browser drop the request entirely ("Failed to fetch"), which silently
-  // broke self-serve workspace creation from uploads.sh. Everything else
-  // under /v1/* stays uncredentialed: bearer tokens are the boundary there.
-  .use("/v1/*", (c, next) => (c.req.path === "/v1/workspaces" ? adminUiCors : consoleCors)(c, next))
+  // `/v1/workspaces` (and its `/:name` / `/:name/restore` lifecycle
+  // subroutes from #249) is the one `/v1/*` surface authenticated by session
+  // COOKIE, so its CORS must be credentialed like /me/* — the uncredentialed
+  // consoleCors preflight makes the browser drop the request entirely
+  // ("Failed to fetch"), which silently broke self-serve workspace creation
+  // from uploads.sh. Everything else under /v1/* stays uncredentialed:
+  // bearer tokens are the boundary there.
+  .use("/v1/*", (c, next) =>
+    (c.req.path === "/v1/workspaces" || c.req.path.startsWith("/v1/workspaces/")
+      ? adminUiCors
+      : consoleCors)(c, next),
+  )
   .route("/admin", admin)
   .route("/admin-ui", adminUi)
   .route("/me", me)


### PR DESCRIPTION
Found while prod-smoke-testing #255: the credentialed `adminUiCors` only matched the exact `/v1/workspaces` path, so the new session-cookie lifecycle subroutes (`DELETE /v1/workspaces/:name`, `POST /v1/workspaces/:name/restore`) fell through to the uncredentialed `consoleCors` — and `adminUiCors` didn't allow `DELETE` at all. Any future console UI calling these cross-origin from uploads.sh would fail preflight ("Failed to fetch").

- Match the `/v1/workspaces/` prefix as well as the exact path (reserved-name policy means no real workspace can collide with the `workspaces` segment).
- Add `DELETE` to `adminUiCors.allowMethods`.
- New preflight tests in `cors.test.ts` for the subroutes, DELETE included.

The API itself was unaffected for same-origin/non-browser callers — the endpoints were verified working in prod via same-origin session fetches (create → soft delete → 409 repeat → restore → 409 re-restore, then admin hard-delete cleanup).