### PR TITLE
docs(skills): make stage-as-you-go the default branch-staging loop

### DIFF
--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -52,10 +52,40 @@ optimizer only rewrites still images (PNG/JPEG → WebP).
 
 ## Step 2 — Host and embed
 
-For the common case — files attached to the current branch's PR — use
-`uploads attach`. It infers the PR, uploads under stable keys in parallel, and
-maintains a single managed "attachments" comment. Multi-file runs keep going if
-one path fails (`failures` in `--json`; exit `1` when any failed):
+**Default loop: stage as you go, from the first visual milestone.** Don't wait
+for a PR to exist. The moment you have something worth capturing — mid-task,
+still on a branch, no PR yet — attach it right then with `uploads attach
+--branch`:
+
+```bash
+uploads attach ./step1-before.png --branch
+uploads attach ./step2-after.png --branch      # later in the same task, same branch
+```
+
+This uploads under stable, branch-keyed paths (no PR/issue target needed, no
+comment yet — there's nothing to comment on until a PR exists). Keep doing
+this at each meaningful visual milestone as you work; don't batch everything
+into one attach at the end.
+
+**The PR comment assembles itself — you don't drive that step.** Once the PR
+opens (whether via `gh pr create` or the GitHub UI), every branch-staged file
+gets promoted into that PR's attachments and the managed "📎 Attachments"
+comment is created automatically:
+
+- **With the uploads-sh GitHub App installed** on the repo, a webhook does
+  this the moment the PR opens, reopens, or gets a new commit — no CLI call
+  required at all.
+- **Without the App**, the next `uploads attach` you run against that PR
+  triggers the same promotion + comment refresh as a side effect. If you have
+  nothing new to add right after opening the PR, run `uploads attach
+--promote` (zero file arguments) to promote and refresh explicitly — it
+  exits `0` even if nothing was staged. Skip auto-promotion on a given call
+  with `--no-promote`.
+
+**"PR already exists" is just the simple case of the same command** — same
+`uploads attach`, just pointed at a PR/issue number instead of a branch, and
+the comment updates immediately since there's already something to comment
+on:
 
 ```bash
 uploads attach ./before.png ./after.png
@@ -79,19 +109,23 @@ uploads put ./demo.gif --format url
 Always embed the returned **markdown** (or `embedUrl`) in GitHub — it uses the
 no-cache host so overwrites propagate. Don't hand-build storage URLs.
 
-**Capturing before the PR exists?** (e.g. mid-task on a branch, no PR yet)
-stage with `uploads attach --branch` instead — same upload path, but keyed to
-the branch rather than a PR/issue number:
+**Bot comment not showing up?** The managed comment needs a repo↔workspace
+binding (normally created implicitly by the first comment/promote call, or by
+installing the GitHub App). If a comment you expected doesn't appear, check
+the binding first:
 
 ```bash
-uploads attach ./shot.png --branch
+uploads github link --status
 ```
 
-Once you open the PR (`gh pr create`), the next `uploads attach` to it
-auto-promotes those staged files into the PR's attachments (and refreshes the
-comment) — no extra step needed. If that first attach has no new file to add,
-run `uploads attach --promote` instead to promote and refresh without
-uploading anything.
+That's read-only and shows the current binding (or that the repo is
+unbound) without claiming anything.
+
+**Curate, don't dump.** The comment inlines up to **16 images**; anything past
+that collapses into a `<details>` overflow list. Name and pick shots
+meaningfully (`before.png`/`after.png`, not `capture-1`..`capture-40`) rather
+than attaching every incidental screenshot from a long session — a curated
+handful of milestones reads better than a dumped folder.
 
 ## Step 3 — Embed well
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -41,19 +41,32 @@ uploads attach ./shot.png --issue 45 --repo buildinternet/uploads
 Pass `--no-comment` when only stable URLs are wanted. Use `put` for lower-level
 naming and output control.
 
-**No PR yet?** `uploads attach ./shot.png --branch [name]` stages files under
-`gh/<owner>/<repo>/branch/<branch>/<filename>` instead of a PR/issue number —
-same upload path, no target flags, no comment (there's nothing to comment on
-yet). With no value, `--branch` resolves the current git branch; `/` in the
-name sanitizes to `-`. Once a PR opens for that branch, the next
-`uploads attach` targeting it **auto-promotes** those staged files into the
-PR's attachment prefix before the comment refresh — no extra step. If that
-first attach has nothing new to upload, run `uploads attach --promote`
-(zero file arguments) to promote and refresh the comment on its own; it
-exits `0` even when nothing was staged. Skip auto-promotion with
-`--no-promote`. Promotion only applies to PRs, never issues, and both paths
-degrade silently (no error) if the workspace's server doesn't support
-promotion yet.
+**Stage as you go, before a PR exists.** `uploads attach ./shot.png --branch
+[name]` stages files under `gh/<owner>/<repo>/branch/<branch>/<filename>`
+instead of a PR/issue number — same upload path, no target flags, no comment
+(there's nothing to comment on yet). With no value, `--branch` resolves the
+current git branch; `/` in the name sanitizes to `-`. Attach this way at every
+visual milestone during the work, not just once at the end.
+
+Getting those files into the PR's attachments comment needs no extra step
+once a PR exists for that branch:
+
+- **GitHub App installed** on the repo: a webhook auto-promotes staged files
+  into the PR's attachment prefix and creates/updates the managed comment the
+  moment the PR opens, reopens, or gets a new commit.
+- **No GitHub App**: the next `uploads attach` targeting that PR
+  **auto-promotes** those staged files into the PR's attachment prefix before
+  the comment refresh. If that first attach has nothing new to upload, run
+  `uploads attach --promote` (zero file arguments) to promote and refresh the
+  comment on its own; it exits `0` even when nothing was staged. Skip
+  auto-promotion on a given call with `--no-promote`.
+
+Promotion only applies to PRs, never issues, and both paths degrade silently
+(no error) if the workspace's server doesn't support promotion yet.
+
+**Comment missing?** Check the repo↔workspace binding first —
+`uploads github link --status` (read-only, shows the binding without
+claiming it). See "Repo binding" below.
 
 The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites


### PR DESCRIPTION
## Summary

Branch staging (`uploads attach --branch`, webhook promotion into the PR bot comment) shipped in #309–#316 and is live, but both agent skills still framed it as an aside ("Capturing before the PR exists?"). This makes stage-as-you-go the default loop the skills teach, with the "PR already exists" path as the simple case rather than the default framing.

- **`skills/github-screenshots/SKILL.md`**: Step 2 now opens with "stage as you go" — attach at every visual milestone during work, before a PR exists. Explains that the comment assembles itself once the PR opens (webhook if the GitHub App is installed, or the next `uploads attach`/`uploads attach --promote` if not) — the agent doesn't drive that step. The "PR already exists" flow is now presented as the same command, just simpler.
- **`skills/uploads-cli/SKILL.md`**: same reframing applied to its branch-staging section, verified against the actual CLI flag semantics in `packages/uploads/src/commands.ts` (`--branch`, `--promote`, `--no-promote`, mutual-exclusion rules, exit-0-when-nothing-staged behavior).
- Documented the **16-image inline cap** on the managed comment and the `<details>` overflow — advise curating/naming shots meaningfully instead of dumping many captures.
- Documented **`uploads github link --status`** as the first check when the bot comment doesn't show up (read-only binding check, doesn't claim).
- No changes needed for `--no-promote` behavior beyond documenting it accurately — flag semantics were verified against `runAttach`/`attemptPromoteBranch` in `packages/uploads/src/commands.ts` rather than assumed.

## Bundled-copy sweep (Claude plugin marketplace, #225)

Checked `.claude-plugin/marketplace.json` and `plugins/claude/uploads/` — the plugin's `skills` array points directly at `./skills/github-screenshots` and `./skills/uploads-cli` (the same files edited here). **No duplicated copies found** — nothing to sync, the plugin always ships the current skill source.

## #189 skills-split debt — what's fixed here vs. still owed

Within this repo: no lingering live references to the retired external `buildinternet/skills` repo. The only hits are two historical dated planning docs (`docs/superpowers/plans/2026-07-15-github-screenshots-skill.md`, `docs/superpowers/specs/2026-07-15-github-screenshots-skill-design.md`) that describe the migration itself as a record of what happened — left as-is since they're archived history, not live documentation.

**Still owed (follow-up, out of scope for this repo):**
- [ ] Tombstone the retired `buildinternet/skills` repo (or at least the `github-screenshots` path within it) pointing at `buildinternet/uploads`.
- [ ] Sweep other buildinternet repos' `CLAUDE.md` for references to the old external skill location and update them to `uploads install` / this repo's `skills/*`.

Fixes #320
