### PR TITLE
feat: operator users page with ban/deactivate

### DIFF
--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -329,3 +329,25 @@ export async function revokeToken(
     .run();
   return { match, ambiguous: false };
 }
+
+/**
+ * Soft-revoke every active workspace API token minted by this Better Auth
+ * user. Paired with the admin plugin's ban-user (which only wipes sessions)
+ * so an abuse ban also cuts off CLI/API keys the user already issued.
+ * Tokens with a null `minting_user_id` (pre-tracking rows) are left alone.
+ */
+export async function revokeTokensForMintingUser(
+  db: D1Database,
+  userId: string,
+  now = new Date(),
+): Promise<number> {
+  if (!userId) return 0;
+  const result = await db
+    .prepare(
+      `UPDATE auth_tokens SET revoked_at = ?
+       WHERE minting_user_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(now.toISOString(), userId)
+    .run();
+  return result.meta?.changes ?? 0;
+}

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -611,3 +611,120 @@ describe("workspace limits editing", () => {
     expect(JSON.parse(store.get("ws:acme")!).maxStorageBytes).toBe(250_000_000);
   });
 });
+
+describe("POST /admin-ui/users/:userId/ban", () => {
+  function banEnv(user: typeof ADMIN_USER | typeof NON_ADMIN_USER | null) {
+    const banCalls: { path: string; body: unknown }[] = [];
+    let revokedBinds: unknown[] | null = null;
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+      }
+      if (url.pathname === "/api/auth/admin/ban-user") {
+        return req.json().then((body) => {
+          banCalls.push({ path: url.pathname, body });
+          const b = body as { userId: string; banReason?: string };
+          return Response.json({
+            user: {
+              id: b.userId,
+              email: "target@b.com",
+              name: "Target",
+              banned: true,
+              banReason: b.banReason ?? "Banned by operator",
+            },
+          });
+        });
+      }
+      if (url.pathname === "/api/auth/admin/unban-user") {
+        return req.json().then((body) => {
+          banCalls.push({ path: url.pathname, body });
+          const b = body as { userId: string };
+          return Response.json({
+            user: { id: b.userId, email: "target@b.com", name: "Target", banned: false },
+          });
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const db = {
+      prepare: (sql: string) => ({
+        bind: (...values: unknown[]) => ({
+          run: async () => {
+            if (sql.includes("minting_user_id")) {
+              revokedBinds = values;
+              return { meta: { changes: 2 } };
+            }
+            return { meta: { changes: 0 } };
+          },
+        }),
+      }),
+    };
+    const env = { AUTH: auth, DB: db } as unknown as Env;
+    return { env, banCalls, getRevokedBinds: () => revokedBinds };
+  }
+
+  it("proxies ban-user and soft-revokes minted workspace tokens", async () => {
+    const { env, banCalls, getRevokedBinds } = banEnv(ADMIN_USER);
+    const res = await app().request(
+      "/admin-ui/users/u-target/ban",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", cookie: "session=abc" },
+        body: JSON.stringify({ banReason: "spam" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      user: { id: string; banned: boolean; banReason: string };
+      tokensRevoked: number;
+    };
+    expect(body.user).toMatchObject({ id: "u-target", banned: true, banReason: "spam" });
+    expect(body.tokensRevoked).toBe(2);
+    expect(banCalls).toEqual([
+      { path: "/api/auth/admin/ban-user", body: { userId: "u-target", banReason: "spam" } },
+    ]);
+    expect(getRevokedBinds()?.[1]).toBe("u-target");
+  });
+
+  it("rejects self-ban without calling the auth worker", async () => {
+    const { env, banCalls } = banEnv(ADMIN_USER);
+    const res = await app().request(
+      "/admin-ui/users/u-admin/ban",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(banCalls).toEqual([]);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { env } = banEnv(NON_ADMIN_USER);
+    const res = await app().request(
+      "/admin-ui/users/u-target/ban",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("unbans via the admin plugin", async () => {
+    const { env, banCalls } = banEnv(ADMIN_USER);
+    const res = await app().request(
+      "/admin-ui/users/u-target/unban",
+      { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(banCalls).toEqual([
+      { path: "/api/auth/admin/unban-user", body: { userId: "u-target" } },
+    ]);
+    const body = (await res.json()) as { user: { banned: boolean } };
+    expect(body.user.banned).toBe(false);
+  });
+});

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -6,9 +6,11 @@
  * Workspaces slot on apps/web.
  */
 import {
+  ForbiddenError,
   NotFoundError,
   RateLimitedError,
   ServiceUnavailableError,
+  UnauthorizedError,
   ValidationError,
 } from "@uploads/errors";
 import { Hono } from "hono";
@@ -16,6 +18,7 @@ import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
   createEnrollment,
+  revokeTokensForMintingUser,
   validateScopes,
 } from "../auth-db";
 import { allowWrite } from "../guards";
@@ -32,6 +35,94 @@ import { isPurgedTombstone, loadWorkspaceRecordRaw, type WorkspaceRecord } from 
 import { LIMIT_FIELDS, validateLimitsPatch } from "../workspace-limits";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const BAN_REASON_MAX = 500;
+const DEFAULT_BAN_REASON = "Banned by operator";
+
+/** Prefer Better Auth's top-level `message`, then nested `error.message`. */
+function authErrorMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== "object") return fallback;
+  const p = payload as { message?: unknown; error?: unknown };
+  if (typeof p.message === "string" && p.message) return p.message;
+  if (typeof p.error === "string" && p.error) return p.error;
+  if (p.error && typeof p.error === "object") {
+    const nested = (p.error as { message?: unknown }).message;
+    if (typeof nested === "string" && nested) return nested;
+  }
+  return fallback;
+}
+
+/**
+ * Forward the caller's session cookie/bearer to a Better Auth admin plugin
+ * path (ban-user / unban-user). Those endpoints own admin/last-admin/self-ban
+ * checks; this layer maps status → AppError.
+ */
+async function proxyAdminAuth(
+  env: Env,
+  req: Request,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; payload: unknown }> {
+  const headers = new Headers({ "content-type": "application/json" });
+  const cookie = req.headers.get("cookie");
+  const authorization = req.headers.get("authorization");
+  if (cookie) headers.set("cookie", cookie);
+  if (authorization) headers.set("authorization", authorization);
+
+  let response: Response;
+  try {
+    response = await env.AUTH.fetch(`https://auth.internal${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new ServiceUnavailableError("auth service is unavailable", {
+      code: "auth_service_unavailable",
+      cause: err,
+    });
+  }
+  return { status: response.status, payload: await response.json().catch(() => null) };
+}
+
+function throwAuthAdminError(status: number, payload: unknown, action: "ban" | "unban"): never {
+  const message = authErrorMessage(payload, `failed to ${action} user`);
+  if (status === 401) throw new UnauthorizedError();
+  if (status === 403)
+    throw new ForbiddenError(message, { code: "ban_forbidden", details: payload });
+  if (status === 404) throw new NotFoundError("user not found", { code: "user_not_found" });
+  if (status === 400)
+    throw new ValidationError(message, { code: "ban_rejected", details: payload });
+  throw new ServiceUnavailableError(message, {
+    code: "auth_service_unavailable",
+    details: { status, payload },
+  });
+}
+
+function requireUserIdParam(raw: string): string {
+  const userId = raw.trim();
+  if (!userId) throw new ValidationError("userId is required", { code: "invalid_user_id" });
+  return userId;
+}
+
+function userFromAuthPayload(payload: unknown): unknown {
+  if (payload && typeof payload === "object" && "user" in payload) {
+    return (payload as { user: unknown }).user;
+  }
+  return payload;
+}
+
+function parseBanReason(body: unknown): string {
+  if (!body || typeof body !== "object") return DEFAULT_BAN_REASON;
+  const raw = (body as { banReason?: unknown }).banReason;
+  if (typeof raw !== "string") return DEFAULT_BAN_REASON;
+  const trimmed = raw.trim();
+  if (trimmed.length > BAN_REASON_MAX) {
+    throw new ValidationError(`ban reason must be ≤ ${BAN_REASON_MAX} characters`, {
+      code: "ban_reason_too_long",
+    });
+  }
+  return trimmed || DEFAULT_BAN_REASON;
+}
 
 // Invite links share the same D1 enrollment records as the ADMIN_TOKEN-gated
 // POST /admin/enrollments path (apps/api/src/routes/admin.ts) — same code
