### PR TITLE
feat(cli,web): stamp gh.title at attach time, show it in the rail

### DIFF
--- a/.changeset/gh-title-connected-work-label.md
+++ b/.changeset/gh-title-connected-work-label.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads attach` and `put --pr`/`--issue` now also stamp `gh.title` with the resolved PR/issue title (best-effort via local `gh`, never blocks the upload) so the connected-work label in the workspace rail can show the real title instead of the bare `owner/repo#123` ref.

--- a/apps/web/src/lib/gh-context.test.ts
+++ b/apps/web/src/lib/gh-context.test.ts
@@ -28,6 +28,15 @@ describe("gh-context", () => {
     expect(ghWorkItemFromMetadata(undefined)).toBeNull();
     expect(ghWorkItemFromMetadata({ "gh.repo": "o/uploads" })).toBeNull();
   });
+  it("uses gh.title as the label when present (issue #267)", () => {
+    const item = ghWorkItemFromMetadata({ ...pr, "gh.title": "Fix the login bug" });
+    expect(item!.label).toBe("Fix the login bug");
+    expect(item!.ref).toBe("o/uploads#1789"); // ref stays the raw coordinate, unaffected
+  });
+  it("falls back to ref when gh.title is absent or empty (older files)", () => {
+    expect(ghWorkItemFromMetadata(pr)!.label).toBe("o/uploads#1789");
+    expect(ghWorkItemFromMetadata({ ...pr, "gh.title": "" })!.label).toBe("o/uploads#1789");
+  });
   it("dedupes connected work by ref", () => {
     const items = connectedWork([
       { metadata: pr },

--- a/apps/web/src/lib/gh-context.ts
+++ b/apps/web/src/lib/gh-context.ts
@@ -3,10 +3,12 @@
  * `packages/uploads/src/github.ts`): a "connected work" list for the
  * right-rail summary and an exact-PR-match check for the files-tab banner.
  *
- * Files carry exactly four keys when tagged: `gh.repo` (lowercased
+ * Files carry four required keys when tagged: `gh.repo` (lowercased
  * `owner/name`), `gh.kind` (`pull` | `issue`), `gh.number` (decimal string),
- * `gh.ref` (lowercased `owner/repo#number`). There is no `gh.title` — labels
- * are derived from `ref` alone. `githubUrl` mirrors `deriveGithubContext` in
+ * `gh.ref` (lowercased `owner/repo#number`). A fifth, optional `gh.title`
+ * (issue #267) holds the real PR/issue title the CLI resolved at attach
+ * time; older files never had it stamped, so the label falls back to `ref`
+ * when it's absent. `githubUrl` mirrors `deriveGithubContext` in
  * `apps/api/src/routes/public-files.ts`.
  */
 
@@ -18,7 +20,7 @@ export interface GhWorkItem {
   number: string;
   ref: string;
   url: string;
-  /** Same as `ref` (e.g. "o/uploads#1789"). */
+  /** `gh.title` when the CLI resolved one at attach time, else `ref` (e.g. "o/uploads#1789"). */
   label: string;
   kindLabel: "pull request" | "issue";
 }
@@ -43,13 +45,14 @@ export function ghWorkItemFromMetadata(
   const ref = meta["gh.ref"];
   if (!repo || !kind || !number || !ref) return null;
   if (kind !== "pull" && kind !== "issue") return null;
+  const title = meta["gh.title"];
   return {
     repo,
     kind,
     number,
     ref,
     url: githubUrl(repo, kind, number),
-    label: ref,
+    label: title ? title : ref,
     kindLabel: kind === "pull" ? "pull request" : "issue",
   };
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,7 +149,9 @@ Rules: keys `^[a-z][a-z0-9._-]{0,63}$` (lowercase; dots allowed); values 1–512
 printable ASCII; at most 24 pairs per request. Re-upload **with** `--meta`
 replaces the whole metadata set; re-upload **without** `--meta` leaves existing
 pairs alone. `uploads attach` and `put --pr`/`--issue` also stamp `gh.repo` /
-`gh.kind` / `gh.number` / `gh.ref` automatically.
+`gh.kind` / `gh.number` / `gh.ref` automatically, plus `gh.title` when the
+PR/issue title is resolvable via local `gh` (best-effort — never blocks the
+upload).
 
 Non-`gh.*` metadata may appear on the public `/f/…` file page — don't store
 secrets or private notes.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -42,6 +42,7 @@ import {
   resolveCurrentPullRequest,
   classifyGhNumber,
   execRunner,
+  ghMetadataFromTargetWithTitle,
   upsertAttachmentsComment,
   type CommandRunner,
 } from "./github-gh.js";
@@ -785,9 +786,9 @@ export async function runAttach(
   // target pairs always win over a same-named --meta extra (documented above).
   // Validate the merged map (not just the extras) so the 24-key/8KB caps are
   // enforced client-side even when extras alone are under the cap but extras
-  // + the 4 gh.* pairs push the merged map over it.
+  // + the gh.* pairs push the merged map over it.
   const metaExtras = parseMetaFlags(flagValues(parsed.flags, "--meta"));
-  const metadata = { ...metaExtras, ...ghMetadataFromTarget(target) };
+  const metadata = { ...metaExtras, ...ghMetadataFromTargetWithTitle(target, run) };
   if (Object.keys(metadata).length > 0) validateMetaMap(metadata);
 
   const logHuman = !ctx.quiet && !ctx.json;
@@ -973,7 +974,7 @@ export async function runPut(
   let metadata = userMeta;
   let attachedRef: string | undefined;
   if (ghTarget) {
-    const merged = { ...userMeta, ...ghMetadataFromTarget(ghTarget) };
+    const merged = { ...userMeta, ...ghMetadataFromTargetWithTitle(ghTarget, run) };
     validateMetaMap(merged); // enforce 24-key/8KB caps on the merged map (matches attach)
     metadata = merged;
     attachedRef = merged["gh.ref"];
@@ -989,7 +990,7 @@ export async function runPut(
         run,
       );
       if (autoTarget) {
-        const autoMeta = ghMetadataFromTarget(autoTarget);
+        const autoMeta = ghMetadataFromTargetWithTitle(autoTarget, run);
         const merged = { ...autoMeta, ...userMeta };
         // Auto resolution must never fail the upload: if merging the gh.* pairs
         // would exceed the metadata caps, drop them and upload with --meta only.

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -20,8 +20,7 @@ import {
 import { resolvePutDefaults } from "../config.js";
 import { loadDefaultsRaw, resolveScreenshotDefaults } from "../config-file.js";
 import { resolvePutPrefix } from "../destinations.js";
-import { ghMetadataFromTarget } from "../github.js";
-import { execRunner, type CommandRunner } from "../github-gh.js";
+import { execRunner, ghMetadataFromTargetWithTitle, type CommandRunner } from "../github-gh.js";
 import { parseMetaFlags, validateMetaMap } from "../metadata.js";
 import { writeJson, writeStdout } from "../io.js";
 import {
@@ -243,7 +242,7 @@ export async function runScreenshot(
   const metaExtras = parseMetaFlags(flagValues(parsed.flags, "--meta"));
   let metadata: Record<string, string> | undefined = metaExtras;
   if (ghTarget) {
-    metadata = { ...metaExtras, ...ghMetadataFromTarget(ghTarget) };
+    metadata = { ...metaExtras, ...ghMetadataFromTargetWithTitle(ghTarget, run) };
     validateMetaMap(metadata);
   } else if (Object.keys(metaExtras).length > 0) {
     validateMetaMap(metaExtras);

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -2,10 +2,12 @@ import { execFileSync } from "node:child_process";
 import { UsageError } from "./cli-args.js";
 import {
   ATTACHMENTS_MARKER,
+  ghMetadataFromTarget,
   isValidRepo,
   parseRepoFromRemoteUrl,
   type GhTarget,
 } from "./github.js";
+import { META_VALUE_MAX, isMetaValueSafe } from "./metadata.js";
 
 /** Runs a command and returns stdout; throws on non-zero exit. Injectable for tests. */
 export type CommandRunner = (cmd: string, args: string[], input?: string) => string;
@@ -100,6 +102,57 @@ export function classifyGhNumber(
     // gh missing / not found / network — caller skips
   }
   return undefined;
+}
+
+/**
+ * Best-effort PR/issue title lookup via local `gh`. Returns undefined on any
+ * failure (gh missing, unauthenticated, network, 404) — mirrors
+ * `resolveCurrentPullRequest`/`classifyGhNumber`'s degrade-don't-throw
+ * pattern. A title is a nice-to-have annotation, never a blocker: callers
+ * must never let this failure abort an upload.
+ */
+export function resolveGhTitle(
+  target: GhTarget,
+  run: CommandRunner = execRunner,
+): string | undefined {
+  try {
+    const out = run("gh", [
+      target.kind === "pull" ? "pr" : "issue",
+      "view",
+      String(target.num),
+      "--repo",
+      target.repo,
+      "--json",
+      "title",
+      "--jq",
+      ".title",
+    ]).trim();
+    return out.length > 0 ? out : undefined;
+  } catch {
+    // gh missing / unauthenticated / not found / network — caller skips
+    return undefined;
+  }
+}
+
+/**
+ * `ghMetadataFromTarget`'s 4 pairs, plus a best-effort `gh.title` (issue #267)
+ * when `resolveGhTitle` yields one that also satisfies the metadata-value
+ * rule every other pair follows (1-512 printable ASCII — `metadata.ts`'s
+ * `META_VALUE_MAX`/`isMetaValueSafe`). Truncated to `META_VALUE_MAX` first;
+ * a title left empty or unsafe by truncation (e.g. non-ASCII — real titles
+ * often contain emoji or curly quotes) is silently omitted rather than
+ * sanitized, matching `resolveGhTitle`'s own "degrade, don't fail the
+ * upload" contract.
+ */
+export function ghMetadataFromTargetWithTitle(
+  target: GhTarget,
+  run: CommandRunner = execRunner,
+): Record<string, string> {
+  const base = ghMetadataFromTarget(target);
+  const title = resolveGhTitle(target, run);
+  if (title === undefined) return base;
+  const truncated = title.length > META_VALUE_MAX ? title.slice(0, META_VALUE_MAX) : title;
+  return isMetaValueSafe(truncated) ? { ...base, "gh.title": truncated } : base;
 }
 
 interface GhComment {

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -23,11 +23,12 @@ import {
   type UploadsClientConfig,
 } from "../config.js";
 import { resolvePutPrefix } from "../destinations.js";
-import { ghKeyPrefix, ghMetadataFromTarget, type GhTarget } from "../github.js";
+import { ghKeyPrefix, type GhTarget } from "../github.js";
 import { validateMetaMap } from "../metadata.js";
 import { type OptimizeImageOptions } from "../optimize.js";
 import {
   execRunner,
+  ghMetadataFromTargetWithTitle,
   resolveCurrentPullRequest,
   resolveRepo,
   type CommandRunner,
@@ -933,10 +934,10 @@ export function createUploadsMcpTools(opts: {
         // explicit target pairs always win over a same-named metadata extra
         // (mirrors runAttach in ../commands.js). Validate the merged map (not
         // just the extras) so the 24-key/8KB caps are enforced client-side —
-        // extras alone might pass while extras + the 4 gh.* pairs exceed the
+        // extras alone might pass while extras + the gh.* pairs exceed the
         // cap, which would otherwise only be caught server-side after upload.
         const metaExtras = optStringRecord(args, "metadata") ?? {};
-        const metadata = { ...metaExtras, ...ghMetadataFromTarget(target) };
+        const metadata = { ...metaExtras, ...ghMetadataFromTargetWithTitle(target, run) };
         if (Object.keys(metadata).length > 0) validateMetaMap(metadata);
 
         const { uploads, failures } = await uploadAttachments({

--- a/packages/uploads/src/metadata.ts
+++ b/packages/uploads/src/metadata.ts
@@ -50,6 +50,17 @@ export function validateMetaEntry(key: string, value: string): void {
 }
 
 /**
+ * Non-throwing version of `validateMetaEntry`'s value check (length +
+ * printable-ASCII), for callers that want to silently drop a value that
+ * doesn't fit rather than reject the whole request — e.g. a best-effort
+ * `gh.title` derived from a real-world PR/issue title, which may contain
+ * unicode (emoji, curly quotes) that the metadata value rule disallows.
+ */
+export function isMetaValueSafe(value: string): boolean {
+  return value.length >= 1 && value.length <= META_VALUE_MAX && VALUE_SAFE_RE.test(value);
+}
+
+/**
  * Split `k=v` on the FIRST "=" (so values may themselves contain "="), then
  * validate the pair. Throws `UsageError` on malformed input.
  */

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -75,10 +75,20 @@ function ctxWith(client: UploadsClient): CliContext {
   };
 }
 
-function ghRunner() {
+/**
+ * `opts.title` set → the gh.title lookup (`pr|issue view <num> --json title`)
+ * resolves it; unset → it throws, same as gh being unable to resolve a title
+ * (the default for every existing test in this file, so none of them see an
+ * unexpected gh.title show up in their metadata assertions).
+ */
+function ghRunner(opts: { title?: string } = {}) {
   const calls: string[][] = [];
   const run: CommandRunner = (cmd, args) => {
     calls.push([cmd, ...args]);
+    if ((args[0] === "pr" || args[0] === "issue") && args[1] === "view" && args.includes("title")) {
+      if (opts.title !== undefined) return `${opts.title}\n`;
+      throw new Error("gh: title not resolvable");
+    }
     if (args[0] === "repo") return "buildinternet/uploads\n";
     if (args[0] === "pr" && args[1] === "view") return "123\n";
     if (args[1]?.includes("per_page=100")) return "[]";
@@ -218,7 +228,11 @@ describe("runAttach", () => {
       run,
     );
     expect(puts).toEqual(["gh/o/r/issues/45/artifact.zip"]);
-    expect(calls).toEqual([]);
+    // No comment-sync calls (--no-comment); the only gh call is the
+    // best-effort gh.title lookup, which this fixture fails by default.
+    expect(calls).toEqual([
+      ["gh", "issue", "view", "45", "--repo", "o/r", "--json", "title", "--jq", ".title"],
+    ]);
   });
 
   it("requires an inferable current PR when no target is supplied", async () => {
@@ -318,5 +332,33 @@ describe("runAttach gh.* metadata", () => {
     await expect(
       runAttach(ctxWith(client), [...files("shot.png"), ...metaFlags], false, run),
     ).rejects.toThrow(UsageError);
+  });
+});
+
+describe("runAttach gh.title metadata (issue #267)", () => {
+  it("stamps gh.title when the resolved PR title is available", async () => {
+    const { client, metadataByKey } = fakeClient();
+    const { run } = ghRunner({ title: "Fix the login bug" });
+    await runAttach(ctxWith(client), files("shot.png"), false, run);
+    expect(metadataByKey["gh/buildinternet/uploads/pull/123/shot.png"]).toEqual({
+      "gh.repo": "buildinternet/uploads",
+      "gh.kind": "pull",
+      "gh.number": "123",
+      "gh.ref": "buildinternet/uploads#123",
+      "gh.title": "Fix the login bug",
+    });
+  });
+
+  it("omits gh.title (and does not fail the upload) when the title can't be resolved", async () => {
+    const { client, puts, metadataByKey } = fakeClient();
+    const { run } = ghRunner(); // no opts.title → gh title lookup throws
+    expect(await runAttach(ctxWith(client), files("shot.png"), false, run)).toBe(0);
+    expect(puts).toEqual(["gh/buildinternet/uploads/pull/123/shot.png"]);
+    expect(metadataByKey["gh/buildinternet/uploads/pull/123/shot.png"]).toEqual({
+      "gh.repo": "buildinternet/uploads",
+      "gh.kind": "pull",
+      "gh.number": "123",
+      "gh.ref": "buildinternet/uploads#123",
+    });
   });
 });

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -531,11 +531,29 @@ describe("runPut gh.* metadata (explicit target)", () => {
   });
 });
 
-/** Fake gh: answers `gh pr view` (branch→PR) and `gh api` (classify). */
-function ghRunner(opts: { pr?: number; classify?: "pull" | "issue" }): CommandRunner {
+/**
+ * Fake gh: answers `gh pr view` (branch→PR), `gh api` (classify), and the
+ * gh.title lookup (`pr|issue view <num> --json title`) when `opts.title` is
+ * set — otherwise it throws, same as gh being unable to resolve a title (the
+ * default, so existing callers never see an unexpected gh.title).
+ */
+function ghRunner(opts: {
+  pr?: number;
+  classify?: "pull" | "issue";
+  title?: string;
+}): CommandRunner {
   return (cmd, args) => {
     if (cmd === "git" && args[0] === "rev-parse") return "feature/thing\n"; // current branch
     if (cmd === "gh" && args[0] === "repo") return "o/r\n"; // resolveRepo fallback
+    if (
+      cmd === "gh" &&
+      (args[0] === "pr" || args[0] === "issue") &&
+      args[1] === "view" &&
+      args.includes("title")
+    ) {
+      if (opts.title !== undefined) return `${opts.title}\n`;
+      throw new Error("gh: title not resolvable");
+    }
     if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
       if (opts.pr) return `${opts.pr}\n`;
       throw new Error("no pull request found");
@@ -613,6 +631,53 @@ describe("runPut auto gh.* metadata (default path)", () => {
       ghRunner({ pr: 481 }),
     );
     expect(puts[0].metadata!["gh.number"]).toBe("5");
+  });
+});
+
+describe("runPut gh.title metadata (issue #267)", () => {
+  it("stamps gh.title on the explicit --pr path when the title resolves", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "128", "--repo", "o/r"],
+      false,
+      ghRunner({ title: "Fix the login bug" }),
+    );
+    expect(puts[0].metadata).toMatchObject({
+      "gh.ref": "o/r#128",
+      "gh.title": "Fix the login bug",
+    });
+  });
+
+  it("omits gh.title on the explicit --pr path when it can't be resolved (never fails the upload)", async () => {
+    const { client, puts } = fakeClient();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "128", "--repo", "o/r"],
+      false,
+      noRun,
+    );
+    expect(code).toBe(0);
+    expect(puts[0].metadata!["gh.title"]).toBeUndefined();
+    expect(puts[0].metadata!["gh.ref"]).toBe("o/r#128");
+  });
+
+  it("stamps gh.title on the auto-resolved path when the title resolves", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(
+      ctxWith(client),
+      [tmpFile(), "--repo", "o/r"],
+      false,
+      ghRunner({ pr: 481, title: "Add dark mode" }),
+    );
+    expect(puts[0].metadata).toMatchObject({ "gh.ref": "o/r#481", "gh.title": "Add dark mode" });
+  });
+
+  it("omits gh.title on the auto-resolved path when it can't be resolved", async () => {
+    const { client, puts } = fakeClient();
+    await runPut(ctxWith(client), [tmpFile(), "--repo", "o/r"], false, ghRunner({ pr: 481 }));
+    expect(puts[0].metadata!["gh.title"]).toBeUndefined();
+    expect(puts[0].metadata!["gh.ref"]).toBe("o/r#481");
   });
 });
 

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -276,3 +276,44 @@ describe("runScreenshot upload tail", () => {
     expect(payload.url).toContain("https://x.test/");
   });
 });
+
+describe("runScreenshot gh.title metadata (issue #267)", () => {
+  it("stamps gh.title alongside the base gh.* pairs when the title resolves", async () => {
+    const { client, puts } = fakeClient();
+    const run: CommandRunner = (cmd, args) => {
+      if (cmd === "gh" && args[0] === "pr" && args[1] === "view" && args.includes("title")) {
+        return "Add dark mode toggle\n";
+      }
+      throw new Error(`unexpected: ${cmd} ${args.join(" ")}`);
+    };
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--pr", "9", "--repo", "o/r"],
+      false,
+      run,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts[0]?.metadata).toMatchObject({
+      "gh.ref": "o/r#9",
+      "gh.title": "Add dark mode toggle",
+    });
+  });
+
+  it("omits gh.title (never fails the capture) when the title can't be resolved", async () => {
+    const { client, puts } = fakeClient();
+    const run: CommandRunner = () => {
+      throw new Error("gh: not authenticated");
+    };
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--pr", "9", "--repo", "o/r"],
+      false,
+      run,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(puts[0]?.metadata!["gh.title"]).toBeUndefined();
+    expect(puts[0]?.metadata!["gh.ref"]).toBe("o/r#9");
+  });
+});

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -3,7 +3,9 @@ import { UsageError } from "../src/cli-args.js";
 import { ATTACHMENTS_MARKER, type GhTarget } from "../src/github.js";
 import {
   classifyGhNumber,
+  ghMetadataFromTargetWithTitle,
   resolveCurrentPullRequest,
+  resolveGhTitle,
   resolveRepo,
   upsertAttachmentsComment,
   type CommandRunner,
@@ -141,6 +143,102 @@ describe("upsertAttachmentsComment", () => {
     expect(patch.args).toContain("repos/o/r/issues/comments/42");
     expect(patch.args).toContain("PATCH");
     expect(patch.input).toContain("new body");
+  });
+});
+
+describe("resolveGhTitle", () => {
+  const pr: GhTarget = { repo: "o/r", kind: "pull", num: 208 };
+  const issue: GhTarget = { repo: "o/r", kind: "issues", num: 45 };
+
+  it("resolves a PR title via gh pr view", () => {
+    const run: CommandRunner = (cmd, args) => {
+      expect(cmd).toBe("gh");
+      expect(args).toEqual([
+        "pr",
+        "view",
+        "208",
+        "--repo",
+        "o/r",
+        "--json",
+        "title",
+        "--jq",
+        ".title",
+      ]);
+      return "Fix the thing\n";
+    };
+    expect(resolveGhTitle(pr, run)).toBe("Fix the thing");
+  });
+
+  it("resolves an issue title via gh issue view", () => {
+    const run: CommandRunner = (cmd, args) => {
+      expect(args).toEqual([
+        "issue",
+        "view",
+        "45",
+        "--repo",
+        "o/r",
+        "--json",
+        "title",
+        "--jq",
+        ".title",
+      ]);
+      return "Something is broken\n";
+    };
+    expect(resolveGhTitle(issue, run)).toBe("Something is broken");
+  });
+
+  it("returns undefined when gh throws (missing/unauthenticated/404/network)", () => {
+    const run: CommandRunner = () => {
+      throw new Error("gh: not found");
+    };
+    expect(resolveGhTitle(pr, run)).toBeUndefined();
+  });
+
+  it("returns undefined when gh yields an empty title", () => {
+    const run: CommandRunner = () => "  \n";
+    expect(resolveGhTitle(pr, run)).toBeUndefined();
+  });
+});
+
+describe("ghMetadataFromTargetWithTitle", () => {
+  const pr: GhTarget = { repo: "o/r", kind: "pull", num: 208 };
+
+  it("stamps gh.title alongside the base 4 pairs when a title resolves", () => {
+    const run: CommandRunner = () => "Fix the thing\n";
+    expect(ghMetadataFromTargetWithTitle(pr, run)).toEqual({
+      "gh.repo": "o/r",
+      "gh.kind": "pull",
+      "gh.number": "208",
+      "gh.ref": "o/r#208",
+      "gh.title": "Fix the thing",
+    });
+  });
+
+  it("omits gh.title (never throws) when the runner fails", () => {
+    const run: CommandRunner = () => {
+      throw new Error("gh: not authenticated");
+    };
+    expect(ghMetadataFromTargetWithTitle(pr, run)).toEqual({
+      "gh.repo": "o/r",
+      "gh.kind": "pull",
+      "gh.number": "208",
+      "gh.ref": "o/r#208",
+    });
+  });
+
+  it("truncates a title longer than 512 chars", () => {
+    const long = "x".repeat(600);
+    const run: CommandRunner = () => `${long}\n`;
+    const metadata = ghMetadataFromTargetWithTitle(pr, run);
+    expect(metadata["gh.title"]).toHaveLength(512);
+    expect(metadata["gh.title"]).toBe("x".repeat(512));
+  });
+
+  it("omits gh.title when the resolved title fails the printable-ASCII value rule", () => {
+    const run: CommandRunner = () => "Ship 🚀 emoji release\n";
+    const metadata = ghMetadataFromTargetWithTitle(pr, run);
+    expect(metadata["gh.title"]).toBeUndefined();
+    expect(metadata["gh.ref"]).toBe("o/r#208"); // base 4 pairs still present
   });
 });
 

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -174,10 +174,20 @@ function galleryFactory() {
   return { factory, configs, calls };
 }
 
-function ghRunner() {
+/**
+ * `opts.title` set → the gh.title lookup (`pr|issue view <num> --json title`)
+ * resolves it; unset → it throws, same as gh being unable to resolve a title
+ * (the default for every existing test in this file, so none of them see an
+ * unexpected gh.title show up in their metadata assertions).
+ */
+function ghRunner(opts: { title?: string } = {}) {
   const calls: string[][] = [];
   const run: CommandRunner = (cmd, args) => {
     calls.push([cmd, ...args]);
+    if ((args[0] === "pr" || args[0] === "issue") && args[1] === "view" && args.includes("title")) {
+      if (opts.title !== undefined) return `${opts.title}\n`;
+      throw new Error("gh: title not resolvable");
+    }
     if (args[0] === "repo") return "buildinternet/uploads\n";
     if (args[0] === "pr" && args[1] === "view") return "123\n";
     if (args[1]?.includes("per_page=100")) return "[]";
@@ -732,6 +742,40 @@ describe("tools/call attach", () => {
     expect(res.result.isError).toBe(true);
     expect(res.result.content[0].text).toContain("too many");
     expect(puts.length).toBe(0);
+  });
+
+  it("stamps gh.title (issue #267) when the resolved PR title is available", async () => {
+    const { run } = ghRunner({ title: "Fix the login bug" });
+    const { server, puts } = serverWith({ runner: run });
+    const dir = mkdtempSync(join(tmpdir(), "uploads-mcp-test-"));
+    const file = join(dir, "before.png");
+    writeFileSync(file, "png");
+
+    await rpc(server, "tools/call", { name: "attach", arguments: { files: [file] } });
+    expect(puts[0].metadata).toEqual({
+      "gh.repo": "buildinternet/uploads",
+      "gh.kind": "pull",
+      "gh.number": "123",
+      "gh.ref": "buildinternet/uploads#123",
+      "gh.title": "Fix the login bug",
+    });
+  });
+
+  it("omits gh.title (and does not fail the upload) when the title can't be resolved", async () => {
+    const { run } = ghRunner(); // no opts.title → gh title lookup throws
+    const { server, puts } = serverWith({ runner: run });
+    const dir = mkdtempSync(join(tmpdir(), "uploads-mcp-test-"));
+    const file = join(dir, "before.png");
+    writeFileSync(file, "png");
+
+    const res = await rpc(server, "tools/call", { name: "attach", arguments: { files: [file] } });
+    expect(res.result.isError).toBe(false);
+    expect(puts[0].metadata).toEqual({
+      "gh.repo": "buildinternet/uploads",
+      "gh.kind": "pull",
+      "gh.number": "123",
+      "gh.ref": "buildinternet/uploads#123",
+    });
   });
 });
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -331,6 +331,8 @@ a numeric `--ref`), so the file's `/f/` page shows an "Attached to" link. This i
 on by default and best-effort; disable it with `--no-auto`, `--no-git`, or `UPLOADS_NO_AUTO_META=1`.
 On this auto path an explicit `--meta gh.*` overrides the auto-derived value — the
 opposite of the `--pr`/`--issue` precedence below, where the target's own `gh.*` always wins.
+Both paths also stamp `gh.title` with the resolved PR/issue title when local `gh`
+can resolve one — best-effort, never blocks the upload if it can't.
 
 **Re-upload semantics:** re-uploading to an existing key **with** `--meta` replaces
 that file's entire metadata set (delete-then-set, not a merge); re-uploading
@@ -401,7 +403,9 @@ Keep `url` (storage host) when you need a durable share link outside GitHub.
 gh.ref=myorg/myapp#123` or `uploads list --meta gh.repo=myorg/myapp` finds
 everything attached to that PR/issue without needing the `gh/...` prefix. Add
 `--meta k=v` extras for your own pairs on top — a `--meta gh.*` override loses
-to the target's own `gh.*` values.
+to the target's own `gh.*` values. It also stamps `gh.title` with the real
+PR/issue title when resolvable via local `gh` (best-effort; omitted rather
+than failing the upload if `gh` can't resolve one).
 
 ### Option B — managed attachments comment (`--comment` / `comment`)
 


### PR DESCRIPTION
Addresses #267 — the connected-work rail showed each linked item as its bare `owner/repo#123` ref because no PR/issue title was stored. This captures the title **at attach time** and displays it, with the ref as a fallback.

## What changed

**CLI (`@buildinternet/uploads`)**
- New `resolveGhTitle(target, run)` in `github-gh.ts` shells out to the local `gh` (`gh pr view <n> --repo <repo> --json title --jq .title`, `gh issue view …` for issues), mirroring the existing `resolveCurrentPullRequest` degrade-don't-throw pattern — returns `undefined` on any failure (gh missing / unauthenticated / 404 / network).
- New `ghMetadataFromTargetWithTitle(target, run)` adds `gh.title` to the existing 4 `gh.*` pairs, truncated to `META_VALUE_MAX` (512) and **dropped** (via a new non-throwing `isMetaValueSafe`) when empty or non-printable-ASCII. The pure `ghMetadataFromTarget` is untouched.
- Threaded into every gh-metadata assembly site: `put` (explicit `--pr`/`--issue` and the auto-resolved path), `attach`, `screenshot`, and the MCP `attach` tool. **A failed or missing title never blocks an upload.**

**Web (`@uploads/web`)**
- `gh-context.ts` uses `gh.title` as the connected-work item label when present and non-empty, else the existing ref. `kindLabel`, dedup, and `exactPrMatch` are unchanged; the rail already HTML-escapes the label.

## Scope

Forward-only by design: files attached before this keep showing the ref. **Live title fetching at render time and backfill of older files are intentionally deferred** (the follow-ups discussed on #267). No GitHub API dependency is added to the web app.

## Verification

- Full suite **1606 passed** (137 files); typecheck 0 errors; oxlint + oxfmt clean.
- Independently reviewed (fresh reviewer): no Critical/Important findings; confirmed titles stamp when resolvable, are omitted (upload still succeeds) when not, truncate at 512, and the web label falls back correctly.
- Changeset bumps **only** `@buildinternet/uploads` (minor) — confirmed via `changeset status`; no `@uploads/*` package is included (they're on the ignore list).
