### PR TITLE
feat(api): reconcile managed attachments comment on issue_comment webhook

### DIFF
--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -144,7 +144,10 @@ const COMMENT_ID_TTL = 60 * 60 * 24 * 30; // 30 days.
  * workspace, phase 4b). A cache entry written under the pre-4b key format
  * (`ghcomment:<repo>#<num>`, no workspace dimension) simply misses under this
  * key and falls through to a fresh marker hunt — no migration needed. */
-function commentCacheKey(workspaceName: string, target: Pick<GhTarget, "repo" | "num">): string {
+export function commentCacheKey(
+  workspaceName: string,
+  target: Pick<GhTarget, "repo" | "num">,
+): string {
   return `ghcomment:${workspaceName}:${target.repo.toLowerCase()}#${target.num}`;
 }
 

--- a/apps/api/src/github-webhook-reconcile.test.ts
+++ b/apps/api/src/github-webhook-reconcile.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Issue #291: `issue_comment` webhook reconcile (`handleWebhook`'s
+ * `issue_comment` handling in github-webhook.ts). Mirrors
+ * github-webhook-auto-promote.test.ts's structure/fakes — calls
+ * `handleWebhook` directly (no `ctx`) so assertions are deterministic
+ * without draining a `waitUntil` queue.
+ */
+import { describe, expect, it } from "vitest";
+import { handleWebhook } from "./github-webhook";
+import { recordRepoLink } from "./github-repo-links";
+import { replaceFileMetadata } from "./file-metadata";
+import { sha256Hex, type WorkspaceRecord } from "./workspace";
+import { FakeKv } from "../test/fake-kv";
+import { FakeR2Bucket } from "../test/fake-r2";
+import { UsageFakeD1 } from "../test/usage-fake-d1";
+import { GITHUB_APP_CFG_ENV } from "../test/github-app-env";
+
+const WS = "acme";
+const PREFIX = "acme/";
+const REPO = "acme/web";
+const NUM = 12;
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+const MARKER_BODY = "before\n<!-- uploads.sh:attachments ws=acme -->\nstuff";
+
+async function baseEnv(): Promise<{ env: Env; db: UsageFakeD1; bucket: FakeR2Bucket }> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: PREFIX,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex("unused"), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const bucket = new FakeR2Bucket();
+  const db = new UsageFakeD1();
+  const githubCache = new FakeKv();
+  githubCache.store.set("ghinst:acme/web", { value: "42" });
+  githubCache.store.set("ghtok:42", { value: "cached-token" });
+  const env = {
+    REGISTRY: registry,
+    DB: db,
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: githubCache,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, db, bucket };
+}
+
+async function seedAttachment(env: Env, filename: string) {
+  const bucket = (env as unknown as { UPLOADS_DEFAULT: FakeR2Bucket }).UPLOADS_DEFAULT;
+  await bucket.put(`${PREFIX}gh/acme/web/issues/${NUM}/${filename}`, PNG, {
+    httpMetadata: { contentType: "image/png" },
+  });
+  await replaceFileMetadata(env.DB, WS, `gh/acme/web/issues/${NUM}/${filename}`, {
+    "gh.repo": REPO,
+    "gh.kind": "issues",
+    "gh.num": String(NUM),
+  });
+}
+
+function issueCommentPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: "deleted",
+    repository: { full_name: REPO },
+    issue: { number: NUM },
+    comment: { body: MARKER_BODY, user: { login: "uploads-sh[bot]", type: "Bot" } },
+    sender: { login: "someone", type: "User" },
+    ...overrides,
+  };
+}
+
+function withMockGithub(handler: () => Promise<void>) {
+  const realFetch = globalThis.fetch;
+  let postCalled = false;
+  globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+    if (String(url).includes(`/issues/${NUM}/comments`)) {
+      if (init.method === "POST") {
+        postCalled = true;
+        return new Response(
+          JSON.stringify({ id: 9, html_url: `https://github.com/${REPO}/issues/${NUM}#c9` }),
+          { status: 201 },
+        );
+      }
+      return new Response(JSON.stringify([]), { status: 200 });
+    }
+    return new Response("nf", { status: 404 });
+  }) as unknown as typeof fetch;
+  return handler()
+    .then(() => postCalled)
+    .finally(() => {
+      globalThis.fetch = realFetch;
+    });
+}
+
+describe("handleWebhook issue_comment reconcile", () => {
+  it("reconciles (recreates the comment) on a bot-authored deletion of the marker comment", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedAttachment(env, "hero.png");
+
+    const postCalled = await withMockGithub(() =>
+      handleWebhook(env, "issue_comment", issueCommentPayload()),
+    );
+    expect(postCalled).toBe(true);
+  });
+
+  it("reconciles on an edit that still carries the marker (non-bot sender)", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedAttachment(env, "hero.png");
+
+    const postCalled = await withMockGithub(() =>
+      handleWebhook(env, "issue_comment", issueCommentPayload({ action: "edited" })),
+    );
+    expect(postCalled).toBe(true);
+  });
+
+  it("ignores an ordinary human comment (created, no marker)", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+
+    let fetchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(
+        env,
+        "issue_comment",
+        issueCommentPayload({
+          action: "created",
+          comment: { body: "just chatting", user: { login: "someone", type: "User" } },
+        }),
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("ignores a deleted comment authored by a human, even if it happens to include the marker text", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+
+    let fetchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(
+        env,
+        "issue_comment",
+        issueCommentPayload({
+          comment: { body: MARKER_BODY, user: { login: "human", type: "User" } },
+        }),
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("does not re-trigger off its own edit (sender is a bot) — loop guard", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedAttachment(env, "hero.png");
+
+    let fetchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(
+        env,
+        "issue_comment",
+        issueCommentPayload({
+          action: "edited",
+          sender: { login: "uploads-sh[bot]", type: "Bot" },
+        }),
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("no-ops when the repo has no binding", async () => {
+    const { env } = await baseEnv();
+
+    let fetchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(env, "issue_comment", issueCommentPayload());
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("invalidates the stale cached comment id before re-hunting, so a deleted comment id isn't reused", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedAttachment(env, "hero.png");
+    const githubCache = (env as unknown as { GITHUB_CACHE: FakeKv }).GITHUB_CACHE;
+    githubCache.store.set(`ghcomment:${WS}:${REPO.toLowerCase()}#${NUM}`, { value: "stale-id" });
+
+    let patchCalled = false;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes(`/issues/comments/stale-id`)) {
+        patchCalled = true;
+        return new Response("nf", { status: 404 });
+      }
+      if (String(url).includes(`/issues/${NUM}/comments`)) {
+        if (init.method === "POST") {
+          return new Response(
+            JSON.stringify({ id: 9, html_url: `https://github.com/${REPO}/issues/${NUM}#c9` }),
+            { status: 201 },
+          );
+        }
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(env, "issue_comment", issueCommentPayload());
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    // The cache was pre-invalidated by reconcile, so upsertBotComment never
+    // even attempts the stale-id PATCH — it goes straight to the marker hunt.
+    expect(patchCalled).toBe(false);
+  });
+
+  it("never throws / never lets a downstream error escape", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+    await seedAttachment(env, "hero.png");
+
+    const bucket = (env as unknown as { UPLOADS_DEFAULT: FakeR2Bucket }).UPLOADS_DEFAULT;
+    const realGet = bucket.get.bind(bucket);
+    bucket.get = (async () => {
+      throw new Error("boom");
+    }) as typeof bucket.get;
+    try {
+      await expect(
+        handleWebhook(env, "issue_comment", issueCommentPayload()),
+      ).resolves.toBeUndefined();
+    } finally {
+      bucket.get = realGet;
+    }
+  });
+
+  it("does not import any binding-write helper (recordRepoLink/setRepoLink) — read/delete only", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath, URL: NodeURL } = await import("node:url");
+    const src = readFileSync(
+      fileURLToPath(new NodeURL("./github-webhook.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(src).not.toMatch(/recordRepoLink/);
+    expect(src).not.toMatch(/setRepoLink/);
+  });
+});

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -15,13 +15,23 @@
  * involvement. This runs off the request's fast path via `ctx.waitUntil` so
  * the webhook still responds 204 promptly; every failure inside is caught
  * and logged, never surfaced as a 5xx.
+ *
+ * Reconcile (`issue_comment` `edited`/`deleted`, issue #291): heals the
+ * managed comment when it's deleted or mangled out from under the bot (the
+ * cached `ghcomment:` id going stale). Gated by a cheap, I/O-free payload
+ * check (`isReconcilableCommentEvent`) since this event fires on every
+ * comment in every installed repo — only a bot-authored deletion or an edit
+ * still carrying the attachments marker proceeds to the (binding-gated)
+ * gather+upsert. Same `ctx.waitUntil`/degrade-safe doctrine as above; never
+ * creates a repo binding, only consumes `findRepoLink`.
  */
 
 import { githubAppConfig, installationForRepo } from "./github-app";
-import { gatherCommentBody, upsertBotComment } from "./github-comment";
+import { commentCacheKey, gatherCommentBody, upsertBotComment } from "./github-comment";
+import { ATTACHMENTS_MARKER } from "./github-comment-render";
 import type { GhTarget } from "./github-comment-render";
 import { promoteBranchAttachments } from "./github-promote";
-import { deleteRepoLink, findRepoLink } from "./github-repo-links";
+import { deleteRepoLink, findRepoLink, type RepoLink } from "./github-repo-links";
 import { loadWorkspaceRecord } from "./workspace";
 
 const enc = new TextEncoder();
@@ -93,12 +103,58 @@ interface PullRequestPayload {
 }
 
 /**
+ * Look up the repo's bound workspace, gather its own current attachments for
+ * `target`, and upsert the managed comment from that render. Shared by both
+ * auto-promotion (after a fresh promote) and reconcile (after an
+ * invalidation) — read/delete-only against `github_repo_links` per the #326
+ * gate: a missing/tombstoned linked workspace cleans up the stale link and
+ * no-ops, never creates a new one. Caller is responsible for catching.
+ */
+async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Promise<void> {
+  const ws = await loadWorkspaceRecord(env, link.workspaceName);
+  if (!ws) {
+    // The bound workspace is gone or tombstoned — the link is stale;
+    // clean it up so a future claim (e.g. from another workspace) isn't
+    // blocked by first-claim-wins forever.
+    await deleteRepoLink(env.DB, target.repo);
+    return;
+  }
+
+  const gathered = await gatherCommentBody(env, ws, link.workspaceName, target);
+  if (gathered.skip) return; // nothing staged and nothing pre-existing — no empty comment.
+
+  const cfg = githubAppConfig(env);
+  if (!cfg) return;
+  const installId = link.installationId ?? (await installationForRepo(env, cfg, target.repo));
+  if (installId === null) return;
+
+  const result = await upsertBotComment(
+    env,
+    cfg,
+    installId,
+    target,
+    gathered.body,
+    link.workspaceName,
+  );
+  if ("degrade" in result) {
+    console.error(
+      JSON.stringify({
+        message: "webhook bot-comment degraded",
+        repo: target.repo,
+        num: target.num,
+        reason: result.degrade,
+      }),
+    );
+  }
+}
+
+/**
  * Best-effort webhook-driven auto-promotion for one `pull_request` delivery.
  * No-ops (never throws) on: a cross-repo PR (fork head), no repo link, a
- * missing/tombstoned linked workspace (also cleans up the stale link), or
- * any downstream promote/gather/comment failure. Reuses
- * `promoteBranchAttachments` and `gatherCommentBody`/`upsertBotComment`
- * verbatim — no duplicated copy/render/post logic.
+ * missing/tombstoned linked workspace, or any downstream promote/gather/
+ * comment failure. Reuses `promoteBranchAttachments` and `gatherAndUpsert`
+ * (which itself reuses `gatherCommentBody`/`upsertBotComment` verbatim) — no
+ * duplicated copy/render/post logic.
  */
 async function autoPromoteAndComment(env: Env, p: PullRequestPayload): Promise<void> {
   const repo = p.repository?.full_name;
@@ -125,9 +181,6 @@ async function autoPromoteAndComment(env: Env, p: PullRequestPayload): Promise<v
 
     const ws = await loadWorkspaceRecord(env, link.workspaceName);
     if (!ws) {
-      // The bound workspace is gone or tombstoned — the link is stale;
-      // clean it up so a future claim (e.g. from another workspace) isn't
-      // blocked by first-claim-wins forever.
       await deleteRepoLink(env.DB, repo);
       return;
     }
@@ -139,40 +192,97 @@ async function autoPromoteAndComment(env: Env, p: PullRequestPayload): Promise<v
     });
 
     // Gather AFTER promoting: the just-promoted copies are now real objects
-    // under the PR's attachment prefix, so this single gather call (reused
-    // verbatim from the comment route) already reflects them — no separate
-    // "promoted > 0" branch needed.
+    // under the PR's attachment prefix, so this single gather call already
+    // reflects them — no separate "promoted > 0" branch needed.
     const target: GhTarget = { repo, kind: "pull", num };
-    const gathered = await gatherCommentBody(env, ws, link.workspaceName, target);
-    if (gathered.skip) return; // nothing staged and nothing pre-existing — no empty comment.
-
-    const cfg = githubAppConfig(env);
-    if (!cfg) return;
-    const installId = link.installationId ?? (await installationForRepo(env, cfg, repo));
-    if (installId === null) return;
-
-    const result = await upsertBotComment(
-      env,
-      cfg,
-      installId,
-      target,
-      gathered.body,
-      link.workspaceName,
-    );
-    if ("degrade" in result) {
-      console.error(
-        JSON.stringify({
-          message: "webhook auto-comment degraded",
-          repo,
-          num,
-          reason: result.degrade,
-        }),
-      );
-    }
+    await gatherAndUpsert(env, link, target);
   } catch (err) {
     console.error(
       JSON.stringify({
         message: "webhook auto-promote failed",
+        repo,
+        num,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+/** Substring shared by every managed-comment marker variant (legacy + the
+ * per-workspace `ws=<slug>` namespaced form) — cheap to test for without
+ * parsing which marker it is. Derived from `ATTACHMENTS_MARKER` so there is
+ * one source of truth for the literal. */
+const MARKER_SUBSTRING = ATTACHMENTS_MARKER.replace(/^<!--\s*|\s*-->$/g, "");
+
+interface IssueCommentPayload {
+  action?: unknown;
+  repository?: { full_name?: unknown };
+  issue?: { number?: unknown; pull_request?: unknown };
+  comment?: { body?: unknown; user?: { login?: unknown; type?: unknown } };
+  sender?: { login?: unknown; type?: unknown };
+}
+
+/**
+ * True iff this `issue_comment` delivery plausibly concerns the managed
+ * attachments comment and is worth the (DB + GitHub API) cost of reconciling.
+ * This event class fires on EVERY comment in every installed repo, so the
+ * check here must stay a pure, allocation-free read of the payload already
+ * in hand — no I/O.
+ *
+ * - `created`: never relevant (a fresh human/bot comment is not the managed
+ *   one going stale) — cheap reject on `action` alone.
+ * - `deleted`: relevant only when the deleted comment was authored by a bot
+ *   AND its (still-included, pre-deletion) body carries the marker —
+ *   otherwise it's someone's unrelated comment.
+ * - `edited`: relevant only when the current body still carries the marker.
+ *   Loop guard lives here too: an edit whose `sender` is itself a bot is
+ *   assumed to be our own `upsertBotComment` PATCH (GitHub attributes App-
+ *   token writes to the App's bot user) and is skipped, so reconcile never
+ *   re-triggers off its own write.
+ */
+function isReconcilableCommentEvent(p: IssueCommentPayload): boolean {
+  const body = p.comment?.body;
+  if (typeof body !== "string" || !body.includes(MARKER_SUBSTRING)) return false;
+
+  if (p.action === "deleted") {
+    return p.comment?.user?.type === "Bot";
+  }
+  if (p.action === "edited") {
+    if (p.sender?.type === "Bot") return false; // our own write — no loop.
+    return true;
+  }
+  return false; // "created" and anything else.
+}
+
+/**
+ * Best-effort reconcile for one `issue_comment` delivery: when the managed
+ * comment was deleted or mangled out from under us, drop the (now stale)
+ * cached comment id and re-run gather+upsert so it's recreated/repaired from
+ * the bound workspace's own data. Same degrade-safe doctrine as
+ * `autoPromoteAndComment`: swallow every failure, never 5xx, never create a
+ * repo binding (read/delete-only via `findRepoLink`/`deleteRepoLink`).
+ */
+async function reconcileBotComment(env: Env, p: IssueCommentPayload): Promise<void> {
+  if (!isReconcilableCommentEvent(p)) return;
+
+  const repo = p.repository?.full_name;
+  const num = p.issue?.number;
+  if (typeof repo !== "string" || typeof num !== "number") return;
+
+  try {
+    const link = await findRepoLink(env.DB, repo);
+    if (!link) return;
+
+    const target: GhTarget = { repo, kind: p.issue?.pull_request ? "pull" : "issues", num };
+    // Force a fresh marker hunt + write rather than trusting a cached id that
+    // may point at the very comment that was just deleted/mangled.
+    await env.GITHUB_CACHE.delete(commentCacheKey(link.workspaceName, target));
+
+    await gatherAndUpsert(env, link, target);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "webhook comment reconcile failed",
         repo,
         num,
         error: err instanceof Error ? err.message : String(err),
@@ -228,5 +338,12 @@ export async function handleWebhook(
       if (ctx) ctx.waitUntil(work);
       else await work; // no executionCtx (e.g. some test/call sites) — run inline.
     }
+  } else if (eventType === "issue_comment") {
+    // isReconcilableCommentEvent's cheap payload-only check runs before any
+    // I/O, so the common case (an ordinary human comment on any installed
+    // repo — this event fires on every one) returns near-instantly.
+    const work = reconcileBotComment(env, p as IssueCommentPayload);
+    if (ctx) ctx.waitUntil(work);
+    else await work;
   }
 }

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -144,6 +144,12 @@ const TOC = [
       attachment auto-promotion silently do nothing. Run <code>uploads github doctor</code> to
       check: it calls the App API directly and reports any missing subscription.
     </p>
+    <p>
+      We also recommend subscribing to the <code>issue_comment</code> event. It's optional — the
+      App works fully without it — but it lets the managed attachments comment self-heal if it's
+      ever deleted or edited out from under the bot, instead of waiting for the next PR push to
+      re-render it.
+    </p>
   </section>
 
   <section id="without-it">


### PR DESCRIPTION
## Summary

- Heals the managed `uploads-sh[bot]` attachments comment on `issue_comment` webhook deliveries: if it's deleted or edited/mangled out from under the bot, reconcile invalidates the cached `ghcomment:` id and re-runs the existing binding-gated gather+upsert flow so it's recreated/repaired from the bound workspace's own data.
- Extracted a shared `gatherAndUpsert` helper in `apps/api/src/github-webhook.ts` so `pull_request` auto-promotion and the new `issue_comment` reconcile both reuse the same "load bound workspace → gather → upsert" logic (was previously copy-pasted inline in `autoPromoteAndComment`).
- Event filtering is a pure, I/O-free check on the payload (`isReconcilableCommentEvent`) — this event fires on every comment in every installed repo, so ordinary human comments return immediately with no DB/API calls:
  - `created`: never relevant, rejected on `action` alone.
  - `deleted`: relevant only if the deleted comment's (still-included, pre-deletion) body carries the attachments marker **and** its author's `user.type` is `"Bot"`.
  - `edited`: relevant only if the current body still carries the marker.
- Loop guard: an `edited` event whose `sender.type` is `"Bot"` is treated as our own `upsertBotComment` PATCH (GitHub attributes App-token writes to the App's bot user) and is skipped — reconcile never re-triggers off its own write.
- Same degrade-safe doctrine as the existing `pull_request` handling: every failure is caught and logged, never surfaced as a 5xx; the webhook path stays read/delete-only against `github_repo_links` (`findRepoLink`/`deleteRepoLink`) — it never creates a binding (kept the existing pinning test green, added the same "no recordRepoLink/setRepoLink import" assertion to the new test file).
- `REQUIRED_WEBHOOK_EVENTS` (`apps/api/src/github-app.ts`) is **unchanged** — kept `issue_comment` out of it. Reconcile is a nice-to-have self-heal, not required for the App's core functionality (title cache invalidation, auto-promotion), so an uninstalled/unsubscribed `issue_comment` event should not turn the `uploads github doctor` health check red for existing installs. Instead, `apps/web/src/pages/docs/github-app.astro` now recommends subscribing to `issue_comment` as optional. Happy to reconsider and add it to a "recommended" (non-`ok`-gating) tier in the doctor output as a follow-up if we want visibility into whether it's subscribed.

## Operator step (required after deploy)

This handler does nothing until the App is subscribed to the event — same silent-failure trap issue #293/#324 fixed for `issues`/`pull_request`. After deploying this PR:

1. Go to the GitHub App settings (`github.com/settings/apps/<your-app>` or org equivalent) → **Permissions & events** → **Subscribe to events**.
2. Tick **`issue_comment`**.
3. Save.

Fixes #291

## Test plan

- [x] `pnpm --filter @uploads/api test` — 821 tests passed (added `apps/api/src/github-webhook-reconcile.test.ts`: relevant bot-deletion reconciles, relevant marker-bearing edit reconciles, ordinary human `created` comment ignored (no fetch calls), human-authored deletion with marker-like text ignored, bot-sender edit doesn't loop, no-binding no-op, stale cached id is invalidated before re-hunting (no wasted PATCH-to-404), a forced downstream throw is swallowed, and the existing "no binding-write import" pin is asserted against the updated file).
- [x] `pnpm -r typecheck` — clean (pre-existing Astro-file warnings unrelated to this change).
- [ ] After deploy: tick `issue_comment` under the App's Subscribe to events (see Operator step above), then verify by deleting/mangling a managed comment on a bound repo and confirming it's recreated.
