### PR TITLE
feat: gallery item page parity with file share view

### DIFF
--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -36,6 +36,16 @@ export const META_MAX_TOTAL_BYTES = 8192;
 /** Max value length in characters. */
 export const META_VALUE_MAX = 512;
 
+/**
+ * Trim and cap a display string to META_VALUE_MAX.
+ * Used for public GitHub titles (stamped or live-resolved).
+ */
+export function displayTitle(raw: string | undefined): string | undefined {
+  const t = raw?.trim();
+  if (!t) return undefined;
+  return t.length > META_VALUE_MAX ? t.slice(0, META_VALUE_MAX) : t;
+}
+
 // Printable ASCII only — same rule as provenance.ts's VALUE_SAFE_RE.
 const VALUE_SAFE_RE = /^[\x20-\x7E]+$/;
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -147,6 +147,38 @@ export function resolveUploadedAtMeta(
   return now.toISOString();
 }
 
+/** Same-second tolerance so storage noise does not force dual public date fields. */
+const PUBLIC_DATE_EQUAL_MS = 1000;
+
+/**
+ * Public share/gallery date fields from a Files SDK head.
+ * Prefer `uploaded-at` stamp; fall back to provider `lastModified`.
+ * Emit `modified` only when mtime meaningfully differs (fresh put → single field).
+ */
+export function publicObjectDateFields(meta: {
+  lastModified?: number;
+  metadata?: Record<string, string>;
+}): { uploaded?: string; modified?: string } {
+  const modifiedIso =
+    meta.lastModified != null && Number.isFinite(meta.lastModified)
+      ? new Date(meta.lastModified).toISOString()
+      : undefined;
+  const stamped = meta.metadata?.[UPLOADED_AT_META_KEY];
+  const uploadedIso =
+    typeof stamped === "string" && Number.isFinite(Date.parse(stamped))
+      ? new Date(stamped).toISOString()
+      : modifiedIso;
+
+  if (!uploadedIso) return {};
+  if (
+    !modifiedIso ||
+    Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso)) < PUBLIC_DATE_EQUAL_MS
+  ) {
+    return { uploaded: uploadedIso };
+  }
+  return { uploaded: uploadedIso, modified: modifiedIso };
+}
+
 /**
  * Upload with the workspace's guardrails applied: size cap and content-type
  * allowlist, the stored content type sniffed from the bytes rather than taken

--- a/apps/api/src/gallery-service-references.test.ts
+++ b/apps/api/src/gallery-service-references.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { enrichPublicReferences } from "./gallery-service";
+import type { GalleryExternalReferenceRecord } from "./galleries";
+import * as titles from "./github-titles";
+import { FakeKv } from "../test/fake-kv";
+
+function ref(
+  over: Partial<GalleryExternalReferenceRecord> &
+    Pick<GalleryExternalReferenceRecord, "locator_json" | "canonical_url">,
+): GalleryExternalReferenceRecord {
+  return {
+    id: over.id ?? "ref_1",
+    gallery_id: over.gallery_id ?? "gal_abcdefghijklmnopqrstuv",
+    provider: over.provider ?? "github",
+    resource_type: over.resource_type ?? "item",
+    normalized_key: over.normalized_key ?? "github:item:o/r#9",
+    locator_json: over.locator_json,
+    canonical_url: over.canonical_url,
+    created_at: over.created_at ?? "2026-07-20T00:00:00.000Z",
+    updated_at: over.updated_at ?? "2026-07-20T00:00:00.000Z",
+  };
+}
+
+describe("enrichPublicReferences", () => {
+  it("overlays title + kind and rewrites PR URLs when resolve succeeds", async () => {
+    vi.spyOn(titles, "resolveTitles").mockResolvedValue({
+      "o/r#9": { title: "Ship gallery parity", state: "open", kind: "pull" },
+    });
+    vi.spyOn(titles, "withPublicTitleBudget").mockImplementation(async (work) => work);
+
+    const out = await enrichPublicReferences({ GITHUB_CACHE: new FakeKv() } as unknown as Env, [
+      ref({
+        locator_json: JSON.stringify({ owner: "o", repository: "r", number: 9 }),
+        canonical_url: "https://github.com/o/r/issues/9",
+      }),
+    ]);
+
+    expect(out).toEqual([
+      {
+        provider: "github",
+        resourceType: "item",
+        coordinate: "o/r#9",
+        canonicalUrl: "https://github.com/o/r/pull/9",
+        title: "Ship gallery parity",
+        kind: "pull",
+      },
+    ]);
+  });
+
+  it("keeps bare references when resolve returns null / times out", async () => {
+    vi.spyOn(titles, "withPublicTitleBudget").mockResolvedValue(null);
+
+    const out = await enrichPublicReferences({ GITHUB_CACHE: new FakeKv() } as unknown as Env, [
+      ref({
+        locator_json: JSON.stringify({ owner: "o", repository: "r", number: 9 }),
+        canonical_url: "https://github.com/o/r/issues/9",
+      }),
+    ]);
+
+    expect(out).toEqual([
+      {
+        provider: "github",
+        resourceType: "item",
+        coordinate: "o/r#9",
+        canonicalUrl: "https://github.com/o/r/issues/9",
+      },
+    ]);
+  });
+});

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -4,6 +4,8 @@ import {
   ServiceUnavailableError,
   ValidationError,
 } from "@uploads/errors";
+import { publicObjectDateFields } from "./files-core";
+import { displayTitle } from "./file-metadata";
 import {
   type GalleryCursor,
   type GalleryItemRecord,
@@ -13,9 +15,18 @@ import {
   type PublicGallery,
   projectPublicGallery,
 } from "./galleries";
+import { resolveTitles, withPublicTitleBudget, type TitleInfo } from "./github-titles";
 import { objectPublicUrls, storage, storageConfig } from "./storage";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
+
+/** Fields we read from a Files SDK head when hydrating gallery items. */
+type GalleryObjectHead = {
+  type?: string;
+  size?: number;
+  lastModified?: number;
+  metadata?: Record<string, string>;
+};
 
 export interface GalleryItemDto {
   id: string;
@@ -31,6 +42,10 @@ export interface GalleryItemDto {
   pageUrl: string;
   contentType: string | null;
   size: number | null;
+  /** First-upload ISO when known from object head; null for missing items. */
+  uploaded: string | null;
+  /** Last-modified ISO when it meaningfully differs from uploaded; else null. */
+  modified: string | null;
 }
 export interface PublicGalleryItemDto {
   id: string;
@@ -42,6 +57,12 @@ export interface PublicGalleryItemDto {
   url: string | null;
   embedUrl: string | null;
   contentType: string | null;
+  /** Byte size when available; null for missing/tombstone items. */
+  size: number | null;
+  /** First-upload time when known; omitted when unavailable. */
+  uploaded?: string;
+  /** Distinct last-modified when it differs from uploaded. */
+  modified?: string;
 }
 export interface GalleryDto {
   id: string;
@@ -77,6 +98,10 @@ export interface PublicGalleryReferenceDto {
   resourceType: string;
   coordinate: string;
   canonicalUrl: string | null;
+  /** Live-resolved (or cached) GitHub title when available. */
+  title?: string;
+  /** pull vs issue when title resolve (or URL path) knows; drives the chip glyph. */
+  kind?: "pull" | "issue";
 }
 export interface ExternalReferenceDto {
   id: string;
@@ -236,10 +261,10 @@ export async function hydrateGalleryItems(
     });
   }
   return mapBounded(items, 8, async (item) => {
-    let meta: { type?: string; size?: number } | null;
+    let meta: GalleryObjectHead | null;
     try {
       meta = (await store.exists(item.object_key))
-        ? ((await store.head(item.object_key)) as { type?: string; size?: number })
+        ? ((await store.head(item.object_key)) as GalleryObjectHead)
         : null;
     } catch (cause) {
       throw new ServiceUnavailableError("Gallery storage unavailable.", {
@@ -254,6 +279,7 @@ export async function hydrateGalleryItems(
       throw new ServiceUnavailableError("Gallery object is not publicly served.", {
         code: "gallery_object_not_public",
       });
+    const dates = meta ? publicObjectDateFields(meta) : {};
     return {
       id: item.id,
       objectKey: item.object_key,
@@ -266,6 +292,8 @@ export async function hydrateGalleryItems(
       embedUrl: urls.embedUrl,
       contentType: meta?.type ?? null,
       size: meta?.size ?? null,
+      uploaded: dates.uploaded ?? null,
+      modified: dates.modified ?? null,
     };
   });
 }
@@ -317,6 +345,51 @@ export async function hydrateOwnerGallery(
   };
 }
 
+/** Rewrite `owner/repo#N` to a pull URL when title resolve says it's a PR. */
+function githubPullUrl(coordinate: string): string | null {
+  const match = /^([^/]+)\/([^#]+)#([1-9][0-9]*)$/.exec(coordinate);
+  if (!match) return null;
+  return `https://github.com/${match[1]}/${match[2]}/pull/${match[3]}`;
+}
+
+/**
+ * Overlay live/cached GitHub titles onto public gallery references.
+ * Failures and budget timeouts never fail the public gallery response.
+ */
+export async function enrichPublicReferences(
+  env: Env,
+  references: GalleryExternalReferenceRecord[],
+): Promise<PublicGalleryReferenceDto[]> {
+  const base = references.map(publicReferenceDto);
+  const githubRefs = [
+    ...new Set(
+      base
+        .filter((ref) => ref.provider.toLowerCase() === "github")
+        .map((ref) => ref.coordinate.toLowerCase()),
+    ),
+  ];
+  if (githubRefs.length === 0) return base;
+
+  // Missing GITHUB_CACHE / App misconfig / transient / budget — keep bare refs.
+  const titles: Record<string, TitleInfo | null> =
+    (await withPublicTitleBudget(resolveTitles(env, githubRefs)).catch(() => null)) ?? {};
+
+  return base.map((ref) => {
+    if (ref.provider.toLowerCase() !== "github") return ref;
+    const info = titles[ref.coordinate.toLowerCase()];
+    if (!info) return ref;
+    const title = displayTitle(info.title);
+    // Prefer pull URL when resolve knows it's a PR (API always stamps /issues/).
+    const pullUrl = info.kind === "pull" ? githubPullUrl(ref.coordinate) : null;
+    return {
+      ...ref,
+      ...(title ? { title } : {}),
+      kind: info.kind,
+      canonicalUrl: pullUrl ?? ref.canonicalUrl,
+    };
+  });
+}
+
 export async function hydratePublicGallery(
   env: Env,
   workspace: WorkspaceRecord,
@@ -324,7 +397,10 @@ export async function hydratePublicGallery(
   items: GalleryItemRecord[],
   references: GalleryExternalReferenceRecord[] = [],
 ): Promise<PublicGalleryDto> {
-  const hydrated = await hydrateGalleryItems(env, workspace, items);
+  const [hydrated, publicReferences] = await Promise.all([
+    hydrateGalleryItems(env, workspace, items),
+    enrichPublicReferences(env, references),
+  ]);
   return {
     ...projectPublicGallery(record),
     items: hydrated.map((item) => ({
@@ -337,7 +413,10 @@ export async function hydratePublicGallery(
       url: item.url,
       embedUrl: item.embedUrl,
       contentType: item.contentType,
+      size: item.size,
+      ...(item.uploaded ? { uploaded: item.uploaded } : {}),
+      ...(item.modified ? { modified: item.modified } : {}),
     })),
-    references: references.map(publicReferenceDto),
+    references: publicReferences,
   };
 }

--- a/apps/api/src/github-titles.ts
+++ b/apps/api/src/github-titles.ts
@@ -119,6 +119,31 @@ async function resolveOne(
   return null;
 }
 
+/**
+ * Cap live GitHub title resolve on public share/gallery JSON paths only.
+ * `resolveTitles` can spend up to ~8s per hop; apps/web aborts at 4s.
+ * Member-rail `/me` keeps the full resolve budget.
+ */
+export const PUBLIC_TITLE_RESOLVE_BUDGET_MS = 1400;
+
+/** Race work against the public title budget; null on timeout (errors propagate). */
+export async function withPublicTitleBudget<T>(
+  work: Promise<T>,
+  budgetMs: number = PUBLIC_TITLE_RESOLVE_BUDGET_MS,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), budgetMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 /** Batch resolve; misses fetch concurrently; a per-ref failure is that ref's `null`. */
 export async function resolveTitles(
   env: Env,

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,62 +1,12 @@
 import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import type { Files } from "@uploads/storage";
-import { badKey, downloadResponse, UPLOADED_AT_META_KEY } from "../files-core";
-import { getFileMetadata, META_VALUE_MAX } from "../file-metadata";
-import { resolveTitles } from "../github-titles";
+import { badKey, downloadResponse, publicObjectDateFields } from "../files-core";
+import { displayTitle, getFileMetadata } from "../file-metadata";
+import { resolveTitles, withPublicTitleBudget } from "../github-titles";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
-
-/** Same-second tolerance so storage noise does not force dual fields. */
-const DATE_EQUAL_MS = 1000;
-
-/**
- * Cap live GitHub title resolve on the public share JSON path only.
- * `resolveTitles` can spend up to ~8s per hop; apps/web aborts at 4s.
- * Member-rail `/me` keeps the full resolve budget.
- */
-const PUBLIC_TITLE_RESOLVE_BUDGET_MS = 1400;
-
-/**
- * Prefer `uploaded-at` stamp; fall back to provider `lastModified`.
- * Emit `modified` only when mtime meaningfully differs (fresh put → single field).
- */
-function publicDateFields(meta: { lastModified?: number; metadata?: Record<string, string> }): {
-  uploaded?: string;
-  modified?: string;
-} {
-  const modifiedIso =
-    meta.lastModified != null && Number.isFinite(meta.lastModified)
-      ? new Date(meta.lastModified).toISOString()
-      : undefined;
-  const stamped = meta.metadata?.[UPLOADED_AT_META_KEY];
-  const uploadedIso =
-    typeof stamped === "string" && Number.isFinite(Date.parse(stamped))
-      ? new Date(stamped).toISOString()
-      : modifiedIso;
-
-  if (!uploadedIso) return {};
-  if (!modifiedIso || Math.abs(Date.parse(modifiedIso) - Date.parse(uploadedIso)) < DATE_EQUAL_MS) {
-    return { uploaded: uploadedIso };
-  }
-  return { uploaded: uploadedIso, modified: modifiedIso };
-}
-
-/** Race work against the public title budget; null on timeout (errors propagate). */
-async function withPublicTitleBudget<T>(work: Promise<T>): Promise<T | null> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      work,
-      new Promise<null>((resolve) => {
-        timer = setTimeout(() => resolve(null), PUBLIC_TITLE_RESOLVE_BUDGET_MS);
-      }),
-    ]);
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-  }
-}
 
 type GithubKind = "pull" | "issue";
 
@@ -76,13 +26,6 @@ const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 const POSITIVE_INT_RE = /^[1-9][0-9]*$/;
 /** Lowercased `owner/repo#number` — same shape as CLI `gh.ref` / resolveTitles keys. */
 const GH_REF_RE = /^[a-z0-9._-]+\/[a-z0-9._-]+#[1-9][0-9]*$/;
-
-/** Cap titles to the same bound as stored metadata values (META_VALUE_MAX). */
-function displayTitle(raw: string | undefined): string | undefined {
-  const t = raw?.trim();
-  if (!t) return undefined;
-  return t.length > META_VALUE_MAX ? t.slice(0, META_VALUE_MAX) : t;
-}
 
 /**
  * Derives the `github` convenience object from `gh.repo`/`gh.kind`/`gh.number`
@@ -235,7 +178,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     embedUrl: urls.embedUrl,
     size: meta.size ?? 0,
     contentType: meta.type ?? "application/octet-stream",
-    ...publicDateFields(meta),
+    ...publicObjectDateFields(meta),
     ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     ...(github ? { github } : {}),
   });

--- a/apps/api/test/files-core-uploaded-at.test.ts
+++ b/apps/api/test/files-core-uploaded-at.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveUploadedAtMeta, UPLOADED_AT_META_KEY } from "../src/files-core";
+import {
+  publicObjectDateFields,
+  resolveUploadedAtMeta,
+  UPLOADED_AT_META_KEY,
+} from "../src/files-core";
 
 describe("resolveUploadedAtMeta", () => {
   const now = new Date("2026-07-20T12:00:00.000Z");
@@ -36,5 +40,35 @@ describe("resolveUploadedAtMeta", () => {
 
   it("ignores non-finite lastModified and falls back to now", () => {
     expect(resolveUploadedAtMeta({ lastModified: Number.NaN }, now)).toBe(now.toISOString());
+  });
+});
+
+describe("publicObjectDateFields", () => {
+  it("emits only uploaded when stamp and mtime match", () => {
+    const t = Date.parse("2026-07-20T12:00:00.000Z");
+    expect(
+      publicObjectDateFields({
+        lastModified: t,
+        metadata: { [UPLOADED_AT_META_KEY]: new Date(t).toISOString() },
+      }),
+    ).toEqual({ uploaded: new Date(t).toISOString() });
+  });
+
+  it("emits modified when mtime differs from the stamp", () => {
+    const uploaded = "2026-01-01T00:00:00.000Z";
+    const modified = Date.parse("2026-07-20T12:00:00.000Z");
+    expect(
+      publicObjectDateFields({
+        lastModified: modified,
+        metadata: { [UPLOADED_AT_META_KEY]: uploaded },
+      }),
+    ).toEqual({ uploaded, modified: new Date(modified).toISOString() });
+  });
+
+  it("falls back to lastModified when stamp is missing", () => {
+    const lm = Date.parse("2026-03-01T00:00:00.000Z");
+    expect(publicObjectDateFields({ lastModified: lm, metadata: {} })).toEqual({
+      uploaded: new Date(lm).toISOString(),
+    });
   });
 });

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -453,24 +453,35 @@ describe("gallery routes with SQLite D1", () => {
     expect(publicBody).not.toHaveProperty("workspace");
     expect(publicBody).not.toHaveProperty("deletedAt");
     const publicItem = (publicBody.items as Record<string, unknown>[])[0];
-    expect(Object.keys(publicItem)).toEqual([
-      "id",
-      "filename",
-      "position",
-      "caption",
-      "altText",
-      "status",
-      "url",
-      "embedUrl",
-      "contentType",
-    ]);
+    // size + uploaded are always present for available objects; modified only
+    // when it meaningfully differs from uploaded (publicObjectDateFields).
+    expect(Object.keys(publicItem).sort()).toEqual(
+      [
+        "id",
+        "filename",
+        "position",
+        "caption",
+        "altText",
+        "status",
+        "url",
+        "embedUrl",
+        "contentType",
+        "size",
+        "uploaded",
+        ...(publicItem.modified !== undefined ? ["modified"] : []),
+      ].sort(),
+    );
     expect(publicItem).toMatchObject({
       filename: "one.png",
       contentType: "application/octet-stream",
       status: "available",
       caption: "Launch",
       altText: "Screenshot",
+      size: expect.any(Number),
+      uploaded: expect.any(String),
     });
+    expect(publicItem.size).toBeGreaterThan(0);
+    expect(Number.isFinite(Date.parse(publicItem.uploaded as string))).toBe(true);
     const removed = await request(`/v1/alpha/galleries/${gallery.id}`, {
       method: "DELETE",
       body: JSON.stringify({ expectedVersion: 2 }),
@@ -548,22 +559,27 @@ describe("gallery routes with SQLite D1", () => {
     expect(publicView.status).toBe(200);
     const publicBody = (await publicView.json()) as { references: Record<string, unknown>[] };
     expect(publicBody.references).toHaveLength(2);
+    // Without GitHub App/cache in the test env, titles/kind stay omitted.
     expect(publicBody.references).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           provider: "github",
           resourceType: "item",
           coordinate: "buildinternet/uploads#123",
           canonicalUrl: "https://github.com/buildinternet/uploads/issues/123",
-        },
-        {
+        }),
+        expect.objectContaining({
           provider: "github",
           resourceType: "item",
           coordinate: "buildinternet/new-uploads#123",
           canonicalUrl: "https://github.com/buildinternet/new-uploads/issues/123",
-        },
+        }),
       ]),
     );
+    for (const ref of publicBody.references) {
+      expect(ref).not.toHaveProperty("title");
+      expect(ref).not.toHaveProperty("kind");
+    }
 
     const secondGallery = await create();
     expect(

--- a/apps/web/src/components/GalleryReferences.astro
+++ b/apps/web/src/components/GalleryReferences.astro
@@ -1,32 +1,177 @@
 ---
+/**
+ * Connected work items for public gallery pages.
+ *
+ * Renders GitHub refs as the same chip shape the public file share page uses
+ * for `file.github` (kind icon + optional title + `owner/repo#N`). Non-github
+ * providers stay as provider + coordinate.
+ *
+ * `variant`:
+ *   - `panel` (default) — bordered block under the gallery index / full page
+ *   - `inline` — chips inside the item-page details rail (no outer card)
+ */
+import { GH_KIND_PATH, GITHUB_MARK_PATH } from "../lib/brand-icons";
+import { galleryReferenceChip } from "../lib/gallery-reference-chip";
 import type { PublicGalleryReference } from "../lib/public-gallery";
 
 interface Props {
   references: PublicGalleryReference[];
+  variant?: "panel" | "inline";
 }
 
-const { references } = Astro.props;
+const { references, variant = "panel" } = Astro.props;
+const chips = references.map(galleryReferenceChip);
+const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
 ---
 
-{references.length > 0 && (
-  <aside class="refs">
-    <h2>Connected work items</h2>
-    <ul>
-      {references.map((reference) => (
-        <li>
-          <span class="provider">{reference.provider}</span>
-          {reference.canonicalUrl ? <a href={reference.canonicalUrl} rel="noopener noreferrer">{reference.coordinate}</a> : reference.coordinate}
-        </li>
-      ))}
-    </ul>
-  </aside>
-)}
+{
+  chips.length > 0 && (
+    <aside class={refsClass}>
+      <h2>Connected work items</h2>
+      <ul>
+        {chips.map((chip) => (
+          <li>
+            {chip.href ? (
+              <a
+                class="gh-chip"
+                href={chip.href}
+                rel="noopener noreferrer"
+                aria-label={chip.ariaLabel}
+              >
+                {chip.glyph === "kind" && chip.kind && (
+                  <svg
+                    class="gh-chip-icon"
+                    viewBox="0 0 16 16"
+                    width="14"
+                    height="14"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <title>{chip.kindLabel}</title>
+                    <path fill="currentColor" d={GH_KIND_PATH[chip.kind]} />
+                  </svg>
+                )}
+                {chip.glyph === "github-mark" && (
+                  <svg
+                    class="gh-chip-icon"
+                    viewBox="0 0 24 24"
+                    width="14"
+                    height="14"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path fill="currentColor" d={GITHUB_MARK_PATH} />
+                  </svg>
+                )}
+                {chip.glyph === "provider" && <span class="provider">{chip.provider}</span>}
+                <span class="gh-chip-text">
+                  {chip.title ? (
+                    <>
+                      <span class="gh-chip-title">{chip.title}</span>
+                      <span class="gh-chip-ref">{chip.coordinate}</span>
+                    </>
+                  ) : (
+                    <span class="gh-chip-name">{chip.coordinate}</span>
+                  )}
+                </span>
+              </a>
+            ) : (
+              <span class="gh-chip gh-chip--static">
+                <span class="provider">{chip.provider}</span>
+                <span class="gh-chip-name">{chip.coordinate}</span>
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}
 
 <style>
-  .refs { margin:30px 0 0; padding:16px 18px; border:1px solid var(--line); border-radius:10px; background:var(--panel); }
-  .refs h2 { margin:0 0 10px; color:var(--muted); font:11px var(--mono); letter-spacing:.14em; text-transform:uppercase; font-weight:600; }
-  .refs ul { margin:0; padding:0; list-style:none; display:flex; flex-direction:column; gap:8px; }
-  .refs li { font:13px var(--mono); color:var(--body); overflow-wrap:anywhere; }
-  .refs .provider { color:var(--muted); margin-right:8px; }
-  a { color:var(--fg); text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent); text-underline-offset:3px; }
+  .refs {
+    margin: 30px 0 0;
+    padding: 16px 18px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg, 10px);
+    background: var(--panel);
+  }
+  /* Nested inside the item-page rail — drop the outer card so chips sit like
+     the file share page's gh-chip under the filename. */
+  .refs--inline {
+    margin: 0 0 12px;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+  }
+  .refs h2 {
+    margin: 0 0 10px;
+    color: var(--muted);
+    font: 11px var(--mono);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+  .refs--inline h2 {
+    margin: 0 0 8px;
+    letter-spacing: 0.08em;
+  }
+  .refs ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+  .gh-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: var(--panel);
+    color: var(--fg);
+    font: 12px var(--mono);
+    text-decoration: none;
+    max-width: 100%;
+  }
+  a.gh-chip:hover,
+  a.gh-chip:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent);
+    outline: none;
+  }
+  .gh-chip--static {
+    color: var(--body);
+  }
+  .gh-chip-icon {
+    flex: none;
+  }
+  .gh-chip-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .gh-chip-title {
+    overflow-wrap: anywhere;
+    font-weight: 600;
+  }
+  .gh-chip-ref {
+    color: var(--muted);
+    font-size: 11px;
+    overflow-wrap: anywhere;
+  }
+  .gh-chip-name {
+    overflow-wrap: anywhere;
+  }
+  .provider {
+    color: var(--muted);
+    font: 11px var(--mono);
+    text-transform: lowercase;
+  }
 </style>

--- a/apps/web/src/lib/gallery-reference-chip.test.ts
+++ b/apps/web/src/lib/gallery-reference-chip.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { galleryReferenceChip, kindFromCanonicalUrl } from "./gallery-reference-chip";
+
+describe("kindFromCanonicalUrl", () => {
+  it("detects pull vs issue from the path", () => {
+    expect(kindFromCanonicalUrl("https://github.com/buildinternet/uploads/pull/66")).toBe("pull");
+    expect(kindFromCanonicalUrl("https://github.com/buildinternet/uploads/issues/66")).toBe(
+      "issue",
+    );
+  });
+
+  it("returns null for missing, non-github, or unrecognised paths", () => {
+    expect(kindFromCanonicalUrl(null)).toBeNull();
+    expect(kindFromCanonicalUrl("https://example.com/issues/1")).toBeNull();
+    expect(kindFromCanonicalUrl("https://github.com/buildinternet/uploads")).toBeNull();
+    expect(kindFromCanonicalUrl("not a url")).toBeNull();
+  });
+});
+
+describe("galleryReferenceChip", () => {
+  it("builds a kind-aware github chip from the canonical URL", () => {
+    const chip = galleryReferenceChip({
+      provider: "github",
+      resourceType: "item",
+      coordinate: "buildinternet/uploads#66",
+      canonicalUrl: "https://github.com/buildinternet/uploads/issues/66",
+    });
+    expect(chip.kind).toBe("issue");
+    expect(chip.kindLabel).toBe("issue");
+    expect(chip.glyph).toBe("kind");
+    expect(chip.title).toBeNull();
+    expect(chip.coordinate).toBe("buildinternet/uploads#66");
+    expect(chip.href).toBe("https://github.com/buildinternet/uploads/issues/66");
+    expect(chip.ariaLabel).toBe("issue buildinternet/uploads#66 on GitHub");
+  });
+
+  it("prefers API kind + title over URL path", () => {
+    const chip = galleryReferenceChip({
+      provider: "github",
+      resourceType: "item",
+      coordinate: "o/r#9",
+      // API historically stamps /issues/ even for PRs; kind from resolve wins.
+      canonicalUrl: "https://github.com/o/r/issues/9",
+      kind: "pull",
+      title: "Gallery item parity",
+    });
+    expect(chip.kind).toBe("pull");
+    expect(chip.kindLabel).toBe("pull request");
+    expect(chip.glyph).toBe("kind");
+    expect(chip.title).toBe("Gallery item parity");
+    expect(chip.ariaLabel).toBe("pull request Gallery item parity (o/r#9) on GitHub");
+  });
+
+  it("labels pull requests when the URL path says so", () => {
+    const chip = galleryReferenceChip({
+      provider: "GitHub",
+      resourceType: "item",
+      coordinate: "o/r#9",
+      canonicalUrl: "https://github.com/o/r/pull/9",
+    });
+    expect(chip.kind).toBe("pull");
+    expect(chip.kindLabel).toBe("pull request");
+    expect(chip.glyph).toBe("kind");
+    expect(chip.ariaLabel).toBe("pull request o/r#9 on GitHub");
+  });
+
+  it("leaves non-github providers as plain chips without a kind", () => {
+    const chip = galleryReferenceChip({
+      provider: "linear",
+      resourceType: "issue",
+      coordinate: "UP-1",
+      canonicalUrl: "https://linear.app/team/issue/UP-1",
+    });
+    expect(chip.kind).toBeNull();
+    expect(chip.kindLabel).toBeNull();
+    expect(chip.glyph).toBe("provider");
+    expect(chip.provider).toBe("linear");
+    expect(chip.ariaLabel).toBe("linear UP-1");
+  });
+
+  it("falls back to the GitHub mark when kind is unknown", () => {
+    const chip = galleryReferenceChip({
+      provider: "github",
+      resourceType: "item",
+      coordinate: "o/r#9",
+      canonicalUrl: "https://github.com/o/r",
+    });
+    expect(chip.kind).toBeNull();
+    expect(chip.glyph).toBe("github-mark");
+    expect(chip.ariaLabel).toBe("GitHub o/r#9");
+  });
+});

--- a/apps/web/src/lib/gallery-reference-chip.ts
+++ b/apps/web/src/lib/gallery-reference-chip.ts
@@ -1,0 +1,99 @@
+/**
+ * Present gallery external references the same way the public file page
+ * presents `file.github` — a chip with a kind icon (PR vs issue), optional
+ * title, and `owner/repo#N`.
+ *
+ * Kind preference: API-provided `kind` (from title resolve) → path on
+ * `canonicalUrl` (`/pull/` vs `/issues/`) → null (GitHub mark only).
+ */
+
+import type { PublicGalleryReference } from "./public-gallery";
+
+export type GalleryReferenceKind = "pull" | "issue";
+
+/** Which glyph the chip should render in the leading slot. */
+export type GalleryReferenceGlyph = "kind" | "github-mark" | "provider";
+
+export interface GalleryReferenceChip {
+  provider: string;
+  coordinate: string;
+  href: string | null;
+  title: string | null;
+  /** Present for github refs when we can show a kind-aware chip. */
+  kind: GalleryReferenceKind | null;
+  kindLabel: "pull request" | "issue" | null;
+  /** Leading icon choice for the template (avoids nested ternaries in Astro). */
+  glyph: GalleryReferenceGlyph;
+  ariaLabel: string;
+}
+
+function kindLabelFor(kind: GalleryReferenceKind | null): "pull request" | "issue" | null {
+  if (kind === "pull") return "pull request";
+  if (kind === "issue") return "issue";
+  return null;
+}
+
+function githubAriaLabel(
+  kindLabel: "pull request" | "issue" | null,
+  title: string | null,
+  coordinate: string,
+): string {
+  if (kindLabel && title) return `${kindLabel} ${title} (${coordinate}) on GitHub`;
+  if (kindLabel) return `${kindLabel} ${coordinate} on GitHub`;
+  if (title) return `GitHub ${title} (${coordinate})`;
+  return `GitHub ${coordinate}`;
+}
+
+/** Map one public gallery reference into chip presentation fields. */
+export function galleryReferenceChip(reference: PublicGalleryReference): GalleryReferenceChip {
+  const coordinate = reference.coordinate;
+  const href = reference.canonicalUrl;
+  const provider = reference.provider;
+  const title =
+    typeof reference.title === "string" && reference.title.trim() ? reference.title.trim() : null;
+
+  if (provider.toLowerCase() !== "github") {
+    return {
+      provider,
+      coordinate,
+      href,
+      title,
+      kind: null,
+      kindLabel: null,
+      glyph: "provider",
+      ariaLabel: href ? `${provider} ${coordinate}` : `${provider} ${coordinate} (no link)`,
+    };
+  }
+
+  const kind =
+    reference.kind === "pull" || reference.kind === "issue"
+      ? reference.kind
+      : kindFromCanonicalUrl(href);
+  const kindLabel = kindLabelFor(kind);
+
+  return {
+    provider: "github",
+    coordinate,
+    href,
+    title,
+    kind,
+    kindLabel,
+    glyph: kind ? "kind" : "github-mark",
+    ariaLabel: githubAriaLabel(kindLabel, title, coordinate),
+  };
+}
+
+/** Prefer `/pull/` over `/issues/` path segments; null when the URL is missing or ambiguous. */
+export function kindFromCanonicalUrl(url: string | null): GalleryReferenceKind | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.toLowerCase() !== "github.com") return null;
+    // /owner/repo/pull/123 or /owner/repo/issues/123
+    if (/\/pull\/[1-9][0-9]*\/?$/.test(parsed.pathname)) return "pull";
+    if (/\/issues\/[1-9][0-9]*\/?$/.test(parsed.pathname)) return "issue";
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -28,6 +28,8 @@ const gallery = {
       url: "https://storage.uploads.sh/screen.png",
       embedUrl: "https://embed.uploads.sh/screen.png" as string | null,
       contentType: "image/png",
+      size: 20480,
+      uploaded: "2026-07-13T12:00:00.000Z",
     },
   ],
   references: [
@@ -36,6 +38,8 @@ const gallery = {
       resourceType: "item",
       coordinate: "buildinternet/uploads#123",
       canonicalUrl: "https://github.com/buildinternet/uploads/issues/123",
+      kind: "issue" as const,
+      title: "Gallery smoke",
     },
   ],
 } as const;
@@ -129,6 +133,42 @@ describe("public gallery API", () => {
       isPublicGallery({
         ...gallery,
         references: Array.from({ length: 21 }, () => gallery.references[0]),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts size/date fields and optional reference title/kind; rejects bad values", () => {
+    expect(
+      isPublicGallery({
+        ...gallery,
+        items: [{ ...gallery.items[0], size: null, uploaded: null, modified: null }],
+      }),
+    ).toBe(true);
+    // Older deploys omit size/uploaded entirely.
+    const { size: _s, uploaded: _u, ...legacyItem } = gallery.items[0];
+    expect(isPublicGallery({ ...gallery, items: [legacyItem] })).toBe(true);
+    expect(
+      isPublicGallery({
+        ...gallery,
+        items: [{ ...gallery.items[0], size: -1 }],
+      }),
+    ).toBe(false);
+    expect(
+      isPublicGallery({
+        ...gallery,
+        items: [{ ...gallery.items[0], uploaded: "not-a-date" }],
+      }),
+    ).toBe(false);
+    expect(
+      isPublicGallery({
+        ...gallery,
+        references: [{ ...gallery.references[0], kind: "wiki" }],
+      }),
+    ).toBe(false);
+    expect(
+      isPublicGallery({
+        ...gallery,
+        references: [{ ...gallery.references[0], title: "" }],
       }),
     ).toBe(false);
   });

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -11,6 +11,12 @@ export interface PublicGalleryItem {
   /** Embed-host URL when the dual-host policy applies; null otherwise. Always present (see gallery-service.ts). */
   embedUrl: string | null;
   contentType: string | null;
+  /** Byte size when available; null for missing/tombstone items. */
+  size: number | null;
+  /** First-upload ISO when known; omitted when unavailable. */
+  uploaded?: string | null;
+  /** Distinct last-modified ISO when it differs from uploaded. */
+  modified?: string | null;
 }
 
 export interface PublicGalleryReference {
@@ -18,6 +24,10 @@ export interface PublicGalleryReference {
   resourceType: string;
   coordinate: string;
   canonicalUrl: string | null;
+  /** Live-resolved GitHub title when the API enriched the reference. */
+  title?: string;
+  /** pull vs issue when known (title resolve or URL path). */
+  kind?: "pull" | "issue";
 }
 
 export interface PublicGallery {
@@ -128,6 +138,12 @@ function safeUrl(value: unknown): value is string | null {
   }
 }
 
+/** Optional public date field: omitted, null, or a parseable ISO string. */
+function optionalIsoDate(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  return text(value, 64) && Number.isFinite(Date.parse(value));
+}
+
 export function isPublicGallery(value: unknown): value is PublicGallery {
   if (typeof value !== "object" || value === null) return false;
   const gallery = value as Record<string, unknown>;
@@ -154,11 +170,18 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
     const referencesValid = gallery.references.every((entry) => {
       if (typeof entry !== "object" || entry === null) return false;
       const reference = entry as Record<string, unknown>;
+      const titleOk =
+        reference.title === undefined ||
+        (text(reference.title, 512) && (reference.title as string).length > 0);
+      const kindOk =
+        reference.kind === undefined || reference.kind === "pull" || reference.kind === "issue";
       return (
         text(reference.provider, 40) &&
         text(reference.resourceType, 40) &&
         text(reference.coordinate, 200) &&
-        safeUrl(reference.canonicalUrl)
+        safeUrl(reference.canonicalUrl) &&
+        titleOk &&
+        kindOk
       );
     });
     if (!referencesValid) return false;
@@ -167,6 +190,11 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
   return gallery.items.every((entry) => {
     if (typeof entry !== "object" || entry === null) return false;
     const item = entry as Record<string, unknown>;
+    // Older API deploys omit size/uploaded/modified — accept either shape.
+    const sizeOk =
+      item.size === undefined ||
+      item.size === null ||
+      (Number.isSafeInteger(item.size) && (item.size as number) >= 0);
     return (
       text(item.id, 64) &&
       text(item.filename, 1024) &&
@@ -178,6 +206,9 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
       safeUrl(item.url) &&
       safeUrl(item.embedUrl) &&
       nullableText(item.contentType, 128) &&
+      sizeOk &&
+      optionalIsoDate(item.uploaded) &&
+      optionalIsoDate(item.modified) &&
       (item.status === "missing" ? item.url === null : item.url !== null)
     );
   });

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -6,6 +6,12 @@ import Footer from "../../../components/Footer.astro";
 import GalleryReferences from "../../../components/GalleryReferences.astro";
 import { buildEmbedFormats, type EmbedFormatOption } from "../../../lib/embed-formats";
 import {
+  formatBytes,
+  formatFileDate,
+  sameUtcDay,
+  shouldShowModified,
+} from "../../../lib/public-file";
+import {
   applyPublicGalleryHeaders,
   fetchPublicGallery,
   galleryItemDownloadUrl,
@@ -59,6 +65,17 @@ const downloadUrl =
   item && item.status === "available" ? galleryItemDownloadUrl(origin, id, item.id) : null;
 const oembedHref =
   gallery && item ? oembedDiscoveryHref(canonical, Astro.url.origin) : null;
+const uploadedIso = item?.uploaded ?? null;
+const modifiedIso = item?.modified ?? null;
+const showModified = shouldShowModified(uploadedIso, modifiedIso);
+const withTime = Boolean(
+  showModified && uploadedIso && modifiedIso && sameUtcDay(uploadedIso, modifiedIso),
+);
+const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime }) : null;
+const modifiedLabel =
+  showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime }) : null;
+const sizeLabel =
+  item && item.size != null && Number.isSafeInteger(item.size) ? formatBytes(item.size) : null;
 ---
 
 <!doctype html>
@@ -86,39 +103,57 @@ const oembedHref =
       * { box-sizing:border-box; }
       body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }
       .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
-      nav { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
+      nav.top { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
-      .crumbs { margin-bottom:20px; color:var(--muted); font:13px var(--mono); overflow-wrap:anywhere; }
+      .crumbs { margin-bottom:12px; color:var(--muted); font:13px var(--mono); overflow-wrap:anywhere; }
+      .crumbs .count { color:var(--muted); }
+      .filetitle { margin:0 0 16px; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
       .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
       .media { min-height:320px; max-height:78vh; background:var(--bg); display:grid; place-items:center; overflow:hidden; }
       img,video { max-width:100%; max-height:78vh; width:auto; height:auto; object-fit:contain; display:block; }
       .fallback { padding:60px 30px; text-align:center; color:var(--muted); font:13px/1.6 var(--mono); }
-      .fallback strong { display:block; color:var(--red); margin-bottom:8px; }
+      .fallback strong { display:block; color:var(--fg); margin-bottom:8px; }
       .fallback a { color:var(--fg); overflow-wrap:anywhere; }
-      .details { padding:18px 20px 20px; border-top:1px solid var(--line); }
-      .filename { color:var(--fg); font:600 14px var(--mono); overflow-wrap:anywhere; }
-      .caption { margin-top:10px; color:var(--body); font-size:15px; line-height:1.6; white-space:pre-wrap; }
-      .original { display:inline-block; margin-top:12px; color:var(--muted); font:12px var(--mono); }
-      .original:hover, .original:focus-visible { color:var(--accent); outline:none; }
+      .details { padding:18px 20px 22px; border-top:1px solid var(--line); }
+      .caption { margin:0 0 12px; color:var(--body); font-size:15px; line-height:1.6; white-space:pre-wrap; }
+      dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:0 0 4px; font:12px var(--mono); }
+      dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
+      dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
       .pager { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:22px 0 0; font:13px var(--mono); }
       .pager a, .pager span.disabled { display:inline-block; padding:10px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); text-decoration:none; }
       .pager a:hover, .pager a:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
       .pager span.disabled { color:var(--muted); }
-      .count { color:var(--muted); }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
       a { color:var(--fg); text-decoration-color:color-mix(in srgb,var(--accent) 55%,transparent); text-underline-offset:3px; }
-      @media (max-width:760px) { .shell{width:min(100% - 32px,1080px);padding-top:24px} .media{min-height:220px} .pager a,.pager span.disabled{padding:8px 12px} }
-      .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); clip-path:inset(50%); white-space:nowrap; border:0; }
+      @media (min-width: 1080px) {
+        /* align with signed-in --bp-rail (1080px); media queries can't read custom props */
+        .shell { width: min(1200px, calc(100% - 48px)); }
+        .stage {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+        }
+        .details {
+          border-top: none;
+          border-left: 1px solid var(--line);
+          max-height: 78vh;
+          overflow: auto;
+        }
+      }
+      @media (max-width: 760px) {
+        .shell { width: min(100% - 32px, 1080px); padding-top: 24px; }
+        .media { min-height: 220px; }
+        .pager a, .pager span.disabled { padding: 8px 12px; }
+      }
     </style>
   </head>
   <body>
     <main class="shell">
-      <nav><Brand /><span class="public">public gallery</span></nav>
+      <nav class="top"><Brand /><span class="public">public gallery</span></nav>
       {gallery && item ? (
         <>
-          <h1 class="sr-only">{item.filename}</h1>
           <div class="crumbs"><a href={listPath}>{gallery.title}</a> · <span class="count">{index + 1} of {items.length}</span></div>
+          <h1 class="filetitle">{item.filename}</h1>
           <figure class="stage" style="margin:0">
             <div class="media">
               {kind(item) === "image" && <img src={item.url!} alt={item.altText ?? item.caption ?? item.filename} decoding="async" />}
@@ -128,13 +163,21 @@ const oembedHref =
               {kind(item) === "missing" && <div class="fallback"><strong>Removed or expired</strong><span>This item remains in the gallery to preserve its place.</span></div>}
             </div>
             <figcaption class="details" id="item-caption">
-              <div class="filename">{item.filename}</div>
+              <GalleryReferences references={gallery.references} variant="inline" />
               {item.caption && <div class="caption">{item.caption}</div>}
-              {item.status === "available" && kind(item) !== "unsupported" && (
-                <a class="original" href={item.url!} rel="noopener noreferrer">Open original</a>
+              {(sizeLabel || uploadedLabel || modifiedLabel) && (
+                <dl class="meta">
+                  {sizeLabel && (<><dt>Size</dt><dd>{sizeLabel}</dd></>)}
+                  {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
+                  {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}
+                </dl>
               )}
               {item.status === "available" && (
-                <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl} />
+                <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
+                  {kind(item) !== "unsupported" && item.url && (
+                    <a class="original" href={item.url} rel="noopener noreferrer">Open original ↗</a>
+                  )}
+                </CopyAsControls>
               )}
             </figcaption>
           </figure>
@@ -143,7 +186,6 @@ const oembedHref =
             <a href={listPath}>All items</a>
             {next ? <a href={itemPath(next)} rel="next">{next.filename} →</a> : <span class="disabled">End →</span>}
           </nav>
-          <GalleryReferences references={gallery.references} />
           <Footer />
         </>
       ) : (


### PR DESCRIPTION
## In plain terms

The public gallery item page now looks and behaves like the standalone file share page: a side rail on large screens, size/upload dates, GitHub PR/issue chips with titles when available, and the same Open original / Download / Copy as controls. Linked work items are no longer a plain text list.

## What it does

- **Layout:** gallery item page gets the ≥1080px media | rail layout (stacked on narrow viewports), with filename as a visible title
- **Actions:** Open original ↗ slots into `CopyAsControls` next to Download (same as `/f/…`)
- **Connected work:** GitHub references render as chips (kind icon + optional title + `owner/repo#N`); chips sit in the item rail; gallery index uses the same chip styling in a panel
- **API public gallery JSON:**
  - items: `size`, optional `uploaded` / `modified` (same rules as public files via shared `publicObjectDateFields`)
  - references: optional `title` + `kind` from live/cached `resolveTitles` (budgeted; never fails the gallery response); PR URLs rewritten from `/issues/` when kind is pull
- Shared helpers: `publicObjectDateFields`, `withPublicTitleBudget`, `displayTitle`

## What it is not

- Not a per-item GitHub context model (refs stay gallery-level)
- Does not backfill titles offline when the GitHub App/cache is unavailable (chips still work with `owner/repo#N`)
- No CLI/package version bump (web + API only)

## How to try it

Open a public gallery item that has a linked GitHub issue/PR, e.g.:

https://uploads.sh/g/gal_5dgl3TJzlXW6_CqTsTAo8Q/c12e8c0b-4101-4f7b-9385-24ce88c043b4

After deploy: expect chips (with title when resolve succeeds), size/uploaded in the rail, and wide-screen two-column layout.

## Technical notes

- `GET /public/galleries/:id` projection is additive only
- Title resolve reuses the public-file budget path so gallery SSR stays under web’s 4s fetch timeout
- Follow-up from the deferred “gallery parity” note in the file share rail design

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run test/routes-galleries.test.ts test/files-core-uploaded-at.test.ts test/routes-public-files.test.ts src/gallery-service-references.test.ts src/github-titles.test.ts`
- [x] `pnpm --filter @uploads/web exec vitest run src/lib/gallery-reference-chip.test.ts src/lib/public-gallery.test.ts`
- [x] Pre-commit types + lint-staged (oxlint/oxfmt)
- [ ] Manual: public gallery item page on a wide viewport with linked work