### PR TITLE
feat(cli): auto-promote branch-staged attachments on PR attach

### DIFF
--- a/.changeset/attach-promote-branch-staged.md
+++ b/.changeset/attach-promote-branch-staged.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads attach` now auto-promotes branch-staged attachments (`attach --branch`) into a PR's attachment prefix the first time you attach to that PR, before refreshing the managed comment — no extra step needed once a PR opens for a branch you staged files against. Use `uploads attach --promote` (no file arguments) to promote and refresh the comment without uploading anything new, or `--no-promote` to opt out of the automatic behavior. Promotion talks to a new server endpoint and degrades silently (never fails the attach) when that endpoint isn't available yet.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -232,6 +232,23 @@ export type GithubCommentResult =
       required?: string[];
     };
 
+/** `POST /v1/:workspace/github/promote` request/response (server contract, PR #310). */
+export interface PromoteBranchAttachmentsOptions {
+  repo: string;
+  num: number;
+  branch: string;
+}
+
+export interface PromoteSkip {
+  key: string;
+  reason: string;
+}
+
+export interface PromoteBranchAttachmentsResult {
+  promoted: string[];
+  skipped: PromoteSkip[];
+}
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -960,6 +977,25 @@ export function createUploadsClient(config: UploadsClientConfig) {
       return request<GithubCommentResult>(
         "POST",
         `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/comment`,
+        {
+          body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+
+    /**
+     * Promote a workspace's branch-staged attachments into a PR's stable
+     * attachment prefix (server contract, PR #310 — degrade-safe callers
+     * treat any failure, including a 404 from an older/self-hosted worker
+     * that doesn't have this route yet, as "nothing promoted").
+     */
+    async promoteBranchAttachments(
+      opts: PromoteBranchAttachmentsOptions,
+    ): Promise<PromoteBranchAttachmentsResult> {
+      return request<PromoteBranchAttachmentsResult>(
+        "POST",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/promote`,
         {
           body: new TextEncoder().encode(JSON.stringify(opts)),
           headers: { "Content-Type": "application/json" },

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -952,7 +952,7 @@ function promotionNote(
 ): string {
   const n = promotion.promoted.length;
   const branchSuffix = branch ? ` from branch ${branch}` : "";
-  return `>> promoted ${n} staged screenshot${n === 1 ? "" : "s"}${branchSuffix}\n`;
+  return `>> promoted ${n} staged attachment${n === 1 ? "" : "s"}${branchSuffix}\n`;
 }
 
 export async function runAttach(

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -4,6 +4,7 @@ import { mapBounded } from "./async.js";
 import {
   createUploadsClient,
   type GalleryItem,
+  type PromoteBranchAttachmentsResult,
   type PutResult,
   type UploadsClient,
 } from "./client.js";
@@ -576,15 +577,29 @@ With no value, --branch resolves the current git branch. Staged files are
 public like every other attachment — same public-URL caveat applies. There is
 no managed comment for a branch (no PR/issue to comment on yet); --branch
 never runs the comment sync and cannot combine with --pr/--issue/--comment.
-Promoting staged files into the PR's managed comment once one opens ships in
-a later phase — for now, find them again with
-"uploads find gh.branch=<branch>".
+
+Promotion: once a PR exists, staged files for the current branch are picked
+up automatically the first time you attach to that PR (a plain "uploads
+attach <file> --pr <num>", or the inferred-PR default with no target flags) —
+they're copied into the PR's attachment prefix before the managed comment is
+built, so they show up in the same run. Pass --no-promote to skip that. If
+you'd rather promote without attaching a new file (e.g. right after
+"gh pr create" with nothing new to upload), run "uploads attach --promote"
+with no file arguments — it resolves the PR the same way, promotes, and
+refreshes the comment; it exits 0 even if nothing was staged. --promote only
+takes effect with zero files and cannot combine with --branch/--issue/
+--no-promote. Promotion never applies to issues. Staged files stay findable
+with "uploads find gh.branch=<branch>" either way.
 
 Options:
   --pr <num>            Attach to this pull request
   --issue <num>         Attach to this issue
   --branch [name]       Stage against a branch, pre-PR (default: current git branch);
                         not with --pr/--issue/--comment
+  --promote             No files: promote branch-staged attachments into the
+                        resolved PR and refresh the comment; not with
+                        --branch/--issue/--no-promote
+  --no-promote          Skip auto-promoting branch-staged attachments (default path only)
   --repo <owner/repo>   Repository (default: gh/git inference)
   --no-comment          Upload only; don't create/update the managed comment
   --content-type <mime> Override Content-Type (applied to every file; ignored when optimize rewrites)
@@ -612,6 +627,7 @@ Examples:
   uploads attach ./shot.png --meta app=myapp --meta page=settings
   uploads attach ./shot.png --branch
   uploads attach ./shot.png --branch feature/new-settings
+  uploads attach --promote
 `;
 
 export type AttachUploadItem = PutResult & {
@@ -910,6 +926,35 @@ export async function uploadPuts(opts: {
   return { uploads, failures, firstError };
 }
 
+/**
+ * Best-effort call to `POST /v1/:workspace/github/promote` (server contract,
+ * PR #310). Degrade-safe like `syncAttachmentsComment`'s bot path: an older
+ * or self-hosted worker without this route (404), a forbidden token (403),
+ * or a network error all collapse to "nothing promoted" — the caller must
+ * never let this fail the attach. Returns undefined on any failure.
+ */
+async function attemptPromoteBranch(
+  client: UploadsClient,
+  target: GhTarget,
+  branch: string,
+): Promise<PromoteBranchAttachmentsResult | undefined> {
+  try {
+    return await client.promoteBranchAttachments({ repo: target.repo, num: target.num, branch });
+  } catch {
+    return undefined;
+  }
+}
+
+/** Human-mode note for a promotion that actually promoted something. */
+function promotionNote(
+  promotion: PromoteBranchAttachmentsResult,
+  branch: string | undefined,
+): string {
+  const n = promotion.promoted.length;
+  const branchSuffix = branch ? ` from branch ${branch}` : "";
+  return `>> promoted ${n} staged screenshot${n === 1 ? "" : "s"}${branchSuffix}\n`;
+}
+
 export async function runAttach(
   ctx: CliContext,
   args: string[],
@@ -921,12 +966,35 @@ export async function runAttach(
     writeCommandHelp(ATTACH_HELP);
     return 0;
   }
+  if (parsed.flags.has("--no-comment") && typeof parsed.flags.get("--no-comment") === "string") {
+    throw new UsageError("--no-comment takes no value — place it after the file arguments");
+  }
+  if (parsed.flags.has("--promote") && typeof parsed.flags.get("--promote") === "string") {
+    throw new UsageError("--promote takes no value — place it after the file arguments");
+  }
+  if (parsed.flags.has("--no-promote") && typeof parsed.flags.get("--no-promote") === "string") {
+    throw new UsageError("--no-promote takes no value — place it after the file arguments");
+  }
+
+  if (parsed.flags.has("--promote")) {
+    if (parsed.positionals.length > 0) {
+      throw new UsageError(
+        "--promote takes no file arguments — attaching a file to a PR already auto-promotes " +
+          "staged files; use `uploads attach <file> --pr <num>` instead",
+      );
+    }
+    if (parsed.flags.has("--branch"))
+      throw new UsageError("--promote cannot be combined with --branch");
+    if (parsed.flags.has("--issue"))
+      throw new UsageError("--promote cannot be combined with --issue");
+    if (parsed.flags.has("--no-promote"))
+      throw new UsageError("--promote cannot be combined with --no-promote");
+    return runAttachPromoteOnly(ctx, parsed, run);
+  }
+
   if (parsed.positionals.length === 0) {
     writeCommandHelp(ATTACH_HELP);
     return 2;
-  }
-  if (parsed.flags.has("--no-comment") && typeof parsed.flags.get("--no-comment") === "string") {
-    throw new UsageError("--no-comment takes no value — place it after the file arguments");
   }
 
   const branchArg = branchFromFlags(parsed.flags, run);
@@ -977,6 +1045,27 @@ export async function runAttach(
     throw firstError instanceof Error ? firstError : new Error(String(firstError));
   }
 
+  // Auto-promote: before the comment sync, best-effort promote this
+  // workspace's own branch-staged attachments (from an earlier `attach
+  // --branch` while the PR didn't exist yet) into this PR's attachment
+  // prefix, so the comment gather below sees them in the same invocation.
+  // Never for issues (branch staging only ever targets a future PR), never
+  // with --no-promote, and silently skipped (no client call at all) when the
+  // current git branch can't be resolved (detached HEAD, not a repo) — this
+  // must never fail the attach itself.
+  let promotion: PromoteBranchAttachmentsResult | undefined;
+  let promotedBranch: string | undefined;
+  if (target.kind === "pull" && !parsed.flags.has("--no-promote")) {
+    try {
+      promotedBranch = resolveCurrentBranch(run);
+    } catch {
+      promotedBranch = undefined;
+    }
+    if (promotedBranch !== undefined) {
+      promotion = await attemptPromoteBranch(ctx.client, target, promotedBranch);
+    }
+  }
+
   let comment: AttachmentsCommentResult | undefined;
   let commentError: string | undefined;
   // Skip comment refresh when every upload failed — nothing new from this batch.
@@ -992,7 +1081,14 @@ export async function runAttach(
   }
 
   if (ctx.json) {
-    await writeJson({ target, uploads, failures, comment, commentError });
+    await writeJson({
+      target,
+      uploads,
+      failures,
+      comment,
+      commentError,
+      promotion: promotion ?? null,
+    });
   } else {
     for (const result of uploads) {
       if (logHuman) {
@@ -1010,6 +1106,9 @@ export async function runAttach(
     }
     for (const failure of failures) {
       process.stderr.write(`warning: could not upload ${failure.file}: ${failure.error.message}\n`);
+    }
+    if (!ctx.quiet && promotion && promotion.promoted.length > 0) {
+      process.stderr.write(promotionNote(promotion, promotedBranch));
     }
     if (!ctx.quiet && comment)
       process.stderr.write(
@@ -1094,6 +1193,64 @@ async function runAttachBranch(
     }
   }
   return failures.length === 0 ? 0 : 1;
+}
+
+/**
+ * `attach --promote` with zero file arguments: resolve the PR target (same
+ * resolution as the default `runAttach` path), promote this workspace's
+ * branch-staged attachments into it, then run the comment sync — useful
+ * right after `gh pr create` when the PR was opened without a fresh attach
+ * (auto-promotion on the default path only fires when you attach a file).
+ * Unlike the default path's best-effort branch resolution, this is an
+ * explicit user action: `resolveCurrentBranch` throwing (detached HEAD, not
+ * a repo) propagates as a UsageError instead of silently skipping. Always
+ * exits 0 — an empty staging prefix is success, not a failure.
+ */
+async function runAttachPromoteOnly(
+  ctx: CliContext,
+  parsed: CommandFlags,
+  run: CommandRunner,
+): Promise<number> {
+  const explicitTarget = ghTargetFromFlags(parsed.flags, run);
+  const target =
+    explicitTarget ??
+    resolveCurrentPullRequest(resolveRepo(flagString(parsed.flags, "--repo"), run), run);
+  const branch = resolveCurrentBranch(run);
+
+  const promotion = await attemptPromoteBranch(ctx.client, target, branch);
+
+  let comment: AttachmentsCommentResult | undefined;
+  let commentError: string | undefined;
+  if (!parsed.flags.has("--no-comment")) {
+    try {
+      comment = await syncAttachmentsComment(ctx.client, target, run);
+    } catch (err) {
+      commentError = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `warning: promotion succeeded but the GitHub comment failed (is gh installed and authenticated?): ${commentError}\n`,
+      );
+    }
+  }
+
+  if (ctx.json) {
+    await writeJson({
+      target,
+      uploads: [],
+      failures: [],
+      comment,
+      commentError,
+      promotion: promotion ?? null,
+    });
+  } else {
+    if (!ctx.quiet && promotion && promotion.promoted.length > 0) {
+      process.stderr.write(promotionNote(promotion, branch));
+    }
+    if (!ctx.quiet && comment)
+      process.stderr.write(
+        `>> attachments comment ${comment.action}${commentViaSuffix(comment.via)}\n`,
+      );
+  }
+  return 0;
 }
 
 export async function runPut(

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -640,7 +640,7 @@ describe("runAttach auto-promote (default PR path)", () => {
     } finally {
       vi.restoreAllMocks();
     }
-    expect(stderr.join("")).toContain(">> promoted 1 staged screenshot from branch feature-x\n");
+    expect(stderr.join("")).toContain(">> promoted 1 staged attachment from branch feature-x\n");
   });
 
   it("stays quiet when promotion runs but promotes nothing", async () => {

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
-import type { UploadsClient } from "../src/client.js";
+import type { PromoteBranchAttachmentsResult, UploadsClient } from "../src/client.js";
 import { runAttach, type CliContext } from "../src/commands.js";
 import { UploadsError } from "../src/errors.js";
 import type { CommandRunner } from "../src/github-gh.js";
@@ -20,9 +20,17 @@ function files(...names: string[]): string[] {
 function fakeClient(opts?: {
   /** Reject put for keys whose leaf matches this predicate. */
   failLeaf?: (leaf: string) => boolean | Error;
+  /** `client.promoteBranchAttachments` behavior; omitted → method is absent (older-server simulation). */
+  promote?: (opts: {
+    repo: string;
+    num: number;
+    branch: string;
+  }) => Promise<PromoteBranchAttachmentsResult> | PromoteBranchAttachmentsResult;
 }) {
   const puts: string[] = [];
   const metadataByKey: Record<string, Record<string, string> | undefined> = {};
+  const promoteCalls: { repo: string; num: number; branch: string }[] = [];
+  const callOrder: string[] = [];
   const list = async ({ prefix }: { prefix?: string } = {}) => ({
     items: puts
       .filter((key) => key.startsWith(prefix ?? ""))
@@ -52,11 +60,31 @@ function fakeClient(opts?: {
       };
     },
     list,
-    listAll: async (listOpts: { prefix?: string } = {}) => (await list(listOpts)).items,
+    listAll: async (listOpts: { prefix?: string } = {}) => {
+      callOrder.push("comment-gather");
+      return (await list(listOpts)).items;
+    },
     findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
     getGallery: async () => ({ items: [] }),
+    ...(opts?.promote
+      ? {
+          promoteBranchAttachments: async (promoteOpts: {
+            repo: string;
+            num: number;
+            branch: string;
+          }) => {
+            promoteCalls.push(promoteOpts);
+            callOrder.push("promote");
+            const result = await opts.promote!(promoteOpts);
+            // Simulate the server-side effect: promoted keys become real
+            // objects under the workspace, visible to a subsequent list.
+            for (const key of result.promoted) if (!puts.includes(key)) puts.push(key);
+            return result;
+          },
+        }
+      : {}),
   } as unknown as UploadsClient;
-  return { client, puts, metadataByKey };
+  return { client, puts, metadataByKey, promoteCalls, callOrder };
 }
 
 function ctxWith(client: UploadsClient): CliContext {
@@ -477,5 +505,303 @@ describe("runAttach gh.title metadata (issue #267)", () => {
       "gh.number": "123",
       "gh.ref": "buildinternet/uploads#123",
     });
+  });
+});
+
+/**
+ * A `gh`/`git` runner that fully controls the current branch (`git rev-parse
+ * --abbrev-ref HEAD`) as well as the usual PR-view/title-view stubs, so
+ * promotion tests can assert on the exact branch name sent to the promote
+ * endpoint. `branch: undefined` simulates detached HEAD ("HEAD").
+ */
+function promoteRunner(
+  opts: { branch?: string | undefined; detached?: boolean; title?: string } = {},
+): { run: CommandRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const branch = opts.detached ? "HEAD" : (opts.branch ?? "feature-x");
+  const run: CommandRunner = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    if (cmd === "git" && args[0] === "rev-parse") return `${branch}\n`;
+    if (args[0] === "repo") return "buildinternet/uploads\n";
+    if ((args[0] === "pr" || args[0] === "issue") && args[1] === "view" && args.includes("title")) {
+      if (opts.title !== undefined) return `${opts.title}\n`;
+      throw new Error("gh: title not resolvable");
+    }
+    if (args[0] === "pr" && args[1] === "view") return "123\n";
+    if (args[1]?.includes("per_page=100")) return "[]";
+    return JSON.stringify({ id: 9 });
+  };
+  return { run, calls };
+}
+
+describe("runAttach auto-promote (default PR path)", () => {
+  it("calls promoteBranchAttachments with the resolved repo/num/branch before the comment sync", async () => {
+    const { client, promoteCalls, callOrder } = fakeClient({
+      promote: async () => ({
+        promoted: ["gh/buildinternet/uploads/pull/123/hero.png"],
+        skipped: [],
+      }),
+    });
+    const { run } = promoteRunner({ branch: "feature-x" });
+    expect(await runAttach(ctxWith(client), files("shot.png"), false, run)).toBe(0);
+    expect(promoteCalls).toEqual([
+      { repo: "buildinternet/uploads", num: 123, branch: "feature-x" },
+    ]);
+    expect(callOrder.indexOf("promote")).toBeLessThan(callOrder.indexOf("comment-gather"));
+  });
+
+  it("never promotes for an --issue target", async () => {
+    const { client, promoteCalls } = fakeClient({
+      promote: async () => ({ promoted: [], skipped: [] }),
+    });
+    const { run } = promoteRunner();
+    await runAttach(
+      ctxWith(client),
+      [...files("artifact.zip"), "--issue", "45", "--repo", "o/r"],
+      false,
+      run,
+    );
+    expect(promoteCalls).toEqual([]);
+  });
+
+  it("silently skips promotion when the endpoint 404s (older/self-hosted server)", async () => {
+    const { client } = fakeClient({
+      promote: async () => {
+        throw new UploadsError("not found", "NOT_FOUND", 404);
+      },
+    });
+    const { run } = promoteRunner();
+    expect(await runAttach(ctxWith(client), files("shot.png"), false, run)).toBe(0);
+  });
+
+  it("silently skips promotion on a network error", async () => {
+    const { client } = fakeClient({
+      promote: async () => {
+        throw new UploadsError("network request failed", "NETWORK");
+      },
+    });
+    const { run } = promoteRunner();
+    expect(await runAttach(ctxWith(client), files("shot.png"), false, run)).toBe(0);
+  });
+
+  it("silently skips promotion when the client has no promoteBranchAttachments method at all", async () => {
+    const { client } = fakeClient(); // no `promote` opt → method absent
+    const { run } = promoteRunner();
+    expect(await runAttach(ctxWith(client), files("shot.png"), false, run)).toBe(0);
+  });
+
+  it("silently skips promotion on detached HEAD", async () => {
+    const { client, promoteCalls } = fakeClient({
+      promote: async () => ({ promoted: [], skipped: [] }),
+    });
+    // Explicit --pr so target resolution doesn't itself need the current
+    // branch (resolveCurrentPullRequest also shells out to git rev-parse) —
+    // isolates the assertion to auto-promote's own best-effort branch read.
+    const { run } = promoteRunner({ detached: true });
+    expect(
+      await runAttach(
+        ctxWith(client),
+        [...files("shot.png"), "--pr", "123", "--repo", "buildinternet/uploads"],
+        false,
+        run,
+      ),
+    ).toBe(0);
+    expect(promoteCalls).toEqual([]);
+  });
+
+  it("--no-promote skips the promote call entirely", async () => {
+    const { client, promoteCalls } = fakeClient({
+      promote: async () => ({ promoted: ["x"], skipped: [] }),
+    });
+    const { run } = promoteRunner();
+    await runAttach(ctxWith(client), [...files("shot.png"), "--no-promote"], false, run);
+    expect(promoteCalls).toEqual([]);
+  });
+
+  it("prints a human note only when something was actually promoted", async () => {
+    const { client } = fakeClient({
+      promote: async () => ({
+        promoted: ["gh/buildinternet/uploads/pull/123/hero.png"],
+        skipped: [],
+      }),
+    });
+    const { run } = promoteRunner({ branch: "feature-x" });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    try {
+      await runAttach(ctx, files("shot.png"), false, run);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(stderr.join("")).toContain(">> promoted 1 staged screenshot from branch feature-x\n");
+  });
+
+  it("stays quiet when promotion runs but promotes nothing", async () => {
+    const { client } = fakeClient({
+      promote: async () => ({ promoted: [], skipped: [] }),
+    });
+    const { run } = promoteRunner();
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    try {
+      await runAttach(ctx, files("shot.png"), false, run);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(stderr.join("")).not.toContain("promoted");
+  });
+
+  it("includes a `promotion` field in JSON output", async () => {
+    const { client } = fakeClient({
+      promote: async () => ({
+        promoted: ["gh/buildinternet/uploads/pull/123/hero.png"],
+        skipped: [{ key: "gh/buildinternet/uploads/branch/feature-x/stale.png", reason: "stale" }],
+      }),
+    });
+    const { run } = promoteRunner({ branch: "feature-x" });
+    const ctx = { ...ctxWith(client), json: true };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      await runAttach(ctx, files("shot.png"), false, run);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    const payload = JSON.parse(chunks.join("")) as {
+      promotion: PromoteBranchAttachmentsResult | null;
+    };
+    expect(payload.promotion).toEqual({
+      promoted: ["gh/buildinternet/uploads/pull/123/hero.png"],
+      skipped: [{ key: "gh/buildinternet/uploads/branch/feature-x/stale.png", reason: "stale" }],
+    });
+  });
+
+  it("JSON output has promotion: null when the endpoint is unavailable", async () => {
+    const { client } = fakeClient({
+      promote: async () => {
+        throw new UploadsError("not found", "NOT_FOUND", 404);
+      },
+    });
+    const { run } = promoteRunner();
+    const ctx = { ...ctxWith(client), json: true };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      await runAttach(ctx, files("shot.png"), false, run);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    const payload = JSON.parse(chunks.join("")) as { promotion: unknown };
+    expect(payload.promotion).toBeNull();
+  });
+});
+
+describe("runAttach --promote (explicit promote-only mode)", () => {
+  it("promotes staged files with zero file arguments and refreshes the comment", async () => {
+    const { client, promoteCalls, callOrder } = fakeClient({
+      promote: async () => ({
+        promoted: ["gh/buildinternet/uploads/pull/123/hero.png"],
+        skipped: [],
+      }),
+    });
+    const { run, calls } = promoteRunner({ branch: "feature-x" });
+    expect(await runAttach(ctxWith(client), ["--promote"], false, run)).toBe(0);
+    expect(promoteCalls).toEqual([
+      { repo: "buildinternet/uploads", num: 123, branch: "feature-x" },
+    ]);
+    expect(callOrder.indexOf("promote")).toBeLessThan(callOrder.indexOf("comment-gather"));
+    expect(
+      calls.some((call) => call.includes("repos/buildinternet/uploads/issues/123/comments")),
+    ).toBe(true);
+  });
+
+  it("exits 0 with empty promoted/skipped when nothing was staged", async () => {
+    const { client, promoteCalls } = fakeClient({
+      promote: async () => ({ promoted: [], skipped: [] }),
+    });
+    const { run } = promoteRunner();
+    const ctx = { ...ctxWith(client), json: true };
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runAttach(ctx, ["--promote"], false, run)).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(promoteCalls).toHaveLength(1);
+    const payload = JSON.parse(chunks.join("")) as {
+      uploads: unknown[];
+      failures: unknown[];
+      promotion: PromoteBranchAttachmentsResult | null;
+    };
+    expect(payload.uploads).toEqual([]);
+    expect(payload.failures).toEqual([]);
+    expect(payload.promotion).toEqual({ promoted: [], skipped: [] });
+  });
+
+  it("supports an explicit --pr target", async () => {
+    const { client, promoteCalls } = fakeClient({
+      promote: async () => ({ promoted: [], skipped: [] }),
+    });
+    const { run } = promoteRunner({ branch: "feature-x" });
+    await runAttach(ctxWith(client), ["--promote", "--pr", "77", "--repo", "o/r"], false, run);
+    expect(promoteCalls).toEqual([{ repo: "o/r", num: 77, branch: "feature-x" }]);
+  });
+
+  it("still requires an inferable PR when no target is supplied", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runAttach(ctxWith(client), ["--promote"], false, noPullRequestRunner),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("propagates a UsageError on detached HEAD (explicit action, not silently skipped)", async () => {
+    const { client } = fakeClient();
+    const { run } = promoteRunner({ detached: true });
+    await expect(runAttach(ctxWith(client), ["--promote"], false, run)).rejects.toThrow(UsageError);
+  });
+
+  it("rejects --promote combined with files", async () => {
+    const { client } = fakeClient();
+    const { run } = promoteRunner();
+    await expect(
+      runAttach(ctxWith(client), [...files("shot.png"), "--promote"], false, run),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it.each([
+    ["--branch", "feature/x"],
+    ["--issue", "45"],
+    ["--no-promote", undefined],
+  ])("rejects --promote combined with %s", async (flag, value) => {
+    const { client } = fakeClient();
+    const { run } = promoteRunner();
+    const extra = value !== undefined ? [flag, value] : [flag];
+    await expect(runAttach(ctxWith(client), ["--promote", ...extra], false, run)).rejects.toThrow(
+      UsageError,
+    );
   });
 });

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -79,6 +79,20 @@ uploads put ./demo.gif --format url
 Always embed the returned **markdown** (or `embedUrl`) in GitHub — it uses the
 no-cache host so overwrites propagate. Don't hand-build storage URLs.
 
+**Capturing before the PR exists?** (e.g. mid-task on a branch, no PR yet)
+stage with `uploads attach --branch` instead — same upload path, but keyed to
+the branch rather than a PR/issue number:
+
+```bash
+uploads attach ./shot.png --branch
+```
+
+Once you open the PR (`gh pr create`), the next `uploads attach` to it
+auto-promotes those staged files into the PR's attachments (and refreshes the
+comment) — no extra step needed. If that first attach has no new file to add,
+run `uploads attach --promote` instead to promote and refresh without
+uploading anything.
+
 ## Step 3 — Embed well
 
 - **Meaningful alt text**, always (`--alt`).

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -41,6 +41,20 @@ uploads attach ./shot.png --issue 45 --repo buildinternet/uploads
 Pass `--no-comment` when only stable URLs are wanted. Use `put` for lower-level
 naming and output control.
 
+**No PR yet?** `uploads attach ./shot.png --branch [name]` stages files under
+`gh/<owner>/<repo>/branch/<branch>/<filename>` instead of a PR/issue number —
+same upload path, no target flags, no comment (there's nothing to comment on
+yet). With no value, `--branch` resolves the current git branch; `/` in the
+name sanitizes to `-`. Once a PR opens for that branch, the next
+`uploads attach` targeting it **auto-promotes** those staged files into the
+PR's attachment prefix before the comment refresh — no extra step. If that
+first attach has nothing new to upload, run `uploads attach --promote`
+(zero file arguments) to promote and refresh the comment on its own; it
+exits `0` even when nothing was staged. Skip auto-promotion with
+`--no-promote`. Promotion only applies to PRs, never issues, and both paths
+degrade silently (no error) if the workspace's server doesn't support
+promotion yet.
+
 The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
 in place and the URL never changes. There is **no confirmation prompt** — hot-swap is


### PR DESCRIPTION
## Summary

Phase 2b: CLI wiring for promoting branch-staged attachments into a PR once
one exists.

- **Auto-promote on PR attach**: the default `uploads attach` PR path (and
  an explicit `--pr`) now best-effort calls
  `POST /v1/:workspace/github/promote` with the current git branch before
  refreshing the managed comment, so files staged earlier via
  `attach --branch` show up in the same invocation the PR gets its first
  attach. Never for `--issue` targets. `--no-promote` opts out.
- **`uploads attach --promote`**: explicit promote-only mode with zero file
  arguments — resolves the PR the same way the default path does, promotes,
  refreshes the comment, and exits `0` even when nothing was staged. Useful
  right after `gh pr create` when there's nothing new to upload yet.
  `--promote` rejects file arguments (points at the auto-promote default
  instead) and rejects `--branch`/`--issue`/`--no-promote`.
- Branch resolution differs by path on purpose: the default path's
  auto-promote is best-effort (detached HEAD / non-repo silently skips
  promotion, never fails the attach); `--promote` is an explicit action, so
  the same failure surfaces as a `UsageError`.
- `--json` output gets a `promotion` field (`{promoted, skipped}` or `null`
  when the call failed/was skipped); human mode prints a short
  `>> promoted N staged screenshot(s) from branch <b>` note only when
  something actually promoted.
- `ATTACH_HELP` documents the new flags and flow; both `skills/github-screenshots`
  and `skills/uploads-cli` gained a short section on pre-PR staging →
  promotion.
- One changeset (`@buildinternet/uploads` only, minor).

## Contract dependency

Built against #310's contract (`POST /v1/:workspace/github/promote`, body
`{repo, num, branch}`, response `{promoted: string[], skipped: {key,
reason}[]}`), which is **open but not yet merged**. Every promote call is
wrapped so any failure — 404 from an older/self-hosted server that doesn't
have the route yet, 403, network error — degrades to "nothing promoted"
without failing the attach, mirroring how `syncAttachmentsComment` already
falls back to local `gh` when the bot-comment endpoint is unavailable. No
behavior here depends on #310's exact skip-reason strings or edge-case
semantics, only the top-level `{promoted, skipped}` shape.

## Out of scope

- Automatic promotion triggered by GitHub webhooks (e.g. on PR-opened) —
  that's Phase 3.
- Any changes to `apps/api` (owned by the PR #310 branch, currently being
  amended by another agent).

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test` — 579 tests pass,
      including new coverage for: auto-promote payload + ordering before the
      comment sync, never-for-issues, silent skip on 404/network
      error/missing client method/detached HEAD, `--no-promote`, human-mode
      promoted-note (present/absent), `--json` `promotion` field
      (populated/null), `--promote` happy path + empty-staging exit 0,
      explicit `--pr` with `--promote`, still-requires-inferable-PR,
      detached-HEAD UsageError in explicit mode, and every disallowed flag
      combination.
- [x] `pnpm --filter @buildinternet/uploads run typecheck`
- [x] `pnpm --filter @buildinternet/uploads run build`
- [x] `oxlint`/`oxfmt` clean on touched files (pre-existing warnings only,
      untouched files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `uploads attach` now automatically promotes branch-staged attachments when attaching to a pull request.
  - Added `--promote` to promote existing staged attachments without uploading files.
  - Added `--no-promote` to disable automatic promotion.
  - Promotion details are included in JSON output and human-readable status messages.

- **Bug Fixes**
  - Promotion failures are handled gracefully so attachments can still be uploaded.

- **Documentation**
  - Added guidance for staging uploads before a pull request exists and promoting them afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->