### PR TITLE
feat(api,cli): gh.status lifecycle tag — query in-flight staged media

### DIFF
--- a/.changeset/gh-status-lifecycle-tag.md
+++ b/.changeset/gh-status-lifecycle-tag.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Branch-staged attaches now stamp `gh.status=staged`, and server-side promotion flips the staged original to `gh.status=promoted`. In-flight staged media becomes a plain equality query: `uploads find gh.status=staged` (narrow with `gh.branch=<name>` or `gh.repo=<owner/name>`).

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -180,10 +180,13 @@ export async function promoteBranchAttachments(
     promoted.push(destKey);
     try {
       // Merge (not replace) onto the staged original: mark it promoted
-      // without disturbing its own gh.repo/gh.kind/gh.branch/gh.staged-at tags.
+      // without disturbing its own gh.repo/gh.kind/gh.branch/gh.staged-at
+      // tags. `gh.status` (issue #339) flips so in-flight staged media is a
+      // plain equality query (`meta.gh.status=staged`).
       await setFileMetadata(env.DB, workspaceName, key, {
         "gh.promoted-to": ref,
         "gh.promoted-at": nowIso,
+        "gh.status": "promoted",
       });
     } catch (err) {
       console.error(

--- a/apps/api/src/routes/github-promote-route.test.ts
+++ b/apps/api/src/routes/github-promote-route.test.ts
@@ -232,6 +232,9 @@ describe("POST /v1/:workspace/github/promote", () => {
     expect(originalMeta["gh.branch"]).toBe(BRANCH);
     expect(originalMeta["gh.promoted-to"]).toBe("acme/web#12");
     expect(typeof originalMeta["gh.promoted-at"]).toBe("string");
+    // Lifecycle flip (issue #339): the staged original is no longer
+    // "in flight" once promoted.
+    expect(originalMeta["gh.status"]).toBe("promoted");
 
     // Promotion also upserts the PR activity rollup (issue #338) via
     // putObject's gh.kind=pull metadata hook.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,7 +151,9 @@ replaces the whole metadata set; re-upload **without** `--meta` leaves existing
 pairs alone. `uploads attach` and `put --pr`/`--issue` also stamp `gh.repo` /
 `gh.kind` / `gh.number` / `gh.ref` automatically, plus `gh.title` when the
 PR/issue title is resolvable via local `gh` (best-effort — never blocks the
-upload).
+upload). Branch staging (`attach --branch`) stamps `gh.status=staged`, flipped
+to `promoted` on promotion — query in-flight files with
+`uploads find gh.status=staged`.
 
 Non-`gh.*` metadata may appear on the public `/f/…` file page — don't store
 secrets or private notes.

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -129,6 +129,11 @@ export function ghMetadataForBranch(
     "gh.kind": "branch",
     "gh.branch": branchLower,
     "gh.staged-at": now.toISOString().replace(/\.\d{3}Z$/, "Z"),
+    // Lifecycle tag (issue #339): flipped to "promoted" by server-side
+    // promotion, so "in-flight staged media" is a plain equality query
+    // (`meta.gh.status=staged`) — the metadata filter API can't express
+    // "gh.promoted-at absent".
+    "gh.status": "staged",
   };
 }
 

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -112,12 +112,13 @@ describe("ghBranchKeyPrefix / ghBranchAttachmentKey", () => {
 describe("ghMetadataForBranch", () => {
   const now = new Date("2026-07-20T18:00:00.123Z");
 
-  it("writes gh.repo/gh.kind=branch/gh.branch/gh.staged-at (no gh.number/gh.ref/gh.title)", () => {
+  it("writes gh.repo/gh.kind=branch/gh.branch/gh.staged-at/gh.status (no gh.number/gh.ref/gh.title)", () => {
     expect(ghMetadataForBranch("BuildInternet/Uploads", "main", now)).toEqual({
       "gh.repo": "buildinternet/uploads",
       "gh.kind": "branch",
       "gh.branch": "main",
       "gh.staged-at": "2026-07-20T18:00:00Z",
+      "gh.status": "staged",
     });
   });
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -46,7 +46,10 @@ naming and output control.
 instead of a PR/issue number — same upload path, no target flags, no comment
 (there's nothing to comment on yet). With no value, `--branch` resolves the
 current git branch; `/` in the name sanitizes to `-`. Attach this way at every
-visual milestone during the work, not just once at the end.
+visual milestone during the work, not just once at the end. Staged files carry
+`gh.status=staged` until promotion flips them to `promoted`, so
+`uploads find gh.status=staged` (add `gh.branch=<name>` to narrow) lists what's
+still in flight.
 
 Getting those files into the PR's attachments comment needs no extra step
 once a PR exists for that branch:


### PR DESCRIPTION
# In plain terms

There was no way to ask "which staged screenshots are still in flight?" — a staged file becomes not-in-flight when promotion stamps `gh.promoted-at`, but the metadata filter API only does equality, so "promoted-at absent" wasn't expressible. This adds a plain lifecycle tag that makes the question a one-liner. Specced in #339; companion to the activity feed (#341) and uploader attribution (#340).

# What it does

- `uploads attach --branch` (and everything else using `ghMetadataForBranch`) now stamps `gh.status=staged` on branch-staged files.
- Server-side promotion flips the staged original to `gh.status=promoted` in the same merge-tag write that records `gh.promoted-to`/`gh.promoted-at`.
- In-flight staged media becomes an equality query through the existing find/list surface:

```bash
uploads find gh.status=staged
uploads find gh.status=staged gh.branch=feat/my-branch
```

# What it is not

- No new query semantics — the reaper keeps using `gh.staged-at`/`gh.promoted-at` as source of truth; `gh.status` is a denormalized convenience.
- Pre-existing staged rows lack the tag (no backfill); the 30-day staging reaper ages them out, so the gap self-closes.
- No dedicated `uploads github staged` command yet — `find` covers it; sugar can come later if it earns its keep.

# Technical notes

- CLI: `packages/uploads/src/github.ts` (`ghMetadataForBranch`); server: `apps/api/src/github-promote.ts` merge-tag. Docs synced in `skills/uploads-cli/SKILL.md` + `docs/cli.md`; changeset included (minor).

# Test plan

- [x] `pnpm test` (2024 passing, incl. updated branch-metadata + promote-route assertions)
- [x] `pnpm typecheck` / `pnpm check`
- [ ] Post-merge smoke: stage a file on a branch in prod, `uploads find gh.status=staged`, promote, confirm flip

Closes #339