@@ -318,6 +409,42 @@ export const adminUi = new Hono<SessionVars>()
     }
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
     return c.json(await limitsResponse(c.env, name, record));
+  })
+
+  // Ban / unban (abuse). Proxies Better Auth admin ban/unban; ban also
+  // soft-revokes workspace API tokens the user minted.
+  .post("/users/:userId/ban", async (c) => {
+    const userId = requireUserIdParam(c.req.param("userId"));
+    if (c.get("sessionUser")?.id === userId) {
+      throw new ValidationError("you cannot ban yourself", { code: "cannot_ban_self" });
+    }
+    const banReason = parseBanReason(await c.req.json().catch(() => ({})));
+    const { status, payload } = await proxyAdminAuth(c.env, c.req.raw, "/api/auth/admin/ban-user", {
+      userId,
+      banReason,
+    });
+    if (status < 200 || status >= 300) throwAuthAdminError(status, payload, "ban");
+
+    // Best-effort: ban already wiped sessions; a D1 blip must not undo it.
+    let tokensRevoked = 0;
+    try {
+      tokensRevoked = await revokeTokensForMintingUser(c.env.DB, userId);
+    } catch {
+      tokensRevoked = 0;
+    }
+    return c.json({ user: userFromAuthPayload(payload), tokensRevoked });
+  })
+
+  .post("/users/:userId/unban", async (c) => {
+    const userId = requireUserIdParam(c.req.param("userId"));
+    const { status, payload } = await proxyAdminAuth(
+      c.env,
+      c.req.raw,
+      "/api/auth/admin/unban-user",
+      { userId },
+    );
+    if (status < 200 || status >= 300) throwAuthAdminError(status, payload, "unban");
+    return c.json({ user: userFromAuthPayload(payload) });
   })
 
   // OAuth client registrations — proxied 1:1 to Lane 1's internal routes

