### PR TITLE
docs(web): GitHub App docs page (post-install landing)

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -9,6 +9,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, get a URL for any file, capture a screenshot
+- [Docs: GitHub App](https://uploads.sh/docs/github-app): optional install for bot-posted attachment comments and private-repo PR/issue titles
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://uploads.sh/docs/github-app</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://uploads.sh/docs/agents</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -453,6 +453,17 @@ const fullTitle = `${title} · uploads.sh`;
       @media (max-width: 560px) {
         .doc .ghc .imgs { grid-template-columns: 1fr; }
       }
+      /* Post-install banner (docs/github-app), revealed by ?setup_action=install|update. */
+      .doc .installed {
+        margin: 0 0 28px;
+        padding: 12px 16px;
+        border: 1px solid color-mix(in srgb, var(--green) 35%, transparent);
+        border-radius: 8px;
+        background: color-mix(in srgb, var(--green) 8%, transparent);
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .doc .installed strong { color: var(--green); }
       .doc .note {
         margin: 20px 0 0;
         color: var(--muted);

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -41,6 +41,7 @@ const DOCS_NAV = [
     items: [
       { slug: "overview", href: "/docs", label: "Overview" },
       { slug: "attach", href: "/docs/attach-pull-request-images", label: "Attach & share" },
+      { slug: "github-app", href: "/docs/github-app", label: "GitHub App" },
       { slug: "agents", href: "/docs/agents", label: "Set up your agent" },
       { slug: "reference", href: "/docs/reference", label: "Reference" },
     ],

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -74,6 +74,10 @@ const REPO = "https://github.com/buildinternet/uploads";
         <h3>Attach &amp; share <span class="go">→</span></h3>
         <p>Post files to a PR or issue, get a URL for any file, and capture a screenshot.</p>
       </a>
+      <a class="card" href="/docs/github-app">
+        <h3>GitHub App <span class="go">→</span></h3>
+        <p>Optional install: comments post as uploads-sh[bot] and private-repo titles show up.</p>
+      </a>
       <a class="card" href="/docs/agents">
         <h3>Set up your agent <span class="go">→</span></h3>
         <p>Install the agent skill and the MCP server so your agent uploads on its own.</p>

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -76,7 +76,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   </section>
 
   <nav class="page-nav" aria-label="More docs">
-    <a class="prev" href="/docs/attach-pull-request-images"><span class="dir">← Back</span>Attach &amp; share</a>
+    <a class="prev" href="/docs/github-app"><span class="dir">← Back</span>GitHub App</a>
     <a class="next" href="/docs/reference"><span class="dir">Next →</span>Reference</a>
   </nav>
 </DocsLayout>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -182,6 +182,6 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
 
   <nav class="page-nav" aria-label="More docs">
     <a class="prev" href="/docs"><span class="dir">← Back</span>Overview</a>
-    <a class="next" href="/docs/agents"><span class="dir">Next →</span>Set up your agent</a>
+    <a class="next" href="/docs/github-app"><span class="dir">Next →</span>GitHub App</a>
   </nav>
 </DocsLayout>

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -23,13 +23,16 @@ const TOC = [
   active="github-app"
   toc={TOC}
 >
+  {/* Post-install landing: GitHub's Setup URL redirect arrives with
+      ?setup_action=install|update, which reveals this banner client-side. */}
+  <aside class="installed" id="installed-note" hidden aria-live="polite">
+    <strong data-installed-heading>App installed — you're done.</strong> There is nothing to
+    configure on this side. The CLI notices the installation automatically the next time you
+    run <code>uploads attach</code>.
+  </aside>
+
   <section class="lead" id="what-it-adds">
     <h2>What it adds <a class="anchor" href="#what-it-adds" aria-label="Link to this section">#</a></h2>
-    <p>
-      <strong>Just installed the App? You're done.</strong> There is nothing to configure on
-      this side — the CLI notices the installation automatically the next time you run&#32;
-      <code>uploads attach</code>.
-    </p>
     <p>
       Everything in these docs works without the App. Installing the&#32;
       <a href={APP_URL}>uploads-sh GitHub App</a> on your repos upgrades three things:
@@ -107,3 +110,19 @@ const TOC = [
     <a class="next" href="/docs/agents"><span class="dir">Next →</span>Set up your agent</a>
   </nav>
 </DocsLayout>
+
+
+<script is:inline>
+  // GitHub's post-install redirect lands here with ?setup_action=install|update.
+  (() => {
+    const action = new URLSearchParams(location.search).get("setup_action");
+    if (action !== "install" && action !== "update") return;
+    const note = document.getElementById("installed-note");
+    if (!note) return;
+    if (action === "update") {
+      const heading = note.querySelector("[data-installed-heading]");
+      if (heading) heading.textContent = "Installation updated — you're done.";
+    }
+    note.hidden = false;
+  })();
+</script>

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -1,0 +1,109 @@
+---
+// uploads.sh — docs / GitHub App. What installing the uploads-sh App adds on
+// top of the CLI (bot comments, private-repo titles, live title updates), and
+// the post-install landing page (the App's Setup URL points here).
+import DocsLayout from "../../layouts/DocsLayout.astro";
+
+const APP_URL = "https://github.com/apps/uploads-sh";
+
+const TOC = [
+  { id: "what-it-adds", label: "What it adds" },
+  { id: "install", label: "Install it" },
+  { id: "permissions", label: "Permissions" },
+  { id: "without-it", label: "Without the App" },
+];
+---
+
+<DocsLayout
+  title="GitHub App"
+  description="Install the uploads-sh GitHub App so attachment comments post as uploads-sh[bot], private-repo PR and issue titles show on file pages, and titles stay current."
+  path="/docs/github-app"
+  heading="GitHub App"
+  tagline="Optional, but nicer: bot-posted comments and live PR/issue titles."
+  active="github-app"
+  toc={TOC}
+>
+  <section class="lead" id="what-it-adds">
+    <h2>What it adds <a class="anchor" href="#what-it-adds" aria-label="Link to this section">#</a></h2>
+    <p>
+      <strong>Just installed the App? You're done.</strong> There is nothing to configure on
+      this side — the CLI notices the installation automatically the next time you run&#32;
+      <code>uploads attach</code>.
+    </p>
+    <p>
+      Everything in these docs works without the App. Installing the&#32;
+      <a href={APP_URL}>uploads-sh GitHub App</a> on your repos upgrades three things:
+    </p>
+    <ul>
+      <li>
+        <strong>Comments post as <code>uploads-sh[bot]</code>.</strong> The managed
+        "📎 Attachments" comment is created and updated by the App on the server, instead of
+        under your own GitHub identity via the local <code>gh</code> CLI. That keeps
+        attachment noise off your account — and it works in environments with no&#32;
+        <code>gh</code> auth at all.
+      </li>
+      <li>
+        <strong>File pages show titles for private repos.</strong> A file attached to a PR or
+        issue gets a share page that names its PR or issue. For public repos that works out
+        of the box; for private repos the App is what grants read access to the title.
+      </li>
+      <li>
+        <strong>Titles stay current.</strong> The App's webhooks tell uploads.sh when a PR or
+        issue is renamed, closed, or merged, so file pages don't show stale titles.
+      </li>
+    </ul>
+  </section>
+
+  <section id="install">
+    <h2>Install it <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
+    <p>
+      Install from <a href={APP_URL}>github.com/apps/uploads-sh</a>. Pick the organization or
+      account, then choose the repositories you attach files to — "only select repositories"
+      is fine, and you can add more later from GitHub's settings.
+    </p>
+    <p>
+      That's the whole setup. The next <code>uploads attach</code> against an installed repo
+      prints <code>(uploads-sh[bot])</code> instead of <code>(via gh)</code>:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads attach ./after.png</span>
+      <button type="button" data-copy="uploads attach ./after.png" aria-live="polite">copy</button>
+    </div>
+    <div class="block" aria-label="Example output">
+      <pre>&gt;&gt; uploading ./after.png
+<span class="ok">&gt;&gt; attachments comment updated (uploads-sh[bot])</span></pre>
+    </div>
+  </section>
+
+  <section id="permissions">
+    <h2>Permissions <a class="anchor" href="#permissions" aria-label="Link to this section">#</a></h2>
+    <p>The App asks for the minimum it needs:</p>
+    <ul>
+      <li>
+        <strong>Issues and Pull requests: read &amp; write</strong> — read titles and state,
+        and post the one managed attachments comment. It never touches other comments, PR
+        descriptions, or your code.
+      </li>
+    </ul>
+    <p>
+      If your org installed the App before a permission was added, GitHub holds the upgrade
+      until an org admin approves it. The CLI tells you when that's the case — it prints the
+      exact approval link and falls back to posting via <code>gh</code> in the meantime.
+    </p>
+  </section>
+
+  <section id="without-it">
+    <h2>Without the App <a class="anchor" href="#without-it" aria-label="Link to this section">#</a></h2>
+    <p>
+      No install, no problem: <code>uploads attach</code> posts the same managed comment
+      through your local <code>gh</code> CLI, and file pages still resolve titles for public
+      repos. Uninstalling later just returns you to that behavior — hosted files and their
+      URLs are unaffected either way.
+    </p>
+  </section>
+
+  <nav class="page-nav" aria-label="More docs">
+    <a class="prev" href="/docs/attach-pull-request-images"><span class="dir">← Back</span>Attach &amp; share</a>
+    <a class="next" href="/docs/agents"><span class="dir">Next →</span>Set up your agent</a>
+  </nav>
+</DocsLayout>


### PR DESCRIPTION
## Summary

- New public docs page `/docs/github-app` documenting the uploads-sh GitHub App: what installing adds (comments posted as `uploads-sh[bot]`, private-repo PR/issue titles on file pages, webhook-kept title freshness), install steps, requested permissions (incl. the pending-org-approval case from #292), and behavior without the App.
- Doubles as the App's post-install landing page: GitHub's Setup URL redirect arrives with `?setup_action=install|update`, which reveals a green "App installed — you're done" banner at the top (client-side, hidden otherwise; the `update` case says "Installation updated").
- Wired into the site: DocsLayout left-nav entry, docs-hub card, prev/next chain on Attach & share / Agents, plus `sitemap.xml` and `llms.txt` entries.

## Verification

- Rendered the page and docs hub in the local dev server; checked nav links, TOC, and copy (fixed three Astro whitespace-collapse spots with `&#32;`).
- Verified the banner appears with `?setup_action=install` and stays `display: none` without it.

## Follow-up (manual)

- Set the GitHub App's Setup URL to `https://uploads.sh/docs/github-app`; leave "Redirect on update" unchecked.

## Screenshots

Default page:

<img width="760" alt="GitHub App docs page" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/302/localhost-docs-github-app.webp">

Arriving from GitHub's post-install redirect (`?setup_action=install`):

<img width="760" alt="Post-install banner revealed by setup_action=install" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/302/post-install-banner.webp">
