### PR TITLE
feat(web): tidy file-page Copy-as, add linked Markdown image, default to it

### DIFF
--- a/apps/web/src/components/CopyAsControls.astro
+++ b/apps/web/src/components/CopyAsControls.astro
@@ -32,21 +32,23 @@ const show = Boolean(downloadUrl) || formats.length > 0;
             <select id="copy-format" aria-label="Copy as format">
               {formats.map((format) => <option value={format.id}>{format.label}</option>)}
             </select>
-            <input
-              id="copy-value"
-              type="text"
-              readonly
-              value={defaultCopyValue}
-              aria-label="Value to copy"
-            />
-            <button
-              type="button"
-              id="copy-format-btn"
-              data-copy={defaultCopyValue}
-              aria-live="polite"
-            >
-              Copy
-            </button>
+            <div class="copyout">
+              <input
+                id="copy-value"
+                type="text"
+                readonly
+                value={defaultCopyValue}
+                aria-label="Value to copy"
+              />
+              <button
+                type="button"
+                id="copy-format-btn"
+                data-copy={defaultCopyValue}
+                aria-live="polite"
+              >
+                Copy
+              </button>
+            </div>
           </div>
         </span>
       )}
@@ -129,9 +131,10 @@ const show = Boolean(downloadUrl) || formats.length > 0;
     color: var(--accent);
     outline: none;
   }
+  /* Always its own full-width row so the narrow file-page rail never overflows */
   .linkfield {
-    flex: 1;
-    min-width: 260px;
+    flex: 1 1 100%;
+    min-width: 0;
   }
   .linkfield label {
     display: block;
@@ -141,39 +144,52 @@ const show = Boolean(downloadUrl) || formats.length > 0;
     font: 11px var(--mono);
     margin-bottom: 5px;
   }
