### PR TITLE
feat(api): scoped admin/operator token minting for CLI admin operations (#257)

### DIFF
--- a/.changeset/admin-scope-widening.md
+++ b/.changeset/admin-scope-widening.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Widen the token-mint scope types to accept `"admin:read"` and `"admin:write"` alongside the existing file scopes, so CLI/SDK callers can request operator scopes minted by an admin session (#257). No new commands or flags.

--- a/.changeset/admin-scope-widening.md
+++ b/.changeset/admin-scope-widening.md
@@ -1,5 +1,0 @@
----
-"@buildinternet/uploads": patch
----
-
-Widen the token-mint scope types to accept `"admin:read"` and `"admin:write"` alongside the existing file scopes, so CLI/SDK callers can request operator scopes minted by an admin session (#257). No new commands or flags.

--- a/.changeset/operator-scope-widening.md
+++ b/.changeset/operator-scope-widening.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Widen the token-mint scope types to accept `"operator:read"` and `"operator:write"` alongside the existing file scopes, so CLI/SDK callers can request operator scopes minted by an admin session (#257). No new commands or flags.

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
-import { findActiveToken, isAdminScope } from "./auth-db";
+import { findActiveToken, isOperatorScope } from "./auth-db";
 import { hexToBytes, sha256Hex, workspaceNameFromToken } from "./workspace";
 
 const READ_METHODS = new Set(["GET", "HEAD"]);
@@ -8,13 +8,13 @@ const READ_METHODS = new Set(["GET", "HEAD"]);
 /**
  * Gates /admin/* on either the static ADMIN_TOKEN secret (break-glass, fails
  * closed if unset/empty — unchanged behavior) or a D1-backed operator token
- * minted via POST /v1/tokens with an admin:* scope (issue #257). The
+ * minted via POST /v1/tokens with an operator:* scope (issue #257). The
  * ADMIN_TOKEN check runs first and is timing-safe; scoped-token auth is
  * attempted only after it fails, and works even when ADMIN_TOKEN is unset
  * (the fail-closed rule applies to the static-secret path only).
  *
- * Scope rule: `admin:write` is a superset that also grants read access;
- * `admin:read` only grants GET/HEAD.
+ * Scope rule: `operator:write` is a superset that also grants read access;
+ * `operator:read` only grants GET/HEAD.
  */
 export const adminAuth: MiddlewareHandler<{
   Bindings: Env;
@@ -42,19 +42,19 @@ export const adminAuth: MiddlewareHandler<{
   const record = await findActiveToken(c.env.DB, workspace, token);
   if (!record) throw new UnauthorizedError();
 
-  // record.scopes is admin-token-or-file-token JSON; parseScopes (auth-db.ts)
-  // is file-scope-only, so parse directly here and keep just the admin ones.
+  // record.scopes is operator-token-or-file-token JSON; parseScopes (auth-db.ts)
+  // is file-scope-only, so parse directly here and keep just the operator ones.
   let parsed: unknown;
   try {
     parsed = JSON.parse(record.scopes);
   } catch {
     parsed = [];
   }
-  const scopes = new Set(Array.isArray(parsed) ? parsed.filter(isAdminScope) : []);
+  const scopes = new Set(Array.isArray(parsed) ? parsed.filter(isOperatorScope) : []);
   const requiresWrite = !READ_METHODS.has(c.req.method);
   const hasAccess = requiresWrite
-    ? scopes.has("admin:write")
-    : scopes.has("admin:read") || scopes.has("admin:write");
+    ? scopes.has("operator:write")
+    : scopes.has("operator:read") || scopes.has("operator:write");
   if (!hasAccess) throw new ForbiddenError();
 
   c.set("adminTokenId", record.id);

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,23 +1,62 @@
-import { UnauthorizedError } from "@uploads/errors";
+import { ForbiddenError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
-import { hexToBytes, sha256Hex } from "./workspace";
+import { findActiveToken, isAdminScope } from "./auth-db";
+import { hexToBytes, sha256Hex, workspaceNameFromToken } from "./workspace";
+
+const READ_METHODS = new Set(["GET", "HEAD"]);
 
 /**
- * Gates /admin/* on the ADMIN_TOKEN secret. Fails closed: if the secret is
- * unset/empty, every request is 401. Compares SHA-256 digests in constant time.
+ * Gates /admin/* on either the static ADMIN_TOKEN secret (break-glass, fails
+ * closed if unset/empty — unchanged behavior) or a D1-backed operator token
+ * minted via POST /v1/tokens with an admin:* scope (issue #257). The
+ * ADMIN_TOKEN check runs first and is timing-safe; scoped-token auth is
+ * attempted only after it fails, and works even when ADMIN_TOKEN is unset
+ * (the fail-closed rule applies to the static-secret path only).
+ *
+ * Scope rule: `admin:write` is a superset that also grants read access;
+ * `admin:read` only grants GET/HEAD.
  */
-export const adminAuth: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+export const adminAuth: MiddlewareHandler<{
+  Bindings: Env;
+  Variables: { adminTokenId?: string };
+}> = async (c, next) => {
   const secret = c.env.ADMIN_TOKEN ?? "";
   const header = c.req.header("Authorization") ?? "";
   const token = header.startsWith("Bearer ") ? header.slice(7) : "";
 
   const providedHash = await sha256Hex(token);
   const expectedHash = secret ? await sha256Hex(secret) : providedHash.replace(/./g, "0");
-  const ok =
+  const staticOk =
     secret.length > 0 &&
     token.length > 0 &&
     crypto.subtle.timingSafeEqual(hexToBytes(providedHash), hexToBytes(expectedHash));
 
-  if (!ok) throw new UnauthorizedError();
+  if (staticOk) {
+    await next();
+    return;
+  }
+
+  const workspace = token ? workspaceNameFromToken(token) : undefined;
+  if (!workspace) throw new UnauthorizedError();
+
+  const record = await findActiveToken(c.env.DB, workspace, token);
+  if (!record) throw new UnauthorizedError();
+
+  // record.scopes is admin-token-or-file-token JSON; parseScopes (auth-db.ts)
+  // is file-scope-only, so parse directly here and keep just the admin ones.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(record.scopes);
+  } catch {
+    parsed = [];
+  }
+  const scopes = new Set(Array.isArray(parsed) ? parsed.filter(isAdminScope) : []);
+  const requiresWrite = !READ_METHODS.has(c.req.method);
+  const hasAccess = requiresWrite
+    ? scopes.has("admin:write")
+    : scopes.has("admin:read") || scopes.has("admin:write");
+  if (!hasAccess) throw new ForbiddenError();
+
+  c.set("adminTokenId", record.id);
   await next();
 };

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -8,11 +8,11 @@ export type FileScope = (typeof FILE_SCOPES)[number];
 // better-auth `admin` role (see routes/tokens.ts). Distinct from FILE_SCOPES
 // so existing file-scope-only callers (routes/admin.ts, routes/admin-ui.ts)
 // can't accidentally accept them.
-export const ADMIN_SCOPES = ["admin:read", "admin:write"] as const;
-export type AdminScope = (typeof ADMIN_SCOPES)[number];
+export const OPERATOR_SCOPES = ["operator:read", "operator:write"] as const;
+export type OperatorScope = (typeof OPERATOR_SCOPES)[number];
 
-export function isAdminScope(value: unknown): value is AdminScope {
-  return typeof value === "string" && ADMIN_SCOPES.includes(value as AdminScope);
+export function isOperatorScope(value: unknown): value is OperatorScope {
+  return typeof value === "string" && OPERATOR_SCOPES.includes(value as OperatorScope);
 }
 
 // Invite code lifetime. 2h gives a human time to onboard after receiving the
@@ -67,20 +67,20 @@ export function validateScopes(value: unknown, defaults: FileScope[]): FileScope
 export function validateScopes(
   value: unknown,
   defaults: FileScope[],
-  opts: { allowAdmin?: boolean },
-): (FileScope | AdminScope)[] | null;
+  opts: { allowOperator?: boolean },
+): (FileScope | OperatorScope)[] | null;
 export function validateScopes(
   value: unknown,
   defaults: FileScope[],
-  opts?: { allowAdmin?: boolean },
-): (FileScope | AdminScope)[] | null {
+  opts?: { allowOperator?: boolean },
+): (FileScope | OperatorScope)[] | null {
   if (value === undefined) return defaults;
   if (!Array.isArray(value) || value.length === 0) return null;
-  const isValid = opts?.allowAdmin
-    ? (v: unknown) => isFileScope(v) || isAdminScope(v)
+  const isValid = opts?.allowOperator
+    ? (v: unknown) => isFileScope(v) || isOperatorScope(v)
     : isFileScope;
   if (!value.every(isValid)) return null;
-  return [...new Set(value)] as (FileScope | AdminScope)[];
+  return [...new Set(value)] as (FileScope | OperatorScope)[];
 }
 
 function randomSecret(prefix: string, bytes = 24): string {
@@ -122,7 +122,7 @@ export async function createToken(
     label?: string;
     // Widened beyond FileScope so admin-scoped operator tokens (issue #257)
     // can be minted through the same path; storage is just a JSON TEXT column.
-    scopes: (FileScope | AdminScope)[];
+    scopes: (FileScope | OperatorScope)[];
     expiresAt?: Date;
     mintedByUserId?: string | null;
     now?: Date;

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -3,6 +3,18 @@ import { sha256Hex } from "./workspace";
 export const FILE_SCOPES = ["files:read", "files:write", "files:delete"] as const;
 export type FileScope = (typeof FILE_SCOPES)[number];
 
+// Operator/admin scopes for session-minted tokens (issue #257). Never granted
+// by default — only when explicitly requested by a session user holding the
+// better-auth `admin` role (see routes/tokens.ts). Distinct from FILE_SCOPES
+// so existing file-scope-only callers (routes/admin.ts, routes/admin-ui.ts)
+// can't accidentally accept them.
+export const ADMIN_SCOPES = ["admin:read", "admin:write"] as const;
+export type AdminScope = (typeof ADMIN_SCOPES)[number];
+
+export function isAdminScope(value: unknown): value is AdminScope {
+  return typeof value === "string" && ADMIN_SCOPES.includes(value as AdminScope);
+}
+
 // Invite code lifetime. 2h gives a human time to onboard after receiving the
 // link out-of-band, while keeping the single-use secret short-lived. Override
 // per-invite with --expires-in up to MAX_ENROLLMENT_SECONDS (see routes/admin).
@@ -51,10 +63,24 @@ export function isFileScope(value: unknown): value is FileScope {
   return typeof value === "string" && FILE_SCOPES.includes(value as FileScope);
 }
 
-export function validateScopes(value: unknown, defaults: FileScope[]): FileScope[] | null {
+export function validateScopes(value: unknown, defaults: FileScope[]): FileScope[] | null;
+export function validateScopes(
+  value: unknown,
+  defaults: FileScope[],
+  opts: { allowAdmin?: boolean },
+): (FileScope | AdminScope)[] | null;
+export function validateScopes(
+  value: unknown,
+  defaults: FileScope[],
+  opts?: { allowAdmin?: boolean },
+): (FileScope | AdminScope)[] | null {
   if (value === undefined) return defaults;
-  if (!Array.isArray(value) || value.length === 0 || !value.every(isFileScope)) return null;
-  return [...new Set(value)];
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const isValid = opts?.allowAdmin
+    ? (v: unknown) => isFileScope(v) || isAdminScope(v)
+    : isFileScope;
+  if (!value.every(isValid)) return null;
+  return [...new Set(value)] as (FileScope | AdminScope)[];
 }
 
 function randomSecret(prefix: string, bytes = 24): string {
@@ -94,7 +120,9 @@ export async function createToken(
   input: {
     workspace: string;
     label?: string;
-    scopes: FileScope[];
+    // Widened beyond FileScope so admin-scoped operator tokens (issue #257)
+    // can be minted through the same path; storage is just a JSON TEXT column.
+    scopes: (FileScope | AdminScope)[];
     expiresAt?: Date;
     mintedByUserId?: string | null;
     now?: Date;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,8 +38,10 @@ const consoleCors = cors({
 // src/session-auth.ts — requireAdminUser for /admin-ui, requireSessionUser
 // only for /me), so unlike consoleCors above they must be credentialed —
 // same treatment as apps/auth's authCors for the web origin's cross-origin
-// browser calls (uploads.sh -> api.uploads.sh). The ADMIN_TOKEN-gated
-// `/admin/*` surface is bearer-token-only and deliberately untouched.
+// browser calls (uploads.sh -> api.uploads.sh). The `/admin/*` surface is
+// bearer-token-only and deliberately untouched by CORS credentials — it
+// accepts either the static ADMIN_TOKEN break-glass secret or a D1-backed
+// operator token minted via POST /v1/tokens with an admin:* scope (#257).
 const adminUiCors = cors({
   origin: (origin, c) => {
     if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;

--- a/apps/api/src/routes/admin-scoped-token.test.ts
+++ b/apps/api/src/routes/admin-scoped-token.test.ts
@@ -63,33 +63,33 @@ function deleteTokens(bearer: string) {
 }
 
 describe("adminAuth accepts D1-backed scoped operator tokens", () => {
-  it("admin:read token can GET /admin/tokens", async () => {
+  it("operator:read token can GET /admin/tokens", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
-      scopes: ["admin:read"],
+      scopes: ["operator:read"],
     });
     const { app, env } = appWith({ db });
     const res = await app.request(getTokens(token), {}, env);
     expect(res.status).toBe(200);
   });
 
-  it("admin:read token gets 403 on DELETE /admin/tokens", async () => {
+  it("operator:read token gets 403 on DELETE /admin/tokens", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
-      scopes: ["admin:read"],
+      scopes: ["operator:read"],
     });
     const { app, env } = appWith({ db });
     const res = await app.request(deleteTokens(token), {}, env);
     expect(res.status).toBe(403);
   });
 
-  it("admin:write token can GET and DELETE (superset of admin:read)", async () => {
+  it("operator:write token can GET and DELETE (superset of operator:read)", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
-      scopes: ["admin:write"],
+      scopes: ["operator:write"],
     });
     const { app, env } = appWith({ db });
     const getRes = await app.request(getTokens(token), {}, env);
@@ -106,7 +106,7 @@ describe("adminAuth accepts D1-backed scoped operator tokens", () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token, record } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
-      scopes: ["admin:read"],
+      scopes: ["operator:read"],
     });
     await db
       .prepare(`UPDATE auth_tokens SET revoked_at = ? WHERE id = ?`)
@@ -121,7 +121,7 @@ describe("adminAuth accepts D1-backed scoped operator tokens", () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
-      scopes: ["admin:read"],
+      scopes: ["operator:read"],
       expiresAt: new Date(Date.now() - 1000),
     });
     const { app, env } = appWith({ db });
@@ -129,7 +129,7 @@ describe("adminAuth accepts D1-backed scoped operator tokens", () => {
     expect(res.status).toBe(401);
   });
 
-  it("a files-only token (no admin scope) is rejected with 403", async () => {
+  it("a files-only token (no operator scope) is rejected with 403", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
@@ -151,7 +151,7 @@ describe("adminAuth accepts D1-backed scoped operator tokens", () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {
       workspace: "acme",
-      scopes: ["admin:read"],
+      scopes: ["operator:read"],
     });
     const { app, env } = appWith({ db, adminToken: undefined });
     const res = await app.request(getTokens(token), {}, env);

--- a/apps/api/src/routes/admin-scoped-token.test.ts
+++ b/apps/api/src/routes/admin-scoped-token.test.ts
@@ -36,7 +36,8 @@ function fakeKv(records: Record<string, unknown>) {
 }
 
 function appWith(opts: { adminToken?: string | undefined; db: SqliteD1 }) {
-  const { adminToken = ADMIN_TOKEN, db } = opts;
+  const adminToken = "adminToken" in opts ? opts.adminToken : ADMIN_TOKEN;
+  const { db } = opts;
   const app = new Hono<{ Bindings: Env }>()
     .route("/admin", admin)
     .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/admin-scoped-token.test.ts
+++ b/apps/api/src/routes/admin-scoped-token.test.ts
@@ -1,0 +1,171 @@
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it } from "vitest";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { createToken } from "../auth-db";
+import { respondError } from "../error-response";
+import { admin } from "./admin";
+
+const ADMIN_TOKEN = "test-admin-token";
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+];
+
+const RECORD = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "UPLOADS_DEFAULT",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+beforeAll(() => {
+  if (typeof crypto.subtle.timingSafeEqual !== "function") {
+    (
+      crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+    ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+      a.length === b.length && a.every((byte, i) => byte === b[i]);
+  }
+});
+
+function fakeKv(records: Record<string, unknown>) {
+  const store = new Map(Object.entries(records));
+  return {
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+  };
+}
+
+function appWith(opts: { adminToken?: string | undefined; db: SqliteD1 }) {
+  const { adminToken = ADMIN_TOKEN, db } = opts;
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/admin", admin)
+    .onError((err, c) => respondError(c, err));
+  const env = {
+    ADMIN_TOKEN: adminToken,
+    REGISTRY: fakeKv({ "ws:acme": RECORD }),
+    DB: database(db),
+  } as unknown as Env;
+  return { app, env };
+}
+
+function getTokens(bearer: string) {
+  return new Request("https://api.uploads.sh/admin/tokens?workspace=acme", {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+}
+
+function deleteTokens(bearer: string) {
+  return new Request("https://api.uploads.sh/admin/tokens", {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json" },
+    body: JSON.stringify({ workspace: "acme", label: "nope" }),
+  });
+}
+
+describe("adminAuth accepts D1-backed scoped operator tokens", () => {
+  it("admin:read token can GET /admin/tokens", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["admin:read"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(getTokens(token), {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("admin:read token gets 403 on DELETE /admin/tokens", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["admin:read"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(deleteTokens(token), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("admin:write token can GET and DELETE (superset of admin:read)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["admin:write"],
+    });
+    const { app, env } = appWith({ db });
+    const getRes = await app.request(getTokens(token), {}, env);
+    expect(getRes.status).toBe(200);
+    // DELETE reaches the handler (403 forbidden by scope check would mean
+    // adminAuth rejected it before the route ran); a 404 here means adminAuth
+    // let it through and the route itself found no matching token.
+    const deleteRes = await app.request(deleteTokens(token), {}, env);
+    expect(deleteRes.status).not.toBe(401);
+    expect(deleteRes.status).not.toBe(403);
+  });
+
+  it("revoked token is rejected with 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token, record } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["admin:read"],
+    });
+    await db
+      .prepare(`UPDATE auth_tokens SET revoked_at = ? WHERE id = ?`)
+      .bind(new Date().toISOString(), record.id)
+      .run();
+    const { app, env } = appWith({ db });
+    const res = await app.request(getTokens(token), {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("expired token is rejected with 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["admin:read"],
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(getTokens(token), {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("a files-only token (no admin scope) is rejected with 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["files:read", "files:write"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(getTokens(token), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("the static ADMIN_TOKEN still works", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db });
+    const res = await app.request(getTokens(ADMIN_TOKEN), {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("a valid scoped token works even when ADMIN_TOKEN is unset", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["admin:read"],
+    });
+    const { app, env } = appWith({ db, adminToken: undefined });
+    const res = await app.request(getTokens(token), {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("no auth header is rejected with 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db });
+    const res = await app.request(
+      new Request("https://api.uploads.sh/admin/tokens?workspace=acme"),
+      {},
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -282,3 +282,43 @@ describe("POST /v1/tokens mint", () => {
     expect(res.status).toBe(201);
   });
 });
+
+describe("POST /v1/tokens admin scopes", () => {
+  it("400s when a non-admin requests an admin scope", async () => {
+    const res = await post(stubEnv({ user: { ...USER, role: "user" } }), {
+      grants: [{ workspace: "acme", scopes: ["admin:read"] }],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_scopes" },
+    });
+  });
+
+  it("allows an admin user to mint admin:write alongside file scopes", async () => {
+    const cap = captureDb();
+    const res = await post(stubEnv({ user: { ...USER, role: "admin" }, db: cap.db }), {
+      grants: [{ workspace: "acme", scopes: ["files:read", "admin:write"] }],
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["files:read", "admin:write"]);
+  });
+
+  it("allows a multi-role admin user (comma-separated role) to mint admin scopes", async () => {
+    const res = await post(stubEnv({ user: { ...USER, role: "admin,support" } }), {
+      grants: [{ workspace: "acme", scopes: ["admin:read"] }],
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["admin:read"]);
+  });
+
+  it("never includes admin scopes in the default mint", async () => {
+    const res = await post(stubEnv({ user: { ...USER, role: "admin" } }), {
+      grants: [{ workspace: "acme" }],
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["files:read", "files:write"]);
+  });
+});

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -283,10 +283,10 @@ describe("POST /v1/tokens mint", () => {
   });
 });
 
-describe("POST /v1/tokens admin scopes", () => {
-  it("400s when a non-admin requests an admin scope", async () => {
+describe("POST /v1/tokens operator scopes", () => {
+  it("400s when a non-admin requests an operator scope", async () => {
     const res = await post(stubEnv({ user: { ...USER, role: "user" } }), {
-      grants: [{ workspace: "acme", scopes: ["admin:read"] }],
+      grants: [{ workspace: "acme", scopes: ["operator:read"] }],
     });
     expect(res.status).toBe(400);
     expect((await res.json()) as { error: { code: string } }).toMatchObject({
@@ -294,26 +294,26 @@ describe("POST /v1/tokens admin scopes", () => {
     });
   });
 
-  it("allows an admin user to mint admin:write alongside file scopes", async () => {
+  it("allows an admin user to mint operator:write alongside file scopes", async () => {
     const cap = captureDb();
     const res = await post(stubEnv({ user: { ...USER, role: "admin" }, db: cap.db }), {
-      grants: [{ workspace: "acme", scopes: ["files:read", "admin:write"] }],
+      grants: [{ workspace: "acme", scopes: ["files:read", "operator:write"] }],
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as { scopes: string[] };
-    expect(body.scopes).toEqual(["files:read", "admin:write"]);
+    expect(body.scopes).toEqual(["files:read", "operator:write"]);
   });
 
-  it("allows a multi-role admin user (comma-separated role) to mint admin scopes", async () => {
+  it("allows a multi-role admin user (comma-separated role) to mint operator scopes", async () => {
     const res = await post(stubEnv({ user: { ...USER, role: "admin,support" } }), {
-      grants: [{ workspace: "acme", scopes: ["admin:read"] }],
+      grants: [{ workspace: "acme", scopes: ["operator:read"] }],
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as { scopes: string[] };
-    expect(body.scopes).toEqual(["admin:read"]);
+    expect(body.scopes).toEqual(["operator:read"]);
   });
 
-  it("never includes admin scopes in the default mint", async () => {
+  it("never includes operator scopes in the default mint", async () => {
     const res = await post(stubEnv({ user: { ...USER, role: "admin" } }), {
       grants: [{ workspace: "acme" }],
     });

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -20,7 +20,7 @@ import {
   validateScopes,
   DEFAULT_TOKEN_SECONDS,
   MAX_TOKEN_SECONDS,
-  type AdminScope,
+  type OperatorScope,
   type FileScope,
 } from "../auth-db";
 import { allowWrite } from "../guards";
@@ -37,13 +37,13 @@ const MAX_BODY_BYTES = 4096;
 const MAX_LABEL_LEN = 200;
 // Scopes a mint defaults to when the grant omits them — read+write, but not
 // delete (least surprise; the CLI sends explicit scopes anyway). Never
-// includes admin scopes — those must be explicitly requested and are gated on
+// includes operator scopes — those must be explicitly requested and are gated on
 // the minting user's admin role (see the mint handler below).
 const DEFAULT_MINT_SCOPES: FileScope[] = ["files:read", "files:write"];
 
 interface Grant {
   workspace: string;
-  scopes: (FileScope | AdminScope)[];
+  scopes: (FileScope | OperatorScope)[];
 }
 
 /**
@@ -51,14 +51,14 @@ interface Grant {
  * Throws ValidationError (400) on any malformed input. `grants` is an array by
  * contract, but v1 permits exactly one entry.
  *
- * `allowAdmin` gates whether admin:* scopes are accepted at all — callers
+ * `allowOperator` gates whether operator:* scopes are accepted at all — callers
  * pass this only when the session user holds the admin role, so a non-admin
- * requesting an admin scope fails the same `invalid_scopes` validation as any
+ * requesting an operator scope fails the same `invalid_scopes` validation as any
  * other unknown scope (issue #257 spec), not a distinct 403.
  */
 function parseMintRequest(
   parsed: unknown,
-  opts: { allowAdmin: boolean },
+  opts: { allowOperator: boolean },
 ): {
   grant: Grant;
   label?: string;
@@ -91,7 +91,7 @@ function parseMintRequest(
     throw new ValidationError("grant.workspace is invalid", { code: "invalid_workspace" });
   }
   const scopes = validateScopes(grantObj.scopes, DEFAULT_MINT_SCOPES, {
-    allowAdmin: opts.allowAdmin,
+    allowOperator: opts.allowOperator,
   });
   if (scopes === null) {
     throw new ValidationError("grant.scopes contains an unknown scope", { code: "invalid_scopes" });
@@ -170,7 +170,7 @@ export const tokens = new Hono<SessionVars>()
     // requireSessionUser guarantees this is set.
     const user = c.get("sessionUser")!;
     const { grant, label, ttlSeconds } = parseMintRequest(parsed, {
-      allowAdmin: userHasAdminRole(user),
+      allowOperator: userHasAdminRole(user),
     });
 
     // Three independent lookups — resolve them concurrently, then gate. The

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -20,30 +20,46 @@ import {
   validateScopes,
   DEFAULT_TOKEN_SECONDS,
   MAX_TOKEN_SECONDS,
+  type AdminScope,
   type FileScope,
 } from "../auth-db";
 import { allowWrite } from "../guards";
 import { membershipsForUser, orgForWorkspace } from "../org-workspaces";
-import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
+import {
+  requireSessionUser,
+  sessionAuth,
+  userHasAdminRole,
+  type SessionVars,
+} from "../session-auth";
 import { loadWorkspaceRecord, WS_NAME_RE } from "../workspace";
 
 const MAX_BODY_BYTES = 4096;
 const MAX_LABEL_LEN = 200;
 // Scopes a mint defaults to when the grant omits them — read+write, but not
-// delete (least surprise; the CLI sends explicit scopes anyway).
+// delete (least surprise; the CLI sends explicit scopes anyway). Never
+// includes admin scopes — those must be explicitly requested and are gated on
+// the minting user's admin role (see the mint handler below).
 const DEFAULT_MINT_SCOPES: FileScope[] = ["files:read", "files:write"];
 
 interface Grant {
   workspace: string;
-  scopes: FileScope[];
+  scopes: (FileScope | AdminScope)[];
 }
 
 /**
  * Validate the request body into a single normalized grant + label/ttl.
  * Throws ValidationError (400) on any malformed input. `grants` is an array by
  * contract, but v1 permits exactly one entry.
+ *
+ * `allowAdmin` gates whether admin:* scopes are accepted at all — callers
+ * pass this only when the session user holds the admin role, so a non-admin
+ * requesting an admin scope fails the same `invalid_scopes` validation as any
+ * other unknown scope (issue #257 spec), not a distinct 403.
  */
-function parseMintRequest(parsed: unknown): {
+function parseMintRequest(
+  parsed: unknown,
+  opts: { allowAdmin: boolean },
+): {
   grant: Grant;
   label?: string;
   ttlSeconds: number;
@@ -74,7 +90,9 @@ function parseMintRequest(parsed: unknown): {
   if (!WS_NAME_RE.test(workspace)) {
     throw new ValidationError("grant.workspace is invalid", { code: "invalid_workspace" });
   }
-  const scopes = validateScopes(grantObj.scopes, DEFAULT_MINT_SCOPES);
+  const scopes = validateScopes(grantObj.scopes, DEFAULT_MINT_SCOPES, {
+    allowAdmin: opts.allowAdmin,
+  });
   if (scopes === null) {
     throw new ValidationError("grant.scopes contains an unknown scope", { code: "invalid_scopes" });
   }
@@ -149,10 +167,11 @@ export const tokens = new Hono<SessionVars>()
       throw new ValidationError("request body must be valid JSON", { code: "invalid_request" });
     }
 
-    const { grant, label, ttlSeconds } = parseMintRequest(parsed);
-
     // requireSessionUser guarantees this is set.
     const user = c.get("sessionUser")!;
+    const { grant, label, ttlSeconds } = parseMintRequest(parsed, {
+      allowAdmin: userHasAdminRole(user),
+    });
 
     // Three independent lookups — resolve them concurrently, then gate. The
     // workspace must exist as a KV tenant record (a token is meaningless

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -5,6 +5,7 @@ import {
   requireAdminUser,
   requireSessionUser,
   sessionAuth,
+  userHasAdminRole,
   type SessionVars,
 } from "./session-auth";
 
@@ -97,5 +98,37 @@ describe("sessionAuth", () => {
     const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
     const res = await appWith(auth).request("/private", {}, env(auth));
     expect(res.status).toBe(401);
+  });
+
+  it("allows requireAdminUser for a multi-role user (comma-separated role)", async () => {
+    const user = { id: "u3", email: "admin2@b.com", name: "Admin2", role: "admin,support" };
+    const auth = stubAuth(
+      () => new Response(JSON.stringify({ session: {}, user }), { status: 200 }),
+    );
+    const res = await appWith(auth).request("/admin-only", {}, env(auth));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("userHasAdminRole", () => {
+  it("returns false for null/undefined user or role", () => {
+    expect(userHasAdminRole(null)).toBe(false);
+    expect(userHasAdminRole({ id: "1", email: "a@b.com", name: "A" })).toBe(false);
+  });
+
+  it("returns true for an exact 'admin' role", () => {
+    expect(userHasAdminRole({ id: "1", email: "a@b.com", name: "A", role: "admin" })).toBe(true);
+  });
+
+  it("returns true for a comma-separated role list containing 'admin'", () => {
+    expect(userHasAdminRole({ id: "1", email: "a@b.com", name: "A", role: "support,admin" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false when 'admin' is not among the roles", () => {
+    expect(userHasAdminRole({ id: "1", email: "a@b.com", name: "A", role: "support,editor" })).toBe(
+      false,
+    );
   });
 });

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -91,10 +91,22 @@ export const requireSessionUser: MiddlewareHandler<SessionVars> = async (c, next
   await next();
 };
 
+/**
+ * Better Auth supports comma-separated multi-role strings (e.g.
+ * `"admin,support"`); mirrors `hasAdminRole` in apps/auth/src/auth.ts.
+ */
+export function userHasAdminRole(user: SessionUser | null | undefined): boolean {
+  if (!user?.role) return false;
+  return user.role
+    .split(",")
+    .map((r) => r.trim())
+    .includes("admin");
+}
+
 /** 403s unless the session user has the global `admin` role (D3's admin plugin). */
 export const requireAdminUser: MiddlewareHandler<SessionVars> = async (c, next) => {
   const user = c.get("sessionUser");
   if (!user) throw new UnauthorizedError();
-  if (user.role !== "admin") throw new ForbiddenError("admin role required");
+  if (!userHasAdminRole(user)) throw new ForbiddenError("admin role required");
   await next();
 };

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -680,6 +680,69 @@ describe("GET ?metadata=1 / PATCH /v1/:workspace/files/:key", () => {
     expect(json.error.type).toBe("insufficient_scope");
   });
 
+  it("a token mixing an admin scope with a file scope grants no extra file permissions (issue #257)", async () => {
+    // Regression for #257: a token minted with scopes ["files:read",
+    // "admin:write"] must never grant the file route any more than a
+    // files:read-only token would. `parseScopes` (auth-db.ts) requires
+    // *every* entry in the stored array to be a valid FileScope
+    // (`parsed.every(isFileScope)`), so the presence of the admin:write
+    // scope makes the whole array fail validation and workspaceAuth
+    // (workspace.ts) resolves `authScopes` to `[]` — fail-closed, not a
+    // partial grant of files:read. Both PUT (files:write) and PATCH
+    // (files:write) must stay 403, and — importantly — this token gets
+    // *no* files:read reach either, confirming admin:write cannot be used
+    // to smuggle in any file permission, read or write.
+    const MIXED_TOKEN = "files-read-plus-admin-write-token";
+    const { env } = await makeEnv(
+      {},
+      { scopedToken: { rawToken: MIXED_TOKEN, scopes: ["files:read", "admin:write"] } },
+    );
+    await putShot(env);
+
+    // The mixed-scope token has no read access: the admin scope poisons the
+    // whole scope set rather than being silently dropped in isolation.
+    const get = await getMeta(env, "screenshots/shot.png", MIXED_TOKEN);
+    expect(get.status).toBe(403);
+    const getJson = (await get.json()) as { error: { type: string } };
+    expect(getJson.error.type).toBe("insufficient_scope");
+
+    // Nor does it get file-write access via the admin:write scope.
+    const patch = await patchMeta(
+      env,
+      "screenshots/shot.png",
+      { set: { app: "web" } },
+      MIXED_TOKEN,
+    );
+    expect(patch.status).toBe(403);
+    const patchJson = (await patch.json()) as { error: { type: string } };
+    expect(patchJson.error.type).toBe("insufficient_scope");
+
+    // Same for a raw PUT (also requires files:write).
+    const put = await app.request(
+      "/v1/default/files/screenshots/shot.png",
+      {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${MIXED_TOKEN}`, "Content-Type": "image/png" },
+        body: PNG,
+      },
+      env,
+    );
+    expect(put.status).toBe(403);
+    const putJson = (await put.json()) as { error: { type: string } };
+    expect(putJson.error.type).toBe("insufficient_scope");
+  });
+
+  it("a plain files:read-only token still gets file-route read access (baseline for the mixed-scope case above)", async () => {
+    const READ_ONLY_TOKEN = "files-read-only-token";
+    const { env } = await makeEnv(
+      {},
+      { scopedToken: { rawToken: READ_ONLY_TOKEN, scopes: ["files:read"] } },
+    );
+    await putShot(env);
+    const get = await getMeta(env, "screenshots/shot.png", READ_ONLY_TOKEN);
+    expect(get.status).toBe(200);
+  });
+
   it("GET ?metadata=1 / PATCH round-trip on a key with several raw slashes", async () => {
     const { env } = await makeEnv();
     const deepKey = "a/b/c/d/deep.png";

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -680,33 +680,33 @@ describe("GET ?metadata=1 / PATCH /v1/:workspace/files/:key", () => {
     expect(json.error.type).toBe("insufficient_scope");
   });
 
-  it("a token mixing an admin scope with a file scope grants no extra file permissions (issue #257)", async () => {
+  it("a token mixing an operator scope with a file scope grants no extra file permissions (issue #257)", async () => {
     // Regression for #257: a token minted with scopes ["files:read",
-    // "admin:write"] must never grant the file route any more than a
+    // "operator:write"] must never grant the file route any more than a
     // files:read-only token would. `parseScopes` (auth-db.ts) requires
     // *every* entry in the stored array to be a valid FileScope
-    // (`parsed.every(isFileScope)`), so the presence of the admin:write
+    // (`parsed.every(isFileScope)`), so the presence of the operator:write
     // scope makes the whole array fail validation and workspaceAuth
     // (workspace.ts) resolves `authScopes` to `[]` — fail-closed, not a
     // partial grant of files:read. Both PUT (files:write) and PATCH
     // (files:write) must stay 403, and — importantly — this token gets
-    // *no* files:read reach either, confirming admin:write cannot be used
+    // *no* files:read reach either, confirming operator:write cannot be used
     // to smuggle in any file permission, read or write.
-    const MIXED_TOKEN = "files-read-plus-admin-write-token";
+    const MIXED_TOKEN = "files-read-plus-operator-write-token";
     const { env } = await makeEnv(
       {},
-      { scopedToken: { rawToken: MIXED_TOKEN, scopes: ["files:read", "admin:write"] } },
+      { scopedToken: { rawToken: MIXED_TOKEN, scopes: ["files:read", "operator:write"] } },
     );
     await putShot(env);
 
-    // The mixed-scope token has no read access: the admin scope poisons the
+    // The mixed-scope token has no read access: the operator scope poisons the
     // whole scope set rather than being silently dropped in isolation.
     const get = await getMeta(env, "screenshots/shot.png", MIXED_TOKEN);
     expect(get.status).toBe(403);
     const getJson = (await get.json()) as { error: { type: string } };
     expect(getJson.error.type).toBe("insufficient_scope");
 
-    // Nor does it get file-write access via the admin:write scope.
+    // Nor does it get file-write access via the operator:write scope.
     const patch = await patchMeta(
       env,
       "screenshots/shot.png",

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -76,19 +76,19 @@ curl -XDELETE https://api.uploads.sh/admin/tokens \
 ## Operator scopes
 
 Better-auth admins can also mint their own workspace tokens with opt-in
-`admin:read` / `admin:write` scopes via the session-authed `POST /v1/tokens`
-(no `ADMIN_TOKEN` involved). `admin:write` is a superset of `admin:read`.
+`operator:read` / `operator:write` scopes via the session-authed `POST /v1/tokens`
+(no `ADMIN_TOKEN` involved). `operator:write` is a superset of `operator:read`.
 Tokens carrying either scope are accepted by `/admin/*` alongside
 `ADMIN_TOKEN`, and are revoked or listed the same way as any other token —
 via the `GET`/`DELETE /admin/tokens` endpoints above. Although an operator
 token is minted against (and stored under) a specific workspace, the
-`admin:read` / `admin:write` scopes themselves grant global operator
+`operator:read` / `operator:write` scopes themselves grant global operator
 authority across all of `/admin/*` — the same reach as `ADMIN_TOKEN` — not
-just admin access scoped to that one workspace; the workspace only anchors
+just operator access scoped to that one workspace; the workspace only anchors
 where the token is stored and which workspace's token list it appears
 under for revocation.
 
-Note that a token minted with an admin scope gets **no** file-route access,
+Note that a token minted with an operator scope gets **no** file-route access,
 even if file scopes were also requested alongside it — scope parsing on the
 file routes fails the whole scope array when it contains any non-file
 scope. Mint a separate files-only token for file operations and a

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -72,3 +72,12 @@ curl -XDELETE https://api.uploads.sh/admin/tokens \
   -d '{"workspace":"default","hashPrefix":"a1b2c3d4"}'
 # or: -d '{"workspace":"default","label":"ci"}'
 ```
+
+## Operator scopes
+
+Better-auth admins can also mint their own workspace tokens with opt-in
+`admin:read` / `admin:write` scopes via the session-authed `POST /v1/tokens`
+(no `ADMIN_TOKEN` involved). `admin:write` is a superset of `admin:read`.
+Tokens carrying either scope are accepted by `/admin/*` alongside
+`ADMIN_TOKEN`, and are revoked or listed the same way as any other token —
+via the `GET`/`DELETE /admin/tokens` endpoints above.

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -80,4 +80,10 @@ Better-auth admins can also mint their own workspace tokens with opt-in
 (no `ADMIN_TOKEN` involved). `admin:write` is a superset of `admin:read`.
 Tokens carrying either scope are accepted by `/admin/*` alongside
 `ADMIN_TOKEN`, and are revoked or listed the same way as any other token —
-via the `GET`/`DELETE /admin/tokens` endpoints above.
+via the `GET`/`DELETE /admin/tokens` endpoints above. Although an operator
+token is minted against (and stored under) a specific workspace, the
+`admin:read` / `admin:write` scopes themselves grant global operator
+authority across all of `/admin/*` — the same reach as `ADMIN_TOKEN` — not
+just admin access scoped to that one workspace; the workspace only anchors
+where the token is stored and which workspace's token list it appears
+under for revocation.

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -87,3 +87,9 @@ authority across all of `/admin/*` — the same reach as `ADMIN_TOKEN` — not
 just admin access scoped to that one workspace; the workspace only anchors
 where the token is stored and which workspace's token list it appears
 under for revocation.
+
+Note that a token minted with an admin scope gets **no** file-route access,
+even if file scopes were also requested alongside it — scope parsing on the
+file routes fails the whole scope array when it contains any non-file
+scope. Mint a separate files-only token for file operations and a
+dedicated operator token for `/admin/*`.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -6,6 +6,14 @@ import { buildScreenshotKey } from "./keys.js";
 import { packageVersion } from "./package-version.js";
 import { resolveEmbedUrl } from "./public-urls.js";
 
+/** Scoped-operator-token permission scope. */
+export type TokenScope =
+  | "files:read"
+  | "files:write"
+  | "files:delete"
+  | "operator:read"
+  | "operator:write";
+
 /** Allowlisted object provenance (maps to X-Uploads-Meta-* on put). */
 export type ProvenanceInput = {
   client?: string;
@@ -244,9 +252,7 @@ export interface EnrollmentExchangeResult {
   apiUrl?: string;
   workspace: string;
   token: string;
-  scopes?: Array<
-    "files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write"
-  >;
+  scopes?: Array<TokenScope>;
   expiresAt?: string;
 }
 
@@ -293,9 +299,7 @@ export function createEnrollment(
     email?: string;
     enrollmentSeconds?: number;
     tokenExpiresInSeconds?: number;
-    scopes?: Array<
-      "files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write"
-    >;
+    scopes?: Array<TokenScope>;
   },
 ): Promise<EnrollmentCreateResult> {
   return jsonRequest(`${apiUrl.replace(/\/$/, "")}/admin/enrollments`, {
@@ -490,7 +494,7 @@ export async function createWorkspaceRequest(
 export interface MintTokenResult {
   token: string;
   workspace: string;
-  scopes: Array<"files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write">;
+  scopes: Array<TokenScope>;
   label: string | null;
   expiresAt: string | null;
 }
@@ -534,9 +538,7 @@ export function mintWorkspaceToken(
   accessToken: string,
   input: {
     workspace: string;
-    scopes?: Array<
-      "files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write"
-    >;
+    scopes?: Array<TokenScope>;
     label?: string;
     ttlSeconds?: number;
   },

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -244,7 +244,7 @@ export interface EnrollmentExchangeResult {
   apiUrl?: string;
   workspace: string;
   token: string;
-  scopes?: Array<"files:read" | "files:write" | "files:delete">;
+  scopes?: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
   expiresAt?: string;
 }
 
@@ -291,7 +291,7 @@ export function createEnrollment(
     email?: string;
     enrollmentSeconds?: number;
     tokenExpiresInSeconds?: number;
-    scopes?: Array<"files:read" | "files:write" | "files:delete">;
+    scopes?: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
   },
 ): Promise<EnrollmentCreateResult> {
   return jsonRequest(`${apiUrl.replace(/\/$/, "")}/admin/enrollments`, {
@@ -486,7 +486,7 @@ export async function createWorkspaceRequest(
 export interface MintTokenResult {
   token: string;
   workspace: string;
-  scopes: Array<"files:read" | "files:write" | "files:delete">;
+  scopes: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
   label: string | null;
   expiresAt: string | null;
 }
@@ -530,7 +530,7 @@ export function mintWorkspaceToken(
   accessToken: string,
   input: {
     workspace: string;
-    scopes?: Array<"files:read" | "files:write" | "files:delete">;
+    scopes?: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
     label?: string;
     ttlSeconds?: number;
   },

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -244,7 +244,9 @@ export interface EnrollmentExchangeResult {
   apiUrl?: string;
   workspace: string;
   token: string;
-  scopes?: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
+  scopes?: Array<
+    "files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write"
+  >;
   expiresAt?: string;
 }
 
@@ -291,7 +293,9 @@ export function createEnrollment(
     email?: string;
     enrollmentSeconds?: number;
     tokenExpiresInSeconds?: number;
-    scopes?: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
+    scopes?: Array<
+      "files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write"
+    >;
   },
 ): Promise<EnrollmentCreateResult> {
   return jsonRequest(`${apiUrl.replace(/\/$/, "")}/admin/enrollments`, {
@@ -486,7 +490,7 @@ export async function createWorkspaceRequest(
 export interface MintTokenResult {
   token: string;
   workspace: string;
-  scopes: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
+  scopes: Array<"files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write">;
   label: string | null;
   expiresAt: string | null;
 }
@@ -530,7 +534,9 @@ export function mintWorkspaceToken(
   accessToken: string,
   input: {
     workspace: string;
-    scopes?: Array<"files:read" | "files:write" | "files:delete" | "admin:read" | "admin:write">;
+    scopes?: Array<
+      "files:read" | "files:write" | "files:delete" | "operator:read" | "operator:write"
+    >;
     label?: string;
     ttlSeconds?: number;
   },


### PR DESCRIPTION
Implements #257: admins can mint workspace tokens carrying opt-in operator scopes (`operator:read`, `operator:write`) via `POST /v1/tokens`, and `/admin/*` accepts those tokens alongside the static `ADMIN_TOKEN` — giving per-token revocation, labels, and attribution (`minting_user_id`) instead of only the shared break-glass secret.

## What changed

- **`apps/api/src/auth-db.ts`** — new `OPERATOR_SCOPES` (`operator:read`, `operator:write`), `isOperatorScope`, and a `validateScopes(..., { allowOperator })` overload. All existing callers (`/admin/tokens`, enrollments, admin-ui invite links) stay file-scopes-only.
- **`apps/api/src/routes/tokens.ts`** — mint requests that include admin scopes require the session user to hold the better-auth `admin` role; non-admins get 400 `invalid_scopes`. Default mint scopes are unchanged (`files:read`, `files:write`) — admin scopes are never implicit.
- **`apps/api/src/session-auth.ts`** — new `userHasAdminRole` using better-auth comma-split multi-role semantics; `requireAdminUser` now uses it (fixes a pre-existing bug where a `"admin,support"` role was rejected).
- **`apps/api/src/admin.ts`** — `adminAuth` now accepts D1-backed operator tokens after the timing-safe `ADMIN_TOKEN` check: `operator:read` grants GET/HEAD, `operator:write` grants everything (superset). Revoked/expired/files-only/legacy-null-scope tokens are rejected fail-closed. `ADMIN_TOKEN` behavior is unchanged and remains break-glass; scoped tokens also work when `ADMIN_TOKEN` is unset.
- **`packages/uploads`** — client scope unions widened to allow the new scopes (no new commands/flags); patch changeset included.
- **`docs/admin-tokens.md`** — operator-scopes section, including two sharp edges: operator authority is global across `/admin/*` (the minted workspace only anchors storage/revocation), and a token carrying an admin scope gets **no** file-route access (file-route scope parsing fails closed on any non-file scope) — mint separate tokens.

## Guardrails (per issue)

- `apps/auth` is completely untouched — nothing here lands in `OAUTH_SCOPES`, so DCR-registered MCP clients cannot request admin scopes.
- Note: this deliberately relaxes the prior "`/admin/*` is bearer-token-only and deliberately untouched" boundary noted in `apps/api/src/index.ts`; the comment there is updated.

## Testing

- `pnpm test` at repo root: 131 files / 1477 tests passing (includes new coverage: role gating incl. multi-role, default-mint safety, read/write scope mapping on `/admin/*`, revoked/expired/files-only rejection, no-`ADMIN_TOKEN` operation, and a regression pinning mixed-scope tokens to zero file-route access).

Closes #257

> Naming note: scopes were renamed from `admin:*` to `operator:*` mid-review — they express platform-wide operator authority, distinct from the (weaker) workspace-admin org role. The better-auth `admin` user role, `/admin/*` paths, and `ADMIN_TOKEN` keep their names.
