### PR TITLE
feat(dev): portless named .localhost origins for the local auth stack

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,15 @@
       "autoPort": true
     },
     {
+      "name": "stack-raw",
+      "runtimeExecutable": "zsh",
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"${NVM_DIR:-$HOME/.nvm}\"; [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm use --silent; PORTLESS=0 node scripts/dev-stack.mjs"
+      ],
+      "port": 4321
+    },
+    {
       "name": "web-preview",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@uploads/web", "preview", "--port", "4322"],

--- a/apps/auth/src/auth.test.ts
+++ b/apps/auth/src/auth.test.ts
@@ -28,8 +28,14 @@ describe("deriveCookieDomain", () => {
     expect(deriveCookieDomain("http://localhost:8788")).toBeUndefined();
   });
 
-  it("returns undefined for a *.localhost host", () => {
+  it("returns undefined for a bare *.localhost host (no shareable parent)", () => {
     expect(deriveCookieDomain("http://auth.localhost:8788")).toBeUndefined();
+  });
+
+  it("shares the last-two-label parent for portless *.localhost hosts", () => {
+    expect(deriveCookieDomain("https://auth.uploads.localhost")).toBe(".uploads.localhost");
+    expect(deriveCookieDomain("http://auth.uploads.localhost:1355")).toBe(".uploads.localhost");
+    expect(deriveCookieDomain("https://fix-ui.auth.uploads.localhost")).toBe(".uploads.localhost");
   });
 
   it("returns undefined for an IP host", () => {

--- a/apps/auth/src/auth.test.ts
+++ b/apps/auth/src/auth.test.ts
@@ -32,6 +32,15 @@ describe("deriveCookieDomain", () => {
     expect(deriveCookieDomain("http://auth.localhost:8788")).toBeUndefined();
   });
 
+  it("anchors the real-TLD portless zone parent across worktree prefixes", () => {
+    expect(deriveCookieDomain("https://auth.uploads.local.buildinternet.dev")).toBe(
+      ".uploads.local.buildinternet.dev",
+    );
+    expect(deriveCookieDomain("https://fix-ui.auth.uploads.local.buildinternet.dev")).toBe(
+      ".uploads.local.buildinternet.dev",
+    );
+  });
+
   it("shares the last-two-label parent for portless *.localhost hosts", () => {
     expect(deriveCookieDomain("https://auth.uploads.localhost")).toBe(".uploads.localhost");
     expect(deriveCookieDomain("http://auth.uploads.localhost:1355")).toBe(".uploads.localhost");

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -325,6 +325,13 @@ export function deriveCookieDomain(betterAuthUrl: string | undefined): string | 
     return parts.length >= 3 ? "." + parts.slice(-2).join(".") : undefined;
   }
   const parts = host.split(".");
+  // Real-TLD portless zone (see trusted-origins.ts): anchor on
+  // `.uploads.local.buildinternet.dev` so worktree-prefixed hosts
+  // (fix-ui.auth.uploads.local.buildinternet.dev) share the same parent as
+  // the web app, mirroring the `.localhost` rule above.
+  if (host.endsWith(".uploads.local.buildinternet.dev")) {
+    return "." + parts.slice(-4).join(".");
+  }
   if (parts.length < 2) return undefined;
   if (parts.length === 2) return "." + host;
   return "." + parts.slice(1).join(".");

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -312,8 +312,17 @@ export function deriveCookieDomain(betterAuthUrl: string | undefined): string | 
   } catch {
     return undefined;
   }
-  if (host === "localhost" || /^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.endsWith(".localhost")) {
+  if (host === "localhost" || /^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
     return undefined;
+  }
+  if (host.endsWith(".localhost")) {
+    // Portless dev (see the `portless` skill): auth.uploads.localhost shares a
+    // session cookie with uploads.localhost via the `.<name>.localhost` parent.
+    // Always anchor on the last two labels so worktree-prefixed hosts
+    // (fix-ui.auth.uploads.localhost) land on the same parent as the web app.
+    // A bare `<name>.localhost` has no shareable parent — host-only cookie.
+    const parts = host.split(".");
+    return parts.length >= 3 ? "." + parts.slice(-2).join(".") : undefined;
   }
   const parts = host.split(".");
   if (parts.length < 2) return undefined;

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -121,6 +121,43 @@ describe("local demo session", () => {
     expect(wrongOrigin.status).toBe(404);
   });
 
+  it("is absent for non-loopback or mismatched portless-style origins", async () => {
+    for (const env of [
+      // Real TLD, not `.localhost` — never enables the bypass.
+      localEnv({
+        BETTER_AUTH_URL: "https://auth.local.uploads.sh",
+        WEB_ORIGIN: "https://local.uploads.sh",
+      }),
+      // Bare `.localhost` auth host has no shareable parent.
+      localEnv({ BETTER_AUTH_URL: "https://auth.localhost", WEB_ORIGIN: "https://web.localhost" }),
+      // Web host outside the auth host's `.uploads.localhost` parent.
+      localEnv({
+        BETTER_AUTH_URL: "https://auth.uploads.localhost",
+        WEB_ORIGIN: "https://other.localhost",
+      }),
+    ]) {
+      const res = await app.request(
+        "/api/auth/dev-session",
+        { method: "POST", headers: { Origin: env.WEB_ORIGIN ?? "" } },
+        env,
+      );
+      expect(res.status).toBe(404);
+    }
+  });
+
+  it("is available for a matched portless *.localhost pair", async () => {
+    const env = localEnv({
+      BETTER_AUTH_URL: "https://auth.uploads.localhost",
+      WEB_ORIGIN: "https://uploads.localhost",
+    });
+    const res = await app.request(
+      "/api/auth/dev-session",
+      { method: "POST", headers: { Origin: "https://uploads.localhost" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
   it("seeds an ordinary member and issues a standard Better Auth session", async () => {
     const env = localEnv();
     const res = await app.request(

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { createAuth, type AuthEnv } from "./auth";
 import { internal } from "./internal-routes";
 import { isInternalRequest } from "./internal";
-import { LOCAL_STACK_WEB_ORIGIN, localDemoEnabled } from "./local-demo";
+import { localDemoEnabled } from "./local-demo";
 import { isTrustedOrigin } from "./trusted-origins";
 import { runAuthRetentionSweep } from "./retention-sweep";
 import { sweepOauthClients } from "./oauth-client-reaper";
@@ -74,7 +74,7 @@ export const app = new Hono<{ Bindings: AuthEnv }>()
   // Better Auth handling so its normal CSRF/origin machinery cannot leak a
   // different status for an endpoint that should not exist.
   .use("/api/auth/dev-session", async (c, next) => {
-    if (!localDemoEnabled(c.env) || c.req.header("origin") !== LOCAL_STACK_WEB_ORIGIN) {
+    if (!localDemoEnabled(c.env) || c.req.header("origin") !== c.env.WEB_ORIGIN) {
       return c.json({ error: { code: "not_found", message: "Not found" } }, 404);
     }
     await next();

--- a/apps/auth/src/local-demo.ts
+++ b/apps/auth/src/local-demo.ts
@@ -15,6 +15,33 @@ import * as schema from "./schema";
 export const LOCAL_STACK_AUTH_ORIGIN = "http://127.0.0.1:8788";
 export const LOCAL_STACK_WEB_ORIGIN = "http://127.0.0.1:4321";
 
+/**
+ * Portless dev origins (see the `portless` skill): the stack runs at
+ * https://auth.<name>.localhost / https://<name>.localhost (optionally
+ * worktree-prefixed, optionally on the sudo-less proxy port, e.g.
+ * http://uploads.localhost:1355). Accept the pair only when the auth host has
+ * a shareable `.<name>.localhost` parent and the web host lives under that
+ * same parent — the exact property the shared session cookie depends on.
+ * `.localhost` names resolve to loopback by spec, so this stays as local-only
+ * as the IP-literal pair above.
+ */
+function portlessLocalStackOrigins(authUrl: string | undefined, webOrigin: string | undefined) {
+  if (!authUrl || !webOrigin) return false;
+  let auth: URL;
+  let web: URL;
+  try {
+    auth = new URL(authUrl);
+    web = new URL(webOrigin);
+  } catch {
+    return false;
+  }
+  if (!/^https?:$/.test(auth.protocol) || !/^https?:$/.test(web.protocol)) return false;
+  const parts = auth.hostname.split(".");
+  if (parts.length < 3 || parts.at(-1) !== "localhost") return false;
+  const base = parts.slice(-2).join(".");
+  return web.hostname === base || web.hostname.endsWith("." + base);
+}
+
 const DEMO_USER = {
   id: "local-dev-demo-user",
   email: "dev-demo@uploads.local",
@@ -24,16 +51,19 @@ const DEMO_ORGANIZATION = { id: "local-dev-demo-org", slug: "dev-demo", name: "D
 
 /**
  * The route is deliberately unavailable unless the lifecycle runner explicitly
- * opts in. Exact origins avoid accidentally enabling an identity bypass on a
- * public preview, a localhost alias, or a partially configured environment.
+ * opts in. Loopback-only origin shapes (exact IP-literal pair, or a matched
+ * portless `*.localhost` pair) avoid accidentally enabling an identity bypass
+ * on a public preview, a real-TLD alias, or a partially configured environment.
  */
 export function localDemoEnabled(env: AuthEnv): boolean {
-  return (
-    env.LOCAL_STACK === "true" &&
-    env.ENVIRONMENT === "development" &&
+  if (env.LOCAL_STACK !== "true" || env.ENVIRONMENT !== "development") return false;
+  if (
     env.BETTER_AUTH_URL === LOCAL_STACK_AUTH_ORIGIN &&
     env.WEB_ORIGIN === LOCAL_STACK_WEB_ORIGIN
-  );
+  ) {
+    return true;
+  }
+  return portlessLocalStackOrigins(env.BETTER_AUTH_URL, env.WEB_ORIGIN);
 }
 
 async function ensureDemoIdentity(env: AuthEnv) {
@@ -104,8 +134,9 @@ export function localDemoPlugin(env: AuthEnv) {
         { method: "POST", requireHeaders: true },
         async (ctx) => {
           // Keep a wrong/missing browser origin indistinguishable from an
-          // absent route. The plugin is itself omitted outside localDemoEnabled.
-          if (ctx.headers?.get("origin") !== LOCAL_STACK_WEB_ORIGIN) {
+          // absent route. The plugin is itself omitted outside localDemoEnabled,
+          // which has already vetted WEB_ORIGIN as a loopback-only shape.
+          if (ctx.headers?.get("origin") !== env.WEB_ORIGIN) {
             return new Response("Not Found", { status: 404 });
           }
           const user = await ensureDemoIdentity(env);

--- a/apps/auth/src/trusted-origins.test.ts
+++ b/apps/auth/src/trusted-origins.test.ts
@@ -53,12 +53,16 @@ describe("isTrustedOrigin", () => {
 
   it("allows the real-TLD portless OAuth zone outside production only", () => {
     const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
-    expect(isTrustedOrigin("https://local.uploads.sh", env)).toBe(true);
-    expect(isTrustedOrigin("https://auth.local.uploads.sh", env)).toBe(true);
-    expect(isTrustedOrigin("https://fix-ui.auth.local.uploads.sh", env)).toBe(true);
-    expect(isTrustedOrigin("http://auth.local.uploads.sh", env)).toBe(false);
-    expect(isTrustedOrigin("https://evil-local.uploads.sh", env)).toBe(false);
-    expect(isTrustedOrigin("https://auth.local.uploads.sh", prodEnv)).toBe(false);
+    const zone = "uploads.local.buildinternet.dev";
+    expect(isTrustedOrigin(`https://${zone}`, env)).toBe(true);
+    expect(isTrustedOrigin(`https://auth.${zone}`, env)).toBe(true);
+    expect(isTrustedOrigin(`https://fix-ui.auth.${zone}`, env)).toBe(true);
+    expect(isTrustedOrigin(`http://auth.${zone}`, env)).toBe(false);
+    expect(isTrustedOrigin("https://evil-uploads.local.buildinternet.dev", env)).toBe(false);
+    // Never under uploads.sh — the local zone must not share prod's
+    // registrable domain (cookie scope).
+    expect(isTrustedOrigin("https://auth.local.uploads.sh", env)).toBe(false);
+    expect(isTrustedOrigin(`https://auth.${zone}`, prodEnv)).toBe(false);
   });
 
   it("rejects unrelated hosts outside production", () => {

--- a/apps/auth/src/trusted-origins.test.ts
+++ b/apps/auth/src/trusted-origins.test.ts
@@ -46,6 +46,9 @@ describe("isTrustedOrigin", () => {
   it("allows portless *.localhost origins outside production", () => {
     const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
     expect(isTrustedOrigin("https://uploads.localhost", env)).toBe(true);
+    expect(isTrustedOrigin("https://auth.uploads.localhost", env)).toBe(true);
+    expect(isTrustedOrigin("https://fix-ui.auth.uploads.localhost", env)).toBe(true);
+    expect(isTrustedOrigin("http://uploads.localhost:1355", env)).toBe(true);
   });
 
   it("rejects unrelated hosts outside production", () => {

--- a/apps/auth/src/trusted-origins.test.ts
+++ b/apps/auth/src/trusted-origins.test.ts
@@ -51,6 +51,16 @@ describe("isTrustedOrigin", () => {
     expect(isTrustedOrigin("http://uploads.localhost:1355", env)).toBe(true);
   });
 
+  it("allows the real-TLD portless OAuth zone outside production only", () => {
+    const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
+    expect(isTrustedOrigin("https://local.uploads.sh", env)).toBe(true);
+    expect(isTrustedOrigin("https://auth.local.uploads.sh", env)).toBe(true);
+    expect(isTrustedOrigin("https://fix-ui.auth.local.uploads.sh", env)).toBe(true);
+    expect(isTrustedOrigin("http://auth.local.uploads.sh", env)).toBe(false);
+    expect(isTrustedOrigin("https://evil-local.uploads.sh", env)).toBe(false);
+    expect(isTrustedOrigin("https://auth.local.uploads.sh", prodEnv)).toBe(false);
+  });
+
   it("rejects unrelated hosts outside production", () => {
     const env = { WEB_ORIGIN: "https://uploads.sh", ENVIRONMENT: "development" };
     expect(isTrustedOrigin("https://evil.example", env)).toBe(false);

--- a/apps/auth/src/trusted-origins.ts
+++ b/apps/auth/src/trusted-origins.ts
@@ -13,6 +13,12 @@ const LOCALHOST_ORIGIN_RE = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 // prefixed https://fix-ui.uploads.localhost, or the sudo-less proxy fallback
 // http://uploads.localhost:1355. `.localhost` resolves to loopback by spec.
 const PORTLESS_ORIGIN_RE = /^https?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?$/;
+// Real-TLD portless mode for OAuth providers that reject `*.localhost`
+// redirect URIs (see the `oauth` skill and the sibling repos' matching
+// `*.local.buildinternet.dev` zones): PORTLESS_TLD=sh PORTLESS_NAME=local.uploads
+// serves https://local.uploads.sh + subdomains, resolved to loopback via
+// `portless hosts sync`. Non-production only, same as the other dev regexes.
+const LOCAL_UPLOADS_SH_ORIGIN_RE = /^https:\/\/([a-z0-9-]+\.)*local\.uploads\.sh$/;
 
 export type TrustedOriginsEnv = {
   WEB_ORIGIN?: string;
@@ -44,5 +50,9 @@ export function authTrustedOrigins(env: TrustedOriginsEnv): string[] {
 export function isTrustedOrigin(origin: string, env: TrustedOriginsEnv): boolean {
   if (authTrustedOrigins(env).includes(origin)) return true;
   if (env.ENVIRONMENT === "production") return false;
-  return LOCALHOST_ORIGIN_RE.test(origin) || PORTLESS_ORIGIN_RE.test(origin);
+  return (
+    LOCALHOST_ORIGIN_RE.test(origin) ||
+    PORTLESS_ORIGIN_RE.test(origin) ||
+    LOCAL_UPLOADS_SH_ORIGIN_RE.test(origin)
+  );
 }

--- a/apps/auth/src/trusted-origins.ts
+++ b/apps/auth/src/trusted-origins.ts
@@ -14,11 +14,14 @@ const LOCALHOST_ORIGIN_RE = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 // http://uploads.localhost:1355. `.localhost` resolves to loopback by spec.
 const PORTLESS_ORIGIN_RE = /^https?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?$/;
 // Real-TLD portless mode for OAuth providers that reject `*.localhost`
-// redirect URIs (see the `oauth` skill and the sibling repos' matching
-// `*.local.buildinternet.dev` zones): PORTLESS_TLD=sh PORTLESS_NAME=local.uploads
-// serves https://local.uploads.sh + subdomains, resolved to loopback via
-// `portless hosts sync`. Non-production only, same as the other dev regexes.
-const LOCAL_UPLOADS_SH_ORIGIN_RE = /^https:\/\/([a-z0-9-]+\.)*local\.uploads\.sh$/;
+// redirect URIs (see the `oauth` skill): PORTLESS_TLD=dev
+// PORTLESS_NAME=uploads.local.buildinternet serves
+// https://uploads.local.buildinternet.dev + subdomains, resolved to loopback
+// via public DNS. Deliberately on the shared infra domain (matching the
+// sibling repos) rather than under uploads.sh, so prod's `Domain=.uploads.sh`
+// session cookies never overlap the local zone. Non-production only.
+const LOCAL_BUILDINTERNET_ORIGIN_RE =
+  /^https:\/\/([a-z0-9-]+\.)*uploads\.local\.buildinternet\.dev$/;
 
 export type TrustedOriginsEnv = {
   WEB_ORIGIN?: string;
@@ -53,6 +56,6 @@ export function isTrustedOrigin(origin: string, env: TrustedOriginsEnv): boolean
   return (
     LOCALHOST_ORIGIN_RE.test(origin) ||
     PORTLESS_ORIGIN_RE.test(origin) ||
-    LOCAL_UPLOADS_SH_ORIGIN_RE.test(origin)
+    LOCAL_BUILDINTERNET_ORIGIN_RE.test(origin)
   );
 }

--- a/apps/auth/src/trusted-origins.ts
+++ b/apps/auth/src/trusted-origins.ts
@@ -8,9 +8,11 @@
  */
 
 const LOCALHOST_ORIGIN_RE = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
-// Portless dev (see the `portless` skill): named `*.localhost` origins with no
-// port, e.g. https://uploads.localhost.
-const PORTLESS_ORIGIN_RE = /^https?:\/\/[a-z0-9-]+\.localhost$/;
+// Portless dev (see the `portless` skill): named `*.localhost` origins, e.g.
+// https://uploads.localhost, https://auth.uploads.localhost, a worktree-
+// prefixed https://fix-ui.uploads.localhost, or the sudo-less proxy fallback
+// http://uploads.localhost:1355. `.localhost` resolves to loopback by spec.
+const PORTLESS_ORIGIN_RE = /^https?:\/\/[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?$/;
 
 export type TrustedOriginsEnv = {
   WEB_ORIGIN?: string;

--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -8,6 +8,12 @@
 # here points the signed-in pages (and their CSP connect-src, which is derived
 # from the same origins — see resolveSignedInOrigins in
 # src/lib/signed-in-page.ts) at the local auth/API workers instead. Matches
-# the ports used by `pnpm dev:stack` (see scripts/dev-stack-common.mjs).
+# the ports used by standalone `pnpm dev:web` against loopback workers.
+#
+# NOTE: `pnpm dev:stack` runs through portless (see docs/local-dev.md) and
+# injects the named origins (https://auth.uploads.localhost etc.) via process
+# env at startup — it does not need this file. If you run the portless stack
+# and signed-in pages still resolve loopback/prod origins, a stale .dev.vars
+# here is the usual culprit.
 UPLOADS_AUTH_ORIGIN=http://127.0.0.1:8788
 UPLOADS_API_ORIGIN=http://127.0.0.1:8787

--- a/apps/web/src/lib/signed-in-page.ts
+++ b/apps/web/src/lib/signed-in-page.ts
@@ -19,12 +19,22 @@ export function resolveSignedInOrigins(env: OriginEnv): {
   authOrigin: string;
   apiOrigin: string;
 } {
+  // In dev, the stack supervisor (scripts/dev-stack.mjs) injects the live
+  // portless origins as PUBLIC_* process env — but the Cloudflare adapter's
+  // runtime env lets a stale apps/web/.dev.vars shadow them. Prefer the
+  // supervisor's values in dev so the CSP and clients point at the workers
+  // that are actually running; production is untouched (PUBLIC_* is unset
+  // there, so the runtime-env chain below still decides).
+  const devAuth = import.meta.env.DEV ? import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN : undefined;
+  const devApi = import.meta.env.DEV ? import.meta.env.PUBLIC_UPLOADS_API_ORIGIN : undefined;
   return {
     authOrigin:
+      devAuth ??
       env.UPLOADS_AUTH_ORIGIN ??
       import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ??
       "https://auth.uploads.sh",
     apiOrigin:
+      devApi ??
       env.UPLOADS_API_ORIGIN ??
       import.meta.env.PUBLIC_UPLOADS_API_ORIGIN ??
       "https://api.uploads.sh",

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -51,29 +51,36 @@ Notes:
   enables for the exact loopback pair or a matched `*.localhost` pair — never
   for real-TLD origins.
 
-### Real-TLD mode for OAuth (`*.local.uploads.sh`)
+### Real-TLD mode for OAuth (`*.uploads.local.buildinternet.dev`)
 
-Some OAuth providers (Google, Apple) reject `*.localhost` redirect URIs, so —
-like the sibling repos' `*.local.buildinternet.dev` zones — the stack can run
-under a real TLD instead:
+Some OAuth providers (Google, Apple) reject `*.localhost` redirect URIs, so
+the stack can run under a real TLD instead — on the shared
+`local.buildinternet.dev` infra zone, same as the sibling repos:
 
 ```bash
-PORTLESS_TLD=sh PORTLESS_NAME=local.uploads pnpm dev:stack
-# -> https://local.uploads.sh / https://auth.local.uploads.sh / https://api.local.uploads.sh
+PORTLESS_TLD=dev PORTLESS_NAME=uploads.local.buildinternet pnpm dev:stack
+# -> https://uploads.local.buildinternet.dev
+#    https://auth.uploads.local.buildinternet.dev
+#    https://api.uploads.local.buildinternet.dev
 ```
 
-No hosts-file setup needed: `local.uploads.sh` and `*.local.uploads.sh` are
-public DNS-only A records → `127.0.0.1` in the uploads.sh Cloudflare zone
-(never proxy them), so the names resolve to loopback on any machine —
-including worktree-prefixed ones. `pnpm exec portless hosts sync` is only a
-fallback for offline work.
+The zone is deliberately NOT under uploads.sh: prod sets its session cookie
+with `Domain=.uploads.sh`, so a `local.uploads.sh` zone would leak prod
+cookies into local dev stacks (and let local software set cookies scoped to
+prod). The infra domain has no production cookies to overlap.
+
+DNS: `local.buildinternet.dev` + `*.local.buildinternet.dev` are public
+DNS-only A records → `127.0.0.1` (never proxy them), so the names resolve to
+loopback on any machine, worktree prefixes included.
+`pnpm exec portless hosts sync` is only a fallback for offline work.
 
 These origins are trusted by the auth worker outside production (https only).
 Register the provider's redirect URI as
-`https://auth.local.uploads.sh/api/auth/callback/<provider>`. Note the
-`dev-session` bypass is intentionally unavailable in this mode — sign in
-through the real provider flow you're testing. GitHub accepts loopback
-callbacks, so day-to-day GitHub testing can stay on `PORTLESS=0` instead.
+`https://auth.uploads.local.buildinternet.dev/api/auth/callback/<provider>`.
+Note the `dev-session` bypass is intentionally unavailable in this mode —
+sign in through the real provider flow you're testing. GitHub accepts
+loopback callbacks, so day-to-day GitHub testing can stay on `PORTLESS=0`
+instead.
 
 `bootstrap` is idempotent (safe to re-run; never overwrites your env files or
 re-mints an existing local workspace) and `doctor` is read-only. `dev:stack`

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -51,6 +51,25 @@ Notes:
   enables for the exact loopback pair or a matched `*.localhost` pair — never
   for real-TLD origins.
 
+### Real-TLD mode for OAuth (`*.local.uploads.sh`)
+
+Some OAuth providers (Google, Apple) reject `*.localhost` redirect URIs, so —
+like the sibling repos' `*.local.buildinternet.dev` zones — the stack can run
+under a real TLD instead:
+
+```bash
+PORTLESS_TLD=sh PORTLESS_NAME=local.uploads pnpm dev:stack
+# -> https://local.uploads.sh / https://auth.local.uploads.sh / https://api.local.uploads.sh
+pnpm exec portless hosts sync   # resolve the names to loopback via /etc/hosts
+```
+
+These origins are trusted by the auth worker outside production (https only).
+Register the provider's redirect URI as
+`https://auth.local.uploads.sh/api/auth/callback/<provider>`. Note the
+`dev-session` bypass is intentionally unavailable in this mode — sign in
+through the real provider flow you're testing. GitHub accepts loopback
+callbacks, so day-to-day GitHub testing can stay on `PORTLESS=0` instead.
+
 `bootstrap` is idempotent (safe to re-run; never overwrites your env files or
 re-mints an existing local workspace) and `doctor` is read-only. `dev:stack`
 uses the real Workers, Better Auth cookie, service binding, membership checks,

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -60,8 +60,13 @@ under a real TLD instead:
 ```bash
 PORTLESS_TLD=sh PORTLESS_NAME=local.uploads pnpm dev:stack
 # -> https://local.uploads.sh / https://auth.local.uploads.sh / https://api.local.uploads.sh
-pnpm exec portless hosts sync   # resolve the names to loopback via /etc/hosts
 ```
+
+No hosts-file setup needed: `local.uploads.sh` and `*.local.uploads.sh` are
+public DNS-only A records → `127.0.0.1` in the uploads.sh Cloudflare zone
+(never proxy them), so the names resolve to loopback on any machine —
+including worktree-prefixed ones. `pnpm exec portless hosts sync` is only a
+fallback for offline work.
 
 These origins are trusted by the auth worker outside production (https only).
 Register the provider's redirect URI as

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -43,10 +43,14 @@ Notes:
   is unavailable, portless falls back to plain HTTP on `:1355` — the stack
   handles both. `pnpm exec portless doctor` diagnoses routing/CA issues, and
   `pnpm exec portless service install` keeps the proxy across reboots.
-- `PORTLESS=0 pnpm dev:stack` restores the legacy pinned loopback ports
-  (`127.0.0.1:4321/8787/8788`). This is also the path to use when testing the
-  dev GitHub OAuth app, whose callback is pinned to
-  `http://127.0.0.1:8788/api/auth/callback/github`.
+- `pnpm dev:stack:raw` (or `PORTLESS=0 pnpm dev:stack`) restores the legacy
+  pinned loopback ports (`127.0.0.1:4321/8787/8788`). This is also the path
+  to use when testing the dev GitHub OAuth app, whose callback is pinned to
+  `http://127.0.0.1:8788/api/auth/callback/github`. The `stack-raw` launch
+  config (.claude/launch.json) boots the same thing with a port-based
+  preview; in portless mode the web port is dynamic, so open the printed
+  `previewUrl` directly instead.
+- `pnpm dev:stack:oauth` is the named alias for the real-TLD mode below.
 - The zero-input `/api/auth/dev-session` bypass stays fail-closed: it only
   enables for the exact loopback pair or a matched `*.localhost` pair — never
   for real-TLD origins.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -10,11 +10,46 @@ pnpm doctor           # diagnose the setup — reports what's missing and how to
 
 pnpm dev              # API on :8787 (local R2 + KV + D1)
 pnpm dev:web          # Astro site
-pnpm dev:stack        # authenticated Auth + API + Web stack, ready at 127.0.0.1:4321
+pnpm dev:stack        # authenticated Auth + API + Web stack (portless, see below)
 pnpm dev:stack:check --json  # machine-readable readiness + session/API smoke proof
 pnpm check            # lint + format (CI gate)
 pnpm typecheck        # wrangler types + tsc across workspaces
 ```
+
+## Named local URLs (portless)
+
+`pnpm dev:stack` runs through [portless](https://npmjs.com/portless), so the
+stack gets stable named `.localhost` origins instead of bare ports:
+
+| Service | URL                              |
+| ------- | -------------------------------- |
+| web     | `https://uploads.localhost`      |
+| auth    | `https://auth.uploads.localhost` |
+| api     | `https://api.uploads.localhost`  |
+
+The shared `.uploads.localhost` parent is what makes local auth work like
+prod: the Better Auth session cookie set by the auth worker is sent to web
+and api the same way `.uploads.sh` cookies are, so signed-in pages
+(`/account/*`, `/admin/*`) just work in a local browser — including agent
+browser panels. In a linked git worktree, portless prefixes the branch name
+(`fix-ui.uploads.localhost` / `fix-ui.auth.uploads.localhost`); the cookie
+parent still anchors on the last two labels, so nothing else changes.
+`dev:stack` prints the resolved `previewUrl` when ready, and
+`pnpm dev:stack:check --json` reports it too.
+
+Notes:
+
+- First run may prompt for sudo so the proxy can bind :443 (HTTPS). If sudo
+  is unavailable, portless falls back to plain HTTP on `:1355` — the stack
+  handles both. `pnpm exec portless doctor` diagnoses routing/CA issues, and
+  `pnpm exec portless service install` keeps the proxy across reboots.
+- `PORTLESS=0 pnpm dev:stack` restores the legacy pinned loopback ports
+  (`127.0.0.1:4321/8787/8788`). This is also the path to use when testing the
+  dev GitHub OAuth app, whose callback is pinned to
+  `http://127.0.0.1:8788/api/auth/callback/github`.
+- The zero-input `/api/auth/dev-session` bypass stays fail-closed: it only
+  enables for the exact loopback pair or a matched `*.localhost` pair — never
+  for real-TLD origins.
 
 `bootstrap` is idempotent (safe to re-run; never overwrites your env files or
 re-mints an existing local workspace) and `doctor` is read-only. `dev:stack`

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -74,6 +74,13 @@ DNS-only A records → `127.0.0.1` (never proxy them), so the names resolve to
 loopback on any machine, worktree prefixes included.
 `pnpm exec portless hosts sync` is only a fallback for offline work.
 
+The proxy only serves TLDs it was started with, so if yours runs with the
+default `.localhost` only, this mode auto-starts a second proxy on `:1355`
+and the URLs carry that port. For clean port-free URLs, run one proxy with
+both TLDs: `sudo portless proxy stop && sudo portless proxy start --https
+--tld localhost --tld dev` (or bake it in with
+`portless service install --tld localhost --tld dev`).
+
 These origins are trusted by the auth worker outside production (https only).
 Register the provider's redirect URI as
 `https://auth.uploads.local.buildinternet.dev/api/auth/callback/<provider>`.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
     "oxlint-tsgolint": "^0.24.0",
+    "portless": "^0.15.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev:mcp": "pnpm --filter @uploads/mcp dev",
     "dev:auth": "pnpm --filter @uploads/auth dev",
     "dev:stack": "node scripts/dev-stack.mjs",
+    "dev:stack:raw": "PORTLESS=0 node scripts/dev-stack.mjs",
+    "dev:stack:oauth": "PORTLESS_TLD=dev PORTLESS_NAME=uploads.local.buildinternet node scripts/dev-stack.mjs",
     "dev:stack:check": "node scripts/dev-stack-check.mjs",
     "dev:stack:smoke": "node scripts/dev-stack-smoke.mjs",
     "build": "pnpm --filter @uploads/web build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.24.0
         version: 0.24.0
+      portless:
+        specifier: ^0.15.4
+        version: 0.15.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3875,6 +3878,12 @@ packages:
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  portless@0.15.4:
+    resolution: {integrity: sha512-tOxEsdlDGuPHO6DPkuK3c3mMV5ctXEgVFm53Sa8nfZ2RsRGTq4By424C6z5+JWfNbd3ktR5SOd1FJBOlB1Woqg==}
+    engines: {node: '>=24'}
+    os: [darwin, linux, win32]
     hasBin: true
 
   postcss-load-config@6.0.1:
@@ -7999,6 +8008,8 @@ snapshots:
 
   playwright-core@1.61.1:
     optional: true
+
+  portless@0.15.4: {}
 
   postcss-load-config@6.0.1(postcss@8.5.16)(yaml@2.9.0):
     dependencies:

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,9 @@
+{
+  "name": "uploads",
+  "apps": {
+    "apps/web": { "name": "uploads" },
+    "apps/api": { "name": "api.uploads" },
+    "apps/auth": { "name": "auth.uploads" },
+    "apps/mcp": { "name": "mcp.uploads" }
+  }
+}

--- a/scripts/dev-stack-common.mjs
+++ b/scripts/dev-stack-common.mjs
@@ -1,7 +1,65 @@
 /** Shared local-stack endpoints, cookie jar, fixture uploads, and smoke flow. */
-export const AUTH_ORIGIN = "http://127.0.0.1:8788";
-export const API_ORIGIN = "http://127.0.0.1:8787";
-export const WEB_ORIGIN = "http://127.0.0.1:4321";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Portless (see the `portless` skill) gives the stack named HTTPS origins with
+// a shared `.uploads.localhost` cookie parent, so the Better Auth session
+// spans web/auth/api locally the same way `.uploads.sh` does in prod.
+// `PORTLESS=0` falls back to the legacy loopback ports (also the path for the
+// dev GitHub OAuth app, whose callback is pinned to 127.0.0.1:8788).
+export const USE_PORTLESS = process.env.PORTLESS !== "0";
+export const PORTLESS_BASE = process.env.PORTLESS_NAME || "uploads";
+
+const PORTLESS_CA = join(process.env.PORTLESS_STATE_DIR || join(homedir(), ".portless"), "ca.pem");
+
+// Pre-start the proxy: `portless run` can auto-start it, but only with a TTY
+// (binding :443 may sudo-prompt), so agent/CI shells must pre-start or the
+// child exits. Idempotent when already running; reuses the persisted config
+// (port/TLS), and first HTTPS start also generates the local CA. If this
+// fails (e.g. sudo needed but unavailable), fall back to the unprivileged
+// port so the stack still comes up: URLs then include :1355.
+if (USE_PORTLESS) {
+  const started = spawnSync("pnpm", ["exec", "portless", "proxy", "start"], { stdio: "inherit" });
+  if (started.status !== 0) {
+    spawnSync("pnpm", ["exec", "portless", "proxy", "start", "--port", "1355"], {
+      stdio: "inherit",
+    });
+  }
+}
+
+// Node's fetch does not use the system trust store, so the portless local CA
+// must be handed to this process via NODE_EXTRA_CA_CERTS — which Node only
+// reads at startup. Re-exec once with it set before any request is made.
+if (USE_PORTLESS && existsSync(PORTLESS_CA) && process.env.NODE_EXTRA_CA_CERTS !== PORTLESS_CA) {
+  const rerun = spawnSync(process.execPath, process.argv.slice(1), {
+    stdio: "inherit",
+    env: { ...process.env, NODE_EXTRA_CA_CERTS: PORTLESS_CA },
+  });
+  process.exit(rerun.status ?? 1);
+}
+
+/** Resolve the (possibly worktree-prefixed) portless URL for a service name. */
+function portlessUrl(name) {
+  const result = spawnSync("pnpm", ["exec", "portless", "get", name], { encoding: "utf8" });
+  const url = result.stdout?.trim().split("\n").at(-1);
+  if (result.status !== 0 || !url?.startsWith("http")) {
+    throw new Error(
+      `portless get ${name} failed (${result.stderr?.trim() || `exit ${result.status}`}). ` +
+        "Run `pnpm exec portless doctor`, or set PORTLESS=0 to use plain loopback ports.",
+    );
+  }
+  return url;
+}
+
+export const AUTH_ORIGIN = USE_PORTLESS
+  ? portlessUrl(`auth.${PORTLESS_BASE}`)
+  : "http://127.0.0.1:8788";
+export const API_ORIGIN = USE_PORTLESS
+  ? portlessUrl(`api.${PORTLESS_BASE}`)
+  : "http://127.0.0.1:8787";
+export const WEB_ORIGIN = USE_PORTLESS ? portlessUrl(PORTLESS_BASE) : "http://127.0.0.1:4321";
 export const PREVIEW_URL = `${WEB_ORIGIN}/account/workspaces`;
 export const DEMO_WORKSPACE = "dev-demo";
 

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -234,7 +234,11 @@ async function main() {
 
   await seedFixtures(token);
   if (stopping) return;
-  const smoke = await runSmoke();
+  // Real-TLD mode (e.g. *.local.uploads.sh for OAuth testing — see
+  // docs/local-dev.md) intentionally disables the dev-session bypass the
+  // smoke relies on; report ready without it.
+  const demoAvailable = /(\.localhost|^127\.0\.0\.1)$/.test(new URL(AUTH_ORIGIN).hostname);
+  const smoke = demoAvailable ? await runSmoke() : "skipped (real-TLD mode has no dev-session)";
   if (stopping) return;
   console.log(JSON.stringify({ ready: true, previewUrl: PREVIEW_URL, smoke }));
 

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -10,7 +10,9 @@ import { dirname, resolve } from "node:path";
 import {
   API_ORIGIN,
   AUTH_ORIGIN,
+  PORTLESS_BASE,
   PREVIEW_URL,
+  USE_PORTLESS,
   WEB_ORIGIN,
   runSmoke,
   seedFixtures,
@@ -118,43 +120,65 @@ async function main() {
   );
   if (stopping) return;
 
-  start("auth", [
-    "--filter",
-    "@uploads/auth",
-    "exec",
-    "wrangler",
-    "dev",
-    "--local",
-    "--ip",
-    "127.0.0.1",
-    "--port",
-    "8788",
-    "--var",
-    "LOCAL_STACK:true",
-    "--var",
-    "ENVIRONMENT:development",
-    "--var",
-    `BETTER_AUTH_URL:${AUTH_ORIGIN}`,
-    "--var",
-    `WEB_ORIGIN:${WEB_ORIGIN}`,
-  ]);
+  // Portless mode: `portless run` assigns a free port via $PORT, registers the
+  // named HTTPS route (auto-starting the proxy), and prefixes worktree branch
+  // names — wrangler/astro just bind the assigned loopback port. PORTLESS=0
+  // keeps the legacy pinned ports (also the dev GitHub OAuth callback path).
+  const portlessWrap = (name, script) =>
+    USE_PORTLESS ? ["exec", "portless", "run", "--name", name, "sh", "-c", script] : null;
+
+  const authVars =
+    `--var LOCAL_STACK:true --var ENVIRONMENT:development ` +
+    `--var BETTER_AUTH_URL:${AUTH_ORIGIN} --var WEB_ORIGIN:${WEB_ORIGIN}`;
+  start(
+    "auth",
+    portlessWrap(
+      `auth.${PORTLESS_BASE}`,
+      `pnpm --filter @uploads/auth exec wrangler dev --local --ip 127.0.0.1 --port "$PORT" ${authVars}`,
+    ) ?? [
+      "--filter",
+      "@uploads/auth",
+      "exec",
+      "wrangler",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      "8788",
+      "--var",
+      "LOCAL_STACK:true",
+      "--var",
+      "ENVIRONMENT:development",
+      "--var",
+      `BETTER_AUTH_URL:${AUTH_ORIGIN}`,
+      "--var",
+      `WEB_ORIGIN:${WEB_ORIGIN}`,
+    ],
+  );
   await waitFor(`${AUTH_ORIGIN}/health`, "auth");
   if (stopping) return;
 
-  start("api", [
-    "--filter",
-    "@uploads/api",
-    "exec",
-    "wrangler",
-    "dev",
-    "--local",
-    "--ip",
-    "127.0.0.1",
-    "--port",
-    "8787",
-    "--var",
-    `WEB_ORIGIN:${WEB_ORIGIN}`,
-  ]);
+  start(
+    "api",
+    portlessWrap(
+      `api.${PORTLESS_BASE}`,
+      `pnpm --filter @uploads/api exec wrangler dev --local --ip 127.0.0.1 --port "$PORT" --var WEB_ORIGIN:${WEB_ORIGIN}`,
+    ) ?? [
+      "--filter",
+      "@uploads/api",
+      "exec",
+      "wrangler",
+      "dev",
+      "--local",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      "8787",
+      "--var",
+      `WEB_ORIGIN:${WEB_ORIGIN}`,
+    ],
+  );
   await waitFor(`${API_ORIGIN}/health`, "api");
   if (stopping) return;
 
@@ -168,7 +192,20 @@ async function main() {
 
   start(
     "web",
-    ["--filter", "@uploads/web", "exec", "astro", "dev", "--host", "127.0.0.1", "--port", "4321"],
+    portlessWrap(
+      PORTLESS_BASE,
+      `pnpm --filter @uploads/web exec astro dev --host 127.0.0.1 --port "$PORT"`,
+    ) ?? [
+      "--filter",
+      "@uploads/web",
+      "exec",
+      "astro",
+      "dev",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "4321",
+    ],
     {
       ...process.env,
       UPLOADS_AUTH_ORIGIN: AUTH_ORIGIN,


### PR DESCRIPTION
## Why

Agents (and humans) struggled to reach signed-in pages locally: the session cookie minted by the auth worker on `127.0.0.1:8788` never spanned web (`:4321`) or api (`:8787`), `localhost` vs `127.0.0.1` were different cookie sites, and stale/prod origin fallbacks tripped the strict CSP. Modeled on the ~/Code/sunny and ~/Code/releases portless setups.

## What

`pnpm dev:stack` now runs through [portless](https://npmjs.com/portless):

| Service | URL |
| --- | --- |
| web | `https://uploads.localhost` |
| auth | `https://auth.uploads.localhost` |
| api | `https://api.uploads.localhost` |

The shared `.uploads.localhost` cookie parent makes the Better Auth session span all three workers exactly like `.uploads.sh` in prod. Worktrees get branch-prefixed hosts; the cookie parent anchors on the last two labels so nothing else changes.

- `deriveCookieDomain`: multi-label `*.localhost` → `.<name>.localhost` parent; bare `x.localhost` stays host-only
- `PORTLESS_ORIGIN_RE`: multi-label + proxy-port (`:1355`) origins
- dev-session gate: accepts a matched `*.localhost` pair (loopback by spec); real-TLD origins never enable the bypass; origin header now checked against configured `WEB_ORIGIN`
- `resolveSignedInOrigins`: in dev, supervisor-injected `PUBLIC_*` origins beat a stale `apps/web/.dev.vars` (prod untouched)
- dev-stack: pre-starts the proxy (task runners must — no TTY means no sudo prompt), unprivileged-port fallback, re-execs with the portless CA so Node `fetch` verifies TLS, resolves origins via `portless get`; `PORTLESS=0` keeps the legacy pinned loopback ports (dev GitHub OAuth callback path)
- docs/local-dev.md: new portless section

## Verified

- `pnpm dev:stack` boots and its smoke passes end-to-end over the named origins (dev-session → get-session → API membership → file listing)
- Agent browser panel: minted a dev session from the web origin and rendered the signed-in `/account/workspaces` shell (files, usage, membership) — the original pain case
- `pnpm check`, `pnpm typecheck`, full `pnpm test` (1589 passing)
- Debug note: a root-owned `~/.portless/ca.srl` (from an old sudo proxy run) silently produced 0-byte per-host certs and TLS aborts; removing it fixed cert issuance. `pnpm exec portless doctor` didn't catch this.