### PR TITLE
feat(web,api,auth): people-tab pending invites + member management (#275)

### DIFF
--- a/apps/api/src/org-workspaces.test.ts
+++ b/apps/api/src/org-workspaces.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { deleteOrg, listOrgs, orgForWorkspace, workspacesForOrg } from "./org-workspaces";
+import { ForbiddenError, NotFoundError } from "@uploads/errors";
+import {
+  deleteOrg,
+  invitesForOrg,
+  listOrgs,
+  orgForWorkspace,
+  removeMember,
+  revokeInvite,
+  updateMemberRole,
+  workspacesForOrg,
+} from "./org-workspaces";
 
 /** Stub matching the Fetcher interface's `.fetch()` shape used by env.AUTH. */
 function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
@@ -109,5 +119,69 @@ describe("deleteOrg force flag (#250)", () => {
       return new Response(null, { status: 200 });
     });
     await deleteOrg(envWith(auth), "acme", { force: true });
+  });
+});
+
+describe("invitesForOrg", () => {
+  it("returns the invites array", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.url).toBe("https://auth.internal/internal/orgs/acme/invites");
+      return Response.json({
+        invites: [{ id: "i1", email: "a@x.com", role: "member", status: "pending", expiresAt: 1 }],
+      });
+    });
+    expect(await invitesForOrg(envWith(auth), "acme")).toEqual([
+      { id: "i1", email: "a@x.com", role: "member", status: "pending", expiresAt: 1 },
+    ]);
+  });
+
+  it("throws ServiceUnavailable on a non-ok response", async () => {
+    const auth = stubAuth(() => new Response("nope", { status: 500 }));
+    await expect(invitesForOrg(envWith(auth), "acme")).rejects.toThrow();
+  });
+});
+
+describe("revokeInvite / removeMember / updateMemberRole error mapping", () => {
+  it("revokeInvite maps 404 to NotFoundError", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.url).toBe("https://auth.internal/internal/orgs/acme/invites/i1?actorUserId=u1");
+      expect(req.method).toBe("DELETE");
+      return Response.json({ error: { code: "invite_not_found" } }, { status: 404 });
+    });
+    await expect(revokeInvite(envWith(auth), "acme", "i1", "u1")).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("removeMember maps 403 to ForbiddenError", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.url).toBe("https://auth.internal/internal/orgs/acme/members/m1?actorUserId=u1");
+      expect(req.method).toBe("DELETE");
+      return Response.json({ error: { code: "actor_not_authorized" } }, { status: 403 });
+    });
+    await expect(removeMember(envWith(auth), "acme", "m1", "u1")).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+  });
+
+  it("updateMemberRole returns the updated member on 200", async () => {
+    const auth = stubAuth((req) => {
+      expect(req.url).toBe("https://auth.internal/internal/orgs/acme/members/m1");
+      expect(req.method).toBe("PATCH");
+      expect(req.headers.get("content-type")).toBe("application/json");
+      return Response.json({ member: { id: "m1", userId: "u2", role: "admin" } });
+    });
+    expect(await updateMemberRole(envWith(auth), "acme", "m1", "admin", "u1")).toEqual({
+      id: "m1",
+      userId: "u2",
+      role: "admin",
+    });
+  });
+
+  it("updateMemberRole maps 400 to a thrown error", async () => {
+    const auth = stubAuth(() =>
+      Response.json({ error: { code: "invalid_role" } }, { status: 400 }),
+    );
+    await expect(updateMemberRole(envWith(auth), "acme", "m1", "owner", "u1")).rejects.toThrow();
   });
 });

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -16,7 +16,13 @@
  * database, by design, see plan D1's "ownership boundary").
  */
 
-import { ConflictError, ServiceUnavailableError } from "@uploads/errors";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ServiceUnavailableError,
+  ValidationError,
+} from "@uploads/errors";
 
 export interface OrgSummary {
   id: string;
@@ -93,6 +99,99 @@ export async function membersForOrg(env: Env, slug: string): Promise<OrgMember[]
   }
   const body = (await response.json().catch(() => null)) as { members?: OrgMember[] } | null;
   return body?.members ?? [];
+}
+
+/** A pending invite row from `/internal/orgs/:slug/invites`. */
+export interface OrgInvite {
+  id: string;
+  email: string;
+  role: string | null;
+  status: string;
+  expiresAt: string | number | null;
+}
+
+/** Pending invites for an org. Non-ok is an auth-worker outage/bug (5xx), like the reads above. */
+export async function invitesForOrg(env: Env, slug: string): Promise<OrgInvite[]> {
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/invites`,
+    { headers: internalHeaders() },
+  );
+  if (!response.ok) {
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: response.status },
+    });
+  }
+  const body = (await response.json().catch(() => null)) as { invites?: OrgInvite[] } | null;
+  return body?.invites ?? [];
+}
+
+/**
+ * Maps the auth worker's authorization/validation failures to AppErrors. 403 →
+ * Forbidden, 404 → NotFound, 400 → Validation; anything else is treated as an
+ * outage. Shared by revoke/remove/role helpers below.
+ */
+async function throwForManageError(response: Response, context: string): Promise<never> {
+  const body = (await response.json().catch(() => null)) as { error?: { code?: string } } | null;
+  const code = body?.error?.code;
+  if (response.status === 403) throw new ForbiddenError(context, { code: code ?? "forbidden" });
+  if (response.status === 404) throw new NotFoundError(context, { code: code ?? "not_found" });
+  if (response.status === 400)
+    throw new ValidationError(context, { code: code ?? "invalid_request" });
+  throw new ServiceUnavailableError("auth service returned an unexpected status", {
+    code: "auth_lookup_failed",
+    details: { status: response.status },
+  });
+}
+
+/** Revoke a pending invite. `actorUserId` is the acting session user (authz). */
+export async function revokeInvite(
+  env: Env,
+  slug: string,
+  inviteId: string,
+  actorUserId: string,
+): Promise<void> {
+  const url = `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/invites/${encodeURIComponent(inviteId)}?actorUserId=${encodeURIComponent(actorUserId)}`;
+  const response = await env.AUTH.fetch(url, { method: "DELETE", headers: internalHeaders() });
+  if (!response.ok) await throwForManageError(response, "could not revoke invite");
+}
+
+/** Remove a member (by opaque member id). `actorUserId` is the acting session user. */
+export async function removeMember(
+  env: Env,
+  slug: string,
+  memberId: string,
+  actorUserId: string,
+): Promise<void> {
+  const url = `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/members/${encodeURIComponent(memberId)}?actorUserId=${encodeURIComponent(actorUserId)}`;
+  const response = await env.AUTH.fetch(url, { method: "DELETE", headers: internalHeaders() });
+  if (!response.ok) await throwForManageError(response, "could not remove member");
+}
+
+/** Change a member's role (admin↔member). Returns the updated member. */
+export async function updateMemberRole(
+  env: Env,
+  slug: string,
+  memberId: string,
+  role: string,
+  actorUserId: string,
+): Promise<{ id: string; userId: string; role: string }> {
+  const headers = internalHeaders();
+  headers.set("content-type", "application/json");
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/members/${encodeURIComponent(memberId)}`,
+    { method: "PATCH", headers, body: JSON.stringify({ actorUserId, role }) },
+  );
+  if (!response.ok) await throwForManageError(response, "could not change member role");
+  const body = (await response.json().catch(() => null)) as {
+    member?: { id: string; userId: string; role: string };
+  } | null;
+  if (!body?.member) {
+    throw new ServiceUnavailableError("auth service returned a malformed body", {
+      code: "auth_lookup_failed",
+    });
+  }
+  return body.member;
 }
 
 /**

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -395,6 +395,199 @@ describe("GET /me/workspaces/:name/members", () => {
   });
 });
 
+describe("GET /me/workspaces/:name/members id exposure", () => {
+  function membersEnv(role: string): Env {
+    return stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role }]);
+      }
+      if (path === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+      }
+      if (path === "/internal/orgs/acme/members") {
+        return Response.json({
+          members: [
+            {
+              id: "m1",
+              userId: "u1",
+              email: "a@b.com",
+              name: "Ada",
+              role: "owner",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+  }
+
+  it("includes member id for an admin/owner caller", async () => {
+    const env = membersEnv("owner");
+    const res = await app().request("/me/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members[0]).toHaveProperty("id", "m1");
+  });
+
+  it("includes member id for an admin caller", async () => {
+    const env = membersEnv("admin");
+    const res = await app().request("/me/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members[0]).toHaveProperty("id", "m1");
+  });
+
+  it("omits member id for a plain member caller", async () => {
+    const env = membersEnv("member");
+    const res = await app().request("/me/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members[0]).not.toHaveProperty("id");
+  });
+});
+
+describe("member management routes", () => {
+  function manageEnv(opts: {
+    workspace?: string;
+    role: string;
+    onManage?: (path: string, req: Request) => Response | Promise<Response> | undefined;
+  }): Env {
+    const { workspace = "acme", role, onManage } = opts;
+    const auth = stubAuth(async (req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/memberships") {
+        return Response.json([{ organizationId: "org1", organizationSlug: workspace, role }]);
+      }
+      if (url.pathname === `/internal/orgs/${workspace}`) {
+        return Response.json({ organization: { id: "org1", slug: workspace, name: workspace } });
+      }
+      const handled = onManage?.(url.pathname, req);
+      if (handled) return handled;
+      if (url.pathname === `/internal/orgs/${workspace}/invites`) {
+        return Response.json({ invites: [] });
+      }
+      if (
+        url.pathname.startsWith(`/internal/orgs/${workspace}/invites/`) &&
+        req.method === "DELETE"
+      ) {
+        return Response.json({ ok: true });
+      }
+      if (
+        url.pathname.startsWith(`/internal/orgs/${workspace}/members/`) &&
+        req.method === "DELETE"
+      ) {
+        return Response.json({ ok: true });
+      }
+      if (
+        url.pathname.startsWith(`/internal/orgs/${workspace}/members/`) &&
+        req.method === "PATCH"
+      ) {
+        return Response.json({ member: { id: "m1", userId: "u1", role: "admin" } });
+      }
+      return new Response(null, { status: 404 });
+    });
+    return { AUTH: auth, DB: new UsageFakeD1() } as unknown as Env;
+  }
+
+  it("GET invites requires admin/owner (403 for a member)", async () => {
+    const env = manageEnv({ role: "member" });
+    const res = await app().request("/me/workspaces/acme/invites", {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("GET invites returns pending invites for an admin", async () => {
+    const env = manageEnv({ role: "admin" });
+    const res = await app().request("/me/workspaces/acme/invites", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { communal: boolean; invites: unknown[] };
+    expect(body.invites).toBeInstanceOf(Array);
+  });
+
+  it("DELETE invites revokes for an admin/owner", async () => {
+    const env = manageEnv({ role: "owner" });
+    const res = await app().request("/me/workspaces/acme/invites/inv1", { method: "DELETE" }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("DELETE invites 403s for a plain member", async () => {
+    const env = manageEnv({ role: "member" });
+    const res = await app().request("/me/workspaces/acme/invites/inv1", { method: "DELETE" }, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE members removes a member for an admin/owner", async () => {
+    const env = manageEnv({ role: "owner" });
+    const res = await app().request("/me/workspaces/acme/members/m1", { method: "DELETE" }, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("DELETE members 403s for a plain member", async () => {
+    const env = manageEnv({ role: "member" });
+    const res = await app().request("/me/workspaces/acme/members/m1", { method: "DELETE" }, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("PATCH members changes the role for an admin/owner", async () => {
+    const env = manageEnv({ role: "owner" });
+    const res = await app().request(
+      "/me/workspaces/acme/members/m1",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { member: { role: string } };
+    expect(body.member.role).toBe("admin");
+  });
+
+  it("PATCH members validates the role", async () => {
+    const env = manageEnv({ role: "owner" });
+    const res = await app().request(
+      "/me/workspaces/acme/members/m1",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ role: "owner" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_role" },
+    });
+  });
+
+  it("PATCH members 403s for a plain member", async () => {
+    const env = manageEnv({ role: "member" });
+    const res = await app().request(
+      "/me/workspaces/acme/members/m1",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("communal workspace short-circuits invites for an admin/owner caller", async () => {
+    const env = manageEnv({ workspace: "default", role: "owner" });
+    const res = await app().request("/me/workspaces/default/invites", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ communal: true, invites: [] });
+  });
+});
+
 describe("GET /me/workspaces/:name/galleries", () => {
   it("404s for a workspace the caller is not a member of", async () => {
     const env = stubEnv(USER, (path) => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -23,9 +23,13 @@ import { listGalleries } from "../galleries";
 import { gallerySummary } from "../gallery-service";
 import { allowWrite } from "../guards";
 import {
+  invitesForOrg,
   membersForOrg,
   membershipsForUser,
   orgForWorkspace,
+  removeMember,
+  revokeInvite,
+  updateMemberRole,
   workspacesForOrg,
 } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
@@ -187,11 +191,15 @@ export const me = new Hono<SessionVars>()
     if (ws.communal) return c.json({ communal: true, members: [] });
 
     // `ws.organization` was already resolved by the membership lookup — no
-    // second org fetch. Internal `id`/`userId` never reach teammates.
+    // second org fetch. Internal `id`/`userId` never reach teammates; admins
+    // and owners get the opaque `id` too, since they need it to target the
+    // management routes below.
+    const canManage = ws.role === "admin" || ws.role === "owner";
     const members = await membersForOrg(c.env, ws.organization.slug);
     return c.json({
       communal: false,
       members: members.map((m) => ({
+        ...(canManage ? { id: m.id } : {}),
         email: m.email ?? "",
         name: m.name ?? "",
         role: m.role ?? "member",
@@ -474,4 +482,54 @@ export const me = new Hono<SessionVars>()
     const acceptUrl =
       payload?.acceptUrl ?? (id ? `${webOrigin}/accept-invitation/${id}` : undefined);
     return c.json({ ...payload, acceptUrl }, response.status === 200 ? 200 : 201);
+  })
+
+  // Pending invites for this workspace — admin/owner only (they can revoke).
+  .get("/workspaces/:name/invites", async (c) => {
+    const name = c.req.param("name");
+    const ws = await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    if (ws.communal) return c.json({ communal: true, invites: [] });
+    const invites = await invitesForOrg(c.env, ws.organization.slug);
+    return c.json({ communal: false, invites });
+  })
+
+  // Revoke a pending invite — admin/owner only.
+  .delete("/workspaces/:name/invites/:id", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
+    await revokeInvite(c.env, ws.organization.slug, c.req.param("id"), userId);
+    return c.json({ ok: true });
+  })
+
+  // Remove a member (by opaque member id) — admin/owner only; matrix enforced in auth worker.
+  .delete("/workspaces/:name/members/:memberId", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
+    await removeMember(c.env, ws.organization.slug, c.req.param("memberId"), userId);
+    return c.json({ ok: true });
+  })
+
+  // Change a member's role (admin<->member) — owner-only enforced in auth worker.
+  .patch("/workspaces/:name/members/:memberId", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
+    const body = await c.req.json<{ role?: unknown }>().catch(() => ({}) as { role?: unknown });
+    const role = typeof body.role === "string" ? body.role.trim() : "";
+    if (role !== "admin" && role !== "member") {
+      throw new ValidationError("role must be admin or member", { code: "invalid_role" });
+    }
+    const member = await updateMemberRole(
+      c.env,
+      ws.organization.slug,
+      c.req.param("memberId"),
+      role,
+      userId,
+    );
+    return c.json({ member });
   });

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1085,4 +1085,88 @@ describe("DB-backed behavior", () => {
       });
     });
   });
+
+  describe("DELETE /internal/orgs/:slug/members/:memberId", () => {
+    async function seed() {
+      const org = await seedOrg();
+      const owner = await seedUser({ id: "u_owner", email: "owner@x.com" });
+      const admin = await seedUser({ id: "u_admin", email: "admin@x.com" });
+      const admin2 = await seedUser({ id: "u_admin2", email: "admin2@x.com" });
+      const member = await seedUser({ id: "u_member", email: "member@x.com" });
+      const rows = [
+        { id: "m_owner", userId: owner.id, role: "owner" },
+        { id: "m_admin", userId: admin.id, role: "admin" },
+        { id: "m_admin2", userId: admin2.id, role: "admin" },
+        { id: "m_member", userId: member.id, role: "member" },
+      ];
+      for (const r of rows) {
+        await orm.insert(schema.member).values({
+          id: r.id,
+          organizationId: org.id,
+          userId: r.userId,
+          role: r.role,
+          createdAt: new Date(),
+        });
+      }
+      return { org, owner, admin, admin2, member };
+    }
+    const del = (slug: string, memberId: string, actorUserId: string) =>
+      app().request(
+        `/internal/orgs/${slug}/members/${memberId}?actorUserId=${actorUserId}`,
+        { method: "DELETE" },
+        dbEnv(),
+      );
+
+    it("lets an admin remove a member", async () => {
+      const { org, admin } = await seed();
+      const res = await del(org.slug, "m_member", admin.id);
+      expect(res.status).toBe(200);
+      const rows = await orm.select().from(schema.member).where(eq(schema.member.id, "m_member"));
+      expect(rows).toHaveLength(0);
+    });
+    it("forbids an admin removing another admin", async () => {
+      const { org, admin } = await seed();
+      const res = await del(org.slug, "m_admin2", admin.id);
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "actor_not_authorized" },
+      });
+    });
+    it("lets an owner remove an admin", async () => {
+      const { org, owner } = await seed();
+      const res = await del(org.slug, "m_admin", owner.id);
+      expect(res.status).toBe(200);
+    });
+    it("never removes an owner", async () => {
+      // Actor is admin (not owner) here so this exercises the
+      // owner-protection check specifically, rather than colliding with the
+      // self-removal check (which fires first per the brief's ordering and
+      // is covered separately by "blocks removing yourself" below) —
+      // the brief's verbatim test used owner-as-actor here, which is
+      // actually self-removal of the owner and would hit cannot_modify_self
+      // (400) before ever reaching the owner-protection branch.
+      const { org, admin } = await seed();
+      const res = await del(org.slug, "m_owner", admin.id);
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "cannot_modify_owner" },
+      });
+    });
+    it("blocks removing yourself", async () => {
+      const { org, admin } = await seed();
+      const res = await del(org.slug, "m_admin", admin.id);
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "cannot_modify_self" },
+      });
+    });
+    it("404s for an unknown member id", async () => {
+      const { org, owner } = await seed();
+      const res = await del(org.slug, "nope", owner.id);
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "member_not_found" },
+      });
+    });
+  });
 });

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1017,4 +1017,72 @@ describe("DB-backed behavior", () => {
       expect(await unknownRes.json()).toEqual({ githubLinked: false });
     });
   });
+
+  describe("DELETE /internal/orgs/:slug/invites/:id", () => {
+    async function seed(actorRole: string) {
+      const org = await seedOrg();
+      const actor = await seedUser({ id: "u_actor", email: "actor@x.com" });
+      await orm.insert(schema.member).values({
+        id: "m_actor",
+        organizationId: org.id,
+        userId: actor.id,
+        role: actorRole,
+        createdAt: new Date(),
+      });
+      const inviteId = "inv_1";
+      await orm.insert(schema.invitation).values({
+        id: inviteId,
+        organizationId: org.id,
+        email: "invitee@x.com",
+        role: "member",
+        status: "pending",
+        expiresAt: new Date(Date.now() + 86400000),
+        inviterId: actor.id,
+        createdAt: new Date(),
+      });
+      return { org, actor, inviteId };
+    }
+
+    it("revokes a pending invite for an admin actor", async () => {
+      const { org, actor, inviteId } = await seed("admin");
+      const res = await app().request(
+        `/internal/orgs/${org.slug}/invites/${inviteId}?actorUserId=${actor.id}`,
+        { method: "DELETE" },
+        dbEnv(),
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      const rows = await orm
+        .select()
+        .from(schema.invitation)
+        .where(eq(schema.invitation.id, inviteId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("403s when the actor is only a member", async () => {
+      const { org, actor, inviteId } = await seed("member");
+      const res = await app().request(
+        `/internal/orgs/${org.slug}/invites/${inviteId}?actorUserId=${actor.id}`,
+        { method: "DELETE" },
+        dbEnv(),
+      );
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "actor_not_authorized" },
+      });
+    });
+
+    it("404s for an unknown invite id", async () => {
+      const { org, actor } = await seed("owner");
+      const res = await app().request(
+        `/internal/orgs/${org.slug}/invites/nope?actorUserId=${actor.id}`,
+        { method: "DELETE" },
+        dbEnv(),
+      );
+      expect(res.status).toBe(404);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "invite_not_found" },
+      });
+    });
+  });
 });

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -1169,4 +1169,98 @@ describe("DB-backed behavior", () => {
       });
     });
   });
+
+  describe("PATCH /internal/orgs/:slug/members/:memberId", () => {
+    async function seed() {
+      const org = await seedOrg();
+      const owner = await seedUser({ id: "u_owner", email: "owner@x.com" });
+      const admin = await seedUser({ id: "u_admin", email: "admin@x.com" });
+      const admin2 = await seedUser({ id: "u_admin2", email: "admin2@x.com" });
+      const member = await seedUser({ id: "u_member", email: "member@x.com" });
+      const rows = [
+        { id: "m_owner", userId: owner.id, role: "owner" },
+        { id: "m_admin", userId: admin.id, role: "admin" },
+        { id: "m_admin2", userId: admin2.id, role: "admin" },
+        { id: "m_member", userId: member.id, role: "member" },
+      ];
+      for (const r of rows) {
+        await orm.insert(schema.member).values({
+          id: r.id,
+          organizationId: org.id,
+          userId: r.userId,
+          role: r.role,
+          createdAt: new Date(),
+        });
+      }
+      return { org, owner, admin, admin2, member };
+    }
+    const patch = (slug: string, memberId: string, actorUserId: string, role: string) =>
+      app().request(
+        `/internal/orgs/${slug}/members/${memberId}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ actorUserId, role }),
+        },
+        dbEnv(),
+      );
+
+    it("lets an owner promote a member to admin", async () => {
+      const { org, owner } = await seed();
+      const res = await patch(org.slug, "m_member", owner.id, "admin");
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { member: { role: string } }).toMatchObject({
+        member: { id: "m_member", role: "admin" },
+      });
+      const [row] = await orm.select().from(schema.member).where(eq(schema.member.id, "m_member"));
+      expect(row.role).toBe("admin");
+    });
+    it("forbids an admin changing roles", async () => {
+      const { org, admin } = await seed();
+      const res = await patch(org.slug, "m_member", admin.id, "admin");
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "actor_not_authorized" },
+      });
+    });
+    it("rejects an invalid target role", async () => {
+      const { org, owner } = await seed();
+      const res = await patch(org.slug, "m_member", owner.id, "owner");
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "invalid_role" },
+      });
+    });
+    // Brief correction (identical flaw to Task 2's "never removes an owner"
+    // test): the brief's verbatim version has the OWNER act on their own
+    // member row, which hits the self-check (400 cannot_modify_self) before
+    // ever reaching the owner-protection branch — so it doesn't actually
+    // exercise cannot_modify_owner. Using an admin actor targeting the owner
+    // row instead reaches the owner-protection check. Self-protection is
+    // separately covered by "blocks changing your own role" below.
+    it("never modifies an owner", async () => {
+      const { org, admin } = await seed();
+      const res = await patch(org.slug, "m_owner", admin.id, "member");
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "cannot_modify_owner" },
+      });
+    });
+    it("blocks changing your own role", async () => {
+      const { org, admin } = await seed();
+      const res = await patch(org.slug, "m_admin", admin.id, "member");
+      expect(res.status).toBe(400);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "cannot_modify_self" },
+      });
+    });
+    it("is idempotent when the role is unchanged", async () => {
+      const { org, owner } = await seed();
+      const res = await patch(org.slug, "m_admin", owner.id, "admin");
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { member: { role: string } }).toMatchObject({
+        member: { role: "admin" },
+      });
+    });
+  });
 });

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -29,6 +29,20 @@ async function actorRole(
   return row?.role ?? null;
 }
 
+/** A target member row (id/userId/role) scoped to the org, or null if none. */
+async function loadTargetMember(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  orgId: string,
+  memberId: string,
+): Promise<{ id: string; userId: string; role: string } | null> {
+  const [row] = await db
+    .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
+    .from(schema.member)
+    .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, orgId)))
+    .limit(1);
+  return row ?? null;
+}
+
 // Lane 1 (operator OAuth admin panel contract, .context/2026-07-18-oauth-admin-panel-contract.md):
 // validation error shape differs from the rest of this file's errorJson —
 // the contract locks in `{error:"invalid_request", message}` for these routes.
