### PR TITLE
feat(admin): operator page to send test transactional emails

### DIFF
--- a/apps/api/src/admin-email-preview.test.ts
+++ b/apps/api/src/admin-email-preview.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import {
+  EMAIL_PREVIEW_TYPES,
+  isEmailPreviewType,
+  resolvePreviewRecipient,
+} from "./admin-email-preview";
+import { respondError } from "./error-response";
+import { adminUi } from "./routes/admin-ui";
+
+const ADMIN_USER = { id: "u-admin", email: "admin@example.com", name: "Admin", role: "admin" };
+const NON_ADMIN = { id: "u-plain", email: "plain@example.com", name: "Plain", role: "user" };
+
+function stubAuth(user: typeof ADMIN_USER | null): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+      }
+      return new Response("{}", { status: 404 });
+    }) as Fetcher["fetch"],
+  };
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/admin-ui", adminUi)
+    .onError((err, c) => respondError(c, err));
+}
+
+describe("email preview helpers", () => {
+  it("recognizes known types only", () => {
+    expect(isEmailPreviewType("magic-link")).toBe(true);
+    expect(isEmailPreviewType("not-a-type")).toBe(false);
+  });
+
+  it("defaults the recipient to the session email", () => {
+    expect(resolvePreviewRecipient("admin@example.com", undefined)).toBe("admin@example.com");
+  });
+
+  it("accepts an explicit recipient override", () => {
+    expect(resolvePreviewRecipient("admin@example.com", "other@gmail.com")).toBe("other@gmail.com");
+  });
+
+  it("rejects a bad recipient override", () => {
+    expect(() => resolvePreviewRecipient("admin@example.com", "not-an-email")).toThrow(
+      /invalid recipient/i,
+    );
+  });
+});
+
+describe("GET /admin-ui/dev/emails", () => {
+  it("lists preview types for admins", async () => {
+    const env = { AUTH: stubAuth(ADMIN_USER) } as unknown as Env;
+    const res = await app().request("/admin-ui/dev/emails", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { types: typeof EMAIL_PREVIEW_TYPES };
+    expect(body.types.map((t) => t.id)).toEqual(EMAIL_PREVIEW_TYPES.map((t) => t.id));
+  });
+
+  it("401s without a session", async () => {
+    const env = { AUTH: stubAuth(null) } as unknown as Env;
+    const res = await app().request("/admin-ui/dev/emails", {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /admin-ui/dev/emails/:type", () => {
+  it("rejects unknown types", async () => {
+    const env = { AUTH: stubAuth(ADMIN_USER) } as unknown as Env;
+    const res = await app().request("/admin-ui/dev/emails/not-a-type", { method: "POST" }, env);
+    expect(res.status).toBe(400);
+  });
+
+  it("403s for non-admins", async () => {
+    const env = { AUTH: stubAuth(NON_ADMIN) } as unknown as Env;
+    const res = await app().request("/admin-ui/dev/emails/magic-link", { method: "POST" }, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("503s when EMAIL is not bound", async () => {
+    const env = { AUTH: stubAuth(ADMIN_USER), WEB_ORIGIN: "https://uploads.sh" } as unknown as Env;
+    const res = await app().request("/admin-ui/dev/emails/magic-link", { method: "POST" }, env);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("email_not_configured");
+  });
+
+  it("sends each preview type to the signed-in admin", async () => {
+    const sent: { to: string; subject: string; from: { email: string }; html?: string }[] = [];
+    const email = {
+      send: vi.fn(
+        async (msg: { to: string; subject: string; from: { email: string }; html?: string }) => {
+          sent.push(msg);
+          return { messageId: "test" };
+        },
+      ),
+    };
+    const env = {
+      AUTH: stubAuth(ADMIN_USER),
+      EMAIL: email,
+      WEB_ORIGIN: "https://uploads.sh",
+    } as unknown as Env;
+
+    for (const preview of EMAIL_PREVIEW_TYPES) {
+      sent.length = 0;
+      const res = await app().request(
+        `/admin-ui/dev/emails/${preview.id}`,
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; to: string; type: string; subject: string };
+      expect(body).toMatchObject({ ok: true, to: "admin@example.com", type: preview.id });
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.to).toBe("admin@example.com");
+      expect(sent[0]?.html).toContain("<!doctype html>");
+      // CTA emails embed Gmail ViewAction; member-joined is notification-only.
+      if (preview.id === "member-joined") {
+        expect(sent[0]?.html).not.toContain("ViewAction");
+      } else {
+        expect(sent[0]?.html).toContain("ViewAction");
+      }
+    }
+  });
+
+  it("honors an explicit to address", async () => {
+    const email = {
+      send: vi.fn(async () => ({ messageId: "test" })),
+    };
+    const env = {
+      AUTH: stubAuth(ADMIN_USER),
+      EMAIL: email,
+      WEB_ORIGIN: "https://uploads.sh",
+    } as unknown as Env;
+    const res = await app().request(
+      "/admin-ui/dev/emails/magic-link",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ to: "schema.whitelisting+sample@gmail.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(email.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "schema.whitelisting+sample@gmail.com" }),
+    );
+  });
+});

--- a/apps/api/src/admin-email-preview.test.ts
+++ b/apps/api/src/admin-email-preview.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
 import {
   EMAIL_PREVIEW_TYPES,
   isEmailPreviewType,
@@ -8,16 +8,15 @@ import {
 import { respondError } from "./error-response";
 import { adminUi } from "./routes/admin-ui";
 
-const ADMIN_USER = { id: "u-admin", email: "admin@example.com", name: "Admin", role: "admin" };
-const NON_ADMIN = { id: "u-plain", email: "plain@example.com", name: "Plain", role: "user" };
+const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin", role: "admin" };
+const USER = { id: "u-plain", email: "plain@example.com", name: "Plain", role: "user" };
 
-function stubAuth(user: typeof ADMIN_USER | null): Pick<Fetcher, "fetch"> {
+function stubAuth(user: typeof ADMIN | null): Pick<Fetcher, "fetch"> {
   return {
     fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
       const req = input instanceof Request ? input : new Request(input, init);
-      const url = new URL(req.url);
-      if (url.pathname === "/api/auth/get-session") {
-        return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+      if (new URL(req.url).pathname === "/api/auth/get-session") {
+        return Response.json(user ? { session: {}, user } : null);
       }
       return new Response("{}", { status: 404 });
     }) as Fetcher["fetch"],
@@ -30,79 +29,53 @@ function app() {
     .onError((err, c) => respondError(c, err));
 }
 
-describe("email preview helpers", () => {
-  it("recognizes known types only", () => {
+function envWith(user: typeof ADMIN | null, extra: Partial<Env> = {}): Env {
+  return { AUTH: stubAuth(user), WEB_ORIGIN: "https://uploads.sh", ...extra } as unknown as Env;
+}
+
+describe("preview helpers", () => {
+  it("validates type ids and recipients", () => {
     expect(isEmailPreviewType("magic-link")).toBe(true);
-    expect(isEmailPreviewType("not-a-type")).toBe(false);
-  });
-
-  it("defaults the recipient to the session email", () => {
+    expect(isEmailPreviewType("nope")).toBe(false);
     expect(resolvePreviewRecipient("admin@example.com", undefined)).toBe("admin@example.com");
-  });
-
-  it("accepts an explicit recipient override", () => {
     expect(resolvePreviewRecipient("admin@example.com", "other@gmail.com")).toBe("other@gmail.com");
-  });
-
-  it("rejects a bad recipient override", () => {
-    expect(() => resolvePreviewRecipient("admin@example.com", "not-an-email")).toThrow(
-      /invalid recipient/i,
-    );
-  });
-});
-
-describe("GET /admin-ui/dev/emails", () => {
-  it("lists preview types for admins", async () => {
-    const env = { AUTH: stubAuth(ADMIN_USER) } as unknown as Env;
-    const res = await app().request("/admin-ui/dev/emails", {}, env);
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { types: typeof EMAIL_PREVIEW_TYPES };
-    expect(body.types.map((t) => t.id)).toEqual(EMAIL_PREVIEW_TYPES.map((t) => t.id));
-  });
-
-  it("401s without a session", async () => {
-    const env = { AUTH: stubAuth(null) } as unknown as Env;
-    const res = await app().request("/admin-ui/dev/emails", {}, env);
-    expect(res.status).toBe(401);
+    expect(() => resolvePreviewRecipient("admin@example.com", "bad")).toThrow(/invalid recipient/i);
   });
 });
 
 describe("POST /admin-ui/dev/emails/:type", () => {
-  it("rejects unknown types", async () => {
-    const env = { AUTH: stubAuth(ADMIN_USER) } as unknown as Env;
-    const res = await app().request("/admin-ui/dev/emails/not-a-type", { method: "POST" }, env);
-    expect(res.status).toBe(400);
+  it("gates auth and unknown types", async () => {
+    expect(
+      (await app().request("/admin-ui/dev/emails/magic-link", { method: "POST" }, envWith(null)))
+        .status,
+    ).toBe(401);
+    expect(
+      (await app().request("/admin-ui/dev/emails/magic-link", { method: "POST" }, envWith(USER)))
+        .status,
+    ).toBe(403);
+    expect(
+      (await app().request("/admin-ui/dev/emails/not-a-type", { method: "POST" }, envWith(ADMIN)))
+        .status,
+    ).toBe(400);
   });
 
-  it("403s for non-admins", async () => {
-    const env = { AUTH: stubAuth(NON_ADMIN) } as unknown as Env;
-    const res = await app().request("/admin-ui/dev/emails/magic-link", { method: "POST" }, env);
-    expect(res.status).toBe(403);
-  });
+  it("503s without EMAIL and sends each type when bound", async () => {
+    const missing = await app().request(
+      "/admin-ui/dev/emails/magic-link",
+      { method: "POST" },
+      envWith(ADMIN),
+    );
+    expect(missing.status).toBe(503);
+    expect(((await missing.json()) as { error: { code: string } }).error.code).toBe(
+      "email_not_configured",
+    );
 
-  it("503s when EMAIL is not bound", async () => {
-    const env = { AUTH: stubAuth(ADMIN_USER), WEB_ORIGIN: "https://uploads.sh" } as unknown as Env;
-    const res = await app().request("/admin-ui/dev/emails/magic-link", { method: "POST" }, env);
-    expect(res.status).toBe(503);
-    const body = (await res.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("email_not_configured");
-  });
-
-  it("sends each preview type to the signed-in admin", async () => {
-    const sent: { to: string; subject: string; from: { email: string }; html?: string }[] = [];
-    const email = {
-      send: vi.fn(
-        async (msg: { to: string; subject: string; from: { email: string }; html?: string }) => {
-          sent.push(msg);
-          return { messageId: "test" };
-        },
-      ),
-    };
-    const env = {
-      AUTH: stubAuth(ADMIN_USER),
-      EMAIL: email,
-      WEB_ORIGIN: "https://uploads.sh",
-    } as unknown as Env;
+    const sent: { to: string }[] = [];
+    const send = vi.fn(async (msg: { to: string }) => {
+      sent.push(msg);
+      return { messageId: "test" };
+    });
+    const env = envWith(ADMIN, { EMAIL: { send } } as unknown as Env);
 
     for (const preview of EMAIL_PREVIEW_TYPES) {
       sent.length = 0;
@@ -112,29 +85,15 @@ describe("POST /admin-ui/dev/emails/:type", () => {
         env,
       );
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { ok: boolean; to: string; type: string; subject: string };
-      expect(body).toMatchObject({ ok: true, to: "admin@example.com", type: preview.id });
-      expect(sent).toHaveLength(1);
-      expect(sent[0]?.to).toBe("admin@example.com");
-      expect(sent[0]?.html).toContain("<!doctype html>");
-      // CTA emails embed Gmail ViewAction; member-joined is notification-only.
-      if (preview.id === "member-joined") {
-        expect(sent[0]?.html).not.toContain("ViewAction");
-      } else {
-        expect(sent[0]?.html).toContain("ViewAction");
-      }
+      expect(await res.json()).toMatchObject({
+        ok: true,
+        to: "admin@example.com",
+        type: preview.id,
+      });
+      expect(sent).toEqual([{ to: "admin@example.com" }]);
     }
-  });
 
-  it("honors an explicit to address", async () => {
-    const email = {
-      send: vi.fn(async () => ({ messageId: "test" })),
-    };
-    const env = {
-      AUTH: stubAuth(ADMIN_USER),
-      EMAIL: email,
-      WEB_ORIGIN: "https://uploads.sh",
-    } as unknown as Env;
+    sent.length = 0;
     const res = await app().request(
       "/admin-ui/dev/emails/magic-link",
       {
@@ -145,8 +104,15 @@ describe("POST /admin-ui/dev/emails/:type", () => {
       env,
     );
     expect(res.status).toBe(200);
-    expect(email.send).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "schema.whitelisting+sample@gmail.com" }),
-    );
+    expect(sent[0]?.to).toBe("schema.whitelisting+sample@gmail.com");
+  });
+});
+
+describe("GET /admin-ui/dev/emails", () => {
+  it("lists types for admins", async () => {
+    const res = await app().request("/admin-ui/dev/emails", {}, envWith(ADMIN));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { types: { id: string }[] };
+    expect(body.types.map((t) => t.id)).toEqual(EMAIL_PREVIEW_TYPES.map((t) => t.id));
   });
 });

--- a/apps/api/src/admin-email-preview.test.ts
+++ b/apps/api/src/admin-email-preview.test.ts
@@ -90,7 +90,8 @@ describe("POST /admin-ui/dev/emails/:type", () => {
         to: "admin@example.com",
         type: preview.id,
       });
-      expect(sent).toEqual([{ to: "admin@example.com" }]);
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.to).toBe("admin@example.com");
     }
 
     sent.length = 0;

--- a/apps/api/src/admin-email-preview.ts
+++ b/apps/api/src/admin-email-preview.ts
@@ -1,0 +1,144 @@
+/**
+ * Operator self-send for transactional email templates (admin /admin/email).
+ * Uses placeholder tokens so links will not complete a real auth/invite flow.
+ * Pattern mirrors either's admin-email-preview.
+ */
+import {
+  renderEnrollmentInvitationEmail,
+  renderMagicLinkEmail,
+  renderMemberJoinedEmail,
+  renderOrgInvitationEmail,
+  type RenderedEmail,
+} from "@uploads/email";
+import { ServiceUnavailableError, ValidationError } from "@uploads/errors";
+
+export const EMAIL_PREVIEW_TYPES = [
+  { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
+  { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
+  { id: "member-joined", label: "Member joined notify", category: "Auth" },
+  {
+    id: "enrollment-invitation",
+    label: "Enrollment invitation",
+    category: "Invites",
+  },
+] as const;
+
+export type EmailPreviewType = (typeof EMAIL_PREVIEW_TYPES)[number]["id"];
+
+const PREVIEW_TYPE_IDS = new Set<string>(EMAIL_PREVIEW_TYPES.map((e) => e.id));
+
+const AUTH_FROM = { name: "uploads.sh", email: "noreply@uploads.sh" } as const;
+const INVITE_FROM = { name: "uploads.sh", email: "invites@uploads.sh" } as const;
+
+export function isEmailPreviewType(value: unknown): value is EmailPreviewType {
+  return typeof value === "string" && PREVIEW_TYPE_IDS.has(value);
+}
+
+function webOrigin(env: Env): string {
+  const raw = typeof env.WEB_ORIGIN === "string" ? env.WEB_ORIGIN : "https://uploads.sh";
+  return raw.replace(/\/$/, "") || "https://uploads.sh";
+}
+
+function renderPreview(
+  type: EmailPreviewType,
+  origin: string,
+): {
+  from: { name: string; email: string };
+  rendered: RenderedEmail;
+} {
+  switch (type) {
+    case "magic-link":
+      return {
+        from: AUTH_FROM,
+        rendered: renderMagicLinkEmail({
+          url: `${origin}/api/auth/magic-link/verify?token=preview-example`,
+          webOrigin: origin,
+        }),
+      };
+    case "org-invitation":
+      return {
+        from: AUTH_FROM,
+        rendered: renderOrgInvitationEmail({
+          url: `${origin}/accept-invitation/preview-example`,
+          organizationName: "preview-workspace",
+          inviterEmail: "operator@uploads.sh",
+          webOrigin: origin,
+        }),
+      };
+    case "member-joined":
+      return {
+        from: AUTH_FROM,
+        rendered: renderMemberJoinedEmail({
+          organizationName: "preview-workspace",
+          memberEmail: "new-member@example.com",
+          webOrigin: origin,
+        }),
+      };
+    case "enrollment-invitation": {
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      return {
+        from: INVITE_FROM,
+        rendered: renderEnrollmentInvitationEmail({
+          workspaceName: "preview-workspace",
+          link: `${origin}/invite?id=upi_preview#code=preview-example`,
+          expiresAt,
+        }),
+      };
+    }
+  }
+}
+
+/**
+ * Send a sample product email to `to`. Throws ValidationError for bad types
+ * and ServiceUnavailableError when Email Sending is missing or fails.
+ */
+export async function sendEmailPreview(
+  env: Env,
+  type: EmailPreviewType,
+  to: string,
+): Promise<{ subject: string; from: string }> {
+  if (!env.EMAIL) {
+    throw new ServiceUnavailableError("email sending is not configured", {
+      code: "email_not_configured",
+    });
+  }
+
+  const origin = webOrigin(env);
+  const { from, rendered } = renderPreview(type, origin);
+
+  try {
+    await env.EMAIL.send({
+      to,
+      from,
+      subject: rendered.subject,
+      text: rendered.text,
+      html: rendered.html,
+    });
+  } catch (err) {
+    throw new ServiceUnavailableError("failed to send preview email", {
+      code: "email_send_failed",
+      cause: err,
+    });
+  }
+
+  console.log(`[admin email preview] sent "${rendered.subject}" (${type}) to ${to}`);
+  return { subject: rendered.subject, from: from.email };
+}
+
+/** Optional body `to` — must be a plausible address when provided. */
+export function resolvePreviewRecipient(sessionEmail: string | undefined, bodyTo: unknown): string {
+  if (typeof bodyTo === "string" && bodyTo.trim()) {
+    const to = bodyTo.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(to)) {
+      throw new ValidationError("invalid recipient email", { code: "invalid_email" });
+    }
+    return to;
+  }
+  const fallback = sessionEmail?.trim();
+  if (!fallback || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fallback)) {
+    throw new ValidationError("signed-in account has no deliverable email", {
+      code: "no_deliverable_email",
+    });
+  }
+  return fallback;
+}

--- a/apps/api/src/admin-email-preview.ts
+++ b/apps/api/src/admin-email-preview.ts
@@ -1,14 +1,12 @@
 /**
- * Operator self-send for transactional email templates (admin /admin/email).
- * Uses placeholder tokens so links will not complete a real auth/invite flow.
- * Pattern mirrors either's admin-email-preview.
+ * Operator self-send for transactional email templates (/admin/email).
+ * Placeholder tokens only — links do not complete a real auth/invite flow.
  */
 import {
   renderEnrollmentInvitationEmail,
   renderMagicLinkEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
-  type RenderedEmail,
 } from "@uploads/email";
 import { ServiceUnavailableError, ValidationError } from "@uploads/errors";
 
@@ -16,41 +14,42 @@ export const EMAIL_PREVIEW_TYPES = [
   { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
-  {
-    id: "enrollment-invitation",
-    label: "Enrollment invitation",
-    category: "Invites",
-  },
+  { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;
 
 export type EmailPreviewType = (typeof EMAIL_PREVIEW_TYPES)[number]["id"];
 
-const PREVIEW_TYPE_IDS = new Set<string>(EMAIL_PREVIEW_TYPES.map((e) => e.id));
-
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const AUTH_FROM = { name: "uploads.sh", email: "noreply@uploads.sh" } as const;
 const INVITE_FROM = { name: "uploads.sh", email: "invites@uploads.sh" } as const;
 
 export function isEmailPreviewType(value: unknown): value is EmailPreviewType {
-  return typeof value === "string" && PREVIEW_TYPE_IDS.has(value);
+  return typeof value === "string" && EMAIL_PREVIEW_TYPES.some((t) => t.id === value);
+}
+
+/** Prefer body `to`, else the signed-in admin's email. */
+export function resolvePreviewRecipient(sessionEmail: string | undefined, bodyTo: unknown): string {
+  const override = typeof bodyTo === "string" ? bodyTo.trim() : "";
+  const candidate = override || sessionEmail?.trim() || "";
+  if (!EMAIL_RE.test(candidate)) {
+    throw new ValidationError(
+      override ? "invalid recipient email" : "signed-in account has no deliverable email",
+      { code: override ? "invalid_email" : "no_deliverable_email" },
+    );
+  }
+  return candidate;
 }
 
 function webOrigin(env: Env): string {
-  const raw = typeof env.WEB_ORIGIN === "string" ? env.WEB_ORIGIN : "https://uploads.sh";
-  return raw.replace(/\/$/, "") || "https://uploads.sh";
+  return (env.WEB_ORIGIN || "https://uploads.sh").replace(/\/$/, "");
 }
 
-function renderPreview(
-  type: EmailPreviewType,
-  origin: string,
-): {
-  from: { name: string; email: string };
-  rendered: RenderedEmail;
-} {
+function renderPreview(type: EmailPreviewType, origin: string) {
   switch (type) {
     case "magic-link":
       return {
         from: AUTH_FROM,
-        rendered: renderMagicLinkEmail({
+        ...renderMagicLinkEmail({
           url: `${origin}/api/auth/magic-link/verify?token=preview-example`,
           webOrigin: origin,
         }),
@@ -58,7 +57,7 @@ function renderPreview(
     case "org-invitation":
       return {
         from: AUTH_FROM,
-        rendered: renderOrgInvitationEmail({
+        ...renderOrgInvitationEmail({
           url: `${origin}/accept-invitation/preview-example`,
           organizationName: "preview-workspace",
           inviterEmail: "operator@uploads.sh",
@@ -68,77 +67,45 @@ function renderPreview(
     case "member-joined":
       return {
         from: AUTH_FROM,
-        rendered: renderMemberJoinedEmail({
+        ...renderMemberJoinedEmail({
           organizationName: "preview-workspace",
           memberEmail: "new-member@example.com",
           webOrigin: origin,
         }),
       };
-    case "enrollment-invitation": {
-      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    case "enrollment-invitation":
       return {
         from: INVITE_FROM,
-        rendered: renderEnrollmentInvitationEmail({
+        ...renderEnrollmentInvitationEmail({
           workspaceName: "preview-workspace",
           link: `${origin}/invite?id=upi_preview#code=preview-example`,
-          expiresAt,
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
         }),
       };
-    }
   }
 }
 
-/**
- * Send a sample product email to `to`. Throws ValidationError for bad types
- * and ServiceUnavailableError when Email Sending is missing or fails.
- */
+/** Send a sample product email. Throws when Email Sending is missing or fails. */
 export async function sendEmailPreview(
   env: Env,
   type: EmailPreviewType,
   to: string,
-): Promise<{ subject: string; from: string }> {
+): Promise<{ subject: string }> {
   if (!env.EMAIL) {
     throw new ServiceUnavailableError("email sending is not configured", {
       code: "email_not_configured",
     });
   }
 
-  const origin = webOrigin(env);
-  const { from, rendered } = renderPreview(type, origin);
-
+  const { from, subject, text, html } = renderPreview(type, webOrigin(env));
   try {
-    await env.EMAIL.send({
-      to,
-      from,
-      subject: rendered.subject,
-      text: rendered.text,
-      html: rendered.html,
-    });
+    await env.EMAIL.send({ to, from, subject, text, html });
   } catch (err) {
     throw new ServiceUnavailableError("failed to send preview email", {
       code: "email_send_failed",
       cause: err,
     });
   }
-
-  console.log(`[admin email preview] sent "${rendered.subject}" (${type}) to ${to}`);
-  return { subject: rendered.subject, from: from.email };
-}
-
-/** Optional body `to` — must be a plausible address when provided. */
-export function resolvePreviewRecipient(sessionEmail: string | undefined, bodyTo: unknown): string {
-  if (typeof bodyTo === "string" && bodyTo.trim()) {
-    const to = bodyTo.trim();
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(to)) {
-      throw new ValidationError("invalid recipient email", { code: "invalid_email" });
-    }
-    return to;
-  }
-  const fallback = sessionEmail?.trim();
-  if (!fallback || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(fallback)) {
-    throw new ValidationError("signed-in account has no deliverable email", {
-      code: "no_deliverable_email",
-    });
-  }
-  return fallback;
+  console.log(`[admin email preview] sent "${subject}" (${type}) to ${to}`);
+  return { subject };
 }

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -657,18 +657,19 @@ export const adminUi = new Hono<SessionVars>()
   })
 
   // Transactional email previews — operator self-send with placeholder tokens.
+  // Type list is also hard-coded in apps/web admin/email.astro (keep in sync).
   .get("/dev/emails", (c) => c.json({ types: EMAIL_PREVIEW_TYPES }))
 
   .post("/dev/emails/:type", async (c) => {
-    const typeParam = c.req.param("type");
-    if (!isEmailPreviewType(typeParam)) {
+    const type = c.req.param("type");
+    if (!isEmailPreviewType(type)) {
       throw new ValidationError("unknown email preview type", {
         code: "unknown_email_preview_type",
-        details: { type: typeParam },
+        details: { type },
       });
     }
     const body = (await c.req.json().catch(() => ({}))) as { to?: unknown };
     const to = resolvePreviewRecipient(c.get("sessionUser")?.email, body.to);
-    const { subject, from } = await sendEmailPreview(c.env, typeParam, to);
-    return c.json({ ok: true, type: typeParam, to, subject, from });
+    const { subject } = await sendEmailPreview(c.env, type, to);
+    return c.json({ ok: true, type, to, subject });
   });

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -15,6 +15,12 @@ import {
 } from "@uploads/errors";
 import { Hono } from "hono";
 import {
+  EMAIL_PREVIEW_TYPES,
+  isEmailPreviewType,
+  resolvePreviewRecipient,
+  sendEmailPreview,
+} from "../admin-email-preview";
+import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
   createEnrollment,
@@ -648,4 +654,21 @@ export const adminUi = new Hono<SessionVars>()
     return proxyOauthClients(c.env, `/internal/oauth-clients/${encodeURIComponent(clientId)}`, {
       method: "DELETE",
     });
+  })
+
+  // Transactional email previews — operator self-send with placeholder tokens.
+  .get("/dev/emails", (c) => c.json({ types: EMAIL_PREVIEW_TYPES }))
+
+  .post("/dev/emails/:type", async (c) => {
+    const typeParam = c.req.param("type");
+    if (!isEmailPreviewType(typeParam)) {
+      throw new ValidationError("unknown email preview type", {
+        code: "unknown_email_preview_type",
+        details: { type: typeParam },
+      });
+    }
+    const body = (await c.req.json().catch(() => ({}))) as { to?: unknown };
+    const to = resolvePreviewRecipient(c.get("sessionUser")?.email, body.to);
+    const { subject, from } = await sendEmailPreview(c.env, typeParam, to);
+    return c.json({ ok: true, type: typeParam, to, subject, from });
   });

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -20,7 +20,7 @@ import SiteHeader from "../components/SiteHeader.astro";
 import ViewTransitions from "../components/ViewTransitions.astro";
 import "../styles/signed-in-shell.css";
 
-export type AdminSection = "workspaces" | "users" | "oauth";
+export type AdminSection = "workspaces" | "users" | "oauth" | "email";
 
 interface Props {
   section: AdminSection;
@@ -32,6 +32,7 @@ const titles: Record<AdminSection, string> = {
   workspaces: "Admin",
   users: "Users · Admin",
   oauth: "OAuth apps · Admin",
+  email: "Email · Admin",
 };
 const docTitle = `${titles[section]} · uploads.sh`;
 
@@ -44,6 +45,7 @@ const nav: { href: string; section: AdminSection; label: string }[] = [
   { href: "/admin", section: "workspaces", label: "Workspaces" },
   { href: "/admin/users", section: "users", label: "Users" },
   { href: "/admin/oauth", section: "oauth", label: "OAuth apps" },
+  { href: "/admin/email", section: "email", label: "Email" },
 ];
 ---
 

--- a/apps/web/src/pages-reachability.test.ts
+++ b/apps/web/src/pages-reachability.test.ts
@@ -34,6 +34,7 @@ describe.each([
   { path: "/login", title: "Sign in · uploads.sh" },
   { path: "/admin", title: "Admin · uploads.sh" },
   { path: "/admin/users", title: "Users · Admin · uploads.sh" },
+  { path: "/admin/email", title: "Email · Admin · uploads.sh" },
   { path: "/accept-invitation/upi_abc123", title: "Accept invitation · uploads.sh" },
   { path: "/account", title: "Account · uploads.sh" },
   { path: "/account/workspaces", title: "Workspaces · uploads.sh" },

--- a/apps/web/src/pages/admin/email.astro
+++ b/apps/web/src/pages/admin/email.astro
@@ -1,13 +1,22 @@
 ---
 /**
- * Operator transactional email previews — send sample templates to yourself
- * (or an override address) to check HTML, deliverability, and Gmail markup.
- * Backed by POST /admin-ui/dev/emails/:type on apps/api.
+ * Operator transactional email previews. POST /admin-ui/dev/emails/:type.
+ * Type list mirrors EMAIL_PREVIEW_TYPES in apps/api/src/admin-email-preview.ts.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-email.css";
 
 export const prerender = false;
+
+// Keep in sync with apps/api/src/admin-email-preview.ts EMAIL_PREVIEW_TYPES.
+const PREVIEW_TYPES = [
+  { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
+  { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
+  { id: "member-joined", label: "Member joined notify", category: "Auth" },
+  { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
+] as const;
+
+const categories = [...new Set(PREVIEW_TYPES.map((t) => t.category))];
 ---
 
 <AdminLayout section="email">
@@ -16,168 +25,108 @@ export const prerender = false;
     <p>
       Send a sample of each product email through Cloudflare Email Sending.
       Links use placeholder tokens and will not complete a real sign-in or invite.
-      Defaults to your signed-in address; override when testing Gmail markup or
-      another inbox.
+      Defaults to your signed-in address; override for another inbox (e.g. Gmail markup tests).
     </p>
 
-    <form id="email-recipient" class="email-recipient" autocomplete="off">
+    <div class="email-recipient">
       <label for="email-to">Send to</label>
-      <input
-        type="email"
-        id="email-to"
-        name="to"
-        placeholder="you@example.com"
-        maxlength="320"
-      />
-    </form>
+      <input type="email" id="email-to" maxlength="320" placeholder="you@example.com" />
+    </div>
 
-    <div id="email-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
-    <div id="email-action-status" role="status" hidden></div>
-    <div id="email-list"></div>
+    <div id="email-action-status" class="email-status" role="status" hidden></div>
+
+    {
+      categories.map((category) => (
+        <section class="email-category">
+          <h3>{category}</h3>
+          <ul class="email-type-list">
+            {PREVIEW_TYPES.filter((t) => t.category === category).map((t) => (
+              <li class="email-row">
+                <span class="email-row-label">{t.label}</span>
+                <button type="button" class="email-send" data-type={t.id}>
+                  Send preview
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))
+    }
   </section>
 
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
 
-    type PreviewType = { id: string; label: string; category: string };
-
-    function escapeHtml(value: string): string {
-      return value.replace(
-        /[&<>"']/g,
-        (ch) =>
-          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
-      );
-    }
-
     onAstroPageLoad(() => {
-      if (!document.getElementById("email-list")) return;
+      if (!document.getElementById("email-to")) return;
 
       const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
       const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
-
-      const statusEl = requireElement<HTMLElement>("#email-status", "admin email");
-      const actionStatus = requireElement<HTMLElement>("#email-action-status", "admin email");
-      const listEl = requireElement<HTMLElement>("#email-list", "admin email");
       const toInput = requireElement<HTMLInputElement>("#email-to", "admin email");
+      const statusEl = requireElement<HTMLElement>("#email-action-status", "admin email");
+      const buttons = [...document.querySelectorAll<HTMLButtonElement>("button.email-send")];
 
-      let sendingId: string | null = null;
+      let busy = false;
 
-      function setAction(message: string, state: "ok" | "error" | "idle" = "idle") {
-        if (state === "idle" || !message) {
-          actionStatus.hidden = true;
-          actionStatus.textContent = "";
-          actionStatus.removeAttribute("data-state");
-          return;
-        }
-        actionStatus.hidden = false;
-        actionStatus.textContent = message;
-        actionStatus.dataset.state = state;
-      }
-
-      function renderList(types: PreviewType[]) {
-        const categories = [...new Set(types.map((t) => t.category))];
-        listEl.innerHTML = categories
-          .map((category) => {
-            const rows = types
-              .filter((t) => t.category === category)
-              .map(
-                (t) => `
-              <li class="email-row" data-type="${escapeHtml(t.id)}">
-                <div class="email-row-copy">
-                  <p class="email-row-label">${escapeHtml(t.label)}</p>
-                  <p class="email-row-id mono">${escapeHtml(t.id)}</p>
-                </div>
-                <button type="button" class="email-send" data-type="${escapeHtml(t.id)}">
-                  Send preview
-                </button>
-              </li>`,
-              )
-              .join("");
-            return `
-              <section class="email-category">
-                <h3>${escapeHtml(category)}</h3>
-                <ul class="email-type-list">${rows}</ul>
-              </section>`;
-          })
-          .join("");
-
-        listEl.querySelectorAll<HTMLButtonElement>("button.email-send").forEach((btn) => {
-          btn.addEventListener("click", () => {
-            void sendPreview(btn.dataset.type ?? "");
-          });
-        });
+      function setStatus(message: string, state?: "ok" | "error") {
+        statusEl.hidden = !message;
+        statusEl.textContent = message;
+        if (state) statusEl.dataset.state = state;
+        else delete statusEl.dataset.state;
       }
 
       function setBusy(typeId: string | null) {
-        sendingId = typeId;
-        listEl.querySelectorAll<HTMLButtonElement>("button.email-send").forEach((btn) => {
-          const active = btn.dataset.type === typeId;
-          btn.disabled = typeId != null;
-          btn.textContent = active ? "Sending…" : "Send preview";
-        });
+        busy = typeId != null;
+        for (const btn of buttons) {
+          btn.disabled = busy;
+          btn.textContent = btn.dataset.type === typeId ? "Sending…" : "Send preview";
+        }
       }
 
       async function sendPreview(typeId: string) {
-        if (!typeId || sendingId) return;
+        if (!typeId || busy) return;
         setBusy(typeId);
-        setAction("");
+        setStatus("");
         try {
-          const body: { to?: string } = {};
-          const override = toInput.value.trim();
-          if (override) body.to = override;
-
+          const to = toInput.value.trim();
           const res = await fetch(`${apiOrigin}/admin-ui/dev/emails/${encodeURIComponent(typeId)}`, {
             method: "POST",
             credentials: "include",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify(body),
+            body: JSON.stringify(to ? { to } : {}),
           });
           const payload = (await res.json().catch(() => null)) as {
             ok?: boolean;
             to?: string;
             subject?: string;
-            error?: { message?: string; code?: string };
+            error?: { message?: string };
           } | null;
 
           if (!res.ok || !payload?.ok || !payload.to) {
-            const msg =
+            setStatus(
               payload?.error?.message ||
-              (res.status === 503
-                ? "Email Sending is not configured on this environment."
-                : `Could not send (${res.status}).`);
-            setAction(msg, "error");
+                (res.status === 503
+                  ? "Email Sending is not configured on this environment."
+                  : `Could not send (${res.status}).`),
+              "error",
+            );
             return;
           }
-
-          setAction(`Sent “${payload.subject ?? typeId}” to ${payload.to}`, "ok");
+          setStatus(`Sent “${payload.subject ?? typeId}” to ${payload.to}`, "ok");
         } catch {
-          setAction("Could not send the preview email.", "error");
+          setStatus("Could not send the preview email.", "error");
         } finally {
           setBusy(null);
         }
       }
 
       onSession((user) => {
-        if (user?.email && !toInput.value) {
-          toInput.placeholder = user.email;
-          toInput.value = user.email;
-        }
+        if (user?.email && !toInput.value) toInput.value = user.email;
       });
 
-      void (async () => {
-        try {
-          const res = await fetch(`${apiOrigin}/admin-ui/dev/emails`, {
-            credentials: "include",
-            cache: "no-store",
-          });
-          if (!res.ok) throw new Error(`list failed: ${res.status}`);
-          const body = (await res.json()) as { types: PreviewType[] };
-          statusEl.textContent = "";
-          renderList(body.types ?? []);
-        } catch {
-          statusEl.textContent = "Could not load email templates.";
-        }
-      })();
+      for (const btn of buttons) {
+        btn.addEventListener("click", () => void sendPreview(btn.dataset.type ?? ""));
+      }
     });
   </script>
 </AdminLayout>

--- a/apps/web/src/pages/admin/email.astro
+++ b/apps/web/src/pages/admin/email.astro
@@ -1,0 +1,183 @@
+---
+/**
+ * Operator transactional email previews — send sample templates to yourself
+ * (or an override address) to check HTML, deliverability, and Gmail markup.
+ * Backed by POST /admin-ui/dev/emails/:type on apps/api.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-email.css";
+
+export const prerender = false;
+---
+
+<AdminLayout section="email">
+  <section class="card">
+    <h2>Email previews</h2>
+    <p>
+      Send a sample of each product email through Cloudflare Email Sending.
+      Links use placeholder tokens and will not complete a real sign-in or invite.
+      Defaults to your signed-in address; override when testing Gmail markup or
+      another inbox.
+    </p>
+
+    <form id="email-recipient" class="email-recipient" autocomplete="off">
+      <label for="email-to">Send to</label>
+      <input
+        type="email"
+        id="email-to"
+        name="to"
+        placeholder="you@example.com"
+        maxlength="320"
+      />
+    </form>
+
+    <div id="email-status" class="muted" style="margin-top:12px;font-size:13px">Loading…</div>
+    <div id="email-action-status" role="status" hidden></div>
+    <div id="email-list"></div>
+  </section>
+
+  <script>
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
+
+    type PreviewType = { id: string; label: string; category: string };
+
+    function escapeHtml(value: string): string {
+      return value.replace(
+        /[&<>"']/g,
+        (ch) =>
+          ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
+      );
+    }
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("email-list")) return;
+
+      const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
+
+      const statusEl = requireElement<HTMLElement>("#email-status", "admin email");
+      const actionStatus = requireElement<HTMLElement>("#email-action-status", "admin email");
+      const listEl = requireElement<HTMLElement>("#email-list", "admin email");
+      const toInput = requireElement<HTMLInputElement>("#email-to", "admin email");
+
+      let sendingId: string | null = null;
+
+      function setAction(message: string, state: "ok" | "error" | "idle" = "idle") {
+        if (state === "idle" || !message) {
+          actionStatus.hidden = true;
+          actionStatus.textContent = "";
+          actionStatus.removeAttribute("data-state");
+          return;
+        }
+        actionStatus.hidden = false;
+        actionStatus.textContent = message;
+        actionStatus.dataset.state = state;
+      }
+
+      function renderList(types: PreviewType[]) {
+        const categories = [...new Set(types.map((t) => t.category))];
+        listEl.innerHTML = categories
+          .map((category) => {
+            const rows = types
+              .filter((t) => t.category === category)
+              .map(
+                (t) => `
+              <li class="email-row" data-type="${escapeHtml(t.id)}">
+                <div class="email-row-copy">
+                  <p class="email-row-label">${escapeHtml(t.label)}</p>
+                  <p class="email-row-id mono">${escapeHtml(t.id)}</p>
+                </div>
+                <button type="button" class="email-send" data-type="${escapeHtml(t.id)}">
+                  Send preview
+                </button>
+              </li>`,
+              )
+              .join("");
+            return `
+              <section class="email-category">
+                <h3>${escapeHtml(category)}</h3>
+                <ul class="email-type-list">${rows}</ul>
+              </section>`;
+          })
+          .join("");
+
+        listEl.querySelectorAll<HTMLButtonElement>("button.email-send").forEach((btn) => {
+          btn.addEventListener("click", () => {
+            void sendPreview(btn.dataset.type ?? "");
+          });
+        });
+      }
+
+      function setBusy(typeId: string | null) {
+        sendingId = typeId;
+        listEl.querySelectorAll<HTMLButtonElement>("button.email-send").forEach((btn) => {
+          const active = btn.dataset.type === typeId;
+          btn.disabled = typeId != null;
+          btn.textContent = active ? "Sending…" : "Send preview";
+        });
+      }
+
+      async function sendPreview(typeId: string) {
+        if (!typeId || sendingId) return;
+        setBusy(typeId);
+        setAction("");
+        try {
+          const body: { to?: string } = {};
+          const override = toInput.value.trim();
+          if (override) body.to = override;
+
+          const res = await fetch(`${apiOrigin}/admin-ui/dev/emails/${encodeURIComponent(typeId)}`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(body),
+          });
+          const payload = (await res.json().catch(() => null)) as {
+            ok?: boolean;
+            to?: string;
+            subject?: string;
+            error?: { message?: string; code?: string };
+          } | null;
+
+          if (!res.ok || !payload?.ok || !payload.to) {
+            const msg =
+              payload?.error?.message ||
+              (res.status === 503
+                ? "Email Sending is not configured on this environment."
+                : `Could not send (${res.status}).`);
+            setAction(msg, "error");
+            return;
+          }
+
+          setAction(`Sent “${payload.subject ?? typeId}” to ${payload.to}`, "ok");
+        } catch {
+          setAction("Could not send the preview email.", "error");
+        } finally {
+          setBusy(null);
+        }
+      }
+
+      onSession((user) => {
+        if (user?.email && !toInput.value) {
+          toInput.placeholder = user.email;
+          toInput.value = user.email;
+        }
+      });
+
+      void (async () => {
+        try {
+          const res = await fetch(`${apiOrigin}/admin-ui/dev/emails`, {
+            credentials: "include",
+            cache: "no-store",
+          });
+          if (!res.ok) throw new Error(`list failed: ${res.status}`);
+          const body = (await res.json()) as { types: PreviewType[] };
+          statusEl.textContent = "";
+          renderList(body.types ?? []);
+        } catch {
+          statusEl.textContent = "Could not load email templates.";
+        }
+      })();
+    });
+  </script>
+</AdminLayout>

--- a/apps/web/src/styles/admin-email.css
+++ b/apps/web/src/styles/admin-email.css
@@ -1,0 +1,112 @@
+/* Operator email previews on /admin/email */
+
+.email-recipient {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  margin-top: 14px;
+  max-width: 480px;
+}
+.email-recipient label {
+  font: 11px var(--mono);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.email-recipient input[type="email"] {
+  flex: 1 1 220px;
+  min-width: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 7px 9px;
+  font: 12px var(--mono);
+}
+.email-recipient input[type="email"]:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+
+#email-action-status {
+  margin-top: 12px;
+  font: 12px var(--mono);
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+#email-action-status[data-state="ok"] {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+}
+#email-action-status[data-state="error"] {
+  color: #f0a8a8;
+  border-color: color-mix(in srgb, #c44 45%, var(--line));
+}
+
+#email-list {
+  margin-top: 18px;
+  display: grid;
+  gap: 22px;
+}
+
+.email-category h3 {
+  margin: 0 0 10px;
+  font: 600 12px var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.email-type-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.email-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.email-row-label {
+  margin: 0;
+  font: 600 14px var(--sans);
+  color: var(--fg);
+}
+.email-row-id {
+  margin: 3px 0 0;
+  font: 11px var(--mono);
+  color: var(--muted);
+}
+
+.email-send {
+  font: 11px var(--mono);
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 7px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.email-send:hover:not(:disabled),
+.email-send:focus-visible:not(:disabled) {
+  border-color: var(--accent);
+  outline: none;
+}
+.email-send:disabled {
+  opacity: 0.55;
+  cursor: default;
+}

--- a/apps/web/src/styles/admin-email.css
+++ b/apps/web/src/styles/admin-email.css
@@ -29,7 +29,7 @@
   border-color: var(--accent);
 }
 
-#email-action-status {
+.email-status {
   margin-top: 12px;
   font: 12px var(--mono);
   padding: 8px 10px;
@@ -37,21 +37,13 @@
   border: 1px solid var(--line);
   background: var(--panel);
 }
-#email-action-status[data-state="ok"] {
-  color: var(--fg);
-  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
-}
-#email-action-status[data-state="error"] {
+.email-status[data-state="error"] {
   color: #f0a8a8;
-  border-color: color-mix(in srgb, #c44 45%, var(--line));
 }
 
-#email-list {
-  margin-top: 18px;
-  display: grid;
-  gap: 22px;
+.email-category {
+  margin-top: 22px;
 }
-
 .email-category h3 {
   margin: 0 0 10px;
   font: 600 12px var(--mono);
@@ -79,16 +71,9 @@
   border-radius: 8px;
   background: var(--panel);
 }
-
 .email-row-label {
-  margin: 0;
   font: 600 14px var(--sans);
   color: var(--fg);
-}
-.email-row-id {
-  margin: 3px 0 0;
-  font: 11px var(--mono);
-  color: var(--muted);
 }
 
 .email-send {


### PR DESCRIPTION
## In plain terms

Operators can open **Admin → Email** and fire a sample of each real product email to their own inbox (or another address). That makes it easy to check HTML, Cloudflare Email Sending, and Gmail action markup without minting real invites or magic links.

## What it does

- New `/admin/email` page (sidebar: **Email**)
- Session-gated API:
  - `GET /admin-ui/dev/emails` — list preview types
  - `POST /admin-ui/dev/emails/:type` — send sample (optional body `{ "to": "…" }`)
- Templates covered:
  - Magic sign-in link
  - Workspace (org) invitation
  - Member joined notify
  - Enrollment invitation
- Placeholder tokens only — links do not complete real auth/invite flows
- Uses production senders (`noreply@` / `invites@`) so From/auth looks real

## What it is not

- Not a bulk mailer or user-facing feature
- Not a substitute for Google schema registration (but useful for the sample send)

## How to try it

1. Sign in as an admin on production (or local with Email Sending).
2. Open `/admin/email`.
3. Confirm the recipient (defaults to your account email).
4. Click **Send preview** on a template and check the inbox / Gmail “Show original”.

## Technical notes

- Pattern follows either’s `admin-email-preview` (list + send-to-self).
- Implementation: `apps/api/src/admin-email-preview.ts` + routes on `admin-ui`.
- Missing `EMAIL` binding returns `503` / `email_not_configured`.

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run src/admin-email-preview.test.ts`
- [x] `pnpm --filter @uploads/web exec vitest run src/pages-reachability.test.ts`
- [ ] Manually send magic-link preview to a Gmail address and confirm SPF/DKIM + ViewAction markup