### PR TITLE
fix(cli): guard attach --branch against filename lookahead

### DIFF
--- a/.changeset/attach-branch-filename-guard.md
+++ b/.changeset/attach-branch-filename-guard.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads attach --branch <name>` now rejects a value that looks like a file
+(an existing path on disk, or a name with a media/document extension like
+`.png`/`.pdf`) instead of silently swallowing it as the branch name. Fixes
+`uploads attach --branch shot.png` staging under a branch literally named
+"shot.png" — use `uploads attach shot.png --branch` (auto-detect the current
+branch) or `uploads attach --branch <name> shot.png` instead. Ordinary dotted
+branch names like `v1.2` or `release/1.2` are unaffected.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, extname } from "node:path";
 import { mapBounded } from "./async.js";
 import {
   createUploadsClient,
@@ -205,11 +205,53 @@ export function ghTargetFromFlags(
 }
 
 /**
+ * Extensions that mark a `--branch` value as almost certainly a filename that
+ * got swallowed by the optional-value lookahead (e.g. `--branch shot.png`
+ * with no other file args). Branch names legitimately contain dots (e.g.
+ * `release/1.2`, `v1.2.3`), so this only matches known media/document
+ * extensions, never bare dotted segments.
+ */
+const BRANCH_LIKE_FILE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".svg",
+  ".ico",
+  ".tif",
+  ".tiff",
+  ".heic",
+  ".avif",
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".webm",
+  ".mkv",
+  ".pdf",
+]);
+
+/**
+ * True when `value` looks like a filename that was mistakenly consumed as the
+ * `--branch` value: it names a file that exists on disk, or its extension is
+ * a known media/document type. Ordinary branch names (including dotted ones
+ * like `v1.2` or `release/1.2`) never match either check.
+ */
+function looksLikeFileNotBranch(value: string): boolean {
+  if (existsSync(value)) return true;
+  return BRANCH_LIKE_FILE_EXTENSIONS.has(extname(value).toLowerCase());
+}
+
+/**
  * Reads `--branch [name]` — an optional-value flag: `--branch` alone resolves
  * the current git branch (`resolveCurrentBranch`); `--branch feature/x` uses
  * the given name verbatim. Returns undefined when the flag is absent at all
  * (distinct from an empty/whitespace value, which is rejected). Throws
- * UsageError if `--branch` is given more than once.
+ * UsageError if `--branch` is given more than once, or if the value looks
+ * like a filename accidentally swallowed by the optional-value lookahead
+ * (e.g. `uploads attach --branch shot.png` with no other file args) — see
+ * `looksLikeFileNotBranch`.
  */
 export function branchFromFlags(
   flags: CommandFlags["flags"],
@@ -219,7 +261,16 @@ export function branchFromFlags(
   const raw = flags.get("--branch");
   if (Array.isArray(raw)) throw new UsageError("--branch may only be given once");
   if (raw === true) return resolveCurrentBranch(run);
-  if (typeof raw === "string" && raw.trim().length > 0) return raw;
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    if (looksLikeFileNotBranch(raw)) {
+      throw new UsageError(
+        `"${raw}" looks like a file, not a branch name — did you mean ` +
+          `"uploads attach ${raw} --branch" (auto-detect the current branch), ` +
+          `or "uploads attach --branch <name> ${raw}" (explicit branch name)?`,
+      );
+    }
+    return raw;
+  }
   throw new UsageError("--branch requires a non-empty branch name");
 }
 
@@ -995,12 +1046,17 @@ export async function runAttach(
     return runAttachPromoteOnly(ctx, parsed, run);
   }
 
+  // Validate --branch (including the filename-lookahead guard) before the
+  // zero-positionals bailout below — otherwise `uploads attach --branch
+  // shot.png` (where shot.png is swallowed as the branch value, leaving no
+  // file args) would silently print help instead of a clear UsageError.
+  const branchArg = branchFromFlags(parsed.flags, run);
+
   if (parsed.positionals.length === 0) {
     writeCommandHelp(ATTACH_HELP);
     return 2;
   }
 
