### PR TITLE
fix(scripts): make dev-stack fixture seeding idempotent

### DIFF
--- a/scripts/dev-stack-common.mjs
+++ b/scripts/dev-stack-common.mjs
@@ -128,14 +128,23 @@ export async function waitFor(url, label, timeoutMs = 30_000) {
   );
 }
 
-/** Upload the normal API fixtures with the newly minted dev-demo bearer token. */
+/**
+ * Upload the normal API fixtures with the newly minted dev-demo bearer token.
+ * Local R2 state persists across boots, so the strict-overwrite contract
+ * (issue #174) would 409 every fixture after the first — seeding opts into
+ * replacement the same way the CLI's `--replace` does to stay idempotent.
+ */
 export async function seedFixtures(token) {
   for (const key of FIXTURES) {
     const response = await boundedFetch(
       `${API_ORIGIN}/v1/${encodeURIComponent(DEMO_WORKSPACE)}/files/${key}`,
       {
         method: "PUT",
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "image/png" },
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "image/png",
+          "X-Uploads-Replace": "1",
+        },
         body: PNG,
       },
     );


### PR DESCRIPTION
## Problem

`pnpm dev:stack` (also `node scripts/dev-stack.mjs` and the `stack` entry in
`.claude/launch.json`) crashed on every boot after the first:

```
Error: fixture upload screenshots/feature/after.png failed (409): {"error":{"code":"key_exists",...}}
    at requireOk (scripts/dev-stack-common.mjs:110:9)
    at async seedFixtures (scripts/dev-stack-common.mjs:142:5)
```

`seedFixtures` PUT each fixture without opting into overwrite. Since the
strict-overwrite contract landed (#174) that PUT refuses to replace an existing
key, so the local R2 state persisted from the previous boot made seeding fail.

The failure mode was worse than the message suggests: the crash happens *after*
all three wranglers are up, and the supervisor's group-kill then tears them
down. The stack appears to boot and then dies, and the operator sees only 502s.
Two agents lost time to this.

## Fix

Seeding now sends `X-Uploads-Replace: 1` — the same opt-in the CLI's `--replace`
sends (`packages/uploads/src/client.ts`), accepted by the PUT route alongside
`?replace=1` (`apps/api/src/routes/files.ts`).

Chose that over tolerating the 409 as success: swallowing it would leave stale
fixture bytes in place and hide a genuine conflict, whereas replacing keeps the
seed authoritative and matches the contract clients already use.

`scripts/dev-stack-smoke.mjs` and `scripts/dev-stack-check.mjs` were checked for
the same pattern — both only call `runSmoke()`, which is read-only.
`scripts/smoke-contract.mjs` PUTs to a fresh UUID key per run, so it can't
collide.

## Verification

Two consecutive boots against the same `apps/api/.wrangler` state:

- Boot 1 → `PUT .../after.png 201`, `{"ready":true,...}`, smoke passed.
- Boot 2 (state now holds the fixture) → both fixture PUTs `201`,
  `{"ready":true,...}`, smoke passed, workers stayed up.

To confirm boot 2 wasn't passing because the key had vanished, a bare PUT to the
same key against the live API still returns `409 key_exists` — the object really
persists, and the strict contract remains enforced for every other caller.

No changeset: this touches local dev scripts only, not `@buildinternet/uploads`.