+  /* Stacked: format chooser on top, value + Copy beneath — keeps every control
+     legible in the ~300px rail instead of crushing them into one row. */
   .copyrow {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .copyout {
     display: flex;
     gap: 6px;
     align-items: stretch;
   }
   .copyrow select,
-  .copyrow input,
-  .copyrow button {
+  .copyout input,
+  .copyout button {
     padding: 8px;
     border: 1px solid var(--line);
     border-radius: var(--radius-md);
     font: 12px var(--mono);
   }
   .copyrow select,
-  .copyrow input {
+  .copyout input {
     background: var(--bg);
     color: var(--body);
   }
-  .copyrow input {
+  .copyrow select {
+    width: 100%;
+  }
+  .copyout input {
     flex: 1;
     min-width: 0;
     padding: 8px 10px;
   }
-  .copyrow button {
-    padding: 8px 12px;
-    background: var(--panel);
-    color: var(--fg);
+  /* Primary action — solid accent, mirroring the repo's .ul-btn--solid pattern. */
+  .copyout button {
+    padding: 8px 14px;
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg);
+    font-weight: 600;
     cursor: pointer;
   }
-  .copyrow button:hover,
-  .copyrow button:focus-visible {
-    border-color: var(--accent);
-    color: var(--accent);
+  .copyout button:hover,
+  .copyout button:focus-visible {
+    background: color-mix(in srgb, var(--accent) 88%, #fff);
+    border-color: color-mix(in srgb, var(--accent) 88%, #fff);
     outline: none;
   }
 </style>

--- a/apps/web/src/lib/embed-formats.test.ts
+++ b/apps/web/src/lib/embed-formats.test.ts
@@ -9,19 +9,25 @@ const base = {
 };
 
 describe("buildEmbedFormats", () => {
-  it("returns all five formats, in order, for an image", () => {
+  it("returns all six formats for an image, with the linked Markdown image first (default)", () => {
     const formats = buildEmbedFormats({ ...base, kind: "image" });
     expect(formats.map((f) => f.id)).toEqual([
+      "markdown-image-linked",
+      "markdown-image",
       "page",
       "url",
-      "markdown-image",
       "markdown-link",
       "html-img",
     ]);
     expect(formats).toEqual([
+      {
+        id: "markdown-image-linked",
+        label: "Markdown image (linked)",
+        value: `[![](${base.embedUrl})](${base.canonical})`,
+      },
+      { id: "markdown-image", label: "Markdown image", value: `![](${base.embedUrl})` },
       { id: "page", label: "Page link", value: base.canonical },
       { id: "url", label: "Direct file URL", value: base.url },
-      { id: "markdown-image", label: "Markdown image", value: `![](${base.embedUrl})` },
       { id: "markdown-link", label: "Markdown link", value: `[shot.png](${base.canonical})` },
       {
         id: "html-img",
@@ -29,6 +35,15 @@ describe("buildEmbedFormats", () => {
         value: `<img src="${base.embedUrl}" alt="shot.png">`,
       },
     ]);
+  });
+
+  it("defaults to the linked Markdown image for images (first element)", () => {
+    const formats = buildEmbedFormats({ ...base, kind: "image" });
+    expect(formats[0]).toEqual({
+      id: "markdown-image-linked",
+      label: "Markdown image (linked)",
+      value: `[![](${base.embedUrl})](${base.canonical})`,
+    });
   });
 
   it("drops the markdown-image and html-img formats for video/file/unsupported kinds", () => {

--- a/apps/web/src/lib/embed-formats.ts
+++ b/apps/web/src/lib/embed-formats.ts
@@ -4,7 +4,13 @@
  * Dependency-free so it stays unit-testable without a render harness.
  */
 
-export type EmbedFormatId = "page" | "url" | "markdown-image" | "markdown-link" | "html-img";
+export type EmbedFormatId =
+  | "page"
+  | "url"
+  | "markdown-image"
+  | "markdown-image-linked"
+  | "markdown-link"
+  | "html-img";
 
 /** Escapes `&`, `<`, `>`, and `"` for HTML attribute values. */
 function escapeHtmlAttr(s: string): string {
@@ -42,20 +48,30 @@ export interface EmbedFormatInput {
 }
 
 /**
- * Formats in design-spec §3.3 order: Page link, Direct file URL, Markdown image
- * (image only), Markdown link, HTML `<img>` (image only). Embed *snippet*
- * formats prefer `embedUrl` and fall back to `url`; "Direct file URL" always
- * uses the stable `url` (same convention as the CLI MARKDOWN path).
+ * The first element is the pre-selected default. For images that's the linked
+ * Markdown image — the agent-PR headline: a screenshot that opens the file page
+ * when clicked. Full order for images: Markdown image (linked), Markdown image,
+ * Page link, Direct file URL, Markdown link, HTML `<img>`. Non-image kinds get
+ * Page link, Direct file URL, Markdown link (Page link is their default). Embed
+ * *snippet* formats prefer `embedUrl` and fall back to `url`; "Direct file URL"
+ * always uses the stable `url` (same convention as the CLI MARKDOWN path).
  */
 export function buildEmbedFormats(input: EmbedFormatInput): EmbedFormatOption[] {
   const embedSrc = input.embedUrl ?? input.url;
   const isImage = input.kind === "image";
   return [
+    ...(isImage
+      ? [
+          {
+            id: "markdown-image-linked" as const,
+            label: "Markdown image (linked)",
+            value: `[![](${embedSrc})](${input.canonical})`,
+          },
+          { id: "markdown-image" as const, label: "Markdown image", value: `![](${embedSrc})` },
+        ]
+      : []),
     { id: "page", label: "Page link", value: input.canonical },
     { id: "url", label: "Direct file URL", value: input.url },
-    ...(isImage
-      ? [{ id: "markdown-image" as const, label: "Markdown image", value: `![](${embedSrc})` }]
-      : []),
     {
       id: "markdown-link",
       label: "Markdown link",

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -122,7 +122,7 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       .fallback strong { display:block; color:var(--fg); margin-bottom:8px; }
       .fallback a { color:var(--fg); overflow-wrap:anywhere; }
       .details { padding:18px 20px 22px; border-top:1px solid var(--line); }
-      .filename { color:var(--fg); font:600 14px var(--mono); overflow-wrap:anywhere; }
+      .filetitle { margin:0 0 16px; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
       dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:14px 0 0; font:12px var(--mono); }
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
@@ -159,7 +159,6 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
         .shell { width: min(100% - 32px, 1080px); padding-top: 24px; }
         .media { min-height: 220px; }
       }
-      .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); clip-path:inset(50%); white-space:nowrap; border:0; }
     </style>
   </head>
   <body>
@@ -167,7 +166,7 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       <nav class="top"><Brand /><span class="public">public file</span></nav>
       {file ? (
         <>
-          <h1 class="sr-only">{filename}</h1>
+          <h1 class="filetitle">{filename}</h1>
           <figure class="stage" style="margin:0">
             <div class="media">
               {kind(file.contentType) === "image" && <img src={file.url} alt={filename} decoding="async" />}
@@ -176,7 +175,6 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
               {kind(file.contentType) === "unsupported" && <div class="fallback"><strong>Unsupported media type</strong><span>This file cannot be previewed inline.</span></div>}
             </div>
             <figcaption class="details">
-              <div class="filename">{filename}</div>
               {gh && (
                 <a
                   class="gh-chip"

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -208,7 +208,6 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
                 </a>
               )}
               <dl class="meta">
-                <dt>Type</dt><dd>{file.contentType}</dd>
                 <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
                 {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
                 {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}


### PR DESCRIPTION
Cleans up the file share page (`/f/…`) right column and its Copy-as control, and adds a linked-image embed format.

## Changes

- **Fix the crushed Copy-as control.** The format `select`, value field, and Copy button shared one horizontal row, but the file-page rail is only ~300px — squeezing the value input down to a broken-looking `https:` sliver. It's now stacked: a full-width format `select` over a value + Copy row, so every control stays legible. (`min-width` on the field is dropped so it can never overflow the narrow rail.)
- **Add a "Markdown image (linked)" format** — the embeddable image wrapped in a link back to the file page (`[![](embedSrc)](pageUrl)`). Image-only. This is the agent-PR headline: a screenshot that opens the file page when clicked.
- **Default to the linked Markdown image for images.** It's now first in the format list, so it's pre-selected. Non-image files are unchanged and keep **Page link** as their default (they have no linked-image format).
- **Make Copy the primary action** — solid accent, mirroring the repo's `.ul-btn--solid` pattern.
- **Drop the mime-type `Type` row** from the file-page metadata (`image/png` etc. — too detailed to be useful for now).
- **Move the filename above the image.** It was an `sr-only` h1 plus a right-column label; it's now a visible title (slightly larger mono) directly above the media, removed from the details column.

The Copy-as component and format builder are shared with the gallery item page (`/g/…`), so the new default and primary-Copy styling apply there too. The `Type`-row removal and title move are file-page only.

## After

![File page after cleanup](https://embed.uploads.sh/default/screenshots/uploads/2026-07-20/localhost-f-buildinternet-screenshots-releases-1789-forgot-light-eed4b6.png-abeb9d.webp)

## Testing

- `apps/web` unit tests updated and passing (8/8), including the new default-first order and the linked-image wrap.
- `astro check` clean (0 errors).
- Verified in the browser against production data: title above the image, stacked Copy-as layout, "Markdown image (linked)" pre-selected with the correct `[![](…)](…)` value, primary Copy button, no Type row.

No changeset — `@uploads/web` is release-ignored.
