### PR TITLE
fix: keep account sidebar and shell width consistent

### DIFF
--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -1,21 +1,17 @@
 ---
 /**
- * Shared shell for /account and /account/* — flat sidebar nav with real
- * paths (file-based routing), session gate chrome, sign-out, and an
- * optional right-rail column (`<AccountLayout><Fragment slot="rail">…`).
+ * Shared shell for /account/* — flat sidebar, session gate, optional rail.
  *
- * Workspace navigation uses a switcher model: the section heading is the
- * current workspace name (dropdown of memberships + "+ new workspace").
- * When a workspace is active, files / galleries / people / settings live
- * as flat rows under that heading. Tab state is derived from the URL.
+ * Sidebar: workspace switcher + section tabs (from URL or last-used cache,
+ * so personal routes keep the same nav) + Personal (account / developers).
+ * Admin + sign-out live only in the header avatar menu.
  *
- * ClientRouter holds the current view while the next account route loads
- * (no blank-page flicker). Scripts re-boot on `astro:page-load`.
+ * Layout is always nav · content · rail (empty rail reserves width). Scripts
+ * re-boot on `astro:page-load` (ClientRouter).
  */
 import { env } from "cloudflare:workers";
 import {
   applyAuthSecurityHeaders,
-  resolveShowConsoleLinks,
   resolveSignedInOrigins,
   signedInCsp,
 } from "../lib/signed-in-page";
@@ -63,7 +59,6 @@ const workspaceBase = workspace
   : "";
 const switcherHeading = workspace || "workspaces";
 
-const showConsoleLinks = await resolveShowConsoleLinks(env);
 const { authOrigin, apiOrigin } = resolveSignedInOrigins(env);
 // Header (not meta): frame-ancestors is ignored on meta CSP.
 applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrigin));
@@ -93,11 +88,11 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
     <button class="button" type="button" id="session-retry">Try again</button>
   </div>
 
-  <div id="app" class:list={["account-shell", { "account-shell--rail": hasRail }]} hidden>
+  <div id="app" class="account-shell" hidden>
     <SiteHeader authOrigin={authOrigin} />
 
     <div class="shell">
-      <div class="layout" data-rail={hasRail ? "true" : "false"}>
+      <div class="layout">
         <nav class="side" aria-label="Account sections">
           <div class="ws-switcher" id="ws-switcher">
             <button
@@ -147,7 +142,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
             }
           </div>
 
-          <div class="side-label">you</div>
+          <div class="side-label">Personal</div>
           <a
             href="/account/profile"
             class="side-link"
@@ -162,34 +157,29 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
           >
             developers
           </a>
-
-          <div class="side-foot">
-            {showConsoleLinks ? <a href="/console">console →</a> : null}
-            <a href="/admin" id="admin-link" hidden>admin →</a>
-            <button type="button" id="sign-out-btn">sign out</button>
-          </div>
         </nav>
 
         <div class="content">
           <slot />
         </div>
 
-        {hasRail ? (
-          <aside class="rail" aria-label="Workspace summary">
-            <slot name="rail" />
-          </aside>
-        ) : null}
+        <aside
+          class="rail"
+          aria-label="Workspace summary"
+          aria-hidden={hasRail ? undefined : "true"}
+          data-empty={hasRail ? undefined : ""}
+        >
+          {hasRail ? <slot name="rail" /> : null}
+        </aside>
       </div>
 
       <Footer />
     </div>
   </div>
 
