### PR TITLE
fix(web): restore full site footer spacing and width

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -5,9 +5,13 @@
  * bar with the maintainer credit + a cross-link to the sibling Build Internet
  * tool (releases.sh links back to us the same way).
  *
- * Full-bleed border; inner column is max-width + centered (same pattern as
- * releases.sh). Do not nest this inside a left-aligned content shell — place
- * it as a sibling of `.shell` so it centers on the viewport.
+ * Layout contract (mirrors releases.sh):
+ * - Full-bleed border; inner column is max-width + centered.
+ * - Place as a *sibling* of the content shell (`.shell`, `main`, `.docs-shell`),
+ *   not nested inside a max-width column — otherwise the footer shrinks with
+ *   the reading column and `margin-top: auto` has nothing to push against.
+ * - Body is a flex column (`min-height: 100dvh`); content shell is `flex: 1`;
+ *   footer uses `margin-top: auto` so short pages pin it to the viewport bottom.
  *
  * `compact` keeps the original one-liner for the centered auth/error cards.
  */
@@ -97,6 +101,9 @@ const COLUMNS: FooterColumn[] = [
 <style>
   .site-footer {
     width: 100%;
+    /* Sticky bottom when body is a flex column and a sibling content shell
+       has flex:1. When content is taller than the viewport this collapses to
+       0 — content shells supply their own bottom padding for breathing room. */
     margin-top: auto;
     border-top: 1px solid var(--line, #232327);
     color: var(--muted, #7d7d77);
@@ -104,12 +111,13 @@ const COLUMNS: FooterColumn[] = [
     letter-spacing: 0.01em;
     line-height: 1.7;
   }
-  /* Centered column — independent of any left-aligned account/admin shell. */
+  /* Centered column — independent of any left-aligned account/admin shell.
+     Vertical rhythm mirrors releases.sh (pt-10 / pb-6 on the link grid). */
   .site-footer__inner {
     width: 100%;
     max-width: var(--width-shell, 960px);
     margin: 0 auto;
-    padding: 0 20px 28px;
+    padding: 40px 24px 24px;
     box-sizing: border-box;
   }
   .site-footer.compact .site-footer__inner {
@@ -136,7 +144,6 @@ const COLUMNS: FooterColumn[] = [
     display: grid;
     grid-template-columns: 1.4fr 1fr 1fr;
     gap: 24px 32px;
-    padding: 24px 0 10px;
   }
   .wordmark {
     font-weight: 600;
@@ -146,30 +153,30 @@ const COLUMNS: FooterColumn[] = [
   .site-footer a.wordmark:hover,
   .site-footer a.wordmark:focus-visible { color: var(--accent, #c27eff); }
   .brand p {
-    margin: 4px 0 0;
+    margin: 8px 0 0;
     max-width: 30ch;
   }
   .col-title {
     font-size: 10.5px;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    margin-bottom: 8px;
+    margin-bottom: 12px;
   }
   .cols ul {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 3px;
+    gap: 8px;
   }
   .family {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    gap: 4px 24px;
+    gap: 8px 24px;
     border-top: 1px solid var(--line, #232327);
-    margin-top: 14px;
-    padding: 12px 0 0;
+    margin-top: 28px;
+    padding: 16px 0 0;
     font-size: 11.5px;
   }
   .family p {

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -90,12 +90,16 @@ const fullTitle = `${title} · uploads.sh`;
       }
 
       /* ---------- shell + three-column grid ----------
-         SiteHeader is full-bleed above; content column is constrained. */
+         SiteHeader is full-bleed above; content column is constrained.
+         Footer is a *sibling* of .docs-shell (body flex child), not nested
+         here — nesting would shrink the footer to the 1120px shell and leave
+         no gap between article end and the footer border. */
       .docs-shell {
         width: min(1120px, 100%);
         margin: 0 auto;
         padding: 32px 24px 64px;
-        flex: 1;
+        flex: 1 0 auto;
+        box-sizing: border-box;
       }
       .docs-grid {
         display: flex;
@@ -557,9 +561,9 @@ const fullTitle = `${title} · uploads.sh`;
           )
         }
       </div>
-
-      <Footer />
     </div>
+
+    <Footer />
 
     <script>
       // Module scripts run once per session; re-wire after every ClientRouter swap.

--- a/apps/web/src/layouts/ErrorLayout.astro
+++ b/apps/web/src/layouts/ErrorLayout.astro
@@ -106,12 +106,6 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
         border-color: var(--accent);
         outline: none;
       }
-      /* Full site footer under the card, same column width as legal pages. */
-      .error-foot {
-        width: min(var(--width-content, 720px), 100%);
-        margin: 0 auto;
-        padding: 0 24px 28px;
-      }
     </style>
   </head>
   <body>
@@ -135,8 +129,7 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
         </section>
       </div>
     </main>
-    <div class="error-foot">
-      <Footer />
-    </div>
+    {/* Full-bleed shell footer — sibling of main, same as legal/content pages. */}
+    <Footer />
   </body>
 </html>

--- a/apps/web/src/layouts/LegalLayout.astro
+++ b/apps/web/src/layouts/LegalLayout.astro
@@ -86,7 +86,8 @@ const authOrigin = import.meta.env.PUBLIC_UPLOADS_AUTH_ORIGIN ?? "https://auth.u
       <article>
         <slot />
       </article>
-      <Footer />
     </main>
+    {/* Sibling of main so the full-bleed footer centers on the viewport. */}
+    <Footer />
   </body>
 </html>

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -43,9 +43,19 @@ const authOrigin =
         font: 14px/1.5 var(--mono);
         font-variant-ligatures: none;
         font-feature-settings: "calt" 0, "liga" 0;
-        padding: 40px 24px 64px;
+        display: flex;
+        flex-direction: column;
+        padding: 0;
       }
-      main { width: min(var(--width-content, 720px), 100%); margin: 0 auto; display: grid; gap: 16px; }
+      main {
+        width: min(var(--width-content, 720px), 100%);
+        margin: 0 auto;
+        padding: 40px 24px 64px;
+        display: grid;
+        gap: 16px;
+        flex: 1 0 auto;
+        box-sizing: border-box;
+      }
       h1 { font-size: 1.15rem; font-weight: 600; margin: 0; }
       p.muted { color: var(--muted); margin: 0; font-size: 0.9rem; }
       label {
@@ -207,8 +217,8 @@ const authOrigin =
         </div>
       </section>
 
-      <Footer />
     </main>
+    <Footer />
     <script define:vars={{ authOrigin }}>
       window.__UPLOADS_AUTH_ORIGIN__ = authOrigin;
     </script>

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -111,8 +111,8 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
     )}
     <style>
       * { box-sizing:border-box; }
-      body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }
-      .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
+      body { margin:0; min-height:100dvh; color:var(--fg); background:var(--bg); font-family:var(--sans); display:flex; flex-direction:column; }
+      .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:0 auto; padding:36px 0 64px; flex:1 0 auto; box-sizing:border-box; }
       nav.top { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
       .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
@@ -230,7 +230,6 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
               </CopyAsControls>
             </figcaption>
           </figure>
-          <Footer />
         </>
       ) : result.status === "auth_required" ? (
         <section class="error" id="auth-required">
@@ -244,6 +243,7 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
         <section class="error"><code>{result.status === "unavailable" ? "file.unavailable" : "file.not_found"}</code><h1>{result.status === "unavailable" ? "File temporarily unavailable" : "File not found"}</h1><p>{result.status === "unavailable" ? "The file service could not be reached. Please try again shortly." : "This file may have been removed, or the link is incorrect."}</p></section>
       )}
     </main>
+    <Footer />
     {result.status === "auth_required" && (
       // Progressive-enhancement, client-side authorization path — a second
       // gate parallel to the server-side one this page already applied via

--- a/apps/web/src/pages/g/[id].astro
+++ b/apps/web/src/pages/g/[id].astro
@@ -55,8 +55,8 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
     )}
     <style>
       * { box-sizing:border-box; }
-      body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }
-      .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
+      body { margin:0; min-height:100dvh; color:var(--fg); background:var(--bg); font-family:var(--sans); display:flex; flex-direction:column; }
+      .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:0 auto; padding:36px 0 64px; flex:1 0 auto; box-sizing:border-box; }
       nav { display:flex; align-items:center; justify-content:space-between; margin-bottom:40px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
       header { max-width:720px; margin-bottom:28px; }
@@ -113,11 +113,11 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
             </section>
           )}
           <GalleryReferences references={gallery.references} />
