### PR TITLE
feat(api): workspace-governance token scopes for the org-admin tier (#262)

### DIFF
--- a/.changeset/workspace-governance-scope-widening.md
+++ b/.changeset/workspace-governance-scope-widening.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Widen the token-mint scope types to accept `"workspace:invite"` and `"workspace:manage"` alongside the existing file and operator scopes, so CLI/SDK callers can request org-admin-gated workspace-governance scopes minted via `POST /v1/tokens` (#262). No new commands or flags.

--- a/apps/api/src/auth-db.test.ts
+++ b/apps/api/src/auth-db.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWorkspaceScope,
+  parseScopes,
+  validateScopes,
+  WORKSPACE_SCOPES,
+  type FileScope,
+} from "./auth-db";
+
+const DEFAULTS: FileScope[] = ["files:read", "files:write"];
+
+describe("isWorkspaceScope (#262)", () => {
+  it("recognizes workspace:invite and workspace:manage", () => {
+    for (const scope of WORKSPACE_SCOPES) {
+      expect(isWorkspaceScope(scope)).toBe(true);
+    }
+  });
+
+  it("rejects unrelated strings", () => {
+    expect(isWorkspaceScope("files:read")).toBe(false);
+    expect(isWorkspaceScope("operator:read")).toBe(false);
+    expect(isWorkspaceScope("workspace:nuke")).toBe(false);
+  });
+});
+
+describe("validateScopes allowWorkspace gating (#262)", () => {
+  it("rejects workspace:* scopes when allowWorkspace is omitted (existing callers unchanged)", () => {
+    expect(validateScopes(["workspace:invite"], DEFAULTS)).toBeNull();
+  });
+
+  it("rejects workspace:* scopes when allowWorkspace is false", () => {
+    expect(validateScopes(["workspace:invite"], DEFAULTS, { allowWorkspace: false })).toBeNull();
+  });
+
+  it("accepts workspace:* scopes when allowWorkspace is true", () => {
+    expect(
+      validateScopes(["files:read", "workspace:invite"], DEFAULTS, { allowWorkspace: true }),
+    ).toEqual(["files:read", "workspace:invite"]);
+  });
+
+  it("requires both gates for a mixed operator:* + workspace:* request", () => {
+    // Only allowOperator set -> workspace:* still rejected.
+    expect(
+      validateScopes(["operator:read", "workspace:invite"], DEFAULTS, { allowOperator: true }),
+    ).toBeNull();
+    // Only allowWorkspace set -> operator:* still rejected.
+    expect(
+      validateScopes(["operator:read", "workspace:invite"], DEFAULTS, { allowWorkspace: true }),
+    ).toBeNull();
+    // Both set -> accepted.
+    expect(
+      validateScopes(["operator:read", "workspace:invite"], DEFAULTS, {
+        allowOperator: true,
+        allowWorkspace: true,
+      }),
+    ).toEqual(["operator:read", "workspace:invite"]);
+  });
+});
+
+describe("parseScopes fail-closed for governance scopes (#262)", () => {
+  it("rejects an array containing a workspace:* scope — a governance token has zero file access", () => {
+    expect(parseScopes(JSON.stringify(["workspace:invite"]))).toEqual([]);
+  });
+
+  it("rejects a mixed file + workspace:* array (no partial file access)", () => {
+    expect(parseScopes(JSON.stringify(["files:read", "workspace:invite"]))).toEqual([]);
+  });
+
+  it("still parses plain file scopes", () => {
+    expect(parseScopes(JSON.stringify(["files:read"]))).toEqual(["files:read"]);
+  });
+});

--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -15,6 +15,19 @@ export function isOperatorScope(value: unknown): value is OperatorScope {
   return typeof value === "string" && OPERATOR_SCOPES.includes(value as OperatorScope);
 }
 
+// Workspace-governance scopes for session-minted tokens (issue #262). Like
+// OPERATOR_SCOPES, never granted by default — only when explicitly requested
+// by a session user holding org role `admin`/`owner` in the target workspace
+// (see routes/tokens.ts mint handler). A `workspace:*` token authorizes
+// governance actions (e.g. inviting members) only on the workspace embedded
+// in the token; it carries zero file access (parseScopes rejects it outright).
+export const WORKSPACE_SCOPES = ["workspace:invite", "workspace:manage"] as const;
+export type WorkspaceScope = (typeof WORKSPACE_SCOPES)[number];
+
+export function isWorkspaceScope(value: unknown): value is WorkspaceScope {
+  return typeof value === "string" && WORKSPACE_SCOPES.includes(value as WorkspaceScope);
+}
+
 // Invite code lifetime. 2h gives a human time to onboard after receiving the
 // link out-of-band, while keeping the single-use secret short-lived. Override
 // per-invite with --expires-in up to MAX_ENROLLMENT_SECONDS (see routes/admin).
@@ -67,20 +80,21 @@ export function validateScopes(value: unknown, defaults: FileScope[]): FileScope
 export function validateScopes(
   value: unknown,
   defaults: FileScope[],
-  opts: { allowOperator?: boolean },
-): (FileScope | OperatorScope)[] | null;
+  opts: { allowOperator?: boolean; allowWorkspace?: boolean },
+): (FileScope | OperatorScope | WorkspaceScope)[] | null;
 export function validateScopes(
   value: unknown,
   defaults: FileScope[],
-  opts?: { allowOperator?: boolean },
-): (FileScope | OperatorScope)[] | null {
+  opts?: { allowOperator?: boolean; allowWorkspace?: boolean },
+): (FileScope | OperatorScope | WorkspaceScope)[] | null {
   if (value === undefined) return defaults;
   if (!Array.isArray(value) || value.length === 0) return null;
-  const isValid = opts?.allowOperator
-    ? (v: unknown) => isFileScope(v) || isOperatorScope(v)
-    : isFileScope;
+  const isValid = (v: unknown) =>
+    isFileScope(v) ||
+    (opts?.allowOperator === true && isOperatorScope(v)) ||
+    (opts?.allowWorkspace === true && isWorkspaceScope(v));
   if (!value.every(isValid)) return null;
-  return [...new Set(value)] as (FileScope | OperatorScope)[];
+  return [...new Set(value)] as (FileScope | OperatorScope | WorkspaceScope)[];
 }
 
 function randomSecret(prefix: string, bytes = 24): string {
@@ -120,9 +134,10 @@ export async function createToken(
   input: {
     workspace: string;
     label?: string;
-    // Widened beyond FileScope so admin-scoped operator tokens (issue #257)
-    // can be minted through the same path; storage is just a JSON TEXT column.
-    scopes: (FileScope | OperatorScope)[];
+    // Widened beyond FileScope so admin-scoped operator tokens (issue #257) and
+    // workspace-governance tokens (issue #262) can be minted through the same
+    // path; storage is just a JSON TEXT column.
+    scopes: (FileScope | OperatorScope | WorkspaceScope)[];
     expiresAt?: Date;
     mintedByUserId?: string | null;
     now?: Date;

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -95,8 +95,16 @@ function requireUserId(c: Context<SessionVars>): string {
   return userId;
 }
 
-/** Membership admin|owner for this workspace — 404 if not a member, 403 if member but not privileged. */
-async function adminWorkspaceOr403(env: Env, userId: string, name: string): Promise<MyWorkspace> {
+/**
+ * Membership admin|owner for this workspace — 404 if not a member, 403 if
+ * member but not privileged. Exported for reuse by the self-serve token
+ * governance dual-auth guard (`workspaces.ts`, issue #262 Task 3).
+ */
+export async function adminWorkspaceOr403(
+  env: Env,
+  userId: string,
+  name: string,
+): Promise<MyWorkspace> {
   const ws = await memberWorkspaceOr404(env, userId, name);
   if (ws.role !== "admin" && ws.role !== "owner") {
     throw new ForbiddenError("workspace admin or owner role required", {

--- a/apps/api/src/routes/tokens.test.ts
+++ b/apps/api/src/routes/tokens.test.ts
@@ -322,3 +322,102 @@ describe("POST /v1/tokens operator scopes", () => {
     expect(body.scopes).toEqual(["files:read", "files:write"]);
   });
 });
+
+describe("POST /v1/tokens workspace-governance scopes (#262)", () => {
+  it("400s when an org member (not admin/owner) requests workspace:invite", async () => {
+    const res = await post(
+      stubEnv({
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "member" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["workspace:invite"] }] },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_scopes" },
+    });
+  });
+
+  it("201s when the caller is an org admin in the target workspace", async () => {
+    const res = await post(
+      stubEnv({
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "admin" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["workspace:invite"] }] },
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["workspace:invite"]);
+  });
+
+  it("201s when the caller is an org owner in the target workspace", async () => {
+    const res = await post(
+      stubEnv({
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "owner" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["workspace:manage"] }] },
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["workspace:manage"]);
+  });
+
+  it("400s for a platform admin without an org admin/owner role in the workspace — no bypass", async () => {
+    const res = await post(
+      stubEnv({
+        user: { ...USER, role: "admin" },
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "member" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["workspace:invite"] }] },
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_scopes" },
+    });
+  });
+
+  it("never includes workspace scopes in the default mint, even for an org owner", async () => {
+    const res = await post(
+      stubEnv({
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "owner" }],
+      }),
+      { grants: [{ workspace: "acme" }] },
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["files:read", "files:write"]);
+  });
+
+  it("requires both gates for a mixed operator:* + workspace:* request", async () => {
+    // Org owner (workspace gate passes) but non-admin platform role (operator gate fails).
+    const failsOperatorGate = await post(
+      stubEnv({
+        user: { ...USER, role: "user" },
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "owner" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["operator:read", "workspace:invite"] }] },
+    );
+    expect(failsOperatorGate.status).toBe(400);
+
+    // Platform admin (operator gate passes) but plain member (workspace gate fails).
+    const failsWorkspaceGate = await post(
+      stubEnv({
+        user: { ...USER, role: "admin" },
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "member" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["operator:read", "workspace:invite"] }] },
+    );
+    expect(failsWorkspaceGate.status).toBe(400);
+
+    // Both gates pass.
+    const bothPass = await post(
+      stubEnv({
+        user: { ...USER, role: "admin" },
+        memberships: [{ organizationId: ORG.id, organizationSlug: ORG.slug, role: "owner" }],
+      }),
+      { grants: [{ workspace: "acme", scopes: ["operator:read", "workspace:invite"] }] },
+    );
+    expect(bothPass.status).toBe(201);
+    const body = (await bothPass.json()) as { scopes: string[] };
+    expect(body.scopes).toEqual(["operator:read", "workspace:invite"]);
+  });
+});

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -20,7 +20,6 @@ import {
   validateScopes,
   DEFAULT_TOKEN_SECONDS,
   MAX_TOKEN_SECONDS,
-  type OperatorScope,
   type FileScope,
 } from "../auth-db";
 import { allowWrite } from "../guards";
