### PR TITLE
feat(api): promotion endpoint for branch-staged attachments

### DIFF
--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -19,8 +19,21 @@ import { storage } from "./storage";
 import { objectVisibility } from "./visibility";
 import type { WorkspaceRecord } from "./workspace";
 
-/** Max staged files processed per call — bounds the work a pathological branch prefix can trigger. */
-export const PROMOTE_STAGED_CAP = 100;
+/**
+ * Max staged files processed per call — bounds the work a pathological branch
+ * prefix can trigger, and keeps the request's subrequest count well inside
+ * the Workers paid-plan ceiling (1000/request; this worker runs on paid).
+ * Each promoted file costs ~9 subrequests: R2 get (download) + R2 head +
+ * R2 put, each inside `putObject`, plus that call's D1 usage-read,
+ * reservation batch, usage-record batch, and metadata-replace batch, plus
+ * this module's own D1 read + write batch to tag the staged original. Fixed
+ * per-request overhead (auth's KV + D1 lookups, the rate limiter, the R2
+ * list page, the batched D1 metadata read) adds ~5 more. At the old cap of
+ * 100 that's ~905 subrequests worst case — over 90% of the ceiling, too
+ * little margin against list pagination or a workspace with extra budget
+ * checks. At 50 it's ~455 (well under half), so this is set to 50.
+ */
+export const PROMOTE_STAGED_CAP = 50;
 
 /** Staged files older than this (by their `gh.staged-at` D1 tag) are skipped, not promoted. */
 const FRESHNESS_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -145,8 +158,27 @@ export async function promoteBranchAttachments(
           "gh.promoted-at": nowIso,
         },
       });