-          <Footer />
         </>
       ) : (
         <section class="error"><code>{result.status === "not_found" ? "gallery.not_found" : "gallery.unavailable"}</code><h1>{result.status === "not_found" ? "Gallery not found" : "Gallery temporarily unavailable"}</h1><p>{result.status === "not_found" ? "Check the link or ask the gallery owner for a current URL." : "The gallery service could not be reached. Please try again shortly."}</p></section>
       )}
     </main>
+    <Footer />
   </body>
 </html>

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -84,8 +84,8 @@ const oembedHref =
     )}
     <style>
       * { box-sizing:border-box; }
-      body { margin:0; min-height:100vh; color:var(--fg); background:var(--bg); font-family:var(--sans); }
-      .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:auto; padding:36px 0 64px; }
+      body { margin:0; min-height:100dvh; color:var(--fg); background:var(--bg); font-family:var(--sans); display:flex; flex-direction:column; }
+      .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:0 auto; padding:36px 0 64px; flex:1 0 auto; box-sizing:border-box; }
       nav { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
       .crumbs { margin-bottom:20px; color:var(--muted); font:13px var(--mono); overflow-wrap:anywhere; }
@@ -144,11 +144,11 @@ const oembedHref =
             {next ? <a href={itemPath(next)} rel="next">{next.filename} →</a> : <span class="disabled">End →</span>}
           </nav>
           <GalleryReferences references={gallery.references} />
-          <Footer />
         </>
       ) : (
         <section class="error"><code>{result.status === "unavailable" ? "gallery.unavailable" : "gallery.item_not_found"}</code><h1>{result.status === "unavailable" ? "Gallery temporarily unavailable" : "Media not found"}</h1><p>{result.status === "unavailable" ? "The gallery service could not be reached. Please try again shortly." : "This item may have been removed, or the link is incorrect."}</p>{result.status !== "unavailable" && <p><a href={listPath}>View the gallery</a></p>}</section>
       )}
     </main>
