### PR TITLE
feat(api): workspace-repo binding + webhook auto-promotion of staged attachments

### DIFF
--- a/apps/api/migrations/20260720120000_github_repo_links.sql
+++ b/apps/api/migrations/20260720120000_github_repo_links.sql
@@ -1,0 +1,14 @@
+-- Workspace<->repo binding for webhook-driven auto-promotion (phase 3). One
+-- repo maps to at most one workspace; "first claim wins" is enforced at the
+-- application layer via INSERT OR IGNORE (see github-repo-links.ts), not by
+-- re-registration here.
+CREATE TABLE github_repo_links (
+  repo_full_name TEXT PRIMARY KEY,
+  workspace_name TEXT NOT NULL,
+  installation_id INTEGER,
+  source TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX github_repo_links_workspace_idx
+  ON github_repo_links (workspace_name);

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -1,0 +1,125 @@
+/**
+ * Workspace<->repo binding (`github_repo_links` D1 table), phase 3 of the
+ * GitHub App integration. One repo maps to at most one workspace —
+ * "first claim wins": `recordRepoLink` uses `INSERT OR IGNORE`, so a second
+ * workspace that later comments/promotes against an already-linked repo
+ * never steals or overwrites the binding. This narrows the webhook
+ * auto-promotion path (github-webhook.ts) to a single, previously-proven
+ * workspace per repo, without touching the existing any-workspace-can-call
+ * `/github/comment` and `/github/promote` endpoints (those stay
+ * workspace-authed and unaffected by binding).
+ *
+ * There is no explicit claim command yet (deferred to the CLI-side
+ * `uploads github link`, PR #311) — the only way a link is created today is
+ * implicitly, as a side effect of a successful authenticated comment or
+ * promote call (see routes/github-comment.ts, routes/github-promote.ts).
+ */
+
+export interface RepoLink {
+  repo: string;
+  workspaceName: string;
+  installationId: number | null;
+  source: string;
+  createdAt: string;
+}
+
+interface RepoLinkRow {
+  repo_full_name: string;
+  workspace_name: string;
+  installation_id: number | null;
+  source: string;
+  created_at: string;
+}
+
+function normalizeRepo(repo: string): string {
+  return repo.toLowerCase();
+}
+
+function rowToLink(row: RepoLinkRow): RepoLink {
+  return {
+    repo: row.repo_full_name,
+    workspaceName: row.workspace_name,
+    installationId: row.installation_id,
+    source: row.source,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * Best-effort claim: first caller to link a repo wins, and later calls for
+ * the same repo (from any workspace, including the same one) are silently
+ * ignored (`INSERT OR IGNORE` on the primary key). Never throws — a D1 blip
+ * here must not affect the comment/promote response it rides along with;
+ * failures are logged and swallowed.
+ */
+export async function recordRepoLink(
+  db: D1Database,
+  repo: string,
+  workspaceName: string,
+  source: string,
+  installationId: number | null = null,
+  now = new Date(),
+): Promise<void> {
+  try {
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO github_repo_links
+           (repo_full_name, workspace_name, installation_id, source, created_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .bind(normalizeRepo(repo), workspaceName, installationId, source, now.toISOString())
+      .run();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "repo link record failed",
+        repo,
+        workspaceName,
+        source,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+/** The workspace bound to `repo`, or null if unclaimed. Never throws (callers treat a D1 failure as "no link"). */
+export async function findRepoLink(db: D1Database, repo: string): Promise<RepoLink | null> {
+  try {
+    const row = await db
+      .prepare(`SELECT * FROM github_repo_links WHERE repo_full_name = ?`)
+      .bind(normalizeRepo(repo))
+      .first<RepoLinkRow>();
+    return row ? rowToLink(row) : null;
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "repo link lookup failed",
+        repo,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}
+
+/**
+ * Removes a stale link (e.g. its workspace was deleted/tombstoned). Never
+ * throws — cleanup is best-effort; a failed delete just means the next
+ * webhook delivery re-discovers the same stale state and retries the cleanup.
+ */
+export async function deleteRepoLink(db: D1Database, repo: string): Promise<void> {
+  try {
+    await db
+      .prepare(`DELETE FROM github_repo_links WHERE repo_full_name = ?`)
+      .bind(normalizeRepo(repo))
+      .run();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "repo link delete failed",
+        repo,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}

--- a/apps/api/src/github-webhook-auto-promote.test.ts
+++ b/apps/api/src/github-webhook-auto-promote.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Phase 3 webhook-driven auto-promotion (`handleWebhook`'s `pull_request`
+ * handling in github-webhook.ts). Route-level HMAC/verification is covered
+ * by routes/github-webhook-route.test.ts; this suite calls `handleWebhook`
+ * directly (no `ctx` — see github-webhook.ts's inline-when-no-ctx fallback)
+ * so every assertion below is deterministic without needing to drain a
+ * `waitUntil` queue.
+ */
+import { describe, expect, it } from "vitest";
+import { handleWebhook } from "./github-webhook";
+import { recordRepoLink } from "./github-repo-links";
+import { replaceFileMetadata } from "./file-metadata";
+import { sha256Hex, type WorkspaceRecord } from "./workspace";
+import { FakeKv } from "../test/fake-kv";
+import { FakeR2Bucket } from "../test/fake-r2";
+import { UsageFakeD1 } from "../test/usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "../test/github-app-env";
+
+const WS = "acme";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const BRANCH = "feat-x";
+const NUM = 12;
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+function stagedKey(filename: string): string {
+  return `gh/acme/web/branch/${BRANCH}/${filename}`;
+}
+function destKey(filename: string): string {
+  return `gh/acme/web/pull/${NUM}/${filename}`;
+}
+
+async function baseEnv(): Promise<{ env: Env; db: UsageFakeD1; bucket: FakeR2Bucket }> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex("unused"), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const githubCache = new FakeKv();
+  githubCache.store.set("ghinst:acme/web", { value: "42" });
+  githubCache.store.set("ghtok:42", { value: "cached-token" });
+  const env = {
+    REGISTRY: registry,
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: githubCache,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, bucket };
+}
+
+async function seedStaged(env: Env, filename: string) {
+  const bucket = (env as unknown as { UPLOADS_DEFAULT: FakeR2Bucket }).UPLOADS_DEFAULT;
+  await bucket.put(`${PREFIX}${stagedKey(filename)}`, PNG, {
+    httpMetadata: { contentType: "image/png" },
+  });
+  await replaceFileMetadata(env.DB, WS, stagedKey(filename), {
+    "gh.repo": REPO,
+    "gh.kind": "branch",
+    "gh.branch": BRANCH,
+    "gh.staged-at": new Date().toISOString(),
+  });
+}
+
+function prPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: "opened",
+    repository: { full_name: REPO },
+    pull_request: {
+      number: NUM,
+      head: { ref: BRANCH, repo: { full_name: REPO } },
+    },
+    ...overrides,
+  };
+}
+
+function withMockPost(handler: () => Promise<void>) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+    if (String(url).includes(`/issues/${NUM}/comments`)) {
+      return init.method === "POST"
+        ? new Response(
+            JSON.stringify({ id: 9, html_url: `https://github.com/${REPO}/pull/${NUM}#c9` }),
+            { status: 201 },
+          )
+        : new Response(JSON.stringify([]), { status: 200 });
+    }
+    return new Response("nf", { status: 404 });
+  }) as unknown as typeof fetch;
+  return handler().finally(() => {
+    globalThis.fetch = realFetch;
+  });
+}
+
+describe("handleWebhook pull_request auto-promotion", () => {
+  it("no-ops when the repo has no binding", async () => {
+    const { env } = await baseEnv();
+    await handleWebhook(env, "pull_request", prPayload());
+    // No throw, no comment attempt (fetch never stubbed/called) — nothing to assert beyond survival.
+  });
+
+  it("promotes staged attachments and upserts the bot comment when a binding exists", async () => {
+    const { env, bucket } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedStaged(env, "hero.png");
+
+    await withMockPost(() => handleWebhook(env, "pull_request", prPayload()));
+
+    expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
+  });
+
+  it("does not post a comment for a fork PR (head repo differs from base repo)", async () => {
+    const { env, bucket } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedStaged(env, "hero.png");
+
+    let fetchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(
+        env,
+        "pull_request",
+        prPayload({
+          pull_request: {
+            number: NUM,
+            head: { ref: BRANCH, repo: { full_name: "someone-else/fork" } },
+          },
+        }),
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    // Promotion itself is workspace-data-only and repo-agnostic in check, but
+    // the fork guard must stop everything (promote + comment) before either runs.
+    expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(false);
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("cleans up the link and no-ops when the bound workspace is gone", async () => {
+    const { env, db } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, "ghost-workspace", "promote");
+
+    await handleWebhook(env, "pull_request", prPayload());
+
+    expect(db.repoLinks.has(REPO)).toBe(false);
+  });
+
+  it("cleans up the link and no-ops when the bound workspace is soft-deleted", async () => {
+    const { env, db } = await baseEnv();
+    const registry = (env as unknown as { REGISTRY: { get: (k: string) => unknown } }).REGISTRY;
+    const original = registry.get.bind(registry);
+    (env as unknown as { REGISTRY: unknown }).REGISTRY = {
+      get: async (key: string) => {
+        const record = (await original(key)) as WorkspaceRecord | null;
+        return record ? { ...record, deletedAt: new Date().toISOString() } : null;
+      },
+    };
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+
+    await handleWebhook(env, "pull_request", prPayload());
+
+    expect(db.repoLinks.has(REPO)).toBe(false);
+  });
+
+  it("re-promotes on synchronize", async () => {
+    const { env, bucket } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedStaged(env, "hero.png");
+
+    await withMockPost(() => handleWebhook(env, "pull_request", prPayload({ action: "opened" })));
+    await bucket.delete(`${PREFIX}${destKey("hero.png")}`);
+    await withMockPost(() =>
+      handleWebhook(env, "pull_request", prPayload({ action: "synchronize" })),
+    );
+
+    expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
+  });
+
+  it("does not post a comment when nothing is staged and nothing pre-exists", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+
+    let fetchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(env, "pull_request", prPayload());
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("ignores actions outside the promote set (e.g. closed)", async () => {
+    const { env, bucket } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedStaged(env, "hero.png");
+
+    await handleWebhook(env, "pull_request", prPayload({ action: "closed" }));
+
+    expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(false);
+  });
+
+  it("never throws / never lets a downstream error escape", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedStaged(env, "hero.png");
+
+    // Break promotion at the R2 layer to force an internal throw.
+    const bucket = (env as unknown as { UPLOADS_DEFAULT: FakeR2Bucket }).UPLOADS_DEFAULT;
+    const realGet = bucket.get.bind(bucket);
+    bucket.get = (async () => {
+      throw new Error("boom");
+    }) as typeof bucket.get;
+    try {
+      await expect(handleWebhook(env, "pull_request", prPayload())).resolves.toBeUndefined();
+    } finally {
+      bucket.get = realGet;
+    }
+  });
+});

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -1,11 +1,28 @@
 /**
  * GitHub App webhook verification + cache invalidation (spec
- * .context/284-github-webhooks-design.md). Every delivery is HMAC-verified,
- * then dispatched to a set of targeted KV deletes against GITHUB_CACHE — no
- * key-prefix scans. All handlers tolerate missing fields: a partial payload
- * means "nothing to invalidate here", never a throw. Entries self-heal via
- * their phase-1 TTLs, so a dropped delete only reverts to TTL latency.
+ * .context/284-github-webhooks-design.md), plus phase 3 webhook-driven
+ * auto-promotion. Every delivery is HMAC-verified, then dispatched to a set
+ * of targeted KV deletes against GITHUB_CACHE — no key-prefix scans. All
+ * handlers tolerate missing fields: a partial payload means "nothing to
+ * invalidate here", never a throw. Entries self-heal via their phase-1 TTLs,
+ * so a dropped delete only reverts to TTL latency.
+ *
+ * Auto-promotion (`pull_request` `opened`/`reopened`/`synchronize`): if the
+ * PR's repo is bound to a workspace (github-repo-links.ts), that workspace's
+ * branch-staged attachments are promoted into the PR's attachment prefix
+ * (reusing github-promote.ts) and the managed bot comment is upserted
+ * (reusing github-comment.ts's gather+render+upsert) — with zero CLI
+ * involvement. This runs off the request's fast path via `ctx.waitUntil` so
+ * the webhook still responds 204 promptly; every failure inside is caught
+ * and logged, never surfaced as a 5xx.
  */
+
+import { githubAppConfig, installationForRepo } from "./github-app";
+import { gatherCommentBody, upsertBotComment } from "./github-comment";
+import type { GhTarget } from "./github-comment-render";
+import { promoteBranchAttachments } from "./github-promote";
+import { deleteRepoLink, findRepoLink } from "./github-repo-links";
+import { loadWorkspaceRecord } from "./workspace";
 
 const enc = new TextEncoder();
 
@@ -63,11 +80,113 @@ function repoFullNames(value: unknown): string[] {
   return out;
 }
 
+/** `pull_request` actions that trigger auto-promotion (a fresh/updated head to promote from). */
+const PROMOTE_ACTIONS = new Set(["opened", "reopened", "synchronize"]);
+
+interface PullRequestPayload {
+  action?: unknown;
+  repository?: { full_name?: unknown };
+  pull_request?: {
+    number?: unknown;
+    head?: { ref?: unknown; repo?: { full_name?: unknown } };
+  };
+}
+
 /**
- * Invalidate the phase-1 cache entries implied by one webhook delivery.
- * `ping` and unknown events are no-ops. Never throws on partial payloads.
+ * Best-effort webhook-driven auto-promotion for one `pull_request` delivery.
+ * No-ops (never throws) on: a cross-repo PR (fork head), no repo link, a
+ * missing/tombstoned linked workspace (also cleans up the stale link), or
+ * any downstream promote/gather/comment failure. Reuses
+ * `promoteBranchAttachments` and `gatherCommentBody`/`upsertBotComment`
+ * verbatim — no duplicated copy/render/post logic.
  */
-export async function handleWebhook(env: Env, eventType: string, payload: unknown): Promise<void> {
+async function autoPromoteAndComment(env: Env, p: PullRequestPayload): Promise<void> {
+  const repo = p.repository?.full_name;
+  const pr = p.pull_request;
+  const num = pr?.number;
+  const headRef = pr?.head?.ref;
+  const headRepo = pr?.head?.repo?.full_name;
+  if (
+    typeof repo !== "string" ||
+    typeof num !== "number" ||
+    typeof headRef !== "string" ||
+    typeof headRepo !== "string"
+  ) {
+    return;
+  }
+  // Fork PRs stage attachments under the fork's own workspace context (if
+  // any) — never promote a base repo's binding against a head branch that
+  // lives in a different repo.
+  if (headRepo.toLowerCase() !== repo.toLowerCase()) return;
+
+  try {
+    const link = await findRepoLink(env.DB, repo);
+    if (!link) return;
+
+    const ws = await loadWorkspaceRecord(env, link.workspaceName);
+    if (!ws) {
+      // The bound workspace is gone or tombstoned — the link is stale;
+      // clean it up so a future claim (e.g. from another workspace) isn't
+      // blocked by first-claim-wins forever.
+      await deleteRepoLink(env.DB, repo);
+      return;
+    }
+
+    await promoteBranchAttachments(env, ws, link.workspaceName, {
+      repo,
+      num,
+      branch: headRef,
+    });
+
+    // Gather AFTER promoting: the just-promoted copies are now real objects
+    // under the PR's attachment prefix, so this single gather call (reused
+    // verbatim from the comment route) already reflects them — no separate
+    // "promoted > 0" branch needed.
+    const target: GhTarget = { repo, kind: "pull", num };
+    const gathered = await gatherCommentBody(env, ws, link.workspaceName, target);
+    if (gathered.skip) return; // nothing staged and nothing pre-existing — no empty comment.
+
+    const cfg = githubAppConfig(env);
+    if (!cfg) return;
+    const installId = link.installationId ?? (await installationForRepo(env, cfg, repo));
+    if (installId === null) return;
+
+    const result = await upsertBotComment(env, cfg, installId, target, gathered.body);
+    if ("degrade" in result) {
+      console.error(
+        JSON.stringify({
+          message: "webhook auto-comment degraded",
+          repo,
+          num,
+          reason: result.degrade,
+        }),
+      );
+    }
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "webhook auto-promote failed",
+        repo,
+        num,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+/**
+ * Invalidate the phase-1 cache entries implied by one webhook delivery, and
+ * (for a same-repo `pull_request` opened/reopened/synchronize) kick off
+ * best-effort auto-promotion via `ctx.waitUntil` so the response isn't
+ * delayed by it. `ping` and unknown events are no-ops. Never throws on
+ * partial payloads.
+ */
+export async function handleWebhook(
+  env: Env,
+  eventType: string,
+  payload: unknown,
+  ctx?: Pick<ExecutionContext, "waitUntil">,
+): Promise<void> {
   const p = (payload ?? {}) as Record<string, unknown>;
   const keys: string[] = [];
 
@@ -94,4 +213,13 @@ export async function handleWebhook(env: Env, eventType: string, payload: unknow
   // harmless — the entry self-heals on its phase-1 TTL — so a webhook outage
   // must never break anything.
   await Promise.allSettled(keys.map((key) => env.GITHUB_CACHE.delete(key)));
+
+  if (eventType === "pull_request") {
+    const action = (p as PullRequestPayload).action;
+    if (typeof action === "string" && PROMOTE_ACTIONS.has(action)) {
+      const work = autoPromoteAndComment(env, p as PullRequestPayload);
+      if (ctx) ctx.waitUntil(work);
+      else await work; // no executionCtx (e.g. some test/call sites) — run inline.
+    }
+  }
 }

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -5,6 +5,34 @@ import { FakeKv } from "../../test/fake-kv";
 import { FakeR2Bucket } from "../../test/fake-r2";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { GITHUB_APP_CFG_ENV } from "../../test/github-app-env";
+import { RepoLinksTable } from "../../test/helpers/fake-repo-links-table";
+
+/**
+ * A minimal D1 stand-in (auth-token lookup + galleries read both no-op) with
+ * a real `RepoLinksTable` wired in, for the implicit-claim tests below —
+ * mirrors the inline `db` object the "posts as the bot" test above already
+ * uses, extended so `github_repo_links` statements actually persist.
+ */
+function claimTestDb(): { db: D1Database; links: RepoLinksTable } {
+  const links = new RepoLinksTable();
+  const db = {
+    prepare: (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      let values: unknown[] = [];
+      const stmt = {
+        bind: (...v: unknown[]) => {
+          values = v;
+          return stmt;
+        },
+        first: async () => links.tryFirst(normalized, values) ?? null,
+        all: async () => ({ results: [] }),
+        run: async () => links.tryRun(normalized, values) ?? {},
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+  return { db, links };
+}
 
 // `crypto.subtle.timingSafeEqual` is a Workers-runtime extension to Web
 // Crypto (used by workspaceAuth, see ../workspace.ts) that plain Node's
@@ -202,5 +230,112 @@ describe("POST /v1/:workspace/github/comment", () => {
     } finally {
       globalThis.fetch = realFetch;
     }
+  });
+});
+
+describe("POST /v1/:workspace/github/comment implicit repo-link claim", () => {
+  async function envWithBucket(db: D1Database): Promise<Env> {
+    const hash = await sha256Hex(TOKEN);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/web", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", new Uint8Array([0x89, 0x50]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+    return {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: bucket,
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+  }
+
+  it("records a link when the comment actually posts", async () => {
+    const { db, links } = claimTestDb();
+    const env = await envWithBucket(db);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/acme/web/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
+      expect(res.status).toBe(200);
+      const link = links.rows.get("acme/web");
+      expect(link).toMatchObject({ workspace_name: WS, source: "comment", installation_id: 42 });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("does not record a link when nothing was posted (degrade)", async () => {
+    const { db, links } = claimTestDb();
+    const env = await envWithBucket(db);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) =>
+      String(url).includes("/issues/12/comments")
+        ? new Response("no", { status: 403 })
+        : new Response("nf", { status: 404 })) as unknown as typeof fetch;
+    try {
+      const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
+      expect(res.status).toBe(200);
+      expect(links.rows.has("acme/web")).toBe(false);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("does not record a link when gathering skips (nothing to post)", async () => {
+    const { db, links } = claimTestDb();
+    const hash = await sha256Hex(TOKEN);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/web", { value: "42" });
+    const env = {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ posted: true, action: "skipped", count: 0 });
+    expect(links.rows.has("acme/web")).toBe(false);
   });
 });

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -9,6 +9,7 @@ import { ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { gatherCommentBody, upsertBotComment } from "../github-comment";
 import { githubAppConfig, installationForRepo } from "../github-app";
+import { recordRepoLink } from "../github-repo-links";
 import type { GhTargetKind } from "../github-comment-render";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
@@ -86,6 +87,13 @@ export const githubComment = new Hono<WorkspaceVars>().post(
       if (result.degrade === "forbidden") return c.json(forbiddenDecline(target.repo, installId));
       return c.json({ posted: false, reason: result.degrade });
     }
+
+    // Implicit claim (phase 3): the comment actually posted, so this
+    // workspace has proven authenticated write access to this repo's
+    // PR/issue thread — best-effort record it as the repo's bound workspace.
+    // First-claim-wins (recordRepoLink) and never affects this response.
+    await recordRepoLink(c.env.DB, target.repo, c.get("workspaceName"), "comment", installId);
+
     return c.json({
       posted: true,
       action: result.action,

--- a/apps/api/src/routes/github-promote-route.test.ts
+++ b/apps/api/src/routes/github-promote-route.test.ts
@@ -373,4 +373,33 @@ describe("POST /v1/:workspace/github/promote", () => {
     // Destination object is real.
     expect(seeded.bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
   });
+
+  it("records an implicit repo-link claim on a successful (2xx) promote", async () => {
+    const seeded = await seededEnv();
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    const link = seeded.db.repoLinks.get("acme/web");
+    expect(link).toMatchObject({ workspace_name: WS, source: "promote" });
+  });
+
+  it("first-claim-wins: a second workspace's promote never overwrites an existing link", async () => {
+    const seeded = await seededEnv();
+    seeded.db.repoLinks.set("acme/web", {
+      repo_full_name: "acme/web",
+      workspace_name: "someone-else",
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await post(seeded.env, { repo: REPO, num: NUM, branch: BRANCH });
+    expect(res.status).toBe(200);
+    expect(seeded.db.repoLinks.get("acme/web")?.workspace_name).toBe("someone-else");
+  });
+
+  it("does not record a link on a validation failure", async () => {
+    const seeded = await seededEnv();
+    const res = await post(seeded.env, { repo: "not-a-repo", num: 0, branch: "" });
+    expect(res.status).toBe(400);
+    expect(seeded.db.repoLinks.has("acme/web")).toBe(false);
+  });
 });

--- a/apps/api/src/routes/github-promote.ts
+++ b/apps/api/src/routes/github-promote.ts
@@ -10,6 +10,7 @@
 import { ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { promoteBranchAttachments } from "../github-promote";
+import { recordRepoLink } from "../github-repo-links";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
@@ -63,6 +64,13 @@ export const githubPromote = new Hono<WorkspaceVars>().post(
       c.get("workspaceName"),
       target,
     );
+
+    // Implicit claim (phase 3): reaching a 2xx response means this workspace
+    // has proven authenticated write access to this repo's branch-staged
+    // attachments — best-effort record it as the repo's bound workspace.
+    // First-claim-wins (recordRepoLink) and never affects this response.
+    await recordRepoLink(c.env.DB, target.repo, c.get("workspaceName"), "promote");
+
     return c.json(result);
   },
 );

--- a/apps/api/src/routes/github-webhook.ts
+++ b/apps/api/src/routes/github-webhook.ts
@@ -39,6 +39,16 @@ githubWebhook.post("/", async (c) => {
     return c.body(null, 204);
   }
 
-  await handleWebhook(c.env, c.req.header("x-github-event") ?? "", payload);
+  // c.executionCtx throws when no platform ExecutionContext was supplied
+  // (e.g. app.request(...) in tests without a 4th arg) — treat that as "no
+  // waitUntil available" rather than let it escape as a 500.
+  let executionCtx: Pick<ExecutionContext, "waitUntil"> | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
+
+  await handleWebhook(c.env, c.req.header("x-github-event") ?? "", payload, executionCtx);
   return c.body(null, 204);
 });

--- a/apps/api/test/github-repo-links-sqlite.test.ts
+++ b/apps/api/test/github-repo-links-sqlite.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { deleteRepoLink, findRepoLink, recordRepoLink } from "../src/github-repo-links";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260720120000_github_repo_links.sql";
+
+describe("github repo links persistence against SQLite", () => {
+  it("returns null for an unclaimed repo", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await expect(findRepoLink(database(sqlite), "acme/web")).resolves.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("records a claim and lowercases the repo key", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "Acme/Web", "acme", "comment", 42);
+      const link = await findRepoLink(database(sqlite), "acme/web");
+      expect(link).toMatchObject({
+        repo: "acme/web",
+        workspaceName: "acme",
+        installationId: 42,
+        source: "comment",
+      });
+      expect(typeof link?.createdAt).toBe("string");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("first claim wins: a later call from a different workspace is ignored", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
+      await recordRepoLink(database(sqlite), "acme/web", "someone-else", "promote");
+      const link = await findRepoLink(database(sqlite), "acme/web");
+      expect(link?.workspaceName).toBe("acme");
+      expect(link?.source).toBe("comment");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("a later call from the SAME workspace is also a no-op (row unchanged)", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment", 1);
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "promote", 2);
+      const link = await findRepoLink(database(sqlite), "acme/web");
+      expect(link?.source).toBe("comment");
+      expect(link?.installationId).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deletes a link", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
+      await deleteRepoLink(database(sqlite), "acme/web");
+      await expect(findRepoLink(database(sqlite), "acme/web")).resolves.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deleting a non-existent link is a harmless no-op", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await expect(deleteRepoLink(database(sqlite), "acme/nope")).resolves.toBeUndefined();
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/helpers/fake-repo-links-table.ts
+++ b/apps/api/test/helpers/fake-repo-links-table.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared in-memory `github_repo_links` table backing for route/webhook tests
+ * (usage-fake-d1.ts) — mirrors the real D1 semantics (INSERT OR IGNORE:
+ * first claim wins) without a full sqlite-backed D1. See
+ * github-repo-links-sqlite.test.ts for the real-SQL-semantics coverage.
+ */
+
+export interface RepoLinkRow {
+  repo_full_name: string;
+  workspace_name: string;
+  installation_id: number | null;
+  source: string;
+  created_at: string;
+}
+
+export interface FakeRunResult {
+  success: true;
+  meta: { changes: number };
+  results: [];
+}
+
+export interface FakeFirstResult<T> {
+  success: true;
+  results: T[];
+  meta: Record<string, unknown>;
+}
+
+export class RepoLinksTable {
+  readonly rows = new Map<string, RepoLinkRow>();
+
+  tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
+    if (normalizedSql.startsWith("INSERT OR IGNORE INTO github_repo_links")) {
+      const [repo, workspace, installationId, source, createdAt] = args as [
+        string,
+        string,
+        number | null,
+        string,
+        string,
+      ];
+      if (this.rows.has(repo)) return { success: true, meta: { changes: 0 }, results: [] };
+      this.rows.set(repo, {
+        repo_full_name: repo,
+        workspace_name: workspace,
+        installation_id: installationId,
+        source,
+        created_at: createdAt,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (normalizedSql.startsWith("DELETE FROM github_repo_links")) {
+      const [repo] = args as [string];
+      const existed = this.rows.delete(repo);
+      return { success: true, meta: { changes: existed ? 1 : 0 }, results: [] };
+    }
+    return undefined;
+  }
+
+  tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
+    if (normalizedSql.startsWith("SELECT * FROM github_repo_links")) {
+      const [repo] = args as [string];
+      return (this.rows.get(repo) as T) ?? null;
+    }
+    return undefined;
+  }
+}

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -4,6 +4,7 @@
  */
 
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
+import { RepoLinksTable } from "./helpers/fake-repo-links-table";
 
 export type UsageRow = {
   workspace: string;
@@ -23,6 +24,12 @@ export class UsageFakeD1 {
   get fileMetadata() {
     return this.fileMetadataTable.metadata;
   }
+  // Backs `github_repo_links` for implicit-claim (comment/promote routes)
+  // and webhook auto-promotion tests.
+  private repoLinksTable = new RepoLinksTable();
+  get repoLinks() {
+    return this.repoLinksTable.rows;
+  }
 
   prepare = (sql: string) => {
     const normalized = sql.replace(/\s+/g, " ").trim();
@@ -38,16 +45,27 @@ export class UsageFakeD1 {
         if (normalized.includes("FROM workspace_usage")) {
           return this.usage.get(values[0] as string) ?? null;
         }
+        const linkResult = this.repoLinksTable.tryFirst(normalized, values);
+        if (linkResult !== undefined) return linkResult;
         throw new Error(`unsupported first: ${normalized}`);
       },
       all: async <T>() => {
         const result = this.fileMetadataTable.tryAll<T>(normalized, values);
         if (result) return result;
+        // Galleries aren't modeled by this fake (route/gallery-specific tests
+        // bring their own D1 stand-in) — an empty page is a safe, honest
+        // default for callers (e.g. the webhook auto-promote gather) that
+        // only care that "no galleries" doesn't blow up.
+        if (normalized.includes("FROM galleries") || normalized.includes("gallery_")) {
+          return { success: true as const, results: [] as T[], meta: {} };
+        }
         throw new Error(`unsupported all: ${normalized}`);
       },
       run: async () => {
         const metaResult = this.fileMetadataTable.tryRun(normalized, values);
         if (metaResult) return metaResult;
+        const linkResult = this.repoLinksTable.tryRun(normalized, values);
+        if (linkResult) return linkResult;
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
           // applyUsageDelta: (ws, period, updatedAt) with zeros
           // setUsageTotals: (ws, bytes, objects, period, updatedAt)


### PR DESCRIPTION
## Summary

Server-side phase 3 of the GitHub App integration: a workspace↔repo binding
plus webhook-driven auto-promotion, so a PR that opens/reopens/updates in a
bound repo gets its branch-staged attachments promoted and the managed bot
comment posted with zero CLI involvement.

- **Binding table** (`github_repo_links`, migration
  `20260720120000_github_repo_links.sql`): `repo_full_name` (lowercased) →
  `workspace_name`, plus `installation_id`/`source`/`created_at`. One repo
  maps to at most one workspace. `apps/api/src/github-repo-links.ts` exposes
  `recordRepoLink` / `findRepoLink` / `deleteRepoLink`, all best-effort
  (never throw — a D1 blip here must not affect the request it rides along
  with).
- **Trust model — first claim wins.** `recordRepoLink` uses `INSERT OR
  IGNORE`, so once a repo is claimed, a later call from *any* workspace
  (including the original) is silently ignored. The only claim path today is
  **implicit**: a successful (comment actually posted) `POST
  /:workspace/github/comment`, or any successful (2xx) `POST
  /:workspace/github/promote`, best-effort records the calling workspace as
  the repo's binding. There's no explicit claim command yet — that's the
  deferred CLI-side `uploads github link` (tracked against #311's follow-up).
  This narrows today's "any authenticated workspace can comment/promote for
  any repo" surface only for the new webhook auto-promotion path: the
  webhook only ever acts on behalf of whichever workspace claimed the repo
  first, not an arbitrary one.
- **Webhook auto-promotion** (`github-webhook.ts`'s `handleWebhook`, now
  taking an optional `ExecutionContext`-shaped `ctx`): on `pull_request`
  `opened`/`reopened`/`synchronize`, same-repo only (a fork PR's head repo
  differing from the base repo is a no-op), it looks up the repo's binding,
  loads the workspace (a missing/tombstoned workspace triggers best-effort
  link cleanup + no-op), then reuses `promoteBranchAttachments` verbatim,
  followed by `gatherCommentBody` + `upsertBotComment` (also reused
  verbatim — gathering *after* promoting means the just-promoted files are
  already visible, so there's no separate "promoted > 0" branch). No
  attachments staged and nothing pre-existing → no comment is created. The
  existing per-delivery `ghref` cache invalidation is unchanged and stays
  synchronous for every action. The new work runs via `ctx.waitUntil` so the
  webhook still responds 204 promptly; every failure inside is caught and
  JSON-logged, never surfaced as a 5xx (the route falls back to running it
  inline when no `ExecutionContext` is available, e.g. in tests).

### Deferred (unchanged from the phase 3 brief)

- CLI `uploads github link` explicit-claim command and any related marker
  changes (`packages/uploads`, `skills/` — PR #311 territory, not touched
  here).
- Per-workspace comment-marker namespacing — binding's one-workspace-per-repo
  rule already prevents webhook-side clobbering, so this stays a single
  shared `<!-- uploads.sh:attachments -->` marker for now.
- A reaper/sweep for stale `github_repo_links` rows beyond the webhook path's
  own best-effort cleanup-on-missing-workspace.

## Deploy / migration notes

- New D1 migration: `apps/api/migrations/20260720120000_github_repo_links.sql`
  (`github_repo_links` table + a `workspace_name` index). Needs
  `pnpm migrate:d1` (remote) before/at deploy — nothing else reads or writes
  this table until the migration lands.
- No new env vars/secrets. The App is already subscribed to `pull_request`
  webhooks (phase 2 PR A), so no GitHub App configuration change is needed.
- `apps/api` stays changeset-free (private package).

## Test plan

- [x] `pnpm test` — 1900 tests pass, incl. new suites:
      `apps/api/test/github-repo-links-sqlite.test.ts` (real-SQL semantics:
      first-claim-wins, lowercasing, delete),
      `apps/api/src/github-webhook-auto-promote.test.ts` (promote+comment on
      a bound repo, fork-PR no-op, missing/tombstoned-workspace cleanup,
      re-promotion on `synchronize`, no-comment-when-nothing-to-show,
      ignored actions, and that a downstream error never escapes
      `handleWebhook`), plus implicit-claim coverage added to
      `routes/github-comment-route.test.ts` and
      `routes/github-promote-route.test.ts`.
- [x] `pnpm --filter @uploads/api run typecheck` — clean.
- [x] `oxlint` / `oxfmt` — clean on all touched files (repo-wide pre-existing
      warnings in unrelated apps are untouched).
