### PR TITLE
fix(api): allow PATCH in browser CORS preflights

### DIFF
--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -63,4 +63,39 @@ describe("CORS preflights from the web origin", () => {
     const res = await preflight("/me/workspaces");
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
   });
+
+  it("allows PATCH on admin-ui (workspace limits + oauth client edits)", async () => {
+    const res = await app.request(
+      "https://api.uploads.sh/admin-ui/workspaces/ryan/limits",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://uploads.sh",
+          "Access-Control-Request-Method": "PATCH",
+          "Access-Control-Request-Headers": "content-type",
+        },
+      },
+      env,
+    );
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("PATCH");
+  });
+
+  it("allows PATCH on /me (member role + file visibility)", async () => {
+    const res = await app.request(
+      "https://api.uploads.sh/me/workspaces/acme/members/user_1",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://uploads.sh",
+          "Access-Control-Request-Method": "PATCH",
+          "Access-Control-Request-Headers": "content-type",
+        },
+      },
+      env,
+    );
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("PATCH");
+  });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -29,7 +29,8 @@ const consoleCors = cors({
     if (/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) return origin;
     return null;
   },
-  allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+  // PATCH is used by browser console clients for file metadata + galleries.
+  allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
   allowHeaders: ["Authorization", "Content-Type"],
   maxAge: 86400,
 });
@@ -49,7 +50,10 @@ const adminUiCors = cors({
     return null;
   },
   credentials: true,
-  allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+  // PATCH: admin workspace limits, OAuth client edits, /me member role +
+  // file-visibility updates. Omitting it fails the browser preflight with
+  // "Method PATCH is not allowed by Access-Control-Allow-Methods".
+  allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
   allowHeaders: ["Content-Type"],
   maxAge: 86400,
 });


### PR DESCRIPTION
## In plain terms

Saving workspace limits in the admin dashboard failed in the browser: the API route accepts `PATCH`, but CORS only advertised `GET`/`POST`/`DELETE`/`OPTIONS`, so the preflight from `uploads.sh` to `api.uploads.sh` was blocked.

## What it does

- Adds `PATCH` to `adminUiCors` (cookie-auth: `/admin-ui/*`, `/me/*`, session `/v1/workspaces*`)
- Adds `PATCH` to `consoleCors` (bearer browser console: file metadata + galleries)
- Covers admin-ui and `/me` PATCH preflights in `cors.test.ts`

## What it is not

- No web UI change
- Does not add `PUT` (no browser client uses it today; CLI uploads are not subject to CORS)

## How to try it

After the API worker deploys:

1. Open Admin → a workspace → edit limits → **Save limits**
2. Confirm the request succeeds (no “Method PATCH is not allowed…” in the console)

## Technical notes

- Handler was already correct (`PATCH /admin-ui/workspaces/:name/limits`); only the allow-list was wrong
- Same gap would also break OAuth client edits and `/me` member/visibility PATCHes

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run src/cors.test.ts test/cors.test.ts`
- [ ] After merge/deploy: save limits in prod admin UI