### PR TITLE
feat: file share page title, dual dates, and large-screen rail

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -34,6 +34,9 @@ import type { WorkspaceRecord } from "./workspace";
 // kept replaced images stale for hours.
 export const UPLOAD_CACHE_CONTROL = "public, max-age=60";
 
+/** Server-only first-upload stamp (Files SDK object metadata). Not client provenance. */
+export const UPLOADED_AT_META_KEY = "uploaded-at";
+
 const KEY_RE = /^[\w!*'()./-]+$/;
 
 export function badKey(key: string): boolean {
@@ -90,14 +93,44 @@ export function finalizeUploadKey(key: string, ws: KeyPolicyRecord): string {
   return finalKey;
 }
 
-/** Size of an existing object, or `null` if missing / unreadable (metering may drift). */
-async function existingSize(store: Files, key: string): Promise<number | null> {
+/** Prior object head fields needed for metering + uploaded-at, or null if missing. */
+async function existingHead(
+  store: Files,
+  key: string,
+): Promise<{ size: number; lastModified?: number; metadata?: Record<string, string> } | null> {
   try {
     const meta = await store.head(key);
-    return meta.size ?? 0;
+    return {
+      size: meta.size ?? 0,
+      lastModified: meta.lastModified,
+      metadata: meta.metadata,
+    };
   } catch {
     return null;
   }
+}
+
+/** Size of an existing object, or `null` if missing / unreadable (metering may drift). */
+async function existingSize(store: Files, key: string): Promise<number | null> {
+  const head = await existingHead(store, key);
+  return head?.size ?? null;
+}
+
+/**
+ * Decide `uploaded-at` for a put. Create → now; overwrite → prior stamp, else
+ * prior lastModified (legacy), else now. Never accepts a client-supplied value.
+ */
+export function resolveUploadedAtMeta(
+  prior: { lastModified?: number; metadata?: Record<string, string> } | null,
+  now: Date = new Date(),
+): string {
+  if (!prior) return now.toISOString();
+  const stamped = prior.metadata?.[UPLOADED_AT_META_KEY];
+  if (typeof stamped === "string" && Number.isFinite(Date.parse(stamped))) return stamped;
+  if (prior.lastModified != null && Number.isFinite(prior.lastModified)) {
+    return new Date(prior.lastModified).toISOString();
+  }
+  return now.toISOString();
 }
 
 /**
@@ -153,12 +186,15 @@ export async function putObject(
   if (!inspection.ok) throw inspection.error;
 
   const store = await storage(env, ws);
-  // Pre-upload head: size for ledger delta. files-sdk upload() has no
+  // Pre-upload head: size for ledger delta + prior uploaded-at / mtime so
+  // overwrites keep first-upload time. files-sdk upload() has no
   // replaced/exists flag on UploadResult, so we derive it here.
-  const prev = await existingSize(store, finalKey);
-  const replaced = prev !== null;
+  const prior = await existingHead(store, finalKey);
+  const replaced = prior !== null;
+  const prevSize = prior?.size ?? null;
   const newSize = bytes.byteLength;
-  const deltaBytes = prev === null ? newSize : newSize - prev;
+  const deltaBytes = prevSize === null ? newSize : newSize - prevSize;
+  const uploadedAt = resolveUploadedAtMeta(prior);
 
   const usage = await getWorkspaceUsage(env.DB, workspaceName);
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
@@ -179,6 +215,7 @@ export async function putObject(
   // Client headers first; always attach content-sha256 of the final stored body
   // (never trust a client-supplied hash). Visibility lives alongside provenance
   // in the same custom-metadata bag but is tracked separately (not client-free-form).
+  // `uploaded-at` is server-only — set on the final bag, never via sanitizeProvenance.
   const provenance: ProvenanceMap = {
     ...sanitizeProvenance(opts?.provenance, { clientOnly: true }),
     "content-sha256": await contentSha256Hex(bytes),
@@ -189,6 +226,7 @@ export async function putObject(
     // Only written when private — absence is the (majority) public default,
     // matching the historical shape of objects uploaded before this existed.
     ...(storedVisibility ? { [VISIBILITY_META_KEY]: storedVisibility } : {}),
+    [UPLOADED_AT_META_KEY]: uploadedAt,
   };
 
   try {

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -186,14 +186,12 @@ export async function putObject(
   if (!inspection.ok) throw inspection.error;
 
   const store = await storage(env, ws);
-  // Pre-upload head: size for ledger delta + prior uploaded-at / mtime so
-  // overwrites keep first-upload time. files-sdk upload() has no
-  // replaced/exists flag on UploadResult, so we derive it here.
+  // Pre-upload head: ledger size delta + prior stamp/mtime (overwrite keeps first upload).
+  // files-sdk upload() has no replaced/exists flag, so we derive it here.
   const prior = await existingHead(store, finalKey);
   const replaced = prior !== null;
-  const prevSize = prior?.size ?? null;
   const newSize = bytes.byteLength;
-  const deltaBytes = prevSize === null ? newSize : newSize - prevSize;
+  const deltaBytes = newSize - (prior?.size ?? 0);
   const uploadedAt = resolveUploadedAtMeta(prior);
 
   const usage = await getWorkspaceUsage(env.DB, workspaceName);

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -2,7 +2,8 @@ import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import type { Files } from "@uploads/storage";
 import { badKey, downloadResponse, UPLOADED_AT_META_KEY } from "../files-core";
-import { getFileMetadata } from "../file-metadata";
+import { getFileMetadata, META_VALUE_MAX } from "../file-metadata";
+import { resolveTitles } from "../github-titles";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
@@ -45,6 +46,8 @@ interface GithubContext {
   kind: GithubKind;
   number: number;
   url: string;
+  /** Attach-time stamp and/or live resolveTitles overlay; omitted when unknown. */
+  title?: string;
 }
 
 // Deliberately permissive (not the full GitHub owner/repo charset) — this only
@@ -52,11 +55,21 @@ interface GithubContext {
 // leaving the raw `gh.*` pairs in `metadata` (see task-5 brief).
 const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 const POSITIVE_INT_RE = /^[1-9][0-9]*$/;
+/** Lowercased `owner/repo#number` — same shape as CLI `gh.ref` / resolveTitles keys. */
+const GH_REF_RE = /^[a-z0-9._-]+\/[a-z0-9._-]+#[1-9][0-9]*$/;
+
+/** Cap titles to the same bound as stored metadata values (META_VALUE_MAX). */
+function displayTitle(raw: string | undefined): string | undefined {
+  const t = raw?.trim();
+  if (!t) return undefined;
+  return t.length > META_VALUE_MAX ? t.slice(0, META_VALUE_MAX) : t;
+}
 
 /**
  * Derives the `github` convenience object from `gh.repo`/`gh.kind`/`gh.number`
  * when all three are present and valid. Any missing or malformed piece omits
  * the object entirely — the raw pairs still flow through in `metadata`.
+ * Optional `gh.title` becomes `github.title` (live resolve may overwrite later).
  */
 function deriveGithubContext(metadata: Record<string, string>): GithubContext | undefined {
   const repo = metadata["gh.repo"];
@@ -70,7 +83,25 @@ function deriveGithubContext(metadata: Record<string, string>): GithubContext | 
   if (!Number.isSafeInteger(number)) return undefined;
 
   const path = kind === "pull" ? "pull" : "issues";
-  return { repo, kind, number, url: `https://github.com/${repo}/${path}/${number}` };
+  const base: GithubContext = {
+    repo,
+    kind,
+    number,
+    url: `https://github.com/${repo}/${path}/${number}`,
+  };
+  const stamped = displayTitle(metadata["gh.title"]);
+  return stamped ? { ...base, title: stamped } : base;
+}
+
+/**
+ * Cache / resolveTitles key for a derived github context. Prefer stamped
+ * `gh.ref` when well-formed (already lowercased by the CLI); else build from
+ * repo + number so keys match `ghref:owner/repo#num`.
+ */
+function githubRefKey(metadata: Record<string, string>, github: GithubContext): string {
+  const stamped = metadata["gh.ref"]?.trim().toLowerCase();
+  if (stamped && GH_REF_RE.test(stamped)) return stamped;
+  return `${github.repo.toLowerCase()}#${github.number}`;
 }
 
 interface ResolvedPublicObject {
@@ -161,7 +192,24 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   // Fetched only after the visibility gate above — a private object 401s
   // before this D1 read ever happens, so metadata never leaks.
   const metadata = await getFileMetadata(c.env.DB, workspace, key);
-  const github = deriveGithubContext(metadata);
+  let github = deriveGithubContext(metadata);
+
+  // Live title (KV-cached App ladder) wins over attach-time gh.title. Failures
+  // never 500 — keep the stamp or omit title entirely.
+  if (github) {
+    try {
+      const ref = githubRefKey(metadata, github);
+      const titles = await resolveTitles(c.env, [ref]);
+      const live = displayTitle(titles[ref]?.title);
+      if (live) github = { ...github, title: live };
+    } catch {
+      // Missing GITHUB_CACHE / App misconfig / transient — stamped or no title.
+    }
+    if (!github.title) {
+      const { title: _drop, ...rest } = github;
+      github = rest;
+    }
+  }
 
   const dates = publicDateFields(meta);
   return c.json({

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,11 +1,42 @@
 import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import type { Files } from "@uploads/storage";
-import { badKey, downloadResponse } from "../files-core";
+import { badKey, downloadResponse, UPLOADED_AT_META_KEY } from "../files-core";
 import { getFileMetadata } from "../file-metadata";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
+
+/** Same-second tolerance so storage noise does not force dual fields. */
+const DATE_EQUAL_MS = 1000;
+
+/**
+ * Prefer Files SDK `uploaded-at` for first-upload time; fall back to provider
+ * `lastModified`. Emit `modified` only when mtime meaningfully differs so share
+ * pages can show revisions without dual chips on a fresh put.
+ */
+function publicDateFields(meta: { lastModified?: number; metadata?: Record<string, string> }): {
+  uploaded?: string;
+  modified?: string;
+} {
+  const modifiedIso =
+    meta.lastModified != null && Number.isFinite(meta.lastModified)
+      ? new Date(meta.lastModified).toISOString()
+      : undefined;
+  const stamped = meta.metadata?.[UPLOADED_AT_META_KEY];
+  const uploadedIso =
+    typeof stamped === "string" && Number.isFinite(Date.parse(stamped))
+      ? new Date(stamped).toISOString()
+      : modifiedIso;
+
+  if (!uploadedIso && !modifiedIso) return {};
+  if (!uploadedIso) return modifiedIso ? { uploaded: modifiedIso } : {};
+  if (!modifiedIso) return { uploaded: uploadedIso };
+
+  const delta = Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso));
+  if (delta < DATE_EQUAL_MS) return { uploaded: uploadedIso };
+  return { uploaded: uploadedIso, modified: modifiedIso };
+}
 
 type GithubKind = "pull" | "issue";
 
@@ -132,6 +163,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   const metadata = await getFileMetadata(c.env.DB, workspace, key);
   const github = deriveGithubContext(metadata);
 
+  const dates = publicDateFields(meta);
   return c.json({
     workspace,
     key,
@@ -139,7 +171,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     embedUrl: urls.embedUrl,
     size: meta.size ?? 0,
     contentType: meta.type ?? "application/octet-stream",
-    ...(meta.lastModified != null ? { uploaded: new Date(meta.lastModified).toISOString() } : {}),
+    ...dates,
     ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     ...(github ? { github } : {}),
   });

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -12,6 +12,14 @@ import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 const DATE_EQUAL_MS = 1000;
 
 /**
+ * Cap live GitHub title resolve on the public share JSON path only.
+ * `resolveTitles` can spend up to ~8s per GitHub hop; apps/web's
+ * `fetchPublicFile` aborts at 4s — a cold miss must not push the whole
+ * response past that. Member-rail `/me` keeps the full resolve budget.
+ */
+const PUBLIC_TITLE_RESOLVE_BUDGET_MS = 1400;
+
+/**
  * Prefer Files SDK `uploaded-at` for first-upload time; fall back to provider
  * `lastModified`. Emit `modified` only when mtime meaningfully differs so share
  * pages can show revisions without dual chips on a fresh put.
@@ -25,13 +33,14 @@ function publicDateFields(meta: { lastModified?: number; metadata?: Record<strin
       ? new Date(meta.lastModified).toISOString()
       : undefined;
   const stamped = meta.metadata?.[UPLOADED_AT_META_KEY];
+  // When the stamp is missing/invalid, uploaded falls back to mtime — so a
+  // falsy uploadedIso implies no usable timestamp at all.
   const uploadedIso =
     typeof stamped === "string" && Number.isFinite(Date.parse(stamped))
       ? new Date(stamped).toISOString()
       : modifiedIso;
 
-  if (!uploadedIso && !modifiedIso) return {};
-  if (!uploadedIso) return modifiedIso ? { uploaded: modifiedIso } : {};
+  if (!uploadedIso) return {};
   if (!modifiedIso) return { uploaded: uploadedIso };
 
   const delta = Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso));
@@ -195,13 +204,28 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   let github = deriveGithubContext(metadata);
 
   // Live title (KV-cached App ladder) wins over attach-time gh.title. Failures
-  // never 500 — keep the stamp or omit title entirely.
+  // and budget timeouts never 500 — keep the stamp or omit title entirely.
+  // Budget is public-path only so cold GitHub resolve cannot trip apps/web's
+  // 4s fetchPublicFile abort (member rail still uses full resolveTitles).
   if (github) {
     try {
       const ref = githubRefKey(metadata, github);
-      const titles = await resolveTitles(c.env, [ref]);
-      const live = displayTitle(titles[ref]?.title);
-      if (live) github = { ...github, title: live };
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const titles = await Promise.race([
+          resolveTitles(c.env, [ref]),
+          new Promise<null>((resolve) => {
+            timer = setTimeout(() => resolve(null), PUBLIC_TITLE_RESOLVE_BUDGET_MS);
+          }),
+        ]);
+        if (titles) {
+          const live = displayTitle(titles[ref]?.title);
+          if (live) github = { ...github, title: live };
+        }
+        // Budget won → leave stamped title (or omit below).
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
     } catch {
       // Missing GITHUB_CACHE / App misconfig / transient — stamped or no title.
     }

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -13,16 +13,14 @@ const DATE_EQUAL_MS = 1000;
 
 /**
  * Cap live GitHub title resolve on the public share JSON path only.
- * `resolveTitles` can spend up to ~8s per GitHub hop; apps/web's
- * `fetchPublicFile` aborts at 4s — a cold miss must not push the whole
- * response past that. Member-rail `/me` keeps the full resolve budget.
+ * `resolveTitles` can spend up to ~8s per hop; apps/web aborts at 4s.
+ * Member-rail `/me` keeps the full resolve budget.
  */
 const PUBLIC_TITLE_RESOLVE_BUDGET_MS = 1400;
 
 /**
- * Prefer Files SDK `uploaded-at` for first-upload time; fall back to provider
- * `lastModified`. Emit `modified` only when mtime meaningfully differs so share
- * pages can show revisions without dual chips on a fresh put.
+ * Prefer `uploaded-at` stamp; fall back to provider `lastModified`.
+ * Emit `modified` only when mtime meaningfully differs (fresh put → single field).
  */
 function publicDateFields(meta: { lastModified?: number; metadata?: Record<string, string> }): {
   uploaded?: string;
@@ -33,19 +31,31 @@ function publicDateFields(meta: { lastModified?: number; metadata?: Record<strin
       ? new Date(meta.lastModified).toISOString()
       : undefined;
   const stamped = meta.metadata?.[UPLOADED_AT_META_KEY];
-  // When the stamp is missing/invalid, uploaded falls back to mtime — so a
-  // falsy uploadedIso implies no usable timestamp at all.
   const uploadedIso =
     typeof stamped === "string" && Number.isFinite(Date.parse(stamped))
       ? new Date(stamped).toISOString()
       : modifiedIso;
 
   if (!uploadedIso) return {};
-  if (!modifiedIso) return { uploaded: uploadedIso };
-
-  const delta = Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso));
-  if (delta < DATE_EQUAL_MS) return { uploaded: uploadedIso };
+  if (!modifiedIso || Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso)) < DATE_EQUAL_MS) {
+    return { uploaded: uploadedIso };
+  }
   return { uploaded: uploadedIso, modified: modifiedIso };
+}
+
+/** Race work against the public title budget; null on timeout (errors propagate). */
+async function withPublicTitleBudget<T>(work: Promise<T>): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), PUBLIC_TITLE_RESOLVE_BUDGET_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 type GithubKind = "pull" | "issue";
@@ -92,14 +102,14 @@ function deriveGithubContext(metadata: Record<string, string>): GithubContext | 
   if (!Number.isSafeInteger(number)) return undefined;
 
   const path = kind === "pull" ? "pull" : "issues";
-  const base: GithubContext = {
+  const title = displayTitle(metadata["gh.title"]);
+  return {
     repo,
     kind,
     number,
     url: `https://github.com/${repo}/${path}/${number}`,
+    ...(title ? { title } : {}),
   };
-  const stamped = displayTitle(metadata["gh.title"]);
-  return stamped ? { ...base, title: stamped } : base;
 }
 
 /**
@@ -198,44 +208,26 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     return downloadResponse(store, key, filename);
   }
 
-  // Fetched only after the visibility gate above — a private object 401s
-  // before this D1 read ever happens, so metadata never leaks.
+  // After the visibility gate — private objects 401 before this D1 read.
   const metadata = await getFileMetadata(c.env.DB, workspace, key);
   let github = deriveGithubContext(metadata);
 
-  // Live title (KV-cached App ladder) wins over attach-time gh.title. Failures
-  // and budget timeouts never 500 — keep the stamp or omit title entirely.
-  // Budget is public-path only so cold GitHub resolve cannot trip apps/web's
-  // 4s fetchPublicFile abort (member rail still uses full resolveTitles).
+  // Live title (KV-cached App ladder) wins over stamped gh.title. Failures and
+  // budget timeouts never 500 — keep the stamp or omit title entirely.
   if (github) {
+    const ref = githubRefKey(metadata, github);
+    let title = github.title;
     try {
-      const ref = githubRefKey(metadata, github);
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      try {
-        const titles = await Promise.race([
-          resolveTitles(c.env, [ref]),
-          new Promise<null>((resolve) => {
-            timer = setTimeout(() => resolve(null), PUBLIC_TITLE_RESOLVE_BUDGET_MS);
-          }),
-        ]);
-        if (titles) {
-          const live = displayTitle(titles[ref]?.title);
-          if (live) github = { ...github, title: live };
-        }
-        // Budget won → leave stamped title (or omit below).
-      } finally {
-        if (timer !== undefined) clearTimeout(timer);
-      }
+      const titles = await withPublicTitleBudget(resolveTitles(c.env, [ref]));
+      const live = titles ? displayTitle(titles[ref]?.title) : undefined;
+      if (live) title = live;
     } catch {
-      // Missing GITHUB_CACHE / App misconfig / transient — stamped or no title.
+      // Missing GITHUB_CACHE / App misconfig / transient — keep stamp if any.
     }
-    if (!github.title) {
-      const { title: _drop, ...rest } = github;
-      github = rest;
-    }
+    const { title: _drop, ...base } = github;
+    github = title ? { ...base, title } : base;
   }
 
-  const dates = publicDateFields(meta);
   return c.json({
     workspace,
     key,
@@ -243,7 +235,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     embedUrl: urls.embedUrl,
     size: meta.size ?? 0,
     contentType: meta.type ?? "application/octet-stream",
-    ...dates,
+    ...publicDateFields(meta),
     ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     ...(github ? { github } : {}),
   });

--- a/apps/api/test/files-core-uploaded-at.test.ts
+++ b/apps/api/test/files-core-uploaded-at.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveUploadedAtMeta, UPLOADED_AT_META_KEY } from "../src/files-core";
+
+describe("resolveUploadedAtMeta", () => {
+  const now = new Date("2026-07-20T12:00:00.000Z");
+
+  it("returns now when there is no prior object (create)", () => {
+    expect(resolveUploadedAtMeta(null, now)).toBe(now.toISOString());
+  });
+
+  it("preserves a valid prior uploaded-at stamp", () => {
+    const stamped = "2026-01-01T00:00:00.000Z";
+    expect(
+      resolveUploadedAtMeta(
+        {
+          lastModified: Date.parse("2026-06-01T00:00:00.000Z"),
+          metadata: { [UPLOADED_AT_META_KEY]: stamped },
+        },
+        now,
+      ),
+    ).toBe(stamped);
+  });
+
+  it("seeds from prior lastModified when stamp is missing (legacy)", () => {
+    const lm = Date.parse("2026-01-15T10:00:00.000Z");
+    expect(resolveUploadedAtMeta({ lastModified: lm, metadata: {} }, now)).toBe(
+      new Date(lm).toISOString(),
+    );
+  });
+
+  it("falls back to now when prior stamp is invalid and lastModified is missing", () => {
+    expect(resolveUploadedAtMeta({ metadata: { [UPLOADED_AT_META_KEY]: "not-a-date" } }, now)).toBe(
+      now.toISOString(),
+    );
+  });
+
+  it("ignores non-finite lastModified and falls back to now", () => {
+    expect(resolveUploadedAtMeta({ lastModified: Number.NaN }, now)).toBe(now.toISOString());
+  });
+});

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -266,7 +266,11 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     });
     expect(json.metadata?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
     expect(json.metadata?.["content-sha256"]).not.toBe("0".repeat(64));
-    expect(bucket.store.get("default/screenshots/shot.png")?.customMetadata).toEqual(json.metadata);
+    // R2 bag is provenance plus server-only keys (uploaded-at); put/head JSON
+    // still returns the allowlisted provenance subset only.
+    const storedMeta = bucket.store.get("default/screenshots/shot.png")?.customMetadata;
+    expect(storedMeta).toMatchObject(json.metadata!);
+    expect(storedMeta?.["uploaded-at"]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
     const head = await app.request(
       "/v1/default/files/screenshots/shot.png",
@@ -282,6 +286,7 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(headJson.key).toBe("screenshots/shot.png");
     expect(headJson.contentType).toBe("image/png");
     expect(headJson.metadata).toEqual(json.metadata);
+    expect(headJson.metadata).not.toHaveProperty("uploaded-at");
   });
 
   it("stores private visibility from the upload header and surfaces it on authed head", async () => {

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
+import { FakeKv } from "./fake-kv";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
@@ -341,6 +342,59 @@ describe("GET /public/files/:workspace/:key", () => {
     const json = (await res.json()) as Record<string, unknown>;
     expect(json).not.toHaveProperty("metadata");
     expect(json).not.toHaveProperty("github");
+  });
+
+  it("includes github.title from stamped gh.title when live resolve is unavailable", async () => {
+    // No GITHUB_CACHE / App → resolveTitles throws or returns nulls; stamp still wins.
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedShot(env, {
+      "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+      "X-Uploads-Meta-gh.kind": "pull",
+      "X-Uploads-Meta-gh.number": "142",
+      "X-Uploads-Meta-gh.title": "Fix the login bug",
+    });
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { github?: { title?: string } };
+    expect(json.github?.title).toBe("Fix the login bug");
+  });
+
+  it("prefers live-resolved title over stamped gh.title", async () => {
+    const kv = new FakeKv();
+    // Cache hit short-circuits before App config is required (no network).
+    kv.store.set("ghref:buildinternet/uploads#142", {
+      value: JSON.stringify({
+        v: { title: "Live title from cache", state: "open", kind: "pull" },
+      }),
+    });
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    (env as { GITHUB_CACHE?: FakeKv }).GITHUB_CACHE = kv;
+
+    await seedShot(env, {
+      "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+      "X-Uploads-Meta-gh.kind": "pull",
+      "X-Uploads-Meta-gh.number": "142",
+      "X-Uploads-Meta-gh.title": "Stamped title",
+    });
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { github?: { title?: string } };
+    expect(json.github?.title).toBe("Live title from cache");
+  });
+
+  it("omits github.title when neither stamp nor live resolve provides one", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedShot(env, {
+      "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+      "X-Uploads-Meta-gh.kind": "pull",
+      "X-Uploads-Meta-gh.number": "142",
+    });
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { github?: { title?: string } };
+    expect(json.github).toBeDefined();
+    expect(json.github).not.toHaveProperty("title");
   });
 });
 

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -434,3 +434,37 @@ describe("GET /public/files/:workspace/:key?download=1", () => {
     expect(bytes).toEqual(PNG);
   });
 });
+
+// Task 1: first-upload stamp on putObject (Files SDK custom metadata).
+// Public JSON dual-date mapping is Task 2 — these only assert R2 customMetadata.
+describe("putObject uploaded-at stamp", () => {
+  it("stamps uploaded-at on first put and preserves it across overwrite", async () => {
+    const { env, bucket } = await makeEnv();
+    await seedShot(env);
+
+    const key = "default/screenshots/shot.png";
+    const first = bucket.store.get(key);
+    expect(first).toBeTruthy();
+    const firstStamp = first!.customMetadata?.["uploaded-at"];
+    expect(firstStamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Overwrite same key
+    await seedShot(env);
+    expect(bucket.store.get(key)?.customMetadata?.["uploaded-at"]).toBe(firstStamp);
+  });
+
+  it("seeds uploaded-at from prior lastModified when overwriting a legacy object", async () => {
+    const { env, bucket } = await makeEnv();
+    await seedShot(env);
+    const key = "default/screenshots/shot.png";
+    const obj = bucket.store.get(key)!;
+    const priorLm = new Date("2026-01-15T10:00:00.000Z");
+    // Strip stamp + backdate mtime to simulate pre-feature object
+    obj.customMetadata = { ...obj.customMetadata };
+    delete obj.customMetadata["uploaded-at"];
+    bucket.setUploaded(key, priorLm);
+
+    await seedShot(env);
+    expect(bucket.store.get(key)?.customMetadata?.["uploaded-at"]).toBe(priorLm.toISOString());
+  });
+});

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -396,6 +396,39 @@ describe("GET /public/files/:workspace/:key", () => {
     expect(json.github).toBeDefined();
     expect(json.github).not.toHaveProperty("title");
   });
+
+  it("keeps stamped title when live resolve exceeds the public budget", async () => {
+    // Slow GITHUB_CACHE.get simulates a cold ladder that would otherwise
+    // approach resolveTitles' ~8s GitHub abort and trip apps/web's 4s fetch.
+    // Public route races resolve with ~1.4s and must return the stamp.
+    const slowKv = {
+      async get() {
+        await new Promise((r) => setTimeout(r, 5000));
+        return null;
+      },
+      async put() {
+        /* no-op */
+      },
+    };
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    (env as { GITHUB_CACHE?: typeof slowKv }).GITHUB_CACHE = slowKv;
+
+    await seedShot(env, {
+      "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+      "X-Uploads-Meta-gh.kind": "pull",
+      "X-Uploads-Meta-gh.number": "142",
+      "X-Uploads-Meta-gh.title": "Stamped under budget",
+    });
+
+    const started = Date.now();
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    const elapsedMs = Date.now() - started;
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { github?: { title?: string } };
+    expect(json.github?.title).toBe("Stamped under budget");
+    // Budget 1400ms + request overhead; must stay well under web's 4s abort.
+    expect(elapsedMs).toBeLessThan(3000);
+  });
 });
 
 // Task 3 (corrected): forced-download streaming lives behind a `?download=1`

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -435,6 +435,35 @@ describe("GET /public/files/:workspace/:key?download=1", () => {
   });
 });
 
