### PR TITLE
feat(cli): actionable insufficient_scope errors

### DIFF
--- a/.changeset/insufficient-scope-hint.md
+++ b/.changeset/insufficient-scope-hint.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Scope failures are now actionable: an `insufficient_scope` API error surfaces as "token lacks the files:delete scope" with a hint to re-run `uploads login` (or mint with `--scopes`), instead of a bare "forbidden".

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -153,6 +153,8 @@ const ERROR_HINTS: Partial<Record<UploadsError["code"], string>> = {
     "hint: use a typed destination (`--destination screenshots|gh`) or an allowed prefix; operators set allowlists with `pnpm workspace:limits --allowed-prefixes`\n",
   UNAUTHORIZED:
     "hint: token rejected — run `uploads login` to sign in again, or check UPLOADS_TOKEN / --token\n",
+  INSUFFICIENT_SCOPE:
+    "hint: re-run `uploads login` for a full-scope token (or mint one with --scopes)\n",
   BROWSER_NOT_FOUND:
     "hint: no local browser found; try --via remote, or install Chrome / npx playwright install chromium\n",
   RATE_LIMITED: "hint: transient rate limit — wait ~60s and retry\n",

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -659,10 +659,21 @@ function galleriesBase(config: UploadsClientConfig): string {
   return `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/galleries`;
 }
 
-function mapApiError(status: number, error: string, code?: string): UploadsError {
+function mapApiError(
+  status: number,
+  error: string,
+  code?: string,
+  requiredScope?: string,
+): UploadsError {
   const normalized = error.toLowerCase();
   if (status === 401 || code === "unauthorized" || normalized === "unauthorized") {
     return new UploadsError(error, "UNAUTHORIZED", status);
+  }
+  if (code === "insufficient_scope") {
+    // The server's message is a bare "forbidden" — name the missing scope so
+    // the failure is actionable without a doctor run.
+    const message = requiredScope ? `token lacks the ${requiredScope} scope` : error;
+    return new UploadsError(message, "INSUFFICIENT_SCOPE", status);
   }
   if (status === 404 || code === "not_found" || normalized === "not found") {
     return new UploadsError(error, "NOT_FOUND", status);
@@ -696,14 +707,18 @@ function mapApiError(status: number, error: string, code?: string): UploadsError
 export function extractErrorFields(
   body: unknown,
   fallback = "request failed",
-): { message: string; code?: string } {
+): { message: string; code?: string; requiredScope?: string } {
   if (typeof body === "object" && body && "error" in body) {
     const err = (body as { error: unknown }).error;
     if (typeof err === "object" && err && "message" in err) {
-      const nested = err as { message?: unknown; code?: unknown };
+      const nested = err as { message?: unknown; code?: unknown; details?: unknown };
+      const details = nested.details as { required_scope?: unknown } | undefined;
       return {
         message: typeof nested.message === "string" ? nested.message : fallback,
         code: typeof nested.code === "string" ? nested.code : undefined,
+        ...(typeof details?.required_scope === "string"
+          ? { requiredScope: details.required_scope }
+          : {}),
       };
     }
     if (typeof err === "string") {
@@ -721,14 +736,17 @@ export function extractErrorFields(
 export async function parseErrorEnvelope(
   res: Response,
   fallback = "request failed",
-): Promise<{ message: string; code?: string }> {
+): Promise<{ message: string; code?: string; requiredScope?: string }> {
   const body = await res.json().catch(() => ({}));
   return extractErrorFields(body, fallback);
 }
 
 async function parseErrorResponse(res: Response): Promise<UploadsError> {
-  const { message, code } = await parseErrorEnvelope(res, res.statusText || "request failed");
-  return mapApiError(res.status, message, code);
+  const { message, code, requiredScope } = await parseErrorEnvelope(
+    res,
+    res.statusText || "request failed",
+  );
+  return mapApiError(res.status, message, code, requiredScope);
 }
 
 export function createUploadsClient(config: UploadsClientConfig) {

--- a/packages/uploads/src/errors.ts
+++ b/packages/uploads/src/errors.ts
@@ -4,6 +4,7 @@ export type UploadsErrorCode =
   | "FILE_NOT_FOUND"
   | "NOT_FOUND"
   | "UNAUTHORIZED"
+  | "INSUFFICIENT_SCOPE"
   | "INVALID_KEY"
   | "KEY_POLICY"
   | "STORAGE_QUOTA"

--- a/packages/uploads/test/client-errors.test.ts
+++ b/packages/uploads/test/client-errors.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createUploadsClient } from "../src/client.js";
+import { UploadsError } from "../src/errors.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function client() {
+  return createUploadsClient({
+    apiUrl: "https://api.test",
+    workspace: "test",
+    token: "up_test_x",
+  });
+}
+
+describe("insufficient_scope error mapping", () => {
+  it("maps to INSUFFICIENT_SCOPE and names the missing scope from details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                type: "insufficient_scope",
+                code: "insufficient_scope",
+                message: "forbidden",
+                details: { required_scope: "files:delete" },
+              },
+            }),
+            { status: 403 },
+          ),
+      ),
+    );
+    const err = await client()
+      .delete("screenshots/a.png")
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    expect(err).toBeInstanceOf(UploadsError);
+    expect((err as UploadsError).code).toBe("INSUFFICIENT_SCOPE");
+    expect((err as UploadsError).message).toContain("files:delete");
+  });
+
+  it("keeps the server message when details carry no scope", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                type: "insufficient_scope",
+                code: "insufficient_scope",
+                message: "forbidden",
+              },
+            }),
+            { status: 403 },
+          ),
+      ),
+    );
+    const err = await client()
+      .delete("screenshots/a.png")
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    expect((err as UploadsError).code).toBe("INSUFFICIENT_SCOPE");
+    expect((err as UploadsError).message).toBe("forbidden");
+  });
+});


### PR DESCRIPTION
## In plain terms
When a token lacks a scope (e.g. a pre-#349 login token hitting `uploads delete`), the CLI printed just `error: forbidden`. The server already sends a structured `insufficient_scope` error with `required_scope` in the details — the CLI just dropped it. Now the failure names the missing scope and tells the user how to fix it.

## What it does
- `parseErrorEnvelope`/`extractErrorFields` carry `details.required_scope` through.
- New `INSUFFICIENT_SCOPE` error code; message becomes "token lacks the files:delete scope" when the detail is present.
- New hint line: re-run `uploads login` for a full-scope token, or mint with `--scopes`.

## What it is not
- No server changes; the envelope already carried everything needed.

## Test plan
- New client tests for the mapping with and without the `required_scope` detail. CLI suite 614 passed; typecheck clean.
