### PR TITLE
docs(visibility): frame file visibility as unlisted, not byte-private

### DIFF
--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -395,6 +395,16 @@ export const me = new Hono<SessionVars>()
   // (head/size-cap/download/re-upload) live in files-core's
   // `setObjectVisibility`; this route keeps auth, key validation, body
   // validation, and error mapping.
+  //
+  // Wire value stays "public" | "private" (issue #166: renaming the field
+  // would be a breaking API change), but the semantics are "unlisted," not
+  // byte-private: `visibility: "private"` hides an object from the public
+  // file listing and 401-gates `/public/files/...` + the `/f/…` page
+  // (public-files.ts). On a workspace with `publicBaseUrl` the raw object URL
+  // still serves bytes unsigned to anyone who has it — this endpoint never
+  // controlled that. Document that distinction anywhere this field is
+  // surfaced to API consumers; don't call it "private" in a byte-privacy
+  // sense.
   .patch("/workspaces/:name/files/visibility", async (c) => {
     const name = c.req.param("name");
     await memberWorkspaceOr404(c.env, requireUserId(c), name);

--- a/apps/web/src/components/AccountFileBrowser.tsx
+++ b/apps/web/src/components/AccountFileBrowser.tsx
@@ -145,7 +145,7 @@ export function AccountFileBrowser({
               disabled={busy}
               onClick={() => void toggleVisibility(file.key, next, applyLocally)}
             >
-              {busy ? "…" : isPrivate ? "Make public" : "Make private"}
+              {busy ? "…" : isPrivate ? "Make public" : "Unlist"}
             </Button>
           );
         }}

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -683,13 +683,20 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
                   {typeof file.size === "number" ? formatBytes(file.size) : "—"}
                 </span>
                 <span className="wft-type">{type}</span>
-                <span className={`wft-vis ${priv ? "wft-vis--private" : "wft-vis--public"}`}>
+                <span
+                  className={`wft-vis ${priv ? "wft-vis--private" : "wft-vis--public"}`}
+                  title={
+                    priv
+                      ? "Unlisted: hidden from listings and the /f/ page unless signed in. The raw file URL still works for anyone who has it."
+                      : "Public: listed and reachable by anyone with the URL."
+                  }
+                >
                   {priv ? (
                     <LockIcon className="wft-vis__icon" />
                   ) : (
                     <span className="wft-vis__dot" aria-hidden="true" />
                   )}
-                  {priv ? "private" : "public"}
+                  {priv ? "unlisted" : "public"}
                 </span>
                 <div className="wft-menu">
                   <button
@@ -718,7 +725,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
                         disabled={busy}
                         onClick={() => void toggleVisibility(file)}
                       >
-                        {priv ? "make public" : "make private"}
+                        {priv ? "make public" : "unlist"}
                       </button>
                     </div>
                   )}

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -42,6 +42,15 @@ const REPO = "https://github.com/buildinternet/uploads";
         media attached to private repositories. Don't upload secrets or sensitive UI.
       </li>
       <li>
