### PR TITLE
fix(web,api): folder browsing, responsive layout, people list for the workspace view

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,15 @@
       "autoPort": true
     },
     {
+      "name": "stack",
+      "runtimeExecutable": "zsh",
+      "runtimeArgs": [
+        "-c",
+        "export NVM_DIR=\"${NVM_DIR:-$HOME/.nvm}\"; [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm use --silent; node scripts/dev-stack.mjs"
+      ],
+      "port": 4321
+    },
+    {
       "name": "stack-raw",
       "runtimeExecutable": "zsh",
       "runtimeArgs": [

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -64,6 +64,37 @@ export async function membershipsForUser(env: Env, userId: string): Promise<Memb
   return body as Membership[];
 }
 
+/** A raw member row from the auth worker's `/internal/orgs/:slug/members`. */
+export interface OrgMember {
+  id: string;
+  userId: string;
+  email: string;
+  name: string | null;
+  role: string;
+  createdAt?: string;
+}
+
+/**
+ * Members of an org via `GET /internal/orgs/:slug/members` over the AUTH
+ * binding. Non-ok is an auth-worker outage/bug, surfaced as a 5xx like the
+ * lookups above. Shared by the admin panel (raw rows) and the member-facing
+ * people tab (which sanitizes before responding).
+ */
+export async function membersForOrg(env: Env, slug: string): Promise<OrgMember[]> {
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/members`,
+    { headers: internalHeaders() },
+  );
+  if (!response.ok) {
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: response.status },
+    });
+  }
+  const body = (await response.json().catch(() => null)) as { members?: OrgMember[] } | null;
+  return body?.members ?? [];
+}
+
 /**
  * The organization for a given workspace name, or null if none exists yet
  * (e.g. the workspace predates the Phase 3 backfill, or was never

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -20,7 +20,7 @@ import {
 } from "../auth-db";
 import { allowWrite } from "../guards";
 import { deriveWebOrigin, inviteLinkUrl } from "../invite-links";
-import { orgForWorkspace } from "../org-workspaces";
+import { membersForOrg, orgForWorkspace } from "../org-workspaces";
 import {
   requireAdminUser,
   requireSessionUser,
@@ -133,16 +133,7 @@ export const adminUi = new Hono<SessionVars>()
     if (!org)
       throw new NotFoundError("no organization for this workspace", { code: "org_not_found" });
 
-    const response = await c.env.AUTH.fetch(
-      `https://auth.internal/internal/orgs/${encodeURIComponent(org.slug)}/members`,
-      { headers: { "x-uploads-internal": "1" } },
-    );
-    if (!response.ok) {
-      throw new ValidationError("failed to list members", {
-        details: await response.json().catch(() => null),
-      });
-    }
-    return c.json(await response.json());
+    return c.json({ members: await membersForOrg(c.env, org.slug) });
   })
 
   // Pending invites for the org backing this workspace.

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -102,7 +102,11 @@ describe("GET /me/workspaces", () => {
       workspaces: { workspace: string; hasPublicUrl: boolean }[];
     };
     expect(body.workspaces).toEqual([
-      expect.objectContaining({ workspace: "acme", hasPublicUrl: true }),
+      expect.objectContaining({
+        workspace: "acme",
+        hasPublicUrl: true,
+        publicBaseUrl: "https://storage.uploads.sh",
+      }),
     ]);
   });
 
@@ -333,6 +337,63 @@ const R2_RECORD = {
   prefix: "acme/",
   publicBaseUrl: "https://storage.uploads.sh",
 };
