### PR TITLE
feat: add grid view for workspace files

### DIFF
--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -1,10 +1,10 @@
 /**
  * The 3A workspace files tab — filter bar, chips ↔ breadcrumbs, a conditional
- * exact-PR-match banner, and the file row grid (thumbnail, size, type,
- * visibility, `⋯` actions). Replaces `WorkspaceFiles` + `AccountFileBrowser` +
- * `MetadataSearchResults` as the single island mounted by
- * `pages/account/workspaces/[name].astro`. See
- * `.superpowers/sdd/task-8-brief.md` for the row grid / thumbnail / chip spec.
+ * exact-PR-match banner, and the file listing (list or grid view: thumbnail,
+ * size, type, visibility, `⋯` actions). Replaces `WorkspaceFiles` +
+ * `AccountFileBrowser` + `MetadataSearchResults` as the single island mounted
+ * by `pages/account/workspaces/[name].astro`. See
+ * `.superpowers/sdd/task-8-brief.md` for the row / thumbnail / chip spec.
  *
  * Data source: `listWorkspaceFolder` when no filters are active (folder
  * browse, URL-synced via `workspace-browse-url`), `searchWorkspaceFiles` when
@@ -14,6 +14,10 @@
  * right-rail "connected work" section (Task 7's
  * `window.__uploadsSetConnectedWork` hook) and checked for an exact
  * single-pull-request match (the banner).
+ *
+ * List vs grid is a soft client preference: `?view=list|grid` in the URL
+ * (wins when present), else `uploads:filesView` in localStorage, else list.
+ * Browse/search URL writers leave `view` alone, so folder/filter nav keeps it.
  */
 import { Callout } from "@uploads/ui";
 import "@uploads/ui/styles.css";
@@ -47,6 +51,7 @@ import {
   readBrowseLocation,
   replaceBrowseLocation,
 } from "../lib/workspace-browse-url";
+import { replaceFilesView, resolveFilesView, type FilesView } from "../lib/workspace-files-view";
 import {
   isValidMetaKey,
   isValidMetaValue,
@@ -153,6 +158,133 @@ function FolderIcon({ className }: { className?: string }) {
   );
 }
 
