### PR TITLE
refactor(api,mcp): stamp workspace slug on WorkspaceRecord so listings always carry pageUrl

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -420,7 +420,7 @@ export interface ListedObject {
    * `getMetadataForKeys`) and merge it onto each row.
    */
   metadata?: Record<string, string>;
-  /** Canonical public `/f/` page URL (issue #135). Present only when `url` is set and the caller passed `workspaceName`. */
+  /** Canonical public `/f/` page URL (issue #135). Present only when `url` is set and the workspace record carries a slug (`ws.name`, issue #303). */
   pageUrl?: string;
 }
 
@@ -443,7 +443,6 @@ export async function listObjects(
     delimiter?: string;
     limit?: number;
     cursor?: string;
-    workspaceName?: string;
   } = {},
 ): Promise<{ items: ListedObject[]; cursor: string | null; prefixes?: string[] }> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 1000);
@@ -468,9 +467,7 @@ export async function listObjects(
         embedUrl: urls.embedUrl,
         ...storedMetaJson(item),
         ...(visibility ? { visibility } : {}),
-        ...(urls.url && opts.workspaceName
-          ? { pageUrl: filePageUrl(env, opts.workspaceName, item.key) }
-          : {}),
+        ...(urls.url && ws.name ? { pageUrl: filePageUrl(env, ws.name, item.key) } : {}),
       };
     }),
     cursor: result.cursor ?? null,

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -64,7 +64,6 @@ async function gatherAttachments(
       prefix: ghKeyPrefix(target),
       limit: 1000,
       cursor,
-      workspaceName,
     });
     for (const o of page.items)
       items.push({ key: o.key, url: o.url, embedUrl: o.embedUrl, pageUrl: o.pageUrl });

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -41,7 +41,7 @@ export async function gatherCommentBody(
   // Attachments (R2 list) and galleries (D1) are independent reads — overlap
   // them so the request only waits the longer of the two, not their sum.
   const [items, galleries] = await Promise.all([
-    gatherAttachments(env, ws, workspaceName, target),
+    gatherAttachments(env, ws, target),
     gatherGalleries(env, ws, workspaceName, target),
   ]);
 
@@ -54,7 +54,6 @@ export async function gatherCommentBody(
 async function gatherAttachments(
   env: Env,
   ws: WorkspaceRecord,
-  workspaceName: string,
   target: GhTarget,
 ): Promise<AttachmentItem[]> {
   const items: AttachmentItem[] = [];

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -198,7 +198,6 @@ export const files = new Hono<WorkspaceVars>()
         prefix,
         limit,
         cursor,
-        workspaceName: c.get("workspaceName"),
       }),
     );
   })

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -669,7 +669,7 @@ describe("GET /me/workspaces/:name/files", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       communal: boolean;
-      files: { key: string; url: string }[];
+      files: { key: string; url: string; pageUrl?: string }[];
     };
     expect(body.communal).toBe(false);
     expect(body.files).toHaveLength(1);
@@ -677,6 +677,10 @@ describe("GET /me/workspaces/:name/files", () => {
       key: "f/x/shot.png",
       url: "https://storage.uploads.sh/acme/f/x/shot.png",
     });
