### PR TITLE
fix: polish account shell UI (footer, rail, people, sidebar)

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -5,6 +5,10 @@
  * bar with the maintainer credit + a cross-link to the sibling Build Internet
  * tool (releases.sh links back to us the same way).
  *
+ * Full-bleed border; inner column is max-width + centered (same pattern as
+ * releases.sh). Do not nest this inside a left-aligned content shell — place
+ * it as a sibling of `.shell` so it centers on the viewport.
+ *
  * `compact` keeps the original one-liner for the centered auth/error cards.
  */
 interface Props {
@@ -45,42 +49,46 @@ const COLUMNS: FooterColumn[] = [
 {
   compact ? (
     <footer class="site-footer compact">
-      a <a href="https://buildinternet.com">Build Internet</a> project · <a href={REPO}>source</a>{" "}
-      · <a href="/docs">docs</a> · <a href="/terms">terms</a> · <a href="/privacy">privacy</a>
+      <div class="site-footer__inner">
+        a <a href="https://buildinternet.com">Build Internet</a> project · <a href={REPO}>source</a>{" "}
+        · <a href="/docs">docs</a> · <a href="/terms">terms</a> · <a href="/privacy">privacy</a>
+      </div>
     </footer>
   ) : (
     <footer class="site-footer">
-      <div class="cols">
-        <div class="brand">
-          <a class="wordmark" href="/">
-            uploads.sh
-          </a>
-          <p>Screenshots &amp; recordings for agent PRs.</p>
+      <div class="site-footer__inner">
+        <div class="cols">
+          <div class="brand">
+            <a class="wordmark" href="/">
+              uploads.sh
+            </a>
+            <p>Screenshots &amp; recordings for agent PRs.</p>
+          </div>
+          {COLUMNS.map((column) => (
+            <nav aria-label={column.title}>
+              <div class="col-title">{column.title}</div>
+              <ul>
+                {column.links.map((link) => (
+                  <li>
+                    <a href={link.href}>{link.label}</a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
         </div>
-        {COLUMNS.map((column) => (
-          <nav aria-label={column.title}>
-            <div class="col-title">{column.title}</div>
-            <ul>
-              {column.links.map((link) => (
-                <li>
-                  <a href={link.href}>{link.label}</a>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        ))}
-      </div>
-      <div class="family">
-        <p>
-          Maintained by <a href="https://zachdunn.com">Zach Dunn</a> /{" "}
-          <a href="https://buildinternet.com">Build Internet</a>.
-        </p>
-        <p>
-          Release notes registry for agents —{" "}
-          <a href={RELEASES_URL} rel="noopener">
-            releases.sh →
-          </a>
-        </p>
+        <div class="family">
+          <p>
+            Maintained by <a href="https://zachdunn.com">Zach Dunn</a> /{" "}
+            <a href="https://buildinternet.com">Build Internet</a>.
+          </p>
+          <p>
+            Release notes registry for agents —{" "}
+            <a href={RELEASES_URL} rel="noopener">
+              releases.sh →
+            </a>
+          </p>
+        </div>
       </div>
     </footer>
   )
@@ -88,16 +96,29 @@ const COLUMNS: FooterColumn[] = [
 
 <style>
   .site-footer {
-    margin-top: 56px;
+    width: 100%;
+    margin-top: auto;
     border-top: 1px solid var(--line, #232327);
     color: var(--muted, #7d7d77);
     font: 12px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
     letter-spacing: 0.01em;
     line-height: 1.7;
   }
+  /* Centered column — independent of any left-aligned account/admin shell. */
+  .site-footer__inner {
+    width: 100%;
+    max-width: var(--width-shell, 960px);
+    margin: 0 auto;
+    padding: 0 20px 28px;
+    box-sizing: border-box;
+  }
+  .site-footer.compact .site-footer__inner {
+    padding-top: 16px;
+    padding-bottom: 0;
+    max-width: none;
+  }
   .site-footer.compact {
     margin-top: 26px;
-    padding-top: 16px;
     font-size: 11.5px;
   }
   .site-footer a {

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -104,7 +104,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
               aria-controls="ws-switcher-menu"
             >
               <span class="ws-switcher__label" id="ws-switcher-label">{switcherHeading}</span>
-              <span class="ws-switcher__chevron" aria-hidden="true">▾</span>
+              <span class="ws-switcher__chevron" aria-hidden="true" title="Switch workspace">▾</span>
             </button>
             <div class="ws-switcher__menu" id="ws-switcher-menu" hidden>
               {/* Filled client-side after session + /me/workspaces (cached for paint). */}
@@ -172,9 +172,10 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
           {hasRail ? <slot name="rail" /> : null}
         </aside>
       </div>
-
-      <Footer />
     </div>
+
+    {/* Sibling of .shell so the footer centers on the viewport. */}
+    <Footer />
   </div>
 
 {/* Optimistic shell + workspace section nav before deferred modules run.

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -103,9 +103,10 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
           <slot />
         </div>
       </div>
-
-      <Footer />
     </div>
+
+    {/* Sibling of .shell so the footer centers on the viewport. */}
+    <Footer />
   </div>
 
 {/* Sync optimistic paint for admins only — same cache key as account-shell.

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -51,17 +51,6 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
         </div>
         <div class="ws-rail__actions">
           <a class="ws-rail__invite" href={invitePath}>invite teammate</a>
-          <div class="ws-rail__copyrow">
-            <code><span class="ws-rail__prompt">$ </span>uploads put ./file.png</code>
-            <button
-              type="button"
-              class="ws-rail__copy"
-              data-copy="uploads put ./file.png"
-              aria-live="polite"
-            >
-              copy
-            </button>
-          </div>
         </div>
       </section>
     </div>
@@ -69,50 +58,14 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
 </AccountLayout>
 
 <style>
-  /* Rail wrapper — `display: contents` so the section children participate
-     directly in AccountLayout's `aside.rail` grid (which already supplies
-     `display:grid; gap:22px`); see account-shell.css. Do not add spacing
-     rules here — that's the shared container's job. */
-  .ws-rail {
-    display: contents;
-  }
-
-  /* Section scaffolding (heading row) is server-rendered — plain scoped
-     selectors. Section *bodies* are filled via innerHTML by workspace-rail.ts,
-     so anything reaching into them below wraps the injected class in
-     :global() — Astro's scope attribute only ever lands on elements this
-     component itself renders, so a dynamically-injected node needs :global()
-     to be matched at all. `.account-shell` is likewise wrapped in :global()
-     (it's AccountLayout's element, not this component's), kept only as a
-     belt-and-suspenders ancestor gate. */
-  .ws-rail__section {
-    font-size: 12.5px;
-  }
-  .ws-rail__head {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin: 0 0 12px;
-  }
-  .ws-rail__label {
-    color: var(--muted);
-    font-size: 10.5px;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    white-space: nowrap;
-  }
-  .ws-rail__rule {
-    flex: 1;
-    height: 1px;
-    background: var(--line);
-  }
-
-  /* Connected work — rows are innerHTML-injected by renderConnectedWorkHtml. */
+  /* Section *bodies* are filled via innerHTML by workspace-rail.ts, so
+     injected classes need :global() — Astro scope only lands on elements
+     this component renders. Shared section chrome (`.ws-rail`, head/label/
+     rule) lives in account-shell.css for profile + workspace rails. */
   .ws-rail__connected-list {
     display: grid;
     gap: 10px;
   }
-  /* "show N more" toggle — innerHTML-injected by bindConnectedWorkSetter. */
   :global(.account-shell) .ws-rail :global(.ws-rail__more) {
     justify-self: start;
     padding: 2px 0;
@@ -155,17 +108,8 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     color: var(--accent);
     outline: none;
   }
-  :global(.account-shell) .ws-rail :global(.ws-rail__connected-sub) {
-    color: var(--muted);
-    font-size: 11.5px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 
-  /* Usage — renderUsageHtml() output uses @uploads/ui's globally-styled
-     `.ul-progress*` classes (no CSS needed here); style only its plain-text
-     fallback (`.usage-text`/`.usage-meta`, from workspace-ui.ts). */
+  /* Usage — meters use global `.ul-progress*`; style plain-text fallback only. */
   :global(.account-shell) .ws-rail :global(.usage-text) {
     color: var(--muted);
   }
@@ -191,10 +135,6 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  :global(.account-shell) .ws-rail :global(.ws-rail__dd--accent) {
-    color: var(--accent);
-  }
-  /* Public-url link — innerHTML-injected by renderDetailsHtml. */
   :global(.account-shell) .ws-rail :global(.ws-rail__link) {
     color: var(--fg);
     text-decoration: none;
@@ -205,7 +145,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     outline: none;
   }
 
-  /* Quick actions — server-rendered, static (no session data needed). */
+  /* Quick actions — server-rendered, static. */
   .ws-rail__actions {
     display: grid;
     gap: 8px;
@@ -219,45 +159,6 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
   .ws-rail__invite:focus-visible {
     color: var(--accent);
     outline: none;
-  }
-  .ws-rail__copyrow {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    padding: 8px 10px;
-    border: 1px solid var(--line);
-    border-radius: 2px;
-    background: var(--panel);
-  }
-  .ws-rail__copyrow code {
-    flex: 1;
-    min-width: 0;
-    white-space: nowrap;
-    overflow-x: auto;
-    scrollbar-width: none;
-    font: 11.5px var(--mono);
-  }
-  .ws-rail__prompt {
-    color: var(--accent);
-  }
-  .ws-rail__copy {
-    flex: none;
-    font: 11px var(--mono);
-    color: var(--accent);
-    background: none;
-    border: 1px solid var(--line);
-    border-radius: 2px;
-    padding: 4px 8px;
-    cursor: pointer;
-  }
-  .ws-rail__copy:hover,
-  .ws-rail__copy:focus-visible {
-    border-color: var(--accent);
-    outline: none;
-  }
-  .ws-rail__copy.done {
-    color: var(--green);
-    border-color: var(--green);
   }
 </style>
 

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -85,13 +85,11 @@ describe("renderDetailsHtml", () => {
   it("renders the public url as a host-labeled link when the URL is known", () => {
     const html = renderDetailsHtml({
       organization: { slug: "buildinternet" },
-      role: "admin",
       hasPublicUrl: true,
       publicBaseUrl: "https://storage.uploads.sh/",
     });
     expect(html).toContain(">buildinternet<");
-    expect(html).toContain(">admin<");
-    expect(html).toContain('class="ws-rail__dd ws-rail__dd--accent"');
+    expect(html).not.toContain("your role");
     expect(html).toContain('href="https://storage.uploads.sh/"');
     expect(html).toContain(">storage.uploads.sh</a>");
     expect(html).not.toContain(">configured<");
@@ -100,7 +98,6 @@ describe("renderDetailsHtml", () => {
   it("falls back to 'configured' when an older API sends only the boolean", () => {
     const html = renderDetailsHtml({
       organization: { slug: "buildinternet" },
-      role: "admin",
       hasPublicUrl: true,
     });
     expect(html).toContain(">configured<");
@@ -110,7 +107,6 @@ describe("renderDetailsHtml", () => {
   it("escapes an interpolated public url", () => {
     const html = renderDetailsHtml({
       organization: { slug: "acme" },
-      role: "member",
       hasPublicUrl: true,
       publicBaseUrl: 'https://x.example/"><script>alert(1)</script>',
     });
@@ -121,21 +117,18 @@ describe("renderDetailsHtml", () => {
   it("renders an em-dash for public url when hasPublicUrl is false", () => {
     const html = renderDetailsHtml({
       organization: { slug: "side-project" },
-      role: "member",
       hasPublicUrl: false,
     });
     expect(html).toContain(">—<");
     expect(html).not.toContain(">configured<");
   });
 
-  it("escapes interpolated slug/role", () => {
+  it("escapes interpolated slug", () => {
     const html = renderDetailsHtml({
       organization: { slug: '<img src=x onerror="alert(1)">' },
-      role: "<b>admin</b>",
       hasPublicUrl: false,
     });
     expect(html).not.toContain("<img");
-    expect(html).not.toContain("<b>admin</b>");
     expect(html).toContain("&lt;img");
   });
 });

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -8,7 +8,7 @@
  *    synchronously, before any network round trip, so a files-tab script that
  *    races ahead of this module's session-gated fetches never calls a
  *    not-yet-defined function;
- *  - fetches `getWorkspaceSummary` → details and usage (role is in details).
+ *  - fetches `getWorkspaceSummary` → details and usage.
  *
  * Connected-work hook contract (Task 8's files tab is the only caller):
  *   `window.__uploadsSetConnectedWork(items: GhWorkItem[], titles?: GithubTitleMap): void`
@@ -19,7 +19,7 @@
  */
 import { getWorkspaceSummary, type GithubTitleMap, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
-import { bindCopyButtons, escapeHtml, renderUsageHtml } from "./workspace-ui";
+import { escapeHtml, renderUsageHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
 import { applyGhTitles, type GhKind, type GhWorkItem } from "./gh-context";
 
@@ -52,17 +52,16 @@ export function renderConnectedWorkHtml(items: GhWorkItem[]): string {
 /** Minimal shape `renderDetailsHtml` needs — `MyWorkspace` is a structural superset. */
 export interface WorkspaceRailDetails {
   organization: { slug: string };
-  role: string;
   hasPublicUrl: boolean;
   publicBaseUrl?: string;
 }
 
 /**
- * Pure builder for the rail's "details" `<dt>/<dd>` pairs. The public-URL cell
- * links to the workspace's `publicBaseUrl`, labeled by its host (the scheme is
- * always https and only pads the narrow rail). `hasPublicUrl` without a URL
- * string means an older API that predates `publicBaseUrl` in the listing —
- * fall back to the old "configured" label rather than fabricating a URL.
+ * Pure builder for the rail/settings "details" `<dt>/<dd>` pairs (slug +
+ * public URL only — role lives on People / Account). The public-URL cell
+ * links to `publicBaseUrl`, labeled by host. `hasPublicUrl` without a URL
+ * string means an older API that predates `publicBaseUrl` — fall back to
+ * "configured" rather than fabricating a URL.
  */
 export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
   const host = ws.publicBaseUrl?.replace(/^https?:\/\//, "").replace(/\/$/, "");
@@ -71,7 +70,6 @@ export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
     : escapeHtml(ws.hasPublicUrl ? "configured" : "—");
   return (
     `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${escapeHtml(ws.organization.slug)}</dd>` +
-    `<dt class="ws-rail__dt">your role</dt><dd class="ws-rail__dd ws-rail__dd--accent">${escapeHtml(ws.role)}</dd>` +
     `<dt class="ws-rail__dt">public url</dt><dd class="ws-rail__dd">${publicUrlHtml}</dd>`
   );
 }
@@ -174,9 +172,6 @@ export function initWorkspaceRail(
 
   const setConnectedWork = bindConnectedWorkSetter(root);
   setConnectedWork([]);
-
-  const railRoot = root.querySelector<HTMLElement>("[data-workspace-rail]");
-  if (railRoot) bindCopyButtons(railRoot);
 
   const detailsEl = root.querySelector<HTMLElement>("[data-rail-details]");
   const usageEl = root.querySelector<HTMLElement>("[data-rail-usage]");

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -68,10 +68,13 @@ describe("renderMembersHtml controls", () => {
 });
 
 describe("renderInvitesHtml", () => {
-  it("renders a revoke control per invite", () => {
+  it("renders a people-list row with pending status and revoke", () => {
     const html = renderInvitesHtml([{ id: "i1", email: "a@x.com", status: "pending" }]);
     expect(html).toContain('data-invite-id="i1"');
     expect(html).toContain("a@x.com");
+    expect(html).toContain("member-row--pending");
+    expect(html).toContain("pending");
+    expect(html).toContain("invite-row__revoke");
   });
   it("returns empty string for no invites", () => {
     expect(renderInvitesHtml([])).toBe("");

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -165,26 +165,30 @@ export function renderMembersHtml(members: MemberRow[], opts: MemberRowOptions =
     .join("");
 }
 
-/** Pure row builder for the pending-invites list. `[]` → `""` (caller shows empty state). */
+/**
+ * Pending invites as people-list rows (same `.member-row` surface as members).
+ * Status badge + revoke. `[]` → `""` (caller omits the block).
+ */
 export function renderInvitesHtml(
   invites: { id: string; email: string; status: string }[],
 ): string {
   return invites
-    .map(
-      (inv) =>
-        `<div class="invite-row"><span class="invite-row__email">${escapeHtml(inv.email)}</span>` +
-        `<span class="invite-row__status">${escapeHtml(inv.status)}</span>` +
-        `<button type="button" class="text-btn invite-row__revoke" data-invite-id="${escapeHtml(inv.id)}" data-invite-email="${escapeHtml(inv.email)}">Revoke</button></div>`,
-    )
+    .map((inv) => {
+      const status = inv.status || "pending";
+      return (
+        `<div class="member-row member-row--pending">` +
+        `<span class="member-row__who"><span class="member-row__name">${escapeHtml(inv.email)}</span></span>` +
+        `<span class="member-row__actions">` +
+        `<span class="member-row__role member-row__role--pending">${escapeHtml(status)}</span>` +
+        `<button type="button" class="text-btn invite-row__revoke" data-invite-id="${escapeHtml(inv.id)}" data-invite-email="${escapeHtml(inv.email)}">Revoke</button>` +
+        `</span></div>`
+      );
+    })
     .join("");
 }
 
 export function isWorkspaceAdminRole(role: string): boolean {
   return role === "admin" || role === "owner";
-}
-
-export function operatorInviteCommand(workspace: string): string {
-  return `uploads admin invite create --workspace ${workspace} --email teammate@example.com`;
 }
 
 const WORKSPACE_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -22,16 +22,6 @@ export const prerender = false;
       <div id="accounts-status" class="muted detail-status">Loading…</div>
       <ul class="detail-list" id="accounts-list" hidden></ul>
       <p id="accounts-error" class="detail-error" role="alert" hidden></p>
-      <p class="muted settings-note">
-        Have a workspace under another email? Connect GitHub here (or sign in
-        with that email via magic link, then connect) to link the two.
-      </p>
-    </div>
-
-    <div class="settings-section">
-      <h2>Workspaces</h2>
-      <div id="access-status" class="muted detail-status">Loading…</div>
-      <ul class="detail-list" id="access-list" hidden></ul>
     </div>
 
     <div class="settings-section">
@@ -46,6 +36,32 @@ export const prerender = false;
     </div>
   </section>
 
+  <Fragment slot="rail">
+    <div class="ws-rail" data-account-rail>
+      <section class="ws-rail__section">
+        <div class="ws-rail__head">
+          <span class="ws-rail__label">tip</span>
+          <span class="ws-rail__rule"></span>
+        </div>
+        <p class="account-rail-tip">
+          Have a workspace under another email? Connect GitHub here (or sign in
+          with that email via magic link, then connect) to link the two.
+        </p>
+      </section>
+    </div>
+  </Fragment>
+
+  <style>
+    /* Section chrome is shared via account-shell.css; tip body is profile-only. */
+    .account-rail-tip {
+      margin: 0;
+      color: var(--muted);
+      font-size: 12.5px;
+      line-height: 1.55;
+      text-wrap: pretty;
+    }
+  </style>
+
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import {
@@ -58,19 +74,14 @@ export const prerender = false;
       type LinkedAccount,
       type ProviderAccountInfo,
     } from "../../lib/auth-client";
-    import { getMyWorkspaces } from "../../lib/api-client";
     import { githubMarkSvg } from "../../lib/brand-icons";
     import { deviceLabel, formatSessionTime, isCliUserAgent } from "../../lib/session-device";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("acct-email")) return;
 
-    const w = window as unknown as {
-      __UPLOADS_AUTH_ORIGIN__: string;
-      __UPLOADS_API_ORIGIN__: string;
-    };
-    const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
-    const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+    const authOrigin = (window as unknown as { __UPLOADS_AUTH_ORIGIN__: string })
+      .__UPLOADS_AUTH_ORIGIN__;
 
     const escapeHtml = (value: string) =>
       value.replace(/[&<>"']/g, (ch) =>
@@ -196,54 +207,6 @@ export const prerender = false;
               <div class="detail-meta">${escapeHtml(row.detail)}</div>
             </div>
             ${action}
-          </li>`;
-        })
-        .join("");
-    }
-
-    async function loadWorkspaceAccess(): Promise<void> {
-      const status = requireElement<HTMLElement>("#access-status", "account profile");
-      const list = requireElement<HTMLUListElement>("#access-list", "account profile");
-      list.hidden = true;
-      showStatus(status, "Loading…");
-
-      const result = await getMyWorkspaces(apiOrigin);
-      if (result.kind === "unavailable") {
-        showStatus(status, "Couldn’t load workspace access.");
-        return;
-      }
-      const { workspaces } = result;
-      if (!workspaces.length) {
-        showStatus(
-          status,
-          'No workspaces yet — <a href="/account/workspaces/new">create one</a> or accept an invite.',
-          { html: true },
-        );
-        return;
-      }
-
-      status.hidden = true;
-      list.hidden = false;
-      list.innerHTML = workspaces
-        .map((ws) => {
-          const name = ws.organization.name || ws.workspace;
-          const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
-          const meta = [
-            ws.workspace !== name ? ws.workspace : null,
-            ws.role,
-          ]
-            .filter(Boolean)
-            .join(" · ");
-          return `<li>
-            <div class="detail-main">
-              <div class="detail-title">
-                <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>
-              </div>
-              <div class="detail-meta">${escapeHtml(meta)}</div>
-            </div>
-            <div class="detail-action">
-              <a class="text-btn" href="${escapeHtml(href)}">Open</a>
-            </div>
           </li>`;
         })
         .join("");
@@ -389,7 +352,6 @@ export const prerender = false;
       requireElement<HTMLElement>("#acct-role", "account profile").textContent =
         user.role || "member";
       void loadAccounts();
-      void loadWorkspaceAccess();
       void loadSessions();
     });
     });

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -1,7 +1,8 @@
 ---
 /**
- * Workspace people tab — session-authed teammate invites, plus the
- * operator-only ADMIN_TOKEN enrollment command for site admins.
+ * Workspace people tab — session-authed teammate list + invites.
+ * Pending invites render in the same people list (not a separate section).
+ * Operator ADMIN_TOKEN enrollment lives under /admin, not here.
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
@@ -32,13 +33,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
       </div>
 
-      <div class="settings-section" id="ws-invites-section" hidden>
-        <h2>Pending invites</h2>
-        <div id="ws-invites" class="invite-list">
-          <p class="muted" id="ws-invites-status" role="status">Loading invites…</p>
-        </div>
-      </div>
-
       <div class="settings-section" id="ws-invite-section">
         <h2>Invite</h2>
         <p class="settings-note muted">Accept link, then <code>uploads login</code>.</p>
@@ -62,15 +56,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           <p class="muted cli-note" id="ws-invite-link" hidden></p>
         </div>
       </div>
-
-      <div class="settings-section" id="ws-operator-card" hidden>
-        <h2>Operator enrollment</h2>
-        <p class="settings-note muted"><code>ADMIN_TOKEN</code> only.</p>
-        <div class="command">
-          <code id="ws-operator-cmd"></code>
-          <button type="button" id="ws-operator-copy" aria-live="polite">copy</button>
-        </div>
-      </div>
     </section>
   </div>
 
@@ -88,15 +73,15 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       revokeWorkspaceInvite,
       removeWorkspaceMember,
       updateWorkspaceMemberRole,
+      type ManageResult,
     } from "../../../../lib/api-client";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import {
-      bindCopyButtons,
       escapeHtml,
       isWorkspaceAdminRole,
-      operatorInviteCommand,
       renderInvitesHtml,
       renderMembersHtml,
+      type MemberRow,
     } from "../../../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
@@ -120,18 +105,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
       const appEl = requireElement<HTMLElement>("#ws-app", page);
       const slugEl = requireElement<HTMLElement>("#ws-slug", page);
-      const operatorCard = requireElement<HTMLElement>("#ws-operator-card", page);
       const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
       const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
-      const operatorCmd = requireElement<HTMLElement>("#ws-operator-cmd", page);
-      const operatorCopy = requireElement<HTMLButtonElement>("#ws-operator-copy", page);
       const inviteForm = requireElement<HTMLFormElement>("#ws-invite-form", page);
       const inviteSection = requireElement<HTMLElement>("#ws-invite-section", page);
       const membersEl = requireElement<HTMLElement>("#ws-members", page);
-      const invitesSection = requireElement<HTMLElement>("#ws-invites-section", page);
-      const invitesEl = requireElement<HTMLElement>("#ws-invites", page);
 
-      let sessionRole: string | null | undefined;
       let sessionEmail: string | undefined;
       /** People-list controls: canManage + viewerRole feed renderMembersHtml. */
       let memberOpts: { canManage: boolean; viewerRole: string; selfEmail?: string } = {
@@ -148,6 +127,28 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         retryBtn.hidden = !retry;
       }
 
+      function paintPeopleList(
+        members: MemberRow[],
+        invites: { id: string; email: string; status: string }[],
+      ): void {
+        const memberHtml = members.length ? renderMembersHtml(members, memberOpts) : "";
+        const inviteHtml =
+          memberOpts.canManage && invites.length ? renderInvitesHtml(invites) : "";
+        const html = memberHtml + inviteHtml;
+        membersEl.innerHTML = html || '<p class="muted">Just you so far.</p>';
+      }
+
+      function applyMemberOpts(result: {
+        canManage: boolean;
+        role: string;
+      }): void {
+        memberOpts = {
+          canManage: result.canManage,
+          viewerRole: result.role,
+          selfEmail: sessionEmail,
+        };
+      }
+
       async function loadInvitePage(): Promise<void> {
         if (!stillHere()) return;
         statusEl.hidden = false;
@@ -156,8 +157,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         retryBtn.hidden = true;
         appEl.hidden = true;
 
-        // One combined people payload (authz + members + invites) instead of
-        // full workspace list + members + invites round-trips.
+        // One combined people payload (authz + members + invites).
         const result = await getWorkspacePeople(apiOrigin, workspaceName);
         if (!stillHere()) return;
         if (result.kind === "unavailable") {
@@ -169,60 +169,27 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           return;
         }
 
-        // Every member sees the people list; inviting stays admin-only (site
-        // operators may still open the page for the ADMIN_TOKEN command).
-        inviteSection.hidden = !isWorkspaceAdminRole(result.role) && sessionRole !== "admin";
-        inviteForm.hidden = !isWorkspaceAdminRole(result.role);
-
-        memberOpts = {
-          canManage: result.canManage,
-          viewerRole: result.role,
-          selfEmail: sessionEmail,
-        };
-        invitesSection.hidden = !memberOpts.canManage;
+        // Every member sees the people list; inviting stays workspace-admin-only.
+        const canInvite = isWorkspaceAdminRole(result.role);
+        inviteSection.hidden = !canInvite;
+        inviteForm.hidden = !canInvite;
+        applyMemberOpts(result);
 
         statusEl.hidden = true;
         appEl.hidden = false;
-
-        membersEl.innerHTML = result.members.length
-          ? renderMembersHtml(result.members, memberOpts)
-          : '<p class="muted">Just you so far.</p>';
-        if (memberOpts.canManage) {
-          invitesEl.innerHTML = result.invites.length
-            ? renderInvitesHtml(result.invites)
-            : '<p class="muted">No pending invites.</p>';
-        }
+        paintPeopleList(result.members, result.invites);
 
         const displayName = result.organization.name || workspaceName;
         slugEl.textContent =
           displayName === workspaceName ? workspaceName : `${displayName} · ${workspaceName}`;
         document.title = `People · ${displayName} · uploads.sh`;
-
-        const isOperator = sessionRole === "admin";
-        operatorCard.hidden = !isOperator;
-        if (isOperator) {
-          const cmd = operatorInviteCommand(workspaceName);
-          operatorCmd.textContent = cmd;
-          operatorCopy.dataset.copy = cmd;
-        }
       }
 
       async function refreshPeopleLists(): Promise<void> {
         const result = await getWorkspacePeople(apiOrigin, workspaceName);
         if (!stillHere() || result.kind !== "ok") return;
-        memberOpts = {
-          canManage: result.canManage,
-          viewerRole: result.role,
-          selfEmail: sessionEmail,
-        };
-        membersEl.innerHTML = result.members.length
-          ? renderMembersHtml(result.members, memberOpts)
-          : '<p class="muted">Just you so far.</p>';
-        if (memberOpts.canManage) {
-          invitesEl.innerHTML = result.invites.length
-            ? renderInvitesHtml(result.invites)
-            : '<p class="muted">No pending invites.</p>';
-        }
+        applyMemberOpts(result);
+        paintPeopleList(result.members, result.invites);
       }
 
       function manageErrorText(reason: string, action: string): string {
@@ -232,7 +199,25 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         return `Couldn’t ${action}. Try again.`;
       }
 
-      bindCopyButtons(document);
+      /** Confirm → disable → API → refresh; shared by remove/revoke. */
+      function runManageAction(
+        btn: HTMLButtonElement,
+        confirmMessage: string,
+        actionLabel: string,
+        request: () => Promise<ManageResult>,
+      ): void {
+        if (!confirm(confirmMessage)) return;
+        void (async () => {
+          btn.disabled = true;
+          const res = await request();
+          if (!stillHere()) return;
+          if (res.kind === "ok") void refreshPeopleLists();
+          else {
+            btn.disabled = false;
+            alert(manageErrorText(res.reason, actionLabel));
+          }
+        })();
+      }
 
       inviteForm.addEventListener("submit", (event) => {
         void (async () => {
@@ -280,23 +265,32 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       });
 
       membersEl.addEventListener("click", (event) => {
-        const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(
-          ".member-row__remove",
+        const target = event.target as HTMLElement;
+        const removeBtn = target.closest<HTMLButtonElement>(".member-row__remove");
+        if (removeBtn) {
+          const memberId = removeBtn.dataset.memberId ?? "";
+          const email = removeBtn.dataset.memberEmail ?? "this member";
+          if (!memberId) return;
+          runManageAction(
+            removeBtn,
+            `Remove ${email} from this workspace?`,
+            "remove this member",
+            () => removeWorkspaceMember(apiOrigin, workspaceName, memberId),
+          );
+          return;
+        }
+
+        const revokeBtn = target.closest<HTMLButtonElement>(".invite-row__revoke");
+        if (!revokeBtn) return;
+        const inviteId = revokeBtn.dataset.inviteId ?? "";
+        const email = revokeBtn.dataset.inviteEmail ?? "this invite";
+        if (!inviteId) return;
+        runManageAction(
+          revokeBtn,
+          `Revoke the pending invite for ${email}?`,
+          "revoke this invite",
+          () => revokeWorkspaceInvite(apiOrigin, workspaceName, inviteId),
         );
-        if (!btn) return;
-        void (async () => {
-          const memberId = btn.dataset.memberId ?? "";
-          const email = btn.dataset.memberEmail ?? "this member";
-          if (!memberId || !confirm(`Remove ${email} from this workspace?`)) return;
-          btn.disabled = true;
-          const res = await removeWorkspaceMember(apiOrigin, workspaceName, memberId);
-          if (!stillHere()) return;
-          if (res.kind === "ok") void refreshPeopleLists();
-          else {
-            btn.disabled = false;
-            alert(manageErrorText(res.reason, "remove this member"));
-          }
-        })();
       });
 
       membersEl.addEventListener("change", (event) => {
@@ -321,32 +315,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         })();
       });
 
-      invitesEl.addEventListener("click", (event) => {
-        const btn = (event.target as HTMLElement).closest<HTMLButtonElement>(
-          ".invite-row__revoke",
-        );
-        if (!btn) return;
-        void (async () => {
-          const inviteId = btn.dataset.inviteId ?? "";
-          const email = btn.dataset.inviteEmail ?? "this invite";
-          if (!inviteId || !confirm(`Revoke the pending invite for ${email}?`)) return;
-          btn.disabled = true;
-          const res = await revokeWorkspaceInvite(apiOrigin, workspaceName, inviteId);
-          if (!stillHere()) return;
-          if (res.kind === "ok") void refreshPeopleLists();
-          else {
-            btn.disabled = false;
-            alert(manageErrorText(res.reason, "revoke this invite"));
-          }
-        })();
-      });
-
       retryBtn.addEventListener("click", () => {
         void loadInvitePage();
       });
 
       onSession((user) => {
-        sessionRole = user.role;
         sessionEmail = user.email;
         void loadInvitePage();
       });

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -1,8 +1,8 @@
 ---
 /**
  * Workspace settings tab — thin stub (design 3A §5.3). The rail already
- * surfaces slug/role/public-url live; this repeats the same summary in the
- * main column (visible without the rail, e.g. on narrow viewports) via a
+ * surfaces slug/public-url live; this repeats the same summary in the main
+ * column (visible without the rail, e.g. on narrow viewports) via a
  * `<details>` disclosure. No new endpoints — reuses `getMyWorkspaces` +
  * `renderDetailsHtml` from the rail module.
  */
@@ -23,7 +23,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         <summary>Workspace details</summary>
         <dl class="kv" data-ws-settings-details></dl>
       </details>
-      <p class="muted settings-note">More workspace settings coming soon.</p>
     </div>
   </section>
 

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1212,29 +1212,7 @@ button.wft-name--btn {
   }
 }
 
-/* People tab: pending-invite rows + member-row management controls (#275). */
-.invite-list {
-  display: grid;
-  gap: 6px;
-}
-.invite-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.invite-row__email {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.invite-row__status {
-  font-size: 12px;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
+/* People tab: pending invites share the member-row surface + revoke control. */
 .member-row__actions {
   display: flex;
   align-items: center;
@@ -1243,4 +1221,11 @@ button.wft-name--btn {
 .member-row__role-select {
   font: inherit;
   padding: 2px 6px;
+}
+.member-row__role--pending {
+  color: var(--accent);
+}
+.member-row--pending .member-row__name {
+  font-weight: 500;
+  color: var(--muted);
 }

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -25,29 +25,42 @@
   min-width: 0;
 }
 
-/* Flat nav rows ---------------------------------------------------------- */
+/* Flat nav rows ----------------------------------------------------------
+   Beat signed-in-shell's pill treatment (`border-radius` + panel border on
+   `nav.side a[aria-current]`). Account nav is flush type with a quiet
+   rectangular active wash — no rounded chip, consistent horizontal inset. */
 .account-shell nav.side {
+  --side-inset: 8px;
   gap: 2px;
   font-size: 13px;
 }
 .account-shell nav.side .side-link {
   display: block;
-  padding: 5px 0;
+  padding: 5px var(--side-inset);
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--muted);
   text-decoration: none;
 }
 .account-shell nav.side .side-link:hover,
 .account-shell nav.side .side-link:focus-visible {
   color: var(--fg);
+  background: transparent;
   outline: none;
 }
 .account-shell nav.side .side-link[aria-current] {
   color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 0;
+  border-radius: 0;
 }
 
-/* Section labels (PERSONAL). Workspace heading is the switcher trigger. */
+/* Section labels (PERSONAL). Same horizontal inset as side-links. */
 .account-shell nav.side .side-label {
   margin: 14px 0 4px;
+  padding: 0 var(--side-inset);
   color: var(--muted);
   font-size: 10.5px;
   letter-spacing: 0.14em;
@@ -63,10 +76,10 @@
 .account-shell nav.side .ws-switcher .ws-switcher__trigger {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   width: 100%;
   max-width: 100%;
-  padding: 0;
+  padding: 0 var(--side-inset);
   margin: 0;
   border: 0;
   border-radius: 0;
@@ -91,11 +104,38 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Visible switcher affordance — boxed chevron, not tiny label-tracking text. */
 .account-shell nav.side .ws-switcher__chevron {
   flex: none;
-  font-size: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-left: auto;
+  border: 1px solid color-mix(in srgb, var(--line) 90%, var(--muted));
+  border-radius: 3px;
+  color: var(--fg);
+  font-size: 10px;
+  line-height: 1;
   letter-spacing: 0;
-  opacity: 0.7;
+}
+.account-shell nav.side .ws-switcher .ws-switcher__trigger:hover .ws-switcher__chevron,
+.account-shell nav.side .ws-switcher .ws-switcher__trigger:focus-visible .ws-switcher__chevron,
+.account-shell
+  nav.side
+  .ws-switcher
+  .ws-switcher__trigger[aria-expanded="true"]
+  .ws-switcher__chevron {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.account-shell
+  nav.side
+  .ws-switcher
+  .ws-switcher__trigger[aria-expanded="true"]
+  .ws-switcher__chevron {
+  transform: rotate(180deg);
 }
 .account-shell nav.side .ws-switcher__menu {
   position: absolute;
@@ -161,6 +201,34 @@
   position: sticky;
   top: 28px;
   min-width: 0;
+}
+
+/* Shared rail section chrome (workspace rail + profile tip). Wrapper is
+   `display: contents` so section children sit directly in `aside.rail`'s
+   grid (gap already set above). */
+.account-shell .ws-rail {
+  display: contents;
+}
+.account-shell .ws-rail__section {
+  font-size: 12.5px;
+}
+.account-shell .ws-rail__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 12px;
+}
+.account-shell .ws-rail__label {
+  color: var(--muted);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.account-shell .ws-rail__rule {
+  flex: 1;
+  height: 1px;
+  background: var(--line);
 }
 
 /* Mid-width (--bp-stack+1 … --bp-rail): drop rail beside content, restack

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -64,10 +64,12 @@ code {
 
 /* Sticky footer (signed-in shells only): body is a flex column; #app /
    #dashboard grow as full-width columns. SiteHeader is full-bleed at the
-   top; .shell is the constrained content column below it. .layout takes
-   free space so content stays top-aligned and the footer sits at the
-   viewport bottom when the page is short. When content is taller than the
-   viewport, the footer scrolls after it. */
+   top; .shell is the constrained content column below it. Footer is a
+   *sibling* of .shell (not nested inside it) so its max-width column can
+   center on the viewport — same pattern as releases.sh. .layout takes free
+   space so content stays top-aligned and the footer sits at the viewport
+   bottom when the page is short. When content is taller than the viewport,
+   the footer scrolls after it. */
 #app,
 #dashboard {
   flex: 1;
@@ -77,7 +79,7 @@ code {
   min-width: 0;
 }
 .shell {
-  flex: 1;
+  flex: 1 0 auto;
   display: flex;
   flex-direction: column;
   width: 100%;


### PR DESCRIPTION
## In plain terms

The signed-in account shell had a few layout and chrome issues after the recent nav overhaul: the footer sat inside the left-aligned content column instead of centering like releases.sh, the sidebar active pill hugged the left edge, and several pages showed redundant or premature UI (CLI put example, pending-invites block, operator enrollment on People, workspaces list on Account).

This cleans those up so the shell feels quieter and more consistent.

## What it does

- **Footer**: sibling of `.shell` (full-bleed border, centered max-width column) on account + admin shells
- **Sidebar**: flat active wash (no rounded border chip), consistent horizontal inset; clearer workspace switcher chevron
- **Rail**: drop “your role” and the `uploads put` copy block; keep invite teammate
- **Settings**: remove “coming soon”
- **Account**: link-email tip moves to the right rail; remove redundant Workspaces section
- **People**: pending invites appear in the people list; remove separate pending section and operator enrollment (site-admin tooling doesn’t belong on a workspace people page)

## What it is not

- No API or auth changes
- Operator enrollment is removed from People only — not re-homed under `/admin` yet
- No new CLI docs or skill updates

## How to try it

1. Sign in and open a workspace (e.g. `/account/workspaces/<name>/people`).
2. Check footer centers under the full viewport, not the left shell column.
3. Confirm sidebar current-page highlight has inset and no rounded border chip.
4. Rail: no role line, no `uploads put` row; invite still present.
5. Account: tip in rail, no Workspaces list.
6. People: pending invites (if any) sit in the same list as members.

## Technical notes

- Shared rail section chrome moved into `account-shell.css` (workspace + profile tip).
- Dead helpers removed (`operatorInviteCommand`, rail `bindCopyButtons` wiring).
- Tests: `workspace-rail`, `workspace-ui`, `cli-setup-state`, `client-router-boot`.

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/workspace-rail.test.ts src/lib/workspace-ui.test.ts src/lib/cli-setup-state.test.ts src/lib/client-router-boot.test.ts`
- [x] `pnpm --filter @uploads/web exec tsc --noEmit -p tsconfig.json`
- [ ] Spot-check signed-in pages in the browser (footer, sidebar, people, profile rail)