### PR TITLE
feat(api,cli): check GitHub App webhook event subscriptions

### DIFF
--- a/.changeset/doctor-github-webhook-events.md
+++ b/.changeset/doctor-github-webhook-events.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads github doctor` to check whether the GitHub App is subscribed to the webhook events uploads.sh needs (`issues`, `pull_request`). A missing subscription previously failed silently — the App's ping stayed green while webhook auto-promotion and title-cache invalidation quietly did nothing.

--- a/apps/api/src/github-app.test.ts
+++ b/apps/api/src/github-app.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { appJwt, githubAppConfig, installationForRepo, installationToken } from "./github-app";
+import {
+  appEventSubscriptions,
+  appJwt,
+  githubAppConfig,
+  installationForRepo,
+  installationToken,
+} from "./github-app";
 import { FakeKv } from "../test/fake-kv";
 
 /** Generate a throwaway RSA key and return its PKCS#8 PEM + public CryptoKey. */
@@ -66,6 +72,36 @@ describe("appJwt", () => {
       new TextEncoder().encode(`${h}.${p}`),
     );
     expect(ok).toBe(true);
+  });
+});
+
+describe("appEventSubscriptions", () => {
+  it("returns the App's subscribed events from GET /app", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe("https://api.github.com/app");
+      return new Response(JSON.stringify({ events: ["ping", "issues", "pull_request"] }), {
+        status: 200,
+      });
+    }) as typeof fetch;
+    expect(await appEventSubscriptions(cfgWith(pem), fetchImpl)).toEqual([
+      "ping",
+      "issues",
+      "pull_request",
+    ]);
+  });
+
+  it("returns null on a non-ok response", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async () => new Response("", { status: 401 })) as typeof fetch;
+    expect(await appEventSubscriptions(cfgWith(pem), fetchImpl)).toBeNull();
+  });
+
+  it("returns null when events is missing or malformed", async () => {
+    const { pem } = await testKeyPair();
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({}), { status: 200 })) as typeof fetch;
+    expect(await appEventSubscriptions(cfgWith(pem), fetchImpl)).toBeNull();
   });
 });
 

--- a/apps/api/src/github-app.ts
+++ b/apps/api/src/github-app.ts
@@ -82,6 +82,41 @@ export function githubFetch(
 }
 
 /**
+ * Webhook event types this worker's handler actually reads (see
+ * `handleWebhook` in ./github-webhook.ts): `issues`/`pull_request` drive
+ * auto-promotion and title-cache invalidation. These are NOT sent unless the
+ * App owner ticks them under Settings → Permissions & events → Subscribe to
+ * events — unlike `installation`/`installation_repositories`/`ping`, which
+ * GitHub always sends regardless of subscription. Issue #293's follow-up:
+ * the App shipped with ping green but these two unsubscribed, silently
+ * breaking both features.
+ */
+export const REQUIRED_WEBHOOK_EVENTS = ["issues", "pull_request"] as const;
+
+/**
+ * The App's subscribed webhook events, straight from `GET /app` (App-JWT
+ * auth, not installation-token — this is app-level metadata, no installation
+ * needed). Returns null on any failure so callers degrade the same way the
+ * rest of this module does: "unknown" is never reported as "broken".
+ */
+export async function appEventSubscriptions(
+  cfg: GithubAppConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string[] | null> {
+  try {
+    const res = await githubFetch(fetchImpl, "https://api.github.com/app", {
+      headers: githubHeaders(await appJwt(cfg)),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { events?: unknown };
+    if (!Array.isArray(body.events)) return null;
+    return body.events.filter((e): e is string => typeof e === "string");
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Installation id for `repo` ("owner/name"), or null when the App is not
  * installed there. 404 (not installed) is cached as "none"; transient
  * failures are not cached.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import { githubWebhook } from "./routes/github-webhook";
 import { githubComment } from "./routes/github-comment";
 import { githubPromote } from "./routes/github-promote";
 import { githubLink } from "./routes/github-link";
+import { githubHealth } from "./routes/github-health";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -137,6 +138,9 @@ export const app = new Hono<WorkspaceVars>()
   // Phase 4b: explicit claim/inspect for the workspace<->repo binding (see
   // github-repo-links.ts) — same base path, distinct sub-route "/link".
   .route("/v1/:workspace/github", githubLink)
+  // Issue #293 follow-up: App-level webhook event subscription check, same
+  // base path, distinct sub-route "/health".
+  .route("/v1/:workspace/github", githubHealth)
   .onError((err, c) => respondError(c, err))
   .notFound((c) => respondError(c, new NotFoundError()));
 

--- a/apps/api/src/routes/github-health-route.test.ts
+++ b/apps/api/src/routes/github-health-route.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { app } from "../index";
+import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import { GITHUB_APP_CFG_ENV } from "../../test/github-app-env";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+// Same node-vs-workerd Web Crypto gap as github-link-route.test.ts — this
+// suite exercises the real workspaceAuth middleware end to end.
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+const WS = "acme";
+const TOKEN = "up_acme_testtoken";
+
+/** Generate a throwaway RSA key and return its PKCS#8 PEM (github-app.test.ts's helper). */
+async function testKeyPem(): Promise<string> {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer;
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
+}
+
+async function seededEnv(extraEnv: Record<string, unknown> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: `${WS}/`,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex(TOKEN), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  return { REGISTRY: registry, DB: new UsageFakeD1(), ...extraEnv } as unknown as Env;
+}
+
+function getHealth(env: Env) {
+  return app.request(
+    `/v1/${WS}/github/health`,
+    { headers: { authorization: `Bearer ${TOKEN}` } },
+    env,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GET /v1/:workspace/github/health", () => {
+  it("reports not configured when GitHub App env is unset", async () => {
+    const env = await seededEnv();
+    const res = await getHealth(env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ configured: false, ok: false });
+  });
+
+  it("reports ok when subscribed to all required events", async () => {
+    const pem = await testKeyPem();
+    const env = await seededEnv({ ...GITHUB_APP_CFG_ENV, GITHUB_APP_PRIVATE_KEY: pem });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ events: ["ping", "issues", "pull_request"] }), {
+            status: 200,
+          }),
+      ),
+    );
+    const res = await getHealth(env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      configured: true,
+      ok: true,
+      missingEvents: [],
+      requiredEvents: ["issues", "pull_request"],
+    });
+  });
+
+  it("reports missing events when the App isn't subscribed", async () => {
+    const pem = await testKeyPem();
+    const env = await seededEnv({ ...GITHUB_APP_CFG_ENV, GITHUB_APP_PRIVATE_KEY: pem });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ events: ["ping"] }), { status: 200 })),
+    );
+    const res = await getHealth(env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; missingEvents: string[]; hint?: string };
+    expect(body.ok).toBe(false);
+    expect(body.missingEvents).toEqual(["issues", "pull_request"]);
+    expect(body.hint).toContain("issues, pull_request");
+  });
+
+  it("reports the check as failed when GET /app fails", async () => {
+    const pem = await testKeyPem();
+    const env = await seededEnv({ ...GITHUB_APP_CFG_ENV, GITHUB_APP_PRIVATE_KEY: pem });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 500 })),
+    );
+    const res = await getHealth(env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ configured: true, ok: false, events: null });
+  });
+
+  it("401s with no bearer token", async () => {
+    const env = await seededEnv();
+    const res = await app.request(`/v1/${WS}/github/health`, {}, env);
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/github-health.ts
+++ b/apps/api/src/routes/github-health.ts
@@ -1,0 +1,69 @@
+/**
+ * `/v1/:workspace/github/health` — GitHub App configuration + webhook event
+ * subscription check (issue #293 follow-up). Doctor-style diagnostic: the
+ * App can have a green ping (URL + secret configured, `installation` events
+ * flowing) while `issues`/`pull_request` are unticked under Settings →
+ * Permissions & events → Subscribe to events, which silently disables
+ * webhook auto-promotion and title-cache invalidation with no error anyone
+ * sees. This surfaces that gap instead of requiring someone to notice via
+ * `GET /app/hook/deliveries`.
+ */
+import { Hono } from "hono";
+import { appEventSubscriptions, githubAppConfig, REQUIRED_WEBHOOK_EVENTS } from "../github-app";
+import { requireScope, type WorkspaceVars } from "../workspace";
+
+export interface GithubHealthResult {
+  /** false when GITHUB_APP_ID/PRIVATE_KEY/HOME_INSTALLATION_ID aren't all set — the whole integration is off. */
+  configured: boolean;
+  /** true only when configured AND every required event is subscribed. */
+  ok: boolean;
+  /** The App's subscribed webhook events from `GET /app`, or null if that call failed/is unknown. */
+  events: string[] | null;
+  /** Events uploads.sh's webhook handler needs but the App isn't subscribed to. Empty when ok. */
+  missingEvents: string[];
+  requiredEvents: readonly string[];
+  hint?: string;
+}
+
+export const githubHealth = new Hono<WorkspaceVars>().get(
+  "/health",
+  requireScope("files:read"),
+  async (c) => {
+    const cfg = githubAppConfig(c.env);
+    if (!cfg) {
+      return c.json<GithubHealthResult>({
+        configured: false,
+        ok: false,
+        events: null,
+        missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
+        requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+        hint: "GitHub App is not configured on this worker (GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY/GITHUB_APP_HOME_INSTALLATION_ID)",
+      });
+    }
+
+    const events = await appEventSubscriptions(cfg);
+    if (events === null) {
+      return c.json<GithubHealthResult>({
+        configured: true,
+        ok: false,
+        events: null,
+        missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
+        requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+        hint: "could not reach GET /app to read subscribed webhook events — try again shortly",
+      });
+    }
+
+    const missingEvents = REQUIRED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
+    return c.json<GithubHealthResult>({
+      configured: true,
+      ok: missingEvents.length === 0,
+      events,
+      missingEvents,
+      requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+      hint:
+        missingEvents.length > 0
+          ? `subscribe to ${missingEvents.join(", ")} at github.com/settings/apps/<your-app> → Permissions & events → Subscribe to events`
+          : undefined,
+    });
+  },
+);

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -135,6 +135,15 @@ const TOC = [
       until an org admin approves it. The CLI tells you when that's the case — it prints the
       exact approval link and falls back to posting via <code>gh</code> in the meantime.
     </p>
+    <p>
+      The App also needs to be <strong>subscribed to the <code>issues</code> and
+      <code>pull_request</code> webhook events</strong> (Settings → your App →
+      <em>Permissions &amp; events</em> → <em>Subscribe to events</em>). Without them the App's
+      ping still shows green — GitHub always sends <code>ping</code> and installation events
+      regardless of subscription — but webhook-driven title cache invalidation and branch-staged
+      attachment auto-promotion silently do nothing. Run <code>uploads github doctor</code> to
+      check: it calls the App API directly and reports any missing subscription.
+    </p>
   </section>
 
   <section id="without-it">

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -152,7 +152,10 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
   {
     name: "github",
     summary: "Claim/inspect this workspace's binding to a GitHub repo",
-    subcommands: [{ name: "link", summary: "Claim or inspect the repo binding" }],
+    subcommands: [
+      { name: "link", summary: "Claim or inspect the repo binding" },
+      { name: "doctor", summary: "Check the GitHub App's webhook event subscriptions" },
+    ],
   },
   {
     name: "list",

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -267,6 +267,16 @@ export interface HealthResult {
   ok: boolean;
 }
 
+/** `GET /v1/:workspace/github/health` result (issue #293 follow-up). */
+export interface GithubHealthResult {
+  configured: boolean;
+  ok: boolean;
+  events: string[] | null;
+  missingEvents: string[];
+  requiredEvents: string[];
+  hint?: string;
+}
+
 export interface UsageResult {
   workspace: string;
   bytes: number;
@@ -1042,6 +1052,18 @@ export function createUploadsClient(config: UploadsClientConfig) {
           body: new TextEncoder().encode(JSON.stringify({ repo })),
           headers: { "Content-Type": "application/json" },
         },
+      );
+    },
+
+    /**
+     * GitHub App configuration + webhook event subscription check. Throws
+     * `UploadsError` (status 404) on an older/self-hosted server without
+     * this route — callers treat that as "unknown", not "broken".
+     */
+    async githubHealth(): Promise<GithubHealthResult> {
+      return request<GithubHealthResult>(
+        "GET",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/health`,
       );
     },
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -4,6 +4,7 @@ import { mapBounded } from "./async.js";
 import {
   createUploadsClient,
   type GalleryItem,
+  type GithubHealthResult,
   type PromoteBranchAttachmentsResult,
   type PutResult,
   type UploadsClient,
@@ -2061,6 +2062,7 @@ export async function runComment(
 // --- github link ---
 
 const GITHUB_HELP = `uploads github link [--repo <owner/name>] [--status] [--workspace <name>]
+uploads github doctor [--workspace <name>]
 
 Claim or inspect this workspace's binding to a GitHub repo (see the managed
 attachments comment / webhook auto-promotion, which use this binding).
@@ -2072,11 +2074,35 @@ instead.
 the git remote). --status only inspects the current binding (files:read);
 without it, the command claims the repo (files:write).
 
+\`doctor\` checks the GitHub App itself: whether it's configured on the
+server, and whether it's subscribed to the webhook events uploads.sh's
+handler needs (issues, pull_request — see docs/github-app). A missing
+subscription is the classic silent failure: the App's ping stays green
+while webhook auto-promotion and title-cache invalidation quietly do
+nothing.
+
 Examples:
   uploads github link
   uploads github link --repo buildinternet/uploads
   uploads github link --status
+  uploads github doctor
 `;
+
+function formatGithubDoctor(result: GithubHealthResult): string {
+  if (!result.configured) {
+    return `github app: not configured on this server${result.hint ? ` — ${result.hint}` : ""}\n`;
+  }
+  if (result.events === null) {
+    return `github app: configured, but health check failed${result.hint ? ` — ${result.hint}` : ""}\n`;
+  }
+  if (result.ok) {
+    return `github app: ok — subscribed to ${result.requiredEvents.join(", ")}\n`;
+  }
+  return (
+    `github app: missing webhook event subscription(s): ${result.missingEvents.join(", ")}\n` +
+    (result.hint ? `  ${result.hint}\n` : "")
+  );
+}
 
 function formatGithubLink(
   repo: string,
@@ -2099,7 +2125,29 @@ export async function runGithub(
     writeCommandHelp(GITHUB_HELP);
     return help || parsed.help ? 0 : 2;
   }
-  if (action !== "link") throw new UsageError(`unknown github subcommand: ${action}`);
+  if (action !== "link" && action !== "doctor") {
+    throw new UsageError(`unknown github subcommand: ${action}`);
+  }
+
+  if (action === "doctor") {
+    let result: GithubHealthResult;
+    try {
+      result = await ctx.client.githubHealth();
+    } catch (err) {
+      if (err instanceof UploadsError && err.status === 404) {
+        throw new UsageError(
+          "server does not support the GitHub App health check yet (404) — upgrade the uploads.sh API/self-hosted worker",
+        );
+      }
+      throw err;
+    }
+    if (ctx.json) {
+      await writeJson(result);
+    } else {
+      await writeStdout(formatGithubDoctor(result));
+    }
+    return result.ok ? 0 : 1;
+  }
 
   const repo = resolveRepo(flagString(parsed.flags, "--repo"), run);
   const statusOnly = flagBool(parsed.flags, "--status");

--- a/packages/uploads/test/commands-github-doctor.test.ts
+++ b/packages/uploads/test/commands-github-doctor.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { UsageError } from "../src/cli-args.js";
+import { UploadsError } from "../src/errors.js";
+import type { GithubHealthResult, UploadsClient } from "../src/client.js";
+import { runGithub, type CliContext } from "../src/commands.js";
+
+function ctxWith(client: UploadsClient, json = false): CliContext {
+  return {
+    config: {
+      apiUrl: "https://x.test",
+      workspace: "acme",
+      token: "up_acme_x",
+      workspaceSource: "override",
+      configPath: "/tmp/uploads-test-config",
+      configExists: false,
+    },
+    client,
+    json,
+    quiet: true,
+  };
+}
+
+function clientWith(result: GithubHealthResult): UploadsClient {
+  return { githubHealth: async () => result } as unknown as UploadsClient;
+}
+
+describe("runGithub (doctor)", () => {
+  it("exits 0 and prints ok when subscribed to all required events", async () => {
+    const stdout: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => (stdout.push(String(chunk)), true));
+    try {
+      const code = await runGithub(
+        ctxWith(
+          clientWith({
+            configured: true,
+            ok: true,
+            events: ["ping", "issues", "pull_request"],
+            missingEvents: [],
+            requiredEvents: ["issues", "pull_request"],
+          }),
+        ),
+        ["doctor"],
+      );
+      expect(code).toBe(0);
+      expect(stdout.join("")).toContain("ok");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("exits 1 and reports missing events", async () => {
+    const stdout: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => (stdout.push(String(chunk)), true));
+    try {
+      const code = await runGithub(
+        ctxWith(
+          clientWith({
+            configured: true,
+            ok: false,
+            events: ["ping"],
+            missingEvents: ["issues", "pull_request"],
+            requiredEvents: ["issues", "pull_request"],
+            hint: "subscribe to issues, pull_request at github.com/settings/apps/…",
+          }),
+        ),
+        ["doctor"],
+      );
+      expect(code).toBe(1);
+      expect(stdout.join("")).toContain("issues, pull_request");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("exits 1 when the App isn't configured", async () => {
+    const code = await runGithub(
+      ctxWith(
+        clientWith({
+          configured: false,
+          ok: false,
+          events: null,
+          missingEvents: ["issues", "pull_request"],
+          requiredEvents: ["issues", "pull_request"],
+        }),
+      ),
+      ["doctor", "--json"],
+      false,
+    );
+    expect(code).toBe(1);
+  });
+
+  it("emits JSON with --json", async () => {
+    let written: unknown;
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      written = JSON.parse(String(chunk));
+      return true;
+    });
+    try {
+      const ctx = ctxWith(
+        clientWith({
+          configured: true,
+          ok: true,
+          events: ["issues", "pull_request"],
+          missingEvents: [],
+          requiredEvents: ["issues", "pull_request"],
+        }),
+        true,
+      );
+      const code = await runGithub(ctx, ["doctor"]);
+      expect(code).toBe(0);
+      expect(written).toMatchObject({ ok: true });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("degrades clearly on a 404 (older server without the health route)", async () => {
+    const client = {
+      githubHealth: async () => {
+        throw new UploadsError("not found", "NOT_FOUND", 404);
+      },
+    } as unknown as UploadsClient;
+    await expect(runGithub(ctxWith(client), ["doctor"])).rejects.toThrow(UsageError);
+  });
+});


### PR DESCRIPTION
## Summary
- The GitHub App can ship with a green ping while `issues`/`pull_request` are never ticked under Settings → Permissions & events → Subscribe to events — silently disabling webhook auto-promotion (#288) and title-cache invalidation, with nothing that surfaces the gap.
- Adds `GET /v1/:workspace/github/health`: uses the App JWT to call `GET /app` (which returns the App's subscribed `events`), and compares against the required list (`issues`, `pull_request` — the events `handleWebhook` actually reads).
- Adds `uploads github doctor`, a CLI check against that endpoint, reporting missing subscriptions and a pointer to Settings → Permissions & events → Subscribe to events.
- Documents the required subscription list on the GitHub App docs page (`apps/web/src/pages/docs/github-app.astro`, Permissions section).

## Where the check lives
- Server-side: `apps/api/src/github-app.ts` (`appEventSubscriptions`, `REQUIRED_WEBHOOK_EVENTS`), wired into `apps/api/src/routes/github-health.ts`, mounted at `/v1/:workspace/github/health` (same auth pattern as `/github/link`).
- CLI-side: `packages/uploads/src/client.ts` (`githubHealth()`), `packages/uploads/src/commands.ts` (`runGithub` gains a `doctor` subaction), `packages/uploads/src/cli-catalog.ts` (help catalog entry).

## Required events enforced
`issues`, `pull_request` — the two event types `handleWebhook` (`apps/api/src/github-webhook.ts`) reads for title invalidation and pull-request auto-promotion. (`installation`/`installation_repositories`/`ping` are always sent by GitHub regardless of subscription, so they're not part of the required list.)

## Test plan
- [x] `pnpm test` — 1945 tests pass across the monorepo (apps/api, packages/uploads, apps/web, apps/auth, apps/mcp, packages/errors/email/storage)
- [x] `pnpm run typecheck` — clean
- [x] New tests: `apps/api/src/github-app.test.ts` (`appEventSubscriptions` unit tests), `apps/api/src/routes/github-health-route.test.ts` (route: not-configured, ok, missing-events, upstream-failure, 401), `packages/uploads/test/commands-github-doctor.test.ts` (CLI: ok/missing/not-configured/--json/404-degrade)

Addresses the webhook-subscription follow-up on #293 (leaving the issue open — it also covers phases beyond this).
