### PR TITLE
fix(api,cli): cross-tenant authorization for the bot-comment endpoint

### DIFF
--- a/.changeset/comment-cross-tenant-authz.md
+++ b/.changeset/comment-cross-tenant-authz.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Stop falling back to the local `gh` path when the server declines a comment post with `not_authorized` (cross-tenant repo binding) — surface the decline with a hint to `uploads github link --status` instead, since a silent gh fallback would just work around the server-side gate with the human's own credentials.

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -339,3 +339,194 @@ describe("POST /v1/:workspace/github/comment implicit repo-link claim", () => {
     expect(links.rows.has("acme/web")).toBe(false);
   });
 });
+
+describe("POST /v1/:workspace/github/comment cross-tenant authorization (issue #297)", () => {
+  async function envWithBucketAndLinks(
+    db: D1Database,
+    opts: { workspace?: string; prefix?: string } = {},
+  ): Promise<Env> {
+    const ws = opts.workspace ?? WS;
+    const hash = await sha256Hex(TOKEN);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: opts.prefix ?? `${ws}/`,
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${ws}` ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:orgB/repo", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const bucket = new FakeR2Bucket();
+    await bucket.put(
+      `${record.prefix}gh/orgB/repo/pull/12/hero.png`,
+      new Uint8Array([0x89, 0x50]),
+      { httpMetadata: { contentType: "image/png" } },
+    );
+    return {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: bucket,
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+  }
+
+  function postAs(env: Env, workspace: string, token: string, body: unknown) {
+    return app.request(
+      `/v1/${workspace}/github/comment`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      env,
+    );
+  }
+
+  it("allows the comment when the caller owns the repo's binding", async () => {
+    const { db, links } = claimTestDb();
+    links.rows.set("orgb/repo", {
+      repo_full_name: "orgb/repo",
+      workspace_name: WS,
+      installation_id: 42,
+      source: "comment",
+      created_at: new Date().toISOString(),
+    });
+    const env = await envWithBucketAndLinks(db);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/orgB/repo/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await postAs(env, WS, TOKEN, { repo: "orgB/repo", num: 12, kind: "pull" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { posted: boolean };
+      expect(body.posted).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("implicitly claims an unbound repo for a non-communal workspace", async () => {
+    const { db, links } = claimTestDb();
+    const env = await envWithBucketAndLinks(db);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/orgB/repo/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await postAs(env, WS, TOKEN, { repo: "orgB/repo", num: 12, kind: "pull" });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { posted: boolean };
+      expect(body.posted).toBe(true);
+      const link = links.rows.get("orgb/repo");
+      expect(link).toMatchObject({ workspace_name: WS, source: "comment" });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("soft-declines when the repo is bound to a different workspace", async () => {
+    const { db, links } = claimTestDb();
+    links.rows.set("orgb/repo", {
+      repo_full_name: "orgb/repo",
+      workspace_name: "other-ws",
+      installation_id: 42,
+      source: "comment",
+      created_at: new Date().toISOString(),
+    });
+    const env = await envWithBucketAndLinks(db);
+
+    const res = await postAs(env, WS, TOKEN, { repo: "orgB/repo", num: 12, kind: "pull" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { posted: boolean; reason: string; message: string };
+    expect(body).toEqual({
+      posted: false,
+      reason: "not_authorized",
+      message: expect.stringContaining('bound to a different workspace ("other-ws")'),
+    });
+    // The decline must fire before any GitHub API call or implicit claim.
+    expect(links.rows.get("orgb/repo")?.workspace_name).toBe("other-ws");
+  });
+
+  it("soft-declines an unbound repo for the communal default workspace", async () => {
+    const { db, links } = claimTestDb();
+    const hash = await sha256Hex("up_default_testtoken");
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "default/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === "ws:default" ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:orgB/repo", { value: "42" });
+    const env = {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: new FakeR2Bucket(),
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    const res = await postAs(env, "default", "up_default_testtoken", {
+      repo: "orgB/repo",
+      num: 12,
+      kind: "pull",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { posted: boolean; reason: string; message: string };
+    expect(body.posted).toBe(false);
+    expect(body.reason).toBe("not_authorized");
+    expect(body.message).toContain("communal");
+    expect(links.rows.has("orgb/repo")).toBe(false);
+  });
+
+  it("never allows posting when the strict repo-link lookup hits a D1 outage", async () => {
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          first: async () => {
+            throw new Error("D1 unavailable");
+          },
+          all: async () => ({ results: [] }),
+          run: async () => ({}),
+        }),
+      }),
+    } as unknown as D1Database;
+    const env = await envWithBucketAndLinks(db);
+
+    const res = await postAs(env, WS, TOKEN, { repo: "orgB/repo", num: 12, kind: "pull" });
+    // Never a silent allow: the outage must not degrade to "unbound".
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -9,10 +9,11 @@ import { ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import { gatherCommentBody, upsertBotComment } from "../github-comment";
 import { githubAppConfig, installationForRepo } from "../github-app";
-import { recordRepoLink } from "../github-repo-links";
+import { findRepoLinkStrict, recordRepoLink } from "../github-repo-links";
 import type { GhTargetKind } from "../github-comment-render";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
+import { isCommunal } from "./me";
 import { jsonBody } from "./json-body";
 
 // Same owner/name grammar as public-files.ts's deriveGithubContext, plus a guard
@@ -36,6 +37,54 @@ function parseTarget(body: Record<string, unknown>): {
   if (kind !== "pull" && kind !== "issues")
     throw new ValidationError('kind must be "pull" or "issues".');
   return { repo, num, kind };
+}
+
+/**
+ * Cross-tenant authorization gate (issue #297 baseline control). The App is
+ * installed org-wide, so every workspace's token can resolve an installation
+ * for *any* org's repo — without this check, workspace A could post/deface
+ * `uploads-sh[bot]` comments on workspace B's bound repo using A's own
+ * uploaded images under a crafted `gh/<B's org>/...` key prefix.
+ *
+ * Uses the strict lookup (`findRepoLinkStrict`) deliberately: a D1 failure
+ * here must propagate (5xx via the app's error handler) rather than degrade
+ * to "unbound", which would silently allow posting during an outage.
+ *
+ * - Bound to this workspace, or unbound and this workspace may claim it →
+ *   `null` (allowed; the existing implicit-claim call below handles the
+ *   unbound case).
+ * - Bound to a different workspace → decline.
+ * - Unbound and the caller is the communal `default` workspace → decline;
+ *   `default` may only post to repos already bound to `default` — it can
+ *   never claim a fresh repo (the widest cross-tenant exposure named in the
+ *   issue).
+ */
+async function checkRepoAuthorization(
+  env: Env,
+  repo: string,
+  workspaceName: string,
+): Promise<{ posted: false; reason: "not_authorized"; message: string } | null> {
+  const link = await findRepoLinkStrict(env.DB, repo);
+  if (link) {
+    if (link.workspaceName === workspaceName) return null;
+    return {
+      posted: false,
+      reason: "not_authorized",
+      message:
+        `${repo} is bound to a different workspace ("${link.workspaceName}") — this ` +
+        `workspace is not authorized to post the uploads-sh[bot] comment there.`,
+    };
+  }
+  if (isCommunal(env, workspaceName)) {
+    return {
+      posted: false,
+      reason: "not_authorized",
+      message:
+        `${repo} isn't bound to a workspace yet, and the communal "default" workspace ` +
+        `can't claim new repos. Use a dedicated workspace to post there for the first time.`,
+    };
+  }
+  return null;
 }
 
 /**
@@ -64,6 +113,10 @@ export const githubComment = new Hono<WorkspaceVars>().post(
   requireScope("files:read"),
   async (c) => {
     const target = parseTarget(await jsonBody(c));
+    const workspaceName = c.get("workspaceName");
+    const decline = await checkRepoAuthorization(c.env, target.repo, workspaceName);
+    if (decline) return c.json(decline);
+
     const cfg = githubAppConfig(c.env);
     if (!cfg) return c.json({ posted: false, reason: "app_unconfigured" });
     const installId = await installationForRepo(c.env, cfg, target.repo);

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -213,11 +213,20 @@ export interface FindGalleriesByReferenceOptions {
   cursor?: string;
 }
 
-/** Reasons the bot did not post; the CLI treats any of them as "fall back to gh". */
+/**
+ * Reasons the bot did not post. The CLI falls back to the local `gh` path
+ * for all of these except `not_authorized` (issue #297 baseline control):
+ * the target repo is bound to a different workspace (or is unbound and the
+ * caller is the communal `default` workspace, which can't claim new repos).
+ * Falling back to `gh` there would let the human's own credentials post
+ * anyway, defeating the point of the server-side gate, so the CLI surfaces
+ * the decline instead.
+ */
 export type GithubCommentDeclineReason =
   | "app_unconfigured"
   | "not_installed"
   | "forbidden"
+  | "not_authorized"
   | "unavailable";
 
 export type GithubCommentResult =

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -4,6 +4,7 @@ import { mapBounded } from "./async.js";
 import {
   createUploadsClient,
   type GalleryItem,
+  type GithubCommentResult,
   type GithubHealthResult,
   type PromoteBranchAttachmentsResult,
   type PutResult,
@@ -515,19 +516,45 @@ export function commentViaSuffix(via: AttachmentsCommentResult["via"]): string {
   return via === "bot" ? " (uploads-sh[bot])" : " (via gh)";
 }
 
+/**
+ * Thrown by `syncAttachmentsComment` when the server declines with
+ * `not_authorized` (issue #297 baseline control) — this repo is bound to a
+ * different workspace, or unbound and unclaimable by the communal `default`
+ * workspace. Deliberately not caught by the generic "bot endpoint
+ * unreachable" fallback below: falling back to gh here would let the
+ * human's own credentials post anyway, defeating the point of the
+ * server-side gate.
+ */
+export class GithubCommentAuthorizationError extends Error {}
+
 export async function syncAttachmentsComment(
   client: UploadsClient,
   target: GhTarget,
   run: CommandRunner,
   workspace?: string,
 ): Promise<AttachmentsCommentResult> {
+  let bot: GithubCommentResult | undefined;
   try {
-    const bot = await client.upsertGithubComment({
+    bot = await client.upsertGithubComment({
       repo: target.repo,
       num: target.num,
       kind: target.kind,
     });
+  } catch {
+    // Endpoint absent/unreachable (self-hosted, network, older worker) — fall
+    // through to the gh path below.
+    bot = undefined;
+  }
+
+  if (bot) {
     if (bot.posted) return { action: bot.action, count: bot.count, via: "bot" };
+    if (bot.reason === "not_authorized") {
+      throw new GithubCommentAuthorizationError(
+        `${bot.message ?? `${target.repo} is not authorized for this workspace.`}\n` +
+          `Run \`uploads github link --status --repo ${target.repo}\` to see who owns the ` +
+          `binding, use that workspace instead, or post the comment manually with gh.`,
+      );
+    }
     // Installed-but-unapproved is a fixable misconfiguration, not a silent
     // degrade: tell the user (and how to fix it) before falling back to gh.
     if (bot.reason === "forbidden" && bot.message) {
@@ -536,9 +563,6 @@ export async function syncAttachmentsComment(
           `Posting via local gh in the meantime.\n`,
       );
     }
-  } catch {
-    // Endpoint absent/unreachable (self-hosted, network, older worker) — fall
-    // through to the gh path below.
   }
 
   // gh fallback: gather from this workspace's own data and post via local `gh`.
@@ -2081,6 +2105,11 @@ listing everything uploaded for it. Posts as uploads-sh[bot] when the GitHub
 App is installed on the repo; otherwise via your local gh auth. Finds its own
 prior comment via a hidden marker and edits it in place; never touches other
 comments or the description.
+
+If this repo is bound to a different workspace (or unbound and you're on the
+communal "default" workspace), the bot post is declined and this command
+fails rather than silently falling back to gh — see \`uploads github link
+--status\`.
 
 Examples:
   uploads --env-file .env comment --pr 123

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
 import type { UploadsClient } from "../src/client.js";
-import { runComment, syncAttachmentsComment, type CliContext } from "../src/commands.js";
+import {
+  GithubCommentAuthorizationError,
+  runComment,
+  syncAttachmentsComment,
+  type CliContext,
+} from "../src/commands.js";
 import { attachmentsMarker } from "../src/github.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
@@ -214,6 +219,24 @@ describe("syncAttachmentsComment", () => {
     } finally {
       stderr.mockRestore();
     }
+  });
+
+  it("does not fall back to gh on not_authorized (issue #297) — throws with a hint instead", async () => {
+    const client = fakeClient({
+      upsertGithubComment: async () => ({
+        posted: false,
+        reason: "not_authorized",
+        message: 'acme/web is bound to a different workspace ("other-ws").',
+      }),
+    });
+    const run = vi.fn(); // gh runner must NOT be called
+    await expect(
+      syncAttachmentsComment(client, { repo: "acme/web", num: 12, kind: "pull" }, run),
+    ).rejects.toThrow(GithubCommentAuthorizationError);
+    await expect(
+      syncAttachmentsComment(client, { repo: "acme/web", num: 12, kind: "pull" }, run),
+    ).rejects.toThrow(/uploads github link --status/);
+    expect(run).not.toHaveBeenCalled();
   });
 
   it("falls back to the gh path when the endpoint throws (self-hosted 404)", async () => {


### PR DESCRIPTION
## Summary

Addresses the baseline control of #297 (the workspace↔repo binding structural gate), not the full issue — the actor-on-PR fine-grained enhancement (issue #297's control 2) remains deferred. References #326.

`POST /v1/:workspace/github/comment` only rendered the calling workspace's own attachments (good), but never checked the calling workspace was entitled to post to the target repo. Since the uploads.sh GitHub App is installed org-wide, any workspace could resolve a write token for any other org's repo and post/deface `uploads-sh[bot]` comments there using its own uploaded images under a crafted `gh/<other-org>/...` key prefix.

This unblocks #298 (publishing the "add media" command), which the issue notes would otherwise invite strangers to try the exploit.

### Gate logic (per call site)

- `POST /v1/:workspace/github/comment` (`apps/api/src/routes/github-comment.ts`): before resolving the App installation, look up the repo's binding with the **strict** lookup (`findRepoLinkStrict`, propagates D1 errors instead of degrading to "unbound"):
  - Bound to the calling workspace → allowed.
  - Bound to a **different** workspace → soft decline `{posted:false, reason:"not_authorized", message}` (still 200, never 5xx).
  - Unbound → implicitly claimed for the calling workspace via the existing `recordRepoLink` first-claim-wins call, **except** when the caller is the communal `default` workspace, which may only post to repos already bound to `default` and can never claim a fresh one — soft decline explaining a dedicated workspace is needed.
  - A D1 failure during the strict lookup throws and propagates to the app's normal error handler (5xx) — it is never treated as "unbound", so an outage can't be used to bypass the gate.
- `POST /v1/:workspace/github/promote` (`apps/api/src/routes/github-promote.ts`): **left unchanged**. It never calls the GitHub API to post a comment (pure copy of the calling workspace's own branch-staged attachments into its own PR prefix), so it's out of scope for "posts the bot comment on behalf of an explicit workspace call."
- The inbound webhook auto-promotion path (`github-webhook.ts`) was already binding-gated from earlier work and is untouched.

### Communal `default` detection

Reused the existing precedent from the Better Auth work: `isCommunal(env, name)` in `apps/api/src/routes/me.ts`, which compares against `env.DEFAULT_WORKSPACE || "default"`.

### CLI behavior

`packages/uploads/src/commands.ts`'s `syncAttachmentsComment` no longer falls back to the local `gh` path when the server declines with `reason:"not_authorized"` — it throws a new `GithubCommentAuthorizationError` with a message plus a `uploads github link --status --repo <repo>` hint, so the human makes an explicit choice instead of silently working around the gate with their own credentials. All other `posted:false` reasons (`app_unconfigured`, `not_installed`, `forbidden`, `unavailable`) keep the existing gh-fallback behavior. `COMMENT_HELP` gets a short note about the new decline. Changeset added (patch) for `@buildinternet/uploads`.

## Test plan

- [x] `pnpm --filter @uploads/api test` — 810 passed (5 new: allowed via own binding, implicit claim, declined for another workspace's binding, declined for communal default + unbound, D1-outage propagates as 5xx instead of "unbound")
- [x] `pnpm --filter @buildinternet/uploads test` — 604 passed (1 new: CLI does not fall back to gh on `not_authorized`, throws with the link-status hint)
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm test` (full repo) — 1986 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added cross-workspace authorization checks for GitHub comment posting.
  - Prevented comments from being posted to repositories linked to another workspace.
  - Prevented communal workspaces from claiming unlinked repositories.
  - Surfaced authorization declines instead of silently falling back to the local GitHub CLI.
  - Added guidance to check repository linking with `uploads github link --status`.
- **Documentation**
  - Updated comment command help to explain workspace-binding restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->