### PR TITLE
feat(api,web): server-resolved PR/issue titles for the connected-work rail

### DIFF
--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -24,10 +24,10 @@ interface Env {
    * Set to "1" or "true" to reject new reports.
    */
   REPORTS_DISABLED?: string;
-  /** GitHub App id (spec .context/267-github-app-titles-design.md). Unset disables title resolution. */
-  GITHUB_APP_ID?: string;
-  /** GitHub App private key, PKCS#8 PEM (converted via openssl pkcs8 -topk8). */
+  /**
+   * GitHub App private key, PKCS#8 PEM (converted via openssl pkcs8 -topk8).
+   * The App ids live in wrangler.jsonc vars (they're public); this is the one
+   * true secret, so unset still disables title resolution gracefully.
+   */
   GITHUB_APP_PRIVATE_KEY?: string;
-  /** Installation id of the App's home (buildinternet) installation — public-repo token source. */
-  GITHUB_APP_HOME_INSTALLATION_ID?: string;
 }

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -24,4 +24,10 @@ interface Env {
    * Set to "1" or "true" to reject new reports.
    */
   REPORTS_DISABLED?: string;
+  /** GitHub App id (spec .context/267-github-app-titles-design.md). Unset disables title resolution. */
+  GITHUB_APP_ID?: string;
+  /** GitHub App private key, PKCS#8 PEM (converted via openssl pkcs8 -topk8). */
+  GITHUB_APP_PRIVATE_KEY?: string;
+  /** Installation id of the App's home (buildinternet) installation — public-repo token source. */
+  GITHUB_APP_HOME_INSTALLATION_ID?: string;
 }

