### PR TITLE
audit: github_repo_links write paths already gated; pin webhook read-only invariant

### DIFF
--- a/apps/api/src/github-webhook-auto-promote.test.ts
+++ b/apps/api/src/github-webhook-auto-promote.test.ts
@@ -217,6 +217,30 @@ describe("handleWebhook pull_request auto-promotion", () => {
     expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(false);
   });
 
+  // Issue #326: bindings must never be mintable off an unauthenticated (HMAC-only)
+  // path. The webhook consumes an existing binding (findRepoLink) and only ever
+  // deletes a stale one (deleteRepoLink) — it must never create one, even for a
+  // same-repo, promote-eligible PR event on a previously unbound repo.
+  it("never creates a binding for an unbound repo, even on a promotable same-repo PR event", async () => {
+    const { env, db } = await baseEnv();
+    await seedStaged(env, "hero.png");
+
+    await withMockPost(() => handleWebhook(env, "pull_request", prPayload({ action: "opened" })));
+
+    expect(db.repoLinks.has(REPO)).toBe(false);
+  });
+
+  it("does not import any binding-write helper (recordRepoLink/setRepoLink) — read/delete only", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath, URL: NodeURL } = await import("node:url");
+    const src = readFileSync(
+      fileURLToPath(new NodeURL("./github-webhook.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(src).not.toMatch(/recordRepoLink/);
+    expect(src).not.toMatch(/setRepoLink/);
+  });
+
   it("never throws / never lets a downstream error escape", async () => {
     const { env } = await baseEnv();
     await recordRepoLink(env.DB, REPO, WS, "promote");


### PR DESCRIPTION
## Summary

Issue #326 asks for an audit of every `github_repo_links` write path, since PR #327 made bindings authorization-bearing for same-repo bot-comment posting (and #325's lifecycle work builds on the same table). The concern: a binding must never be mintable as a side effect of a weakly-authenticated (or unauthenticated) call — only from an explicit workspace-scoped authenticated claim or admin override.

**Audit result: every write path already meets the bar. No production code changes needed.** This PR adds tests that pin the invariant so it can't silently regress.

## Audit table

| Call site | Function | Auth context | Verdict |
|---|---|---|---|
| `apps/api/src/routes/github-comment.ts:155` (`POST /v1/:workspace/github/comment`) | `recordRepoLink` (INSERT OR IGNORE, implicit claim) | `workspaceAuth` (mounted at `/v1/:workspace/*`) + `writeRateLimit` + `requireScope("files:read")`, plus `checkRepoAuthorization` cross-tenant gate (issue #297 baseline) | **OK** — workspace-authed, only fires after the bot comment actually posted. Explicitly called out in the issue as the accepted baseline from #327. |
| `apps/api/src/routes/github-promote.ts:72` (`POST /v1/:workspace/github/promote`) | `recordRepoLink` (implicit claim) | `workspaceAuth` + `writeRateLimit` + `requireScope("files:write")` | **OK** — workspace-authed, only fires after a successful promote of the calling workspace's own staged attachments. |
| `apps/api/src/routes/github-link.ts:72` (`POST /v1/:workspace/github/link`) | `recordRepoLink` (explicit claim) | `workspaceAuth` + `writeRateLimit` + `requireScope("files:write")` | **OK** — this is the dedicated explicit-claim endpoint the issue asks for; first-claim-wins via `INSERT OR IGNORE`. |
| `apps/api/src/routes/admin-ui.ts:550` (`PUT /admin-ui/github-links`) | `setRepoLink` (operator override, overwrites owner) | `.use("/*", sessionAuth, requireSessionUser, requireAdminUser)` on the whole `admin-ui` router, plus per-route `allowWrite`/workspace-existence checks | **OK** — admin session auth, not reachable without it. |
| `apps/api/src/github-webhook.ts` (`handleWebhook` → `autoPromoteAndComment`, HMAC-verified GitHub webhook) | `findRepoLink` (read) + `deleteRepoLink` (cleanup of stale/tombstoned-workspace bindings) — **no write/create call** | HMAC signature only, no workspace token; mounted at `/v1/github/webhook`, registered *before* the `workspaceAuth` middleware in `index.ts` | **OK — this is the path the issue is most worried about, and it never writes.** It only *consumes* an existing binding to auto-promote/comment, and only *deletes* a binding when the bound workspace is gone. Confirmed by reading the whole file and grepping for `recordRepoLink`/`setRepoLink` (zero hits outside test files). |

No implicit-claim path was found that lacks equivalent auth, and the webhook — the one path with the weakest possible auth (HMAC, no workspace token) — was already read/delete-only before this PR.

## Minimum binding age (optional idea from the issue)

Deferred, per the issue's own framing. Same-repo posting (the #297/#327 gate) must not get an age gate — that would break the legitimate first-claim-then-immediately-post flow, which is exactly how a workspace establishes its binding today. A minimum age would only matter once cross-repo/fork trust decisions exist (the #317 trust-model work), and that mechanism isn't built yet. Adding an age check now would be speculative and have no consumer; better to add it alongside whatever fork-trust logic actually needs it. `created_at` is already stored on every row (`github_repo_links.created_at`), so nothing here blocks adding it later.

## What changed

Added tests to `apps/api/src/github-webhook-auto-promote.test.ts` to pin the invariant:
- `handleWebhook` never creates a `github_repo_links` row for a previously-unbound repo, even on a promotable, same-repo `pull_request` event with staged attachments ready to go.
- A static source-scan asserting `github-webhook.ts` never imports `recordRepoLink`/`setRepoLink` — catches a future accidental import even before behavior tests would.

## Test plan

- [x] `pnpm --filter @uploads/api test` — 812/812 passing (includes the 2 new tests)
- [x] `pnpm -r typecheck` — clean across all workspace projects

Fixes #326
