### PR TITLE
feat(email): embed Gmail go-to and one-click action markup

### DIFF
--- a/packages/email/src/card.ts
+++ b/packages/email/src/card.ts
@@ -5,6 +5,12 @@
  * move it here too. Type follows the site's split: sans for headline and body,
  * mono reserved for the wordmark, eyebrow, button label, and metadata. Geist
  * itself can't load in a mail client, so the fallback stacks are the design.
+ *
+ * CTA emails embed Gmail action JSON-LD (ViewAction by default). One-click
+ * ConfirmAction/SaveAction is opt-in via `gmailAction` when a handler URL
+ * exists. Production inbox buttons need a registered sender.
+ * https://developers.google.com/workspace/gmail/markup/reference/go-to-action
+ * https://developers.google.com/workspace/gmail/markup/reference/one-click-action
  */
 
 export type RenderedEmail = {
@@ -12,6 +18,19 @@ export type RenderedEmail = {
   text: string;
   html: string;
 };
+
+/**
+ * Gmail inbox action. Prefer ViewAction (go-to) for page CTAs; use
+ * ConfirmAction/SaveAction only when Google can hit a dedicated handler URL.
+ */
+export type GmailAction =
+  | { type: "ViewAction"; name: string; url: string; description?: string }
+  | {
+      type: "ConfirmAction" | "SaveAction";
+      name: string;
+      handlerUrl: string;
+      description?: string;
+    };
 
 export type EmailCardInput = {
   subject: string;
@@ -26,6 +45,8 @@ export type EmailCardInput = {
   noteHtml?: string;
   footNoteHtml?: string;
   webOrigin?: string;
+  /** Defaults to a ViewAction from `cta`. Pass `false` to suppress. */
+  gmailAction?: GmailAction | false;
 };
 
 const SANS =
@@ -82,12 +103,54 @@ function webOriginOf(input: EmailCardInput): string {
   return DEFAULT_WEB_ORIGIN;
 }
 
+/** Gmail button label: drop trailing CTA arrows ("Sign in →" → "Sign in"). */
+function actionName(label: string): string {
+  return label.replace(/\s*[→›»]\s*$/u, "").trim();
+}
+
+function resolveGmailAction(input: EmailCardInput): GmailAction | null {
+  if (input.gmailAction === false) return null;
+  if (input.gmailAction) return input.gmailAction;
+  if (!input.cta) return null;
+  return {
+    type: "ViewAction",
+    name: actionName(input.cta.label),
+    url: input.cta.url,
+    description: input.preheader || input.title,
+  };
+}
+
+function gmailJsonLd(action: GmailAction, publisherUrl: string): string {
+  const description = action.description;
+  const potentialAction =
+    action.type === "ViewAction"
+      ? { "@type": "ViewAction", name: action.name, url: action.url }
+      : {
+          "@type": action.type,
+          name: action.name,
+          handler: { "@type": "HttpActionHandler", url: action.handlerUrl },
+        };
+  const data = {
+    "@context": "http://schema.org",
+    "@type": "EmailMessage",
+    potentialAction,
+    ...(description ? { description } : {}),
+    publisher: { "@type": "Organization", name: "uploads.sh", url: publisherUrl },
+  };
+  // Escape `<` so a hostile URL cannot break out of the script element.
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+  return `<script type="application/ld+json">${json}</script>`;
+}
+
 /** Dark-card shell shared by every uploads.sh email. */
 export function renderEmailCard(input: EmailCardInput): RenderedEmail {
   const webOrigin = webOriginOf(input);
   const title = escapeHtml(input.title);
   const eyebrow = escapeHtml(input.eyebrow);
   const preheader = escapeHtml(input.preheader);
+
+  const action = resolveGmailAction(input);
+  const gmailMarkup = action ? gmailJsonLd(action, webOrigin) : "";
 
   const cta = input.cta
     ? `<tr><td style="padding-bottom:16px;">
@@ -122,6 +185,7 @@ export function renderEmailCard(input: EmailCardInput): RenderedEmail {
 <html lang="en">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"></head>
 <body style="margin:0;padding:0;background-color:${BG};">
+${gmailMarkup}
 <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${BG};">
 <tr><td align="center" style="padding:40px 16px;">

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -3,6 +3,7 @@ export {
   renderEmailCard,
   strong,
   type EmailCardInput,
+  type GmailAction,
   type RenderedEmail,
 } from "./card";
 export { renderMagicLinkEmail } from "./auth";

--- a/packages/email/test/invites.test.ts
+++ b/packages/email/test/invites.test.ts
@@ -3,9 +3,16 @@ import {
   escapeHtml,
   renderEmailCard,
   renderEnrollmentInvitationEmail,
+  renderMagicLinkEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
 } from "../src/index";
+
+function parseJsonLd(html: string): Record<string, unknown> | null {
+  const match = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+  if (!match?.[1]) return null;
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
 
 describe("escapeHtml", () => {
   it("escapes angle brackets and quotes", () => {
@@ -15,7 +22,7 @@ describe("escapeHtml", () => {
 });
 
 describe("renderEmailCard", () => {
-  it("builds a full HTML document with CTA", () => {
+  it("builds a full HTML document with CTA and inferred ViewAction", () => {
     const out = renderEmailCard({
       subject: "Test",
       preheader: "Preview line",
@@ -32,9 +39,77 @@ describe("renderEmailCard", () => {
     expect(out.html).toContain("Go →");
     expect(out.html).toContain("/terms");
     expect(out.html).toContain("/privacy");
+
+    const ld = parseJsonLd(out.html);
+    expect(ld?.["@type"]).toBe("EmailMessage");
+    expect(ld?.potentialAction).toEqual({
+      "@type": "ViewAction",
+      name: "Go",
+      url: "https://uploads.sh/x",
+    });
+    expect(ld?.description).toBe("Preview line");
+    expect(ld?.publisher).toEqual({
+      "@type": "Organization",
+      name: "uploads.sh",
+      url: "https://uploads.sh",
+    });
   });
 
-  it("omits the CTA block when not provided", () => {
+  it("embeds an explicit one-click ConfirmAction", () => {
+    const out = renderEmailCard({
+      subject: "Approve",
+      preheader: "Needs your approval",
+      eyebrow: "Approval",
+      title: "Approve request",
+      bodyHtml: "Please approve.",
+      text: "Please approve.",
+      cta: { url: "https://uploads.sh/approve/1", label: "Review →" },
+      gmailAction: {
+        type: "ConfirmAction",
+        name: "Approve",
+        handlerUrl: "https://api.uploads.sh/v1/actions/approve?id=1",
+        description: "Approve this request",
+      },
+    });
+    expect(parseJsonLd(out.html)?.potentialAction).toEqual({
+      "@type": "ConfirmAction",
+      name: "Approve",
+      handler: {
+        "@type": "HttpActionHandler",
+        url: "https://api.uploads.sh/v1/actions/approve?id=1",
+      },
+    });
+  });
+
+  it("suppresses Gmail markup when gmailAction is false", () => {
+    const out = renderEmailCard({
+      subject: "Test",
+      preheader: "p",
+      eyebrow: "x",
+      title: "t",
+      bodyHtml: "b",
+      text: "b",
+      cta: { url: "https://uploads.sh/x", label: "Go →" },
+      gmailAction: false,
+    });
+    expect(out.html).not.toContain("application/ld+json");
+  });
+
+  it("escapes </ in JSON-LD so script tags cannot break out", () => {
+    const out = renderEmailCard({
+      subject: "Test",
+      preheader: "p",
+      eyebrow: "x",
+      title: "t",
+      bodyHtml: "b",
+      text: "b",
+      cta: { url: "https://uploads.sh/</script>alert(1)", label: "Go" },
+    });
+    expect(out.html).toContain("\\u003c/script>");
+    expect(out.html).not.toMatch(/ld\+json">[\s\S]*<\/script>alert/);
+  });
+
+  it("omits the CTA block and Gmail markup when not provided", () => {
     const out = renderEmailCard({
       subject: "Notify",
       preheader: "p",
@@ -45,13 +120,27 @@ describe("renderEmailCard", () => {
     });
     expect(out.html).not.toContain("background-color:#c27eff");
     expect(out.html).not.toContain("Or paste this link");
+    expect(out.html).not.toContain("application/ld+json");
+  });
+});
+
+describe("renderMagicLinkEmail", () => {
+  it("embeds a Sign in ViewAction for the magic-link URL", () => {
+    const url = "https://uploads.sh/api/auth/magic-link/verify?token=abc";
+    const ld = parseJsonLd(renderMagicLinkEmail({ url }).html);
+    expect(ld?.potentialAction).toEqual({
+      "@type": "ViewAction",
+      name: "Sign in",
+      url,
+    });
   });
 });
 
 describe("renderOrgInvitationEmail", () => {
-  it("escapes org name and inviter in HTML", () => {
+  it("escapes org name and inviter, and embeds Accept invitation ViewAction", () => {
+    const url = "https://uploads.sh/accept-invitation/abc";
     const out = renderOrgInvitationEmail({
-      url: "https://uploads.sh/accept-invitation/abc",
+      url,
       organizationName: `<img src=x onerror=alert(1)>`,
       inviterEmail: `"><script>alert(2)</script>`,
     });
@@ -60,21 +149,32 @@ describe("renderOrgInvitationEmail", () => {
     expect(out.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
     expect(out.subject).toContain("<img");
     expect(out.html).toContain("Accept invitation");
-    expect(out.text).toContain("https://uploads.sh/accept-invitation/abc");
+    expect(out.text).toContain(url);
+    expect(parseJsonLd(out.html)?.potentialAction).toEqual({
+      "@type": "ViewAction",
+      name: "Accept invitation",
+      url,
+    });
   });
 });
 
 describe("renderEnrollmentInvitationEmail", () => {
   it("special-cases the default workspace subject and body", () => {
+    const link = "https://uploads.sh/invite?id=upi_x#code=secret";
     const out = renderEnrollmentInvitationEmail({
       workspaceName: "default",
-      link: "https://uploads.sh/invite?id=upi_x#code=secret",
+      link,
       expiresAt: "2030-01-15T12:00:00.000Z",
     });
     expect(out.subject).toBe("You've been given access to uploads.sh");
     expect(out.text).toContain("#code=secret");
     expect(out.html).toContain("You've been given access");
     expect(out.html).toContain("laptop");
+    expect(parseJsonLd(out.html)?.potentialAction).toEqual({
+      "@type": "ViewAction",
+      name: "Accept invitation",
+      url: link,
+    });
   });
 
   it("names a non-default workspace in the subject", () => {
@@ -99,7 +199,7 @@ describe("renderEnrollmentInvitationEmail", () => {
 });
 
 describe("renderMemberJoinedEmail", () => {
-  it("names the joiner and workspace", () => {
+  it("names the joiner and workspace without Gmail action markup", () => {
     const out = renderMemberJoinedEmail({
       organizationName: "buildinternet",
       memberEmail: "new@example.com",
@@ -109,5 +209,6 @@ describe("renderMemberJoinedEmail", () => {
     expect(out.html).toContain("new@example.com");
     expect(out.html).toContain("buildinternet");
     expect(out.text).toContain("accepted your invitation");
+    expect(out.html).not.toContain("application/ld+json");
   });
 });


### PR DESCRIPTION
## In plain terms

Gmail can show an inbox button on emails that include the right schema.org markup. This adds that markup to our shared email card so sign-in and invite emails can surface a “Sign in” / “Accept invitation” button in Gmail, and so future one-click confirms can opt in when we have a real handler endpoint.

## What it does

- Embeds JSON-LD `EmailMessage` markup in the shared card HTML
- **Go-To (`ViewAction`)** is inferred automatically from any card CTA (magic link, org invite, enrollment invite)
- **One-Click (`ConfirmAction` / `SaveAction`)** is available via `gmailAction` when a dedicated handler URL exists
- Notification-only emails (member joined) stay markup-free
- Escapes `<` in JSON-LD so a hostile URL can’t break out of the script tag

## What it is not

- Not a production-ready Gmail button by itself — inbox buttons still require a registered sender with Google
- Not wiring one-click handlers on the API; current accept/sign-in flows need a full page/session, so they use go-to only

## Technical notes

- Changes live in `@uploads/email` (`packages/email/src/card.ts`)
- Pass `gmailAction: false` to suppress markup on a CTA email
- Explicit one-click example: `{ type: "ConfirmAction", name: "…", handlerUrl: "https://…" }`

## Test plan

- [x] `pnpm --filter @uploads/email test`
- [x] `pnpm --filter @uploads/email typecheck`
- [ ] Optional: paste a rendered magic-link HTML body into [Google’s markup tester](https://www.google.com/webmasters/markup-tester/)