### PR TITLE
feat(api,cli): bot-owned GitHub attachments comment (phase 2 PR B)

### DIFF
--- a/.changeset/github-bot-comment.md
+++ b/.changeset/github-bot-comment.md
@@ -1,0 +1,8 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Managed attachments comment can now be posted by the uploads.sh GitHub App as
+`uploads-sh[bot]` when the App is installed on the target repo, so `--comment` /
+`uploads comment` no longer require a locally authenticated `gh`. Falls back to
+the existing `gh`-authored comment where the App is not installed.

--- a/.changeset/github-bot-comment.md
+++ b/.changeset/github-bot-comment.md
@@ -6,3 +6,7 @@ Managed attachments comment can now be posted by the uploads.sh GitHub App as
 `uploads-sh[bot]` when the App is installed on the target repo, so `--comment` /
 `uploads comment` no longer require a locally authenticated `gh`. Falls back to
 the existing `gh`-authored comment where the App is not installed.
+
+Both paths now find and edit the existing managed comment on threads past 100
+comments (the `gh` fallback paginates the lookup), so updating attachment media
+edits the one comment in place instead of posting a duplicate.

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { attachmentsCommentBody } from "./github-comment-render";
+
+const golden = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new NodeURL("../../../test/fixtures/github-comment-golden.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+) as { items: any[]; galleries: any[]; expected: string };
+
+describe("attachmentsCommentBody (api copy)", () => {
+  it("renders the golden body byte-for-byte", () => {
+    expect(attachmentsCommentBody(golden.items, golden.galleries)).toBe(golden.expected);
+  });
+});

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -1,0 +1,159 @@
+/**
+ * Server-side COPY of the CLI's managed-comment renderer + gh-key helpers
+ * (packages/uploads/src/github.ts). The published CLI imports no @uploads/*
+ * package, so the renderer cannot be shared — it is copied here for the bot
+ * path. Kept byte-identical to the CLI copy by test/fixtures/github-comment-
+ * golden.json, asserted from both sides. Change both copies together.
+ */
+
+export type GhTargetKind = "pull" | "issues";
+
+export interface GhTarget {
+  /** "owner/name" */
+  repo: string;
+  kind: GhTargetKind;
+  num: number;
+}
+
+function sanitizeKeySegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+export function ghKeyPrefix(target: GhTarget): string {
+  const [owner, name] = target.repo.split("/");
+  return `gh/${sanitizeKeySegment(owner)}/${sanitizeKeySegment(name)}/${target.kind}/${target.num}/`;
+}
+
+/** GitHub-embed helper (content type). Copied from packages/uploads/src/embed.ts. */
+function inferContentType(filename: string): string {
+  const ext = filename.includes(".")
+    ? filename.slice(filename.lastIndexOf(".") + 1).toLowerCase()
+    : "";
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    case "svg":
+      return "image/svg+xml";
+    case "mp4":
+      return "video/mp4";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */
+export const ATTACHMENTS_MARKER = "<!-- uploads.sh:attachments -->";
+
+export interface AttachmentItem {
+  key: string;
+  url: string | null;
+  /** Prefer for `<img src>` on GitHub (Camo-friendly host). Falls back to `url`. */
+  embedUrl?: string | null;
+}
+
+/** A public gallery linked to the PR or issue whose managed comment is syncing. */
+export interface GalleryCommentItem {
+  title: string;
+  /** Canonical URL returned by the API; callers must not synthesize it. */
+  url: string;
+  /** A bounded set of available images; each links to its item page when known, else the gallery. */
+  previews?: { url: string; alt: string; embedUrl?: string | null; itemUrl?: string }[];
+}
+
+/** Default max width for images in the managed attachments comment (HTML img). */
+export const ATTACHMENT_IMAGE_WIDTH_DEFAULT = 400;
+/** Portrait / device mockups — keep phones readable, not full-column. */
+export const ATTACHMENT_IMAGE_WIDTH_PORTRAIT = 280;
+/** Wide UI / browser chrome. */
+export const ATTACHMENT_IMAGE_WIDTH_WIDE = 640;
+
+/**
+ * Pick a display width for GitHub comment embeds. Filenames are a weak but
+ * practical signal (we don't re-fetch dimensions when rebuilding the comment).
+ */
+export function attachmentImageWidth(filename: string): number {
+  const n = filename.toLowerCase();
+  if (/(?:^|[-_.])(browser|desktop|dashboard|wide)(?:[-_.]|$)/.test(n)) {
+    return ATTACHMENT_IMAGE_WIDTH_WIDE;
+  }
+  if (
+    /(?:^|[-_.])(phone|iphone|ipad|pixel|android|mobile|device)(?:[-_.]|$)/.test(n) ||
+    /iphone|pixel-?\d/.test(n)
+  ) {
+    return ATTACHMENT_IMAGE_WIDTH_PORTRAIT;
+  }
+  return ATTACHMENT_IMAGE_WIDTH_DEFAULT;
+}
+
+function escapeHtmlAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function escapeHtmlText(s: string): string {
+  return escapeHtmlAttr(s).replace(/'/g, "&#39;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Render the one marker-owned GitHub comment. When there are no galleries this
+ * intentionally preserves the legacy attachment-only body byte-for-byte.
+ */
+export function attachmentsCommentBody(
+  items: AttachmentItem[],
+  galleries: GalleryCommentItem[] = [],
+): string {
+  // Non-mutating sort (equivalent to Array#toSorted) — the api worker's
+  // tsconfig targets lib ES2022, which predates Array#toSorted (ES2023);
+  // packages/uploads/src/github.ts uses toSorted directly.
+  const sorted = [...items].sort((a, b) => a.key.localeCompare(b.key));
+  const sortedGalleries = [...galleries].sort(
+    (a, b) => a.title.localeCompare(b.title) || a.url.localeCompare(b.url),
+  );
+  const lines: string[] = [ATTACHMENTS_MARKER];
+  if (sortedGalleries.length > 0) {
+    lines.push("### 🖼️ Galleries", "");
+    for (const gallery of sortedGalleries) {
+      const href = escapeHtmlAttr(gallery.url);
+      lines.push(`#### <a href="${href}">${escapeHtmlText(gallery.title)}</a>`);
+      for (const preview of gallery.previews ?? []) {
+        const previewHref = preview.itemUrl ? escapeHtmlAttr(preview.itemUrl) : href;
+        const previewSrc = escapeHtmlAttr(preview.embedUrl ?? preview.url);
+        lines.push(
+          `<a href="${previewHref}"><img width="320" alt="${escapeHtmlAttr(preview.alt)}" src="${previewSrc}"></a>`,
+        );
+      }
+      lines.push(`<sub><a href="${href}">Open gallery</a></sub>`, "");
+    }
+    lines.push("");
+  }
+  if (sorted.length > 0 || sortedGalleries.length === 0) lines.push("### 📎 Attachments", "");
+  for (const item of sorted) {
+    const name = item.key.slice(item.key.lastIndexOf("/") + 1);
+    const stable = item.url;
+    const src = item.embedUrl ?? item.url;
+    if (src && inferContentType(name).startsWith("image/")) {
+      // Markdown ![]() has no width control — phone frames become full-column giants.
+      // img src uses embed host when available (Camo revalidates); click-through keeps stable URL.
+      const w = attachmentImageWidth(name);
+      const alt = escapeHtmlAttr(name);
+      const href = escapeHtmlAttr(stable ?? src);
+      const imgSrc = escapeHtmlAttr(src);
+      lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
+      lines.push("");
+    } else if (stable) {
+      lines.push(`- [${name}](${stable})`);
+    } else {
+      lines.push(`- ${name}`);
+    }
+  }
+  lines.push(
+    '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',
+  );
+  return lines.join("\n");
+}

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { gatherCommentBody } from "./github-comment";
+import { ATTACHMENTS_MARKER } from "./github-comment-render";
+import { addExternalReference, addGalleryItem, createGallery } from "./galleries";
+import type { WorkspaceRecord } from "./workspace";
+import { FakeR2Bucket } from "../test/fake-r2";
+import { SqliteD1, database } from "../test/helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260711180000_galleries.sql";
+const PRAGMAS = ["PRAGMA foreign_keys = ON"];
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function makeTestEnv() {
+  const sqlite = new SqliteD1(MIGRATION, PRAGMAS);
+  const bucket = new FakeR2Bucket();
+  const ws: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "shared",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+  };
+  const env = {
+    DB: database(sqlite),
+    WEB_ORIGIN: "https://uploads.test",
+    UPLOADS_DEFAULT: bucket,
+  } as unknown as Env;
+  return { env, ws, workspaceName: "acme", bucket, sqlite };
+}
+
+describe("gatherCommentBody", () => {
+  it("returns skip when the workspace has no attachments and no galleries", async () => {
+    const { env, ws, workspaceName } = makeTestEnv();
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    expect(result).toEqual({ skip: true });
+  });
+
+  it("renders the workspace's own attachments under the gh prefix", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    expect(result.skip).toBe(false);
+    if (result.skip) return;
+    expect(result.body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
+    expect(result.body).toContain("hero.png");
+    expect(result.count).toBe(1);
+  });
+
+  it("renders galleries linked to the PR via an external reference, scoped to the calling workspace", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/screenshots/one.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const created = await createGallery(env.DB, {
+      workspace: workspaceName,
+      title: "Launch media",
+    });
+    if (created.status !== "ok") throw new Error(`create failed: ${created.status}`);
+    const item = await addGalleryItem(env.DB, workspaceName, created.value.id, {
+      expectedVersion: 1,
+      objectKey: "screenshots/one.png",
+    });
+    if (item.status !== "ok") throw new Error(`add item failed: ${item.status}`);
+    const reference = await addExternalReference(env.DB, workspaceName, created.value.id, {
+      expectedVersion: 2,
+      provider: "github",
+      resourceType: "item",
+      normalizedKey: "github:item:acme/web#12",
+      locator: { owner: "acme", repository: "web", number: 12 },
+      canonicalUrl: "https://github.com/acme/web/issues/12",
+    });
+    if (reference.status !== "ok") throw new Error(`add reference failed: ${reference.status}`);
+
+    // A different workspace's gallery, linked to the same PR — must not leak in.
+    const otherCreated = await createGallery(env.DB, { workspace: "other-ws", title: "Not ours" });
+    if (otherCreated.status !== "ok") throw new Error("other create failed");
+    const otherReference = await addExternalReference(env.DB, "other-ws", otherCreated.value.id, {
+      expectedVersion: 1,
+      provider: "github",
+      resourceType: "item",
+      normalizedKey: "github:item:acme/web#12",
+      locator: { owner: "acme", repository: "web", number: 12 },
+      canonicalUrl: "https://github.com/acme/web/issues/12",
+    });
+    if (otherReference.status !== "ok") throw new Error("other reference failed");
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    expect(result.skip).toBe(false);
+    if (result.skip) return;
+    expect(result.body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
+    expect(result.body).toContain("Launch media");
+    expect(result.body).not.toContain("Not ours");
+    expect(result.count).toBe(1);
+  });
+});

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -307,4 +307,135 @@ describe("upsertBotComment", () => {
     );
     expect(res).toEqual({ degrade: "unavailable" });
   });
+
+  it("uses a cached comment id to PATCH directly, without listing", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    await kv.put("ghcomment:acme/web#12", "55");
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      // A cache hit must never list — fail loudly if it does.
+      if (url.includes("/issues/12/comments")) throw new Error("listed on cache hit");
+      if (url.includes("/issues/comments/55") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 55, html_url: "https://github.com/acme/web/pull/12#c55" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c55",
+    });
+  });
+
+  it("re-hunts and recreates when the cached comment was deleted (404), refreshing the cache", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    await kv.put("ghcomment:acme/web#12", "55");
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/comments/55")) return new Response("gone", { status: 404 });
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 88, html_url: "https://github.com/acme/web/pull/12#c88" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c88",
+    });
+    expect(await kv.get("ghcomment:acme/web#12")).toBe("88");
+  });
+
+  it("finds the marker comment beyond the first page and caches its id", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, body: "noise" }));
+    const fetchImpl = (async (url: string) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("&page=2")) {
+        return new Response(JSON.stringify([{ id: 777, body: ATTACHMENTS_MARKER }]), {
+          status: 200,
+        });
+      }
+      if (url.includes("&page=1")) return new Response(JSON.stringify(fullPage), { status: 200 });
+      if (url.includes("/issues/comments/777")) {
+        return new Response(
+          JSON.stringify({ id: 777, html_url: "https://github.com/acme/web/pull/12#c777" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c777",
+    });
+    expect(await kv.get("ghcomment:acme/web#12")).toBe("777");
+  });
+
+  it("caches the id of a freshly created comment", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": (init) =>
+        init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 99, html_url: "https://github.com/acme/web/pull/12#c99" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c99",
+    });
+    expect(await kv.get("ghcomment:acme/web#12")).toBe("99");
+  });
 });

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -1,11 +1,12 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from "vitest";
-import { gatherCommentBody } from "./github-comment";
+import { gatherCommentBody, upsertBotComment } from "./github-comment";
 import { ATTACHMENTS_MARKER } from "./github-comment-render";
 import { addExternalReference, addGalleryItem, createGallery } from "./galleries";
 import type { WorkspaceRecord } from "./workspace";
 import { FakeR2Bucket } from "../test/fake-r2";