+describe("GET /public/files uploaded + modified dates", () => {
+  it("returns uploaded from uploaded-at and omits modified when equal", async () => {
+    const { env } = await makeEnv();
+    await seedShot(env);
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    const json = (await res.json()) as { uploaded?: string; modified?: string };
+    expect(json.uploaded).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    // Fresh put: lastModified ≈ uploaded-at → modified omitted
+    expect(json.modified).toBeUndefined();
+  });
+
+  it("includes modified when lastModified differs from uploaded-at", async () => {
+    const { env, bucket } = await makeEnv();
+    await seedShot(env);
+    const entry = [...bucket.store.entries()].find(([k]) => k.endsWith("screenshots/shot.png"))!;
+    // Keep uploaded-at, advance R2 mtime
+    entry[1].customMetadata = {
+      ...entry[1].customMetadata,
+      "uploaded-at": "2026-01-01T00:00:00.000Z",
+    };
+    bucket.setUploaded(entry[0], new Date("2026-06-15T12:00:00.000Z"));
+
+    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    const json = (await res.json()) as { uploaded?: string; modified?: string };
+    expect(json.uploaded).toBe("2026-01-01T00:00:00.000Z");
+    expect(json.modified).toBe("2026-06-15T12:00:00.000Z");
+  });
+});
+
 // Task 1: first-upload stamp on putObject (Files SDK custom metadata).
 // Public JSON dual-date mapping is Task 2 — these only assert R2 customMetadata.
 describe("putObject uploaded-at stamp", () => {

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -154,13 +154,15 @@ describe("isPublicFile", () => {
 });
 
 describe("shouldShowModified", () => {
-  it("is false when modified missing or within 60s", () => {
+  it("is false when modified missing or within 60s on the same UTC day", () => {
     expect(shouldShowModified("2026-07-01T00:00:00.000Z", null)).toBe(false);
     expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:00:30.000Z")).toBe(false);
   });
   it("is true when day differs or delta > 60s", () => {
     expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-02T00:00:00.000Z")).toBe(true);
     expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:02:00.000Z")).toBe(true);
+    // Midnight boundary: delta 20s but different UTC days → still show modified.
+    expect(shouldShowModified("2026-07-01T23:59:50.000Z", "2026-07-02T00:00:10.000Z")).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -7,9 +7,12 @@ import {
   fileKind,
   filePath,
   formatBytes,
+  formatFileDate,
   isPublicFile,
   isSafeKey,
   PUBLIC_FILE_CSP,
+  sameUtcDay,
+  shouldShowModified,
 } from "./public-file";
 
 const file = {
@@ -116,6 +119,65 @@ describe("isPublicFile", () => {
       isPublicFile({ ...file, github: { ...base, url: "http://github.com/x/y/pull/1" } }),
     ).toBe(false);
   });
+
+  it("accepts optional modified and github.title", () => {
+    expect(
+      isPublicFile({
+        ...file,
+        modified: "2026-07-14T12:00:00.000Z",
+        github: {
+          repo: "o/r",
+          kind: "pull",
+          number: 1,
+          url: "https://github.com/o/r/pull/1",
+          title: "Fix the thing",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects overlong github.title and bad modified", () => {
+    expect(
+      isPublicFile({
+        ...file,
+        github: {
+          repo: "o/r",
+          kind: "pull",
+          number: 1,
+          url: "https://github.com/o/r/pull/1",
+          title: "x".repeat(513),
+        },
+      }),
+    ).toBe(false);
+    expect(isPublicFile({ ...file, modified: "not-a-date" })).toBe(false);
+  });
+});
+
+describe("shouldShowModified", () => {
+  it("is false when modified missing or within 60s", () => {
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", null)).toBe(false);
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:00:30.000Z")).toBe(false);
+  });
+  it("is true when day differs or delta > 60s", () => {
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-02T00:00:00.000Z")).toBe(true);
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:02:00.000Z")).toBe(true);
+  });
+});
+
+describe("formatFileDate", () => {
+  it("formats date-only and withTime; returns null for invalid input", () => {
+    expect(formatFileDate("2026-07-01T15:30:00.000Z")).toMatch(/Jul/);
+    expect(formatFileDate("2026-07-01T15:30:00.000Z", { withTime: true })).toMatch(/Jul/);
+    expect(formatFileDate("not-a-date")).toBe(null);
+  });
+});
+
+describe("sameUtcDay", () => {
+  it("compares UTC calendar days", () => {
+    expect(sameUtcDay("2026-07-01T00:00:00.000Z", "2026-07-01T23:59:59.000Z")).toBe(true);
+    expect(sameUtcDay("2026-07-01T00:00:00.000Z", "2026-07-02T00:00:00.000Z")).toBe(false);
+    expect(sameUtcDay("not-a-date", "2026-07-01T00:00:00.000Z")).toBe(false);
+  });
 });
 
 describe("key safety + path building", () => {
@@ -165,7 +227,7 @@ describe("fetchPublicFile", () => {
       origin: "https://api.uploads.sh",
       fetch: fetcher,
     });
-    expect(result).toEqual({ status: "ok", file: { ...file } });
+    expect(result).toEqual({ status: "ok", file: { ...file, modified: null } });
     expect(String(fetcher.mock.calls[0][0])).toBe(
       "https://api.uploads.sh/public/files/acme/screenshots/shot.png",
     );

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -340,7 +340,9 @@ const SHOW_MODIFIED_MS = 60_000;
 /**
  * Whether the share page should surface a separate "modified" date alongside
  * uploaded. False when either timestamp is missing/invalid or they are within
- * 60 seconds of each other (R2 often stamps both to the same write).
+ * 60 seconds of each other on the same UTC day (R2 often stamps both to the
+ * same write). True when the UTC calendar day differs even if the delta is
+ * small (midnight boundary), or when delta exceeds 60s on the same day.
  */
 export function shouldShowModified(
   uploaded: string | null | undefined,
@@ -350,6 +352,7 @@ export function shouldShowModified(
   const a = Date.parse(uploaded);
   const b = Date.parse(modified);
   if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  if (!sameUtcDay(uploaded, modified)) return true;
   if (Math.abs(b - a) <= SHOW_MODIFIED_MS) return false;
   return true;
 }

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -11,6 +11,8 @@ export interface GithubContext {
   kind: "pull" | "issue";
   number: number;
   url: string;
+  /** Issue/PR title when the API resolved it; omitted when unavailable. */
+  title?: string;
 }
 
 /** Allowlisted metadata for one public object, as returned by the API. */
@@ -23,6 +25,8 @@ export interface PublicFile {
   size: number;
   contentType: string;
   uploaded: string | null;
+  /** Present when API reports a distinct last-modified time. */
+  modified?: string | null;
   /** Queryable `gh.*`-and-other custom metadata pairs; omitted when there are none. */
   metadata?: Record<string, string>;
   /** Convenience view of `gh.repo`/`gh.kind`/`gh.number`, when all three are present and valid. */
@@ -205,12 +209,15 @@ function isMetadataMap(value: unknown): value is Record<string, string> {
 function isGithubContext(value: unknown): value is GithubContext {
   if (typeof value !== "object" || value === null) return false;
   const github = value as Record<string, unknown>;
+  const titleOk =
+    github.title === undefined || (text(github.title, 512) && (github.title as string).length > 0);
   return (
     text(github.repo, 200) &&
     (github.kind === "pull" || github.kind === "issue") &&
     Number.isSafeInteger(github.number) &&
     (github.number as number) > 0 &&
-    httpsUrl(github.url)
+    httpsUrl(github.url) &&
+    titleOk
   );
 }
 
@@ -222,6 +229,10 @@ export function isPublicFile(value: unknown): value is PublicFile {
     file.uploaded === undefined ||
     file.uploaded === null ||
     (text(file.uploaded, 64) && Number.isFinite(Date.parse(file.uploaded as string)));
+  const modifiedOk =
+    file.modified === undefined ||
+    file.modified === null ||
+    (text(file.modified, 64) && Number.isFinite(Date.parse(file.modified as string)));
   const metadataOk = file.metadata === undefined || isMetadataMap(file.metadata);
   const githubOk = file.github === undefined || isGithubContext(file.github);
   return (
@@ -233,6 +244,7 @@ export function isPublicFile(value: unknown): value is PublicFile {
     (file.size as number) >= 0 &&
     text(file.contentType, 128) &&
     uploadedOk &&
+    modifiedOk &&
     metadataOk &&
     githubOk
   );
@@ -292,7 +304,14 @@ export async function fetchPublicFile(
     if (!response.ok) return { status: "unavailable" };
     const value: unknown = await response.json();
     return isPublicFile(value)
-      ? { status: "ok", file: { ...value, uploaded: value.uploaded ?? null } }
+      ? {
+          status: "ok",
+          file: {
+            ...value,
+            uploaded: value.uploaded ?? null,
+            modified: value.modified ?? null,
+          },
+        }
       : { status: "unavailable" };
   } catch {
     return { status: "unavailable" };
@@ -313,4 +332,56 @@ export function formatBytes(bytes: number): string {
     unit += 1;
   }
   return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+/** Hide "modified" when missing or effectively the same instant as uploaded (≤60s). */
+const SHOW_MODIFIED_MS = 60_000;
+
+/**
+ * Whether the share page should surface a separate "modified" date alongside
+ * uploaded. False when either timestamp is missing/invalid or they are within
+ * 60 seconds of each other (R2 often stamps both to the same write).
+ */
+export function shouldShowModified(
+  uploaded: string | null | undefined,
+  modified: string | null | undefined,
+): boolean {
+  if (!uploaded || !modified) return false;
+  const a = Date.parse(uploaded);
+  const b = Date.parse(modified);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  if (Math.abs(b - a) <= SHOW_MODIFIED_MS) return false;
+  return true;
+}
+
+/** Locale-formatted date for the share-page metadata rail; null if unparseable. */
+export function formatFileDate(iso: string, opts?: { withTime?: boolean }): string | null {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return null;
+  if (opts?.withTime) {
+    return d.toLocaleString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** True when both timestamps fall on the same UTC calendar day. */
+export function sameUtcDay(a: string, b: string): boolean {
+  const da = new Date(a);
+  const db = new Date(b);
+  if (!Number.isFinite(da.getTime()) || !Number.isFinite(db.getTime())) return false;
+  return (
+    da.getUTCFullYear() === db.getUTCFullYear() &&
+    da.getUTCMonth() === db.getUTCMonth() &&
+    da.getUTCDate() === db.getUTCDate()
+  );
 }

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -221,18 +221,19 @@ function isGithubContext(value: unknown): value is GithubContext {
   );
 }
 
+/** Optional ISO timestamp field: absent, null, or a bounded parseable string. */
+function optionalIsoDate(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (text(value, 64) && Number.isFinite(Date.parse(value as string)))
+  );
+}
+
 /** Validate an untrusted API response against the bounded {@link PublicFile} shape. */
 export function isPublicFile(value: unknown): value is PublicFile {
   if (typeof value !== "object" || value === null) return false;
   const file = value as Record<string, unknown>;
-  const uploadedOk =
-    file.uploaded === undefined ||
-    file.uploaded === null ||
-    (text(file.uploaded, 64) && Number.isFinite(Date.parse(file.uploaded as string)));
-  const modifiedOk =
-    file.modified === undefined ||
-    file.modified === null ||
-    (text(file.modified, 64) && Number.isFinite(Date.parse(file.modified as string)));
   const metadataOk = file.metadata === undefined || isMetadataMap(file.metadata);
   const githubOk = file.github === undefined || isGithubContext(file.github);
   return (
@@ -243,8 +244,8 @@ export function isPublicFile(value: unknown): value is PublicFile {
     Number.isSafeInteger(file.size) &&
     (file.size as number) >= 0 &&
     text(file.contentType, 128) &&
-    uploadedOk &&
-    modifiedOk &&
+    optionalIsoDate(file.uploaded) &&
+    optionalIsoDate(file.modified) &&
     metadataOk &&
     githubOk
   );
@@ -334,15 +335,12 @@ export function formatBytes(bytes: number): string {
   return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
 }
 
-/** Hide "modified" when missing or effectively the same instant as uploaded (≤60s). */
+/** Same-day writes within this window share one "Uploaded" chip (R2 mtime noise). */
 const SHOW_MODIFIED_MS = 60_000;
 
 /**
- * Whether the share page should surface a separate "modified" date alongside
- * uploaded. False when either timestamp is missing/invalid or they are within
- * 60 seconds of each other on the same UTC day (R2 often stamps both to the
- * same write). True when the UTC calendar day differs even if the delta is
- * small (midnight boundary), or when delta exceeds 60s on the same day.
+ * Show a separate "Modified" date when timestamps differ by calendar day or
+ * by more than 60s on the same UTC day. Midnight crossings always show both.
  */
 export function shouldShowModified(
   uploaded: string | null | undefined,
@@ -352,39 +350,32 @@ export function shouldShowModified(
   const a = Date.parse(uploaded);
   const b = Date.parse(modified);
   if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
-  if (!sameUtcDay(uploaded, modified)) return true;
-  if (Math.abs(b - a) <= SHOW_MODIFIED_MS) return false;
-  return true;
+  return !sameUtcDay(uploaded, modified) || Math.abs(b - a) > SHOW_MODIFIED_MS;
 }
 
 /** Locale-formatted date for the share-page metadata rail; null if unparseable. */
 export function formatFileDate(iso: string, opts?: { withTime?: boolean }): string | null {
   const d = new Date(iso);
   if (!Number.isFinite(d.getTime())) return null;
+  const dateOpts: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  };
   if (opts?.withTime) {
     return d.toLocaleString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
+      ...dateOpts,
       hour: "numeric",
       minute: "2-digit",
     });
   }
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
+  return d.toLocaleDateString("en-US", dateOpts);
 }
 
 /** True when both timestamps fall on the same UTC calendar day. */
 export function sameUtcDay(a: string, b: string): boolean {
-  const da = new Date(a);
-  const db = new Date(b);
-  if (!Number.isFinite(da.getTime()) || !Number.isFinite(db.getTime())) return false;
-  return (
-    da.getUTCFullYear() === db.getUTCFullYear() &&
-    da.getUTCMonth() === db.getUTCMonth() &&
-    da.getUTCDate() === db.getUTCDate()
-  );
+  const da = Date.parse(a);
+  const db = Date.parse(b);
+  if (!Number.isFinite(da) || !Number.isFinite(db)) return false;
+  return new Date(da).toISOString().slice(0, 10) === new Date(db).toISOString().slice(0, 10);
 }

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -44,14 +44,20 @@ const filename = key.split("/").filter(Boolean).pop() ?? key;
 const uploadedIso = file?.uploaded ?? null;
 const modifiedIso = file?.modified ?? null;
 const showModified = shouldShowModified(uploadedIso, modifiedIso);
-const useTime =
-  showModified &&
-  uploadedIso &&
-  modifiedIso &&
-  sameUtcDay(uploadedIso, modifiedIso);
-const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime: !!useTime }) : null;
+const withTime = Boolean(
+  showModified && uploadedIso && modifiedIso && sameUtcDay(uploadedIso, modifiedIso),
+);
+const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime }) : null;
 const modifiedLabel =
-  showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime: !!useTime }) : null;
+  showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime }) : null;
+const gh = file?.github;
+const ghKindLabel = gh?.kind === "pull" ? "Pull request" : gh ? "Issue" : "";
+const ghRef = gh ? `${gh.repo}#${gh.number}` : "";
+const ghAriaLabel = gh
+  ? gh.title
+    ? `${ghKindLabel} ${gh.title} (${ghRef}) on GitHub`
+    : `${ghKindLabel} ${ghRef} on GitHub`
+  : "";
 const canonical = new URL(file ? filePath(workspace, key) : Astro.url.pathname, Astro.url.origin)
   .href;
 // Generic metadata list excludes `gh.*` pairs — those render as the GitHub
@@ -141,20 +147,12 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
         .stage {
           display: grid;
           grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
-          align-items: stretch;
-        }
-        .media {
-          min-height: 320px;
-          max-height: 78vh;
         }
         .details {
           border-top: none;
           border-left: 1px solid var(--line);
           max-height: 78vh;
           overflow: auto;
-          display: flex;
-          flex-direction: column;
-          gap: 0;
         }
       }
       @media (max-width: 760px) {
@@ -179,16 +177,12 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
             </div>
             <figcaption class="details">
               <div class="filename">{filename}</div>
-              {file.github && (
+              {gh && (
                 <a
                   class="gh-chip"
-                  href={file.github.url}
+                  href={gh.url}
                   rel="noopener noreferrer"
-                  aria-label={
-                    file.github.title
-                      ? `${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.title} (${file.github.repo}#${file.github.number}) on GitHub`
-                      : `${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.repo}#${file.github.number} on GitHub`
-                  }
+                  aria-label={ghAriaLabel}
                 >
                   <svg
                     class="gh-chip-icon"
@@ -198,17 +192,17 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
                     aria-hidden="true"
                     focusable="false"
                   >
-                    <title>{file.github.kind === "pull" ? "pull request" : "issue"}</title>
-                    <path fill="currentColor" d={GH_KIND_PATH[file.github.kind]} />
+                    <title>{gh.kind === "pull" ? "pull request" : "issue"}</title>
+                    <path fill="currentColor" d={GH_KIND_PATH[gh.kind]} />
                   </svg>
                   <span class="gh-chip-text">
-                    {file.github.title ? (
+                    {gh.title ? (
                       <>
-                        <span class="gh-chip-title">{file.github.title}</span>
-                        <span class="gh-chip-ref">{file.github.repo}#{file.github.number}</span>
+                        <span class="gh-chip-title">{gh.title}</span>
+                        <span class="gh-chip-ref">{ghRef}</span>
                       </>
                     ) : (
-                      <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+                      <span class="gh-chip-name">{ghRef}</span>
                     )}
                   </span>
                 </a>

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -13,6 +13,9 @@ import {
   fileKind as kind,
   filePath,
   formatBytes,
+  formatFileDate,
+  shouldShowModified,
+  sameUtcDay,
 } from "../../../lib/public-file";
 import { oembedDiscoveryHref } from "../../../lib/oembed";
 import { env } from "cloudflare:workers";
@@ -38,11 +41,17 @@ else if (result.status === "auth_required") Astro.response.status = 401;
 else if (!file) Astro.response.status = 404;
 
 const filename = key.split("/").filter(Boolean).pop() ?? key;
-const uploaded = file?.uploaded ? new Date(file.uploaded) : null;
-const uploadedLabel =
-  uploaded && Number.isFinite(uploaded.getTime())
-    ? uploaded.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })
-    : null;
+const uploadedIso = file?.uploaded ?? null;
+const modifiedIso = file?.modified ?? null;
+const showModified = shouldShowModified(uploadedIso, modifiedIso);
+const useTime =
+  showModified &&
+  uploadedIso &&
+  modifiedIso &&
+  sameUtcDay(uploadedIso, modifiedIso);
+const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime: !!useTime }) : null;
+const modifiedLabel =
+  showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime: !!useTime }) : null;
 const canonical = new URL(file ? filePath(workspace, key) : Astro.url.pathname, Astro.url.origin)
   .href;
 // Generic metadata list excludes `gh.*` pairs — those render as the GitHub
@@ -114,6 +123,9 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       .gh-chip { display:inline-flex; align-items:center; gap:6px; margin:10px 0 0; padding:6px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
       .gh-chip:hover, .gh-chip:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
       .gh-chip-icon { flex:none; }
+      .gh-chip-text { display:flex; flex-direction:column; gap:2px; min-width:0; }
+      .gh-chip-title { overflow-wrap:anywhere; font-weight:600; }
+      .gh-chip-ref { color:var(--muted); font-size:11px; overflow-wrap:anywhere; }
       .gh-chip-name { overflow-wrap:anywhere; }
       .section-label { margin:16px 0 0; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); }
       dl.meta.metadata { margin-top:6px; }
@@ -123,7 +135,32 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       .error .signin:hover, .error .signin:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
       .error .checking { display:block; margin-top:14px; color:var(--muted); font:12px var(--mono); }
       a { color:var(--fg); text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent); text-underline-offset:3px; }
-      @media (max-width:760px) { .shell{width:min(100% - 32px,1080px);padding-top:24px} .media{min-height:220px} }
+      @media (min-width: 1080px) {
+        /* align with signed-in --bp-rail (1080px); media queries can't read custom props */
+        .shell { width: min(1200px, calc(100% - 48px)); }
+        .stage {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+          align-items: stretch;
+        }
+        .media {
+          min-height: 320px;
+          max-height: 78vh;
+        }
+        .details {
+          border-top: none;
+          border-left: 1px solid var(--line);
+          max-height: 78vh;
+          overflow: auto;
+          display: flex;
+          flex-direction: column;
+          gap: 0;
+        }
+      }
+      @media (max-width: 760px) {
+        .shell { width: min(100% - 32px, 1080px); padding-top: 24px; }
+        .media { min-height: 220px; }
+      }
       .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); clip-path:inset(50%); white-space:nowrap; border:0; }
     </style>
   </head>
@@ -147,7 +184,11 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
                   class="gh-chip"
                   href={file.github.url}
                   rel="noopener noreferrer"
-                  aria-label={`${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.repo}#${file.github.number} on GitHub`}
+                  aria-label={
+                    file.github.title
+                      ? `${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.title} (${file.github.repo}#${file.github.number}) on GitHub`
+                      : `${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.repo}#${file.github.number} on GitHub`
+                  }
                 >
                   <svg
                     class="gh-chip-icon"
@@ -160,13 +201,23 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
                     <title>{file.github.kind === "pull" ? "pull request" : "issue"}</title>
                     <path fill="currentColor" d={GH_KIND_PATH[file.github.kind]} />
                   </svg>
-                  <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+                  <span class="gh-chip-text">
+                    {file.github.title ? (
+                      <>
+                        <span class="gh-chip-title">{file.github.title}</span>
+                        <span class="gh-chip-ref">{file.github.repo}#{file.github.number}</span>
+                      </>
+                    ) : (
+                      <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+                    )}
+                  </span>
                 </a>
               )}
               <dl class="meta">
                 <dt>Type</dt><dd>{file.contentType}</dd>
                 <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
-                {uploadedLabel && <><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>}
+                {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
+                {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}
               </dl>
               {metadataEntries.length > 0 && (
                 <>

--- a/docs/superpowers/plans/2026-07-20-file-share-page-title-dates-rail.md
+++ b/docs/superpowers/plans/2026-07-20-file-share-page-title-dates-rail.md
@@ -1,0 +1,846 @@
+# Public file share page — title, dual dates, rail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On `/f/<workspace>/<key>`, show GitHub PR/issue titles (stamp then live resolve), first-upload vs last-modified when they differ, and a large-screen media|meta right rail.
+
+**Architecture:** Stamp server-only Files SDK custom metadata `uploaded-at` on put (preserve on overwrite). Enrich `GET /public/files/:workspace/:key` with `uploaded` / optional `modified` and `github.title` (stamped `gh.title` then `resolveTitles`). Update the Astro public file page validators + chip/meta UI + CSS rail ≥1080px. No client GitHub calls; no gallery-item parity this PR.
+
+**Tech Stack:** Cloudflare Workers, Hono, Files SDK via `@uploads/storage`, Vitest, Astro SSR (`apps/web`).
+
+**Spec:** `docs/superpowers/specs/2026-07-20-file-share-page-title-dates-rail-design.md`
+
+**Worktree:** `.claude/worktrees/file-share-page-rail` on branch `feat/file-share-page-title-dates-rail`
+
+## Global Constraints
+
+- All object I/O through Files SDK (`store.head` / `store.upload({ metadata })`) via `createStorage()` — never `files.raw` for this feature.
+- `uploaded-at` is **server-only** (not client provenance, not D1 `file_metadata`).
+- Live title resolution must **never** fail the public JSON response (catch → stamp/ref fallback).
+- Public page stays noindex / CSP posture unchanged except existing polish script allowance.
+- Do not auto-request CodeRabbit.
+- Prefer `pnpm --filter @uploads/api test` / `pnpm --filter @uploads/web test` (or path-scoped vitest) over full monorepo suite during iteration.
+- Product CLI examples in docs use `uploads …`, not `pnpm uploads …`.
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `apps/api/src/files-core.ts` | Stamp/preserve `uploaded-at` on `putObject`; `existingHead` replaces size-only preflight |
+| `apps/api/src/routes/public-files.ts` | Emit `uploaded`/`modified`/`github.title`; call `resolveTitles` |
+| `apps/web/src/lib/public-file.ts` | DTO types + validation for `modified` and `github.title`; pure date/display helpers |
+| `apps/web/src/lib/public-file.test.ts` | Validator + helper tests |
+| `apps/web/src/pages/f/[workspace]/[...key].astro` | Chip title, dual dates, rail CSS |
+| `apps/api/test/routes-public-files.test.ts` | Integration tests for public JSON |
+| `docs/api.md` | Only if public files response is already documented — note new fields |
+
+---
+
+### Task 1: Stamp and preserve `uploaded-at` on put
+
+**Files:**
+- Modify: `apps/api/src/files-core.ts` (`existingSize` → richer preflight, `putObject` metadata bag)
+- Test: `apps/api/test/routes-public-files.test.ts` (route-level puts + head via FakeR2) **or** add `apps/api/test/files-core-uploaded-at.test.ts` if unit-testing `putObject` is easier with existing fixtures
+
+**Interfaces:**
+- Consumes: Files SDK `StoredFile` from `store.head` (`size`, `lastModified?`, `metadata?`)
+- Produces: object custom metadata always includes `uploaded-at` ISO string after every successful `putObject`
+- Constant: `UPLOADED_AT_META_KEY = "uploaded-at"` (export from `files-core.ts` or a one-line export next to visibility key for tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/api/test/routes-public-files.test.ts` (reuse `makeEnv`, `seedShot`, `FakeR2Bucket`):
+
+```ts
+it("stamps uploaded-at on first put and preserves it across overwrite", async () => {
+  const { env, bucket } = await makeEnv();
+  await seedShot(env);
+
+  const key = "default/screenshots/shot.png"; // FakeR2 stores physical key with workspace prefix
+  // Prefer reading via storage head: list bucket.store keys if prefix differs
+  const stored = [...bucket.store.entries()].find(([k]) => k.endsWith("screenshots/shot.png"));
+  expect(stored).toBeTruthy();
+  const [, first] = stored!;
+  const firstStamp = first.customMetadata?.["uploaded-at"];
+  expect(firstStamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+  // Overwrite
+  await seedShot(env); // same key put again
+  const stored2 = [...bucket.store.entries()].find(([k]) => k.endsWith("screenshots/shot.png"));
+  expect(stored2![1].customMetadata?.["uploaded-at"]).toBe(firstStamp);
+});
+
+it("seeds uploaded-at from prior lastModified when overwriting a legacy object", async () => {
+  const { env, bucket } = await makeEnv();
+  await seedShot(env);
+  const entry = [...bucket.store.entries()].find(([k]) => k.endsWith("screenshots/shot.png"))!;
+  const priorLm = new Date("2026-01-15T10:00:00.000Z");
+  // Strip stamp + backdate mtime to simulate pre-feature object
+  entry[1].customMetadata = { ...(entry[1].customMetadata ?? {}) };
+  delete entry[1].customMetadata!["uploaded-at"];
+  bucket.setUploaded(entry[0], priorLm);
+
+  await seedShot(env);
+  const after = [...bucket.store.entries()].find(([k]) => k.endsWith("screenshots/shot.png"))!;
+  expect(after[1].customMetadata?.["uploaded-at"]).toBe(priorLm.toISOString());
+});
+```
+
+Adjust the physical key lookup to match how `FakeR2Bucket` stores prefixed keys in this suite (inspect one `seedShot` result if needed — workspace `default` uses `prefix: "default/"`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts -t "uploaded-at"`
+
+Expected: FAIL — `uploaded-at` undefined on customMetadata.
+
+- [ ] **Step 3: Implement preflight + stamp in `putObject`**
+
+In `apps/api/src/files-core.ts`:
+
+1. Export the key constant:
+
+```ts
+/** Server-only first-upload stamp (Files SDK object metadata). Not client provenance. */
+export const UPLOADED_AT_META_KEY = "uploaded-at";
+```
+
+2. Replace `existingSize` with a private helper that returns full prior info:
+
+```ts
+async function existingHead(
+  store: Files,
+  key: string,
+): Promise<{ size: number; lastModified?: number; metadata?: Record<string, string> } | null> {
+  try {
+    const meta = await store.head(key);
+    return {
+      size: meta.size ?? 0,
+      lastModified: meta.lastModified,
+      metadata: meta.metadata,
+    };
+  } catch {
+    return null;
+  }
+}
+```
+
+Update `deleteObject` / any other `existingSize` callers in this file to use `existingHead` and read `.size` (or keep a thin `existingSize` wrapper that returns `existingHead(...).then(h => h?.size ?? null)`).
+
+3. Pure resolver (keep next to putObject or as a named export for unit tests):
+
+```ts
+/** Decide uploaded-at for a put. Create → now; overwrite → prior stamp, else prior LM, else now. */
+export function resolveUploadedAtMeta(
+  prior: { lastModified?: number; metadata?: Record<string, string> } | null,
+  now: Date = new Date(),
+): string {
+  if (!prior) return now.toISOString();
+  const stamped = prior.metadata?.[UPLOADED_AT_META_KEY];
+  if (typeof stamped === "string" && Number.isFinite(Date.parse(stamped))) return stamped;
+  if (prior.lastModified != null && Number.isFinite(prior.lastModified)) {
+    return new Date(prior.lastModified).toISOString();
+  }
+  return now.toISOString();
+}
+```
+
+4. In `putObject`, after `const store = await storage(...)`:
+
+```ts
+const prior = await existingHead(store, finalKey);
+const replaced = prior !== null;
+const prevSize = prior?.size ?? null;
+// deltaBytes uses prevSize the same way existingSize did
+const uploadedAt = resolveUploadedAtMeta(prior);
+
+const storageMetadata: Record<string, string> = {
+  ...provenance,
+  ...(storedVisibility ? { [VISIBILITY_META_KEY]: storedVisibility } : {}),
+  [UPLOADED_AT_META_KEY]: uploadedAt,
+};
+```
+
+**Do not** put `uploaded-at` through `sanitizeProvenance` (client allowlist would drop it). Set it only on the final `storageMetadata` bag.
+
+5. `setObjectVisibility` already spreads `current.metadata` — once puts write `uploaded-at`, toggles preserve it with no code change. Still add a regression test in Task 1 or Task 2.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts -t "uploaded-at"`
+
+Expected: PASS.
+
+Also run the full public-files suite once:  
+`pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/files-core.ts apps/api/test/routes-public-files.test.ts
+git commit -m "$(cat <<'EOF'
+feat(api): stamp uploaded-at on put and preserve across overwrite
+
+Server-only Files SDK metadata for first-upload time so public file
+pages can show Uploaded vs Modified after in-place revisions.
+EOF
+)"
+```
+
+---
+
+### Task 2: Public JSON `uploaded` + `modified`
+
+**Files:**
+- Modify: `apps/api/src/routes/public-files.ts`
+- Modify: `apps/api/test/routes-public-files.test.ts`
+
+**Interfaces:**
+- Consumes: `meta.lastModified`, `meta.metadata?.["uploaded-at"]` from `resolvePublicObject`
+- Produces: response fields `uploaded?: string`, `modified?: string` per spec §4–5
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+it("returns uploaded from uploaded-at and omits modified when equal", async () => {
+  const { env } = await makeEnv();
+  await seedShot(env);
+  const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+  const json = (await res.json()) as { uploaded?: string; modified?: string };
+  expect(json.uploaded).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  // Fresh put: lastModified ≈ uploaded-at → modified omitted
+  expect(json.modified).toBeUndefined();
+});
+
+it("includes modified when lastModified differs from uploaded-at", async () => {
+  const { env, bucket } = await makeEnv();
+  await seedShot(env);
+  const entry = [...bucket.store.entries()].find(([k]) => k.endsWith("screenshots/shot.png"))!;
+  // Keep uploaded-at, advance R2 mtime
+  entry[1].customMetadata = {
+    ...entry[1].customMetadata,
+    "uploaded-at": "2026-01-01T00:00:00.000Z",
+  };
+  bucket.setUploaded(entry[0], new Date("2026-06-15T12:00:00.000Z"));
+
+  const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+  const json = (await res.json()) as { uploaded?: string; modified?: string };
+  expect(json.uploaded).toBe("2026-01-01T00:00:00.000Z");
+  expect(json.modified).toBe("2026-06-15T12:00:00.000Z");
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL** (modified never present / uploaded still only lastModified semantics if stamp missing on old code paths)
+
+Run: `pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts -t "uploaded from uploaded-at|includes modified"`
+
+- [ ] **Step 3: Implement date field builder in `public-files.ts`**
+
+```ts
+const UPLOADED_AT_META_KEY = "uploaded-at"; // or import from files-core
+
+/** Same-second tolerance so storage noise does not force dual fields. */
+const DATE_EQUAL_MS = 1000;
+
+function publicDateFields(meta: {
+  lastModified?: number;
+  metadata?: Record<string, string>;
+}): { uploaded?: string; modified?: string } {
+  const modifiedIso =
+    meta.lastModified != null && Number.isFinite(meta.lastModified)
+      ? new Date(meta.lastModified).toISOString()
+      : undefined;
+  const stamped = meta.metadata?.[UPLOADED_AT_META_KEY];
+  const uploadedIso =
+    typeof stamped === "string" && Number.isFinite(Date.parse(stamped))
+      ? new Date(stamped).toISOString()
+      : modifiedIso;
+
+  if (!uploadedIso && !modifiedIso) return {};
+  if (!uploadedIso) return modifiedIso ? { uploaded: modifiedIso } : {};
+  if (!modifiedIso) return { uploaded: uploadedIso };
+
+  const delta = Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso));
+  if (delta < DATE_EQUAL_MS) return { uploaded: uploadedIso };
+  return { uploaded: uploadedIso, modified: modifiedIso };
+}
+```
+
+In the GET handler, replace the single lastModified spread:
+
+```ts
+const dates = publicDateFields(meta);
+return c.json({
+  workspace,
+  key,
+  url: urls.url,
+  embedUrl: urls.embedUrl,
+  size: meta.size ?? 0,
+  contentType: meta.type ?? "application/octet-stream",
+  ...dates,
+  ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  ...(github ? { github } : {}),
+});
+```
+
+Ensure `resolvePublicObject` / `store.head` exposes custom metadata on `meta.metadata` (FakeR2 + files-sdk r2 adapter already map `customMetadata` → `metadata`).
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/public-files.ts apps/api/test/routes-public-files.test.ts
+git commit -m "$(cat <<'EOF'
+feat(api): expose uploaded and modified on public file metadata
+
+Prefer Files SDK uploaded-at for first upload; emit modified only when
+lastModified meaningfully differs so share pages can show revisions.
+EOF
+)"
+```
+
+---
+
+### Task 3: `github.title` on public files (stamp + live resolve)
+
+**Files:**
+- Modify: `apps/api/src/routes/public-files.ts` (`deriveGithubContext`, GET handler)
+- Modify: `apps/api/test/routes-public-files.test.ts`
+- Optionally extend `makeEnv` to include a minimal `GITHUB_CACHE` KV + App vars when testing live resolve
+
+**Interfaces:**
+- Consumes: `resolveTitles(env, refs)` from `apps/api/src/github-titles.ts` → `Record<string, TitleInfo | null>`
+- Produces: `github.title?: string` on the public DTO
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+it("includes github.title from stamped gh.title when live resolve is unavailable", async () => {
+  const { env } = await makeEnv({}, { db: makeFakeDB() });
+  // No GITHUB_CACHE / App → resolveTitles returns nulls
+  await seedShot(env, {
+    "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+    "X-Uploads-Meta-gh.kind": "pull",
+    "X-Uploads-Meta-gh.number": "142",
+    "X-Uploads-Meta-gh.title": "Fix the login bug",
+  });
+  const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+  const json = (await res.json()) as { github?: { title?: string } };
+  expect(json.github?.title).toBe("Fix the login bug");
+});
+
+it("prefers live-resolved title over stamped gh.title", async () => {
+  const kv = new Map<string, string>();
+  const { env } = await makeEnv({}, { db: makeFakeDB() });
+  // Attach GITHUB_CACHE + App config the same way github-titles-route.test.ts does
+  (env as any).GITHUB_CACHE = {
+    get: async (k: string, type?: string) => {
+      const v = kv.get(k);
+      if (v == null) return null;
+      return type === "json" ? JSON.parse(v) : v;
+    },
+    put: async (k: string, v: string) => {
+      kv.set(k, v);
+    },
+  };
+  // Pre-seed cache so no real GitHub network call is needed
+  await (env as any).GITHUB_CACHE.put(
+    "ghref:buildinternet/uploads#142",
+    JSON.stringify({
+      v: { title: "Live title from cache", state: "open", kind: "pull" },
+    }),
+  );
+
+  await seedShot(env, {
+    "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+    "X-Uploads-Meta-gh.kind": "pull",
+    "X-Uploads-Meta-gh.number": "142",
+    "X-Uploads-Meta-gh.title": "Stamped title",
+  });
+
+  const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+  const json = (await res.json()) as { github?: { title?: string } };
+  expect(json.github?.title).toBe("Live title from cache");
+});
+
+it("omits github.title when neither stamp nor live resolve provides one", async () => {
+  const { env } = await makeEnv({}, { db: makeFakeDB() });
+  await seedShot(env, {
+    "X-Uploads-Meta-gh.repo": "buildinternet/uploads",
+    "X-Uploads-Meta-gh.kind": "pull",
+    "X-Uploads-Meta-gh.number": "142",
+  });
+  const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+  const json = (await res.json()) as { github?: { title?: string } };
+  expect(json.github).toBeDefined();
+  expect(json.github).not.toHaveProperty("title");
+});
+```
+
+Mirror KV fixture details from `apps/api/src/routes/github-titles-route.test.ts` / `github-titles.test.ts` if cache key format or App gating differs. `resolveTitles` without App config returns null without caching — stamped path must still work.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+- [ ] **Step 3: Implement**
+
+Extend `GithubContext`:
+
+```ts
+interface GithubContext {
+  repo: string;
+  kind: GithubKind;
+  number: number;
+  url: string;
+  title?: string;
+}
+```
+
+In `deriveGithubContext`, after building base object:
+
+```ts
+const stamped = metadata["gh.title"]?.trim();
+const base = { repo, kind, number, url: `https://github.com/${repo}/${path}/${number}` };
+return stamped ? { ...base, title: stamped } : base;
+```
+
+(If `gh.title` can exceed safe display length, cap at 512 to match META_VALUE_MAX.)
+
+In the GET handler:
+
+```ts
+import { resolveTitles } from "../github-titles";
+
+let github = deriveGithubContext(metadata);
+if (github) {
+  const ref = `${github.repo.toLowerCase()}#${github.number}`;
+  try {
+    const titles = await resolveTitles(c.env, [ref]);
+    const live = titles[ref]?.title?.trim();
+    if (live) github = { ...github, title: live };
+  } catch {
+    // keep stamped / no title
+  }
+  if (!github.title) {
+    const { title: _drop, ...rest } = github;
+    github = rest;
+  }
+}
+```
+
+Note: refs in this codebase are stored lowercased in `gh.ref` / `gh.repo`. Prefer building ref as `${metadata["gh.ref"]}` when present and well-formed, else `${repo.toLowerCase()}#${number}` so cache keys match the rail.
+
+When omitting empty title, strip the key rather than sending `title: undefined` in JSON (Hono/JSON typically drops undefined, but be explicit).
+
+Update existing test that `expect(json.github).toEqual({...})` without title — still valid if title absent.
+
+- [ ] **Step 4: Run full public-files tests — expect PASS**
+
+Run: `pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/public-files.ts apps/api/test/routes-public-files.test.ts
+git commit -m "$(cat <<'EOF'
+feat(api): include GitHub title on public file metadata
+
+Prefer live resolveTitles (KV-cached App ladder) over stamped gh.title
+so share pages can show PR/issue titles without a public batch API.
+EOF
+)"
+```
+
+---
+
+### Task 4: Web DTO validation + pure display helpers
+
+**Files:**
+- Modify: `apps/web/src/lib/public-file.ts`
+- Modify: `apps/web/src/lib/public-file.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `GithubContext.title?: string`
+  - `PublicFile.modified: string | null` (or optional; match `uploaded` nullability style)
+  - `shouldShowModified(uploaded: string | null, modified: string | null): boolean`
+  - `formatFileDate(iso: string, opts?: { withTime?: boolean }): string | null`
+
+- [ ] **Step 1: Write failing tests in `public-file.test.ts`**
+
+```ts
+it("accepts optional modified and github.title", () => {
+  expect(
+    isPublicFile({
+      ...file,
+      modified: "2026-07-14T12:00:00.000Z",
+      github: {
+        repo: "o/r",
+        kind: "pull",
+        number: 1,
+        url: "https://github.com/o/r/pull/1",
+        title: "Fix the thing",
+      },
+    }),
+  ).toBe(true);
+});
+
+it("rejects overlong github.title and bad modified", () => {
+  expect(
+    isPublicFile({
+      ...file,
+      github: {
+        repo: "o/r",
+        kind: "pull",
+        number: 1,
+        url: "https://github.com/o/r/pull/1",
+        title: "x".repeat(513),
+      },
+    }),
+  ).toBe(false);
+  expect(isPublicFile({ ...file, modified: "not-a-date" })).toBe(false);
+});
+
+describe("shouldShowModified", () => {
+  it("is false when modified missing or within 60s", () => {
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", null)).toBe(false);
+    expect(
+      shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:00:30.000Z"),
+    ).toBe(false);
+  });
+  it("is true when day differs or delta > 60s", () => {
+    expect(
+      shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-02T00:00:00.000Z"),
+    ).toBe(true);
+    expect(
+      shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:02:00.000Z"),
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @uploads/web exec vitest run src/lib/public-file.test.ts`
+
+- [ ] **Step 3: Implement types + validators + helpers**
+
+```ts
+export interface GithubContext {
+  repo: string;
+  kind: "pull" | "issue";
+  number: number;
+  url: string;
+  title?: string;
+}
+
+export interface PublicFile {
+  // ...existing fields
+  uploaded: string | null;
+  /** Present when API reports a distinct last-modified time. */
+  modified?: string | null;
+  // ...
+}
+
+function isGithubContext(value: unknown): value is GithubContext {
+  // existing checks...
+  const titleOk =
+    github.title === undefined ||
+    (text(github.title, 512) && (github.title as string).length > 0);
+  return /* existing */ && titleOk;
+}
+
+// in isPublicFile:
+const modifiedOk =
+  file.modified === undefined ||
+  file.modified === null ||
+  (text(file.modified, 64) && Number.isFinite(Date.parse(file.modified as string)));
+```
+
+```ts
+const SHOW_MODIFIED_MS = 60_000;
+
+export function shouldShowModified(
+  uploaded: string | null | undefined,
+  modified: string | null | undefined,
+): boolean {
+  if (!uploaded || !modified) return false;
+  const a = Date.parse(uploaded);
+  const b = Date.parse(modified);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  if (Math.abs(b - a) <= SHOW_MODIFIED_MS) return false;
+  return true;
+}
+
+export function formatFileDate(
+  iso: string,
+  opts?: { withTime?: boolean },
+): string | null {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return null;
+  if (opts?.withTime) {
+    return d.toLocaleString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** True when both timestamps fall on the same UTC calendar day. */
+export function sameUtcDay(a: string, b: string): boolean {
+  const da = new Date(a);
+  const db = new Date(b);
+  if (!Number.isFinite(da.getTime()) || !Number.isFinite(db.getTime())) return false;
+  return (
+    da.getUTCFullYear() === db.getUTCFullYear() &&
+    da.getUTCMonth() === db.getUTCMonth() &&
+    da.getUTCDate() === db.getUTCDate()
+  );
+}
+```
+
+In `fetchPublicFile` ok branch, normalize:
+
+```ts
+file: {
+  ...value,
+  uploaded: value.uploaded ?? null,
+  modified: value.modified ?? null,
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/public-file.ts apps/web/src/lib/public-file.test.ts
+git commit -m "$(cat <<'EOF'
+feat(web): accept public file modified + github.title DTOs
+
+Validate the enriched public-files fields and add pure helpers for
+dual-date display on the share page.
+EOF
+)"
+```
+
+---
+
+### Task 5: Share page UI — chip title, dual dates, large-screen rail
+
+**Files:**
+- Modify: `apps/web/src/pages/f/[workspace]/[...key].astro`
+
+**Interfaces:**
+- Consumes: `file.github.title`, `file.uploaded`, `file.modified`, helpers from Task 4
+
+- [ ] **Step 1: Frontmatter — compute display values**
+
+Near existing `uploaded` / `uploadedLabel` logic:
+
+```ts
+import {
+  // existing imports...
+  formatFileDate,
+  shouldShowModified,
+  sameUtcDay,
+} from "../../../lib/public-file";
+
+const uploadedIso = file?.uploaded ?? null;
+const modifiedIso = file?.modified ?? null;
+const showModified = shouldShowModified(uploadedIso, modifiedIso);
+const useTime =
+  showModified &&
+  uploadedIso &&
+  modifiedIso &&
+  sameUtcDay(uploadedIso, modifiedIso);
+const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime: !!useTime }) : null;
+const modifiedLabel =
+  showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime: !!useTime }) : null;
+```
+
+- [ ] **Step 2: Update GitHub chip markup**
+
+```astro
+{file.github && (
+  <a
+    class="gh-chip"
+    href={file.github.url}
+    rel="noopener noreferrer"
+    aria-label={
+      file.github.title
+        ? `${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.title} (${file.github.repo}#${file.github.number}) on GitHub`
+        : `${file.github.kind === "pull" ? "Pull request" : "Issue"} ${file.github.repo}#${file.github.number} on GitHub`
+    }
+  >
+    <!-- kind svg unchanged -->
+    <span class="gh-chip-text">
+      {file.github.title ? (
+        <>
+          <span class="gh-chip-title">{file.github.title}</span>
+          <span class="gh-chip-ref">{file.github.repo}#{file.github.number}</span>
+        </>
+      ) : (
+        <span class="gh-chip-name">{file.github.repo}#{file.github.number}</span>
+      )}
+    </span>
+  </a>
+)}
+```
+
+CSS additions:
+
+```css
+.gh-chip-text { display:flex; flex-direction:column; gap:2px; min-width:0; }
+.gh-chip-title { overflow-wrap:anywhere; font-weight:600; }
+.gh-chip-ref { color:var(--muted); font-size:11px; overflow-wrap:anywhere; }
+```
+
+- [ ] **Step 3: Dual date rows**
+
+```astro
+<dl class="meta">
+  <dt>Type</dt><dd>{file.contentType}</dd>
+  <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
+  {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
+  {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}
+</dl>
+```
+
+- [ ] **Step 4: Large-screen rail layout**
+
+Update shell + stage styles (keep narrow stack):
+
+```css
+.shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
+/* ...existing... */
+.details { padding:18px 20px 22px; border-top:1px solid var(--line); }
+
+@media (min-width: 1080px) {
+  /* align with signed-in --bp-rail (1080px); media queries can't read custom props */
+  .shell { width: min(1200px, calc(100% - 48px)); }
+  .stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+    align-items: stretch;
+  }
+  .media {
+    min-height: 320px;
+    max-height: 78vh;
+  }
+  .details {
+    border-top: none;
+    border-left: 1px solid var(--line);
+    max-height: 78vh;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+}
+@media (max-width: 760px) {
+  .shell { width: min(100% - 32px, 1080px); padding-top: 24px; }
+  .media { min-height: 220px; }
+}
+```
+
+Ensure `CopyAsControls` still sits at the bottom of `.details` (no markup move required if it's already last in figcaption).
+
+- [ ] **Step 5: Manual / light verification**
+
+Run web unit tests:  
+`pnpm --filter @uploads/web exec vitest run src/lib/public-file.test.ts`
+
+If local dev is available: open a file with `gh.*` metadata and confirm chip + rail at ≥1080px width. No Playwright required.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/f/\[workspace\]/\[...key\].astro
+git commit -m "$(cat <<'EOF'
+feat(web): file share page title, dual dates, and large-screen rail
+
+Show GitHub titles on the chip, Uploaded+Modified when revisions
+differ, and a media|meta layout from 1080px up.
+EOF
+)"
+```
+
+---
+
+### Task 6: Docs touch (only if needed) + final verification
+
+**Files:**
+- Modify (conditional): `docs/api.md` — only if `GET /public/files` response is already documented
+- No changeset required (private workers + web app; no `@buildinternet/uploads` user-facing package change unless you also change CLI)
+
+- [ ] **Step 1: Check docs**
+
+```bash
+rg -n "public/files|uploaded" docs/api.md | head -20
+```
+
+If the public endpoint is documented, add `modified?` and `github.title?` in one short sentence. If not documented, skip.
+
+- [ ] **Step 2: Full relevant test gates**
+
+```bash
+pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts
+pnpm --filter @uploads/web exec vitest run src/lib/public-file.test.ts
+```
+
+Expected: all PASS.
+
+Optional typecheck if you touched Env usage (GITHUB_CACHE already on Env for titles):
+
+```bash
+pnpm --filter @uploads/api typecheck
+pnpm --filter @uploads/web typecheck
+```
+
+- [ ] **Step 3: Commit docs if changed**
+
+```bash
+git add docs/api.md
+git commit -m "docs(api): note public file modified and github.title fields"
+```
+
+- [ ] **Step 4: Stop — ready for PR**
+
+Do not open the PR unless asked. Summarize commits on `feat/file-share-page-title-dates-rail`.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+| --- | --- |
+| `uploaded-at` on create / preserve on overwrite | Task 1 |
+| Legacy overwrite seeds from prior lastModified | Task 1 |
+| Visibility rewrite preserves stamp | Task 1 (automatic via metadata spread) + optional assert |
+| Public `uploaded` / `modified` fields | Task 2 |
+| Omit `modified` when ~equal | Task 2 |
+| `github.title` stamp + live resolve | Task 3 |
+| Resolve failure never 500s | Task 3 |
+| Web DTO validation | Task 4 |
+| Dual-date UI (60s / day rules + time if same day) | Task 4–5 |
+| Chip title + secondary ref | Task 5 |
+| Rail ≥1080px | Task 5 |
+| Files SDK only | Tasks 1–2 |
+| Gallery out of scope | — |
+| No public batch titles API | Task 3 (inline resolve only) |
+
+## Self-review notes
+
+- No TBD/placeholder steps.
+- `UPLOADED_AT_META_KEY` / `resolveUploadedAtMeta` / `publicDateFields` / `shouldShowModified` names are consistent across tasks.
+- `github` equality tests that use `.toEqual` without `title` remain correct when title is omitted.
+- Cache ref casing: Task 3 uses lowercased repo / `gh.ref` when present to match `resolveTitles` keys used by the rail.

--- a/docs/superpowers/plans/2026-07-20-file-share-page-title-dates-rail.md
+++ b/docs/superpowers/plans/2026-07-20-file-share-page-title-dates-rail.md
@@ -24,25 +24,27 @@
 
 ## File map
 
-| File | Responsibility |
-| --- | --- |
-| `apps/api/src/files-core.ts` | Stamp/preserve `uploaded-at` on `putObject`; `existingHead` replaces size-only preflight |
-| `apps/api/src/routes/public-files.ts` | Emit `uploaded`/`modified`/`github.title`; call `resolveTitles` |
-| `apps/web/src/lib/public-file.ts` | DTO types + validation for `modified` and `github.title`; pure date/display helpers |
-| `apps/web/src/lib/public-file.test.ts` | Validator + helper tests |
-| `apps/web/src/pages/f/[workspace]/[...key].astro` | Chip title, dual dates, rail CSS |
-| `apps/api/test/routes-public-files.test.ts` | Integration tests for public JSON |
-| `docs/api.md` | Only if public files response is already documented — note new fields |
+| File                                              | Responsibility                                                                           |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `apps/api/src/files-core.ts`                      | Stamp/preserve `uploaded-at` on `putObject`; `existingHead` replaces size-only preflight |
+| `apps/api/src/routes/public-files.ts`             | Emit `uploaded`/`modified`/`github.title`; call `resolveTitles`                          |
+| `apps/web/src/lib/public-file.ts`                 | DTO types + validation for `modified` and `github.title`; pure date/display helpers      |
+| `apps/web/src/lib/public-file.test.ts`            | Validator + helper tests                                                                 |
+| `apps/web/src/pages/f/[workspace]/[...key].astro` | Chip title, dual dates, rail CSS                                                         |
+| `apps/api/test/routes-public-files.test.ts`       | Integration tests for public JSON                                                        |
+| `docs/api.md`                                     | Only if public files response is already documented — note new fields                    |
 
 ---
 
 ### Task 1: Stamp and preserve `uploaded-at` on put
 
 **Files:**
+
 - Modify: `apps/api/src/files-core.ts` (`existingSize` → richer preflight, `putObject` metadata bag)
 - Test: `apps/api/test/routes-public-files.test.ts` (route-level puts + head via FakeR2) **or** add `apps/api/test/files-core-uploaded-at.test.ts` if unit-testing `putObject` is easier with existing fixtures
 
 **Interfaces:**
+
 - Consumes: Files SDK `StoredFile` from `store.head` (`size`, `lastModified?`, `metadata?`)
 - Produces: object custom metadata always includes `uploaded-at` ISO string after every successful `putObject`
 - Constant: `UPLOADED_AT_META_KEY = "uploaded-at"` (export from `files-core.ts` or a one-line export next to visibility key for tests)
@@ -192,10 +194,12 @@ EOF
 ### Task 2: Public JSON `uploaded` + `modified`
 
 **Files:**
+
 - Modify: `apps/api/src/routes/public-files.ts`
 - Modify: `apps/api/test/routes-public-files.test.ts`
 
 **Interfaces:**
+
 - Consumes: `meta.lastModified`, `meta.metadata?.["uploaded-at"]` from `resolvePublicObject`
 - Produces: response fields `uploaded?: string`, `modified?: string` per spec §4–5
 
@@ -242,10 +246,10 @@ const UPLOADED_AT_META_KEY = "uploaded-at"; // or import from files-core
 /** Same-second tolerance so storage noise does not force dual fields. */
 const DATE_EQUAL_MS = 1000;
 
-function publicDateFields(meta: {
-  lastModified?: number;
-  metadata?: Record<string, string>;
-}): { uploaded?: string; modified?: string } {
+function publicDateFields(meta: { lastModified?: number; metadata?: Record<string, string> }): {
+  uploaded?: string;
+  modified?: string;
+} {
   const modifiedIso =
     meta.lastModified != null && Number.isFinite(meta.lastModified)
       ? new Date(meta.lastModified).toISOString()
@@ -305,11 +309,13 @@ EOF
 ### Task 3: `github.title` on public files (stamp + live resolve)
 
 **Files:**
+
 - Modify: `apps/api/src/routes/public-files.ts` (`deriveGithubContext`, GET handler)
 - Modify: `apps/api/test/routes-public-files.test.ts`
 - Optionally extend `makeEnv` to include a minimal `GITHUB_CACHE` KV + App vars when testing live resolve
 
 **Interfaces:**
+
 - Consumes: `resolveTitles(env, refs)` from `apps/api/src/github-titles.ts` → `Record<string, TitleInfo | null>`
 - Produces: `github.title?: string` on the public DTO
 
@@ -456,10 +462,12 @@ EOF
 ### Task 4: Web DTO validation + pure display helpers
 
 **Files:**
+
 - Modify: `apps/web/src/lib/public-file.ts`
 - Modify: `apps/web/src/lib/public-file.test.ts`
 
 **Interfaces:**
+
 - Produces:
   - `GithubContext.title?: string`
   - `PublicFile.modified: string | null` (or optional; match `uploaded` nullability style)
@@ -504,17 +512,11 @@ it("rejects overlong github.title and bad modified", () => {
 describe("shouldShowModified", () => {
   it("is false when modified missing or within 60s", () => {
     expect(shouldShowModified("2026-07-01T00:00:00.000Z", null)).toBe(false);
-    expect(
-      shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:00:30.000Z"),
-    ).toBe(false);
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:00:30.000Z")).toBe(false);
   });
   it("is true when day differs or delta > 60s", () => {
-    expect(
-      shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-02T00:00:00.000Z"),
-    ).toBe(true);
-    expect(
-      shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:02:00.000Z"),
-    ).toBe(true);
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-02T00:00:00.000Z")).toBe(true);
+    expect(shouldShowModified("2026-07-01T00:00:00.000Z", "2026-07-01T00:02:00.000Z")).toBe(true);
   });
 });
 ```
@@ -572,10 +574,7 @@ export function shouldShowModified(
   return true;
 }
 
-export function formatFileDate(
-  iso: string,
-  opts?: { withTime?: boolean },
-): string | null {
+export function formatFileDate(iso: string, opts?: { withTime?: boolean }): string | null {
   const d = new Date(iso);
   if (!Number.isFinite(d.getTime())) return null;
   if (opts?.withTime) {
@@ -637,9 +636,11 @@ EOF
 ### Task 5: Share page UI — chip title, dual dates, large-screen rail
 
 **Files:**
+
 - Modify: `apps/web/src/pages/f/[workspace]/[...key].astro`
 
 **Interfaces:**
+
 - Consumes: `file.github.title`, `file.uploaded`, `file.modified`, helpers from Task 4
 
 - [ ] **Step 1: Frontmatter — compute display values**
@@ -657,11 +658,7 @@ import {
 const uploadedIso = file?.uploaded ?? null;
 const modifiedIso = file?.modified ?? null;
 const showModified = shouldShowModified(uploadedIso, modifiedIso);
-const useTime =
-  showModified &&
-  uploadedIso &&
-  modifiedIso &&
-  sameUtcDay(uploadedIso, modifiedIso);
+const useTime = showModified && uploadedIso && modifiedIso && sameUtcDay(uploadedIso, modifiedIso);
 const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime: !!useTime }) : null;
 const modifiedLabel =
   showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime: !!useTime }) : null;
@@ -699,9 +696,21 @@ const modifiedLabel =
 CSS additions:
 
 ```css
-.gh-chip-text { display:flex; flex-direction:column; gap:2px; min-width:0; }
-.gh-chip-title { overflow-wrap:anywhere; font-weight:600; }
-.gh-chip-ref { color:var(--muted); font-size:11px; overflow-wrap:anywhere; }
+.gh-chip-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.gh-chip-title {
+  overflow-wrap: anywhere;
+  font-weight: 600;
+}
+.gh-chip-ref {
+  color: var(--muted);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
 ```
 
 - [ ] **Step 3: Dual date rows**
@@ -720,13 +729,22 @@ CSS additions:
 Update shell + stage styles (keep narrow stack):
 
 ```css
-.shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
+.shell {
+  width: min(var(--width-viewer, 1080px), calc(100% - 48px));
+  margin: auto;
+  padding: 36px 0 64px;
+}
 /* ...existing... */
-.details { padding:18px 20px 22px; border-top:1px solid var(--line); }
+.details {
+  padding: 18px 20px 22px;
+  border-top: 1px solid var(--line);
+}
 
 @media (min-width: 1080px) {
   /* align with signed-in --bp-rail (1080px); media queries can't read custom props */
-  .shell { width: min(1200px, calc(100% - 48px)); }
+  .shell {
+    width: min(1200px, calc(100% - 48px));
+  }
   .stage {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
@@ -747,8 +765,13 @@ Update shell + stage styles (keep narrow stack):
   }
 }
 @media (max-width: 760px) {
-  .shell { width: min(100% - 32px, 1080px); padding-top: 24px; }
-  .media { min-height: 220px; }
+  .shell {
+    width: min(100% - 32px, 1080px);
+    padding-top: 24px;
+  }
+  .media {
+    min-height: 220px;
+  }
 }
 ```
 
@@ -779,6 +802,7 @@ EOF
 ### Task 6: Docs touch (only if needed) + final verification
 
 **Files:**
+
 - Modify (conditional): `docs/api.md` — only if `GET /public/files` response is already documented
 - No changeset required (private workers + web app; no `@buildinternet/uploads` user-facing package change unless you also change CLI)
 
@@ -821,22 +845,22 @@ Do not open the PR unless asked. Summarize commits on `feat/file-share-page-titl
 
 ## Spec coverage checklist
 
-| Spec requirement | Task |
-| --- | --- |
-| `uploaded-at` on create / preserve on overwrite | Task 1 |
-| Legacy overwrite seeds from prior lastModified | Task 1 |
-| Visibility rewrite preserves stamp | Task 1 (automatic via metadata spread) + optional assert |
-| Public `uploaded` / `modified` fields | Task 2 |
-| Omit `modified` when ~equal | Task 2 |
-| `github.title` stamp + live resolve | Task 3 |
-| Resolve failure never 500s | Task 3 |
-| Web DTO validation | Task 4 |
-| Dual-date UI (60s / day rules + time if same day) | Task 4–5 |
-| Chip title + secondary ref | Task 5 |
-| Rail ≥1080px | Task 5 |
-| Files SDK only | Tasks 1–2 |
-| Gallery out of scope | — |
-| No public batch titles API | Task 3 (inline resolve only) |
+| Spec requirement                                  | Task                                                     |
+| ------------------------------------------------- | -------------------------------------------------------- |
+| `uploaded-at` on create / preserve on overwrite   | Task 1                                                   |
+| Legacy overwrite seeds from prior lastModified    | Task 1                                                   |
+| Visibility rewrite preserves stamp                | Task 1 (automatic via metadata spread) + optional assert |
+| Public `uploaded` / `modified` fields             | Task 2                                                   |
+| Omit `modified` when ~equal                       | Task 2                                                   |
+| `github.title` stamp + live resolve               | Task 3                                                   |
+| Resolve failure never 500s                        | Task 3                                                   |
+| Web DTO validation                                | Task 4                                                   |
+| Dual-date UI (60s / day rules + time if same day) | Task 4–5                                                 |
+| Chip title + secondary ref                        | Task 5                                                   |
+| Rail ≥1080px                                      | Task 5                                                   |
+| Files SDK only                                    | Tasks 1–2                                                |
+| Gallery out of scope                              | —                                                        |
+| No public batch titles API                        | Task 3 (inline resolve only)                             |
 
 ## Self-review notes
 

--- a/docs/superpowers/specs/2026-07-20-file-share-page-title-dates-rail-design.md
+++ b/docs/superpowers/specs/2026-07-20-file-share-page-title-dates-rail-design.md
@@ -34,12 +34,12 @@ The public file share page (`/f/<workspace>/<key>`) is the durable link people p
 
 **Enrich the public-file API + page layout**, using the existing Files SDK surface through `@uploads/storage` / `createStorage()` — not raw R2 bindings.
 
-| Concern | Where | Mechanism |
-| --- | --- | --- |
+| Concern            | Where                              | Mechanism                                                                                              |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | First-upload stamp | `putObject` (+ visibility rewrite) | Files SDK `upload({ metadata })` key `uploaded-at`; preserve from prior `head().metadata` on overwrite |
-| Modified time | public-files route | Files SDK `head().lastModified` (already used, today labeled `uploaded`) |
-| Title | public-files route | `gh.title` from D1 file_metadata → overlay `resolveTitles` (App + `GITHUB_CACHE`) |
-| Layout | file page Astro + CSS | media \| rail grid ≥ ~1080px; stack below |
+| Modified time      | public-files route                 | Files SDK `head().lastModified` (already used, today labeled `uploaded`)                               |
+| Title              | public-files route                 | `gh.title` from D1 file_metadata → overlay `resolveTitles` (App + `GITHUB_CACHE`)                      |
+| Layout             | file page Astro + CSS              | media \| rail grid ≥ ~1080px; stack below                                                              |
 
 ## 4. Data model
 
@@ -98,11 +98,11 @@ Extend the existing response (no breaking renames of required fields beyond clar
 
 On the share page `dl.meta`:
 
-| Condition | UI |
-| --- | --- |
-| only `uploaded` | `Uploaded` → formatted date (unchanged label) |
-| `uploaded` + `modified` and they differ by calendar day **or** by more than 60 seconds | show both rows: `Uploaded`, `Modified` |
-| both present but within 60s / same instant | show only `Uploaded` |
+| Condition                                                                              | UI                                            |
+| -------------------------------------------------------------------------------------- | --------------------------------------------- |
+| only `uploaded`                                                                        | `Uploaded` → formatted date (unchanged label) |
+| `uploaded` + `modified` and they differ by calendar day **or** by more than 60 seconds | show both rows: `Uploaded`, `Modified`        |
+| both present but within 60s / same instant                                             | show only `Uploaded`                          |
 
 Formatting stays `toLocaleDateString("en-US", { year, month: "short", day: "numeric" })` unless both are same calendar day but still differ by >60s — then include time on both rows so the distinction is readable (optional polish; default can keep date-only if product prefers less noise).
 
@@ -158,11 +158,11 @@ No React island; plain Astro + inline styles as today. Footer remains below the 
 
 All object I/O continues through `createStorage()` → Files `Files` instance:
 
-| Operation | SDK | Notes |
-| --- | --- | --- |
-| Pre-put existence / prior mtime / prior metadata | `store.head(key)` or existing `existingSize` + head | Use `lastModified` + `metadata` from `StoredFile` |
-| Write with stamp | `store.upload(key, bytes, { contentType, cacheControl, metadata })` | Merge provenance + visibility + `uploaded-at` |
-| Public read meta | `store.head(key)` already in `resolvePublicObject` | Map fields in JSON builder |
+| Operation                                        | SDK                                                                 | Notes                                             |
+| ------------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------- |
+| Pre-put existence / prior mtime / prior metadata | `store.head(key)` or existing `existingSize` + head                 | Use `lastModified` + `metadata` from `StoredFile` |
+| Write with stamp                                 | `store.upload(key, bytes, { contentType, cacheControl, metadata })` | Merge provenance + visibility + `uploaded-at`     |
+| Public read meta                                 | `store.head(key)` already in `resolvePublicObject`                  | Map fields in JSON builder                        |
 
 Do **not** call R2 `customMetadata` APIs via `files.raw` for this feature. If a future adapter lacks metadata round-trip, dual dates degrade to lastModified-only (single field) without breaking uploads.
 
@@ -217,7 +217,9 @@ CSS (wide):
 
 ```css
 @media (min-width: 1080px) {
-  .shell { width: min(1200px, calc(100% - 48px)); }
+  .shell {
+    width: min(1200px, calc(100% - 48px));
+  }
   .stage {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
@@ -229,18 +231,20 @@ CSS (wide):
     max-height: 78vh;
     overflow: auto;
   }
-  .media { max-height: 78vh; }
+  .media {
+    max-height: 78vh;
+  }
 }
 ```
 
 ## 11. Error handling
 
-| Failure | Behavior |
-| --- | --- |
-| `resolveTitles` slow/fail | omit live title; keep stamp or ref-only chip |
-| Invalid / missing `uploaded-at` | `uploaded` falls back to `lastModified` |
-| Adapter without metadata | single date field; puts still succeed |
-| Private file | unchanged `auth_required` branch; no title resolve after 401 |
+| Failure                         | Behavior                                                     |
+| ------------------------------- | ------------------------------------------------------------ |
+| `resolveTitles` slow/fail       | omit live title; keep stamp or ref-only chip                 |
+| Invalid / missing `uploaded-at` | `uploaded` falls back to `lastModified`                      |
+| Adapter without metadata        | single date field; puts still succeed                        |
+| Private file                    | unchanged `auth_required` branch; no title resolve after 401 |
 
 Public CSP / noindex / no-store headers unchanged from the file-page polish posture.
 
@@ -275,11 +279,11 @@ Public CSP / noindex / no-store headers unchanged from the file-page polish post
 
 ## 15. Decisions log
 
-| # | Decision | Choice |
-| --- | --- | --- |
-| Title source | Stamped + live resolve (like rail) | approved |
+| #                    | Decision                                                | Choice   |
+| -------------------- | ------------------------------------------------------- | -------- |
+| Title source         | Stamped + live resolve (like rail)                      | approved |
 | First-upload storage | Files SDK metadata `uploaded-at`, preserve on overwrite | approved |
-| Layout | Media left, meta+actions right ≥1080px | approved |
-| Architecture | Enrich public-file API + page layout | approved |
-| Gallery parity | Out of scope this PR | approved |
-| Dual-date display | Both when day differs or \|Δ\| > 60s | approved |
+| Layout               | Media left, meta+actions right ≥1080px                  | approved |
+| Architecture         | Enrich public-file API + page layout                    | approved |
+| Gallery parity       | Out of scope this PR                                    | approved |
+| Dual-date display    | Both when day differs or \|Δ\| > 60s                    | approved |

--- a/docs/superpowers/specs/2026-07-20-file-share-page-title-dates-rail-design.md
+++ b/docs/superpowers/specs/2026-07-20-file-share-page-title-dates-rail-design.md
@@ -1,0 +1,285 @@
+# Public file share page — title, dual dates, large-screen rail
+
+**Date:** 2026-07-20  
+**Branch / worktree:** `feat/file-share-page-title-dates-rail`  
+**Scope:** public file page `apps/web/src/pages/f/[workspace]/[...key].astro` (ok / file-found branch), the public JSON it consumes (`GET /public/files/:workspace/:key`), and the put/visibility write paths that must stamp and preserve first-upload time.  
+**Status:** design approved (2026-07-20).
+
+## 1. Problem
+
+The public file share page (`/f/<workspace>/<key>`) is the durable link people paste for a single upload. Three gaps relative to recent product work:
+
+1. **GitHub title.** CLI attach paths now stamp `gh.title`, and the signed-in connected-work rail also live-resolves titles via the GitHub App + KV cache (#267 / #270 / #282). The share page still shows only `owner/repo#N` on the chip.
+2. **Revision dates.** Overwriting the same key is a first-class workflow (stable URL hot-swap). The page exposes a single “Uploaded” field that is really object `lastModified`, so a revision erases the original upload time in the UI.
+3. **Large-screen layout.** Metadata and download/copy controls sit under the media stage in a full-width caption. On wide viewports that wastes horizontal space and pushes actions below the fold.
+
+## 2. Goals & non-goals
+
+**Goals**
+
+- Show the PR/issue **title** on the share-page GitHub chip, matching the rail’s stamp-then-live-resolve preference order.
+- Track **first upload** vs **last modified** through Files SDK object metadata so revisions can show both when they differ.
+- On large screens, place metadata + download/copy controls in a **right rail** beside the media; keep today’s stacked layout on narrow screens.
+- Keep the public page script-light on the happy path (no client GitHub fetches); enrichment stays server-side.
+
+**Non-goals**
+
+- Gallery item page (`/g/:id/:item`) layout/title/date parity (follow-up unless free).
+- A new public batch `github-titles` endpoint (resolution is only for this single-object public route).
+- Client-side live unfurl or open/closed/merged state badges.
+- Backfilling `uploaded-at` for objects never re-put after this ships.
+- Auto-requesting CodeRabbit on the PR.
+
+## 3. Approach (approved)
+
+**Enrich the public-file API + page layout**, using the existing Files SDK surface through `@uploads/storage` / `createStorage()` — not raw R2 bindings.
+
+| Concern | Where | Mechanism |
+| --- | --- | --- |
+| First-upload stamp | `putObject` (+ visibility rewrite) | Files SDK `upload({ metadata })` key `uploaded-at`; preserve from prior `head().metadata` on overwrite |
+| Modified time | public-files route | Files SDK `head().lastModified` (already used, today labeled `uploaded`) |
+| Title | public-files route | `gh.title` from D1 file_metadata → overlay `resolveTitles` (App + `GITHUB_CACHE`) |
+| Layout | file page Astro + CSS | media \| rail grid ≥ ~1080px; stack below |
+
+## 4. Data model
+
+### 4.1 `uploaded-at` (R2 / Files SDK custom metadata)
+
+- **Key:** `uploaded-at` (lowercase, hyphenated — same style as provenance keys in `provenance.ts`).
+- **Value:** ISO-8601 UTC string (printable ASCII, short enough for provenance-style caps; treat as server-only).
+- **Write rules:**
+  - **Create** (`putObject` when key did not exist): set `uploaded-at` to now (request time is fine; need not match provider mtime exactly).
+  - **Overwrite** (key existed): `head` first (already done for size/ledger), copy prior `uploaded-at` if present and valid; if missing (legacy object), set `uploaded-at` to the prior object’s `lastModified` when available, else now. Never accept `uploaded-at` from client headers / provenance allowlist.
+  - **Visibility rewrite** (`toggleVisibility` / equivalent full rewrite): must carry `uploaded-at` forward with the rest of preserved metadata so a private/public flip does not reset first-upload time.
+- **Not** stored in D1 `file_metadata` (queryable tags stay for `gh.*` and user tags). First-upload is object provenance, co-located with the bytes.
+
+### 4.2 Public JSON DTO (`GET /public/files/:workspace/:key`)
+
+Extend the existing response (no breaking renames of required fields beyond clarifying semantics):
+
+```ts
+{
+  workspace: string;
+  key: string;
+  url: string;
+  embedUrl: string | null;
+  size: number;
+  contentType: string;
+  /** First-upload time when known; else falls back to lastModified (legacy). ISO. */
+  uploaded?: string;
+  /**
+   * Object last-modified from Files SDK head(). Included when present and
+   * meaningfully different from `uploaded` (see §5). Omitted when equal /
+   * missing so old clients keep a single-field mental model.
+   */
+  modified?: string;
+  metadata?: Record<string, string>;
+  github?: {
+    repo: string;
+    kind: "pull" | "issue";
+    number: number;
+    url: string;
+    /** Prefer live resolve; fall back to stamped gh.title. Omitted when neither. */
+    title?: string;
+  };
+}
+```
+
+**Field derivation**
+
+- `modified` = ISO from `meta.lastModified` when defined.
+- `uploaded` = ISO from object metadata `uploaded-at` when valid; else same as today’s fallback (`lastModified`).
+- `modified` **omitted from JSON** when absent, or when equal to `uploaded` within a small tolerance (same second is enough for storage noise) so single-date objects stay one field.
+- `github.title` = live `resolveTitles` title if non-null; else stamped `metadata["gh.title"]` if non-empty; else omit.
+
+`apps/web` `PublicFile` / `GithubContext` validators in `public-file.ts` gain optional `modified` and `github.title` with the same bounded-string rules as other fields.
+
+## 5. Dates UI rules
+
+On the share page `dl.meta`:
+
+| Condition | UI |
+| --- | --- |
+| only `uploaded` | `Uploaded` → formatted date (unchanged label) |
+| `uploaded` + `modified` and they differ by calendar day **or** by more than 60 seconds | show both rows: `Uploaded`, `Modified` |
+| both present but within 60s / same instant | show only `Uploaded` |
+
+Formatting stays `toLocaleDateString("en-US", { year, month: "short", day: "numeric" })` unless both are same calendar day but still differ by >60s — then include time on both rows so the distinction is readable (optional polish; default can keep date-only if product prefers less noise).
+
+**Recommended default:** date-only labels; if same calendar day but dual-date condition trips on the 60s rule, append short time (`hour`/`minute`) to both.
+
+## 6. GitHub title (public path)
+
+### 6.1 Server
+
+In `apps/api/src/routes/public-files.ts` after visibility gate + `getFileMetadata`:
+
+1. `deriveGithubContext(metadata)` — extend to pass through optional `title` from `gh.title` when it passes the same printable/length checks used elsewhere (≤512).
+2. If a github context exists, build `ref` = `${repo}#${number}` (lowercase repo already stored) and call `resolveTitles(env, [ref])` once.
+3. If the map entry has a non-empty `title`, set `github.title` to that (live wins over stamp).
+4. Any resolve failure / timeout / missing App config → keep stamped title or omit; **never** fail the public JSON response.
+
+Reuse `resolveTitles` from `apps/api/src/github-titles.ts` as-is (8s abort, KV cache, App token ladder). Do not open a new unauthenticated public titles API.
+
+### 6.2 Chip UI
+
+Replace chip text so that when `file.github.title` is present:
+
+```
+[kind icon]  {title}
+             {repo}#{number}   ← muted secondary line or same-row secondary
+```
+
+When title is absent: keep today’s `repo#number` single line.
+
+`aria-label`: include kind, title (if any), and `repo#number`.
+
+No client script for titles.
+
+## 7. Large-screen layout
+
+**Breakpoint:** ~1080px (align with documented `--bp-rail` in `signed-in-shell.css`; file page uses a local media query with that pixel value + comment referencing the scale — media queries cannot read custom properties).
+
+**Wide (≥1080px)**
+
+- `.stage` → CSS grid: `1fr` media column + fixed rail (~300px, clamp 280–320px).
+- `.media` stays visual focus (`min-height`, `max-height: 78vh`, contain).
+- `.details` becomes the right rail: filename, gh-chip, meta dl, optional Metadata section, `CopyAsControls` (+ Open original).
+- Rail may scroll if content exceeds media height (`overflow: auto; max-height: ~78vh` or match media column).
+- Shell width: widen slightly so media is not crushed, e.g. `min(var(--width-viewer, 1200px), calc(100% - 48px))` on this page only (or bump viewer token if already shared with gallery — prefer page-local override if gallery stays stacked).
+
+**Narrow (&lt;1080px)**
+
+- Keep current single-column stack: media full width, details under media (matches screenshot baseline).
+
+No React island; plain Astro + inline styles as today. Footer remains below the stage.
+
+## 8. Files SDK usage (explicit)
+
+All object I/O continues through `createStorage()` → Files `Files` instance:
+
+| Operation | SDK | Notes |
+| --- | --- | --- |
+| Pre-put existence / prior mtime / prior metadata | `store.head(key)` or existing `existingSize` + head | Use `lastModified` + `metadata` from `StoredFile` |
+| Write with stamp | `store.upload(key, bytes, { contentType, cacheControl, metadata })` | Merge provenance + visibility + `uploaded-at` |
+| Public read meta | `store.head(key)` already in `resolvePublicObject` | Map fields in JSON builder |
+
+Do **not** call R2 `customMetadata` APIs via `files.raw` for this feature. If a future adapter lacks metadata round-trip, dual dates degrade to lastModified-only (single field) without breaking uploads.
+
+## 9. Write-path changes (API)
+
+### 9.1 `putObject` (`files-core.ts`)
+
+Today: pre-put `existingSize` only. Extend to capture prior `lastModified` + `metadata["uploaded-at"]` when the object exists (one head is enough — reuse if `existingSize` already heads).
+
+```ts
+// pseudocode
+const prior = await store.head(finalKey).catch(() => null);
+const replaced = prior != null;
+const uploadedAt =
+  prior?.metadata?.["uploaded-at"] && isValidIso(prior.metadata["uploaded-at"])
+    ? prior.metadata["uploaded-at"]
+    : prior?.lastModified != null
+      ? new Date(prior.lastModified).toISOString()
+      : new Date().toISOString();
+// first create: always now
+const uploadedAtFinal = replaced ? uploadedAt : new Date().toISOString();
+
+storageMetadata = {
+  ...provenance,
+  ...(visibility ? { visibility } : {}),
+  "uploaded-at": uploadedAtFinal,
+};
+```
+
+Ensure `uploaded-at` is **not** stripped by `sanitizeProvenance` (it is not a client provenance key — set only in the server `storageMetadata` bag after sanitize).
+
+### 9.2 Visibility rewrite
+
+When rewriting object metadata for visibility, merge existing `uploaded-at` from the pre-rewrite head into the new metadata map.
+
+## 10. Web page structure (sketch)
+
+```html
+<figure class="stage">
+  <div class="media">…</div>
+  <figcaption class="details">
+    <div class="filename">…</div>
+    <!-- gh-chip with title + optional secondary ref -->
+    <dl class="meta">Type / Size / Uploaded [/ Modified]</dl>
+    <!-- optional Metadata section -->
+    <CopyAsControls>…</CopyAsControls>
+  </figcaption>
+</figure>
+```
+
+CSS (wide):
+
+```css
+@media (min-width: 1080px) {
+  .shell { width: min(1200px, calc(100% - 48px)); }
+  .stage {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+    align-items: stretch;
+  }
+  .details {
+    border-top: none;
+    border-left: 1px solid var(--line);
+    max-height: 78vh;
+    overflow: auto;
+  }
+  .media { max-height: 78vh; }
+}
+```
+
+## 11. Error handling
+
+| Failure | Behavior |
+| --- | --- |
+| `resolveTitles` slow/fail | omit live title; keep stamp or ref-only chip |
+| Invalid / missing `uploaded-at` | `uploaded` falls back to `lastModified` |
+| Adapter without metadata | single date field; puts still succeed |
+| Private file | unchanged `auth_required` branch; no title resolve after 401 |
+
+Public CSP / noindex / no-store headers unchanged from the file-page polish posture.
+
+## 12. Testing
+
+**API**
+
+- `putObject` first put sets `uploaded-at`.
+- Overwrite preserves prior `uploaded-at` (and does not advance it).
+- Legacy overwrite (no prior stamp): seeds `uploaded-at` from prior `lastModified`.
+- Visibility rewrite preserves `uploaded-at`.
+- Public files JSON: `uploaded` / `modified` / `github.title` shape; `modified` omitted when equal; title prefers mocked live resolve over stamp; resolve throw does not 500.
+
+**Web**
+
+- `public-file.ts` accepts optional `modified` + `github.title`; rejects oversized/control chars.
+- Pure helpers if extracted (e.g. `shouldShowModified(uploaded, modified)`, chip label) unit-tested.
+- Optional light markup test only if already patterned in repo; otherwise manual / Playwright not required for this PR.
+
+## 13. Implementation order (for the plan)
+
+1. Stamp/preserve `uploaded-at` in `putObject` + visibility rewrite + tests.
+2. Public-files DTO: `uploaded` / `modified` + `github.title` (stamp + `resolveTitles`) + tests.
+3. Web DTO validation + page: chip title, dual dates, rail layout + tests.
+4. Docs touch if `docs/api.md` documents the public files response (only if already listed).
+
+## 14. Open follow-ups (explicitly deferred)
+
+- Gallery item page same rail + title + dates.
+- Optional one-shot backfill job for `uploaded-at` on popular keys (not required).
+- Showing full timestamp tooltips on hover for power users.
+
+## 15. Decisions log
+
+| # | Decision | Choice |
+| --- | --- | --- |
+| Title source | Stamped + live resolve (like rail) | approved |
+| First-upload storage | Files SDK metadata `uploaded-at`, preserve on overwrite | approved |
+| Layout | Media left, meta+actions right ≥1080px | approved |
+| Architecture | Enrich public-file API + page layout | approved |
+| Gallery parity | Out of scope this PR | approved |
+| Dual-date display | Both when day differs or \|Δ\| > 60s | approved |


### PR DESCRIPTION
## In plain terms

Public file share pages (`/f/…`) now show the real GitHub PR/issue title when we know it, call out both first-upload and last-modified times after in-place revisions, and put metadata + download/copy controls in a right rail on wide screens instead of burying them under the preview.

## What it does

- Stamps server-only Files SDK metadata `uploaded-at` on put; preserves it across overwrite (and visibility rewrite via existing metadata spread)
- Public `GET /public/files` returns `uploaded` (prefer stamp), optional `modified` when mtime meaningfully differs, and `github.title` (stamped `gh.title`, then live resolve with a **1.4s budget** so share-page loads stay under the web 4s abort)
- Share page chip: title + secondary `owner/repo#N` when present
- Dual date rows when day differs or Δ > 60s (with time-of-day when same UTC day)
- ≥1080px layout: media left, meta/actions rail right (~280–320px); stack below that width

## What it is not

- No gallery-item page parity (follow-up)
- No public batch titles API — resolution is single-object, server-side only
- No backfill of `uploaded-at` for objects never re-put after this ships
- No CodeRabbit auto-request

## How to try it

1. Upload or attach with GitHub context so `gh.*` (and ideally `gh.title`) is set.
2. Open `https://uploads.sh/f/<workspace>/<key>` (or local web + API).
3. Confirm chip title, Uploaded/Modified when you overwrite the same key after a delay, and the side rail at ≥1080px width.

```bash
uploads put ./shot.png --pr 123
# open the returned page URL
```

## Technical notes

- Design: `docs/superpowers/specs/2026-07-20-file-share-page-title-dates-rail-design.md`
- Plan: `docs/superpowers/plans/2026-07-20-file-share-page-title-dates-rail.md`
- `resolveTitles` on the public path is budgeted; member-rail `/me` path unchanged
- Simplification pass after implementation (net cleaner control flow, shared validators)

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run test/routes-public-files.test.ts test/files-core-uploaded-at.test.ts` (34)
- [x] `pnpm --filter @uploads/web exec vitest run src/lib/public-file.test.ts` (26)
- [ ] Manual: titled chip + dual dates after overwrite + rail at wide viewport