@@ -378,21 +392,25 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (!org) {
       return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
     }
-    const role = await actorRole(db, org.id, requestActorUserId);
+    // Actor and invite lookups are independent; the authz check still gates
+    // before the not-found check below.
+    const [role, [invite]] = await Promise.all([
+      actorRole(db, org.id, requestActorUserId),
+      db
+        .select({ id: schema.invitation.id })
+        .from(schema.invitation)
+        .where(
+          and(
+            eq(schema.invitation.id, inviteId),
+            eq(schema.invitation.organizationId, org.id),
+            eq(schema.invitation.status, "pending"),
+          ),
+        )
+        .limit(1),
+    ]);
     if (role !== "owner" && role !== "admin") {
       return c.json(errorJson("actor_not_authorized", "actor must be an org admin or owner"), 403);
     }
-    const [invite] = await db
-      .select({ id: schema.invitation.id })
-      .from(schema.invitation)
-      .where(
-        and(
-          eq(schema.invitation.id, inviteId),
-          eq(schema.invitation.organizationId, org.id),
-          eq(schema.invitation.status, "pending"),
-        ),
-      )
-      .limit(1);
     if (!invite) {
       return c.json(errorJson("invite_not_found", "no pending invite with that id"), 404);
     }
@@ -414,11 +432,12 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (!org) {
       return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
     }
-    const [target] = await db
-      .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
-      .from(schema.member)
-      .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, org.id)))
-      .limit(1);
+    // Target and actor lookups are independent; the ordered checks below run
+    // against the already-fetched rows.
+    const [target, role] = await Promise.all([
+      loadTargetMember(db, org.id, memberId),
+      actorRole(db, org.id, requestActorUserId),
+    ]);
     if (!target) {
       return c.json(errorJson("member_not_found", "no member with that id in this org"), 404);
     }
@@ -428,7 +447,6 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (target.role === "owner") {
       return c.json(errorJson("cannot_modify_owner", "the workspace owner cannot be removed"), 403);
     }
-    const role = await actorRole(db, org.id, requestActorUserId);
     if (role !== "owner" && role !== "admin") {
       return c.json(errorJson("actor_not_authorized", "actor must be an org admin or owner"), 403);
     }
@@ -461,11 +479,12 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (!org) {
       return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
     }
-    const [target] = await db
-      .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
-      .from(schema.member)
-      .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, org.id)))
-      .limit(1);
+    // Target and actor lookups are independent; the ordered checks below run
+    // against the already-fetched rows.
+    const [target, role] = await Promise.all([
+      loadTargetMember(db, org.id, memberId),
+      actorRole(db, org.id, requestActorUserId),
+    ]);
     if (!target) {
       return c.json(errorJson("member_not_found", "no member with that id in this org"), 404);
     }
@@ -475,7 +494,6 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     if (target.role === "owner") {
       return c.json(errorJson("cannot_modify_owner", "the workspace owner's role is fixed"), 403);
     }
-    const role = await actorRole(db, org.id, requestActorUserId);
     if (role !== "owner") {
       return c.json(
         errorJson("actor_not_authorized", "only an owner can change member roles"),

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -399,6 +399,46 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     await db.delete(schema.invitation).where(eq(schema.invitation.id, invite.id));
     return c.json({ ok: true });
   })
+  // Task 2 (#275): admin/owner-authorized member removal, used by the
+  // workspace people tab's member management. Reuses actorRole() above.
+  .delete("/orgs/:slug/members/:memberId", async (c) => {
+    const slug = c.req.param("slug");
+    const memberId = c.req.param("memberId");
+    const requestActorUserId = c.req.query("actorUserId") ?? "";
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const [target] = await db
+      .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
+      .from(schema.member)
+      .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, org.id)))
+      .limit(1);
+    if (!target) {
+      return c.json(errorJson("member_not_found", "no member with that id in this org"), 404);
+    }
+    if (target.userId === requestActorUserId) {
+      return c.json(errorJson("cannot_modify_self", "you cannot remove yourself"), 400);
+    }
+    if (target.role === "owner") {
+      return c.json(errorJson("cannot_modify_owner", "the workspace owner cannot be removed"), 403);
+    }
+    const role = await actorRole(db, org.id, requestActorUserId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json(errorJson("actor_not_authorized", "actor must be an org admin or owner"), 403);
+    }
+    // Only owners may remove admins; admins may remove members only.
+    if (target.role === "admin" && role !== "owner") {
+      return c.json(errorJson("actor_not_authorized", "only an owner can remove an admin"), 403);
+    }
+    await db.delete(schema.member).where(eq(schema.member.id, target.id));
+    return c.json({ ok: true });
+  })
   // Phase 3 (plan scope B): server-side invite creation for
   // POST /admin-ui/workspaces/:name/invites on apps/api.
   //

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -439,6 +439,54 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     await db.delete(schema.member).where(eq(schema.member.id, target.id));
     return c.json({ ok: true });
   })