+import { FakeKv } from "../test/fake-kv";
 import { SqliteD1, database } from "../test/helpers/sqlite-d1";
 
 const MIGRATION = "migrations/20260711180000_galleries.sql";
@@ -15,6 +16,7 @@ const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 function makeTestEnv() {
   const sqlite = new SqliteD1(MIGRATION, PRAGMAS);
   const bucket = new FakeR2Bucket();
+  const kv = new FakeKv();
   const ws: WorkspaceRecord = {
     provider: "r2",
     bucket: "shared",
@@ -26,8 +28,36 @@ function makeTestEnv() {
     DB: database(sqlite),
     WEB_ORIGIN: "https://uploads.test",
     UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: kv,
   } as unknown as Env;
-  return { env, ws, workspaceName: "acme", bucket, sqlite };
+  return { env, ws, workspaceName: "acme", bucket, kv, sqlite };
+}
+
+/** Generate a throwaway RSA key and return its PKCS#8 PEM (mirrors github-app.test.ts's testKeyPair). */
+async function testPem(): Promise<string> {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer;
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
+}
+
+function fakeFetch(routes: Record<string, (init: RequestInit) => Response>): typeof fetch {
+  return (async (url: string, init: RequestInit = {}) => {
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (url.includes(pattern)) return handler(init);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
 }
 
 describe("gatherCommentBody", () => {
@@ -107,5 +137,174 @@ describe("gatherCommentBody", () => {
     expect(result.body).toContain("Launch media");
     expect(result.body).not.toContain("Not ours");
     expect(result.count).toBe(1);
+  });
+});
+
+describe("upsertBotComment", () => {
+  it("creates the comment when no marker comment exists", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": (init) =>
+        init.method === "POST"
+          ? new Response(JSON.stringify({ html_url: "https://github.com/acme/web/pull/12#c1" }), {
+              status: 201,
+            })
+          : new Response(JSON.stringify([]), { status: 200 }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c1",
+    });
+  });
+
+  it("patches the existing marker comment", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": () =>
+        new Response(
+          JSON.stringify([{ id: 7, body: `x ${ATTACHMENTS_MARKER} y`, html_url: "u" }]),
+          {
+            status: 200,
+          },
+        ),
+      "/issues/comments/7": () =>
+        new Response(JSON.stringify({ html_url: "https://github.com/acme/web/pull/12#c7" }), {
+          status: 200,
+        }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+  });
+
+  it("tolerates a marker comment authored by someone else — matches on body, not author", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": () =>
+        new Response(
+          JSON.stringify([
+            { id: 3, body: "unrelated comment", html_url: "u" },
+            { id: 7, body: `${ATTACHMENTS_MARKER}\nold body`, html_url: "u" },
+          ]),
+          { status: 200 },
+        ),
+      "/issues/comments/7": () =>
+        new Response(JSON.stringify({ html_url: "https://github.com/acme/web/pull/12#c7" }), {
+          status: 200,
+        }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+  });
+
+  it("degrades to forbidden on 403 from the write call", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": (init) =>
+        init.method === "POST"
+          ? new Response("no", { status: 403 })
+          : new Response(JSON.stringify([]), { status: 200 }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({ degrade: "forbidden" });
+  });
+
+  it("degrades to forbidden on 403 from the list call", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": () => new Response("no", { status: 403 }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({ degrade: "forbidden" });
+  });
+
+  it("degrades to unavailable when the installation token mint fails", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response("nope", { status: 401 }),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({ degrade: "unavailable" });
+  });
+
+  it("degrades to unavailable when the write call throws (network error)", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    // Pre-seed the cached token so no signing/minting is needed for this case.
+    await kv.put("ghtok:42", "cached-token");
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/issues/12/comments") && init.method !== "POST") {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      fetchImpl,
+    );
+    expect(res).toEqual({ degrade: "unavailable" });
   });
 });

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -1,0 +1,84 @@
+/**
+ * Server-side gather: list the calling workspace's own R2 objects under the
+ * stable gh key prefix, plus its own galleries linked to the PR/issue
+ * coordinate, then render the managed comment body via
+ * `attachmentsCommentBody`. This is the trust boundary — the server renders
+ * ONLY from the calling workspace's own data (its own bucket/prefix, its own
+ * D1 rows scoped by workspace name).
+ */
+
+import { listObjects } from "./files-core";
+import { findGalleriesByReference, listGalleryItems, type GalleryCursor } from "./galleries";
+import { galleryUrl, hydrateOwnerGallery } from "./gallery-service";
+import { parseExternalReference } from "./external-references";
+import type { WorkspaceRecord } from "./workspace";
+import {
+  attachmentsCommentBody,
+  ghKeyPrefix,
+  type AttachmentItem,
+  type GalleryCommentItem,
+  type GhTarget,
+} from "./github-comment-render";
+
+/**
+ * Gather a workspace's own PR/issue attachments + galleries into a rendered
+ * managed-comment body.
+ *
+ * @param ws The calling workspace's storage record — objects are listed from
+ *   its own bucket/prefix only.
+ * @param workspaceName The calling workspace's slug — galleries are looked up
+ *   scoped to this name only (D1 rows are tenant-scoped by this string, not
+ *   by anything derived from `ws`).
+ */
+export async function gatherCommentBody(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  target: GhTarget,
+): Promise<{ skip: true } | { skip: false; body: string; count: number }> {
+  // Attachments: the workspace's own objects under the stable gh key prefix.
+  const items: AttachmentItem[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await listObjects(env, ws, { prefix: ghKeyPrefix(target), limit: 1000, cursor });
+    for (const o of page.items) items.push({ key: o.key, url: o.url, embedUrl: o.embedUrl });
+    cursor = page.cursor ?? undefined;
+  } while (cursor);
+
+  // Galleries linked to this PR/issue (kind-agnostic coordinate), scoped to
+  // this workspace only.
+  const ref = parseExternalReference("github", `${target.repo.toLowerCase()}#${target.num}`);
+  const galleries: GalleryCommentItem[] = [];
+  if (ref.ok) {
+    let gCursor: GalleryCursor | undefined;
+    do {
+      const page = await findGalleriesByReference(env.DB, workspaceName, ref.value.normalizedKey, {
+        limit: 100,
+        cursor: gCursor,
+      });
+      for (const rec of page.galleries) {
+        const dto = await hydrateOwnerGallery(
+          env,
+          ws,
+          rec,
+          await listGalleryItems(env.DB, workspaceName, rec.id),
+        );
+        const previews = dto.items
+          .filter((i) => i.status === "available" && i.url && i.contentType?.startsWith("image/"))
+          .slice(0, 3)
+          .map((i) => ({
+            url: i.url as string,
+            embedUrl: i.embedUrl,
+            alt: i.altText ?? i.objectKey,
+            itemUrl: i.pageUrl,
+          }));
+        galleries.push({ title: rec.title, url: galleryUrl(env, rec.id), previews });
+      }
+      gCursor = page.nextCursor ?? undefined;
+    } while (gCursor);
+  }
+
+  const count = items.length + galleries.length;
+  if (count === 0) return { skip: true };
+  return { skip: false, body: attachmentsCommentBody(items, galleries), count };
+}

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -38,7 +38,24 @@ export async function gatherCommentBody(
   workspaceName: string,
   target: GhTarget,
 ): Promise<{ skip: true } | { skip: false; body: string; count: number }> {
-  // Attachments: the workspace's own objects under the stable gh key prefix.
+  // Attachments (R2 list) and galleries (D1) are independent reads — overlap
+  // them so the request only waits the longer of the two, not their sum.
+  const [items, galleries] = await Promise.all([
+    gatherAttachments(env, ws, target),
+    gatherGalleries(env, ws, workspaceName, target),
+  ]);
+
+  const count = items.length + galleries.length;
+  if (count === 0) return { skip: true };
+  return { skip: false, body: attachmentsCommentBody(items, galleries), count };
+}
+
+/** The workspace's own objects under the stable gh key prefix. */
+async function gatherAttachments(
+  env: Env,
+  ws: WorkspaceRecord,
+  target: GhTarget,
+): Promise<AttachmentItem[]> {
   const items: AttachmentItem[] = [];
   let cursor: string | undefined;
   do {
@@ -46,19 +63,31 @@ export async function gatherCommentBody(
     for (const o of page.items) items.push({ key: o.key, url: o.url, embedUrl: o.embedUrl });
     cursor = page.cursor ?? undefined;
   } while (cursor);
+  return items;
+}
 
-  // Galleries linked to this PR/issue (kind-agnostic coordinate), scoped to
-  // this workspace only.
+/**
+ * Galleries linked to this PR/issue (kind-agnostic coordinate), scoped to this
+ * workspace only. Each page's galleries hydrate concurrently (mirrors the CLI's
+ * original `Promise.all` gather).
+ */
+async function gatherGalleries(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  target: GhTarget,
+): Promise<GalleryCommentItem[]> {
   const ref = parseExternalReference("github", `${target.repo.toLowerCase()}#${target.num}`);
+  if (!ref.ok) return [];
   const galleries: GalleryCommentItem[] = [];
-  if (ref.ok) {
-    let gCursor: GalleryCursor | undefined;
-    do {
-      const page = await findGalleriesByReference(env.DB, workspaceName, ref.value.normalizedKey, {
-        limit: 100,
-        cursor: gCursor,
-      });
-      for (const rec of page.galleries) {
+  let gCursor: GalleryCursor | undefined;
+  do {
+    const page = await findGalleriesByReference(env.DB, workspaceName, ref.value.normalizedKey, {
+      limit: 100,
+      cursor: gCursor,
+    });
+    const pageItems = await Promise.all(
+      page.galleries.map(async (rec) => {
         const dto = await hydrateOwnerGallery(
           env,
           ws,
@@ -74,15 +103,13 @@ export async function gatherCommentBody(
             alt: i.altText ?? i.objectKey,
             itemUrl: i.pageUrl,
           }));
-        galleries.push({ title: rec.title, url: galleryUrl(env, rec.id), previews });
-      }
-      gCursor = page.nextCursor ?? undefined;
-    } while (gCursor);
-  }
-
-  const count = items.length + galleries.length;
-  if (count === 0) return { skip: true };
-  return { skip: false, body: attachmentsCommentBody(items, galleries), count };
+        return { title: rec.title, url: galleryUrl(env, rec.id), previews };
+      }),
+    );
+    galleries.push(...pageItems);
+    gCursor = page.nextCursor ?? undefined;
+  } while (gCursor);
+  return galleries;
 }
 
 interface GhComment {
@@ -150,10 +177,10 @@ export async function upsertBotComment(
     return { ok: true, commentUrl: parsed.html_url ?? "" };
   };
 
-  if (existing) {
-    const r = await write(`${base}/issues/comments/${existing.id}`, "PATCH");
-    return r.ok ? { action: "updated", commentUrl: r.commentUrl } : { degrade: r.degrade };
-  }
-  const r = await write(`${base}/issues/${target.num}/comments`, "POST");
-  return r.ok ? { action: "created", commentUrl: r.commentUrl } : { degrade: r.degrade };
+  const url = existing
+    ? `${base}/issues/comments/${existing.id}`
+    : `${base}/issues/${target.num}/comments`;
+  const r = await write(url, existing ? "PATCH" : "POST");
+  if (!r.ok) return { degrade: r.degrade };
+  return { action: existing ? "updated" : "created", commentUrl: r.commentUrl };
 }

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -118,12 +118,33 @@ interface GhComment {
   html_url: string;
 }
 
