### PR TITLE
fix: suppress bare / captions and prefer file-page links

### DIFF
--- a/.changeset/suppress-bare-root-path-caption.md
+++ b/.changeset/suppress-bare-root-path-caption.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Omit a bare `/` path from managed attachment comment captions (still stored and searchable).

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -155,13 +155,17 @@ function escapeMarkdownText(s: string): string {
  * `PATCH /v1/:workspace/files/:key` can set any valid metadata value. A
  * whitespace-only value passes that validation (length-1 printable ASCII), so
  * treat it as absent rather than rendering a dangling separator.
+ *
+ * Bare `/` is stored/searchable but omitted from captions (issue #375) —
+ * alone it is a stray character, and as a prefix next to `state` it is
+ * noise. Only exact `/` after trim is suppressed.
  */
 function metaCaptionParts(meta: AttachmentItem["meta"]): string[] {
   const parts: string[] = [];
-  for (const value of [meta?.path, meta?.state]) {
-    const trimmed = value?.trim();
-    if (trimmed) parts.push(trimmed);
-  }
+  const path = meta?.path?.trim();
+  if (path && path !== "/") parts.push(path);
+  const state = meta?.state?.trim();
+  if (state) parts.push(state);
   return parts;
 }
 

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -76,6 +76,8 @@ interface FileTableRow {
   contentType?: string;
   visibility?: FileVisibility;
   metadata?: Record<string, string>;
+  /** Public `/f/` file-page URL when present (issue #308). */
+  pageUrl?: string;
 }
 
 type ListingState =
@@ -286,10 +288,9 @@ function sizeLabel(size: number | undefined): string {
 }
 
 // ── URL-resolution helpers (open-file / copy-link) ────────────────────────
-// Mirrors AccountFileBrowser's hasPublicUrl-branching open logic verbatim:
-// a workspace with a stable public domain always opens through the chrome-
-// wrapped `/f/` page (issue #135); otherwise (private/BYO without a public
-// domain) resolve a short-lived signed URL via the member-gated endpoint.
+// Prefer API `pageUrl` (`/f/…` file page, issue #308), else same-origin
+// `/f/` when the workspace has a public domain (issue #135), else a
+// short-lived signed URL for private/BYO workspaces.
 
 async function resolveSignedFileUrl(
   apiOrigin: string,
@@ -305,20 +306,33 @@ async function resolveSignedFileUrl(
   return result.response.ok && typeof body.url === "string" ? body.url : null;
 }
 
+function openInNewTab(url: string): void {
+  const tab = window.open(url, "_blank");
+  if (tab) tab.opener = null;
+}
+
 /** "1 file" / "2 files" — `plural` defaults to `${singular}s`, override for irregulars (e.g. "match" → "matches"). */
 function pluralCount(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
-function openFile(apiOrigin: string, workspace: string, hasPublicUrl: boolean, key: string): void {
+function openFile(
+  apiOrigin: string,
+  workspace: string,
+  hasPublicUrl: boolean,
+  file: Pick<FileTableRow, "key" | "pageUrl">,
+): void {
+  if (file.pageUrl) {
+    openInNewTab(file.pageUrl);
+    return;
+  }
   if (hasPublicUrl) {
-    const tab = window.open(filePath(workspace, key), "_blank");
-    if (tab) tab.opener = null;
+    openInNewTab(filePath(workspace, file.key));
     return;
   }
   const tab = window.open("about:blank", "_blank");
   if (tab) tab.opener = null;
-  void resolveSignedFileUrl(apiOrigin, workspace, key).then((url) => {
+  void resolveSignedFileUrl(apiOrigin, workspace, file.key).then((url) => {
     if (url) {
       if (tab) tab.location.replace(url);
       else window.location.assign(url);
@@ -546,7 +560,9 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
   };
 
   const copyLink = async (file: FileTableRow, button: HTMLButtonElement) => {
-    const url = file.url ?? (await resolveSignedFileUrl(apiOrigin, workspace, file.key));
+    // Prefer pageUrl (file page), then storage URL, then signed link.
+    const url =
+      file.pageUrl ?? file.url ?? (await resolveSignedFileUrl(apiOrigin, workspace, file.key));
     if (!url) {
       setActionError(`Couldn't get a link for "${leafName(file.key)}".`);
       return;
@@ -815,7 +831,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
                 <button
                   type="button"
                   className="wft-name wft-name--btn"
-                  onClick={() => openFile(apiOrigin, workspace, info.hasPublicUrl, file.key)}
+                  onClick={() => openFile(apiOrigin, workspace, info.hasPublicUrl, file)}
                 >
                   {thumb.kind !== "none" && <FileThumb thumb={thumb} />}
                   <span className="wft-filename">{name}</span>
@@ -861,7 +877,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
             const thumb = pickThumbnail(file);
             const type = fileTypeLabel(file);
             const priv = isPrivateFile(file);
-            const open = () => openFile(apiOrigin, workspace, info.hasPublicUrl, file.key);
+            const open = () => openFile(apiOrigin, workspace, info.hasPublicUrl, file);
 
             return (
               <div className="wft-card" key={file.key}>

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -255,6 +255,7 @@ describe("listWorkspaceFolder", () => {
               key: "f/x.png",
               url: "https://s/acme/f/x.png",
               embedUrl: "https://s/acme/f/x.png?embed",
+              pageUrl: "https://uploads.sh/f/acme/f/x.png",
               size: 1024,
               contentType: "image/png",
               uploaded: "2026-07-19T00:00:00.000Z",
@@ -274,6 +275,7 @@ describe("listWorkspaceFolder", () => {
           key: "f/x.png",
           url: "https://s/acme/f/x.png",
           embedUrl: "https://s/acme/f/x.png?embed",
+          pageUrl: "https://uploads.sh/f/acme/f/x.png",
           size: 1024,
           contentType: "image/png",
           uploaded: "2026-07-19T00:00:00.000Z",
@@ -284,6 +286,22 @@ describe("listWorkspaceFolder", () => {
       prefixes: ["f/"],
       cursor: "next-cursor",
     });
+  });
+
+  it("omits pageUrl when the API leaves it off (BYO / no public base)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          files: [{ key: "f/x.png", url: null, embedUrl: null }],
+          prefixes: [],
+          cursor: null,
+        }),
+      ),
+    );
+
+    const result = await listWorkspaceFolder("http://127.0.0.1:8787", "acme");
+    expect(result.files[0]?.pageUrl).toBeUndefined();
   });
 
   it("normalizes a null cursor to undefined", async () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -210,6 +210,8 @@ export interface WorkspaceFile {
   uploaded?: string;
   /** Present (== "private") only when the file was marked private (issue #139). */
   visibility?: "private";
+  /** Public `/f/` file-page URL when the workspace has a public base (issue #308). */
+  pageUrl?: string;
 }
 
 function isWorkspaceFile(value: unknown): value is WorkspaceFile {
@@ -558,6 +560,8 @@ export interface SearchFileItem {
   url: string | null;
   embedUrl: string | null;
   metadata: Record<string, string>;
+  /** Public `/f/` file-page URL when present (issue #308). */
+  pageUrl?: string;
 }
 
 export type SearchFilesResult =
@@ -572,7 +576,8 @@ function isSearchFileItem(value: unknown): value is SearchFileItem {
     (item.url === null || typeof item.url === "string") &&
     (item.embedUrl === null || typeof item.embedUrl === "string") &&
     typeof item.metadata === "object" &&
-    item.metadata !== null
+    item.metadata !== null &&
+    (item.pageUrl === undefined || typeof item.pageUrl === "string")
   );
 }
 
@@ -656,6 +661,8 @@ export interface WorkspaceFolderFile {
   uploaded?: string;
   visibility?: "public" | "private";
   metadata?: Record<string, string>;
+  /** Public `/f/` file-page URL when present (issue #308). Prefer for open/copy. */
+  pageUrl?: string;
 }
 
 export interface WorkspaceFolderListing {
@@ -692,6 +699,7 @@ function toWorkspaceFolderFile(raw: Record<string, unknown>): WorkspaceFolderFil
       raw.metadata && typeof raw.metadata === "object"
         ? (raw.metadata as Record<string, string>)
         : undefined,
+    pageUrl: typeof raw.pageUrl === "string" && raw.pageUrl ? raw.pageUrl : undefined,
   };
 }
 

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -265,13 +265,17 @@ function escapeMarkdownText(s: string): string {
  * `PATCH /v1/:workspace/files/:key` can set any valid metadata value. A
  * whitespace-only value passes that validation (length-1 printable ASCII), so
  * treat it as absent rather than rendering a dangling separator.
+ *
+ * Bare `/` is stored/searchable but omitted from captions (issue #375) —
+ * alone it is a stray character, and as a prefix next to `state` it is
+ * noise. Only exact `/` after trim is suppressed.
  */
 function metaCaptionParts(meta: AttachmentItem["meta"]): string[] {
   const parts: string[] = [];
-  for (const value of [meta?.path, meta?.state]) {
-    const trimmed = value?.trim();
-    if (trimmed) parts.push(trimmed);
-  }
+  const path = meta?.path?.trim();
+  if (path && path !== "/") parts.push(path);
+  const state = meta?.state?.trim();
+  if (state) parts.push(state);
   return parts;
 }
 

--- a/packages/uploads/test/github.test.ts
+++ b/packages/uploads/test/github.test.ts
@@ -291,4 +291,24 @@ describe("attachmentsCommentBody", () => {
     ]);
     expect(body).toContain('<a href="https://x.test/after.png"><img');
   });
+
+  it("suppresses a bare / path caption (issue #375)", () => {
+    const body = attachmentsCommentBody([
+      {
+        key: "gh/o/r/pull/1/home.webp",
+        url: "https://x.test/home.webp",
+        embedUrl: "https://embed.test/home.webp",
+        meta: { path: "/" },
+      },
+      {
+        key: "gh/o/r/pull/1/home-before.webp",
+        url: "https://x.test/home-before.webp",
+        embedUrl: "https://embed.test/home-before.webp",
+        meta: { path: "/", state: "before" },
+      },
+    ]);
+    expect(body).not.toContain("<sub>/</sub>");
+    expect(body).not.toContain("/ · before");
+    expect(body).toContain("<sub>before</sub>");
+  });
 });

--- a/test/fixtures/github-comment-golden-meta.json
+++ b/test/fixtures/github-comment-golden-meta.json
@@ -48,6 +48,20 @@
       "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/plain.log"
     },
     {
+      "key": "gh/acme/web/pull/12/root-only.webp",
+      "url": "https://uploads.sh/f/root-only.webp",
+      "embedUrl": "https://embed.uploads.sh/f/root-only.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/root-only.webp",
+      "meta": { "path": "/" }
+    },
+    {
+      "key": "gh/acme/web/pull/12/root-state.webp",
+      "url": "https://uploads.sh/f/root-state.webp",
+      "embedUrl": "https://embed.uploads.sh/f/root-state.webp",
+      "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/root-state.webp",
+      "meta": { "path": "/", "state": "before" }
+    },
+    {
       "key": "gh/acme/web/pull/12/ws.webp",
       "url": "https://uploads.sh/f/ws.webp",
       "embedUrl": "https://embed.uploads.sh/f/ws.webp",
@@ -56,5 +70,5 @@
     }
   ],
   "galleries": [],
-  "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/after.webp\"><img width=\"400\" alt=\"after.webp\" src=\"https://embed.uploads.sh/f/after.webp\"></a>\n<sub>/settings · after</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/before.webp\"><img width=\"400\" alt=\"before.webp\" src=\"https://embed.uploads.sh/f/before.webp\"></a>\n<sub>/settings · before</sub>\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log) · /admin?a=1&amp;b=2 · error\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/only-path.webp\"><img width=\"400\" alt=\"only-path.webp\" src=\"https://embed.uploads.sh/f/only-path.webp\"></a>\n<sub>/pricing</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/only-state.webp\"><img width=\"400\" alt=\"only-state.webp\" src=\"https://embed.uploads.sh/f/only-state.webp\"></a>\n<sub>empty</sub>\n\n- [plain.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/plain.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/ws.webp\"><img width=\"400\" alt=\"ws.webp\" src=\"https://embed.uploads.sh/f/ws.webp\"></a>\n<sub>after</sub>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+  "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/after.webp\"><img width=\"400\" alt=\"after.webp\" src=\"https://embed.uploads.sh/f/after.webp\"></a>\n<sub>/settings · after</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/before.webp\"><img width=\"400\" alt=\"before.webp\" src=\"https://embed.uploads.sh/f/before.webp\"></a>\n<sub>/settings · before</sub>\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log) · /admin?a=1&amp;b=2 · error\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/only-path.webp\"><img width=\"400\" alt=\"only-path.webp\" src=\"https://embed.uploads.sh/f/only-path.webp\"></a>\n<sub>/pricing</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/only-state.webp\"><img width=\"400\" alt=\"only-state.webp\" src=\"https://embed.uploads.sh/f/only-state.webp\"></a>\n<sub>empty</sub>\n\n- [plain.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/plain.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/root-only.webp\"><img width=\"400\" alt=\"root-only.webp\" src=\"https://embed.uploads.sh/f/root-only.webp\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/root-state.webp\"><img width=\"400\" alt=\"root-state.webp\" src=\"https://embed.uploads.sh/f/root-state.webp\"></a>\n<sub>before</sub>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/ws.webp\"><img width=\"400\" alt=\"ws.webp\" src=\"https://embed.uploads.sh/f/ws.webp\"></a>\n<sub>after</sub>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
 }


### PR DESCRIPTION
## In plain terms

Two small polish items: managed attachment comments no longer show a lonely `/` under homepage screenshots, and the account file browser open/copy actions use the real `/f/` file page when the API provides it.

## What it does

- **#375** — Always omit a bare `/` path from attachment captions (render-side only). `path=/` stays stored and searchable; `state` alone still captions when present (`before`, not `/ · before`).
- **#308** — Plumb `pageUrl` through the web DTOs and prefer it for open + copy link in `WorkspaceFileTable`. Absent for BYO/private-only workspaces; existing fallbacks unchanged.
- Changeset for the published CLI render tweak.

## What it is not

- No re-render of historical GitHub comments (new renders only).
- No capture-side change — bare `/` is still a valid stored path.
- No change to non-meta golden comment fixtures.

## How to try it

```bash
# Caption: path=/ alone should emit no <sub>; path=/ + state=before → <sub>before</sub>
uploads put ./shot.png --pr <N> --comment --meta path=/ --state before

# File browser: copy link on a public-CDN workspace file should copy https://…/f/<ws>/<key>
```

## Technical notes

- `metaCaptionParts` updated in both deliberate copies (`packages/uploads` + `apps/api`).
- Golden meta fixture extended with root-only / root+state cases.

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test -- github.test.ts github-render-golden.test.ts`
- [x] `pnpm --filter @uploads/api test -- github-comment-render.test.ts`
- [x] `pnpm --filter @uploads/web test -- api-client.test.ts`
- [ ] Smoke managed comment with `path=/` only and with `path=/` + `state`
- [ ] Smoke account files tab open + copy on a public workspace

Closes #375
Closes #308