+
+describe("GET /me/workspaces/:name/members", () => {
+  it("404s for a workspace the caller is not a member of", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("short-circuits the communal workspace with an empty list", async () => {
+    const env = memberEnv({ workspace: "default", db: new UsageFakeD1() });
+    const res = await app().request("/me/workspaces/default/members", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ communal: true, members: [] });
+  });
+
+  it("returns sanitized member rows for a member's workspace", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          { organizationId: "org1", organizationSlug: "acme", role: "member" },
+        ]);
+      }
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+      }
+      if (path === "/internal/orgs/acme/members") {
+        return Response.json({
+          members: [
+            {
+              id: "m1",
+              userId: "u1",
+              email: "a@b.com",
+              name: "Ada",
+              role: "owner",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+            { id: "m2", userId: "u2", email: "c@d.com", name: null, role: "member" },
+          ],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(200);
+    // Internal `id`/`userId` never reach the member-facing payload.
+    expect(await res.json()).toEqual({
+      communal: false,
+      members: [
+        { email: "a@b.com", name: "Ada", role: "owner", createdAt: "2026-01-01T00:00:00.000Z" },
+        { email: "c@d.com", name: "", role: "member" },
+      ],
+    });
+  });
+});
 
 describe("GET /me/workspaces/:name/galleries", () => {
   it("404s for a workspace the caller is not a member of", async () => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -22,7 +22,12 @@ import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { gallerySummary } from "../gallery-service";
 import { allowWrite } from "../guards";
-import { membershipsForUser, orgForWorkspace, workspacesForOrg } from "../org-workspaces";
+import {
+  membersForOrg,
+  membershipsForUser,
+  orgForWorkspace,
+  workspacesForOrg,
+} from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
@@ -148,10 +153,11 @@ export const me = new Hono<SessionVars>()
     const workspaces = await myWorkspaces(c.env, userId);
     const withPublicUrl = await Promise.all(
       workspaces.map(async (ws) => {
-        const hasPublicUrl = ws.communal
-          ? false
-          : Boolean((await loadWorkspaceRecord(c.env, ws.workspace))?.publicBaseUrl);
-        return Object.assign({}, ws, { hasPublicUrl });
+        const publicBaseUrl = ws.communal
+          ? undefined
+          : (await loadWorkspaceRecord(c.env, ws.workspace))?.publicBaseUrl;
+        // `hasPublicUrl` kept alongside the URL itself for existing consumers.
+        return Object.assign({}, ws, { hasPublicUrl: Boolean(publicBaseUrl), publicBaseUrl });
       }),
     );
     return c.json({ workspaces: withPublicUrl });
@@ -169,6 +175,29 @@ export const me = new Hono<SessionVars>()
 
     const usage = await getWorkspaceUsage(c.env.DB, name);
     return c.json(usageWithLimits(usage, record));
+  })
+
+  // People in one workspace — member-gated (any member may see who they share
+  // the workspace with; only the fields a teammate needs, not the raw member
+  // rows the admin panel gets). Communal is a shared public space with no real
+  // team behind it — same branch-free `communal: true` shape as galleries.
+  .get("/workspaces/:name/members", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    if (ws.communal) return c.json({ communal: true, members: [] });
+
+    // `ws.organization` was already resolved by the membership lookup — no
+    // second org fetch. Internal `id`/`userId` never reach teammates.
+    const members = await membersForOrg(c.env, ws.organization.slug);
+    return c.json({
+      communal: false,
+      members: members.map((m) => ({
+        email: m.email ?? "",
+        name: m.name ?? "",
+        role: m.role ?? "member",
+        createdAt: m.createdAt,
+      })),
+    });
   })
 
   // Galleries in one workspace — member-gated. The communal workspace is a

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -488,7 +488,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
           />
         </span>
         <button type="submit" className="input-group__action">
-          [add]
+          add
         </button>
       </form>
       {filterError && (
@@ -580,7 +580,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
             target="_blank"
             rel="noopener noreferrer"
           >
-            [open on github ↗]
+            open on github ↗
           </a>
         </div>
       )}
@@ -588,8 +588,8 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
       <div className="wft-grid">
         <div className="wft-head">
           <span>name</span>
-          <span>size</span>
-          <span>type</span>
+          <span className="wft-head__size">size</span>
+          <span className="wft-head__type">type</span>
           <span>visibility</span>
           <span />
         </div>

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -89,7 +89,7 @@ const invitePath = `${base}/people`;
           <span class="ws-rail__rule"></span>
         </div>
         <div class="ws-rail__actions">
-          <a class="ws-rail__invite" href={invitePath}>[invite teammate]</a>
+          <a class="ws-rail__invite" href={invitePath}>invite teammate</a>
           <div class="ws-rail__copyrow">
             <code><span class="ws-rail__prompt">$ </span>uploads put ./file.png</code>
             <button