+/** KV TTL for a cached comment id. A stale id self-heals: a 404 on PATCH drops
+ * it and re-hunts. Long only to spare the hunt on active PRs. */
+const COMMENT_ID_TTL = 60 * 60 * 24 * 30; // 30 days.
+
+/** KV key for the managed comment's id, keyed by the coordinate the comment is
+ * unique on (repo#num — one managed comment per PR/issue, shared marker). */
+function commentCacheKey(target: Pick<GhTarget, "repo" | "num">): string {
+  return `ghcomment:${target.repo.toLowerCase()}#${target.num}`;
+}
+
+/** One create/patch write. `status` is 0 for a thrown request (network error). */
+type WriteOutcome = { ok: true; id?: number; commentUrl: string } | { ok: false; status: number };
+
+const degradeFor = (status: number): "forbidden" | "unavailable" =>
+  status === 403 ? "forbidden" : "unavailable";
+
 /**
  * Create or patch the one managed comment (identified by `ATTACHMENTS_MARKER`)
  * on a PR/issue, authenticated as the GitHub App installation (not the
  * calling user). Degrade-safe: any failure — 403, other non-2xx, a thrown
  * token mint, or a network error — resolves to a `degrade` result rather than
  * throwing, since a failed bot comment must never fail the caller's request.
+ *
+ * A cached comment id (KV) is the fast path: re-editing media becomes a single
+ * PATCH with no listing. The id is only an optimization — the marker in the
+ * body stays authoritative, so a stale/deleted id (404) drops the cache and
+ * falls back to the marker hunt, which pages through the whole thread.
  */
 export async function upsertBotComment(
   env: Env,
@@ -139,28 +160,9 @@ export async function upsertBotComment(
   if (!token) return { degrade: "unavailable" };
   const base = `https://api.github.com/repos/${target.repo}`;
   const jsonHeaders = { ...githubHeaders(token), "content-type": "application/json" };
+  const cacheKey = commentCacheKey(target);
 
-  let listRes: Response;
-  try {
-    listRes = await githubFetch(fetchImpl, `${base}/issues/${target.num}/comments?per_page=100`, {
-      headers: githubHeaders(token),
-    });
-  } catch {
-    return { degrade: "unavailable" };
-  }
-  if (listRes.status === 403) return { degrade: "forbidden" };
-  if (!listRes.ok) return { degrade: "unavailable" };
-  const comments = (await listRes.json().catch(() => [])) as GhComment[];
-  const existing = Array.isArray(comments)
-    ? comments.find((c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER))
-    : undefined;
-
-  const write = async (
-    url: string,
-    method: "POST" | "PATCH",
-  ): Promise<
-    { ok: true; commentUrl: string } | { ok: false; degrade: "forbidden" | "unavailable" }
-  > => {
+  const write = async (url: string, method: "POST" | "PATCH"): Promise<WriteOutcome> => {
     let res: Response;
     try {
       res = await githubFetch(fetchImpl, url, {
@@ -169,18 +171,77 @@ export async function upsertBotComment(
         body: JSON.stringify({ body }),
       });
     } catch {
-      return { ok: false, degrade: "unavailable" };
+      return { ok: false, status: 0 };
     }
-    if (res.status === 403) return { ok: false, degrade: "forbidden" };
-    if (!res.ok) return { ok: false, degrade: "unavailable" };
-    const parsed = (await res.json().catch(() => ({}))) as { html_url?: string };
-    return { ok: true, commentUrl: parsed.html_url ?? "" };
+    if (!res.ok) return { ok: false, status: res.status };
+    const parsed = (await res.json().catch(() => ({}))) as { id?: number; html_url?: string };
+    return { ok: true, id: parsed.id, commentUrl: parsed.html_url ?? "" };
   };
 
-  const url = existing
-    ? `${base}/issues/comments/${existing.id}`
-    : `${base}/issues/${target.num}/comments`;
-  const r = await write(url, existing ? "PATCH" : "POST");
-  if (!r.ok) return { degrade: r.degrade };
+  // Fast path: a cached id lets us PATCH the comment directly, no listing.
+  const cachedId = (await env.GITHUB_CACHE.get(cacheKey)) as string | null;
+  if (cachedId) {
+    const r = await write(`${base}/issues/comments/${cachedId}`, "PATCH");
+    if (r.ok) return { action: "updated", commentUrl: r.commentUrl };
+    if (r.status !== 404) return { degrade: degradeFor(r.status) };
+    // 404: the comment was deleted out from under us. Drop the stale id and
+    // fall through to a fresh hunt + create.
+    await env.GITHUB_CACHE.delete(cacheKey);
+  }
+
+  // Slow path: find the marker comment across all pages (a busy thread can push
+  // it past the first 100), then patch it; otherwise create a new one.
+  const found = await findMarkerComment(fetchImpl, token, base, target.num);
+  if (found.degrade) return { degrade: found.degrade };
+  const existing = found.comment;
+
+  const r = existing
+    ? await write(`${base}/issues/comments/${existing.id}`, "PATCH")
+    : await write(`${base}/issues/${target.num}/comments`, "POST");
+  if (!r.ok) return { degrade: degradeFor(r.status) };
+
+  const id = existing?.id ?? r.id;
+  if (id !== undefined) {
+    await env.GITHUB_CACHE.put(cacheKey, String(id), { expirationTtl: COMMENT_ID_TTL });
+  }
   return { action: existing ? "updated" : "created", commentUrl: r.commentUrl };
+}
+
+/**
+ * Page through the PR/issue comments (oldest-first) until the marker comment is
+ * found or the pages run out. Bounded so a pathological thread can't loop
+ * unboundedly; the cap is far beyond any real attachments thread, and the id
+ * cache means this hunt runs at most once per comment anyway.
+ */
+async function findMarkerComment(
+  fetchImpl: typeof fetch,
+  token: string,
+  base: string,
+  num: number,
+): Promise<{ comment?: GhComment; degrade?: "forbidden" | "unavailable" }> {
+  const MAX_PAGES = 20; // 2000 comments.
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    let res: Response;
+    try {
+      res = await githubFetch(
+        fetchImpl,
+        `${base}/issues/${num}/comments?per_page=100&page=${page}`,
+        {
+          headers: githubHeaders(token),
+        },
+      );
+    } catch {
+      return { degrade: "unavailable" };
+    }
+    if (res.status === 403) return { degrade: "forbidden" };
+    if (!res.ok) return { degrade: "unavailable" };
+    const comments = (await res.json().catch(() => [])) as GhComment[];
+    if (!Array.isArray(comments)) return {};
+    const hit = comments.find(
+      (c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER),
+    );
+    if (hit) return { comment: hit };
+    if (comments.length < 100) return {}; // last page reached, not found.
+  }
+  return {}; // page cap hit without a match — treat as not found (create).
 }

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -12,9 +12,11 @@ import { findGalleriesByReference, listGalleryItems, type GalleryCursor } from "
 import { galleryUrl, hydrateOwnerGallery } from "./gallery-service";
 import { parseExternalReference } from "./external-references";
 import type { WorkspaceRecord } from "./workspace";
+import { githubFetch, githubHeaders, installationToken, type GithubAppConfig } from "./github-app";
 import {
   attachmentsCommentBody,
   ghKeyPrefix,
+  ATTACHMENTS_MARKER,
   type AttachmentItem,
   type GalleryCommentItem,
   type GhTarget,
@@ -81,4 +83,77 @@ export async function gatherCommentBody(
   const count = items.length + galleries.length;
   if (count === 0) return { skip: true };
   return { skip: false, body: attachmentsCommentBody(items, galleries), count };
+}
+
+interface GhComment {
+  id: number;
+  body: string;
+  html_url: string;
+}
+
+/**
+ * Create or patch the one managed comment (identified by `ATTACHMENTS_MARKER`)
+ * on a PR/issue, authenticated as the GitHub App installation (not the
+ * calling user). Degrade-safe: any failure — 403, other non-2xx, a thrown
+ * token mint, or a network error — resolves to a `degrade` result rather than
+ * throwing, since a failed bot comment must never fail the caller's request.
+ */
+export async function upsertBotComment(
+  env: Env,
+  cfg: GithubAppConfig,
+  installationId: number,
+  target: Pick<GhTarget, "repo" | "num">,
+  body: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<
+  { action: "created" | "updated"; commentUrl: string } | { degrade: "forbidden" | "unavailable" }
+> {
+  const token = await installationToken(env, cfg, installationId, fetchImpl);
+  if (!token) return { degrade: "unavailable" };
+  const base = `https://api.github.com/repos/${target.repo}`;
+  const jsonHeaders = { ...githubHeaders(token), "content-type": "application/json" };
+
+  let listRes: Response;
+  try {
+    listRes = await githubFetch(fetchImpl, `${base}/issues/${target.num}/comments?per_page=100`, {
+      headers: githubHeaders(token),
+    });
+  } catch {
+    return { degrade: "unavailable" };
+  }
+  if (listRes.status === 403) return { degrade: "forbidden" };
+  if (!listRes.ok) return { degrade: "unavailable" };
+  const comments = (await listRes.json().catch(() => [])) as GhComment[];
+  const existing = Array.isArray(comments)
+    ? comments.find((c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER))
+    : undefined;
+
+  const write = async (
+    url: string,
+    method: "POST" | "PATCH",
+  ): Promise<
+    { ok: true; commentUrl: string } | { ok: false; degrade: "forbidden" | "unavailable" }
+  > => {
+    let res: Response;
+    try {
+      res = await githubFetch(fetchImpl, url, {
+        method,
+        headers: jsonHeaders,
+        body: JSON.stringify({ body }),
+      });
+    } catch {
+      return { ok: false, degrade: "unavailable" };
+    }
+    if (res.status === 403) return { ok: false, degrade: "forbidden" };
+    if (!res.ok) return { ok: false, degrade: "unavailable" };
+    const parsed = (await res.json().catch(() => ({}))) as { html_url?: string };
+    return { ok: true, commentUrl: parsed.html_url ?? "" };
+  };
+
+  if (existing) {
+    const r = await write(`${base}/issues/comments/${existing.id}`, "PATCH");
+    return r.ok ? { action: "updated", commentUrl: r.commentUrl } : { degrade: r.degrade };
+  }
+  const r = await write(`${base}/issues/${target.num}/comments`, "POST");
+  return r.ok ? { action: "created", commentUrl: r.commentUrl } : { degrade: r.degrade };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import { telemetry } from "./routes/telemetry";
 import { reports } from "./routes/reports";
 import { render } from "./routes/render";
 import { githubWebhook } from "./routes/github-webhook";
+import { githubComment } from "./routes/github-comment";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -123,6 +124,9 @@ export const app = new Hono<WorkspaceVars>()
   .route("/v1/:workspace/galleries", galleries)
   .route("/v1/:workspace/files", files)
   .route("/v1/:workspace/usage", usage)
+  // Bot-owned managed comment (phase 2 PR B). Workspace-authed (unlike the
+  // HMAC-public /v1/github/webhook above) — behind the workspaceAuth guard.
+  .route("/v1/:workspace/github", githubComment)
   .onError((err, c) => respondError(c, err))
   .notFound((c) => respondError(c, new NotFoundError()));
 

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -35,13 +35,7 @@ import { writeRateLimit } from "../guards";
 import { parseExternalReference } from "../external-references";
 import { publicUrl, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
-
-async function jsonBody(c: Context<WorkspaceVars>): Promise<Record<string, unknown>> {
-  const body = await c.req.json<unknown>().catch(() => null);
-  if (typeof body !== "object" || body === null || Array.isArray(body))
-    throw new ValidationError("Expected a JSON object.");
-  return body as Record<string, unknown>;
-}
+import { jsonBody } from "./json-body";
 
 async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
   const record = await getGallery(c.env.DB, c.get("workspaceName"), id);

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { app } from "../index";
 import { sha256Hex, type WorkspaceRecord } from "../workspace";
 import { FakeKv } from "../../test/fake-kv";
+import { FakeR2Bucket } from "../../test/fake-r2";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { GITHUB_APP_CFG_ENV } from "../../test/github-app-env";
 
@@ -65,5 +66,76 @@ describe("POST /v1/:workspace/github/comment", () => {
     const env = await seededEnv();
     const res = await post(env, { repo: "not-a-repo", num: 0, kind: "nope" });
     expect(res.status).toBe(400);
+  });
+
+  it("400s on a dot-only repo segment (path-traversal guard)", async () => {
+    const env = await seededEnv();
+    const res = await post(env, { repo: "../etc", num: 12, kind: "pull" });
+    expect(res.status).toBe(400);
+  });
+
+  it("posts as the bot and returns the upsert result end-to-end", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/web", { value: "42" }); // installed
+    githubCache.store.set("ghtok:42", { value: "cached-token" }); // skip JWT mint
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", new Uint8Array([0x89, 0x50]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+    // Minimal D1: null for the auth-token lookup, empty for the galleries read.
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => null,
+          all: async () => ({ results: [] }),
+          run: async () => ({}),
+        }),
+      }),
+    } as unknown as D1Database;
+    const env = {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: bucket,
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/acme/web/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        posted: true,
+        action: "created",
+        count: 1,
+        commentUrl: "https://github.com/acme/web/pull/12#c5",
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../index";
+import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import { FakeKv } from "../../test/fake-kv";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "../../test/github-app-env";
+
+// `crypto.subtle.timingSafeEqual` is a Workers-runtime extension to Web
+// Crypto (used by workspaceAuth, see ../workspace.ts) that plain Node's
+// `crypto` doesn't implement, and this repo has no vitest workerd pool
+// configured. Polyfill a (non-constant-time, test-only) equivalent so this
+// file can exercise the real workspaceAuth middleware end to end.
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+const WS = "acme";
+const TOKEN = "up_acme_testtoken";
+
+async function seededEnv(opts: { installNone?: boolean } = {}): Promise<Env> {
+  const hash = await sha256Hex(TOKEN);
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    tokens: [{ hash, createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const githubCache = new FakeKv();
+  if (opts.installNone) githubCache.store.set("ghinst:acme/web", { value: "none" });
+  return {
+    REGISTRY: registry,
+    DB: new UsageFakeD1(),
+    GITHUB_CACHE: githubCache,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+}
+
+function post(env: Env, body: unknown) {
+  return app.request(
+    `/v1/${WS}/github/comment`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("POST /v1/:workspace/github/comment", () => {
+  it("returns not_installed when the App has no installation for the repo", async () => {
+    const env = await seededEnv({ installNone: true });
+    const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ posted: false, reason: "not_installed" });
+  });
+
+  it("400s on a malformed body", async () => {
+    const env = await seededEnv();
+    const res = await post(env, { repo: "not-a-repo", num: 0, kind: "nope" });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -6,13 +6,16 @@
  * { posted: false, reason } so the CLI falls back to its local-gh path.
  */
 import { ValidationError } from "@uploads/errors";
-import { Hono, type Context } from "hono";
+import { Hono } from "hono";
 import { gatherCommentBody, upsertBotComment } from "../github-comment";
 import { githubAppConfig, installationForRepo } from "../github-app";
 import type { GhTargetKind } from "../github-comment-render";
 import { requireScope, type WorkspaceVars } from "../workspace";
+import { jsonBody } from "./json-body";
 
-const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+// Same owner/name grammar as public-files.ts's deriveGithubContext, so a repo
+// string validates identically across the API.
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 
 function parseTarget(body: Record<string, unknown>): {
   repo: string;
@@ -29,13 +32,6 @@ function parseTarget(body: Record<string, unknown>): {
   if (kind !== "pull" && kind !== "issues")
     throw new ValidationError('kind must be "pull" or "issues".');
   return { repo, num, kind };
-}
-
-async function jsonBody(c: Context<WorkspaceVars>): Promise<Record<string, unknown>> {
-  const body = await c.req.json<unknown>().catch(() => null);
-  if (typeof body !== "object" || body === null || Array.isArray(body))
-    throw new ValidationError("Expected a JSON object.");
-  return body as Record<string, unknown>;
 }
 
 export const githubComment = new Hono<WorkspaceVars>().post(

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /v1/:workspace/github/comment (phase 2 PR B). Workspace-authed. Renders
+ * the calling workspace's own attachments + galleries for a PR/issue and, when
+ * the App is installed with write, upserts the managed comment as the bot.
+ * Never 5xxs on an integration failure — a bot-post problem returns
+ * { posted: false, reason } so the CLI falls back to its local-gh path.
+ */
+import { ValidationError } from "@uploads/errors";
+import { Hono, type Context } from "hono";
+import { gatherCommentBody, upsertBotComment } from "../github-comment";
+import { githubAppConfig, installationForRepo } from "../github-app";
+import type { GhTargetKind } from "../github-comment-render";
+import { requireScope, type WorkspaceVars } from "../workspace";
+
+const REPO_RE = /^[^/\s]+\/[^/\s]+$/;
+
+function parseTarget(body: Record<string, unknown>): {
+  repo: string;
+  num: number;
+  kind: GhTargetKind;
+} {
+  const repo = typeof body.repo === "string" ? body.repo : "";
+  const num = typeof body.num === "number" ? body.num : Number(body.num);
+  const kind = body.kind;
+  if (!REPO_RE.test(repo))
+    throw new ValidationError("repo must be owner/name.", { code: "invalid_repo" });
+  if (!Number.isSafeInteger(num) || num < 1)
+    throw new ValidationError("num must be a positive integer.");
+  if (kind !== "pull" && kind !== "issues")
+    throw new ValidationError('kind must be "pull" or "issues".');
+  return { repo, num, kind };
+}
+
+async function jsonBody(c: Context<WorkspaceVars>): Promise<Record<string, unknown>> {
+  const body = await c.req.json<unknown>().catch(() => null);
+  if (typeof body !== "object" || body === null || Array.isArray(body))
+    throw new ValidationError("Expected a JSON object.");
+  return body as Record<string, unknown>;
+}
+
+export const githubComment = new Hono<WorkspaceVars>().post(
+  "/comment",
+  requireScope("files:read"),
+  async (c) => {
+    const target = parseTarget(await jsonBody(c));
+    const cfg = githubAppConfig(c.env);
+    if (!cfg) return c.json({ posted: false, reason: "app_unconfigured" });
+    const installId = await installationForRepo(c.env, cfg, target.repo);
+    if (installId === null) return c.json({ posted: false, reason: "not_installed" });
+
+    const gathered = await gatherCommentBody(
+      c.env,
+      c.get("workspace"),
+      c.get("workspaceName"),
+      target,
+    );
+    if (gathered.skip) return c.json({ posted: true, action: "skipped", count: 0 });
+
+    const result = await upsertBotComment(c.env, cfg, installId, target, gathered.body);
+    if ("degrade" in result) return c.json({ posted: false, reason: result.degrade });
+    return c.json({
+      posted: true,
+      action: result.action,
+      count: gathered.count,
+      commentUrl: result.commentUrl,
+    });
+  },
+);

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -10,12 +10,15 @@ import { Hono } from "hono";
 import { gatherCommentBody, upsertBotComment } from "../github-comment";
 import { githubAppConfig, installationForRepo } from "../github-app";
 import type { GhTargetKind } from "../github-comment-render";
+import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
 
-// Same owner/name grammar as public-files.ts's deriveGithubContext, so a repo
-// string validates identically across the API.
+// Same owner/name grammar as public-files.ts's deriveGithubContext, plus a guard
+// against dot-only segments (".", "..") — unlike public-files this repo string is
+// interpolated into a server-side api.github.com path, where "../" would traverse.
 const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const DOTS_ONLY_RE = /^\.+$/;
 
 function parseTarget(body: Record<string, unknown>): {
   repo: string;
@@ -23,9 +26,9 @@ function parseTarget(body: Record<string, unknown>): {
   kind: GhTargetKind;
 } {
   const repo = typeof body.repo === "string" ? body.repo : "";
-  const num = typeof body.num === "number" ? body.num : Number(body.num);
+  const num = typeof body.num === "number" ? body.num : NaN;
   const kind = body.kind;
-  if (!REPO_RE.test(repo))
+  if (!REPO_RE.test(repo) || repo.split("/").some((seg) => DOTS_ONLY_RE.test(seg)))
     throw new ValidationError("repo must be owner/name.", { code: "invalid_repo" });
   if (!Number.isSafeInteger(num) || num < 1)
     throw new ValidationError("num must be a positive integer.");
@@ -36,6 +39,7 @@ function parseTarget(body: Record<string, unknown>): {
 
 export const githubComment = new Hono<WorkspaceVars>().post(
   "/comment",
+  writeRateLimit,
   requireScope("files:read"),
   async (c) => {
     const target = parseTarget(await jsonBody(c));

--- a/apps/api/src/routes/json-body.ts
+++ b/apps/api/src/routes/json-body.ts
@@ -1,0 +1,11 @@
+import { ValidationError } from "@uploads/errors";
+import type { Context } from "hono";
+import type { WorkspaceVars } from "../workspace";
+
+/** Parse a request body as a JSON object, rejecting arrays, `null`, and non-objects. */
+export async function jsonBody(c: Context<WorkspaceVars>): Promise<Record<string, unknown>> {
+  const body = await c.req.json<unknown>().catch(() => null);
+  if (typeof body !== "object" || body === null || Array.isArray(body))
+    throw new ValidationError("Expected a JSON object.");
+  return body as Record<string, unknown>;
+}

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -211,6 +211,10 @@ export interface FindGalleriesByReferenceOptions {
   cursor?: string;
 }
 
+export type GithubCommentResult =
+  | { posted: true; action: "created" | "updated" | "skipped"; count: number; commentUrl?: string }
+  | { posted: false; reason: string };
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -929,6 +933,21 @@ export function createUploadsClient(config: UploadsClientConfig) {
       if (opts.limit != null) params.set("limit", String(opts.limit));
       if (opts.cursor) params.set("cursor", opts.cursor);
       return request<GalleryListResult>("GET", galleriesBase(config) + "/by-reference?" + params);
+    },
+
+    async upsertGithubComment(opts: {
+      repo: string;
+      num: number;
+      kind: "pull" | "issues";
+    }): Promise<GithubCommentResult> {
+      return request<GithubCommentResult>(
+        "POST",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/comment`,
+        {
+          body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     },
 
     async health(): Promise<HealthResult> {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -211,9 +211,16 @@ export interface FindGalleriesByReferenceOptions {
   cursor?: string;
 }
 
+/** Reasons the bot did not post; the CLI treats any of them as "fall back to gh". */
+export type GithubCommentDeclineReason =
+  | "app_unconfigured"
+  | "not_installed"
+  | "forbidden"
+  | "unavailable";
+
 export type GithubCommentResult =
   | { posted: true; action: "created" | "updated" | "skipped"; count: number; commentUrl?: string }
-  | { posted: false; reason: string };
+  | { posted: false; reason: GithubCommentDeclineReason };
 
 export interface HealthResult {
   ok: boolean;

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -427,89 +427,89 @@ export function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
  * failure — callers decide whether that is fatal (`comment` command) or a
  * warning (`put --comment`).
  */
+export interface AttachmentsCommentResult {
+  action: "created" | "updated" | "skipped";
+  count: number;
+  /** Who posted the comment: the GitHub App bot, or the local `gh` fallback. */
+  via: "bot" | "gh";
+}
+
+/** Human-mode suffix noting who posted the managed comment. */
+export function commentViaSuffix(via: AttachmentsCommentResult["via"]): string {
+  return via === "bot" ? " (uploads-sh[bot])" : " (via gh)";
+}
+
 export async function syncAttachmentsComment(
   client: UploadsClient,
   target: GhTarget,
   run: CommandRunner,
-): Promise<{ action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }> {
+): Promise<AttachmentsCommentResult> {
   try {
     const bot = await client.upsertGithubComment({
       repo: target.repo,
       num: target.num,
       kind: target.kind,
     });
-    if (bot.posted) {
-      return {
-        action: bot.action,
-        count: bot.action === "skipped" ? 0 : (bot.count ?? 0),
-        via: "bot",
-      };
-    }
+    if (bot.posted) return { action: bot.action, count: bot.count, via: "bot" };
   } catch {
     // Endpoint absent/unreachable (self-hosted, network, older worker) — fall
     // through to the gh path below.
   }
-  return runGhPath();
 
-  async function runGhPath(): Promise<{
-    action: "created" | "updated" | "skipped";
-    count: number;
-    via: "bot" | "gh";
-  }> {
-    const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
-      ({ key, url, embedUrl }) => ({ key, url, embedUrl }),
-    );
+  // gh fallback: gather from this workspace's own data and post via local `gh`.
+  const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
+    ({ key, url, embedUrl }) => ({ key, url, embedUrl }),
+  );
 
-    const galleries: (GalleryCommentItem & { id: string })[] = [];
-    let cursor: string | undefined;
-    do {
-      const page = await client.findGalleriesByReference({
-        provider: "github",
-        // GitHub references intentionally do not distinguish PRs from issues.
-        coordinate: `${target.repo.toLowerCase()}#${target.num}`,
-        cursor,
-      });
-      galleries.push(...page.galleries.map(({ id, title, url }) => ({ title, url, id })));
-      cursor = page.nextCursor ?? undefined;
-    } while (cursor);
+  const galleries: (GalleryCommentItem & { id: string })[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await client.findGalleriesByReference({
+      provider: "github",
+      // GitHub references intentionally do not distinguish PRs from issues.
+      coordinate: `${target.repo.toLowerCase()}#${target.num}`,
+      cursor,
+    });
+    galleries.push(...page.galleries.map(({ id, title, url }) => ({ title, url, id })));
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor);
 
-    const previewGalleries = await Promise.all(
-      galleries.map(async ({ id, ...gallery }) => {
-        try {
-          const detail = await client.getGallery(id);
-          return {
-            ...gallery,
-            previews: detail.items
-              .filter(
-                (item) =>
-                  item.status === "available" && item.url && item.contentType?.startsWith("image/"),
-              )
-              .slice(0, 3)
-              .map((item) => ({
-                url: item.url!,
-                embedUrl: item.embedUrl,
-                alt: item.altText ?? item.objectKey,
-                itemUrl: item.pageUrl,
-              })),
-          };
-        } catch {
-          // A deleted or temporarily unavailable gallery still gets a safe title link.
-          return gallery;
-        }
-      }),
-    );
+  const previewGalleries = await Promise.all(
+    galleries.map(async ({ id, ...gallery }) => {
+      try {
+        const detail = await client.getGallery(id);
+        return {
+          ...gallery,
+          previews: detail.items
+            .filter(
+              (item) =>
+                item.status === "available" && item.url && item.contentType?.startsWith("image/"),
+            )
+            .slice(0, 3)
+            .map((item) => ({
+              url: item.url!,
+              embedUrl: item.embedUrl,
+              alt: item.altText ?? item.objectKey,
+              itemUrl: item.pageUrl,
+            })),
+        };
+      } catch {
+        // A deleted or temporarily unavailable gallery still gets a safe title link.
+        return gallery;
+      }
+    }),
+  );
 
-    if (items.length === 0 && previewGalleries.length === 0)
-      return { action: "skipped", count: 0, via: "gh" };
+  if (items.length === 0 && previewGalleries.length === 0)
+    return { action: "skipped", count: 0, via: "gh" };
 
-    const body = attachmentsCommentBody(items, previewGalleries);
-    const { created } = upsertAttachmentsComment(target, body, run);
-    return {
-      action: created ? "created" : "updated",
-      count: items.length + previewGalleries.length,
-      via: "gh",
-    };
-  }
+  const body = attachmentsCommentBody(items, previewGalleries);
+  const { created } = upsertAttachmentsComment(target, body, run);
+  return {
+    action: created ? "created" : "updated",
+    count: items.length + previewGalleries.length,
+    via: "gh",
+  };
 }
 
 // --- attach ---
@@ -848,9 +848,7 @@ export async function runAttach(
     throw firstError instanceof Error ? firstError : new Error(String(firstError));
   }
 
-  let comment:
-    | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
-    | undefined;
+  let comment: AttachmentsCommentResult | undefined;
   let commentError: string | undefined;
   // Skip comment refresh when every upload failed — nothing new from this batch.
   if (!parsed.flags.has("--no-comment") && uploads.length > 0) {
@@ -886,7 +884,7 @@ export async function runAttach(
     }
     if (!ctx.quiet && comment)
       process.stderr.write(
-        `>> attachments comment ${comment.action}${comment.via === "bot" ? " (uploads-sh[bot])" : " (via gh)"}\n`,
+        `>> attachments comment ${comment.action}${commentViaSuffix(comment.via)}\n`,
       );
     if (!ctx.quiet && uploads.length > 0) {
       const ref = ghMetadataFromTarget(target)["gh.ref"];
@@ -1109,16 +1107,14 @@ export async function runPut(
     }
   }
 
-  let comment:
-    | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
-    | undefined;
+  let comment: AttachmentsCommentResult | undefined;
   let commentError: string | undefined;
   if (wantComment && ghTarget && uploads.length > 0) {
     try {
       comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
       if (logHuman)
         process.stderr.write(
-          `>> attachments comment ${comment.action}${comment.via === "bot" ? " (uploads-sh[bot])" : " (via gh)"}\n`,
+          `>> attachments comment ${comment.action}${commentViaSuffix(comment.via)}\n`,
         );
     } catch (err) {
       commentError = err instanceof Error ? err.message : String(err);
@@ -1690,7 +1686,7 @@ export async function runComment(
   if (ctx.json) {
     await writeJson({ ...target, ...result });
   } else if (!ctx.quiet) {
-    const via = result.via === "bot" ? " (uploads-sh[bot])" : " (via gh)";
+    const via = commentViaSuffix(result.via);
     process.stderr.write(
       result.action === "skipped"
         ? `no attachments under ${ghKeyPrefix(target)} — nothing to do\n`

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -418,62 +418,96 @@ export function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
 
 /**
  * List every attachment under the target's prefix and create/update the
- * managed comment. Throws on gh failure — callers decide whether that is
- * fatal (`comment` command) or a warning (`put --comment`).
+ * managed comment. Prefers the server-side bot endpoint (`uploads-sh[bot]`,
+ * rendered from this workspace's own data); any failure to post that way —
+ * not installed, declined, self-hosted 404, network error — falls through to
+ * the local-`gh` path so self-hosters keep working unchanged. Throws on gh
+ * failure — callers decide whether that is fatal (`comment` command) or a
+ * warning (`put --comment`).
  */
 export async function syncAttachmentsComment(
   client: UploadsClient,
   target: GhTarget,
   run: CommandRunner,
-): Promise<{ action: "created" | "updated" | "skipped"; count: number }> {
-  const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
-    ({ key, url, embedUrl }) => ({ key, url, embedUrl }),
-  );
-
-  const galleries: (GalleryCommentItem & { id: string })[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await client.findGalleriesByReference({
-      provider: "github",
-      // GitHub references intentionally do not distinguish PRs from issues.
-      coordinate: `${target.repo.toLowerCase()}#${target.num}`,
-      cursor,
+): Promise<{ action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }> {
+  try {
+    const bot = await client.upsertGithubComment({
+      repo: target.repo,
+      num: target.num,
+      kind: target.kind,
     });
-    galleries.push(...page.galleries.map(({ id, title, url }) => ({ title, url, id })));
-    cursor = page.nextCursor ?? undefined;
-  } while (cursor);
+    if (bot.posted) {
+      return {
+        action: bot.action,
+        count: bot.action === "skipped" ? 0 : (bot.count ?? 0),
+        via: "bot",
+      };
+    }
+  } catch {
+    // Endpoint absent/unreachable (self-hosted, network, older worker) — fall
+    // through to the gh path below.
+  }
+  return runGhPath();
 
-  const previewGalleries = await Promise.all(
-    galleries.map(async ({ id, ...gallery }) => {
-      try {
-        const detail = await client.getGallery(id);
-        return {
-          ...gallery,
-          previews: detail.items
-            .filter(
-              (item) =>
-                item.status === "available" && item.url && item.contentType?.startsWith("image/"),
-            )
-            .slice(0, 3)
-            .map((item) => ({
-              url: item.url!,
-              embedUrl: item.embedUrl,
-              alt: item.altText ?? item.objectKey,
-              itemUrl: item.pageUrl,
-            })),
-        };
-      } catch {
-        // A deleted or temporarily unavailable gallery still gets a safe title link.
-        return gallery;
-      }
-    }),
-  );
+  async function runGhPath(): Promise<{
+    action: "created" | "updated" | "skipped";
+    count: number;
+    via: "bot" | "gh";
+  }> {
+    const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
+      ({ key, url, embedUrl }) => ({ key, url, embedUrl }),
+    );
 
-  if (items.length === 0 && previewGalleries.length === 0) return { action: "skipped", count: 0 };
+    const galleries: (GalleryCommentItem & { id: string })[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await client.findGalleriesByReference({
+        provider: "github",
+        // GitHub references intentionally do not distinguish PRs from issues.
+        coordinate: `${target.repo.toLowerCase()}#${target.num}`,
+        cursor,
+      });
+      galleries.push(...page.galleries.map(({ id, title, url }) => ({ title, url, id })));
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor);
 
-  const body = attachmentsCommentBody(items, previewGalleries);
-  const { created } = upsertAttachmentsComment(target, body, run);
-  return { action: created ? "created" : "updated", count: items.length + previewGalleries.length };
+    const previewGalleries = await Promise.all(
+      galleries.map(async ({ id, ...gallery }) => {
+        try {
+          const detail = await client.getGallery(id);
+          return {
+            ...gallery,
+            previews: detail.items
+              .filter(
+                (item) =>
+                  item.status === "available" && item.url && item.contentType?.startsWith("image/"),
+              )
+              .slice(0, 3)
+              .map((item) => ({
+                url: item.url!,
+                embedUrl: item.embedUrl,
+                alt: item.altText ?? item.objectKey,
+                itemUrl: item.pageUrl,
+              })),
+          };
+        } catch {
+          // A deleted or temporarily unavailable gallery still gets a safe title link.
+          return gallery;
+        }
+      }),
+    );
+
+    if (items.length === 0 && previewGalleries.length === 0)
+      return { action: "skipped", count: 0, via: "gh" };
+
+    const body = attachmentsCommentBody(items, previewGalleries);
+    const { created } = upsertAttachmentsComment(target, body, run);
+    return {
+      action: created ? "created" : "updated",
+      count: items.length + previewGalleries.length,
+      via: "gh",
+    };
+  }
 }
 
 // --- attach ---
@@ -812,7 +846,9 @@ export async function runAttach(
     throw firstError instanceof Error ? firstError : new Error(String(firstError));
   }
 
-  let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+  let comment:
+    | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
+    | undefined;
   let commentError: string | undefined;
   // Skip comment refresh when every upload failed — nothing new from this batch.
   if (!parsed.flags.has("--no-comment") && uploads.length > 0) {
@@ -846,7 +882,10 @@ export async function runAttach(
     for (const failure of failures) {
       process.stderr.write(`warning: could not upload ${failure.file}: ${failure.error.message}\n`);
     }
-    if (!ctx.quiet && comment) process.stderr.write(`>> attachments comment ${comment.action}\n`);
+    if (!ctx.quiet && comment)
+      process.stderr.write(
+        `>> attachments comment ${comment.action}${comment.via === "bot" ? " (uploads-sh[bot])" : " (via gh)"}\n`,
+      );
     if (!ctx.quiet && uploads.length > 0) {
       const ref = ghMetadataFromTarget(target)["gh.ref"];
       process.stderr.write(`>> find these later: uploads find gh.ref=${ref}\n`);
@@ -1068,12 +1107,17 @@ export async function runPut(
     }
   }
 
-  let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+  let comment:
+    | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
+    | undefined;
   let commentError: string | undefined;
   if (wantComment && ghTarget && uploads.length > 0) {
     try {
       comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
-      if (logHuman) process.stderr.write(`>> attachments comment ${comment.action}\n`);
+      if (logHuman)
+        process.stderr.write(
+          `>> attachments comment ${comment.action}${comment.via === "bot" ? " (uploads-sh[bot])" : " (via gh)"}\n`,
+        );
     } catch (err) {
       commentError = err instanceof Error ? err.message : String(err);
       process.stderr.write(
@@ -1643,10 +1687,11 @@ export async function runComment(
   if (ctx.json) {
     await writeJson({ ...target, ...result });
   } else if (!ctx.quiet) {
+    const via = result.via === "bot" ? " (uploads-sh[bot])" : " (via gh)";
     process.stderr.write(
       result.action === "skipped"
         ? `no attachments under ${ghKeyPrefix(target)} — nothing to do\n`
-        : `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})\n`,
+        : `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})${via}\n`,
     );
   }
   return 0;

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -143,7 +143,9 @@ Options:
   --format human|url|markdown|json
   --pr <num>            Attach to a pull request: key gh/<owner>/<repo>/pull/<num>/<name> (stable URL, no hash)
   --issue <num>         Attach to an issue: key gh/<owner>/<repo>/issues/<num>/<name>
-  --comment             With --pr/--issue: update one managed comment with attachments and linked galleries via local gh auth
+  --comment             With --pr/--issue: update one managed comment with
+                        attachments and linked galleries. Posts as uploads-sh[bot]
+                        when the GitHub App is installed; otherwise via local gh.
   --gallery <id>         Add the uploaded object(s) to this public gallery
   --meta <k=v>          Queryable custom metadata (repeatable; value may contain "="): key ^[a-z][a-z0-9._-]{0,63}$, value 1-512 printable ASCII, max 24 pairs
                         Re-uploading to an existing key WITH --meta replaces that file's
@@ -1660,7 +1662,8 @@ export async function runDelete(ctx: CliContext, args: string[], help = false): 
 const COMMENT_HELP = `uploads comment (--pr <num> | --issue <num>) [--repo <owner/name>] [--workspace <name>]
 
 Create or update the managed attachments comment on a GitHub PR or issue,
-listing everything uploaded for it. Uses your local gh auth. Finds its own
+listing everything uploaded for it. Posts as uploads-sh[bot] when the GitHub
+App is installed on the repo; otherwise via your local gh auth. Finds its own
 prior comment via a hidden marker and edits it in place; never touches other
 comments or the description.
 

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -14,6 +14,8 @@ import {
   ghTargetFromFlags,
   optimizeOptionsFromFlags,
   syncAttachmentsComment,
+  commentViaSuffix,
+  type AttachmentsCommentResult,
   uploadPreparedImage,
   type CliContext,
 } from "../commands.js";
@@ -328,16 +330,14 @@ export async function runScreenshot(
     }
   }
 
-  let comment:
-    | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
-    | undefined;
+  let comment: AttachmentsCommentResult | undefined;
   let commentError: string | undefined;
   if (wantComment && ghTarget) {
     try {
       comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
       if (logHuman)
         process.stderr.write(
-          `>> attachments comment ${comment.action}${comment.via === "bot" ? " (uploads-sh[bot])" : " (via gh)"}\n`,
+          `>> attachments comment ${comment.action}${commentViaSuffix(comment.via)}\n`,
         );
     } catch (err) {
       commentError = err instanceof Error ? err.message : String(err);

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -87,7 +87,9 @@ Options:
   --keep-exif               Keep EXIF/XMP/ICC when optimizing
   --pr <num>                Attach to a pull request (stable URL, no hash)
   --issue <num>             Attach to an issue
-  --comment                 With --pr/--issue: update the managed attachments comment
+  --comment                 With --pr/--issue: update the managed attachments comment.
+                             Posts as uploads-sh[bot] when the GitHub App is installed;
+                             otherwise via local gh.
   --gallery <id>            Add the uploaded object to this public gallery
   --meta <k=v>              Queryable custom metadata (repeatable)
   --workspace, -w <name>    Override workspace
@@ -326,12 +328,17 @@ export async function runScreenshot(
     }
   }
 
-  let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+  let comment:
+    | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
+    | undefined;
   let commentError: string | undefined;
   if (wantComment && ghTarget) {
     try {
       comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
-      if (logHuman) process.stderr.write(`>> attachments comment ${comment.action}\n`);
+      if (logHuman)
+        process.stderr.write(
+          `>> attachments comment ${comment.action}${comment.via === "bot" ? " (uploads-sh[bot])" : " (via gh)"}\n`,
+        );
     } catch (err) {
       commentError = err instanceof Error ? err.message : String(err);
       process.stderr.write(

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -162,10 +162,15 @@ interface GhComment {
 
 /**
  * PR comments live on the issues endpoint, so one path covers PRs and issues.
- * Only the first 100 comments are searched (accepted v1 limitation).
+ * `--paginate` follows Link headers and merges every page into one array, so the
+ * marker comment is found even on threads past 100 comments.
  */
 function findManagedComment(target: GhTarget, run: CommandRunner): GhComment | undefined {
-  const raw = run("gh", ["api", `repos/${target.repo}/issues/${target.num}/comments?per_page=100`]);
+  const raw = run("gh", [
+    "api",
+    `repos/${target.repo}/issues/${target.num}/comments?per_page=100`,
+    "--paginate",
+  ]);
   const comments = JSON.parse(raw) as GhComment[];
   return comments.find((c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER));
 }

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -188,7 +188,9 @@ export function createUploadsMcpTools(opts: {
   }
 
   const syncComment = async (client: UploadsClient, target: GhTarget) => {
-    let comment: { action: "created" | "updated" | "skipped"; count: number } | undefined;
+    let comment:
+      | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
+      | undefined;
     let commentError: string | undefined;
     try {
       comment = await syncAttachmentsComment(client, target, run);

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -11,6 +11,7 @@ import {
   buildDoctorReport,
   makeGhTarget,
   syncAttachmentsComment,
+  type AttachmentsCommentResult,
   uploadAttachments,
   uploadPreparedImage,
   uploadPuts,
@@ -188,9 +189,7 @@ export function createUploadsMcpTools(opts: {
   }
 
   const syncComment = async (client: UploadsClient, target: GhTarget) => {
-    let comment:
-      | { action: "created" | "updated" | "skipped"; count: number; via: "bot" | "gh" }
-      | undefined;
+    let comment: AttachmentsCommentResult | undefined;
     let commentError: string | undefined;
     try {
       comment = await syncAttachmentsComment(client, target, run);

--- a/packages/uploads/test/client-github-comment.test.ts
+++ b/packages/uploads/test/client-github-comment.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { createUploadsClient } from "../src/client.js";
+
+describe("upsertGithubComment", () => {
+  it("POSTs { repo, num, kind } to /v1/:workspace/github/comment and returns the result", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ posted: true, action: "created", count: 2, commentUrl: "u" }),
+          { status: 200 },
+        ),
+      );
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "acme",
+      token: "tok",
+    });
+    const res = await client.upsertGithubComment({ repo: "acme/web", num: 12, kind: "pull" });
+    expect(res).toEqual({ posted: true, action: "created", count: 2, commentUrl: "u" });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://api.test/v1/acme/github/comment");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(new TextDecoder().decode(init?.body as Uint8Array))).toEqual({
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
 import type { UploadsClient } from "../src/client.js";
-import { runComment, type CliContext } from "../src/commands.js";
+import { runComment, syncAttachmentsComment, type CliContext } from "../src/commands.js";
 import { ATTACHMENTS_MARKER } from "../src/github.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
@@ -19,7 +19,30 @@ function listClient(
     findGalleriesByReference: async () =>
       galleryPages[page++] ?? { galleries: [], nextCursor: null },
     getGallery: async (id: string) => ({ id, items: [] }),
+    // The bot path always declines in these tests, so every existing test
+    // (written for the gh path) keeps exercising the gh fallback.
+    upsertGithubComment: async () => ({ posted: false, reason: "not_installed" }),
   } as unknown as UploadsClient;
+}
+
+/** Minimal client stub for syncAttachmentsComment's bot/gh branch tests. */
+function fakeClient(overrides: Partial<UploadsClient> = {}): UploadsClient {
+  return {
+    listAll: async () => [],
+    findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+    getGallery: async (id: string) => ({ id, items: [] }),
+    upsertGithubComment: async () => ({ posted: false, reason: "not_installed" }),
+    ...overrides,
+  } as unknown as UploadsClient;
+}
+
+/** gh runner that reports no existing comments and creates a new one. */
+function ghRunnerThatFindsNoMarkerThenCreates(): CommandRunner {
+  return (cmd, args) => {
+    if (cmd !== "gh") throw new Error(`unexpected command: ${cmd}`);
+    if (args[1]?.includes("per_page=100")) return "[]";
+    return JSON.stringify({ id: 9 });
+  };
 }
 
 function ctxWith(client: UploadsClient): CliContext {
@@ -124,5 +147,59 @@ describe("runComment", () => {
     const create = calls.find((call) => call.args.includes("repos/o/r/issues/5/comments"));
     expect(create?.input).toContain('src="https://storage.test/one.webp"');
     expect(create?.input).not.toContain("movie.mp4");
+  });
+});
+
+describe("syncAttachmentsComment", () => {
+  it("short-circuits to the bot path on posted:true (no gh calls)", async () => {
+    const client = fakeClient({
+      upsertGithubComment: async () => ({
+        posted: true,
+        action: "created",
+        count: 3,
+        commentUrl: "u",
+      }),
+    });
+    const run = vi.fn(); // gh runner must NOT be called
+    const res = await syncAttachmentsComment(
+      client,
+      { repo: "acme/web", num: 12, kind: "pull" },
+      run,
+    );
+    expect(res).toEqual({ action: "created", count: 3, via: "bot" });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the gh path on posted:false", async () => {
+    const client = fakeClient({
+      upsertGithubComment: async () => ({ posted: false, reason: "not_installed" }),
+      listAll: async () => [{ key: "gh/acme/web/pull/12/a.png", url: "u", embedUrl: null }],
+      findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+    });
+    const run = ghRunnerThatFindsNoMarkerThenCreates();
+    const res = await syncAttachmentsComment(
+      client,
+      { repo: "acme/web", num: 12, kind: "pull" },
+      run,
+    );
+    expect(res.via).toBe("gh");
+    expect(res.action).toBe("created");
+  });
+
+  it("falls back to the gh path when the endpoint throws (self-hosted 404)", async () => {
+    const client = fakeClient({
+      upsertGithubComment: async () => {
+        throw new Error("404");
+      },
+      listAll: async () => [{ key: "gh/acme/web/pull/12/a.png", url: "u", embedUrl: null }],
+      findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+    });
+    const run = ghRunnerThatFindsNoMarkerThenCreates();
+    const res = await syncAttachmentsComment(
+      client,
+      { repo: "acme/web", num: 12, kind: "pull" },
+      run,
+    );
+    expect(res.via).toBe("gh");
   });
 });

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -119,6 +119,8 @@ describe("upsertAttachmentsComment", () => {
     });
     const result = upsertAttachmentsComment(target, `${ATTACHMENTS_MARKER}\nbody`, run);
     expect(result.created).toBe(true);
+    // The lookup paginates so the marker is found past the first 100 comments.
+    expect(calls[0].args).toContain("--paginate");
     const post = calls[1];
     expect(post.args).toContain("repos/o/r/issues/5/comments");
     expect(post.args).toContain("body=@-");

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { attachmentsCommentBody } from "../src/github.js";
+
+const golden = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../../../test/fixtures/github-comment-golden.json", import.meta.url)),
+    "utf8",
+  ),
+) as { items: any[]; galleries: any[]; expected: string };
+
+describe("attachmentsCommentBody (CLI copy)", () => {
+  it("renders the golden body byte-for-byte", () => {
+    expect(attachmentsCommentBody(golden.items, golden.galleries)).toBe(golden.expected);
+  });
+});

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -455,7 +455,11 @@ describe("tools/call put", () => {
     });
     expect(res.result.isError).toBe(false);
     expect(puts[0].key).toBe("gh/o/r/pull/123/after.png");
-    expect(res.result.structuredContent.comment).toEqual({ action: "created", count: 1 });
+    expect(res.result.structuredContent.comment).toEqual({
+      action: "created",
+      count: 1,
+      via: "gh",
+    });
     expect(calls.some((call) => call.includes("repos/o/r/issues/123/comments"))).toBe(true);
   });
 
@@ -602,7 +606,11 @@ describe("tools/call attach", () => {
     });
     expect(res.result.structuredContent.uploads[0].markdown).toContain("before.png");
     expect(res.result.structuredContent.failures).toEqual([]);
-    expect(res.result.structuredContent.comment).toEqual({ action: "created", count: 1 });
+    expect(res.result.structuredContent.comment).toEqual({
+      action: "created",
+      count: 1,
+      via: "gh",
+    });
     expect(calls.some((call) => call[1] === "pr" && call[2] === "view")).toBe(true);
   });
 
@@ -844,6 +852,7 @@ describe("tools/call list, delete, comment", () => {
       num: 45,
       action: "created",
       count: 1,
+      via: "gh",
     });
   });
 });

--- a/test/fixtures/github-comment-golden.json
+++ b/test/fixtures/github-comment-golden.json
@@ -1,0 +1,29 @@
+{
+  "items": [
+    {
+      "key": "gh/acme/web/pull/12/hero.png",
+      "url": "https://uploads.sh/f/hero.png",
+      "embedUrl": "https://embed.uploads.sh/f/hero.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/build.log",
+      "url": "https://uploads.sh/f/build.log",
+      "embedUrl": null
+    }
+  ],
+  "galleries": [
+    {
+      "title": "Design review",
+      "url": "https://uploads.sh/g/abc",
+      "previews": [
+        {
+          "url": "https://uploads.sh/g/abc/i1.png",
+          "embedUrl": "https://embed.uploads.sh/g/abc/i1.png",
+          "alt": "screen one",
+          "itemUrl": "https://uploads.sh/g/abc/i1"
+        }
+      ]
+    }
+  ],
+  "expected": "<!-- uploads.sh:attachments -->\n### 🖼️ Galleries\n\n#### <a href=\"https://uploads.sh/g/abc\">Design review</a>\n<a href=\"https://uploads.sh/g/abc/i1\"><img width=\"320\" alt=\"screen one\" src=\"https://embed.uploads.sh/g/abc/i1.png\"></a>\n<sub><a href=\"https://uploads.sh/g/abc\">Open gallery</a></sub>\n\n\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/build.log)\n<a href=\"https://uploads.sh/f/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>"
+}


### PR DESCRIPTION
## GitHub App phase 2, PR B — bot-owned attachments comment

Closes the second half of #284 (phase 2). PR A (#288) added webhooks + cache invalidation; this PR adds the bot-owned managed comment.

When the "uploads.sh" GitHub App is installed on the target repo, the managed PR/issue attachments comment is now posted server-side as `uploads-sh[bot]` via an installation token. Uploaders no longer need a locally authenticated `gh` for `--comment` / `uploads comment`. Where the App isn't installed, the CLI falls back to its existing local-`gh` path, unchanged.

### How it works

- **New endpoint `POST /v1/:workspace/github/comment`** (workspace-authed) gathers the **calling workspace's own** attachments (`gh/…` key prefix) + galleries for the coordinate, renders the marker comment body server-side, and — when the App is installed with write — upserts it as the bot. Returns `{ posted: true, action, count, commentUrl }` or `{ posted: false, reason }`.
- **CLI** calls the endpoint first; on `posted: true` it's done, otherwise (not installed / `403` / self-hosted 404 / any error) it runs its existing gather → render → `gh` upsert. Human output distinguishes bot vs `gh`.
- **Edits in place, never duplicates.** The server caches the managed comment's id in `GITHUB_CACHE` keyed by `repo#num`, so re-editing attachment media is a single `PATCH` with no listing. The id is an optimization only — a `404` (comment deleted) drops it and falls back to the marker hunt, which now **pages through the whole thread** (a busy PR can push the comment past the first 100). The `gh` fallback gains `--paginate` for the same reason, so both paths edit the one comment in place on 100+ comment threads instead of posting a second.

### Before → after

**Before** — every uploader needs an authenticated local `gh`; the comment is authored by whoever ran the command:

```mermaid
flowchart LR
  U["uploads comment --pr N"] --> CLI["CLI"]
  CLI --> G["gather attachments + galleries"]
  G --> R["render comment body"]
  R --> GH{"local gh<br/>authenticated?"}
  GH -- yes --> POST["gh upserts comment<br/>(authored by the user)"]
  GH -- no --> FAIL["command fails —<br/>no comment posted"]
```

**After** — the server posts as `uploads-sh[bot]` when the App is installed; the local-`gh` path stays as the fallback, so nothing regresses:

```mermaid
flowchart TB
  U["uploads comment --pr N"] --> CLI["CLI"]
  CLI --> EP["POST /v1/:workspace/github/comment<br/>(workspace-authed, sends only repo + num + kind)"]
  EP --> SRV["server gathers the workspace's<br/>OWN attachments + galleries"]
  SRV --> SR["server renders comment body"]
  SR --> INST{"App installed<br/>with write?"}
  INST -- yes --> CACHE{"cached comment id?<br/>(GITHUB_CACHE: repo#num)"}
  CACHE -- hit --> PATCH["PATCH that comment directly<br/>(one call, no listing)"]
  CACHE -- "miss / 404 deleted" --> HUNT["hunt marker comment,<br/>paginated → PATCH or POST,<br/>cache the id"]
  PATCH --> DONE(["posted: true — edited in place"])
  HUNT --> DONE
  INST -- "no / 403 / 404 / error" --> DECL["posted: false, reason"]
  DECL --> FB["CLI falls back to existing gather →<br/>render → gh upsert (paginated marker hunt)"]
  FB --> DONE2(["posted via gh<br/>(unchanged path)"])
```

### Design decisions

- **Server renders from the workspace's own data only** — the endpoint takes `{ repo, num, kind }`, never a caller-supplied body. This is the trust boundary: since the App is installed org-wide, a client-supplied body would let any workspace token make the bot post arbitrary markdown to any org PR. Rendering strictly from the workspace's own uploads prevents that.
- **Two renderers, drift-guarded.** The published CLI imports no `@uploads/*` package, so the renderer is a deliberate copy in the api worker. A shared golden fixture (`test/fixtures/github-comment-golden.json`) is asserted byte-for-byte from both sides, so the copies can't drift.
- **The CLI's `gh` path stays fully intact** as the deepest fallback — self-hosters (App not configured, or an older worker without this route) keep working exactly as before.
- **Write gating degrades, it doesn't block.** A missing install or a `403` (write not yet approved) falls through to `gh`, so this is safe to merge before the live-App permission upgrade.

### Deploy step (out-of-band, after merge)

The bot path stays dormant until the App has write access:

1. Edit the live "uploads.sh" App: add **Issues: Read & write** + **Pull requests: Read & write**.
2. Approve the updated permissions on the `buildinternet` org install.
3. Verify: run `uploads comment --pr <n>` from an environment without `gh` auth against a repo where the App is installed; the comment should appear as `uploads-sh[bot]`.

No new secrets/bindings — the added permissions travel with the existing installation token.

### Testing

- Server: `github-comment.ts` units (gather scoping + cross-workspace isolation, create/patch, 403 → forbidden, token/network → unavailable, empty → skipped); route tests (auth, validation, `not_installed`).
- CLI: `syncAttachmentsComment` prefers bot on `posted: true` (no `gh` call), falls back on `posted: false` and on a thrown endpoint call; client method request shape.
- Full suite green (1779 tests), api + CLI typechecks clean.
- Includes a simplification pass (parallelized gather, deduped branches, shared `jsonBody` route helper, shared `AttachmentsCommentResult` type + `via` suffix helper, tightened result/reason types).

### Notes

- **Changeset** targets `@buildinternet/uploads` (CLI). api/web-only changes remain changeset-ignored.
- Unblocks #65 (galleries in the comment) for the bot-posted path too.
- Follow-up #291 tracks self-healing the managed comment on `issue_comment` webhook events (drift reconciliation); no new event subscription until that handler lands.