+    // #303: this route never passed `workspaceName` into listObjects, so
+    // pageUrl was always missing here — loadWorkspaceRecord now stamps
+    // `name` from the lookup key, so listObjects computes it unconditionally.
+    expect(body.files[0].pageUrl).toBe("https://uploads.test/f/acme/f/x/shot.png");
   });
 
   it("lists a folder with prefix and hydrates gh.* metadata + public urls", async () => {

--- a/apps/api/src/self-serve-defaults.test.ts
+++ b/apps/api/src/self-serve-defaults.test.ts
@@ -9,6 +9,7 @@ describe("selfServeWorkspaceRecord", () => {
       now: new Date("2026-07-14T00:00:00Z"),
     });
     expect(record).toMatchObject({
+      name: "zachbot",
       provider: "r2",
       bucket: "uploads-default",
       binding: "UPLOADS_DEFAULT",

--- a/apps/api/src/self-serve-defaults.ts
+++ b/apps/api/src/self-serve-defaults.ts
@@ -23,6 +23,7 @@ export function selfServeWorkspaceRecord(args: {
   now: Date;
 }): WorkspaceRecord {
   return {
+    name: args.name,
     provider: "r2",
     bucket: "uploads-default",
     binding: "UPLOADS_DEFAULT",

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -26,7 +26,15 @@ function fakeRegistry(records: Record<string, unknown>): Env["REGISTRY"] {
 describe("loadWorkspaceRecord (#247 soft-delete filtering)", () => {
   it("returns the record for a normal workspace", async () => {
     const env = { REGISTRY: fakeRegistry({ "ws:acme": RECORD }) } as unknown as Env;
-    expect(await loadWorkspaceRecord(env, "acme")).toEqual(RECORD);
+    expect(await loadWorkspaceRecord(env, "acme")).toEqual({ ...RECORD, name: "acme" });
+  });
+
+  it("stamps name from the lookup key, not the stored JSON, even when the JSON has a different/absent name (#303)", async () => {
+    const stale: WorkspaceRecord = { ...RECORD, name: "stale-old-name" };
+    const env = { REGISTRY: fakeRegistry({ "ws:acme": stale }) } as unknown as Env;
+    expect((await loadWorkspaceRecord(env, "acme"))?.name).toBe("acme");
+    const raw = (await loadWorkspaceRecordRaw(env, "acme")) as WorkspaceRecord | null;
+    expect(raw?.name).toBe("acme");
   });
 
   it("returns null for a soft-deleted workspace (auth path denies like unknown)", async () => {
@@ -37,8 +45,8 @@ describe("loadWorkspaceRecord (#247 soft-delete filtering)", () => {
     };
     const env = { REGISTRY: fakeRegistry({ "ws:acme": softDeleted }) } as unknown as Env;
     expect(await loadWorkspaceRecord(env, "acme")).toBeNull();
-    // But the raw read (used by admin routes / the sweep) still sees it.
-    expect(await loadWorkspaceRecordRaw(env, "acme")).toEqual(softDeleted);
+    // But the raw read (used by admin routes / the sweep) still sees it, stamped too.
+    expect(await loadWorkspaceRecordRaw(env, "acme")).toEqual({ ...softDeleted, name: "acme" });
   });
 
   it("returns null for a purged tombstone", async () => {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -18,6 +18,12 @@ export type { FileScope } from "./auth-db";
  * record are a SHA-256 token hash plus (optional) bucket-scoped S3 keys.
  */
 export interface WorkspaceRecord {
+  /**
+   * The registry slug this record was loaded under; stamped by the loaders
+   * from the validated lookup key, not read from stored JSON. Absent only on
+   * records built outside the loaders.
+   */
+  name?: string;
   provider: StorageProvider;
   bucket: string;
   /** Name of an R2 binding declared in wrangler.jsonc (e.g. "UPLOADS"). When set, I/O uses the binding. */
@@ -175,7 +181,9 @@ export async function loadWorkspaceRecord(
   // unknown workspace (uniform 404/401 across every auth/serving path) while
   // still occupying the KV key, so the slug can't be re-registered.
   if (!record || isPurgedTombstone(record) || record.deletedAt) return null;
-  return record;
+  // Stamp the slug from the validated lookup key, never from the stored
+  // JSON — the key is the source of truth even if the blob is stale/hand-edited.
+  return { ...record, name };
 }
 
 /**
@@ -189,7 +197,13 @@ export async function loadWorkspaceRecordRaw(
   name: string | undefined,
 ): Promise<WorkspaceRecord | PurgedTombstone | null> {
   if (!name || !WS_NAME_RE.test(name)) return null;
-  return env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(`ws:${name}`, { type: "json" });
+  const record = await env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(`ws:${name}`, {
+    type: "json",
+  });
+  if (!record || isPurgedTombstone(record)) return record;
+  // Stamp the slug from the validated lookup key (same rule as loadWorkspaceRecord);
+  // tombstones are left untouched — they're not a WorkspaceRecord.
+  return { ...record, name };
 }
 
 function workspaceAuthWith(

--- a/apps/api/test/list-page-url.test.ts
+++ b/apps/api/test/list-page-url.test.ts
@@ -8,7 +8,7 @@ function makeEnv(bucket: FakeR2Bucket) {
   return { UPLOADS_DEFAULT: bucket, WEB_ORIGIN: "https://uploads.sh" } as unknown as Env;
 }
 
-const record: WorkspaceRecord = {
+const baseRecord: WorkspaceRecord = {
   provider: "r2",
   bucket: "uploads-default",
   binding: "UPLOADS_DEFAULT",
@@ -17,21 +17,23 @@ const record: WorkspaceRecord = {
 };
 
 describe("listObjects pageUrl", () => {
-  it("emits a /f/ pageUrl for public-url objects when workspaceName is given", async () => {
+  it("emits a /f/ pageUrl for public-url objects when the record carries a slug", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put("default/gh/o/r/pull/1/a.png", new Uint8Array([1, 2, 3]));
     const env = makeEnv(bucket);
+    const record: WorkspaceRecord = { ...baseRecord, name: "acme" };
     const { items } = await listObjects(env, record, {
       prefix: "gh/o/r/pull/1/",
-      workspaceName: "acme",
     });
     expect(items[0].pageUrl).toBe("https://uploads.sh/f/acme/gh/o/r/pull/1/a.png");
   });
 
-  it("omits pageUrl when workspaceName is not provided", async () => {
+  it("omits pageUrl when the record has no slug", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put("default/gh/o/r/pull/1/a.png", new Uint8Array([1, 2, 3]));
-    const { items } = await listObjects(makeEnv(bucket), record, { prefix: "gh/o/r/pull/1/" });
+    const { items } = await listObjects(makeEnv(bucket), baseRecord, {
+      prefix: "gh/o/r/pull/1/",
+    });
     expect(items[0].pageUrl).toBeUndefined();
   });
 });

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -102,6 +102,7 @@ async function makeEnv(
     d1?: { tokenHash: string; scopes: string };
     rateLimitOk?: boolean;
     record?: Partial<WorkspaceRecord>;
+    webOrigin?: string;
   } = {},
 ): Promise<{
   env: Env;
@@ -239,6 +240,7 @@ async function makeEnv(
       },
     },
     UPLOADS: bucket,
+    ...(options.webOrigin === undefined ? {} : { WEB_ORIGIN: options.webOrigin }),
     ...(options.rateLimitOk === undefined
       ? {}
       : {
@@ -945,7 +947,7 @@ describe("mcp worker", () => {
   });
 
   it("lists uploaded objects with public urls, then deletes them", async () => {
-    const { env, bucket } = await makeEnv();
+    const { env, bucket } = await makeEnv({ webOrigin: "https://uploads.test" });
     await callTool(env, "put", {
       contentBase64: PNG_B64,
       filename: "shot.png",
@@ -957,10 +959,16 @@ describe("mcp worker", () => {
     const items = listed.structuredContent?.items as {
       key: string;
       url: string;
+      pageUrl?: string;
     }[];
     expect(items).toHaveLength(1);
     expect(items[0].key).toBe("shots/shot.png");
     expect(items[0].url).toBe("https://storage.example.com/shots/shot.png");
+    // #303: the MCP `list` tool resolves its workspace record via
+    // loadWorkspaceRecord (apps/mcp/src/index.ts), which stamps `name` from
+    // the validated lookup key ("test-ws") — so pageUrl comes for free here,
+    // no opt to remember.
+    expect(items[0].pageUrl).toBe("https://uploads.test/f/test-ws/shots/shot.png");
 
     const deleted = await callTool(env, "delete", { key: "shots/shot.png" });
     expect(deleted.isError).toBe(false);


### PR DESCRIPTION
Closes #303.

## Problem

PR #301 added a server-computed `pageUrl` (`/f/<workspace>/<key>`) to object listings, but because `WorkspaceRecord` had no name field, `listObjects` took an **optional** `workspaceName` param and only emitted `pageUrl` when a caller passed it. Two call sites forgot: the authenticated `/me` file browser **and** the MCP `list` tool — both silently returned items without `pageUrl`.

## Fix (deep)

Put the slug on the record instead of threading it per-call:

- **`WorkspaceRecord.name`** — stamped by the loaders (`loadWorkspaceRecord` / `loadWorkspaceRecordRaw`) from the **validated lookup key**, never trusted from the stored KV JSON (a test proves the key wins over a stale/wrong `name` in the blob). Tombstones are left unstamped.
- **`listObjects`** now computes `pageUrl` from `ws.name` and the `workspaceName?` opt is **dropped**. Gated on `urls.url && ws.name`, so a record without a slug safely omits `pageUrl` (never a wrong URL) — same graceful degradation as before.
- The `/me` route and MCP `list` tool pass the record and now get `pageUrl` **for free** — both resolve their record through `loadWorkspaceRecord`, so no per-call plumbing was needed (verified by new behavioral tests on both paths).

## Scope

- **API + MCP only.** Both are private/ignored packages → **no changeset**.
- Deliberately out of scope: rendering a file-page link in the `/me` web UI (adding `pageUrl` to the JSON is inert there today) — filed as a separate follow-up. Also untouched: `admin.ts`'s raw `workspace()` helper and `public-galleries.ts` raw reads (they don't need `pageUrl`).

## Testing

- Loader stamping test (validated key beats stored JSON; tombstone unstamped).
- `/me` and MCP `list` now assert `pageUrl` presence (previously unexercised).
- `list-page-url` reworked to drive `record.name` instead of the removed opt; "no slug → omitted" case retained.
- Full suite green (1798), api + mcp typechecks clean.

Enables #304 (a per-workspace linking toggle now has a natural home on `WorkspaceRecord`).