--- a/apps/api/src/session-auth.test.ts
+++ b/apps/api/src/session-auth.test.ts
@@ -33,6 +33,20 @@ function env(auth: Pick<Fetcher, "fetch">) {
 }
 
 describe("sessionAuth", () => {
+  it("treats a banned session user as signed out", async () => {
+    const user = {
+      id: "u1",
+      email: "banned@example.com",
+      name: "Banned",
+      banned: true,
+    };
+    const auth = stubAuth(
+      () => new Response(JSON.stringify({ session: {}, user }), { status: 200 }),
+    );
+    const res = await appWith(auth).request("/whoami", {}, env(auth));
+    expect(await res.json()).toEqual({ sessionUser: null });
+  });
+
   it("sets sessionUser to null when there is no cookie/session", async () => {
     const auth = stubAuth(() => new Response(JSON.stringify(null), { status: 200 }));
     const res = await appWith(auth).request("/whoami", {}, env(auth));

--- a/apps/api/src/session-auth.ts
+++ b/apps/api/src/session-auth.ts
@@ -14,6 +14,8 @@ export interface SessionUser {
   email: string;
   name: string;
   role?: string | null;
+  /** Set by Better Auth's admin plugin when the account is banned. */
+  banned?: boolean | null;
   [key: string]: unknown;
 }
 
@@ -76,6 +78,10 @@ async function resolveSessionUser(env: Env, req: Request): Promise<SessionUser |
         code: "auth_session_unavailable",
       });
     }
+    // Defense in depth: ban-user deletes sessions, but if a banned flag still
+    // rides on a leftover cookie, treat the caller as signed out so /me and
+    // /admin-ui cannot keep serving them.
+    if (body.user.banned === true) return null;
     return body.user;
   } catch (err) {
     if (err instanceof ServiceUnavailableError) throw err;

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -392,6 +392,10 @@ function buildAuth(
       admin({
         defaultRole: "user",
         adminRoles: ["admin"],
+        // Shown when a banned account tries to open a new session (magic link,
+        // GitHub, device flow). Operators set bans from /admin/users.
+        bannedUserMessage:
+          "This account has been deactivated. Contact support if you believe this is a mistake.",
       }),
       // D3/D4 (Phase 3): orgs, membership, invitations. No `team` support.
       // No org auto-provisioning hook — workspaces (and their 1:1 orgs) are

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  banUser,
   getAccountInfo,
   getOAuthPublicClient,
   getSession,
+  isBannedAuthError,
   linkGitHub,
   listAccounts,
+  listAdminUsers,
   listSessions,
   revokeSession,
   sendMagicLink,
@@ -13,6 +16,7 @@ import {
   setOAuthWorkspaceChoice,
   startLocalDemoSession,
   submitOAuthConsent,
+  unbanUser,
 } from "./auth-client";
 import { BROWSER_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "./request";
 
@@ -51,6 +55,19 @@ describe("getSession", () => {
       "http://127.0.0.1:8788/api/auth/get-session",
       expect.objectContaining({ cache: "no-store", credentials: "include" }),
     );
+  });
+
+  it("treats a banned session payload as signed out", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          session: {},
+          user: { id: "u1", email: "a@b.com", name: "A", banned: true },
+        }),
+      ),
+    );
+    await expect(getSession("http://127.0.0.1:8788")).resolves.toEqual({ kind: "signed_out" });
   });
 
   it("reports service failures and network errors as unavailable", async () => {
@@ -132,6 +149,173 @@ describe("listSessions / listAccounts", () => {
         scopes: ["read:user", "user:email"],
       },
     ]);
+  });
+});
+
+describe("listAdminUsers", () => {
+  it("parses the admin list-users payload and builds the query string", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        users: [
+          {
+            id: "u1",
+            email: "admin@example.com",
+            name: "Admin",
+            emailVerified: true,
+            role: "admin",
+            banned: false,
+            createdAt: "2026-07-01T00:00:00.000Z",
+          },
+          { id: "bad" },
+        ],
+        total: 1,
+        limit: 50,
+      }),
+    );
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(
+      listAdminUsers("https://auth.uploads.sh", {
+        limit: 50,
+        searchValue: "admin@",
+        searchField: "email",
+      }),
+    ).resolves.toEqual({
+      users: [
+        {
+          id: "u1",
+          email: "admin@example.com",
+          name: "Admin",
+          emailVerified: true,
+          role: "admin",
+          banned: false,
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+      total: 1,
+      limit: 50,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      expect.stringMatching(/^https:\/\/auth\.uploads\.sh\/api\/auth\/admin\/list-users\?/),
+      expect.objectContaining({ credentials: "include", cache: "no-store" }),
+    );
+    const requestedUrl = String(fetcher.mock.calls.at(0)?.at(0) ?? "");
+    const called = new URL(requestedUrl);
+    expect(called.searchParams.get("limit")).toBe("50");
+    expect(called.searchParams.get("searchValue")).toBe("admin@");
+    expect(called.searchParams.get("searchField")).toBe("email");
+    expect(called.searchParams.get("searchOperator")).toBe("contains");
+    expect(called.searchParams.get("sortBy")).toBe("createdAt");
+    expect(called.searchParams.get("sortDirection")).toBe("desc");
+  });
+
+  it("returns null on forbidden, outage, or malformed body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 403 })),
+    );
+    await expect(listAdminUsers("http://127.0.0.1:8788")).resolves.toBeNull();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+    await expect(listAdminUsers("http://127.0.0.1:8788")).resolves.toBeNull();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ notUsers: [] })),
+    );
+    await expect(listAdminUsers("http://127.0.0.1:8788")).resolves.toBeNull();
+  });
+});
+
+describe("banUser / unbanUser", () => {
+  it("posts to admin-ui ban and returns tokensRevoked", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        user: {
+          id: "u1",
+          email: "a@b.com",
+          name: "A",
+          emailVerified: true,
+          banned: true,
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+        tokensRevoked: 3,
+      }),
+    );
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(banUser("https://api.uploads.sh", "u1", { banReason: "spam" })).resolves.toEqual({
+      ok: true,
+      tokensRevoked: 3,
+      user: {
+        id: "u1",
+        email: "a@b.com",
+        name: "A",
+        emailVerified: true,
+        banned: true,
+        createdAt: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.uploads.sh/admin-ui/users/u1/ban",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify({ banReason: "spam" }),
+      }),
+    );
+  });
+
+  it("maps ban failures and unban success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { error: { message: "you cannot ban yourself", code: "cannot_ban_self" } },
+          { status: 400 },
+        ),
+      ),
+    );
+    await expect(banUser("https://api.uploads.sh", "u1")).resolves.toEqual({
+      ok: false,
+      status: 400,
+      message: "you cannot ban yourself",
+      code: "cannot_ban_self",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          user: {
+            id: "u1",
+            email: "a@b.com",
+            name: "A",
+            emailVerified: true,
+            banned: false,
+            createdAt: "2026-07-01T00:00:00.000Z",
+          },
+        }),
+      ),
+    );
+    await expect(unbanUser("https://api.uploads.sh", "u1")).resolves.toMatchObject({
+      ok: true,
+      tokensRevoked: 0,
+      user: { id: "u1", banned: false },
+    });
+  });
+});
+
+describe("isBannedAuthError", () => {
+  it("detects BANNED_USER codes and ban copy", () => {
+    expect(isBannedAuthError({ error: "BANNED_USER" })).toBe(true);
+    expect(isBannedAuthError({ errorCode: "banned_user" })).toBe(true);
+    expect(isBannedAuthError({ message: "This account has been deactivated." })).toBe(true);
+    expect(isBannedAuthError({ error: "access_denied" })).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -31,9 +31,15 @@ export interface SessionUser {
   name: string;
   image?: string | null;
   role?: string | null;
+  /** Set when Better Auth's admin plugin has banned the account. */
+  banned?: boolean | null;
   /** First CLI device-flow session (sticky); de-emphasizes account setup. */
   cliOnboardedAt?: string | Date | null;
 }
+
+/** Operator-facing copy when sign-in is refused for a banned account. */
+export const BANNED_ACCOUNT_MESSAGE =
+  "This account has been deactivated. Contact support if you believe this is a mistake.";
 
 /** Session row from get-session / list-sessions. */
 export interface AuthSession {
@@ -108,6 +114,9 @@ export async function getSession(origin: string): Promise<SessionResult> {
   const body = (await response.json().catch(() => undefined)) as SessionResponse | null | undefined;
   if (body === null) return { kind: "signed_out" };
   if (!body || !body.user) return { kind: "unavailable", reason: "malformed" };
+  // Ban clears sessions; if a banned flag still appears, treat as signed out
+  // so shells never paint account chrome for a deactivated user.
+  if (body.user.banned === true) return { kind: "signed_out" };
   return { kind: "signed_in", session: body };
 }
 
@@ -406,6 +415,196 @@ export async function listSessions(origin: string): Promise<AuthSession[] | null
     const r = row as Record<string, unknown>;
     return typeof r.id === "string" && typeof r.token === "string";
   });
+}
+
+/**
+ * Global user row from Better Auth's admin plugin (`GET /admin/list-users`).
+ * Session + `user.role === "admin"` required; non-admins get 403.
+ */
+export interface AdminUser {
+  id: string;
+  email: string;
+  name: string;
+  emailVerified: boolean;
+  image?: string | null;
+  role?: string | null;
+  banned?: boolean | null;
+  banReason?: string | null;
+  createdAt: string | Date;
+  updatedAt?: string | Date;
+  cliOnboardedAt?: string | Date | null;
+}
+
+export interface ListAdminUsersResult {
+  users: AdminUser[];
+  total: number;
+  limit?: number;
+  offset?: number;
+}
+
+export type ListAdminUsersOptions = {
+  /** Max rows (Better Auth coerces the query string). Default 100. */
+  limit?: number;
+  offset?: number;
+  /** Substring match on email or name (see `searchField`). */
+  searchValue?: string;
+  searchField?: "email" | "name";
+  sortBy?: string;
+  sortDirection?: "asc" | "desc";
+};
+
+function parseAdminUserRow(row: unknown): AdminUser | null {
+  if (!row || typeof row !== "object") return null;
+  const r = row as Record<string, unknown>;
+  if (typeof r.id !== "string" || typeof r.email !== "string" || typeof r.name !== "string") {
+    return null;
+  }
+  return {
+    id: r.id,
+    email: r.email,
+    name: r.name,
+    emailVerified: Boolean(r.emailVerified),
+    createdAt: (r.createdAt as string | Date) ?? new Date(0),
+    ...(r.image !== undefined ? { image: r.image as string | null } : {}),
+    ...(r.role !== undefined ? { role: r.role as string | null } : {}),
+    ...(r.banned !== undefined ? { banned: r.banned as boolean | null } : {}),
+    ...(r.banReason !== undefined ? { banReason: r.banReason as string | null } : {}),
+    ...(r.updatedAt !== undefined ? { updatedAt: r.updatedAt as string | Date } : {}),
+    ...(r.cliOnboardedAt !== undefined
+      ? { cliOnboardedAt: r.cliOnboardedAt as string | Date | null }
+      : {}),
+  };
+}
+
+/**
+ * GET /api/auth/admin/list-users — operator directory for `/admin/users`.
+ * Null on outage / non-2xx so the page can tell "couldn't load" from empty.
+ */
+export async function listAdminUsers(
+  origin: string,
+  options: ListAdminUsersOptions = {},
+): Promise<ListAdminUsersResult | null> {
+  const params = new URLSearchParams({
+    limit: String(options.limit ?? 100),
+    sortBy: options.sortBy ?? "createdAt",
+    sortDirection: options.sortDirection ?? "desc",
+  });
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  if (options.searchValue) {
+    params.set("searchValue", options.searchValue);
+    params.set("searchField", options.searchField ?? "email");
+    params.set("searchOperator", "contains");
+  }
+
+  const result = await fetchWithTimeout(
+    `${authOrigin(origin)}/api/auth/admin/list-users?${params}`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return null;
+  const body = (await result.response.json().catch(() => undefined)) as
+    | { users?: unknown; total?: unknown; limit?: unknown; offset?: unknown }
+    | null
+    | undefined;
+  if (!body || !Array.isArray(body.users) || typeof body.total !== "number") return null;
+
+  const users = body.users
+    .map((row) => parseAdminUserRow(row))
+    .filter((u): u is AdminUser => u !== null);
+
+  return {
+    users,
+    total: body.total,
+    ...(typeof body.limit === "number" ? { limit: body.limit } : {}),
+    ...(typeof body.offset === "number" ? { offset: body.offset } : {}),
+  };
+}
+
+export type BanUserResult =
+  | { ok: true; user: AdminUser | null; tokensRevoked: number }
+  | { ok: false; status: number; message: string; code?: string };
+
+type BanWirePayload = {
+  user?: unknown;
+  tokensRevoked?: unknown;
+  error?: { message?: string; code?: string } | string;
+  message?: string;
+} | null;
+
+function wireError(payload: BanWirePayload, fallback: string): { message: string; code?: string } {
+  if (payload?.error && typeof payload.error === "object") {
+    return {
+      message: payload.error.message || fallback,
+      code: payload.error.code,
+    };
+  }
+  if (typeof payload?.error === "string") return { message: payload.error };
+  if (payload?.message) return { message: payload.message };
+  return { message: fallback };
+}
+
+async function postAdminUserAction(
+  apiOrigin: string,
+  userId: string,
+  action: "ban" | "unban",
+  body: Record<string, unknown>,
+): Promise<BanUserResult> {
+  try {
+    const res = await fetch(
+      `${apiOrigin.replace(/\/$/, "")}/admin-ui/users/${encodeURIComponent(userId)}/${action}`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    const payload = (await res.json().catch(() => null)) as BanWirePayload;
+    if (!res.ok) {
+      const { message, code } = wireError(payload, `${action} failed (${res.status})`);
+      return { ok: false, status: res.status, message, code };
+    }
+    return {
+      ok: true,
+      user: parseAdminUserRow(payload?.user),
+      tokensRevoked: typeof payload?.tokensRevoked === "number" ? payload.tokensRevoked : 0,
+    };
+  } catch {
+    return { ok: false, status: 0, message: "Couldn't reach the API." };
+  }
+}
+
+/** POST /admin-ui/users/:id/ban — wipe sessions + revoke minted workspace tokens. */
+export function banUser(
+  apiOrigin: string,
+  userId: string,
+  options: { banReason?: string } = {},
+): Promise<BanUserResult> {
+  return postAdminUserAction(apiOrigin, userId, "ban", {
+    banReason: options.banReason?.trim() || undefined,
+  });
+}
+
+/** POST /admin-ui/users/:id/unban — clears ban flags (does not restore tokens). */
+export function unbanUser(apiOrigin: string, userId: string): Promise<BanUserResult> {
+  return postAdminUserAction(apiOrigin, userId, "unban", {});
+}
+
+/** True when a login callback / error body is a Better Auth ban refusal. */
+export function isBannedAuthError(input: {
+  error?: string | null;
+  errorCode?: string | null;
+  message?: string | null;
+}): boolean {
+  const blob = [input.error, input.errorCode, input.message]
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+    .join(" ")
+    .toLowerCase();
+  return (
+    blob.includes("banned_user") ||
+    blob.includes("has been banned") ||
+    blob.includes("has been deactivated") ||
+    blob.includes("you have been banned")
+  );
 }
 
 /** GET /api/auth/list-accounts — linked identity providers (e.g. GitHub). */

--- a/apps/web/src/pages/admin/users.astro
+++ b/apps/web/src/pages/admin/users.astro
@@ -1,5 +1,10 @@
 ---
+/**
+ * Operator user directory — list/search + ban/unban.
+ * List: Better Auth admin list-users. Ban/unban: /admin-ui/users/:id/{ban,unban}.
+ */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-users.css";
 
 export const prerender = false;
 ---
@@ -7,6 +12,244 @@ export const prerender = false;
 <AdminLayout section="users">
   <section class="card">
     <h2>Users</h2>
-    <p class="muted">Coming in a later phase.</p>
+    <p>
+      Deactivate an account for abuse — ends their sessions and revokes workspace
+      API tokens they minted. Reactivate restores sign-in only (tokens stay revoked).
+    </p>
+    <form id="users-search" class="users-search" role="search">
+      <label class="sr-only" for="users-search-input">Search by email</label>
+      <input
+        type="search"
+        id="users-search-input"
+        name="q"
+        placeholder="Search email…"
+        autocomplete="off"
+        maxlength="200"
+      />
+      <button type="submit">Search</button>
+    </form>
+    <div id="users-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+    <div id="users-action-status" role="status" hidden></div>
+    <div id="users-list"></div>
   </section>
+
+  <script>
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
+    import {
+      banUser,
+      listAdminUsers,
+      unbanUser,
+      type AdminUser,
+    } from "../../lib/auth-client";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("users-list")) return;
+
+      const w = window as unknown as {
+        __UPLOADS_AUTH_ORIGIN__: string;
+        __UPLOADS_API_ORIGIN__: string;
+      };
+      const authOrigin = w.__UPLOADS_AUTH_ORIGIN__.replace(/\/$/, "");
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
+
+      const usersStatus = requireElement<HTMLElement>("#users-status", "admin users");
+      const usersList = requireElement<HTMLElement>("#users-list", "admin users");
+      const actionStatus = requireElement<HTMLElement>("#users-action-status", "admin users");
+      const searchForm = requireElement<HTMLFormElement>("#users-search", "admin users");
+      const searchInput = requireElement<HTMLInputElement>("#users-search-input", "admin users");
+
+      let sessionUserId: string | null = null;
+      /** Latest list keyed by id — used by delegated ban/unban handlers. */
+      let usersById = new Map<string, AdminUser>();
+
+      const esc = (value: string) =>
+        value.replace(/[&<>"']/g, (ch) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+        );
+
+      function formatDate(value: string | Date): string {
+        const d = value instanceof Date ? value : new Date(value);
+        return Number.isNaN(d.getTime())
+          ? "—"
+          : d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+      }
+
+      function isAdmin(role: string | null | undefined): boolean {
+        return Boolean(role?.split(",").map((r) => r.trim()).includes("admin"));
+      }
+
+      function setStatus(state: "ready" | "error" | "", text: string): void {
+        if (!text) {
+          actionStatus.hidden = true;
+          actionStatus.textContent = "";
+          delete actionStatus.dataset.state;
+          return;
+        }
+        actionStatus.dataset.state = state;
+        actionStatus.textContent = text;
+        actionStatus.hidden = false;
+      }
+
+      function actionsHtml(user: AdminUser): string {
+        if (sessionUserId && user.id === sessionUserId) {
+          return `<p class="muted users-self-note">That's you — ban is unavailable.</p>`;
+        }
+        if (user.banned) {
+          return `<div class="users-actions">
+            <button type="button" class="users-unban-btn" data-user-id="${esc(user.id)}">
+              Reactivate account
+            </button>
+          </div>`;
+        }
+        return `<form class="users-ban-form" data-user-id="${esc(user.id)}">
+          <label>
+            Reason (optional)
+            <input type="text" class="users-ban-reason" maxlength="500"
+              placeholder="Abuse, spam, …" autocomplete="off" />
+          </label>
+          <button type="submit" class="users-ban-btn">Deactivate account</button>
+        </form>`;
+      }
+
+      function renderUser(user: AdminUser): HTMLElement {
+        const row = document.createElement("details");
+        row.className = user.banned ? "user-row is-banned" : "user-row";
+        const displayName =
+          user.name?.trim() && user.name !== user.email ? esc(user.name) : "";
+        const pills = [
+          isAdmin(user.role) ? `<span class="pill users-badge-admin">Admin</span>` : "",
+          user.banned ? `<span class="pill users-badge-banned">Deactivated</span>` : "",
+          !user.emailVerified
+            ? `<span class="pill users-badge-unverified">Unverified</span>`
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+        const cli =
+          user.cliOnboardedAt != null && String(user.cliOnboardedAt)
+            ? formatDate(user.cliOnboardedAt)
+            : "never";
+
+        row.innerHTML = `
+          <summary>
+            <div class="user-row-main">
+              <span class="email">${esc(user.email)}</span>${pills}
+            </div>
+            <div class="user-row-meta">
+              ${displayName ? `<span class="name">${displayName}</span>` : ""}
+              <span class="muted">joined ${esc(formatDate(user.createdAt))}</span>
+            </div>
+          </summary>
+          <div class="user-row-detail">
+            <div><span class="muted">id</span> <code>${esc(user.id)}</code></div>
+            <div><span class="muted">role</span> ${esc(user.role?.trim() || "user")}</div>
+            <div><span class="muted">CLI onboarded</span> ${esc(cli)}</div>
+            ${
+              user.banned && user.banReason
+                ? `<div><span class="muted">reason</span> ${esc(user.banReason)}</div>`
+                : ""
+            }
+            ${actionsHtml(user)}
+          </div>`;
+        return row;
+      }
+
+      async function loadUsers(q?: string) {
+        usersStatus.hidden = false;
+        usersStatus.textContent = "Loading…";
+        usersList.innerHTML = "";
+        usersById = new Map();
+
+        const result = await listAdminUsers(authOrigin, {
+          limit: 200,
+          searchValue: q?.trim() || undefined,
+          searchField: "email",
+        });
+        if (!result) {
+          usersStatus.textContent = "Failed to load users.";
+          return;
+        }
+        if (!result.users.length) {
+          usersStatus.textContent = q?.trim() ? "No users match that search." : "No users yet.";
+          return;
+        }
+        usersStatus.textContent =
+          result.total > result.users.length
+            ? `Showing ${result.users.length} of ${result.total}`
+            : `${result.total} user${result.total === 1 ? "" : "s"}`;
+        for (const user of result.users) {
+          usersById.set(user.id, user);
+          usersList.appendChild(renderUser(user));
+        }
+      }
+
+      // One delegated handler for all ban/unban controls.
+      usersList.addEventListener("submit", (event) => {
+        const form = (event.target as HTMLElement).closest<HTMLFormElement>(".users-ban-form");
+        if (!form || !usersList.contains(form)) return;
+        event.preventDefault();
+        const userId = form.dataset.userId;
+        const user = userId ? usersById.get(userId) : undefined;
+        if (!user) return;
+        if (
+          !window.confirm(
+            `Deactivate ${user.email}?\n\nThey will be signed out everywhere and any workspace API tokens they minted will be revoked.`,
+          )
+        ) {
+          return;
+        }
+        const reason = form.querySelector<HTMLInputElement>(".users-ban-reason")?.value;
+        const btn = form.querySelector<HTMLButtonElement>(".users-ban-btn");
+        void (async () => {
+          if (btn) btn.disabled = true;
+          setStatus("", "");
+          const result = await banUser(apiOrigin, user.id, { banReason: reason });
+          if (!result.ok) {
+            setStatus("error", result.message || "Couldn't deactivate that account.");
+            if (btn) btn.disabled = false;
+            return;
+          }
+          const tokenNote =
+            result.tokensRevoked > 0
+              ? ` Revoked ${result.tokensRevoked} workspace token${result.tokensRevoked === 1 ? "" : "s"}.`
+              : "";
+          setStatus("ready", `Deactivated ${user.email}.${tokenNote}`);
+          void loadUsers(searchInput.value);
+        })();
+      });
+
+      usersList.addEventListener("click", (event) => {
+        const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(".users-unban-btn");
+        if (!btn || !usersList.contains(btn)) return;
+        const userId = btn.dataset.userId;
+        const user = userId ? usersById.get(userId) : undefined;
+        if (!user) return;
+        void (async () => {
+          btn.disabled = true;
+          setStatus("", "");
+          const result = await unbanUser(apiOrigin, user.id);
+          if (!result.ok) {
+            setStatus("error", result.message || "Couldn't reactivate that account.");
+            btn.disabled = false;
+            return;
+          }
+          setStatus(
+            "ready",
+            `Reactivated ${user.email}. They can sign in again; previously revoked tokens stay revoked.`,
+          );
+          void loadUsers(searchInput.value);
+        })();
+      });
+
+      searchForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        void loadUsers(searchInput.value);
+      });
+
+      onSession((user) => {
+        sessionUserId = user.id;
+        void loadUsers(searchInput.value);
+      });
+    });
+  </script>
 </AdminLayout>

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -81,7 +81,12 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
 </script>
 <script>
-  import { sendMagicLink, signInWithGitHub } from "../lib/auth-client";
+  import {
+    BANNED_ACCOUNT_MESSAGE,
+    isBannedAuthError,
+    sendMagicLink,
+    signInWithGitHub,
+  } from "../lib/auth-client";
 
   const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string }).__UPLOADS_AUTH_ORIGIN__;
 
