### PR TITLE
docs(readme): pre-PR branch staging and promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ npx @buildinternet/uploads attach ./before.png ./after.png
 `attach` detects the GitHub repository and current PR through `gh`, uploads
 all files, and creates or updates one managed attachments comment.
 
+No PR yet? Stage files against the branch while you work — `uploads attach
+./shot.png --branch` — and they are promoted into the PR's attachments
+automatically when one opens: instantly if the
+[GitHub App](https://uploads.sh/docs/github-app) is installed, otherwise on
+your first `uploads attach` (or `uploads attach --promote`) after the PR
+exists.
+
 An uploads.sh administrator invites your email to a workspace; `uploads login`
 opens a browser to sign in (GitHub or a magic link) and saves the resulting
 workspace token — see [enrollment](docs/enrollment.md). Hosted files are

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -83,6 +83,17 @@ infers the pull request for the current branch via `gh`, uploads stable URLs, an
 or updates one marker-owned GitHub comment. It keeps loose `gh/...` attachments and linked public galleries in distinct sections, shows up to three available gallery images inline, and updates that same comment in place on every sync. Use `--pr`, `--issue`, and `--repo` to select
 the target explicitly, or `--no-comment` to upload without changing GitHub comments.
 
+**Branch staging (pre-PR):** `attach <files> --branch [name]` (also on
+`screenshot`) stages files against a git branch before any PR exists — the
+working mode for coding agents capturing as they go. Staged files live under
+`gh/<owner>/<repo>/branch/<branch>/…` and are promoted into the PR's
+attachments when one opens: automatically via the
+[GitHub App](https://uploads.sh/docs/github-app) webhook, or on the first
+`attach` after the PR exists (`--promote` forces it with no new files,
+`--no-promote` opts out). `uploads github link` inspects or claims the
+workspace↔repo binding the webhook path uses. Promoted staging is cleaned up
+server-side after ~7 days (~30 for branches that never got a PR).
+
 **Screenshot capture:** `uploads screenshot <url|file.html>` renders a page to a
 hosted image in one step — no separate browser tooling needed. `--via auto`
 (default) drives a Chrome/Chromium already on the machine (`playwright-core`


### PR DESCRIPTION
Documents the new branch-staging flow (shipped in #309-#315, CLI 0.15.0) in the root and CLI READMEs: stage with `attach --branch` before a PR exists, automatic promotion on PR open (App webhook) or first post-PR attach, `--promote`/`--no-promote`, `uploads github link`, and staging cleanup timing.

This PR is also the live smoke test of the webhook path: a screenshot of the docs page was staged against this branch before opening the PR, and no CLI comment/attach command has been run against the PR itself — if the uploads-sh[bot] attachments comment appears below, the pull_request webhook promoted it end-to-end on its own.
