### PR TITLE
feat(email): rebrand the email template and correct the PR-comment mockup

### DIFF
--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -5,7 +5,7 @@
  */
 
 import {
-  escapeHtml,
+  renderMagicLinkEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
   type RenderedEmail,
@@ -44,14 +44,8 @@ export type SendAuthEmailArgs =
 
 function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
   switch (args.template) {
-    case "magic-link": {
-      const { url } = args.context;
-      return {
-        subject: "Sign in to uploads.sh",
-        text: `Sign in to uploads.sh by opening this link (expires in 15 minutes):\n\n${url}\n\nIf you didn't request this, you can ignore this email.`,
-        html: `<p>Sign in to uploads.sh by clicking the link below. It expires in 15 minutes.</p><p><a href="${escapeHtml(url)}">Sign in to uploads.sh</a></p><p>If you didn't request this, you can ignore this email.</p>`,
-      };
-    }
+    case "magic-link":
+      return renderMagicLinkEmail({ ...args.context, webOrigin });
     case "invitation":
       return renderOrgInvitationEmail({ ...args.context, webOrigin });
     case "member-joined":

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -381,10 +381,13 @@ const fullTitle = `${title} · uploads.sh`;
       .doc .ghc .avatar {
         width: 40px;
         height: 40px;
-        border-radius: 50%;
+        border-radius: 6px;
         background: #21262e;
         border: 1px solid #30363d;
+        display: grid;
+        place-items: center;
       }
+      .doc .ghc .avatar svg { width: 32px; height: 32px; }
       .doc .ghc .bubble {
         background: #161b22;
         border: 1px solid #30363d;
@@ -415,6 +418,15 @@ const fullTitle = `${title} · uploads.sh`;
         color: #8b949e;
       }
       .doc .ghc .head .user { color: #e6edf3; font-weight: 600; }
+      .doc .ghc .head .bot-chip {
+        font: 10px var(--sans);
+        letter-spacing: 0.02em;
+        color: #8b949e;
+        border: 1px solid #30363d;
+        border-radius: 999px;
+        padding: 0 6px;
+        background: transparent;
+      }
       .doc .ghc .head .badge {
         font: 11px var(--mono);
         color: #8b949e;

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -34,12 +34,28 @@ const TOC = [
     <div
       class="ghc"
       role="img"
-      aria-label="Wireframe of the managed GitHub attachments comment with an inline image"
+      aria-label="Wireframe of the managed GitHub attachments comment, posted by the uploads.sh bot, with an inline image"
     >
-      <div class="avatar"></div>
+      <div class="avatar">
+        <svg viewBox="0 0 32 32" shape-rendering="crispEdges" aria-hidden="true">
+          <path d="M4 0H28V4H32V28H28V32H4V28H0V4H4Z" fill="#0d1117" />
+          <g fill="#c27eff">
+            <path d="M14 4h4v4h-4z M10 6h4v4h-4z M18 6h4v4h-4z M6 8h4v4h-4z M22 8h4v4h-4z" />
+            <path
+              opacity=".55"
+              d="M14 12h4v4h-4z M10 14h4v4h-4z M18 14h4v4h-4z M6 16h4v4h-4z M22 16h4v4h-4z"
+            />
+            <path
+              opacity=".28"
+              d="M14 20h4v4h-4z M10 22h4v4h-4z M18 22h4v4h-4z M6 24h4v4h-4z M22 24h4v4h-4z"
+            />
+          </g>
+        </svg>
+      </div>
       <div class="bubble">
         <div class="head">
-          <span class="user">you</span>
+          <span class="user">uploads-sh[bot]</span>
+          <span class="bot-chip">bot</span>
           <span>commented just now</span>
           <span class="badge">managed by uploads</span>
         </div>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -162,10 +162,13 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       .ghc .avatar {
         width: 40px;
         height: 40px;
-        border-radius: 50%;
+        border-radius: 6px;
         background: #21262e;
         border: 1px solid #30363d;
+        display: grid;
+        place-items: center;
       }
+      .ghc .avatar svg { width: 32px; height: 32px; }
       .ghc .bubble {
         background: #161b22;
         border: 1px solid #30363d;
@@ -196,6 +199,15 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         color: #8b949e;
       }
       .ghc .head .user { color: #e6edf3; font-weight: 600; }
+      .ghc .head .bot-chip {
+        font: 10px var(--sans);
+        letter-spacing: 0.02em;
+        color: #8b949e;
+        border: 1px solid #30363d;
+        border-radius: 999px;
+        padding: 0 6px;
+        background: transparent;
+      }
       .ghc .head .badge {
         font: 11px var(--mono);
         color: #8b949e;
@@ -495,12 +507,28 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       <section
         class="ghc"
         role="img"
-        aria-label="Wireframe of the managed GitHub attachments comment with two inline images"
+        aria-label="Wireframe of the managed GitHub attachments comment, posted by the uploads.sh bot, with two inline images"
       >
-        <div class="avatar"></div>
+        <div class="avatar">
+          <svg viewBox="0 0 32 32" shape-rendering="crispEdges" aria-hidden="true">
+            <path d="M4 0H28V4H32V28H28V32H4V28H0V4H4Z" fill="#0d1117" />
+            <g fill="#c27eff">
+              <path d="M14 4h4v4h-4z M10 6h4v4h-4z M18 6h4v4h-4z M6 8h4v4h-4z M22 8h4v4h-4z" />
+              <path
+                opacity=".55"
+                d="M14 12h4v4h-4z M10 14h4v4h-4z M18 14h4v4h-4z M6 16h4v4h-4z M22 16h4v4h-4z"
+              />
+              <path
+                opacity=".28"
+                d="M14 20h4v4h-4z M10 22h4v4h-4z M18 22h4v4h-4z M6 24h4v4h-4z M22 24h4v4h-4z"
+              />
+            </g>
+          </svg>
+        </div>
         <div class="bubble">
           <div class="head">
-            <span class="user">you</span>
+            <span class="user">uploads-sh[bot]</span>
+            <span class="bot-chip">bot</span>
             <span>commented just now</span>
             <span class="badge">managed by uploads.sh</span>
           </div>

--- a/packages/email/src/auth.ts
+++ b/packages/email/src/auth.ts
@@ -1,0 +1,27 @@
+import { renderEmailCard, type RenderedEmail } from "./card";
+
+const IGNORE = "If you didn't request this, you can safely ignore this email.";
+
+/** Passwordless sign-in link (Better Auth magic link → 15 minute expiry). */
+export function renderMagicLinkEmail(ctx: { url: string; webOrigin?: string }): RenderedEmail {
+  return renderEmailCard({
+    subject: "Sign in to uploads.sh",
+    preheader: "Your sign-in link — it expires in 15 minutes.",
+    eyebrow: "Sign in",
+    title: "Sign in to uploads.sh",
+    bodyHtml: "Use the button below to sign in. The link expires in 15 minutes.",
+    text: [
+      "Sign in to uploads.sh by opening this link (expires in 15 minutes):",
+      "",
+      ctx.url,
+      "",
+      IGNORE,
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+    ].join("\n"),
+    cta: { url: ctx.url, label: "Sign in →" },
+    footNoteHtml: IGNORE,
+    webOrigin: ctx.webOrigin,
+  });
+}

--- a/packages/email/src/card.ts
+++ b/packages/email/src/card.ts
@@ -1,3 +1,12 @@
+/**
+ * The shared uploads.sh email shell.
+ *
+ * Colors and radii track `packages/ui/src/tokens.css` — when a token moves there,
+ * move it here too. Type follows the site's split: sans for headline and body,
+ * mono reserved for the wordmark, eyebrow, button label, and metadata. Geist
+ * itself can't load in a mail client, so the fallback stacks are the design.
+ */
+
 export type RenderedEmail = {
   subject: string;
   text: string;
@@ -7,6 +16,8 @@ export type RenderedEmail = {
 export type EmailCardInput = {
   subject: string;
   preheader: string;
+  /** Short mono uppercase label above the title, e.g. "Invitation". */
+  eyebrow: string;
   title: string;
   /** May include pre-escaped markup (e.g. from `strong()`). Escape user values first. */
   bodyHtml: string;
@@ -17,8 +28,35 @@ export type EmailCardInput = {
   webOrigin?: string;
 };
 
+const SANS =
+  "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji'";
 const MONO = "ui-monospace,'SF Mono',SFMono-Regular,Menlo,Consolas,monospace";
+
+/* tokens.css */
+const BG = "#0a0a0b";
+const PANEL = "#121214";
+const LINE = "#232327";
+const FG = "#ececea";
+const BODY = "#b3b3ad";
+const MUTED = "#8a8a83";
+const ACCENT = "#c27eff";
+
 const DEFAULT_WEB_ORIGIN = "https://uploads.sh";
+
+/**
+ * The brand mark from `packages/ui/src/Brand.tsx`, rasterized (SVG doesn't
+ * render in Gmail or Outlook). Clients that block remote images fall back to
+ * the mono wordmark beside it, which is why the wordmark is always drawn.
+ *
+ * Served from our own bucket so mail clients fetch brand assets from an
+ * uploads.sh origin. Immutable: to change the mark, upload a new key rather
+ * than overwriting this one.
+ *
+ *   wrangler r2 object put "uploads-default/_internal/brand/email-mark-256.png" \
+ *     --remote --file mark.png --content-type image/png \
+ *     --cache-control "public, max-age=31536000, immutable"
+ */
+const MARK_URL = "https://storage.uploads.sh/_internal/brand/email-mark-256.png";
 
 export function escapeHtml(value: string): string {
   return value.replace(
@@ -29,7 +67,7 @@ export function escapeHtml(value: string): string {
 
 /** Escaped emphasis span for bodyHtml. */
 export function strong(value: string): string {
-  return `<strong style="color:#f2edfb;">${escapeHtml(value)}</strong>`;
+  return `<strong style="color:${FG};font-weight:600;">${escapeHtml(value)}</strong>`;
 }
 
 function webOriginOf(input: EmailCardInput): string {
@@ -44,51 +82,69 @@ function webOriginOf(input: EmailCardInput): string {
   return DEFAULT_WEB_ORIGIN;
 }
 
-/** Dark-card shell shared by invite and membership emails (API + auth). */
+/** Dark-card shell shared by every uploads.sh email. */
 export function renderEmailCard(input: EmailCardInput): RenderedEmail {
   const webOrigin = webOriginOf(input);
   const title = escapeHtml(input.title);
+  const eyebrow = escapeHtml(input.eyebrow);
   const preheader = escapeHtml(input.preheader);
+
   const cta = input.cta
-    ? `<tr><td>
+    ? `<tr><td style="padding-bottom:16px;">
           <table role="presentation" cellpadding="0" cellspacing="0"><tr>
-            <td style="background-color:#b794ff;border-radius:8px;">
-              <a href="${escapeHtml(input.cta.url)}" style="display:inline-block;padding:13px 26px;font-family:${MONO};font-size:15px;font-weight:700;color:#171128;text-decoration:none;">${escapeHtml(input.cta.label)}</a>
+            <td style="background-color:${ACCENT};border-radius:8px;">
+              <a href="${escapeHtml(input.cta.url)}" style="display:inline-block;padding:12px 22px;font-family:${MONO};font-size:14px;font-weight:600;color:${BG};text-decoration:none;">${escapeHtml(input.cta.label)}</a>
             </td>
           </tr></table>
+        </td></tr>
+        <tr><td style="font-family:${MONO};font-size:12px;line-height:1.6;color:${MUTED};word-break:break-all;">
+          Or paste this link into your browser:<br>
+          <a href="${escapeHtml(input.cta.url)}" style="color:${BODY};text-decoration:underline;">${escapeHtml(input.cta.url)}</a>
         </td></tr>`
     : "";
+
   const note = input.noteHtml
-    ? `<tr><td style="font-family:${MONO};font-size:12px;line-height:1.6;color:#8e86a5;padding-top:14px;">${input.noteHtml}</td></tr>`
+    ? `<tr><td style="font-family:${MONO};font-size:12px;line-height:1.6;color:${MUTED};padding-top:14px;">${input.noteHtml}</td></tr>`
     : "";
+
   const foot = input.footNoteHtml
-    ? `<tr><td style="padding-top:26px;"><div style="border-top:1px solid #2b1f46;"></div></td></tr>
-        <tr><td style="font-family:${MONO};font-size:12px;line-height:1.7;color:#8e86a5;padding-top:18px;">${input.footNoteHtml}</td></tr>`
+    ? `<tr><td style="padding-top:26px;"><div style="border-top:1px solid ${LINE};font-size:0;line-height:0;">&nbsp;</div></td></tr>
+        <tr><td style="font-family:${MONO};font-size:12px;line-height:1.7;color:${MUTED};padding-top:18px;">${input.footNoteHtml}</td></tr>`
     : "";
+
+  // Body only needs breathing room below it when something follows in the card.
+  const bodyGap = input.cta || input.noteHtml ? 24 : 2;
+
   const terms = escapeHtml(`${webOrigin}/terms`);
   const privacy = escapeHtml(`${webOrigin}/privacy`);
 
   const html = `<!doctype html>
 <html lang="en">
-<head><meta charset="utf-8"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"></head>
-<body style="margin:0;padding:0;background-color:#0b0813;">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"></head>
+<body style="margin:0;padding:0;background-color:${BG};">
 <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>
-<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0b0813;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BG};">
 <tr><td align="center" style="padding:40px 16px;">
   <table role="presentation" width="520" cellpadding="0" cellspacing="0" style="max-width:520px;width:100%;">
-    <tr><td style="font-family:${MONO};font-size:13px;letter-spacing:.08em;color:#b794ff;padding:0 4px 14px;">&#9650; uploads.sh</td></tr>
-    <tr><td style="background-color:#151024;border:1px solid #2b1f46;border-radius:12px;padding:36px 34px;">
+    <tr><td style="padding:0 2px 16px;">
+      <table role="presentation" cellpadding="0" cellspacing="0"><tr>
+        <td style="padding-right:9px;line-height:0;"><img src="${MARK_URL}" width="22" height="22" alt="" style="display:block;width:22px;height:22px;border:0;"></td>
+        <td style="font-family:${MONO};font-size:14px;font-weight:600;letter-spacing:.01em;color:${FG};">uploads.sh</td>
+      </tr></table>
+    </td></tr>
+    <tr><td style="background-color:${PANEL};border:1px solid ${LINE};border-radius:10px;padding:32px;">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-        <tr><td style="font-family:${MONO};font-size:24px;line-height:1.3;font-weight:700;color:#f2edfb;padding-bottom:12px;">${title}</td></tr>
-        <tr><td style="font-family:${MONO};font-size:14px;line-height:1.7;color:#b9b0cf;padding-bottom:26px;">${input.bodyHtml}</td></tr>
+        <tr><td style="font-family:${MONO};font-size:11px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:${ACCENT};padding-bottom:14px;">${eyebrow}</td></tr>
+        <tr><td style="font-family:${SANS};font-size:22px;line-height:1.35;font-weight:600;letter-spacing:-.01em;color:${FG};padding-bottom:12px;">${title}</td></tr>
+        <tr><td style="font-family:${SANS};font-size:15px;line-height:1.65;color:${BODY};padding-bottom:${bodyGap}px;">${input.bodyHtml}</td></tr>
         ${cta}
         ${note}
         ${foot}
       </table>
     </td></tr>
-    <tr><td align="center" style="font-family:${MONO};font-size:11px;line-height:1.8;color:#6f6787;padding:22px 4px 0;">
-      uploads.sh &middot; a <a href="https://buildinternet.com" style="color:#8e86a5;text-decoration:underline;">Build Internet</a> project<br>
-      <a href="${terms}" style="color:#8e86a5;text-decoration:underline;">Terms</a> &nbsp;&middot;&nbsp; <a href="${privacy}" style="color:#8e86a5;text-decoration:underline;">Privacy</a>
+    <tr><td align="center" style="font-family:${MONO};font-size:11px;line-height:1.9;color:#6f6f69;padding:22px 4px 0;">
+      uploads.sh &middot; a <a href="https://buildinternet.com" style="color:${MUTED};text-decoration:underline;">Build Internet</a> project<br>
+      <a href="${terms}" style="color:${MUTED};text-decoration:underline;">Terms</a> &nbsp;&middot;&nbsp; <a href="${privacy}" style="color:${MUTED};text-decoration:underline;">Privacy</a>
     </td></tr>
   </table>
 </td></tr>

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -5,6 +5,7 @@ export {
   type EmailCardInput,
   type RenderedEmail,
 } from "./card";
+export { renderMagicLinkEmail } from "./auth";
 export {
   renderEnrollmentInvitationEmail,
   renderMemberJoinedEmail,

--- a/packages/email/src/invites.ts
+++ b/packages/email/src/invites.ts
@@ -16,6 +16,7 @@ export function renderOrgInvitationEmail(ctx: {
   return renderEmailCard({
     subject: `You're invited to ${ctx.organizationName} on uploads.sh`,
     preheader: lead,
+    eyebrow: "Invitation",
     title: "You're invited",
     bodyHtml: `${strong(ctx.inviterEmail)} invited you to join ${strong(ctx.organizationName)} on uploads.sh.`,
     text: [
@@ -69,6 +70,7 @@ export function renderEnrollmentInvitationEmail(ctx: {
       ? "You've been given access to uploads.sh"
       : `You're invited to ${ctx.workspaceName} on uploads.sh`,
     preheader: `${invitedTo} — one click to accept, link expires ${expires}.`,
+    eyebrow: "Invitation",
     title: "You're invited",
     bodyHtml: isDefault
       ? `You've been given access to ${strong("uploads.sh")} &mdash; ${PITCH}.`
@@ -102,6 +104,7 @@ export function renderMemberJoinedEmail(ctx: {
   return renderEmailCard({
     subject: `${ctx.memberEmail} joined ${ctx.organizationName} on uploads.sh`,
     preheader: `${ctx.memberEmail} joined ${ctx.organizationName}.`,
+    eyebrow: "Membership",
     title: "Someone joined",
     bodyHtml: `${strong(ctx.memberEmail)} accepted your invitation and joined ${strong(ctx.organizationName)} on uploads.sh.`,
     text: [lead, "", "—", "uploads.sh · a Build Internet project"].join("\n"),

--- a/packages/email/test/invites.test.ts
+++ b/packages/email/test/invites.test.ts
@@ -19,6 +19,7 @@ describe("renderEmailCard", () => {
     const out = renderEmailCard({
       subject: "Test",
       preheader: "Preview line",
+      eyebrow: "Invitation",
       title: "Hello",
       bodyHtml: "Body <strong>here</strong>",
       text: "Body here",
@@ -37,11 +38,13 @@ describe("renderEmailCard", () => {
     const out = renderEmailCard({
       subject: "Notify",
       preheader: "p",
+      eyebrow: "Membership",
       title: "Joined",
       bodyHtml: "ok",
       text: "ok",
     });
-    expect(out.html).not.toContain("background-color:#b794ff");
+    expect(out.html).not.toContain("background-color:#c27eff");
+    expect(out.html).not.toContain("Or paste this link");
   });
 });
 


### PR DESCRIPTION
## In plain terms

Our outbound email stopped looking like uploads.sh. The card template predates the
current design tokens — it sits on a purple-black background, uses an older violet,
and sets every line in monospace. The magic-link email, the one nearly every new user
sees first, wasn't using the card at all; it went out as unstyled `<p>` tags.

This re-cuts the card against `packages/ui/src/tokens.css` and brings magic-link into
it, so all four emails share one shell that matches the product.

It also fixes a smaller accuracy problem on the site: the wireframe of the managed
attachments comment showed **you** as the commenter, which is the local `gh` fallback.
With the GitHub App installed — the path most people are on — the comment is posted by
`uploads-sh[bot]`. The mockup now shows that.

## What it does

- **Palette and type follow the tokens.** Neutral `#0a0a0b` ground, `#121214` card on a
  `#232327` hairline, `#c27eff` accent. Sans for headline and body; mono kept for the
  wordmark, eyebrow, button label, and metadata — the same split the site uses. Mail
  clients can't load Geist, so the fallback stacks are the design rather than a
  degraded version of it.
- **Magic-link joins the shell.** New `renderMagicLinkEmail` in `@uploads/email`;
  `apps/auth` renders through it instead of hand-rolled markup.
- **A new `eyebrow` slot** (`SIGN IN` / `INVITATION` / `MEMBERSHIP`) gives each email an
  identity at a glance without per-email artwork. It's a required field, so a new email
  can't silently ship without one.
- **A "or paste this link" fallback URL** under every CTA. The invites didn't have one,
  which matters when a button gets mangled or the mail is forwarded.
- **The brand mark is in the header now**, rasterized from `Brand.tsx` and served from
  `storage.uploads.sh`. The wordmark is always drawn next to it, so clients that block
  remote images still read as uploads.sh rather than showing a lone broken-image icon.
- **The PR-comment mockup names the bot**, adds the small `bot` chip GitHub renders
  beside App comments, and uses the uploads.sh mark as the avatar with the square-ish
  corners GitHub gives bot accounts.

## What it is not

- **No changeset.** Nothing here touches `@buildinternet/uploads`. Only `@uploads/email`
  (private), `apps/auth`, and `apps/web` change, and a changeset naming an ignored
  package would block the next npm publish.
- **No copy rewrites.** Subjects, preheaders, and body text are unchanged except for the
  magic-link email, which had no styled version to preserve.
- **No new email types.** Same five sends as before.

## Reviewer notes

**SVG is not an option for the mark.** Gmail strips `<svg>` outright and Outlook's Word
rendering engine ignores it, so the header uses a PNG rasterized from the same path data
as `Brand.tsx`. It lives at a stable, immutable key in our own bucket:

```
wrangler r2 object put "uploads-default/_internal/brand/email-mark-256.png" \
  --remote --file mark.png --content-type image/png \
  --cache-control "public, max-age=31536000, immutable"
```

Already uploaded and serving (`200`, `image/png`, immutable). It's under `_internal/`
so it sits outside any workspace prefix, following the convention in `docs/ops.md`.
The key is immutable by design — changing the mark means a new key, not an overwrite.

**Two tests changed**, both calling `renderEmailCard` directly: they now pass the
required `eyebrow`, and the "no CTA" test asserts against `#c27eff` instead of the
retired `#b794ff`. No golden files were regenerated.

**One hardcoded color, deliberately.** The mockup avatar's plate is `#0d1117` rather
than `var(--panel)`. Those mockups intentionally use GitHub's palette (`#21262e`,
`#161b22`, `#30363d`), and the token value was too low-contrast against the avatar tile.

**Known cosmetic nit:** at ~390px the homepage mockup's comment header wraps to three
lines instead of two, because `uploads-sh[bot]` is longer than `you`. GitHub wraps there
too and it's a wireframe, so I left it. Easy to fix by hiding the timestamp on narrow
screens if you'd rather.

## How to try it

The emails render from real functions, so the quickest check is a unit-level render, or
just read the previews I generated while building this. For the site change:

```bash
pnpm --filter @uploads/web dev
```

…then look at `/` (the "And on your pull request" mockup) and `/docs/attach-pull-request-images`.

## Test plan

- [x] `pnpm test` — 2237 tests / 177 files passing
- [x] `pnpm --filter @uploads/email test` — 8 passing
- [x] `pnpm --filter @uploads/email typecheck` clean
- [x] `pnpm run format` (oxfmt) clean; pre-commit hook (`pnpm types` + oxlint) passed on both commits
- [x] Both site pages checked in a browser at desktop and 390px; mark confirmed rendering at 32px with `shape-rendering="crispEdges"` actually applied
- [x] Hosted mark verified live: `curl -sI https://storage.uploads.sh/_internal/brand/email-mark-256.png`
- [ ] Send one real email per template from a deployed environment and check it in Gmail + Outlook, with images both allowed and blocked
