### PR TITLE
docs(web): consolidate responsive breakpoints into a documented scale

### DIFF
--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1220,10 +1220,11 @@ button.wft-name--btn {
   text-transform: uppercase;
 }
 
-/* Narrow screens: the five fixed columns (64/64/92/32 + gaps) leave the name
+/* --bp-file-grid: the five fixed columns (64/64/92/32 + gaps) leave the name
    track nothing to render in, so filenames ellipsize to zero width. Drop the
    size and type columns (their values still live in the file's own page) and
-   keep name / visibility / actions. */
+   keep name / visibility / actions. See the breakpoint scale in
+   signed-in-shell.css. */
 @media (max-width: 560px) {
   .wft-row,
   .wft-head {

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -125,11 +125,12 @@
   top: 28px;
 }
 
-/* Mid-width: not enough room for the fixed 272px rail column next to the
-   content (the file grid needs ~320px minimum, so anything under ~1080px
-   viewport lets content paint into the rail). Keep the side nav, drop to
-   2-col, and move the rail under the main column instead. Bounded below at
-   681px so the ≤680 full-stack rules stay the single source of truth there. */
+/* Mid-width rail tier (--bp-stack+1 … --bp-rail): not enough room for the
+   fixed 272px rail column next to the content (the file grid needs ~320px
+   minimum), so keep the side nav, drop to 2-col, and move the rail under the
+   main column. Bounded below at 681px (--bp-stack + 1) so the ≤680 full-stack
+   rules stay the single authority at that edge. See the breakpoint scale in
+   signed-in-shell.css. */
 @media (min-width: 681px) and (max-width: 1080px) {
   .account-shell .layout[data-rail="true"] {
     grid-template-columns: 180px minmax(0, 1fr);
@@ -145,6 +146,7 @@
   }
 }
 
+/* --bp-stack: collapse to a single column (mirrors signed-in-shell.css). */
 @media (max-width: 680px) {
   .account-shell .layout,
   .account-shell .layout[data-rail="true"] {

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -1,5 +1,25 @@
 /* Shared shell/sidebar styles for /account/* and /admin/* signed-in pages.
    Tokens + @font-face come from @uploads/ui/styles.css via <BaseHead />. */
+
+/* ── Responsive breakpoint scale ──────────────────────────────────────────
+   The single source of truth for the signed-in-page breakpoints. Media
+   queries can't read CSS custom properties, so these live as documentation,
+   not `--bp-*` variables — do NOT add ad-hoc widths elsewhere; extend this
+   list and reference it by name instead.
+
+     --bp-rail       1080px   Below this the fixed 272px right rail has no
+                              room beside the content grid, so it restacks
+                              under the main column (account-shell.css).
+     --bp-stack       680px   At/below this the nav + layout collapse to a
+                              single full-width column (this file +
+                              account-shell.css). The mid-width rail tier is
+                              bounded at min-width: 681px — the +1 pixel above
+                              --bp-stack — so the ≤680 stack rules stay the
+                              lone authority at that edge. Keep 680/681
+                              adjacent if either moves.
+     --bp-file-grid   560px   At/below this the workspace file table drops its
+                              size + type columns (account-content.css).
+   ─────────────────────────────────────────────────────────────────────── */
 * {
   box-sizing: border-box;
 }
@@ -269,6 +289,7 @@ span.muted {
   background: var(--bg);
 }
 
+/* --bp-stack: collapse the shell to a single full-width column. */
 @media (max-width: 680px) {
   .layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #276.

The signed-in shell carried four ad-hoc breakpoint values across three stylesheets, kept in sync only by scattered per-query comments:

- **680 / 681** — the stack boundary (`account-shell.css` + `signed-in-shell.css`)
- **1080** — mid-width rail restack (`account-shell.css`)
- **560** — file-grid column drop (`account-content.css`)

The #274 review flagged that a third responsive surface already exists, so this introduces the documented breakpoint scale that follow-up called for.

## What changed

- Added a single **Responsive breakpoint scale** block at the top of `signed-in-shell.css` naming the three boundaries — `--bp-rail` (1080), `--bp-stack` (680), `--bp-file-grid` (560) — with the rationale for the 680/681 adjacency in one place.
- Each of the four media queries now references the scale by name in its comment.

Media queries can't read CSS custom properties and the app has no PostCSS pipeline, so the scale is documentation (not `--bp-*` variables) per the option the issue sanctioned — a note in the block warns against defining them as variables that would silently fail in a media query.

**Comment-only — no media query conditions or pixel values changed, so rendering is identical.**