@@ -41,26 +40,24 @@ const MAX_LABEL_LEN = 200;
 // the minting user's admin role (see the mint handler below).
 const DEFAULT_MINT_SCOPES: FileScope[] = ["files:read", "files:write"];
 
-interface Grant {
+interface RawGrant {
   workspace: string;
-  scopes: (FileScope | OperatorScope)[];
+  rawScopes: unknown;
 }
 
 /**
- * Validate the request body into a single normalized grant + label/ttl.
- * Throws ValidationError (400) on any malformed input. `grants` is an array by
- * contract, but v1 permits exactly one entry.
+ * Parse the request body into a normalized (but not-yet-scope-validated)
+ * grant + label/ttl. Throws ValidationError (400) on any malformed input.
+ * `grants` is an array by contract, but v1 permits exactly one entry.
  *
- * `allowOperator` gates whether operator:* scopes are accepted at all — callers
- * pass this only when the session user holds the admin role, so a non-admin
- * requesting an operator scope fails the same `invalid_scopes` validation as any
- * other unknown scope (issue #257 spec), not a distinct 403.
+ * Scope validation is deferred to the caller (see the mint handler below):
+ * whether operator:* / workspace:* scopes are acceptable depends on the
+ * session user's admin role (operator) and, for workspace:* scopes, on the
+ * caller's org role in the *target workspace* — which this function doesn't
+ * resolve. That keeps this parser a pure structural check.
  */
-function parseMintRequest(
-  parsed: unknown,
-  opts: { allowOperator: boolean },
-): {
-  grant: Grant;
+function parseMintRequest(parsed: unknown): {
+  grant: RawGrant;
   label?: string;
   ttlSeconds: number;
 } {
@@ -90,13 +87,6 @@ function parseMintRequest(
   if (!WS_NAME_RE.test(workspace)) {
     throw new ValidationError("grant.workspace is invalid", { code: "invalid_workspace" });
   }
-  const scopes = validateScopes(grantObj.scopes, DEFAULT_MINT_SCOPES, {
-    allowOperator: opts.allowOperator,
-  });
-  if (scopes === null) {
-    throw new ValidationError("grant.scopes contains an unknown scope", { code: "invalid_scopes" });
-  }
-
   let label: string | undefined;
   if (body.label !== undefined) {
     if (typeof body.label !== "string") {
@@ -129,7 +119,7 @@ function parseMintRequest(
     ttlSeconds = body.ttlSeconds;
   }
 
-  return { grant: { workspace, scopes }, label, ttlSeconds };
+  return { grant: { workspace, rawScopes: grantObj.scopes }, label, ttlSeconds };
 }
 
 export const tokens = new Hono<SessionVars>()
@@ -169,9 +159,7 @@ export const tokens = new Hono<SessionVars>()
 
     // requireSessionUser guarantees this is set.
     const user = c.get("sessionUser")!;
-    const { grant, label, ttlSeconds } = parseMintRequest(parsed, {
-      allowOperator: userHasAdminRole(user),
-    });
+    const { grant, label, ttlSeconds } = parseMintRequest(parsed);
 
     // Three independent lookups — resolve them concurrently, then gate. The
     // workspace must exist as a KV tenant record (a token is meaningless
@@ -184,8 +172,25 @@ export const tokens = new Hono<SessionVars>()
       orgForWorkspace(c.env, grant.workspace),
       membershipsForUser(c.env, user.id),
     ]);
-    if (!record || !org || !memberships.some((m) => m.organizationId === org.id)) {
+    const membership = org ? memberships.find((m) => m.organizationId === org.id) : undefined;
+    if (!record || !org || !membership) {
       throw new ForbiddenError("no access to this workspace", { code: "workspace_forbidden" });
+    }
+
+    // workspace:* scopes require the caller's org role in THIS workspace to be
+    // admin/owner (string check matching adminWorkspaceOr403 in routes/me.ts).
+    // Platform-admin role does NOT bypass this — operators already have
+    // /admin-ui, so a platform admin without an org role here still fails
+    // invalid_scopes, same as any other unauthorized scope request (#262).
+    const allowWorkspace = membership.role === "admin" || membership.role === "owner";
+    const scopes = validateScopes(grant.rawScopes, DEFAULT_MINT_SCOPES, {
+      allowOperator: userHasAdminRole(user),
+      allowWorkspace,
+    });
+    if (scopes === null) {
+      throw new ValidationError("grant.scopes contains an unknown scope", {
+        code: "invalid_scopes",
+      });
     }
 
     // Throttle minting per workspace — checked only after the membership gate,
@@ -199,7 +204,7 @@ export const tokens = new Hono<SessionVars>()
     const { token, record: tokenRecord } = await createToken(c.env.DB, {
       workspace: grant.workspace,
       label,
-      scopes: grant.scopes,
+      scopes,
       expiresAt,
       mintedByUserId: user.id,
     });
@@ -208,7 +213,7 @@ export const tokens = new Hono<SessionVars>()
       {
         token,
         workspace: grant.workspace,
-        scopes: grant.scopes,
+        scopes,
         label: tokenRecord.label,
         expiresAt: tokenRecord.expires_at,
       },

--- a/apps/api/src/routes/workspace-governance-invite.test.ts
+++ b/apps/api/src/routes/workspace-governance-invite.test.ts
@@ -1,0 +1,209 @@
+/**
+ * POST /v1/workspaces/:name/invites (issue #262) — token-authed invite via
+ * `workspaceGovernanceAuth`. Follows the `admin-scoped-token.test.ts` idiom
+ * (real SQLite-backed D1 via `createToken`) plus the `stubAuth` idiom from
+ * `me.test.ts`/`workspaces.test.ts` for the AUTH service binding.
+ */
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it } from "vitest";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { createToken } from "../auth-db";
+import { respondError } from "../error-response";
+import { workspaces } from "./workspaces";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+];
+
+const MINTER_ID = "user-minter-1";
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+function appWith(opts: {
+  db: SqliteD1;
+  onInvite?: (body: unknown) => Response | Promise<Response>;
+  orgFound?: boolean;
+}) {
+  const { db, onInvite, orgFound = true } = opts;
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/v1/workspaces", workspaces)
+    .onError((err, c) => respondError(c, err));
+  const auth = stubAuth(async (req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/internal/orgs/acme") {
+      if (!orgFound) return new Response(null, { status: 404 });
+      return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } });
+    }
+    if (url.pathname === "/internal/invite" && req.method === "POST") {
+      const body = await req.json();
+      if (onInvite) return onInvite(body);
+      return Response.json(
+        {
+          invitation: {
+            id: "inv1",
+            organizationId: "org1",
+            email: (body as { email?: string }).email,
+            role: "member",
+            status: "pending",
+          },
+        },
+        { status: 201 },
+      );
+    }
+    return new Response(null, { status: 404 });
+  });
+  const env = { AUTH: auth, DB: database(db) } as unknown as Env;
+  return { app, env };
+}
+
+function inviteRequest(workspace: string, bearer: string, body: Record<string, unknown> = {}) {
+  return new Request(`https://api.uploads.sh/v1/workspaces/${workspace}/invites`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json" },
+    body: JSON.stringify({ email: "t@example.com", ...body }),
+  });
+}
+
+describe("POST /v1/workspaces/:name/invites", () => {
+  it("happy path: workspace:invite token invites, attributed to minting_user_id", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+      mintedByUserId: MINTER_ID,
+    });
+    let captured: unknown;
+    const { app, env } = appWith({
+      db,
+      onInvite: (body) => {
+        captured = body;
+        return Response.json(
+          { invitation: { id: "inv1", email: "t@example.com", status: "pending" } },
+          { status: 201 },
+        );
+      },
+    });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(201);
+    expect(captured).toMatchObject({
+      organizationSlug: "acme",
+      email: "t@example.com",
+      role: "member",
+      inviterUserId: MINTER_ID,
+    });
+  });
+
+  it("foreign-workspace token gets 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "other",
+      scopes: ["workspace:invite"],
+      mintedByUserId: MINTER_ID,
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("minter demoted (auth worker stub rejects) surfaces the error", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+      mintedByUserId: MINTER_ID,
+    });
+    const { app, env } = appWith({
+      db,
+      onInvite: () => Response.json({ error: { code: "inviter_not_authorized" } }, { status: 403 }),
+    });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "inviter_not_authorized" },
+    });
+  });
+
+  it("file-scope token is rejected with 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["files:read", "files:write"],
+      mintedByUserId: MINTER_ID,
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("operator-only token is rejected with 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["operator:write"],
+      mintedByUserId: MINTER_ID,
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("revoked token is rejected with 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token, record } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+      mintedByUserId: MINTER_ID,
+    });
+    await db
+      .prepare(`UPDATE auth_tokens SET revoked_at = ? WHERE id = ?`)
+      .bind(new Date().toISOString(), record.id)
+      .run();
+    const { app, env } = appWith({ db });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("expired token is rejected with 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+      mintedByUserId: MINTER_ID,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("no auth header is rejected with 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db });
+    const res = await app.request(
+      new Request("https://api.uploads.sh/v1/workspaces/acme/invites", { method: "POST" }),
+      {},
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("a governance token has zero file access — parseScopes stays fail-closed", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { record } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite", "workspace:manage"],
+      mintedByUserId: MINTER_ID,
+    });
+    // Import lazily to avoid pulling in unrelated route wiring at module load.
+    const { parseScopes } = await import("../auth-db");
+    expect(parseScopes(record.scopes)).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/workspace-governance-invite.test.ts
+++ b/apps/api/src/routes/workspace-governance-invite.test.ts
@@ -5,7 +5,7 @@
  * `me.test.ts`/`workspaces.test.ts` for the AUTH service binding.
  */
 import { Hono } from "hono";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
 import { createToken } from "../auth-db";
 import { respondError } from "../error-response";
