### PR TITLE
docs(web,skills): cover binding lifecycle, doctor, and comment self-heal

### DIFF
--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -10,7 +10,9 @@ const TOC = [
   { id: "what-it-adds", label: "What it adds" },
   { id: "install", label: "Install it" },
   { id: "staging", label: "Staging before a PR exists" },
-  { id: "permissions", label: "Permissions" },
+  { id: "permissions", label: "Permissions & events" },
+  { id: "bindings", label: "Repo bindings" },
+  { id: "self-healing", label: "Self-healing comments" },
   { id: "without-it", label: "Without the App" },
 ];
 ---
@@ -31,6 +33,19 @@ const TOC = [
     configure on this side. The CLI notices the installation automatically the next time you
     run <code>uploads attach</code>.
   </aside>
+
+  <p>
+    Landed here from a <code>uploads-sh[bot]</code> comment's "docs" link? That comment is a
+    managed, auto-updating attachment list — images and files someone uploaded for this PR or
+    issue, kept current under one collapsible block instead of scattered across separate
+    comments. Anyone with repo access can add to it:
+    install the <a href="https://www.npmjs.com/package/@buildinternet/uploads">uploads CLI</a>,
+    run <code>uploads login</code> once, then <code>uploads put ./file.png --pr 123 --comment</code>
+    (or <code>--issue 123</code>) to upload a file and refresh the comment in one step. See&#32;
+    <a href="/docs/attach-pull-request-images">Attach &amp; share</a> for the full put/attach
+    walkthrough. The rest of this page is about the optional GitHub App that makes that comment
+    post as the bot instead of via your own <code>gh</code> auth.
+  </p>
 
   <section class="lead" id="what-it-adds">
     <h2>What it adds <a class="anchor" href="#what-it-adds" aria-label="Link to this section">#</a></h2>
@@ -121,7 +136,7 @@ const TOC = [
   </section>
 
   <section id="permissions">
-    <h2>Permissions <a class="anchor" href="#permissions" aria-label="Link to this section">#</a></h2>
+    <h2>Permissions &amp; events <a class="anchor" href="#permissions" aria-label="Link to this section">#</a></h2>
     <p>The App asks for the minimum it needs:</p>
     <ul>
       <li>
@@ -136,19 +151,76 @@ const TOC = [
       exact approval link and falls back to posting via <code>gh</code> in the meantime.
     </p>
     <p>
-      The App also needs to be <strong>subscribed to the <code>issues</code> and
-      <code>pull_request</code> webhook events</strong> (Settings → your App →
-      <em>Permissions &amp; events</em> → <em>Subscribe to events</em>). Without them the App's
-      ping still shows green — GitHub always sends <code>ping</code> and installation events
-      regardless of subscription — but webhook-driven title cache invalidation and branch-staged
-      attachment auto-promotion silently do nothing. Run <code>uploads github doctor</code> to
-      check: it calls the App API directly and reports any missing subscription.
+      Permissions alone aren't enough — the App also has to be
+      <strong>subscribed to webhook events</strong> (Settings → your App →
+      <em>Permissions &amp; events</em> → <em>Subscribe to events</em>):
+    </p>
+    <ul>
+      <li>
+        <strong>Required — <code>issues</code> and <code>pull_request</code>.</strong> Without
+        these the App's ping still shows green (GitHub always sends <code>ping</code> and
+        installation events regardless of subscription) but webhook-driven title cache
+        invalidation and branch-staged attachment auto-promotion silently do nothing.
+      </li>
+      <li>
+        <strong>Recommended — <code>issue_comment</code>.</strong> Optional; the App works fully
+        without it. It's what lets the managed attachments comment&#32;
+        <a href="#self-healing">self-heal</a> if it's ever deleted or edited out from under the
+        bot, instead of waiting for the next PR push to re-render it.
+      </li>
+    </ul>
+    <p>
+      Run <code>uploads github doctor</code> to check: it calls the App API directly and
+      reports any missing required subscription, so a silent misconfiguration doesn't sit there
+      unnoticed.
+    </p>
+    <div class="cmd">
+      <span class="text">uploads github doctor</span>
+      <button type="button" data-copy="uploads github doctor" aria-live="polite">copy</button>
+    </div>
+  </section>
+
+  <section id="bindings">
+    <h2>Repo bindings <a class="anchor" href="#bindings" aria-label="Link to this section">#</a></h2>
+    <p>
+      One repo maps to at most one workspace's managed comment — first claim wins. The binding
+      is normally created implicitly the first time a workspace successfully comments, attaches,
+      or promotes against a repo; you can also inspect or claim it explicitly:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads github link --status</span>
+      <button type="button" data-copy="uploads github link --status" aria-live="polite">copy</button>
+    </div>
+    <p>
+      Claiming an already-bound repo never steals it from whoever claimed it first — the
+      command just reports the current owner. <code>uploads github unlink</code> releases a
+      binding your own workspace owns; it fails if another workspace owns it, same as claiming
+      does. If a binding is stuck or abandoned, an operator can reassign or remove it from the
+      admin panel without going through the owning workspace at all.
     </p>
     <p>
-      We also recommend subscribing to the <code>issue_comment</code> event. It's optional — the
-      App works fully without it — but it lets the managed attachments comment self-heal if it's
-      ever deleted or edited out from under the bot, instead of waiting for the next PR push to
-      re-render it.
+      <strong>Other workspaces can't post to your repo.</strong> If your repo is bound to your
+      workspace, a different workspace's <code>comment</code>/<code>attach</code> call against it
+      is declined outright (<code>not_authorized</code>) — it does not fall back to posting
+      under that person's own <code>gh</code> credentials, so there's no way for someone else's
+      workspace to deface or duplicate the bot comment on your repo. The one exception runs the
+      other way: the shared, communal <code>default</code> workspace can post to repos it
+      already owns, but it can never claim a fresh, unbound repo — that keeps the widest-shared
+      workspace from silently annexing other people's repos.
+    </p>
+  </section>
+
+  <section id="self-healing">
+    <h2>Self-healing comments <a class="anchor" href="#self-healing" aria-label="Link to this section">#</a></h2>
+    <p>
+      With the <code>issue_comment</code> event subscribed (see
+      <a href="#permissions">Permissions &amp; events</a> above), deleting the managed
+      <code>uploads-sh[bot]</code> comment — or editing out its hidden marker — doesn't leave a
+      PR or issue without one for long. The next <code>issue_comment</code> webhook delivery
+      notices it's gone or mangled and recreates it automatically, with the same attachment
+      list it would have shown. No CLI call needed to trigger it. If an agent notices the
+      comment briefly missing, that's expected — it isn't a signal to panic-repost with a fresh
+      <code>uploads comment</code> call.
     </p>
   </section>
 

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -109,17 +109,28 @@ uploads put ./demo.gif --format url
 Always embed the returned **markdown** (or `embedUrl`) in GitHub — it uses the
 no-cache host so overwrites propagate. Don't hand-build storage URLs.
 
-**Bot comment not showing up?** The managed comment needs a repo↔workspace
-binding (normally created implicitly by the first comment/promote call, or by
-installing the GitHub App). If a comment you expected doesn't appear, check
-the binding first:
+**Comment briefly disappeared? Don't panic-repost.** If the App is installed
+and subscribed to the `issue_comment` event, a deleted or edited-out managed
+comment self-heals automatically on the next webhook delivery — no need to
+run `comment`/`attach` again just to bring it back.
+
+**Bot comment not showing up at all?** The managed comment needs a
+repo↔workspace binding (normally created implicitly by the first
+comment/promote call, or by installing the GitHub App). If a comment you
+expected doesn't appear, check the binding first:
 
 ```bash
 uploads github link --status
 ```
 
 That's read-only and shows the current binding (or that the repo is
-unbound) without claiming anything.
+unbound) without claiming anything. If the CLI reports `not_authorized`
+instead, the repo is already bound to a _different_ workspace (or unbound
+under the communal `default` workspace, which can't claim new repos) — it
+won't fall back to posting via your own `gh` auth in that case. The fix is
+`uploads github unlink --repo owner/name` from the owning workspace, or
+asking an operator to reassign the binding; switching to the workspace that
+already owns it also works.
 
 **Curate, don't dump.** The comment inlines up to **16 images**; anything past
 that collapses into a `<details>` overflow list. Name and pick shots

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -64,9 +64,11 @@ once a PR exists for that branch:
 Promotion only applies to PRs, never issues, and both paths degrade silently
 (no error) if the workspace's server doesn't support promotion yet.
 
-**Comment missing?** Check the repo↔workspace binding first —
-`uploads github link --status` (read-only, shows the binding without
-claiming it). See "Repo binding" below.
+**Comment missing?** First, give it a moment — if the App is installed and
+subscribed to `issue_comment`, a deleted or mangled bot comment self-heals on
+the next webhook delivery; don't panic-repost. If it's still missing, check
+the repo↔workspace binding — `uploads github link --status` (read-only, shows
+the binding without claiming it). See "Repo binding" below.
 
 The killer feature for GitHub: `--pr`/`--issue` produce **hash-free, stable keys**
 (`gh/<owner>/<repo>/pull/<num>/<name>`), so re-uploading the same filename overwrites
@@ -457,21 +459,40 @@ managed comment on a shared repo (namespaced under the hood) instead of
 clobbering another workspace's — use `uploads github link` (below) to see or
 set which workspace a repo is bound to.
 
-### Repo binding (`uploads github link`)
+### Repo binding (`uploads github link` / `unlink` / `doctor`)
 
 The managed comment and webhook auto-promotion use a first-claim-wins binding
 between a repo and a workspace, normally created implicitly by your first
-`comment`/`put --comment`/promote call. Inspect or explicitly claim it:
+`comment`/`put --comment`/promote call. Inspect, claim, or release it:
 
 ```bash
 uploads github link                       # claim the current repo for this workspace
 uploads github link --repo owner/name     # claim a specific repo
 uploads github link --status              # read-only: show the current binding, don't claim
+uploads github unlink --repo owner/name   # release a binding this workspace owns
+uploads github doctor                     # check the App itself (config + webhook events)
 ```
 
 Claiming an already-bound repo never steals it — the command reports the
-existing owner instead. On an older/self-hosted server without this route it
-fails with a clear "server does not support repo bindings yet" message.
+existing owner instead. `unlink` only releases a binding this workspace owns;
+it 403s if another workspace owns it (an operator can reassign or remove it
+from the admin panel instead). On an older/self-hosted server without these
+routes they fail with a clear "server does not support repo bindings/GitHub
+App health check yet" message.
+
+**`not_authorized` on `comment`/`attach --comment`** means the repo is bound
+to a different workspace (or unbound and you're on the communal `default`
+workspace, which can never claim a fresh repo). This is a hard decline, not a
+degrade — the CLI does **not** fall back to posting via local `gh` in this
+case, unlike other bot-post failures. Run `uploads github link --status` to
+see who owns it, switch to that workspace, or ask an operator to reassign the
+binding.
+
+`uploads github doctor` checks the App's own configuration and webhook event
+subscriptions (needs `issues` + `pull_request`; `issue_comment` is
+recommended so a deleted/mangled bot comment self-heals instead of waiting
+for the next PR push) — useful when webhook-driven behavior (auto-promotion,
+title updates, self-healing) seems to be silently doing nothing.
 
 ### Embedding best practices
 


### PR DESCRIPTION
## Summary

Documentation sweep for what shipped to production/npm today (0.16.0/0.16.1): `github doctor`/health check (#324), binding lifecycle (unlink, admin reassign) (#325), cross-tenant authorization/`not_authorized` (#327), comment self-healing (#332), and the self-documenting comment footer (#331).

### apps/web/src/pages/docs/github-app.astro

Was stale/incomplete: had accreted a doctor note and a recommended-`issue_comment` note as separate paragraphs under one "Permissions" heading, with nothing at all about repo bindings, unlink, admin reassignment, or the cross-tenant guarantee — and nothing oriented at a stranger arriving from the bot comment's "docs" link.

Changed:
- Renamed the section "Permissions" → "Permissions & events" and split it into required (`issues`, `pull_request`) vs recommended (`issue_comment`) subsections, with `doctor` framed as the verification tool for both.
- Added a **Repo bindings** section: first-claim-wins, `uploads github unlink`, admin-panel reassign/remove, and a plain-language reassurance that another workspace's `not_authorized` decline means it cannot post to your repo (no `gh` fallback), with the one exception (communal `default` can post to repos it already owns but can never claim a fresh one).
- Added a **Self-healing comments** section explaining the `issue_comment`-driven automatic reconstruction.
- Added a short newcomer-orientation paragraph up top for readers who've never seen the CLI (what the bot comment is, how to install/sign in, the put/attach loop), linking to the existing Attach & share page for the full walkthrough.

### skills/uploads-cli/SKILL.md

The "Repo binding" section only covered `link`/`link --status` (added in #322, before unlink/doctor/not_authorized existed). Added: `unlink` and `doctor` to the command list and examples, a paragraph on what `not_authorized` means (bound elsewhere, or communal `default` can't claim) and that there's no `gh` fallback on that decline, and a doctor-usage note tied to the webhook events it checks. Updated the "Comment missing?" pointer to check self-healing first before assuming a binding problem.

### skills/github-screenshots/SKILL.md

Same era gap. Added a "Comment briefly disappeared? Don't panic-repost" callout ahead of the existing binding-check guidance, and extended that guidance to explain `not_authorized` and its remedy (`unlink` from the owning workspace, or an operator reassign).

### Other surfaces audited, no changes needed

- `apps/web/src/pages/docs.astro` (hub), `attach-pull-request-images.astro`, `agents.astro`, `reference.astro` — no stale claims about bindings/comments/GitHub flow.
- `README.md` — only a link to `/docs/github-app`, nothing to update.
- `attach --branch` filename guard (#321) and the dev stale-dist warning (#329) — both are internal/dev-only fixes with no doc-facing behavior; confirmed via the commits, no changes made.
- No changeset added — these are docs/skills-only changes (skills ship from the repo via `uploads install`, same as #322's precedent of adding no changeset for skill-only edits).

## Test plan

- [x] `pnpm -r typecheck` — exits 0 (Astro page typechecks clean; pre-existing `is:inline` hints on unrelated pages, no new errors/warnings)
- [x] `pnpm format` (oxfmt) — clean, only touched the 3 files in this PR
- [x] Manual diff review of `.astro` file for the `&#32;` whitespace-collapse gotcha on line-wrapped inline elements
- [ ] Visual verification in the browser was inconclusive (a stale/conflicting dev server on port 4321 from another concurrent session in this repo showed the old page) — content is verified by direct source review and diff instead
