### PR TITLE
fix(web): resolve PR/issue title in files-tab banner

### DIFF
--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -17,15 +17,18 @@
  */
 import { Callout } from "@uploads/ui";
 import "@uploads/ui/styles.css";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import type { ConnectedWorkSetter } from "../lib/workspace-rail";
-import { connectedWork, exactPrMatch, type GhWorkItem } from "../lib/gh-context";
+import { applyGhTitles, connectedWork, exactPrMatch, type GhWorkItem } from "../lib/gh-context";
 import {
+  GITHUB_TITLES_MAX_REFS,
+  getGithubTitles,
   getMyWorkspaces,
   listWorkspaceFolder,
   searchWorkspaceFiles,
   setFileVisibility,
   type FileVisibility,
+  type GithubTitleMap,
 } from "../lib/api-client";
 import { filePath, formatBytes } from "../lib/public-file";
 import {
@@ -215,6 +218,8 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
   const [openMenuKey, setOpenMenuKey] = useState<string | null>(null);
   const [togglingKeys, setTogglingKeys] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
+  const [githubTitles, setGithubTitles] = useState<GithubTitleMap | null>(null);
+  const githubTitlesGeneration = useRef(0);
 
   const filtersKey = filters.map((f) => `${f.key}=${f.value}`).join("&");
   const filtered = filters.length > 0;
@@ -241,6 +246,8 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
   useEffect(() => {
     if (info.status !== "ready" || info.communal) return;
     let cancelled = false;
+    githubTitlesGeneration.current += 1;
+    setGithubTitles(null);
     setState({ status: "loading" });
     async function run() {
       if (filtered) {
@@ -273,13 +280,36 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiOrigin, workspace, info, filtered, filtersKey, prefix]);
 
-  // Push the current row set to the rail + banner on every resolved listing.
+  // Resolve connected-work titles once per listing. The generation guard keeps
+  // a slower, superseded listing from repainting the current banner or rail.
+  useEffect(() => {
+    if (state.status !== "ok") return;
+    const generation = githubTitlesGeneration.current;
+    let cancelled = false;
+    const items = connectedWork(state.files);
+    const refs = [...new Set(items.map((item) => item.ref))].slice(0, GITHUB_TITLES_MAX_REFS);
+    if (!refs.length) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    void getGithubTitles(apiOrigin, workspace, refs).then((titles) => {
+      if (cancelled || generation !== githubTitlesGeneration.current) return;
+      setGithubTitles(titles);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiOrigin, workspace, state]);
+
+  // Share the table's title resolution with the rail so both surfaces paint
+  // the same label without the rail issuing a second request.
   useEffect(() => {
     if (state.status !== "ok") return;
     const setter = (window as unknown as { __uploadsSetConnectedWork?: ConnectedWorkSetter })
       .__uploadsSetConnectedWork;
-    setter?.(connectedWork(state.files));
-  }, [state]);
+    setter?.(connectedWork(state.files), githubTitles ?? undefined);
+  }, [githubTitles, state]);
 
   // Close the open `⋯` menu on outside click / Escape.
   useEffect(() => {
@@ -450,7 +480,8 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
     );
   }
 
-  const match: GhWorkItem | null = state.status === "ok" ? exactPrMatch(state.files) : null;
+  const bareMatch: GhWorkItem | null = state.status === "ok" ? exactPrMatch(state.files) : null;
+  const match = bareMatch && githubTitles ? applyGhTitles([bareMatch], githubTitles)[0] : bareMatch;
   const count = state.status === "ok" ? state.files.length : 0;
   const folderCount = state.status === "ok" ? state.prefixes.length : 0;
   const topLabel =

--- a/apps/web/src/lib/gh-context.test.ts
+++ b/apps/web/src/lib/gh-context.test.ts
@@ -56,6 +56,15 @@ describe("gh-context", () => {
   it("exactPrMatch: one pull ref across all tagged files", () => {
     expect(exactPrMatch([{ metadata: pr }, { metadata: pr }])!.ref).toBe("o/uploads#1789");
   });
+  it("exactPrMatch can use a fetched title while keeping its ref fallback", () => {
+    const match = exactPrMatch([{ metadata: pr }])!;
+    expect(
+      applyGhTitles([match], {
+        "o/uploads#1789": { title: "Use the resolved title", state: "open", kind: "pull" },
+      })[0].label,
+    ).toBe("Use the resolved title");
+    expect(applyGhTitles([match], { "o/uploads#1789": null })[0].label).toBe("o/uploads#1789");
+  });
   it("exactPrMatch: null on mixed refs or when the single ref is an issue", () => {
     expect(exactPrMatch([{ metadata: pr }, { metadata: issue }])).toBeNull();
     expect(exactPrMatch([{ metadata: issue }])).toBeNull();

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -12,15 +12,13 @@
  *  - fetches `getMyWorkspaceUsage` → usage meters (`renderUsageHtml`, reused as-is).
  *
  * Connected-work hook contract (Task 8's files tab is the only caller):
- *   `window.__uploadsSetConnectedWork(items: GhWorkItem[]): void`
+ *   `window.__uploadsSetConnectedWork(items: GhWorkItem[], titles?: GithubTitleMap): void`
  * Call with the current view's deduped `connectedWork(files)` result. A
  * non-empty array shows the "connected work" section and renders one row per
  * item; an empty array hides it. Non-files tabs never call it, so the section
  * stays hidden by construction.
  */
 import {
-  GITHUB_TITLES_MAX_REFS,
-  getGithubTitles,
   getMyWorkspaces,
   getMyWorkspaceUsage,
   type GithubTitleMap,
@@ -31,7 +29,8 @@ import { bindCopyButtons, escapeHtml, renderUsageHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
 import { applyGhTitles, type GhKind, type GhWorkItem } from "./gh-context";
 
-export type ConnectedWorkSetter = (items: GhWorkItem[]) => void;
+/** Optional titles come from the files tab's one listing-scoped title request. */
+export type ConnectedWorkSetter = (items: GhWorkItem[], titles?: GithubTitleMap) => void;
 
 declare global {
   interface Window {
@@ -107,13 +106,9 @@ export function planTitleRepaint(
   return updated.some((item, i) => item.label !== items[i].label) ? updated : null;
 }
 
-function bindConnectedWorkSetter(
-  root: Document | Element,
-  resolveTitles?: (refs: string[]) => Promise<GithubTitleMap | null>,
-): ConnectedWorkSetter {
+function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter {
   const section = root.querySelector<HTMLElement>("[data-rail-connected]");
   const list = root.querySelector<HTMLElement>("[data-rail-connected-list]");
-  let generation = 0;
   // Whether the user has clicked "show N more" for the current item set. A
   // title-resolution repaint (same generation) must preserve this so it
   // doesn't collapse the list the user just expanded; a genuinely new setter
@@ -154,16 +149,9 @@ function bindConnectedWorkSetter(
     paint(expanded ? items.length : CONNECTED_WORK_CAP);
   };
 
-  const setter: ConnectedWorkSetter = (items) => {
-    const current = ++generation;
-    paintItems(items);
-    if (!items.length || !resolveTitles) return;
-    const refs = [...new Set(items.map((item) => item.ref))].slice(0, GITHUB_TITLES_MAX_REFS);
-    void resolveTitles(refs).then((titles) => {
-      if (current !== generation) return; // a newer paint superseded this fetch
-      const relabeled = planTitleRepaint(items, titles);
-      if (relabeled) paintItems(relabeled, true);
-    });
+  const setter: ConnectedWorkSetter = (items, titles) => {
+    const relabeled = planTitleRepaint(items, titles ?? null);
+    paintItems(relabeled ?? items, titles !== undefined);
   };
   window.__uploadsSetConnectedWork = setter;
   return setter;
@@ -190,9 +178,7 @@ export function initWorkspaceRail(
 ): void {
   const root = opts.root ?? document;
 
-  const setConnectedWork = bindConnectedWorkSetter(root, (refs) =>
-    getGithubTitles(apiOrigin, workspace, refs),
-  );
+  const setConnectedWork = bindConnectedWorkSetter(root);
   setConnectedWork([]);
 
   const railRoot = root.querySelector<HTMLElement>("[data-workspace-rail]");


### PR DESCRIPTION
## What

The files-tab exact-PR-match banner (the boxed `owner/repo#123` row above the file list) rendered the bare `gh.ref` for any file lacking an attach-time `gh.title`. It never called the title resolver that #282 wired into the right-rail connected-work section, so older/untitled attaches could only ever show the raw ref — even though the repo, kind, and number were all known.

## How

Resolve titles **once per listing** in `WorkspaceFileTable` and share the ref→title map across both surfaces:

- `WorkspaceFileTable` fetches `GET /me/workspaces/:name/github-titles` for the deduped, capped refs and caches the `GithubTitleMap` in state (generation-counter + `cancelled` guard so a superseded listing can't repaint stale labels).
- The banner's `match` runs through `applyGhTitles`, so it shows the resolved title, falling back to the bare ref on a miss/null.
- The rail's `__uploadsSetConnectedWork` hook now accepts the shared map (`(items, titles?)`) instead of issuing its own fetch — one round trip feeds both surfaces.

Degradation is unchanged: no session / non-member / resolver null → bare ref, exactly as before.

## Test

- New/adjusted unit tests in `gh-context.test.ts` cover resolved-title and null-map fallback.
- `pnpm typecheck`, `pnpm format --check`, and the `gh-context` / `workspace-rail` / `github-titles` test suites pass.
- No changeset (web/api are ignored packages).

Split out of #284, which stays scoped to webhooks + the bot-owned attachments comment.

Closes #285