-{/* Sync optimistic paint: show the shell before deferred modules run so
-    /account → /account/workspaces does not flash "Checking your session…".
-    Key must match SESSION_CACHE_KEY in account-shell.ts. Not a security
-    boundary — revalidated by resolveSessionGate immediately after.
-    data-astro-rerun: ClientRouter must re-apply this after every body swap. */}
+{/* Optimistic shell + workspace section nav before deferred modules run.
+    Keys match SESSION_CACHE_KEY / ACTIVE_WORKSPACE_CACHE_KEY. Not a security
+    boundary — revalidated after. data-astro-rerun: re-apply after body swap. */}
 <script is:inline data-astro-rerun>
   (function () {
     try {
@@ -199,11 +189,31 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
       if (!user || !user.email) return;
       var checking = document.getElementById("checking");
       var app = document.getElementById("app");
-      var adminLink = document.getElementById("admin-link");
       if (checking) checking.hidden = true;
       if (app) app.hidden = false;
-      if (adminLink && user.role === "admin") adminLink.hidden = false;
       window.__uploadsSessionUser = user;
+
+      // Remember workspace from URL; on personal routes restore last-used section nav.
+      var m = location.pathname.match(/^\/account\/workspaces\/([^/]+)/);
+      var pathWs = m && m[1] !== "new" ? decodeURIComponent(m[1]) : "";
+      if (pathWs) {
+        try { sessionStorage.setItem("uploads:activeWorkspace", pathWs); } catch (e) {}
+      }
+      var activeWs = pathWs || sessionStorage.getItem("uploads:activeWorkspace") || "";
+      if (!activeWs || !/^[a-z0-9][a-z0-9-]{1,62}$/.test(activeWs)) return;
+      var section = document.getElementById("workspace-section-nav");
+      if (!section || !section.hidden) return;
+      var label = document.getElementById("ws-switcher-label");
+      if (label && !pathWs) label.textContent = activeWs;
+      var base = "/account/workspaces/" + encodeURIComponent(activeWs);
+      var paths = ["", "/galleries", "/people", "/settings"];
+      var names = ["files", "galleries", "people", "settings"];
+      var html = "";
+      for (var i = 0; i < paths.length; i++) {
+        html += '<a href="' + base + paths[i] + '" class="side-link">' + names[i] + "</a>";
+      }
+      section.innerHTML = html;
+      section.hidden = false;
     } catch (e) {}
   })();
 </script>
@@ -218,13 +228,11 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 ></script>
 <script>
   import {
-    initSignOut,
     onAstroPageLoad,
     requireElement,
     resolveSessionGate,
   } from "../lib/account-shell";
