### PR TITLE
feat(api): GitHub webhooks for phase-1 title-cache invalidation (phase 2 PR A)

### DIFF
--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -30,10 +30,4 @@ interface Env {
    * true secret, so unset still disables title resolution gracefully.
    */
   GITHUB_APP_PRIVATE_KEY?: string;
-  /**
-   * HMAC secret for GitHub App webhook deliveries (X-Hub-Signature-256).
-   * Set via `wrangler secret put GITHUB_WEBHOOK_SECRET`; unset disables the
-   * webhook endpoint (503), degrading title freshness to phase-1 TTL-only.
-   */
-  GITHUB_WEBHOOK_SECRET?: string;
 }

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -30,4 +30,12 @@ interface Env {
    * true secret, so unset still disables title resolution gracefully.
    */
   GITHUB_APP_PRIVATE_KEY?: string;
+  /**
+   * HMAC secret for GitHub App webhook deliveries (X-Hub-Signature-256), set via
+   * `wrangler secret put`. Declared here (not only in the generated
+   * worker-configuration.d.ts) because that file is git-ignored and regenerated
+   * in CI without remote secrets — same reason GITHUB_APP_PRIVATE_KEY is here.
+   * Unset/empty disables the webhook endpoint (503).
+   */
+  GITHUB_APP_WEBHOOK_SECRET?: string;
 }

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -30,4 +30,10 @@ interface Env {
    * true secret, so unset still disables title resolution gracefully.
    */
   GITHUB_APP_PRIVATE_KEY?: string;
+  /**
+   * HMAC secret for GitHub App webhook deliveries (X-Hub-Signature-256).
+   * Set via `wrangler secret put GITHUB_WEBHOOK_SECRET`; unset disables the
+   * webhook endpoint (503), degrading title freshness to phase-1 TTL-only.
+   */
+  GITHUB_WEBHOOK_SECRET?: string;
 }

--- a/apps/api/src/github-webhook-mount.test.ts
+++ b/apps/api/src/github-webhook-mount.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { app } from "./index";
+import { FakeKv } from "../test/fake-kv";
+
+describe("webhook route mounting", () => {
+  it("reaches the webhook handler (503), not the workspace guard, for /v1/github/webhook", async () => {
+    // No GITHUB_APP_WEBHOOK_SECRET → the webhook handler returns 503. A 401
+    // (workspaceAuth) or 404 (notFound) would mean the route is misordered.
+    const res = await app.request(
+      "/v1/github/webhook",
+      { method: "POST", body: "{}", headers: { "content-type": "application/json" } },
+      { GITHUB_CACHE: new FakeKv() } as unknown as Env,
+    );
+    expect(res.status).toBe(503);
+  });
+});

