### PR TITLE
feat(api,cli,errors): surface GitHub App permission mismatch as actionable guidance

### DIFF
--- a/.changeset/github-comment-forbidden-guidance.md
+++ b/.changeset/github-comment-forbidden-guidance.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/uploads": patch
+---
+
+When the uploads.sh GitHub App is installed but hasn't been granted Issues /
+Pull requests write yet, `uploads comment` (and `--comment`) now prints a short
+note explaining that an admin must approve the added permissions — with a link
+to do it — before falling back to the local `gh` path, instead of falling back
+silently.

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -138,4 +138,69 @@ describe("POST /v1/:workspace/github/comment", () => {
       globalThis.fetch = realFetch;
     }
   });
+
+  it("enriches a forbidden decline with an actionable message + fix link", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/web", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", new Uint8Array([0x89, 0x50]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => null,
+          all: async () => ({ results: [] }),
+          run: async () => ({}),
+        }),
+      }),
+    } as unknown as D1Database;
+    const env = {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: bucket,
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) =>
+      String(url).includes("/issues/12/comments")
+        ? new Response("no", { status: 403 }) // App lacks write
+        : new Response("nf", { status: 404 })) as unknown as typeof fetch;
+    try {
+      const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        posted: boolean;
+        reason: string;
+        message: string;
+        fixUrl: string;
+        required: string[];
+      };
+      expect(body.posted).toBe(false);
+      expect(body.reason).toBe("forbidden");
+      expect(body.message).toContain("Issues and Pull requests write");
+      expect(body.fixUrl).toBe(
+        "https://github.com/organizations/acme/settings/installations/42/permissions/update",
+      );
+      expect(body.required).toEqual(["issues:write", "pull_requests:write"]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
 });

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -37,6 +37,26 @@ function parseTarget(body: Record<string, unknown>): {
   return { repo, num, kind };
 }
 
