### PR TITLE
feat(api): per-PR media activity rollup + recent-PRs feed

### DIFF
--- a/apps/api/migrations/20260721150000_github_pr_activity.sql
+++ b/apps/api/migrations/20260721150000_github_pr_activity.sql
@@ -1,0 +1,18 @@
+-- Per-PR media activity rollup (issue #338). One row per PR ref
+-- ("owner/repo#n", lowercased); upserted whenever PR-tagged media is written
+-- (promote or direct --pr attach, both via putObject). Powers the
+-- "recent PRs with media" feed — not an event log, and media_count is a
+-- monotonic events counter (overwrites re-count), not a distinct-file count.
+CREATE TABLE github_pr_activity (
+  ref TEXT PRIMARY KEY,
+  repo_full_name TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  branch TEXT,
+  workspace_name TEXT NOT NULL,
+  media_count INTEGER NOT NULL DEFAULT 0,
+  first_media_at TEXT NOT NULL,
+  last_media_at TEXT NOT NULL
+);
+
+CREATE INDEX github_pr_activity_workspace_recent_idx
+  ON github_pr_activity (workspace_name, last_media_at DESC);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -14,6 +14,7 @@ import {
   uploadBudgetDenial,
 } from "./budget";
 import { deleteFileMetadata, replaceFileMetadata, validateMetadataEntries } from "./file-metadata";
+import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
 import {
@@ -257,6 +258,7 @@ export async function putObject(
     // one atomic batch (replaceFileMetadata) rather than a delete followed
     // by a separate re-read-then-write.
     await replaceFileMetadata(env.DB, workspaceName, finalKey, opts.metadata);
+    await recordPrActivityFromMetadata(env.DB, workspaceName, opts.metadata);
   }
 
   const cfg = await storageConfig(env, ws);

--- a/apps/api/src/github-pr-activity.ts
+++ b/apps/api/src/github-pr-activity.ts
@@ -1,0 +1,153 @@
+/**
+ * Per-PR media activity rollup (`github_pr_activity` D1 table, issue #338).
+ * A row is upserted from putObject whenever an object carrying
+ * `gh.kind=pull` metadata lands — server-side promotion and direct `--pr`
+ * attaches both flow through that choke point — so the table answers
+ * "which PRs recently got media?" without a webhook event log.
+ *
+ * `media_count` counts media-write events (an overwrite of the same key
+ * counts again), not distinct files; treat it as an activity signal, not an
+ * inventory. Rows are keyed by `ref` ("owner/repo#n", lowercased) and carry
+ * the last workspace that wrote media for the PR (in practice one workspace
+ * per repo, per the `github_repo_links` binding model).
+ */
+
+export interface PrActivity {
+  ref: string;
+  repo: string;
+  prNumber: number;
+  branch: string | null;
+  workspaceName: string;
+  mediaCount: number;
+  firstMediaAt: string;
+  lastMediaAt: string;
+}
+
+interface PrActivityRow {
+  ref: string;
+  repo_full_name: string;
+  pr_number: number;
+  branch: string | null;
+  workspace_name: string;
+  media_count: number;
+  first_media_at: string;
+  last_media_at: string;
+}
+
+function rowToActivity(row: PrActivityRow): PrActivity {
+  return {
+    ref: row.ref,
+    repo: row.repo_full_name,
+    prNumber: row.pr_number,
+    branch: row.branch,
+    workspaceName: row.workspace_name,
+    mediaCount: row.media_count,
+    firstMediaAt: row.first_media_at,
+    lastMediaAt: row.last_media_at,
+  };
+}
+
+export interface PrMediaEvent {
+  /** "owner/name" — lowercased here, so callers can pass tag values as-is. */
+  repo: string;
+  prNumber: number;
+  branch?: string | null;
+  workspaceName: string;
+  /** Media writes this event represents (>= 1). */
+  count: number;
+}
+
+/**
+ * Best-effort upsert: never throws — activity tracking rides along with an
+ * upload/promote response and a D1 blip here must not fail that request.
+ * `first_media_at` is set once; `last_media_at` always advances; a null
+ * branch never clobbers a previously recorded one.
+ */
+export async function recordPrMediaActivity(
+  db: D1Database,
+  event: PrMediaEvent,
+  now = new Date(),
+): Promise<void> {
+  const repo = event.repo.toLowerCase();
+  const ref = `${repo}#${event.prNumber}`;
+  try {
+    await db
+      .prepare(
+        `INSERT INTO github_pr_activity
+           (ref, repo_full_name, pr_number, branch, workspace_name,
+            media_count, first_media_at, last_media_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(ref) DO UPDATE SET
+           media_count = media_count + excluded.media_count,
+           branch = COALESCE(excluded.branch, branch),
+           workspace_name = excluded.workspace_name,
+           last_media_at = excluded.last_media_at`,
+      )
+      .bind(
+        ref,
+        repo,
+        event.prNumber,
+        event.branch ?? null,
+        event.workspaceName,
+        event.count,
+        now.toISOString(),
+        now.toISOString(),
+      )
+      .run();
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "pr activity record failed",
+        ref,
+        workspaceName: event.workspaceName,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+/**
+ * The putObject hook (files-core.ts): derives a PR media event from an
+ * object's custom-metadata tag set. Only `gh.kind=pull` objects with a
+ * well-formed repo + number count; anything else (branch-staged files,
+ * issue attaches, non-GitHub uploads, malformed tags) is silently ignored.
+ * Never throws (recordPrMediaActivity swallows D1 failures).
+ */
+export async function recordPrActivityFromMetadata(
+  db: D1Database,
+  workspaceName: string,
+  metadata: Record<string, string>,
+): Promise<void> {
+  if (metadata["gh.kind"] !== "pull") return;
+  const repo = metadata["gh.repo"];
+  const prNumber = Number(metadata["gh.number"]);
+  if (!repo || !repo.includes("/") || !Number.isInteger(prNumber) || prNumber <= 0) return;
+  await recordPrMediaActivity(db, {
+    repo,
+    prNumber,
+    branch: metadata["gh.branch"] ?? null,
+    workspaceName,
+    count: 1,
+  });
+}
+
+/**
+ * The workspace's PRs with media, most recent activity first. Strict — the
+ * read endpoint should surface a D1 failure as a 5xx, not an empty feed.
+ */
+export async function listPrActivityForWorkspace(
+  db: D1Database,
+  workspaceName: string,
+  limit: number,
+): Promise<PrActivity[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM github_pr_activity
+       WHERE workspace_name = ?
+       ORDER BY last_media_at DESC
+       LIMIT ?`,
+    )
+    .bind(workspaceName, limit)
+    .all<PrActivityRow>();
+  return (results ?? []).map(rowToActivity);
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -25,6 +25,7 @@ import { githubComment } from "./routes/github-comment";
 import { githubPromote } from "./routes/github-promote";
 import { githubLink } from "./routes/github-link";
 import { githubHealth } from "./routes/github-health";
+import { githubActivity } from "./routes/github-activity";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -142,6 +143,9 @@ export const app = new Hono<WorkspaceVars>()
   // Issue #293 follow-up: App-level webhook event subscription check, same
   // base path, distinct sub-route "/health".
   .route("/v1/:workspace/github", githubHealth)
+  // Issue #338: recent-PRs-with-media feed, same base path, distinct
+  // sub-route "/activity".
+  .route("/v1/:workspace/github", githubActivity)
   .onError((err, c) => respondError(c, err))
   .notFound((c) => respondError(c, new NotFoundError()));
 

--- a/apps/api/src/routes/github-activity-route.test.ts
+++ b/apps/api/src/routes/github-activity-route.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../index";
+import { sha256Hex, type WorkspaceRecord } from "../workspace";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+
+// Same node-vs-workerd Web Crypto gap as github-link-route.test.ts — this
+// suite exercises the real workspaceAuth middleware end to end.
+if (typeof crypto.subtle.timingSafeEqual !== "function") {
+  (
+    crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+  ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+    a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+const WS = "acme";
+const TOKEN = "up_acme_testtoken";
+
+async function seededEnv(workspace = WS, token = TOKEN): Promise<{ env: Env; db: UsageFakeD1 }> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: `${workspace}/`,
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex(token), createdAt: new Date().toISOString() }],
+  };
+  const registry = {
+    get: (async (key: string) =>
+      key === `ws:${workspace}` ? record : null) as unknown as KVNamespace["get"],
+  };
+  const db = new UsageFakeD1();
+  const env = { REGISTRY: registry, DB: db } as unknown as Env;
+  return { env, db };
+}
+
+function get(env: Env, workspace: string, token: string, query = "") {
+  return app.request(
+    `/v1/${workspace}/github/activity${query}`,
+    { headers: { authorization: `Bearer ${token}` } },
+    env,
+  );
+}
+
+function seedActivity(db: UsageFakeD1, prNumber: number, lastMediaAt: string, workspace = WS) {
+  db.prActivity.set(`acme/web#${prNumber}`, {
+    ref: `acme/web#${prNumber}`,
+    repo_full_name: "acme/web",
+    pr_number: prNumber,
+    branch: "feat/x",
+    workspace_name: workspace,
+    media_count: 3,
+    first_media_at: "2026-07-20T09:00:00.000Z",
+    last_media_at: lastMediaAt,
+  });
+}
+
+describe("GET /v1/:workspace/github/activity", () => {
+  it("requires auth", async () => {
+    const { env } = await seededEnv();
+    const res = await get(env, WS, "wrong-token");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns an empty feed when the workspace has no PR media activity", async () => {
+    const { env } = await seededEnv();
+    const res = await get(env, WS, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ workspace: WS, activity: [] });
+  });
+
+  it("lists the workspace's PRs, most recent media first", async () => {
+    const { env, db } = await seededEnv();
+    seedActivity(db, 1, "2026-07-21T10:00:00.000Z");
+    seedActivity(db, 2, "2026-07-21T12:00:00.000Z");
+    seedActivity(db, 99, "2026-07-21T13:00:00.000Z", "someone-else");
+    const res = await get(env, WS, TOKEN);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { activity: { prNumber: number; mediaCount: number }[] };
+    expect(body.activity.map((a) => a.prNumber)).toEqual([2, 1]);
+    expect(body.activity[0]).toMatchObject({
+      ref: "acme/web#2",
+      repo: "acme/web",
+      branch: "feat/x",
+      mediaCount: 3,
+      lastMediaAt: "2026-07-21T12:00:00.000Z",
+    });
+  });
+
+  it("honors limit and rejects a malformed one", async () => {
+    const { env, db } = await seededEnv();
+    seedActivity(db, 1, "2026-07-21T10:00:00.000Z");
+    seedActivity(db, 2, "2026-07-21T12:00:00.000Z");
+    const ok = await get(env, WS, TOKEN, "?limit=1");
+    const body = (await ok.json()) as { activity: unknown[] };
+    expect(body.activity).toHaveLength(1);
+    for (const bad of ["0", "101", "abc", "1.5"]) {
+      const res = await get(env, WS, TOKEN, `?limit=${bad}`);
+      expect(res.status).toBe(400);
+    }
+  });
+});

--- a/apps/api/src/routes/github-activity.ts
+++ b/apps/api/src/routes/github-activity.ts
@@ -1,0 +1,36 @@
+/**
+ * `/v1/:workspace/github/activity` (issue #338). Read-only feed of the
+ * workspace's PRs that recently received media, backed by the
+ * `github_pr_activity` rollup (see ../github-pr-activity.ts — upserted from
+ * putObject whenever `gh.kind=pull` metadata lands). Strict read: a D1
+ * failure surfaces as a 5xx rather than an empty-looking feed.
+ */
+import { ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import { listPrActivityForWorkspace } from "../github-pr-activity";
+import { requireScope, type WorkspaceVars } from "../workspace";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function parseLimit(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_LIMIT;
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new ValidationError(`limit must be an integer between 1 and ${MAX_LIMIT}.`, {
+      code: "invalid_limit",
+    });
+  }
+  return limit;
+}
+
+export const githubActivity = new Hono<WorkspaceVars>().get(
+  "/activity",
+  requireScope("files:read"),
+  async (c) => {
+    const limit = parseLimit(c.req.query("limit"));
+    const workspaceName = c.get("workspaceName");
+    const activity = await listPrActivityForWorkspace(c.env.DB, workspaceName, limit);
+    return c.json({ workspace: workspaceName, activity });
+  },
+);

--- a/apps/api/src/routes/github-promote-route.test.ts
+++ b/apps/api/src/routes/github-promote-route.test.ts
@@ -232,6 +232,16 @@ describe("POST /v1/:workspace/github/promote", () => {
     expect(originalMeta["gh.branch"]).toBe(BRANCH);
     expect(originalMeta["gh.promoted-to"]).toBe("acme/web#12");
     expect(typeof originalMeta["gh.promoted-at"]).toBe("string");
+
+    // Promotion also upserts the PR activity rollup (issue #338) via
+    // putObject's gh.kind=pull metadata hook.
+    expect(seeded.db.prActivity.get("acme/web#12")).toMatchObject({
+      repo_full_name: "acme/web",
+      pr_number: NUM,
+      branch: BRANCH,
+      workspace_name: WS,
+      media_count: 1,
+    });
   });
 
   it("treats a missing gh.staged-at as fresh (workspace's own data)", async () => {

--- a/apps/api/test/github-pr-activity-sqlite.test.ts
+++ b/apps/api/test/github-pr-activity-sqlite.test.ts
@@ -1,0 +1,150 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import {
+  listPrActivityForWorkspace,
+  recordPrActivityFromMetadata,
+  recordPrMediaActivity,
+} from "../src/github-pr-activity";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260721150000_github_pr_activity.sql";
+
+describe("github pr activity persistence against SQLite", () => {
+  it("returns an empty feed for a workspace with no activity", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await expect(listPrActivityForWorkspace(database(sqlite), "acme", 20)).resolves.toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("records an event and lowercases the repo into the ref", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      await recordPrMediaActivity(database(sqlite), {
+        repo: "Acme/Web",
+        prNumber: 7,
+        branch: "feat/x",
+        workspaceName: "acme",
+        count: 2,
+      });
+      const [row] = await listPrActivityForWorkspace(database(sqlite), "acme", 20);
+      expect(row).toMatchObject({
+        ref: "acme/web#7",
+        repo: "acme/web",
+        prNumber: 7,
+        branch: "feat/x",
+        workspaceName: "acme",
+        mediaCount: 2,
+      });
+      expect(row.firstMediaAt).toBe(row.lastMediaAt);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("upserts: increments the count, advances last_media_at, keeps first_media_at", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const t1 = new Date("2026-07-21T10:00:00Z");
+      const t2 = new Date("2026-07-21T11:00:00Z");
+      const event = { repo: "acme/web", prNumber: 7, workspaceName: "acme", count: 1 };
+      await recordPrMediaActivity(db, { ...event, branch: "feat/x" }, t1);
+      await recordPrMediaActivity(db, { ...event, branch: null }, t2);
+      const [row] = await listPrActivityForWorkspace(db, "acme", 20);
+      expect(row.mediaCount).toBe(2);
+      expect(row.firstMediaAt).toBe(t1.toISOString());
+      expect(row.lastMediaAt).toBe(t2.toISOString());
+      // A null branch never clobbers a previously recorded one (COALESCE).
+      expect(row.branch).toBe("feat/x");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("orders the feed by most recent activity and honors the limit", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      for (const [num, at] of [
+        [1, "2026-07-21T10:00:00Z"],
+        [2, "2026-07-21T12:00:00Z"],
+        [3, "2026-07-21T11:00:00Z"],
+      ] as const) {
+        await recordPrMediaActivity(
+          db,
+          { repo: "acme/web", prNumber: num, workspaceName: "acme", count: 1 },
+          new Date(at),
+        );
+      }
+      const rows = await listPrActivityForWorkspace(db, "acme", 2);
+      expect(rows.map((r) => r.prNumber)).toEqual([2, 3]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("scopes the feed to the requested workspace", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await recordPrMediaActivity(db, {
+        repo: "acme/web",
+        prNumber: 1,
+        workspaceName: "acme",
+        count: 1,
+      });
+      await recordPrMediaActivity(db, {
+        repo: "other/repo",
+        prNumber: 2,
+        workspaceName: "other",
+        count: 1,
+      });
+      const rows = await listPrActivityForWorkspace(db, "acme", 20);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ref).toBe("acme/web#1");
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("recordPrActivityFromMetadata", () => {
+  it("records only well-formed gh.kind=pull tag sets", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await recordPrActivityFromMetadata(db, "acme", {
+        "gh.repo": "acme/web",
+        "gh.kind": "pull",
+        "gh.number": "7",
+        "gh.branch": "feat/x",
+      });
+      // Ignored: branch-staged, issue attach, malformed number, missing repo.
+      await recordPrActivityFromMetadata(db, "acme", {
+        "gh.repo": "acme/web",
+        "gh.kind": "branch",
+        "gh.branch": "feat/x",
+      });
+      await recordPrActivityFromMetadata(db, "acme", {
+        "gh.repo": "acme/web",
+        "gh.kind": "issue",
+        "gh.number": "9",
+      });
+      await recordPrActivityFromMetadata(db, "acme", {
+        "gh.repo": "acme/web",
+        "gh.kind": "pull",
+        "gh.number": "nope",
+      });
+      await recordPrActivityFromMetadata(db, "acme", { "gh.kind": "pull", "gh.number": "7" });
+      const rows = await listPrActivityForWorkspace(db, "acme", 20);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ ref: "acme/web#7", branch: "feat/x", mediaCount: 1 });
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/helpers/fake-pr-activity-table.ts
+++ b/apps/api/test/helpers/fake-pr-activity-table.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared in-memory `github_pr_activity` table backing for route tests
+ * (usage-fake-d1.ts) — mirrors the real upsert semantics (count increments,
+ * first_media_at set once, COALESCE'd branch) without a sqlite-backed D1.
+ * See ../github-pr-activity-sqlite.test.ts for real-SQL-semantics coverage.
+ */
+
+import type { FakeAllResult, FakeRunResult } from "./fake-repo-links-table";
+
+export interface PrActivityRow {
+  ref: string;
+  repo_full_name: string;
+  pr_number: number;
+  branch: string | null;
+  workspace_name: string;
+  media_count: number;
+  first_media_at: string;
+  last_media_at: string;
+}
+
+export class PrActivityTable {
+  readonly rows = new Map<string, PrActivityRow>();
+
+  tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
+    if (normalizedSql.startsWith("INSERT INTO github_pr_activity")) {
+      const [ref, repo, prNumber, branch, workspace, count, firstAt, lastAt] = args as [
+        string,
+        string,
+        number,
+        string | null,
+        string,
+        number,
+        string,
+        string,
+      ];
+      const existing = this.rows.get(ref);
+      if (existing) {
+        this.rows.set(ref, {
+          ...existing,
+          media_count: existing.media_count + count,
+          branch: branch ?? existing.branch,
+          workspace_name: workspace,
+          last_media_at: lastAt,
+        });
+      } else {
+        this.rows.set(ref, {
+          ref,
+          repo_full_name: repo,
+          pr_number: prNumber,
+          branch,
+          workspace_name: workspace,
+          media_count: count,
+          first_media_at: firstAt,
+          last_media_at: lastAt,
+        });
+      }
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    return undefined;
+  }
+
+  tryAll<T>(normalizedSql: string, args: unknown[]): FakeAllResult<T> | undefined {
+    if (normalizedSql.startsWith("SELECT * FROM github_pr_activity WHERE workspace_name")) {
+      const [workspace, limit] = args as [string, number];
+      // Non-mutating sort — lib ES2022 predates Array#toSorted (see
+      // fake-repo-links-table.ts).
+      const results = [...this.rows.values()]
+        .filter((row) => row.workspace_name === workspace)
+        .sort((a, b) => b.last_media_at.localeCompare(a.last_media_at))
+        .slice(0, limit);
+      return { success: true, results: results as T[], meta: {} };
+    }
+    return undefined;
+  }
+}

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -4,6 +4,7 @@
  */
 
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
+import { PrActivityTable } from "./helpers/fake-pr-activity-table";
 import { RepoLinksTable } from "./helpers/fake-repo-links-table";
 
 export type UsageRow = {
@@ -30,6 +31,12 @@ export class UsageFakeD1 {
   get repoLinks() {
     return this.repoLinksTable.rows;
   }
+  // Backs `github_pr_activity` — putObject upserts a row whenever
+  // gh.kind=pull metadata lands (issue #338).
+  private prActivityTable = new PrActivityTable();
+  get prActivity() {
+    return this.prActivityTable.rows;
+  }
 
   prepare = (sql: string) => {
     const normalized = sql.replace(/\s+/g, " ").trim();
@@ -54,6 +61,8 @@ export class UsageFakeD1 {
         if (result) return result;
         const linkResult = this.repoLinksTable.tryAll<T>(normalized, values);
         if (linkResult) return linkResult;
+        const activityResult = this.prActivityTable.tryAll<T>(normalized, values);
+        if (activityResult) return activityResult;
         // Galleries aren't modeled by this fake (route/gallery-specific tests
         // bring their own D1 stand-in) — an empty page is a safe, honest
         // default for callers (e.g. the webhook auto-promote gather) that
@@ -68,6 +77,8 @@ export class UsageFakeD1 {
         if (metaResult) return metaResult;
         const linkResult = this.repoLinksTable.tryRun(normalized, values);
         if (linkResult) return linkResult;
+        const activityResult = this.prActivityTable.tryRun(normalized, values);
+        if (activityResult) return activityResult;
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
           // applyUsageDelta: (ws, period, updatedAt) with zeros
           // setUsageTotals: (ws, bytes, objects, period, updatedAt)


### PR DESCRIPTION
# In plain terms

Until now there was no way to ask "which PRs recently got media through uploads?" — PR identity only existed as scattered `gh.*` tags on individual files, with no grouping or time ordering. This adds a small per-PR activity rollup that updates itself whenever PR media lands, plus a feed endpoint to read it. It's the first piece of the repo-activity work specced in #338 (companions: #339 in-flight staged view, #340 uploader attribution).

# What it does

- New D1 table `github_pr_activity`: one row per PR ref (`owner/repo#n`), tracking branch, workspace, a media-event count, and first/last media timestamps.
- Rows are upserted from `putObject` — the single choke point both server-side promotion and direct `--pr` attaches flow through — whenever an object carries well-formed `gh.kind=pull` metadata. Best-effort: a D1 blip never fails the upload/promote it rides along with.
- New workspace-authed read endpoint: `GET /v1/:workspace/github/activity?limit=…` → recent PRs with media, most recent first.

# What it is not

- Not a webhook event log; raw deliveries are still not persisted.
- `media_count` counts media-write events (an overwrite counts again), not distinct files — an activity signal, not an inventory.
- No PR title/state enrichment, no cross-workspace/admin feed, no CLI surface yet.

# Technical notes

- `apps/api/src/github-pr-activity.ts` follows the `github-repo-links.ts` helper pattern (best-effort write, strict read). Migration `20260721150000_github_pr_activity.sql`.
- Upsert semantics: count increments, `last_media_at` advances, `first_media_at` sticks, a null branch never clobbers a recorded one (`COALESCE`).
- Tests: sqlite-backed semantics suite, route suite, and a promote-route assertion that promotion populates the rollup. Fake D1 gained a `github_pr_activity` table helper.

# Test plan

- [x] `pnpm --filter @uploads/api test` (842 passing)
- [x] `pnpm typecheck`
- [x] `pnpm check`
- [ ] Post-merge: migration auto-applies via d1-migrations workflow; curl the feed on prod

Closes #338