@@ -106,6 +111,18 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
   // query, instead of stranding the pending authorize request at /account.
   // The consent endpoint re-validates the signature server-side.
   const params = new URLSearchParams(location.search);
+
+  // Surface ban refusals after OAuth / magic-link callback (?error=BANNED_USER).
+  if (
+    isBannedAuthError({
+      error: params.get("error"),
+      errorCode: params.get("error_code") ?? params.get("code"),
+      message: params.get("error_description") ?? params.get("message"),
+    })
+  ) {
+    errorBox.textContent = BANNED_ACCOUNT_MESSAGE;
+    errorBox.hidden = false;
+  }
   const defaultCallback = params.has("sig")
     ? `${location.origin}/oauth/consent${location.search}`
     : `${location.origin}/account#cli-setup`;

--- a/apps/web/src/styles/admin-users.css
+++ b/apps/web/src/styles/admin-users.css
@@ -1,0 +1,177 @@
+/* Admin user directory on /admin/users (JS-injected markup). */
+.users-search {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 12px;
+  max-width: 420px;
+}
+.users-search input[type="search"] {
+  flex: 1 1 200px;
+  min-width: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 7px 9px;
+  font: 12px var(--mono);
+}
+.users-search button {
+  font: 11px var(--mono);
+  color: var(--accent);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 7px 12px;
+  cursor: pointer;
+}
+.users-search button:hover,
+.users-search button:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+#users-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+.user-row {
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.user-row summary {
+  cursor: pointer;
+  list-style: none;
+}
+.user-row summary::-webkit-details-marker {
+  display: none;
+}
+.user-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.user-row-main .email {
+  color: var(--fg);
+  font-weight: 600;
+  font-size: 13px;
+  font-family: var(--mono);
+}
+.user-row-meta {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+.user-row-meta .name {
+  color: var(--body);
+}
+.user-row-detail {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+  display: grid;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--body);
+}
+.user-row-detail code {
+  font: 11px var(--mono);
+  color: var(--fg);
+  word-break: break-all;
+}
+
+.pill.users-badge-admin {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.pill.users-badge-banned {
+  color: var(--red);
+  border-color: var(--red);
+}
+.pill.users-badge-unverified {
+  color: var(--muted);
+}
+
+.user-row.is-banned {
+  border-color: color-mix(in srgb, var(--red) 35%, var(--line));
+}
+
+.users-ban-form {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+  max-width: 360px;
+}
+.users-ban-form label {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.users-ban-form input {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 7px 9px;
+  font: 12px var(--mono);
+  text-transform: none;
+  letter-spacing: normal;
+}
+.users-actions {
+  margin-top: 4px;
+}
+.users-ban-btn,
+.users-unban-btn {
+  font: 11px var(--mono);
+  border-radius: 6px;
+  padding: 7px 12px;
+  cursor: pointer;
+  background: var(--panel);
+  border: 1px solid var(--line);
+}
+.users-ban-btn {
+  color: var(--red);
+  border-color: color-mix(in srgb, var(--red) 40%, var(--line));
+}
+.users-ban-btn:hover,
+.users-ban-btn:focus-visible {
+  border-color: var(--red);
+  outline: none;
+}
+.users-unban-btn {
+  color: var(--accent);
+}
+.users-unban-btn:hover,
+.users-unban-btn:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.users-ban-btn:disabled,
+.users-unban-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.users-self-note {
+  margin: 4px 0 0;
+}
+#users-action-status {
+  margin-top: 10px;
+  font-size: 12px;
+}
+#users-action-status[data-state="error"] {
+  color: var(--red);
+}
+#users-action-status[data-state="ready"] {
+  color: var(--accent);
+}