-  import { resolveActiveWorkspace } from "../lib/workspace-browse-url";
-  import { initWorkspacesNav, workspaceTabFromPathname } from "../lib/workspaces-nav";
+  import { initWorkspacesNav } from "../lib/workspaces-nav";
 
   onAstroPageLoad(() => {
     if (!document.getElementById("app")) return;
@@ -234,30 +242,18 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
       __UPLOADS_API_ORIGIN__: string;
       __UPLOADS_ACTIVE_WORKSPACE__: string;
     };
-    const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
-    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
 
-    // Pathname wins when the boot global is empty/stale after ClientRouter nav.
-    const activeWorkspace = resolveActiveWorkspace(
-      location.pathname,
-      w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
-    );
-
-    initSignOut(authOrigin);
-    initWorkspacesNav(apiOrigin, {
-      active: activeWorkspace,
-      activeTab: workspaceTabFromPathname(location.pathname),
+    // Boot global is a hint; init resolves URL → boot → last-used cache.
+    initWorkspacesNav(w.__UPLOADS_API_ORIGIN__, {
+      active: w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
     });
 
     void resolveSessionGate({
-      authOrigin,
+      authOrigin: w.__UPLOADS_AUTH_ORIGIN__,
       checking: requireElement<HTMLElement>("#checking", "account"),
       denied: requireElement<HTMLElement>("#signed-out", "account"),
       unavailable: requireElement<HTMLElement>("#auth-unavailable", "account"),
       app: requireElement<HTMLElement>("#app", "account"),
-    }).then((result) => {
-      requireElement<HTMLElement>("#admin-link", "account").hidden =
-        result?.user.role !== "admin";
     });
 
     const retry = document.querySelector<HTMLButtonElement>("#session-retry");

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -52,8 +52,10 @@ export function writeCachedSessionUser(user: SessionUser): void {
 export function clearCachedSessionUser(): void {
   try {
     sessionStorage.removeItem(SESSION_CACHE_KEY);
-    // Membership list is also a session-scoped UX cache — drop it with the user.
+    // Keep in sync with WORKSPACES_CACHE_KEY / ACTIVE_WORKSPACE_CACHE_KEY
+    // in workspaces-nav.ts (avoid importing that module from here).
     sessionStorage.removeItem("uploads:myWorkspaces");
+    sessionStorage.removeItem("uploads:activeWorkspace");
   } catch {
     // ignore
   }

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  ACTIVE_WORKSPACE_CACHE_KEY,
+  clearCachedActiveWorkspace,
   clearCachedWorkspaces,
+  readCachedActiveWorkspace,
   readCachedWorkspaces,
   renderSwitcherMenuHtml,
   renderWorkspaceSectionNavHtml,
+  resolveSidebarWorkspace,
   switcherLabel,
   workspaceTabFromPathname,
+  writeCachedActiveWorkspace,
   writeCachedWorkspaces,
   WORKSPACES_CACHE_KEY,
 } from "./workspaces-nav";
@@ -79,6 +84,46 @@ describe("workspaceTabFromPathname", () => {
   });
 });
 
+describe("active workspace cache + resolveSidebarWorkspace", () => {
+  it("round-trips the last-used workspace slug", () => {
+    installStorage();
+    writeCachedActiveWorkspace("buildinternet");
+    expect(readCachedActiveWorkspace()).toBe("buildinternet");
+    clearCachedActiveWorkspace();
+    expect(readCachedActiveWorkspace()).toBe("");
+    expect(sessionStorage.getItem(ACTIVE_WORKSPACE_CACHE_KEY)).toBeNull();
+  });
+
+  it("rejects invalid slugs", () => {
+    installStorage();
+    writeCachedActiveWorkspace("Not_Valid");
+    expect(readCachedActiveWorkspace()).toBe("");
+    writeCachedActiveWorkspace("new");
+    expect(readCachedActiveWorkspace()).toBe("");
+  });
+
+  it("prefers the URL and refreshes the last-used cache", () => {
+    installStorage();
+    writeCachedActiveWorkspace("side");
+    expect(resolveSidebarWorkspace("/account/workspaces/buildinternet", "side")).toBe(
+      "buildinternet",
+    );
+    expect(readCachedActiveWorkspace()).toBe("buildinternet");
+  });
+
+  it("falls back to last-used cache on personal routes", () => {
+    installStorage();
+    writeCachedActiveWorkspace("buildinternet");
+    expect(resolveSidebarWorkspace("/account/profile", "")).toBe("buildinternet");
+    expect(resolveSidebarWorkspace("/account/developers", "side")).toBe("side");
+  });
+
+  it("returns empty when nothing is known", () => {
+    installStorage();
+    expect(resolveSidebarWorkspace("/account/profile", "")).toBe("");
+  });
+});
+
 describe("switcherLabel", () => {
   it("prefers the membership display name, falls back to slug or workspaces", () => {
     expect(switcherLabel(sample, "side")).toBe("Side Project");
@@ -123,5 +168,11 @@ describe("renderWorkspaceSectionNavHtml", () => {
 
   it("returns empty when no workspace is active", () => {
     expect(renderWorkspaceSectionNavHtml("")).toBe("");
+  });
+
+  it("marks no tab current when activeTab is empty (personal routes)", () => {
+    const html = renderWorkspaceSectionNavHtml("buildinternet", "");
+    expect(html).not.toContain('aria-current="page"');
+    expect(html).toContain('href="/account/workspaces/buildinternet"');
   });
 });

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -3,16 +3,21 @@
  *
  * Section heading = current workspace (dropdown of memberships + "+ new
  * workspace"). When a workspace is active, files / galleries / people /
- * settings sit as flat rows underneath. Membership list is cached in
- * sessionStorage for instant paint, then revalidated after session.
+ * settings sit as flat rows underneath.
+ *
+ * Memberships and last-used workspace are cached in sessionStorage for
+ * instant paint (revalidated after session). Last-used keeps personal
+ * routes (`/account/profile`, `/account/developers`) from collapsing the
+ * workspace section nav.
  */
 import { getMyWorkspaces, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
-import { resolveActiveWorkspace } from "./workspace-browse-url";
+import { isBrowseWorkspace, workspaceFromPathname } from "./workspace-browse-url";
 import { escapeHtml } from "./workspace-ui";
 
-/** sessionStorage key — UX only; membership is still enforced server-side. */
+/** sessionStorage keys — UX only; membership is still enforced server-side. */
 export const WORKSPACES_CACHE_KEY = "uploads:myWorkspaces";
+export const ACTIVE_WORKSPACE_CACHE_KEY = "uploads:activeWorkspace";
 
 export type WorkspaceNavTab = "files" | "galleries" | "people" | "settings";
 
@@ -35,10 +40,34 @@ export type WorkspacesNavOptions = {
 
 type CachePayload = { workspaces: MyWorkspace[] };
 
-export function readCachedWorkspaces(): MyWorkspace[] | null {
+function storageGet(key: string): string | null {
   try {
-    const raw = sessionStorage.getItem(WORKSPACES_CACHE_KEY);
-    if (!raw) return null;
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storageSet(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    // Private mode / quota — nav still works without the cache.
+  }
+}
+
+function storageRemove(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+export function readCachedWorkspaces(): MyWorkspace[] | null {
+  const raw = storageGet(WORKSPACES_CACHE_KEY);
+  if (!raw) return null;
+  try {
     const parsed = JSON.parse(raw) as CachePayload;
     if (!parsed || !Array.isArray(parsed.workspaces)) return null;
     return parsed.workspaces.filter(
@@ -55,19 +84,39 @@ export function readCachedWorkspaces(): MyWorkspace[] | null {
 }
 
 export function writeCachedWorkspaces(workspaces: MyWorkspace[]): void {
-  try {
-    sessionStorage.setItem(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces }));
-  } catch {
-    // Private mode / quota — nav still works without the cache.
-  }
+  storageSet(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces }));
 }
 
 export function clearCachedWorkspaces(): void {
-  try {
-    sessionStorage.removeItem(WORKSPACES_CACHE_KEY);
-  } catch {
-    // ignore
+  storageRemove(WORKSPACES_CACHE_KEY);
+}
+
+export function readCachedActiveWorkspace(): string {
+  const raw = storageGet(ACTIVE_WORKSPACE_CACHE_KEY);
+  return raw && isBrowseWorkspace(raw) ? raw : "";
+}
+
+export function writeCachedActiveWorkspace(workspace: string): void {
+  if (isBrowseWorkspace(workspace)) storageSet(ACTIVE_WORKSPACE_CACHE_KEY, workspace);
+}
+
+export function clearCachedActiveWorkspace(): void {
+  storageRemove(ACTIVE_WORKSPACE_CACHE_KEY);
+}
+
+/**
+ * Workspace slug for the account sidebar.
+ * URL → layout boot global → last-used cache. Visiting a workspace route
+ * refreshes the last-used cache.
+ */
+export function resolveSidebarWorkspace(pathname: string, bootGlobal = ""): string {
+  const fromPath = workspaceFromPathname(pathname);
+  if (fromPath) {
+    writeCachedActiveWorkspace(fromPath);
+    return fromPath;
   }
+  const fallback = bootGlobal || readCachedActiveWorkspace();
+  return isBrowseWorkspace(fallback) ? fallback : "";
 }
 
 function displayName(ws: MyWorkspace): string {
@@ -148,8 +197,14 @@ function closeMenu(els: SwitcherEls): void {
 }
 
 function paint(els: SwitcherEls, workspaces: MyWorkspace[], opts: WorkspacesNavOptions): void {
-  const active = opts.active ?? "";
-  const activeTab = opts.activeTab || "files";
+  let active = opts.active ?? "";
+  // Drop a stale last-used slug if the user is no longer a member.
+  if (active && workspaces.length > 0 && !workspaces.some((ws) => ws.workspace === active)) {
+    clearCachedActiveWorkspace();
+    active = "";
+  }
+  // Empty on personal routes so no workspace tab is falsely current.
+  const activeTab = opts.activeTab || "";
 
   els.label.textContent = switcherLabel(workspaces, active);
   els.menu.innerHTML = renderSwitcherMenuHtml(workspaces, { active });
@@ -214,14 +269,12 @@ export function initWorkspacesNav(apiOrigin: string, options: WorkspacesNavOptio
   const els: SwitcherEls = { trigger, label, menu, section };
   bindSwitcher(els);
 
-  // Pathname wins after ClientRouter body swaps (boot global can lag).
   const opts: WorkspacesNavOptions = {
-    active: resolveActiveWorkspace(location.pathname, options.active ?? ""),
+    active: resolveSidebarWorkspace(location.pathname, options.active ?? ""),
     activeTab: options.activeTab || workspaceTabFromPathname(location.pathname),
   };
 
-  const cached = readCachedWorkspaces();
-  paint(els, cached ?? [], opts);
+  paint(els, readCachedWorkspaces() ?? [], opts);
 
   onSession(() => {
     void getMyWorkspaces(apiOrigin).then((result) => {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -973,25 +973,9 @@ section.card .ws-messages .command {
   outline: none;
 }
 
-/* Workspace tab pages (files/galleries/people/settings) render a 3-column
-   nav · content · rail layout that needs more room than the default 960px
-   account reading width. AccountLayout adds `account-shell--rail` to #app only
-   when a rail slot is present (the workspace tabs), so /account list pages and
-   /admin (#dashboard) keep the default width. This widens `.shell` via the
-   `--width-shell` custom property it already reads (signed-in-shell.css). */
-.account-shell--rail {
-  --width-shell: 1200px;
-}
-
-/* Clamp the content grid track so long, non-wrapping settings content (e.g.
-   the people tab's `uploads admin invite create …` command) shrinks and
-   scrolls within the column instead of growing to its max-content width and
-   overflowing under the rail. `.content` (signed-in-shell.css) is a grid with
-   an implicit auto track; scoped to rail pages so /account and /admin are
-   untouched, and it composes with the mobile restack in account-shell.css. */
-.account-shell--rail .content {
-  grid-template-columns: minmax(0, 1fr);
-}
+/* Shell width + content clamp for the account 3-column layout live in
+   account-shell.css (always-on nav · content · rail). /admin keeps the
+   default 960px reading width via signed-in-shell.css. */
 
 .wft-grid {
   margin-top: 8px;

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -1,19 +1,28 @@
-/* Flat 3A account nav + optional right-rail column for /account/*.
+/* Flat 3A account nav + right-rail column for /account/*.
    Every selector here is scoped under `.account-shell` (the AccountLayout
-   `#app` root) so /admin/* — which shares nav.side / .layout / .side-foot
-   markup and signed-in-shell.css — renders exactly as before. Do NOT add
-   an unscoped nav.side, .layout, or .side-foot rule to this file; put
-   account-only overrides here instead of editing signed-in-shell.css. */
+   `#app` root) so /admin/* — which shares nav.side / .layout markup and
+   signed-in-shell.css — renders exactly as before. Do NOT add an unscoped
+   nav.side or .layout rule to this file; put account-only overrides here
+   instead of editing signed-in-shell.css. */
 
-/* Layout grid: 2-col by default, 3-col (+ rail) when AccountLayout is given
-   a `rail` slot (data-rail="true", set server-side via Astro.slots.has). */
-.account-shell .layout {
-  grid-template-columns: 180px 1fr;
-  gap: 24px;
+/* Always 3 columns (nav · content · rail) at the same shell width so
+   personal and workspace pages share content geometry. Empty rail still
+   reserves the track. Shell is left-aligned so the nav does not re-center
+   as the viewport grows. */
+.account-shell {
+  --width-shell: 1200px;
 }
-.account-shell .layout[data-rail="true"] {
+.account-shell .shell {
+  margin-left: 0;
+  margin-right: auto;
+}
+.account-shell .layout {
   grid-template-columns: 180px minmax(0, 1fr) 272px;
   gap: 40px;
+}
+.account-shell .content {
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
 }
 
 /* Flat nav rows ---------------------------------------------------------- */
@@ -21,8 +30,6 @@
   gap: 2px;
   font-size: 13px;
 }
-
-/* Flat rows — active = accent color only. */
 .account-shell nav.side .side-link {
   display: block;
   padding: 5px 0;
@@ -38,7 +45,7 @@
   color: var(--accent);
 }
 
-/* Section labels (YOU). Workspace heading is the switcher trigger. */
+/* Section labels (PERSONAL). Workspace heading is the switcher trigger. */
 .account-shell nav.side .side-label {
   margin: 14px 0 4px;
   color: var(--muted);
@@ -146,64 +153,25 @@
   display: none;
 }
 
-/* Foot — console / admin / sign out. */
-.account-shell nav.side .side-foot {
-  margin-top: 16px;
-  padding-top: 14px;
-  border-top: 1px solid var(--line);
-  gap: 6px;
-}
-.account-shell nav.side .side-foot a {
-  display: block;
-  font-size: 12px;
-  color: var(--muted);
-  text-decoration: none;
-}
-.account-shell nav.side .side-foot a:hover,
-.account-shell nav.side .side-foot a:focus-visible {
-  color: var(--accent);
-  outline: none;
-}
-.account-shell nav.side .side-foot button {
-  padding: 5px 0;
-  border: 0;
-  border-radius: 0;
-  background: none;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-  text-align: left;
-}
-.account-shell nav.side .side-foot button:hover,
-.account-shell nav.side .side-foot button:focus-visible {
-  color: var(--red);
-  outline: none;
-}
-
-/* Right rail --------------------------------------------------------------
-   Container mechanics only — the rail's own section content (connected
-   work, usage, details, quick actions) is supplied by the page via the
-   `rail` slot and styled where it's rendered. */
+/* Right rail — always a grid track; content from the `rail` slot. */
 .account-shell aside.rail {
   display: grid;
   gap: 22px;
   font-size: 12.5px;
   position: sticky;
   top: 28px;
+  min-width: 0;
 }
 
-/* Mid-width rail tier (--bp-stack+1 … --bp-rail): not enough room for the
-   fixed 272px rail column next to the content (the file grid needs ~320px
-   minimum), so keep the side nav, drop to 2-col, and move the rail under the
-   main column. Bounded below at 681px (--bp-stack + 1) so the ≤680 full-stack
-   rules stay the single authority at that edge. See the breakpoint scale in
-   signed-in-shell.css. */
+/* Mid-width (--bp-stack+1 … --bp-rail): drop rail beside content, restack
+   under the main column. Hide empty rails so they leave no hairline. See
+   breakpoint scale in signed-in-shell.css. */
 @media (min-width: 681px) and (max-width: 1080px) {
-  .account-shell .layout[data-rail="true"] {
+  .account-shell .layout {
     grid-template-columns: 180px minmax(0, 1fr);
     gap: 24px;
   }
-  .account-shell .layout[data-rail="true"] aside.rail {
+  .account-shell aside.rail {
     grid-column: 2;
     position: static;
     top: auto;
@@ -211,12 +179,14 @@
     padding-top: 20px;
     border-top: 1px solid var(--line);
   }
+  .account-shell aside.rail[data-empty] {
+    display: none;
+  }
 }
 
-/* --bp-stack: collapse to a single column (mirrors signed-in-shell.css). */
+/* --bp-stack: single column. */
 @media (max-width: 680px) {
-  .account-shell .layout,
-  .account-shell .layout[data-rail="true"] {
+  .account-shell .layout {
     grid-template-columns: 1fr;
     gap: 24px;
   }
@@ -224,17 +194,11 @@
   .account-shell nav.side .ws-switcher {
     grid-column: 1 / -1;
   }
-  .account-shell nav.side .side-foot {
-    grid-column: 1 / -1;
-    border: 0;
-    margin: 0;
-    padding: 0;
-    grid-template-columns: subgrid;
-  }
-  /* Rail stacks below main; sticky positioning only makes sense in the
-     desktop 3-col layout. */
   .account-shell aside.rail {
     position: static;
     top: auto;
+  }
+  .account-shell aside.rail[data-empty] {
+    display: none;
   }
 }


### PR DESCRIPTION
## In plain terms

Moving between workspace tabs and personal account settings used to reshuffle the chrome: the workspace section links disappeared, the shell swapped between two- and three-column layouts, and content jumped sideways. This keeps one sidebar and one content width across those surfaces.

## What it does

- Remembers the last-used workspace so `/account/profile` and `/account/developers` keep the same workspace switcher + files / galleries / people / settings links
- Renames the sidebar section **You** → **Personal**
- Removes admin / sign-out (and the optional console link) from the left nav — they already live in the header avatar menu
- Always uses a left-aligned `nav · content · rail` grid at 1200px so personal pages reserve the rail track even when empty

## What it is not

- Not a redesign of account page content (cards, settings sections)
- Does not fill the personal-page rail with usage/details (empty gutter on purpose for geometry)

## How to try it

1. Sign in and open a workspace (e.g. files).
2. Click **account** under Personal — sidebar should still show the workspace name and section links; content should not jump width.
3. Confirm admin / sign-out only appear in the top-right menu.
4. Sign out and confirm the last-used workspace cache is cleared with the session.

## Technical notes

- Last-used slug: `sessionStorage` key `uploads:activeWorkspace` (cleared with session)
- Optimistic inline script still paints section links before deferred modules; `initWorkspacesNav` revalidates after session
- Empty rail uses `data-empty` so the track is reserved on desktop and hidden when restacked

## Test plan

- [x] `pnpm --filter @uploads/web test` (282 passed)
- [ ] Manual: workspace → account → developers → back to files, watch sidebar + content width
- [ ] Manual: sign-out clears last-used workspace; next sign-in starts without a phantom workspace nav until one is opened