--- a/apps/api/src/github-webhook.test.ts
+++ b/apps/api/src/github-webhook.test.ts
@@ -1,0 +1,103 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { handleWebhook, verifySignature } from "./github-webhook";
+import { FakeKv } from "../test/fake-kv";
+
+const SECRET = "webhook-secret";
+const sign = (body: string) => `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+
+function envWith(kv: FakeKv): Env {
+  return { GITHUB_CACHE: kv } as unknown as Env;
+}
+
+describe("verifySignature", () => {
+  it("accepts a correctly signed body", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    expect(await verifySignature(body, sign(body), SECRET)).toBe(true);
+  });
+
+  it("rejects a tampered body", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    expect(await verifySignature(`${body} `, sign(body), SECRET)).toBe(false);
+  });
+
+  it("rejects the wrong secret", async () => {
+    const body = "x";
+    expect(await verifySignature(body, sign(body), "other-secret")).toBe(false);
+  });
+
+  it("rejects a missing or malformed header", async () => {
+    expect(await verifySignature("x", null, SECRET)).toBe(false);
+    expect(await verifySignature("x", "not-sha256", SECRET)).toBe(false);
+  });
+});
+
+describe("handleWebhook", () => {
+  it("installation created drops the token and each repo's install entry", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghtok:42", { value: "t" });
+    kv.store.set("ghinst:owner/repo", { value: "42" });
+    kv.store.set("ghinst:other/keep", { value: "9" });
+    await handleWebhook(envWith(kv), "installation", {
+      action: "created",
+      installation: { id: 42 },
+      repositories: [{ full_name: "Owner/Repo" }],
+    });
+    expect(kv.store.has("ghtok:42")).toBe(false);
+    expect(kv.store.has("ghinst:owner/repo")).toBe(false);
+    expect(kv.store.has("ghinst:other/keep")).toBe(true);
+  });
+
+  it("installation suspend without a repo list drops only the token", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghtok:42", { value: "t" });
+    kv.store.set("ghinst:owner/repo", { value: "42" });
+    await handleWebhook(envWith(kv), "installation", {
+      action: "suspend",
+      installation: { id: 42 },
+    });
+    expect(kv.store.has("ghtok:42")).toBe(false);
+    expect(kv.store.has("ghinst:owner/repo")).toBe(true);
+  });
+
+  it("installation_repositories drops both added and removed install entries", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghinst:o/a", { value: "1" });
+    kv.store.set("ghinst:o/b", { value: "1" });
+    await handleWebhook(envWith(kv), "installation_repositories", {
+      action: "added",
+      repositories_added: [{ full_name: "O/A" }],
+      repositories_removed: [{ full_name: "O/B" }],
+    });
+    expect(kv.store.has("ghinst:o/a")).toBe(false);
+    expect(kv.store.has("ghinst:o/b")).toBe(false);
+  });
+
+  it("issues and pull_request drop the ref cache on any action", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghref:owner/repo#7", { value: "{}" });
+    kv.store.set("ghref:o/r#3", { value: "{}" });
+    await handleWebhook(envWith(kv), "issues", {
+      action: "closed",
+      repository: { full_name: "Owner/Repo" },
+      issue: { number: 7 },
+    });
+    await handleWebhook(envWith(kv), "pull_request", {
+      action: "synchronize",
+      repository: { full_name: "O/R" },
+      pull_request: { number: 3 },
+    });
+    expect(kv.store.has("ghref:owner/repo#7")).toBe(false);
+    expect(kv.store.has("ghref:o/r#3")).toBe(false);
+  });
+
+  it("ignores unknown events and never throws on malformed payloads", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghref:o/r#1", { value: "{}" });
+    await handleWebhook(envWith(kv), "ping", {});
+    await handleWebhook(envWith(kv), "issues", null);
+    await handleWebhook(envWith(kv), "issues", {});
+    await handleWebhook(envWith(kv), "star", { repository: { full_name: "o/r" } });
+    expect(kv.store.has("ghref:o/r#1")).toBe(true);
+  });
+});

--- a/apps/api/src/github-webhook.test.ts
+++ b/apps/api/src/github-webhook.test.ts
@@ -100,4 +100,21 @@ describe("handleWebhook", () => {
     await handleWebhook(envWith(kv), "star", { repository: { full_name: "o/r" } });
     expect(kv.store.has("ghref:o/r#1")).toBe(true);
   });
+
+  it("resolves even when a KV delete rejects", async () => {
+    const env = {
+      GITHUB_CACHE: {
+        delete: async () => {
+          throw new Error("kv down");
+        },
+      },
+    } as unknown as Env;
+    await expect(
+      handleWebhook(env, "issues", {
+        action: "edited",
+        repository: { full_name: "o/r" },
+        issue: { number: 1 },
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -24,6 +24,10 @@ async function hmacSha256Hex(secret: string, body: string): Promise<string> {
   return hex;
 }
 
+// Constant-time compare is hand-rolled over the hex strings rather than via the
+// Workers-native `crypto.subtle.timingSafeEqual` (as admin.ts/workspace.ts do):
+// that API is a Workers-only extension absent from this repo's plain-Node vitest
+// runtime, so reusing it would make this security-sensitive path untestable.
 /** Constant-time compare of two hex strings (length check + XOR accumulate). */
 function timingSafeEqualHex(a: string, b: string): boolean {
   if (a.length !== b.length) return false;

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -1,0 +1,89 @@
+/**
+ * GitHub App webhook verification + cache invalidation (spec
+ * .context/284-github-webhooks-design.md). Every delivery is HMAC-verified,
+ * then dispatched to a set of targeted KV deletes against GITHUB_CACHE — no
+ * key-prefix scans. All handlers tolerate missing fields: a partial payload
+ * means "nothing to invalidate here", never a throw. Entries self-heal via
+ * their phase-1 TTLs, so a dropped delete only reverts to TTL latency.
+ */
+
+const enc = new TextEncoder();
+
+/** Lowercase hex HMAC-SHA256 of `body` under `secret`, matching GitHub's digest. */
+async function hmacSha256Hex(secret: string, body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(body));
+  let hex = "";
+  for (const b of new Uint8Array(sig)) hex += b.toString(16).padStart(2, "0");
+  return hex;
+}
+
+/** Constant-time compare of two hex strings (length check + XOR accumulate). */
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * True iff `signatureHeader` (`X-Hub-Signature-256`, `sha256=<hex>`) is a valid
+ * HMAC of the exact raw body under `secret`. Callers MUST verify before parsing
+ * JSON — the signature is over the bytes GitHub sent.
+ */
+export async function verifySignature(
+  rawBody: string,
+  signatureHeader: string | null,
+  secret: string,
+): Promise<boolean> {
+  if (!signatureHeader || !signatureHeader.startsWith("sha256=")) return false;
+  const provided = signatureHeader.slice("sha256=".length);
+  const expected = await hmacSha256Hex(secret, rawBody);
+  return timingSafeEqualHex(provided, expected);
+}
+
+/** Lowercased `full_name` strings from a repositories-array field; [] if absent/malformed. */
+function repoFullNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const entry of value) {
+    const name = (entry as { full_name?: unknown } | null)?.full_name;
+    if (typeof name === "string") out.push(name.toLowerCase());
+  }
+  return out;
+}
+
+/**
+ * Invalidate the phase-1 cache entries implied by one webhook delivery.
+ * `ping` and unknown events are no-ops. Never throws on partial payloads.
+ */
+export async function handleWebhook(env: Env, eventType: string, payload: unknown): Promise<void> {
+  const p = (payload ?? {}) as Record<string, unknown>;
+  const keys: string[] = [];
+
+  if (eventType === "installation") {
+    const id = (p.installation as { id?: unknown } | undefined)?.id;
+    if (typeof id === "number") keys.push(`ghtok:${id}`);
+    for (const repo of repoFullNames(p.repositories)) keys.push(`ghinst:${repo}`);
+  } else if (eventType === "installation_repositories") {
+    for (const repo of repoFullNames(p.repositories_added)) keys.push(`ghinst:${repo}`);
+    for (const repo of repoFullNames(p.repositories_removed)) keys.push(`ghinst:${repo}`);
+  } else if (eventType === "issues" || eventType === "pull_request") {
+    const fullName = (p.repository as { full_name?: unknown } | undefined)?.full_name;
+    const item = (eventType === "issues" ? p.issue : p.pull_request) as
+      | { number?: unknown }
+      | undefined;
+    if (typeof fullName === "string" && typeof item?.number === "number") {
+      keys.push(`ghref:${fullName.toLowerCase()}#${item.number}`);
+    }
+  }
+  // ping and unknown events fall through with no keys.
+
+  await Promise.all(keys.map((key) => env.GITHUB_CACHE.delete(key)));
+}

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -85,5 +85,9 @@ export async function handleWebhook(env: Env, eventType: string, payload: unknow
   }
   // ping and unknown events fall through with no keys.
 