--- a/apps/api/src/github-app.test.ts
+++ b/apps/api/src/github-app.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { appJwt, githubAppConfig, installationForRepo, installationToken } from "./github-app";
+import { FakeKv } from "../test/fake-kv";
+
+/** Generate a throwaway RSA key and return its PKCS#8 PEM + public CryptoKey. */
+async function testKeyPair(): Promise<{ pem: string; publicKey: CryptoKey }> {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer;
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  const pem = `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
+  return { pem, publicKey: pair.publicKey };
+}
+
+function cfgWith(pem: string) {
+  return { appId: "12345", privateKey: pem, homeInstallationId: "777" };
+}
+
+function envWith(kv: FakeKv): Env {
+  return { GITHUB_CACHE: kv } as unknown as Env;
+}
+
+const b64urlJson = (part: string) =>
+  JSON.parse(Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString());
+
+describe("githubAppConfig", () => {
+  it("returns null unless all three members are set", () => {
+    expect(githubAppConfig({} as Env)).toBeNull();
+    expect(
+      githubAppConfig({ GITHUB_APP_ID: "1", GITHUB_APP_PRIVATE_KEY: "k" } as unknown as Env),
+    ).toBeNull();
+    const full = {
+      GITHUB_APP_ID: "1",
+      GITHUB_APP_PRIVATE_KEY: "k",
+      GITHUB_APP_HOME_INSTALLATION_ID: "2",
+    } as unknown as Env;
+    expect(githubAppConfig(full)).toEqual({ appId: "1", privateKey: "k", homeInstallationId: "2" });
+  });
+});
+
+describe("appJwt", () => {
+  it("mints a verifiable RS256 JWT with iss/iat/exp", async () => {
+    const { pem, publicKey } = await testKeyPair();
+    const now = 1_800_000_000_000;
+    const jwt = await appJwt(cfgWith(pem), now);
+    const [h, p, s] = jwt.split(".");
+    expect(b64urlJson(h)).toEqual({ alg: "RS256", typ: "JWT" });
+    const claims = b64urlJson(p);
+    expect(claims.iss).toBe("12345");
+    expect(claims.iat).toBe(1_800_000_000 - 60);
+    expect(claims.exp).toBe(1_800_000_000 + 540);
+    const sig = Uint8Array.from(Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64"));
+    const ok = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      publicKey,
+      sig,
+      new TextEncoder().encode(`${h}.${p}`),
+    );
+    expect(ok).toBe(true);
+  });
+});
+
+describe("installationForRepo", () => {
+  it("fetches, caches the id for 1h, and serves the cache without refetching", async () => {
+    const { pem } = await testKeyPair();
+    const kv = new FakeKv();
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      return new Response(JSON.stringify({ id: 4242 }), { status: 200 });
+    }) as typeof fetch;
+    expect(await installationForRepo(envWith(kv), cfgWith(pem), "o/r", fetchImpl)).toBe(4242);
+    expect(kv.store.get("ghinst:o/r")).toEqual({ value: "4242", expirationTtl: 3600 });
+    expect(await installationForRepo(envWith(kv), cfgWith(pem), "o/r", fetchImpl)).toBe(4242);
+    expect(calls).toBe(1);
+  });
+
+  it("caches a 404 as none for 1h", async () => {
+    const { pem } = await testKeyPair();
+    const kv = new FakeKv();
+    const fetchImpl = (async () => new Response("", { status: 404 })) as typeof fetch;
+    expect(await installationForRepo(envWith(kv), cfgWith(pem), "o/r", fetchImpl)).toBeNull();
+    expect(kv.store.get("ghinst:o/r")).toEqual({ value: "none", expirationTtl: 3600 });
+  });
+
+  it("does not cache transient errors", async () => {
+    const { pem } = await testKeyPair();
+    const kv = new FakeKv();
+    const fetchImpl = (async () => new Response("", { status: 502 })) as typeof fetch;
+    expect(await installationForRepo(envWith(kv), cfgWith(pem), "o/r", fetchImpl)).toBeNull();
+    expect(kv.store.size).toBe(0);
+  });
+});
+
+describe("installationToken", () => {
+  it("mints via POST, caches for 50min, serves the cache", async () => {
+    const { pem } = await testKeyPair();
+    const kv = new FakeKv();
+    let calls = 0;
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls++;
+      expect(String(input)).toBe("https://api.github.com/app/installations/4242/access_tokens");
+      expect(init?.method).toBe("POST");
+      return new Response(JSON.stringify({ token: "ghs_abc" }), { status: 201 });
+    }) as typeof fetch;
+    expect(await installationToken(envWith(kv), cfgWith(pem), 4242, fetchImpl)).toBe("ghs_abc");
+    expect(kv.store.get("ghtok:4242")).toEqual({ value: "ghs_abc", expirationTtl: 3000 });
+    expect(await installationToken(envWith(kv), cfgWith(pem), 4242, fetchImpl)).toBe("ghs_abc");
+    expect(calls).toBe(1);
+  });
+
+  it("returns null (uncached) on a non-201", async () => {
+    const { pem } = await testKeyPair();
+    const kv = new FakeKv();
+    const fetchImpl = (async () => new Response("", { status: 401 })) as typeof fetch;
+    expect(await installationToken(envWith(kv), cfgWith(pem), 4242, fetchImpl)).toBeNull();
+    expect(kv.store.size).toBe(0);
+  });
+});

--- a/apps/api/src/github-app.ts
+++ b/apps/api/src/github-app.ts
@@ -1,0 +1,132 @@
+/**
+ * GitHub App auth for the api worker (spec: .context/267-github-app-titles-design.md).
+ * JWT → installation discovery → installation token, each KV-cached in
+ * GITHUB_CACHE. Every function degrades to null on failure — callers treat
+ * "no token" as "no title", never as an error.
+ */
+
+export interface GithubAppConfig {
+  appId: string;
+  privateKey: string;
+  homeInstallationId: string;
+}
+
+/** All-or-nothing read of the App env members; null disables the integration. */
+export function githubAppConfig(env: Env): GithubAppConfig | null {
+  const appId = env.GITHUB_APP_ID;
+  const privateKey = env.GITHUB_APP_PRIVATE_KEY;
+  const homeInstallationId = env.GITHUB_APP_HOME_INSTALLATION_ID;
+  if (!appId || !privateKey || !homeInstallationId) return null;
+  return { appId, privateKey, homeInstallationId };
+}
+
+const b64url = (bytes: Uint8Array): string =>
+  btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+function pemToPkcs8(pem: string): ArrayBuffer {
+  const body = pem.replace(/-----(BEGIN|END) PRIVATE KEY-----/g, "").replace(/\s+/g, "");
+  const raw = atob(body);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+  return bytes.buffer;
+}
+
+/** 10-minute RS256 App JWT, backdated 60s for clock drift. */
+export async function appJwt(cfg: GithubAppConfig, nowMs = Date.now()): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToPkcs8(cfg.privateKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const enc = new TextEncoder();
+  const now = Math.floor(nowMs / 1000);
+  const header = b64url(enc.encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
+  const payload = b64url(
+    enc.encode(JSON.stringify({ iat: now - 60, exp: now + 540, iss: cfg.appId })),
+  );
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    enc.encode(`${header}.${payload}`),
+  );
+  return `${header}.${payload}.${b64url(new Uint8Array(signature))}`;
+}
+
+/** Standard headers for every GitHub API call this worker makes. */
+export function githubHeaders(token: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${token}`,
+    accept: "application/vnd.github+json",
+    "user-agent": "uploads.sh",
+    "x-github-api-version": "2022-11-28",
+  };
+}
+
+const INSTALL_TTL = 3600;
+const TOKEN_TTL = 3000; // GitHub tokens live 60min; cache 50.
+
+/**
+ * Installation id for `repo` ("owner/name"), or null when the App is not
+ * installed there. 404 (not installed) is cached as "none"; transient
+ * failures are not cached.
+ */
+export async function installationForRepo(
+  env: Env,
+  cfg: GithubAppConfig,
+  repo: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number | null> {
+  const key = `ghinst:${repo}`;
+  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  if (cached !== null) return cached === "none" ? null : Number(cached);
+  try {
+    const res = await fetchImpl(`https://api.github.com/repos/${repo}/installation`, {
+      headers: githubHeaders(await appJwt(cfg)),
+    });
+    if (res.status === 404) {
+      await env.GITHUB_CACHE.put(key, "none", { expirationTtl: INSTALL_TTL });
+      return null;
+    }
+    if (!res.ok) return null;
+    const body = (await res.json()) as { id?: number };
+    if (typeof body.id !== "number") return null;
+    await env.GITHUB_CACHE.put(key, String(body.id), { expirationTtl: INSTALL_TTL });
+    return body.id;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Short-lived installation token, KV-cached below its 60-minute life. Tokens
+ * are read-only (App permissions) and expire server-side, so KV storage is an
+ * accepted trade-off (spec §Components).
+ */
+export async function installationToken(
+  env: Env,
+  cfg: GithubAppConfig,
+  installationId: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  const key = `ghtok:${installationId}`;
+  const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
+  if (cached !== null) return cached;
+  try {
+    const res = await fetchImpl(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      { method: "POST", headers: githubHeaders(await appJwt(cfg)) },
+    );
+    if (res.status !== 201) return null;
+    const body = (await res.json()) as { token?: string };
+    if (typeof body.token !== "string") return null;
+    await env.GITHUB_CACHE.put(key, body.token, { expirationTtl: TOKEN_TTL });
+    return body.token;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/github-app.ts
+++ b/apps/api/src/github-app.ts
@@ -66,6 +66,22 @@ const INSTALL_TTL = 3600;
 const TOKEN_TTL = 3000; // GitHub tokens live 60min; cache 50.
 
 /**
+ * Hard deadline on every outbound GitHub call: the titles endpoint awaits
+ * these in the request path, so a hanging upstream must abort fast and fall
+ * into each caller's existing degrade-to-null handling.
+ */
+const GITHUB_FETCH_TIMEOUT_MS = 8000;
+
+/** `fetchImpl` with the standard GitHub deadline attached. */
+export function githubFetch(
+  fetchImpl: typeof fetch,
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  return fetchImpl(url, { ...init, signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS) });
+}
+
+/**
  * Installation id for `repo` ("owner/name"), or null when the App is not
  * installed there. 404 (not installed) is cached as "none"; transient
  * failures are not cached.
@@ -80,7 +96,7 @@ export async function installationForRepo(
   const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
   if (cached !== null) return cached === "none" ? null : Number(cached);
   try {
-    const res = await fetchImpl(`https://api.github.com/repos/${repo}/installation`, {
+    const res = await githubFetch(fetchImpl, `https://api.github.com/repos/${repo}/installation`, {
       headers: githubHeaders(await appJwt(cfg)),
     });
     if (res.status === 404) {
@@ -112,7 +128,8 @@ export async function installationToken(
   const cached = (await env.GITHUB_CACHE.get(key)) as string | null;
   if (cached !== null) return cached;
   try {
-    const res = await fetchImpl(
+    const res = await githubFetch(
+      fetchImpl,
       `https://api.github.com/app/installations/${installationId}/access_tokens`,
       { method: "POST", headers: githubHeaders(await appJwt(cfg)) },
     );

--- a/apps/api/src/github-app.ts
+++ b/apps/api/src/github-app.ts
@@ -5,6 +5,8 @@
  * "no token" as "no title", never as an error.
  */
 
+import { b64urlDecode, b64urlEncode } from "./secrets";
+
 export interface GithubAppConfig {
   appId: string;
   privateKey: string;
@@ -20,18 +22,11 @@ export function githubAppConfig(env: Env): GithubAppConfig | null {
   return { appId, privateKey, homeInstallationId };
 }
 
-const b64url = (bytes: Uint8Array): string =>
-  btoa(String.fromCharCode(...bytes))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-
+// b64urlDecode accepts plain base64 too (the -/_ swaps no-op, PEM bodies are
+// already padded), so one shared codec covers both the JWT parts and the key.
 function pemToPkcs8(pem: string): ArrayBuffer {
   const body = pem.replace(/-----(BEGIN|END) PRIVATE KEY-----/g, "").replace(/\s+/g, "");
-  const raw = atob(body);
-  const bytes = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
-  return bytes.buffer;
+  return b64urlDecode(body).buffer as ArrayBuffer;
 }
 
 /** 10-minute RS256 App JWT, backdated 60s for clock drift. */
@@ -45,8 +40,8 @@ export async function appJwt(cfg: GithubAppConfig, nowMs = Date.now()): Promise<
   );
   const enc = new TextEncoder();
   const now = Math.floor(nowMs / 1000);
-  const header = b64url(enc.encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
-  const payload = b64url(
+  const header = b64urlEncode(enc.encode(JSON.stringify({ alg: "RS256", typ: "JWT" })));
+  const payload = b64urlEncode(
     enc.encode(JSON.stringify({ iat: now - 60, exp: now + 540, iss: cfg.appId })),
   );
   const signature = await crypto.subtle.sign(
@@ -54,7 +49,7 @@ export async function appJwt(cfg: GithubAppConfig, nowMs = Date.now()): Promise<
     key,
     enc.encode(`${header}.${payload}`),
   );
-  return `${header}.${payload}.${b64url(new Uint8Array(signature))}`;
+  return `${header}.${payload}.${b64urlEncode(new Uint8Array(signature))}`;
 }
 
 /** Standard headers for every GitHub API call this worker makes. */

--- a/apps/api/src/github-titles.test.ts
+++ b/apps/api/src/github-titles.test.ts
@@ -56,6 +56,22 @@ describe("resolveTitles", () => {
     expect(out["o/r#9"]).toEqual({ title: "Cached", state: "open", kind: "issue" });
   });
 
+  it("falls back to the repo installation when the home token itself fails to mint", async () => {
+    const kv = new FakeKv();
+    // No ghtok:777 seeded and the dummy private key can't sign, so the home
+    // mint fails; the cached repo installation must still be tried.
+    kv.store.set("ghinst:o/r", { value: "4242" });
+    kv.store.set("ghtok:4242", { value: "ghs_inst" });
+    const fetchImpl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(((init?.headers ?? {}) as Record<string, string>).authorization).toBe(
+        "Bearer ghs_inst",
+      );
+      return new Response(issueJson(), { status: 200 });
+    }) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/r#9"], fetchImpl);
+    expect(out["o/r#9"]).toEqual({ title: "Fix the thing", state: "open", kind: "issue" });
+  });
+
   it("falls back to the repo's own installation on 404, then negative-caches a double miss", async () => {
     const kv = new FakeKv();
     seedHomeToken(kv);

--- a/apps/api/src/github-titles.test.ts
+++ b/apps/api/src/github-titles.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { resolveTitles } from "./github-titles";
 import { FakeKv } from "../test/fake-kv";
-
-const CFG_ENV = {
-  GITHUB_APP_ID: "12345",
-  // resolveTitles never mints a JWT when a token is already cached, so the
-  // key material can be a dummy in every test that pre-seeds ghtok:*.
-  GITHUB_APP_PRIVATE_KEY: "unused",
-  GITHUB_APP_HOME_INSTALLATION_ID: "777",
-};
+import { GITHUB_APP_CFG_ENV as CFG_ENV } from "../test/github-app-env";
 
 function envWith(kv: FakeKv): Env {
   return { ...CFG_ENV, GITHUB_CACHE: kv } as unknown as Env;

--- a/apps/api/src/github-titles.test.ts
+++ b/apps/api/src/github-titles.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { resolveTitles } from "./github-titles";
+import { FakeKv } from "../test/fake-kv";
+
+const CFG_ENV = {
+  GITHUB_APP_ID: "12345",
+  // resolveTitles never mints a JWT when a token is already cached, so the
+  // key material can be a dummy in every test that pre-seeds ghtok:*.
+  GITHUB_APP_PRIVATE_KEY: "unused",
+  GITHUB_APP_HOME_INSTALLATION_ID: "777",
+};
+
+function envWith(kv: FakeKv): Env {
+  return { ...CFG_ENV, GITHUB_CACHE: kv } as unknown as Env;
+}
+
+/** Seed the home installation token so tests exercise the issue fetch only. */
+function seedHomeToken(kv: FakeKv): void {
+  kv.store.set("ghtok:777", { value: "ghs_home" });
+}
+
+const issueJson = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({ title: "Fix the thing", state: "open", ...over });
+
+describe("resolveTitles", () => {
+  it("resolves an open issue via the home token and caches it for 1h", async () => {
+    const kv = new FakeKv();
+    seedHomeToken(kv);
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.github.com/repos/o/r/issues/9");
+      expect(((init?.headers ?? {}) as Record<string, string>).authorization).toBe(
+        "Bearer ghs_home",
+      );
+      return new Response(issueJson(), { status: 200 });
+    }) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/r#9"], fetchImpl);
+    expect(out["o/r#9"]).toEqual({ title: "Fix the thing", state: "open", kind: "issue" });
+    expect(kv.store.get("ghref:o/r#9")?.expirationTtl).toBe(3600);
+  });
+
+  it("marks merged PRs and caches closed/merged for 24h", async () => {
+    const kv = new FakeKv();
+    seedHomeToken(kv);
+    const fetchImpl = (async () =>
+      new Response(
+        issueJson({ state: "closed", pull_request: { merged_at: "2026-07-01T00:00:00Z" } }),
+        { status: 200 },
+      )) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/r#9"], fetchImpl);
+    expect(out["o/r#9"]).toEqual({ title: "Fix the thing", state: "merged", kind: "pull" });
+    expect(kv.store.get("ghref:o/r#9")?.expirationTtl).toBe(86400);
+  });
+
+  it("serves the ref cache without any fetch", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghref:o/r#9", {
+      value: JSON.stringify({ v: { title: "Cached", state: "open", kind: "issue" } }),
+    });
+    const fetchImpl = (async () => {
+      throw new Error("must not fetch");
+    }) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/r#9"], fetchImpl);
+    expect(out["o/r#9"]).toEqual({ title: "Cached", state: "open", kind: "issue" });
+  });
+
+  it("falls back to the repo's own installation on 404, then negative-caches a double miss", async () => {
+    const kv = new FakeKv();
+    seedHomeToken(kv);
+    kv.store.set("ghinst:o/priv", { value: "4242" });
+    kv.store.set("ghtok:4242", { value: "ghs_inst" });
+    const seen: string[] = [];
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(((init?.headers ?? {}) as Record<string, string>).authorization);
+      return new Response("", { status: 404 });
+    }) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/priv#1"], fetchImpl);
+    expect(out["o/priv#1"]).toBeNull();
+    expect(seen).toEqual(["Bearer ghs_home", "Bearer ghs_inst"]);
+    expect(kv.store.get("ghref:o/priv#1")).toEqual({
+      value: JSON.stringify({ v: null }),
+      expirationTtl: 3600,
+    });
+  });
+
+  it("skips the installation retry when the repo has none cached, and negative-caches", async () => {
+    const kv = new FakeKv();
+    seedHomeToken(kv);
+    kv.store.set("ghinst:o/priv", { value: "none" });
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      return new Response("", { status: 404 });
+    }) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/priv#1"], fetchImpl);
+    expect(out["o/priv#1"]).toBeNull();
+    expect(calls).toBe(1);
+    expect(kv.store.get("ghref:o/priv#1")?.expirationTtl).toBe(3600);
+  });
+
+  it("extends the negative TTL to the rate-limit reset on 403", async () => {
+    const kv = new FakeKv();
+    seedHomeToken(kv);
+    kv.store.set("ghinst:o/r", { value: "none" });
+    const reset = String(Math.floor(Date.now() / 1000) + 7200);
+    const fetchImpl = (async () =>
+      new Response("", {
+        status: 403,
+        headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": reset },
+      })) as typeof fetch;
+    const out = await resolveTitles(envWith(kv), ["o/r#9"], fetchImpl);
+    expect(out["o/r#9"]).toBeNull();
+    const ttl = kv.store.get("ghref:o/r#9")?.expirationTtl ?? 0;
+    expect(ttl).toBeGreaterThan(3600);
+    expect(ttl).toBeLessThanOrEqual(7260);
+  });
+
+  it("returns null per ref without caching when the App env is unset", async () => {
+    const kv = new FakeKv();
+    const fetchImpl = (async () => {
+      throw new Error("must not fetch");
+    }) as typeof fetch;
+    const out = await resolveTitles({ GITHUB_CACHE: kv } as unknown as Env, ["o/r#9"], fetchImpl);
+    expect(out["o/r#9"]).toBeNull();
+    expect(kv.store.size).toBe(0);
+  });
+});

