### PR TITLE
feat(api): per-workspace toggle for managed-comment file-page linking

### DIFF
--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -420,7 +420,7 @@ export interface ListedObject {
    * `getMetadataForKeys`) and merge it onto each row.
    */
   metadata?: Record<string, string>;
-  /** Canonical public `/f/` page URL (issue #135). Present only when `url` is set and the caller passed `workspaceName`. */
+  /** Canonical public `/f/` page URL (issue #135). Present only when `url` is set and the workspace record carries a slug (`ws.name`, issue #303). */
   pageUrl?: string;
 }
 
@@ -443,7 +443,6 @@ export async function listObjects(
     delimiter?: string;
     limit?: number;
     cursor?: string;
-    workspaceName?: string;
   } = {},
 ): Promise<{ items: ListedObject[]; cursor: string | null; prefixes?: string[] }> {
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 1000);
@@ -468,9 +467,7 @@ export async function listObjects(
         embedUrl: urls.embedUrl,
         ...storedMetaJson(item),
         ...(visibility ? { visibility } : {}),
-        ...(urls.url && opts.workspaceName
-          ? { pageUrl: filePageUrl(env, opts.workspaceName, item.key) }
-          : {}),
+        ...(urls.url && ws.name ? { pageUrl: filePageUrl(env, ws.name, item.key) } : {}),
       };
     }),
     cursor: result.cursor ?? null,

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -88,6 +88,55 @@ describe("gatherCommentBody", () => {
     expect(result.count).toBe(1);
   });
 
