### PR TITLE
perf: cut D1 rows-read on admin and metadata paths

### DIFF
--- a/apps/api/migrations/20260721160000_d1_query_indexes.sql
+++ b/apps/api/migrations/20260721160000_d1_query_indexes.sql
@@ -1,0 +1,11 @@
+-- Hot-path D1 indexes (rows-read):
+-- 1) Cross-workspace metadata (staging reaper: gh.kind=branch). Existing
+--    file_metadata_lookup_idx leads with workspace, so it cannot serve this.
+-- 2) Ban-time revoke by minting user (revokeTokensForMintingUser).
+
+CREATE INDEX IF NOT EXISTS file_metadata_value_lookup_idx
+  ON file_metadata (meta_key, meta_value);
+
+CREATE INDEX IF NOT EXISTS auth_tokens_minting_user_idx
+  ON auth_tokens (minting_user_id)
+  WHERE minting_user_id IS NOT NULL AND revoked_at IS NULL;

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -261,12 +261,9 @@ export async function replaceFileMetadata(
 }
 
 /**
- * Cross-workspace `(meta_key, meta_value)` lookup — not workspace-scoped like
- * `findObjectsByMetadata`. Staging reaper uses this for `gh.kind=branch`.
+ * Cross-workspace `(meta_key, meta_value)` lookup (staging reaper: `gh.kind=branch`).
  * Bounded by `limit`; ordered by (workspace, object_key).
- *
- * Needs `file_metadata_value_lookup_idx (meta_key, meta_value)`; the
- * workspace-leading lookup index cannot serve this predicate.
+ * Needs `file_metadata_value_lookup_idx` — workspace-leading index cannot serve this.
  */
 export async function findObjectsByMetadataAcrossWorkspaces(
   db: D1Database,

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -261,12 +261,12 @@ export async function replaceFileMetadata(
 }
 
 /**
- * Cross-workspace lookup of objects carrying a given `(meta_key, meta_value)`
- * pair — unlike `findObjectsByMetadata`, not scoped to a single workspace.
- * Used by the staging reaper (branch-staged attachment cleanup) to discover
- * `gh.kind=branch` rows across every workspace in one query. Bounded by
- * `limit`; ordering is stable (workspace, object_key) so repeated calls with
- * the same limit see the same head of the set.
+ * Cross-workspace `(meta_key, meta_value)` lookup — not workspace-scoped like
+ * `findObjectsByMetadata`. Staging reaper uses this for `gh.kind=branch`.
+ * Bounded by `limit`; ordered by (workspace, object_key).
+ *
+ * Needs `file_metadata_value_lookup_idx (meta_key, meta_value)`; the
+ * workspace-leading lookup index cannot serve this predicate.
  */
 export async function findObjectsByMetadataAcrossWorkspaces(
   db: D1Database,
@@ -304,6 +304,12 @@ function escapeLikePattern(raw: string): string {
  * Finds objects whose metadata matches ALL `filters` (ANDed equality), with
  * an optional key-prefix and result limit. Returns each match's key plus its
  * full metadata map (not just the matched pairs).
+ *
+ * Index-aware against `file_metadata_lookup_idx (workspace, meta_key, meta_value)`:
+ * - one filter → equality (+ optional prefix) + LIMIT
+ * - multi-filter → INTERSECT of per-filter key sets (each leg uses the index)
+ *   rather than OR + GROUP BY HAVING, which over-reads when any filter value
+ *   is common (e.g. `gh.kind=pull`).
  */
 export async function findObjectsByMetadata(
   db: D1Database,
@@ -315,18 +321,30 @@ export async function findObjectsByMetadata(
   if (entries.length === 0) return [];
 
   const limit = Math.max(1, Math.min(opts.limit ?? FIND_DEFAULT_LIMIT, FIND_MAX_LIMIT));
+  const params: unknown[] = [];
+  const legs = entries.map(([key, value]) => {
+    params.push(workspace, key, value);
+    return `SELECT object_key FROM file_metadata WHERE workspace = ? AND meta_key = ? AND meta_value = ?`;
+  });
 
-  const conditions = entries.map(() => `(meta_key = ? AND meta_value = ?)`).join(" OR ");
-  const params: unknown[] = [workspace];
-  for (const [key, value] of entries) params.push(key, value);
-
-  let sql = `SELECT object_key FROM file_metadata WHERE workspace = ? AND (${conditions})`;
-  if (opts.prefix) {
-    sql += ` AND object_key LIKE ? || '%' ESCAPE '\\'`;
-    params.push(escapeLikePattern(opts.prefix));
+  // Single filter: prefix in-leg so LIMIT applies to the narrowed set.
+  // Multi-filter: INTERSECT first, then prefix/limit on the intersection.
+  let sql: string;
+  if (entries.length === 1) {
+    sql = legs[0]!;
+    if (opts.prefix) {
+      sql += ` AND object_key LIKE ? || '%' ESCAPE '\\'`;
+      params.push(escapeLikePattern(opts.prefix));
+    }
+  } else {
+    sql = `SELECT object_key FROM (${legs.join(" INTERSECT ")})`;
+    if (opts.prefix) {
+      sql += ` WHERE object_key LIKE ? || '%' ESCAPE '\\'`;
+      params.push(escapeLikePattern(opts.prefix));
+    }
   }
-  sql += ` GROUP BY object_key HAVING COUNT(DISTINCT meta_key) = ? ORDER BY object_key LIMIT ?`;
-  params.push(entries.length, limit);
+  sql += ` ORDER BY object_key LIMIT ?`;
+  params.push(limit);
 
   const matched = await db
     .prepare(sql)
@@ -335,20 +353,8 @@ export async function findObjectsByMetadata(
   const keys = matched.results.map((row) => row.object_key);
   if (keys.length === 0) return [];
 
-  const placeholders = keys.map(() => "?").join(", ");
-  const hydrated = await db
-    .prepare(
-      `SELECT object_key, meta_key, meta_value FROM file_metadata
-       WHERE workspace = ? AND object_key IN (${placeholders})`,
-    )
-    .bind(workspace, ...keys)
-    .all<{ object_key: string; meta_key: string; meta_value: string }>();
-
-  const byKey = new Map<string, Record<string, string>>(keys.map((key) => [key, {}]));
-  for (const row of hydrated.results) {
-    byKey.get(row.object_key)![row.meta_key] = row.meta_value;
-  }
-  return keys.map((key) => ({ key, metadata: byKey.get(key)! }));
+  const byKey = await getMetadataForKeys(db, workspace, keys);
+  return keys.map((key) => ({ key, metadata: byKey.get(key) ?? {} }));
 }
 
 /** Max object keys bound into a single `object_key IN (...)` statement (SQLite's ~999 host-parameter limit, kept well under it). */

--- a/apps/api/src/github-pr-activity.ts
+++ b/apps/api/src/github-pr-activity.ts
@@ -142,7 +142,9 @@ export async function listPrActivityForWorkspace(
 ): Promise<PrActivity[]> {
   const { results } = await db
     .prepare(
-      `SELECT * FROM github_pr_activity
+      `SELECT ref, repo_full_name, pr_number, branch, workspace_name,
+              media_count, first_media_at, last_media_at
+       FROM github_pr_activity
        WHERE workspace_name = ?
        ORDER BY last_media_at DESC
        LIMIT ?`,

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -86,7 +86,10 @@ export async function recordRepoLink(
 export async function findRepoLink(db: D1Database, repo: string): Promise<RepoLink | null> {
   try {
     const row = await db
-      .prepare(`SELECT * FROM github_repo_links WHERE repo_full_name = ?`)
+      .prepare(
+        `SELECT repo_full_name, workspace_name, installation_id, source, created_at
+         FROM github_repo_links WHERE repo_full_name = ?`,
+      )
       .bind(normalizeRepo(repo))
       .first<RepoLinkRow>();
     return row ? rowToLink(row) : null;
@@ -110,7 +113,10 @@ export async function findRepoLink(db: D1Database, repo: string): Promise<RepoLi
  */
 export async function findRepoLinkStrict(db: D1Database, repo: string): Promise<RepoLink | null> {
   const row = await db
-    .prepare(`SELECT * FROM github_repo_links WHERE repo_full_name = ?`)
+    .prepare(
+      `SELECT repo_full_name, workspace_name, installation_id, source, created_at
+       FROM github_repo_links WHERE repo_full_name = ?`,
+    )
     .bind(normalizeRepo(repo))
     .first<RepoLinkRow>();
   return row ? rowToLink(row) : null;
@@ -183,7 +189,10 @@ export async function listRepoLinksForWorkspace(
   workspaceName: string,
 ): Promise<RepoLink[]> {
   const { results } = await db
-    .prepare(`SELECT * FROM github_repo_links WHERE workspace_name = ? ORDER BY created_at DESC`)
+    .prepare(
+      `SELECT repo_full_name, workspace_name, installation_id, source, created_at
+       FROM github_repo_links WHERE workspace_name = ? ORDER BY created_at DESC`,
+    )
     .bind(workspaceName)
     .all<RepoLinkRow>();
   return (results ?? []).map(rowToLink);

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -72,14 +72,8 @@ function parseMembershipRows(body: unknown): Membership[] | null {
 
 /**
  * A user's org memberships via `GET /internal/memberships?userId=` over the
- * AUTH binding. Like `orgForWorkspace`, a non-ok (or malformed) response is an
- * auth-worker outage/bug — surfaced as a 5xx — NOT "this user has no
- * memberships", so an outage can never masquerade as lost access. A user with
- * genuinely no memberships gets a 200 with `[]`. Shared by the session-auth
- * surfaces that need it (src/routes/me.ts, src/routes/tokens.ts).
- *
- * Pass `slug` to resolve a single org membership (member-gated routes) in one
- * indexed join instead of listing every membership and scanning.
+ * AUTH binding. Non-ok/malformed → 5xx (outage ≠ empty memberships). Pass
+ * `slug` for a single-org lookup (member-gated routes: one indexed join).
  */
 export async function membershipsForUser(
   env: Env,

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -33,6 +33,8 @@ export interface OrgSummary {
 export interface Membership {
   organizationId: string;
   organizationSlug: string;
+  /** Org display name from AUTH; falls back to slug when an older worker omits it. */
+  organizationName: string;
   role: string;
 }
 
@@ -42,6 +44,32 @@ function internalHeaders(): Headers {
   return new Headers({ "x-uploads-internal": "1" });
 }
 
+function parseMembershipRows(body: unknown): Membership[] | null {
+  if (!Array.isArray(body)) return null;
+  const out: Membership[] = [];
+  for (const raw of body) {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    if (
+      typeof row.organizationId !== "string" ||
+      typeof row.organizationSlug !== "string" ||
+      typeof row.role !== "string"
+    ) {
+      return null;
+    }
+    out.push({
+      organizationId: row.organizationId,
+      organizationSlug: row.organizationSlug,
+      organizationName:
+        typeof row.organizationName === "string" && row.organizationName
+          ? row.organizationName
+          : row.organizationSlug,
+      role: row.role,
+    });
+  }
+  return out;
+}
+
 /**
  * A user's org memberships via `GET /internal/memberships?userId=` over the
  * AUTH binding. Like `orgForWorkspace`, a non-ok (or malformed) response is an
@@ -49,12 +77,20 @@ function internalHeaders(): Headers {
  * memberships", so an outage can never masquerade as lost access. A user with
  * genuinely no memberships gets a 200 with `[]`. Shared by the session-auth
  * surfaces that need it (src/routes/me.ts, src/routes/tokens.ts).
+ *
+ * Pass `slug` to resolve a single org membership (member-gated routes) in one
+ * indexed join instead of listing every membership and scanning.
  */
-export async function membershipsForUser(env: Env, userId: string): Promise<Membership[]> {
-  const response = await env.AUTH.fetch(
-    `${INTERNAL_ORIGIN}/internal/memberships?userId=${encodeURIComponent(userId)}`,
-    { headers: internalHeaders() },
-  );
+export async function membershipsForUser(
+  env: Env,
+  userId: string,
+  opts?: { slug?: string },
+): Promise<Membership[]> {
+  const url = new URL(`${INTERNAL_ORIGIN}/internal/memberships`);
+  url.searchParams.set("userId", userId);
+  if (opts?.slug) url.searchParams.set("slug", opts.slug);
+
+  const response = await env.AUTH.fetch(url.toString(), { headers: internalHeaders() });
   if (!response.ok) {
     throw new ServiceUnavailableError("auth service returned an unexpected status", {
       code: "auth_lookup_failed",
@@ -62,12 +98,23 @@ export async function membershipsForUser(env: Env, userId: string): Promise<Memb
     });
   }
   const body = await response.json().catch(() => null);
-  if (!Array.isArray(body)) {
+  const rows = parseMembershipRows(body);
+  if (!rows) {
     throw new ServiceUnavailableError("auth service returned a malformed body", {
       code: "auth_lookup_failed",
     });
   }
-  return body as Membership[];
+  return rows;
+}
+
+/**
+ * Workspace names granted by one membership. Today the mapping is 1:1
+ * (`organization.slug === workspace name`); keep this helper as the only
+ * place that expands a membership into workspace names so multi-workspace
+ * orgs only touch `org-workspaces.ts`.
+ */
+export function workspacesFromMembership(membership: Membership): string[] {
+  return [membership.organizationSlug];
 }
 
 /** A raw member row from the auth worker's `/internal/orgs/:slug/members`. */

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -68,11 +68,15 @@ describe("GET /admin-ui/workspaces", () => {
       if (url.pathname === "/api/auth/get-session") {
         return new Response(JSON.stringify({ session: {}, user: ADMIN_USER }), { status: 200 });
       }
-      if (url.pathname === "/internal/orgs/acme") {
+      if (url.pathname === "/internal/orgs/summaries") {
         return Response.json({
-          organization: { id: "org1", slug: "acme", name: "acme" },
-          memberCount: 2,
-          pendingInviteCount: 1,
+          organizations: [
+            {
+              organization: { id: "org1", slug: "acme", name: "acme" },
+              memberCount: 2,
+              pendingInviteCount: 1,
+            },
+          ],
         });
       }
       return new Response(null, { status: 404 });
@@ -87,6 +91,32 @@ describe("GET /admin-ui/workspaces", () => {
           organization: { id: "org1", slug: "acme", name: "acme" },
           memberCount: 2,
           pendingInviteCount: 1,
+        },
+      ],
+    });
+  });
+
+  it("leaves org null when a workspace has no matching summary", async () => {
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: ADMIN_USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/orgs/summaries") {
+        return Response.json({ organizations: [] });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const env = { AUTH: auth, REGISTRY: fakeKv(["orphan"]) } as unknown as Env;
+    const res = await app().request("/admin-ui/workspaces", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspaces: [
+        {
+          workspace: "orphan",
+          organization: null,
+          memberCount: 0,
+          pendingInviteCount: 0,
         },
       ],
     });

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -149,13 +149,20 @@ interface OrgSummary {
   pendingInviteCount: number;
 }
 
-async function orgSummaryForWorkspace(env: Env, name: string): Promise<OrgSummary | null> {
-  const response = await env.AUTH.fetch(
-    `https://auth.internal/internal/orgs/${encodeURIComponent(name)}`,
-    { headers: { "x-uploads-internal": "1" } },
-  );
-  if (!response.ok) return null;
-  return (await response.json().catch(() => null)) as OrgSummary | null;
+/** Org member/invite counts for the admin workspace list — one AUTH round-trip. */
+async function allOrgSummaries(env: Env): Promise<Map<string, OrgSummary>> {
+  const response = await env.AUTH.fetch(`https://auth.internal/internal/orgs/summaries`, {
+    headers: { "x-uploads-internal": "1" },
+  });
+  if (!response.ok) return new Map();
+  const body = (await response.json().catch(() => null)) as {
+    organizations?: OrgSummary[];
+  } | null;
+  const map = new Map<string, OrgSummary>();
+  for (const row of body?.organizations ?? []) {
+    if (row?.organization?.slug) map.set(row.organization.slug, row);
+  }
+  return map;
 }
 
 /**
@@ -303,17 +310,16 @@ export const adminUi = new Hono<SessionVars>()
       cursor = page.list_complete ? undefined : page.cursor;
     } while (cursor);
 
-    const workspaces = await Promise.all(
-      names.map(async (name) => {
-        const summary = await orgSummaryForWorkspace(c.env, name);
-        return {
-          workspace: name,
-          organization: summary?.organization ?? null,
-          memberCount: summary?.memberCount ?? 0,
-          pendingInviteCount: summary?.pendingInviteCount ?? 0,
-        };
-      }),
-    );
+    const summaries = await allOrgSummaries(c.env);
+    const workspaces = names.map((name) => {
+      const summary = summaries.get(name);
+      return {
+        workspace: name,
+        organization: summary?.organization ?? null,
+        memberCount: summary?.memberCount ?? 0,
+        pendingInviteCount: summary?.pendingInviteCount ?? 0,
+      };
+    });
     return c.json({ workspaces });
   })
 

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -30,7 +30,7 @@ import {
 } from "../github-repo-links";
 import { allowWrite } from "../guards";
 import { deriveWebOrigin, inviteLinkUrl } from "../invite-links";
-import { membersForOrg, orgForWorkspace } from "../org-workspaces";
+import { invitesForOrg, membersForOrg, orgForWorkspace } from "../org-workspaces";
 import {
   requireAdminUser,
   requireSessionUser,
@@ -340,16 +340,7 @@ export const adminUi = new Hono<SessionVars>()
     if (!org)
       throw new NotFoundError("no organization for this workspace", { code: "org_not_found" });
 
-    const response = await c.env.AUTH.fetch(
-      `https://auth.internal/internal/orgs/${encodeURIComponent(org.slug)}/invites`,
-      { headers: { "x-uploads-internal": "1" } },
-    );
-    if (!response.ok) {
-      throw new ValidationError("failed to list invites", {
-        details: await response.json().catch(() => null),
-      });
-    }
-    return c.json(await response.json());
+    return c.json({ invites: await invitesForOrg(c.env, org.slug) });
   })
 
   // Invite an email to the org backing this workspace.

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -55,13 +55,17 @@ describe("/me auth gate", () => {
 });
 
 describe("GET /me/workspaces", () => {
-  it("maps memberships to workspaces via workspacesForOrg", async () => {
+  it("maps memberships to workspaces without per-org AUTH round-trips", async () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") {
-        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role: "owner" }]);
-      }
-      if (path === "/internal/orgs/acme") {
-        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "owner",
+          },
+        ]);
       }
       return new Response(null, { status: 404 });
     });
@@ -83,10 +87,14 @@ describe("GET /me/workspaces", () => {
   it("flags hasPublicUrl for a workspace whose storage record has a publicBaseUrl", async () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") {
-        return Response.json([{ organizationId: "org1", organizationSlug: "acme", role: "owner" }]);
-      }
-      if (path === "/internal/orgs/acme") {
-        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "owner",
+          },
+        ]);
       }
       return new Response(null, { status: 404 });
     });
@@ -114,11 +122,13 @@ describe("GET /me/workspaces", () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") {
         return Response.json([
-          { organizationId: "org2", organizationSlug: "default", role: "member" },
+          {
+            organizationId: "org2",
+            organizationSlug: "default",
+            organizationName: "Default",
+            role: "member",
+          },
         ]);
-      }
-      if (path === "/internal/orgs/default") {
-        return Response.json({ organization: { id: "org2", slug: "default", name: "Default" } });
       }
       return new Response(null, { status: 404 });
     });
@@ -143,15 +153,19 @@ describe("GET /me/workspaces", () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") {
         return Response.json([
-          { organizationId: "org1", organizationSlug: "acme", role: "admin" },
-          { organizationId: "org2", organizationSlug: "default", role: "member" },
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "admin",
+          },
+          {
+            organizationId: "org2",
+            organizationSlug: "default",
+            organizationName: "Default",
+            role: "member",
+          },
         ]);
-      }
-      if (path === "/internal/orgs/acme") {
-        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
-      }
-      if (path === "/internal/orgs/default") {
-        return Response.json({ organization: { id: "org2", slug: "default", name: "Default" } });
       }
       return new Response(null, { status: 404 });
     });
@@ -291,7 +305,14 @@ function memberEnv(opts: {
       return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
     }
     if (url.pathname === "/internal/memberships") {
-      return Response.json([{ organizationId: "org1", organizationSlug: workspace, role }]);
+      return Response.json([
+        {
+          organizationId: "org1",
+          organizationSlug: workspace,
+          organizationName: workspace,
+          role,
+        },
+      ]);
     }
     if (url.pathname === `/internal/orgs/${workspace}`) {
       return Response.json({ organization: { id: "org1", slug: workspace, name: workspace } });
@@ -337,6 +358,112 @@ const R2_RECORD = {
   prefix: "acme/",
   publicBaseUrl: "https://storage.uploads.sh",
 };
+
+describe("GET /me/workspaces/:name/summary", () => {
+  it("returns membership + usage + public URL in one payload", async () => {
+    const db = new UsageFakeD1();
+    db.usage.set("acme", {
+      workspace: "acme",
+      bytes: 1024,
+      objects: 2,
+      uploads_in_period: 3,
+      period_start: "2026-07",
+      updated_at: "2026-07-21T00:00:00.000Z",
+    });
+    const env = memberEnv({ workspace: "acme", role: "owner", db, record: R2_RECORD });
+    const res = await app().request("/me/workspaces/acme/summary", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      workspace: "acme",
+      role: "owner",
+      communal: false,
+      hasPublicUrl: true,
+      publicBaseUrl: "https://storage.uploads.sh",
+      usage: { workspace: "acme", bytes: 1024, objects: 2, uploadsInPeriod: 3 },
+    });
+  });
+
+  it("404s when the caller is not a member", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/summary", {}, env);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /me/workspaces/:name/people", () => {
+  it("returns members + invites for an admin in one authz pass", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "admin",
+          },
+        ]);
+      }
+      if (path === "/internal/orgs/acme/members") {
+        return Response.json({
+          members: [
+            { id: "m1", userId: "u1", email: "a@b.com", name: "Ada", role: "owner" },
+            { id: "m2", userId: "u2", email: "c@d.com", name: null, role: "member" },
+          ],
+        });
+      }
+      if (path === "/internal/orgs/acme/invites") {
+        return Response.json({
+          invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending" }],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/people", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      communal: false,
+      role: "admin",
+      canManage: true,
+      organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+      members: [
+        { id: "m1", email: "a@b.com", name: "Ada", role: "owner" },
+        { id: "m2", email: "c@d.com", name: "", role: "member" },
+      ],
+      invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending" }],
+    });
+  });
+
+  it("omits invites for a non-admin member", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "member",
+          },
+        ]);
+      }
+      if (path === "/internal/orgs/acme/members") {
+        return Response.json({
+          members: [{ id: "m1", userId: "u1", email: "a@b.com", name: "Ada", role: "owner" }],
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/people", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      canManage: false,
+      members: [{ email: "a@b.com", name: "Ada", role: "owner" }],
+      invites: [],
+    });
+  });
+});
 
 describe("GET /me/workspaces/:name/members", () => {
   it("404s for a workspace the caller is not a member of", async () => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -28,7 +28,6 @@ import {
   invitesForOrg,
   membersForOrg,
   membershipsForUser,
-  orgForWorkspace,
   removeMember,
   revokeInvite,
   updateMemberRole,
@@ -79,7 +78,11 @@ function myWorkspaceFromMembership(
   };
 }
 
-/** Sanitize org members for the account people UI (optional id for managers). */
+function canManageRole(role: string): boolean {
+  return role === "admin" || role === "owner";
+}
+
+/** Sanitize org members for the account people UI (opaque `id` only for managers). */
 function projectMembers(members: OrgMember[], canManage: boolean) {
   return members.map((m) => {
     const row: {
@@ -116,18 +119,12 @@ async function myWorkspaces(env: Env, userId: string): Promise<MyWorkspace[]> {
 }
 
 /**
- * The caller's membership entry for `name`, or a uniform 404. Authorization for
- * every `/workspaces/:name/*` route is this lookup: a workspace absent from the
- * caller's memberships 404s (`workspace_not_found`) rather than 403ing, so
- * membership can't be probed for workspace existence.
- *
- * Uses a slug-scoped membership query (one AUTH D1 join) rather than loading
- * the caller's full workspace list.
+ * Caller's membership for `name`, or a uniform 404 (not 403 — no existence
+ * probe). Slug-scoped membership query (one AUTH join), not the full list.
  */
 async function memberWorkspaceOr404(env: Env, userId: string, name: string): Promise<MyWorkspace> {
-  // Today's 1:1 mapping: workspace name === org slug, so a slug-filtered
-  // membership lookup is exact. If multi-workspace orgs land, resolve via
-  // workspacesFromMembership over the full list instead.
+  // 1:1 today: workspace name === org slug. Multi-workspace orgs would expand
+  // via workspacesFromMembership over the full list instead.
   const [membership] = await membershipsForUser(env, userId, { slug: name });
   if (!membership || !workspacesFromMembership(membership).includes(name)) {
     throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
@@ -221,8 +218,7 @@ export const me = new Hono<SessionVars>()
     return c.json(usageWithLimits(usage, record));
   })
 
-  // Workspace shell payload for the account rail / header: membership +
-  // public URL + usage in one authz pass (replaces getMyWorkspaces + usage).
+  // Workspace shell for the account rail: membership + public URL + usage.
   .get("/workspaces/:name/summary", async (c) => {
     const name = c.req.param("name");
     const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
@@ -253,20 +249,14 @@ export const me = new Hono<SessionVars>()
     });
   })
 
-  // People in one workspace — member-gated (any member may see who they share
-  // the workspace with; only the fields a teammate needs, not the raw member
-  // rows the admin panel gets). Communal is a shared public space with no real
-  // team behind it — same branch-free `communal: true` shape as galleries.
+  // People in one workspace — member-gated (teammate fields only, not admin raw
+  // rows). Communal: shared public space, empty list (same shape as galleries).
   .get("/workspaces/:name/members", async (c) => {
     const name = c.req.param("name");
     const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
     if (ws.communal) return c.json({ communal: true, members: [] });
 
-    // `ws.organization` was already resolved by the membership lookup — no
-    // second org fetch. Internal `id`/`userId` never reach teammates; admins
-    // and owners get the opaque `id` too, since they need it to target the
-    // management routes below.
-    const canManage = ws.role === "admin" || ws.role === "owner";
+    const canManage = canManageRole(ws.role);
     const members = await membersForOrg(c.env, ws.organization.slug);
     return c.json({
       communal: false,
@@ -274,8 +264,7 @@ export const me = new Hono<SessionVars>()
     });
   })
 
-  // People tab: members + (for admins) pending invites + role in one request
-  // so the page does not re-run membership authz three times.
+  // People tab: members + (for admins) pending invites + role in one authz pass.
   .get("/workspaces/:name/people", async (c) => {
     const name = c.req.param("name");
     const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
@@ -289,7 +278,7 @@ export const me = new Hono<SessionVars>()
       });
     }
 
-    const canManage = ws.role === "admin" || ws.role === "owner";
+    const canManage = canManageRole(ws.role);
     const [members, invites] = await Promise.all([
       membersForOrg(c.env, ws.organization.slug),
       canManage ? invitesForOrg(c.env, ws.organization.slug) : Promise.resolve([]),
@@ -515,17 +504,11 @@ export const me = new Hono<SessionVars>()
   .post("/workspaces/:name/invites", async (c) => {
     const name = c.req.param("name");
     const userId = requireUserId(c);
-    await adminWorkspaceOr403(c.env, userId, name);
+    // Membership already carries org slug (1:1 mapping) — no second org fetch.
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
 
     if (!(await allowWrite(c.env, name))) {
       throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const org = await orgForWorkspace(c.env, name);
-    if (!org) {
-      throw new NotFoundError("no organization for this workspace — ask a site operator", {
-        code: "org_not_found",
-      });
     }
 
     const body = await c.req
@@ -554,7 +537,7 @@ export const me = new Hono<SessionVars>()
       method: "POST",
       headers: { "content-type": "application/json", "x-uploads-internal": "1" },
       body: JSON.stringify({
-        organizationSlug: org.slug,
+        organizationSlug: ws.organization.slug,
         email,
         role,
         inviterUserId: userId,

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -32,7 +32,9 @@ import {
   removeMember,
   revokeInvite,
   updateMemberRole,
-  workspacesForOrg,
+  workspacesFromMembership,
+  type Membership,
+  type OrgMember,
 } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
@@ -60,30 +62,54 @@ export function isCommunal(env: Env, name: string): boolean {
   return name === (env.DEFAULT_WORKSPACE || "default");
 }
 
+function myWorkspaceFromMembership(
+  env: Env,
+  membership: Membership,
+  workspace: string,
+): MyWorkspace {
+  return {
+    workspace,
+    organization: {
+      id: membership.organizationId,
+      slug: membership.organizationSlug,
+      name: membership.organizationName || membership.organizationSlug,
+    },
+    role: membership.role,
+    communal: isCommunal(env, workspace),
+  };
+}
+
+/** Sanitize org members for the account people UI (optional id for managers). */
+function projectMembers(members: OrgMember[], canManage: boolean) {
+  return members.map((m) => {
+    const row: {
+      id?: string;
+      email: string;
+      name: string;
+      role: string;
+      createdAt?: string;
+    } = {
+      email: m.email ?? "",
+      name: m.name ?? "",
+      role: m.role ?? "member",
+      createdAt: m.createdAt,
+    };
+    if (canManage) row.id = m.id;
+    return row;
+  });
+}
+
 /**
- * Every workspace the user's memberships map to, one entry per (workspace,
- * membership) pair — `workspacesForOrg` never assumes slug === workspace
- * name directly, so this is a small fan-out rather than a 1:1 zip.
+ * Every workspace the user's memberships map to. Memberships already include
+ * org id/slug/name from AUTH, so this is one service call — not N org
+ * lookups. Workspace names come from `workspacesFromMembership` (today 1:1).
  */
 async function myWorkspaces(env: Env, userId: string): Promise<MyWorkspace[]> {
   const memberships = await membershipsForUser(env, userId);
   const out: MyWorkspace[] = [];
   for (const membership of memberships) {
-    const [org, names] = await Promise.all([
-      orgForWorkspace(env, membership.organizationSlug),
-      workspacesForOrg(env, membership.organizationSlug),
-    ]);
-    for (const workspace of names) {
-      out.push({
-        workspace,
-        organization: org ?? {
-          id: membership.organizationId,
-          slug: membership.organizationSlug,
-          name: membership.organizationSlug,
-        },
-        role: membership.role,
-        communal: isCommunal(env, workspace),
-      });
+    for (const workspace of workspacesFromMembership(membership)) {
+      out.push(myWorkspaceFromMembership(env, membership, workspace));
     }
   }
   return out;
@@ -94,12 +120,19 @@ async function myWorkspaces(env: Env, userId: string): Promise<MyWorkspace[]> {
  * every `/workspaces/:name/*` route is this lookup: a workspace absent from the
  * caller's memberships 404s (`workspace_not_found`) rather than 403ing, so
  * membership can't be probed for workspace existence.
+ *
+ * Uses a slug-scoped membership query (one AUTH D1 join) rather than loading
+ * the caller's full workspace list.
  */
 async function memberWorkspaceOr404(env: Env, userId: string, name: string): Promise<MyWorkspace> {
-  const workspaces = await myWorkspaces(env, userId);
-  const ws = workspaces.find((w) => w.workspace === name);
-  if (!ws) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-  return ws;
+  // Today's 1:1 mapping: workspace name === org slug, so a slug-filtered
+  // membership lookup is exact. If multi-workspace orgs land, resolve via
+  // workspacesFromMembership over the full list instead.
+  const [membership] = await membershipsForUser(env, userId, { slug: name });
+  if (!membership || !workspacesFromMembership(membership).includes(name)) {
+    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  }
+  return myWorkspaceFromMembership(env, membership, name);
 }
 
 function requireUserId(c: Context<SessionVars>): string {
@@ -139,8 +172,13 @@ export async function adminWorkspaceOr403(
  * "not authorized" outcome rather than a membership-probing 404.
  */
 export async function isWorkspaceOwner(env: Env, userId: string, name: string): Promise<boolean> {
-  const workspaces = await myWorkspaces(env, userId);
-  return workspaces.some((w) => w.workspace === name && w.role === "owner");
+  try {
+    const ws = await memberWorkspaceOr404(env, userId, name);
+    return ws.role === "owner";
+  } catch (err) {
+    if (err instanceof NotFoundError) return false;
+    throw err;
+  }
 }
 
 export const me = new Hono<SessionVars>()
@@ -183,6 +221,38 @@ export const me = new Hono<SessionVars>()
     return c.json(usageWithLimits(usage, record));
   })
 
+  // Workspace shell payload for the account rail / header: membership +
+  // public URL + usage in one authz pass (replaces getMyWorkspaces + usage).
+  .get("/workspaces/:name/summary", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record && !ws.communal) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const publicBaseUrl = ws.communal ? undefined : record?.publicBaseUrl;
+    let usage: ReturnType<typeof usageWithLimits> | null = null;
+    if (record) {
+      try {
+        usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
+      } catch {
+        usage = null;
+      }
+    }
+
+    return c.json({
+      workspace: ws.workspace,
+      organization: ws.organization,
+      role: ws.role,
+      communal: ws.communal,
+      hasPublicUrl: Boolean(publicBaseUrl),
+      publicBaseUrl,
+      usage,
+    });
+  })
+
   // People in one workspace — member-gated (any member may see who they share
   // the workspace with; only the fields a teammate needs, not the raw member
   // rows the admin panel gets). Communal is a shared public space with no real
@@ -200,13 +270,38 @@ export const me = new Hono<SessionVars>()
     const members = await membersForOrg(c.env, ws.organization.slug);
     return c.json({
       communal: false,
-      members: members.map((m) => ({
-        ...(canManage ? { id: m.id } : {}),
-        email: m.email ?? "",
-        name: m.name ?? "",
-        role: m.role ?? "member",
-        createdAt: m.createdAt,
-      })),
+      members: projectMembers(members, canManage),
+    });
+  })
+
+  // People tab: members + (for admins) pending invites + role in one request
+  // so the page does not re-run membership authz three times.
+  .get("/workspaces/:name/people", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    if (ws.communal) {
+      return c.json({
+        communal: true,
+        role: ws.role,
+        canManage: false,
+        members: [],
+        invites: [],
+      });
+    }
+
+    const canManage = ws.role === "admin" || ws.role === "owner";
+    const [members, invites] = await Promise.all([
+      membersForOrg(c.env, ws.organization.slug),
+      canManage ? invitesForOrg(c.env, ws.organization.slug) : Promise.resolve([]),
+    ]);
+
+    return c.json({
+      communal: false,
+      role: ws.role,
+      canManage,
+      organization: ws.organization,
+      members: projectMembers(members, canManage),
+      invites: canManage ? invites : [],
     });
   })
 

--- a/apps/api/src/staging-reaper.ts
+++ b/apps/api/src/staging-reaper.ts
@@ -15,7 +15,7 @@
  * `/v1/:workspace/files` DELETE route uses.
  */
 import { deleteObject } from "./files-core";
-import { findObjectsByMetadataAcrossWorkspaces, getFileMetadata } from "./file-metadata";
+import { findObjectsByMetadataAcrossWorkspaces, getMetadataForKeys } from "./file-metadata";
 import { loadWorkspaceRecord } from "./workspace";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -65,20 +65,36 @@ export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
   let skipped = 0;
   const workspaceCache = new Map<string, Awaited<ReturnType<typeof loadWorkspaceRecord>>>();
 
+  // One getMetadataForKeys IN-list query per workspace (not per candidate).
+  const keysByWorkspace = new Map<string, string[]>();
   for (const { workspace, key } of candidates) {
     if (!looksLikeBranchStagingKey(key)) {
       skipped += 1;
       continue;
     }
+    const list = keysByWorkspace.get(workspace);
+    if (list) list.push(key);
+    else keysByWorkspace.set(workspace, [key]);
+  }
 
-    let meta: Record<string, string>;
+  const metaByWorkspace = new Map<string, Map<string, Record<string, string>>>();
+  const hydrateFailed = new Set<string>();
+  for (const [workspace, keys] of keysByWorkspace) {
     try {
-      meta = await getFileMetadata(env.DB, workspace, key);
+      metaByWorkspace.set(workspace, await getMetadataForKeys(env.DB, workspace, keys));
     } catch (err) {
-      errors.push({ workspace, key, error: err instanceof Error ? err.message : String(err) });
-      continue;
+      hydrateFailed.add(workspace);
+      const message = err instanceof Error ? err.message : String(err);
+      for (const key of keys) errors.push({ workspace, key, error: message });
     }
-    if (meta["gh.kind"] !== "branch") {
+  }
+
+  for (const { workspace, key } of candidates) {
+    if (!looksLikeBranchStagingKey(key) || hydrateFailed.has(workspace)) continue;
+
+    const meta = metaByWorkspace.get(workspace)?.get(key);
+    // Missing: row raced away between candidate scan and hydrate.
+    if (!meta || meta["gh.kind"] !== "branch") {
       skipped += 1;
       continue;
     }
@@ -91,7 +107,6 @@ export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
     } else if (isOlderThan(meta["gh.staged-at"], ABANDONED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
       reason = "abandoned";
     }
-
     if (!reason) {
       skipped += 1;
       continue;

--- a/apps/api/src/staging-reaper.ts
+++ b/apps/api/src/staging-reaper.ts
@@ -65,7 +65,7 @@ export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
   let skipped = 0;
   const workspaceCache = new Map<string, Awaited<ReturnType<typeof loadWorkspaceRecord>>>();
 
-  // One getMetadataForKeys IN-list query per workspace (not per candidate).
+  // Group valid keys by workspace so hydrate is one IN-list query per workspace.
   const keysByWorkspace = new Map<string, string[]>();
   for (const { workspace, key } of candidates) {
     if (!looksLikeBranchStagingKey(key)) {
@@ -89,44 +89,48 @@ export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
     }
   }
 
-  for (const { workspace, key } of candidates) {
-    if (!looksLikeBranchStagingKey(key) || hydrateFailed.has(workspace)) continue;
+  // Candidates arrive ordered by (workspace, key); Map insertion order preserves that.
+  for (const [workspace, keys] of keysByWorkspace) {
+    if (hydrateFailed.has(workspace)) continue;
+    const metaMap = metaByWorkspace.get(workspace);
 
-    const meta = metaByWorkspace.get(workspace)?.get(key);
-    // Missing: row raced away between candidate scan and hydrate.
-    if (!meta || meta["gh.kind"] !== "branch") {
-      skipped += 1;
-      continue;
-    }
-
-    let reason: "promoted" | "abandoned" | undefined;
-    if (meta["gh.promoted-at"]) {
-      if (isOlderThan(meta["gh.promoted-at"], PROMOTED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
-        reason = "promoted";
+    for (const key of keys) {
+      const meta = metaMap?.get(key);
+      // Missing: row raced away between candidate scan and hydrate.
+      if (!meta || meta["gh.kind"] !== "branch") {
+        skipped += 1;
+        continue;
       }
-    } else if (isOlderThan(meta["gh.staged-at"], ABANDONED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
-      reason = "abandoned";
-    }
-    if (!reason) {
-      skipped += 1;
-      continue;
-    }
 
-    let ws = workspaceCache.get(workspace);
-    if (ws === undefined) {
-      ws = await loadWorkspaceRecord(env, workspace);
-      workspaceCache.set(workspace, ws);
-    }
-    if (!ws) {
-      errors.push({ workspace, key, error: "workspace not found" });
-      continue;
-    }
+      let reason: "promoted" | "abandoned" | undefined;
+      if (meta["gh.promoted-at"]) {
+        if (isOlderThan(meta["gh.promoted-at"], PROMOTED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
+          reason = "promoted";
+        }
+      } else if (isOlderThan(meta["gh.staged-at"], ABANDONED_MAX_AGE_DAYS * MS_PER_DAY, now)) {
+        reason = "abandoned";
+      }
+      if (!reason) {
+        skipped += 1;
+        continue;
+      }
 
-    try {
-      await deleteObject(env, ws, key, workspace);
-      deleted.push({ workspace, key, reason });
-    } catch (err) {
-      errors.push({ workspace, key, error: err instanceof Error ? err.message : String(err) });
+      let ws = workspaceCache.get(workspace);
+      if (ws === undefined) {
+        ws = await loadWorkspaceRecord(env, workspace);
+        workspaceCache.set(workspace, ws);
+      }
+      if (!ws) {
+        errors.push({ workspace, key, error: "workspace not found" });
+        continue;
+      }
+
+      try {
+        await deleteObject(env, ws, key, workspace);
+        deleted.push({ workspace, key, reason });
+      } catch (err) {
+        errors.push({ workspace, key, error: err instanceof Error ? err.message : String(err) });
+      }
     }
   }
 

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -72,40 +72,42 @@ export class FileMetadataTable {
       );
       return { success: true, results: results as T[], meta: {} };
     }
-    // findObjectsByMetadata's match query: ANDed equality filters (parsed by
-    // counting the repeated `(meta_key = ? AND meta_value = ?)` clause), an
-    // optional prefix LIKE, and a trailing HAVING-count + LIMIT. Mirrors the
-    // real SQL semantics against the in-memory store so route-level filter
-    // tests exercise real wiring, not a stub.
-    if (normalizedSql.startsWith("SELECT object_key FROM file_metadata WHERE workspace")) {
+    // findObjectsByMetadata: single equality, or multi-filter INTERSECT legs.
+    // Args: (workspace, key, value)×N, optional escaped prefix, limit.
+    if (
+      normalizedSql.startsWith("SELECT object_key FROM file_metadata WHERE workspace") ||
+      normalizedSql.startsWith("SELECT object_key FROM (SELECT object_key FROM file_metadata")
+    ) {
       const filterCount = (normalizedSql.match(/meta_key = \? AND meta_value = \?/g) ?? []).length;
       const hasPrefix = normalizedSql.includes("object_key LIKE ? || '%'");
-      let idx = 0;
-      const workspace = args[idx++] as string;
-      const filters: Array<[string, string]> = [];
+      const filters: Array<{ workspace: string; key: string; value: string }> = [];
       for (let i = 0; i < filterCount; i++) {
-        filters.push([args[idx] as string, args[idx + 1] as string]);
-        idx += 2;
+        const base = i * 3;
+        filters.push({
+          workspace: args[base] as string,
+          key: args[base + 1] as string,
+          value: args[base + 2] as string,
+        });
       }
+      let idx = filterCount * 3;
       const prefix = hasPrefix ? (args[idx++] as string) : undefined;
-      const requiredCount = args[idx++] as number;
-      const limit = args[idx++] as number;
+      const limit = args[idx] as number;
+      const workspace = filters[0]?.workspace;
+      if (!workspace || filters.some((f) => f.workspace !== workspace)) {
+        return { success: true, results: [] as T[], meta: {} };
+      }
 
       const results: { object_key: string }[] = [];
-      const prefixMatch = `${workspace} `;
-      for (const [scopedKey, map] of this.metadata.entries()) {
-        if (!scopedKey.startsWith(prefixMatch)) continue;
-        const objectKey = scopedKey.slice(prefixMatch.length);
+      const scopePrefix = `${workspace} `;
+      for (const [scopedKey, map] of this.metadata) {
+        if (!scopedKey.startsWith(scopePrefix)) continue;
+        const objectKey = scopedKey.slice(scopePrefix.length);
         if (prefix && !objectKey.startsWith(prefix)) continue;
-        let matchCount = 0;
-        for (const [key, value] of filters) {
-          if (map.get(key) === value) matchCount++;
+        if (filters.every((f) => map.get(f.key) === f.value)) {
+          results.push({ object_key: objectKey });
         }
-        if (matchCount === requiredCount) results.push({ object_key: objectKey });
       }
-      results.sort((a, b) =>
-        a.object_key < b.object_key ? -1 : a.object_key > b.object_key ? 1 : 0,
-      );
+      results.sort((a, b) => a.object_key.localeCompare(b.object_key));
       return { success: true, results: results.slice(0, limit) as T[], meta: {} };
     }
     if (normalizedSql.startsWith("SELECT object_key, meta_key, meta_value FROM file_metadata")) {

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -73,7 +73,7 @@ export class FileMetadataTable {
       return { success: true, results: results as T[], meta: {} };
     }
     // findObjectsByMetadata: single equality, or multi-filter INTERSECT legs.
-    // Args: (workspace, key, value)×N, optional escaped prefix, limit.
+    // Args: (workspace, key, value)×N, optional LIKE-escaped prefix, limit.
     if (
       normalizedSql.startsWith("SELECT object_key FROM file_metadata WHERE workspace") ||
       normalizedSql.startsWith("SELECT object_key FROM (SELECT object_key FROM file_metadata")
@@ -90,7 +90,8 @@ export class FileMetadataTable {
         });
       }
       let idx = filterCount * 3;
-      const prefix = hasPrefix ? (args[idx++] as string) : undefined;
+      // Bound prefix is ESCAPE-quoted for SQL LIKE; strip escapes for startsWith.
+      const prefix = hasPrefix ? String(args[idx++]).replace(/\\([\\%_])/g, "$1") : undefined;
       const limit = args[idx] as number;
       const workspace = filters[0]?.workspace;
       if (!workspace || filters.some((f) => f.workspace !== workspace)) {

--- a/apps/api/test/helpers/fake-pr-activity-table.ts
+++ b/apps/api/test/helpers/fake-pr-activity-table.ts
@@ -60,10 +60,12 @@ export class PrActivityTable {
   }
 
   tryAll<T>(normalizedSql: string, args: unknown[]): FakeAllResult<T> | undefined {
-    if (normalizedSql.startsWith("SELECT * FROM github_pr_activity WHERE workspace_name")) {
+    if (
+      normalizedSql.includes("FROM github_pr_activity") &&
+      normalizedSql.includes("workspace_name")
+    ) {
       const [workspace, limit] = args as [string, number];
-      // Non-mutating sort — lib ES2022 predates Array#toSorted (see
-      // fake-repo-links-table.ts).
+      // Copy + sort: lib ES2022 predates Array#toSorted.
       const results = [...this.rows.values()]
         .filter((row) => row.workspace_name === workspace)
         .sort((a, b) => b.last_media_at.localeCompare(a.last_media_at))

--- a/apps/api/test/helpers/fake-repo-links-table.ts
+++ b/apps/api/test/helpers/fake-repo-links-table.ts
@@ -99,21 +99,18 @@ export class RepoLinksTable {
   }
 
   tryFirst<T>(normalizedSql: string, args: unknown[]): T | null | undefined {
-    if (normalizedSql.startsWith("SELECT * FROM github_repo_links WHERE repo_full_name")) {
+    if (normalizedSql.includes("FROM github_repo_links WHERE repo_full_name")) {
       const [repo] = args as [string];
       return (this.rows.get(repo) as T) ?? null;
     }
     return undefined;
   }
 
-  // listRepoLinksForWorkspace (issue #318, admin visibility): all bindings
-  // owned by one workspace, newest first — matches the real `ORDER BY
-  // created_at DESC`.
+  // listRepoLinksForWorkspace: bindings for one workspace, newest first.
   tryAll<T>(normalizedSql: string, args: unknown[]): FakeAllResult<T> | undefined {
-    if (normalizedSql.startsWith("SELECT * FROM github_repo_links WHERE workspace_name")) {
+    if (normalizedSql.includes("FROM github_repo_links WHERE workspace_name")) {
       const [workspace] = args as [string];
-      // Non-mutating sort (see github-comment-render.ts: this worker's
-      // tsconfig targets lib ES2022, which predates Array#toSorted).
+      // Copy + sort: lib ES2022 predates Array#toSorted.
       const results = [...this.rows.values()]
         .filter((row) => row.workspace_name === workspace)
         .sort((a, b) => b.created_at.localeCompare(a.created_at));

--- a/apps/auth/migrations/20260721160000_invitation_org_status_idx.sql
+++ b/apps/auth/migrations/20260721160000_invitation_org_status_idx.sql
@@ -1,0 +1,5 @@
+-- Pending-invite COUNT/list: (organization_id, status = 'pending').
+-- Composite lets those paths skip non-pending rows on long invite histories.
+
+CREATE INDEX IF NOT EXISTS idx_invitation_organization_status
+  ON invitation (organization_id, status);

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -332,9 +332,54 @@ describe("DB-backed behavior", () => {
       const body = (await res.json()) as Array<{
         organizationId: string;
         organizationSlug: string;
+        organizationName: string;
         role: string;
       }>;
-      expect(body).toEqual([{ organizationId: org.id, organizationSlug: org.slug, role: "owner" }]);
+      expect(body).toEqual([
+        {
+          organizationId: org.id,
+          organizationSlug: org.slug,
+          organizationName: org.name,
+          role: "owner",
+        },
+      ]);
+    });
+
+    it("filters to a single org when slug is provided", async () => {
+      const user = await seedUser();
+      const acme = await seedOrg({ slug: "acme", name: "Acme" });
+      const beta = await seedOrg({ slug: "beta", name: "Beta" });
+      await orm.insert(schema.member).values([
+        {
+          id: crypto.randomUUID(),
+          organizationId: acme.id,
+          userId: user.id,
+          role: "owner",
+          createdAt: new Date(),
+        },
+        {
+          id: crypto.randomUUID(),
+          organizationId: beta.id,
+          userId: user.id,
+          role: "member",
+          createdAt: new Date(),
+        },
+      ]);
+
+      const res = await app().request(
+        `/internal/memberships?userId=${user.id}&slug=acme`,
+        {},
+        dbEnv(),
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([
+        {
+          organizationId: acme.id,
+          organizationSlug: "acme",
+          organizationName: "Acme",
+          role: "owner",
+        },
+      ]);
     });
 
     it("returns an empty list for a user with no memberships", async () => {

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -396,6 +396,53 @@ describe("DB-backed behavior", () => {
     });
   });
 
+  describe("GET /internal/orgs/summaries", () => {
+    it("returns every org with aggregated member and pending-invite counts", async () => {
+      const acme = await seedOrg({ slug: "acme", name: "Acme" });
+      const beta = await seedOrg({ slug: "beta", name: "Beta" });
+      const user = await seedUser();
+      await orm.insert(schema.member).values([
+        {
+          id: crypto.randomUUID(),
+          organizationId: acme.id,
+          userId: user.id,
+          role: "owner",
+          createdAt: new Date(),
+        },
+        {
+          id: crypto.randomUUID(),
+          organizationId: beta.id,
+          userId: user.id,
+          role: "member",
+          createdAt: new Date(),
+        },
+      ]);
+      await orm.insert(schema.invitation).values({
+        id: crypto.randomUUID(),
+        organizationId: acme.id,
+        email: "pending@example.com",
+        role: "member",
+        status: "pending",
+        expiresAt: new Date(Date.now() + 86_400_000),
+        inviterId: user.id,
+        createdAt: new Date(),
+      });
+
+      const res = await app().request("/internal/orgs/summaries", {}, dbEnv());
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        organizations: Array<{
+          organization: { slug: string };
+          memberCount: number;
+          pendingInviteCount: number;
+        }>;
+      };
+      const bySlug = new Map(body.organizations.map((row) => [row.organization.slug, row]));
+      expect(bySlug.get("acme")).toMatchObject({ memberCount: 1, pendingInviteCount: 1 });
+      expect(bySlug.get("beta")).toMatchObject({ memberCount: 1, pendingInviteCount: 0 });
+    });
+  });
+
   describe("POST /internal/invite", () => {
     async function seedOrgAdmin(
       role: "owner" | "admin" | "member" = "owner",

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -199,23 +199,32 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
   // Phase 3 (plan scope A): memberships for a user, used by
   // apps/api/src/org-workspaces.ts and the admin-ui endpoints to resolve
   // "what orgs/workspaces can this user act on".
+  // Optional `slug` filters to one org (member-gated route authz: one D1
+  // join instead of loading every membership then scanning).
   .get("/memberships", async (c) => {
     const userId = c.req.query("userId")?.trim();
     if (!userId) {
       return c.json(errorJson("invalid_user_id", "userId is required"), 400);
     }
+    const slug = c.req.query("slug")?.trim() || undefined;
 
     const db = drizzle(c.env.DB, { schema });
-    const rows = await db
+    const conditions = [eq(schema.member.userId, userId)];
+    if (slug) conditions.push(eq(schema.organization.slug, slug));
+
+    const query = db
       .select({
         organizationId: schema.member.organizationId,
         organizationSlug: schema.organization.slug,
+        organizationName: schema.organization.name,
         role: schema.member.role,
       })
       .from(schema.member)
       .innerJoin(schema.organization, eq(schema.member.organizationId, schema.organization.id))
-      .where(eq(schema.member.userId, userId));
+      .where(and(...conditions));
 
+    // Single-org lookups only need one row (LIMIT 1 still bills one match).
+    const rows = slug ? await query.limit(1) : await query;
     return c.json(rows);
   })
   // Phase 3 (plan scope A): admin-provisioned org creation, idempotent on

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -295,34 +295,86 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .from(schema.organization);
     return c.json({ organizations: rows });
   })
+  // Admin workspace list: every org's member/invite counts in three D1 queries
+  // (orgs + grouped member COUNT + grouped pending-invite COUNT), not N×3.
+  // Registered before `/orgs/:slug` so "summaries" is not treated as a slug.
+  .get("/orgs/summaries", async (c) => {
+    const db = drizzle(c.env.DB, { schema });
+    const [orgs, memberRows, inviteRows] = await Promise.all([
+      db
+        .select({
+          id: schema.organization.id,
+          slug: schema.organization.slug,
+          name: schema.organization.name,
+        })
+        .from(schema.organization),
+      db
+        .select({
+          organizationId: schema.member.organizationId,
+          memberCount: count(),
+        })
+        .from(schema.member)
+        .groupBy(schema.member.organizationId),
+      db
+        .select({
+          organizationId: schema.invitation.organizationId,
+          pendingInviteCount: count(),
+        })
+        .from(schema.invitation)
+        .where(eq(schema.invitation.status, "pending"))
+        .groupBy(schema.invitation.organizationId),
+    ]);
+
+    const membersByOrg = new Map(memberRows.map((row) => [row.organizationId, row.memberCount]));
+    const invitesByOrg = new Map(
+      inviteRows.map((row) => [row.organizationId, row.pendingInviteCount]),
+    );
+
+    return c.json({
+      organizations: orgs.map((org) => ({
+        organization: { id: org.id, slug: org.slug, name: org.name },
+        memberCount: membersByOrg.get(org.id) ?? 0,
+        pendingInviteCount: invitesByOrg.get(org.id) ?? 0,
+      })),
+    });
+  })
   // Phase 3 (plan scope B): org lookup + member/invite counts for
-  // GET /admin-ui/workspaces on apps/api.
+  // single-workspace admin detail / orgForWorkspace.
   .get("/orgs/:slug", async (c) => {
     const slug = c.req.param("slug");
     const db = drizzle(c.env.DB, { schema });
     const [org] = await db
-      .select()
+      .select({
+        id: schema.organization.id,
+        slug: schema.organization.slug,
+        name: schema.organization.name,
+      })
       .from(schema.organization)
       .where(eq(schema.organization.slug, slug))
       .limit(1);
     if (!org) {
       return c.json(errorJson("organization_not_found", "no organization with that slug"), 404);
     }
-    const members = await db
-      .select({ id: schema.member.id })
-      .from(schema.member)
-      .where(eq(schema.member.organizationId, org.id));
-    const invites = await db
-      .select({ id: schema.invitation.id })
-      .from(schema.invitation)
-      .where(
-        and(eq(schema.invitation.organizationId, org.id), eq(schema.invitation.status, "pending")),
-      );
-    const pendingInvites = invites.length;
+    // COUNT aggregates (not id lists + .length) so only the count crosses the wire.
+    const [[memberRow], [inviteRow]] = await Promise.all([
+      db
+        .select({ memberCount: count() })
+        .from(schema.member)
+        .where(eq(schema.member.organizationId, org.id)),
+      db
+        .select({ pendingInviteCount: count() })
+        .from(schema.invitation)
+        .where(
+          and(
+            eq(schema.invitation.organizationId, org.id),
+            eq(schema.invitation.status, "pending"),
+          ),
+        ),
+    ]);
     return c.json({
       organization: { id: org.id, slug: org.slug, name: org.name },
-      memberCount: members.length,
-      pendingInviteCount: pendingInvites,
+      memberCount: memberRow?.memberCount ?? 0,
+      pendingInviteCount: inviteRow?.pendingInviteCount ?? 0,
     });
   })
   // Phase 3 (plan scope B): member list for GET /admin-ui/workspaces/:name/members.
@@ -774,11 +826,11 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       );
     }
     const force = c.req.query("force") === "1" || c.req.query("force") === "true";
-    const members = await db
-      .select({ id: schema.member.id })
+    const [memberCountRow] = await db
+      .select({ memberCount: count() })
       .from(schema.member)
       .where(eq(schema.member.organizationId, org.id));
-    if (members.length > 1 && !force) {
+    if ((memberCountRow?.memberCount ?? 0) > 1 && !force) {
       return c.json(errorJson("org_not_empty", "organization has more than one member"), 409);
     }
     await db.delete(schema.member).where(eq(schema.member.organizationId, org.id));

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -196,11 +196,8 @@ function validateOptionalUrl(value: unknown): { ok: true; value: string | null }
 }
 
 export const internal = new Hono<{ Bindings: AuthEnv }>()
-  // Phase 3 (plan scope A): memberships for a user, used by
-  // apps/api/src/org-workspaces.ts and the admin-ui endpoints to resolve
-  // "what orgs/workspaces can this user act on".
-  // Optional `slug` filters to one org (member-gated route authz: one D1
-  // join instead of loading every membership then scanning).
+  // Memberships for a user (org-workspaces + member-gated /me routes).
+  // Optional `slug` → one-org authz lookup (LIMIT 1; bills one match).
   .get("/memberships", async (c) => {
     const userId = c.req.query("userId")?.trim();
     if (!userId) {
@@ -223,7 +220,6 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .innerJoin(schema.organization, eq(schema.member.organizationId, schema.organization.id))
       .where(and(...conditions));
 
-    // Single-org lookups only need one row (LIMIT 1 still bills one match).
     const rows = slug ? await query.limit(1) : await query;
     return c.json(rows);
   })
@@ -304,9 +300,8 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       .from(schema.organization);
     return c.json({ organizations: rows });
   })
-  // Admin workspace list: every org's member/invite counts in three D1 queries
-  // (orgs + grouped member COUNT + grouped pending-invite COUNT), not N×3.
-  // Registered before `/orgs/:slug` so "summaries" is not treated as a slug.
+  // Admin list: all org member/pending-invite counts in 3 queries (not N×3).
+  // Registered before `/orgs/:slug` so "summaries" is not parsed as a slug.
   .get("/orgs/summaries", async (c) => {
     const db = drizzle(c.env.DB, { schema });
     const [orgs, memberRows, inviteRows] = await Promise.all([
@@ -912,31 +907,31 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     // orderBy asc by default; contract wants createdAt desc.
     rows.reverse();
 
-    // Two grouped aggregate queries instead of one statsForClient() call per
-    // row — avoids an N+1 (2N) query fan-out on the list endpoint.
-    const consentRows = await db
-      .select({
-        clientId: schema.oauthConsent.clientId,
-        consentCount: countDistinct(schema.oauthConsent.userId),
-        lastConsentAt: max(schema.oauthConsent.createdAt),
-      })
-      .from(schema.oauthConsent)
-      .groupBy(schema.oauthConsent.clientId);
+    // Grouped aggregates instead of statsForClient() per row (avoids N+1).
+    const [consentRows, tokenRows] = await Promise.all([
+      db
+        .select({
+          clientId: schema.oauthConsent.clientId,
+          consentCount: countDistinct(schema.oauthConsent.userId),
+          lastConsentAt: max(schema.oauthConsent.createdAt),
+        })
+        .from(schema.oauthConsent)
+        .groupBy(schema.oauthConsent.clientId),
+      db
+        .select({
+          clientId: schema.oauthRefreshToken.clientId,
+          activeTokenCount: count(),
+        })
+        .from(schema.oauthRefreshToken)
+        .where(
+          and(
+            isNull(schema.oauthRefreshToken.revoked),
+            gt(schema.oauthRefreshToken.expiresAt, new Date()),
+          ),
+        )
+        .groupBy(schema.oauthRefreshToken.clientId),
+    ]);
     const consentByClient = new Map(consentRows.map((row) => [row.clientId, row]));
-
-    const tokenRows = await db
-      .select({
-        clientId: schema.oauthRefreshToken.clientId,
-        activeTokenCount: count(),
-      })
-      .from(schema.oauthRefreshToken)
-      .where(
-        and(
-          isNull(schema.oauthRefreshToken.revoked),
-          gt(schema.oauthRefreshToken.expiresAt, new Date()),
-        ),
-      )
-      .groupBy(schema.oauthRefreshToken.clientId);
     const tokensByClient = new Map(tokenRows.map((row) => [row.clientId, row.activeTokenCount]));
 
     const clients = rows.map((row) => {

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -210,7 +210,11 @@ export const invitation = sqliteTable(
       .references(() => user.id, { onDelete: "cascade" }),
     createdAt: timestampCol("created_at"),
   },
-  (t) => [index("idx_invitation_organization_id").on(t.organizationId)],
+  (t) => [
+    index("idx_invitation_organization_id").on(t.organizationId),
+    // Pending counts/list: (org, status). Migration: 20260721160000_invitation_org_status_idx.sql
+    index("idx_invitation_organization_status").on(t.organizationId, t.status),
+  ],
 );
 
 /**

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -181,29 +181,42 @@ async function makeEnv(
                 meta: {},
               };
             }
-            // findObjectsByMetadata's first query: matches by ANDed key/value
-            // pairs (+ optional escaped-LIKE prefix), grouped/having-counted.
-            // Good enough for tests — not a general SQL engine.
-            if (normalized.startsWith("SELECT object_key FROM file_metadata WHERE workspace")) {
+            // findObjectsByMetadata: single equality or multi-filter INTERSECT
+            // legs — args are (workspace, key, value)×N, optional escaped
+            // prefix, limit. Mirrors apps/api/test/helpers/fake-file-metadata-table.
+            if (
+              normalized.startsWith("SELECT object_key FROM file_metadata WHERE workspace") ||
+              normalized.startsWith("SELECT object_key FROM (SELECT object_key FROM file_metadata")
+            ) {
               const vals = values as unknown[];
-              const ws = vals[0] as string;
-              const hasPrefix = normalized.includes("LIKE");
-              const pairsEnd = hasPrefix ? vals.length - 3 : vals.length - 2;
-              const pairs: Array<[string, string]> = [];
-              for (let i = 1; i < pairsEnd; i += 2) {
-                pairs.push([vals[i] as string, vals[i + 1] as string]);
+              const filterCount = (normalized.match(/meta_key = \? AND meta_value = \?/g) ?? [])
+                .length;
+              const hasPrefix = normalized.includes("object_key LIKE ? || '%'");
+              const filters: Array<{ workspace: string; key: string; value: string }> = [];
+              for (let i = 0; i < filterCount; i++) {
+                const base = i * 3;
+                filters.push({
+                  workspace: vals[base] as string,
+                  key: vals[base + 1] as string,
+                  value: vals[base + 2] as string,
+                });
               }
+              let idx = filterCount * 3;
               const prefix = hasPrefix
-                ? (vals[pairsEnd] as string).replace(/\\([%_\\])/g, "$1")
+                ? String(vals[idx++]).replace(/\\([\\%_])/g, "$1")
                 : undefined;
-              const limit = vals[vals.length - 1] as number;
+              const limit = vals[idx] as number;
+              const ws = filters[0]?.workspace;
 
               const matches: string[] = [];
-              for (const [scoped, map] of metadata.entries()) {
-                const [scopedWs, objectKey] = scoped.split(" ");
-                if (scopedWs !== ws) continue;
-                if (prefix !== undefined && !objectKey.startsWith(prefix)) continue;
-                if (pairs.every(([k, v]) => map.get(k) === v)) matches.push(objectKey);
+              if (ws && filters.every((f) => f.workspace === ws)) {
+                const scopePrefix = `${ws} `;
+                for (const [scoped, map] of metadata.entries()) {
+                  if (!scoped.startsWith(scopePrefix)) continue;
+                  const objectKey = scoped.slice(scopePrefix.length);
+                  if (prefix !== undefined && !objectKey.startsWith(prefix)) continue;
+                  if (filters.every((f) => map.get(f.key) === f.value)) matches.push(objectKey);
+                }
               }
               matches.sort();
               return {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -97,6 +97,19 @@ export interface WorkspaceUsage {
   uploadsRemaining?: number;
 }
 
+function parseWorkspaceUsage(body: unknown): WorkspaceUsage | null {
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof (body as WorkspaceUsage).bytes !== "number" ||
+    typeof (body as WorkspaceUsage).objects !== "number" ||
+    typeof (body as WorkspaceUsage).uploadsInPeriod !== "number"
+  ) {
+    return null;
+  }
+  return body as WorkspaceUsage;
+}
+
 /** GET /me/workspaces/:name/usage. Returns null on any non-2xx or malformed body. */
 export async function getMyWorkspaceUsage(
   apiOrigin: string,
@@ -107,17 +120,48 @@ export async function getMyWorkspaceUsage(
     { credentials: "include", cache: "no-store" },
   );
   if (result.kind === "unavailable" || !result.response.ok) return null;
-  const body = (await result.response.json().catch(() => null)) as WorkspaceUsage | null;
-  if (
-    !body ||
-    typeof body !== "object" ||
-    typeof body.bytes !== "number" ||
-    typeof body.objects !== "number" ||
-    typeof body.uploadsInPeriod !== "number"
-  ) {
-    return null;
-  }
-  return body;
+  return parseWorkspaceUsage(await result.response.json().catch(() => null));
+}
+
+export type WorkspaceSummaryResult =
+  | {
+      kind: "success";
+      workspace: MyWorkspace;
+      usage: WorkspaceUsage | null;
+    }
+  | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" | "not_found" };
+
+/**
+ * GET /me/workspaces/:name/summary — membership + public URL + usage for the
+ * workspace shell/rail (one authz pass instead of full list + usage).
+ */
+export async function getWorkspaceSummary(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceSummaryResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/summary`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body || !isMyWorkspaceCore(body)) return { kind: "unavailable", reason: "malformed" };
+  const raw = body as Record<string, unknown>;
+  return {
+    kind: "success",
+    workspace: {
+      workspace: body.workspace,
+      organization: body.organization,
+      role: body.role,
+      communal: raw.communal === true,
+      hasPublicUrl: raw.hasPublicUrl === true,
+      publicBaseUrl: typeof raw.publicBaseUrl === "string" ? raw.publicBaseUrl : undefined,
+    },
+    usage: parseWorkspaceUsage(raw.usage),
+  };
 }
 
 /**
@@ -259,6 +303,16 @@ function isMemberCandidate(
   return typeof row.email === "string" && typeof row.role === "string";
 }
 
+function mapWorkspaceMembers(list: unknown[]): WorkspaceMember[] {
+  return list.filter(isMemberCandidate).map((row) => ({
+    id: typeof row.id === "string" ? row.id : undefined,
+    email: row.email,
+    name: typeof row.name === "string" ? row.name : "",
+    role: row.role,
+    createdAt: typeof row.createdAt === "string" ? row.createdAt : undefined,
+  }));
+}
+
 /** GET /me/workspaces/:name/members — teammates in the workspace, member-gated. */
 export async function getWorkspaceMembers(
   apiOrigin: string,
@@ -277,13 +331,60 @@ export async function getWorkspaceMembers(
   return {
     kind: "ok",
     communal: body.communal === true,
-    members: body.members.filter(isMemberCandidate).map((row) => ({
-      id: typeof row.id === "string" ? row.id : undefined,
-      email: row.email,
-      name: typeof row.name === "string" ? row.name : "",
-      role: row.role,
-      createdAt: typeof row.createdAt === "string" ? row.createdAt : undefined,
-    })),
+    members: mapWorkspaceMembers(body.members),
+  };
+}
+
+export type WorkspacePeopleResult =
+  | {
+      kind: "ok";
+      communal: boolean;
+      role: string;
+      canManage: boolean;
+      organization: { id: string; slug: string; name: string };
+      members: WorkspaceMember[];
+      invites: WorkspaceInvite[];
+    }
+  | { kind: "unavailable"; reason?: "not_found" | "server" | RequestFailure };
+
+/**
+ * GET /me/workspaces/:name/people — members + invites (+ role) for the people
+ * tab in one request.
+ */
+export async function getWorkspacePeople(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspacePeopleResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/people`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body || !Array.isArray(body.members) || typeof body.role !== "string") {
+    return { kind: "unavailable", reason: "server" };
+  }
+  const org = body.organization as Record<string, unknown> | undefined;
+  return {
+    kind: "ok",
+    communal: body.communal === true,
+    role: body.role,
+    canManage: body.canManage === true,
+    organization: {
+      id: typeof org?.id === "string" ? org.id : "",
+      slug: typeof org?.slug === "string" ? org.slug : name,
+      name: typeof org?.name === "string" ? org.name : name,
+    },
+    members: mapWorkspaceMembers(body.members),
+    invites: Array.isArray(body.invites)
+      ? body.invites.filter(
+          (v): v is WorkspaceInvite =>
+            !!v && typeof v === "object" && typeof (v as { id?: unknown }).id === "string",
+        )
+      : [],
   };
 }
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -49,6 +49,23 @@ function isMyWorkspaceCore(
   );
 }
 
+/** Coerce optional/legacy fields; shared by list + summary mappers. */
+function mapMyWorkspace(ws: Omit<MyWorkspace, "communal" | "hasPublicUrl">): MyWorkspace {
+  const raw = ws as Omit<MyWorkspace, "communal" | "hasPublicUrl"> & {
+    communal?: unknown;
+    hasPublicUrl?: unknown;
+    publicBaseUrl?: unknown;
+  };
+  return {
+    workspace: raw.workspace,
+    organization: raw.organization,
+    role: raw.role,
+    communal: raw.communal === true,
+    hasPublicUrl: raw.hasPublicUrl === true,
+    publicBaseUrl: typeof raw.publicBaseUrl === "string" ? raw.publicBaseUrl : undefined,
+  };
+}
+
 export type WorkspacesResult =
   | { kind: "success"; workspaces: MyWorkspace[] }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
@@ -68,19 +85,7 @@ export async function getMyWorkspaces(apiOrigin: string): Promise<WorkspacesResu
   if (!body || !Array.isArray(body.workspaces)) return { kind: "unavailable", reason: "malformed" };
   return {
     kind: "success",
-    workspaces: body.workspaces.filter(isMyWorkspaceCore).map(
-      (ws): MyWorkspace => ({
-        workspace: ws.workspace,
-        organization: ws.organization,
-        role: ws.role,
-        communal: (ws as { communal?: unknown }).communal === true,
-        hasPublicUrl: (ws as { hasPublicUrl?: unknown }).hasPublicUrl === true,
-        publicBaseUrl:
-          typeof (ws as { publicBaseUrl?: unknown }).publicBaseUrl === "string"
-            ? (ws as { publicBaseUrl: string }).publicBaseUrl
-            : undefined,
-      }),
-    ),
+    workspaces: body.workspaces.filter(isMyWorkspaceCore).map(mapMyWorkspace),
   };
 }
 
@@ -149,18 +154,11 @@ export async function getWorkspaceSummary(
   if (!response.ok) return { kind: "unavailable", reason: "server" };
   const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
   if (!body || !isMyWorkspaceCore(body)) return { kind: "unavailable", reason: "malformed" };
-  const raw = body as Record<string, unknown>;
   return {
     kind: "success",
-    workspace: {
-      workspace: body.workspace,
-      organization: body.organization,
-      role: body.role,
-      communal: raw.communal === true,
-      hasPublicUrl: raw.hasPublicUrl === true,
-      publicBaseUrl: typeof raw.publicBaseUrl === "string" ? raw.publicBaseUrl : undefined,
-    },
-    usage: parseWorkspaceUsage(raw.usage),
+    workspace: mapMyWorkspace(body),
+    // `usage` is summary-only; not part of the workspace core shape.
+    usage: parseWorkspaceUsage((body as Record<string, unknown>).usage),
   };
 }
 

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -8,8 +8,8 @@
  *    synchronously, before any network round trip, so a files-tab script that
  *    races ahead of this module's session-gated fetches never calls a
  *    not-yet-defined function;
- *  - fetches `getMyWorkspaces` → role badge (header) + details (slug/role/public url);
- *  - fetches `getMyWorkspaceUsage` → usage meters (`renderUsageHtml`, reused as-is).
+ *  - fetches `getWorkspaceSummary` → role badge, details, and usage in one call
+ *    (membership + usage, not the full workspace list).
  *
  * Connected-work hook contract (Task 8's files tab is the only caller):
  *   `window.__uploadsSetConnectedWork(items: GhWorkItem[], titles?: GithubTitleMap): void`
@@ -18,12 +18,7 @@
  * item; an empty array hides it. Non-files tabs never call it, so the section
  * stays hidden by construction.
  */
-import {
-  getMyWorkspaces,
-  getMyWorkspaceUsage,
-  type GithubTitleMap,
-  type MyWorkspace,
-} from "./api-client";
+import { getWorkspaceSummary, type GithubTitleMap, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
 import { bindCopyButtons, escapeHtml, renderUsageHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
@@ -189,27 +184,21 @@ export function initWorkspaceRail(
   const usageEl = root.querySelector<HTMLElement>("[data-rail-usage]");
 
   onSession(() => {
-    void getMyWorkspaces(apiOrigin).then((result) => {
+    void getWorkspaceSummary(apiOrigin, workspace).then((result) => {
       if (result.kind !== "success") {
-        // Mirror the usage fetch below (and the files tab's explicit outage
-        // state) rather than leaving the details list silently blank.
         if (detailsEl) detailsEl.textContent = "Details unavailable.";
+        if (usageEl) usageEl.textContent = "Usage unavailable.";
         return;
       }
-      const ws: MyWorkspace | undefined = result.workspaces.find(
-        (item) => item.workspace === workspace,
-      );
-      if (!ws) return;
+      const ws: MyWorkspace = result.workspace;
       if (roleBadge) {
         roleBadge.textContent = ws.role;
         roleBadge.hidden = false;
       }
       if (detailsEl) detailsEl.innerHTML = renderDetailsHtml(ws);
-    });
-
-    void getMyWorkspaceUsage(apiOrigin, workspace).then((usage) => {
-      if (!usageEl) return;
-      usageEl.innerHTML = usage ? renderUsageHtml(usage) : "Usage unavailable.";
+      if (usageEl) {
+        usageEl.innerHTML = result.usage ? renderUsageHtml(result.usage) : "Usage unavailable.";
+      }
     });
   });
 }

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -8,8 +8,7 @@
  *    synchronously, before any network round trip, so a files-tab script that
  *    races ahead of this module's session-gated fetches never calls a
  *    not-yet-defined function;
- *  - fetches `getWorkspaceSummary` → role badge, details, and usage in one call
- *    (membership + usage, not the full workspace list).
+ *  - fetches `getWorkspaceSummary` → role badge, details, and usage.
  *
  * Connected-work hook contract (Task 8's files tab is the only caller):
  *   `window.__uploadsSetConnectedWork(items: GhWorkItem[], titles?: GithubTitleMap): void`

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -83,15 +83,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       requireElement,
     } from "../../../../lib/account-shell";
     import {
-      getMyWorkspaces,
-      getWorkspaceMembers,
+      getWorkspacePeople,
       inviteToWorkspace,
-      getWorkspaceInvites,
       revokeWorkspaceInvite,
       removeWorkspaceMember,
       updateWorkspaceMemberRole,
     } from "../../../../lib/api-client";
-    import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import {
       bindCopyButtons,
@@ -155,78 +152,70 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         retryBtn.hidden = true;
         appEl.hidden = true;
 
-        const result = await getMyWorkspaces(apiOrigin);
+        // One combined people payload (authz + members + invites) instead of
+        // full workspace list + members + invites round-trips.
+        const result = await getWorkspacePeople(apiOrigin, workspaceName);
         if (!stillHere()) return;
         if (result.kind === "unavailable") {
-          showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
-          return;
-        }
-
-        writeCachedWorkspaces(result.workspaces);
-
-        const ws = result.workspaces.find((item) => item.workspace === workspaceName);
-        if (!ws) {
-          showError("You don’t have access to this workspace.", false);
+          if (result.reason === "not_found") {
+            showError("You don’t have access to this workspace.", false);
+            return;
+          }
+          showError("People are temporarily unavailable. Check the local stack or try again.");
           return;
         }
 
         // Every member sees the people list; inviting stays admin-only (site
         // operators may still open the page for the ADMIN_TOKEN command).
-        inviteSection.hidden = !isWorkspaceAdminRole(ws.role) && sessionRole !== "admin";
-        inviteForm.hidden = !isWorkspaceAdminRole(ws.role);
+        inviteSection.hidden = !isWorkspaceAdminRole(result.role) && sessionRole !== "admin";
+        inviteForm.hidden = !isWorkspaceAdminRole(result.role);
 
-        canManage = isWorkspaceAdminRole(ws.role);
+        canManage = result.canManage;
         invitesSection.hidden = !canManage;
 
         statusEl.hidden = true;
         appEl.hidden = false;
 
-        void loadMembers();
-        if (canManage) void loadInvites();
+        if (result.communal) {
+          membersEl.innerHTML =
+            '<p class="muted">Shared, public space — no member list to show.</p>';
+          invitesEl.innerHTML = "";
+        } else {
+          membersEl.innerHTML = result.members.length
+            ? renderMembersHtml(result.members, { canManage, selfEmail: sessionEmail })
+            : '<p class="muted">Just you so far.</p>';
+          if (canManage) {
+            invitesEl.innerHTML = result.invites.length
+              ? renderInvitesHtml(result.invites)
+              : '<p class="muted">No pending invites.</p>';
+          }
+        }
 
-        const displayName = ws.organization.name || ws.workspace;
+        const displayName = result.organization.name || workspaceName;
         slugEl.textContent =
-          displayName === ws.workspace ? ws.workspace : `${displayName} · ${ws.workspace}`;
+          displayName === workspaceName ? workspaceName : `${displayName} · ${workspaceName}`;
         document.title = `People · ${displayName} · uploads.sh`;
 
         const isOperator = sessionRole === "admin";
         operatorCard.hidden = !isOperator;
         if (isOperator) {
-          const cmd = operatorInviteCommand(ws.workspace);
+          const cmd = operatorInviteCommand(workspaceName);
           operatorCmd.textContent = cmd;
           operatorCopy.dataset.copy = cmd;
         }
       }
 
-      async function loadMembers(): Promise<void> {
-        const result = await getWorkspaceMembers(apiOrigin, workspaceName);
-        if (!stillHere()) return;
-        if (result.kind === "unavailable") {
-          membersEl.innerHTML =
-            '<p class="muted" role="alert">People are temporarily unavailable. Reload to try again.</p>';
-          return;
-        }
-        if (result.communal) {
-          membersEl.innerHTML =
-            '<p class="muted">Shared, public space — no member list to show.</p>';
-          return;
-        }
+      async function refreshPeopleLists(): Promise<void> {
+        const result = await getWorkspacePeople(apiOrigin, workspaceName);
+        if (!stillHere() || result.kind !== "ok" || result.communal) return;
         membersEl.innerHTML = result.members.length
           ? renderMembersHtml(result.members, { canManage, selfEmail: sessionEmail })
           : '<p class="muted">Just you so far.</p>';
-      }
-
-      async function loadInvites(): Promise<void> {
-        const result = await getWorkspaceInvites(apiOrigin, workspaceName);
-        if (!stillHere()) return;
-        if (result.kind === "unavailable") {
-          invitesEl.innerHTML =
-            '<p class="muted" role="alert">Invites are temporarily unavailable. Reload to try again.</p>';
-          return;
+        if (canManage) {
+          invitesEl.innerHTML = result.invites.length
+            ? renderInvitesHtml(result.invites)
+            : '<p class="muted">No pending invites.</p>';
         }
-        invitesEl.innerHTML = result.invites.length
-          ? renderInvitesHtml(result.invites)
-          : '<p class="muted">No pending invites.</p>';
       }
 
       function manageErrorText(reason: string, action: string): string {
@@ -269,6 +258,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
               inviteLink.hidden = false;
               inviteLink.innerHTML = `Accept link: <a href="${escapeHtml(result.acceptUrl)}">${escapeHtml(result.acceptUrl)}</a>`;
             }
+            if (canManage) void refreshPeopleLists();
             return;
           }
           inviteStatus.textContent =
@@ -292,7 +282,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           btn.disabled = true;
           const res = await removeWorkspaceMember(apiOrigin, workspaceName, memberId);
           if (!stillHere()) return;
-          if (res.kind === "ok") void loadMembers();
+          if (res.kind === "ok") void refreshPeopleLists();
           else {
             btn.disabled = false;
             alert(manageErrorText(res.reason, "remove this member"));
@@ -317,7 +307,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           const res = await updateWorkspaceMemberRole(apiOrigin, workspaceName, memberId, role);
           if (!stillHere()) return;
           select.disabled = false;
-          if (res.kind === "ok") void loadMembers();
+          if (res.kind === "ok") void refreshPeopleLists();
           else alert(manageErrorText(res.reason, "change this role"));
         })();
       });
@@ -334,7 +324,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           btn.disabled = true;
           const res = await revokeWorkspaceInvite(apiOrigin, workspaceName, inviteId);
           if (!stillHere()) return;
-          if (res.kind === "ok") void loadInvites();
+          if (res.kind === "ok") void refreshPeopleLists();
           else {
             btn.disabled = false;
             alert(manageErrorText(res.reason, "revoke this invite"));

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -247,12 +247,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           submit.disabled = false;
 
           if (result.kind === "ok") {
-            inviteStatus.textContent =
-              result.emailConfigured === true
-                ? `Invitation emailed to ${email}.`
-                : result.emailConfigured === false
-                  ? `Invite created for ${email} — share the accept link below.`
-                  : `Invite created for ${email}.`;
+            if (result.emailConfigured === true) {
+              inviteStatus.textContent = `Invitation emailed to ${email}.`;
+            } else if (result.emailConfigured === false) {
+              inviteStatus.textContent = `Invite created for ${email} — share the accept link below.`;
+            } else {
+              inviteStatus.textContent = `Invite created for ${email}.`;
+            }
             if (emailInput) emailInput.value = "";
             if (result.acceptUrl) {
               inviteLink.hidden = false;
@@ -261,12 +262,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             if (canManage) void refreshPeopleLists();
             return;
           }
-          inviteStatus.textContent =
-            result.reason === "forbidden"
-              ? "You need workspace admin access to invite."
-              : result.reason === "invalid"
-                ? "That email doesn’t look valid."
-                : "Couldn’t create the invite. Try again.";
+          if (result.reason === "forbidden") {
+            inviteStatus.textContent = "You need workspace admin access to invite.";
+          } else if (result.reason === "invalid") {
+            inviteStatus.textContent = "That email doesn’t look valid.";
+          } else {
+            inviteStatus.textContent = "Couldn’t create the invite. Try again.";
+          }
         })();
       });
 


### PR DESCRIPTION
## In plain terms

D1 bills primarily on rows read. Admin and account dashboards were doing more work than needed: N org-summary round-trips, counting by loading every member id, over-reading metadata multi-filters, and (on the account shell) reloading the full workspace list just to show one workspace's role and usage.

This keeps the same UI behavior while reading fewer rows and making fewer AUTH/API round-trips.

## What it does

### Query / index optimizations
- **Admin workspaces list**: one AUTH call to `GET /internal/orgs/summaries` (three aggregate D1 queries) instead of N×3 per workspace
- **Org summary counts**: `COUNT(*)` instead of selecting every member/invite id
- **Metadata search**: multi-filter AND via index-friendly `INTERSECT`
- **Staging reaper**: batch hydrate with `getMetadataForKeys` per workspace
- **Indexes** (new migrations):
  - API: `file_metadata (meta_key, meta_value)`, partial `auth_tokens (minting_user_id)`
  - Auth: `invitation (organization_id, status)`

### New / extended endpoints (dashboard batching)
- **`GET /internal/memberships?userId=&slug=`** — optional single-org membership + `organizationName` on rows
- **Membership authz** — `memberWorkspaceOr404` uses a slug-scoped lookup (one join), not the full list + N org fetches
- **`GET /me/workspaces/:name/summary`** — membership + public URL + usage (workspace rail)
- **`GET /me/workspaces/:name/people`** — members + invites + role (people tab)

Existing list/members/usage endpoints remain for other callers.

## What it is not
- No user-facing CLI package / changeset release
- Not a redesign of multi-workspace orgs (still 1:1 slug === workspace)

## How to try it
After deploy + D1 migrations for api + auth:

1. `/admin` workspaces list still shows member/invite counts
2. Workspace rail still shows role + usage (now via `/summary`)
3. People tab still lists teammates/invites (now via `/people`)
4. Multi-filter metadata search returns the same matches

## Test plan
- [x] Auth internal-routes tests
- [x] API me + admin-ui + file-metadata + staging-reaper tests
- [x] Web api-client tests
- [ ] Apply D1 migrations on staging/prod for new indexes