### PR TITLE
feat(api,cli): recommended (non-gating) issue_comment webhook tier

### DIFF
--- a/.changeset/doctor-recommended-events.md
+++ b/.changeset/doctor-recommended-events.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads github doctor` now reports `issue_comment` as a recommended (non-gating) webhook event subscription. When the GitHub App is otherwise healthy but not subscribed to `issue_comment`, doctor prints a `note:` line and still exits 0 — required events (`issues`, `pull_request`) are unaffected. `--json` output gains `recommendedEvents` and `missingRecommendedEvents`; older servers whose health payload predates these fields are handled gracefully.

--- a/apps/api/src/github-app.ts
+++ b/apps/api/src/github-app.ts
@@ -94,6 +94,16 @@ export function githubFetch(
 export const REQUIRED_WEBHOOK_EVENTS = ["issues", "pull_request"] as const;
 
 /**
+ * Webhook events that are useful but not load-bearing: `issue_comment`
+ * enables bot-comment self-healing (reconciling the managed attachments
+ * comment when someone edits/deletes it) but nothing breaks silently without
+ * it the way it would for REQUIRED_WEBHOOK_EVENTS. Missing recommended events
+ * never flip the health check's `ok` to false — they're surfaced as a
+ * separate, non-gating tier (issue #333).
+ */
+export const RECOMMENDED_WEBHOOK_EVENTS = ["issue_comment"] as const;
+
+/**
  * The App's subscribed webhook events, straight from `GET /app` (App-JWT
  * auth, not installation-token — this is app-level metadata, no installation
  * needed). Returns null on any failure so callers degrade the same way the

--- a/apps/api/src/routes/github-health-route.test.ts
+++ b/apps/api/src/routes/github-health-route.test.ts
@@ -67,7 +67,12 @@ describe("GET /v1/:workspace/github/health", () => {
     const env = await seededEnv();
     const res = await getHealth(env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ configured: false, ok: false });
+    expect(await res.json()).toMatchObject({
+      configured: false,
+      ok: false,
+      recommendedEvents: ["issue_comment"],
+      missingRecommendedEvents: ["issue_comment"],
+    });
   });
 
   it("reports ok when subscribed to all required events", async () => {
@@ -89,6 +94,30 @@ describe("GET /v1/:workspace/github/health", () => {
       ok: true,
       missingEvents: [],
       requiredEvents: ["issues", "pull_request"],
+      recommendedEvents: ["issue_comment"],
+      missingRecommendedEvents: ["issue_comment"],
+    });
+  });
+
+  it("reports ok=true and no missing recommended events when subscribed to issue_comment too", async () => {
+    const pem = await testKeyPem();
+    const env = await seededEnv({ ...GITHUB_APP_CFG_ENV, GITHUB_APP_PRIVATE_KEY: pem });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ events: ["ping", "issues", "pull_request", "issue_comment"] }),
+            { status: 200 },
+          ),
+      ),
+    );
+    const res = await getHealth(env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      missingEvents: [],
+      missingRecommendedEvents: [],
     });
   });
 
@@ -107,6 +136,18 @@ describe("GET /v1/:workspace/github/health", () => {
     expect(body.hint).toContain("issues, pull_request");
   });
 
+  it("stays ok=false based only on required events even when recommended events are also missing", async () => {
+    const pem = await testKeyPem();
+    const env = await seededEnv({ ...GITHUB_APP_CFG_ENV, GITHUB_APP_PRIVATE_KEY: pem });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ events: ["ping"] }), { status: 200 })),
+    );
+    const res = await getHealth(env);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: false, missingRecommendedEvents: ["issue_comment"] });
+  });
+
   it("reports the check as failed when GET /app fails", async () => {
     const pem = await testKeyPem();
     const env = await seededEnv({ ...GITHUB_APP_CFG_ENV, GITHUB_APP_PRIVATE_KEY: pem });
@@ -116,7 +157,13 @@ describe("GET /v1/:workspace/github/health", () => {
     );
     const res = await getHealth(env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ configured: true, ok: false, events: null });
+    expect(await res.json()).toMatchObject({
+      configured: true,
+      ok: false,
+      events: null,
+      recommendedEvents: ["issue_comment"],
+      missingRecommendedEvents: ["issue_comment"],
+    });
   });
 
   it("401s with no bearer token", async () => {

--- a/apps/api/src/routes/github-health.ts
+++ b/apps/api/src/routes/github-health.ts
@@ -7,21 +7,34 @@
  * webhook auto-promotion and title-cache invalidation with no error anyone
  * sees. This surfaces that gap instead of requiring someone to notice via
  * `GET /app/hook/deliveries`.
+ *
+ * `issue_comment` is tracked separately as a recommended (non-gating) tier
+ * (issue #333) — missing it never flips `ok` to false, it only surfaces a
+ * hint that bot-comment self-healing isn't enabled.
  */
 import { Hono } from "hono";
-import { appEventSubscriptions, githubAppConfig, REQUIRED_WEBHOOK_EVENTS } from "../github-app";
+import {
+  appEventSubscriptions,
+  githubAppConfig,
+  RECOMMENDED_WEBHOOK_EVENTS,
+  REQUIRED_WEBHOOK_EVENTS,
+} from "../github-app";
 import { requireScope, type WorkspaceVars } from "../workspace";
 
 export interface GithubHealthResult {
   /** false when GITHUB_APP_ID/PRIVATE_KEY/HOME_INSTALLATION_ID aren't all set — the whole integration is off. */
   configured: boolean;
-  /** true only when configured AND every required event is subscribed. */
+  /** true only when configured AND every required event is subscribed. Missing recommended events never affect this. */
   ok: boolean;
   /** The App's subscribed webhook events from `GET /app`, or null if that call failed/is unknown. */
   events: string[] | null;
   /** Events uploads.sh's webhook handler needs but the App isn't subscribed to. Empty when ok. */
   missingEvents: string[];
   requiredEvents: readonly string[];
+  /** Events that improve behavior but aren't required — e.g. `issue_comment` for bot-comment self-healing. */
+  recommendedEvents: readonly string[];
+  /** Recommended events the App isn't subscribed to. Never gates `ok`. */
+  missingRecommendedEvents: string[];
   hint?: string;
 }
 
@@ -37,6 +50,8 @@ export const githubHealth = new Hono<WorkspaceVars>().get(
         events: null,
         missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
         requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+        recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
+        missingRecommendedEvents: [...RECOMMENDED_WEBHOOK_EVENTS],
         hint: "GitHub App is not configured on this worker (GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY/GITHUB_APP_HOME_INSTALLATION_ID)",
       });
     }
@@ -49,17 +64,22 @@ export const githubHealth = new Hono<WorkspaceVars>().get(
         events: null,
         missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
         requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+        recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
+        missingRecommendedEvents: [...RECOMMENDED_WEBHOOK_EVENTS],
         hint: "could not reach GET /app to read subscribed webhook events — try again shortly",
       });
     }
 
     const missingEvents = REQUIRED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
+    const missingRecommendedEvents = RECOMMENDED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
     return c.json<GithubHealthResult>({
       configured: true,
       ok: missingEvents.length === 0,
       events,
       missingEvents,
       requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+      recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
+      missingRecommendedEvents,
       hint:
         missingEvents.length > 0
           ? `subscribe to ${missingEvents.join(", ")} at github.com/settings/apps/<your-app> → Permissions & events → Subscribe to events`

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -290,6 +290,13 @@ export interface GithubHealthResult {
   events: string[] | null;
   missingEvents: string[];
   requiredEvents: string[];
+  /**
+   * Recommended-but-non-gating events, e.g. `issue_comment` (issue #333).
+   * Optional: older servers' health payload predates this field — treat a
+   * missing field as "no recommendations", not an error.
+   */
+  recommendedEvents?: string[];
+  missingRecommendedEvents?: string[];
   hint?: string;
 }
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2177,6 +2177,17 @@ Examples:
   uploads github doctor
 `;
 