@@ -193,6 +193,21 @@ describe("POST /v1/workspaces/:name/invites", () => {
       env,
     );
     expect(res.status).toBe(401);
+  });
+
+  it("token with no minting_user_id (enrollment-code-derived) is rejected with 403 no_minting_user", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+      // mintedByUserId omitted — mirrors enrollment-code-derived/pre-migration tokens.
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(inviteRequest("acme", token), {}, env);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "no_minting_user" },
+    });
   });
 
   it("a governance token has zero file access — parseScopes stays fail-closed", async () => {

--- a/apps/api/src/routes/workspace-governance-tokens.test.ts
+++ b/apps/api/src/routes/workspace-governance-tokens.test.ts
@@ -175,6 +175,17 @@ describe("GET /v1/workspaces/:name/tokens", () => {
     expect(res.status).toBe(401);
   });
 
+  it("malformed up_ bearer (no workspace segment) is rejected even with a valid org-admin session (no fallback)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    // The bearer starts with `up_` but doesn't even parse to a workspace
+    // name (workspaceNameFromToken returns undefined) — this must still be
+    // treated as an authoritative-but-invalid credential, not silently fall
+    // through to the valid session on the same request.
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(listReq("acme", "up_"), {}, env);
+    expect(res.status).toBe(401);
+  });
+
   it("workspace:invite-only token gets 403 (wrong scope for this route)", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {

--- a/apps/api/src/routes/workspace-governance-tokens.test.ts
+++ b/apps/api/src/routes/workspace-governance-tokens.test.ts
@@ -164,6 +164,17 @@ describe("GET /v1/workspaces/:name/tokens", () => {
     expect(res.status).toBe(403);
   });
 
+  it("shaped-but-invalid up_ bearer is rejected even with a valid org-admin session (no fallback)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    // Valid admin session available via cookies/get-session — but the
+    // request explicitly presents a `up_`-shaped bearer that matches no
+    // active token. Fail-closed: the bearer is authoritative, no silent
+    // session fallback.
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(listReq("acme", "up_acme_notarealtoken"), {}, env);
+    expect(res.status).toBe(401);
+  });
+
   it("workspace:invite-only token gets 403 (wrong scope for this route)", async () => {
     const db = new SqliteD1(MIGRATIONS);
     const { token } = await createToken(db as unknown as D1Database, {

--- a/apps/api/src/routes/workspace-governance-tokens.test.ts
+++ b/apps/api/src/routes/workspace-governance-tokens.test.ts
@@ -1,0 +1,281 @@
+/**
+ * GET/DELETE /v1/workspaces/:name/tokens (issue #262 Task 3) — self-serve
+ * token governance, dual-authed: EITHER a session user with org role
+ * admin/owner in :name (stubAuth idiom from workspaces.test.ts) OR a D1
+ * `workspace:manage`-scoped token bound to :name (createToken idiom from
+ * workspace-governance-invite.test.ts).
+ */
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { createToken } from "../auth-db";
+import { respondError } from "../error-response";
+import { workspaces } from "./workspaces";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+];
+
+const USER = { id: "u1", email: "z@x.com", name: "Zach" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+function appWith(opts: {
+  db: SqliteD1;
+  session?: boolean;
+  role?: string;
+  memberships?: { organizationId: string; organizationSlug: string; role: string }[];
+}) {
+  const {
+    db,
+    session = false,
+    role = "admin",
+    memberships = [{ organizationId: "org1", organizationSlug: "acme", role }],
+  } = opts;
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/v1/workspaces", workspaces)
+    .onError((err, c) => respondError(c, err));
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify(session ? { session: {}, user: USER } : null), {
+        status: 200,
+      });
+    }
+    if (url.pathname === "/internal/memberships") {
+      return new Response(JSON.stringify(memberships), { status: 200 });
+    }
+    if (url.pathname === "/internal/orgs/acme") {
+      return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } });
+    }
+    return new Response("not found", { status: 404 });
+  });
+  const env = { AUTH: auth, DB: database(db) } as unknown as Env;
+  return { app, env };
+}
+
+function listReq(workspace: string, bearer?: string) {
+  return new Request(`https://api.uploads.sh/v1/workspaces/${workspace}/tokens`, {
+    headers: bearer ? { authorization: `Bearer ${bearer}` } : {},
+  });
+}
+
+function revokeReq(workspace: string, bearer: string | undefined, body: Record<string, unknown>) {
+  return new Request(`https://api.uploads.sh/v1/workspaces/${workspace}/tokens`, {
+    method: "DELETE",
+    headers: {
+      "content-type": "application/json",
+      ...(bearer ? { authorization: `Bearer ${bearer}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// Session-authed requests carry a Better Auth bearer session token (not a
+// `up_<workspace>_…` token) on the Authorization header, mirroring
+// workspaces.test.ts. workspaceManageAuth must route these through the
+// session path, not the workspace-token path.
+const SESSION_BEARER = "sess";
+
+describe("GET /v1/workspaces/:name/tokens", () => {
+  it("org admin session sees active D1 tokens, redacted", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { record } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      label: "ci-bot",
+      scopes: ["workspace:manage"],
+      mintedByUserId: "someone-else",
+    });
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(listReq("acme", SESSION_BEARER), {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tokens: { label: string | null; hashPrefix: string }[] };
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0]).toMatchObject({
+      label: "ci-bot",
+      hashPrefix: record.token_hash.slice(0, 8),
+      scopes: ["workspace:manage"],
+    });
+    // Never the raw token value.
+    expect(JSON.stringify(body)).not.toContain(record.token_hash);
+  });
+
+  it("org owner session also works", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:manage"],
+    });
+    const { app, env } = appWith({ db, session: true, role: "owner" });
+    const res = await app.request(listReq("acme", SESSION_BEARER), {}, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("plain member session gets 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db, session: true, role: "member" });
+    const res = await app.request(listReq("acme", SESSION_BEARER), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("no session at all gets 401", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db, session: false });
+    const res = await app.request(listReq("acme"), {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("workspace:manage token works for its own workspace", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:manage"],
+    });
+    await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      label: "another",
+      scopes: ["workspace:manage"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(listReq("acme", token), {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { tokens: unknown[] };
+    // Both the caller's own token and the sibling token are D1 rows for this
+    // workspace — both are listed.
+    expect(body.tokens).toHaveLength(2);
+  });
+
+  it("workspace:manage token bound to a different workspace is rejected", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "other",
+      scopes: ["workspace:manage"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(listReq("acme", token), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("workspace:invite-only token gets 403 (wrong scope for this route)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(listReq("acme", token), {}, env);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("DELETE /v1/workspaces/:name/tokens", () => {
+  it("org admin session revokes by label and flips revoked_at", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { record } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      label: "stale-ci",
+      scopes: ["workspace:manage"],
+    });
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(
+      revokeReq("acme", SESSION_BEARER, { label: "stale-ci" }),
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revoked: { label: string | null } };
+    expect(body.revoked).toMatchObject({ label: "stale-ci" });
+
+    const row = await db
+      .prepare("SELECT revoked_at FROM auth_tokens WHERE id = ?")
+      .bind(record.id)
+      .first<{ revoked_at: string | null }>();
+    expect(row?.revoked_at).not.toBeNull();
+  });
+
+  it("workspace:manage token revokes by hashPrefix, own workspace only", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token: managerToken } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:manage"],
+    });
+    const { record: victimRecord } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      label: "victim",
+      scopes: ["workspace:invite"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(
+      revokeReq("acme", managerToken, { hashPrefix: victimRecord.token_hash.slice(0, 12) }),
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const row = await db
+      .prepare("SELECT revoked_at FROM auth_tokens WHERE id = ?")
+      .bind(victimRecord.id)
+      .first<{ revoked_at: string | null }>();
+    expect(row?.revoked_at).not.toBeNull();
+  });
+
+  it("plain member session gets 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:manage"],
+    });
+    const { app, env } = appWith({ db, session: true, role: "member" });
+    const res = await app.request(revokeReq("acme", SESSION_BEARER, { label: "x" }), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("workspace:invite-only token gets 403", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+    });
+    const { app, env } = appWith({ db });
+    const res = await app.request(revokeReq("acme", token, { label: "x" }), {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("no selector is a 400", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(revokeReq("acme", SESSION_BEARER, {}), {}, env);
+    expect(res.status).toBe(400);
+  });
+
+  it("no match is a 404", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(revokeReq("acme", SESSION_BEARER, { label: "nope" }), {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("ambiguous label across multiple tokens is a 409", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      label: "dup",
+      scopes: ["workspace:manage"],
+    });
+    await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      label: "dup",
+      scopes: ["workspace:invite"],
+    });
+    const { app, env } = appWith({ db, session: true, role: "admin" });
+    const res = await app.request(revokeReq("acme", SESSION_BEARER, { label: "dup" }), {}, env);
+    expect(res.status).toBe(409);
+  });
+});

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -16,7 +16,13 @@ import {
 import { Hono } from "hono";
 import { isCommunal } from "./me";
 import { allowWorkspaceCreate, allowWrite } from "../guards";
-import { deleteOrg, isGithubLinked, membershipsForUser, provisionOrg } from "../org-workspaces";
+import {
+  deleteOrg,
+  isGithubLinked,
+  membershipsForUser,
+  orgForWorkspace,
+  provisionOrg,
+} from "../org-workspaces";
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { validateSlug } from "../slug-policy";
@@ -27,7 +33,10 @@ import {
   loadWorkspaceRecordRaw,
   stampRestore,
   stampSoftDelete,
+  workspaceGovernanceAuth,
 } from "../workspace";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 
@@ -235,4 +244,87 @@ workspaces.post("/:name/restore", sessionAuth, requireSessionUser, async (c) => 
   );
 
   return c.json({ ok: true, workspace: name });
+});
+
+/**
+ * Token-authed invite (issue #262) — mirrors `POST /me/workspaces/:name/invites`
+ * but is bearer-token-authed with a D1 `workspace:invite`-scoped token
+ * (`workspaceGovernanceAuth`, see `../workspace.ts`) instead of a session
+ * cookie. Per the plan's invite-attribution rule, the invite acts as the
+ * token's `minting_user_id` — the auth worker's internal invite route
+ * independently re-checks that user's org admin/owner role server-side
+ * (`apps/auth/src/internal-routes.ts`), so a minter who lost their org role
+ * can no longer invite with an old token even though the token itself is
+ * still active.
+ */
+workspaces.post("/:name/invites", workspaceGovernanceAuth("workspace:invite"), async (c) => {
+  const name = c.req.param("name");
+  requireWorkspaceName(name);
+
+  const mintingUserId = c.get("governanceMintingUserId");
+  if (!mintingUserId) {
+    // Enrollment-code-derived or pre-migration tokens have no minting user
+    // to attribute the invite to (and thus nothing for the auth worker's
+    // org-role re-check to run against) — treat as unauthorized.
+    throw new ForbiddenError("token has no attributable minting user", {
+      code: "no_minting_user",
+    });
+  }
+
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
+  const org = await orgForWorkspace(c.env, name);
+  if (!org) {
+    throw new NotFoundError("no organization for this workspace — ask a site operator", {
+      code: "org_not_found",
+    });
+  }
+
+  const body = await c.req
+    .json<{ email?: unknown; role?: unknown }>()
+    .catch(() => ({}) as { email?: unknown; role?: unknown });
+  const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  const role = typeof body.role === "string" ? body.role.trim() : "member";
+  if (!email || !EMAIL_RE.test(email)) {
+    throw new ValidationError("invalid email address", { code: "invalid_email" });
+  }
+  if (role !== "member" && role !== "admin") {
+    throw new ValidationError("role must be member or admin", { code: "invalid_role" });
+  }
+
+  const limiter = c.env.INVITE_LIMITER;
+  if (limiter) {
+    const { success } = await limiter.limit({ key: `invite:email:${email}` });
+    if (!success) throw new RateLimitedError("invite rate limit exceeded");
+  }
+
+  const response = await c.env.AUTH.fetch("https://auth.internal/internal/invite", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-uploads-internal": "1" },
+    body: JSON.stringify({
+      organizationSlug: org.slug,
+      email,
+      role,
+      inviterUserId: mintingUserId,
+    }),
+  });
+  const payload = (await response.json().catch(() => null)) as {
+    invitation?: { id?: string };
+    acceptUrl?: string;
+  } | null;
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new ForbiddenError("not authorized to invite to this workspace", {
+        code: "inviter_not_authorized",
+        details: payload,
+      });
+    }
+    throw new ValidationError("failed to create invitation", { details: payload });
+  }
+  const webOrigin = (c.env.WEB_ORIGIN || "https://uploads.sh").replace(/\/$/, "");
+  const id = payload?.invitation?.id;
+  const acceptUrl = payload?.acceptUrl ?? (id ? `${webOrigin}/accept-invitation/${id}` : undefined);
+  return c.json({ ...payload, acceptUrl }, response.status === 200 ? 200 : 201);
 });

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -41,7 +41,6 @@ import {
   stampRestore,
   stampSoftDelete,
   workspaceGovernanceAuth,
-  workspaceNameFromToken,
   type GovernanceVars,
 } from "../workspace";
 
@@ -75,7 +74,12 @@ function workspaceManageAuth(): MiddlewareHandler<ManageAuthVars> {
   return async (c, next) => {
     const authHeader = c.req.header("Authorization");
     const rawToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
-    if (rawToken && workspaceNameFromToken(rawToken) !== undefined) {
+    if (rawToken?.startsWith("up_")) {
+      // Any `up_`-shaped bearer is authoritative, whether or not it parses —
+      // a malformed token (e.g. no workspace segment) must 401, never fall
+      // back to a session cookie that may also be on the request. See the
+      // fail-closed note above.
+      //
       // Sub-middleware Contexts differ only in which Variables key they
       // touch; Hono's `Set` is invariant on Variables so a structural cast
       // is needed at each hand-off (both directions, below).
@@ -414,8 +418,11 @@ workspaces.get("/:name/tokens", workspaceManageAuth(), async (c) => {
   const name = c.req.param("name");
   requireWorkspaceName(name);
 
+  const now = new Date().toISOString();
   const tokens = (await listTokens(c.env.DB, name))
-    .filter((token) => token.revoked_at === null)
+    .filter(
+      (token) => token.revoked_at === null && (token.expires_at === null || token.expires_at > now),
+    )
     .map((token) => ({
       label: token.label,
       createdAt: token.created_at,
@@ -438,11 +445,15 @@ workspaces.delete("/:name/tokens", workspaceManageAuth(), async (c) => {
   const name = c.req.param("name");
   requireWorkspaceName(name);
 
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
   const body = await c.req
-    .json<{ hashPrefix?: string; label?: string }>()
-    .catch(() => ({}) as { hashPrefix?: string; label?: string });
-  const hashPrefix = body.hashPrefix?.trim();
-  const label = body.label?.trim();
+    .json<{ hashPrefix?: unknown; label?: unknown }>()
+    .catch(() => ({}) as { hashPrefix?: unknown; label?: unknown });
+  const hashPrefix = typeof body.hashPrefix === "string" ? body.hashPrefix.trim() : undefined;
+  const label = typeof body.label === "string" ? body.label.trim() : undefined;
   if (!hashPrefix && !label) {
     throw new ValidationError("hashPrefix or label required", {
       code: "hash_prefix_or_label_required",

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -13,8 +13,15 @@ import {
   RateLimitedError,
   ValidationError,
 } from "@uploads/errors";
-import { Hono } from "hono";
-import { isCommunal } from "./me";
+import { Hono, type MiddlewareHandler } from "hono";
+import { adminWorkspaceOr403, isCommunal } from "./me";
+import {
+  isFileScope,
+  isOperatorScope,
+  isWorkspaceScope,
+  listTokens,
+  revokeToken,
+} from "../auth-db";
 import { allowWorkspaceCreate, allowWrite } from "../guards";
 import {
   deleteOrg,
@@ -34,7 +41,66 @@ import {
   stampRestore,
   stampSoftDelete,
   workspaceGovernanceAuth,
+  workspaceNameFromToken,
+  type GovernanceVars,
 } from "../workspace";
+
+const HASH_PREFIX_LEN = 8;
+
+/** Combined context vars for routes reachable by either auth path (issue #262 Task 3). */
+type ManageAuthVars = {
+  Variables: SessionVars["Variables"] & GovernanceVars["Variables"];
+  Bindings: Env;
+};
+
+/**
+ * Dual auth for self-serve token governance (#262 Task 3): EITHER a session
+ * user holding org role admin/owner in `:name` (mirrors `adminWorkspaceOr403`
+ * in `./me.ts`) OR a D1 `workspace:manage`-scoped token bound to `:name`
+ * (`workspaceGovernanceAuth`, see `../workspace.ts`). The bearer value itself
+ * picks the path — `up_<workspace>_…` shaped tokens go through the
+ * governance guard; anything else (including Better Auth bearer sessions,
+ * which also ride the Authorization header — see workspaces.test.ts) falls
+ * back to session-cookie/bearer auth.
+ */
+function workspaceManageAuth(): MiddlewareHandler<ManageAuthVars> {
+  return async (c, next) => {
+    const authHeader = c.req.header("Authorization");
+    const rawToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
+    if (rawToken && workspaceNameFromToken(rawToken) !== undefined) {
+      // Sub-middleware Contexts differ only in which Variables key they
+      // touch; Hono's `Set` is invariant on Variables so a structural cast
+      // is needed at each hand-off (both directions, below).
+      await workspaceGovernanceAuth("workspace:manage")(
+        c as unknown as Parameters<ReturnType<typeof workspaceGovernanceAuth>>[0],
+        next,
+      );
+      return;
+    }
+
+    const sessionC = c as unknown as Parameters<typeof sessionAuth>[0];
+    await sessionAuth(sessionC, async () => {});
+    await requireSessionUser(sessionC, async () => {});
+    const name = c.req.param("name")!;
+    const user = c.get("sessionUser")!;
+    await adminWorkspaceOr403(c.env, user.id, name);
+    c.set("governanceMintingUserId", user.id);
+    await next();
+  };
+}
+
+/** Redacted scope list for display — never surfaces unrecognized/garbage entries. */
+function parseAnyScopes(value: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (v): v is string => isFileScope(v) || isOperatorScope(v) || isWorkspaceScope(v),
+    );
+  } catch {
+    return [];
+  }
+}
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -327,4 +393,67 @@ workspaces.post("/:name/invites", workspaceGovernanceAuth("workspace:invite"), a
   const id = payload?.invitation?.id;
   const acceptUrl = payload?.acceptUrl ?? (id ? `${webOrigin}/accept-invitation/${id}` : undefined);
   return c.json({ ...payload, acceptUrl }, response.status === 200 ? 200 : 201);
+});
+
+/**
+ * Self-serve token list (issue #262 Task 3) — dual-authed via
+ * `workspaceManageAuth`. Mirrors the redacted shape of `GET /admin/tokens`
+ * in `routes/admin.ts`: labels, scopes, created/expiry, hash prefix — NEVER
+ * token values. Active D1 tokens only (revoked tokens don't need self-serve
+ * visibility; the admin surface covers full history).
+ */
+workspaces.get("/:name/tokens", workspaceManageAuth(), async (c) => {
+  const name = c.req.param("name");
+  requireWorkspaceName(name);
+
+  const tokens = (await listTokens(c.env.DB, name))
+    .filter((token) => token.revoked_at === null)
+    .map((token) => ({
+      label: token.label,
+      createdAt: token.created_at,
+      hashPrefix: token.token_hash.slice(0, HASH_PREFIX_LEN),
+      scopes: parseAnyScopes(token.scopes),
+      expiresAt: token.expires_at,
+    }));
+
+  return c.json({ workspace: name, tokens });
+});
+
+/**
+ * Self-serve token revoke (issue #262 Task 3) — dual-authed via
+ * `workspaceManageAuth`. Mirrors the `DELETE /admin/tokens` contract:
+ * revoke by `hashPrefix` or `label`, 404 for no match, 409 for an ambiguous
+ * selector. `revokeToken` already scopes its lookup to `name` and to active
+ * (non-revoked) tokens.
+ */
+workspaces.delete("/:name/tokens", workspaceManageAuth(), async (c) => {
+  const name = c.req.param("name");
+  requireWorkspaceName(name);
+
+  const body = await c.req
+    .json<{ hashPrefix?: string; label?: string }>()
+    .catch(() => ({}) as { hashPrefix?: string; label?: string });
+  const hashPrefix = body.hashPrefix?.trim();
+  const label = body.label?.trim();
+  if (!hashPrefix && !label) {
+    throw new ValidationError("hashPrefix or label required", {
+      code: "hash_prefix_or_label_required",
+    });
+  }
+
+  const result = await revokeToken(c.env.DB, name, { hashPrefix, label });
+  if (result.ambiguous) {
+    throw new ConflictError("selector matches multiple tokens");
+  }
+  if (!result.match) {
+    throw new NotFoundError("no matching token");
+  }
+
+  return c.json({
+    workspace: name,
+    revoked: {
+      label: result.match.label,
+      hashPrefix: result.match.token_hash.slice(0, HASH_PREFIX_LEN),
+    },
+  });
 });

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -62,6 +62,14 @@ type ManageAuthVars = {
  * governance guard; anything else (including Better Auth bearer sessions,
  * which also ride the Authorization header — see workspaces.test.ts) falls
  * back to session-cookie/bearer auth.
+ *
+ * Deliberately fail-closed: when an `up_`-shaped bearer is presented it is
+ * authoritative — an invalid one (revoked/expired/foreign/wrong-scope) is
+ * rejected outright, with NO fallback to a session cookie that may also be
+ * on the request. An explicitly presented credential is judged on its own
+ * merits; silently escalating a bad token to the caller's session would mask
+ * revocation and make "is this token still valid?" unanswerable from the
+ * response.
  */
 function workspaceManageAuth(): MiddlewareHandler<ManageAuthVars> {
   return async (c, next) => {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -1,7 +1,14 @@
-import { InsufficientScopeError, UnauthorizedError } from "@uploads/errors";
+import { ForbiddenError, InsufficientScopeError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 import type { StorageProvider } from "@uploads/storage";
-import { FILE_SCOPES, findActiveToken, parseScopes, type FileScope } from "./auth-db";
+import {
+  FILE_SCOPES,
+  findActiveToken,
+  isWorkspaceScope,
+  parseScopes,
+  type FileScope,
+  type WorkspaceScope,
+} from "./auth-db";
 
 export type { FileScope } from "./auth-db";
 
@@ -282,6 +289,53 @@ export function requireScope(scope: FileScope): MiddlewareHandler<WorkspaceVars>
     if (!c.get("authScopes").includes(scope)) {
       throw new InsufficientScopeError(scope, "forbidden");
     }
+    await next();
+  };
+}
+
+/** Vars set by `workspaceGovernanceAuth` on a matched `workspace:*`-scoped token. */
+export type GovernanceVars = {
+  Variables: {
+    /** `minting_user_id` of the D1 token record — invites/actions act as this user (issue #262). */
+    governanceMintingUserId: string | null;
+  };
+  Bindings: Env;
+};
+
+/**
+ * Guards a `/…/:name/…` route with a D1-backed `workspace:*`-scoped bearer
+ * token (issue #262). Distinct from `tokenWorkspaceAuth`/`requireScope`
+ * (file-plane, `parseScopes` fail-closed on non-file scopes) — a governance
+ * token carries zero file access and this guard never touches `authScopes`.
+ *
+ * Rejects: missing/malformed bearer (401), no active D1 token for the
+ * token's own workspace — revoked/expired/unknown (401), token workspace !==
+ * the `:name` route param (403), and active tokens missing the required
+ * `workspace:*` scope — including file-only or operator-only tokens, which
+ * carry zero workspace scopes (403).
+ */
+export function workspaceGovernanceAuth(scope: WorkspaceScope): MiddlewareHandler<GovernanceVars> {
+  return async (c, next) => {
+    const token = bearerToken(c.req.header("Authorization"));
+    const tokenWorkspace = token ? workspaceNameFromToken(token) : undefined;
+    if (!tokenWorkspace) throw new UnauthorizedError();
+
+    const record = await findActiveToken(c.env.DB, tokenWorkspace, token);
+    if (!record) throw new UnauthorizedError();
+
+    const name = c.req.param("name");
+    if (tokenWorkspace !== name) throw new ForbiddenError();
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(record.scopes);
+    } catch {
+      parsed = [];
+    }
+    const scopes = new Set(Array.isArray(parsed) ? parsed.filter(isWorkspaceScope) : []);
+    if (!scopes.has(scope)) throw new ForbiddenError();
+
+    c.set("governanceMintingUserId", record.minting_user_id);
     await next();
   };
 }

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -93,3 +93,31 @@ even if file scopes were also requested alongside it — scope parsing on the
 file routes fails the whole scope array when it contains any non-file
 scope. Mint a separate files-only token for file operations and a
 dedicated operator token for `/admin/*`.
+
+## Workspace-governance scopes
+
+Org admins/owners can also mint tokens with opt-in `workspace:invite` /
+`workspace:manage` scopes via the same session-authed `POST /v1/tokens` —
+requesting either scope requires the minting session user to hold org role
+`admin` or `owner` in the target workspace (platform-admin/operator status
+does not bypass this check); otherwise the mint request is rejected with
+`400 invalid_scopes`. Unlike operator scopes, workspace-governance scopes are
+strictly **workspace-bounded**: a token only authorizes actions on the
+workspace embedded in it (`up_<workspace>_…`), never any other workspace.
+
+Like operator tokens, a workspace-governance token gets **zero** file-route
+access, even if file scopes are requested alongside it — scope parsing on the
+file routes fails the whole array when it contains any non-file scope. Mint a
+separate files-only token for file operations.
+
+- `workspace:invite` authorizes `POST /v1/workspaces/:name/invites` — sends an
+  organization invite for workspace `:name`, mirroring the session-authed
+  invite endpoint. The invite is attributed to the token's minting user, and
+  the auth worker re-checks that user's org role at invite time, so a token
+  minted by a since-demoted admin can no longer invite.
+- `workspace:manage` authorizes `GET`/`DELETE /v1/workspaces/:name/tokens` —
+  list (redacted: labels, scopes, created/expiry, hash prefix, never the
+  token value) and revoke tokens belonging to workspace `:name`, mirroring the
+  `GET`/`DELETE /admin/tokens` contract above. These routes also accept a
+  plain session with org role `admin`/`owner` in `:name` as an alternative to
+  a `workspace:manage` token.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -12,7 +12,9 @@ export type TokenScope =
   | "files:write"
   | "files:delete"
   | "operator:read"
-  | "operator:write";
+  | "operator:write"
+  | "workspace:invite"
+  | "workspace:manage";
 
 /** Allowlisted object provenance (maps to X-Uploads-Meta-* on put). */
 export type ProvenanceInput = {


### PR DESCRIPTION
Implements #262: gives the org-admin tier its own credential — workspace-bounded governance scopes `workspace:invite` and `workspace:manage` — completing the scope taxonomy started in #257/#261 (`files:*` for members, `workspace:*` for org admins, `operator:*` for platform operators).

## What changed

- **Minting** (`apps/api/src/routes/tokens.ts`, `auth-db.ts`) — `POST /v1/tokens` accepts opt-in `workspace:invite` / `workspace:manage` only when the minting session user holds org role `admin`/`owner` **in the target workspace**; otherwise 400 `invalid_scopes`. Platform-admin/operator status does not bypass the org-role gate (operators already have `/admin-ui`). Mixed requests (`operator:*` + `workspace:*`) must pass both gates independently. Defaults unchanged.
- **Workspace-bounded enforcement** (`workspace.ts` `workspaceGovernanceAuth`) — unlike `operator:*` (global by design), a `workspace:*` token authorizes actions only on the workspace embedded in it; foreign-workspace, revoked, expired, file-only, and operator-only tokens are rejected fail-closed.
- **Token-authed invites** — new `POST /v1/workspaces/:name/invites` (requires `workspace:invite`), mirroring the session invite endpoint. Invites are attributed to the token's `minting_user_id`, and the auth worker re-checks that user's *current* org role at invite time — a token minted by a since-demoted admin can no longer invite. No auth-worker changes were needed (its internal invite route already took an inviter id).
- **Self-serve token governance** — new `GET`/`DELETE /v1/workspaces/:name/tokens` (redacted listing / revoke by hashPrefix or label, mirroring the `/admin/tokens` contracts), dual-authed: org `admin`/`owner` session or a `workspace:manage` token bound to `:name`. Closes the gap where only platform operators could list/revoke a workspace's tokens.
- **CLI + docs** — `TokenScope` alias widened in the published package (patch changeset targeting only `@buildinternet/uploads`); `docs/admin-tokens.md` gains a "Workspace-governance scopes" section.

## Deliberate choices

- **Fail-closed bearer precedence**: on the dual-auth routes, an `up_`-shaped bearer is authoritative — an invalid one is rejected without falling back to a valid session cookie (documented at the decision point and pinned by a regression test).
- **Zero file-plane access**: as with `operator:*`, any token carrying a governance scope gets no file-route access (file-route scope parsing fails closed) — mint separate tokens per plane.
- **Deletion stays creator-gated**: the #249 creator-only deletion gate is deliberately untouched; role-gated deletion remains an open question from the issue.
- **Guardrail held**: `apps/auth` has a zero diff — governance scopes never enter `OAUTH_SCOPES` or any DCR-registerable set.

## Testing

`pnpm test` at root: 134 files / 1519 tests passing; `tsc --noEmit` clean. New coverage includes: org-role mint gating (member/admin/owner/platform-admin-no-bypass), both-gates mixed requests, foreign-workspace rejection, demoted-minter invite rejection, no-minting-user branch, shaped-but-invalid-bearer-with-valid-session composition, revocation flipping `revoked_at`, and redacted listing never exposing token values.

Closes #262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-governance token scopes for sending invites and managing workspace tokens.
  * Added workspace-bounded endpoints to create invites, list active tokens, and revoke tokens.
  * Added support for requesting governance scopes through token creation.

* **Documentation**
  * Documented governance scopes, authorization requirements, workspace boundaries, and file-access behavior.

* **Bug Fixes**
  * Governance tokens now fail closed when scopes are invalid, expired, revoked, or used outside their workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->