@@ -98,7 +98,7 @@ const invitePath = `${base}/people`;
               data-copy="uploads put ./file.png"
               aria-live="polite"
             >
-              [copy]
+              copy
             </button>
           </div>
         </div>
@@ -285,6 +285,16 @@ const invitePath = `${base}/people`;
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__dd--accent) {
     color: var(--accent);
+  }
+  /* Public-url link — innerHTML-injected by renderDetailsHtml. */
+  :global(.account-shell) .ws-rail :global(.ws-rail__link) {
+    color: var(--fg);
+    text-decoration: none;
+  }
+  :global(.account-shell) .ws-rail :global(.ws-rail__link:hover),
+  :global(.account-shell) .ws-rail :global(.ws-rail__link:focus-visible) {
+    color: var(--accent);
+    outline: none;
   }
 
   /* Quick actions — server-rendered, static (no session data needed). */

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -201,7 +201,7 @@ describe("listWorkspaceFolder", () => {
   it("builds the querystring from opts, omitting absent params", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe(
-        "http://127.0.0.1:8787/me/workspaces/acme/files?prefix=f%2F&cursor=abc&limit=50",
+        "http://127.0.0.1:8787/me/workspaces/acme/files?delimiter=%2F&prefix=f%2F&cursor=abc&limit=50",
       );
       expect(init?.credentials).toBe("include");
       return Response.json({ communal: false, files: [], prefixes: [], cursor: null });
@@ -220,6 +220,7 @@ describe("listWorkspaceFolder", () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       expect(url).toContain("prefix=foo%2F");
+      expect(url).toContain("delimiter=%2F");
       expect(url).not.toContain("cursor=");
       expect(url).not.toContain("limit=");
       return Response.json({ communal: false, files: [], prefixes: [], cursor: null });
@@ -230,9 +231,9 @@ describe("listWorkspaceFolder", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  it("omits the querystring entirely when no opts are given", async () => {
+  it("still sends the folder delimiter when no opts are given", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/files");
+      expect(String(input)).toBe("http://127.0.0.1:8787/me/workspaces/acme/files?delimiter=%2F");
       return Response.json({ communal: false, files: [], prefixes: [], cursor: null });
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -26,6 +26,8 @@ export interface MyWorkspace {
    * signed-URL-capable `/me/.../file-url` endpoint instead.
    */
   hasPublicUrl: boolean;
+  /** The public base URL itself (e.g. `https://storage.uploads.sh`), when configured. */
+  publicBaseUrl?: string;
 }
 
 // `communal` and `hasPublicUrl` are intentionally NOT required here: web and
@@ -73,6 +75,10 @@ export async function getMyWorkspaces(apiOrigin: string): Promise<WorkspacesResu
         role: ws.role,
         communal: (ws as { communal?: unknown }).communal === true,
         hasPublicUrl: (ws as { hasPublicUrl?: unknown }).hasPublicUrl === true,
+        publicBaseUrl:
+          typeof (ws as { publicBaseUrl?: unknown }).publicBaseUrl === "string"
+            ? (ws as { publicBaseUrl: string }).publicBaseUrl
+            : undefined,
       }),
     ),
   };
@@ -232,6 +238,52 @@ export type InviteResult =
       emailConfigured?: boolean;
     }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "forbidden" | "invalid" };
+
+export interface WorkspaceMember {
+  email: string;
+  name: string;
+  role: string;
+  createdAt?: string;
+}
+
+export type WorkspaceMembersResult =
+  | { kind: "ok"; communal: boolean; members: WorkspaceMember[] }
+  | { kind: "unavailable" };
+
+function isMemberCandidate(
+  value: unknown,
+): value is { email: string; role: string } & Record<string, unknown> {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Record<string, unknown>;
+  return typeof row.email === "string" && typeof row.role === "string";
+}
+
+/** GET /me/workspaces/:name/members — teammates in the workspace, member-gated. */
+export async function getWorkspaceMembers(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceMembersResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/members`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
+  const body = (await result.response.json().catch(() => null)) as {
+    communal?: unknown;
+    members?: unknown;
+  } | null;
+  if (!body || !Array.isArray(body.members)) return { kind: "unavailable" };
+  return {
+    kind: "ok",
+    communal: body.communal === true,
+    members: body.members.filter(isMemberCandidate).map((row) => ({
+      email: row.email,
+      name: typeof row.name === "string" ? row.name : "",
+      role: row.role,
+      createdAt: typeof row.createdAt === "string" ? row.createdAt : undefined,
+    })),
+  };
+}
 
 /**
  * POST /me/workspaces/:name/invites — workspace admin|owner invites an email.
@@ -425,6 +477,9 @@ export async function listWorkspaceFolder(
   opts: { prefix?: string; cursor?: string; limit?: number } = {},
 ): Promise<WorkspaceFolderListing> {
   const params = new URLSearchParams();
+  // Always list one folder level at a time — without the delimiter the API
+  // returns a flat recursive listing and no `prefixes` (folders).
+  params.set("delimiter", "/");
   if (opts.prefix !== undefined) params.set("prefix", opts.prefix);
   if (opts.cursor !== undefined) params.set("cursor", opts.cursor);
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -81,17 +81,40 @@ describe("renderConnectedWorkHtml", () => {
 });
 
 describe("renderDetailsHtml", () => {
-  it("renders slug, role, and a configured public url", () => {
+  it("renders the public url as a host-labeled link when the URL is known", () => {
+    const html = renderDetailsHtml({
+      organization: { slug: "buildinternet" },
+      role: "admin",
+      hasPublicUrl: true,
+      publicBaseUrl: "https://storage.uploads.sh/",
+    });
+    expect(html).toContain(">buildinternet<");
+    expect(html).toContain(">admin<");
+    expect(html).toContain('class="ws-rail__dd ws-rail__dd--accent"');
+    expect(html).toContain('href="https://storage.uploads.sh/"');
+    expect(html).toContain(">storage.uploads.sh</a>");
+    expect(html).not.toContain(">configured<");
+  });
+
+  it("falls back to 'configured' when an older API sends only the boolean", () => {
     const html = renderDetailsHtml({
       organization: { slug: "buildinternet" },
       role: "admin",
       hasPublicUrl: true,
     });
-    expect(html).toContain(">buildinternet<");
-    expect(html).toContain(">admin<");
-    expect(html).toContain('class="ws-rail__dd ws-rail__dd--accent"');
     expect(html).toContain(">configured<");
-    expect(html).not.toContain("storage.uploads.sh");
+    expect(html).not.toContain("<a");
+  });
+
+  it("escapes an interpolated public url", () => {
+    const html = renderDetailsHtml({
+      organization: { slug: "acme" },
+      role: "member",
+      hasPublicUrl: true,
+      publicBaseUrl: 'https://x.example/"><script>alert(1)</script>',
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
   });
 
   it("renders an em-dash for public url when hasPublicUrl is false", () => {

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -55,19 +55,25 @@ export interface WorkspaceRailDetails {
   organization: { slug: string };
   role: string;
   hasPublicUrl: boolean;
+  publicBaseUrl?: string;
 }
 
 /**
- * Pure builder for the rail's "details" `<dt>/<dd>` pairs. There is no public-URL
- * string on `MyWorkspace` (only the `hasPublicUrl` boolean) — render "configured"
- * / "—" rather than fabricating a URL.
+ * Pure builder for the rail's "details" `<dt>/<dd>` pairs. The public-URL cell
+ * links to the workspace's `publicBaseUrl`, labeled by its host (the scheme is
+ * always https and only pads the narrow rail). `hasPublicUrl` without a URL
+ * string means an older API that predates `publicBaseUrl` in the listing —
+ * fall back to the old "configured" label rather than fabricating a URL.
  */
 export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
-  const publicUrlLabel = ws.hasPublicUrl ? "configured" : "—";
+  const host = ws.publicBaseUrl?.replace(/^https?:\/\//, "").replace(/\/$/, "");
+  const publicUrlHtml = ws.publicBaseUrl
+    ? `<a class="ws-rail__link" href="${escapeHtml(ws.publicBaseUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(host ?? "")}</a>`
+    : escapeHtml(ws.hasPublicUrl ? "configured" : "—");
   return (
     `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${escapeHtml(ws.organization.slug)}</dd>` +
     `<dt class="ws-rail__dt">your role</dt><dd class="ws-rail__dd ws-rail__dd--accent">${escapeHtml(ws.role)}</dd>` +
-    `<dt class="ws-rail__dt">public url</dt><dd class="ws-rail__dd">${escapeHtml(publicUrlLabel)}</dd>`
+    `<dt class="ws-rail__dt">public url</dt><dd class="ws-rail__dd">${publicUrlHtml}</dd>`
   );
 }
 
@@ -156,7 +162,7 @@ export function initWorkspaceRail(
       );
       if (!ws) return;
       if (roleBadge) {
-        roleBadge.textContent = `[${ws.role}]`;
+        roleBadge.textContent = ws.role;
         roleBadge.hidden = false;
       }
       if (detailsEl) detailsEl.innerHTML = renderDetailsHtml(ws);

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { orderOrgsOldestFirst, renderUsageHtml, safeSameOriginPath } from "./workspace-ui";
+import {
+  orderOrgsOldestFirst,
+  renderMembersHtml,
+  renderUsageHtml,
+  safeSameOriginPath,
+} from "./workspace-ui";
+
+describe("renderMembersHtml", () => {
+  it("leads with the display name and shows email as the sub-line", () => {
+    const html = renderMembersHtml([{ email: "a@b.com", name: "Ada", role: "owner" }]);
+    expect(html).toContain(">Ada<");
+    expect(html).toContain(">a@b.com<");
+    expect(html).toContain(">owner<");
+  });
+
+  it("leads with the email when there is no display name, without a sub-line", () => {
+    const html = renderMembersHtml([{ email: "c@d.com", name: "", role: "member" }]);
+    expect(html).toContain('member-row__name">c@d.com<');
+    expect(html).not.toContain("member-row__email");
+  });
+
+  it("escapes interpolated fields and renders [] as empty", () => {
+    const html = renderMembersHtml([
+      { email: "<img src=x>", name: "<b>x</b>", role: '"><script>alert(1)</script>' },
+    ]);
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;img");
+    expect(renderMembersHtml([])).toBe("");
+  });
+});
 
 describe("safeSameOriginPath", () => {
   it("accepts an absolute in-app path with query and hash", () => {

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -115,6 +115,28 @@ export function renderUsageHtml(usage: UsageSnapshot): string {
   return `<div class="ul-progress">${meters.map((m) => progressRowHtml(m.label, m.detail, m.pct)).join("")}</div><div class="usage-meta">${escapeHtml(objects)}</div>`;
 }
 
+/** Minimal member shape `renderMembersHtml` needs — api-client's `WorkspaceMember` satisfies it. */
+export interface MemberRow {
+  email: string;
+  name: string;
+  role: string;
+}
+
+/**
+ * Pure row builder for the people tab's member list. Shows the display name
+ * when the account has one (email then becomes the sub-line), otherwise the
+ * email leads. `[]` → `""` (caller renders its own empty state).
+ */
+export function renderMembersHtml(members: MemberRow[]): string {
+  return members
+    .map((m) => {
+      const lead = m.name || m.email;
+      const sub = m.name ? `<span class="member-row__email">${escapeHtml(m.email)}</span>` : "";
+      return `<div class="member-row"><span class="member-row__who"><span class="member-row__name">${escapeHtml(lead)}</span>${sub}</span><span class="member-row__role">${escapeHtml(m.role)}</span></div>`;
+    })
+    .join("");
+}
+
 export function isWorkspaceAdminRole(role: string): boolean {
   return role === "admin" || role === "owner";
 }

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -22,11 +22,18 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       <div class="settings-section">
         <div class="ws-page-header">
           <div class="ws-title-block">
-            <h2>Invite</h2>
+            <h2>People</h2>
             <p class="muted" id="ws-slug"></p>
           </div>
           <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
         </div>
+        <div id="ws-members" class="member-list">
+          <p class="muted" id="ws-members-status" role="status">Loading people…</p>
+        </div>
+      </div>
+
+      <div class="settings-section" id="ws-invite-section">
+        <h2>Invite</h2>
         <p class="settings-note muted">Accept link, then <code>uploads login</code>.</p>
         <form class="ws-form" id="ws-invite-form">
           <div class="input-group">
@@ -68,7 +75,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       onSession,
       requireElement,
     } from "../../../../lib/account-shell";
-    import { getMyWorkspaces, inviteToWorkspace } from "../../../../lib/api-client";
+    import {
+      getMyWorkspaces,
+      getWorkspaceMembers,
+      inviteToWorkspace,
+    } from "../../../../lib/api-client";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import {
@@ -76,6 +87,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       escapeHtml,
       isWorkspaceAdminRole,
       operatorInviteCommand,
+      renderMembersHtml,
     } from "../../../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
@@ -105,6 +117,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
       const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
       const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
+      const inviteSection = requireElement<HTMLElement>("#ws-invite-section", page);
+      const membersEl = requireElement<HTMLElement>("#ws-members", page);
 
       let sessionRole: string | null | undefined;
 
@@ -140,24 +154,20 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           return;
         }
 
-        if (!isWorkspaceAdminRole(ws.role) && sessionRole !== "admin") {
-          showError("You need workspace admin access to invite teammates.", false);
-          return;
-        }
-
-        // Non-admins who somehow deep-linked should not use the form (site
+        // Every member sees the people list; inviting stays admin-only (site
         // operators may still open the page for the ADMIN_TOKEN command).
-        if (!isWorkspaceAdminRole(ws.role)) {
-          inviteForm.hidden = true;
-        }
+        inviteSection.hidden = !isWorkspaceAdminRole(ws.role) && sessionRole !== "admin";
+        inviteForm.hidden = !isWorkspaceAdminRole(ws.role);
 
         statusEl.hidden = true;
         appEl.hidden = false;
 
+        void loadMembers();
+
         const displayName = ws.organization.name || ws.workspace;
         slugEl.textContent =
           displayName === ws.workspace ? ws.workspace : `${displayName} · ${ws.workspace}`;
-        document.title = `Invite · ${displayName} · uploads.sh`;
+        document.title = `People · ${displayName} · uploads.sh`;
 
         const isOperator = sessionRole === "admin";
         operatorCard.hidden = !isOperator;
@@ -166,6 +176,24 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           operatorCmd.textContent = cmd;
           operatorCopy.dataset.copy = cmd;
         }
+      }
+
+      async function loadMembers(): Promise<void> {
+        const result = await getWorkspaceMembers(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          membersEl.innerHTML =
+            '<p class="muted" role="alert">People are temporarily unavailable. Reload to try again.</p>';
+          return;
+        }
+        if (result.communal) {
+          membersEl.innerHTML =
+            '<p class="muted">Shared, public space — no member list to show.</p>';
+          return;
+        }
+        membersEl.innerHTML = result.members.length
+          ? renderMembersHtml(result.members)
+          : '<p class="muted">Just you so far.</p>';
       }
 
       bindCopyButtons(document);

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1021,7 +1021,7 @@ section.card .ws-messages .command {
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
-.wft-head span:nth-child(2) {
+.wft-head__size {
   text-align: right;
 }
 .wft-row {
@@ -1175,4 +1175,65 @@ button.wft-name--btn {
 }
 .wft-loadmore {
   margin-top: 10px;
+}
+
+/* People tab — member rows (innerHTML-injected by renderMembersHtml). */
+.member-list {
+  display: grid;
+}
+.member-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 9px 2px;
+  border-top: 1px solid var(--line);
+  font-size: 12.5px;
+}
+.member-row:first-child {
+  border-top: 0;
+}
+.member-row__who {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.member-row__name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.member-row__email {
+  color: var(--muted);
+  font-size: 11.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.member-row__role {
+  flex: none;
+  color: var(--muted);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Narrow screens: the five fixed columns (64/64/92/32 + gaps) leave the name
+   track nothing to render in, so filenames ellipsize to zero width. Drop the
+   size and type columns (their values still live in the file's own page) and
+   keep name / visibility / actions. */
+@media (max-width: 560px) {
+  .wft-row,
+  .wft-head {
+    grid-template-columns: minmax(0, 1fr) 92px 32px;
+    gap: 10px;
+  }
+  .wft-head__size,
+  .wft-head__type,
+  .wft-size,
+  .wft-type {
+    display: none;
+  }
 }

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -125,6 +125,26 @@
   top: 28px;
 }
 
+/* Mid-width: not enough room for the fixed 272px rail column next to the
+   content (the file grid needs ~320px minimum, so anything under ~1080px
+   viewport lets content paint into the rail). Keep the side nav, drop to
+   2-col, and move the rail under the main column instead. Bounded below at
+   681px so the ≤680 full-stack rules stay the single source of truth there. */
+@media (min-width: 681px) and (max-width: 1080px) {
+  .account-shell .layout[data-rail="true"] {
+    grid-template-columns: 180px minmax(0, 1fr);
+    gap: 24px;
+  }
+  .account-shell .layout[data-rail="true"] aside.rail {
+    grid-column: 2;
+    position: static;
+    top: auto;
+    margin-top: 8px;
+    padding-top: 20px;
+    border-top: 1px solid var(--line);
+  }
+}
+
 @media (max-width: 680px) {
   .account-shell .layout,
   .account-shell .layout[data-rail="true"] {


### PR DESCRIPTION
Follow-ups to the settings overhaul (#268), all found while dogfooding the new workspace view.

## Folder browsing was flat

The new files tab listed every key in one flat list: `WorkspaceFileTable`'s client never sent `delimiter=/`, and `GET /me/workspaces/:name/files` only groups keys into folder `prefixes` when a delimiter is given. `listWorkspaceFolder` now always sends it, and the client tests lock the param in. Verified end to end on the local stack: root shows folders, drill-down + breadcrumbs + URL sync work, files appear only at their leaf level.

## Responsive layout

The account shell had only two modes — 3-column desktop and a ≤680px full stack. In between, the fixed 180px nav + 272px rail left the content column narrower than the file grid's minimum, so the table painted over the rail.

- **681–1080px**: new 2-column mode — side nav stays, the rail (usage / details / quick actions) moves below the content with a divider.
- **≤560px**: the file grid drops its size/type columns (via semantic `wft-head__*` classes, not positional nth-child) so filenames keep room instead of ellipsizing to zero width.

## Rail shows the real public URL

`/me/workspaces` previously exposed only a `hasPublicUrl` boolean, so the rail could only say "configured". The endpoint now passes `publicBaseUrl` through (boolean kept for existing consumers — three components branch on it for open-vs-sign logic), and the details rail renders a host-labeled link with a "configured" fallback for an older API.

## People tab lists members

New member-gated `GET /me/workspaces/:name/members`, backed by a shared `membersForOrg` helper in `org-workspaces.ts` (also adopted by the `admin-ui` members proxy, which previously inlined the same fetch). The payload is sanitized to `email` / `name` / `role` / `createdAt` — internal member/user IDs never reach teammates. Behavior change: non-admin members now see the people list instead of a hard "admin access required" error; the invite form stays admin-only.

## Copy

Bracketed labels (`[add]`, `[copy]`, `[invite teammate]`, `[open on github ↗]`, `[MEMBER]`) flattened to the plain lowercase style the rest of the app uses.

## Review pass

A 4-angle cleanup review (reuse / simplification / efficiency / altitude) ran before commit; applied: shared `membersForOrg`, dropping a duplicate per-request org fetch in the members route (`memberWorkspaceOr404` already resolves the org), semantic column classes over nth-child, and two parsing/label simplifications. Noted-not-done: server-side `delimiter` default (would diverge from the flat-by-default contract of the token-scoped `/v1/:workspace/files` twin) and a breakpoint token system (no existing convention; only worth it if a third breakpoint appears).

Tests: 818 pass across web + api (new coverage for the delimiter param, members route sanitization/communal/404, member-row rendering + escaping, rail URL fallback + escaping).
