### PR TITLE
docs(web): branch-staged screenshots flow on GitHub App page

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -9,7 +9,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, get a URL for any file, capture a screenshot
-- [Docs: GitHub App](https://uploads.sh/docs/github-app): optional install for bot-posted attachment comments and private-repo PR/issue titles
+- [Docs: GitHub App](https://uploads.sh/docs/github-app): optional install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -90,6 +90,21 @@ const TOC = [
       <span class="text">uploads attach ./shot.png --no-comment <span class="cm"># print URLs, post nothing</span></span>
       <button type="button" data-copy="uploads attach ./shot.png --no-comment" aria-live="polite">copy</button>
     </div>
+    <p>
+      No PR yet? <code>--branch</code> stages files against your current branch instead, so
+      you can attach screenshots while you work:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads attach --branch ./shot.png</span>
+      <button type="button" data-copy="uploads attach --branch ./shot.png" aria-live="polite">copy</button>
+    </div>
+    <p>
+      Once the PR opens, the next <code>attach</code> promotes those staged files onto it
+      automatically — or run <code>uploads attach --promote</code> with no files to do it
+      explicitly (<code>--no-promote</code> opts out). See&#32;
+      <a href="/docs/github-app#staging">GitHub App: staging before a PR exists</a> for how
+      this works with zero CLI involvement.
+    </p>
   </section>
 
   <section id="put">

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -9,6 +9,7 @@ const APP_URL = "https://github.com/apps/uploads-sh";
 const TOC = [
   { id: "what-it-adds", label: "What it adds" },
   { id: "install", label: "Install it" },
+  { id: "staging", label: "Staging before a PR exists" },
   { id: "permissions", label: "Permissions" },
   { id: "without-it", label: "Without the App" },
 ];
@@ -54,6 +55,10 @@ const TOC = [
         <strong>Titles stay current.</strong> The App's webhooks tell uploads.sh when a PR or
         issue is renamed, closed, or merged, so file pages don't show stale titles.
       </li>
+      <li>
+        <strong>Screenshots staged before the PR exists get promoted automatically.</strong>
+        See <a href="#staging">Staging before a PR exists</a> below.
+      </li>
     </ul>
   </section>
 
@@ -76,6 +81,43 @@ const TOC = [
       <pre>&gt;&gt; uploading ./after.png
 <span class="ok">&gt;&gt; attachments comment updated (uploads-sh[bot])</span></pre>
     </div>
+  </section>
+
+  <section id="staging">
+    <h2>Staging before a PR exists <a class="anchor" href="#staging" aria-label="Link to this section">#</a></h2>
+    <p>
+      Working on a branch with no PR open yet? <code>--branch</code> stages screenshots
+      against the branch instead of a PR — no comment to post yet, nothing to target:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads attach --branch ./progress.png</span>
+      <button type="button" data-copy="uploads attach --branch ./progress.png" aria-live="polite">copy</button>
+    </div>
+    <p>
+      It defaults to your current git branch (or pass <code>--branch some-name</code>
+      explicitly). Staged files are hosted and public immediately, same as any attachment —
+      there's just no PR to comment on yet.
+    </p>
+    <p>Once a pull request opens for that branch, staged files land on it one of two ways:</p>
+    <ul>
+      <li>
+        <strong>With the App installed</strong> (and this workspace linked to the repo — that
+        linking happens automatically the first time the workspace posts a comment or
+        promotes for it), the webhook promotes staged files onto the PR and posts or updates
+        the bot comment the moment the PR opens, reopens, or gets new commits. No CLI
+        involvement at all — this is on by default for fresh installs.
+      </li>
+      <li>
+        <strong>Without the App</strong>, the next <code>uploads attach</code> you run against
+        that PR promotes them automatically, or run <code>uploads attach --promote</code> with
+        no files to do it explicitly (<code>--no-promote</code> skips promotion).
+      </li>
+    </ul>
+    <p>
+      Staged files that never make it into a PR are cleaned up on their own — promoted files
+      drop out of the staging area after about 7 days, and anything abandoned is removed after
+      about 30.
+    </p>
   </section>
 
   <section id="permissions">


### PR DESCRIPTION
## Summary
- Add a "Staging before a PR exists" section to `/docs/github-app` covering `uploads attach --branch`, auto-promotion via the App's webhook (zero CLI involvement, on by default for fresh installs), the manual `--promote`/`--no-promote` path, implicit repo-workspace linking, and staged-file cleanup timing.
- Add a short pointer + example to `/docs/attach-pull-request-images` where `--no-comment` is documented, since that's the natural place someone learns about attach flags.
- Touch up the GitHub App line in `llms.txt` to mention branch-staged screenshot promotion.

## Test plan
- [x] `pnpm --filter @uploads/web build` succeeds (astro build + prerender of both changed pages)
- [x] `pnpm format:check` passes (oxfmt)
- [ ] Visual check of rendered `/docs/github-app` and `/docs/attach-pull-request-images` pages