-  const branchArg = branchFromFlags(parsed.flags, run);
   if (branchArg !== undefined) {
     if (parsed.flags.has("--pr")) throw new UsageError("--branch cannot be combined with --pr");
     if (parsed.flags.has("--issue"))

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -478,6 +478,45 @@ describe("runAttach --branch (branch-staged, pre-PR)", () => {
       ),
     ).rejects.toThrow(UsageError);
   });
+
+  describe("--branch filename guard (issue #319)", () => {
+    it("rejects --branch <path> when the value names a file that exists on disk", async () => {
+      const { client } = fakeClient();
+      const { run } = branchRunner();
+      const [existingFile] = files("shot.png");
+      await expect(
+        runAttach(ctxWith(client), ["--branch", existingFile, "--repo", "o/r"], false, run),
+      ).rejects.toThrow(UsageError);
+    });
+
+    it("rejects --branch <name> with a media extension even when the file doesn't exist", async () => {
+      const { client } = fakeClient();
+      const { run } = branchRunner();
+      await expect(
+        runAttach(
+          ctxWith(client),
+          ["--branch", "definitely-not-a-real-file.png", "--repo", "o/r"],
+          false,
+          run,
+        ),
+      ).rejects.toThrow(UsageError);
+    });
+
+    it.each(["v1.2", "v1.2.3", "release/1.2", "feature/thing"])(
+      "accepts a normal branch name %s (dots allowed)",
+      async (branchName) => {
+        const { client, puts } = fakeClient();
+        const { run } = branchRunner(branchName);
+        await runAttach(
+          ctxWith(client),
+          [...files("shot.png"), "--branch", branchName, "--repo", "o/r"],
+          false,
+          run,
+        );
+        expect(puts.length).toBe(1);
+      },
+    );
+  });
 });
 
 describe("runAttach gh.title metadata (issue #267)", () => {


### PR DESCRIPTION
Fixes #319

## Problem

`uploads attach --branch shot.png` (with no other file args) silently parsed
`shot.png` as the branch's optional value — the standard `--flag value`
lookahead in `parseCommandArgs` — leaving zero positional file args. That
either printed help (confusing "did nothing" UX) or, if another file arg was
present, staged the real file under a branch literally named `shot.png`.

## Fix

`branchFromFlags` in `packages/uploads/src/commands.ts` now rejects a
`--branch` value when it looks like a filename rather than a branch name:

- the value names a file that **exists on disk**, or
- the value's extension matches a known media/document type (`.png`, `.jpg`,
  `.jpeg`, `.gif`, `.webp`, `.bmp`, `.svg`, `.ico`, `.tif`, `.tiff`, `.heic`,
  `.avif`, `.mp4`, `.mov`, `.avi`, `.webm`, `.mkv`, `.pdf`).

Either case now throws a `UsageError` suggesting the two correct forms:
- `uploads attach shot.png --branch` (auto-detect the current git branch), or
- `uploads attach --branch <name> shot.png` (explicit branch name + file).

`runAttach` was reordered so this validation runs *before* the existing
"zero positionals → print help" bailout — otherwise the exact bug scenario
(file swallowed as the branch value, leaving no positionals) would still
short-circuit to help instead of the new error.

**Stays allowed:** ordinary branch names, including dotted ones like
`v1.2`, `v1.2.3`, and `release/1.2` — neither check (file-exists,
media-extension) matches them.

## Tests

Added to `packages/uploads/test/commands-attach.test.ts` under a new
`--branch filename guard (issue #319)` describe block:
- rejects `--branch <path>` when the path exists on disk
- rejects `--branch name.png` (media extension) even when the file doesn't exist
- accepts normal branch names `v1.2`, `v1.2.3`, `release/1.2`, `feature/thing`

Also added a `.changeset/attach-branch-filename-guard.md` patch changeset for
`@buildinternet/uploads`.

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test -- commands-attach` — 594 tests passed
- [x] `pnpm --filter @buildinternet/uploads exec tsc --noEmit -p .` — clean
- [x] pre-commit hooks (wrangler types regen + lint-staged oxlint/oxfmt) passed