-  await Promise.all(keys.map((key) => env.GITHUB_CACHE.delete(key)));
+  // Use allSettled, not all: a rejecting delete must never propagate out of
+  // handleWebhook and become a 500 on the webhook route. A failed delete is
+  // harmless — the entry self-heals on its phase-1 TTL — so a webhook outage
+  // must never break anything.
+  await Promise.allSettled(keys.map((key) => env.GITHUB_CACHE.delete(key)));
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,7 @@ import { publicFiles } from "./routes/public-files";
 import { telemetry } from "./routes/telemetry";
 import { reports } from "./routes/reports";
 import { render } from "./routes/render";
+import { githubWebhook } from "./routes/github-webhook";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -114,6 +115,10 @@ export const app = new Hono<WorkspaceVars>()
   // guard: that pattern requires a trailing segment and never matches this
   // route. See src/routes/render.ts.
   .route("/v1/render", render)
+  // GitHub App webhooks (phase 2 PR A). HMAC-verified, no session/bearer auth.
+  // MUST stay before the `/v1/:workspace/*` guard below: that pattern matches
+  // this path, so registration order is what keeps workspaceAuth from running.
+  .route("/v1/github/webhook", githubWebhook)
   .use("/v1/:workspace/*", workspaceAuth)
   .route("/v1/:workspace/galleries", galleries)
   .route("/v1/:workspace/files", files)

