### PR TITLE
fix(web): let PR/issue icon carry the kind instead of repeating the word

### DIFF
--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -95,9 +95,17 @@ function GithubMarkIcon({ className }: { className?: string }) {
   );
 }
 
-function PullRequestIcon({ className }: { className?: string }) {
+function PullRequestIcon({ className, title }: { className?: string; title?: string }) {
   return (
-    <svg className={className} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+    >
+      {title && <title>{title}</title>}
       <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z" />
     </svg>
   );
@@ -568,8 +576,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
 
       {match && (
         <div className="wft-banner">
-          <GithubMarkIcon className="wft-banner__icon" />
-          <span className="wft-banner__kind">{match.kindLabel}</span>
+          <PullRequestIcon className="wft-banner__icon" title={match.kindLabel} />
           <a className="wft-banner__ref" href={match.url} target="_blank" rel="noopener noreferrer">
             {match.label}
           </a>

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -219,7 +219,7 @@ const invitePath = `${base}/people`;
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-item) {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 9px;
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-icon) {
@@ -227,7 +227,6 @@ const invitePath = `${base}/people`;
     height: 14px;
     color: var(--fg);
     flex: none;
-    margin-top: 2px;
   }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-meta) {
     min-width: 0;

--- a/apps/web/src/lib/brand-icons.ts
+++ b/apps/web/src/lib/brand-icons.ts
@@ -16,3 +16,30 @@ export function githubMarkSvg(opts?: { size?: number; className?: string }): str
   const className = opts?.className ? ` class="${opts.className}"` : "";
   return `<svg${className} viewBox="0 0 24 24" width="${size}" height="${size}" aria-hidden="true" focusable="false"><path fill="currentColor" d="${GITHUB_MARK_PATH}"/></svg>`;
 }
+
+/**
+ * Official GitHub octicons (viewBox 0 0 16 16, fill with currentColor) that
+ * stand in for the kind label: the branch glyph reads "pull request", the
+ * circled dot reads "issue". Wherever we show a `gh.*` ref, the icon carries
+ * the kind so we don't repeat the word next to it.
+ */
+export const GH_KIND_PATH: Record<"pull" | "issue", string> = {
+  pull: "M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z",
+  issue:
+    "M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm9 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM8 4a.75.75 0 0 0-.75.75v3.5a.75.75 0 0 0 1.5 0v-3.5A.75.75 0 0 0 8 4Z",
+};
+
+const GH_KIND_LABEL: Record<"pull" | "issue", string> = {
+  pull: "pull request",
+  issue: "issue",
+};
+
+/**
+ * Inline SVG for the PR/issue octicon in script-built HTML. Titled with the
+ * kind so the glyph is announced to assistive tech and shown on hover.
+ */
+export function githubKindSvg(kind: "pull" | "issue", opts?: { className?: string }): string {
+  const className = opts?.className ? ` class="${opts.className}"` : "";
+  const label = GH_KIND_LABEL[kind];
+  return `<svg${className} viewBox="0 0 16 16" width="14" height="14" role="img" aria-label="${label}"><title>${label}</title><path fill="currentColor" d="${GH_KIND_PATH[kind]}"/></svg>`;
+}

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -20,13 +20,14 @@ describe("renderConnectedWorkHtml", () => {
     expect(renderConnectedWorkHtml([])).toBe("");
   });
 
-  it("renders a pull-request row with the label link and kindLabel subtitle", () => {
+  it("renders a pull-request row with the label link and a kind icon (no subtitle)", () => {
     const html = renderConnectedWorkHtml([ghItem()]);
     expect(html).toContain('href="https://github.com/buildinternet/uploads/pull/1789"');
     expect(html).toContain(">buildinternet/uploads#1789<");
-    expect(html).toContain('class="ws-rail__connected-sub"');
-    expect(html).toContain(">pull request<");
     expect(html).toContain("ws-rail__connected-item");
+    // The octicon carries the kind (title/aria-label); no repeated word subtitle.
+    expect(html).not.toContain("ws-rail__connected-sub");
+    expect(html).toContain("<title>pull request</title>");
   });
 
   it("uses a different icon for issue rows than pull-request rows", () => {
@@ -44,8 +45,8 @@ describe("renderConnectedWorkHtml", () => {
     expect(issueHtml).toContain(">issue<");
     expect(issueHtml).not.toBe(pullHtml);
     // Different octicon path data per kind.
-    const pullIconPath = pullHtml.match(/<path d="([^"]+)"/)?.[1];
-    const issueIconPath = issueHtml.match(/<path d="([^"]+)"/)?.[1];
+    const pullIconPath = pullHtml.match(/<path[^>]* d="([^"]+)"/)?.[1];
+    const issueIconPath = issueHtml.match(/<path[^>]* d="([^"]+)"/)?.[1];
     expect(pullIconPath).toBeTruthy();
     expect(issueIconPath).toBeTruthy();
     expect(pullIconPath).not.toBe(issueIconPath);

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -21,6 +21,7 @@
 import { getMyWorkspaces, getMyWorkspaceUsage, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
 import { bindCopyButtons, escapeHtml, renderUsageHtml } from "./workspace-ui";
+import { githubKindSvg } from "./brand-icons";
 import type { GhKind, GhWorkItem } from "./gh-context";
 
 export type ConnectedWorkSetter = (items: GhWorkItem[]) => void;
@@ -32,17 +33,15 @@ declare global {
   }
 }
 
-// Same GitHub mark used for a `kind: "pull"` row and a circled-info glyph for
-// `kind: "issue"`, matching the 3A reference's rail "connected work" rows verbatim
-// (`.context/2026-07-19-settings-overhaul-3a-reference.html` lines ~125 and ~132).
+// The kind octicon (branch = pull request, circled dot = issue) carries the
+// kind on its own, so the row no longer repeats the word as a subtitle.
 const CONNECTED_WORK_ICON: Record<GhKind, string> = {
-  pull: '<svg class="ws-rail__connected-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path></svg>',
-  issue:
-    '<svg class="ws-rail__connected-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm9 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM8 4a.75.75 0 0 0-.75.75v3.5a.75.75 0 0 0 1.5 0v-3.5A.75.75 0 0 0 8 4Z"></path></svg>',
+  pull: githubKindSvg("pull", { className: "ws-rail__connected-icon" }),
+  issue: githubKindSvg("issue", { className: "ws-rail__connected-icon" }),
 };
 
 function connectedWorkRowHtml(item: GhWorkItem): string {
-  return `<div class="ws-rail__connected-item">${CONNECTED_WORK_ICON[item.kind]}<div class="ws-rail__connected-meta"><a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.label)}</a><span class="ws-rail__connected-sub">${escapeHtml(item.kindLabel)}</span></div></div>`;
+  return `<div class="ws-rail__connected-item">${CONNECTED_WORK_ICON[item.kind]}<div class="ws-rail__connected-meta"><a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.label)}</a></div></div>`;
 }
 
 /** Pure row-HTML builder for the rail's "connected work" section. `[]` → `""`. */

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -3,7 +3,7 @@ import BaseHead from "../../../components/BaseHead.astro";
 import Brand from "../../../components/Brand.astro";
 import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
-import GitHubMark from "../../../components/GitHubMark.astro";
+import { GH_KIND_PATH } from "../../../lib/brand-icons";
 import { buildEmbedFormats } from "../../../lib/embed-formats";
 import {
   applyPublicFileHeaders,
@@ -113,8 +113,8 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
       .gh-chip { display:inline-flex; align-items:center; gap:6px; margin:10px 0 0; padding:6px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
       .gh-chip:hover, .gh-chip:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      .gh-chip-icon { flex:none; }
       .gh-chip-name { overflow-wrap:anywhere; }
-      .gh-chip-kind { padding:1px 5px; border:1px solid var(--line); border-radius:4px; color:var(--muted); font-size:10px; text-transform:uppercase; letter-spacing:.06em; }
       .section-label { margin:16px 0 0; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); }
       dl.meta.metadata { margin-top:6px; }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
@@ -143,10 +143,24 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
             <figcaption class="details">
               <div class="filename">{filename}</div>
               {file.github && (
-                <a class="gh-chip" href={file.github.url} rel="noopener noreferrer">
-                  <GitHubMark size={14} />
+                <a
+                  class="gh-chip"
+                  href={file.github.url}
+                  rel="noopener noreferrer"
+                  aria-label={`${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.repo}#${file.github.number} on GitHub`}
+                >
+                  <svg
+                    class="gh-chip-icon"
+                    viewBox="0 0 16 16"
+                    width="14"
+                    height="14"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <title>{file.github.kind === "pull" ? "pull request" : "issue"}</title>
+                    <path fill="currentColor" d={GH_KIND_PATH[file.github.kind]} />
+                  </svg>
                   <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
-                  <span class="gh-chip-kind">{file.github.kind === "pull" ? "PR" : "Issue"}</span>
                 </a>
               )}
               <dl class="meta">

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -951,13 +951,6 @@ section.card .ws-messages .command {
   color: var(--fg);
   flex: none;
 }
-.wft-banner__kind {
-  font-size: 10.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
-  flex: none;
-}
 .wft-banner__ref {
   font-size: 12.5px;
   color: var(--fg);


### PR DESCRIPTION
## What

Wherever a GitHub `gh.*` ref is shown, a kind-specific octicon now stands in for the redundant text label — the branch glyph reads "pull request", the circled dot reads "issue" — so we don't repeat the word next to the ref.

Three surfaces:

- **`/f/` public file page chip** — dropped the `PR`/`Issue` text badge; the leading icon is now the PR/issue octicon.
- **Files-tab banner** (`WorkspaceFileTable`) — swapped the generic GitHub mark + `PULL REQUEST` text for the PR octicon (the banner only ever shows an exact PR match).
- **Right-rail "connected work" rows** — swapped the GitHub-mark/circle icons for the kind octicon and dropped the `pull request`/`issue` subtitle line.

## Details

- Centralized both octicon paths and a `githubKindSvg()` helper in `brand-icons.ts` so the three surfaces share one source of truth.
- The kind stays accessible: `title` + `aria-label` on the icon (rail/banner) and an `aria-label` on the `/f/` chip link, so it's still announced to assistive tech and shown on hover.
- Removed the now-dead `.wft-banner__kind` and `.gh-chip-kind` CSS.

## Testing

- `tsc --noEmit` clean; full web suite green (252 passed). Rail tests updated to assert the icon/title instead of the removed subtitle.
- Changed Astro/React routes compile in the dev server with no errors.

Note: the files-tab banner and rail render only for a signed-in workspace with `gh.*`-tagged files, so live before/after screenshots weren't captured — verified via compile + unit coverage.