### PR TITLE
fix(mcp,docs): carry the canonical vocabulary to the hosted server and docs

### DIFF
--- a/.changeset/hosted-mcp-canonical-metadata.md
+++ b/.changeset/hosted-mcp-canonical-metadata.md
@@ -1,0 +1,8 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Export the canonical metadata helpers (`stateProp`, `appProp`,
+`canonicalMetaFromArgs`, `metadataArgWithCanonical`) from the `/mcp` entry
+point so the hosted MCP server can reuse them instead of keeping its own copy
+of the metadata tool description.

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -7,7 +7,10 @@
  */
 import { buildMarkdown, buildScreenshotKey } from "@buildinternet/uploads";
 import {
+  appProp,
   METADATA_DESCRIPTION,
+  metadataArgWithCanonical,
+  stateProp,
   ToolBatchError,
   batchFailureMessage,
   mapBounded,
@@ -440,8 +443,11 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             type: "object",
             additionalProperties: { type: "string" },
             description:
-              "Queryable custom metadata (key→value), separate from provenance. Omit to leave any metadata already stored for this key untouched; pass an object (even {}) to fully replace it. Keys: lowercase, ^[a-z][a-z0-9._-]{0,63}$. Values: 1-512 printable ASCII characters. Caps: at most 24 keys, at most 8192 total key+value bytes. Suggested keys: app, url, page, device, resolution, commit, branch. `gh.*` is reserved by convention for GitHub PR/issue attachment context (repo/kind/number/ref), normally system-managed by the attach flow.",
+              METADATA_DESCRIPTION +
+              " On this hosted server the gh.* pairs are normally system-managed by the attach flow.",
           },
+          state: stateProp,
+          app: appProp,
           replace: {
             type: "boolean",
             description:
@@ -473,7 +479,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           if (!filename) usage("filename is required");
         }
 
-        let metadata = optStringRecord(args, "metadata");
+        // state/app are explicit input and win over a same-named metadata key.
+        // This server cannot derive the EXIF-sourced keys (no image decoding in
+        // the Workers runtime), so these two are the whole canonical surface here.
+        let metadata = metadataArgWithCanonical(args);
         if (metadata) {
           try {
             validateMetadataEntries(metadata);

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -659,6 +659,36 @@ describe("mcp worker", () => {
     });
   });
 
+  it("stamps the canonical state/app params alongside the upload", async () => {
+    const { env, metadata } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "shot.png",
+      key: "shots/canonical.png",
+      metadata: { path: "/settings" },
+      state: "after",
+      app: "web",
+    });
+    expect(result.isError).toBe(false);
+    expect(Object.fromEntries(metadata.get("test-ws shots/canonical.png") ?? [])).toEqual({
+      path: "/settings",
+      state: "after",
+      app: "web",
+    });
+  });
+
+  it("rejects a state outside the canonical enum, with a suggestion", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "shot.png",
+      key: "shots/bad-state.png",
+      state: "post",
+    });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toContain("did you mean");
+  });
+
   it("leaves existing metadata untouched when the metadata argument is omitted", async () => {
     const { env, metadata } = await makeEnv();
     await callTool(env, "put", {

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -138,13 +138,20 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
     </div>
     <p>
       By default, images are re-encoded to WebP (capped size, high quality) so GitHub embeds
-      stay fast, and <strong>EXIF metadata is stripped</strong>. Use <code>--keep-exif</code>&#32;
-      to keep metadata, or <code>--no-optimize</code> to skip all processing.
+      stay fast, and <strong>EXIF is stripped from the uploaded bytes</strong>. Use&#32;
+      <code>--keep-exif</code> to keep it, or <code>--no-optimize</code> to skip all processing.
+    </p>
+    <p>
+      Before stripping, a small allowlist is read off the image and stored as searchable
+      metadata: <code>viewport</code>, <code>device</code>, <code>software</code>, and&#32;
+      <code>captured</code>. Those values are <strong>publicly visible</strong> on the file's
+      page. GPS coordinates, serial numbers, and personal-name tags are never kept. Pass&#32;
+      <code>--no-auto</code> to store none of it.
     </p>
     <p>
       Each file also gets a shareable page on uploads.sh (under <code>/f/…</code>) that
       supports <a href="https://oembed.com/">oEmbed</a> — so chat apps, notes tools, and
-      other unfurlers can embed the image when you paste the page link. Details are in
+      other unfurlers can embed the image when you paste the page link. Details are in&#32;
       <a href="/docs/reference#good-to-know">Reference</a>.
     </p>
   </section>

--- a/packages/uploads/src/mcp/server.ts
+++ b/packages/uploads/src/mcp/server.ts
@@ -12,8 +12,12 @@ import { errorCodeFromUnknown, recordEvent } from "../telemetry.js";
 import { ToolBatchError } from "./batch-error.js";
 
 export {
+  appProp,
+  canonicalMetaFromArgs,
   METADATA_DESCRIPTION,
+  metadataArgWithCanonical,
   metadataProp,
+  stateProp,
   optBool,
   optPosInt,
   optString,


### PR DESCRIPTION
Follow-ups to #361, from auditing the surfaces that PR didn't touch.

## The hosted MCP was still teaching the wrong keys

#361 fixed `METADATA_DESCRIPTION` so the tool schema stops suggesting `page`
and `resolution` — the exact near-miss spellings the CLI now warns about. But
`apps/mcp/src/tools.ts` had its **own hardcoded copy** of that string, so the
hosted server — the one agents actually connect to over the network — kept
telling them to use `page` and `resolution`. The local stdio MCP was fixed;
the hosted one wasn't. It now composes the shared constant, so this can't
drift again.

Its `put` tool also gains `state`/`app`. It deliberately does **not** derive
the EXIF-sourced keys: there's no image decoding in the Workers runtime
(`sharp` isn't available there), so `state`/`app` are the whole canonical
surface on that server. Both are pure pass-through metadata and cost nothing.

This needed four helpers exported from the package's `/mcp` entry point, which
re-exports a curated list rather than everything — hence the patch changeset.

## The docs made a privacy claim that no longer held

The docs said "**EXIF metadata is stripped**." After #361 that's half the
story: EXIF still leaves the uploaded bytes, but `viewport`/`device`/
`software`/`captured` are promoted into metadata that renders publicly on the
file page. Someone reading that sentence would reasonably conclude nothing
from their camera survives.

Reworded to say what actually happens, name the values, state plainly that
they're publicly visible, and give the `--no-auto` opt-out — plus the denials
(GPS, serial numbers, personal-name tags) so the reassurance that *is* true
stays visible.

![Docs: EXIF stripped from bytes, allowlist stored as searchable public metadata](https://embed.uploads.sh/default/screenshots/misc/2026-07-21/docs-crop-c3b642.webp)

## Drive-by

The paragraph immediately below rendered as "Details are in**Reference**" — a
missing space before the link, the Astro whitespace-collapse gotcha. Live on
the public docs since #254. One character.

## Verification

2165 tests pass; typecheck and lint clean. Two new tests pin the hosted MCP
behavior: `state`/`app` reaching stored metadata, and an out-of-enum `state`
being rejected *with the suggestion* — the hosted server now delegates to the
same validator as the CLI, so `state: "post"` says "did you mean after?"
instead of dumping the enum. The docs page was rendered and screenshotted from
a local build (with `uploads screenshot`, dogfooding the tool).

## Checked, nothing needed

`README.md`, `llms.txt`, `sitemap.xml`, and the `reference`/`agents` docs pages
make no metadata or EXIF claims. `uploads find --help` already shows the
canonical example.
