### PR TITLE
feat: nudge agents to stage screenshots as they work

### DIFF
--- a/.changeset/staging-nudge-output.md
+++ b/.changeset/staging-nudge-output.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads attach --branch` now reminds you that staged files auto-attach to the branch's PR when it opens (or via `uploads attach --promote`), reinforcing the stage-as-you-go loop for agents.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "uploads",
       "source": "./",
       "description": "Get screenshots, GIFs, recordings, and files into GitHub PRs and issues via uploads.sh. Bundles the github-screenshots + uploads-cli skills, a local MCP server, and the /uploads:attach command.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Build Internet"
       },
@@ -21,7 +21,8 @@
       "strict": false,
       "skills": ["./skills/github-screenshots", "./skills/uploads-cli"],
       "commands": "./plugins/claude/uploads/commands",
-      "mcpServers": "./plugins/claude/uploads/.mcp.json"
+      "mcpServers": "./plugins/claude/uploads/.mcp.json",
+      "hooks": "./plugins/claude/uploads/hooks/hooks.json"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,19 @@ successor to the external `github-screenshots` skill's bundled R2 scripts),
 and `skills/uploads-cli` is the full CLI reference it defers to. Keep both in
 sync when the CLI's commands or flags change.
 
+**Screenshots: stage as you go.** If your change is visually observable (web
+UI, email templates, rendered output), capture and stage screenshots at each
+milestone while you work — don't wait for a PR to exist:
+
+```bash
+uploads attach ./after.png --branch --state after   # before|after|empty|error|loading
+```
+
+Opening a PR automatically promotes everything staged for the branch into the
+managed "📎 Attachments" comment (via the GitHub App webhook, or the next
+`uploads attach` / `uploads attach --promote` without it). See
+`skills/github-screenshots` for the full workflow.
+
 Keep API and web separate deployables. All storage access goes through
 `createStorage()` in `packages/storage` — never import files-sdk adapters or
 touch the R2 binding directly from route code. Adding a provider = a new case

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -75,6 +75,95 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
     </div>
   </section>
 
+  <section id="any-agent">
+    <h2>Any coding agent <a class="anchor" href="#any-agent" aria-label="Link to this section">#</a></h2>
+    <p>
+      None of this is Claude-Code-specific. Any agent that can run a shell command can
+      stage screenshots as it works: capture at each visual milestone, run
+      <code>uploads attach --branch --state before|after</code>, and the PR comment
+      assembles itself once a PR opens — via the GitHub App webhook, or the next
+      <code>uploads attach</code> (or <code>uploads attach --promote</code>) if you're not
+      running the App. See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>
+      for the full loop.
+    </p>
+  </section>
+
+  <section id="instructions-file">
+    <h2>Drop this in your instructions file <a class="anchor" href="#instructions-file" aria-label="Link to this section">#</a></h2>
+    <p>
+      Every agent runtime reads some project instructions file — <code>AGENTS.md</code> for
+      Codex, Cursor, and others, <code>CLAUDE.md</code> for Claude Code, <code>.cursor/rules</code>
+      for Cursor rules. Add a block like this to whichever one your agent reads (or all of
+      them — the CLI doesn't care which agent calls it):
+    </p>
+    <div class="block" aria-label="AGENTS.md snippet">
+      <pre>## Screenshots
+When a change is visually observable (UI, layout, styling), capture it as you
+go — don't wait until the PR is open. After each meaningful visual change:
+
+  uploads attach ./shot.png --branch --state before   # or --state after
+
+Stage before/after pairs where it makes sense. No need to open the PR first —
+staged files are promoted into the PR's attachments comment automatically.</pre>
+    </div>
+    <p>
+      Requires the <code>uploads</code> CLI on <code>PATH</code> and <code>uploads login</code>
+      already run once — see <a href="#install">One command</a> above.
+    </p>
+  </section>
+
+  <section id="claude-code-hook">
+    <h2>Claude Code: the plugin's pre-PR reminder <a class="anchor" href="#claude-code-hook" aria-label="Link to this section">#</a></h2>
+    <p>
+      If you're on Claude Code, the <a href="#plugin">uploads plugin</a> bundles the skills
+      above plus a pre-PR hook: the uploads plugin's pre-PR hook reminds the agent when a
+      UI-touching branch has no staged screenshots, so it doesn't open a PR that's about to
+      need a follow-up comment. Nothing else to configure once the plugin is installed.
+    </p>
+  </section>
+
+  <section id="other-hooks">
+    <h2>Other agents with hook systems <a class="anchor" href="#other-hooks" aria-label="Link to this section">#</a></h2>
+    <p>
+      If your agent supports pre-command hooks (or you're willing to wrap <code>gh pr
+      create</code> yourself), the same reminder is a few lines of POSIX shell: check
+      whether anything is staged for the current branch, and print a nudge if not.
+      <strong>Keep it fail-open</strong> — a broken check should never block a PR from being
+      created.
+    </p>
+    <div class="block" aria-label="Generic pre-PR reminder script">
+      <pre>#!/bin/sh
+# Run before `gh pr create` (wrapper, or your agent's pre-command hook).
+# Fails open: any error here just skips the reminder, never blocks the PR.
+set -u
+branch=$(git branch --show-current 2>/dev/null) || exit 0
+[ -n "$branch" ] || exit 0
+# gh.branch metadata is stored lowercased
+branch_key=$(printf '%s' "$branch" | tr '[:upper:]' '[:lower:]')
+
+staged=$(uploads find "gh.branch=$branch_key" 2>/dev/null) || exit 0
+if [ -z "$staged" ]; then
+  echo "note: no screenshots staged for branch '$branch' — if this PR" >&2
+  echo "touches UI, consider 'uploads attach ./shot.png --branch' first" >&2
+fi
+exit 0</pre>
+    </div>
+    <p>
+      <code>uploads find gh.branch=&lt;name&gt;</code> lists what's staged for a branch — see the
+      <strong>uploads-cli</strong> skill for the full query vocabulary.
+    </p>
+  </section>
+
+  <section id="no-hook-fallback">
+    <h2>No hooks at all <a class="anchor" href="#no-hook-fallback" aria-label="Link to this section">#</a></h2>
+    <p>
+      None of the above is required. Even with zero setup, running <code>uploads attach
+      --promote</code> (no file arguments) right after opening a PR picks up everything
+      staged against that branch and posts or refreshes the attachments comment — it exits
+      <code>0</code> even if nothing was staged.
+    </p>
+  </section>
+
   <nav class="page-nav" aria-label="More docs">
     <a class="prev" href="/docs/github-app"><span class="dir">← Back</span>GitHub App</a>
     <a class="next" href="/docs/reference"><span class="dir">Next →</span>Reference</a>

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -6,7 +6,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 
 <DocsLayout
   title="Set up your agent"
-  description="Install the uploads agent skill and MCP server so Claude Code and other agents can attach screenshots to GitHub on their own."
+  description="Install the uploads agent skill and MCP server so your coding agent can attach screenshots to GitHub on its own."
   path="/docs/agents"
   heading="Set up your agent"
   tagline="Teach a coding agent to upload and attach media on its own."
@@ -15,14 +15,17 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <section class="lead" id="install">
     <h2>One command <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
     <p>
-      If you use Claude Code or another agent runtime, one command installs both the agent
-      skill and the hosted MCP server:
+      One command detects your agent runtime and installs both the agent skill and the
+      hosted MCP server:
     </p>
     <div class="cmd">
       <span class="text">uploads install</span>
       <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
     </div>
-    <p>Or set up each piece yourself:</p>
+    <p>
+      Or set up each piece yourself — the skill via <code>npx skills</code>, the MCP
+      server with your runtime's MCP registration (shown here for Claude Code):
+    </p>
     <div class="cmd">
       <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
       <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli" aria-live="polite">copy</button>
@@ -63,7 +66,8 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
       attaching before/after screenshots to the PR it just opened. The <strong>MCP
       server</strong> gives agents the same tools (<code>put</code>, <code>attach</code>,&#32;
       <code>list</code>, <code>delete</code>, and more) over HTTP, using the same token as the
-      CLI. There's also a local stdio variant if you prefer:
+      CLI. There's also a local stdio variant — register <code>uploads mcp</code> with
+      any MCP client, e.g.:
     </p>
     <div class="cmd">
       <span class="text">claude mcp add uploads -- uploads mcp</span>
@@ -75,26 +79,24 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
     </div>
   </section>
 
-  <section id="any-agent">
-    <h2>Any coding agent <a class="anchor" href="#any-agent" aria-label="Link to this section">#</a></h2>
+  <section id="stage-as-you-go">
+    <h2>Stage screenshots as the agent works <a class="anchor" href="#stage-as-you-go" aria-label="Link to this section">#</a></h2>
     <p>
-      None of this is Claude-Code-specific. Any agent that can run a shell command can
-      stage screenshots as it works: capture at each visual milestone, run&#32;
-      <code>uploads attach --branch --state before|after</code>, and the PR comment
-      assembles itself once a PR opens — via the GitHub App webhook, or the next&#32;
-      <code>uploads attach</code> (or <code>uploads attach --promote</code>) if you're not
-      running the App. See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>&#32;
+      Any agent that can run a shell command can capture at each visual milestone, run&#32;
+      <code>uploads attach --branch --state before|after</code>, and let the PR comment
+      assemble itself once a PR opens — via the GitHub App webhook, or the next&#32;
+      <code>uploads attach</code> (or <code>uploads attach --promote</code>) without the
+      App. See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>&#32;
       for the full loop.
     </p>
   </section>
 
   <section id="instructions-file">
-    <h2>Drop this in your instructions file <a class="anchor" href="#instructions-file" aria-label="Link to this section">#</a></h2>
+    <h2>Put it in your instructions file <a class="anchor" href="#instructions-file" aria-label="Link to this section">#</a></h2>
     <p>
-      Every agent runtime reads some project instructions file — <code>AGENTS.md</code> for
-      Codex, Cursor, and others, <code>CLAUDE.md</code> for Claude Code, <code>.cursor/rules</code>
-      for Cursor rules. Add a block like this to whichever one your agent reads (or all of
-      them — the CLI doesn't care which agent calls it):
+      Add a block like this to your project's instructions file —&#32;
+      <code>AGENTS.md</code>, <code>CLAUDE.md</code>, <code>.cursor/rules</code>, wherever
+      your runtime reads project instructions:
     </p>
     <div class="block" aria-label="AGENTS.md snippet">
       <pre>## Screenshots
@@ -112,22 +114,12 @@ staged files are promoted into the PR's attachments comment automatically.</pre>
     </p>
   </section>
 
-  <section id="claude-code-hook">
-    <h2>Claude Code: the plugin's pre-PR reminder <a class="anchor" href="#claude-code-hook" aria-label="Link to this section">#</a></h2>
+  <section id="pre-pr-reminder">
+    <h2>Optional: remind before the PR opens <a class="anchor" href="#pre-pr-reminder" aria-label="Link to this section">#</a></h2>
     <p>
-      If you're on Claude Code, the <a href="#plugin">uploads plugin</a> bundles the skills
-      above plus a pre-PR hook: the uploads plugin's pre-PR hook reminds the agent when a
-      UI-touching branch has no staged screenshots, so it doesn't open a PR that's about to
-      need a follow-up comment. Nothing else to configure once the plugin is installed.
-    </p>
-  </section>
-
-  <section id="other-hooks">
-    <h2>Other agents with hook systems <a class="anchor" href="#other-hooks" aria-label="Link to this section">#</a></h2>
-    <p>
-      If your agent supports pre-command hooks (or you're willing to wrap <code>gh pr
-      create</code> yourself), the same reminder is a few lines of POSIX shell: check
-      whether anything is staged for the current branch, and print a nudge if not.&#32;
+      A useful backstop is a check at <code>gh pr create</code> time: is anything staged
+      for this branch? If your runtime supports pre-command hooks — or you wrap&#32;
+      <code>gh pr create</code> yourself — it's a few lines of shell.&#32;
       <strong>Keep it fail-open</strong> — a broken check should never block a PR from being
       created.
     </p>
@@ -149,18 +141,11 @@ fi
 exit 0</pre>
     </div>
     <p>
-      <code>uploads find gh.branch=&lt;name&gt;</code> lists what's staged for a branch — see the&#32;
-      <strong>uploads-cli</strong> skill for the full query vocabulary.
-    </p>
-  </section>
-
-  <section id="no-hook-fallback">
-    <h2>No hooks at all <a class="anchor" href="#no-hook-fallback" aria-label="Link to this section">#</a></h2>
-    <p>
-      None of the above is required. Even with zero setup, running <code>uploads attach
-      --promote</code> (no file arguments) right after opening a PR picks up everything
-      staged against that branch and posts or refreshes the attachments comment — it exits&#32;
-      <code>0</code> even if nothing was staged.
+      The <a href="#plugin">Claude Code plugin</a> ships this reminder as a bundled hook.
+      And no reminder is required at all — <code>uploads attach --promote</code> (no file
+      arguments) right after opening a PR picks up everything staged against the branch
+      and posts or refreshes the attachments comment; it exits <code>0</code> even if
+      nothing was staged.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -79,11 +79,11 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
     <h2>Any coding agent <a class="anchor" href="#any-agent" aria-label="Link to this section">#</a></h2>
     <p>
       None of this is Claude-Code-specific. Any agent that can run a shell command can
-      stage screenshots as it works: capture at each visual milestone, run
+      stage screenshots as it works: capture at each visual milestone, run&#32;
       <code>uploads attach --branch --state before|after</code>, and the PR comment
-      assembles itself once a PR opens — via the GitHub App webhook, or the next
+      assembles itself once a PR opens — via the GitHub App webhook, or the next&#32;
       <code>uploads attach</code> (or <code>uploads attach --promote</code>) if you're not
-      running the App. See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>
+      running the App. See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>&#32;
       for the full loop.
     </p>
   </section>
@@ -107,7 +107,7 @@ Stage before/after pairs where it makes sense. No need to open the PR first —
 staged files are promoted into the PR's attachments comment automatically.</pre>
     </div>
     <p>
-      Requires the <code>uploads</code> CLI on <code>PATH</code> and <code>uploads login</code>
+      Requires the <code>uploads</code> CLI on <code>PATH</code> and <code>uploads login</code>&#32;
       already run once — see <a href="#install">One command</a> above.
     </p>
   </section>
@@ -127,7 +127,7 @@ staged files are promoted into the PR's attachments comment automatically.</pre>
     <p>
       If your agent supports pre-command hooks (or you're willing to wrap <code>gh pr
       create</code> yourself), the same reminder is a few lines of POSIX shell: check
-      whether anything is staged for the current branch, and print a nudge if not.
+      whether anything is staged for the current branch, and print a nudge if not.&#32;
       <strong>Keep it fail-open</strong> — a broken check should never block a PR from being
       created.
     </p>
@@ -149,7 +149,7 @@ fi
 exit 0</pre>
     </div>
     <p>
-      <code>uploads find gh.branch=&lt;name&gt;</code> lists what's staged for a branch — see the
+      <code>uploads find gh.branch=&lt;name&gt;</code> lists what's staged for a branch — see the&#32;
       <strong>uploads-cli</strong> skill for the full query vocabulary.
     </p>
   </section>
@@ -159,7 +159,7 @@ exit 0</pre>
     <p>
       None of the above is required. Even with zero setup, running <code>uploads attach
       --promote</code> (no file arguments) right after opening a PR picks up everything
-      staged against that branch and posts or refreshes the attachments comment — it exits
+      staged against that branch and posts or refreshes the attachments comment — it exits&#32;
       <code>0</code> even if nothing was staged.
     </p>
   </section>

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1432,6 +1432,10 @@ async function runAttachBranch(
     }
     if (!ctx.quiet && uploads.length > 0) {
       process.stderr.write(`>> find these later: uploads find gh.branch=${branch.toLowerCase()}\n`);
+      process.stderr.write(
+        `>> staged: these auto-attach to this branch's PR when it opens ` +
+          `(or run \`uploads attach --promote\` after opening)\n`,
+      );
     }
   }
   return failures.length === 0 ? 0 : 1;