+/**
+ * Actionable body for a `forbidden` (App installed, write not yet approved)
+ * decline. `fixUrl` is the org install's permission-review page — this product
+ * installs on orgs, so the org form is the right target; the message stands on
+ * its own if an install is ever user-owned.
+ */
+function forbiddenDecline(repo: string, installId: number) {
+  const owner = repo.split("/")[0];
+  return {
+    posted: false as const,
+    reason: "forbidden" as const,
+    message:
+      `The uploads.sh GitHub App is installed on ${repo} but needs Issues and ` +
+      `Pull requests write access approved before it can comment as ` +
+      `uploads-sh[bot]. An org admin must approve the updated permissions.`,
+    fixUrl: `https://github.com/organizations/${owner}/settings/installations/${installId}/permissions/update`,
+    required: ["issues:write", "pull_requests:write"],
+  };
+}
+
 export const githubComment = new Hono<WorkspaceVars>().post(
   "/comment",
   writeRateLimit,
@@ -57,7 +77,15 @@ export const githubComment = new Hono<WorkspaceVars>().post(
     if (gathered.skip) return c.json({ posted: true, action: "skipped", count: 0 });
 
     const result = await upsertBotComment(c.env, cfg, installId, target, gathered.body);
-    if ("degrade" in result) return c.json({ posted: false, reason: result.degrade });
+    if ("degrade" in result) {
+      // A 403 means the App is installed but lacks Issues/PR write (pending org
+      // approval). Enrich that one reason with actionable guidance so the CLI
+      // can tell the user instead of silently falling back to gh. Mirrors the
+      // IntegrationAuthorizationError vocabulary (@uploads/errors) for the soft,
+      // never-5xx decline path.
+      if (result.degrade === "forbidden") return c.json(forbiddenDecline(target.repo, installId));
+      return c.json({ posted: false, reason: result.degrade });
+    }
     return c.json({
       posted: true,
       action: result.action,

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -43,6 +43,9 @@ export const ERROR_CODES = [
   // Auth / enrollment
   "invalid_enrollment",
 
+  // External integrations (GitHub App, OAuth providers, …)
+  "integration_authorization_required",
+
   // Galleries
   "gallery_not_found",
   "gallery_item_not_found",

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -43,6 +43,28 @@ export class ForbiddenError extends AppError {
   }
 }
 
+/**
+ * An external integration (GitHub App, OAuth provider, …) is connected but is
+ * missing a permission that must be granted out of band — e.g. a GitHub App
+ * whose new Issues/Pull-requests write scope is pending org approval. Carries
+ * the provider, the permissions still needed, and an optional `fix_url` the
+ * caller can surface so an admin can approve it. Shares the 403 `forbidden`
+ * category; the specific `code` is what distinguishes it from a plain refusal.
+ */
+export class IntegrationAuthorizationError extends AppError {
+  constructor(
+    provider: string,
+    opts: { required: string[]; fixUrl?: string; message?: string } = { required: [] },
+  ) {
+    super({
+      type: "forbidden",
+      code: "integration_authorization_required",
+      message: opts.message ?? `${provider} needs additional permissions approved.`,
+      details: { provider, required: opts.required, fix_url: opts.fixUrl },
+    });
+  }
+}
+
 /** Missing OAuth/API scope — fixed code + `{ required_scope }` details. */
 export class InsufficientScopeError extends AppError {
   constructor(requiredScope: string, message = "Insufficient scope.") {

--- a/packages/errors/test/errors.test.ts
+++ b/packages/errors/test/errors.test.ts
@@ -8,6 +8,7 @@ import {
   isErrorEnvelope,
   isKnownErrorCode,
   InsufficientStorageError,
+  IntegrationAuthorizationError,
   InternalError,
   NotFoundError,
   RateLimitedError,
@@ -94,6 +95,23 @@ describe("subclasses", () => {
     expect(err.status).toBe(507);
     expect(err.type).toBe("insufficient_storage");
     expect(err.code).toBe("storage_quota_exceeded");
+  });
+
+  it("IntegrationAuthorizationError is a 403 carrying provider + required + fix_url", () => {
+    const err = new IntegrationAuthorizationError("GitHub App", {
+      required: ["issues:write", "pull_requests:write"],
+      fixUrl: "https://github.com/organizations/acme/settings/installations/1/permissions/update",
+      message: "GitHub App needs write approved for acme.",
+    });
+    expect(err.status).toBe(403);
+    expect(err.type).toBe("forbidden");
+    expect(err.code).toBe("integration_authorization_required");
+    expect(err.toWire().error.details).toEqual({
+      provider: "GitHub App",
+      required: ["issues:write", "pull_requests:write"],
+      fix_url: "https://github.com/organizations/acme/settings/installations/1/permissions/update",
+    });
+    expect(err.toWire().error.message).toBe("GitHub App needs write approved for acme.");
   });
 });
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -220,7 +220,15 @@ export type GithubCommentDeclineReason =
 
 export type GithubCommentResult =
   | { posted: true; action: "created" | "updated" | "skipped"; count: number; commentUrl?: string }
-  | { posted: false; reason: GithubCommentDeclineReason };
+  | {
+      posted: false;
+      reason: GithubCommentDeclineReason;
+      // Present on `forbidden` (App installed, write pending approval): a ready
+      // human message + fix link the CLI surfaces instead of degrading silently.
+      message?: string;
+      fixUrl?: string;
+      required?: string[];
+    };
 
 export interface HealthResult {
   ok: boolean;

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -451,6 +451,14 @@ export async function syncAttachmentsComment(
       kind: target.kind,
     });
     if (bot.posted) return { action: bot.action, count: bot.count, via: "bot" };
+    // Installed-but-unapproved is a fixable misconfiguration, not a silent
+    // degrade: tell the user (and how to fix it) before falling back to gh.
+    if (bot.reason === "forbidden" && bot.message) {
+      process.stderr.write(
+        `note: ${bot.message}${bot.fixUrl ? `\n  ${bot.fixUrl}` : ""}\n` +
+          `Posting via local gh in the meantime.\n`,
+      );
+    }
   } catch {
     // Endpoint absent/unreachable (self-hosted, network, older worker) — fall
     // through to the gh path below.

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -186,6 +186,34 @@ describe("syncAttachmentsComment", () => {
     expect(res.action).toBe("created");
   });
 
+  it("warns with the fix message on forbidden, then falls back to gh", async () => {
+    const client = fakeClient({
+      upsertGithubComment: async () => ({
+        posted: false,
+        reason: "forbidden",
+        message: "The uploads.sh GitHub App is installed on acme/web but needs write approved.",
+        fixUrl: "https://github.com/organizations/acme/settings/installations/1/permissions/update",
+        required: ["issues:write", "pull_requests:write"],
+      }),
+      listAll: async () => [{ key: "gh/acme/web/pull/12/a.png", url: "u", embedUrl: null }],
+      findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+    });
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const res = await syncAttachmentsComment(
+        client,
+        { repo: "acme/web", num: 12, kind: "pull" },
+        ghRunnerThatFindsNoMarkerThenCreates(),
+      );
+      expect(res.via).toBe("gh");
+      const printed = stderr.mock.calls.map((c) => String(c[0])).join("");
+      expect(printed).toContain("needs write approved");
+      expect(printed).toContain("/permissions/update");
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   it("falls back to the gh path when the endpoint throws (self-hosted 404)", async () => {
     const client = fakeClient({
       upsertGithubComment: async () => {


### PR DESCRIPTION
## Surface a GitHub App permission mismatch instead of degrading silently

Follow-up to #290. During live smoke testing, `uploads comment` on a repo where the App is installed **but hasn't been granted Issues/Pull requests write yet** (org approval pending) posted as the *user* via the `gh` fallback — correct degrade-safe behavior, but the underlying misconfiguration was completely invisible: the endpoint returned a bare `{posted:false,reason:"forbidden"}` and the CLI fell back without a word.

This makes that one case actionable.

### Changes

- **`@uploads/errors` — new `IntegrationAuthorizationError`.** A 403 (`integration_authorization_required`) carrying `{ provider, required, fix_url }`, mirroring the existing `InsufficientScopeError` pattern. A reusable vocabulary for *"integration is connected but needs an out-of-band grant approved"* — GitHub App scopes today, OAuth re-consent tomorrow. This is the standardized error other features can throw when degrading isn't appropriate.

- **api — enriched `forbidden` decline.** The bot-comment endpoint stays degrade-safe (HTTP 200, never throws), but a `forbidden` now carries a ready-to-print `message`, a `fixUrl` (the org install's permission-review page), and the `required` scopes. The soft decline echoes the same vocabulary the thrown error defines.

- **cli — no more silent fallback on `forbidden`.** `uploads comment` / `--comment` prints the message + fix link, then still falls back to `gh`. Every other decline reason keeps today's quiet fallback.

### Why enrich the wire instead of throwing

Two constraints forced this shape: the endpoint must **never fail the caller's upload** (so it can't throw a 4xx), and the **CLI imports no `@uploads/*` package** (publish constraint), so it can't share an errors module. Both are satisfied by having the server compose the guidance and the CLI render whatever it's handed.

### Probe vs. react

We keep the write **reactive** — attempt it, treat GitHub's 403 as the signal — so there's no added latency on the happy path. GitHub hands us the granted `permissions` for free in the installation-token mint response, which a future admin "App health" panel or `uploads github doctor` can read to show status *without* a write. Those are filed as follow-ups, not built here.

### Testing

- errors: `IntegrationAuthorizationError` shape (403, code, `{provider,required,fix_url}` wire details).
- api: route returns the enriched `forbidden` body (message + exact `fixUrl` + `required`) when GitHub 403s.
- cli: `syncAttachmentsComment` prints the message on `forbidden` then falls back to gh.
- Full suite green (1788), all typechecks clean.

### Notes

- Changeset targets `@buildinternet/uploads` (CLI behavior). api/errors changes are changeset-ignored.
- `fixUrl` uses the org install form (this product installs on orgs); the message stands alone if an install is ever user-owned.
- Deferred follow-ups filed: #293 (admin "GitHub App health" surface + `uploads github doctor`, proactive via free mint-time permissions) and #294 (two stale "via local gh auth" copy strings).
- Verified live after the org approved write: the endpoint now returns `posted:true` and the bot writes to GitHub. (Behavioral note in #293: a `gh`-authored comment predating the write grant gets adopted by the bot via edit, keeping the original author.)