+/** Older servers' health payload predates recommendedEvents/missingRecommendedEvents — treat as no recommendations rather than crashing. */
+function missingRecommendedEventsOf(result: GithubHealthResult): string[] {
+  return Array.isArray(result.missingRecommendedEvents) ? result.missingRecommendedEvents : [];
+}
+
+function recommendedNoteLine(result: GithubHealthResult): string {
+  const missing = missingRecommendedEventsOf(result);
+  if (missing.length === 0) return "";
+  return `note: not subscribed to ${missing.join(", ")} (recommended) — enables bot-comment self-healing; subscribe under the App's Permissions & events\n`;
+}
+
 function formatGithubDoctor(result: GithubHealthResult): string {
   if (!result.configured) {
     return `github app: not configured on this server${result.hint ? ` — ${result.hint}` : ""}\n`;
@@ -2185,11 +2196,15 @@ function formatGithubDoctor(result: GithubHealthResult): string {
     return `github app: configured, but health check failed${result.hint ? ` — ${result.hint}` : ""}\n`;
   }
   if (result.ok) {
-    return `github app: ok — subscribed to ${result.requiredEvents.join(", ")}\n`;
+    return (
+      `github app: ok — subscribed to ${result.requiredEvents.join(", ")}\n` +
+      recommendedNoteLine(result)
+    );
   }
   return (
     `github app: missing webhook event subscription(s): ${result.missingEvents.join(", ")}\n` +
-    (result.hint ? `  ${result.hint}\n` : "")
+    (result.hint ? `  ${result.hint}\n` : "") +
+    recommendedNoteLine(result)
   );
 }
 

--- a/packages/uploads/test/commands-github-doctor.test.ts
+++ b/packages/uploads/test/commands-github-doctor.test.ts
@@ -126,4 +126,61 @@ describe("runGithub (doctor)", () => {
     } as unknown as UploadsClient;
     await expect(runGithub(ctxWith(client), ["doctor"])).rejects.toThrow(UsageError);
   });
