### PR TITLE
feat(api): reap stale branch-staged attachments

### DIFF
--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -260,6 +260,32 @@ export async function replaceFileMetadata(
   await db.batch(statements);
 }
 
+/**
+ * Cross-workspace lookup of objects carrying a given `(meta_key, meta_value)`
+ * pair — unlike `findObjectsByMetadata`, not scoped to a single workspace.
+ * Used by the staging reaper (branch-staged attachment cleanup) to discover
+ * `gh.kind=branch` rows across every workspace in one query. Bounded by
+ * `limit`; ordering is stable (workspace, object_key) so repeated calls with
+ * the same limit see the same head of the set.
+ */
+export async function findObjectsByMetadataAcrossWorkspaces(
+  db: D1Database,
+  metaKey: string,
+  metaValue: string,
+  limit: number,
+): Promise<Array<{ workspace: string; key: string }>> {
+  const result = await db
+    .prepare(
+      `SELECT workspace, object_key FROM file_metadata
+       WHERE meta_key = ? AND meta_value = ?
+       ORDER BY workspace, object_key
+       LIMIT ?`,
+    )
+    .bind(metaKey, metaValue, limit)
+    .all<{ workspace: string; object_key: string }>();
+  return result.results.map((row) => ({ workspace: row.workspace, key: row.object_key }));
+}
+
 const FIND_DEFAULT_LIMIT = 50;
 const FIND_MAX_LIMIT = 500;
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { tokens } from "./routes/tokens";
 import { workspaces } from "./routes/workspaces";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
