### PR TITLE
feat(cli,api): full-scope token on interactive login, doctor scope surfacing

### DIFF
--- a/.changeset/login-full-scope-token.md
+++ b/.changeset/login-full-scope-token.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads login` now mints a full-scope token by default (files:read, files:write, files:delete) so the CLI's own `delete` command works out of the box; pass `--scopes` to narrow it. `uploads doctor` now shows the token's scopes and hints when files:delete is missing.

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -14,7 +14,14 @@ import { requireScope, type WorkspaceVars } from "../workspace";
 export const usage = new Hono<WorkspaceVars>()
   .get("/", requireScope("files:read"), async (c) => {
     const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
-    return c.json(usageWithLimits(snapshot, c.get("workspace")));
+    // `scopes` reflects the presented credential, not the workspace — doctor
+    // uses it to surface a token that can't delete before the user hits a
+    // surprise `forbidden`. Legacy tokens report the full file-scope set,
+    // which is what they actually have.
+    return c.json({
+      ...usageWithLimits(snapshot, c.get("workspace")),
+      scopes: c.get("authScopes"),
+    });
   })
 
   .post("/reconcile", requireScope("files:write"), async (c) => {

--- a/apps/api/test/routes-usage.test.ts
+++ b/apps/api/test/routes-usage.test.ts
@@ -58,6 +58,8 @@ describe("GET /v1/:workspace/usage + put/delete metering", () => {
       objects: 0,
       uploadsInPeriod: 0,
       periodStart: usagePeriodStart(),
+      // Legacy KV-hash token (this suite's TOKEN) → full file-scope set.
+      scopes: ["files:read", "files:write", "files:delete"],
     });
   });
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -311,6 +311,8 @@ export interface UsageResult {
   storageRemainingBytes?: number;
   maxUploadsPerPeriod?: number;
   uploadsRemaining?: number;
+  /** File scopes of the presented token (servers ≥ this field's release). */
+  scopes?: Array<TokenScope>;
 }
 
 export interface ReconcileResult {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2484,6 +2484,8 @@ export interface DoctorReport {
     uploadsInPeriod?: number;
     error?: string;
   };
+  /** File scopes of the presented token (absent against pre-scopes servers). */
+  scopes?: string[];
   /** Workspace/token mismatch warning (also present in hints). */
   warning?: string;
   hints: string[];
@@ -2587,6 +2589,7 @@ export async function buildDoctorReport(
         error?: string;
       }
     | undefined;
+  let scopes: string[] | undefined;
   if (authOk) {
     try {
       const snap = await client.usage();
@@ -2596,6 +2599,12 @@ export async function buildDoctorReport(
         objects: snap.objects,
         uploadsInPeriod: snap.uploadsInPeriod,
       };
+      scopes = snap.scopes;
+      if (scopes && !scopes.includes("files:delete")) {
+        hints.push(
+          "token lacks files:delete (`uploads delete` will be forbidden) — re-run `uploads login` for a full-scope token",
+        );
+      }
     } catch (err) {
       usage = {
         ok: false,
@@ -2620,6 +2629,7 @@ export async function buildDoctorReport(
     health,
     auth: { ok: authOk, error: authError },
     usage,
+    scopes,
     warning: mismatch,
     hints,
     browser,
@@ -2646,6 +2656,7 @@ export async function runDoctor(ctx: CliContext, args: string[], help = false): 
     `workspace: ${report.workspace}`,
     `auth:      ${report.auth.ok ? "ok" : `failed — ${report.auth.error ?? "no token"}`}`,
   ];
+  if (report.scopes) lines.push(`scopes:    ${report.scopes.join(", ")}`);
   if (report.usage) {
     lines.push(
       report.usage.ok

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -34,7 +34,8 @@ Options:
   --create            With --workspace: create the workspace first if your
                       account doesn't have it yet (device flow only) — lets
                       scripted/agent logins provision without a prompt
-  --scopes <list>     Comma-separated scopes (default: files:read,files:write)
+  --scopes <list>     Comma-separated scopes (default:
+                      files:read,files:write,files:delete)
   --label <text>      Token label (default: this machine's hostname)
   --auth-url <url>    Auth base (default: https://auth.uploads.sh)
   --no-open           Don't try to open a browser automatically
@@ -241,7 +242,16 @@ async function runDeviceLogin(
   opts: { apiUrl: string; authUrl: string; noOpen: boolean },
   io: DeviceLoginIo,
 ): Promise<LoginResult> {
-  const scopes = parseScopes(flagString(parsed.flags, "--scopes"));
+  // Interactive login is the user's own credential: default to the full file
+  // scope set (including delete) so the CLI's own `delete` command works out
+  // of the box. Automation tokens minted elsewhere keep the server's
+  // conservative read+write default — narrowness there is a deliberate
+  // choice, not a surprise. `--scopes` still overrides.
+  const scopes = parseScopes(flagString(parsed.flags, "--scopes")) ?? [
+    "files:read",
+    "files:write",
+    "files:delete",
+  ];
   const label = flagString(parsed.flags, "--label") ?? safeHostname();
   const requestedWorkspace = flagString(parsed.flags, "--workspace");
 

--- a/packages/uploads/test/commands-doctor.test.ts
+++ b/packages/uploads/test/commands-doctor.test.ts
@@ -23,6 +23,44 @@ function fakeClient(): UploadsClient {
   } as unknown as UploadsClient;
 }
 
+describe("buildDoctorReport token scopes", () => {
+  it("surfaces the token's scopes and hints when files:delete is missing", async () => {
+    const client = {
+      list: async () => ({ items: [], cursor: null }),
+      health: async () => ({ ok: true }),
+      usage: async () => ({
+        bytes: 0,
+        objects: 0,
+        uploadsInPeriod: 0,
+        scopes: ["files:read", "files:write"],
+      }),
+    } as unknown as UploadsClient;
+    const report = await buildDoctorReport(fakeConfig(), client);
+    expect(report.scopes).toEqual(["files:read", "files:write"]);
+    expect(report.hints.some((h) => h.includes("files:delete"))).toBe(true);
+  });
+
+  it("no delete hint for a full-scope token, no scopes field on older servers", async () => {
+    const full = {
+      list: async () => ({ items: [], cursor: null }),
+      health: async () => ({ ok: true }),
+      usage: async () => ({
+        bytes: 0,
+        objects: 0,
+        uploadsInPeriod: 0,
+        scopes: ["files:read", "files:write", "files:delete"],
+      }),
+    } as unknown as UploadsClient;
+    const fullReport = await buildDoctorReport(fakeConfig(), full);
+    expect(fullReport.hints.some((h) => h.includes("files:delete"))).toBe(false);
+
+    // Pre-scopes server: usage has no scopes field → no line, no hint.
+    const older = await buildDoctorReport(fakeConfig(), fakeClient());
+    expect(older.scopes).toBeUndefined();
+    expect(older.hints.some((h) => h.includes("files:delete"))).toBe(false);
+  });
+});
+
 describe("buildDoctorReport browser section", () => {
   it("reports a browser section (fs scans only — never launches a browser)", async () => {
     const report = await buildDoctorReport(fakeConfig(), fakeClient());

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -215,8 +215,11 @@ describe("runLogin device flow", () => {
     expect((mintCall![1] as RequestInit).headers).toMatchObject({
       Authorization: "Bearer sess-tok",
     });
+    // Interactive login requests the full file-scope set (including delete)
+    // by default — the server's conservative read+write default is for
+    // automation mints, not the user's own credential.
     expect(JSON.parse(String((mintCall![1] as RequestInit).body))).toMatchObject({
-      grants: [{ workspace: "acme" }],
+      grants: [{ workspace: "acme", scopes: ["files:read", "files:write", "files:delete"] }],
     });
     expect(loadConfigFile(path).UPLOADS_TOKEN).toBe(token);
     expect(loadConfigFile(path).UPLOADS_WORKSPACE).toBe("acme");


### PR DESCRIPTION
## In plain terms
A fresh `uploads login` minted a token that couldn't delete files — the CLI's own `delete` command returned `forbidden` while `doctor` reported all-ok. Interactive login is the user's own credential, so it now defaults to the full file-scope set, and `doctor` makes scope gaps visible.

## What it does
- `uploads login` requests `files:read, files:write, files:delete` when `--scopes` isn't given (previously it sent none and inherited the server's conservative read+write default).
- `GET /v1/:ws/usage` now includes `scopes` (the presented token's file scopes; legacy tokens report the full set they effectively have).
- `uploads doctor` prints a `scopes:` line and hints when `files:delete` is missing.

## What it is not
- No change to the server's `DEFAULT_MINT_SCOPES` — automation/CI mints that omit scopes stay read+write by deliberate choice.
- No change to scope enforcement.

## Technical notes
- Marginal risk is small: `files:write` already allows destructive overwrite of existing keys, and deletes are attributable to the minting user (#340/#344).
- `UsageResult.scopes` is optional in the CLI client, so a new CLI against an older server degrades to no scopes line/hint.

## Test plan
- Login test asserts the mint body carries the three scopes; doctor tests cover missing-delete hint, full-scope, and pre-scopes-server cases; usage route test asserts the `scopes` field.
- CLI (612) + API (858) suites pass; typecheck clean.