--- a/apps/api/src/github-titles.ts
+++ b/apps/api/src/github-titles.ts
@@ -7,6 +7,7 @@
  */
 import {
   githubAppConfig,
+  githubFetch,
   githubHeaders,
   installationForRepo,
   installationToken,
@@ -38,7 +39,7 @@ async function fetchIssue(
 ): Promise<FetchOutcome> {
   let res: Response;
   try {
-    res = await fetchImpl(`https://api.github.com/repos/${repo}/issues/${num}`, {
+    res = await githubFetch(fetchImpl, `https://api.github.com/repos/${repo}/issues/${num}`, {
       headers: githubHeaders(token),
     });
   } catch {
@@ -89,7 +90,11 @@ async function resolveOne(
   const homeToken = await getHomeToken();
   if (homeToken) outcome = await fetchIssue(repo, num, homeToken, fetchImpl);
 
-  if (outcome.kind === "no-access") {
+  // Retry via the repo's own installation on no-access, and also when the
+  // home token itself failed to mint (transient blip) — otherwise a ref with
+  // a perfectly good cached installation would be negative-cached for an
+  // hour because of an unrelated home-token failure.
+  if (outcome.kind === "no-access" || homeToken === null) {
     const installId = await installationForRepo(env, cfg, repo, fetchImpl);
     if (installId !== null) {
       const instToken = await installationToken(env, cfg, installId, fetchImpl);

--- a/apps/api/src/github-titles.ts
+++ b/apps/api/src/github-titles.ts
@@ -72,6 +72,7 @@ async function resolveOne(
   env: Env,
   cfg: GithubAppConfig | null,
   ref: string,
+  getHomeToken: () => Promise<string | null>,
   fetchImpl: typeof fetch,
 ): Promise<TitleInfo | null> {
   const cacheKey = `ghref:${ref}`;
@@ -85,7 +86,7 @@ async function resolveOne(
 
   let negativeTtl = NEGATIVE_TTL;
   let outcome: FetchOutcome = { kind: "error" };
-  const homeToken = await installationToken(env, cfg, Number(cfg.homeInstallationId), fetchImpl);
+  const homeToken = await getHomeToken();
   if (homeToken) outcome = await fetchIssue(repo, num, homeToken, fetchImpl);
 
   if (outcome.kind === "no-access") {
@@ -120,10 +121,19 @@ export async function resolveTitles(
   fetchImpl: typeof fetch = fetch,
 ): Promise<Record<string, TitleInfo | null>> {
   const cfg = githubAppConfig(env);
+  // One home-token resolution shared (and lazily started) across the whole
+  // batch: without this, N cache-missing refs would each read the same
+  // `ghtok:` key and — on a cold cache — race N concurrent JWT signs and
+  // token mints against GitHub. Lazy so an all-cache-hit batch stays free.
+  let homeTokenPromise: Promise<string | null> | undefined;
+  const getHomeToken = (): Promise<string | null> =>
+    (homeTokenPromise ??= cfg
+      ? installationToken(env, cfg, Number(cfg.homeInstallationId), fetchImpl)
+      : Promise.resolve(null));
   const out: Record<string, TitleInfo | null> = {};
   await Promise.all(
     refs.map(async (ref) => {
-      out[ref] = await resolveOne(env, cfg, ref, fetchImpl).catch(() => null);
+      out[ref] = await resolveOne(env, cfg, ref, getHomeToken, fetchImpl).catch(() => null);
     }),
   );
   return out;

--- a/apps/api/src/github-titles.ts
+++ b/apps/api/src/github-titles.ts
@@ -50,6 +50,9 @@ async function fetchIssue(
       state?: string;
       pull_request?: { merged_at?: string | null };
     } | null;
+    // A 2xx with an unparseable/malformed body is treated like a transient
+    // error: negative-cached at the base TTL so a misbehaving upstream isn't
+    // re-fetched per paint, and retried once the entry expires.
     if (!body || typeof body.title !== "string") return { kind: "error" };
     const kind: TitleInfo["kind"] = body.pull_request ? "pull" : "issue";
     const state: TitleInfo["state"] =

--- a/apps/api/src/github-titles.ts
+++ b/apps/api/src/github-titles.ts
@@ -1,0 +1,127 @@
+/**
+ * ref → PR/issue title resolution with a KV cache (spec
+ * .context/267-github-app-titles-design.md). Ladder per ref: ghref cache →
+ * home-installation token (public repos, one 5k/hr bucket) → the repo's own
+ * installation token (private repos) → negative cache. Refs arrive already
+ * normalized (`owner/repo#number`, lowercased) by the caller.
+ */
+import {
+  githubAppConfig,
+  githubHeaders,
+  installationForRepo,
+  installationToken,
+  type GithubAppConfig,
+} from "./github-app";
+
+export interface TitleInfo {
+  title: string;
+  state: "open" | "closed" | "merged";
+  kind: "pull" | "issue";
+}
+
+const OPEN_TTL = 3600;
+const SETTLED_TTL = 86400;
+const NEGATIVE_TTL = 3600;
+/** Slack added past the rate-limit reset so the retry lands after it. */
+const RESET_SLACK = 60;
+
+type FetchOutcome =
+  | { kind: "ok"; info: TitleInfo }
+  | { kind: "no-access" }
+  | { kind: "error"; negativeTtl?: number };
+
+async function fetchIssue(
+  repo: string,
+  num: string,
+  token: string,
+  fetchImpl: typeof fetch,
+): Promise<FetchOutcome> {
+  let res: Response;
+  try {
+    res = await fetchImpl(`https://api.github.com/repos/${repo}/issues/${num}`, {
+      headers: githubHeaders(token),
+    });
+  } catch {
+    return { kind: "error" };
+  }
+  if (res.ok) {
+    const body = (await res.json().catch(() => null)) as {
+      title?: string;
+      state?: string;
+      pull_request?: { merged_at?: string | null };
+    } | null;
+    if (!body || typeof body.title !== "string") return { kind: "error" };
+    const kind: TitleInfo["kind"] = body.pull_request ? "pull" : "issue";
+    const state: TitleInfo["state"] =
+      body.state === "closed" ? (body.pull_request?.merged_at ? "merged" : "closed") : "open";
+    return { kind: "ok", info: { title: body.title, state, kind } };
+  }
+  if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
+    const reset = Number(res.headers.get("x-ratelimit-reset"));
+    const until = Number.isFinite(reset) ? reset - Math.floor(Date.now() / 1000) : 0;
+    return { kind: "error", negativeTtl: Math.max(NEGATIVE_TTL, until + RESET_SLACK) };
+  }
+  if (res.status === 404 || res.status === 403 || res.status === 401) return { kind: "no-access" };
+  return { kind: "error" };
+}
+
+async function resolveOne(
+  env: Env,
+  cfg: GithubAppConfig | null,
+  ref: string,
+  fetchImpl: typeof fetch,
+): Promise<TitleInfo | null> {
+  const cacheKey = `ghref:${ref}`;
+  const cached = (await env.GITHUB_CACHE.get(cacheKey, "json")) as { v: TitleInfo | null } | null;
+  if (cached) return cached.v;
+  if (!cfg) return null; // App not configured — degrade without caching.
+
+  const hash = ref.lastIndexOf("#");
+  const repo = ref.slice(0, hash);
+  const num = ref.slice(hash + 1);
+
+  let negativeTtl = NEGATIVE_TTL;
+  let outcome: FetchOutcome = { kind: "error" };
+  const homeToken = await installationToken(env, cfg, Number(cfg.homeInstallationId), fetchImpl);
+  if (homeToken) outcome = await fetchIssue(repo, num, homeToken, fetchImpl);
+
+  if (outcome.kind === "no-access") {
+    const installId = await installationForRepo(env, cfg, repo, fetchImpl);
+    if (installId !== null) {
+      const instToken = await installationToken(env, cfg, installId, fetchImpl);
+      if (instToken) outcome = await fetchIssue(repo, num, instToken, fetchImpl);
+    }
+  }
+
+  if (outcome.kind === "ok") {
+    const ttl = outcome.info.state === "open" ? OPEN_TTL : SETTLED_TTL;
+    await env.GITHUB_CACHE.put(cacheKey, JSON.stringify({ v: outcome.info }), {
+      expirationTtl: ttl,
+    });
+    return outcome.info;
+  }
+  if (outcome.kind === "error" && outcome.negativeTtl) negativeTtl = outcome.negativeTtl;
+  // "no-access" (404/private without install) and rate limits both
+  // negative-cache so uninstalled repos don't hammer the API; transient
+  // errors share the base 1h TTL — acceptable staleness for a display cache.
+  await env.GITHUB_CACHE.put(cacheKey, JSON.stringify({ v: null }), {
+    expirationTtl: negativeTtl,
+  });
+  return null;
+}
+
+/** Batch resolve; misses fetch concurrently; a per-ref failure is that ref's `null`. */
+export async function resolveTitles(
+  env: Env,
+  refs: string[],
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, TitleInfo | null>> {
+  const cfg = githubAppConfig(env);
+  const out: Record<string, TitleInfo | null> = {};
+  await Promise.all(
+    refs.map(async (ref) => {
+      out[ref] = await resolveOne(env, cfg, ref, fetchImpl).catch(() => null);
+    }),
+  );
+  return out;
+}

--- a/apps/api/src/routes/github-titles-route.test.ts
+++ b/apps/api/src/routes/github-titles-route.test.ts
@@ -4,16 +4,9 @@ import { respondError } from "../error-response";
 import { me } from "./me";
 import { FakeKv } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
+import { GITHUB_APP_CFG_ENV as CFG_ENV } from "../../test/github-app-env";
 
 const USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
-
-const CFG_ENV = {
-  GITHUB_APP_ID: "12345",
-  // Route tests never call GitHub — cache-only fixtures — so the key
-  // material can be a dummy.
-  GITHUB_APP_PRIVATE_KEY: "unused",
-  GITHUB_APP_HOME_INSTALLATION_ID: "777",
-};
 
 function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
   return {

--- a/apps/api/src/routes/github-titles-route.test.ts
+++ b/apps/api/src/routes/github-titles-route.test.ts
@@ -1,0 +1,122 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { me } from "./me";
+import { FakeKv } from "../../test/fake-kv";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+const USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+const CFG_ENV = {
+  GITHUB_APP_ID: "12345",
+  // Route tests never call GitHub — cache-only fixtures — so the key
+  // material can be a dummy.
+  GITHUB_APP_PRIVATE_KEY: "unused",
+  GITHUB_APP_HOME_INSTALLATION_ID: "777",
+};
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** A single stub that answers get-session with `user`, and everything else via `onInternal`. */
+function stubEnv(
+  user: typeof USER | null,
+  onInternal: (path: string, req: Request) => Response | Promise<Response>,
+  db: unknown = new UsageFakeD1(),
+): Env {
+  const auth = stubAuth((req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+    }
+    return onInternal(url.pathname, req);
+  });
+  return { AUTH: auth, DB: db, REGISTRY: fakeKv({}) } as unknown as Env;
+}
+
+function fakeKv(records: Record<string, unknown>): Pick<KVNamespace, "get"> {
+  return {
+    get: (async (key: string) =>
+      key in records ? records[key] : null) as unknown as KVNamespace["get"],
+  };
+}
+
+/**
+ * Adapted from me.test.ts's stubEnv/membership scaffolding: USER is a member
+ * of workspace "acme" when `member` is true, and env is merged with
+ * GITHUB_CACHE + the three GITHUB_APP_* vars resolveTitles needs.
+ */
+function memberEnv({ member, kv }: { member: boolean; kv: FakeKv }): Env {
+  const env = stubEnv(USER, (path) => {
+    if (path === "/internal/memberships") {
+      return Response.json(
+        member ? [{ organizationId: "org1", organizationSlug: "acme", role: "member" }] : [],
+      );
+    }
+    if (path === "/internal/orgs/acme") {
+      return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+    }
+    return new Response(null, { status: 404 });
+  });
+  return { ...env, ...CFG_ENV, GITHUB_CACHE: kv } as unknown as Env;
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>().route("/me", me).onError((err, c) => respondError(c, err));
+}
+
+describe("GET /me/workspaces/:name/github-titles", () => {
+  it("404s for a non-member workspace", async () => {
+    const env = memberEnv({ member: false, kv: new FakeKv() });
+    const res = await app().request(
+      "/me/workspaces/acme/github-titles?refs=o/r%231",
+      { headers: { cookie: "s=1" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("400s on missing refs, an invalid ref, and more than 20 refs", async () => {
+    const env = memberEnv({ member: true, kv: new FakeKv() });
+    for (const qs of [
+      "",
+      "?refs=",
+      "?refs=not-a-ref",
+      `?refs=${Array.from({ length: 21 }, (_, i) => `o/r%23${i + 1}`).join(",")}`,
+    ]) {
+      const res = await app().request(
+        `/me/workspaces/acme/github-titles${qs}`,
+        { headers: { cookie: "s=1" } },
+        env,
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("returns cached titles keyed by normalized ref, null for misses", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghref:o/r#1", {
+      value: JSON.stringify({ v: { title: "Ship it", state: "open", kind: "pull" } }),
+    });
+    kv.store.set("ghref:o/r#2", { value: JSON.stringify({ v: null }) });
+    const env = memberEnv({ member: true, kv });
+    const res = await app().request(
+      "/me/workspaces/acme/github-titles?refs=O/R%231,o/r%232",
+      { headers: { cookie: "s=1" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      refs: {
+        "o/r#1": { title: "Ship it", state: "open", kind: "pull" },
+        "o/r#2": null,
+      },
+    });
+  });
+});

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -13,6 +13,7 @@ import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
+import { parseExternalReference } from "../external-references";
 import {
   findObjectsByMetadata,
   getMetadataForKeys,
@@ -21,6 +22,7 @@ import {
 import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { gallerySummary } from "../gallery-service";
+import { resolveTitles } from "../github-titles";
 import { allowWrite } from "../guards";
 import {
   invitesForOrg,
@@ -532,4 +534,36 @@ export const me = new Hono<SessionVars>()
       userId,
     );
     return c.json({ member });
+  })
+
+  // Batch PR/issue titles for the connected-work rail (issue #267). Member-
+  // gated: title text for private repos is sensitive, and membership scoping
+  // keeps this from becoming a public title oracle for whatever repos the
+  // App can read. Per-ref failures are nulls — the endpoint never fails the
+  // batch wholesale.
+  .get("/workspaces/:name/github-titles", async (c) => {
+    const name = c.req.param("name");
+    await memberWorkspaceOr404(c.env, requireUserId(c), name);
+
+    const raw = (c.req.query("refs") ?? "").split(",").filter((s) => s.length > 0);
+    if (raw.length === 0) {
+      throw new ValidationError("refs query parameter required", { code: "refs_required" });
+    }
+    if (raw.length > 20) {
+      throw new ValidationError("at most 20 refs per request", { code: "too_many_refs" });
+    }
+    const normalized = raw.map((coordinate) => {
+      const parsed = parseExternalReference("github", coordinate);
+      if (!parsed.ok) {
+        throw new ValidationError(`invalid ref: ${coordinate}`, { code: "invalid_ref" });
+      }
+      // normalizedKey carries a `github:item:` provider prefix — the gh.ref
+      // metadata shape (and this response's keys) is bare
+      // `owner/repo#number`, so derive it from the locator instead.
+      const { owner, repository, number } = parsed.value.locator;
+      return `${owner}/${repository}#${number}`;
+    });
+
+    const titles = await resolveTitles(c.env, [...new Set(normalized)]);
+    return c.json({ refs: titles });
   });

--- a/apps/api/src/secrets.ts
+++ b/apps/api/src/secrets.ts
@@ -30,14 +30,14 @@ export function secretsKeyRingFromEnv(env: {
   };
 }
 
-function b64urlEncode(buf: ArrayBuffer | Uint8Array): string {
+export function b64urlEncode(buf: ArrayBuffer | Uint8Array): string {
   const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
   let s = "";
   for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
   return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
-function b64urlDecode(s: string): Uint8Array {
+export function b64urlDecode(s: string): Uint8Array {
   const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
   const b64 = s.replace(/-/g, "+").replace(/_/g, "/") + pad;
   const bin = atob(b64);

--- a/apps/api/test/fake-kv.ts
+++ b/apps/api/test/fake-kv.ts
@@ -1,0 +1,14 @@
+/** In-process KV fake: get/put with recorded TTLs. Mirrors the repo's fake-r2 pattern. */
+export class FakeKv {
+  store = new Map<string, { value: string; expirationTtl?: number }>();
+
+  async get(key: string, type?: "text" | "json"): Promise<unknown> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    return type === "json" ? JSON.parse(entry.value) : entry.value;
+  }
+
+  async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
+    this.store.set(key, { value, expirationTtl: opts?.expirationTtl });
+  }
+}

--- a/apps/api/test/github-app-env.ts
+++ b/apps/api/test/github-app-env.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared GitHub App env fixture for title-resolution tests. The key material
+ * is a dummy: these tests either pre-seed `ghtok:*` in the KV fake (so no JWT
+ * is ever minted) or never reach GitHub at all (cache-only route fixtures).
+ */
+export const GITHUB_APP_CFG_ENV = {
+  GITHUB_APP_ID: "12345",
+  GITHUB_APP_PRIVATE_KEY: "unused",
+  GITHUB_APP_HOME_INSTALLATION_ID: "777",
+};

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -15,6 +15,13 @@
     // (see routes/me.ts) skip the personal galleries/files browser for it.
     // Defaults to "default" in code, so this only needs setting to rename it.
     "DEFAULT_WORKSPACE": "default",
+    // GitHub App identity for server-side PR/issue title resolution (#267).
+    // Both ids are public (visible in GitHub URLs); the private key is the
+    // only true secret (GITHUB_APP_PRIVATE_KEY, via wrangler secret).
+    "GITHUB_APP_ID": "4346270",
+    // The App's installation on the buildinternet org — the general-purpose
+    // token source for public-repo reads.
+    "GITHUB_APP_HOME_INSTALLATION_ID": "147814297",
   },
   "routes": [
     {

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -41,7 +41,7 @@
     },
     {
       "binding": "GITHUB_CACHE",
-      "id": "TBD_BY_OPERATOR",
+      "id": "8076084dae50495ab883ec79c1c5968f",
     },
   ],
   // Browser Run binding (POST /v1/render, phase 1). "remote": true is

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -39,6 +39,10 @@
       "binding": "REGISTRY",
       "id": "808bc1c3a86a4675b134e11b6dca303d",
     },
+    {
+      "binding": "GITHUB_CACHE",
+      "id": "TBD_BY_OPERATOR",
+    },
   ],
   // Browser Run binding (POST /v1/render, phase 1). "remote": true is
   // required — quickAction has no Miniflare/local simulation and always

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -523,6 +523,35 @@ export async function searchWorkspaceFiles(
   return { kind: "ok", items: b.items, truncated: b.truncated };
 }
 
+export interface GithubTitleInfo {
+  title: string;
+  state: string;
+  kind: "pull" | "issue";
+}
+export type GithubTitleMap = Record<string, GithubTitleInfo | null>;
+
+/**
+ * Batch PR/issue titles for the connected-work rail (issue #267). `{}` for an
+ * empty ref list (no request); null on outage/non-2xx/malformed body — the
+ * caller keeps its metadata-derived labels.
+ */
+export async function getGithubTitles(
+  apiOrigin: string,
+  name: string,
+  refs: string[],
+): Promise<GithubTitleMap | null> {
+  if (refs.length === 0) return {};
+  const qs = encodeURIComponent(refs.slice(0, 20).join(","));
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/github-titles?refs=${qs}`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return null;
+  const body = (await result.response.json().catch(() => null)) as { refs?: unknown } | null;
+  if (!body || typeof body !== "object" || !body.refs || typeof body.refs !== "object") return null;
+  return body.refs as GithubTitleMap;
+}
+
 export interface WorkspaceFolderFile {
   key: string;
   url: string | null;

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -530,6 +530,9 @@ export interface GithubTitleInfo {
 }
 export type GithubTitleMap = Record<string, GithubTitleInfo | null>;
 
+/** Server-enforced per-request ref cap on `/me/workspaces/:name/github-titles`. */
+export const GITHUB_TITLES_MAX_REFS = 20;
+
 /**
  * Batch PR/issue titles for the connected-work rail (issue #267). `{}` for an
  * empty ref list (no request); null on outage/non-2xx/malformed body — the
@@ -541,7 +544,7 @@ export async function getGithubTitles(
   refs: string[],
 ): Promise<GithubTitleMap | null> {
   if (refs.length === 0) return {};
-  const qs = encodeURIComponent(refs.slice(0, 20).join(","));
+  const qs = encodeURIComponent(refs.slice(0, GITHUB_TITLES_MAX_REFS).join(","));
   const result = await fetchWithTimeout(
     `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/github-titles?refs=${qs}`,
     { credentials: "include", cache: "no-store" },

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -551,8 +551,18 @@ export async function getGithubTitles(
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
   const body = (await result.response.json().catch(() => null)) as { refs?: unknown } | null;
-  if (!body || typeof body !== "object" || !body.refs || typeof body.refs !== "object") return null;
-  return body.refs as GithubTitleMap;
+  const map = body && typeof body === "object" ? body.refs : null;
+  if (!map || typeof map !== "object" || Array.isArray(map)) return null;
+  // Per-entry shape check so a malformed payload can't push a non-string
+  // label into rail rendering: entries are null or a full TitleInfo.
+  for (const entry of Object.values(map)) {
+    if (entry === null) continue;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const t = entry as Record<string, unknown>;
+    if (typeof t.title !== "string" || typeof t.state !== "string") return null;
+    if (t.kind !== "pull" && t.kind !== "issue") return null;
+  }
+  return map as GithubTitleMap;
 }
 
 export interface WorkspaceFolderFile {

--- a/apps/web/src/lib/gh-context.test.ts
+++ b/apps/web/src/lib/gh-context.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { ghWorkItemFromMetadata, connectedWork, exactPrMatch, githubUrl } from "./gh-context";
+import {
+  ghWorkItemFromMetadata,
+  connectedWork,
+  exactPrMatch,
+  githubUrl,
+  applyGhTitles,
+  type GhWorkItem,
+} from "./gh-context";
 
 const pr = {
   "gh.repo": "o/uploads",
@@ -57,5 +64,39 @@ describe("gh-context", () => {
   it("githubUrl maps kind → path", () => {
     expect(githubUrl("o/r", "pull", "5")).toBe("https://github.com/o/r/pull/5");
     expect(githubUrl("o/r", "issue", "5")).toBe("https://github.com/o/r/issues/5");
+  });
+});
+
+function railItem(overrides: Partial<GhWorkItem> = {}): GhWorkItem {
+  return {
+    repo: "o/r",
+    kind: "pull",
+    number: "1",
+    ref: "o/r#1",
+    url: "https://github.com/o/r/pull/1",
+    label: "o/r#1",
+    kindLabel: "pull request",
+    ...overrides,
+  };
+}
+
+describe("applyGhTitles", () => {
+  it("replaces labels for refs with fetched titles and leaves the rest", () => {
+    const items = [railItem(), railItem({ ref: "o/r#2", number: "2", label: "stamped title" })];
+    const out = applyGhTitles(items, {
+      "o/r#1": { title: "Fresh title", state: "open", kind: "pull" },
+      "o/r#2": null,
+    });
+    expect(out[0].label).toBe("Fresh title");
+    expect(out[1].label).toBe("stamped title");
+    expect(items[0].label).toBe("o/r#1"); // input untouched
+  });
+
+  it("ignores empty titles and unknown refs", () => {
+    const items = [railItem()];
+    expect(
+      applyGhTitles(items, { "o/r#1": { title: "", state: "open", kind: "pull" } })[0].label,
+    ).toBe("o/r#1");
+    expect(applyGhTitles(items, {})[0].label).toBe("o/r#1");
   });
 });

--- a/apps/web/src/lib/gh-context.ts
+++ b/apps/web/src/lib/gh-context.ts
@@ -12,6 +12,8 @@
  * `apps/api/src/routes/public-files.ts`.
  */
 
+import type { GithubTitleMap } from "./api-client";
+
 export type GhKind = "pull" | "issue";
 
 export interface GhWorkItem {
@@ -81,4 +83,16 @@ export function exactPrMatch(files: { metadata?: Record<string, string> }[]): Gh
   if (items.length !== 1) return null;
   const [only] = items;
   return only.kind === "pull" ? only : null;
+}
+
+/**
+ * Overlay server-fetched titles (issue #267) onto rail items. A fetched title
+ * is strictly newer than any attach-time `gh.title`, so it wins; refs the
+ * server couldn't resolve (null / absent / empty) keep their existing label.
+ */
+export function applyGhTitles(items: GhWorkItem[], titles: GithubTitleMap): GhWorkItem[] {
+  return items.map((item) => {
+    const fetched = titles[item.ref];
+    return fetched && fetched.title ? { ...item, label: fetched.title } : item;
+  });
 }

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { renderConnectedWorkHtml, renderDetailsHtml } from "./workspace-rail";
+import { planTitleRepaint, renderConnectedWorkHtml, renderDetailsHtml } from "./workspace-rail";
 import type { GhWorkItem } from "./gh-context";
 
 function ghItem(overrides: Partial<GhWorkItem> = {}): GhWorkItem {
@@ -137,5 +137,30 @@ describe("renderDetailsHtml", () => {
     expect(html).not.toContain("<img");
     expect(html).not.toContain("<b>admin</b>");
     expect(html).toContain("&lt;img");
+  });
+});
+
+describe("planTitleRepaint", () => {
+  it("returns relabeled items when any fetched title changes a label", () => {
+    const items = [ghItem()];
+    const out = planTitleRepaint(items, {
+      "buildinternet/uploads#1789": { title: "Real title", state: "open", kind: "pull" },
+    });
+    expect(out?.[0].label).toBe("Real title");
+  });
+
+  it("returns null when nothing changed or the fetch failed", () => {
+    const items = [ghItem()];
+    expect(planTitleRepaint(items, null)).toBeNull();
+    expect(planTitleRepaint(items, {})).toBeNull();
+    expect(
+      planTitleRepaint(items, {
+        "buildinternet/uploads#1789": {
+          title: "buildinternet/uploads#1789",
+          state: "open",
+          kind: "pull",
+        },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -18,11 +18,17 @@
  * item; an empty array hides it. Non-files tabs never call it, so the section
  * stays hidden by construction.
  */
-import { getMyWorkspaces, getMyWorkspaceUsage, type MyWorkspace } from "./api-client";
+import {
+  getGithubTitles,
+  getMyWorkspaces,
+  getMyWorkspaceUsage,
+  type GithubTitleMap,
+  type MyWorkspace,
+} from "./api-client";
 import { onSession } from "./account-shell";
 import { bindCopyButtons, escapeHtml, renderUsageHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
-import type { GhKind, GhWorkItem } from "./gh-context";
+import { applyGhTitles, type GhKind, type GhWorkItem } from "./gh-context";
 
 export type ConnectedWorkSetter = (items: GhWorkItem[]) => void;
 
@@ -86,10 +92,32 @@ export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
 /** Connected-work rows shown before a "show N more" toggle reveals the rest. */
 const CONNECTED_WORK_CAP = 6;
 
-function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter {
+/** Refs sent per rail paint — matches the endpoint's 20-ref cap. */
+const TITLE_FETCH_CAP = 20;
+
+/**
+ * Decide whether a titles response warrants a repaint: the relabeled items
+ * when at least one label changed, else null (failed fetch, empty map, or
+ * titles identical to what's already painted).
+ */
+export function planTitleRepaint(
+  items: GhWorkItem[],
+  titles: GithubTitleMap | null,
+): GhWorkItem[] | null {
+  if (!titles) return null;
+  const updated = applyGhTitles(items, titles);
+  return updated.some((item, i) => item.label !== items[i].label) ? updated : null;
+}
+
+function bindConnectedWorkSetter(
+  root: Document | Element,
+  resolveTitles?: (refs: string[]) => Promise<GithubTitleMap | null>,
+): ConnectedWorkSetter {
   const section = root.querySelector<HTMLElement>("[data-rail-connected]");
   const list = root.querySelector<HTMLElement>("[data-rail-connected-list]");
-  const setter: ConnectedWorkSetter = (items) => {
+  let generation = 0;
+
+  const paintItems = (items: GhWorkItem[]): void => {
     if (!section || !list) return;
     if (!items.length) {
       section.hidden = true;
@@ -112,6 +140,18 @@ function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter 
         ?.addEventListener("click", () => paint(items.length), { once: true });
     };
     paint(CONNECTED_WORK_CAP);
+  };
+
+  const setter: ConnectedWorkSetter = (items) => {
+    const current = ++generation;
+    paintItems(items);
+    if (!items.length || !resolveTitles) return;
+    const refs = [...new Set(items.map((item) => item.ref))].slice(0, TITLE_FETCH_CAP);
+    void resolveTitles(refs).then((titles) => {
+      if (current !== generation) return; // a newer paint superseded this fetch
+      const repaint = planTitleRepaint(items, titles);
+      if (repaint) paintItems(repaint);
+    });
   };
   window.__uploadsSetConnectedWork = setter;
   return setter;
@@ -138,7 +178,9 @@ export function initWorkspaceRail(
 ): void {
   const root = opts.root ?? document;
 
-  const setConnectedWork = bindConnectedWorkSetter(root);
+  const setConnectedWork = bindConnectedWorkSetter(root, (refs) =>
+    getGithubTitles(apiOrigin, workspace, refs),
+  );
   setConnectedWork([]);
 
   const railRoot = root.querySelector<HTMLElement>("[data-workspace-rail]");

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -116,14 +116,23 @@ function bindConnectedWorkSetter(
   const section = root.querySelector<HTMLElement>("[data-rail-connected]");
   const list = root.querySelector<HTMLElement>("[data-rail-connected-list]");
   let generation = 0;
+  // Whether the user has clicked "show N more" for the current item set. A
+  // title-resolution repaint (same generation) must preserve this so it
+  // doesn't collapse the list the user just expanded; a genuinely new setter
+  // call (new generation) starts collapsed again.
+  let expanded = false;
 
-  const paintItems = (items: GhWorkItem[]): void => {
+  // repaint=true means "same item set, just fresher labels" — keep whatever
+  // limit is currently on screen. repaint=false (a fresh setter call) always
+  // starts collapsed.
+  const paintItems = (items: GhWorkItem[], repaint = false): void => {
     if (!section || !list) return;
     if (!items.length) {
       section.hidden = true;
       list.innerHTML = "";
       return;
     }
+    if (!repaint) expanded = false;
     section.hidden = false;
     // A busy workspace can link dozens of PRs/issues; cap the default view and
     // reveal the rest behind one click rather than a wall of rows.
@@ -135,11 +144,16 @@ function bindConnectedWorkSetter(
         (hidden > 0
           ? `<button type="button" class="ws-rail__more" data-rail-more>show ${hidden} more</button>`
           : "");
-      list
-        .querySelector<HTMLButtonElement>("[data-rail-more]")
-        ?.addEventListener("click", () => paint(items.length), { once: true });
+      list.querySelector<HTMLButtonElement>("[data-rail-more]")?.addEventListener(
+        "click",
+        () => {
+          expanded = true;
+          paint(items.length);
+        },
+        { once: true },
+      );
     };
-    paint(CONNECTED_WORK_CAP);
+    paint(expanded ? items.length : CONNECTED_WORK_CAP);
   };
 
   const setter: ConnectedWorkSetter = (items) => {
@@ -149,8 +163,8 @@ function bindConnectedWorkSetter(
     const refs = [...new Set(items.map((item) => item.ref))].slice(0, TITLE_FETCH_CAP);
     void resolveTitles(refs).then((titles) => {
       if (current !== generation) return; // a newer paint superseded this fetch
-      const repaint = planTitleRepaint(items, titles);
-      if (repaint) paintItems(repaint);
+      const relabeled = planTitleRepaint(items, titles);
+      if (relabeled) paintItems(relabeled, true);
     });
   };
   window.__uploadsSetConnectedWork = setter;

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -19,6 +19,7 @@
  * stays hidden by construction.
  */
 import {
+  GITHUB_TITLES_MAX_REFS,
   getGithubTitles,
   getMyWorkspaces,
   getMyWorkspaceUsage,
@@ -92,9 +93,6 @@ export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
 /** Connected-work rows shown before a "show N more" toggle reveals the rest. */
 const CONNECTED_WORK_CAP = 6;
 
-/** Refs sent per rail paint — matches the endpoint's 20-ref cap. */
-const TITLE_FETCH_CAP = 20;
-
 /**
  * Decide whether a titles response warrants a repaint: the relabeled items
  * when at least one label changed, else null (failed fetch, empty map, or
@@ -160,7 +158,7 @@ function bindConnectedWorkSetter(
     const current = ++generation;
     paintItems(items);
     if (!items.length || !resolveTitles) return;
-    const refs = [...new Set(items.map((item) => item.ref))].slice(0, TITLE_FETCH_CAP);
+    const refs = [...new Set(items.map((item) => item.ref))].slice(0, GITHUB_TITLES_MAX_REFS);
     void resolveTitles(refs).then((titles) => {
       if (current !== generation) return; // a newer paint superseded this fetch
       const relabeled = planTitleRepaint(items, titles);


### PR DESCRIPTION
Implements phase 1 of the GitHub App integration (design + plan in `.context/267-*`, session-local).

- **api:** GitHub App auth client — WebCrypto RS256 JWT → KV-cached installation tokens (`ghinst:`/`ghtok:` in a new `GITHUB_CACHE` namespace); ref→title resolution over a token ladder (home installation for public repos → the repo's own installation for private), with TTL'd positive/negative caching and rate-limit-aware backoff; member-gated batch endpoint `GET /me/workspaces/:name/github-titles` (≤20 refs, per-ref nulls never fail the batch).
- **web:** the connected-work rail still paints instantly from metadata (`gh.title`/ref), then swaps in server-resolved titles via a generation-guarded repaint that preserves show-more expansion. Every failure path degrades to today's labels.
- CLI untouched; attach-time `gh.title` stamping remains the offline seed. No changeset (api/web are changeset-ignored).

Verified in the local portless stack: with no App secrets the rail is byte-identical to today (endpoint returns nulls); with a cached title the rail swaps the label in place.

**Operator steps before this is live in prod** (all code degrades safely until then): register the GitHub App (`issues:read`, `pull_requests:read`, webhooks off), install on `buildinternet`, `wrangler kv namespace create GITHUB_CACHE` + fill the id in `apps/api/wrangler.jsonc` (currently `TBD_BY_OPERATOR`), set `GITHUB_APP_PRIVATE_KEY` (PKCS#8) / `GITHUB_APP_ID` / `GITHUB_APP_HOME_INSTALLATION_ID`.

Closes #267

### Before / after (local stack, `dev-demo` files tab)

| Before (no title available) | After (server-resolved title) |
| --- | --- |
| <img width="380" alt="Rail before: ref fallback label" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/282/rail-before.webp"> | <img width="380" alt="Rail after: real PR title" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/282/rail-after.webp"> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic GitHub issue and pull request title resolution for workspace connected-work items.
  * Added a workspace API endpoint to retrieve titles for up to 20 GitHub references.
  * Added caching and fallback handling to improve title loading reliability.
  * Updated connected-work displays with fetched titles without disrupting expanded views.

* **Bug Fixes**
  * Prevented stale title requests from overwriting newer results.
  * Added graceful handling for unavailable, invalid, or inaccessible GitHub references.

* **Tests**
  * Added comprehensive coverage for GitHub authentication, caching, title resolution, API validation, and UI relabeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->