-      promoted.push(destKey);
+    } catch (err) {
+      // Never leak internal error detail (D1/R2 messages, key policy
+      // internals) to API callers — log the detail server-side and report a
+      // generic reason.
+      console.error(
+        JSON.stringify({
+          message: "promote copy failed",
+          key,
+          destKey,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      skipped.push({ key, reason: "copy_failed" });
+      continue;
+    }
 
+    // The copy succeeded — destKey is promoted regardless of what happens
+    // below. Tagging the staged original is best-effort bookkeeping: a
+    // failure here must not un-promote the file or land it in `skipped`.
+    promoted.push(destKey);
+    try {
       // Merge (not replace) onto the staged original: mark it promoted
       // without disturbing its own gh.repo/gh.kind/gh.branch/gh.staged-at tags.
       await setFileMetadata(env.DB, workspaceName, key, {
@@ -154,7 +186,14 @@ export async function promoteBranchAttachments(
         "gh.promoted-at": nowIso,
       });
     } catch (err) {
-      skipped.push({ key, reason: err instanceof Error ? err.message : "copy_failed" });
+      console.error(
+        JSON.stringify({
+          message: "promote: failed to tag staged original",
+          key,
+          destKey,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
     }
   }
 

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -1,0 +1,162 @@
+/**
+ * Server-side promotion (phase 2a): copy a workspace's own branch-staged
+ * attachments (`gh/<owner>/<name>/branch/<branch>/<filename>`) into a PR's
+ * stable attachment prefix (`gh/<owner>/<name>/pull/<num>/<filename>`) so the
+ * managed-comment gatherer (`github-comment.ts`, which lists that prefix)
+ * picks them up unchanged. Pure workspace-data operation: no GitHub API call,
+ * no installation lookup — just reading and writing the calling workspace's
+ * own bucket/prefix and D1 rows.
+ *
+ * Originals are never deleted here (a later-phase reaper owns cleanup); a
+ * second PR promoting the same branch is expected to re-promote and just
+ * overwrites the destination copies (last-write-wins, same contract as any
+ * other overwrite in this API).
+ */
+
+import { getMetadataForKeys, setFileMetadata } from "./file-metadata";
+import { putObject } from "./files-core";
+import { storage } from "./storage";
+import { objectVisibility } from "./visibility";
+import type { WorkspaceRecord } from "./workspace";
+
+/** Max staged files processed per call — bounds the work a pathological branch prefix can trigger. */
+export const PROMOTE_STAGED_CAP = 100;
+
+/** Staged files older than this (by their `gh.staged-at` D1 tag) are skipped, not promoted. */
+const FRESHNESS_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+/** Same segment-sanitization contract as the staged/attachment key layout: non-safe chars → `-`. */
+function sanitizeKeySegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+function stagedPrefix(owner: string, name: string, branch: string): string {
+  return `gh/${sanitizeKeySegment(owner)}/${sanitizeKeySegment(name)}/branch/${sanitizeKeySegment(branch)}/`;
+}
+
+function destinationKey(owner: string, name: string, num: number, filename: string): string {
+  return `gh/${sanitizeKeySegment(owner)}/${sanitizeKeySegment(name)}/pull/${num}/${filename}`;
+}
+
+/**
+ * Missing or unparsable `staged-at` is treated as fresh — it's the workspace's
+ * own data, and a missing tag shouldn't strand a file from ever promoting.
+ */
+function isFresh(stagedAt: string | undefined, nowMs: number): boolean {
+  if (!stagedAt) return true;
+  const parsed = Date.parse(stagedAt);
+  if (!Number.isFinite(parsed)) return true;
+  return nowMs - parsed <= FRESHNESS_WINDOW_MS;
+}
+
+export interface PromoteTarget {
+  /** "owner/name", already validated by the caller. */
+  repo: string;
+  num: number;
+  branch: string;
+}
+
+export interface PromoteSkip {
+  key: string;
+  reason: string;
+}
+
+export interface PromoteResult {
+  /** Destination keys written by this call. */
+  promoted: string[];
+  skipped: PromoteSkip[];
+}
+
+/**
+ * Copy the calling workspace's fresh branch-staged attachments into the
+ * target PR's attachment prefix. Degrade-safe: a single-file copy failure is
+ * collected into `skipped` rather than failing the whole call. Idempotent —
+ * re-running overwrites the destination copies.
+ */
+export async function promoteBranchAttachments(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  target: PromoteTarget,
+): Promise<PromoteResult> {
+  const [owner, name] = target.repo.split("/");
+  const prefix = stagedPrefix(owner, name, target.branch);
+  const store = await storage(env, ws);
+
+  const promoted: string[] = [];
+  const skipped: PromoteSkip[] = [];
+
+  // Enumerate every staged key under the prefix (bounded pagination — a
+  // pathological prefix can't loop forever), then split at the cap: the head
+  // gets processed, everything past it is reported as skipped rather than
+  // silently dropped.
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  const MAX_LIST_PAGES = 50; // 50k objects at the 1000-per-page ceiling; far beyond any real staging prefix.
+  for (let page = 0; page < MAX_LIST_PAGES; page++) {
+    const result = await store.list({ prefix, limit: 1000, cursor });
+    for (const item of result.items) keys.push(item.key);
+    cursor = result.cursor ?? undefined;
+    if (!cursor) break;
+  }
+
+  if (keys.length === 0) return { promoted, skipped };
+
+  const toProcess = keys.slice(0, PROMOTE_STAGED_CAP);
+  for (const key of keys.slice(PROMOTE_STAGED_CAP)) {
+    skipped.push({ key, reason: "cap_exceeded" });
+  }
+
+  const metaByKey = await getMetadataForKeys(env.DB, workspaceName, toProcess);
+  const nowMs = Date.now();
+  const nowIso = new Date(nowMs).toISOString();
+  const ref = `${owner}/${name}#${target.num}`.toLowerCase();
+
+  for (const key of toProcess) {
+    const stagedAt = metaByKey.get(key)?.["gh.staged-at"];
+    if (!isFresh(stagedAt, nowMs)) {
+      skipped.push({ key, reason: "stale" });
+      continue;
+    }
+
+    const filename = key.slice(prefix.length);
+    if (!filename) {
+      skipped.push({ key, reason: "invalid_key" });
+      continue;
+    }
+    const destKey = destinationKey(owner, name, target.num, filename);
+
+    try {
+      const source = await store.download(key);
+      const bytes = new Uint8Array(await source.arrayBuffer());
+      const visibility = objectVisibility(source.metadata);
+
+      // A full replace (opts.metadata): the copy gets a fresh, self-contained
+      // gh.* tag set rather than inheriting the staged original's tags.
+      await putObject(env, ws, destKey, bytes, workspaceName, {
+        provenance: source.metadata,
+        visibility,
+        metadata: {
+          "gh.repo": `${owner}/${name}`.toLowerCase(),
+          "gh.kind": "pull",
+          "gh.number": String(target.num),
+          "gh.ref": ref,
+          "gh.branch": target.branch,
+          "gh.promoted-at": nowIso,
+        },
+      });
+      promoted.push(destKey);
+
+      // Merge (not replace) onto the staged original: mark it promoted
+      // without disturbing its own gh.repo/gh.kind/gh.branch/gh.staged-at tags.
+      await setFileMetadata(env.DB, workspaceName, key, {
+        "gh.promoted-to": ref,
+        "gh.promoted-at": nowIso,
+      });
+    } catch (err) {
+      skipped.push({ key, reason: err instanceof Error ? err.message : "copy_failed" });
+    }
+  }
+
+  return { promoted, skipped };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,7 @@ import { reports } from "./routes/reports";
 import { render } from "./routes/render";
 import { githubWebhook } from "./routes/github-webhook";
 import { githubComment } from "./routes/github-comment";
+import { githubPromote } from "./routes/github-promote";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -127,6 +128,10 @@ export const app = new Hono<WorkspaceVars>()
   // Bot-owned managed comment (phase 2 PR B). Workspace-authed (unlike the
   // HMAC-public /v1/github/webhook above) — behind the workspaceAuth guard.
   .route("/v1/:workspace/github", githubComment)
+  // Phase 2a: promotes branch-staged attachments into a PR's attachment
+  // prefix. Same base path as the comment route above (workspace-authed,
+  // distinct sub-route "/promote" vs "/comment").
+  .route("/v1/:workspace/github", githubPromote)
   .onError((err, c) => respondError(c, err))
   .notFound((c) => respondError(c, new NotFoundError()));
 

--- a/apps/api/src/routes/github-promote-route.test.ts
+++ b/apps/api/src/routes/github-promote-route.test.ts
@@ -290,9 +290,9 @@ describe("POST /v1/:workspace/github/promote", () => {
     expect(seeded.bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
   });
 
-  it("caps at 100 staged files, reporting the overflow as skipped", async () => {
+  it("caps at 50 staged files, reporting the overflow as skipped", async () => {
     const seeded = await seededEnv();
-    for (let i = 0; i < 101; i++) {
+    for (let i = 0; i < 51; i++) {
       await seedStaged(seeded, `f${String(i).padStart(3, "0")}.png`);
     }
 
@@ -302,7 +302,7 @@ describe("POST /v1/:workspace/github/promote", () => {
       promoted: string[];
       skipped: { key: string; reason: string }[];
     };
-    expect(body.promoted.length).toBe(100);
+    expect(body.promoted.length).toBe(50);
     const overflow = body.skipped.filter((s) => s.reason === "cap_exceeded");
     expect(overflow.length).toBe(1);
   });
@@ -337,6 +337,40 @@ describe("POST /v1/:workspace/github/promote", () => {
       skipped: { key: string; reason: string }[];
     };
     expect(body.promoted).toEqual([destKey("good.png")]);
-    expect(body.skipped.some((s) => s.key === stagedKey("ghost.png"))).toBe(true);
+    // Generic reason only — no internal error detail ("boom") leaks to the caller.
+    expect(body.skipped).toEqual([{ key: stagedKey("ghost.png"), reason: "copy_failed" }]);
+  });
+
+  it("still counts a file as promoted when tagging the staged original fails", async () => {
+    const seeded = await seededEnv();
+    await seedStaged(seeded, "hero.png");
+    const originalKey = stagedKey("hero.png");
+
+    // Make the D1 write that tags the *staged original* (gh.promoted-to /
+    // gh.promoted-at, keyed by originalKey) fail, while everything targeting
+    // the destination copy (destKey) succeeds normally.
+    const originalPrepare = seeded.db.prepare.bind(seeded.db);
+    seeded.db.prepare = ((sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      if (!normalized.startsWith("INSERT INTO file_metadata")) return originalPrepare(sql);
+      return {
+        bind: (...args: unknown[]) => {
+          if (args[1] === originalKey) {
+            return { run: async () => Promise.reject(new Error("boom")) };
+          }
+          return originalPrepare(sql).bind(...args);
+        },
+      };
+    }) as typeof seeded.db.prepare;
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { promoted: string[]; skipped: unknown[] };
+    // The copy landed — it must count as promoted, not be dropped into skipped.
+    expect(body.promoted).toEqual([destKey("hero.png")]);
+    expect(body.skipped).toEqual([]);
+
+    // Destination object is real.
+    expect(seeded.bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
   });
 });

--- a/apps/api/src/routes/github-promote-route.test.ts
+++ b/apps/api/src/routes/github-promote-route.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../index";
+import { getFileMetadata, replaceFileMetadata } from "../file-metadata";
+import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import { FakeR2Bucket } from "../../test/fake-r2";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+// Same node-vs-workerd Web Crypto gap as github-comment-route.test.ts — this
+// suite exercises the real workspaceAuth middleware end to end.
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+const WS = "acme";
+const TOKEN = "up_acme_testtoken";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const BRANCH = "feat-x";
+const NUM = 12;
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+function stagedKey(filename: string): string {
+  return `gh/acme/web/branch/${BRANCH}/${filename}`;
+}
+
+function destKey(filename: string): string {
+  return `gh/acme/web/pull/${NUM}/${filename}`;
+}
+
+interface Seeded {
+  env: Env;
+  db: UsageFakeD1;
+  bucket: FakeR2Bucket;
+}
+
+async function seededEnv(
+  opts: {
+    scopedToken?: { rawToken: string; scopes: string[] };
+  } = {},
+): Promise<Seeded> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex(TOKEN), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+
+  const env = {
+    REGISTRY: registry,
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+  } as unknown as Env;
+
+  if (opts.scopedToken) {
+    // Layer a D1-backed scoped token on top of the fake's auth_tokens no-op,
+    // so requireScope has something less than the legacy path's full grant
+    // to reject.
+    const scopedHash = await sha256Hex(opts.scopedToken.rawToken);
+    const scopes = JSON.stringify(opts.scopedToken.scopes);
+    const originalPrepare = db.prepare.bind(db);
+    db.prepare = ((sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      if (normalized.startsWith("SELECT id, workspace, token_hash")) {
+        let args: unknown[] = [];
+        return {
+          bind: (...v: unknown[]) => {
+            args = v;
+            return {
+              first: async () => {
+                const hash = args[1] as string;
+                if (hash !== scopedHash) return null;
+                return {
+                  id: "token-id",
+                  workspace: WS,
+                  token_hash: scopedHash,
+                  label: null,
+                  scopes,
+                  created_at: "2026-07-13T00:00:00.000Z",
+                  expires_at: null,
+                  revoked_at: null,
+                  minting_user_id: null,
+                };
+              },
+              all: async () => ({ results: [] }),
+              run: async () => ({}),
+            };
+          },
+        };
+      }
+      return originalPrepare(sql);
+    }) as typeof db.prepare;
+  }
+
+  return { env, db, bucket };
+}
+
+/** Seed a staged R2 object plus its D1 gh.* branch metadata. */
+async function seedStaged(
+  seeded: Seeded,
+  filename: string,
+  opts: {
+    stagedAt?: string | null; // null = omit entirely
+    visibility?: "private";
+    provenance?: Record<string, string>;
+    bytes?: Uint8Array;
+  } = {},
+) {
+  const bytes = opts.bytes ?? PNG;
+  await seeded.bucket.put(`${PREFIX}${stagedKey(filename)}`, bytes, {
+    httpMetadata: { contentType: "image/png" },
+    customMetadata: {
+      ...(opts.visibility ? { visibility: opts.visibility } : {}),
+      ...opts.provenance,
+    },
+  });
+  const stagedAt = opts.stagedAt === null ? undefined : (opts.stagedAt ?? new Date().toISOString());
+  await replaceFileMetadata(seeded.env.DB, WS, stagedKey(filename), {
+    "gh.repo": "acme/web",
+    "gh.kind": "branch",
+    "gh.branch": BRANCH,
+    ...(stagedAt ? { "gh.staged-at": stagedAt } : {}),
+  });
+}
+
+function post(env: Env, body: unknown, token: string = TOKEN) {
+  return app.request(
+    `/v1/${WS}/github/promote`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("POST /v1/:workspace/github/promote", () => {
+  it("400s on a malformed body", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { repo: "not-a-repo", num: 0, branch: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a dot-only repo segment", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { repo: "../etc", num: 12, branch: "feat" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a non-positive num", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { repo: REPO, num: 0, branch: "feat" });
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on an empty branch", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { repo: REPO, num: 12, branch: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it("401s with no bearer token", async () => {
+    const { env } = await seededEnv();
+    const res = await app.request(
+      `/v1/${WS}/github/promote`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: REPO, num: NUM, branch: BRANCH }),
+      },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("403s a files:read-only scoped token", async () => {
+    const scopedToken = "up_acme_readonly";
+    const { env } = await seededEnv({
+      scopedToken: { rawToken: scopedToken, scopes: ["files:read"] },
+    });
+    const res = await post(env, { repo: REPO, num: NUM, branch: BRANCH }, scopedToken);
+    expect(res.status).toBe(403);
+  });
+
+  it("is a success with empty arrays when the staging prefix is empty", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ promoted: [], skipped: [] });
+  });
+
+  it("promotes a fresh staged file and tags both copy and original", async () => {
+    const seeded = await seededEnv();
+    await seedStaged(seeded, "hero.png");
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { promoted: string[]; skipped: unknown[] };
+    expect(body.promoted).toEqual([destKey("hero.png")]);
+    expect(body.skipped).toEqual([]);
+
+    // Destination object landed in R2 under the workspace's prefix.
+    const stored = seeded.bucket.store.get(`${PREFIX}${destKey("hero.png")}`);
+    expect(stored).toBeDefined();
+    expect(stored?.contentType).toBe("image/png");
+    expect([...(stored?.data ?? [])]).toEqual([...PNG]);
+
+    // Copy's D1 metadata is a full, self-contained gh.* set.
+    const copyMeta = await getFileMetadata(seeded.env.DB, WS, destKey("hero.png"));
+    expect(copyMeta["gh.repo"]).toBe("acme/web");
+    expect(copyMeta["gh.kind"]).toBe("pull");
+    expect(copyMeta["gh.number"]).toBe("12");
+    expect(copyMeta["gh.ref"]).toBe("acme/web#12");
+    expect(copyMeta["gh.branch"]).toBe(BRANCH);
+    expect(typeof copyMeta["gh.promoted-at"]).toBe("string");
+
+    // Original is merge-tagged, not replaced — its staged tags survive.
+    const originalMeta = await getFileMetadata(seeded.env.DB, WS, stagedKey("hero.png"));
+    expect(originalMeta["gh.kind"]).toBe("branch");
+    expect(originalMeta["gh.branch"]).toBe(BRANCH);
+    expect(originalMeta["gh.promoted-to"]).toBe("acme/web#12");
+    expect(typeof originalMeta["gh.promoted-at"]).toBe("string");
+  });
+
+  it("treats a missing gh.staged-at as fresh (workspace's own data)", async () => {
+    const seeded = await seededEnv();
+    await seedStaged(seeded, "hero.png", { stagedAt: null });
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    const body = (await res.json()) as { promoted: string[]; skipped: unknown[] };
+    expect(body.promoted).toEqual([destKey("hero.png")]);
+    expect(body.skipped).toEqual([]);
+  });
+
+  it("skips a staged file older than the 30-day freshness window", async () => {
+    const seeded = await seededEnv();
+    const old = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+    await seedStaged(seeded, "stale.png", { stagedAt: old });
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    const body = (await res.json()) as {
+      promoted: string[];
+      skipped: { key: string; reason: string }[];
+    };
+    expect(body.promoted).toEqual([]);
+    expect(body.skipped).toEqual([{ key: stagedKey("stale.png"), reason: "stale" }]);
+  });
+
+  it("preserves visibility and provenance custom metadata on the copy", async () => {
+    const seeded = await seededEnv();
+    await seedStaged(seeded, "private.png", {
+      visibility: "private",
+      provenance: { client: "uploads-cli", "client-version": "1.2.3" },
+    });
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    const body = (await res.json()) as { promoted: string[] };
+    expect(body.promoted).toEqual([destKey("private.png")]);
+
+    const stored = seeded.bucket.store.get(`${PREFIX}${destKey("private.png")}`);
+    expect(stored?.customMetadata?.visibility).toBe("private");
+    expect(stored?.customMetadata?.client).toBe("uploads-cli");
+    expect(stored?.customMetadata?.["client-version"]).toBe("1.2.3");
+  });
+
+  it("is idempotent: re-promoting overwrites the destination copy", async () => {
+    const seeded = await seededEnv();
+    await seedStaged(seeded, "hero.png");
+
+    const first = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(first.status).toBe(200);
+    const second = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as { promoted: string[]; skipped: unknown[] };
+    expect(body.promoted).toEqual([destKey("hero.png")]);
+    expect(body.skipped).toEqual([]);
+    // Still exactly one destination object, not a duplicate.
+    expect(seeded.bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
+  });
+
+  it("caps at 100 staged files, reporting the overflow as skipped", async () => {
+    const seeded = await seededEnv();
+    for (let i = 0; i < 101; i++) {
+      await seedStaged(seeded, `f${String(i).padStart(3, "0")}.png`);
+    }
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      promoted: string[];
+      skipped: { key: string; reason: string }[];
+    };
+    expect(body.promoted.length).toBe(100);
+    const overflow = body.skipped.filter((s) => s.reason === "cap_exceeded");
+    expect(overflow.length).toBe(1);
+  });
+
+  it("degrades a single-file copy failure to a skip instead of failing the request", async () => {
+    const seeded = await seededEnv();
+    await seedStaged(seeded, "good.png");
+    // Stage a second D1-metadata row with no backing R2 object — download()
+    // returning null/throwing simulates a read-time failure for that one key.
+    await replaceFileMetadata(seeded.env.DB, WS, stagedKey("ghost.png"), {
+      "gh.repo": "acme/web",
+      "gh.kind": "branch",
+      "gh.branch": BRANCH,
+      "gh.staged-at": new Date().toISOString(),
+    });
+    // Fake R2's list() only returns what's actually stored, so "ghost.png"
+    // won't be listed unless it has an object — instead simulate a broken
+    // read on an existing object by corrupting bucket.get for that key.
+    await seeded.bucket.put(`${PREFIX}${stagedKey("ghost.png")}`, PNG, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const realGet = seeded.bucket.get.bind(seeded.bucket);
+    seeded.bucket.get = (async (key: string) => {
+      if (key === `${PREFIX}${stagedKey("ghost.png")}`) throw new Error("boom");
+      return realGet(key);
+    }) as typeof seeded.bucket.get;
+
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      promoted: string[];
+      skipped: { key: string; reason: string }[];
+    };
+    expect(body.promoted).toEqual([destKey("good.png")]);
+    expect(body.skipped.some((s) => s.key === stagedKey("ghost.png"))).toBe(true);
+  });
+});

--- a/apps/api/src/routes/github-promote.ts
+++ b/apps/api/src/routes/github-promote.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /v1/:workspace/github/promote (phase 2a). Workspace-authed. Copies the
+ * calling workspace's own branch-staged attachments
+ * (`gh/<owner>/<name>/branch/<branch>/<filename>`) into the target PR's
+ * stable attachment prefix (`gh/<owner>/<name>/pull/<num>/<filename>`) so the
+ * managed-comment gatherer (routes/github-comment.ts) picks them up
+ * unchanged. Pure workspace-data operation — no GitHub API call, no
+ * installation lookup. See github-promote.ts for the copy logic.
+ */
+import { ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import { promoteBranchAttachments } from "../github-promote";
+import { writeRateLimit } from "../guards";
+import { requireScope, type WorkspaceVars } from "../workspace";
+import { jsonBody } from "./json-body";
+
+// Same repo grammar as routes/github-comment.ts's parseTarget, plus the same
+// dot-only-segment guard (this repo string ends up interpolated into R2 key
+// segments here, not a GitHub API path, but the same traversal-shaped input
+// is worth rejecting up front).
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const DOTS_ONLY_RE = /^\.+$/;
+
+// Printable ASCII only, matching file-metadata.ts's META_VALUE_MAX/VALUE_SAFE_RE
+// — the branch name is stored verbatim as the `gh.branch` D1 metadata value.
+const BRANCH_VALUE_RE = /^[\x20-\x7E]+$/;
+const BRANCH_VALUE_MAX = 512;
+
+interface PromoteBody {
+  repo: string;
+  num: number;
+  branch: string;
+}
+
+function parseBody(body: Record<string, unknown>): PromoteBody {
+  const repo = typeof body.repo === "string" ? body.repo : "";
+  const num = typeof body.num === "number" ? body.num : NaN;
+  const branch = typeof body.branch === "string" ? body.branch : "";
+
+  if (!REPO_RE.test(repo) || repo.split("/").some((seg) => DOTS_ONLY_RE.test(seg))) {
+    throw new ValidationError("repo must be owner/name.", { code: "invalid_repo" });
+  }
+  if (!Number.isSafeInteger(num) || num < 1) {
+    throw new ValidationError("num must be a positive integer.");
+  }
+  if (branch.length === 0 || branch.length > BRANCH_VALUE_MAX || !BRANCH_VALUE_RE.test(branch)) {
+    throw new ValidationError("branch must be a non-empty printable-ASCII string.", {
+      code: "invalid_branch",
+    });
+  }
+  return { repo, num, branch };
+}
+
+export const githubPromote = new Hono<WorkspaceVars>().post(
+  "/promote",
+  writeRateLimit,
+  requireScope("files:write"),
+  async (c) => {
+    const target = parseBody(await jsonBody(c));
+    const result = await promoteBranchAttachments(
+      c.env,
+      c.get("workspace"),
+      c.get("workspaceName"),
+      target,
+    );
+    return c.json(result);
+  },
+);


### PR DESCRIPTION
## Summary

Phase 2a server-side promotion endpoint. `POST /v1/:workspace/github/promote`
copies a workspace's own branch-staged attachments
(`gh/<owner>/<name>/branch/<branch>/<filename>`, written by the CLI staging
lane running in parallel) into the target PR's stable attachment prefix
(`gh/<owner>/<name>/pull/<num>/<filename>`), so the existing managed-comment
gatherer (`github-comment.ts`, which lists that prefix) picks them up
unchanged. Pure workspace-data operation — no GitHub API call, no
installation lookup, no changes to the comment machinery.

## Behavior

- Auth: workspace bearer token, `writeRateLimit`, `requireScope("files:write")`.
- Body: `{ repo: "owner/name", num: number, branch: string }`, validated
  strictly (repo shape incl. dot-only-segment guard, positive int `num`,
  non-empty printable-ASCII `branch`).
- Lists the workspace's own objects under the branch-staged prefix (segments
  sanitized the same way the staged keys are).
- Freshness: a staged file whose `gh.staged-at` D1 tag is older than 30 days
  is skipped (`reason: "stale"`); a missing/unparsable tag is treated as
  fresh, since it's the workspace's own data.
- For each fresh file: reads the object (bytes + R2 custom metadata) and
  writes it to the PR's `pull/<num>/` key via the same `putObject` path every
  other upload goes through — so it inherits the usual budget/usage
  accounting, key-policy checks, and cache-control/`uploaded-at` stamping.
  Content type, visibility, and provenance custom metadata (`client`,
  `client-version`, etc.) are preserved from the source object.
- The copy's D1 metadata is written as a full, self-contained set:
  `gh.repo`, `gh.kind=pull`, `gh.number`, `gh.ref` (`owner/name#num`),
  `gh.branch`, `gh.promoted-at`.
- The staged original is merge-tagged (not replaced, not deleted) with
  `gh.promoted-to` and `gh.promoted-at` — its own `gh.kind=branch` /
  `gh.staged-at` tags survive, so a later reaper phase or a second PR
  re-promoting from the same branch both have what they need.
- Idempotent: re-promoting overwrites the destination copy (last-write-wins,
  same contract as any other overwrite in this API).
- Degrade-safe: a single-file read/write failure is collected into
  `skipped` with a reason instead of failing the whole request.
- Bounded: at most 100 staged files are processed per call; anything past
  that is reported in `skipped` with `reason: "cap_exceeded"` rather than
  silently dropped.
- Response: `{ promoted: string[], skipped: { key, reason }[] }`. An empty
  staging prefix is a 200 with two empty arrays, not an error.

## Out of scope (later phases)

- CLI wiring to call this endpoint (`packages/uploads` — separate lane
  running in parallel; this PR deliberately doesn't touch it).
- Webhook trigger to call promotion automatically on PR open/push.
- The reaper that deletes stale staged originals.

## Test plan

- [x] `pnpm test` (apps/api): all suites pass, including the new
      `github-promote-route.test.ts` (happy path, freshness skip, missing
      `staged-at` treated as fresh, empty prefix, idempotent re-promote,
      metadata correctness on copy AND original, visibility/provenance
      preservation, the 100-file cap, degrade-safe single-file failure,
      auth/scope rejection, validation 400s).
- [x] `pnpm run typecheck` (apps/api, via `wrangler types && tsc --noEmit`).
- [x] `pnpm run lint` / oxfmt — clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to promote staged branch attachments to a pull request.
  * Promoted attachments retain visibility and metadata, with safeguards for stale or invalid files.
  * Supports repeat promotion without creating duplicate destination objects.
  * Reports successfully promoted and skipped attachments, allowing individual failures without stopping the operation.

* **Bug Fixes**
  * Handles missing freshness metadata safely and prevents stale attachments from being promoted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->