### PR DESCRIPTION
## In plain terms

Operators can finally manage accounts from `/admin/users` instead of a “coming later” placeholder: search the directory, deactivate someone for abuse, and reactivate them later. Deactivation ends their sessions, blocks new sign-in, and revokes workspace API tokens they minted.

## What it does

- List + email search via Better Auth `admin/list-users`
- **Deactivate** / **Reactivate** in-app (optional ban reason, confirm dialog, no self-ban)
- Ban path: Better Auth ban-user (sessions wiped) + soft-revoke tokens by `minting_user_id`
- Unban restores sign-in only (tokens stay revoked)
- Login shows a clear deactivated message on ban refusals
- Session gates treat `banned: true` as signed out (web + API)

## What it is not

- No Better Auth dashboard integration
- Does not revoke third-party OAuth app tokens
- Tokens minted before `minting_user_id` tracking are not revoked by user id

## How to try it

1. Sign in as a global admin
2. Open `/admin/users`
3. Expand a non-self user → **Deactivate account**
4. Confirm they can’t sign in; reactivate and sign-in works again

## Technical notes

- `POST /admin-ui/users/:id/ban` and `/unban` (session admin) proxy Better Auth admin endpoints and (on ban) call `revokeTokensForMintingUser`
- `bannedUserMessage` customized on the auth admin plugin
- Last-admin / self-ban guards remain on the Better Auth side

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/auth-client.test.ts`
- [x] `pnpm --filter @uploads/api exec vitest run src/session-auth.test.ts src/routes/admin-ui.test.ts`
- [ ] Manual: ban/unban flow on local stack as admin