### PR TITLE
feat(api,cli): comment image cap, per-workspace markers, uploads github link

### DIFF
--- a/.changeset/gh-comment-cap-markers-link.md
+++ b/.changeset/gh-comment-cap-markers-link.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Managed GitHub comments now cap inline images at 16 (the rest collapse into a `<details>` list) and use a per-workspace marker so two workspaces sharing a repo no longer clobber each other's comment (legacy comments are adopted and migrated automatically). Adds `uploads github link` to inspect or explicitly claim a workspace's binding to a repo.

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -3,17 +3,26 @@ import { fileURLToPath, URL as NodeURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { attachmentsCommentBody } from "./github-comment-render";
 
-const golden = JSON.parse(
-  readFileSync(
-    fileURLToPath(
-      new NodeURL("../../../test/fixtures/github-comment-golden.json", import.meta.url),
+function loadFixture(name: string) {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new NodeURL(`../../../test/fixtures/${name}`, import.meta.url)),
+      "utf8",
     ),
-    "utf8",
-  ),
-) as { items: any[]; galleries: any[]; expected: string };
+  ) as { items: any[]; galleries: any[]; marker?: string; expected: string };
+}
+
+const golden = loadFixture("github-comment-golden.json");
+const goldenCap = loadFixture("github-comment-golden-cap.json");
 
 describe("attachmentsCommentBody (api copy)", () => {
   it("renders the golden body byte-for-byte", () => {
     expect(attachmentsCommentBody(golden.items, golden.galleries)).toBe(golden.expected);
+  });
+
+  it("caps inline images at 16, collapsing the rest into a details block", () => {
+    expect(attachmentsCommentBody(goldenCap.items, goldenCap.galleries, goldenCap.marker)).toBe(
+      goldenCap.expected,
+    );
   });
 });

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -51,6 +51,31 @@ function inferContentType(filename: string): string {
 /** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */
 export const ATTACHMENTS_MARKER = "<!-- uploads.sh:attachments -->";
 
+/** Workspace slugs are `[a-z0-9-]`-ish; only markers built from a slug matching
+ * this are trusted as a distinct namespace — anything else (empty, unsafe
+ * chars) degrades to the shared legacy marker rather than emitting untrusted
+ * text into comment HTML. */
+const WORKSPACE_SLUG_RE = /^[a-z0-9-]{1,64}$/;
+
+/**
+ * Per-workspace marker (`<!-- uploads.sh:attachments ws=<workspace> -->`) so
+ * two workspaces managing the same repo don't clobber each other's comment.
+ * Falls back to the shared legacy marker when `workspace` is missing or does
+ * not look like a safe slug — degrade, don't guess or risk breaking the
+ * comment's HTML.
+ */
+export function attachmentsMarker(workspace?: string): string {
+  if (workspace && WORKSPACE_SLUG_RE.test(workspace)) {
+    return `<!-- uploads.sh:attachments ws=${workspace} -->`;
+  }
+  return ATTACHMENTS_MARKER;
+}
+
+/** Max attachments embedded as inline `<img>` tags before the rest collapse
+ * into a `<details>` link list. Keeps very large threads from becoming a wall
+ * of images. */
+export const MAX_INLINE_ATTACHMENT_IMAGES = 16;
+
 export interface AttachmentItem {
   key: string;
   url: string | null;
@@ -109,6 +134,7 @@ function escapeHtmlText(s: string): string {
 export function attachmentsCommentBody(
   items: AttachmentItem[],
   galleries: GalleryCommentItem[] = [],
+  marker: string = ATTACHMENTS_MARKER,
 ): string {
   // Non-mutating sort (equivalent to Array#toSorted) — the api worker's
   // tsconfig targets lib ES2022, which predates Array#toSorted (ES2023);
@@ -117,7 +143,7 @@ export function attachmentsCommentBody(
   const sortedGalleries = [...galleries].sort(
     (a, b) => a.title.localeCompare(b.title) || a.url.localeCompare(b.url),
   );
-  const lines: string[] = [ATTACHMENTS_MARKER];
+  const lines: string[] = [marker];
   if (sortedGalleries.length > 0) {
     lines.push("### 🖼️ Galleries", "");
     for (const gallery of sortedGalleries) {
@@ -135,18 +161,28 @@ export function attachmentsCommentBody(
     lines.push("");
   }
   if (sorted.length > 0 || sortedGalleries.length === 0) lines.push("### 📎 Attachments", "");
+  let inlinedImages = 0;
+  const overflowImages: AttachmentItem[] = [];
   for (const item of sorted) {
     const name = item.key.slice(item.key.lastIndexOf("/") + 1);
     const stable = item.url;
     const src = item.embedUrl ?? item.url;
     const link = item.pageUrl ?? stable; // click-through: file page when known, else raw
-    if (src && inferContentType(name).startsWith("image/")) {
+    const isImage = Boolean(src) && inferContentType(name).startsWith("image/");
+    if (isImage && inlinedImages >= MAX_INLINE_ATTACHMENT_IMAGES) {
+      // Cap hit — defer to the collapsed overflow list below rather than
+      // embedding every remaining image inline.
+      overflowImages.push(item);
+      continue;
+    }
+    if (isImage) {
+      inlinedImages++;
       // Markdown ![]() has no width control — phone frames become full-column giants.
       // img src uses embed host when available (Camo revalidates); click-through prefers the file page.
       const w = attachmentImageWidth(name);
       const alt = escapeHtmlAttr(name);
-      const href = escapeHtmlAttr(link ?? src);
-      const imgSrc = escapeHtmlAttr(src);
+      const href = escapeHtmlAttr(link ?? (src as string));
+      const imgSrc = escapeHtmlAttr(src as string);
       lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
       lines.push("");
     } else if (link) {
@@ -154,6 +190,16 @@ export function attachmentsCommentBody(
     } else {
       lines.push(`- ${name}`);
     }
+  }
+  if (overflowImages.length > 0) {
+    const n = overflowImages.length;
+    lines.push(`<details><summary>${n} more attachment${n === 1 ? "" : "s"}</summary>`, "");
+    for (const item of overflowImages) {
+      const name = item.key.slice(item.key.lastIndexOf("/") + 1);
+      const link = item.pageUrl ?? item.url;
+      lines.push(link ? `- [${name}](${link})` : `- ${name}`);
+    }
+    lines.push("", "</details>", "");
   }
   lines.push(
     '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 import { gatherCommentBody, upsertBotComment } from "./github-comment";
-import { ATTACHMENTS_MARKER } from "./github-comment-render";
+import { ATTACHMENTS_MARKER, attachmentsMarker } from "./github-comment-render";
 import { addExternalReference, addGalleryItem, createGallery } from "./galleries";
 import type { WorkspaceRecord } from "./workspace";
 import { FakeR2Bucket } from "../test/fake-r2";
@@ -83,7 +83,7 @@ describe("gatherCommentBody", () => {
     });
     expect(result.skip).toBe(false);
     if (result.skip) return;
-    expect(result.body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
+    expect(result.body.startsWith(attachmentsMarker(workspaceName))).toBe(true);
     expect(result.body).toContain("hero.png");
     expect(result.count).toBe(1);
   });
@@ -182,7 +182,7 @@ describe("gatherCommentBody", () => {
     });
     expect(result.skip).toBe(false);
     if (result.skip) return;
-    expect(result.body.startsWith(ATTACHMENTS_MARKER)).toBe(true);
+    expect(result.body.startsWith(attachmentsMarker(workspaceName))).toBe(true);
     expect(result.body).toContain("Launch media");
     expect(result.body).not.toContain("Not ours");
     expect(result.count).toBe(1);
@@ -208,6 +208,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
@@ -239,6 +240,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
@@ -271,6 +273,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
@@ -295,6 +298,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({ degrade: "forbidden" });
@@ -313,6 +317,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({ degrade: "forbidden" });
@@ -330,6 +335,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({ degrade: "unavailable" });
@@ -352,6 +358,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({ degrade: "unavailable" });
@@ -360,7 +367,7 @@ describe("upsertBotComment", () => {
   it("uses a cached comment id to PATCH directly, without listing", async () => {
     const { env, kv } = makeTestEnv();
     const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
-    await kv.put("ghcomment:acme/web#12", "55");
+    await kv.put("ghcomment:acme:acme/web#12", "55");
     const fetchImpl = (async (url: string, init: RequestInit = {}) => {
       if (url.includes("/access_tokens")) {
         return new Response(JSON.stringify({ token: "t" }), { status: 201 });
@@ -381,6 +388,7 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
@@ -392,7 +400,7 @@ describe("upsertBotComment", () => {
   it("re-hunts and recreates when the cached comment was deleted (404), refreshing the cache", async () => {
     const { env, kv } = makeTestEnv();
     const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
-    await kv.put("ghcomment:acme/web#12", "55");
+    await kv.put("ghcomment:acme:acme/web#12", "55");
     const fetchImpl = (async (url: string, init: RequestInit = {}) => {
       if (url.includes("/access_tokens")) {
         return new Response(JSON.stringify({ token: "t" }), { status: 201 });
@@ -414,13 +422,14 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
       action: "created",
       commentUrl: "https://github.com/acme/web/pull/12#c88",
     });
-    expect(await kv.get("ghcomment:acme/web#12")).toBe("88");
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("88");
   });
 
   it("finds the marker comment beyond the first page and caches its id", async () => {
@@ -451,13 +460,14 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
       action: "updated",
       commentUrl: "https://github.com/acme/web/pull/12#c777",
     });
-    expect(await kv.get("ghcomment:acme/web#12")).toBe("777");
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("777");
   });
 
   it("caches the id of a freshly created comment", async () => {
@@ -479,12 +489,120 @@ describe("upsertBotComment", () => {
       42,
       { repo: "acme/web", num: 12 },
       "BODY",
+      "acme",
       fetchImpl,
     );
     expect(res).toEqual({
       action: "created",
       commentUrl: "https://github.com/acme/web/pull/12#c99",
     });
-    expect(await kv.get("ghcomment:acme/web#12")).toBe("99");
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("99");
+  });
+
+  it("finds a namespaced marker comment first, even when a legacy marker comment also exists", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": () =>
+        new Response(
+          JSON.stringify([
+            { id: 1, body: `${ATTACHMENTS_MARKER}\nother workspace's legacy comment` },
+            { id: 2, body: `${attachmentsMarker("acme")}\nours` },
+          ]),
+          { status: 200 },
+        ),
+      "/issues/comments/2": () =>
+        new Response(
+          JSON.stringify({ id: 2, html_url: "https://github.com/acme/web/pull/12#c2" }),
+          {
+            status: 200,
+          },
+        ),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c2",
+    });
+  });
+
+  it("adopts a legacy (unnamespaced) marker comment when no namespaced one exists yet", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": () =>
+        new Response(JSON.stringify([{ id: 5, body: `${ATTACHMENTS_MARKER}\nold body` }]), {
+          status: 200,
+        }),
+      "/issues/comments/5": () =>
+        new Response(
+          JSON.stringify({ id: 5, html_url: "https://github.com/acme/web/pull/12#c5" }),
+          {
+            status: 200,
+          },
+        ),
+    });
+    // The namespaced marker is already the first line of `body` — patching the
+    // legacy comment with it migrates the comment in place.
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      `${attachmentsMarker("acme")}\nnew body`,
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c5",
+    });
+  });
+
+  it("uses a distinct cache key per workspace so two workspaces on one repo never collide", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    await kv.put("ghcomment:acme:acme/web#12", "55");
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      // A cache hit for "acme" must never be used by a different workspace.
+      if (url.includes("/issues/comments/55"))
+        throw new Error("wrong workspace's cache entry used");
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 66, html_url: "https://github.com/other-ws/web/pull/12#c66" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "other-ws",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/other-ws/web/pull/12#c66",
+    });
+    expect(await kv.get("ghcomment:other-ws:acme/web#12")).toBe("66");
   });
 });

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -15,6 +15,7 @@ import type { WorkspaceRecord } from "./workspace";
 import { githubFetch, githubHeaders, installationToken, type GithubAppConfig } from "./github-app";
 import {
   attachmentsCommentBody,
+  attachmentsMarker,
   ghKeyPrefix,
   ATTACHMENTS_MARKER,
   type AttachmentItem,
@@ -47,7 +48,8 @@ export async function gatherCommentBody(
 
   const count = items.length + galleries.length;
   if (count === 0) return { skip: true };
-  return { skip: false, body: attachmentsCommentBody(items, galleries), count };
+  const marker = attachmentsMarker(workspaceName);
+  return { skip: false, body: attachmentsCommentBody(items, galleries, marker), count };
 }
 
 /** The workspace's own objects under the stable gh key prefix. */
@@ -137,10 +139,13 @@ interface GhComment {
  * it and re-hunts. Long only to spare the hunt on active PRs. */
 const COMMENT_ID_TTL = 60 * 60 * 24 * 30; // 30 days.
 
-/** KV key for the managed comment's id, keyed by the coordinate the comment is
- * unique on (repo#num — one managed comment per PR/issue, shared marker). */
-function commentCacheKey(target: Pick<GhTarget, "repo" | "num">): string {
-  return `ghcomment:${target.repo.toLowerCase()}#${target.num}`;
+/** KV key for the managed comment's id, keyed by the workspace + coordinate the
+ * comment is unique on (repo#num — one managed comment per PR/issue per
+ * workspace, phase 4b). A cache entry written under the pre-4b key format
+ * (`ghcomment:<repo>#<num>`, no workspace dimension) simply misses under this
+ * key and falls through to a fresh marker hunt — no migration needed. */
+function commentCacheKey(workspaceName: string, target: Pick<GhTarget, "repo" | "num">): string {
+  return `ghcomment:${workspaceName}:${target.repo.toLowerCase()}#${target.num}`;
 }
 
 /** One create/patch write. `status` is 0 for a thrown request (network error). */
@@ -167,6 +172,7 @@ export async function upsertBotComment(
   installationId: number,
   target: Pick<GhTarget, "repo" | "num">,
   body: string,
+  workspaceName: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<
   { action: "created" | "updated"; commentUrl: string } | { degrade: "forbidden" | "unavailable" }
@@ -175,7 +181,8 @@ export async function upsertBotComment(
   if (!token) return { degrade: "unavailable" };
   const base = `https://api.github.com/repos/${target.repo}`;
   const jsonHeaders = { ...githubHeaders(token), "content-type": "application/json" };
-  const cacheKey = commentCacheKey(target);
+  const cacheKey = commentCacheKey(workspaceName, target);
+  const marker = attachmentsMarker(workspaceName);
 
   const write = async (url: string, method: "POST" | "PATCH"): Promise<WriteOutcome> => {
     let res: Response;
@@ -205,8 +212,11 @@ export async function upsertBotComment(
   }
 
   // Slow path: find the marker comment across all pages (a busy thread can push
-  // it past the first 100), then patch it; otherwise create a new one.
-  const found = await findMarkerComment(fetchImpl, token, base, target.num);
+  // it past the first 100), then patch it; otherwise create a new one. Hunts
+  // the namespaced marker first; a legacy (pre-4b, unnamespaced) comment is
+  // adopted — `body` already carries the namespaced marker, so patching it
+  // migrates the comment in place.
+  const found = await findMarkerComment(fetchImpl, token, base, target.num, marker);
   if (found.degrade) return { degrade: found.degrade };
   const existing = found.comment;
 
@@ -227,14 +237,23 @@ export async function upsertBotComment(
  * found or the pages run out. Bounded so a pathological thread can't loop
  * unboundedly; the cap is far beyond any real attachments thread, and the id
  * cache means this hunt runs at most once per comment anyway.
+ *
+ * Prefers a comment carrying `marker` (the namespaced, per-workspace marker);
+ * if none is found across every page, falls back to a comment carrying the
+ * shared legacy `ATTACHMENTS_MARKER` (pre-4b, unnamespaced) so it can be
+ * adopted and migrated in place. When `marker` IS the legacy marker (no
+ * workspace to namespace with) this collapses to a single hunt, unchanged
+ * from pre-4b behavior.
  */
 async function findMarkerComment(
   fetchImpl: typeof fetch,
   token: string,
   base: string,
   num: number,
+  marker: string,
 ): Promise<{ comment?: GhComment; degrade?: "forbidden" | "unavailable" }> {
   const MAX_PAGES = 20; // 2000 comments.
+  let legacyHit: GhComment | undefined;
   for (let page = 1; page <= MAX_PAGES; page++) {
     let res: Response;
     try {
@@ -251,12 +270,17 @@ async function findMarkerComment(
     if (res.status === 403) return { degrade: "forbidden" };
     if (!res.ok) return { degrade: "unavailable" };
     const comments = (await res.json().catch(() => [])) as GhComment[];
-    if (!Array.isArray(comments)) return {};
-    const hit = comments.find(
-      (c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER),
+    if (!Array.isArray(comments)) return { comment: legacyHit };
+    const namespacedHit = comments.find(
+      (c) => typeof c.body === "string" && c.body.includes(marker),
     );
-    if (hit) return { comment: hit };
-    if (comments.length < 100) return {}; // last page reached, not found.
+    if (namespacedHit) return { comment: namespacedHit };
+    if (!legacyHit && marker !== ATTACHMENTS_MARKER) {
+      legacyHit = comments.find(
+        (c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER),
+      );
+    }
+    if (comments.length < 100) return { comment: legacyHit }; // last page reached.
   }
-  return {}; // page cap hit without a match — treat as not found (create).
+  return { comment: legacyHit }; // page cap hit — best effort, still adopt a legacy hit if seen.
 }

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -151,7 +151,14 @@ async function autoPromoteAndComment(env: Env, p: PullRequestPayload): Promise<v
     const installId = link.installationId ?? (await installationForRepo(env, cfg, repo));
     if (installId === null) return;
 
-    const result = await upsertBotComment(env, cfg, installId, target, gathered.body);
+    const result = await upsertBotComment(
+      env,
+      cfg,
+      installId,
+      target,
+      gathered.body,
+      link.workspaceName,
+    );
     if ("degrade" in result) {
       console.error(
         JSON.stringify({

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,6 +21,7 @@ import { render } from "./routes/render";
 import { githubWebhook } from "./routes/github-webhook";
 import { githubComment } from "./routes/github-comment";
 import { githubPromote } from "./routes/github-promote";
+import { githubLink } from "./routes/github-link";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -132,6 +133,9 @@ export const app = new Hono<WorkspaceVars>()
   // prefix. Same base path as the comment route above (workspace-authed,
   // distinct sub-route "/promote" vs "/comment").
   .route("/v1/:workspace/github", githubPromote)
+  // Phase 4b: explicit claim/inspect for the workspace<->repo binding (see
+  // github-repo-links.ts) — same base path, distinct sub-route "/link".
+  .route("/v1/:workspace/github", githubLink)
   .onError((err, c) => respondError(c, err))
   .notFound((c) => respondError(c, new NotFoundError()));
 

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -77,7 +77,14 @@ export const githubComment = new Hono<WorkspaceVars>().post(
     );
     if (gathered.skip) return c.json({ posted: true, action: "skipped", count: 0 });
 
-    const result = await upsertBotComment(c.env, cfg, installId, target, gathered.body);
+    const result = await upsertBotComment(
+      c.env,
+      cfg,
+      installId,
+      target,
+      gathered.body,
+      c.get("workspaceName"),
+    );
     if ("degrade" in result) {
       // A 403 means the App is installed but lacks Issues/PR write (pending org
       // approval). Enrich that one reason with actionable guidance so the CLI

--- a/apps/api/src/routes/github-link-route.test.ts
+++ b/apps/api/src/routes/github-link-route.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../index";
+import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+// Same node-vs-workerd Web Crypto gap as github-promote-route.test.ts — this
+// suite exercises the real workspaceAuth middleware end to end.
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+const WS = "acme";
+const TOKEN = "up_acme_testtoken";
+const REPO = "acme/web";
+
+interface Seeded {
+  env: Env;
+  db: UsageFakeD1;
+}
+
+async function seededEnv(workspace = WS, token = TOKEN): Promise<Seeded> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: `${workspace}/`,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex(token), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${workspace}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const db = new UsageFakeD1();
+  const env = { REGISTRY: registry, DB: db } as unknown as Env;
+  return { env, db };
+}
+
+function get(env: Env, workspace: string, repo: string, token: string) {
+  return app.request(
+    `/v1/${workspace}/github/link?repo=${encodeURIComponent(repo)}`,
+    {
+      headers: { authorization: `Bearer ${token}` },
+    },
+    env,
+  );
+}
+
+function post(env: Env, workspace: string, body: unknown, token: string) {
+  return app.request(
+    `/v1/${workspace}/github/link`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe("GET /v1/:workspace/github/link", () => {
+  it("reports no binding when the repo is unclaimed", async () => {
+    const { env } = await seededEnv();
+    const res = await get(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: REPO, linked: false, workspace: null });
+  });
+
+  it("reports the binding when the repo is claimed", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: WS,
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await get(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: REPO, linked: true, workspace: WS });
+  });
+
+  it("400s on a malformed repo", async () => {
+    const { env } = await seededEnv();
+    const res = await get(env, WS, "not-a-repo", TOKEN);
+    expect(res.status).toBe(400);
+  });
+
+  it("401s with no bearer token", async () => {
+    const { env } = await seededEnv();
+    const res = await app.request(`/v1/${WS}/github/link?repo=${REPO}`, {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /v1/:workspace/github/link", () => {
+  it("claims an unbound repo", async () => {
+    const { env, db } = await seededEnv();
+    const res = await post(env, WS, { repo: REPO }, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ claimed: true, workspace: WS, source: "cli" });
+    expect(db.repoLinks.get(REPO)).toMatchObject({ workspace_name: WS, source: "cli" });
+  });
+
+  it("honestly reports an already-bound-by-another-workspace repo (claimed: false)", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: "someone-else",
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await post(env, WS, { repo: REPO }, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      claimed: false,
+      linked: true,
+      workspace: "someone-else",
+    });
+    // First-claim-wins: never overwritten.
+    expect(db.repoLinks.get(REPO)?.workspace_name).toBe("someone-else");
+  });
+
+  it("is idempotent for the owning workspace (claimed: true, no duplicate row)", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: WS,
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await post(env, WS, { repo: REPO }, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ claimed: true, workspace: WS, source: "comment" });
+  });
+
+  it("400s on a malformed repo", async () => {
+    const { env } = await seededEnv();
+    const res = await post(env, WS, { repo: "../etc" }, TOKEN);
+    expect(res.status).toBe(400);
+  });
+
+  it("401s with no bearer token", async () => {
+    const { env } = await seededEnv();
+    const res = await app.request(
+      `/v1/${WS}/github/link`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: REPO }),
+      },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -1,0 +1,72 @@
+/**
+ * `/v1/:workspace/github/link` (phase 4b). Explicit claim/inspect for the
+ * workspace<->repo binding (`github_repo_links`, see ../github-repo-links.ts)
+ * that has, until now, only ever been created implicitly as a side effect of
+ * a successful `/github/comment` or `/github/promote` call. Same
+ * first-claim-wins semantics as those implicit claims: `recordRepoLink` is
+ * `INSERT OR IGNORE`, so a POST from a workspace that doesn't already own the
+ * binding never steals it — the response reports who actually owns it
+ * (`claimed: false`, `owner`) rather than silently pretending to succeed.
+ */
+import { ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import { findRepoLink, recordRepoLink, type RepoLink } from "../github-repo-links";
+import { writeRateLimit } from "../guards";
+import { requireScope, type WorkspaceVars } from "../workspace";
+import { jsonBody } from "./json-body";
+
+// Same owner/name grammar + dot-only-segment guard as routes/github-comment.ts's
+// parseTarget (this repo string is looked up/stored, not interpolated into an
+// api.github.com path here, but the same shape is worth validating consistently).
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const DOTS_ONLY_RE = /^\.+$/;
+
+function parseRepo(repo: unknown): string {
+  if (
+    typeof repo !== "string" ||
+    !REPO_RE.test(repo) ||
+    repo.split("/").some((seg) => DOTS_ONLY_RE.test(seg))
+  ) {
+    throw new ValidationError("repo must be owner/name.", { code: "invalid_repo" });
+  }
+  return repo;
+}
+
+function linkResponse(repo: string, link: RepoLink | null) {
+  return {
+    repo,
+    linked: link !== null,
+    workspace: link?.workspaceName ?? null,
+    source: link?.source ?? null,
+    createdAt: link?.createdAt ?? null,
+  };
+}
+
+export const githubLink = new Hono<WorkspaceVars>()
+  .get("/link", requireScope("files:read"), async (c) => {
+    const repo = parseRepo(c.req.query("repo"));
+    const link = await findRepoLink(c.env.DB, repo);
+    return c.json(linkResponse(repo, link));
+  })
+  .post("/link", writeRateLimit, requireScope("files:write"), async (c) => {
+    const repo = parseRepo((await jsonBody(c)).repo);
+    const workspaceName = c.get("workspaceName");
+
+    const before = await findRepoLink(c.env.DB, repo);
+    if (before) {
+      // Already bound — honestly report the owner rather than claiming
+      // success. First-claim-wins: this call never overwrites it, whether
+      // the owner is this workspace or another one.
+      return c.json({
+        claimed: before.workspaceName === workspaceName,
+        ...linkResponse(repo, before),
+      });
+    }
+
+    await recordRepoLink(c.env.DB, repo, workspaceName, "cli");
+    const after = await findRepoLink(c.env.DB, repo);
+    return c.json({
+      claimed: after?.workspaceName === workspaceName,
+      ...linkResponse(repo, after),
+    });
+  });

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -150,6 +150,11 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     summary: "Create/update a PR/issue attachments comment (via gh)",
   },
   {
+    name: "github",
+    summary: "Claim/inspect this workspace's binding to a GitHub repo",
+    subcommands: [{ name: "link", summary: "Claim or inspect the repo binding" }],
+  },
+  {
     name: "list",
     summary: "List objects (--meta k=v filters by queryable metadata)",
     essential: true,

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -21,6 +21,7 @@ import {
   runHealth,
   runDoctor,
   runComment,
+  runGithub,
   runUsage,
   runReconcile,
   runPurgeExpired,
@@ -347,7 +348,8 @@ export async function runCli(argv: string[]): Promise<number> {
       case "reconcile":
       case "purge-expired":
       case "doctor":
-      case "comment": {
+      case "comment":
+      case "github": {
         const ctx = createContext(parsed.globals, !showHelp, cmdArgs);
         switch (parsed.command) {
           case "attach":
@@ -364,6 +366,9 @@ export async function runCli(argv: string[]): Promise<number> {
             break;
           case "comment":
             code = await runComment(ctx, cmdArgs, showHelp);
+            break;
+          case "github":
+            code = await runGithub(ctx, cmdArgs, showHelp);
             break;
           case "list":
             code = await runList(ctx, cmdArgs, showHelp);

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -249,6 +249,20 @@ export interface PromoteBranchAttachmentsResult {
   skipped: PromoteSkip[];
 }
 
+/** `GET`/`POST /v1/:workspace/github/link` result (server contract, phase 4b). */
+export interface GithubLinkResult {
+  repo: string;
+  linked: boolean;
+  workspace: string | null;
+  source: string | null;
+  createdAt: string | null;
+}
+
+/** POST-only: whether THIS call's workspace ended up owning the binding. */
+export interface GithubLinkClaimResult extends GithubLinkResult {
+  claimed: boolean;
+}
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -998,6 +1012,34 @@ export function createUploadsClient(config: UploadsClientConfig) {
         `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/promote`,
         {
           body: new TextEncoder().encode(JSON.stringify(opts)),
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    },
+
+    /** Current binding for `repo`, or `{ linked: false }` if unclaimed. Throws
+     * `UploadsError` (status 404) on an older/self-hosted server without this
+     * route — callers treat that as "bindings unsupported". */
+    async githubLinkStatus(repo: string): Promise<GithubLinkResult> {
+      return request<GithubLinkResult>(
+        "GET",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/link?repo=${encodeURIComponent(repo)}`,
+      );
+    },
+
+    /**
+     * Explicitly claim `repo` for this workspace (first-claim-wins — see
+     * github-repo-links.ts server-side). `claimed: false` in the result means
+     * the repo is already bound to a DIFFERENT workspace; this call never
+     * steals it. Throws `UploadsError` (status 404) on an older/self-hosted
+     * server without this route.
+     */
+    async githubLinkClaim(repo: string): Promise<GithubLinkClaimResult> {
+      return request<GithubLinkClaimResult>(
+        "POST",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/link`,
+        {
+          body: new TextEncoder().encode(JSON.stringify({ repo })),
           headers: { "Content-Type": "application/json" },
         },
       );

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -35,6 +35,7 @@ import {
   ghMetadataFromTarget,
   ghMetadataForBranch,
   attachmentsCommentBody,
+  attachmentsMarker,
   type GhTarget,
   type AttachmentItem,
   type GalleryCommentItem,
@@ -466,6 +467,7 @@ export async function syncAttachmentsComment(
   client: UploadsClient,
   target: GhTarget,
   run: CommandRunner,
+  workspace?: string,
 ): Promise<AttachmentsCommentResult> {
   try {
     const bot = await client.upsertGithubComment({
@@ -539,8 +541,9 @@ export async function syncAttachmentsComment(
   if (items.length === 0 && previewGalleries.length === 0)
     return { action: "skipped", count: 0, via: "gh" };
 
-  const body = attachmentsCommentBody(items, previewGalleries);
-  const { created } = upsertAttachmentsComment(target, body, run);
+  const marker = attachmentsMarker(workspace);
+  const body = attachmentsCommentBody(items, previewGalleries, marker);
+  const { created } = upsertAttachmentsComment(target, body, run, marker);
   return {
     action: created ? "created" : "updated",
     count: items.length + previewGalleries.length,
@@ -1071,7 +1074,7 @@ export async function runAttach(
   // Skip comment refresh when every upload failed — nothing new from this batch.
   if (!parsed.flags.has("--no-comment") && uploads.length > 0) {
     try {
-      comment = await syncAttachmentsComment(ctx.client, target, run);
+      comment = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace);
     } catch (err) {
       commentError = err instanceof Error ? err.message : String(err);
       process.stderr.write(
@@ -1223,7 +1226,7 @@ async function runAttachPromoteOnly(
   let commentError: string | undefined;
   if (!parsed.flags.has("--no-comment")) {
     try {
-      comment = await syncAttachmentsComment(ctx.client, target, run);
+      comment = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace);
     } catch (err) {
       commentError = err instanceof Error ? err.message : String(err);
       process.stderr.write(
@@ -1470,7 +1473,7 @@ export async function runPut(
   let commentError: string | undefined;
   if (wantComment && ghTarget && uploads.length > 0) {
     try {
-      comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
+      comment = await syncAttachmentsComment(ctx.client, ghTarget, run, ctx.config.workspace);
       if (logHuman)
         process.stderr.write(
           `>> attachments comment ${comment.action}${commentViaSuffix(comment.via)}\n`,
@@ -2041,7 +2044,7 @@ export async function runComment(
   const target = ghTargetFromFlags(parsed.flags, run);
   if (!target) throw new UsageError("comment requires --pr or --issue");
 
-  const result = await syncAttachmentsComment(ctx.client, target, run);
+  const result = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace);
   if (ctx.json) {
     await writeJson({ ...target, ...result });
   } else if (!ctx.quiet) {
@@ -2052,6 +2055,85 @@ export async function runComment(
         : `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})${via}\n`,
     );
   }
+  return 0;
+}
+
+// --- github link ---
+
+const GITHUB_HELP = `uploads github link [--repo <owner/name>] [--status] [--workspace <name>]
+
+Claim or inspect this workspace's binding to a GitHub repo (see the managed
+attachments comment / webhook auto-promotion, which use this binding).
+First-claim-wins: claiming an already-bound repo never steals it from
+whichever workspace claimed it first — the command reports who owns it
+instead.
+
+--repo defaults the same way as --pr/--issue elsewhere (gh repo view, then
+the git remote). --status only inspects the current binding (files:read);
+without it, the command claims the repo (files:write).
+
+Examples:
+  uploads github link
+  uploads github link --repo buildinternet/uploads
+  uploads github link --status
+`;
+
+function formatGithubLink(
+  repo: string,
+  result: { workspace: string | null; source: string | null },
+): string {
+  return result.workspace
+    ? `${repo} is bound to workspace "${result.workspace}"${result.source ? ` (${result.source})` : ""}\n`
+    : `${repo} is not bound to any workspace\n`;
+}
+
+export async function runGithub(
+  ctx: CliContext,
+  args: string[],
+  help = false,
+  run: CommandRunner = execRunner,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  const action = parsed.positionals[0];
+  if (help || parsed.help || !action) {
+    writeCommandHelp(GITHUB_HELP);
+    return help || parsed.help ? 0 : 2;
+  }
+  if (action !== "link") throw new UsageError(`unknown github subcommand: ${action}`);
+
+  const repo = resolveRepo(flagString(parsed.flags, "--repo"), run);
+  const statusOnly = flagBool(parsed.flags, "--status");
+
+  let result: {
+    repo: string;
+    linked: boolean;
+    workspace: string | null;
+    source: string | null;
+    claimed?: boolean;
+  };
+  try {
+    result = statusOnly
+      ? await ctx.client.githubLinkStatus(repo)
+      : await ctx.client.githubLinkClaim(repo);
+  } catch (err) {
+    if (err instanceof UploadsError && err.status === 404) {
+      throw new UsageError(
+        "server does not support repo bindings yet (404) — upgrade the uploads.sh API/self-hosted worker",
+      );
+    }
+    throw err;
+  }
+
+  if (ctx.json) {
+    await writeJson(result);
+    return 0;
+  }
+  if (!statusOnly && result.claimed === false) {
+    process.stderr.write(
+      `note: ${repo} is already bound to a different workspace ("${result.workspace}") — first-claim-wins, not overwritten\n`,
+    );
+  }
+  await writeStdout(formatGithubLink(repo, result));
   return 0;
 }
 

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -368,7 +368,7 @@ export async function runScreenshot(
   let commentError: string | undefined;
   if (wantComment && ghTarget) {
     try {
-      comment = await syncAttachmentsComment(ctx.client, ghTarget, run);
+      comment = await syncAttachmentsComment(ctx.client, ghTarget, run, ctx.config.workspace);
       if (logHuman)
         process.stderr.write(
           `>> attachments comment ${comment.action}${commentViaSuffix(comment.via)}\n`,

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -182,14 +182,28 @@ interface GhComment {
  * PR comments live on the issues endpoint, so one path covers PRs and issues.
  * `--paginate` follows Link headers and merges every page into one array, so the
  * marker comment is found even on threads past 100 comments.
+ *
+ * Hunts for `marker` (the namespaced, per-workspace marker) first; when none
+ * is found, falls back to a comment carrying the shared legacy
+ * `ATTACHMENTS_MARKER` (pre-4b, unnamespaced) so it can be adopted and
+ * migrated in place. When `marker` IS the legacy marker (no workspace to
+ * namespace with) this collapses to a single hunt, unchanged from pre-4b
+ * behavior.
  */
-function findManagedComment(target: GhTarget, run: CommandRunner): GhComment | undefined {
+function findManagedComment(
+  target: GhTarget,
+  run: CommandRunner,
+  marker: string,
+): GhComment | undefined {
   const raw = run("gh", [
     "api",
     `repos/${target.repo}/issues/${target.num}/comments?per_page=100`,
     "--paginate",
   ]);
   const comments = JSON.parse(raw) as GhComment[];
+  const namespacedHit = comments.find((c) => typeof c.body === "string" && c.body.includes(marker));
+  if (namespacedHit) return namespacedHit;
+  if (marker === ATTACHMENTS_MARKER) return undefined;
   return comments.find((c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER));
 }
 
@@ -197,13 +211,20 @@ function findManagedComment(target: GhTarget, run: CommandRunner): GhComment | u
  * Create the managed attachments comment, or edit it in place if it already
  * exists. Never touches any other comment. Body is passed via stdin
  * (`-F body=@-`) so it is never shell-interpolated.
+ *
+ * `marker` identifies which comment to hunt for (see `findManagedComment`);
+ * `body` is expected to already carry that same marker as its first line
+ * (built via `attachmentsCommentBody(items, galleries, marker)`), so patching
+ * an adopted legacy comment migrates it to the namespaced marker in place.
+ * Defaults to the shared legacy marker for backward compatibility.
  */
 export function upsertAttachmentsComment(
   target: GhTarget,
   body: string,
   run: CommandRunner = execRunner,
+  marker: string = ATTACHMENTS_MARKER,
 ): { created: boolean } {
-  const existing = findManagedComment(target, run);
+  const existing = findManagedComment(target, run, marker);
   if (existing) {
     run(
       "gh",

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -156,6 +156,31 @@ export function ghMetadataFromTarget(target: GhTarget): Record<string, string> {
 /** Hidden marker identifying the one comment this CLI manages. Never change it — existing comments are found by exact match. */
 export const ATTACHMENTS_MARKER = "<!-- uploads.sh:attachments -->";
 
+/** Workspace slugs are `[a-z0-9-]`-ish; only markers built from a slug matching
+ * this are trusted as a distinct namespace — anything else (empty, unsafe
+ * chars) degrades to the shared legacy marker rather than emitting untrusted
+ * text into comment HTML. */
+const WORKSPACE_SLUG_RE = /^[a-z0-9-]{1,64}$/;
+
+/**
+ * Per-workspace marker (`<!-- uploads.sh:attachments ws=<workspace> -->`) so
+ * two workspaces managing the same repo don't clobber each other's comment.
+ * Falls back to the shared legacy marker when `workspace` is missing or does
+ * not look like a safe slug — degrade, don't guess or risk breaking the
+ * comment's HTML.
+ */
+export function attachmentsMarker(workspace?: string): string {
+  if (workspace && WORKSPACE_SLUG_RE.test(workspace)) {
+    return `<!-- uploads.sh:attachments ws=${workspace} -->`;
+  }
+  return ATTACHMENTS_MARKER;
+}
+
+/** Max attachments embedded as inline `<img>` tags before the rest collapse
+ * into a `<details>` link list. Keeps very large threads from becoming a wall
+ * of images. */
+export const MAX_INLINE_ATTACHMENT_IMAGES = 16;
+
 export interface AttachmentItem {
   key: string;
   url: string | null;
@@ -214,12 +239,13 @@ function escapeHtmlText(s: string): string {
 export function attachmentsCommentBody(
   items: AttachmentItem[],
   galleries: GalleryCommentItem[] = [],
+  marker: string = ATTACHMENTS_MARKER,
 ): string {
   const sorted = items.toSorted((a, b) => a.key.localeCompare(b.key));
   const sortedGalleries = galleries.toSorted(
     (a, b) => a.title.localeCompare(b.title) || a.url.localeCompare(b.url),
   );
-  const lines: string[] = [ATTACHMENTS_MARKER];
+  const lines: string[] = [marker];
   if (sortedGalleries.length > 0) {
     lines.push("### 🖼️ Galleries", "");
     for (const gallery of sortedGalleries) {
@@ -237,18 +263,28 @@ export function attachmentsCommentBody(
     lines.push("");
   }
   if (sorted.length > 0 || sortedGalleries.length === 0) lines.push("### 📎 Attachments", "");
+  let inlinedImages = 0;
+  const overflowImages: AttachmentItem[] = [];
   for (const item of sorted) {
     const name = item.key.slice(item.key.lastIndexOf("/") + 1);
     const stable = item.url;
     const src = item.embedUrl ?? item.url;
     const link = item.pageUrl ?? stable; // click-through: file page when known, else raw
-    if (src && inferContentType(name).startsWith("image/")) {
+    const isImage = Boolean(src) && inferContentType(name).startsWith("image/");
+    if (isImage && inlinedImages >= MAX_INLINE_ATTACHMENT_IMAGES) {
+      // Cap hit — defer to the collapsed overflow list below rather than
+      // embedding every remaining image inline.
+      overflowImages.push(item);
+      continue;
+    }
+    if (isImage) {
+      inlinedImages++;
       // Markdown ![]() has no width control — phone frames become full-column giants.
       // img src uses embed host when available (Camo revalidates); click-through prefers the file page.
       const w = attachmentImageWidth(name);
       const alt = escapeHtmlAttr(name);
-      const href = escapeHtmlAttr(link ?? src);
-      const imgSrc = escapeHtmlAttr(src);
+      const href = escapeHtmlAttr(link ?? (src as string));
+      const imgSrc = escapeHtmlAttr(src as string);
       lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
       lines.push("");
     } else if (link) {
@@ -256,6 +292,16 @@ export function attachmentsCommentBody(
     } else {
       lines.push(`- ${name}`);
     }
+  }
+  if (overflowImages.length > 0) {
+    const n = overflowImages.length;
+    lines.push(`<details><summary>${n} more attachment${n === 1 ? "" : "s"}</summary>`, "");
+    for (const item of overflowImages) {
+      const name = item.key.slice(item.key.lastIndexOf("/") + 1);
+      const link = item.pageUrl ?? item.url;
+      lines.push(link ? `- [${name}](${link})` : `- ${name}`);
+    }
+    lines.push("", "</details>", "");
   }
   lines.push(
     '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -188,11 +188,11 @@ export function createUploadsMcpTools(opts: {
     return { config, client: clientFactory(config) };
   }
 
-  const syncComment = async (client: UploadsClient, target: GhTarget) => {
+  const syncComment = async (client: UploadsClient, target: GhTarget, workspace?: string) => {
     let comment: AttachmentsCommentResult | undefined;
     let commentError: string | undefined;
     try {
-      comment = await syncAttachmentsComment(client, target, run);
+      comment = await syncAttachmentsComment(client, target, run, workspace);
     } catch (err) {
       // Uploads already succeeded; the comment is best-effort by design.
       commentError = err instanceof Error ? err.message : String(err);
@@ -476,7 +476,7 @@ export function createUploadsMcpTools(opts: {
           usage(err instanceof Error ? err.message : String(err));
         }
 
-        const { client } = clientFor(args);
+        const { config, client } = clientFor(args);
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
         const frameOpts = mcpFrameOptions(args);
         const optimizeOpts = mcpOptimizeOptions(args, defaults);
@@ -511,7 +511,7 @@ export function createUploadsMcpTools(opts: {
             throw new ToolBatchError(batchFailureMessage(failures), { uploads, failures });
           }
           if (wantComment && target && uploads.length > 0) {
-            const { comment, commentError } = await syncComment(client, target);
+            const { comment, commentError } = await syncComment(client, target, config.workspace);
             return { uploads, failures, comment, commentError };
           }
           return { uploads, failures };
@@ -550,7 +550,7 @@ export function createUploadsMcpTools(opts: {
             filename: prepared.filename,
           };
           if (wantComment && target) {
-            const { comment, commentError } = await syncComment(client, target);
+            const { comment, commentError } = await syncComment(client, target, config.workspace);
             return { ...result, markdown, optimize, frame: prepared.frame, comment, commentError };
           }
           return {
@@ -586,7 +586,7 @@ export function createUploadsMcpTools(opts: {
           ...(dryRun ? { dryRun: true } : {}),
         };
         if (wantComment && target) {
-          const { comment, commentError } = await syncComment(client, target);
+          const { comment, commentError } = await syncComment(client, target, config.workspace);
           return { ...flat, comment, commentError };
         }
         return flat;
@@ -860,7 +860,7 @@ export function createUploadsMcpTools(opts: {
           ...(dryRun ? { dryRun: true } : {}),
         };
         if (wantComment && target) {
-          const { comment, commentError } = await syncComment(client, target);
+          const { comment, commentError } = await syncComment(client, target, config.workspace);
           return { ...flat, comment, commentError };
         }
         return flat;
@@ -926,7 +926,7 @@ export function createUploadsMcpTools(opts: {
         const target =
           explicitTarget ??
           resolveCurrentPullRequest(resolveRepo(optString(args, "repo"), run), run);
-        const { client } = clientFor(args);
+        const { config, client } = clientFor(args);
         const contentType = optString(args, "contentType");
         const defaults = resolvePutDefaults({ envFile: globals.envFile });
         const frameOpts = mcpFrameOptions(args);
@@ -962,7 +962,7 @@ export function createUploadsMcpTools(opts: {
         }
 
         if (optBool(args, "noComment")) return { target, uploads, failures };
-        const { comment, commentError } = await syncComment(client, target);
+        const { comment, commentError } = await syncComment(client, target, config.workspace);
         return { target, uploads, failures, comment, commentError };
       },
     },
@@ -1171,8 +1171,8 @@ export function createUploadsMcpTools(opts: {
       async handler(args) {
         const target = ghTargetFromArgs(args, run);
         if (!target) usage("comment requires pr or issue");
-        const { client } = clientFor(args);
-        const result = await syncAttachmentsComment(client, target, run);
+        const { config, client } = clientFor(args);
+        const result = await syncAttachmentsComment(client, target, run, config.workspace);
         return { ...target, ...result };
       },
     },

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
 import type { UploadsClient } from "../src/client.js";
 import { runComment, syncAttachmentsComment, type CliContext } from "../src/commands.js";
-import { ATTACHMENTS_MARKER } from "../src/github.js";
+import { attachmentsMarker } from "../src/github.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
 function listClient(
@@ -88,7 +88,9 @@ describe("runComment", () => {
     expect(code).toBe(0);
     const create = calls.find((c) => c.args.includes("repos/o/r/issues/5/comments"));
     expect(create).toBeDefined();
-    expect(create!.input).toContain(ATTACHMENTS_MARKER);
+    // ctxWith's workspace ("test") is a valid slug, so the gh-fallback path
+    // uses the namespaced marker (phase 4b).
+    expect(create!.input).toContain(attachmentsMarker("test"));
     expect(create!.input).toContain("after.png");
   });
 

--- a/packages/uploads/test/commands-github-link.test.ts
+++ b/packages/uploads/test/commands-github-link.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { UsageError } from "../src/cli-args.js";
+import { UploadsError } from "../src/errors.js";
+import type { UploadsClient } from "../src/client.js";
+import { runGithub, type CliContext } from "../src/commands.js";
+import type { CommandRunner } from "../src/github-gh.js";
+
+function ctxWith(client: UploadsClient, json = false): CliContext {
+  return {
+    config: {
+      apiUrl: "https://x.test",
+      workspace: "acme",
+      token: "up_acme_x",
+      workspaceSource: "override",
+      configPath: "/tmp/uploads-test-config",
+      configExists: false,
+    },
+    client,
+    json,
+    quiet: true,
+  };
+}
+
+function runnerWithRepo(repo = "acme/web"): CommandRunner {
+  return (cmd, args) => {
+    if (cmd === "gh" && args[0] === "repo") return repo;
+    throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+  };
+}
+
+describe("runGithub (link)", () => {
+  it("claims an unbound repo by default", async () => {
+    const calls: string[] = [];
+    const client = {
+      githubLinkClaim: async (repo: string) => {
+        calls.push(repo);
+        return {
+          repo,
+          linked: true,
+          workspace: "acme",
+          source: "cli",
+          createdAt: "now",
+          claimed: true,
+        };
+      },
+    } as unknown as UploadsClient;
+    const code = await runGithub(ctxWith(client), ["link"], false, runnerWithRepo());
+    expect(code).toBe(0);
+    expect(calls).toEqual(["acme/web"]);
+  });
+
+  it("--status only inspects, never claims", async () => {
+    let claimCalled = false;
+    const client = {
+      githubLinkStatus: async (repo: string) => ({
+        repo,
+        linked: false,
+        workspace: null,
+        source: null,
+        createdAt: null,
+      }),
+      githubLinkClaim: async () => {
+        claimCalled = true;
+        throw new Error("must not claim");
+      },
+    } as unknown as UploadsClient;
+    const code = await runGithub(ctxWith(client), ["link", "--status"], false, runnerWithRepo());
+    expect(code).toBe(0);
+    expect(claimCalled).toBe(false);
+  });
+
+  it("reports claimed: false when the repo is bound to another workspace", async () => {
+    const client = {
+      githubLinkClaim: async (repo: string) => ({
+        repo,
+        linked: true,
+        workspace: "someone-else",
+        source: "comment",
+        createdAt: "now",
+        claimed: false,
+      }),
+    } as unknown as UploadsClient;
+    const stderr: string[] = [];
+    const spy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: unknown) => (stderr.push(String(chunk)), true));
+    try {
+      const code = await runGithub(ctxWith(client), ["link"], false, runnerWithRepo());
+      expect(code).toBe(0);
+      expect(stderr.join("")).toContain("someone-else");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("degrades clearly on a 404 (older server without bindings)", async () => {
+    const client = {
+      githubLinkClaim: async () => {
+        throw new UploadsError("not found", "NOT_FOUND", 404);
+      },
+    } as unknown as UploadsClient;
+    await expect(runGithub(ctxWith(client), ["link"], false, runnerWithRepo())).rejects.toThrow(
+      UsageError,
+    );
+  });
+
+  it("shows help with no subcommand", async () => {
+    const client = {} as unknown as UploadsClient;
+    const code = await runGithub(ctxWith(client), [], false, runnerWithRepo());
+    expect(code).toBe(2);
+  });
+
+  it("rejects an unknown subcommand", async () => {
+    const client = {} as unknown as UploadsClient;
+    await expect(runGithub(ctxWith(client), ["bogus"], false, runnerWithRepo())).rejects.toThrow(
+      UsageError,
+    );
+  });
+});

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { UsageError } from "../src/cli-args.js";
-import { ATTACHMENTS_MARKER, type GhTarget } from "../src/github.js";
+import { ATTACHMENTS_MARKER, attachmentsMarker, type GhTarget } from "../src/github.js";
 import {
   classifyGhNumber,
   ghMetadataFromTargetWithTitle,
@@ -172,6 +172,44 @@ describe("upsertAttachmentsComment", () => {
     expect(patch.args).toContain("repos/o/r/issues/comments/42");
     expect(patch.args).toContain("PATCH");
     expect(patch.input).toContain("new body");
+  });
+
+  it("hunts for the namespaced marker first, even when a legacy marker comment also exists", () => {
+    const marker = attachmentsMarker("acme");
+    const { run, calls } = fakeRunner({
+      gh: (args) => {
+        if (args[1]?.includes("/comments?per_page=100")) {
+          return JSON.stringify([
+            { id: 1, body: `${ATTACHMENTS_MARKER}\nsomeone else's legacy comment` },
+            { id: 2, body: `${marker}\nours` },
+          ]);
+        }
+        return JSON.stringify({ id: 2 });
+      },
+    });
+    const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
+    expect(result.created).toBe(false);
+    const patch = calls[1];
+    expect(patch.args).toContain("repos/o/r/issues/comments/2");
+  });
+
+  it("adopts a legacy (unnamespaced) marker comment when no namespaced one exists yet", () => {
+    const marker = attachmentsMarker("acme");
+    const { run, calls } = fakeRunner({
+      gh: (args) => {
+        if (args[1]?.includes("/comments?per_page=100")) {
+          return JSON.stringify([{ id: 7, body: `${ATTACHMENTS_MARKER}\nold body` }]);
+        }
+        return JSON.stringify({ id: 7 });
+      },
+    });
+    // The namespaced marker is already the first line of the new body —
+    // patching the legacy comment with it migrates the comment in place.
+    const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
+    expect(result.created).toBe(false);
+    const patch = calls[1];
+    expect(patch.args).toContain("repos/o/r/issues/comments/7");
+    expect(patch.input).toContain(marker);
   });
 });
 

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -3,15 +3,23 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { attachmentsCommentBody } from "../src/github.js";
 
-const golden = JSON.parse(
-  readFileSync(
-    fileURLToPath(new URL("../../../test/fixtures/github-comment-golden.json", import.meta.url)),
-    "utf8",
-  ),
-) as { items: any[]; galleries: any[]; expected: string };
+function loadFixture(name: string) {
+  return JSON.parse(
+    readFileSync(fileURLToPath(new URL(`../../../test/fixtures/${name}`, import.meta.url)), "utf8"),
+  ) as { items: any[]; galleries: any[]; marker?: string; expected: string };
+}
+
+const golden = loadFixture("github-comment-golden.json");
+const goldenCap = loadFixture("github-comment-golden-cap.json");
 
 describe("attachmentsCommentBody (CLI copy)", () => {
   it("renders the golden body byte-for-byte", () => {
     expect(attachmentsCommentBody(golden.items, golden.galleries)).toBe(golden.expected);
+  });
+
+  it("caps inline images at 16, collapsing the rest into a details block", () => {
+    expect(attachmentsCommentBody(goldenCap.items, goldenCap.galleries, goldenCap.marker)).toBe(
+      goldenCap.expected,
+    );
   });
 });

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -438,6 +438,28 @@ uploads comment --pr 123
 uploads comment --issue 45 --repo buildinternet/uploads
 ```
 
+Past 16 inline images, the comment collapses the rest into a `<details>` link
+list so a heavily-screenshotted PR stays readable. Each workspace gets its own
+managed comment on a shared repo (namespaced under the hood) instead of
+clobbering another workspace's — use `uploads github link` (below) to see or
+set which workspace a repo is bound to.
+
+### Repo binding (`uploads github link`)
+
+The managed comment and webhook auto-promotion use a first-claim-wins binding
+between a repo and a workspace, normally created implicitly by your first
+`comment`/`put --comment`/promote call. Inspect or explicitly claim it:
+
+```bash
+uploads github link                       # claim the current repo for this workspace
+uploads github link --repo owner/name     # claim a specific repo
+uploads github link --status              # read-only: show the current binding, don't claim
+```
+
+Claiming an already-bound repo never steals it — the command reports the
+existing owner instead. On an older/self-hosted server without this route it
+fails with a clear "server does not support repo bindings yet" message.
+
 ### Embedding best practices
 
 - **Meaningful alt text**, always — it's what readers with images off and search see.

--- a/test/fixtures/github-comment-golden-cap.json
+++ b/test/fixtures/github-comment-golden-cap.json
@@ -1,0 +1,109 @@
+{
+  "items": [
+    {
+      "key": "gh/acme/web/pull/12/img01.png",
+      "url": "https://uploads.sh/f/img01.png",
+      "embedUrl": "https://embed.uploads.sh/f/img01.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img01.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img02.png",
+      "url": "https://uploads.sh/f/img02.png",
+      "embedUrl": "https://embed.uploads.sh/f/img02.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img02.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img03.png",
+      "url": "https://uploads.sh/f/img03.png",
+      "embedUrl": "https://embed.uploads.sh/f/img03.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img03.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img04.png",
+      "url": "https://uploads.sh/f/img04.png",
+      "embedUrl": "https://embed.uploads.sh/f/img04.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img04.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img05.png",
+      "url": "https://uploads.sh/f/img05.png",
+      "embedUrl": "https://embed.uploads.sh/f/img05.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img05.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img06.png",
+      "url": "https://uploads.sh/f/img06.png",
+      "embedUrl": "https://embed.uploads.sh/f/img06.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img06.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img07.png",
+      "url": "https://uploads.sh/f/img07.png",
+      "embedUrl": "https://embed.uploads.sh/f/img07.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img07.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img08.png",
+      "url": "https://uploads.sh/f/img08.png",
+      "embedUrl": "https://embed.uploads.sh/f/img08.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img08.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img09.png",
+      "url": "https://uploads.sh/f/img09.png",
+      "embedUrl": "https://embed.uploads.sh/f/img09.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img09.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img10.png",
+      "url": "https://uploads.sh/f/img10.png",
+      "embedUrl": "https://embed.uploads.sh/f/img10.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img10.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img11.png",
+      "url": "https://uploads.sh/f/img11.png",
+      "embedUrl": "https://embed.uploads.sh/f/img11.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img11.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img12.png",
+      "url": "https://uploads.sh/f/img12.png",
+      "embedUrl": "https://embed.uploads.sh/f/img12.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img12.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img13.png",
+      "url": "https://uploads.sh/f/img13.png",
+      "embedUrl": "https://embed.uploads.sh/f/img13.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img13.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img14.png",
+      "url": "https://uploads.sh/f/img14.png",
+      "embedUrl": "https://embed.uploads.sh/f/img14.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img14.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img15.png",
+      "url": "https://uploads.sh/f/img15.png",
+      "embedUrl": "https://embed.uploads.sh/f/img15.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img15.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img16.png",
+      "url": "https://uploads.sh/f/img16.png",
+      "embedUrl": "https://embed.uploads.sh/f/img16.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img16.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/img17.png",
+      "url": "https://uploads.sh/f/img17.png",
+      "embedUrl": "https://embed.uploads.sh/f/img17.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/img17.png"
+    }
+  ],
+  "galleries": [],
+  "marker": "<!-- uploads.sh:attachments ws=acme -->",
+  "expected": "<!-- uploads.sh:attachments ws=acme -->\n### 📎 Attachments\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img01.png\"><img width=\"400\" alt=\"img01.png\" src=\"https://embed.uploads.sh/f/img01.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img02.png\"><img width=\"400\" alt=\"img02.png\" src=\"https://embed.uploads.sh/f/img02.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img03.png\"><img width=\"400\" alt=\"img03.png\" src=\"https://embed.uploads.sh/f/img03.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img04.png\"><img width=\"400\" alt=\"img04.png\" src=\"https://embed.uploads.sh/f/img04.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img05.png\"><img width=\"400\" alt=\"img05.png\" src=\"https://embed.uploads.sh/f/img05.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img06.png\"><img width=\"400\" alt=\"img06.png\" src=\"https://embed.uploads.sh/f/img06.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img07.png\"><img width=\"400\" alt=\"img07.png\" src=\"https://embed.uploads.sh/f/img07.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img08.png\"><img width=\"400\" alt=\"img08.png\" src=\"https://embed.uploads.sh/f/img08.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img09.png\"><img width=\"400\" alt=\"img09.png\" src=\"https://embed.uploads.sh/f/img09.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img10.png\"><img width=\"400\" alt=\"img10.png\" src=\"https://embed.uploads.sh/f/img10.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img11.png\"><img width=\"400\" alt=\"img11.png\" src=\"https://embed.uploads.sh/f/img11.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img12.png\"><img width=\"400\" alt=\"img12.png\" src=\"https://embed.uploads.sh/f/img12.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img13.png\"><img width=\"400\" alt=\"img13.png\" src=\"https://embed.uploads.sh/f/img13.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img14.png\"><img width=\"400\" alt=\"img14.png\" src=\"https://embed.uploads.sh/f/img14.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img15.png\"><img width=\"400\" alt=\"img15.png\" src=\"https://embed.uploads.sh/f/img15.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/img16.png\"><img width=\"400\" alt=\"img16.png\" src=\"https://embed.uploads.sh/f/img16.png\"></a>\n\n<details><summary>1 more attachment</summary>\n\n- [img17.png](https://uploads.sh/f/acme/gh/acme/web/pull/12/img17.png)\n\n</details>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>"
+}


### PR DESCRIPTION
## Summary

Phase 4b: three related items in the GitHub comment renderer / CLI.

**1. Comment image cap.** `attachmentsCommentBody` (both the server copy in
`apps/api/src/github-comment-render.ts` and the CLI copy in
`packages/uploads/src/github.ts`) now embeds at most 16 attachments as inline
`<img>`s; the rest collapse into a `<details><summary>N more attachments</summary>…</details>`
block, each as the same link the full render would have used. Galleries keep
their existing 3-preview cap, unchanged. Golden fixture drift guard extended
with a second fixture (`test/fixtures/github-comment-golden-cap.json`, 17
images) exercised from both sides.

**2. Per-workspace markers.** New marker format
`<!-- uploads.sh:attachments ws=<workspace> -->` (workspace slug validated
against `[a-z0-9-]{1,64}`, falling back to the legacy shared marker on
anything else — never trusts an unsafe value into comment HTML). Upsert on
both the server (`upsertBotComment`) and the CLI `gh`-fallback path
(`upsertAttachmentsComment`) hunts for the namespaced marker first; if
absent, adopts a legacy (pre-4b) marker comment by patching it with the new
namespaced-marker body — migration happens automatically on the next sync,
no explicit migration step. Only creates a new comment when neither exists.
The server's KV comment-id cache key gained the workspace dimension
(`ghcomment:<workspace>:<repo>#<num>`); a cache entry written under the old
key format simply misses under the new key and re-hunts.

**3. `uploads github link`.** Explicit claim/inspect for the
workspace<->repo binding (`github_repo_links`, previously only claimed
implicitly via `/github/comment` / `/github/promote`):
- `GET /v1/:workspace/github/link?repo=owner/name` (files:read) — current
  binding or null.
- `POST /v1/:workspace/github/link` `{repo}` (files:write, rate-limited) —
  claims via the existing first-claim-wins `recordRepoLink`; if the repo is
  already bound to a *different* workspace, reports `claimed: false` plus the
  actual owner rather than lying about success.
- CLI: `uploads github link [--repo owner/name]` (repo defaults via the same
  `resolveRepo` order as `--pr`/`--issue` elsewhere) and
  `uploads github link --status` for a read-only check. A 404 (older/
  self-hosted server without this route) surfaces a clear
  "server does not support repo bindings yet" message instead of a raw HTTP
  error.

## Test plan

- [x] `pnpm test` (full root run, including the golden drift guard) — 157
      files / 1922 tests passing
- [x] `pnpm --filter @buildinternet/uploads build` — clean
- [x] `apps/api` typecheck (`wrangler types && tsc --noEmit`) — clean
- [x] `oxlint` / `oxfmt` via the repo's pre-commit hook — clean (only
      pre-existing, unrelated warnings)
- [x] New/updated tests: renderer cap (both copies via golden fixtures),
      namespaced-marker-first hunting, legacy-marker adoption/migration,
      cache-key namespacing, `/github/link` route (claim, already-bound-by-
      another-workspace, validation, auth), `uploads github link` CLI
      command output paths