+  // Task 3 (#275): owner-only member role change, used by the workspace
+  // people tab's member management. Reuses actorRole() above.
+  .patch("/orgs/:slug/members/:memberId", async (c) => {
+    const slug = c.req.param("slug");
+    const memberId = c.req.param("memberId");
+    const body = await c.req
+      .json<{ actorUserId?: unknown; role?: unknown }>()
+      .catch(() => ({}) as { actorUserId?: unknown; role?: unknown });
+    const requestActorUserId = typeof body.actorUserId === "string" ? body.actorUserId : "";
+    const nextRole = typeof body.role === "string" ? body.role.trim() : "";
+    if (nextRole !== "admin" && nextRole !== "member") {
+      return c.json(errorJson("invalid_role", "role must be admin or member"), 400);
+    }
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const [target] = await db
+      .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
+      .from(schema.member)
+      .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, org.id)))
+      .limit(1);
+    if (!target) {
+      return c.json(errorJson("member_not_found", "no member with that id in this org"), 404);
+    }
+    if (target.userId === requestActorUserId) {
+      return c.json(errorJson("cannot_modify_self", "you cannot change your own role"), 400);
+    }
+    if (target.role === "owner") {
+      return c.json(errorJson("cannot_modify_owner", "the workspace owner's role is fixed"), 403);
+    }
+    const role = await actorRole(db, org.id, requestActorUserId);
+    if (role !== "owner") {
+      return c.json(
+        errorJson("actor_not_authorized", "only an owner can change member roles"),
+        403,
+      );
+    }
+    if (target.role !== nextRole) {
+      await db.update(schema.member).set({ role: nextRole }).where(eq(schema.member.id, target.id));
+    }
+    return c.json({ member: { id: target.id, userId: target.userId, role: nextRole } });
+  })
   // Phase 3 (plan scope B): server-side invite creation for
   // POST /admin-ui/workspaces/:name/invites on apps/api.
   //

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -14,6 +14,21 @@ function errorJson(code: string, message: string) {
   return { error: { code, message } } as const;
 }
 
+/** The actor's org-scoped role, or null if they aren't a member of this org. */
+async function actorRole(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  orgId: string,
+  actorUserId: string,
+): Promise<string | null> {
+  if (!actorUserId) return null;
+  const [row] = await db
+    .select({ role: schema.member.role })
+    .from(schema.member)
+    .where(and(eq(schema.member.organizationId, orgId), eq(schema.member.userId, actorUserId)))
+    .limit(1);
+  return row?.role ?? null;
+}
+
 // Lane 1 (operator OAuth admin panel contract, .context/2026-07-18-oauth-admin-panel-contract.md):
 // validation error shape differs from the rest of this file's errorJson —
 // the contract locks in `{error:"invalid_request", message}` for these routes.
@@ -347,6 +362,42 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
         and(eq(schema.invitation.organizationId, org.id), eq(schema.invitation.status, "pending")),
       );
     return c.json({ invites: rows });
+  })
+  // Task 1 (#275): admin/owner-authorized revocation of a pending invite,
+  // used by the workspace people tab's pending-invite management.
+  .delete("/orgs/:slug/invites/:id", async (c) => {
+    const slug = c.req.param("slug");
+    const inviteId = c.req.param("id");
+    const requestActorUserId = c.req.query("actorUserId") ?? "";
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const role = await actorRole(db, org.id, requestActorUserId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json(errorJson("actor_not_authorized", "actor must be an org admin or owner"), 403);
+    }
+    const [invite] = await db
+      .select({ id: schema.invitation.id })
+      .from(schema.invitation)
+      .where(
+        and(
+          eq(schema.invitation.id, inviteId),
+          eq(schema.invitation.organizationId, org.id),
+          eq(schema.invitation.status, "pending"),
+        ),
+      )
+      .limit(1);
+    if (!invite) {
+      return c.json(errorJson("invite_not_found", "no pending invite with that id"), 404);
+    }
+    await db.delete(schema.invitation).where(eq(schema.invitation.id, invite.id));
+    return c.json({ ok: true });
   })
   // Phase 3 (plan scope B): server-side invite creation for
   // POST /admin-ui/workspaces/:name/invites on apps/api.

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getMyWorkspaces,
+  getWorkspaceInvites,
+  getWorkspaceMembers,
   listWorkspaceFolder,
+  removeWorkspaceMember,
+  revokeWorkspaceInvite,
   searchWorkspaceFiles,
   setFileVisibility,