+  it("links an attachment to its /f/ file page by default (flag absent)", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const result = await gatherCommentBody(env, { ...ws, name: workspaceName }, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+    expect(result.skip).toBe(false);
+    if (result.skip) return;
+    expect(result.body).toContain(`/f/${workspaceName}/`);
+  });
+
+  it("links an attachment to its /f/ file page when the flag is explicitly true", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const result = await gatherCommentBody(
+      env,
+      { ...ws, name: workspaceName, githubCommentLinkToFilePage: true },
+      workspaceName,
+      { repo: "acme/web", num: 12, kind: "pull" },
+    );
+    expect(result.skip).toBe(false);
+    if (result.skip) return;
+    expect(result.body).toContain(`/f/${workspaceName}/`);
+  });
+
+  it("links an attachment to the raw url when githubCommentLinkToFilePage is false", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const result = await gatherCommentBody(
+      env,
+      { ...ws, name: workspaceName, githubCommentLinkToFilePage: false },
+      workspaceName,
+      { repo: "acme/web", num: 12, kind: "pull" },
+    );
+    expect(result.skip).toBe(false);
+    if (result.skip) return;
+    expect(result.body).not.toContain(`/f/${workspaceName}/`);
+    // Falls back to the raw storage url.
+    expect(result.body).toContain("storage.uploads.sh");
+  });
+
   it("renders galleries linked to the PR via an external reference, scoped to the calling workspace", async () => {
     const { env, ws, workspaceName, bucket } = makeTestEnv();
     await bucket.put("acme/screenshots/one.png", PNG, {

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -64,7 +64,6 @@ async function gatherAttachments(
       prefix: ghKeyPrefix(target),
       limit: 1000,
       cursor,
-      workspaceName,
     });
     for (const o of page.items)
       items.push({ key: o.key, url: o.url, embedUrl: o.embedUrl, pageUrl: o.pageUrl });

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -41,7 +41,7 @@ export async function gatherCommentBody(
   // Attachments (R2 list) and galleries (D1) are independent reads — overlap
   // them so the request only waits the longer of the two, not their sum.
   const [items, galleries] = await Promise.all([
-    gatherAttachments(env, ws, workspaceName, target),
+    gatherAttachments(env, ws, target),
     gatherGalleries(env, ws, workspaceName, target),
   ]);
 
@@ -54,7 +54,6 @@ export async function gatherCommentBody(
 async function gatherAttachments(
   env: Env,
   ws: WorkspaceRecord,
-  workspaceName: string,
   target: GhTarget,
 ): Promise<AttachmentItem[]> {
   const items: AttachmentItem[] = [];

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -56,6 +56,11 @@ async function gatherAttachments(
   ws: WorkspaceRecord,
   target: GhTarget,
 ): Promise<AttachmentItem[]> {
+  // Per-workspace choice (issue #304): default (undefined/true) links the
+  // managed comment's attachments to their `/f/` file page (issue #301's
+  // behavior); `false` links to raw object bytes instead. Attachments only —
+  // does not affect gallery `itemUrl` below, which is a separate feature.
+  const linkToFilePage = ws.githubCommentLinkToFilePage !== false;
   const items: AttachmentItem[] = [];
   let cursor: string | undefined;
   do {
@@ -65,7 +70,12 @@ async function gatherAttachments(
       cursor,
     });
     for (const o of page.items)
-      items.push({ key: o.key, url: o.url, embedUrl: o.embedUrl, pageUrl: o.pageUrl });
+      items.push({
+        key: o.key,
+        url: o.url,
+        embedUrl: o.embedUrl,
+        pageUrl: linkToFilePage ? o.pageUrl : null,
+      });
     cursor = page.cursor ?? undefined;
   } while (cursor);
   return items;

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -612,6 +612,195 @@ describe("workspace limits editing", () => {
   });
 });
 
+describe("workspace github-comment settings editing", () => {
+  /** Env with a mutable ws:acme record and a session user (no usage needed). */
+  function settingsEnv(user: typeof ADMIN_USER | null, record: Record<string, unknown> | null) {
+    const store = new Map<string, string>();
+    if (record) store.set("ws:acme", JSON.stringify(record));
+    const base = stubEnv(user, () => new Response(null, { status: 404 }));
+    const env = {
+      ...base,
+      REGISTRY: {
+        get: (async (key: string) => {
+          const raw = store.get(key);
+          return raw ? JSON.parse(raw) : null;
+        }) as unknown as KVNamespace["get"],
+        put: (async (key: string, value: string) => {
+          store.set(key, value);
+        }) as unknown as KVNamespace["put"],
+      },
+    } as unknown as Env;
+    return { env, store };
+  }
+
+  const REC = {
+    provider: "r2",
+    bucket: "uploads-default",
+    prefix: "acme/",
+    maxUploadsPerPeriod: 3000,
+    retentionDays: 90,
+  };
+
+  it("GET returns the flag unset by default", async () => {
+    const { env } = settingsEnv(ADMIN_USER, REC);
+    const res = await app().request("/admin-ui/workspaces/acme/settings", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      settings: { githubCommentLinkToFilePage: null },
+    });
+  });
+
+  it("GET reflects a previously-set flag", async () => {
+    const { env } = settingsEnv(ADMIN_USER, { ...REC, githubCommentLinkToFilePage: false });
+    const res = await app().request("/admin-ui/workspaces/acme/settings", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      settings: { githubCommentLinkToFilePage: false },
+    });
+  });
+
+  it("PATCH sets the flag on the record", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: false }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      settings: { githubCommentLinkToFilePage: false },
+    });
+    const saved = JSON.parse(store.get("ws:acme")!);
+    expect(saved.githubCommentLinkToFilePage).toBe(false);
+  });
+
+  it("PATCH with the flag omitted leaves it unchanged", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, { ...REC, githubCommentLinkToFilePage: false });
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const saved = JSON.parse(store.get("ws:acme")!);
+    expect(saved.githubCommentLinkToFilePage).toBe(false);
+  });
+
+  it("PATCH true clears a previously-set false flag", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, { ...REC, githubCommentLinkToFilePage: false });
+    await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: true }),
+      },
+      env,
+    );
+    const saved = JSON.parse(store.get("ws:acme")!);
+    expect(saved.githubCommentLinkToFilePage).toBe(true);
+  });
+
+  it("PATCH preserves other record fields (not clobbered)", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, REC);
+    await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: false }),
+      },
+      env,
+    );
+    const saved = JSON.parse(store.get("ws:acme")!);
+    expect(saved.maxUploadsPerPeriod).toBe(3000);
+    expect(saved.retentionDays).toBe(90);
+    expect(saved.prefix).toBe("acme/");
+  });
+
+  it("PATCH 400s on a non-boolean flag value", async () => {
+    const { env } = settingsEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: "nope" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH 400s on a malformed JSON body", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: "{ not valid json",
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(JSON.parse(store.get("ws:acme")!).githubCommentLinkToFilePage).toBeUndefined();
+  });
+
+  it("404s for an unknown workspace", async () => {
+    const { env } = settingsEnv(ADMIN_USER, null);
+    const res = await app().request("/admin-ui/workspaces/acme/settings", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a soft-deleted workspace", async () => {
+    const { env } = settingsEnv(ADMIN_USER, { ...REC, deletedAt: "2026-07-01T00:00:00.000Z" });
+    const res = await app().request("/admin-ui/workspaces/acme/settings", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { env } = settingsEnv(NON_ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: false }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("PATCH 429s when the per-workspace write budget is exhausted", async () => {
+    const { env } = settingsEnv(ADMIN_USER, REC);
+    (env as Env & { WRITE_LIMITER: { limit: () => Promise<{ success: boolean }> } }).WRITE_LIMITER =
+      { limit: async () => ({ success: false }) };
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: false }),
+      },
+      env,
+    );
+    expect(res.status).toBe(429);
+  });
+});
+
 describe("POST /admin-ui/users/:userId/ban", () => {
   function banEnv(user: typeof ADMIN_USER | typeof NON_ADMIN_USER | null) {
     const banCalls: { path: string; body: unknown }[] = [];

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -204,6 +204,38 @@ async function loadEditableWorkspace(env: Env, name: string): Promise<WorkspaceR
   return record;
 }
 
+/**
+ * Validates a PATCH body for the github-comment settings route (issue #304).
+ * Only `githubCommentLinkToFilePage` is accepted; when present it must be a
+ * boolean. Omitted means "leave unchanged" — distinct from a validation
+ * error, mirroring `validateLimitsPatch`'s omit-vs-invalid distinction.
+ */
+function validateGithubCommentSettingsPatch(body: unknown): {
+  githubCommentLinkToFilePage?: boolean;
+} {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ValidationError("request body must be an object", { code: "invalid_settings" });
+  }
+  const raw = (body as Record<string, unknown>).githubCommentLinkToFilePage;
+  if (raw === undefined) return {};
+  if (typeof raw !== "boolean") {
+    throw new ValidationError("githubCommentLinkToFilePage must be a boolean", {
+      code: "invalid_settings",
+    });
+  }
+  return { githubCommentLinkToFilePage: raw };
+}
+
+/** Response body shared by GET and PATCH: the github-comment settings. */
+function githubCommentSettingsResponse(name: string, record: WorkspaceRecord) {
+  return {
+    workspace: name,
+    settings: {
+      githubCommentLinkToFilePage: record.githubCommentLinkToFilePage ?? null,
+    },
+  };
+}
+
 /** Response body shared by GET and PATCH: current budget limits + usage. */
 async function limitsResponse(env: Env, name: string, record: WorkspaceRecord) {
   const limits = {
@@ -409,6 +441,36 @@ export const adminUi = new Hono<SessionVars>()
     }
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
     return c.json(await limitsResponse(c.env, name, record));
+  })
+
+  // Read the per-workspace managed-comment file-page linking toggle (#304).
+  .get("/workspaces/:name/settings", async (c) => {
+    const name = c.req.param("name");
+    const record = await loadEditableWorkspace(c.env, name);
+    return c.json(githubCommentSettingsResponse(name, record));
+  })
+
+  // Patch the managed-comment file-page linking toggle. Omitted leaves it
+  // unchanged; the whole record is read-modify-written so other fields
+  // (limits, tokens, etc.) survive untouched.
+  .patch("/workspaces/:name/settings", async (c) => {
+    const name = c.req.param("name");
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    const record = await loadEditableWorkspace(c.env, name);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new ValidationError("request body must be valid JSON", { code: "invalid_settings" });
+    }
+    const patch = validateGithubCommentSettingsPatch(body);
+    if ("githubCommentLinkToFilePage" in patch) {
+      record.githubCommentLinkToFilePage = patch.githubCommentLinkToFilePage;
+    }
+    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
+    return c.json(githubCommentSettingsResponse(name, record));
   })
 
   // Ban / unban (abuse). Proxies Better Auth admin ban/unban; ban also

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -198,7 +198,6 @@ export const files = new Hono<WorkspaceVars>()
         prefix,
         limit,
         cursor,
