### PR TITLE
fix(web): show workspace file names + de-cramp the tab layout

### DIFF
--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -34,6 +34,7 @@ import {
   chipKind,
   fileTypeLabel,
   isPrivateFile,
+  leafName,
   pickThumbnail,
   resolveWorkspaceInfo,
   type WorkspaceInfoStatus,
@@ -357,9 +358,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
         patchVisibility(file.key, result.visibility);
         setOpenMenuKey(null);
       } else {
-        setActionError(
-          `Couldn't make "${childName(file.key, prefix)}" ${next}. Try again shortly.`,
-        );
+        setActionError(`Couldn't make "${leafName(file.key)}" ${next}. Try again shortly.`);
       }
     } finally {
       setTogglingKeys((prev) => {
@@ -373,7 +372,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
   const copyLink = async (file: FileTableRow, button: HTMLButtonElement) => {
     const url = file.url ?? (await resolveSignedFileUrl(apiOrigin, workspace, file.key));
     if (!url) {
-      setActionError(`Couldn't get a link for "${childName(file.key, prefix)}".`);
+      setActionError(`Couldn't get a link for "${leafName(file.key)}".`);
       return;
     }
     try {
@@ -619,7 +618,10 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
 
         {state.status === "ok" &&
           state.files.map((file) => {
-            const name = filtered ? childName(file.key, "") : childName(file.key, prefix);
+            // Show the file's own name (leaf), not the full key — at the flat
+            // root the key is the whole `screenshots/…/x.png` path, whose
+            // distinctive tail would otherwise be ellipsized away.
+            const name = leafName(file.key);
             const thumb = pickThumbnail(file);
             const type = fileTypeLabel(file);
             const priv = isPrivateFile(file);

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -80,7 +80,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
     <button class="button" type="button" id="session-retry">Try again</button>
   </div>
 
-  <div id="app" class="account-shell" hidden>
+  <div id="app" class:list={["account-shell", { "account-shell--rail": hasRail }]} hidden>
     <SiteHeader authOrigin={authOrigin} />
 
     <div class="shell">

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -201,6 +201,22 @@ const invitePath = `${base}/people`;
     display: grid;
     gap: 10px;
   }
+  /* "show N more" toggle — innerHTML-injected by bindConnectedWorkSetter. */
+  :global(.account-shell) .ws-rail :global(.ws-rail__more) {
+    justify-self: start;
+    padding: 2px 0;
+    background: none;
+    border: 0;
+    color: var(--muted);
+    font: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  :global(.account-shell) .ws-rail :global(.ws-rail__more:hover),
+  :global(.account-shell) .ws-rail :global(.ws-rail__more:focus-visible) {
+    color: var(--accent);
+    outline: none;
+  }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-item) {
     display: flex;
     align-items: flex-start;

--- a/apps/web/src/lib/workspace-file-row.test.ts
+++ b/apps/web/src/lib/workspace-file-row.test.ts
@@ -6,6 +6,7 @@ import {
   chipKind,
   fileTypeLabel,
   isPrivateFile,
+  leafName,
   pickThumbnail,
   resolveWorkspaceInfo,
 } from "./workspace-file-row";
@@ -115,6 +116,21 @@ describe("childName", () => {
   });
   it("handles the root prefix (empty string)", () => {
     expect(childName("x.png", "")).toBe("x.png");
+  });
+});
+
+describe("leafName", () => {
+  it("returns the last path segment of a nested key", () => {
+    expect(leafName("screenshots/either/280/demographics.png")).toBe("demographics.png");
+  });
+  it("returns the key itself when it has no folder", () => {
+    expect(leafName("solo.png")).toBe("solo.png");
+  });
+  it("ignores a trailing slash (folder-style key)", () => {
+    expect(leafName("screenshots/either/")).toBe("either");
+  });
+  it("falls back to the full key when empty", () => {
+    expect(leafName("")).toBe("");
   });
 });
 

--- a/apps/web/src/lib/workspace-file-row.ts
+++ b/apps/web/src/lib/workspace-file-row.ts
@@ -76,6 +76,13 @@ export function childName(key: string, prefix: string): string {
   return trimmed || key;
 }
 
+/** Last path segment of a key — the file's own name — ignoring a trailing slash. `"a/b/c.png"` → `"c.png"`, `"solo.png"` → `"solo.png"`. Falls back to the full key when empty. */
+export function leafName(key: string): string {
+  const trimmed = key.replace(/\/$/, "");
+  const slash = trimmed.lastIndexOf("/");
+  return (slash === -1 ? trimmed : trimmed.slice(slash + 1)) || key;
+}
+
 export interface BreadcrumbSegment {
   label: string;
   /** Cumulative prefix through this segment, trailing `/` included — pass to folder navigation. */

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -78,6 +78,9 @@ export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
  * WorkspaceLayout page load gets a fresh rail DOM, so re-assigning the global
  * here always points it at the current page's elements.
  */
+/** Connected-work rows shown before a "show N more" toggle reveals the rest. */
+const CONNECTED_WORK_CAP = 6;
+
 function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter {
   const section = root.querySelector<HTMLElement>("[data-rail-connected]");
   const list = root.querySelector<HTMLElement>("[data-rail-connected-list]");
@@ -88,8 +91,22 @@ function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter 
       list.innerHTML = "";
       return;
     }
-    list.innerHTML = renderConnectedWorkHtml(items);
     section.hidden = false;
+    // A busy workspace can link dozens of PRs/issues; cap the default view and
+    // reveal the rest behind one click rather than a wall of rows.
+    const paint = (limit: number): void => {
+      const shown = items.slice(0, limit);
+      const hidden = items.length - shown.length;
+      list.innerHTML =
+        renderConnectedWorkHtml(shown) +
+        (hidden > 0
+          ? `<button type="button" class="ws-rail__more" data-rail-more>show ${hidden} more</button>`
+          : "");
+      list
+        .querySelector<HTMLButtonElement>("[data-rail-more]")
+        ?.addEventListener("click", () => paint(items.length), { once: true });
+    };
+    paint(CONNECTED_WORK_CAP);
   };
   window.__uploadsSetConnectedWork = setter;
   return setter;

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -984,14 +984,24 @@ section.card .ws-messages .command {
   outline: none;
 }
 
+/* Workspace tab pages (files/galleries/people/settings) render a 3-column
+   nav · content · rail layout that needs more room than the default 960px
+   account reading width. AccountLayout adds `account-shell--rail` to #app only
+   when a rail slot is present (the workspace tabs), so /account list pages and
+   /admin (#dashboard) keep the default width. This widens `.shell` via the
+   `--width-shell` custom property it already reads (signed-in-shell.css). */
+.account-shell--rail {
+  --width-shell: 1200px;
+}
+
 .wft-grid {
   margin-top: 8px;
 }
 .wft-row,
 .wft-head {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 90px 110px 100px 44px;
-  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) 64px 64px 92px 32px;
+  gap: 14px;
   align-items: center;
 }
 .wft-head {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -994,6 +994,16 @@ section.card .ws-messages .command {
   --width-shell: 1200px;
 }
 
+/* Clamp the content grid track so long, non-wrapping settings content (e.g.
+   the people tab's `uploads admin invite create …` command) shrinks and
+   scrolls within the column instead of growing to its max-content width and
+   overflowing under the rail. `.content` (signed-in-shell.css) is a grid with
+   an implicit auto track; scoped to rail pages so /account and /admin are
+   untouched, and it composes with the mobile restack in account-shell.css. */
+.account-shell--rail .content {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .wft-grid {
   margin-top: 8px;
 }


### PR DESCRIPTION
Fixes three issues on the shipped workspace files tab (#268), reported from the live view.

## The name column rendered blank

Root cause (confirmed by inspecting the live DOM, not guesswork): the signed-in `.shell` caps at `max-width: 960px`, so the workspace view's main column shrank to ~388px. The file table's fixed columns (size 90 + type 110 + visibility 100 + menu 44 + gaps ≈ 392px) consumed the whole track, collapsing the `minmax(0, 1fr)` **name** column to ~0px. The filename text was present and correctly coloured — it was clipped to nothing by the zero-width column. This is the same root cause as the "cramped" feel.

## Changes

- **Widen the workspace tabs to 1200px** — via the `--width-shell` custom property `.shell` already reads, set on `#app` **only when a rail slot is present** (`AccountLayout` adds `account-shell--rail`). Account list pages and `/admin` (`#dashboard`) keep the 960px width, and `signed-in-shell.css` is untouched, so admin parity holds.
- **Rebalance the file-table columns** (`minmax(0, 1fr) 64px 64px 92px 32px`) so the name track always has room even at the narrow fallback width.
- **Show the file's leaf name** — a new, unit-tested `leafName()` displays `demographics-zodiac-….png` instead of the full `screenshots/either/280/…` key, whose distinctive tail was being ellipsized away.
- **Cap the connected-work rail at 6 rows** with a "show N more" toggle, so a busy workspace's Usage / Details / Quick-actions sections aren't buried under a wall of linked PRs.
- **Fix the people tab overflowing the rail** — `.content` is a grid with an implicit `auto` track, so it grew to the max-content width of the long `uploads admin invite create …` command and pushed the invite card across the rail. Clamp the track to `minmax(0, 1fr)` (scoped to rail pages via `account-shell--rail`) so long, non-wrapping content shrinks and scrolls in its own box. The shared `signed-in-shell.css`/`account-shell.css` (including its ≤680px mobile restack) are untouched.

## Verification

- Web typecheck 0 errors; full suite **1590 passed** (+4 for `leafName`); oxlint + oxfmt clean.
- Verified live against the deployed page by injecting the exact final CSS/behaviour: the name column renders filenames, the layout de-crowds, the rail collapses to 6 + "show N more" (surfacing the previously-buried usage/details panels), the people-tab card no longer overlaps the rail, and the long operator command scrolls within its box. Also confirmed no overflow at a mobile-narrow (~400px) column.

## Notes

Web-only (`apps/web`), no changeset — `apps/web` is on the changeset `ignore` list (Workers-deployed). Admin isolation preserved: `signed-in-shell.css` and all `#dashboard`/`admin` files have an empty diff.
