### PR TITLE
fix(web): keep site chrome alive across ClientRouter navs

### DIFF
--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -54,29 +54,45 @@ const REPO = "https://github.com/buildinternet/uploads";
 {
   star && (
     <script>
-      // Live star count — cached for an hour, silently absent on failure.
-      (async () => {
+      // Live star count (1h localStorage). Module scripts run once per session —
+      // re-fill after ClientRouter swaps; eager boot covers non-router pages.
+      import { onAstroPageLoad } from "../lib/account-shell";
+
+      const STARS_KEY = "gh-stars";
+      const STARS_TTL_MS = 3_600_000;
+
+      function formatStars(n: number): string {
+        return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+      }
+
+      async function fillStarCount(): Promise<void> {
         const el = document.getElementById("star-count");
         if (!el) return;
-        const show = (n: number) => {
-          el.textContent = n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+        const paint = (n: number) => {
+          if (document.contains(el)) el.textContent = formatStars(n);
         };
         try {
-          const cached = JSON.parse(localStorage.getItem("gh-stars") ?? "null");
-          if (cached && typeof cached.n === "number" && Date.now() - cached.t < 3_600_000) {
-            show(cached.n);
+          const cached = JSON.parse(localStorage.getItem(STARS_KEY) ?? "null") as {
+            t?: number;
+            n?: number;
+          } | null;
+          if (cached && typeof cached.n === "number" && Date.now() - (cached.t ?? 0) < STARS_TTL_MS) {
+            paint(cached.n);
             return;
           }
           const res = await fetch("https://api.github.com/repos/buildinternet/uploads");
           if (!res.ok) return;
           const n = ((await res.json()) as { stargazers_count?: unknown }).stargazers_count;
           if (typeof n !== "number") return;
-          localStorage.setItem("gh-stars", JSON.stringify({ t: Date.now(), n }));
-          show(n);
+          localStorage.setItem(STARS_KEY, JSON.stringify({ t: Date.now(), n }));
+          paint(n);
         } catch {
-          /* leave the count empty — the CTA still works */
+          /* count stays empty — the CTA still works */
         }
-      })();
+      }
+
+      void fillStarCount();
+      onAstroPageLoad(() => void fillStarCount());
     </script>
   )
 }

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -550,56 +550,50 @@ const fullTitle = `${title} · uploads.sh`;
     </div>
 
     <script>
-      // Scroll-spy for the right-hand TOC rail: highlight the section in view.
-      const tocLinks = new Map(
-        [...document.querySelectorAll(".docs-toc a")].map((a) => [a.getAttribute("href")?.slice(1), a]),
-      );
-      if (tocLinks.size > 0) {
-        const spy = new IntersectionObserver(
-          (entries) => {
-            for (const entry of entries) {
-              if (!entry.isIntersecting) continue;
-              for (const link of tocLinks.values()) link.removeAttribute("aria-current");
-              tocLinks.get(entry.target.id)?.setAttribute("aria-current", "true");
-            }
-          },
-          { rootMargin: "0px 0px -70% 0px" },
+      // Module scripts run once per session; re-wire after every ClientRouter swap.
+      import { onAstroPageLoad } from "../lib/account-shell";
+      import { bindCopyButtons } from "../lib/workspace-ui";
+
+      let tocSpy: IntersectionObserver | null = null;
+      let copyBound = false;
+
+      function bootDocsChrome(): void {
+        tocSpy?.disconnect();
+        tocSpy = null;
+
+        // TOC rail: highlight the section currently in view.
+        const tocLinks = new Map(
+          [...document.querySelectorAll(".docs-toc a")].map((a) => [
+            a.getAttribute("href")?.slice(1),
+            a,
+          ]),
         );
-        for (const id of tocLinks.keys()) {
-          const section = id && document.getElementById(id);
-          if (section) spy.observe(section);
+        if (tocLinks.size > 0) {
+          tocSpy = new IntersectionObserver(
+            (entries) => {
+              for (const entry of entries) {
+                if (!entry.isIntersecting) continue;
+                for (const link of tocLinks.values()) link.removeAttribute("aria-current");
+                tocLinks.get(entry.target.id)?.setAttribute("aria-current", "true");
+              }
+            },
+            { rootMargin: "0px 0px -70% 0px" },
+          );
+          for (const id of tocLinks.keys()) {
+            const section = id && document.getElementById(id);
+            if (section) tocSpy.observe(section);
+          }
+        }
+
+        // Once on document, scoped to docs cmd rows so account soft-navs do not
+        // double-fire (other shells bind their own copy handlers).
+        if (!copyBound) {
+          copyBound = true;
+          bindCopyButtons(document, ".doc .cmd button[data-copy]");
         }
       }
 
-      for (const btn of document.querySelectorAll(".cmd button")) {
-        btn.addEventListener("click", async () => {
-          const text = btn.getAttribute("data-copy") ?? "";
-          let ok = false;
-          try {
-            await navigator.clipboard.writeText(text);
-            ok = true;
-          } catch {
-            const ta = document.createElement("textarea");
-            ta.value = text;
-            ta.style.position = "fixed";
-            ta.style.opacity = "0";
-            document.body.appendChild(ta);
-            ta.select();
-            try {
-              ok = document.execCommand("copy");
-            } catch {
-              ok = false;
-            }
-            ta.remove();
-          }
-          btn.textContent = ok ? "copied ✓" : "copy failed";
-          btn.classList.toggle("done", ok);
-          setTimeout(() => {
-            btn.textContent = "copy";
-            btn.classList.remove("done");
-          }, 1500);
-        });
-      }
+      onAstroPageLoad(bootDocsChrome);
     </script>
   </body>
 </html>

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -1,8 +1,8 @@
 ---
 /**
  * Shared shell for Astro status pages (404 missing route, 500 application error).
- * Full-bleed SiteHeader + centered card body (same panel + titlebar treatment
- * as the landing terminal).
+ * Same full-bleed SiteHeader + site Footer as legal/content pages; the error
+ * itself is a centered card (landing terminal treatment).
  */
 import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
@@ -17,11 +17,14 @@ interface Props {
 }
 
 const { status, title, message, hint } = Astro.props;
+
+// Static page — auth origin baked at build time (see LegalLayout / landing).
+const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.uploads.sh";
 ---
 
 <html lang="en">
   <head>
-    <BaseHead />
+    <BaseHead preloadSans />
     <meta name="robots" content="noindex, nofollow, noarchive" />
     <meta name="description" content={`${status} ${title} — uploads.sh`} />
     <title>{status} · {title} · uploads.sh</title>
@@ -40,9 +43,8 @@ const { status, title, message, hint } = Astro.props;
         flex: 1;
         display: grid;
         place-items: center;
-        padding: 28px;
+        padding: 28px 24px;
         width: 100%;
-        box-sizing: border-box;
       }
       .card-wrap { width: min(var(--width-card, 480px), 100%); }
       .card {
@@ -104,10 +106,16 @@ const { status, title, message, hint } = Astro.props;
         border-color: var(--accent);
         outline: none;
       }
+      /* Full site footer under the card, same column width as legal pages. */
+      .error-foot {
+        width: min(var(--width-content, 720px), 100%);
+        margin: 0 auto;
+        padding: 0 24px 28px;
+      }
     </style>
   </head>
   <body>
-    <SiteHeader />
+    <SiteHeader authOrigin={authOrigin} />
     <main>
       <div class="card-wrap">
         <section class="card" aria-labelledby="error-title">
@@ -125,8 +133,10 @@ const { status, title, message, hint } = Astro.props;
             </div>
           </div>
         </section>
-        <Footer compact />
       </div>
     </main>
+    <div class="error-foot">
+      <Footer />
+    </div>
   </body>
 </html>

--- a/apps/web/src/lib/client-router-boot.test.ts
+++ b/apps/web/src/lib/client-router-boot.test.ts
@@ -2,6 +2,8 @@
  * Locks in ClientRouter boot invariants that already burned us once:
  * `define:vars` + `data-astro-rerun` injects top-level `const` and throws on
  * the second account navigation, leaving stale __UPLOADS_* globals.
+ * Module scripts that query the DOM must re-run on `astro:page-load` or the
+ * first soft nav leaves dead chrome (empty star count, dead copy buttons, etc.).
  */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -15,17 +17,15 @@ function readSrc(rel: string): string {
 }
 
 describe("ClientRouter boot scripts", () => {
-  const bootFiles = [
+  const dataAstroRerunFiles = [
     "layouts/AccountLayout.astro",
     "layouts/AdminLayout.astro",
     "components/AuthIndicator.astro",
   ] as const;
 
-  it.each(bootFiles)("%s does not combine define:vars with data-astro-rerun", (rel) => {
+  it.each(dataAstroRerunFiles)("%s does not combine define:vars with data-astro-rerun", (rel) => {
     const src = readSrc(rel);
-    // Must re-run after body swap…
     expect(src).toContain("data-astro-rerun");
-    // Attribute form only — comments may still warn about the pitfall.
     // `define:vars` injects top-level const and throws on the second nav.
     expect(src).not.toMatch(/define:vars\s*=/);
   });
@@ -35,5 +35,50 @@ describe("ClientRouter boot scripts", () => {
     expect(src).toContain("__UPLOADS_ACTIVE_WORKSPACE__");
     expect(src).toContain("set:html=");
     expect(src).toContain("JSON.stringify");
+  });
+
+  /** Layouts / chrome that soft-nav under ClientRouter. */
+  const pageLoadBoot = [
+    {
+      rel: "layouts/AccountLayout.astro",
+      needles: ["ViewTransitions", "onAstroPageLoad"],
+    },
+    {
+      rel: "layouts/AdminLayout.astro",
+      needles: ["ViewTransitions", "onAstroPageLoad"],
+    },
+    {
+      rel: "layouts/DocsLayout.astro",
+      needles: ["ViewTransitions", "onAstroPageLoad", "bindCopyButtons", "tocSpy"],
+    },
+    {
+      rel: "components/SiteHeader.astro",
+      needles: ["onAstroPageLoad", "fillStarCount", 'getElementById("star-count")'],
+    },
+  ] as const;
+
+  it.each(pageLoadBoot)(
+    "$rel re-boots interactive chrome after ClientRouter swaps",
+    ({ rel, needles }) => {
+      const src = readSrc(rel);
+      for (const needle of needles) expect(src).toContain(needle);
+    },
+  );
+});
+
+describe("Error page chrome", () => {
+  it("ErrorLayout ships SiteHeader with auth + full site Footer", () => {
+    const src = readSrc("layouts/ErrorLayout.astro");
+    expect(src).toContain("SiteHeader");
+    expect(src).toContain("authOrigin");
+    expect(src).toContain("<Footer");
+    // Full footer (not compact-only under the card) — same chrome as legal pages.
+    expect(src).not.toMatch(/<Footer\s+compact/);
+    expect(src).toContain("PUBLIC_UPLOADS_AUTH_ORIGIN");
+  });
+
+  it("404 and 500 use ErrorLayout", () => {
+    expect(readSrc("pages/404.astro")).toContain("ErrorLayout");
+    expect(readSrc("pages/500.astro")).toContain("ErrorLayout");
   });
 });

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -165,24 +165,33 @@ export function createErrorCopy(code: string): string {
 }
 
 /**
- * Copy-to-clipboard for `button[data-copy]` under `root`.
+ * Copy-to-clipboard via event delegation under `root`.
+ *
+ * Safe after ClientRouter swaps when bound once on a long-lived root (e.g.
+ * `document` with a page-scoped selector) or re-bound on a fresh container
+ * each `astro:page-load`. Narrow `selector` when binding on `document` so
+ * other shells' copy buttons are not double-handled after soft nav.
  *
  * `Node`, not `ParentNode`: this only needs `addEventListener`/`contains`
  * (both on `Node`), and worker-configuration.d.ts's HTMLRewriter `Element`
  * ambiently redeclares `append()`, which makes DOM elements unassignable to
  * `ParentNode`. Same wrangler-types drift worked around in oauth/consent.astro.
  */
-export function bindCopyButtons(root: Node): void {
+export function bindCopyButtons(root: Node, selector = "button[data-copy]"): void {
   root.addEventListener("click", (event) => {
     void (async () => {
-      const button = (event.target as HTMLElement).closest<HTMLButtonElement>("button[data-copy]");
+      const button = (event.target as HTMLElement).closest<HTMLButtonElement>(selector);
       if (!button || !root.contains(button)) return;
+      const previous = button.textContent;
       try {
         await navigator.clipboard.writeText(button.dataset.copy ?? "");
-        const previous = button.textContent;
+        if (!root.contains(button)) return;
         button.textContent = "copied ✓";
+        button.classList.add("done");
         setTimeout(() => {
+          if (!root.contains(button)) return;
           button.textContent = previous;
+          button.classList.remove("done");
         }, 1500);
       } catch {
         // Clipboard blocked — leave the label.


### PR DESCRIPTION
## In plain terms

Soft navigation on the docs site was leaving dead chrome: the GitHub star count vanished after the first page change, and copy buttons / TOC highlighting stopped working. Error pages (404/500) also lacked the normal site header sign-in control and full footer.

## What it does

- Re-fill the GitHub star count on every `astro:page-load` (and on first paint for non-router pages)
- Re-wire docs TOC scroll-spy after ClientRouter body swaps; disconnect the previous observer
- Docs copy buttons use shared `bindCopyButtons` once, scoped to `.doc .cmd` so account soft-navs don’t double-fire
- 404/500: full-bleed `SiteHeader` with auth + full site `Footer` (same chrome as legal pages)
- Regression tests for ClientRouter boot invariants and error-page chrome

## What it is not

- Not adding ClientRouter to landing/auth/error shells
- No CodeRabbit request (small, straightforward UI fix)

## How to try it

1. Open `/docs`, confirm the star count appears, then click another docs nav item — count should stay filled
2. Copy a command on a docs page after navigating — “copied ✓” should still work
3. Scroll a long docs page after navigating — TOC `aria-current` should track the section in view
4. Hit a missing path (or open `/404` and `/500`) — header with Sign in + full footer should be present

## Technical notes

- `bindCopyButtons(root, selector?)` now accepts an optional selector and toggles a short-lived `done` class
- Account/admin shells were already on `onAstroPageLoad`; docs + star CTA were the gaps

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run` (174 tests)
- [ ] Manual: docs soft-nav star count + copy + TOC
- [ ] Manual: `/404` and `/500` header/footer