### PR TITLE
feat(auth,api,web): accidental-deletion guards for official clients, last admin, and communal org

### DIFF
--- a/apps/api/src/routes/admin-ui-oauth-clients.test.ts
+++ b/apps/api/src/routes/admin-ui-oauth-clients.test.ts
@@ -180,6 +180,28 @@ describe("DELETE /admin-ui/oauth-clients/:clientId", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
   });
+
+  it("relays a 409 from the internal endpoint when deleting an official client", async () => {
+    const env = stubEnv(ADMIN_USER, (path, req) => {
+      if (path === "/internal/oauth-clients/c-1") {
+        expect(req.method).toBe("DELETE");
+        return Response.json(
+          {
+            error: "official_client",
+            message: "official clients cannot be deleted; remove the official flag first",
+          },
+          { status: 409 },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/admin-ui/oauth-clients/c-1", { method: "DELETE" }, env);
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "official_client",
+      message: "official clients cannot be deleted; remove the official flag first",
+    });
+  });
 });
 
 describe("AUTH binding outage", () => {

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Audit guard (accidental-deletion class, see ad736b9's official-client
+ * guard): the stock admin() plugin's `/admin/remove-user` and
+ * `/admin/ban-user` routes already reject self-targeting on their own
+ * (better-auth 1.6.23's `YOU_CANNOT_REMOVE_YOURSELF`/`YOU_CANNOT_BAN_YOURSELF`
+ * checks), but had no protection against removing/banning the LAST remaining
+ * admin. `hasAdminRole`/`countActiveAdmins` (src/auth.ts) back the
+ * `hooks.before` guard wired into `buildAuth`.
+ *
+ * These are unit tests against the exported helpers plus one endpoint-level
+ * negative case. Driving the "requester removes a *different* admin who is
+ * the sole ACTIVE admin" case end-to-end isn't reachable through the plugin's
+ * own session/permission stack: the admin() plugin's `adminMiddleware`
+ * requires the requester to already hold the admin role, so if the target is
+ * genuinely the only active admin, the requester (having admin role too)
+ * would have to be that same user — a case the plugin's own self-guard
+ * already rejects first. The one endpoint-level case exercised here (a lone
+ * active admin trying to remove a *banned* ex-admin) is the one reachable
+ * path that still trips the count<=1 check, since a banned admin doesn't
+ * count toward `countActiveAdmins`.
+ */
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, it } from "vitest";
+import { app } from "./index";
+import { countActiveAdmins, hasAdminRole, type AuthEnv } from "./auth";
+import * as schema from "./schema";
+import { createFakeD1 } from "./test/fake-d1";
+
+function dbEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+async function seedUser(
+  env: AuthEnv,
+  overrides: Partial<schema.AuthUser> = {},
+): Promise<schema.AuthUser> {
+  const orm = drizzle(env.DB, { schema });
+  const user: schema.AuthUser = {
+    id: overrides.id ?? crypto.randomUUID(),
+    name: overrides.name ?? "Ada Lovelace",
+    email: overrides.email ?? `ada-${crypto.randomUUID()}@example.com`,
+    emailVerified: overrides.emailVerified ?? true,
+    image: overrides.image ?? null,
+    createdAt: overrides.createdAt ?? new Date(),
+    updatedAt: overrides.updatedAt ?? new Date(),
+    role: overrides.role ?? "user",
+    banned: overrides.banned ?? null,
+    banReason: overrides.banReason ?? null,
+    banExpires: overrides.banExpires ?? null,
+    cliOnboardedAt: overrides.cliOnboardedAt ?? null,
+  };
+  await orm.insert(schema.user).values(user);
+  return user;
+}
+
+/** Seed a session for `user`, returning the raw token to present as a bearer (same pattern as device.test.ts). */
+async function seedSession(env: AuthEnv, userId: string): Promise<string> {
+  const orm = drizzle(env.DB, { schema });
+  const token = `sess-${crypto.randomUUID()}`;
+  await orm.insert(schema.session).values({
+    id: crypto.randomUUID(),
+    userId,
+    token,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return token;
+}
+
+function adminRequest(
+  path: string,
+  sessionToken: string,
+  body: Record<string, unknown>,
+  env: AuthEnv,
+) {
+  return app.request(
+    `/api/auth${path}`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${sessionToken}`,
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("hasAdminRole", () => {
+  it("matches an exact admin role", () => {
+    expect(hasAdminRole("admin")).toBe(true);
+  });
+
+  it("matches admin within a comma-separated role list", () => {
+    expect(hasAdminRole("user,admin")).toBe(true);
+  });
+
+  it("rejects non-admin roles and empty values", () => {
+    expect(hasAdminRole("user")).toBe(false);
+    expect(hasAdminRole("")).toBe(false);
+    expect(hasAdminRole(null)).toBe(false);
+    expect(hasAdminRole(undefined)).toBe(false);
+  });
+});
+
+describe("countActiveAdmins", () => {
+  it("counts only non-banned admin-role users", async () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await seedUser(env, { role: "admin" });
+    await seedUser(env, { role: "admin", banned: true });
+    await seedUser(env, { role: "user" });
+
+    expect(await countActiveAdmins(db)).toBe(1);
+  });
+
+  it("returns 0 when there are no admins", async () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await seedUser(env, { role: "user" });
+
+    expect(await countActiveAdmins(db)).toBe(0);
+  });
+
+  it("counts every active admin when several exist", async () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    await seedUser(env, { role: "admin" });
+    await seedUser(env, { role: "admin" });
+    await seedUser(env, { role: "user" });
+
+    expect(await countActiveAdmins(db)).toBe(2);
+  });
+});
+
+describe("last-admin guard (endpoint-level)", () => {
+  it("blocks removing a banned admin when no other active admin remains", async () => {
+    const env = dbEnv();
+    const activeAdmin = await seedUser(env, { role: "admin" });
+    const bannedAdmin = await seedUser(env, { role: "admin", banned: true });
+    const sessionToken = await seedSession(env, activeAdmin.id);
+
+    const res = await adminRequest(
+      "/admin/remove-user",
+      sessionToken,
+      { userId: bannedAdmin.id },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message).toMatch(/cannot remove the last admin/i);
+
+    const db = drizzle(env.DB, { schema });
+    const [stillThere] = await db
+      .select({ id: schema.user.id })
+      .from(schema.user)
+      .where(eq(schema.user.id, bannedAdmin.id));
+    expect(stillThere).toBeDefined();
+  });
+
+  it("allows removing a non-admin user even with only one admin in the system", async () => {
+    const env = dbEnv();
+    const soleAdmin = await seedUser(env, { role: "admin" });
+    const regularUser = await seedUser(env, { role: "user" });
+    const sessionToken = await seedSession(env, soleAdmin.id);
+
+    const res = await adminRequest(
+      "/admin/remove-user",
+      sessionToken,
+      { userId: regularUser.id },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success?: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("allows removing one of two active admins, leaving the other", async () => {
+    const env = dbEnv();
+    const requester = await seedUser(env, { role: "admin" });
+    const otherAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, requester.id);
+
+    const res = await adminRequest(
+      "/admin/remove-user",
+      sessionToken,
+      { userId: otherAdmin.id },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success?: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("still rejects an admin trying to remove themselves (library's own guard)", async () => {
+    const env = dbEnv();
+    const soleAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, soleAdmin.id);
+
+    const res = await adminRequest(
+      "/admin/remove-user",
+      sessionToken,
+      { userId: soleAdmin.id },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -7,17 +7,17 @@
  * admin. `hasAdminRole`/`countActiveAdmins` (src/auth.ts) back the
  * `hooks.before` guard wired into `buildAuth`.
  *
- * These are unit tests against the exported helpers plus one endpoint-level
- * negative case. Driving the "requester removes a *different* admin who is
- * the sole ACTIVE admin" case end-to-end isn't reachable through the plugin's
- * own session/permission stack: the admin() plugin's `adminMiddleware`
- * requires the requester to already hold the admin role, so if the target is
- * genuinely the only active admin, the requester (having admin role too)
- * would have to be that same user — a case the plugin's own self-guard
- * already rejects first. The one endpoint-level case exercised here (a lone
- * active admin trying to remove a *banned* ex-admin) is the one reachable
- * path that still trips the count<=1 check, since a banned admin doesn't
- * count toward `countActiveAdmins`.
+ * These are unit tests against the exported helpers plus endpoint-level
+ * cases. Driving the "requester removes a *different* admin who is the sole
+ * ACTIVE admin" case end-to-end isn't reachable through the plugin's own
+ * session/permission stack: the admin() plugin's `adminMiddleware` requires
+ * the requester to already hold the admin role, so if the target is genuinely
+ * the only active admin, the requester (having admin role too) would have to
+ * be that same user — a case the plugin's own self-guard already rejects
+ * first. The remove/ban count<=1 branch therefore stays as defense in depth
+ * (banned targets return early — a banned ex-admin is not an active admin
+ * and may be removed freely); the branch is meaningfully reachable via the
+ * set-role/update-user demotion paths tested below.
  */
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -143,7 +143,7 @@ describe("countActiveAdmins", () => {
 });
 
 describe("last-admin guard (endpoint-level)", () => {
-  it("blocks removing a banned admin when no other active admin remains", async () => {
+  it("allows removing a banned ex-admin — they are not an active admin", async () => {
     const env = dbEnv();
     const activeAdmin = await seedUser(env, { role: "admin" });
     const bannedAdmin = await seedUser(env, { role: "admin", banned: true });
@@ -155,16 +155,21 @@ describe("last-admin guard (endpoint-level)", () => {
       { userId: bannedAdmin.id },
       env,
     );
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { message?: string };
-    expect(body.message).toMatch(/cannot remove the last admin/i);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success?: boolean };
+    expect(body.success).toBe(true);
 
     const db = drizzle(env.DB, { schema });
-    const [stillThere] = await db
+    const [removed] = await db
       .select({ id: schema.user.id })
       .from(schema.user)
       .where(eq(schema.user.id, bannedAdmin.id));
-    expect(stillThere).toBeDefined();
+    expect(removed).toBeUndefined();
+    const [survivor] = await db
+      .select({ id: schema.user.id })
+      .from(schema.user)
+      .where(eq(schema.user.id, activeAdmin.id));
+    expect(survivor).toBeDefined();
   });
 
   it("allows removing a non-admin user even with only one admin in the system", async () => {
@@ -213,6 +218,39 @@ describe("last-admin guard (endpoint-level)", () => {
       env,
     );
     expect(res.status).toBe(400);
+  });
+
+  it("blocks the sole admin from banning themselves", async () => {
+    const env = dbEnv();
+    const soleAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, soleAdmin.id);
+
+    const res = await adminRequest("/admin/ban-user", sessionToken, { userId: soleAdmin.id }, env);
+    expect(res.status).toBe(400);
+
+    const db = drizzle(env.DB, { schema });
+    const [row] = await db
+      .select({ banned: schema.user.banned })
+      .from(schema.user)
+      .where(eq(schema.user.id, soleAdmin.id));
+    expect(row?.banned).not.toBe(true);
+  });
+
+  it("allows one of two active admins to ban the other", async () => {
+    const env = dbEnv();
+    const requester = await seedUser(env, { role: "admin" });
+    const otherAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, requester.id);
+
+    const res = await adminRequest("/admin/ban-user", sessionToken, { userId: otherAdmin.id }, env);
+    expect(res.status).toBe(200);
+
+    const db = drizzle(env.DB, { schema });
+    const [row] = await db
+      .select({ banned: schema.user.banned })
+      .from(schema.user)
+      .where(eq(schema.user.id, otherAdmin.id));
+    expect(row?.banned).toBe(true);
   });
 });
 

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -215,3 +215,88 @@ describe("last-admin guard (endpoint-level)", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("last-admin guard: set-role", () => {
+  it("blocks set-role from demoting the last admin (including self-demotion)", async () => {
+    const env = dbEnv();
+    const soleAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, soleAdmin.id);
+
+    const res = await adminRequest(
+      "/admin/set-role",
+      sessionToken,
+      { userId: soleAdmin.id, role: "user" },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message).toMatch(/cannot remove the last admin's admin role/i);
+
+    const db = drizzle(env.DB, { schema });
+    const [stillAdmin] = await db
+      .select({ role: schema.user.role })
+      .from(schema.user)
+      .where(eq(schema.user.id, soleAdmin.id));
+    expect(hasAdminRole(stillAdmin?.role)).toBe(true);
+  });
+
+  it("allows set-role on a non-last admin", async () => {
+    const env = dbEnv();
+    const requester = await seedUser(env, { role: "admin" });
+    const otherAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, requester.id);
+
+    const res = await adminRequest(
+      "/admin/set-role",
+      sessionToken,
+      { userId: otherAdmin.id, role: "user" },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("last-admin guard: update-user", () => {
+  it("blocks update-user from banning the last admin", async () => {
+    // The reachable end-to-end path mirrors admin-last-guard's remove-user
+    // test: adminMiddleware requires the requester to already hold the admin
+    // role, so a sole active admin banning "the last admin" is necessarily
+    // self-targeting. Our hooks.before guard runs before the route handler,
+    // so it trips (with our message) ahead of the library's own
+    // self-ban-only check.
+    const env = dbEnv();
+    const soleAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, soleAdmin.id);
+
+    const res = await adminRequest(
+      "/admin/update-user",
+      sessionToken,
+      { userId: soleAdmin.id, data: { banned: true } },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { message?: string };
+    expect(body.message).toMatch(/cannot ban the last admin/i);
+  });
+
+  it("allows update-user to change unrelated fields on the last admin", async () => {
+    const env = dbEnv();
+    const soleAdmin = await seedUser(env, { role: "admin" });
+    const sessionToken = await seedSession(env, soleAdmin.id);
+
+    const res = await adminRequest(
+      "/admin/update-user",
+      sessionToken,
+      { userId: soleAdmin.id, data: { name: "Renamed Admin" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    const db = drizzle(env.DB, { schema });
+    const [updated] = await db
+      .select({ name: schema.user.name })
+      .from(schema.user)
+      .where(eq(schema.user.id, soleAdmin.id));
+    expect(updated?.name).toBe("Renamed Admin");
+  });
+});

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -9,6 +9,7 @@ import { dash } from "@better-auth/infra";
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { betterAuth } from "better-auth";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import {
@@ -111,6 +112,83 @@ export async function resolveWorkspaceClaims(
     .orderBy(asc(schema.member.createdAt), asc(schema.member.id));
   const workspaces = rows.map((r) => r.slug);
   return { workspace: workspaces[0] ?? null, workspaces };
+}
+
+/**
+ * Global `user.role` value granted by the `admin()` plugin's `adminRoles`
+ * option below. Kept as a literal (not read back from plugin options) since
+ * the plugin config is fixed at a single role and this helper needs it before
+ * `buildAuth` runs.
+ */
+const ADMIN_ROLE = "admin";
+
+/**
+ * Audit guard (accidental-deletion class, see ad736b9's official-client
+ * guard): the stock `admin()` plugin's `/admin/remove-user` and
+ * `/admin/ban-user` REST endpoints already refuse self-targeting (better-auth
+ * 1.6.23's own `YOU_CANNOT_REMOVE_YOURSELF`/`YOU_CANNOT_BAN_YOURSELF` checks),
+ * but have no protection against removing/banning the LAST remaining admin —
+ * doing so locks every operator out of the admin UI with no recovery path
+ * short of a direct DB edit. `user.role` can hold a comma-separated role list
+ * (mirrors the plugin's own `role.split(",")` parsing in its `setRole`
+ * route), so this checks for the admin token anywhere in that list.
+ *
+ * Exported for direct unit testing — driving the plugin's endpoints
+ * end-to-end through the fake-D1 harness is comparatively heavy (see
+ * auth.test.ts).
+ */
+export function hasAdminRole(role: string | null | undefined): boolean {
+  if (!role) return false;
+  return role
+    .split(",")
+    .map((r) => r.trim())
+    .includes(ADMIN_ROLE);
+}
+
+/** Count of non-banned users currently holding the admin role. */
+export async function countActiveAdmins(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+): Promise<number> {
+  const rows = await db
+    .select({ role: schema.user.role, banned: schema.user.banned })
+    .from(schema.user);
+  // Fetch-and-filter in JS rather than a `LIKE`/split in SQL: the role column
+  // is a free-form comma-separated string (see hasAdminRole above), and the
+  // admin user population is small enough that this isn't a real query cost.
+  return rows.filter((r) => hasAdminRole(r.role) && !r.banned).length;
+}
+
+/**
+ * `hooks.before` handler for the `admin()` plugin's remove-user/ban-user
+ * endpoints (fail-closed guard, see `countActiveAdmins` above). Runs on every
+ * request — it's the only per-request hook Better Auth exposes at this
+ * level — so it no-ops for any path other than the two it guards. Self-removal
+ * and self-ban are already rejected by the plugin itself; this only adds the
+ * last-admin check.
+ */
+function lastAdminGuardHook(db: ReturnType<typeof drizzle<typeof schema>>) {
+  return createAuthMiddleware(async (ctx) => {
+    if (ctx.path !== "/admin/remove-user" && ctx.path !== "/admin/ban-user") return;
+    const userId = (ctx.body as { userId?: unknown } | undefined)?.userId;
+    if (typeof userId !== "string" || !userId) return;
+
+    const [target] = await db
+      .select({ role: schema.user.role })
+      .from(schema.user)
+      .where(eq(schema.user.id, userId))
+      .limit(1);
+    if (!target || !hasAdminRole(target.role)) return;
+
+    const activeAdmins = await countActiveAdmins(db);
+    if (activeAdmins <= 1) {
+      throw new APIError("BAD_REQUEST", {
+        message:
+          ctx.path === "/admin/remove-user"
+            ? "cannot remove the last admin"
+            : "cannot ban the last admin",
+      });
+    }
+  });
 }
 
 export type AuthEnv = GitHubCredentialsEnv &
@@ -373,6 +451,11 @@ function buildAuth(
           },
         },
       },
+    },
+    // Fail-closed last-admin guard for the admin() plugin's remove-user/
+    // ban-user endpoints — see lastAdminGuardHook above.
+    hooks: {
+      before: lastAdminGuardHook(db),
     },
     // Fail-closed in production, decoupled from secret resolution (D3/D7):
     // rate limiting is on whenever ENVIRONMENT === "production", regardless

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -211,6 +211,9 @@ function lastAdminGuardHook(db: ReturnType<typeof drizzle<typeof schema>>) {
 
       const target = await getUserRoleState(db, userId);
       if (!target || !hasAdminRole(target.role)) return;
+      // A banned admin is not an active admin: removing or re-banning them
+      // cannot reduce the active-admin count, so the guard stays out of it.
+      if (target.banned) return;
 
       const activeAdmins = await countActiveAdmins(db);
       if (activeAdmins <= 1) {

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -145,6 +145,20 @@ export function hasAdminRole(role: string | null | undefined): boolean {
     .includes(ADMIN_ROLE);
 }
 
+/**
+ * Same admin-role check as `hasAdminRole`, but for the raw `role` value the
+ * admin() plugin's `/admin/set-role` and `/admin/update-user` request bodies
+ * accept — a single string OR an array of strings (see better-auth 1.6.23's
+ * `setRoleBodySchema`/`adminUpdateUserBodySchema` in
+ * `plugins/admin/routes.mjs`, which itself normalizes via `Array.isArray(...)
+ * ? roles.join(",") : roles`).
+ */
+function hasAdminRoleInput(role: unknown): boolean {
+  if (typeof role === "string") return hasAdminRole(role);
+  if (Array.isArray(role)) return hasAdminRole(role.join(","));
+  return false;
+}
+
 /** Count of non-banned users currently holding the admin role. */
 export async function countActiveAdmins(
   db: ReturnType<typeof drizzle<typeof schema>>,
@@ -158,35 +172,102 @@ export async function countActiveAdmins(
   return rows.filter((r) => hasAdminRole(r.role) && !r.banned).length;
 }
 
+/** Role (+ banned) of a single user, for the last-admin guard below. */
+async function getUserRoleState(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  userId: string,
+): Promise<{ role: string | null; banned: boolean | null } | undefined> {
+  const [row] = await db
+    .select({ role: schema.user.role, banned: schema.user.banned })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId))
+    .limit(1);
+  return row;
+}
+
 /**
- * `hooks.before` handler for the `admin()` plugin's remove-user/ban-user
- * endpoints (fail-closed guard, see `countActiveAdmins` above). Runs on every
- * request — it's the only per-request hook Better Auth exposes at this
- * level — so it no-ops for any path other than the two it guards. Self-removal
- * and self-ban are already rejected by the plugin itself; this only adds the
- * last-admin check.
+ * `hooks.before` handler for the `admin()` plugin's remove-user/ban-user/
+ * set-role/update-user endpoints (fail-closed guard, see `countActiveAdmins`
+ * above). Runs on every request — it's the only per-request hook Better Auth
+ * exposes at this level — so it no-ops for any path other than the ones it
+ * guards.
+ *
+ * - `/admin/remove-user`, `/admin/ban-user`: self-removal and self-ban are
+ *   already rejected by the plugin itself; this only adds the last-admin
+ *   check.
+ * - `/admin/set-role` (body `{ userId, role }`) and `/admin/update-user`
+ *   (body `{ userId, data }`, where `data` may carry `role` and/or `banned`)
+ *   have NO built-in last-admin protection at all — `update-user`'s only
+ *   built-in guard blocks self-ban, and neither route stops a caller
+ *   (including the target themselves) from stripping the last admin's role
+ *   or banning them via `data.banned`. Verified against better-auth 1.6.23's
+ *   `plugins/admin/routes.mjs` (`setRole`, `adminUpdateUser`).
  */
 function lastAdminGuardHook(db: ReturnType<typeof drizzle<typeof schema>>) {
   return createAuthMiddleware(async (ctx) => {
-    if (ctx.path !== "/admin/remove-user" && ctx.path !== "/admin/ban-user") return;
-    const userId = (ctx.body as { userId?: unknown } | undefined)?.userId;
-    if (typeof userId !== "string" || !userId) return;
+    if (ctx.path === "/admin/remove-user" || ctx.path === "/admin/ban-user") {
+      const userId = (ctx.body as { userId?: unknown } | undefined)?.userId;
+      if (typeof userId !== "string" || !userId) return;
 
-    const [target] = await db
-      .select({ role: schema.user.role })
-      .from(schema.user)
-      .where(eq(schema.user.id, userId))
-      .limit(1);
-    if (!target || !hasAdminRole(target.role)) return;
+      const target = await getUserRoleState(db, userId);
+      if (!target || !hasAdminRole(target.role)) return;
 
-    const activeAdmins = await countActiveAdmins(db);
-    if (activeAdmins <= 1) {
-      throw new APIError("BAD_REQUEST", {
-        message:
-          ctx.path === "/admin/remove-user"
-            ? "cannot remove the last admin"
-            : "cannot ban the last admin",
-      });
+      const activeAdmins = await countActiveAdmins(db);
+      if (activeAdmins <= 1) {
+        throw new APIError("BAD_REQUEST", {
+          message:
+            ctx.path === "/admin/remove-user"
+              ? "cannot remove the last admin"
+              : "cannot ban the last admin",
+        });
+      }
+      return;
+    }
+
+    if (ctx.path === "/admin/set-role") {
+      const body = ctx.body as { userId?: unknown; role?: unknown } | undefined;
+      const userId = body?.userId;
+      if (typeof userId !== "string" || !userId) return;
+
+      const target = await getUserRoleState(db, userId);
+      // A banned target doesn't count toward `countActiveAdmins`, so it
+      // can't be "the last admin" being demoted — and if the incoming role
+      // still includes admin, nothing about admin-ness is changing.
+      if (!target || target.banned || !hasAdminRole(target.role)) return;
+      if (hasAdminRoleInput(body?.role)) return;
+
+      const activeAdmins = await countActiveAdmins(db);
+      if (activeAdmins <= 1) {
+        throw new APIError("BAD_REQUEST", {
+          message: "cannot remove the last admin's admin role",
+        });
+      }
+      return;
+    }
+
+    if (ctx.path === "/admin/update-user") {
+      const body = ctx.body as { userId?: unknown; data?: unknown } | undefined;
+      const userId = body?.userId;
+      if (typeof userId !== "string" || !userId) return;
+      const data = (body?.data ?? {}) as { role?: unknown; banned?: unknown };
+
+      const target = await getUserRoleState(db, userId);
+      if (!target || target.banned || !hasAdminRole(target.role)) return;
+
+      const willBan = data.banned === true;
+      const rolesInBody = Object.prototype.hasOwnProperty.call(data, "role");
+      const willStripAdmin = rolesInBody && !hasAdminRoleInput(data.role);
+      if (!willBan && !willStripAdmin) return;
+
+      const activeAdmins = await countActiveAdmins(db);
+      if (activeAdmins <= 1) {
+        throw new APIError("BAD_REQUEST", {
+          message: willBan
+            ? "cannot ban the last admin"
+            : "cannot remove the last admin's admin role",
+        });
+      }
+      return;
     }
   });
 }

--- a/apps/auth/src/internal-oauth-clients.test.ts
+++ b/apps/auth/src/internal-oauth-clients.test.ts
@@ -409,6 +409,85 @@ describe("DELETE /internal/oauth-clients/:clientId", () => {
       .where(eqClientIdAccess(clientId));
     expect(remainingAccess).toHaveLength(0);
   });
+
+  it("409s on an official client and leaves its rows intact", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      official: true,
+    });
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const now = new Date();
+    await drizzle(db, { schema })
+      .insert(schema.oauthConsent)
+      .values({
+        id: "consent-official",
+        userId: "user-1",
+        clientId,
+        scopes: ["files:read"],
+        createdAt: now,
+        updatedAt: now,
+      });
+    await drizzle(db, { schema })
+      .insert(schema.oauthRefreshToken)
+      .values({
+        id: "rt-official",
+        token: "tok-official",
+        clientId,
+        userId: "user-1",
+        scopes: ["files:read"],
+        createdAt: now,
+        expiresAt: new Date(Date.now() + 1000 * 60),
+      });
+
+    const res = await jsonReq("DELETE", `/internal/oauth-clients/${clientId}`);
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { error: string; message: string }).toMatchObject({
+      error: "official_client",
+    });
+
+    const remainingClients = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eqClientId(clientId));
+    expect(remainingClients).toHaveLength(1);
+    const remainingConsent = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthConsent)
+      .where(eqClientIdConsent(clientId));
+    expect(remainingConsent).toHaveLength(1);
+    const remainingRefresh = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthRefreshToken)
+      .where(eqClientIdRefresh(clientId));
+    expect(remainingRefresh).toHaveLength(1);
+  });
+
+  it("succeeds after PATCHing official:false on a previously official client", async () => {
+    const created = await jsonReq("POST", "/internal/oauth-clients", {
+      ...validCreateBody,
+      official: true,
+    });
+    const { clientId } = (await created.json()) as { clientId: string };
+
+    const blocked = await jsonReq("DELETE", `/internal/oauth-clients/${clientId}`);
+    expect(blocked.status).toBe(409);
+
+    const patched = await jsonReq("PATCH", `/internal/oauth-clients/${clientId}`, {
+      official: false,
+    });
+    expect(patched.status).toBe(200);
+
+    const res = await jsonReq("DELETE", `/internal/oauth-clients/${clientId}`);
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { ok: boolean }).toMatchObject({ ok: true });
+
+    const remainingClients = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eqClientId(clientId));
+    expect(remainingClients).toHaveLength(0);
+  });
 });
 
 function eqClientId(clientId: string) {

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -878,7 +878,7 @@ describe("DB-backed behavior", () => {
       });
     });
 
-it("force=1 bypasses org_not_empty and deletes a multi-member org (#250)", async () => {
+    it("force=1 bypasses org_not_empty and deletes a multi-member org (#250)", async () => {
       const org = await seedOrg();
       const user1 = await seedUser();
       const user2 = await seedUser();

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -878,7 +878,7 @@ describe("DB-backed behavior", () => {
       });
     });
 
-    it("force=1 bypasses org_not_empty and deletes a multi-member org (#250)", async () => {
+it("force=1 bypasses org_not_empty and deletes a multi-member org (#250)", async () => {
       const org = await seedOrg();
       const user1 = await seedUser();
       const user2 = await seedUser();
@@ -917,6 +917,52 @@ describe("DB-backed behavior", () => {
         .from(schema.member)
         .where(eq(schema.member.organizationId, org.id));
       expect(memberRows).toHaveLength(0);
+    });
+
+    // Accidental-deletion guard (audit, same class as ad736b9's official-client
+    // guard): the communal default workspace must survive even when it has
+    // only its single seeded member, unlike any other single-member org — and
+    // #250's force=1 escape hatch must not bypass it either.
+    it("403s deleting the communal default workspace, even with force=1", async () => {
+      const org = await seedOrg({ slug: "default" });
+      const user = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: user.id,
+        role: "owner",
+        createdAt: new Date(),
+      });
+
+      for (const path of [`/internal/orgs/${org.slug}`, `/internal/orgs/${org.slug}?force=1`]) {
+        const res = await app().request(path, { method: "DELETE" }, dbEnv());
+        expect(res.status).toBe(403);
+        expect((await res.json()) as { error: { code: string } }).toMatchObject({
+          error: { code: "protected_org" },
+        });
+      }
+
+      const orgRows = await orm
+        .select()
+        .from(schema.organization)
+        .where(eq(schema.organization.id, org.id));
+      expect(orgRows).toHaveLength(1);
+    });
+
+    it("still deletes a non-communal single-member org named similarly to 'default'", async () => {
+      const org = await seedOrg({ slug: "default-staging" });
+      const user = await seedUser();
+      await orm.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: org.id,
+        userId: user.id,
+        role: "owner",
+        createdAt: new Date(),
+      });
+
+      const res = await app().request(`/internal/orgs/${org.slug}`, { method: "DELETE" }, dbEnv());
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
     });
   });
 

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -26,6 +26,16 @@ function officialClientError(message: string) {
   return { error: "official_client", message } as const;
 }
 
+/**
+ * Slug of the communal, world-readable default workspace (mirrors apps/api's
+ * `DEFAULT_WORKSPACE` env var / `isCommunal()` in apps/api/src/routes/me.ts).
+ * This worker has no equivalent env binding, so the value is pinned here as a
+ * literal instead — it MUST stay in lockstep with apps/api's default
+ * ("default") or the two workers will disagree about which workspace is
+ * protected.
+ */
+const COMMUNAL_ORG_SLUG = "default";
+
 const REDIRECT_SCHEME_ALLOWLIST = new Set(["https:", "http:"]);
 
 function isLoopbackHost(host: string): boolean {
@@ -599,6 +609,12 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .limit(1);
     if (!org) {
       return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    if (org.slug === COMMUNAL_ORG_SLUG) {
+      return c.json(
+        errorJson("protected_org", "the communal default workspace cannot be deleted"),
+        403,
+      );
     }
     const force = c.req.query("force") === "1" || c.req.query("force") === "true";
     const members = await db

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -21,6 +21,11 @@ function invalidRequest(message: string) {
   return { error: "invalid_request", message } as const;
 }
 
+/** Same shape as invalidRequest, but with a distinct error code for a specific condition. */
+function officialClientError(message: string) {
+  return { error: "official_client", message } as const;
+}
+
 const REDIRECT_SCHEME_ALLOWLIST = new Set(["https:", "http:"]);
 
 function isLoopbackHost(host: string): boolean {
@@ -876,6 +881,14 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .limit(1);
     if (!existing) {
       return c.json({ error: "not_found" }, 404);
+    }
+    if (isOfficial(existing)) {
+      return c.json(
+        officialClientError(
+          "official clients cannot be deleted; remove the official flag first (PATCH official:false)",
+        ),
+        409,
+      );
     }
 
     // Atomic via D1 batch — a partial failure must not leave tokens/consents

--- a/apps/auth/src/oauth-client-reaper.test.ts
+++ b/apps/auth/src/oauth-client-reaper.test.ts
@@ -21,6 +21,7 @@ function seedClient(
     createdAt: Date;
     userId: string | null;
     skipConsent: boolean | null;
+    metadata: Record<string, unknown> | null;
   }> = {},
 ) {
   return drizzle(db, { schema })
@@ -32,6 +33,7 @@ function seedClient(
       scopes: ["files:read"],
       userId: overrides.userId ?? null,
       skipConsent: overrides.skipConsent ?? null,
+      metadata: overrides.metadata ?? null,
       createdAt: overrides.createdAt ?? new Date(),
       updatedAt: overrides.createdAt ?? new Date(),
     });
@@ -129,5 +131,42 @@ describe("sweepOauthClients", () => {
       .from(schema.oauthClient)
       .where(eq(schema.oauthClient.clientId, "uploads-cli"));
     expect(remaining).toHaveLength(1);
+  });
+
+  it("never sweeps a stale, never-used, official operator-panel client (metadata.official)", async () => {
+    // internal-routes.ts's client-create route seeds panel-created official
+    // clients with userId: null + skipConsent: false — identical to an
+    // anonymous DCR registration except for the metadata.official flag. That
+    // flag must be checked in both the listing AND the delete predicate, or
+    // an official client that goes unused past retention gets silently
+    // hard-deleted.
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await seedClient("official-1", { createdAt: old, metadata: { official: true } });
+
+    const result = await sweepOauthClients({ ...env, OAUTH_CLIENT_REAPER_ENABLED: "true" });
+
+    expect(result.candidates).toBe(0);
+    expect(result.reapable).toBe(0);
+    expect(result.deleted).toBe(0);
+
+    const remaining = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, "client-official-1"));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("still reaps a comparable non-official client with the same shape", async () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    await seedClient("non-official-1", { createdAt: old, metadata: null });
+
+    const result = await sweepOauthClients({ ...env, OAUTH_CLIENT_REAPER_ENABLED: "true" });
+
+    expect(result.deleted).toBe(1);
+    const remaining = await drizzle(db, { schema })
+      .select()
+      .from(schema.oauthClient)
+      .where(eq(schema.oauthClient.clientId, "client-non-official-1"));
+    expect(remaining).toHaveLength(0);
   });
 });

--- a/apps/auth/src/oauth-client-reaper.ts
+++ b/apps/auth/src/oauth-client-reaper.ts
@@ -15,6 +15,12 @@
  *     one is added later,
  *   - NOT trusted (`skip_consent` ≠ true) — a future first-party
  *     skip-consent client should never be swept,
+ *   - NOT an operator-panel "official" client (`metadata.official` ≠ true,
+ *     see internal-routes.ts's `isOfficial`/PATCH `official` toggle) — a
+ *     panel-created official client is deliberately `userId: null` +
+ *     `skipConsent: false` (see internal-routes.ts's client-create route),
+ *     which would otherwise satisfy every other predicate above and be
+ *     silently hard-deleted the first time it goes unused past retention,
  *   - zero `oauth_consent` rows AND zero token rows — no user ever
  *     authorized it.
  *
@@ -63,12 +69,25 @@ export function parseRetentionDays(raw: string | undefined): number {
 
 export function drizzleOauthClientReaperStore(db: D1Database): OauthClientReaperStore {
   const d = drizzle(db, { schema });
-  // Anonymous DCR only (user_id null) + not trusted (skip_consent) + stale.
+  // `metadata` is a JSON TEXT column (drizzle's "json" mode only affects
+  // (de)serialization on the JS side); `json_extract` works against it in
+  // both D1 and the node:sqlite test harness (both ship SQLite's JSON1
+  // extension). `coalesce(..., 0) != 1` treats NULL metadata, metadata with
+  // no `official` key, and `official: false` all as "not official" — only an
+  // explicit `official: true` is exempt.
+  const notOfficial = () =>
+    sql`coalesce(json_extract(${schema.oauthClient.metadata}, '$.official'), 0) != 1`;
+  // Anonymous DCR only (user_id null) + not trusted (skip_consent) + not an
+  // operator-panel official client + stale. This same predicate MUST be used
+  // in both the candidate/reapable listings (observability) and the atomic
+  // delete statement (deleteReapable below) — the official exemption is only
+  // safe if it holds in the delete's own WHERE, not just a prior read.
   const candidateWhere = (cutoff: Date) =>
     and(
       lt(schema.oauthClient.createdAt, cutoff),
       isNull(schema.oauthClient.userId),
       or(isNull(schema.oauthClient.skipConsent), eq(schema.oauthClient.skipConsent, false)),
+      notOfficial(),
     );
   // Never used: correlated NOT EXISTS per usage table, evaluated inside the
   // SAME statement as the read/delete it guards — a consent or token created

--- a/apps/web/src/pages/admin/oauth/[clientId].astro
+++ b/apps/web/src/pages/admin/oauth/[clientId].astro
@@ -60,6 +60,9 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         <button type="button" id="oauth-disable-toggle"></button>
         <button type="button" id="oauth-delete" class="oauth-danger">Delete</button>
       </div>
+      <p id="oauth-delete-hint" class="muted" style="font-size:12px;margin-top:4px" hidden>
+        Remove the official flag to enable deletion.
+      </p>
       <div id="oauth-action-status" role="status" hidden></div>
 
       <form id="oauth-edit-form" class="oauth-form" hidden>
@@ -178,6 +181,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
         "admin oauth detail",
       );
       const deleteBtn = requireElement<HTMLButtonElement>("#oauth-delete", "admin oauth detail");
+      const deleteHintEl = requireElement<HTMLElement>("#oauth-delete-hint", "admin oauth detail");
       const actionStatus = requireElement<HTMLElement>("#oauth-action-status", "admin oauth detail");
       const editForm = requireElement<HTMLFormElement>("#oauth-edit-form", "admin oauth detail");
       const editCancelBtn = requireElement<HTMLButtonElement>(
@@ -212,6 +216,8 @@ if (!clientId) return Astro.redirect("/admin/oauth");
           : "Never";
         createdEl.textContent = new Date(client.createdAt).toLocaleString();
         disableToggleBtn.textContent = client.disabled ? "Enable" : "Disable";
+        deleteBtn.disabled = client.official;
+        deleteHintEl.hidden = !client.official;
 
         const nameInput = requireElement<HTMLInputElement>("#oauth-edit-name", "admin oauth detail");
         const redirectsInput = requireElement<HTMLTextAreaElement>(
@@ -362,7 +368,7 @@ if (!clientId) return Astro.redirect("/admin/oauth");
 
       deleteBtn.addEventListener("click", () => {
         void (async () => {
-          if (!current) return;
+          if (!current || current.official) return;
           if (!confirm(`Delete "${current.name}"? This revokes all its tokens and cannot be undone.`))
             return;
           deleteBtn.disabled = true;

--- a/apps/web/src/styles/admin-oauth.css
+++ b/apps/web/src/styles/admin-oauth.css
@@ -131,6 +131,11 @@
 .oauth-danger {
   color: var(--red) !important;
 }
+.oauth-danger:disabled {
+  color: var(--muted) !important;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 
 #oauth-create-status,
 #oauth-action-status {

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -33,10 +33,13 @@ uploads login --workspace acme
 
 The CLI authenticates as the managed official OAuth client `uploads-cli`,
 visible and toggleable by operators in the admin panel at `/admin/oauth`.
-Operators should disable it there rather than hard-deleting it: the seed
-migration only runs once (`INSERT OR IGNORE`, journaled as applied), so a
-deleted `uploads-cli` client is not automatically re-seeded and would break
-CLI login fleet-wide until manually re-inserted.
+Deleting an official client is blocked server-side (`DELETE` returns 409)
+until an operator first clears its official flag (`PATCH official:false`);
+that two-step is deliberate. The seed migration only runs once (`INSERT OR
+IGNORE`, journaled as applied), so a deleted `uploads-cli` client is not
+automatically re-seeded and would break CLI login fleet-wide until manually
+re-inserted — prefer disabling it over clearing the official flag and
+deleting it.
 
 On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
 `UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never


### PR DESCRIPTION
Follow-up to #253: make first-party/system-critical entities hard to delete by accident, in the UI and at the API level. Audit of all destructive admin paths found workspaces already have the gold-standard guard (communal exemption + soft delete + grace/restore); galleries and enrollments have no exposure. This PR closes the gaps that remained.

## Guards added

**Official OAuth clients** — `DELETE /internal/oauth-clients/:clientId` now returns 409 (`official_client`) for clients with `metadata.official: true`; deletion requires deliberately removing the official flag first (PATCH `official: false`). The API proxy relays the 409, and the `/admin/oauth` detail page disables the delete control with a hint (server enforcement is the real guard). Protects the seeded `uploads-cli` client, whose deletion would break CLI login with no automatic re-seed (the migration is journaled).

**Reaper exemption** — the nightly oauth-client reaper now excludes official clients via `json_extract(metadata,'$.official')` in the shared candidate predicate, so the exemption holds in both the listing and the atomic delete statement. Previously a panel-created official client (skipConsent=false, userId NULL) that stayed unused past retention would have been silently hard-deleted.

**Last-admin lockout** — a `hooks.before` guard on the Better Auth admin plugin's user routes blocks: removing or banning yourself, removing/banning the last active admin, and (via `/admin/set-role` and `/admin/update-user`) demoting or banning the last active admin. Without this, one API call could lock every operator out of the admin UI. Handles comma-separated role strings and both string/array role bodies, verified against better-auth 1.6.23's route shapes.

**Communal org** — `DELETE /internal/orgs/:slug` refuses the communal `default` org (403 `protected_org`) even when single-member; previously only multi-member orgs were protected. The slug constant mirrors apps/api's `DEFAULT_WORKSPACE` (noted in-code to keep in lockstep).

## Tests

apps/auth 166/166, apps/api 478/478, typecheck clean across auth/api/web. New coverage: 409 + flag-removal-then-delete flow, proxy 409 relay, reaper official-exemption (stale official survives, non-official reaped), last-admin guard endpoint + helper cases, communal org refusal (with a `default-staging` prefix-confusion negative).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Protected the final active administrator from removal, banning, or demotion.
  - Prevented deletion of official OAuth clients until they are marked non-official.
  - Official operator-panel OAuth clients are now excluded from automatic cleanup.
  - Prevented deletion of the default communal workspace.

- **Bug Fixes**
  - Admin OAuth deletion now clearly reports official-client conflicts.
  - Official OAuth clients are visibly protected in the admin interface.

- **Documentation**
  - Clarified the safe process for managing and deleting the official CLI OAuth client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->