### PR TITLE
feat: github repo link lifecycle — unlink, reassign, admin visibility

### DIFF
--- a/.changeset/github-link-lifecycle.md
+++ b/.changeset/github-link-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads github unlink` to release a workspace's GitHub repo binding (self-serve counterpart to `uploads github link`), and point `github link`'s already-bound-elsewhere output at the remedy.

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -123,3 +123,68 @@ export async function deleteRepoLink(db: D1Database, repo: string): Promise<void
     );
   }
 }
+
+/**
+ * Self-serve unlink (issue #318): removes `repo`'s binding only if it is
+ * currently owned by `workspaceName`. Unlike `deleteRepoLink` (used for
+ * best-effort cleanup of stale/tombstoned-workspace links), this throws on a
+ * D1 failure — the caller (routes/github-link.ts) needs to know whether the
+ * delete actually happened rather than silently reporting success.
+ * Returns true only if a row owned by `workspaceName` was deleted.
+ */
+export async function deleteRepoLinkForWorkspace(
+  db: D1Database,
+  repo: string,
+  workspaceName: string,
+): Promise<boolean> {
+  const result = await db
+    .prepare(`DELETE FROM github_repo_links WHERE repo_full_name = ? AND workspace_name = ?`)
+    .bind(normalizeRepo(repo), workspaceName)
+    .run();
+  return (result.meta.changes ?? 0) > 0;
+}
+
+/**
+ * All repos currently bound to `workspaceName` (admin visibility, issue
+ * #318) — surfaced in the admin panel so an operator can see what a
+ * workspace has claimed without querying D1 directly.
+ */
+export async function listRepoLinksForWorkspace(
+  db: D1Database,
+  workspaceName: string,
+): Promise<RepoLink[]> {
+  const { results } = await db
+    .prepare(`SELECT * FROM github_repo_links WHERE workspace_name = ? ORDER BY created_at DESC`)
+    .bind(workspaceName)
+    .all<RepoLinkRow>();
+  return (results ?? []).map(rowToLink);
+}
+
+/**
+ * Operator override (issue #318): forcibly (re)assigns `repo` to
+ * `workspaceName`, overwriting any existing owner — unlike `recordRepoLink`'s
+ * `INSERT OR IGNORE` first-claim-wins semantics. Used only from the
+ * admin-gated route; self-serve callers never get this power.
+ */
+export async function setRepoLink(
+  db: D1Database,
+  repo: string,
+  workspaceName: string,
+  source: string,
+  installationId: number | null = null,
+  now = new Date(),
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO github_repo_links
+         (repo_full_name, workspace_name, installation_id, source, created_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(repo_full_name) DO UPDATE SET
+         workspace_name = excluded.workspace_name,
+         installation_id = excluded.installation_id,
+         source = excluded.source,
+         created_at = excluded.created_at`,
+    )
+    .bind(normalizeRepo(repo), workspaceName, installationId, source, now.toISOString())
+    .run();
+}

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -103,6 +103,20 @@ export async function findRepoLink(db: D1Database, repo: string): Promise<RepoLi
 }
 
 /**
+ * Strict counterpart to `findRepoLink` for callers that must distinguish
+ * "no binding" from "D1 is unavailable" (self-serve/admin lookups, issue
+ * #318 CodeRabbit review) — a lookup failure here throws instead of being
+ * reported as an honest-looking `{unlinked: false, reason: "not_linked"}`.
+ */
+export async function findRepoLinkStrict(db: D1Database, repo: string): Promise<RepoLink | null> {
+  const row = await db
+    .prepare(`SELECT * FROM github_repo_links WHERE repo_full_name = ?`)
+    .bind(normalizeRepo(repo))
+    .first<RepoLinkRow>();
+  return row ? rowToLink(row) : null;
+}
+
+/**
  * Removes a stale link (e.g. its workspace was deleted/tombstoned). Never
  * throws — cleanup is best-effort; a failed delete just means the next
  * webhook delivery re-discovers the same stale state and retries the cleanup.
@@ -122,6 +136,21 @@ export async function deleteRepoLink(db: D1Database, repo: string): Promise<void
       }),
     );
   }
+}
+
+/**
+ * Strict counterpart to `deleteRepoLink` for the admin operator-override
+ * DELETE route (issue #318 CodeRabbit review) — that route must not report
+ * `unlinked: true` when the D1 delete actually failed, so this propagates
+ * failures instead of catching/logging them. Returns whether a row existed
+ * to delete (not just whether the statement ran).
+ */
+export async function deleteRepoLinkStrict(db: D1Database, repo: string): Promise<boolean> {
+  const result = await db
+    .prepare(`DELETE FROM github_repo_links WHERE repo_full_name = ?`)
+    .bind(normalizeRepo(repo))
+    .run();
+  return (result.meta.changes ?? 0) > 0;
 }
 
 /**

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -920,10 +920,19 @@ describe("POST /admin-ui/users/:userId/ban", () => {
 });
 
 describe("github repo link admin routes (issue #318)", () => {
-  function githubLinksEnv(user: typeof ADMIN_USER | null) {
+  /** `existingWorkspaces` seeds `ws:<name>` KV records so PUT's
+   * destination-workspace-exists check can pass. */
+  function githubLinksEnv(user: typeof ADMIN_USER | null, existingWorkspaces: string[] = []) {
     const db = new UsageFakeD1();
     const base = stubEnv(user, () => new Response(null, { status: 404 }));
-    const env = { ...base, DB: db } as unknown as Env;
+    const registry = {
+      ...(base.REGISTRY as object),
+      get: (async (key: string) =>
+        existingWorkspaces.some((ws) => key === `ws:${ws}`)
+          ? "{}"
+          : null) as unknown as KVNamespace["get"],
+    };
+    const env = { ...base, DB: db, REGISTRY: registry } as unknown as Env;
     return { env, db };
   }
 