--- a/apps/api/src/routes/github-webhook-route.test.ts
+++ b/apps/api/src/routes/github-webhook-route.test.ts
@@ -1,0 +1,65 @@
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { githubWebhook } from "./github-webhook";
+import { FakeKv } from "../../test/fake-kv";
+
+const SECRET = "shh";
+const sign = (body: string) => `sha256=${createHmac("sha256", SECRET).update(body).digest("hex")}`;
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/v1/github/webhook", githubWebhook)
+    .onError((err, c) => respondError(c, err));
+}
+
+function post(body: string, headers: Record<string, string>, env: Env) {
+  return app().request(
+    "/v1/github/webhook",
+    { method: "POST", body, headers: { "content-type": "application/json", ...headers } },
+    env,
+  );
+}
+
+describe("POST /v1/github/webhook", () => {
+  it("503s when the secret is unset", async () => {
+    const env = { GITHUB_CACHE: new FakeKv() } as unknown as Env;
+    expect((await post("{}", {}, env)).status).toBe(503);
+  });
+
+  it("401s on a missing or bad signature", async () => {
+    const env = { GITHUB_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
+    expect((await post("{}", {}, env)).status).toBe(401);
+    expect((await post("{}", { "x-hub-signature-256": "sha256=bad" }, env)).status).toBe(401);
+  });
+
+  it("204s a valid delivery and invalidates the ref cache", async () => {
+    const kv = new FakeKv();
+    kv.store.set("ghref:owner/repo#7", { value: "{}" });
+    const env = { GITHUB_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: kv } as unknown as Env;
+    const body = JSON.stringify({
+      action: "edited",
+      repository: { full_name: "Owner/Repo" },
+      issue: { number: 7 },
+    });
+    const res = await post(
+      body,
+      { "x-hub-signature-256": sign(body), "x-github-event": "issues" },
+      env,
+    );
+    expect(res.status).toBe(204);
+    expect(kv.store.has("ghref:owner/repo#7")).toBe(false);
+  });
+
+  it("204s a ping without touching the cache", async () => {
+    const env = { GITHUB_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
+    const body = "{}";
+    const res = await post(
+      body,
+      { "x-hub-signature-256": sign(body), "x-github-event": "ping" },
+      env,
+    );
+    expect(res.status).toBe(204);
+  });
+});

--- a/apps/api/src/routes/github-webhook-route.test.ts
+++ b/apps/api/src/routes/github-webhook-route.test.ts
@@ -23,14 +23,18 @@ function post(body: string, headers: Record<string, string>, env: Env) {
 }
 
 describe("POST /v1/github/webhook", () => {
-  it("503s when the secret is unset", async () => {
+  it("503s with the standard error envelope when the secret is unset", async () => {
     const env = { GITHUB_CACHE: new FakeKv() } as unknown as Env;
-    expect((await post("{}", {}, env)).status).toBe(503);
+    const res = await post("{}", {}, env);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: { type: "unavailable" } });
   });
 
-  it("401s on a missing or bad signature", async () => {
+  it("401s with one generic error on a missing or bad signature", async () => {
     const env = { GITHUB_APP_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
-    expect((await post("{}", {}, env)).status).toBe(401);
+    const missing = await post("{}", {}, env);
+    expect(missing.status).toBe(401);
+    expect(await missing.json()).toMatchObject({ error: { type: "unauthorized" } });
     expect((await post("{}", { "x-hub-signature-256": "sha256=bad" }, env)).status).toBe(401);
   });
 

--- a/apps/api/src/routes/github-webhook-route.test.ts
+++ b/apps/api/src/routes/github-webhook-route.test.ts
@@ -29,7 +29,7 @@ describe("POST /v1/github/webhook", () => {
   });
 
   it("401s on a missing or bad signature", async () => {
-    const env = { GITHUB_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
+    const env = { GITHUB_APP_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
     expect((await post("{}", {}, env)).status).toBe(401);
     expect((await post("{}", { "x-hub-signature-256": "sha256=bad" }, env)).status).toBe(401);
   });
@@ -37,7 +37,7 @@ describe("POST /v1/github/webhook", () => {
   it("204s a valid delivery and invalidates the ref cache", async () => {
     const kv = new FakeKv();
     kv.store.set("ghref:owner/repo#7", { value: "{}" });
-    const env = { GITHUB_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: kv } as unknown as Env;
+    const env = { GITHUB_APP_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: kv } as unknown as Env;
     const body = JSON.stringify({
       action: "edited",
       repository: { full_name: "Owner/Repo" },
@@ -53,7 +53,7 @@ describe("POST /v1/github/webhook", () => {
   });
 
   it("204s a ping without touching the cache", async () => {
-    const env = { GITHUB_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
+    const env = { GITHUB_APP_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
     const body = "{}";
     const res = await post(
       body,

--- a/apps/api/src/routes/github-webhook-route.test.ts
+++ b/apps/api/src/routes/github-webhook-route.test.ts
@@ -62,4 +62,15 @@ describe("POST /v1/github/webhook", () => {
     );
     expect(res.status).toBe(204);
   });
+
+  it("204s a validly signed delivery whose body is not valid JSON", async () => {
+    const env = { GITHUB_APP_WEBHOOK_SECRET: SECRET, GITHUB_CACHE: new FakeKv() } as unknown as Env;
+    const body = "not json";
+    const res = await post(
+      body,
+      { "x-hub-signature-256": sign(body), "x-github-event": "issues" },
+      env,
+    );
+    expect(res.status).toBe(204);
+  });
 });

--- a/apps/api/src/routes/github-webhook.ts
+++ b/apps/api/src/routes/github-webhook.ts
@@ -1,0 +1,35 @@
+/**
+ * GitHub App webhook endpoint (POST /v1/github/webhook, phase 2 PR A).
+ * Unauthenticated by session/bearer — the X-Hub-Signature-256 HMAC is the auth
+ * boundary. Must be mounted BEFORE the `/v1/:workspace/*` guard in index.ts
+ * (see that file): the guard pattern matches this two-segment path, so ordering
+ * (route handler returns without next()) is what keeps workspaceAuth from
+ * running. Reads the raw body and verifies before parsing JSON.
+ */
+import { Hono } from "hono";
+import { handleWebhook, verifySignature } from "../github-webhook";
+import type { WorkspaceVars } from "../workspace";
+
+export const githubWebhook = new Hono<WorkspaceVars>();
+
+githubWebhook.post("/", async (c) => {
+  const secret = c.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) return c.body(null, 503); // honest "not configured"; never pretend to process.
+
+  const raw = await c.req.text();
+  if (!(await verifySignature(raw, c.req.header("x-hub-signature-256") ?? null, secret))) {
+    return c.body(null, 401);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    // An unparseable body that already passed HMAC is a no-op — GitHub retries
+    // non-2xx and there is nothing to invalidate.
+    return c.body(null, 204);
+  }
+
+  await handleWebhook(c.env, c.req.header("x-github-event") ?? "", payload);
+  return c.body(null, 204);
+});

--- a/apps/api/src/routes/github-webhook.ts
+++ b/apps/api/src/routes/github-webhook.ts
@@ -13,7 +13,7 @@ import type { WorkspaceVars } from "../workspace";
 export const githubWebhook = new Hono<WorkspaceVars>();
 
 githubWebhook.post("/", async (c) => {
-  const secret = c.env.GITHUB_WEBHOOK_SECRET;
+  const secret = c.env.GITHUB_APP_WEBHOOK_SECRET;
   if (!secret) return c.body(null, 503); // honest "not configured"; never pretend to process.
 
   const raw = await c.req.text();

--- a/apps/api/src/routes/github-webhook.ts
+++ b/apps/api/src/routes/github-webhook.ts
@@ -3,9 +3,13 @@
  * Unauthenticated by session/bearer — the X-Hub-Signature-256 HMAC is the auth
  * boundary. Must be mounted BEFORE the `/v1/:workspace/*` guard in index.ts
  * (see that file): the guard pattern matches this two-segment path, so ordering
- * (route handler returns without next()) is what keeps workspaceAuth from
- * running. Reads the raw body and verifies before parsing JSON.
+ * (this handler returns/throws without calling next()) is what keeps
+ * workspaceAuth from running. Reads the raw body and verifies before parsing
+ * JSON. Failures throw the standard AppError subclasses so the shared
+ * respondError path emits the usual `{ error: { code, type, message } }`
+ * envelope (GitHub only reads the status code; the body is for our own logs).
  */
+import { ServiceUnavailableError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import { handleWebhook, verifySignature } from "../github-webhook";
 import type { WorkspaceVars } from "../workspace";
@@ -14,11 +18,16 @@ export const githubWebhook = new Hono<WorkspaceVars>();
 
 githubWebhook.post("/", async (c) => {
   const secret = c.env.GITHUB_APP_WEBHOOK_SECRET;
-  if (!secret) return c.body(null, 503); // honest "not configured"; never pretend to process.
+  // Honest "not configured" (503); never pretend to process a delivery we can't verify.
+  if (!secret) {
+    throw new ServiceUnavailableError("webhook not configured", { code: "webhook_not_configured" });
+  }
 
   const raw = await c.req.text();
   if (!(await verifySignature(raw, c.req.header("x-hub-signature-256") ?? null, secret))) {
-    return c.body(null, 401);
+    // One generic 401 for every signature failure (missing header, wrong
+    // secret, tampered body) — don't reveal which check failed.
+    throw new UnauthorizedError("invalid signature", { code: "invalid_signature" });
   }
 
   let payload: unknown;

--- a/apps/api/test/fake-kv.ts
+++ b/apps/api/test/fake-kv.ts
@@ -11,4 +11,8 @@ export class FakeKv {
   async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
     this.store.set(key, { value, expirationTtl: opts?.expirationTtl });
   }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
 }


### PR DESCRIPTION
Phase 2 (PR A) of the GitHub App integration — webhooks that keep the phase-1 title cache fresh. Advances #284; phase 1 shipped in #282.

## What

An HMAC-verified GitHub webhook endpoint on the api worker that invalidates the phase-1 `GITHUB_CACHE` entries the moment upstream state changes, instead of waiting out the TTL (up to 24h for a settled item, 1h for installs).

- **`POST /v1/github/webhook`** — unauthenticated except for the `X-Hub-Signature-256` HMAC (verified over the raw body, constant-time, before any JSON parse). Mounted ahead of the `/v1/:workspace/*` guard (that pattern matches this path, so registration order is load-bearing — locked in by a test).
- **`src/github-webhook.ts`** — signature verification + an event dispatcher doing **targeted KV deletes only** (no prefix scans):
  - `installation` → drop `ghtok:{id}` + `ghinst:{repo}` per repo (token-only when the payload carries no repo list).
  - `installation_repositories` → drop `ghinst:{repo}` for added + removed.
  - `issues` / `pull_request` (any action) → drop `ghref:{owner/repo#n}`, so both renames and state changes propagate.
  - `ping` / unknown events → no-op; malformed payloads never throw.

## Response contract (degrade-safe on every path)

`503` when the secret is unset, `401` on missing/bad signature, `204` on a verified delivery (including `ping`, unknown events, and an unparseable-after-HMAC body). A rejecting KV delete is swallowed (`Promise.allSettled`) so it never surfaces as a 500 — the entry just self-heals on its TTL. No webhook failure can affect uploads, the rail, or the titles endpoint.

## Scope / decisions

- **KV-only invalidation, no D1** — every event names the specific repo/installation, so no listing is ever required.
- **Secret name `GITHUB_APP_WEBHOOK_SECRET`** — matches the phase-1 `GITHUB_APP_*` convention and the secret already provisioned on the live worker (already declared by generated `worker-configuration.d.ts`, so intentionally not redeclared in `env.d.ts`).
- **Synchronous, not queue-backed** — the workload is idempotent and self-healing, so a DLQ has little to catch. A queue is the right foundation only if later phases add durable, non-self-healing event handling; tracked in #287.
- No permission upgrade, no CLI changes. Bot-owned attachments comment + `issues:write`/`pull_requests:write` remain the next step (PR B, #284).
- No changeset (api-only; changeset-ignored).

## Tests

Plain vitest + in-process fakes, mirroring phase 1: signature accept/tamper/wrong-secret/malformed-header; each event type deletes exactly the right keys; unknown events no-op; malformed payloads never throw; a rejecting-`delete` KV still resolves; route `503`/`401`/`204` incl. unparseable-but-signed body; mount-ordering (secret-absent POST reaches the handler → `503`, not the guard). Full api suite green (659 tests).

## Operator steps before this is live (all degrade-safe until done)

The endpoint returns `503`/`401` and the cache behaves exactly as today until:

1. `GITHUB_APP_WEBHOOK_SECRET` is set on the api worker — **already provisioned**; verify rather than overwrite.
2. On the "uploads.sh" GitHub App: set the webhook URL to `https://api.uploads.sh/v1/github/webhook`, set the same secret, and subscribe to the `installation`, `installation_repositories`, `issues`, and `pull_request` events.
3. Confirm the first `ping` delivery returns `204`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub webhook endpoint that validates signed requests and processes supported event notifications.
  * Automatically refreshes affected cached GitHub installation, repository, issue, and pull request data.
  * Returns clear responses for missing configuration, invalid signatures, malformed payloads, and successful requests.

* **Tests**
  * Added comprehensive coverage for webhook routing, signature validation, event handling, cache invalidation, and failure resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->