### PR TITLE
feat: show path and state metadata in the managed attachments comment

### DIFF
--- a/.changeset/attachment-comment-metadata.md
+++ b/.changeset/attachment-comment-metadata.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Managed GitHub attachment comments now show an upload's canonical `path` and `state` metadata — a screenshot tagged `--state before` on `/settings` renders as `/settings · before` beneath the image instead of just its filename. Attachments without that metadata render exactly as before.

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -364,14 +364,25 @@ const METADATA_LOOKUP_CHUNK = 100;
  * metadata each key already has. Keys with no rows are simply absent from
  * the returned map (not present with an empty object). Chunks the `keys`
  * list to stay under D1/SQLite's bound-parameter limit per statement.
+ *
+ * `opts.metaKeys` narrows the SELECT to the named meta keys (issue #365).
+ * Prefer it on hot paths: the filter rides the `(workspace, object_key,
+ * meta_key)` primary-key index, so the read stays flat at ~3-5 D1 rows per
+ * object key however many keys that object carries. An empty array is treated
+ * as "no filter", not "select nothing" — a silently empty result map is the
+ * worse failure mode for a caller that built the list dynamically.
  */
 export async function getMetadataForKeys(
   db: D1Database,
   workspace: string,
   keys: string[],
+  opts: { metaKeys?: string[] } = {},
 ): Promise<Map<string, Record<string, string>>> {
   const out = new Map<string, Record<string, string>>();
   if (keys.length === 0) return out;
+
+  const metaKeys = opts.metaKeys?.length ? opts.metaKeys : undefined;
+  const metaFilter = metaKeys ? ` AND meta_key IN (${metaKeys.map(() => "?").join(", ")})` : "";
 
   for (let i = 0; i < keys.length; i += METADATA_LOOKUP_CHUNK) {
     const chunk = keys.slice(i, i + METADATA_LOOKUP_CHUNK);
@@ -379,9 +390,9 @@ export async function getMetadataForKeys(
     const result = await db
       .prepare(
         `SELECT object_key, meta_key, meta_value FROM file_metadata
-         WHERE workspace = ? AND object_key IN (${placeholders})`,
+         WHERE workspace = ? AND object_key IN (${placeholders})${metaFilter}`,
       )
-      .bind(workspace, ...chunk)
+      .bind(workspace, ...chunk, ...(metaKeys ?? []))
       .all<{ object_key: string; meta_key: string; meta_value: string }>();
     for (const row of result.results) {
       let map = out.get(row.object_key);

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -41,16 +41,18 @@ describe("attachmentsCommentBody (api copy)", () => {
       url: `https://uploads.sh/f/shot-${i}.png`,
       embedUrl: `https://embed.uploads.sh/f/shot-${i}.png`,
       pageUrl: `https://uploads.sh/f/acme/shot-${i}.png`,
-      meta: { path: "/a_b[c]*d", state: "after" },
+      // Tildes included: GitHub strikes through text wrapped in a matching pair
+      // of one or two tildes, so `~e~` would render struck through unescaped.
+      meta: { path: "/a_b[c]*d~e~", state: "after" },
     }));
 
     const body = attachmentsCommentBody(items);
 
     // Markdown context: the metacharacters are backslash-escaped.
     expect(body).toContain(
-      "- [shot-17.png](https://uploads.sh/f/acme/shot-17.png) · /a\\_b\\[c\\]\\*d · after",
+      "- [shot-17.png](https://uploads.sh/f/acme/shot-17.png) · /a\\_b\\[c\\]\\*d\\~e\\~ · after",
     );
     // HTML context: <sub> needs no markdown escaping, so the value is verbatim.
-    expect(body).toContain("<sub>/a_b[c]*d · after</sub>");
+    expect(body).toContain("<sub>/a_b[c]*d~e~ · after</sub>");
   });
 });

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -14,6 +14,7 @@ function loadFixture(name: string) {
 
 const golden = loadFixture("github-comment-golden.json");
 const goldenCap = loadFixture("github-comment-golden-cap.json");
+const goldenMeta = loadFixture("github-comment-golden-meta.json");
 
 describe("attachmentsCommentBody (api copy)", () => {
   it("renders the golden body byte-for-byte", () => {
@@ -24,5 +25,32 @@ describe("attachmentsCommentBody (api copy)", () => {
     expect(attachmentsCommentBody(goldenCap.items, goldenCap.galleries, goldenCap.marker)).toBe(
       goldenCap.expected,
     );
+  });
+
+  it("renders path/state captions, and nothing when they are absent", () => {
+    expect(attachmentsCommentBody(goldenMeta.items, goldenMeta.galleries)).toBe(
+      goldenMeta.expected,
+    );
+  });
+
+  it("captions overflow rows and escapes markdown metacharacters", () => {
+    // 18 images exceeds MAX_INLINE_ATTACHMENT_IMAGES (16), so the last two
+    // collapse into the <details> list — those rows must caption too.
+    const items = Array.from({ length: 18 }, (_, i) => ({
+      key: `gh/acme/web/pull/12/shot-${String(i).padStart(2, "0")}.png`,
+      url: `https://uploads.sh/f/shot-${i}.png`,
+      embedUrl: `https://embed.uploads.sh/f/shot-${i}.png`,
+      pageUrl: `https://uploads.sh/f/acme/shot-${i}.png`,
+      meta: { path: "/a_b[c]*d", state: "after" },
+    }));
+
+    const body = attachmentsCommentBody(items);
+
+    // Markdown context: the metacharacters are backslash-escaped.
+    expect(body).toContain(
+      "- [shot-17.png](https://uploads.sh/f/acme/shot-17.png) · /a\\_b\\[c\\]\\*d · after",
+    );
+    // HTML context: <sub> needs no markdown escaping, so the value is verbatim.
+    expect(body).toContain("<sub>/a_b[c]*d · after</sub>");
   });
 });

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -135,9 +135,14 @@ function escapeHtmlText(s: string): string {
   return escapeHtmlAttr(s).replace(/'/g, "&#39;").replace(/>/g, "&gt;");
 }
 
-/** Backslash-escape the markdown metacharacters that can appear in a metadata value. */
+/**
+ * Backslash-escape the markdown metacharacters that can appear in a metadata
+ * value. `~` is in the set because GitHub's strikethrough extension treats a
+ * matching pair of ONE or two tildes as markup, so an unescaped `/a~b~c` would
+ * render with `b` struck through.
+ */
 function escapeMarkdownText(s: string): string {
-  return s.replace(/([\\`*_[\]])/g, "\\$1");
+  return s.replace(/([\\`*_[\]~])/g, "\\$1");
 }
 
 /**

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -83,6 +83,14 @@ export interface AttachmentItem {
   embedUrl?: string | null;
   /** Canonical `/f/` file-page URL (server-computed). Preferred click-through target; falls back to `url`. */
   pageUrl?: string | null;
+  /**
+   * The only canonical metadata the managed comment renders (issue #365).
+   * Deliberately two named fields rather than `Record<string, string>`: the
+   * comment is posted publicly, and keeping the set narrow at the type level
+   * mirrors the server-side query filter that never fetches EXIF-derived
+   * keys like `device`/`software` for this path.
+   */
+  meta?: { path?: string; state?: string };
 }
 
 /** A public gallery linked to the PR or issue whose managed comment is syncing. */
@@ -125,6 +133,48 @@ function escapeHtmlAttr(s: string): string {
 
 function escapeHtmlText(s: string): string {
   return escapeHtmlAttr(s).replace(/'/g, "&#39;").replace(/>/g, "&gt;");
+}
+
+/** Backslash-escape the markdown metacharacters that can appear in a metadata value. */
+function escapeMarkdownText(s: string): string {
+  return s.replace(/([\\`*_[\]])/g, "\\$1");
+}
+
+/**
+ * An attachment's caption parts — `path`, then `state` (issue #365). Empty
+ * when neither is usable, so callers emit nothing at all and a body with no
+ * metadata stays byte-identical to the pre-#365 render.
+ *
+ * Neither value is pre-sanitized: metadata values are printable ASCII up to
+ * 512 chars, and while the CLI validates `--state` against a closed enum,
+ * `PATCH /v1/:workspace/files/:key` can set any valid metadata value. A
+ * whitespace-only value passes that validation (length-1 printable ASCII), so
+ * treat it as absent rather than rendering a dangling separator.
+ */
+function metaCaptionParts(meta: AttachmentItem["meta"]): string[] {
+  const parts: string[] = [];
+  for (const value of [meta?.path, meta?.state]) {
+    const trimmed = value?.trim();
+    if (trimmed) parts.push(trimmed);
+  }
+  return parts;
+}
+
+/** `<sub>` caption body for an inline image, or null when there is nothing to say. */
+function metaCaptionHtml(meta: AttachmentItem["meta"]): string | null {
+  const parts = metaCaptionParts(meta);
+  return parts.length > 0 ? parts.map(escapeHtmlText).join(" · ") : null;
+}
+
+/**
+ * ` · …` suffix for a markdown list row, or `""` when there is nothing to add.
+ * HTML-escapes first, then markdown-escapes: HTML escaping introduces no
+ * backslashes or brackets, so the markdown pass cannot corrupt its entities.
+ */
+function metaCaptionMarkdown(meta: AttachmentItem["meta"]): string {
+  const parts = metaCaptionParts(meta);
+  if (parts.length === 0) return "";
+  return ` · ${parts.map((p) => escapeMarkdownText(escapeHtmlText(p))).join(" · ")}`;
 }
 
 /**
@@ -184,11 +234,13 @@ export function attachmentsCommentBody(
       const href = escapeHtmlAttr(link ?? (src as string));
       const imgSrc = escapeHtmlAttr(src as string);
       lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
+      const caption = metaCaptionHtml(item.meta);
+      if (caption) lines.push(`<sub>${caption}</sub>`);
       lines.push("");
     } else if (link) {
-      lines.push(`- [${name}](${link})`);
+      lines.push(`- [${name}](${link})${metaCaptionMarkdown(item.meta)}`);
     } else {
-      lines.push(`- ${name}`);
+      lines.push(`- ${name}${metaCaptionMarkdown(item.meta)}`);
     }
   }
   if (overflowImages.length > 0) {
@@ -197,7 +249,8 @@ export function attachmentsCommentBody(
     for (const item of overflowImages) {
       const name = item.key.slice(item.key.lastIndexOf("/") + 1);
       const link = item.pageUrl ?? item.url;
-      lines.push(link ? `- [${name}](${link})` : `- ${name}`);
+      const suffix = metaCaptionMarkdown(item.meta);
+      lines.push(link ? `- [${name}](${link})${suffix}` : `- ${name}${suffix}`);
     }
     lines.push("", "</details>", "");
   }

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -4,12 +4,16 @@ import { describe, expect, it } from "vitest";
 import { gatherCommentBody, upsertBotComment } from "./github-comment";
 import { ATTACHMENTS_MARKER, attachmentsMarker } from "./github-comment-render";
 import { addExternalReference, addGalleryItem, createGallery } from "./galleries";
+import { replaceFileMetadata } from "./file-metadata";
 import type { WorkspaceRecord } from "./workspace";
 import { FakeR2Bucket } from "../test/fake-r2";
 import { FakeKv } from "../test/fake-kv";
 import { SqliteD1, database } from "../test/helpers/sqlite-d1";
 
-const MIGRATION = "migrations/20260711180000_galleries.sql";
+const MIGRATION = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260713210559_file_metadata.sql",
+];
 const PRAGMAS = ["PRAGMA foreign_keys = ON"];
 const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -186,6 +190,86 @@ describe("gatherCommentBody", () => {
     expect(result.body).toContain("Launch media");
     expect(result.body).not.toContain("Not ours");
     expect(result.count).toBe(1);
+  });
+});
+
+describe("gatherCommentBody attachment metadata (issue #365)", () => {
+  async function seed(env: Env, bucket: FakeR2Bucket, meta: Record<string, string>) {
+    await bucket.put("acme/gh/acme/web/pull/12/before.webp", PNG);
+    await replaceFileMetadata(env.DB, "acme", "gh/acme/web/pull/12/before.webp", meta);
+  }
+
+  it("renders path and state from D1 on the attachment", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await seed(env, bucket, { path: "/settings", state: "before" });
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+
+    expect(result.skip).toBe(false);
+    expect((result as { body: string }).body).toContain("<sub>/settings · before</sub>");
+  });
+
+  it("never fetches or renders EXIF-derived keys", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await seed(env, bucket, {
+      path: "/settings",
+      device: "iPhone 15 Pro",
+      software: "Adobe Photoshop 26.0",
+    });
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+
+    const body = (result as { body: string }).body;
+    expect(body).toContain("<sub>/settings</sub>");
+    expect(body).not.toContain("iPhone");
+    expect(body).not.toContain("Photoshop");
+  });
+
+  it("renders exactly as before when the workspace has no metadata", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await bucket.put("acme/gh/acme/web/pull/12/before.webp", PNG);
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+
+    expect((result as { body: string }).body).not.toContain("<sub>/");
+  });
+
+  it("skips the D1 read entirely when githubCommentShowMetadata is false", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await seed(env, bucket, { path: "/settings", state: "before" });
+
+    let metadataQueries = 0;
+    // Delegate explicitly rather than spreading `env.DB` — it is a class
+    // instance, so a spread would drop its prototype methods.
+    const spied = {
+      prepare: (sql: string) => {
+        if (sql.includes("FROM file_metadata")) metadataQueries++;
+        return env.DB.prepare(sql);
+      },
+      batch: (statements: D1PreparedStatement[]) => env.DB.batch(statements),
+    } as unknown as D1Database;
+
+    const result = await gatherCommentBody(
+      { ...env, DB: spied } as Env,
+      { ...ws, githubCommentShowMetadata: false },
+      workspaceName,
+      { repo: "acme/web", num: 12, kind: "pull" },
+    );
+
+    expect(metadataQueries).toBe(0);
+    expect((result as { body: string }).body).not.toContain("<sub>/settings");
   });
 });
 

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -271,6 +271,31 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
     expect(metadataQueries).toBe(0);
     expect((result as { body: string }).body).not.toContain("<sub>/settings");
   });
+
+  it("does not leak another workspace's metadata for the same object key", async () => {
+    const { env, ws, workspaceName, bucket } = makeTestEnv();
+    await seed(env, bucket, { path: "/settings", state: "before" });
+
+    // A different workspace's metadata on the SAME object key — must not leak
+    // into acme's rendered comment. The D1 row is scoped by the `workspace`
+    // column, not by anything derived from the object key.
+    await replaceFileMetadata(env.DB, "other-ws", "gh/acme/web/pull/12/before.webp", {
+      path: "/intruder-path",
+      state: "compromised",
+    });
+
+    const result = await gatherCommentBody(env, ws, workspaceName, {
+      repo: "acme/web",
+      num: 12,
+      kind: "pull",
+    });
+
+    expect(result.skip).toBe(false);
+    const body = (result as { body: string }).body;
+    expect(body).toContain("<sub>/settings · before</sub>");
+    expect(body).not.toContain("/intruder-path");
+    expect(body).not.toContain("compromised");
+  });
 });
 
 describe("upsertBotComment", () => {

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -8,6 +8,7 @@
  */
 
 import { listObjects } from "./files-core";
+import { getMetadataForKeys } from "./file-metadata";
 import { findGalleriesByReference, listGalleryItems, type GalleryCursor } from "./galleries";
 import { galleryUrl, hydrateOwnerGallery } from "./gallery-service";
 import { parseExternalReference } from "./external-references";
@@ -42,7 +43,7 @@ export async function gatherCommentBody(
   // Attachments (R2 list) and galleries (D1) are independent reads — overlap
   // them so the request only waits the longer of the two, not their sum.
   const [items, galleries] = await Promise.all([
-    gatherAttachments(env, ws, target),
+    gatherAttachments(env, ws, workspaceName, target),
     gatherGalleries(env, ws, workspaceName, target),
   ]);
 
@@ -52,10 +53,19 @@ export async function gatherCommentBody(
   return { skip: false, body: attachmentsCommentBody(items, galleries, marker), count };
 }
 
+/**
+ * The only metadata keys the managed comment reads or renders (issue #365).
+ * Filtering at the query rather than the renderer keeps the D1 cost flat at
+ * ~3-5 rows read per attachment however many keys a file carries, and means
+ * EXIF-derived keys are never fetched for a surface that posts publicly.
+ */
+const COMMENT_META_KEYS = ["path", "state"];
+
 /** The workspace's own objects under the stable gh key prefix. */
 async function gatherAttachments(
   env: Env,
   ws: WorkspaceRecord,
+  workspaceName: string,
   target: GhTarget,
 ): Promise<AttachmentItem[]> {
   // Per-workspace choice (issue #304): default (undefined/true) links the
@@ -63,6 +73,7 @@ async function gatherAttachments(
   // behavior); `false` links to raw object bytes instead. Attachments only —
   // does not affect gallery `itemUrl` below, which is a separate feature.
   const linkToFilePage = ws.githubCommentLinkToFilePage !== false;
+  const showMetadata = ws.githubCommentShowMetadata !== false; // issue #365
   const items: AttachmentItem[] = [];
   let cursor: string | undefined;
   do {
@@ -80,6 +91,25 @@ async function gatherAttachments(
       });
     cursor = page.cursor ?? undefined;
   } while (cursor);
+
+  if (!showMetadata || items.length === 0) return items;
+
+  // D1 rows are tenant-scoped by `workspaceName` (the caller's own slug), not
+  // by anything derived from `ws` — same trust boundary as gatherGalleries.
+  const metaByKey = await getMetadataForKeys(
+    env.DB,
+    workspaceName,
+    items.map((item) => item.key),
+    { metaKeys: COMMENT_META_KEYS },
+  );
+  for (const item of items) {
+    const meta = metaByKey.get(item.key);
+    if (!meta) continue;
+    const { path, state } = meta;
+    if (path || state) {
+      item.meta = { ...(path ? { path } : {}), ...(state ? { state } : {}) };
+    }
+  }
   return items;
 }
 

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -678,7 +678,7 @@ describe("workspace github-comment settings editing", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       workspace: "acme",
-      settings: { githubCommentLinkToFilePage: null },
+      settings: { githubCommentLinkToFilePage: null, githubCommentShowMetadata: null },
     });
   });
 
@@ -688,7 +688,7 @@ describe("workspace github-comment settings editing", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       workspace: "acme",
-      settings: { githubCommentLinkToFilePage: false },
+      settings: { githubCommentLinkToFilePage: false, githubCommentShowMetadata: null },
     });
   });
 
@@ -706,7 +706,7 @@ describe("workspace github-comment settings editing", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       workspace: "acme",
-      settings: { githubCommentLinkToFilePage: false },
+      settings: { githubCommentLinkToFilePage: false, githubCommentShowMetadata: null },
     });
     const saved = JSON.parse(store.get("ws:acme")!);
     expect(saved.githubCommentLinkToFilePage).toBe(false);
@@ -829,6 +829,57 @@ describe("workspace github-comment settings editing", () => {
       env,
     );
     expect(res.status).toBe(429);
+  });
+
+  it("PATCH sets githubCommentShowMetadata on the record", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentShowMetadata: false }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      settings: { githubCommentLinkToFilePage: null, githubCommentShowMetadata: false },
+    });
+    expect(JSON.parse(store.get("ws:acme")!).githubCommentShowMetadata).toBe(false);
+  });
+
+  it("PATCH rejects a non-boolean githubCommentShowMetadata", async () => {
+    const { env } = settingsEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentShowMetadata: "no" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH leaves githubCommentShowMetadata unchanged when omitted", async () => {
+    const { env, store } = settingsEnv(ADMIN_USER, {
+      ...REC,
+      githubCommentShowMetadata: false,
+    });
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ githubCommentLinkToFilePage: true }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(JSON.parse(store.get("ws:acme")!).githubCommentShowMetadata).toBe(false);
   });
 });
 

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -218,26 +218,36 @@ async function loadEditableWorkspace(env: Env, name: string): Promise<WorkspaceR
   return record;
 }
 
+/** The per-workspace managed-comment booleans (issues #304, #365). */
+const GITHUB_COMMENT_SETTING_KEYS = [
+  "githubCommentLinkToFilePage",
+  "githubCommentShowMetadata",
+] as const;
+
+type GithubCommentSettingsPatch = Partial<
+  Record<(typeof GITHUB_COMMENT_SETTING_KEYS)[number], boolean>
+>;
+
 /**
- * Validates a PATCH body for the github-comment settings route (issue #304).
- * Only `githubCommentLinkToFilePage` is accepted; when present it must be a
- * boolean. Omitted means "leave unchanged" — distinct from a validation
- * error, mirroring `validateLimitsPatch`'s omit-vs-invalid distinction.
+ * Validates a PATCH body for the github-comment settings route. Only the known
+ * booleans are accepted; when present each must be a boolean. An omitted key
+ * means "leave unchanged" — distinct from a validation error, mirroring
+ * `validateLimitsPatch`'s omit-vs-invalid distinction.
  */
-function validateGithubCommentSettingsPatch(body: unknown): {
-  githubCommentLinkToFilePage?: boolean;
-} {
+function validateGithubCommentSettingsPatch(body: unknown): GithubCommentSettingsPatch {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new ValidationError("request body must be an object", { code: "invalid_settings" });
   }
-  const raw = (body as Record<string, unknown>).githubCommentLinkToFilePage;
-  if (raw === undefined) return {};
-  if (typeof raw !== "boolean") {
-    throw new ValidationError("githubCommentLinkToFilePage must be a boolean", {
-      code: "invalid_settings",
-    });
+  const patch: GithubCommentSettingsPatch = {};
+  for (const key of GITHUB_COMMENT_SETTING_KEYS) {
+    const raw = (body as Record<string, unknown>)[key];
+    if (raw === undefined) continue;
+    if (typeof raw !== "boolean") {
+      throw new ValidationError(`${key} must be a boolean`, { code: "invalid_settings" });
+    }
+    patch[key] = raw;
   }
-  return { githubCommentLinkToFilePage: raw };
+  return patch;
 }
 
 /** Response body shared by GET and PATCH: the github-comment settings. */
@@ -246,6 +256,7 @@ function githubCommentSettingsResponse(name: string, record: WorkspaceRecord) {
     workspace: name,
     settings: {
       githubCommentLinkToFilePage: record.githubCommentLinkToFilePage ?? null,
+      githubCommentShowMetadata: record.githubCommentShowMetadata ?? null,
     },
   };
 }
@@ -496,8 +507,8 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("request body must be valid JSON", { code: "invalid_settings" });
     }
     const patch = validateGithubCommentSettingsPatch(body);
-    if ("githubCommentLinkToFilePage" in patch) {
-      record.githubCommentLinkToFilePage = patch.githubCommentLinkToFilePage;
+    for (const key of GITHUB_COMMENT_SETTING_KEYS) {
+      if (key in patch) record[key] = patch[key];
     }
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
     return c.json(githubCommentSettingsResponse(name, record));

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -484,14 +484,18 @@ export const adminUi = new Hono<SessionVars>()
     return c.json(await limitsResponse(c.env, name, record));
   })
 
-  // Read the per-workspace managed-comment file-page linking toggle (#304).
+  // Read the per-workspace managed-comment settings: whether attachments
+  // link to their `/f/` file page or raw object bytes (issue #304), and
+  // whether the comment shows an upload's `path`/`state` metadata (issue
+  // #365).
   .get("/workspaces/:name/settings", async (c) => {
     const name = c.req.param("name");
     const record = await loadEditableWorkspace(c.env, name);
     return c.json(githubCommentSettingsResponse(name, record));
   })
 
-  // Patch the managed-comment file-page linking toggle. Omitted leaves it
+  // Patch the managed-comment settings above (file-page linking, #304; the
+  // path/state metadata toggle, #365). Either key may be omitted to leave it
   // unchanged; the whole record is read-modify-written so other fields
   // (limits, tokens, etc.) survive untouched.
   .patch("/workspaces/:name/settings", async (c) => {

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -12,6 +12,7 @@ import {
 import {
   findObjectsByMetadata,
   getFileMetadata,
+  getMetadataForKeys,
   META_MAX_KEYS,
   setFileMetadata,
   validateMetadataFilters,
@@ -248,13 +249,25 @@ export const files = new Hono<WorkspaceVars>()
 
     const { prefix, cursor } = query;
     const limit = Number(c.req.query("limit") ?? 100) || 100;
-    return c.json(
-      await listObjects(c.env, c.get("workspace"), {
-        prefix,
-        limit,
-        cursor,
-      }),
+    const page = await listObjects(c.env, c.get("workspace"), { prefix, limit, cursor });
+
+    // `?metadata=1` hydrates each row's queryable D1 metadata — same spelling
+    // as `GET /v1/:workspace/files/:key?metadata=1` and the same hydration the
+    // session-authed `/me/workspaces/:name/files` already does. Unfiltered by
+    // design: this is a general-purpose listing, not the managed-comment path
+    // (which narrows to `path`/`state` at its own query — issue #365).
+    const metadataParam = c.req.query("metadata");
+    if (metadataParam !== "1" && metadataParam !== "true") return c.json(page);
+
+    const metaByKey = await getMetadataForKeys(
+      c.env.DB,
+      c.get("workspaceName"),
+      page.items.map((item) => item.key),
     );
+    return c.json({
+      ...page,
+      items: page.items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) })),
+    });
   })
 
   // Metadata now lives on the key-at-tail routes (same shape PUT/GET/DELETE

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -92,6 +92,15 @@ export interface WorkspaceRecord {
    * links or any non-comment surface.
    */
   githubCommentLinkToFilePage?: boolean;
+  /**
+   * Governs whether the managed GitHub comment shows an upload's canonical
+   * `path`/`state` metadata (issue #365). Default (undefined/true) = show.
+   * When `false`, the comment renders filenames only and the server skips the
+   * metadata read entirely. Deliberately narrow: no other canonical key is
+   * ever read for this surface, because the comment is posted publicly on
+   * repos whose visibility uploads.sh does not check.
+   */
+  githubCommentShowMetadata?: boolean;
   /** Set by `DELETE /admin/workspaces/:name` (default/soft mode). Present → the workspace is soft-deleted. */
   deletedAt?: string;
   /** `deletedAt` + the grace window (`WORKSPACE_DELETE_GRACE_DAYS`); the retention sweep finalizes at/after this. */

--- a/apps/api/test/file-metadata-sqlite.test.ts
+++ b/apps/api/test/file-metadata-sqlite.test.ts
@@ -371,6 +371,84 @@ describe("file metadata persistence against SQLite", () => {
         sqlite.close();
       }
     });
+
+    it("restricts the result to opts.metaKeys when given", async () => {
+      const sqlite = new SqliteD1(MIGRATION);
+      try {
+        await replaceFileMetadata(database(sqlite), "ws1", "a.png", {
+          path: "/settings",
+          state: "before",
+          device: "iPhone 15 Pro",
+          "gh.repo": "o/r",
+        });
+
+        const out = await getMetadataForKeys(database(sqlite), "ws1", ["a.png"], {
+          metaKeys: ["path", "state"],
+        });
+        // The EXIF-derived key must not come back — the comment path relies on
+        // this to keep `device`/`software` out of a public GitHub comment.
+        expect(out.get("a.png")).toEqual({ path: "/settings", state: "before" });
+      } finally {
+        sqlite.close();
+      }
+    });
+
+    it("omits a key entirely when it has none of the requested meta keys", async () => {
+      const sqlite = new SqliteD1(MIGRATION);
+      try {
+        await replaceFileMetadata(database(sqlite), "ws1", "a.png", { "gh.repo": "o/r" });
+
+        const out = await getMetadataForKeys(database(sqlite), "ws1", ["a.png"], {
+          metaKeys: ["path", "state"],
+        });
+        expect(out.has("a.png")).toBe(false);
+      } finally {
+        sqlite.close();
+      }
+    });
+
+    it("treats an omitted or empty metaKeys list as unfiltered", async () => {
+      const sqlite = new SqliteD1(MIGRATION);
+      try {
+        const all = { path: "/settings", "gh.repo": "o/r" };
+        await replaceFileMetadata(database(sqlite), "ws1", "a.png", all);
+
+        // Empty array means "no filter", NOT "select nothing": a caller that
+        // built the list dynamically is better served by the full map than by
+        // a silently empty one.
+        await expect(
+          getMetadataForKeys(database(sqlite), "ws1", ["a.png"], { metaKeys: [] }),
+        ).resolves.toEqual(new Map([["a.png", all]]));
+        await expect(getMetadataForKeys(database(sqlite), "ws1", ["a.png"], {})).resolves.toEqual(
+          new Map([["a.png", all]]),
+        );
+      } finally {
+        sqlite.close();
+      }
+    });
+
+    it("applies the filter across every chunk when keys exceed the chunk size", async () => {
+      const sqlite = new SqliteD1(MIGRATION);
+      try {
+        const keys = Array.from({ length: 150 }, (_, i) => `f/${i}.png`);
+        for (const key of keys) {
+          await replaceFileMetadata(database(sqlite), "ws1", key, {
+            path: "/p",
+            device: "iPhone 15 Pro",
+          });
+        }
+
+        const out = await getMetadataForKeys(database(sqlite), "ws1", keys, {
+          metaKeys: ["path", "state"],
+        });
+        expect(out.size).toBe(150);
+        // The 101st key proves the filter is bound into the second chunk too,
+        // not just the first prepared statement.
+        expect(out.get("f/100.png")).toEqual({ path: "/p" });
+      } finally {
+        sqlite.close();
+      }
+    });
   });
 
   describe("deleteFileMetadataForWorkspace", () => {

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -112,12 +112,21 @@ export class FileMetadataTable {
       return { success: true, results: results.slice(0, limit) as T[], meta: {} };
     }
     if (normalizedSql.startsWith("SELECT object_key, meta_key, meta_value FROM file_metadata")) {
-      const [workspace, ...keys] = args as [string, ...string[]];
+      // getMetadataForKeys binds (workspace, ...objectKeys, ...metaKeys). The
+      // trailing meta-key filter (issue #365) is optional, so split the args by
+      // how many `?` placeholders the IN-filter actually carries.
+      const metaKeyCount = (normalizedSql.match(/AND meta_key IN \(([^)]*)\)/)?.[1] ?? "")
+        .split(",")
+        .filter((placeholder) => placeholder.trim() === "?").length;
+      const [workspace, ...rest] = args as [string, ...string[]];
+      const keys = metaKeyCount > 0 ? rest.slice(0, -metaKeyCount) : rest;
+      const wanted = metaKeyCount > 0 ? new Set(rest.slice(-metaKeyCount)) : undefined;
       const results: { object_key: string; meta_key: string; meta_value: string }[] = [];
       for (const key of keys) {
         const map = this.metadata.get(this.scopeKey(workspace, key));
         if (!map) continue;
         for (const [meta_key, meta_value] of map.entries()) {
+          if (wanted && !wanted.has(meta_key)) continue;
           results.push({ object_key: key, meta_key, meta_value });
         }
       }

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -1126,6 +1126,30 @@ describe("GET /v1/:workspace/files list + meta.* filter", () => {
     expect(json.error.code).toBe("file_metadata_too_many_filters");
     expect(json.error.details).toEqual({ limit: 24, count: 25 });
   });
+
+  it("hydrates queryable metadata onto list rows when ?metadata=1 is set", async () => {
+    const { env } = await makeEnv();
+    await putShot(env, {
+      headers: { "X-Uploads-Meta-Path": "/settings", "X-Uploads-Meta-State": "before" },
+    });
+
+    const res = await listFiles(env, "?prefix=screenshots/&metadata=1");
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { items: ListedFile[] };
+    expect(json.items[0].key).toBe("screenshots/shot.png");
+    expect(json.items[0].metadata).toEqual({ path: "/settings", state: "before" });
+  });
+
+  it("omits metadata from list rows when the param is absent", async () => {
+    const { env } = await makeEnv();
+    await putShot(env, { headers: { "X-Uploads-Meta-Path": "/settings" } });
+
+    const res = await listFiles(env, "?prefix=screenshots/");
+
+    const json = (await res.json()) as { items: { metadata?: object }[] };
+    expect(json.items[0].metadata).toBeUndefined();
+  });
 });
 
 describe("PUT /v1/:workspace/files uploader attribution (issue #340)", () => {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -58,6 +58,8 @@ export interface ListOptions {
   prefix?: string;
   limit?: number;
   cursor?: string;
+  /** Hydrate each row's queryable D1 metadata (`?metadata=1`). */
+  metadata?: boolean;
 }
 
 export interface FindFilesOptions {
@@ -114,6 +116,8 @@ export interface ListItem {
   pageUrl?: string;
   size?: number;
   uploaded?: string;
+  /** Present only when listed with `metadata: true`, and only for keys that have rows. */
+  metadata?: Record<string, string>;
 }
 
 export interface ListResult {
@@ -809,6 +813,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
     if (opts.prefix) params.set("prefix", opts.prefix);
     if (opts.limit != null) params.set("limit", String(opts.limit));
     if (opts.cursor) params.set("cursor", opts.cursor);
+    if (opts.metadata) params.set("metadata", "1");
     const qs = params.toString();
     const page = await request<ListResult>("GET", `${filesBase(config)}${qs ? `?${qs}` : ""}`);
     return {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -675,14 +675,29 @@ export async function syncAttachmentsComment(
   }
 
   // gh fallback: gather from this workspace's own data and post via local `gh`.
-  // Note (issue #304): this CLI process has no server-side WorkspaceRecord in
-  // scope, so it cannot honor a workspace's githubCommentLinkToFilePage=false
-  // — it always links to the file page here, matching the default. This only
-  // diverges from the bot-posted comment for a workspace that both sets the
-  // flag false and falls through to this gh-fallback path.
-  const items: AttachmentItem[] = (await client.listAll({ prefix: ghKeyPrefix(target) })).map(
-    ({ key, url, embedUrl, pageUrl }) => ({ key, url, embedUrl, pageUrl }),
-  );
+  // Note (issues #304, #365): this CLI process has no server-side
+  // WorkspaceRecord in scope, so it cannot honor a workspace's
+  // githubCommentLinkToFilePage=false or githubCommentShowMetadata=false — it
+  // always links to the file page and always shows metadata here, matching the
+  // defaults. This only diverges from the bot-posted comment for a workspace
+  // that both sets one of those flags false and falls through to this path.
+  const items: AttachmentItem[] = (
+    await client.listAll({ prefix: ghKeyPrefix(target), metadata: true })
+  ).map(({ key, url, embedUrl, pageUrl, metadata }) => {
+    // The list endpoint returns every metadata key; the comment renders only
+    // these two. Narrowing here keeps both render paths byte-identical.
+    const path = metadata?.path;
+    const state = metadata?.state;
+    return {
+      key,
+      url,
+      embedUrl,
+      pageUrl,
+      ...(path || state
+        ? { meta: { ...(path ? { path } : {}), ...(state ? { state } : {}) } }
+        : {}),
+    };
+  });
 
   const galleries: (GalleryCommentItem & { id: string })[] = [];
   let cursor: string | undefined;

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -245,9 +245,14 @@ function escapeHtmlText(s: string): string {
   return escapeHtmlAttr(s).replace(/'/g, "&#39;").replace(/>/g, "&gt;");
 }
 
-/** Backslash-escape the markdown metacharacters that can appear in a metadata value. */
+/**
+ * Backslash-escape the markdown metacharacters that can appear in a metadata
+ * value. `~` is in the set because GitHub's strikethrough extension treats a
+ * matching pair of ONE or two tildes as markup, so an unescaped `/a~b~c` would
+ * render with `b` struck through.
+ */
 function escapeMarkdownText(s: string): string {
-  return s.replace(/([\\`*_[\]])/g, "\\$1");
+  return s.replace(/([\\`*_[\]~])/g, "\\$1");
 }
 
 /**

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -193,6 +193,14 @@ export interface AttachmentItem {
   embedUrl?: string | null;
   /** Canonical `/f/` file-page URL (server-computed). Preferred click-through target; falls back to `url`. */
   pageUrl?: string | null;
+  /**
+   * The only canonical metadata the managed comment renders (issue #365).
+   * Deliberately two named fields rather than `Record<string, string>`: the
+   * comment is posted publicly, and keeping the set narrow at the type level
+   * mirrors the server-side query filter that never fetches EXIF-derived
+   * keys like `device`/`software` for this path.
+   */
+  meta?: { path?: string; state?: string };
 }
 
 /** A public gallery linked to the PR or issue whose managed comment is syncing. */
@@ -235,6 +243,48 @@ function escapeHtmlAttr(s: string): string {
 
 function escapeHtmlText(s: string): string {
   return escapeHtmlAttr(s).replace(/'/g, "&#39;").replace(/>/g, "&gt;");
+}
+
+/** Backslash-escape the markdown metacharacters that can appear in a metadata value. */
+function escapeMarkdownText(s: string): string {
+  return s.replace(/([\\`*_[\]])/g, "\\$1");
+}
+
+/**
+ * An attachment's caption parts — `path`, then `state` (issue #365). Empty
+ * when neither is usable, so callers emit nothing at all and a body with no
+ * metadata stays byte-identical to the pre-#365 render.
+ *
+ * Neither value is pre-sanitized: metadata values are printable ASCII up to
+ * 512 chars, and while the CLI validates `--state` against a closed enum,
+ * `PATCH /v1/:workspace/files/:key` can set any valid metadata value. A
+ * whitespace-only value passes that validation (length-1 printable ASCII), so
+ * treat it as absent rather than rendering a dangling separator.
+ */
+function metaCaptionParts(meta: AttachmentItem["meta"]): string[] {
+  const parts: string[] = [];
+  for (const value of [meta?.path, meta?.state]) {
+    const trimmed = value?.trim();
+    if (trimmed) parts.push(trimmed);
+  }
+  return parts;
+}
+
+/** `<sub>` caption body for an inline image, or null when there is nothing to say. */
+function metaCaptionHtml(meta: AttachmentItem["meta"]): string | null {
+  const parts = metaCaptionParts(meta);
+  return parts.length > 0 ? parts.map(escapeHtmlText).join(" · ") : null;
+}
+
+/**
+ * ` · …` suffix for a markdown list row, or `""` when there is nothing to add.
+ * HTML-escapes first, then markdown-escapes: HTML escaping introduces no
+ * backslashes or brackets, so the markdown pass cannot corrupt its entities.
+ */
+function metaCaptionMarkdown(meta: AttachmentItem["meta"]): string {
+  const parts = metaCaptionParts(meta);
+  if (parts.length === 0) return "";
+  return ` · ${parts.map((p) => escapeMarkdownText(escapeHtmlText(p))).join(" · ")}`;
 }
 
 /**
@@ -291,11 +341,13 @@ export function attachmentsCommentBody(
       const href = escapeHtmlAttr(link ?? (src as string));
       const imgSrc = escapeHtmlAttr(src as string);
       lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
+      const caption = metaCaptionHtml(item.meta);
+      if (caption) lines.push(`<sub>${caption}</sub>`);
       lines.push("");
     } else if (link) {
-      lines.push(`- [${name}](${link})`);
+      lines.push(`- [${name}](${link})${metaCaptionMarkdown(item.meta)}`);
     } else {
-      lines.push(`- ${name}`);
+      lines.push(`- ${name}${metaCaptionMarkdown(item.meta)}`);
     }
   }
   if (overflowImages.length > 0) {
@@ -304,7 +356,8 @@ export function attachmentsCommentBody(
     for (const item of overflowImages) {
       const name = item.key.slice(item.key.lastIndexOf("/") + 1);
       const link = item.pageUrl ?? item.url;
-      lines.push(link ? `- [${name}](${link})` : `- ${name}`);
+      const suffix = metaCaptionMarkdown(item.meta);
+      lines.push(link ? `- [${name}](${link})${suffix}` : `- ${name}${suffix}`);
     }
     lines.push("", "</details>", "");
   }

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -132,3 +132,54 @@ describe("metadata CRUD client methods", () => {
     expect(result.cursor).toBeNull();
   });
 });
+
+describe("list metadata hydration", () => {
+  it("requests metadata=1 and surfaces the hydrated map on list rows", async () => {
+    let seenUrl = "";
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      seenUrl = String(input);
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              key: "gh/acme/web/pull/12/before.webp",
+              url: "https://storage.test/before.webp",
+              metadata: { path: "/settings", state: "before" },
+            },
+          ],
+          cursor: null,
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+
+    const items = await client.listAll({ prefix: "gh/acme/web/pull/12/", metadata: true });
+
+    expect(seenUrl).toContain("metadata=1");
+    expect(items[0].metadata).toEqual({ path: "/settings", state: "before" });
+  });
+
+  it("omits the param when metadata is not requested", async () => {
+    let seenUrl = "";
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      seenUrl = String(input);
+      return new Response(JSON.stringify({ items: [], cursor: null }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+
+    await client.listAll({ prefix: "gh/" });
+
+    expect(seenUrl).not.toContain("metadata");
+  });
+});

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -255,4 +255,34 @@ describe("syncAttachmentsComment", () => {
     );
     expect(res.via).toBe("gh");
   });
+
+  it("renders only path/state from a listing that carries every metadata key", async () => {
+    const client = listClient([
+      {
+        key: "gh/acme/web/pull/12/before.webp",
+        url: "https://storage.test/before.webp",
+        embedUrl: "https://embed.test/before.webp",
+        pageUrl: "https://uploads.sh/f/acme/before.webp",
+        metadata: {
+          path: "/settings",
+          state: "before",
+          device: "iPhone 15 Pro",
+          software: "Adobe Photoshop 26.0",
+        },
+      },
+    ] as never);
+
+    let posted = "";
+    const run: CommandRunner = (cmd, args, input) => {
+      if (args[1]?.includes("per_page=100")) return "[]";
+      if (input) posted = input;
+      return JSON.stringify({ id: 9 });
+    };
+
+    await syncAttachmentsComment(client, { repo: "acme/web", num: 12, kind: "pull" }, run, "acme");
+
+    expect(posted).toContain("<sub>/settings · before</sub>");
+    expect(posted).not.toContain("iPhone");
+    expect(posted).not.toContain("Photoshop");
+  });
 });

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -38,16 +38,18 @@ describe("attachmentsCommentBody (CLI copy)", () => {
       url: `https://uploads.sh/f/shot-${i}.png`,
       embedUrl: `https://embed.uploads.sh/f/shot-${i}.png`,
       pageUrl: `https://uploads.sh/f/acme/shot-${i}.png`,
-      meta: { path: "/a_b[c]*d", state: "after" },
+      // Tildes included: GitHub strikes through text wrapped in a matching pair
+      // of one or two tildes, so `~e~` would render struck through unescaped.
+      meta: { path: "/a_b[c]*d~e~", state: "after" },
     }));
 
     const body = attachmentsCommentBody(items);
 
     // Markdown context: the metacharacters are backslash-escaped.
     expect(body).toContain(
-      "- [shot-17.png](https://uploads.sh/f/acme/shot-17.png) · /a\\_b\\[c\\]\\*d · after",
+      "- [shot-17.png](https://uploads.sh/f/acme/shot-17.png) · /a\\_b\\[c\\]\\*d\\~e\\~ · after",
     );
     // HTML context: <sub> needs no markdown escaping, so the value is verbatim.
-    expect(body).toContain("<sub>/a_b[c]*d · after</sub>");
+    expect(body).toContain("<sub>/a_b[c]*d~e~ · after</sub>");
   });
 });

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -11,6 +11,7 @@ function loadFixture(name: string) {
 
 const golden = loadFixture("github-comment-golden.json");
 const goldenCap = loadFixture("github-comment-golden-cap.json");
+const goldenMeta = loadFixture("github-comment-golden-meta.json");
 
 describe("attachmentsCommentBody (CLI copy)", () => {
   it("renders the golden body byte-for-byte", () => {
@@ -21,5 +22,32 @@ describe("attachmentsCommentBody (CLI copy)", () => {
     expect(attachmentsCommentBody(goldenCap.items, goldenCap.galleries, goldenCap.marker)).toBe(
       goldenCap.expected,
     );
+  });
+
+  it("renders path/state captions, and nothing when they are absent", () => {
+    expect(attachmentsCommentBody(goldenMeta.items, goldenMeta.galleries)).toBe(
+      goldenMeta.expected,
+    );
+  });
+
+  it("captions overflow rows and escapes markdown metacharacters", () => {
+    // 18 images exceeds MAX_INLINE_ATTACHMENT_IMAGES (16), so the last two
+    // collapse into the <details> list — those rows must caption too.
+    const items = Array.from({ length: 18 }, (_, i) => ({
+      key: `gh/acme/web/pull/12/shot-${String(i).padStart(2, "0")}.png`,
+      url: `https://uploads.sh/f/shot-${i}.png`,
+      embedUrl: `https://embed.uploads.sh/f/shot-${i}.png`,
+      pageUrl: `https://uploads.sh/f/acme/shot-${i}.png`,
+      meta: { path: "/a_b[c]*d", state: "after" },
+    }));
+
+    const body = attachmentsCommentBody(items);
+
+    // Markdown context: the metacharacters are backslash-escaped.
+    expect(body).toContain(
+      "- [shot-17.png](https://uploads.sh/f/acme/shot-17.png) · /a\\_b\\[c\\]\\*d · after",
+    );
+    // HTML context: <sub> needs no markdown escaping, so the value is verbatim.
+    expect(body).toContain("<sub>/a_b[c]*d · after</sub>");
   });
 });

--- a/test/fixtures/github-comment-golden-meta.json
+++ b/test/fixtures/github-comment-golden-meta.json
@@ -1,0 +1,60 @@
+{
+  "items": [
+    {
+      "key": "gh/acme/web/pull/12/after.webp",
+      "url": "https://uploads.sh/f/after.webp",
+      "embedUrl": "https://embed.uploads.sh/f/after.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/after.webp",
+      "meta": { "path": "/settings", "state": "after" }
+    },
+    {
+      "key": "gh/acme/web/pull/12/before.webp",
+      "url": "https://uploads.sh/f/before.webp",
+      "embedUrl": "https://embed.uploads.sh/f/before.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/before.webp",
+      "meta": { "path": "/settings", "state": "before" }
+    },
+    {
+      "key": "gh/acme/web/pull/12/build.log",
+      "url": "https://uploads.sh/f/build.log",
+      "embedUrl": null,
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log",
+      "meta": { "path": "/admin?a=1&b=2", "state": "error" }
+    },
+    {
+      "key": "gh/acme/web/pull/12/hero.png",
+      "url": "https://uploads.sh/f/hero.png",
+      "embedUrl": "https://embed.uploads.sh/f/hero.png",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png"
+    },
+    {
+      "key": "gh/acme/web/pull/12/only-path.webp",
+      "url": "https://uploads.sh/f/only-path.webp",
+      "embedUrl": "https://embed.uploads.sh/f/only-path.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/only-path.webp",
+      "meta": { "path": "/pricing" }
+    },
+    {
+      "key": "gh/acme/web/pull/12/only-state.webp",
+      "url": "https://uploads.sh/f/only-state.webp",
+      "embedUrl": "https://embed.uploads.sh/f/only-state.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/only-state.webp",
+      "meta": { "state": "empty" }
+    },
+    {
+      "key": "gh/acme/web/pull/12/plain.log",
+      "url": "https://uploads.sh/f/plain.log",
+      "embedUrl": null,
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/plain.log"
+    },
+    {
+      "key": "gh/acme/web/pull/12/ws.webp",
+      "url": "https://uploads.sh/f/ws.webp",
+      "embedUrl": "https://embed.uploads.sh/f/ws.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/ws.webp",
+      "meta": { "path": "   ", "state": "after" }
+    }
+  ],
+  "galleries": [],
+  "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/after.webp\"><img width=\"400\" alt=\"after.webp\" src=\"https://embed.uploads.sh/f/after.webp\"></a>\n<sub>/settings · after</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/before.webp\"><img width=\"400\" alt=\"before.webp\" src=\"https://embed.uploads.sh/f/before.webp\"></a>\n<sub>/settings · before</sub>\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log) · /admin?a=1&amp;b=2 · error\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/only-path.webp\"><img width=\"400\" alt=\"only-path.webp\" src=\"https://embed.uploads.sh/f/only-path.webp\"></a>\n<sub>/pricing</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/only-state.webp\"><img width=\"400\" alt=\"only-state.webp\" src=\"https://embed.uploads.sh/f/only-state.webp\"></a>\n<sub>empty</sub>\n\n- [plain.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/plain.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/ws.webp\"><img width=\"400\" alt=\"ws.webp\" src=\"https://embed.uploads.sh/f/ws.webp\"></a>\n<sub>after</sub>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+}


### PR DESCRIPTION
Closes #365.

## In plain terms

A screenshot attached to a PR used to show up as `settings-a3f9.webp`. If it was uploaded with `--state before` on `/settings`, it now shows up as `/settings · before` underneath the image. Attachments without that metadata render exactly as they did before.

#361 added the canonical metadata vocabulary; the managed comment ignored all of it. This connects the two.

## What it renders

Inline images get a `<sub>` caption; list rows and the collapsed overflow list get a ` · ` suffix after the filename.

```
### 📎 Attachments

<a href="…/before.webp"><img width="400" alt="before.webp" src="…"></a>
<sub>/settings · before</sub>

<a href="…/after.webp"><img width="400" alt="after.webp" src="…"></a>
<sub>/settings · after</sub>

<a href="…/hero.png"><img width="400" alt="hero.png" src="…"></a>

- [build.log](…) · /admin?a=1&amp;b=2 · error
- [notes.pdf](…)
```

The third shot has no metadata and renders byte-for-byte as it does on `main` today.

## The cost question #365 raised

The issue flagged that this adds a D1 read to a path that runs on **every** webhook delivery, and asked for a rows-read estimate against #352's perf work before shipping. Measured against production D1 rather than estimated — running the real statement shape and reading `rows_read` off the response:

| Query | Keys | Meta rows/key | `rows_read` |
| --- | --- | --- | --- |
| Unfiltered (today's `getMetadataForKeys`) | 2 | 6 | 16 |
| Unfiltered | 4 | 4 | 24 |
| Filtered `AND meta_key IN ('path','state')` | 2 | 6 (2 match) | 8 |
| Filtered, zero matches | 4 | 4 (0 match) | 12 |

So `unfiltered ≈ 2·K + total_rows`, `filtered ≈ 3·K + matched`. Two things follow:

1. **The filtered read is ~3–5 rows per attachment, and stays flat** as the vocabulary grows, because it rides the `(workspace, object_key, meta_key)` primary-key index. Production attachment counts are 1–2 per PR at the median, 8 at the max, so a median delivery pays ~5–10 rows.
2. **The same delivery already pays more.** `autoPromoteAndComment` runs `promoteBranchAttachments` before `gatherAndUpsert`, and that already does a full **unfiltered** `getMetadataForKeys` over the staged keys on every `opened`/`reopened`/`synchronize`. `gatherGalleries` is two more D1 queries. "No D1 on this path" was true of `gatherAttachments` in isolation, not of the sync path.

No perf redesign needed — just a key filter on the existing primitive.

## Privacy

The comment posts publicly, on repos whose visibility uploads.sh does not check. `device` and `software` come from EXIF, so they must not end up there. The restriction lives at the **query**, not the renderer: the server never fetches them for this path, so a later renderer bug can't leak what was never read.

Reinforced twice more: the CLI's fallback narrows at its mapping site, and `AttachmentItem.meta` is typed as `{ path?: string; state?: string }` rather than a metadata bag, so the narrow set is a compile-time property.

## Degradation

The requirement was that a comment with no metadata look exactly like it does today. `test/fixtures/github-comment-golden.json` and `github-comment-golden-cap.json` were **deliberately not regenerated** — their items carry no `meta`, so correct code has to reproduce them byte-for-byte. Leaving them untouched turns them into the regression test. A new third fixture covers the metadata cases from both render paths.

## Decisions worth flagging

- **`path` and `state` only.** `viewport`/`device`/`software` are noise in a PR context; `url` wraps badly. The privacy argument independently points at the same narrow set.
- **Fixed key set, with a per-workspace off switch.** `githubCommentShowMetadata`, default-on, mirroring `githubCommentLinkToFilePage` (#304) exactly — KV-backed, admin-API only, no web UI. Not a configurable key list.
- **The CLI `gh` fallback gets the same data** via a new opt-in `?metadata=1` on `GET /v1/:workspace/files`, so the two render paths don't diverge and the golden fixture stays a real cross-check. It inherits #304's known caveat: the CLI has no `WorkspaceRecord` in scope, so a workspace that sets the flag `false` *and* falls through to `gh` still gets captions.
- **No truncation** of long values — a wrapped caption beats a mangled one.
- Grouping `before`/`after` pairs side by side is the obvious next win and is deliberately out of scope.

## Not in scope

Re-rendering historical comments. New renders only.

## Test plan

- [x] `pnpm test` — 173 files / 2194 tests
- [x] `pnpm typecheck`, `pnpm lint` clean
- [x] Both pre-existing golden fixtures pass **without regeneration**
- [x] Cross-workspace isolation verified by deliberate-failure check: pointing the metadata read at another workspace makes the new test fail with the intruder's caption rendered into the wrong comment
- [ ] Post-deploy: confirm a real PR comment renders captions on an upload tagged with `--state`

## Rollout

No D1 migration — the flag is KV, and the filter uses the existing index. Deploy order doesn't matter: `metadata=1` is additive, and an older worker ignoring it degrades the CLI fallback to today's output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File listings can now optionally include queryable metadata such as upload path and state.
  * Managed GitHub attachment comments can display path/state captions beneath images and alongside attachments, including collapsed items.
  * Added a workspace setting to enable or disable metadata captions.
  * Upload listing clients can request metadata hydration.

* **Bug Fixes**
  * Metadata captions are safely escaped and omitted when unavailable.
  * Metadata remains scoped to the correct workspace and excludes unrelated fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->