--- a/plugins/claude/uploads/README.md
+++ b/plugins/claude/uploads/README.md
@@ -42,9 +42,22 @@ comment on fork branches ([issue #317](https://github.com/buildinternet/uploads/
 That fork check is inherently best-effort — cross-checking the PR's actual
 target repo, as opposed to just whether `origin` is a fork, isn't attempted.
 
-**Disable it:** set `UPLOADS_HOOK_DISABLE=1` in your environment, or remove
-the `hooks` entry from this plugin's `.claude-plugin/marketplace.json` /
-delete `plugins/claude/uploads/hooks/hooks.json` in a local checkout.
+**Disable it:** the hook honors `UPLOADS_HOOK_DISABLE=1`. Set it wherever
+fits the scope you want — Claude Code's `env` settings block is the
+established way to make that durable:
+
+```jsonc
+// ~/.claude/settings.json        → off everywhere, for you
+// <repo>/.claude/settings.json   → off for everyone in one repo
+// <repo>/.claude/settings.local.json → off for just your checkout
+{
+  "env": { "UPLOADS_HOOK_DISABLE": "1" },
+}
+```
+
+Disabling the plugin itself also works but takes the skills and MCP server
+with it. Claude Code has no per-hook toggle today, so the env var is the
+supported per-hook switch.
 
 ## Install
 

--- a/plugins/claude/uploads/README.md
+++ b/plugins/claude/uploads/README.md
@@ -10,15 +10,41 @@ with `source: "./"`, so the whole repo is a one-plugin marketplace.
 
 ## What it bundles
 
-| Component                | Invocation                    | Purpose                                                                           |
-| ------------------------ | ----------------------------- | --------------------------------------------------------------------------------- |
-| github-screenshots skill | `/uploads:github-screenshots` | Capture + host + embed a visual in a PR/issue with a stable per-target key        |
-| uploads-cli skill        | `/uploads:uploads-cli`        | Full `uploads` CLI reference — `put`, `attach`, `screenshot`, galleries, metadata |
-| attach command           | `/uploads:attach`             | Explicit entry point for hosting a file or attaching to a PR/issue                |
-| uploads MCP server       | (tools)                       | Hosted `https://agents.uploads.sh/mcp` — `put`, `list`, `attach`, galleries       |
+| Component                   | Invocation                    | Purpose                                                                           |
+| --------------------------- | ----------------------------- | --------------------------------------------------------------------------------- |
+| github-screenshots skill    | `/uploads:github-screenshots` | Capture + host + embed a visual in a PR/issue with a stable per-target key        |
+| uploads-cli skill           | `/uploads:uploads-cli`        | Full `uploads` CLI reference — `put`, `attach`, `screenshot`, galleries, metadata |
+| attach command              | `/uploads:attach`             | Explicit entry point for hosting a file or attaching to a PR/issue                |
+| uploads MCP server          | (tools)                       | Hosted `https://agents.uploads.sh/mcp` — `put`, `list`, `attach`, galleries       |
+| PR screenshot reminder hook | (automatic)                   | Advisory nudge to stage screenshots before `gh pr create` on a UI-touching branch |
 
 Plugin skills and commands are namespaced by the plugin name (`uploads`), so
 they appear as `/uploads:…`.
+
+## PR screenshot reminder hook
+
+A `PreToolUse` hook (matcher: `Bash`) watches for commands that run
+`gh pr create`. When the current branch's diff against the repo's default
+branch touches visually-observable files — `.astro`, `.tsx`, `.jsx`, `.vue`,
+`.svelte`, `.html`, `.css`, `.scss`, `.less`, or anything under an `/email/`
+path — and `uploads find gh.branch=<branch> --format json` comes back empty,
+the agent gets a short advisory message suggesting
+`uploads attach <shot.png> --branch --state after` before or after opening
+the PR. It never blocks PR creation.
+
+The hook fails open (silently does nothing) whenever it can't be sure:
+non-matching commands, no git repo, no visual files in the diff, the
+`uploads` CLI not installed/authenticated, or the `uploads find` call
+erroring or exceeding its 5-second timeout. On a fork checkout it also tries
+a best-effort `gh repo view --json isFork` check (3s timeout) and, if true,
+appends a note that staged screenshots don't yet auto-promote into the PR
+comment on fork branches ([issue #317](https://github.com/buildinternet/uploads/issues/317)).
+That fork check is inherently best-effort — cross-checking the PR's actual
+target repo, as opposed to just whether `origin` is a fork, isn't attempted.
+
+**Disable it:** set `UPLOADS_HOOK_DISABLE=1` in your environment, or remove
+the `hooks` entry from this plugin's `.claude-plugin/marketplace.json` /
+delete `plugins/claude/uploads/hooks/hooks.json` in a local checkout.
 
 ## Install
 

--- a/plugins/claude/uploads/hooks/hooks.json
+++ b/plugins/claude/uploads/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Advisory reminder to stage screenshots on uploads.sh before opening a PR that touches UI files.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh ${CLAUDE_PLUGIN_ROOT}/hooks/pr-screenshot-reminder.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude/uploads/hooks/pr-screenshot-reminder.sh
+++ b/plugins/claude/uploads/hooks/pr-screenshot-reminder.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+# PreToolUse hook (matcher: Bash) for the uploads plugin.
+#
+# When an agent is about to run `gh pr create` and the branch diff touches
+# visually-observable files (UI markup/styles or anything under an /email/
+# path) but no screenshots are staged on uploads.sh for this branch, emit a
+# non-blocking advisory reminder. Never blocks PR creation: any failure,
+# timeout, or missing tool causes a silent exit 0.
+#
+# Disable this hook by setting UPLOADS_HOOK_DISABLE=1 in your environment,
+# or by removing the hooks entry from plugins/claude/uploads/hooks/hooks.json.
+#
+# Testability: set UPLOADS_HOOK_TEST_FILES to a newline-separated list of
+# changed file paths to bypass the real git diff (used by manual tests).
+
+set -eu
+
+# Fail open on any unexpected error from this point on.
+trap 'exit 0' EXIT
+
+if [ "${UPLOADS_HOOK_DISABLE:-}" = "1" ]; then
+  exit 0
+fi
+
+input="$(cat)"
+
+# Extract the Bash command from the PreToolUse tool_input JSON.
+command="$(printf '%s' "$input" | node -e '
+  let data = "";
+  process.stdin.on("data", d => data += d);
+  process.stdin.on("end", () => {
+    try {
+      const j = JSON.parse(data);
+      process.stdout.write(String((j.tool_input && j.tool_input.command) || ""));
+    } catch (e) {
+      process.stdout.write("");
+    }
+  });
+' 2>/dev/null || true)"
+
+if [ -z "$command" ]; then
+  exit 0
+fi
+
+# Word-boundary-ish match for `gh pr create`, tolerant of flags/prefixes
+# (e.g. `cd foo && gh pr create ...`, `GH_TOKEN=x gh pr create ...`).
+case "$command" in
+  *"gh pr create"*) : ;;
+  *) exit 0 ;;
+esac
+
+# Must be inside a git repo to compute a diff.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+  exit 0
+fi
+
+# Determine the default branch to diff against: prefer origin's HEAD, fall
+# back to main.
+default_branch="$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' | head -n1 || true)"
+if [ -z "$default_branch" ]; then
+  default_branch="main"
+fi
+
+merge_base="$(git merge-base "origin/${default_branch}" HEAD 2>/dev/null || git merge-base "${default_branch}" HEAD 2>/dev/null || true)"
+
+if [ -n "${UPLOADS_HOOK_TEST_FILES:-}" ]; then
+  changed_files="$UPLOADS_HOOK_TEST_FILES"
+elif [ -n "$merge_base" ]; then
+  changed_files="$(git diff --name-only "$merge_base" HEAD 2>/dev/null || true)"
+else
+  changed_files="$(git diff --name-only HEAD 2>/dev/null || true)"
+fi
+
+if [ -z "$changed_files" ]; then
+  exit 0
+fi
+
+is_visual=0
+old_ifs="$IFS"
+IFS='
+'
+for f in $changed_files; do
+  case "$f" in
+    *.astro|*.tsx|*.jsx|*.vue|*.svelte|*.html|*.css|*.scss|*.less)
+      is_visual=1
+      ;;
+    */email/*)
+      is_visual=1
+      ;;
+  esac
+  [ "$is_visual" = "1" ] && break
+done
+IFS="$old_ifs"
+
+if [ "$is_visual" != "1" ]; then
+  exit 0
+fi
+
+# Check whether the CLI is installed at all; fail open if not.
+if ! command -v uploads >/dev/null 2>&1; then
+  exit 0
+fi
+
+branch_lower="$(printf '%s' "$branch" | tr '[:upper:]' '[:lower:]')"
+
+# `timeout` is GNU coreutils and absent on stock macOS; fall back to running
+# bare (the hook-level timeout in hooks.json still bounds us).
+if command -v timeout >/dev/null 2>&1; then
+  run_find() { timeout 5 uploads find "gh.branch=${branch_lower}" --format json 2>/dev/null; }
+else
+  run_find() { uploads find "gh.branch=${branch_lower}" --format json 2>/dev/null; }
+fi
+
+if ! find_output="$(run_find)"; then
+  # Timed out, errored, or uploads isn't configured/logged in — fail open.
+  exit 0
+fi
+# NOTE: zero matches yields empty stdout with exit 0 — that is the "nothing
+# staged" signal, so it must NOT fail open here.
+
+staged_count="$(printf '%s' "$find_output" | node -e '
+  let data = "";
+  process.stdin.on("data", d => data += d);
+  process.stdin.on("end", () => {
+    try {
+      const j = JSON.parse(data);
+      const arr = Array.isArray(j) ? j : (j.items || j.results || j.files || []);
+      process.stdout.write(String(Array.isArray(arr) ? arr.length : 0));
+    } catch (e) {
+      process.stdout.write("0");
+    }
+  });
+' 2>/dev/null || echo 0)"
+
+if [ "$staged_count" != "0" ]; then
+  exit 0
+fi
+
+fork_note=""
+is_fork="$(timeout 3 gh repo view --json isFork -q .isFork 2>/dev/null || true)"
+if [ "$is_fork" = "true" ]; then
+  fork_note=" Note: this looks like a fork branch, so staged screenshots won't auto-promote into the PR comment yet (see issue #317) — attach them manually if you use uploads."
+fi
+
+message="This PR touches UI files (astro/tsx/jsx/vue/svelte/html/css/scss/less or an /email/ path) but no screenshots are staged for branch '${branch}' on uploads.sh. Consider running \`uploads attach <shot.png> --branch --state after\` (and a --state before if useful) before or after opening the PR — the managed attachments comment assembles from staged files automatically.${fork_note}"
+
+# Remove the fail-open trap now that we're emitting a deliberate result.
+trap - EXIT
+
+# Advisory only: no permissionDecision (that would bypass the user's normal
+# permission prompt for the gh command). additionalContext reaches the model;
+# systemMessage is shown to the user.
+node -e '
+  const msg = process.argv[1];
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: msg
+    },
+    systemMessage: msg
+  }));
+' "$message"
+
+exit 0


### PR DESCRIPTION
## What

Improves the DX of branch-staged screenshots so agents actually stage as they work and know a PR will assemble them:

1. **AGENTS.md** — stage-as-you-go section: capture at each visual milestone with `uploads attach --branch --state before|after`; the attachments comment assembles on PR open.
2. **CLI nudge** — `uploads attach --branch` output now says staged files auto-attach to the branch's PR when it opens (or via `uploads attach --promote`). Works for every agent runtime, not just Claude Code. Changeset included (patch).
3. **Plugin hook** — the uploads Claude Code plugin (v0.2.0) ships a `PreToolUse` hook on `gh pr create`: if the branch diff touches visual files (`.astro/.tsx/.jsx/.vue/.svelte/.html/.css/.scss/.less` or `/email/` paths) and `uploads find gh.branch=<branch>` is empty, it injects an advisory reminder (`additionalContext` + `systemMessage`). Strictly non-blocking and fail-open: missing CLI, auth errors, timeouts, no git repo → silent exit 0. No `permissionDecision`, so the user's normal permission prompt is untouched. Softens the message on fork checkouts (#317). Disable with `UPLOADS_HOOK_DISABLE=1`.
4. **Docs** — `/docs/agents` gains agent-agnostic sections: a copy-pastable instructions-file snippet (AGENTS.md / CLAUDE.md / .cursor/rules), a generic fail-open POSIX pre-PR recipe for agents with hook systems, and the zero-setup `uploads attach --promote` fallback.

## Verification

- Full suite: 177 files / 2237 tests pass; typecheck clean; `astro check` clean on the docs page.
- Hook manually tested against real stdin JSON: non-matching command, non-visual diff, missing CLI, real end-to-end `uploads find` (nudge fires), and staged-present (suppressed).
- Review fixes over the first draft: dropped `permissionDecision: "allow"` (would have auto-approved the gh call), handled macOS lacking `timeout`, counted `items` in the find JSON, and treated empty find output as "nothing staged" (verified the CLI emits empty stdout + exit 0 for zero matches).

Related: #317 (fork branches don't auto-promote; hook and README call this out).