+
+  it("exits 0 but prints a note line when only a recommended event is missing", async () => {
+    const stdout: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => (stdout.push(String(chunk)), true));
+    try {
+      const code = await runGithub(
+        ctxWith(
+          clientWith({
+            configured: true,
+            ok: true,
+            events: ["ping", "issues", "pull_request"],
+            missingEvents: [],
+            requiredEvents: ["issues", "pull_request"],
+            recommendedEvents: ["issue_comment"],
+            missingRecommendedEvents: ["issue_comment"],
+          }),
+        ),
+        ["doctor"],
+      );
+      expect(code).toBe(0);
+      const out = stdout.join("");
+      expect(out).toContain("ok");
+      expect(out).toContain("note: not subscribed to issue_comment (recommended)");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("tolerates an older server payload without recommended fields (no crash, no note line)", async () => {
+    const stdout: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => (stdout.push(String(chunk)), true));
+    try {
+      const code = await runGithub(
+        ctxWith(
+          clientWith({
+            configured: true,
+            ok: true,
+            events: ["ping", "issues", "pull_request"],
+            missingEvents: [],
+            requiredEvents: ["issues", "pull_request"],
+            // recommendedEvents/missingRecommendedEvents intentionally omitted
+          }),
+        ),
+        ["doctor"],
+      );
+      expect(code).toBe(0);
+      const out = stdout.join("");
+      expect(out).toContain("ok");
+      expect(out).not.toContain("note:");
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `RECOMMENDED_WEBHOOK_EVENTS = ["issue_comment"]` in `apps/api/src/github-app.ts`, alongside the existing `REQUIRED_WEBHOOK_EVENTS` (`issues`, `pull_request`, unchanged).
- `GET /v1/:workspace/github/health` now returns `recommendedEvents` and `missingRecommendedEvents`. `ok` is based only on required events — a missing recommended event never flips it to false. The not-configured and degrade (events-null) branches populate the new fields too.
- `uploads github doctor` (`packages/uploads/src/commands.ts`) prints an extra `note:` line when ok but a recommended event is missing, e.g.:
  ```
  github app: ok — subscribed to issues, pull_request
  note: not subscribed to issue_comment (recommended) — enables bot-comment self-healing; subscribe under the App's Permissions & events
  ```
  Exit code stays 0. `--json` passes the new fields through. The CLI-side `GithubHealthResult` type marks the new fields optional so older servers whose payload predates them degrade to "no recommendations" instead of crashing.

## Docs

`apps/web/src/pages/docs/github-app.astro` already describes `issue_comment` as an optional/recommended event (not required) — checked and it's still accurate, so left untouched. A docs-sweep is running concurrently on that file on another branch; flagging here in case the coordinator wants to fold in a mention of the doctor note-line output, but no change is currently warranted.

Fixes #333

## Test plan

- [x] `pnpm --filter @uploads/api test` — 823 passed, including new route tests for recommended-events ok/missing/degrade cases
- [x] `pnpm --filter @buildinternet/uploads test` — 610 passed, including new CLI doctor tests for the note line, exit-0-on-recommended-missing, and old-server-payload tolerance
- [x] `pnpm -r typecheck` — 0 errors
- [x] Changeset added (minor, `@buildinternet/uploads`)