+    <Footer />
   </body>
 </html>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -619,9 +619,11 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           <span class="cta-note">free to start in the cloud · open source to self-host</span>
         </div>
       </section>
-
-      <Footer />
     </main>
+
+    {/* Sibling of main (not nested) so the full-bleed footer centers on the
+        viewport at shell width — same contract as releases.sh. */}
+    <Footer />
 
     <script>
       // Replay the terminal session; content below the fold-line is static.


### PR DESCRIPTION
## In plain terms

After the account-shell footer polish (#363), the site footer sat flush against the end of docs content and looked shrunken on the home page. This puts the footer back to normal: full viewport width, centered shell column, and breathing room above it — matching how releases.sh lays out its footer.

## What it does / what it is not

- Hoists the full site footer out of narrow content shells (`main`, `.docs-shell`, public file/gallery shells) so it is a body sibling again
- Restores roomier internal padding (link grid + family bar) so the footer doesn’t feel cramped
- Keeps `margin-top: auto` for sticky short pages; content shells keep bottom padding for the content→footer gap when the page is long
- Does not change link content, compact auth footers, or account/admin shell placement (those were already correct)

## How to try it

```bash
pnpm dev:web
```

Check `/`, `/docs`, a legal page, and a public file page: footer should be full-bleed with a clear gap above it, not squeezed into the reading column.

## Technical notes

Regression from #363: `margin-top: 56px` → `margin-top: auto` while the footer stayed nested inside max-width columns. releases.sh keeps Header / main / Footer as body flex children; we mirror that on public content pages.

## Test plan

- [x] `pnpm --filter @uploads/web test` (290 tests)
- [ ] Visual check on home + docs after deploy/preview