@@ -960,7 +969,7 @@ describe("github repo link admin routes (issue #318)", () => {
 
   describe("PUT /admin-ui/github-links", () => {
     it("reassigns a repo to a different workspace, overwriting the prior owner", async () => {
-      const { env, db } = githubLinksEnv(ADMIN_USER);
+      const { env, db } = githubLinksEnv(ADMIN_USER, ["acme", "new-owner"]);
       db.repoLinks.set("acme/web", {
         repo_full_name: "acme/web",
         workspace_name: "acme",
@@ -988,7 +997,7 @@ describe("github repo link admin routes (issue #318)", () => {
     });
 
     it("400s on a malformed repo", async () => {
-      const { env } = githubLinksEnv(ADMIN_USER);
+      const { env } = githubLinksEnv(ADMIN_USER, ["acme"]);
       const res = await app().request(
         "/admin-ui/github-links",
         {
@@ -1001,8 +1010,24 @@ describe("github repo link admin routes (issue #318)", () => {
       expect(res.status).toBe(400);
     });
 
+    it("404s when the destination workspace doesn't exist (typo guard)", async () => {
+      const { env, db } = githubLinksEnv(ADMIN_USER, []);
+      const res = await app().request(
+        "/admin-ui/github-links",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ repo: "acme/web", workspace: "nonexistent-typo" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(404);
+      // Never created a binding to a workspace that doesn't exist.
+      expect(db.repoLinks.has("acme/web")).toBe(false);
+    });
+
     it("403s for a non-admin session", async () => {
-      const { env } = githubLinksEnv(NON_ADMIN_USER);
+      const { env } = githubLinksEnv(NON_ADMIN_USER, ["acme"]);
       const res = await app().request(
         "/admin-ui/github-links",
         {
@@ -1013,6 +1038,24 @@ describe("github repo link admin routes (issue #318)", () => {
         env,
       );
       expect(res.status).toBe(403);
+    });
+
+    it("429s when the destination workspace's write rate limit is exhausted", async () => {
+      const { env } = githubLinksEnv(ADMIN_USER, ["acme"]);
+      const limited = {
+        ...env,
+        WRITE_LIMITER: { limit: async () => ({ success: false }) },
+      } as unknown as Env;
+      const res = await app().request(
+        "/admin-ui/github-links",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ repo: "acme/web", workspace: "acme" }),
+        },
+        limited,
+      );
+      expect(res.status).toBe(429);
     });
   });
 
@@ -1034,6 +1077,66 @@ describe("github repo link admin routes (issue #318)", () => {
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchObject({ repo: "acme/web", unlinked: true });
       expect(db.repoLinks.has("acme/web")).toBe(false);
+    });
+
+    it("reports not_linked for an unclaimed repo instead of erroring", async () => {
+      const { env } = githubLinksEnv(ADMIN_USER);
+      const res = await app().request(
+        "/admin-ui/github-links?repo=acme%2Fweb",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        repo: "acme/web",
+        unlinked: false,
+        reason: "not_linked",
+      });
+    });
+
+    it("propagates a D1 read failure instead of reporting unlinked: true", async () => {
+      const { env } = githubLinksEnv(ADMIN_USER);
+      const failing = {
+        ...env,
+        DB: {
+          prepare: () => ({
+            bind: () => ({
+              first: async () => {
+                throw new Error("d1 unavailable");
+              },
+            }),
+          }),
+        },
+      } as unknown as Env;
+      const res = await app().request(
+        "/admin-ui/github-links?repo=acme%2Fweb",
+        { method: "DELETE" },
+        failing,
+      );
+      expect(res.status).toBeGreaterThanOrEqual(500);
+    });
+
+    it("429s when the owning workspace's write rate limit is exhausted", async () => {
+      const { env, db } = githubLinksEnv(ADMIN_USER);
+      db.repoLinks.set("acme/web", {
+        repo_full_name: "acme/web",
+        workspace_name: "acme",
+        installation_id: null,
+        source: "comment",
+        created_at: "2026-01-01T00:00:00.000Z",
+      });
+      const limited = {
+        ...env,
+        WRITE_LIMITER: { limit: async () => ({ success: false }) },
+      } as unknown as Env;
+      const res = await app().request(
+        "/admin-ui/github-links?repo=acme%2Fweb",
+        { method: "DELETE" },
+        limited,
+      );
+      expect(res.status).toBe(429);
+      // Rate-limited before the delete ran.
+      expect(db.repoLinks.has("acme/web")).toBe(true);
     });
 
     it("403s for a non-admin session", async () => {

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { respondError } from "../error-response";
 import { adminUi } from "./admin-ui";
 
@@ -915,5 +916,134 @@ describe("POST /admin-ui/users/:userId/ban", () => {
     ]);
     const body = (await res.json()) as { user: { banned: boolean } };
     expect(body.user.banned).toBe(false);
+  });
+});
+
+describe("github repo link admin routes (issue #318)", () => {
+  function githubLinksEnv(user: typeof ADMIN_USER | null) {
+    const db = new UsageFakeD1();
+    const base = stubEnv(user, () => new Response(null, { status: 404 }));
+    const env = { ...base, DB: db } as unknown as Env;
+    return { env, db };
+  }
+
+  describe("GET /workspaces/:name/github-links", () => {
+    it("lists only the bindings owned by this workspace", async () => {
+      const { env, db } = githubLinksEnv(ADMIN_USER);
+      db.repoLinks.set("acme/web", {
+        repo_full_name: "acme/web",
+        workspace_name: "acme",
+        installation_id: null,
+        source: "comment",
+        created_at: "2026-01-01T00:00:00.000Z",
+      });
+      db.repoLinks.set("other/repo", {
+        repo_full_name: "other/repo",
+        workspace_name: "someone-else",
+        installation_id: null,
+        source: "comment",
+        created_at: "2026-01-01T00:00:00.000Z",
+      });
+      const res = await app().request("/admin-ui/workspaces/acme/github-links", {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { workspace: string; links: { repo: string }[] };
+      expect(body.workspace).toBe("acme");
+      expect(body.links.map((l) => l.repo)).toEqual(["acme/web"]);
+    });
+
+    it("403s for a non-admin session", async () => {
+      const { env } = githubLinksEnv(NON_ADMIN_USER);
+      const res = await app().request("/admin-ui/workspaces/acme/github-links", {}, env);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("PUT /admin-ui/github-links", () => {
+    it("reassigns a repo to a different workspace, overwriting the prior owner", async () => {
+      const { env, db } = githubLinksEnv(ADMIN_USER);
+      db.repoLinks.set("acme/web", {
+        repo_full_name: "acme/web",
+        workspace_name: "acme",
+        installation_id: null,
+        source: "comment",
+        created_at: "2026-01-01T00:00:00.000Z",
+      });
+      const res = await app().request(
+        "/admin-ui/github-links",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ repo: "acme/web", workspace: "new-owner" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        repo: "acme/web",
+        workspace: "new-owner",
+        reassigned: true,
+      });
+      expect(db.repoLinks.get("acme/web")?.workspace_name).toBe("new-owner");
+      expect(db.repoLinks.get("acme/web")?.source).toBe("admin");
+    });
+
+    it("400s on a malformed repo", async () => {
+      const { env } = githubLinksEnv(ADMIN_USER);
+      const res = await app().request(
+        "/admin-ui/github-links",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ repo: "not-a-repo", workspace: "acme" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("403s for a non-admin session", async () => {
+      const { env } = githubLinksEnv(NON_ADMIN_USER);
+      const res = await app().request(
+        "/admin-ui/github-links",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ repo: "acme/web", workspace: "acme" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /admin-ui/github-links", () => {
+    it("removes any workspace's binding", async () => {
+      const { env, db } = githubLinksEnv(ADMIN_USER);
+      db.repoLinks.set("acme/web", {
+        repo_full_name: "acme/web",
+        workspace_name: "acme",
+        installation_id: null,
+        source: "comment",
+        created_at: "2026-01-01T00:00:00.000Z",
+      });
+      const res = await app().request(
+        "/admin-ui/github-links?repo=acme%2Fweb",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ repo: "acme/web", unlinked: true });
+      expect(db.repoLinks.has("acme/web")).toBe(false);
+    });
+
+    it("403s for a non-admin session", async () => {
+      const { env } = githubLinksEnv(NON_ADMIN_USER);
+      const res = await app().request(
+        "/admin-ui/github-links?repo=acme%2Fweb",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
   });
 });

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -21,6 +21,12 @@ import {
   revokeTokensForMintingUser,
   validateScopes,
 } from "../auth-db";
+import {
+  deleteRepoLink,
+  listRepoLinksForWorkspace,
+  setRepoLink,
+  type RepoLink,
+} from "../github-repo-links";
 import { allowWrite } from "../guards";
 import { deriveWebOrigin, inviteLinkUrl } from "../invite-links";
 import { membersForOrg, orgForWorkspace } from "../org-workspaces";
@@ -233,6 +239,32 @@ function githubCommentSettingsResponse(name: string, record: WorkspaceRecord) {
     settings: {
       githubCommentLinkToFilePage: record.githubCommentLinkToFilePage ?? null,
     },
+  };
+}
+
+// Same owner/name grammar + dot-only-segment guard as routes/github-link.ts's
+// parseRepo (issue #318 operator-override routes below).
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const DOTS_ONLY_RE = /^\.+$/;
+
+function parseRepoParam(repo: unknown): string {
+  if (
+    typeof repo !== "string" ||
+    !REPO_RE.test(repo) ||
+    repo.split("/").some((seg) => DOTS_ONLY_RE.test(seg))
+  ) {
+    throw new ValidationError("repo must be owner/name.", { code: "invalid_repo" });
+  }
+  return repo;
+}
+
+function repoLinkResponse(link: RepoLink) {
+  return {
+    repo: link.repo,
+    workspace: link.workspaceName,
+    source: link.source,
+    installationId: link.installationId,
+    createdAt: link.createdAt,
   };
 }
 
@@ -471,6 +503,50 @@ export const adminUi = new Hono<SessionVars>()
     }
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
     return c.json(githubCommentSettingsResponse(name, record));
+  })
+
+  // Admin visibility (issue #318): the repos this workspace has claimed in
+  // `github_repo_links`. Read-only — reassigning/removing a binding is the
+  // dedicated /github-links routes below, which act on the repo (any
+  // workspace), not scoped to one workspace's list.
+  .get("/workspaces/:name/github-links", async (c) => {
+    const name = c.req.param("name");
+    const links = await listRepoLinksForWorkspace(c.env.DB, name);
+    return c.json({ workspace: name, links: links.map(repoLinkResponse) });
+  })
+
+  // Operator override (issue #318): forcibly reassign a repo's binding to
+  // `workspace`, overwriting whichever workspace claimed it first. Unlike the
+  // self-serve `/v1/:workspace/github/link` POST (first-claim-wins), this
+  // never reports `claimed: false` — an admin's call always wins.
+  .put("/github-links", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new ValidationError("request body must be valid JSON", { code: "invalid_body" });
+    }
+    const { repo: rawRepo, workspace: rawWorkspace } = (body ?? {}) as {
+      repo?: unknown;
+      workspace?: unknown;
+    };
+    const repo = parseRepoParam(rawRepo);
+    if (typeof rawWorkspace !== "string" || !rawWorkspace.trim()) {
+      throw new ValidationError("workspace is required", { code: "invalid_workspace" });
+    }
+    const workspace = rawWorkspace.trim();
+    await setRepoLink(c.env.DB, repo, workspace, "admin");
+    return c.json({ repo, workspace, reassigned: true });
+  })
+
+  // Operator override (issue #318): remove any repo's binding outright
+  // (stuck/abandoned claim, no replacement owner). Unlike the self-serve
+  // DELETE (workspace-scoped, refuses non-owners), this always succeeds
+  // regardless of who owns the binding.
+  .delete("/github-links", async (c) => {
+    const repo = parseRepoParam(c.req.query("repo"));
+    await deleteRepoLink(c.env.DB, repo);
+    return c.json({ repo, unlinked: true });
   })
 
   // Ban / unban (abuse). Proxies Better Auth admin ban/unban; ban also

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -22,7 +22,8 @@ import {
   validateScopes,
 } from "../auth-db";
 import {
-  deleteRepoLink,
+  deleteRepoLinkStrict,
+  findRepoLinkStrict,
   listRepoLinksForWorkspace,
   setRepoLink,
   type RepoLink,
@@ -518,7 +519,9 @@ export const adminUi = new Hono<SessionVars>()
   // Operator override (issue #318): forcibly reassign a repo's binding to
   // `workspace`, overwriting whichever workspace claimed it first. Unlike the
   // self-serve `/v1/:workspace/github/link` POST (first-claim-wins), this
-  // never reports `claimed: false` — an admin's call always wins.
+  // never reports `claimed: false` — an admin's call always wins. Rate
+  // limited (and workspace-existence checked) against the destination
+  // workspace, same as the other admin-ui writes below.
   .put("/github-links", async (c) => {
     let body: unknown;
     try {
@@ -535,6 +538,15 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("workspace is required", { code: "invalid_workspace" });
     }
     const workspace = rawWorkspace.trim();
+    // A typo'd destination would otherwise silently create a binding owned
+    // by a workspace that doesn't exist (CodeRabbit, issue #318).
+    const existing = await c.env.REGISTRY.get(`ws:${workspace}`);
+    if (!existing) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+    if (!(await allowWrite(c.env, workspace))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
     await setRepoLink(c.env.DB, repo, workspace, "admin");
     return c.json({ repo, workspace, reassigned: true });
   })
@@ -542,11 +554,21 @@ export const adminUi = new Hono<SessionVars>()
   // Operator override (issue #318): remove any repo's binding outright
   // (stuck/abandoned claim, no replacement owner). Unlike the self-serve
   // DELETE (workspace-scoped, refuses non-owners), this always succeeds
-  // regardless of who owns the binding.
+  // regardless of who owns the binding. Uses the strict lookup/delete so a
+  // D1 failure surfaces as an error rather than a false `unlinked: true`
+  // (CodeRabbit, issue #318); rate limited against the current owner
+  // (there's no destination workspace to key on, unlike PUT above).
   .delete("/github-links", async (c) => {
     const repo = parseRepoParam(c.req.query("repo"));
-    await deleteRepoLink(c.env.DB, repo);
-    return c.json({ repo, unlinked: true });
+    const before = await findRepoLinkStrict(c.env.DB, repo);
+    if (!before) {
+      return c.json({ repo, unlinked: false, reason: "not_linked" as const });
+    }
+    if (!(await allowWrite(c.env, before.workspaceName))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    const removed = await deleteRepoLinkStrict(c.env.DB, repo);
+    return c.json({ repo, unlinked: removed });
   })
 
   // Ban / unban (abuse). Proxies Better Auth admin ban/unban; ban also

--- a/apps/api/src/routes/github-link-route.test.ts
+++ b/apps/api/src/routes/github-link-route.test.ts
@@ -219,4 +219,19 @@ describe("DELETE /v1/:workspace/github/link", () => {
     const res = await app.request(`/v1/${WS}/github/link?repo=${REPO}`, { method: "DELETE" }, env);
     expect(res.status).toBe(401);
   });
+
+  it("propagates a D1 read failure instead of reporting not_linked", async () => {
+    const { env } = await seededEnv();
+    const failingDb = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            throw new Error("d1 unavailable");
+          },
+        }),
+      }),
+    };
+    const res = await del({ ...env, DB: failingDb } as unknown as Env, WS, REPO, TOKEN);
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
 });

--- a/apps/api/src/routes/github-link-route.test.ts
+++ b/apps/api/src/routes/github-link-route.test.ts
@@ -61,6 +61,17 @@ function post(env: Env, workspace: string, body: unknown, token: string) {
   );
 }
 
+function del(env: Env, workspace: string, repo: string, token: string) {
+  return app.request(
+    `/v1/${workspace}/github/link?repo=${encodeURIComponent(repo)}`,
+    {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    },
+    env,
+  );
+}
+
 describe("GET /v1/:workspace/github/link", () => {
   it("reports no binding when the repo is unclaimed", async () => {
     const { env } = await seededEnv();
@@ -156,6 +167,56 @@ describe("POST /v1/:workspace/github/link", () => {
       },
       env,
     );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /v1/:workspace/github/link", () => {
+  it("unlinks a binding owned by the calling workspace", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: WS,
+      installation_id: null,
+      source: "cli",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await del(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: REPO, unlinked: true });
+    expect(db.repoLinks.has(REPO)).toBe(false);
+  });
+
+  it("reports not_linked for an unclaimed repo without erroring", async () => {
+    const { env } = await seededEnv();
+    const res = await del(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: REPO, unlinked: false, reason: "not_linked" });
+  });
+
+  it("403s when the caller does not own the binding, and leaves it intact", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: "someone-else",
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await del(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(403);
+    expect(db.repoLinks.get(REPO)?.workspace_name).toBe("someone-else");
+  });
+
+  it("400s on a malformed repo", async () => {
+    const { env } = await seededEnv();
+    const res = await del(env, WS, "not-a-repo", TOKEN);
+    expect(res.status).toBe(400);
+  });
+
+  it("401s with no bearer token", async () => {
+    const { env } = await seededEnv();
+    const res = await app.request(`/v1/${WS}/github/link?repo=${REPO}`, { method: "DELETE" }, env);
     expect(res.status).toBe(401);
   });
 });

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -13,6 +13,7 @@ import { Hono } from "hono";
 import {
   deleteRepoLinkForWorkspace,
   findRepoLink,
+  findRepoLinkStrict,
   recordRepoLink,
   type RepoLink,
 } from "../github-repo-links";
@@ -83,7 +84,11 @@ export const githubLink = new Hono<WorkspaceVars>()
     const repo = parseRepo(c.req.query("repo"));
     const workspaceName = c.get("workspaceName");
 
-    const before = await findRepoLink(c.env.DB, repo);
+    // Strict lookup: unlike the GET/POST handlers above (where a D1 blip
+    // degrading to "unclaimed" is an acceptable inspect-only fallback), a
+    // D1 read failure here must surface as a 5xx, not silently report
+    // `{unlinked: false, reason: "not_linked"}` (CodeRabbit, issue #318).
+    const before = await findRepoLinkStrict(c.env.DB, repo);
     if (!before) {
       return c.json({ repo, unlinked: false, reason: "not_linked" as const });
     }

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -8,9 +8,14 @@
  * binding never steals it — the response reports who actually owns it
  * (`claimed: false`, `owner`) rather than silently pretending to succeed.
  */
-import { ValidationError } from "@uploads/errors";
+import { ValidationError, ForbiddenError } from "@uploads/errors";
 import { Hono } from "hono";
-import { findRepoLink, recordRepoLink, type RepoLink } from "../github-repo-links";
+import {
+  deleteRepoLinkForWorkspace,
+  findRepoLink,
+  recordRepoLink,
+  type RepoLink,
+} from "../github-repo-links";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
@@ -69,4 +74,25 @@ export const githubLink = new Hono<WorkspaceVars>()
       claimed: after?.workspaceName === workspaceName,
       ...linkResponse(repo, after),
     });
+  })
+  // Self-serve unlink (issue #318): a workspace can only remove a binding it
+  // owns — this never lets one workspace unclaim another's repo. Use the
+  // admin-gated route (routes/admin-ui.ts) to reassign or remove someone
+  // else's stuck/abandoned binding.
+  .delete("/link", writeRateLimit, requireScope("files:write"), async (c) => {
+    const repo = parseRepo(c.req.query("repo"));
+    const workspaceName = c.get("workspaceName");
+
+    const before = await findRepoLink(c.env.DB, repo);
+    if (!before) {
+      return c.json({ repo, unlinked: false, reason: "not_linked" as const });
+    }
+    if (before.workspaceName !== workspaceName) {
+      throw new ForbiddenError(
+        `${repo} is bound to a different workspace ("${before.workspaceName}") — ask an operator to reassign it`,
+        { code: "not_link_owner" },
+      );
+    }
+    const removed = await deleteRepoLinkForWorkspace(c.env.DB, repo, workspaceName);
+    return c.json({ repo, unlinked: removed });
   });

--- a/apps/api/test/github-repo-links-sqlite.test.ts
+++ b/apps/api/test/github-repo-links-sqlite.test.ts
@@ -131,11 +131,37 @@ describe("listRepoLinksForWorkspace (admin visibility, issue #318)", () => {
   it("returns only the calling workspace's bindings, newest first", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
-      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
-      await recordRepoLink(database(sqlite), "acme/api", "acme", "cli");
-      await recordRepoLink(database(sqlite), "other/repo", "someone-else", "comment");
+      // Distinct explicit timestamps (not insertion order) so the assertion
+      // below actually exercises `ORDER BY created_at DESC` rather than
+      // passing regardless of ordering (CodeRabbit, issue #318).
+      await recordRepoLink(
+        database(sqlite),
+        "acme/web",
+        "acme",
+        "comment",
+        null,
+        new Date("2026-01-01T00:00:00.000Z"),
+      );
+      await recordRepoLink(
+        database(sqlite),
+        "acme/api",
+        "acme",
+        "cli",
+        null,
+        new Date("2026-02-01T00:00:00.000Z"),
+      );
+      await recordRepoLink(
+        database(sqlite),
+        "other/repo",
+        "someone-else",
+        "comment",
+        null,
+        new Date("2026-03-01T00:00:00.000Z"),
+      );
       const links = await listRepoLinksForWorkspace(database(sqlite), "acme");
-      expect(links.map((l) => l.repo).sort()).toEqual(["acme/api", "acme/web"]);
+      // Newest (acme/api, Feb) first, oldest (acme/web, Jan) last —
+      // "someone-else"'s later (Mar) binding is excluded entirely.
+      expect(links.map((l) => l.repo)).toEqual(["acme/api", "acme/web"]);
       expect(links.every((l) => l.workspaceName === "acme")).toBe(true);
     } finally {
       sqlite.close();

--- a/apps/api/test/github-repo-links-sqlite.test.ts
+++ b/apps/api/test/github-repo-links-sqlite.test.ts
@@ -1,7 +1,14 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from "vitest";
-import { deleteRepoLink, findRepoLink, recordRepoLink } from "../src/github-repo-links";
+import {
+  deleteRepoLink,
+  deleteRepoLinkForWorkspace,
+  findRepoLink,
+  listRepoLinksForWorkspace,
+  recordRepoLink,
+  setRepoLink,
+} from "../src/github-repo-links";
 import { SqliteD1, database } from "./helpers/sqlite-d1";
 
 const MIGRATION = "migrations/20260720120000_github_repo_links.sql";
@@ -74,6 +81,100 @@ describe("github repo links persistence against SQLite", () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
       await expect(deleteRepoLink(database(sqlite), "acme/nope")).resolves.toBeUndefined();
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("deleteRepoLinkForWorkspace (self-serve unlink, issue #318)", () => {
+  it("deletes when the caller owns the binding", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
+      await expect(deleteRepoLinkForWorkspace(database(sqlite), "acme/web", "acme")).resolves.toBe(
+        true,
+      );
+      await expect(findRepoLink(database(sqlite), "acme/web")).resolves.toBeNull();
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("refuses (no-op) when the caller does not own the binding", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
+      await expect(
+        deleteRepoLinkForWorkspace(database(sqlite), "acme/web", "someone-else"),
+      ).resolves.toBe(false);
+      const link = await findRepoLink(database(sqlite), "acme/web");
+      expect(link?.workspaceName).toBe("acme");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("is a harmless no-op on an unclaimed repo", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await expect(deleteRepoLinkForWorkspace(database(sqlite), "acme/nope", "acme")).resolves.toBe(
+        false,
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("listRepoLinksForWorkspace (admin visibility, issue #318)", () => {
+  it("returns only the calling workspace's bindings, newest first", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
+      await recordRepoLink(database(sqlite), "acme/api", "acme", "cli");
+      await recordRepoLink(database(sqlite), "other/repo", "someone-else", "comment");
+      const links = await listRepoLinksForWorkspace(database(sqlite), "acme");
+      expect(links.map((l) => l.repo).sort()).toEqual(["acme/api", "acme/web"]);
+      expect(links.every((l) => l.workspaceName === "acme")).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns an empty list for a workspace with no bindings", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await expect(listRepoLinksForWorkspace(database(sqlite), "acme")).resolves.toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("setRepoLink (operator override, issue #318)", () => {
+  it("creates a binding for an unclaimed repo", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await setRepoLink(database(sqlite), "acme/web", "acme", "admin");
+      const link = await findRepoLink(database(sqlite), "acme/web");
+      expect(link).toMatchObject({ workspaceName: "acme", source: "admin" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("reassigns an existing binding, overwriting the prior owner", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
+      await setRepoLink(database(sqlite), "acme/web", "someone-else", "admin", 7);
+      const link = await findRepoLink(database(sqlite), "acme/web");
+      expect(link).toMatchObject({
+        workspaceName: "someone-else",
+        source: "admin",
+        installationId: 7,
+      });
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/helpers/fake-repo-links-table.ts
+++ b/apps/api/test/helpers/fake-repo-links-table.ts
@@ -25,6 +25,12 @@ export interface FakeFirstResult<T> {
   meta: Record<string, unknown>;
 }
 
+export interface FakeAllResult<T> {
+  success: true;
+  results: T[];
+  meta: Record<string, unknown>;
+}
+
 export class RepoLinksTable {
   readonly rows = new Map<string, RepoLinkRow>();
 
@@ -47,6 +53,43 @@ export class RepoLinksTable {
       });
       return { success: true, meta: { changes: 1 }, results: [] };
     }
+    // Operator override (setRepoLink, issue #318): forcibly assigns/reassigns
+    // a binding, overwriting any existing owner — mirrors the real D1
+    // `ON CONFLICT ... DO UPDATE` in github-repo-links.ts.
+    if (
+      normalizedSql.startsWith("INSERT INTO github_repo_links") &&
+      normalizedSql.includes("ON CONFLICT")
+    ) {
+      const [repo, workspace, installationId, source, createdAt] = args as [
+        string,
+        string,
+        number | null,
+        string,
+        string,
+      ];
+      this.rows.set(repo, {
+        repo_full_name: repo,
+        workspace_name: workspace,
+        installation_id: installationId,
+        source,
+        created_at: createdAt,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    // Self-serve unlink (deleteRepoLinkForWorkspace, issue #318): only
+    // deletes when the caller's workspace matches the current owner.
+    if (
+      normalizedSql.startsWith("DELETE FROM github_repo_links") &&
+      normalizedSql.includes("workspace_name = ?")
+    ) {
+      const [repo, workspace] = args as [string, string];
+      const row = this.rows.get(repo);
+      if (!row || row.workspace_name !== workspace) {
+        return { success: true, meta: { changes: 0 }, results: [] };
+      }
+      this.rows.delete(repo);
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
     if (normalizedSql.startsWith("DELETE FROM github_repo_links")) {
       const [repo] = args as [string];
       const existed = this.rows.delete(repo);
@@ -56,9 +99,25 @@ export class RepoLinksTable {
   }
 
   tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
-    if (normalizedSql.startsWith("SELECT * FROM github_repo_links")) {
+    if (normalizedSql.startsWith("SELECT * FROM github_repo_links WHERE repo_full_name")) {
       const [repo] = args as [string];
       return (this.rows.get(repo) as T) ?? null;
+    }
+    return undefined;
+  }
+
+  // listRepoLinksForWorkspace (issue #318, admin visibility): all bindings
+  // owned by one workspace, newest first — matches the real `ORDER BY
+  // created_at DESC`.
+  tryAll<T>(normalizedSql: string, args: unknown[]): FakeAllResult<T> | undefined {
+    if (normalizedSql.startsWith("SELECT * FROM github_repo_links WHERE workspace_name")) {
+      const [workspace] = args as [string];
+      // Non-mutating sort (see github-comment-render.ts: this worker's
+      // tsconfig targets lib ES2022, which predates Array#toSorted).
+      const results = [...this.rows.values()]
+        .filter((row) => row.workspace_name === workspace)
+        .sort((a, b) => b.created_at.localeCompare(a.created_at));
+      return { success: true, results: results as T[], meta: {} };
     }
     return undefined;
   }

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -52,6 +52,8 @@ export class UsageFakeD1 {
       all: async <T>() => {
         const result = this.fileMetadataTable.tryAll<T>(normalized, values);
         if (result) return result;
+        const linkResult = this.repoLinksTable.tryAll<T>(normalized, values);
+        if (linkResult) return linkResult;
         // Galleries aren't modeled by this fake (route/gallery-specific tests
         // bring their own D1 stand-in) — an empty page is a safe, honest
         // default for callers (e.g. the webhook auto-promote gather) that

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -237,6 +237,32 @@ export const prerender = false;
       return body;
     }
 
+    interface GithubLink {
+      repo: string;
+      workspace: string;
+      source: string;
+      installationId: number | null;
+      createdAt: string;
+    }
+    interface GithubLinksResponse {
+      workspace: string;
+      links: GithubLink[];
+    }
+
+    function renderGithubLinks(host: HTMLElement, links: GithubLink[]): void {
+      host.innerHTML = links.length
+        ? `<h4 class="github-links-heading">GitHub repos claimed</h4>
+           <ul class="github-links-list">
+             ${links
+               .map(
+                 (l) =>
+                   `<li><span class="repo">${escapeHtml(l.repo)}</span><span class="muted">${escapeHtml(l.source)}</span></li>`,
+               )
+               .join("")}
+           </ul>`
+        : "";
+    }
+
     function renderWorkspace(ws: WorkspaceSummary): HTMLElement {
       const details = document.createElement("details");
       details.className = "workspace";
@@ -250,6 +276,7 @@ export const prerender = false;
         <div class="members" data-state="unloaded">Members load when expanded.</div>
         <div class="invites"></div>
         <div class="limits" data-state="unloaded"></div>
+        <div class="github-links" data-state="unloaded"></div>
         ${
           ws.organization
             ? `<form class="invite-form" data-workspace="${escapeHtml(ws.workspace)}">
@@ -276,6 +303,7 @@ export const prerender = false;
 
       let loaded = false;
       let limitsLoaded = false;
+      let githubLinksLoaded = false;
       details.addEventListener("toggle", () => {
         void (async () => {
           if (!details.open || loaded) return;
@@ -328,6 +356,22 @@ export const prerender = false;
             limitsLoaded = true;
           } catch {
             limitsEl.innerHTML = `<p class="muted">Failed to load limits.</p>`;
+          }
+        })();
+        // GitHub repo bindings (issue #318 admin visibility) — same
+        // independent-load pattern as limits, own retry flag.
+        void (async () => {
+          if (!details.open || githubLinksLoaded) return;
+          const githubLinksEl = details.querySelector<HTMLElement>(".github-links");
+          if (!githubLinksEl) return;
+          try {
+            const { links } = await apiGet<GithubLinksResponse>(
+              `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/github-links`,
+            );
+            renderGithubLinks(githubLinksEl, links);
+            githubLinksLoaded = true;
+          } catch {
+            githubLinksEl.innerHTML = `<p class="muted">Failed to load GitHub links.</p>`;
           }
         })();
       });

--- a/apps/web/src/styles/admin-workspaces.css
+++ b/apps/web/src/styles/admin-workspaces.css
@@ -167,6 +167,32 @@
 .workspace .limit-unit:disabled {
   opacity: 0.5;
 }
+.workspace .github-links:not(:empty) {
+  margin-top: 16px;
+  border-top: 1px solid var(--border, #e5e7eb);
+  padding-top: 12px;
+}
+.workspace .github-links-heading {
+  margin: 0 0 8px;
+  font-size: 14px;
+}
+.workspace .github-links-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.workspace .github-links-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+}
+.workspace .github-links-list .repo {
+  font: 12px var(--mono);
+}
 .workspace .limit-unlimited {
   display: inline-flex;
   align-items: center;

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -263,6 +263,13 @@ export interface GithubLinkClaimResult extends GithubLinkResult {
   claimed: boolean;
 }
 
+/** `DELETE /v1/:workspace/github/link` result (issue #318, self-serve unlink). */
+export interface GithubLinkUnlinkResult {
+  repo: string;
+  unlinked: boolean;
+  reason?: "not_linked";
+}
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -1064,6 +1071,20 @@ export function createUploadsClient(config: UploadsClientConfig) {
       return request<GithubHealthResult>(
         "GET",
         `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/health`,
+      );
+    },
+
+    /**
+     * Self-serve unlink (issue #318): removes `repo`'s binding, but only if
+     * this workspace currently owns it. Throws `UploadsError` (status 403)
+     * when a different workspace owns the binding — never steals or
+     * overwrites another workspace's claim. Throws (status 404) on an
+     * older/self-hosted server without this route.
+     */
+    async githubLinkUnlink(repo: string): Promise<GithubLinkUnlinkResult> {
+      return request<GithubLinkUnlinkResult>(
+        "DELETE",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/link?repo=${encodeURIComponent(repo)}`,
       );
     },
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2118,17 +2118,20 @@ export async function runComment(
 // --- github link ---
 
 const GITHUB_HELP = `uploads github link [--repo <owner/name>] [--status] [--workspace <name>]
+uploads github unlink [--repo <owner/name>] [--workspace <name>]
 uploads github doctor [--workspace <name>]
 
-Claim or inspect this workspace's binding to a GitHub repo (see the managed
-attachments comment / webhook auto-promotion, which use this binding).
-First-claim-wins: claiming an already-bound repo never steals it from
-whichever workspace claimed it first — the command reports who owns it
-instead.
+Claim, inspect, or release this workspace's binding to a GitHub repo (see the
+managed attachments comment / webhook auto-promotion, which use this
+binding). First-claim-wins: claiming an already-bound repo never steals it
+from whichever workspace claimed it first — the command reports who owns it,
+and how to get it released, instead.
 
 --repo defaults the same way as --pr/--issue elsewhere (gh repo view, then
 the git remote). --status only inspects the current binding (files:read);
-without it, the command claims the repo (files:write).
+without it, "link" claims the repo (files:write). "unlink" releases a
+binding this workspace owns — it 403s (via the server) if another workspace
+owns it; an operator can reassign or remove that binding instead.
 
 \`doctor\` checks the GitHub App itself: whether it's configured on the
 server, and whether it's subscribed to the webhook events uploads.sh's
@@ -2141,6 +2144,7 @@ Examples:
   uploads github link
   uploads github link --repo buildinternet/uploads
   uploads github link --status
+  uploads github unlink --repo buildinternet/uploads
   uploads github doctor
 `;
 
@@ -2169,45 +2173,27 @@ function formatGithubLink(
     : `${repo} is not bound to any workspace\n`;
 }
 
-export async function runGithub(
-  ctx: CliContext,
-  args: string[],
-  help = false,
-  run: CommandRunner = execRunner,
-): Promise<number> {
-  const parsed = parseCommandArgs(args);
-  const action = parsed.positionals[0];
-  if (help || parsed.help || !action) {
-    writeCommandHelp(GITHUB_HELP);
-    return help || parsed.help ? 0 : 2;
-  }
-  if (action !== "link" && action !== "doctor") {
-    throw new UsageError(`unknown github subcommand: ${action}`);
-  }
-
-  if (action === "doctor") {
-    let result: GithubHealthResult;
-    try {
-      result = await ctx.client.githubHealth();
-    } catch (err) {
-      if (err instanceof UploadsError && err.status === 404) {
-        throw new UsageError(
-          "server does not support the GitHub App health check yet (404) — upgrade the uploads.sh API/self-hosted worker",
-        );
-      }
-      throw err;
+async function runGithubDoctor(ctx: CliContext): Promise<number> {
+  let result: GithubHealthResult;
+  try {
+    result = await ctx.client.githubHealth();
+  } catch (err) {
+    if (err instanceof UploadsError && err.status === 404) {
+      throw new UsageError(
+        "server does not support the GitHub App health check yet (404) — upgrade the uploads.sh API/self-hosted worker",
+      );
     }
-    if (ctx.json) {
-      await writeJson(result);
-    } else {
-      await writeStdout(formatGithubDoctor(result));
-    }
-    return result.ok ? 0 : 1;
+    throw err;
   }
+  if (ctx.json) {
+    await writeJson(result);
+  } else {
+    await writeStdout(formatGithubDoctor(result));
+  }
+  return result.ok ? 0 : 1;
+}
 
-  const repo = resolveRepo(flagString(parsed.flags, "--repo"), run);
-  const statusOnly = flagBool(parsed.flags, "--status");
-
+async function runGithubLink(ctx: CliContext, repo: string, statusOnly: boolean): Promise<number> {
   let result: {
     repo: string;
     linked: boolean;
@@ -2234,11 +2220,67 @@ export async function runGithub(
   }
   if (!statusOnly && result.claimed === false) {
     process.stderr.write(
-      `note: ${repo} is already bound to a different workspace ("${result.workspace}") — first-claim-wins, not overwritten\n`,
+      `note: ${repo} is already bound to a different workspace ("${result.workspace}") — first-claim-wins, not overwritten. Run "uploads github unlink --repo ${repo}" from that workspace, or ask an operator to reassign it.\n`,
     );
   }
   await writeStdout(formatGithubLink(repo, result));
   return 0;
+}
+
+async function runGithubUnlink(ctx: CliContext, repo: string): Promise<number> {
+  let result: { repo: string; unlinked: boolean; reason?: "not_linked" };
+  try {
+    result = await ctx.client.githubLinkUnlink(repo);
+  } catch (err) {
+    if (err instanceof UploadsError && err.status === 404) {
+      throw new UsageError(
+        "server does not support repo bindings yet (404) — upgrade the uploads.sh API/self-hosted worker",
+      );
+    }
+    if (err instanceof UploadsError && err.status === 403) {
+      throw new UsageError(
+        `${repo} is bound to a different workspace — ask an operator to reassign or remove it (${err.message})`,
+      );
+    }
+    throw err;
+  }
+
+  if (ctx.json) {
+    await writeJson(result);
+    return 0;
+  }
+  await writeStdout(
+    result.unlinked
+      ? `unlinked ${repo}\n`
+      : `${repo} was not bound to any workspace — nothing to unlink\n`,
+  );
+  return 0;
+}
+
+export async function runGithub(
+  ctx: CliContext,
+  args: string[],
+  help = false,
+  run: CommandRunner = execRunner,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  const action = parsed.positionals[0];
+  if (help || parsed.help || !action) {
+    writeCommandHelp(GITHUB_HELP);
+    return help || parsed.help ? 0 : 2;
+  }
+  if (action !== "link" && action !== "unlink" && action !== "doctor") {
+    throw new UsageError(`unknown github subcommand: ${action}`);
+  }
+
+  if (action === "doctor") return runGithubDoctor(ctx);
+
+  const repo = resolveRepo(flagString(parsed.flags, "--repo"), run);
+
+  if (action === "unlink") return runGithubUnlink(ctx, repo);
+
+  const statusOnly = flagBool(parsed.flags, "--status");
+  return runGithubLink(ctx, repo, statusOnly);
 }
 
 // --- usage / reconcile / purge ---

--- a/packages/uploads/test/commands-github-link.test.ts
+++ b/packages/uploads/test/commands-github-link.test.ts
@@ -117,3 +117,52 @@ describe("runGithub (link)", () => {
     );
   });
 });
+
+describe("runGithub (unlink, issue #318)", () => {
+  it("unlinks a binding owned by this workspace", async () => {
+    const calls: string[] = [];
+    const client = {
+      githubLinkUnlink: async (repo: string) => {
+        calls.push(repo);
+        return { repo, unlinked: true };
+      },
+    } as unknown as UploadsClient;
+    const code = await runGithub(ctxWith(client), ["unlink"], false, runnerWithRepo());
+    expect(code).toBe(0);
+    expect(calls).toEqual(["acme/web"]);
+  });
+
+  it("reports a no-op when the repo was never bound", async () => {
+    const client = {
+      githubLinkUnlink: async (repo: string) => ({
+        repo,
+        unlinked: false,
+        reason: "not_linked" as const,
+      }),
+    } as unknown as UploadsClient;
+    const code = await runGithub(ctxWith(client), ["unlink"], false, runnerWithRepo());
+    expect(code).toBe(0);
+  });
+
+  it("surfaces a clear error when another workspace owns the binding (403)", async () => {
+    const client = {
+      githubLinkUnlink: async () => {
+        throw new UploadsError("bound to a different workspace", "API_ERROR", 403);
+      },
+    } as unknown as UploadsClient;
+    await expect(runGithub(ctxWith(client), ["unlink"], false, runnerWithRepo())).rejects.toThrow(
+      UsageError,
+    );
+  });
+
+  it("degrades clearly on a 404 (older server without bindings)", async () => {
+    const client = {
+      githubLinkUnlink: async () => {
+        throw new UploadsError("not found", "NOT_FOUND", 404);
+      },
+    } as unknown as UploadsClient;
+    await expect(runGithub(ctxWith(client), ["unlink"], false, runnerWithRepo())).rejects.toThrow(
+      UsageError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`github_repo_links` (#312/#315) was first-claim-wins with no way to release or
fix a binding. This adds the three lifecycle follow-ups from #318:

- **Self-serve unlink**: `DELETE /v1/:workspace/github/link?repo=owner/name`
  removes a binding, but only if the calling workspace owns it (403
  otherwise). CLI: `uploads github unlink [--repo <owner/name>]`. `github
  link`'s "claimed: false" output now points at `unlink` / an operator as the
  remedy.
- **Operator override**: admin-gated routes alongside the existing
  `/admin-ui/workspaces/:name/limits` pattern —
  `PUT /admin-ui/github-links` (body `{ repo, workspace }`) reassigns any
  binding, overwriting the prior owner; `DELETE /admin-ui/github-links?repo=`
  removes any binding outright.
- **Admin visibility**: `GET /admin-ui/workspaces/:name/github-links` lists a
  workspace's claimed repos; the admin workspace panel (apps/web) renders
  them in each workspace's expandable card, next to Limits.

Not included (deliberately, per the issue): the `.uploads.yml` repo-declared
authoritative binding stays future work.

## Auth model

| Route | Auth |
|---|---|
| `DELETE /v1/:workspace/github/link` | workspace-scoped token, `files:write` (same as `POST .../link`) |
| `GET /admin-ui/workspaces/:name/github-links` | session + `requireAdminUser` |
| `PUT /admin-ui/github-links` | session + `requireAdminUser` |
| `DELETE /admin-ui/github-links` | session + `requireAdminUser` |

## Test plan

- [x] `pnpm --filter @uploads/api test` (791 passed) — new coverage: self-serve
      unlink route (owner/non-owner/unclaimed/malformed/401), the three
      operator-override admin-ui routes, and SQLite-backed persistence tests
      for `deleteRepoLinkForWorkspace`, `listRepoLinksForWorkspace`, `setRepoLink`
- [x] `pnpm --filter @buildinternet/uploads test` (592 passed) — new coverage:
      `uploads github unlink` (success, no-op, 403, 404)
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm format` / `pnpm check` — clean (pre-existing warnings only, none in touched files)

Fixes #318


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `uploads github unlink` to remove a workspace’s GitHub repository connection.
  - Added GitHub unlink support to the uploads client, including clear status responses.
  - Admins can view workspace repository connections and reassign or remove them.
  - GitHub repository links now display in the admin workspace details page.

- **Bug Fixes**
  - Improved guidance when a repository is already connected to another workspace.
  - Added clearer handling for unsupported servers and unauthorized unlink attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->