-        workspaceName: c.get("workspaceName"),
       }),
     );
   })

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -669,7 +669,7 @@ describe("GET /me/workspaces/:name/files", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       communal: boolean;
-      files: { key: string; url: string }[];
+      files: { key: string; url: string; pageUrl?: string }[];
     };
     expect(body.communal).toBe(false);
     expect(body.files).toHaveLength(1);
@@ -677,6 +677,10 @@ describe("GET /me/workspaces/:name/files", () => {
       key: "f/x/shot.png",
       url: "https://storage.uploads.sh/acme/f/x/shot.png",
     });
+    // #303: this route never passed `workspaceName` into listObjects, so
+    // pageUrl was always missing here — loadWorkspaceRecord now stamps
+    // `name` from the lookup key, so listObjects computes it unconditionally.
+    expect(body.files[0].pageUrl).toBe("https://uploads.test/f/acme/f/x/shot.png");
   });
 
   it("lists a folder with prefix and hydrates gh.* metadata + public urls", async () => {

--- a/apps/api/src/self-serve-defaults.test.ts
+++ b/apps/api/src/self-serve-defaults.test.ts
@@ -9,6 +9,7 @@ describe("selfServeWorkspaceRecord", () => {
       now: new Date("2026-07-14T00:00:00Z"),
     });
     expect(record).toMatchObject({
+      name: "zachbot",
       provider: "r2",
       bucket: "uploads-default",
       binding: "UPLOADS_DEFAULT",

--- a/apps/api/src/self-serve-defaults.ts
+++ b/apps/api/src/self-serve-defaults.ts
@@ -23,6 +23,7 @@ export function selfServeWorkspaceRecord(args: {
   now: Date;
 }): WorkspaceRecord {
   return {
+    name: args.name,
     provider: "r2",
     bucket: "uploads-default",
     binding: "UPLOADS_DEFAULT",

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -26,7 +26,15 @@ function fakeRegistry(records: Record<string, unknown>): Env["REGISTRY"] {
 describe("loadWorkspaceRecord (#247 soft-delete filtering)", () => {
   it("returns the record for a normal workspace", async () => {
     const env = { REGISTRY: fakeRegistry({ "ws:acme": RECORD }) } as unknown as Env;
-    expect(await loadWorkspaceRecord(env, "acme")).toEqual(RECORD);
+    expect(await loadWorkspaceRecord(env, "acme")).toEqual({ ...RECORD, name: "acme" });
+  });
+
+  it("stamps name from the lookup key, not the stored JSON, even when the JSON has a different/absent name (#303)", async () => {
+    const stale: WorkspaceRecord = { ...RECORD, name: "stale-old-name" };
+    const env = { REGISTRY: fakeRegistry({ "ws:acme": stale }) } as unknown as Env;
+    expect((await loadWorkspaceRecord(env, "acme"))?.name).toBe("acme");
+    const raw = (await loadWorkspaceRecordRaw(env, "acme")) as WorkspaceRecord | null;
+    expect(raw?.name).toBe("acme");
   });
 
   it("returns null for a soft-deleted workspace (auth path denies like unknown)", async () => {
@@ -37,8 +45,8 @@ describe("loadWorkspaceRecord (#247 soft-delete filtering)", () => {
     };
     const env = { REGISTRY: fakeRegistry({ "ws:acme": softDeleted }) } as unknown as Env;
     expect(await loadWorkspaceRecord(env, "acme")).toBeNull();
-    // But the raw read (used by admin routes / the sweep) still sees it.
-    expect(await loadWorkspaceRecordRaw(env, "acme")).toEqual(softDeleted);
+    // But the raw read (used by admin routes / the sweep) still sees it, stamped too.
+    expect(await loadWorkspaceRecordRaw(env, "acme")).toEqual({ ...softDeleted, name: "acme" });
   });
 
   it("returns null for a purged tombstone", async () => {

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -18,6 +18,12 @@ export type { FileScope } from "./auth-db";
  * record are a SHA-256 token hash plus (optional) bucket-scoped S3 keys.
  */
 export interface WorkspaceRecord {
+  /**
+   * The registry slug this record was loaded under; stamped by the loaders
+   * from the validated lookup key, not read from stored JSON. Absent only on
+   * records built outside the loaders.
+   */
+  name?: string;
   provider: StorageProvider;
   bucket: string;
   /** Name of an R2 binding declared in wrangler.jsonc (e.g. "UPLOADS"). When set, I/O uses the binding. */
@@ -175,7 +181,9 @@ export async function loadWorkspaceRecord(
   // unknown workspace (uniform 404/401 across every auth/serving path) while
   // still occupying the KV key, so the slug can't be re-registered.
   if (!record || isPurgedTombstone(record) || record.deletedAt) return null;
-  return record;
+  // Stamp the slug from the validated lookup key, never from the stored
+  // JSON — the key is the source of truth even if the blob is stale/hand-edited.
+  return { ...record, name };
 }
 
 /**
@@ -189,7 +197,13 @@ export async function loadWorkspaceRecordRaw(
   name: string | undefined,
 ): Promise<WorkspaceRecord | PurgedTombstone | null> {
   if (!name || !WS_NAME_RE.test(name)) return null;
-  return env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(`ws:${name}`, { type: "json" });
+  const record = await env.REGISTRY.get<WorkspaceRecord | PurgedTombstone>(`ws:${name}`, {
+    type: "json",
+  });
+  if (!record || isPurgedTombstone(record)) return record;
+  // Stamp the slug from the validated lookup key (same rule as loadWorkspaceRecord);
+  // tombstones are left untouched — they're not a WorkspaceRecord.
+  return { ...record, name };
 }
 
 function workspaceAuthWith(

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -84,6 +84,14 @@ export interface WorkspaceRecord {
   createdByUserId?: string;
   /** ISO timestamp of self-serve creation. */
   createdAt?: string;
+  /**
+   * Governs the managed GitHub-comment attachment click-through target only
+   * (issue #304). When `false`, managed-comment attachments link to raw
+   * object bytes instead of the `/f/` file page. Default (undefined/true) =
+   * link to the file page (issue #301's behavior). Does not affect gallery
+   * links or any non-comment surface.
+   */
+  githubCommentLinkToFilePage?: boolean;
   /** Set by `DELETE /admin/workspaces/:name` (default/soft mode). Present → the workspace is soft-deleted. */
   deletedAt?: string;
   /** `deletedAt` + the grace window (`WORKSPACE_DELETE_GRACE_DAYS`); the retention sweep finalizes at/after this. */

--- a/apps/api/test/list-page-url.test.ts
+++ b/apps/api/test/list-page-url.test.ts
@@ -8,7 +8,7 @@ function makeEnv(bucket: FakeR2Bucket) {
   return { UPLOADS_DEFAULT: bucket, WEB_ORIGIN: "https://uploads.sh" } as unknown as Env;
 }
 
-const record: WorkspaceRecord = {
+const baseRecord: WorkspaceRecord = {
   provider: "r2",
   bucket: "uploads-default",
   binding: "UPLOADS_DEFAULT",
@@ -17,21 +17,23 @@ const record: WorkspaceRecord = {
 };
 
 describe("listObjects pageUrl", () => {
-  it("emits a /f/ pageUrl for public-url objects when workspaceName is given", async () => {
+  it("emits a /f/ pageUrl for public-url objects when the record carries a slug", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put("default/gh/o/r/pull/1/a.png", new Uint8Array([1, 2, 3]));
     const env = makeEnv(bucket);
+    const record: WorkspaceRecord = { ...baseRecord, name: "acme" };
     const { items } = await listObjects(env, record, {
       prefix: "gh/o/r/pull/1/",
-      workspaceName: "acme",
     });
     expect(items[0].pageUrl).toBe("https://uploads.sh/f/acme/gh/o/r/pull/1/a.png");
   });
 
-  it("omits pageUrl when workspaceName is not provided", async () => {
+  it("omits pageUrl when the record has no slug", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put("default/gh/o/r/pull/1/a.png", new Uint8Array([1, 2, 3]));
-    const { items } = await listObjects(makeEnv(bucket), record, { prefix: "gh/o/r/pull/1/" });
+    const { items } = await listObjects(makeEnv(bucket), baseRecord, {
+      prefix: "gh/o/r/pull/1/",
+    });
     expect(items[0].pageUrl).toBeUndefined();
   });
 });

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -102,6 +102,7 @@ async function makeEnv(
     d1?: { tokenHash: string; scopes: string };
     rateLimitOk?: boolean;
     record?: Partial<WorkspaceRecord>;
+    webOrigin?: string;
   } = {},
 ): Promise<{
   env: Env;
@@ -239,6 +240,7 @@ async function makeEnv(
       },
     },
     UPLOADS: bucket,
+    ...(options.webOrigin === undefined ? {} : { WEB_ORIGIN: options.webOrigin }),
     ...(options.rateLimitOk === undefined
       ? {}
       : {
@@ -945,7 +947,7 @@ describe("mcp worker", () => {
   });
 
   it("lists uploaded objects with public urls, then deletes them", async () => {
-    const { env, bucket } = await makeEnv();
+    const { env, bucket } = await makeEnv({ webOrigin: "https://uploads.test" });
     await callTool(env, "put", {
       contentBase64: PNG_B64,
       filename: "shot.png",
@@ -957,10 +959,16 @@ describe("mcp worker", () => {
     const items = listed.structuredContent?.items as {
       key: string;
       url: string;
+      pageUrl?: string;
     }[];
     expect(items).toHaveLength(1);
     expect(items[0].key).toBe("shots/shot.png");
     expect(items[0].url).toBe("https://storage.example.com/shots/shot.png");
+    // #303: the MCP `list` tool resolves its workspace record via
+    // loadWorkspaceRecord (apps/mcp/src/index.ts), which stamps `name` from
+    // the validated lookup key ("test-ws") — so pageUrl comes for free here,
+    // no opt to remember.
+    expect(items[0].pageUrl).toBe("https://uploads.test/f/test-ws/shots/shot.png");
 
     const deleted = await callTool(env, "delete", { key: "shots/shot.png" });
     expect(deleted.isError).toBe(false);

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -465,6 +465,11 @@ export async function syncAttachmentsComment(
   }
 
   // gh fallback: gather from this workspace's own data and post via local `gh`.
+  // Note (issue #304): this CLI process has no server-side WorkspaceRecord in
+  // scope, so it cannot honor a workspace's githubCommentLinkToFilePage=false
+  // — it always links to the file page here, matching the default. This only
+  // diverges from the bot-posted comment for a workspace that both sets the
+  // flag false and falls through to this gh-fallback path.
   const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
     ({ key, url, embedUrl, pageUrl }) => ({ key, url, embedUrl, pageUrl }),
   );


### PR DESCRIPTION
Closes #304 (v1: Option A — per-workspace setting).

> **Stacked on #305** (issue #303). Review/merge #305 first; GitHub will retarget this PR's base to `main` once #305 merges.

## What

Makes the PR #301 behavior (managed-comment attachments link to their `/f/` file page) a **per-workspace choice**, defaulting to the current behavior so no existing workspace changes silently.

- **`WorkspaceRecord.githubCommentLinkToFilePage?: boolean`** — `undefined`/`true` → link to the `/f/` page (default, = #301); `false` → link to raw object bytes.
- **Gate** in `gatherAttachments` (`apps/api/src/github-comment.ts`): when `false`, attachments carry `pageUrl: null`, so the renderer's existing `pageUrl ?? url` precedence falls back to the raw URL — **no renderer change**.
- **Attachments only.** Galleries (`gatherGalleries` / `itemUrl`) are untouched — linking to gallery item pages is a separate feature, not the attachment-vs-raw behavior this toggle governs.
- **Admin editing:** a dedicated `GET`/`PATCH /admin-ui/workspaces/:name/settings` route (requireAdminUser-gated), following the limits route's raw-read + validate + read-modify-write pattern — without reusing the integer-only `validateLimitsPatch`. Read-modify-write preserves all other record fields.

## Scope / decisions

- **Option A only** (per-workspace setting). The **in-repo `.uploads.yml` override (Option B)** is a planned fast-follow — see #307.
- Default = link to file page (preserve #301). No existing workspace sees a change.
- **api-only → no changeset.** The CLI local-`gh` fallback can't honor a server-side workspace flag (no `WorkspaceRecord` in scope), so it keeps linking to the file page (the default); a code comment documents this. This only diverges for a workspace that both sets the flag `false` and falls through to gh-fallback (bot endpoint failed).
- Admin surface is a JSON endpoint (no HTML checkbox wired — no in-scope admin-panel UI found); a UI affordance can follow.

## Testing

- Render gate: absent flag → `/f/` href; `false` → raw href; `true` → `/f/` href.
- Admin route: GET default/reflects; PATCH set/omit(unchanged)/preserve-other-fields/invalid-boolean/malformed-json/404-missing/404-soft-deleted/403-non-admin.
- Gallery path asserted unaffected.
- Full suite green (1813), api typecheck clean.