+  updateWorkspaceMemberRole,
 } from "./api-client";
 
 afterEach(() => {
@@ -353,6 +358,167 @@ describe("listWorkspaceFolder", () => {
       files: [],
       prefixes: [],
       cursor: undefined,
+    });
+  });
+});
+
+describe("getWorkspaceMembers", () => {
+  it("passes member id through when present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          communal: false,
+          members: [{ id: "m1", email: "a@x.com", name: "A", role: "member" }],
+        }),
+      ),
+    );
+
+    const result = await getWorkspaceMembers("http://127.0.0.1:8787", "acme");
+    expect(result).toEqual({
+      kind: "ok",
+      communal: false,
+      members: [{ id: "m1", email: "a@x.com", name: "A", role: "member", createdAt: undefined }],
+    });
+  });
+
+  it("leaves id undefined when the API omits it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          communal: false,
+          members: [{ email: "a@x.com", name: "A", role: "member" }],
+        }),
+      ),
+    );
+
+    const result = await getWorkspaceMembers("http://127.0.0.1:8787", "acme");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.members[0]?.id).toBeUndefined();
+  });
+});
+
+describe("getWorkspaceInvites", () => {
+  it("parses invites and passes id through to members", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          communal: false,
+          invites: [
+            { id: "i1", email: "a@x.com", role: "member", status: "pending", expiresAt: 1 },
+          ],
+        }),
+      ),
+    );
+
+    const res = await getWorkspaceInvites("https://api.test", "acme");
+    expect(res).toMatchObject({ kind: "ok", communal: false });
+    if (res.kind === "ok") expect(res.invites[0]?.id).toBe("i1");
+  });
+
+  it("reports unavailable on a non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 500 })),
+    );
+
+    await expect(getWorkspaceInvites("https://api.test", "acme")).resolves.toEqual({
+      kind: "unavailable",
+    });
+  });
+
+  it("reports unavailable on network failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new TypeError("network down"))),
+    );
+
+    await expect(getWorkspaceInvites("https://api.test", "acme")).resolves.toEqual({
+      kind: "unavailable",
+    });
+  });
+});
+
+describe("manage mutations map status codes", () => {
+  it("revokeWorkspaceInvite → forbidden on 403", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 403 })),
+    );
+
+    await expect(revokeWorkspaceInvite("https://api.test", "acme", "i1")).resolves.toEqual({
+      kind: "unavailable",
+      reason: "forbidden",
+    });
+  });
+
+  it("removeWorkspaceMember → not_found on 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+
+    await expect(removeWorkspaceMember("https://api.test", "acme", "m1")).resolves.toEqual({
+      kind: "unavailable",
+      reason: "not_found",
+    });
+  });
+
+  it("updateWorkspaceMemberRole → invalid on 400", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 400 })),
+    );
+
+    await expect(
+      updateWorkspaceMemberRole("https://api.test", "acme", "m1", "admin"),
+    ).resolves.toEqual({
+      kind: "unavailable",
+      reason: "invalid",
+    });
+  });
+
+  it("updateWorkspaceMemberRole → ok on 200, sending role in the PATCH body", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.test/me/workspaces/acme/members/m1");
+      expect(init?.method).toBe("PATCH");
+      expect(init?.credentials).toBe("include");
+      expect(JSON.parse(init!.body as string)).toEqual({ role: "admin" });
+      return Response.json({ member: { id: "m1", userId: "u2", role: "admin" } }, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      updateWorkspaceMemberRole("https://api.test", "acme", "m1", "admin"),
+    ).resolves.toEqual({ kind: "ok" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("removeWorkspaceMember → ok on 200 via DELETE", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.test/me/workspaces/acme/members/m1");
+      expect(init?.method).toBe("DELETE");
+      expect(init?.credentials).toBe("include");
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(removeWorkspaceMember("https://api.test", "acme", "m1")).resolves.toEqual({
+      kind: "ok",
+    });
+  });
+
+  it("revokeWorkspaceInvite → unavailable(network) on transport failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new TypeError("network down"))),
+    );
+
+    await expect(revokeWorkspaceInvite("https://api.test", "acme", "i1")).resolves.toEqual({
+      kind: "unavailable",
+      reason: "network",
     });
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -344,8 +344,8 @@ export type ManageResult =
       reason: RequestFailure | "server" | "forbidden" | "not_found" | "invalid";
     };
 
-function manageResultFor(status: number, ok: boolean): ManageResult {
-  if (ok) return { kind: "ok" };
+function manageResultFor(status: number): ManageResult {
+  if (status >= 200 && status < 300) return { kind: "ok" };
   if (status === 403) return { kind: "unavailable", reason: "forbidden" };
   if (status === 404) return { kind: "unavailable", reason: "not_found" };
   if (status === 400) return { kind: "unavailable", reason: "invalid" };
@@ -388,7 +388,7 @@ async function manageMutation(
     ...init,
   });
   if (result.kind === "unavailable") return result;
-  return manageResultFor(result.response.status, result.response.ok);
+  return manageResultFor(result.response.status);
 }
 
 /** DELETE /me/workspaces/:name/invites/:id */

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -240,6 +240,7 @@ export type InviteResult =
   | { kind: "unavailable"; reason: RequestFailure | "server" | "forbidden" | "invalid" };
 
 export interface WorkspaceMember {
+  id?: string;
   email: string;
   name: string;
   role: string;
@@ -277,6 +278,7 @@ export async function getWorkspaceMembers(
     kind: "ok",
     communal: body.communal === true,
     members: body.members.filter(isMemberCandidate).map((row) => ({
+      id: typeof row.id === "string" ? row.id : undefined,
       email: row.email,
       name: typeof row.name === "string" ? row.name : "",
       role: row.role,
@@ -321,6 +323,116 @@ export async function inviteToWorkspace(
     acceptUrl: typeof body?.acceptUrl === "string" ? body.acceptUrl : undefined,
     emailConfigured: typeof body?.emailConfigured === "boolean" ? body.emailConfigured : undefined,
   };
+}
+
+export interface WorkspaceInvite {
+  id: string;
+  email: string;
+  role: string | null;
+  status: string;
+  expiresAt: string | number | null;
+}
+
+export type WorkspaceInvitesResult =
+  | { kind: "ok"; communal: boolean; invites: WorkspaceInvite[] }
+  | { kind: "unavailable" };
+
+export type ManageResult =
+  | { kind: "ok" }
+  | {
+      kind: "unavailable";
+      reason: RequestFailure | "server" | "forbidden" | "not_found" | "invalid";
+    };
+
+function manageResultFor(status: number, ok: boolean): ManageResult {
+  if (ok) return { kind: "ok" };
+  if (status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (status === 400) return { kind: "unavailable", reason: "invalid" };
+  return { kind: "unavailable", reason: "server" };
+}
+
+/** GET /me/workspaces/:name/invites — pending invites, admin/owner only. */
+export async function getWorkspaceInvites(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceInvitesResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/invites`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
+  const body = (await result.response.json().catch(() => null)) as {
+    communal?: unknown;
+    invites?: unknown;
+  } | null;
+  if (!body || !Array.isArray(body.invites)) return { kind: "unavailable" };
+  return {
+    kind: "ok",
+    communal: body.communal === true,
+    invites: body.invites.filter(
+      (v): v is WorkspaceInvite =>
+        !!v && typeof v === "object" && typeof (v as { id?: unknown }).id === "string",
+    ),
+  };
+}
+
+async function manageMutation(
+  apiOrigin: string,
+  path: string,
+  init: RequestInit,
+): Promise<ManageResult> {
+  const result = await fetchWithTimeout(`${trimOrigin(apiOrigin)}${path}`, {
+    credentials: "include",
+    cache: "no-store",
+    ...init,
+  });
+  if (result.kind === "unavailable") return result;
+  return manageResultFor(result.response.status, result.response.ok);
+}
+
+/** DELETE /me/workspaces/:name/invites/:id */
+export async function revokeWorkspaceInvite(
+  apiOrigin: string,
+  name: string,
+  inviteId: string,
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/me/workspaces/${encodeURIComponent(name)}/invites/${encodeURIComponent(inviteId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/** DELETE /me/workspaces/:name/members/:memberId */
+export async function removeWorkspaceMember(
+  apiOrigin: string,
+  name: string,
+  memberId: string,
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/me/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/** PATCH /me/workspaces/:name/members/:memberId */
+export async function updateWorkspaceMemberRole(
+  apiOrigin: string,
+  name: string,
+  memberId: string,
+  role: "admin" | "member",
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/me/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role }),
+    },
+  );
 }
 
 export type CreateWorkspaceResult =

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   orderOrgsOldestFirst,
+  renderInvitesHtml,
   renderMembersHtml,
   renderUsageHtml,
   safeSameOriginPath,
@@ -28,6 +29,35 @@ describe("renderMembersHtml", () => {
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;img");
     expect(renderMembersHtml([])).toBe("");
+  });
+});
+
+describe("renderMembersHtml controls", () => {
+  const rows = [
+    { id: "m_owner", email: "owner@x.com", name: "", role: "owner" },
+    { id: "m_admin", email: "admin@x.com", name: "", role: "admin" },
+    { id: "m_me", email: "me@x.com", name: "", role: "admin" },
+  ];
+  it("renders no controls without canManage", () => {
+    const html = renderMembersHtml(rows);
+    expect(html).not.toContain("data-member-id");
+  });
+  it("renders controls for manageable rows only", () => {
+    const html = renderMembersHtml(rows, { canManage: true, selfEmail: "me@x.com" });
+    expect(html).toContain('data-member-id="m_admin"'); // manageable
+    expect(html).not.toContain('data-member-id="m_owner"'); // owner protected
+    expect(html).not.toContain('data-member-id="m_me"'); // self
+  });
+});
+
+describe("renderInvitesHtml", () => {
+  it("renders a revoke control per invite", () => {
+    const html = renderInvitesHtml([{ id: "i1", email: "a@x.com", status: "pending" }]);
+    expect(html).toContain('data-invite-id="i1"');
+    expect(html).toContain("a@x.com");
+  });
+  it("returns empty string for no invites", () => {
+    expect(renderInvitesHtml([])).toBe("");
   });
 });
 

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -117,23 +117,57 @@ export function renderUsageHtml(usage: UsageSnapshot): string {
 
 /** Minimal member shape `renderMembersHtml` needs — api-client's `WorkspaceMember` satisfies it. */
 export interface MemberRow {
+  id?: string;
   email: string;
   name: string;
   role: string;
 }
 
+export interface MemberRowOptions {
+  /** Viewer is owner/admin — enables per-row controls. */
+  canManage?: boolean;
+  /** Viewer's own email — their row never shows controls (no self-removal). */
+  selfEmail?: string;
+}
+
 /**
  * Pure row builder for the people tab's member list. Shows the display name
- * when the account has one (email then becomes the sub-line), otherwise the
- * email leads. `[]` → `""` (caller renders its own empty state).
+ * when set (email becomes the sub-line), else email leads. When `canManage`
+ * and the row has an `id`, non-owner rows other than the viewer's own get a
+ * role `<select>` and a remove button. `[]` → `""`.
  */
-export function renderMembersHtml(members: MemberRow[]): string {
+export function renderMembersHtml(members: MemberRow[], opts: MemberRowOptions = {}): string {
   return members
     .map((m) => {
       const lead = m.name || m.email;
       const sub = m.name ? `<span class="member-row__email">${escapeHtml(m.email)}</span>` : "";
-      return `<div class="member-row"><span class="member-row__who"><span class="member-row__name">${escapeHtml(lead)}</span>${sub}</span><span class="member-row__role">${escapeHtml(m.role)}</span></div>`;
+      const manageable =
+        !!opts.canManage && !!m.id && m.role !== "owner" && m.email !== opts.selfEmail;
+      const controls = manageable
+        ? `<span class="member-row__actions">` +
+          `<select class="member-row__role-select" data-member-id="${escapeHtml(m.id!)}" aria-label="Role for ${escapeHtml(m.email)}">` +
+          `<option value="member"${m.role === "member" ? " selected" : ""}>member</option>` +
+          `<option value="admin"${m.role === "admin" ? " selected" : ""}>admin</option>` +
+          `</select>` +
+          `<button type="button" class="text-btn member-row__remove" data-member-id="${escapeHtml(m.id!)}" data-member-email="${escapeHtml(m.email)}">Remove</button>` +
+          `</span>`
+        : `<span class="member-row__role">${escapeHtml(m.role)}</span>`;
+      return `<div class="member-row"><span class="member-row__who"><span class="member-row__name">${escapeHtml(lead)}</span>${sub}</span>${controls}</div>`;
     })
+    .join("");
+}
+
+/** Pure row builder for the pending-invites list. `[]` → `""` (caller shows empty state). */
+export function renderInvitesHtml(
+  invites: { id: string; email: string; status: string }[],
+): string {
+  return invites
+    .map(
+      (inv) =>
+        `<div class="invite-row"><span class="invite-row__email">${escapeHtml(inv.email)}</span>` +
+        `<span class="invite-row__status">${escapeHtml(inv.status)}</span>` +
+        `<button type="button" class="text-btn invite-row__revoke" data-invite-id="${escapeHtml(inv.id)}" data-invite-email="${escapeHtml(inv.email)}">Revoke</button></div>`,
+    )
     .join("");
 }
 

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -32,6 +32,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
       </div>
 
+      <div class="settings-section" id="ws-invites-section" hidden>
+        <h2>Pending invites</h2>
+        <div id="ws-invites" class="invite-list">
+          <p class="muted" id="ws-invites-status" role="status">Loading invites…</p>
+        </div>
+      </div>
+
       <div class="settings-section" id="ws-invite-section">
         <h2>Invite</h2>
         <p class="settings-note muted">Accept link, then <code>uploads login</code>.</p>
@@ -79,6 +86,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       getMyWorkspaces,
       getWorkspaceMembers,
       inviteToWorkspace,
+      getWorkspaceInvites,
+      revokeWorkspaceInvite,
+      removeWorkspaceMember,
+      updateWorkspaceMemberRole,
     } from "../../../../lib/api-client";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
@@ -87,6 +98,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       escapeHtml,
       isWorkspaceAdminRole,
       operatorInviteCommand,
+      renderInvitesHtml,
       renderMembersHtml,
     } from "../../../../lib/workspace-ui";
 
@@ -119,8 +131,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
       const inviteSection = requireElement<HTMLElement>("#ws-invite-section", page);
       const membersEl = requireElement<HTMLElement>("#ws-members", page);
+      const invitesSection = requireElement<HTMLElement>("#ws-invites-section", page);
+      const invitesEl = requireElement<HTMLElement>("#ws-invites", page);
 
       let sessionRole: string | null | undefined;
+      let sessionEmail: string | undefined;
+      let canManage = false; // viewer is owner/admin of this workspace
 
       function showError(message: string, retry = true): void {
         if (!stillHere()) return;
@@ -159,10 +175,14 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         inviteSection.hidden = !isWorkspaceAdminRole(ws.role) && sessionRole !== "admin";
         inviteForm.hidden = !isWorkspaceAdminRole(ws.role);
 
+        canManage = isWorkspaceAdminRole(ws.role);
+        invitesSection.hidden = !canManage;
+
         statusEl.hidden = true;
         appEl.hidden = false;
 
         void loadMembers();
+        if (canManage) void loadInvites();
 
         const displayName = ws.organization.name || ws.workspace;
         slugEl.textContent =
@@ -192,8 +212,28 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           return;
         }
         membersEl.innerHTML = result.members.length
-          ? renderMembersHtml(result.members)
+          ? renderMembersHtml(result.members, { canManage, selfEmail: sessionEmail })
           : '<p class="muted">Just you so far.</p>';
+      }
+
+      async function loadInvites(): Promise<void> {
+        const result = await getWorkspaceInvites(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          invitesEl.innerHTML =
+            '<p class="muted" role="alert">Invites are temporarily unavailable. Reload to try again.</p>';
+          return;
+        }
+        invitesEl.innerHTML = result.invites.length
+          ? renderInvitesHtml(result.invites)
+          : '<p class="muted">No pending invites.</p>';
+      }
+
+      function manageErrorText(reason: string, action: string): string {
+        if (reason === "forbidden") return `You don’t have permission to ${action}.`;
+        if (reason === "not_found") return `That item no longer exists — reload the page.`;
+        if (reason === "invalid") return `That change isn’t allowed.`;
+        return `Couldn’t ${action}. Try again.`;
       }
 
       bindCopyButtons(document);
@@ -240,12 +280,75 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         })();
       });
 
+      membersEl.addEventListener("click", (event) => {
+        const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(
+          ".member-row__remove",
+        );
+        if (!btn) return;
+        void (async () => {
+          const memberId = btn.dataset.memberId ?? "";
+          const email = btn.dataset.memberEmail ?? "this member";
+          if (!memberId || !confirm(`Remove ${email} from this workspace?`)) return;
+          btn.disabled = true;
+          const res = await removeWorkspaceMember(apiOrigin, workspaceName, memberId);
+          if (!stillHere()) return;
+          if (res.kind === "ok") void loadMembers();
+          else {
+            btn.disabled = false;
+            alert(manageErrorText(res.reason, "remove this member"));
+          }
+        })();
+      });
+
+      membersEl.addEventListener("change", (event) => {
+        // Not closest<HTMLSelectElement>: worker-configuration.d.ts's HTMLRewriter
+        // ambient `Element` redeclares `remove()`, which makes HTMLSelectElement
+        // fail the `T extends Element` constraint (see consent.astro). Fetch as
+        // HTMLElement and cast instead.
+        const select = (event.target as HTMLElement).closest<HTMLElement>(
+          ".member-row__role-select",
+        ) as unknown as HTMLSelectElement | null;
+        if (!select) return;
+        void (async () => {
+          const memberId = select.dataset.memberId ?? "";
+          const role = select.value === "admin" ? "admin" : "member";
+          if (!memberId) return;
+          select.disabled = true;
+          const res = await updateWorkspaceMemberRole(apiOrigin, workspaceName, memberId, role);
+          if (!stillHere()) return;
+          select.disabled = false;
+          if (res.kind === "ok") void loadMembers();
+          else alert(manageErrorText(res.reason, "change this role"));
+        })();
+      });
+
+      invitesEl.addEventListener("click", (event) => {
+        const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(
+          ".invite-row__revoke",
+        );
+        if (!btn) return;
+        void (async () => {
+          const inviteId = btn.dataset.inviteId ?? "";
+          const email = btn.dataset.inviteEmail ?? "this invite";
+          if (!inviteId || !confirm(`Revoke the pending invite for ${email}?`)) return;
+          btn.disabled = true;
+          const res = await revokeWorkspaceInvite(apiOrigin, workspaceName, inviteId);
+          if (!stillHere()) return;
+          if (res.kind === "ok") void loadInvites();
+          else {
+            btn.disabled = false;
+            alert(manageErrorText(res.reason, "revoke this invite"));
+          }
+        })();
+      });
+
       retryBtn.addEventListener("click", () => {
         void loadInvitePage();
       });
 
       onSession((user) => {
         sessionRole = user.role;
+        sessionEmail = user.email;
         void loadInvitePage();
       });
     });

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1238,3 +1238,36 @@ button.wft-name--btn {
     display: none;
   }
 }
+
+/* People tab: pending-invite rows + member-row management controls (#275). */
+.invite-list {
+  display: grid;
+  gap: 6px;
+}
+.invite-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.invite-row__email {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.invite-row__status {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.member-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.member-row__role-select {
+  font: inherit;
+  padding: 2px 6px;
+}

--- a/docs/superpowers/plans/2026-07-19-people-tab-member-management.md
+++ b/docs/superpowers/plans/2026-07-19-people-tab-member-management.md
@@ -1,0 +1,1502 @@
+# People tab: pending invites + member management — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let workspace owners/admins see and revoke pending invites and manage members (remove, change role) from the `/account/workspaces/:name/people` tab.
+
+**Architecture:** Three layers. The auth worker (`apps/auth`) gains three internal routes that own the role-matrix invariants (it holds the `member`/`invitation` tables). `apps/api` adds thin `org-workspaces` helpers and `adminWorkspaceOr403`-gated `/me` routes. `apps/web` adds api-client calls, pure render helpers, and people-tab wiring. Full spec: `docs/superpowers/specs/2026-07-19-people-tab-member-management-design.md`.
+
+**Tech Stack:** Hono, drizzle-orm/d1, better-auth org tables, Astro islands, vitest with in-process fake-D1.
+
+## Global Constraints
+
+- **Permission matrix** (enforced in the auth worker): remove `member` → owner or admin; remove `admin` → owner only; remove/modify `owner` → never (`403 cannot_modify_owner`); promote/demote (`admin↔member`) → owner only; act on self → never (`400 cannot_modify_self`); revoke invite → owner or admin. Actor lacking owner|admin → `403 actor_not_authorized`.
+- **Role values:** `owner | admin | member`. Role-change target role must be `admin` or `member` (`400 invalid_role`); `owner` is never a source or target through these endpoints.
+- **Management targets `member.id`** (opaque), never the global `userId`.
+- **Error shapes:** auth worker uses `errorJson(code, message)` → `{ error: { code, message } }`. `apps/api` throws `@uploads/errors` classes. Auth internal routes are reached only via `env.AUTH.fetch("https://auth.internal/…")` with header `x-uploads-internal: 1`.
+- **No changeset.** `@uploads/auth`, `@uploads/api`, `@uploads/web` are all on the `.changeset/config.json` `ignore` list (Workers-deployed). A changeset here is release poison.
+- **Run tests from repo root** with `pnpm test` (unified vitest). Per-file: `pnpm vitest run <path>`.
+- Repo formats with **oxfmt** (runs in the pre-commit hook) — don't hand-format.
+
+---
+
+### Task 1: Auth worker — revoke pending invite
+
+**Files:**
+
+- Modify: `apps/auth/src/internal-routes.ts` (append a route to the `internal` Hono chain, after the `GET /orgs/:slug/invites` route ~line 350)
+- Test: `apps/auth/src/internal-routes.test.ts`
+
+**Interfaces:**
+
+- Produces: `DELETE /internal/orgs/:slug/invites/:id?actorUserId=<id>` → `200 { ok: true }` | `403 { error:{code:"actor_not_authorized"} }` | `404 { error:{code:"organization_not_found"|"invite_not_found"} }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/auth/src/internal-routes.test.ts` inside the `describe("DB-backed behavior", …)` block (reuse its `orm`, `seedUser`, `seedOrg`, `dbEnv`, `app` helpers). Add a helper to seed a member + a pending invite:
+
+```ts
+describe("DELETE /internal/orgs/:slug/invites/:id", () => {
+  async function seed(actorRole: string) {
+    const org = await seedOrg();
+    const actor = await seedUser({ id: "u_actor", email: "actor@x.com" });
+    await orm.insert(schema.member).values({
+      id: "m_actor",
+      organizationId: org.id,
+      userId: actor.id,
+      role: actorRole,
+      createdAt: new Date(),
+    });
+    const inviteId = "inv_1";
+    await orm.insert(schema.invitation).values({
+      id: inviteId,
+      organizationId: org.id,
+      email: "invitee@x.com",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date(Date.now() + 86400000),
+      inviterId: actor.id,
+      createdAt: new Date(),
+    });
+    return { org, actor, inviteId };
+  }
+
+  it("revokes a pending invite for an admin actor", async () => {
+    const { org, actor, inviteId } = await seed("admin");
+    const res = await app().request(
+      `/internal/orgs/${org.slug}/invites/${inviteId}?actorUserId=${actor.id}`,
+      { method: "DELETE" },
+      dbEnv(),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    const rows = await orm
+      .select()
+      .from(schema.invitation)
+      .where(eq(schema.invitation.id, inviteId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("403s when the actor is only a member", async () => {
+    const { org, actor, inviteId } = await seed("member");
+    const res = await app().request(
+      `/internal/orgs/${org.slug}/invites/${inviteId}?actorUserId=${actor.id}`,
+      { method: "DELETE" },
+      dbEnv(),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "actor_not_authorized" },
+    });
+  });
+
+  it("404s for an unknown invite id", async () => {
+    const { org, actor } = await seed("owner");
+    const res = await app().request(
+      `/internal/orgs/${org.slug}/invites/nope?actorUserId=${actor.id}`,
+      { method: "DELETE" },
+      dbEnv(),
+    );
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invite_not_found" },
+    });
+  });
+});
+```
+
+> Note: if `seedUser` doesn't accept an override arg, match the file's actual signature — check the existing `seedUser`/`seedOrg` helpers near line 130-150 and adapt these calls to them.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/auth/src/internal-routes.test.ts -t "invites/:id"`
+Expected: FAIL (route returns 404 for all — the DELETE path doesn't exist, so Hono returns its default 404 without the `invite_not_found` code, and the revoke/403 assertions fail).
+
+- [ ] **Step 3: Implement the route**
+
+In `apps/auth/src/internal-routes.ts`, add after the `GET /orgs/:slug/invites` route. First add a small shared authz helper near the top (after `errorJson`, ~line 15) — it's reused by Tasks 2 & 3:
+
+```ts
+/** The actor's org-scoped role, or null if they aren't a member of this org. */
+async function actorRole(
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  orgId: string,
+  actorUserId: string,
+): Promise<string | null> {
+  if (!actorUserId) return null;
+  const [row] = await db
+    .select({ role: schema.member.role })
+    .from(schema.member)
+    .where(and(eq(schema.member.organizationId, orgId), eq(schema.member.userId, actorUserId)))
+    .limit(1);
+  return row?.role ?? null;
+}
+```
+
+Then the route:
+
+```ts
+  .delete("/orgs/:slug/invites/:id", async (c) => {
+    const slug = c.req.param("slug");
+    const inviteId = c.req.param("id");
+    const requestActorUserId = c.req.query("actorUserId") ?? "";
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const role = await actorRole(db, org.id, requestActorUserId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json(errorJson("actor_not_authorized", "actor must be an org admin or owner"), 403);
+    }
+    const [invite] = await db
+      .select({ id: schema.invitation.id })
+      .from(schema.invitation)
+      .where(
+        and(
+          eq(schema.invitation.id, inviteId),
+          eq(schema.invitation.organizationId, org.id),
+          eq(schema.invitation.status, "pending"),
+        ),
+      )
+      .limit(1);
+    if (!invite) {
+      return c.json(errorJson("invite_not_found", "no pending invite with that id"), 404);
+    }
+    await db.delete(schema.invitation).where(eq(schema.invitation.id, invite.id));
+    return c.json({ ok: true });
+  })
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/auth/src/internal-routes.test.ts -t "invites/:id"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/auth/src/internal-routes.ts apps/auth/src/internal-routes.test.ts
+git commit -m "feat(auth): internal revoke-invite route (#275)"
+```
+
+---
+
+### Task 2: Auth worker — remove member
+
+**Files:**
+
+- Modify: `apps/auth/src/internal-routes.ts` (append after Task 1's route)
+- Test: `apps/auth/src/internal-routes.test.ts`
+
+**Interfaces:**
+
+- Consumes: `actorRole(db, orgId, actorUserId)` from Task 1.
+- Produces: `DELETE /internal/orgs/:slug/members/:memberId?actorUserId=<id>` → `200 { ok: true }` | `400 { error:{code:"cannot_modify_self"} }` | `403 { error:{code:"cannot_modify_owner"|"actor_not_authorized"} }` | `404 { error:{code:"organization_not_found"|"member_not_found"} }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("DELETE /internal/orgs/:slug/members/:memberId", () => {
+  async function seed() {
+    const org = await seedOrg();
+    const owner = await seedUser({ id: "u_owner", email: "owner@x.com" });
+    const admin = await seedUser({ id: "u_admin", email: "admin@x.com" });
+    const admin2 = await seedUser({ id: "u_admin2", email: "admin2@x.com" });
+    const member = await seedUser({ id: "u_member", email: "member@x.com" });
+    const rows = [
+      { id: "m_owner", userId: owner.id, role: "owner" },
+      { id: "m_admin", userId: admin.id, role: "admin" },
+      { id: "m_admin2", userId: admin2.id, role: "admin" },
+      { id: "m_member", userId: member.id, role: "member" },
+    ];
+    for (const r of rows) {
+      await orm.insert(schema.member).values({
+        id: r.id,
+        organizationId: org.id,
+        userId: r.userId,
+        role: r.role,
+        createdAt: new Date(),
+      });
+    }
+    return { org, owner, admin, admin2, member };
+  }
+  const del = (slug: string, memberId: string, actorUserId: string) =>
+    app().request(
+      `/internal/orgs/${slug}/members/${memberId}?actorUserId=${actorUserId}`,
+      { method: "DELETE" },
+      dbEnv(),
+    );
+
+  it("lets an admin remove a member", async () => {
+    const { org, admin } = await seed();
+    const res = await del(org.slug, "m_member", admin.id);
+    expect(res.status).toBe(200);
+    const rows = await orm.select().from(schema.member).where(eq(schema.member.id, "m_member"));
+    expect(rows).toHaveLength(0);
+  });
+  it("forbids an admin removing another admin", async () => {
+    const { org, admin } = await seed();
+    const res = await del(org.slug, "m_admin2", admin.id);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "actor_not_authorized" },
+    });
+  });
+  it("lets an owner remove an admin", async () => {
+    const { org, owner } = await seed();
+    const res = await del(org.slug, "m_admin", owner.id);
+    expect(res.status).toBe(200);
+  });
+  it("never removes an owner", async () => {
+    const { org, owner } = await seed();
+    const res = await del(org.slug, "m_owner", owner.id);
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "cannot_modify_owner" },
+    });
+  });
+  it("blocks removing yourself", async () => {
+    const { org, admin } = await seed();
+    const res = await del(org.slug, "m_admin", admin.id);
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "cannot_modify_self" },
+    });
+  });
+  it("404s for an unknown member id", async () => {
+    const { org, owner } = await seed();
+    const res = await del(org.slug, "nope", owner.id);
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "member_not_found" },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/auth/src/internal-routes.test.ts -t "members/:memberId"`
+Expected: FAIL (route doesn't exist).
+
+- [ ] **Step 3: Implement the route**
+
+Append after Task 1's route:
+
+```ts
+  .delete("/orgs/:slug/members/:memberId", async (c) => {
+    const slug = c.req.param("slug");
+    const memberId = c.req.param("memberId");
+    const requestActorUserId = c.req.query("actorUserId") ?? "";
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const [target] = await db
+      .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
+      .from(schema.member)
+      .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, org.id)))
+      .limit(1);
+    if (!target) {
+      return c.json(errorJson("member_not_found", "no member with that id in this org"), 404);
+    }
+    if (target.userId === requestActorUserId) {
+      return c.json(errorJson("cannot_modify_self", "you cannot remove yourself"), 400);
+    }
+    if (target.role === "owner") {
+      return c.json(errorJson("cannot_modify_owner", "the workspace owner cannot be removed"), 403);
+    }
+    const role = await actorRole(db, org.id, requestActorUserId);
+    if (role !== "owner" && role !== "admin") {
+      return c.json(errorJson("actor_not_authorized", "actor must be an org admin or owner"), 403);
+    }
+    // Only owners may remove admins; admins may remove members only.
+    if (target.role === "admin" && role !== "owner") {
+      return c.json(errorJson("actor_not_authorized", "only an owner can remove an admin"), 403);
+    }
+    await db.delete(schema.member).where(eq(schema.member.id, target.id));
+    return c.json({ ok: true });
+  })
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/auth/src/internal-routes.test.ts -t "members/:memberId"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/auth/src/internal-routes.ts apps/auth/src/internal-routes.test.ts
+git commit -m "feat(auth): internal remove-member route with role matrix (#275)"
+```
+
+---
+
+### Task 3: Auth worker — change member role
+
+**Files:**
+
+- Modify: `apps/auth/src/internal-routes.ts` (append after Task 2's route)
+- Test: `apps/auth/src/internal-routes.test.ts`
+
+**Interfaces:**
+
+- Consumes: `actorRole` from Task 1; the `seed()` member fixture pattern from Task 2.
+- Produces: `PATCH /internal/orgs/:slug/members/:memberId` body `{ actorUserId, role }` → `200 { member: { id, userId, role } }` | `400 { error:{code:"invalid_role"|"cannot_modify_self"} }` | `403 { error:{code:"cannot_modify_owner"|"actor_not_authorized"} }` | `404 { error:{code:"organization_not_found"|"member_not_found"} }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Reuse the same `seed()` helper (define a local copy in this describe block, or lift Task 2's `seed()` to the parent scope and share it):
+
+```ts
+describe("PATCH /internal/orgs/:slug/members/:memberId", () => {
+  // ...same seed() as Task 2...
+  const patch = (slug: string, memberId: string, actorUserId: string, role: string) =>
+    app().request(
+      `/internal/orgs/${slug}/members/${memberId}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ actorUserId, role }),
+      },
+      dbEnv(),
+    );
+
+  it("lets an owner promote a member to admin", async () => {
+    const { org, owner } = await seed();
+    const res = await patch(org.slug, "m_member", owner.id, "admin");
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { member: { role: string } }).toMatchObject({
+      member: { id: "m_member", role: "admin" },
+    });
+    const [row] = await orm.select().from(schema.member).where(eq(schema.member.id, "m_member"));
+    expect(row.role).toBe("admin");
+  });
+  it("forbids an admin changing roles", async () => {
+    const { org, admin } = await seed();
+    const res = await patch(org.slug, "m_member", admin.id, "admin");
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "actor_not_authorized" },
+    });
+  });
+  it("rejects an invalid target role", async () => {
+    const { org, owner } = await seed();
+    const res = await patch(org.slug, "m_member", owner.id, "owner");
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_role" },
+    });
+  });
+  it("never modifies an owner", async () => {
+    const { org, owner } = await seed();
+    const res = await patch(org.slug, "m_owner", owner.id, "member");
+    expect(res.status).toBe(400); // self-check fires first for the owner acting on self
+    // A second owner acting on this owner would get cannot_modify_owner; self short-circuits here.
+  });
+  it("blocks changing your own role", async () => {
+    const { org, admin } = await seed();
+    const res = await patch(org.slug, "m_admin", admin.id, "member");
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "cannot_modify_self" },
+    });
+  });
+  it("is idempotent when the role is unchanged", async () => {
+    const { org, owner } = await seed();
+    const res = await patch(org.slug, "m_admin", owner.id, "admin");
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { member: { role: string } }).toMatchObject({
+      member: { role: "admin" },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/auth/src/internal-routes.test.ts -t "PATCH /internal/orgs"`
+Expected: FAIL (route doesn't exist).
+
+- [ ] **Step 3: Implement the route**
+
+```ts
+  .patch("/orgs/:slug/members/:memberId", async (c) => {
+    const slug = c.req.param("slug");
+    const memberId = c.req.param("memberId");
+    const body = await c.req
+      .json<{ actorUserId?: unknown; role?: unknown }>()
+      .catch(() => ({}) as { actorUserId?: unknown; role?: unknown });
+    const requestActorUserId = typeof body.actorUserId === "string" ? body.actorUserId : "";
+    const nextRole = typeof body.role === "string" ? body.role.trim() : "";
+    if (nextRole !== "admin" && nextRole !== "member") {
+      return c.json(errorJson("invalid_role", "role must be admin or member"), 400);
+    }
+    const db = drizzle(c.env.DB, { schema });
+    const [org] = await db
+      .select()
+      .from(schema.organization)
+      .where(eq(schema.organization.slug, slug))
+      .limit(1);
+    if (!org) {
+      return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
+    }
+    const [target] = await db
+      .select({ id: schema.member.id, userId: schema.member.userId, role: schema.member.role })
+      .from(schema.member)
+      .where(and(eq(schema.member.id, memberId), eq(schema.member.organizationId, org.id)))
+      .limit(1);
+    if (!target) {
+      return c.json(errorJson("member_not_found", "no member with that id in this org"), 404);
+    }
+    if (target.userId === requestActorUserId) {
+      return c.json(errorJson("cannot_modify_self", "you cannot change your own role"), 400);
+    }
+    if (target.role === "owner") {
+      return c.json(errorJson("cannot_modify_owner", "the workspace owner's role is fixed"), 403);
+    }
+    const role = await actorRole(db, org.id, requestActorUserId);
+    if (role !== "owner") {
+      return c.json(errorJson("actor_not_authorized", "only an owner can change member roles"), 403);
+    }
+    if (target.role !== nextRole) {
+      await db.update(schema.member).set({ role: nextRole }).where(eq(schema.member.id, target.id));
+    }
+    return c.json({ member: { id: target.id, userId: target.userId, role: nextRole } });
+  })
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/auth/src/internal-routes.test.ts -t "PATCH /internal/orgs"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/auth/src/internal-routes.ts apps/auth/src/internal-routes.test.ts
+git commit -m "feat(auth): internal change-member-role route (owner-only) (#275)"
+```
+
+---
+
+### Task 4: API — org-workspaces helpers
+
+**Files:**
+
+- Modify: `apps/api/src/org-workspaces.ts` (append after `membersForOrg`, ~line 96)
+- Test: `apps/api/src/org-workspaces.test.ts`
+
+**Interfaces:**
+
+- Consumes: the auth routes from Tasks 1-3.
+- Produces:
+  - `OrgInvite = { id: string; email: string; role: string | null; status: string; expiresAt: string | number | null }`
+  - `invitesForOrg(env, slug): Promise<OrgInvite[]>`
+  - `revokeInvite(env, slug, inviteId, actorUserId): Promise<void>`
+  - `removeMember(env, slug, memberId, actorUserId): Promise<void>`
+  - `updateMemberRole(env, slug, memberId, role, actorUserId): Promise<{ id: string; userId: string; role: string }>`
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/api/src/org-workspaces.test.ts` already stubs `env.AUTH.fetch` — match its existing fake-AUTH pattern (a function returning `{ AUTH: { fetch: async (url, init) => Response } }`). Add:
+
+```ts
+import { ForbiddenError, NotFoundError } from "@uploads/errors";
+import { invitesForOrg, revokeInvite, removeMember, updateMemberRole } from "./org-workspaces";
+
+function fakeEnv(handler: (url: string, init?: RequestInit) => Response) {
+  return {
+    AUTH: { fetch: async (url: string, init?: RequestInit) => handler(String(url), init) },
+  } as unknown as Env;
+}
+
+describe("invitesForOrg", () => {
+  it("returns the invites array", async () => {
+    const env = fakeEnv(
+      () =>
+        new Response(
+          JSON.stringify({
+            invites: [
+              { id: "i1", email: "a@x.com", role: "member", status: "pending", expiresAt: 1 },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    expect(await invitesForOrg(env, "acme")).toEqual([
+      { id: "i1", email: "a@x.com", role: "member", status: "pending", expiresAt: 1 },
+    ]);
+  });
+  it("throws ServiceUnavailable on a non-ok response", async () => {
+    const env = fakeEnv(() => new Response("nope", { status: 500 }));
+    await expect(invitesForOrg(env, "acme")).rejects.toThrow();
+  });
+});
+
+describe("revokeInvite / removeMember / updateMemberRole error mapping", () => {
+  it("revokeInvite maps 404 to NotFoundError", async () => {
+    const env = fakeEnv(
+      () => new Response(JSON.stringify({ error: { code: "invite_not_found" } }), { status: 404 }),
+    );
+    await expect(revokeInvite(env, "acme", "i1", "u1")).rejects.toBeInstanceOf(NotFoundError);
+  });
+  it("removeMember maps 403 to ForbiddenError", async () => {
+    const env = fakeEnv(
+      () =>
+        new Response(JSON.stringify({ error: { code: "actor_not_authorized" } }), { status: 403 }),
+    );
+    await expect(removeMember(env, "acme", "m1", "u1")).rejects.toBeInstanceOf(ForbiddenError);
+  });
+  it("updateMemberRole returns the updated member on 200", async () => {
+    const env = fakeEnv(
+      () =>
+        new Response(JSON.stringify({ member: { id: "m1", userId: "u2", role: "admin" } }), {
+          status: 200,
+        }),
+    );
+    expect(await updateMemberRole(env, "acme", "m1", "admin", "u1")).toEqual({
+      id: "m1",
+      userId: "u2",
+      role: "admin",
+    });
+  });
+  it("updateMemberRole maps 400 to BadRequest/Validation", async () => {
+    const env = fakeEnv(
+      () => new Response(JSON.stringify({ error: { code: "invalid_role" } }), { status: 400 }),
+    );
+    await expect(updateMemberRole(env, "acme", "m1", "owner", "u1")).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/api/src/org-workspaces.test.ts -t "invitesForOrg|error mapping"`
+Expected: FAIL (functions not exported).
+
+- [ ] **Step 3: Implement the helpers**
+
+In `apps/api/src/org-workspaces.ts`, extend the import and append the helpers. First widen the errors import at line 19:
+
+```ts
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  ServiceUnavailableError,
+  ValidationError,
+} from "@uploads/errors";
+```
+
+Then append after `membersForOrg`:
+
+```ts
+/** A pending invite row from `/internal/orgs/:slug/invites`. */
+export interface OrgInvite {
+  id: string;
+  email: string;
+  role: string | null;
+  status: string;
+  expiresAt: string | number | null;
+}
+
+/** Pending invites for an org. Non-ok is an auth-worker outage/bug (5xx), like the reads above. */
+export async function invitesForOrg(env: Env, slug: string): Promise<OrgInvite[]> {
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/invites`,
+    { headers: internalHeaders() },
+  );
+  if (!response.ok) {
+    throw new ServiceUnavailableError("auth service returned an unexpected status", {
+      code: "auth_lookup_failed",
+      details: { status: response.status },
+    });
+  }
+  const body = (await response.json().catch(() => null)) as { invites?: OrgInvite[] } | null;
+  return body?.invites ?? [];
+}
+
+/**
+ * Maps the auth worker's authorization/validation failures to AppErrors. 403 →
+ * Forbidden, 404 → NotFound, 400 → Validation; anything else is treated as an
+ * outage. Shared by revoke/remove/role helpers below.
+ */
+async function throwForManageError(response: Response, context: string): Promise<never> {
+  const body = (await response.json().catch(() => null)) as { error?: { code?: string } } | null;
+  const code = body?.error?.code;
+  if (response.status === 403) throw new ForbiddenError(context, { code: code ?? "forbidden" });
+  if (response.status === 404) throw new NotFoundError(context, { code: code ?? "not_found" });
+  if (response.status === 400)
+    throw new ValidationError(context, { code: code ?? "invalid_request" });
+  throw new ServiceUnavailableError("auth service returned an unexpected status", {
+    code: "auth_lookup_failed",
+    details: { status: response.status },
+  });
+}
+
+/** Revoke a pending invite. `actorUserId` is the acting session user (authz). */
+export async function revokeInvite(
+  env: Env,
+  slug: string,
+  inviteId: string,
+  actorUserId: string,
+): Promise<void> {
+  const url = `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/invites/${encodeURIComponent(inviteId)}?actorUserId=${encodeURIComponent(actorUserId)}`;
+  const response = await env.AUTH.fetch(url, { method: "DELETE", headers: internalHeaders() });
+  if (!response.ok) await throwForManageError(response, "could not revoke invite");
+}
+
+/** Remove a member (by opaque member id). `actorUserId` is the acting session user. */
+export async function removeMember(
+  env: Env,
+  slug: string,
+  memberId: string,
+  actorUserId: string,
+): Promise<void> {
+  const url = `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/members/${encodeURIComponent(memberId)}?actorUserId=${encodeURIComponent(actorUserId)}`;
+  const response = await env.AUTH.fetch(url, { method: "DELETE", headers: internalHeaders() });
+  if (!response.ok) await throwForManageError(response, "could not remove member");
+}
+
+/** Change a member's role (admin↔member). Returns the updated member. */
+export async function updateMemberRole(
+  env: Env,
+  slug: string,
+  memberId: string,
+  role: string,
+  actorUserId: string,
+): Promise<{ id: string; userId: string; role: string }> {
+  const headers = internalHeaders();
+  headers.set("content-type", "application/json");
+  const response = await env.AUTH.fetch(
+    `${INTERNAL_ORIGIN}/internal/orgs/${encodeURIComponent(slug)}/members/${encodeURIComponent(memberId)}`,
+    { method: "PATCH", headers, body: JSON.stringify({ actorUserId, role }) },
+  );
+  if (!response.ok) await throwForManageError(response, "could not change member role");
+  const body = (await response.json().catch(() => null)) as {
+    member?: { id: string; userId: string; role: string };
+  } | null;
+  if (!body?.member) {
+    throw new ServiceUnavailableError("auth service returned a malformed body", {
+      code: "auth_lookup_failed",
+    });
+  }
+  return body.member;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/api/src/org-workspaces.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/org-workspaces.ts apps/api/src/org-workspaces.test.ts
+git commit -m "feat(api): org-workspaces invite/member management helpers (#275)"
+```
+
+---
+
+### Task 5: API — `/me` routes + member-id exposure
+
+**Files:**
+
+- Modify: `apps/api/src/routes/me.ts` (extend the `GET /workspaces/:name/members` route ~line 184; append 4 routes before the final `;` of the `me` chain ~line 477; extend imports ~line 25-30)
+- Test: `apps/api/src/routes/me.test.ts`
+
+**Interfaces:**
+
+- Consumes: `adminWorkspaceOr403`, `memberWorkspaceOr404`, `requireUserId`, `allowWrite` (existing in me.ts); `invitesForOrg`, `revokeInvite`, `removeMember`, `updateMemberRole` (Task 4).
+- Produces (all under `/me`, credentialed):
+  - `GET /workspaces/:name/members` now includes `id` **only for admin/owner callers**.
+  - `GET /workspaces/:name/invites` → `{ communal, invites }`
+  - `DELETE /workspaces/:name/invites/:id` → `{ ok: true }`
+  - `DELETE /workspaces/:name/members/:memberId` → `{ ok: true }`
+  - `PATCH /workspaces/:name/members/:memberId` `{ role }` → `{ member }`
+
+- [ ] **Step 1: Write the failing tests**
+
+`apps/api/src/routes/me.test.ts` already builds the `me` app with a fake AUTH binding and seeds workspaces/memberships — match its existing helpers (look for how it stubs `myWorkspaces`/AUTH and how it authenticates the session user). Add tests:
+
+```ts
+describe("GET /me/workspaces/:name/members id exposure", () => {
+  it("includes member id for an admin/owner caller", async () => {
+    // seed caller as owner of workspace "acme"; auth /members returns rows incl id
+    const res = await requestAs(ownerSession, "GET", "/me/workspaces/acme/members");
+    const body = await res.json();
+    expect(body.members[0]).toHaveProperty("id");
+  });
+  it("omits member id for a plain member caller", async () => {
+    const res = await requestAs(memberSession, "GET", "/me/workspaces/acme/members");
+    const body = await res.json();
+    expect(body.members[0]).not.toHaveProperty("id");
+  });
+});
+
+describe("member management routes", () => {
+  it("GET invites requires admin/owner (403 for a member)", async () => {
+    const res = await requestAs(memberSession, "GET", "/me/workspaces/acme/invites");
+    expect(res.status).toBe(403);
+  });
+  it("GET invites returns pending invites for an admin", async () => {
+    const res = await requestAs(adminSession, "GET", "/me/workspaces/acme/invites");
+    expect(res.status).toBe(200);
+    expect((await res.json()).invites).toBeInstanceOf(Array);
+  });
+  it("PATCH members validates the role", async () => {
+    const res = await requestAs(ownerSession, "PATCH", "/me/workspaces/acme/members/m1", {
+      role: "owner",
+    });
+    expect(res.status).toBe(400);
+  });
+  it("communal workspace short-circuits invites", async () => {
+    const res = await requestAs(memberOfDefault, "GET", "/me/workspaces/default/invites");
+    // communal is member-visible-empty; adminWorkspaceOr403 still applies — assert to the actual gate
+    expect([200, 403]).toContain(res.status);
+  });
+});
+```
+
+> Adapt `requestAs` / session seeding to the real helpers in `me.test.ts`. The point is: id exposure differs by role, mutating routes are admin-gated, PATCH validates role. If the fake AUTH binding needs to respond to the new internal paths, extend its handler to return `{ invites: [] }` / `{ ok: true }` / `{ member: {...} }` for the new URLs.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/api/src/routes/me.test.ts -t "id exposure|member management"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Extend imports at the top of `me.ts` (the existing `from "../org-workspaces"` import):
+
+```ts
+import {
+  membersForOrg,
+  orgForWorkspace,
+  invitesForOrg,
+  revokeInvite,
+  removeMember,
+  updateMemberRole,
+} from "../org-workspaces";
+```
+
+Replace the members route body (line 184-201) so admins/owners get `id`:
+
+```ts
+  .get("/workspaces/:name/members", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    if (ws.communal) return c.json({ communal: true, members: [] });
+
+    const canManage = ws.role === "admin" || ws.role === "owner";
+    const members = await membersForOrg(c.env, ws.organization.slug);
+    return c.json({
+      communal: false,
+      members: members.map((m) => ({
+        // Opaque member id only for managers — regular teammates never receive it.
+        ...(canManage ? { id: m.id } : {}),
+        email: m.email ?? "",
+        name: m.name ?? "",
+        role: m.role ?? "member",
+        createdAt: m.createdAt,
+      })),
+    });
+  })
+```
+
+Append the four routes just before the closing `;` of the `me` chain (after the `POST /workspaces/:name/invites` route ends at line 477 — turn its trailing `})` into `})` + these, ending the last one with `;`):
+
+```ts
+  // Pending invites for this workspace — admin/owner only (they can revoke).
+  .get("/workspaces/:name/invites", async (c) => {
+    const name = c.req.param("name");
+    const ws = await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    if (ws.communal) return c.json({ communal: true, invites: [] });
+    const invites = await invitesForOrg(c.env, ws.organization.slug);
+    return c.json({ communal: false, invites });
+  })
+
+  // Revoke a pending invite — admin/owner only.
+  .delete("/workspaces/:name/invites/:id", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
+    await revokeInvite(c.env, ws.organization.slug, c.req.param("id"), userId);
+    return c.json({ ok: true });
+  })
+
+  // Remove a member (by opaque member id) — admin/owner only; matrix enforced in auth worker.
+  .delete("/workspaces/:name/members/:memberId", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
+    await removeMember(c.env, ws.organization.slug, c.req.param("memberId"), userId);
+    return c.json({ ok: true });
+  })
+
+  // Change a member's role (admin↔member) — owner-only enforced in auth worker.
+  .patch("/workspaces/:name/members/:memberId", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
+    const body = await c.req
+      .json<{ role?: unknown }>()
+      .catch(() => ({}) as { role?: unknown });
+    const role = typeof body.role === "string" ? body.role.trim() : "";
+    if (role !== "admin" && role !== "member") {
+      throw new ValidationError("role must be admin or member", { code: "invalid_role" });
+    }
+    const member = await updateMemberRole(c.env, ws.organization.slug, c.req.param("memberId"), role, userId);
+    return c.json({ member });
+  });
+```
+
+> `RateLimitedError` and `ValidationError` are already imported in `me.ts` (used by the invite route). Confirm they're in the import list; if not, add them.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/api/src/routes/me.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/me.ts apps/api/src/routes/me.test.ts
+git commit -m "feat(api): /me invite-revoke + member management routes (#275)"
+```
+
+---
+
+### Task 6: Web — api-client functions
+
+**Files:**
+
+- Modify: `apps/web/src/lib/api-client.ts` (extend `WorkspaceMember` ~line 242; add after `inviteToWorkspace` ~line 324)
+- Test: `apps/web/src/lib/api-client.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `WorkspaceMember` gains `id?: string`
+  - `WorkspaceInvite = { id, email, role, status, expiresAt }`, `WorkspaceInvitesResult = { kind:"ok"; communal; invites } | { kind:"unavailable" }`
+  - `getWorkspaceInvites(apiOrigin, name)`, `revokeWorkspaceInvite(apiOrigin, name, inviteId)`, `removeWorkspaceMember(apiOrigin, name, memberId)`, `updateWorkspaceMemberRole(apiOrigin, name, memberId, role)`
+  - `ManageResult = { kind:"ok" } | { kind:"unavailable"; reason: "forbidden"|"not_found"|"invalid"|"server"|RequestFailure }`
+
+- [ ] **Step 1: Write the failing tests**
+
+`api-client.test.ts` mocks `fetch` (check its existing pattern — likely `vi.stubGlobal("fetch", …)` or a `fetchWithTimeout` seam). Add:
+
+```ts
+describe("getWorkspaceInvites", () => {
+  it("parses invites and passes id through to members", async () => {
+    stubFetchJson({
+      communal: false,
+      invites: [{ id: "i1", email: "a@x.com", role: "member", status: "pending", expiresAt: 1 }],
+    });
+    const res = await getWorkspaceInvites("https://api.test", "acme");
+    expect(res).toMatchObject({ kind: "ok", communal: false });
+    if (res.kind === "ok") expect(res.invites[0].id).toBe("i1");
+  });
+});
+describe("manage mutations map status codes", () => {
+  it("revokeWorkspaceInvite → forbidden on 403", async () => {
+    stubFetchStatus(403);
+    expect(await revokeWorkspaceInvite("https://api.test", "acme", "i1")).toEqual({
+      kind: "unavailable",
+      reason: "forbidden",
+    });
+  });
+  it("updateWorkspaceMemberRole → ok on 200", async () => {
+    stubFetchJson({ member: { id: "m1", userId: "u2", role: "admin" } }, 200);
+    expect(await updateWorkspaceMemberRole("https://api.test", "acme", "m1", "admin")).toEqual({
+      kind: "ok",
+    });
+  });
+});
+```
+
+> Use the file's real fetch-stub helpers (match names to what's already imported in `api-client.test.ts`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/web/src/lib/api-client.test.ts -t "getWorkspaceInvites|manage mutations"`
+Expected: FAIL (functions not exported).
+
+- [ ] **Step 3: Implement**
+
+Add `id?: string` to `WorkspaceMember` (line 242) and make `getWorkspaceMembers`' mapper pass it through:
+
+```ts
+export interface WorkspaceMember {
+  id?: string;
+  email: string;
+  name: string;
+  role: string;
+  createdAt?: string;
+}
+```
+
+In `getWorkspaceMembers`' map (line 279-284), add:
+
+```ts
+    members: body.members.filter(isMemberCandidate).map((row) => ({
+      id: typeof row.id === "string" ? row.id : undefined,
+      email: row.email,
+      name: typeof row.name === "string" ? row.name : "",
+      role: row.role,
+      createdAt: typeof row.createdAt === "string" ? row.createdAt : undefined,
+    })),
+```
+
+Append after `inviteToWorkspace`:
+
+```ts
+export interface WorkspaceInvite {
+  id: string;
+  email: string;
+  role: string | null;
+  status: string;
+  expiresAt: string | number | null;
+}
+
+export type WorkspaceInvitesResult =
+  | { kind: "ok"; communal: boolean; invites: WorkspaceInvite[] }
+  | { kind: "unavailable" };
+
+export type ManageResult =
+  | { kind: "ok" }
+  | {
+      kind: "unavailable";
+      reason: RequestFailure | "server" | "forbidden" | "not_found" | "invalid";
+    };
+
+function manageResultFor(status: number, ok: boolean): ManageResult {
+  if (ok) return { kind: "ok" };
+  if (status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (status === 400) return { kind: "unavailable", reason: "invalid" };
+  return { kind: "unavailable", reason: "server" };
+}
+
+/** GET /me/workspaces/:name/invites — pending invites, admin/owner only. */
+export async function getWorkspaceInvites(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceInvitesResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/invites`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return { kind: "unavailable" };
+  const body = (await result.response.json().catch(() => null)) as {
+    communal?: unknown;
+    invites?: unknown;
+  } | null;
+  if (!body || !Array.isArray(body.invites)) return { kind: "unavailable" };
+  return {
+    kind: "ok",
+    communal: body.communal === true,
+    invites: body.invites.filter(
+      (v): v is WorkspaceInvite =>
+        !!v && typeof v === "object" && typeof (v as { id?: unknown }).id === "string",
+    ),
+  };
+}
+
+async function manageMutation(
+  apiOrigin: string,
+  path: string,
+  init: RequestInit,
+): Promise<ManageResult> {
+  const result = await fetchWithTimeout(`${trimOrigin(apiOrigin)}${path}`, {
+    credentials: "include",
+    cache: "no-store",
+    ...init,
+  });
+  if (result.kind === "unavailable") return result;
+  return manageResultFor(result.response.status, result.response.ok);
+}
+
+/** DELETE /me/workspaces/:name/invites/:id */
+export async function revokeWorkspaceInvite(
+  apiOrigin: string,
+  name: string,
+  inviteId: string,
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/me/workspaces/${encodeURIComponent(name)}/invites/${encodeURIComponent(inviteId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/** DELETE /me/workspaces/:name/members/:memberId */
+export async function removeWorkspaceMember(
+  apiOrigin: string,
+  name: string,
+  memberId: string,
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/me/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
+    { method: "DELETE" },
+  );
+}
+
+/** PATCH /me/workspaces/:name/members/:memberId */
+export async function updateWorkspaceMemberRole(
+  apiOrigin: string,
+  name: string,
+  memberId: string,
+  role: "admin" | "member",
+): Promise<ManageResult> {
+  return manageMutation(
+    apiOrigin,
+    `/me/workspaces/${encodeURIComponent(name)}/members/${encodeURIComponent(memberId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role }),
+    },
+  );
+}
+```
+
+> `RequestFailure`, `fetchWithTimeout`, `trimOrigin` already exist in this file (used by the surrounding functions). Confirm `isMemberCandidate` allows extra keys — it uses `Record<string, unknown>`, so `id` passes through fine.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/web/src/lib/api-client.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api-client.ts apps/web/src/lib/api-client.test.ts
+git commit -m "feat(web): api-client invite-revoke + member management calls (#275)"
+```
+
+---
+
+### Task 7: Web — render helpers (invites list + member row controls)
+
+**Files:**
+
+- Modify: `apps/web/src/lib/workspace-ui.ts` (extend `MemberRow` + `renderMembersHtml` ~line 119-138; add `renderInvitesHtml`)
+- Test: `apps/web/src/lib/workspace-ui.test.ts` (create if absent — check first)
+
+**Interfaces:**
+
+- Consumes: `escapeHtml` (in workspace-ui.ts).
+- Produces:
+  - `MemberRow` gains `id?: string`.
+  - `renderMembersHtml(members, opts?: { canManage?: boolean; selfEmail?: string })` — controls only when `canManage` and the row has `id` and `role !== "owner"` and its email !== `selfEmail`.
+  - `renderInvitesHtml(invites: { id: string; email: string; status: string }[]): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/lib/workspace-ui.test.ts` (or add to it):
+
+```ts
+import { describe, expect, it } from "vitest";
+import { renderMembersHtml, renderInvitesHtml } from "./workspace-ui";
+
+describe("renderMembersHtml controls", () => {
+  const rows = [
+    { id: "m_owner", email: "owner@x.com", name: "", role: "owner" },
+    { id: "m_admin", email: "admin@x.com", name: "", role: "admin" },
+    { id: "m_me", email: "me@x.com", name: "", role: "admin" },
+  ];
+  it("renders no controls without canManage", () => {
+    const html = renderMembersHtml(rows);
+    expect(html).not.toContain("data-member-id");
+  });
+  it("renders controls for manageable rows only", () => {
+    const html = renderMembersHtml(rows, { canManage: true, selfEmail: "me@x.com" });
+    expect(html).toContain('data-member-id="m_admin"'); // manageable
+    expect(html).not.toContain('data-member-id="m_owner"'); // owner protected
+    expect(html).not.toContain('data-member-id="m_me"'); // self
+  });
+});
+
+describe("renderInvitesHtml", () => {
+  it("renders a revoke control per invite", () => {
+    const html = renderInvitesHtml([{ id: "i1", email: "a@x.com", status: "pending" }]);
+    expect(html).toContain('data-invite-id="i1"');
+    expect(html).toContain("a@x.com");
+  });
+  it("returns empty string for no invites", () => {
+    expect(renderInvitesHtml([])).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run apps/web/src/lib/workspace-ui.test.ts`
+Expected: FAIL (`renderInvitesHtml` missing; controls not emitted).
+
+- [ ] **Step 3: Implement**
+
+Replace `MemberRow` + `renderMembersHtml` (line 119-138) and add `renderInvitesHtml`:
+
+```ts
+/** Minimal member shape `renderMembersHtml` needs — api-client's `WorkspaceMember` satisfies it. */
+export interface MemberRow {
+  id?: string;
+  email: string;
+  name: string;
+  role: string;
+}
+
+export interface MemberRowOptions {
+  /** Viewer is owner/admin — enables per-row controls. */
+  canManage?: boolean;
+  /** Viewer's own email — their row never shows controls (no self-removal). */
+  selfEmail?: string;
+}
+
+/**
+ * Pure row builder for the people tab's member list. Shows the display name
+ * when set (email becomes the sub-line), else email leads. When `canManage`
+ * and the row has an `id`, non-owner rows other than the viewer's own get a
+ * role `<select>` and a remove button. `[]` → `""`.
+ */
+export function renderMembersHtml(members: MemberRow[], opts: MemberRowOptions = {}): string {
+  return members
+    .map((m) => {
+      const lead = m.name || m.email;
+      const sub = m.name ? `<span class="member-row__email">${escapeHtml(m.email)}</span>` : "";
+      const manageable =
+        !!opts.canManage && !!m.id && m.role !== "owner" && m.email !== opts.selfEmail;
+      const controls = manageable
+        ? `<span class="member-row__actions">` +
+          `<select class="member-row__role-select" data-member-id="${escapeHtml(m.id!)}" aria-label="Role for ${escapeHtml(m.email)}">` +
+          `<option value="member"${m.role === "member" ? " selected" : ""}>member</option>` +
+          `<option value="admin"${m.role === "admin" ? " selected" : ""}>admin</option>` +
+          `</select>` +
+          `<button type="button" class="text-btn member-row__remove" data-member-id="${escapeHtml(m.id!)}" data-member-email="${escapeHtml(m.email)}">Remove</button>` +
+          `</span>`
+        : `<span class="member-row__role">${escapeHtml(m.role)}</span>`;
+      return `<div class="member-row"><span class="member-row__who"><span class="member-row__name">${escapeHtml(lead)}</span>${sub}</span>${controls}</div>`;
+    })
+    .join("");
+}
+
+/** Pure row builder for the pending-invites list. `[]` → `""` (caller shows empty state). */
+export function renderInvitesHtml(
+  invites: { id: string; email: string; status: string }[],
+): string {
+  return invites
+    .map(
+      (inv) =>
+        `<div class="invite-row"><span class="invite-row__email">${escapeHtml(inv.email)}</span>` +
+        `<span class="invite-row__status">${escapeHtml(inv.status)}</span>` +
+        `<button type="button" class="text-btn invite-row__revoke" data-invite-id="${escapeHtml(inv.id)}" data-invite-email="${escapeHtml(inv.email)}">Revoke</button></div>`,
+    )
+    .join("");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run apps/web/src/lib/workspace-ui.test.ts`
+Expected: PASS. Also run `pnpm vitest run apps/web/src/lib/api-client.test.ts` to confirm the `renderMembersHtml` signature change didn't break other callers (search `renderMembersHtml(` usages — only people.astro, updated in Task 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/workspace-ui.ts apps/web/src/lib/workspace-ui.test.ts
+git commit -m "feat(web): render pending-invites + member-row controls (#275)"
+```
+
+---
+
+### Task 8: Web — wire the people tab
+
+**Files:**
+
+- Modify: `apps/web/src/pages/account/workspaces/[name]/people.astro` (markup: add a pending-invites section; script: imports, load invites, member/invite event handlers, pass `canManage`/`selfEmail` to `renderMembersHtml`)
+- Modify: `apps/web/src/styles/account-content.css` (styles for `.invite-row`, `.member-row__actions`)
+
+**Interfaces:**
+
+- Consumes: `getWorkspaceInvites`, `revokeWorkspaceInvite`, `removeWorkspaceMember`, `updateWorkspaceMemberRole` (Task 6); `renderInvitesHtml`, `renderMembersHtml` with options (Task 7). Session `user.email` + `user.role` via `onSession`.
+
+- [ ] **Step 1: Add the invites section markup**
+
+In `people.astro`, after the members `settings-section` (line 33, the `</div>` closing `#ws-members`'s section) and before the invite section, add:
+
+```html
+<div class="settings-section" id="ws-invites-section" hidden>
+  <h2>Pending invites</h2>
+  <div id="ws-invites" class="invite-list">
+    <p class="muted" id="ws-invites-status" role="status">Loading invites…</p>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Extend the script imports and state**
+
+Update the `api-client` import (line 78-82) and `workspace-ui` import (line 85-91):
+
+```ts
+import {
+  getMyWorkspaces,
+  getWorkspaceMembers,
+  inviteToWorkspace,
+  getWorkspaceInvites,
+  revokeWorkspaceInvite,
+  removeWorkspaceMember,
+  updateWorkspaceMemberRole,
+} from "../../../../lib/api-client";
+import {
+  bindCopyButtons,
+  escapeHtml,
+  isWorkspaceAdminRole,
+  operatorInviteCommand,
+  renderInvitesHtml,
+  renderMembersHtml,
+} from "../../../../lib/workspace-ui";
+```
+
+Add element refs near line 121 and track viewer identity/role:
+
+```ts
+const invitesSection = requireElement<HTMLElement>("#ws-invites-section", page);
+const invitesEl = requireElement<HTMLElement>("#ws-invites", page);
+
+let sessionRole: string | null | undefined;
+let sessionEmail: string | undefined;
+let canManage = false; // viewer is owner/admin of this workspace
+```
+
+- [ ] **Step 3: Set `canManage` and load invites in `loadInvitePage`**
+
+In `loadInvitePage`, after computing `ws` (line 160 area), set:
+
+```ts
+canManage = isWorkspaceAdminRole(ws.role);
+invitesSection.hidden = !canManage;
+```
+
+And after `void loadMembers();` (line 165) add:
+
+```ts
+if (canManage) void loadInvites();
+```
+
+- [ ] **Step 4: Update `loadMembers` to pass options, and add `loadInvites`**
+
+Replace the `renderMembersHtml(result.members)` call (line 195) with:
+
+```ts
+membersEl.innerHTML = result.members.length
+  ? renderMembersHtml(result.members, { canManage, selfEmail: sessionEmail })
+  : '<p class="muted">Just you so far.</p>';
+```
+
+Add after `loadMembers` (line 197):
+
+```ts
+async function loadInvites(): Promise<void> {
+  const result = await getWorkspaceInvites(apiOrigin, workspaceName);
+  if (!stillHere()) return;
+  if (result.kind === "unavailable") {
+    invitesEl.innerHTML =
+      '<p class="muted" role="alert">Invites are temporarily unavailable. Reload to try again.</p>';
+    return;
+  }
+  invitesEl.innerHTML = result.invites.length
+    ? renderInvitesHtml(result.invites)
+    : '<p class="muted">No pending invites.</p>';
+}
+```
+
+- [ ] **Step 5: Add delegated event handlers**
+
+After the `inviteForm.addEventListener(...)` block (line 241), add member + invite delegation:
+
+```ts
+membersEl.addEventListener("click", (event) => {
+  const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(".member-row__remove");
+  if (!btn) return;
+  void (async () => {
+    const memberId = btn.dataset.memberId ?? "";
+    const email = btn.dataset.memberEmail ?? "this member";
+    if (!memberId || !confirm(`Remove ${email} from this workspace?`)) return;
+    btn.disabled = true;
+    const res = await removeWorkspaceMember(apiOrigin, workspaceName, memberId);
+    if (!stillHere()) return;
+    if (res.kind === "ok") void loadMembers();
+    else {
+      btn.disabled = false;
+      alert(manageErrorText(res.reason, "remove this member"));
+    }
+  })();
+});
+
+membersEl.addEventListener("change", (event) => {
+  const select = (event.target as HTMLElement).closest<HTMLSelectElement>(
+    ".member-row__role-select",
+  );
+  if (!select) return;
+  void (async () => {
+    const memberId = select.dataset.memberId ?? "";
+    const role = select.value === "admin" ? "admin" : "member";
+    if (!memberId) return;
+    select.disabled = true;
+    const res = await updateWorkspaceMemberRole(apiOrigin, workspaceName, memberId, role);
+    if (!stillHere()) return;
+    select.disabled = false;
+    if (res.kind === "ok") void loadMembers();
+    else alert(manageErrorText(res.reason, "change this role"));
+  })();
+});
+
+invitesEl.addEventListener("click", (event) => {
+  const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(".invite-row__revoke");
+  if (!btn) return;
+  void (async () => {
+    const inviteId = btn.dataset.inviteId ?? "";
+    const email = btn.dataset.inviteEmail ?? "this invite";
+    if (!inviteId || !confirm(`Revoke the pending invite for ${email}?`)) return;
+    btn.disabled = true;
+    const res = await revokeWorkspaceInvite(apiOrigin, workspaceName, inviteId);
+    if (!stillHere()) return;
+    if (res.kind === "ok") void loadInvites();
+    else {
+      btn.disabled = false;
+      alert(manageErrorText(res.reason, "revoke this invite"));
+    }
+  })();
+});
+```
+
+Add a small message helper inside the `onAstroPageLoad` closure (near `showError`):
+
+```ts
+function manageErrorText(reason: string, action: string): string {
+  if (reason === "forbidden") return `You don’t have permission to ${action}.`;
+  if (reason === "not_found") return `That item no longer exists — reload the page.`;
+  if (reason === "invalid") return `That change isn’t allowed.`;
+  return `Couldn’t ${action}. Try again.`;
+}
+```
+
+Set `sessionEmail` in the `onSession` callback (line 247-250):
+
+```ts
+onSession((user) => {
+  sessionRole = user.role;
+  sessionEmail = user.email;
+  void loadInvitePage();
+});
+```
+
+- [ ] **Step 6: Add styles**
+
+Append to `apps/web/src/styles/account-content.css`:
+
+```css
+/* People tab: pending-invite rows + member-row management controls (#275). */
+.invite-list {
+  display: grid;
+  gap: 6px;
+}
+.invite-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.invite-row__email {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.invite-row__status {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.member-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.member-row__role-select {
+  font: inherit;
+  padding: 2px 6px;
+}
+```
+
+- [ ] **Step 7: Verify build + typecheck**
+
+Run: `pnpm --filter @uploads/web types`
+Expected: 0 errors. Then `pnpm vitest run apps/web` — all web tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/pages/account/workspaces/[name]/people.astro apps/web/src/styles/account-content.css
+git commit -m "feat(web): people-tab pending invites + member management UI (#275)"
+```
+
+---
+
+### Task 9: Full verification + browser check + PR
+
+**Files:** none (verification + PR only).
+
+- [ ] **Step 1: Run the full suite + typechecks**
+
+Run: `pnpm test` (root) and `pnpm -r types` (or the per-app `types` scripts).
+Expected: all green, 0 type errors.
+
+- [ ] **Step 2: Browser-verify against the local stack**
+
+Start the web dev server (per `uploads-web-dev-node24` — launch.json sources nvm/Node 24) and, signed in as a workspace owner with at least one other member + a pending invite, load `/account/workspaces/<name>/people`. Confirm: pending-invites section shows with a Revoke button; member rows show a role select + Remove for non-owner, non-self rows; owner and your own row show no controls; a member (non-admin) account sees the list with no controls and no invites section. Capture a screenshot of the people tab for the PR (github-screenshots skill → `uploads` CLI).
+
+If any check fails, diagnose from source, fix, re-run the relevant task's tests, and re-verify.
+
+- [ ] **Step 3: Push + open the PR (no changeset)**
+
+```bash
+git push -u origin claude/people-tab-member-mgmt-275
+gh pr create --repo buildinternet/uploads --base main \
+  --title "feat(web,api,auth): people-tab pending invites + member management (#275)" \
+  --body-file <path to a written PR body: summary, permission matrix table, screenshot, "Closes #275", "no changeset — all three apps Workers-deployed">
+```
+
+Request a CodeRabbit review (auth-changing PR): comment `@coderabbitai review` after the PR opens.
+
+## Notes for the implementer
+
+- **Auth worker route order:** all three new routes attach to the existing `internal` chain in `internal-routes.ts`. Hono matches in definition order; none of these paths collide with existing ones, so append-after-invites is safe.
+- **`seedUser` signature:** Tasks 1-3 assume `seedUser({ id, email })`. Check the real helper in `internal-routes.test.ts` (~line 130) and adapt — it may take positional args or auto-generate ids.
+- **fake AUTH binding in `me.test.ts`:** the new `/me` routes call four new internal URLs. Extend the test's fake `AUTH.fetch` handler to answer `GET …/invites`, `DELETE …/invites/:id`, `DELETE …/members/:id`, `PATCH …/members/:id`.
+- **`allowWrite`** is already imported and used by the invite route — reuse as-is.
+- Keep the owner protected everywhere; never add a UI affordance that targets an owner row.
+
+```
+
+```

--- a/docs/superpowers/specs/2026-07-19-people-tab-member-management-design.md
+++ b/docs/superpowers/specs/2026-07-19-people-tab-member-management-design.md
@@ -1,0 +1,162 @@
+# People tab: pending invites + member management (issue #275)
+
+Follow-up to #274, which added a read-only member list to the workspace **people** tab.
+This adds, all admin/owner-gated on the user-facing `/account/workspaces/:name/people`
+surface only (the `/admin` operator panel stays list-only for now):
+
+- **Pending invites** with **revoke**.
+- **Member management**: remove a member and change a member's role.
+
+## Permission model
+
+Org roles are `owner | admin | member` (the better-auth `member.role`, distinct from the
+global `user.role`). The **last-admin guard from #260 does not apply** — it protects the
+global `admin()` plugin, not the `member` table. Member-management invariants are therefore
+enforced fresh, inside the auth worker (which owns the `member` table).
+
+| Action                          | Owner actor                  | Admin actor                   |
+| ------------------------------- | ---------------------------- | ----------------------------- |
+| Remove a `member`               | ✅                           | ✅                            |
+| Remove an `admin`               | ✅                           | ❌ `403 actor_not_authorized` |
+| Remove an `owner`               | ❌ `403 cannot_modify_owner` | ❌ `403 cannot_modify_owner`  |
+| Promote `member`→`admin`        | ✅                           | ❌ `403 actor_not_authorized` |
+| Demote `admin`→`member`         | ✅                           | ❌ `403 actor_not_authorized` |
+| Set an `owner` to any role      | ❌ `403 cannot_modify_owner` | ❌ `403 cannot_modify_owner`  |
+| Act on **self** (remove / role) | ❌ `400 cannot_modify_self`  | ❌ `400 cannot_modify_self`   |
+| Revoke a pending invite         | ✅                           | ✅                            |
+
+Consequences, by design:
+
+- **Owner is immutable and unremovable via this UI.** There is exactly one owner per org
+  (created at provision; no path mints a second), so "the last owner can never be removed or
+  demoted" holds without any admin-counting query — the owner is simply protected from every
+  actor including themselves.
+- **Changing the admin roster is an owner privilege.** Admins handle members (remove members)
+  but cannot remove, promote, or demote admins, nor touch the owner.
+- **Self-actions are blocked** to avoid accidental self-lockout. "Leave workspace" is a
+  separate future feature, not part of this work.
+
+Role changes are limited to the `admin ↔ member` toggle; `owner` is never a source or target
+role through these endpoints.
+
+## Architecture
+
+Three layers, extending existing patterns at each. Every new endpoint enforces authorization;
+the auth worker is the single source of truth for the role matrix because it holds the tables.
+
+### Layer 1 — auth worker (`apps/auth/src/internal-routes.ts`)
+
+Three new internal routes on the existing `internal` Hono router (reached only via the `AUTH`
+service binding behind `isInternalRequest`). Direct drizzle, matching the file's existing
+insert/select style. Each resolves the org by slug (`404 organization_not_found`), looks up the
+**actor** membership by `actorUserId` and the **target** membership by `member.id`, then applies
+the matrix. Error shape is the file's `errorJson(code, message)` → `{ error: { code, message } }`.
+
+- `DELETE /internal/orgs/:slug/invites/:id`
+  - Query/body: `actorUserId`.
+  - Actor must be org `owner|admin` → else `403 actor_not_authorized`.
+  - Delete `invitation` where `id = :id AND organizationId = org.id AND status = "pending"`.
+    Zero rows → `404 invite_not_found`. → `200 { ok: true }`.
+- `DELETE /internal/orgs/:slug/members/:memberId`
+  - Query/body: `actorUserId`.
+  - Target member row (by `member.id`, scoped to org) → else `404 member_not_found`.
+  - `target.userId === actorUserId` → `400 cannot_modify_self`.
+  - `target.role === "owner"` → `403 cannot_modify_owner`.
+  - `target.role === "admin"` and actor is not `owner` → `403 actor_not_authorized`.
+  - Actor not `owner|admin` → `403 actor_not_authorized`.
+  - Delete the `member` row. → `200 { ok: true }`.
+- `PATCH /internal/orgs/:slug/members/:memberId`
+  - Body: `{ actorUserId, role }`, `role ∈ {admin, member}` → else `400 invalid_role`.
+  - Target member row → else `404 member_not_found`.
+  - `target.userId === actorUserId` → `400 cannot_modify_self`.
+  - `target.role === "owner"` → `403 cannot_modify_owner`.
+  - Actor is not `owner` → `403 actor_not_authorized` (only owners change roles).
+  - Idempotent: already at `role` → `200` no-op.
+  - Update `member.role`. → `200 { member: { id, userId, role } }`.
+
+### Layer 2 — API (`apps/api`)
+
+New helpers in `src/org-workspaces.ts`, following the established `internalHeaders()` /
+`env.AUTH.fetch(INTERNAL_ORIGIN + …)` pattern and `@uploads/errors` mapping
+(`ServiceUnavailableError` for non-ok/malformed, `ConflictError` for 409, per-function 404):
+
+- `invitesForOrg(env, slug): Promise<OrgInvite[]>` — `GET …/invites`, returns `body.invites ?? []`.
+  `OrgInvite = { id, email, role: string | null, status, expiresAt }`.
+- `revokeInvite(env, slug, inviteId, actorUserId): Promise<void>` — `DELETE …/invites/:id`;
+  map `404 → NotFoundError`, `403 → ForbiddenError`.
+- `removeMember(env, slug, memberId, actorUserId): Promise<void>` — `DELETE …/members/:memberId`;
+  map `404 → NotFoundError`, `403 → ForbiddenError`, `400 → BadRequestError`.
+- `updateMemberRole(env, slug, memberId, role, actorUserId): Promise<{ id, userId, role }>` —
+  `PATCH …/members/:memberId`; same error mapping.
+
+New routes in `src/routes/me.ts`, appended to the `me` chain. All gated by the existing
+exported `adminWorkspaceOr403(env, userId, name)`; the three mutating routes also pass through
+the existing `allowWrite` limiter guard (as `POST …/invites` already does). `actorUserId` is the
+session user id (`requireUserId(c)`).
+
+- `GET /workspaces/:name/invites` — `adminWorkspaceOr403`; `communal` → `{ communal: true, invites: [] }`;
+  else `{ communal: false, invites: invitesForOrg(slug) }` (id retained — needed to revoke; email
+  visible is fine on an admin-gated route).
+- `DELETE /workspaces/:name/invites/:id` — `adminWorkspaceOr403` + `allowWrite` → `revokeInvite`.
+- `DELETE /workspaces/:name/members/:memberId` — `adminWorkspaceOr403` + `allowWrite` → `removeMember`.
+- `PATCH /workspaces/:name/members/:memberId` — `adminWorkspaceOr403` + `allowWrite`,
+  body `{ role }` validated `∈ {admin, member}` → `updateMemberRole`.
+
+**Member handle exposure.** Management targets the opaque `member.id`, never the global
+`userId`. The existing `GET /workspaces/:name/members` route (member-gated, seen by all members)
+is extended to include `id` **only when the caller is `adminWorkspaceOr403`-eligible** (owner or
+admin). It also already returns `role`; regular members keep today's sanitized
+`{ email, name, role, createdAt }` with no `id` and thus no actionable handle. To decide whether
+to include `id`, the route checks the caller's role from the same membership lookup rather than a
+second fetch.
+
+### Layer 3 — web (`apps/web`)
+
+`src/lib/api-client.ts` gains, following the `getWorkspaceMembers` / `inviteToWorkspace` shape
+(`credentials: "include"`, typed result unions):
+
+- `getWorkspaceInvites(apiOrigin, name): Promise<WorkspaceInvitesResult>` where
+  `WorkspaceInvitesResult = { kind:"ok", communal, invites: WorkspaceInvite[] } | { kind:"unavailable" }`,
+  `WorkspaceInvite = { id, email, role, status, expiresAt }`.
+- `revokeWorkspaceInvite(apiOrigin, name, inviteId)`, `removeWorkspaceMember(apiOrigin, name, memberId)`,
+  `updateWorkspaceMemberRole(apiOrigin, name, memberId, role)` — each returning a small
+  `{ ok } | { error }` union mapping `403 → forbidden`, `404 → not_found`, `400 → invalid`.
+- `WorkspaceMember` gains optional `id?: string`.
+
+`src/pages/account/workspaces/[name]/people.astro` + `src/lib/workspace-ui.ts`:
+
+- A **Pending invites** section (new `#ws-invites` container), rendered for admin/owner only,
+  populated by `getWorkspaceInvites`. `renderInvitesHtml(invites)` renders each row with the
+  email, status, and a **revoke** button (`data-invite-id`); empty state "No pending invites."
+- `renderMembersHtml` rows gain per-row controls — a role `<select>` (`admin`/`member`) and a
+  **remove** button — rendered only when the viewer is admin/owner **and** the row has an `id`,
+  and **suppressed on owner rows** (`role === "owner"`) and on the **viewer's own row** (matched
+  by email against the session). Rows still render without controls otherwise (unchanged for
+  regular members).
+- Delegated event handlers wire revoke / remove / role-change, each with a `confirm()` on the
+  destructive/irreversible ones, error surfacing, and a reload of the affected list on success.
+  The server remains the real gate; client hiding is cosmetic.
+
+## Testing
+
+- **auth** (`apps/auth`): unit tests for the three routes — full authz matrix (owner vs admin vs
+  member actor × member/admin/owner target), owner protection, self protection, `invalid_role`,
+  idempotent role no-op, and the `404`s. Mirror `internal-routes` / `admin-last-guard.test.ts`
+  fixtures.
+- **api** (`apps/api`): `me.ts` route tests (gating, communal short-circuit, `id` exposed only to
+  admin/owner) and `org-workspaces` helper tests (error mapping) against the in-process fakes.
+- **web** (`apps/web`): `workspace-ui` unit tests for `renderInvitesHtml` and the members-row
+  controls (owner row and self row omit controls; non-admin viewer omits controls).
+
+## Out of scope
+
+- The `/admin` operator panel (stays list-only; a possible separate follow-up).
+- "Leave workspace" / self-removal.
+- Minting additional owners / ownership transfer.
+- Editing an existing invite's role (revoke + re-invite instead).
+
+## Release
+
+No changeset. `@uploads/auth`, `@uploads/api`, and `@uploads/web` are all on the changeset
+`ignore` list (Workers-deployed via Workers Builds CI); a changeset targeting them is release
+poison. Merge to `main` auto-deploys.


### PR DESCRIPTION
Closes #275. Follow-up to #274, which added a read-only member list to the workspace **people** tab. This adds pending-invite listing with revoke, and member management (remove, change role) — all admin/owner-gated, on the user-facing `/account/workspaces/:name/people` surface only.

## Permission matrix

Enforced in the **auth worker** (it owns the `member`/`invitation` tables); the `/me` API layer only coarse-gates (`adminWorkspaceOr403` = admin|owner) and passes `actorUserId`.

| Action | Owner | Admin |
|---|---|---|
| Remove a `member` | ✅ | ✅ |
| Remove an `admin` | ✅ | ❌ 403 |
| Remove / modify an `owner` | ❌ protected | ❌ protected |
| Promote `member`→`admin` / demote `admin`→`member` | ✅ | ❌ 403 |
| Act on **yourself** | ❌ 400 | ❌ 400 |
| Revoke a pending invite | ✅ | ✅ |

The `owner` is immutable and unremovable (exactly one, set at provision), so "the last owner is never removed/demoted" holds without a counting query. The #260 last-admin guard protects the *global* `admin()` plugin, not org members, so this ships its own protections. Role changes are limited to `admin↔member`; `owner` is never a role-change source or target.

## What's in it, per layer

- **Auth worker** (`apps/auth/src/internal-routes.ts`) — 3 new internal routes (`DELETE …/invites/:id`, `DELETE …/members/:memberId`, `PATCH …/members/:memberId`), each enforcing the matrix via a shared `actorRole` helper. Direct drizzle, `errorJson` shape.
- **API** (`apps/api`) — `org-workspaces` helpers (`invitesForOrg`/`revokeInvite`/`removeMember`/`updateMemberRole`) mapping auth errors to `@uploads/errors`, plus 4 `adminWorkspaceOr403`+`allowWrite`-gated `/me` routes. The members list now exposes the opaque `member.id` **only to admin/owner callers** — regular members keep today's sanitized payload with no handle.
- **Web** (`apps/web`) — api-client calls, escaped render helpers (`renderInvitesHtml` + per-row controls in `renderMembersHtml`), and people-tab wiring: a Pending-invites section with revoke, and per-member role `select` + remove, suppressed on owner rows and your own row. `confirm()` on destructive actions; server is the real gate.

Management targets `member.id`, never the global `userId`.

## Testing

- Full repo suite **1672/1672** (137 files); `@uploads/api` + `@uploads/auth` types clean; `@uploads/web` typecheck 0 errors/0 warnings; oxfmt clean.
- TDD per task (auth authz-matrix incl. owner/self protection; api route gating + id-exposure-by-role + helper error mapping; web status mapping + owner/self row exclusions).
- **Deferred:** live populated-view browser verification needs the full 3-server stack + a seeded session/members/invite (same precedent as #268). The logic is covered by the suite above plus per-layer and whole-branch review.

## Notes

- **No changeset** — `@uploads/auth`, `@uploads/api`, `@uploads/web` are all on the changeset ignore list (Workers-deployed); a changeset would be release poison.
- Spec + plan committed under `docs/superpowers/`.
- Deferred Minors (non-blocking, from review): a few test-coverage nits (cross-org invite test, idempotent-write assertion, XSS-payload regression test) and a DRY gate-pair in `me.ts`. Can fold into a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pending invite management, including viewing and revoking invites.
  * Added member management controls for authorized workspace administrators and owners.
  * Administrators can remove eligible members; owners can update member roles.
  * Added safeguards preventing self-removal, owner changes, and unauthorized actions.
  * Improved the People tab with role controls, removal actions, invite status, and confirmation feedback.
* **Bug Fixes**
  * Improved handling and display of permission, validation, missing-resource, and service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->