+function ListViewIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M2.5 4h11M2.5 8h11M2.5 12h11" />
+    </svg>
+  );
+}
+
+function GridViewIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      aria-hidden="true"
+    >
+      <rect x="2.5" y="2.5" width="4.5" height="4.5" rx="0.5" />
+      <rect x="9" y="2.5" width="4.5" height="4.5" rx="0.5" />
+      <rect x="2.5" y="9" width="4.5" height="4.5" rx="0.5" />
+      <rect x="9" y="9" width="4.5" height="4.5" rx="0.5" />
+    </svg>
+  );
+}
+
+function FileThumb({ thumb }: { thumb: ReturnType<typeof pickThumbnail> }) {
+  if (thumb.kind === "image") {
+    return (
+      <span
+        className="wft-thumb"
+        style={{ backgroundImage: `url(${thumb.src})` }}
+        aria-hidden="true"
+      />
+    );
+  }
+  return (
+    <span className="wft-thumb wft-thumb--tile" aria-hidden="true">
+      {thumb.kind === "video" && <PlayIcon />}
+      {thumb.kind === "lock" && <LockIcon />}
+    </span>
+  );
+}
+
+function VisibilityBadge({ private: priv }: { private: boolean }) {
+  return (
+    <span
+      className={`wft-vis ${priv ? "wft-vis--private" : "wft-vis--public"}`}
+      title={
+        priv
+          ? "Unlisted: hidden from listings and the /f/ page unless signed in. The raw file URL still works for anyone who has it."
+          : "Public: listed and reachable by anyone with the URL."
+      }
+    >
+      {priv ? (
+        <LockIcon className="wft-vis__icon" />
+      ) : (
+        <span className="wft-vis__dot" aria-hidden="true" />
+      )}
+      {priv ? "unlisted" : "public"}
+    </span>
+  );
+}
+
+function FileActionsMenu({
+  open,
+  busy,
+  isPrivate,
+  onToggle,
+  onCopy,
+  onToggleVisibility,
+}: {
+  open: boolean;
+  busy: boolean;
+  isPrivate: boolean;
+  onToggle: () => void;
+  onCopy: (button: HTMLButtonElement) => void;
+  onToggleVisibility: () => void;
+}) {
+  return (
+    <div className="wft-menu">
+      <button
+        type="button"
+        className="wft-menu__trigger"
+        aria-expanded={open}
+        aria-label="File actions"
+        onClick={onToggle}
+      >
+        ⋯
+      </button>
+      {open && (
+        <div role="menu" className="wft-menu__popover">
+          <button
+            type="button"
+            role="menuitem"
+            className="wft-menu__item"
+            onClick={(e) => onCopy(e.currentTarget)}
+          >
+            copy link
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="wft-menu__item"
+            disabled={busy}
+            onClick={onToggleVisibility}
+          >
+            {isPrivate ? "make public" : "unlist"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function sizeLabel(size: number | undefined): string {
+  return typeof size === "number" ? formatBytes(size) : "—";
+}
+
 // ── URL-resolution helpers (open-file / copy-link) ────────────────────────
 // Mirrors AccountFileBrowser's hasPublicUrl-branching open logic verbatim:
 // a workspace with a stable public domain always opens through the chrome-
@@ -219,7 +351,14 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
   const [togglingKeys, setTogglingKeys] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
   const [githubTitles, setGithubTitles] = useState<GithubTitleMap | null>(null);
+  const [view, setView] = useState<FilesView>(() => resolveFilesView(window.location.search));
   const githubTitlesGeneration = useRef(0);
+
+  const setFilesView = (next: FilesView) => {
+    setView(next);
+    replaceFilesView(next);
+    setOpenMenuKey(null);
+  };
 
   const filtersKey = filters.map((f) => `${f.key}=${f.value}`).join("&");
   const filtered = filters.length > 0;
@@ -469,8 +608,11 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
 
   const bareMatch: GhWorkItem | null = state.status === "ok" ? exactPrMatch(state.files) : null;
   const match = bareMatch && githubTitles ? applyGhTitles([bareMatch], githubTitles)[0] : bareMatch;
-  const count = state.status === "ok" ? state.files.length : 0;
-  const folderCount = state.status === "ok" ? state.prefixes.length : 0;
+  // Folders only in browse mode (search has no prefix tree). Empty while loading/error.
+  const folders = state.status === "ok" && !filtered ? state.prefixes : [];
+  const files = state.status === "ok" ? state.files : [];
+  const count = files.length;
+  const folderCount = folders.length;
   const topLabel =
     state.status === "loading"
       ? ""
@@ -533,6 +675,26 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
         <span className="wft-sectionhead__label">files</span>
         <span className="wft-sectionhead__rule" />
         <span className="wft-sectionhead__count">{topLabel}</span>
+        <div className="wft-view" role="group" aria-label="File layout">
+          {(
+            [
+              ["list", "List view", ListViewIcon],
+              ["grid", "Grid view", GridViewIcon],
+            ] as const
+          ).map(([id, label, Icon]) => (
+            <button
+              key={id}
+              type="button"
+              className="wft-view__btn"
+              aria-pressed={view === id}
+              aria-label={label}
+              title={label}
+              onClick={() => setFilesView(id)}
+            >
+              <Icon />
+            </button>
+          ))}
+        </div>
       </div>
 
       {filtered ? (
@@ -610,18 +772,17 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
         </div>
       )}
 
-      <div className="wft-grid">
-        <div className="wft-head">
-          <span>name</span>
-          <span className="wft-head__size">size</span>
-          <span className="wft-head__type">type</span>
-          <span>visibility</span>
-          <span />
-        </div>
+      {view === "list" ? (
+        <div className="wft-grid">
+          <div className="wft-head">
+            <span>name</span>
+            <span className="wft-head__size">size</span>
+            <span className="wft-head__type">type</span>
+            <span>visibility</span>
+            <span />
+          </div>
 
-        {state.status === "ok" &&
-          !filtered &&
-          state.prefixes.map((folder) => (
+          {folders.map((folder) => (
             <button
               key={folder}
               type="button"
@@ -641,17 +802,13 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
             </button>
           ))}
 
-        {state.status === "ok" &&
-          state.files.map((file) => {
-            // Show the file's own name (leaf), not the full key — at the flat
-            // root the key is the whole `screenshots/…/x.png` path, whose
-            // distinctive tail would otherwise be ellipsized away.
+          {files.map((file) => {
+            // Leaf name only — at the flat root the key is `screenshots/…/x.png`,
+            // and ellipsis would otherwise hide the distinctive tail.
             const name = leafName(file.key);
             const thumb = pickThumbnail(file);
             const type = fileTypeLabel(file);
             const priv = isPrivateFile(file);
-            const menuOpen = openMenuKey === file.key;
-            const busy = togglingKeys.has(file.key);
 
             return (
               <div className="wft-row" key={file.key}>
@@ -660,82 +817,105 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
                   className="wft-name wft-name--btn"
                   onClick={() => openFile(apiOrigin, workspace, info.hasPublicUrl, file.key)}
                 >
-                  {thumb.kind === "image" && (
+                  {thumb.kind !== "none" && <FileThumb thumb={thumb} />}
+                  <span className="wft-filename">{name}</span>
+                </button>
+                <span className="wft-size">{sizeLabel(file.size)}</span>
+                <span className="wft-type">{type}</span>
+                <VisibilityBadge private={priv} />
+                <FileActionsMenu
+                  open={openMenuKey === file.key}
+                  busy={togglingKeys.has(file.key)}
+                  isPrivate={priv}
+                  onToggle={() => setOpenMenuKey((prev) => (prev === file.key ? null : file.key))}
+                  onCopy={(btn) => void copyLink(file, btn)}
+                  onToggleVisibility={() => void toggleVisibility(file)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="wft-cards">
+          {folders.map((folder) => (
+            <button
+              key={folder}
+              type="button"
+              className="wft-card wft-card--folder"
+              onClick={() => navigate(folder)}
+            >
+              <span className="wft-card__media" aria-hidden="true">
+                <span className="wft-card__placeholder">
+                  <FolderIcon />
+                </span>
+              </span>
+              <span className="wft-card__body">
+                <span className="wft-card__name">{childName(folder, prefix)}/</span>
+                <span className="wft-card__meta">folder</span>
+              </span>
+            </button>
+          ))}
+
+          {files.map((file) => {
+            const name = leafName(file.key);
+            const thumb = pickThumbnail(file);
+            const type = fileTypeLabel(file);
+            const priv = isPrivateFile(file);
+            const open = () => openFile(apiOrigin, workspace, info.hasPublicUrl, file.key);
+
+            return (
+              <div className="wft-card" key={file.key}>
+                <button
+                  type="button"
+                  className="wft-card__media"
+                  onClick={open}
+                  aria-label={`Open ${name}`}
+                >
+                  {thumb.kind === "image" ? (
                     <span
-                      className="wft-thumb"
+                      className="wft-card__img"
                       style={{ backgroundImage: `url(${thumb.src})` }}
                       aria-hidden="true"
                     />
-                  )}
-                  {thumb.kind === "video" && (
-                    <span className="wft-thumb wft-thumb--tile" aria-hidden="true">
-                      <PlayIcon />
-                    </span>
-                  )}
-                  {thumb.kind === "lock" && (
-                    <span className="wft-thumb wft-thumb--tile" aria-hidden="true">
-                      <LockIcon />
-                    </span>
-                  )}
-                  <span className="wft-filename">{name}</span>
-                </button>
-                <span className="wft-size">
-                  {typeof file.size === "number" ? formatBytes(file.size) : "—"}
-                </span>
-                <span className="wft-type">{type}</span>
-                <span
-                  className={`wft-vis ${priv ? "wft-vis--private" : "wft-vis--public"}`}
-                  title={
-                    priv
-                      ? "Unlisted: hidden from listings and the /f/ page unless signed in. The raw file URL still works for anyone who has it."
-                      : "Public: listed and reachable by anyone with the URL."
-                  }
-                >
-                  {priv ? (
-                    <LockIcon className="wft-vis__icon" />
                   ) : (
-                    <span className="wft-vis__dot" aria-hidden="true" />
+                    <span className="wft-card__placeholder" aria-hidden="true">
+                      {thumb.kind === "video" && <PlayIcon />}
+                      {thumb.kind === "lock" && <LockIcon />}
+                      {thumb.kind === "none" && <span className="wft-card__ext">{type}</span>}
+                    </span>
                   )}
-                  {priv ? "unlisted" : "public"}
-                </span>
-                <div className="wft-menu">
-                  <button
-                    type="button"
-                    className="wft-menu__trigger"
-                    aria-expanded={menuOpen}
-                    aria-label="File actions"
-                    onClick={() => setOpenMenuKey((prev) => (prev === file.key ? null : file.key))}
-                  >
-                    ⋯
-                  </button>
-                  {menuOpen && (
-                    <div role="menu" className="wft-menu__popover">
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className="wft-menu__item"
-                        onClick={(e) => void copyLink(file, e.currentTarget)}
-                      >
-                        copy link
-                      </button>
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className="wft-menu__item"
-                        disabled={busy}
-                        onClick={() => void toggleVisibility(file)}
-                      >
-                        {priv ? "make public" : "unlist"}
-                      </button>
-                    </div>
-                  )}
+                </button>
+                <div className="wft-card__body">
+                  <div className="wft-card__title">
+                    <button type="button" className="wft-card__name" title={name} onClick={open}>
+                      {name}
+                    </button>
+                    <FileActionsMenu
+                      open={openMenuKey === file.key}
+                      busy={togglingKeys.has(file.key)}
+                      isPrivate={priv}
+                      onToggle={() =>
+                        setOpenMenuKey((prev) => (prev === file.key ? null : file.key))
+                      }
+                      onCopy={(btn) => void copyLink(file, btn)}
+                      onToggleVisibility={() => void toggleVisibility(file)}
+                    />
+                  </div>
+                  <div className="wft-card__meta">
+                    <span>
+                      {sizeLabel(file.size)} · {type}
+                    </span>
+                    <span className="wft-card__spacer" />
+                    <VisibilityBadge private={priv} />
+                  </div>
                 </div>
               </div>
             );
           })}
+        </div>
+      )}
 
-        <div className="wft-end">{endLabel}</div>
-      </div>
+      <div className="wft-end">{endLabel}</div>
 
       {state.status === "ok" && state.cursor && (
         <button type="button" className="wft-loadmore text-btn" onClick={() => void loadMore()}>

--- a/apps/web/src/lib/workspace-browse-url.test.ts
+++ b/apps/web/src/lib/workspace-browse-url.test.ts
@@ -89,7 +89,7 @@ describe("readBrowseLocation", () => {
 
 describe("applyBrowseLocation", () => {
   it("writes path-based workspace routes and keeps other search keys", () => {
-    const base = new URL("https://uploads.sh/account/workspaces?tab=1");
+    const base = new URL("https://uploads.sh/account/workspaces?tab=1&view=grid");
     const withPath = applyBrowseLocation(base, {
       workspace: "buildinternet",
       path: "screenshots/",
@@ -98,11 +98,14 @@ describe("applyBrowseLocation", () => {
     expect(withPath.searchParams.get("ws")).toBeNull();
     expect(withPath.searchParams.get("path")).toBe("screenshots/");
     expect(withPath.searchParams.get("tab")).toBe("1");
+    // Layout preference is owned by workspace-files-view; folder nav must keep it.
+    expect(withPath.searchParams.get("view")).toBe("grid");
 
     const cleared = applyBrowseLocation(withPath, { workspace: "", path: "ignored" });
     expect(cleared.searchParams.get("ws")).toBeNull();
     expect(cleared.searchParams.get("path")).toBeNull();
     expect(cleared.searchParams.get("tab")).toBe("1");
+    expect(cleared.searchParams.get("view")).toBe("grid");
   });
 
   it("updates path only when already on the workspace page", () => {

--- a/apps/web/src/lib/workspace-files-view.test.ts
+++ b/apps/web/src/lib/workspace-files-view.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyFilesView,
+  parseFilesView,
+  readFilesViewParam,
+  resolveFilesView,
+} from "./workspace-files-view";
+
+describe("parseFilesView", () => {
+  it("accepts list and grid", () => {
+    expect(parseFilesView("list")).toBe("list");
+    expect(parseFilesView("grid")).toBe("grid");
+  });
+
+  it("rejects unknown values", () => {
+    expect(parseFilesView("cards")).toBeNull();
+    expect(parseFilesView("")).toBeNull();
+    expect(parseFilesView(null)).toBeNull();
+    expect(parseFilesView(undefined)).toBeNull();
+  });
+});
+
+describe("readFilesViewParam", () => {
+  it("reads view from a query string", () => {
+    expect(readFilesViewParam("?path=screenshots/&view=grid")).toBe("grid");
+    expect(readFilesViewParam("view=list&meta.gh.repo=a/b")).toBe("list");
+  });
+
+  it("returns null when the param is missing or invalid", () => {
+    expect(readFilesViewParam("?path=screenshots/")).toBeNull();
+    expect(readFilesViewParam("?view=masonry")).toBeNull();
+  });
+});
+
+describe("resolveFilesView", () => {
+  it("prefers the URL over a stored preference", () => {
+    expect(resolveFilesView("?view=list", "grid")).toBe("list");
+    expect(resolveFilesView("?view=grid", "list")).toBe("grid");
+  });
+
+  it("falls back to storage, then list", () => {
+    expect(resolveFilesView("", "grid")).toBe("grid");
+    expect(resolveFilesView("?path=f/", "list")).toBe("list");
+    expect(resolveFilesView("", null)).toBe("list");
+    expect(resolveFilesView("", "cards")).toBe("list");
+  });
+});
+
+describe("applyFilesView", () => {
+  it("sets view without clobbering other params", () => {
+    const base = new URL("https://uploads.sh/account/workspaces/acme?path=screenshots/");
+    const next = applyFilesView(base, "grid");
+    expect(next.searchParams.get("view")).toBe("grid");
+    expect(next.searchParams.get("path")).toBe("screenshots/");
+  });
+
+  it("can override a prior view value", () => {
+    const base = new URL("https://uploads.sh/account/workspaces/acme?view=grid");
+    expect(applyFilesView(base, "list").searchParams.get("view")).toBe("list");
+  });
+});

--- a/apps/web/src/lib/workspace-files-view.ts
+++ b/apps/web/src/lib/workspace-files-view.ts
@@ -1,0 +1,56 @@
+/**
+ * List vs grid layout for the workspace files tab (`?view=list|grid`).
+ *
+ * Resolution: query → localStorage → `"list"`. Toggle writes both (URL for
+ * sharing, storage for return visits). Browse/search writers leave `view`
+ * alone, so folder/filter navigation keeps the layout.
+ */
+
+export type FilesView = "list" | "grid";
+
+const VIEW_PARAM = "view";
+const STORAGE_KEY = "uploads:filesView";
+
+export function parseFilesView(value: string | null | undefined): FilesView | null {
+  return value === "list" || value === "grid" ? value : null;
+}
+
+/** Read `view` from a query string (`?view=grid` or `view=grid`). */
+export function readFilesViewParam(search: string): FilesView | null {
+  const raw = search.startsWith("?") ? search.slice(1) : search;
+  return parseFilesView(new URLSearchParams(raw).get(VIEW_PARAM));
+}
+
+function readStored(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** URL wins, then storage (injectable for tests), then list. */
+export function resolveFilesView(search: string, stored: string | null = readStored()): FilesView {
+  return readFilesViewParam(search) ?? parseFilesView(stored) ?? "list";
+}
+
+/** Copy `current` with `view` set. Always explicit so `?view=list` overrides storage. */
+export function applyFilesView(current: URL, view: FilesView): URL {
+  const next = new URL(current.href);
+  next.searchParams.set(VIEW_PARAM, view);
+  return next;
+}
+
+/** Persist layout to localStorage + address bar (no history entry). */
+export function replaceFilesView(view: FilesView): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, view);
+  } catch {
+    // private mode / quota — preference is session-only then
+  }
+  const next = applyFilesView(new URL(window.location.href), view);
+  const target = `${next.pathname}${next.search}${next.hash}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (target !== current) window.history.replaceState(window.history.state, "", target);
+}

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -82,7 +82,7 @@ describe("renderConnectedWorkHtml", () => {
 });
 
 describe("renderDetailsHtml", () => {
-  it("renders the public url as a host-labeled link when the URL is known", () => {
+  it("renders the base url as plain host text when the URL is known", () => {
     const html = renderDetailsHtml({
       organization: { slug: "buildinternet" },
       hasPublicUrl: true,
@@ -90,8 +90,10 @@ describe("renderDetailsHtml", () => {
     });
     expect(html).toContain(">buildinternet<");
     expect(html).not.toContain("your role");
-    expect(html).toContain('href="https://storage.uploads.sh/"');
-    expect(html).toContain(">storage.uploads.sh</a>");
+    expect(html).toContain(">base url<");
+    expect(html).toContain(">storage.uploads.sh<");
+    expect(html).not.toContain("<a");
+    expect(html).not.toContain("href=");
     expect(html).not.toContain(">configured<");
   });
 
@@ -104,7 +106,7 @@ describe("renderDetailsHtml", () => {
     expect(html).not.toContain("<a");
   });
 
-  it("escapes an interpolated public url", () => {
+  it("escapes an interpolated base url", () => {
     const html = renderDetailsHtml({
       organization: { slug: "acme" },
       hasPublicUrl: true,
@@ -114,7 +116,7 @@ describe("renderDetailsHtml", () => {
     expect(html).toContain("&lt;script&gt;");
   });
 
-  it("renders an em-dash for public url when hasPublicUrl is false", () => {
+  it("renders an em-dash for base url when hasPublicUrl is false", () => {
     const html = renderDetailsHtml({
       organization: { slug: "side-project" },
       hasPublicUrl: false,

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -58,19 +58,20 @@ export interface WorkspaceRailDetails {
 
 /**
  * Pure builder for the rail/settings "details" `<dt>/<dd>` pairs (slug +
- * public URL only — role lives on People / Account). The public-URL cell
- * links to `publicBaseUrl`, labeled by host. `hasPublicUrl` without a URL
- * string means an older API that predates `publicBaseUrl` — fall back to
- * "configured" rather than fabricating a URL.
+ * base URL only — role lives on People / Account). The base-URL cell is
+ * plain text (host of the stable public origin, e.g. `storage.uploads.sh`)
+ * — it is a bucket root, not a useful page to open. `hasPublicUrl` without
+ * a URL string means an older API that predates `publicBaseUrl` — fall back
+ * to "configured" rather than fabricating a URL.
  */
 export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
   const host = ws.publicBaseUrl?.replace(/^https?:\/\//, "").replace(/\/$/, "");
-  const publicUrlHtml = ws.publicBaseUrl
-    ? `<a class="ws-rail__link" href="${escapeHtml(ws.publicBaseUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(host ?? "")}</a>`
+  const baseUrlHtml = ws.publicBaseUrl
+    ? escapeHtml(host ?? "")
     : escapeHtml(ws.hasPublicUrl ? "configured" : "—");
   return (
     `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${escapeHtml(ws.organization.slug)}</dd>` +
-    `<dt class="ws-rail__dt">public url</dt><dd class="ws-rail__dd">${publicUrlHtml}</dd>`
+    `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${baseUrlHtml}</dd>`
   );
 }
 

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -781,9 +781,10 @@ section.card .ws-messages .command {
 }
 
 /* Workspace files tab (3A) — WorkspaceFileTable ─────────────────────────
-   Filter bar + chips/breadcrumbs + optional PR banner + file row grid.
-   Column widths mirror the 3A reference verbatim:
-   name(minmax(0,1fr)) · size(90px) · type(110px) · visibility(100px) · ⋯(44px). */
+   Filter bar + chips/breadcrumbs + optional PR banner + list or card grid.
+   List column widths: name · size · type · visibility · ⋯ .
+   Grid view is a separate card layout (`.wft-cards`); layout is ?view= +
+   soft localStorage fallback (see workspace-files-view.ts). */
 
 .wft {
   display: grid;
@@ -837,6 +838,44 @@ section.card .ws-messages .command {
 .wft-sectionhead__count {
   color: var(--muted);
   font-size: 12px;
+}
+
+/* List / grid layout toggle — sits after the file count in the section head. */
+.wft-view {
+  display: inline-flex;
+  flex: none;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.wft-view__btn {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-right: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.wft-view__btn:last-child {
+  border-right: 0;
+}
+.wft-view__btn svg {
+  width: 13px;
+  height: 13px;
+}
+.wft-view__btn:hover,
+.wft-view__btn:focus-visible {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  outline: none;
+}
+.wft-view__btn[aria-pressed="true"] {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .wft-chips {
@@ -1148,6 +1187,145 @@ button.wft-name--btn {
 }
 .wft-loadmore {
   margin-top: 10px;
+}
+
+/* Grid (card) layout — larger thumbs; folders are one full-card button. */
+.wft-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+.wft-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg, 10px);
+  overflow: hidden;
+  transition: border-color 0.12s ease;
+}
+.wft-card:hover,
+.wft-card:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+}
+button.wft-card {
+  width: 100%;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+button.wft-card:hover,
+button.wft-card:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.wft-card__media {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg);
+  cursor: pointer;
+  color: inherit;
+  overflow: hidden;
+}
+.wft-card__media:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+.wft-card__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+}
+.wft-card__placeholder {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  color: var(--muted);
+}
+.wft-card__placeholder svg {
+  width: 22px;
+  height: 22px;
+}
+.wft-card__ext {
+  font: 11px var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.wft-card__body {
+  display: grid;
+  gap: 6px;
+  padding: 10px 11px 12px;
+  min-width: 0;
+}
+.wft-card__title {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.wft-card__name {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 12.5px var(--mono);
+  color: var(--fg);
+  background: none;
+  border: 0;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+button.wft-card__name:hover,
+button.wft-card__name:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+.wft-card--folder .wft-card__name {
+  cursor: inherit;
+}
+.wft-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font: 11px var(--mono);
+  color: var(--muted);
+}
+.wft-card__meta > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.wft-card__spacer {
+  flex: 1 1 auto;
+}
+.wft-card .wft-menu {
+  flex: none;
+}
+.wft-card .wft-vis {
+  font-size: 11px;
+}
+
+@media (max-width: 560px) {
+  .wft-cards {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px;
+  }
 }
 
 /* People tab — member rows (innerHTML-injected by renderMembersHtml). */


### PR DESCRIPTION
## In plain terms

The workspace files tab only had a dense table. Screenshots are hard to scan that way, so this adds a grid of larger thumbnails you can switch to with a control next to the file count. The layout rides along in the URL (`?view=grid`) and is also remembered softly in the browser for next time.

## What it does

- List / grid toggle in the files section head
- Grid cards with 16:10 thumbnails, name, size · type, visibility, and the same `⋯` actions (copy link / unlist)
- Folders get card tiles that navigate the path
- Layout resolution: `?view=list|grid` → `localStorage` → list
- Folder and metadata-filter navigation leave `view` alone, so the choice sticks
- Shared menu helper so list and grid stay in sync

## What it is not

- Not a durable account setting (client-only preference)
- No change to listing APIs, visibility, or public `/f/` behavior
- Does not auto-request CodeRabbit

## How to try it

1. Open a workspace files tab with a few images.
2. Click the grid icon next to the file count — cards should show larger previews.
3. Confirm the address bar has `?view=grid`.
4. Navigate into a folder or add a metadata filter — layout should stay grid.
5. Switch back to list; URL should show `?view=list`.

## Technical notes

- View helpers: `apps/web/src/lib/workspace-files-view.ts`
- UI: `WorkspaceFileTable` + `account-content.css` (`.wft-view`, `.wft-cards`)

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/workspace-files-view.test.ts src/lib/workspace-browse-url.test.ts`
- [x] `pnpm --filter @uploads/web exec tsc --noEmit -p tsconfig.json`
- [ ] Manual: toggle list/grid on a workspace with images, folders, and an unlisted file