+        <strong>The visibility toggle unlists — it doesn't lock down bytes.</strong> Marking a
+        file "private" hides it from your workspace's public file listing and gates the
+        <code>/f/…</code> page behind sign-in. The raw file URL (<code>storage.uploads.sh/…</code>)
+        keeps serving the same bytes to anyone who already has it, and edge caches can keep
+        serving recently-public bytes for a short window after the toggle. Treat it as
+        "unlisted," not "private." True byte-level privacy would require a workspace with no
+        public domain (signed URLs only), which isn't how uploads.sh workspaces work today.
+      </li>
+      <li>
         <strong>Share pages support embeds.</strong> Every public file and gallery has a
         page at <code>/f/…</code> or <code>/g/…</code> with
         <a href="https://oembed.com/">oEmbed</a> discovery, so tools that unfurl links can

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -235,8 +235,8 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       ) : result.status === "auth_required" ? (
         <section class="error" id="auth-required">
           <code>file.auth_required</code>
-          <h1>This file is private</h1>
-          <p>Sign in to view this file if you're a member of this workspace.</p>
+          <h1>This file is unlisted</h1>
+          <p>Sign in to view this page if you're a member of this workspace.</p>
           <a class="signin" id="signin-link" href="/login">Sign in</a>
           <span class="checking" id="auth-checking" hidden>Checking your session…</span>
         </section>

--- a/apps/web/src/pages/terms.astro
+++ b/apps/web/src/pages/terms.astro
@@ -55,7 +55,8 @@ import LegalLayout from "../layouts/LegalLayout.astro";
       <strong>Uploaded files are public by link.</strong> Files are served from public URLs
       (for example <code>storage.uploads.sh</code>). The URLs are unguessable but not access
       controlled: anyone who has a link can fetch the file. Don't upload anything that must stay
-      private.
+      private. Marking a file "private" in a workspace hides it from listings and the file page
+      unless you're signed in — it does not restrict the underlying URL.
     </li>
     <li>
       <strong>You must have the rights to what you upload.</strong> Only upload content you own

--- a/packages/ui/src/FileBrowser.tsx
+++ b/packages/ui/src/FileBrowser.tsx
@@ -178,7 +178,7 @@ export function FileBrowser({
                       {formatBytes(item.size)} · {item.type || "unknown"}
                     </small>
                   </span>
-                  {isPrivate?.(item) ? <Badge tone="neutral">Private</Badge> : null}
+                  {isPrivate?.(item) ? <Badge tone="neutral">Unlisted</Badge> : null}
                 </button>
                 {itemActions?.(item, {
                   refresh: () => void load(),


### PR DESCRIPTION
## Summary

Reframes the per-file `visibility` flag as "unlisted," not byte-level privacy, per #166. No new access control — this is a copy/docs sweep to stop implying that marking a file "private" restricts the raw object URL.

- `apps/web/src/pages/docs/reference.astro`: new "Good to know" bullet explaining the toggle hides files from listings and gates the `/f/` page, but the raw storage URL still serves bytes to anyone who has it, plus a note on edge-cache propagation and what true byte privacy would require.
- `apps/web/src/pages/f/[workspace]/[...key].astro`: the `/f/` page's auth-gated error state now says "This file is unlisted" / "Sign in to view this page" instead of "This file is private" / "view this file".
- `apps/web/src/pages/terms.astro`: added a sentence clarifying the "private" toggle only affects listings/the file page, not the underlying URL.
- `apps/web/src/components/WorkspaceFileTable.tsx` (live file browser UI): visibility chip now reads "unlisted" (with a hover tooltip explaining the raw URL still works) instead of "private"; the row action reads "unlist" instead of "make private".
- `apps/web/src/components/AccountFileBrowser.tsx`, `packages/ui/src/FileBrowser.tsx`: same copy fix in the shared design-system `FileBrowser` badge ("Unlisted" instead of "Private") and its (currently unused) `AccountFileBrowser` consumer, for consistency.
- `apps/api/src/routes/me.ts`: added a doc comment on the `PATCH /workspaces/:name/files/visibility` handler spelling out the actual semantics for API consumers. The wire value stays `"public" | "private"` — renaming it would be a breaking API change (per the issue).

## Audit notes (already honest, left unchanged)

- `docs/cli.md`'s existing "Privacy" callout, `docs/roadmap.md`'s "Private-repo embed privacy" section, and `docs/workspaces.md`'s "no private tier today" line already describe the trust model correctly.
- `skills/uploads-cli/SKILL.md` and `skills/github-screenshots/SKILL.md` already state uploads are public regardless of GitHub repo visibility, and don't expose a visibility-toggle command (the CLI has no `visibility` flag today — the toggle only exists in the web UI / `PATCH /me/workspaces/:name/files/visibility`).
- `packages/uploads/src/commands.ts` (`put`/`attach` help text) already says uploads are public even for private/internal repos.
- MCP tool descriptions (`packages/uploads/src/mcp/tools.ts`) don't reference the visibility flag at all — nothing to correct there.
- `apps/api/src/routes/public-files.ts`'s existing code comments on the visibility gate were already precise about "metadata-only enforcement"; no change needed.
- `apps/web/public/llms.txt` and `docs/deletion.md`'s edge-cache caveats were already accurate; no page addition, so no sitemap.xml/llms.txt update was needed.

## Test plan

- [x] `pnpm test` — 169 test files / 2098 tests passed
- [x] `pnpm typecheck` — 0 errors across all workspaces
- [x] `pnpm check` — lint clean (pre-existing warnings unrelated to this change), formatting clean