+import { runStagingReaper } from "./staging-reaper";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";
@@ -145,6 +146,18 @@ export default {
         console.error(
           JSON.stringify({
             message: "retention_sweep_failed",
+            error: appErr.message,
+            code: appErr.code,
+          }),
+        );
+      }),
+    );
+    ctx.waitUntil(
+      runStagingReaper(env).catch((err) => {
+        const appErr = AppError.from(err);
+        console.error(
+          JSON.stringify({
+            message: "staging_reap_failed",
             error: appErr.message,
             code: appErr.code,
           }),

--- a/apps/api/src/staging-reaper.ts
+++ b/apps/api/src/staging-reaper.ts
@@ -1,0 +1,129 @@
+/**
+ * Phase 4a: reaper for branch-staged GitHub attachments (`gh/<owner>/<repo>/branch/<branch>/<file>`,
+ * D1 `file_metadata` tags `gh.kind=branch`, `gh.staged-at`). Two cleanup rules:
+ *
+ * - Promoted: `gh.promoted-at` older than PROMOTED_MAX_AGE_DAYS → delete. The
+ *   staged original already did its job once promoted into a PR; keep it
+ *   around briefly (in case the promotion needs to be redone) then reap it.
+ * - Abandoned: no `gh.promoted-at`/`gh.promoted-to` (never promoted) and
+ *   `gh.staged-at` older than ABANDONED_MAX_AGE_DAYS → delete. Missing or
+ *   unparsable `gh.staged-at` is left alone — never guess-delete.
+ *
+ * Invoked from the Worker scheduled handler alongside `runRetentionSweep`.
+ * Deletion goes through `deleteObject` (files-core.ts) so R2, D1 metadata,
+ * and the workspace usage ledger stay consistent — the same path the
+ * `/v1/:workspace/files` DELETE route uses.
+ */
+import { deleteObject } from "./files-core";
+import { findObjectsByMetadataAcrossWorkspaces, getFileMetadata } from "./file-metadata";
+import { loadWorkspaceRecord } from "./workspace";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** `gh.promoted-at` older than this is reaped. */
+export const PROMOTED_MAX_AGE_DAYS = 7;
+/** `gh.staged-at` (never promoted) older than this is reaped. */
+export const ABANDONED_MAX_AGE_DAYS = 30;
+
+/**
+ * Candidates scanned per invocation (cross-workspace `gh.kind=branch` D1
+ * query) — also the effective cap on deletions per run, mirroring the
+ * batch discipline of the existing retention sweep/purge passes.
+ */
+export const STAGING_REAP_SCAN_LIMIT = 300;
+
+export interface StagingReapResult {
+  scanned: number;
+  deleted: Array<{ workspace: string; key: string; reason: "promoted" | "abandoned" }>;
+  skipped: number;
+  errors: Array<{ workspace: string; key: string; error: string }>;
+}
+
+function isOlderThan(iso: string | undefined, maxAgeMs: number, now: number): boolean {
+  if (!iso) return false;
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return false;
+  return now - ms > maxAgeMs;
+}
+
+/** Belt-and-braces: never delete anything outside the branch-staging keyspace, however it got flagged. */
+function looksLikeBranchStagingKey(key: string): boolean {
+  return key.startsWith("gh/") && key.includes("/branch/");
+}
+
+export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
+  const now = Date.now();
+  const candidates = await findObjectsByMetadataAcrossWorkspaces(
+    env.DB,
+    "gh.kind",
+    "branch",
+    STAGING_REAP_SCAN_LIMIT,
+  );
+
+  const deleted: StagingReapResult["deleted"] = [];
+  const errors: StagingReapResult["errors"] = [];
+  let skipped = 0;
+  const workspaceCache = new Map<string, Awaited<ReturnType<typeof loadWorkspaceRecord>>>();
+
+  for (const { workspace, key } of candidates) {
+    if (!looksLikeBranchStagingKey(key)) {
+      skipped += 1;
+      continue;
+    }
+
+    let meta: Record<string, string>;
+    try {
+      meta = await getFileMetadata(env.DB, workspace, key);
+    } catch (err) {
+      errors.push({ workspace, key, error: err instanceof Error ? err.message : String(err) });
+      continue;
+    }
+    if (meta["gh.kind"] !== "branch") {
+      skipped += 1;
+      continue;
+    }
+
+    let reason: "promoted" | "abandoned" | undefined;
+    if (meta["gh.promoted-at"]) {
+      if (isOlderThan(meta["gh.promoted-at"], PROMOTED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
+        reason = "promoted";
+      }
+    } else if (isOlderThan(meta["gh.staged-at"], ABANDONED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
+      reason = "abandoned";
+    }
+
+    if (!reason) {
+      skipped += 1;
+      continue;
+    }
+
+    let ws = workspaceCache.get(workspace);
+    if (ws === undefined) {
+      ws = await loadWorkspaceRecord(env, workspace);
+      workspaceCache.set(workspace, ws);
+    }
+    if (!ws) {
+      errors.push({ workspace, key, error: "workspace not found" });
+      continue;
+    }
+
+    try {
+      await deleteObject(env, ws, key, workspace);
+      deleted.push({ workspace, key, reason });
+    } catch (err) {
+      errors.push({ workspace, key, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  const result: StagingReapResult = { scanned: candidates.length, deleted, skipped, errors };
+  console.log(
+    JSON.stringify({
+      message: "staging_reap",
+      scanned: result.scanned,
+      deleted: result.deleted.length,
+      skipped: result.skipped,
+      errors: result.errors.length,
+    }),
+  );
+  return result;
+}

--- a/apps/api/test/staging-reaper.test.ts
+++ b/apps/api/test/staging-reaper.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import {
+  ABANDONED_MAX_AGE_DAYS,
+  PROMOTED_MAX_AGE_DAYS,
+  runStagingReaper,
+  STAGING_REAP_SCAN_LIMIT,
+} from "../src/staging-reaper";
+import { getFileMetadata, replaceFileMetadata } from "../src/file-metadata";
+import type { WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260710140000_workspace_usage.sql",
+];
+
+const WS = "acme";
+const RECORD: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "BUCKET",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function fakeRegistry(records: Record<string, unknown>) {
+  const store = new Map(Object.entries(records));
+  return {
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+  };
+}
+
+function makeEnv(opts: { db: SqliteD1; bucket?: FakeR2Bucket; workspaces?: string[] }) {
+  const { db, bucket = new FakeR2Bucket() } = opts;
+  const workspaces = opts.workspaces ?? [WS];
+  const registry = fakeRegistry(Object.fromEntries(workspaces.map((w) => [`ws:${w}`, RECORD])));
+  const env = {
+    REGISTRY: registry,
+    BUCKET: bucket,
+    DB: database(db),
+  } as unknown as Env;
+  return { env, bucket };
+}
+
+function branchKey(workspace: string, branch: string, filename: string): string {
+  return `gh/${workspace}/repo/branch/${branch}/${filename}`;
+}
+
+async function seed(
+  db: SqliteD1,
+  bucket: FakeR2Bucket,
+  workspace: string,
+  key: string,
+  tags: Record<string, string>,
+) {
+  await bucket.put(key, PNG, { httpMetadata: { contentType: "image/png" } });
+  await replaceFileMetadata(database(db), workspace, key, tags);
+}
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * MS_PER_DAY).toISOString();
+}
+
+describe("runStagingReaper", () => {
+  it("deletes a promoted staging file older than the promoted max age", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const key = branchKey(WS, "feat-x", "shot.png");
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.repo": "acme/repo",
+        "gh.branch": "feat-x",
+        "gh.staged-at": daysAgo(PROMOTED_MAX_AGE_DAYS + 10),
+        "gh.promoted-to": "pull/12",
+        "gh.promoted-at": daysAgo(PROMOTED_MAX_AGE_DAYS + 1),
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([{ workspace: WS, key, reason: "promoted" }]);
+      expect(bucket.store.has(key)).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("keeps a recently promoted staging file", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const key = branchKey(WS, "feat-x", "shot.png");
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.repo": "acme/repo",
+        "gh.branch": "feat-x",
+        "gh.staged-at": daysAgo(20),
+        "gh.promoted-to": "pull/12",
+        "gh.promoted-at": daysAgo(1),
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([]);
+      expect(bucket.store.has(key)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deletes an abandoned staging file older than the abandoned max age", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const key = branchKey(WS, "feat-y", "shot.png");
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.repo": "acme/repo",
+        "gh.branch": "feat-y",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([{ workspace: WS, key, reason: "abandoned" }]);
+      expect(bucket.store.has(key)).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("keeps a recently staged, never-promoted file", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const key = branchKey(WS, "feat-y", "shot.png");
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.repo": "acme/repo",
+        "gh.branch": "feat-y",
+        "gh.staged-at": daysAgo(5),
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([]);
+      expect(bucket.store.has(key)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never deletes on a missing or unparsable gh.staged-at", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const missing = branchKey(WS, "feat-z", "no-staged-at.png");
+      const bad = branchKey(WS, "feat-z", "bad-staged-at.png");
+      await seed(sqlite, bucket, WS, missing, {
+        "gh.kind": "branch",
+        "gh.repo": "acme/repo",
+        "gh.branch": "feat-z",
+      });
+      await seed(sqlite, bucket, WS, bad, {
+        "gh.kind": "branch",
+        "gh.repo": "acme/repo",
+        "gh.branch": "feat-z",
+        "gh.staged-at": "not-a-timestamp",
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([]);
+      expect(bucket.store.has(missing)).toBe(true);
+      expect(bucket.store.has(bad)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("leaves non-branch gh.* files untouched", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const prKey = `gh/${WS}/repo/pull/12/shot.png`;
+      await seed(sqlite, bucket, WS, prKey, {
+        "gh.kind": "pull",
+        "gh.repo": "acme/repo",
+        "gh.number": "12",
+        "gh.promoted-at": daysAgo(PROMOTED_MAX_AGE_DAYS + 30),
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([]);
+      expect(bucket.store.has(prKey)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("belt-and-braces: refuses to delete a gh.kind=branch row whose key isn't shaped like branch staging", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      // Same tags as an eligible abandoned row, but the key doesn't match the
+      // `gh/<owner>/<repo>/branch/<branch>/<file>` shape — must be skipped
+      // even though the D1 tags alone would say "delete me".
+      const key = "not-a-branch-staging-key.png";
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([]);
+      expect(result.skipped).toBe(1);
+      expect(bucket.store.has(key)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("bounds deletions to the scan cap per run", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      const count = STAGING_REAP_SCAN_LIMIT + 5;
+      for (let i = 0; i < count; i++) {
+        const key = branchKey(WS, "feat-many", `shot-${i}.png`);
+        await seed(sqlite, bucket, WS, key, {
+          "gh.kind": "branch",
+          "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+        });
+      }
+      const { env } = makeEnv({ db: sqlite, bucket });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.scanned).toBe(STAGING_REAP_SCAN_LIMIT);
+      expect(result.deleted.length).toBe(STAGING_REAP_SCAN_LIMIT);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("isolates a per-object delete failure without dropping other candidates", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      const okKey = branchKey(WS, "feat-ok", "shot.png");
+      const badKey = branchKey("ghost-ws", "feat-bad", "shot.png");
+      await seed(sqlite, bucket, WS, okKey, {
+        "gh.kind": "branch",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+      // A row scoped to a workspace with no `ws:` registry record — the
+      // reaper must record it as an error and keep going.
+      await replaceFileMetadata(database(sqlite), "ghost-ws", badKey, {
+        "gh.kind": "branch",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+      const { env } = makeEnv({ db: sqlite, bucket, workspaces: [WS] });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.deleted).toEqual([{ workspace: WS, key: okKey, reason: "abandoned" }]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({ workspace: "ghost-ws", key: badKey });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("leaves D1 metadata behind once the row is deleted", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket } = makeEnv({ db: sqlite });
+      const key = branchKey(WS, "feat-y", "shot.png");
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+
+      await runStagingReaper(env);
+
+      const meta = await getFileMetadata(database(sqlite), WS, key);
+      expect(meta).toEqual({});
+    } finally {
+      sqlite.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 4a: reaps branch-staged GitHub attachments (`gh/<owner>/<repo>/branch/<branch>/<file>`) that are no longer needed:
  - **Promoted staging**: `gh.kind=branch` and `gh.promoted-at` older than 7 days → deleted.
  - **Abandoned staging**: `gh.kind=branch`, never promoted, `gh.staged-at` older than 30 days → deleted. Missing/unparsable `gh.staged-at` is left alone (never guess-delete).
- Discovery via a new cross-workspace D1 `file_metadata` query (`findObjectsByMetadataAcrossWorkspaces` in `apps/api/src/file-metadata.ts`), bounded to 300 candidates per run (`STAGING_REAP_SCAN_LIMIT`), which also caps deletions per invocation.
- Belt-and-braces: skips any matched row whose object key doesn't actually look like `gh/.../branch/...`, even if its D1 tags say otherwise.
- Deletion goes through the existing `deleteObject` (`files-core.ts`) — same path the DELETE route uses — so R2, D1 metadata, and the workspace usage ledger stay consistent.
- Wired into the existing scheduled handler in `apps/api/src/index.ts` as a sibling `ctx.waitUntil` alongside `runRetentionSweep`, logging a JSON summary line on the same `usage.ts` console convention.

## Decisions
- No new env vars needed.
- `apps/api` is a private package — no changeset.
- Left `packages/uploads`, `skills/`, `apps/web`, `github-comment*.ts`, `github-repo-links.ts`, and `routes/github-*` untouched per the phase boundary.

## Test plan
- [x] `pnpm test` — 1910 passed (156 files), including new `apps/api/test/staging-reaper.test.ts` (10 cases: promoted-old deleted, promoted-recent kept, abandoned-old deleted, abandoned-recent kept, missing/unparsable staged-at kept, non-branch `gh.*` untouched, run cap respected, key-shape belt-and-braces, per-object failure isolation, D1 metadata cleaned up on delete).
- [x] `pnpm --filter @uploads/api run typecheck` — clean.
- [x] lint/format via pre-commit hook (oxlint + oxfmt) — clean.
