### PR TITLE
feat(email): first-membership welcome with next steps

### DIFF
--- a/apps/api/src/admin-email-preview.ts
+++ b/apps/api/src/admin-email-preview.ts
@@ -7,6 +7,7 @@ import {
   renderMagicLinkEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
+  renderWelcomeEmail,
 } from "@uploads/email";
 import { ServiceUnavailableError, ValidationError } from "@uploads/errors";
 
@@ -14,6 +15,7 @@ export const EMAIL_PREVIEW_TYPES = [
   { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
+  { id: "welcome", label: "Welcome / next steps", category: "Auth" },
   { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;
 
@@ -70,6 +72,14 @@ function renderPreview(type: EmailPreviewType, origin: string) {
         ...renderMemberJoinedEmail({
           organizationName: "preview-workspace",
           memberEmail: "new-member@example.com",
+          webOrigin: origin,
+        }),
+      };
+    case "welcome":
+      return {
+        from: AUTH_FROM,
+        ...renderWelcomeEmail({
+          workspaceName: "preview-workspace",
           webOrigin: origin,
         }),
       };

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SqliteD1 } from "../../test/helpers/sqlite-d1";
 import { createToken } from "../auth-db";
 import { respondError } from "../error-response";
@@ -22,6 +22,13 @@ interface EnvOpts {
   onDeleteOrg?: (slug: string) => void;
   putThrows?: boolean;
   wsCreateLimiterAllows?: boolean;
+  emailSend?: (msg: {
+    to: string;
+    from: { name: string; email: string };
+    subject: string;
+    text?: string;
+    html?: string;
+  }) => Promise<unknown>;
 }
 
 function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
@@ -47,6 +54,7 @@ function stubEnv(opts: EnvOpts = {}): Env {
     onDeleteOrg,
     putThrows = false,
     wsCreateLimiterAllows,
+    emailSend,
   } = opts;
 
   const auth = stubAuth((req) => {
@@ -109,10 +117,19 @@ function stubEnv(opts: EnvOpts = {}): Env {
           limit: (async () => ({ success: wsCreateLimiterAllows })) as unknown,
         } as unknown as Env["WS_CREATE_LIMITER"]);
 
-  return Object.assign({ AUTH: auth, REGISTRY: registry, __puts: puts } as unknown as Env, {
-    __puts: puts,
-    ...(wsCreateLimiter ? { WS_CREATE_LIMITER: wsCreateLimiter } : {}),
-  });
+  return Object.assign(
+    {
+      AUTH: auth,
+      REGISTRY: registry,
+      WEB_ORIGIN: "https://uploads.sh",
+      __puts: puts,
+      ...(emailSend ? { EMAIL: { send: emailSend } } : {}),
+    } as unknown as Env,
+    {
+      __puts: puts,
+      ...(wsCreateLimiter ? { WS_CREATE_LIMITER: wsCreateLimiter } : {}),
+    },
+  );
 }
 
 function app() {
@@ -271,6 +288,31 @@ describe("POST /v1/workspaces", () => {
     const res = await post(env, { name: "zachbot" });
     expect(res.status).toBeGreaterThanOrEqual(500);
     expect(deletedSlug).toBe("zachbot");
+  });
+
+  it("sends a welcome email on the user's first workspace", async () => {
+    const emailSend = vi.fn().mockResolvedValue({});
+    const env = stubEnv({ memberships: [], emailSend });
+    const res = await post(env, { name: "zachbot" });
+    expect(res.status).toBe(201);
+    expect(emailSend).toHaveBeenCalledTimes(1);
+    const msg = emailSend.mock.calls[0]?.[0];
+    expect(msg.to).toBe("z@x.com");
+    expect(msg.subject).toBe("Welcome to uploads.sh");
+    expect(msg.html).toContain("zachbot");
+    expect(msg.html).toContain("uploads install");
+  });
+
+  it("does not send welcome when the user already has a membership", async () => {
+    const emailSend = vi.fn().mockResolvedValue({});
+    const env = stubEnv({
+      memberships: [{ organizationId: "o1", organizationSlug: "existing", role: "member" }],
+      kvRecords: { existing: { provider: "r2", bucket: "b" } },
+      emailSend,
+    });
+    const res = await post(env, { name: "zachbot" });
+    expect(res.status).toBe(201);
+    expect(emailSend).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -33,6 +33,7 @@ import {
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { validateSlug } from "../slug-policy";
+import { sendWelcomeEmail } from "../welcome-email";
 import {
   isPastGrace,
   isPurgedTombstone,
@@ -173,6 +174,7 @@ export const workspaces = new Hono<SessionVars>().post(
     // Cap counts only self-serve workspaces the user OWNS — BYO/operator
     // workspaces (no selfServe flag) never burn the allowance.
     const memberships = await membershipsForUser(c.env, user.id);
+    const isFirstMembership = memberships.length === 0;
     const owned = memberships.filter((m) => m.role === "owner");
     const records = await Promise.all(
       owned.map((m) => loadWorkspaceRecord(c.env, m.organizationSlug)),
@@ -206,6 +208,17 @@ export const workspaces = new Hono<SessionVars>().post(
         console.error("self-serve rollback failed: org", name, "may be orphaned", rollbackErr),
       );
       throw err;
+    }
+
+    // First workspace ever → welcome email (never throws). waitUntil when
+    // available so the isolate outlives the 201; await in unit tests.
+    if (isFirstMembership && user.email) {
+      const welcome = sendWelcomeEmail(c.env, { to: user.email, workspaceName: name });
+      try {
+        c.executionCtx.waitUntil(welcome);
+      } catch {
+        await welcome;
+      }
     }
 
     return c.json(

--- a/apps/api/src/welcome-email.test.ts
+++ b/apps/api/src/welcome-email.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendWelcomeEmail } from "./welcome-email";
+
+describe("sendWelcomeEmail", () => {
+  it("logs instead of throwing when EMAIL is absent", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      sendWelcomeEmail(
+        { WEB_ORIGIN: "https://uploads.sh" },
+        { to: "a@example.com", workspaceName: "acme" },
+      ),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("Welcome to uploads.sh");
+    warn.mockRestore();
+  });
+
+  it("sends from noreply@uploads.sh with the welcome template", async () => {
+    const send = vi.fn().mockResolvedValue({});
+    await sendWelcomeEmail(
+      { EMAIL: { send }, WEB_ORIGIN: "https://uploads.sh" },
+      { to: "new@example.com", workspaceName: "acme" },
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+    const args = send.mock.calls[0]?.[0];
+    expect(args.to).toBe("new@example.com");
+    expect(args.from).toEqual({ name: "uploads.sh", email: "noreply@uploads.sh" });
+    expect(args.subject).toBe("Welcome to uploads.sh");
+    expect(args.html).toContain("uploads install");
+    expect(args.html).toContain("acme");
+    expect(args.html).toContain("https://github.com/apps/uploads-sh");
+  });
+
+  it("never throws when send fails", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("boom"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      sendWelcomeEmail(
+        { EMAIL: { send }, WEB_ORIGIN: "https://uploads.sh" },
+        { to: "a@example.com", workspaceName: "x" },
+      ),
+    ).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/api/src/welcome-email.ts
+++ b/apps/api/src/welcome-email.ts
@@ -1,0 +1,45 @@
+/**
+ * Self-serve first-workspace welcome. Auth invite-accept uses sendAuthEmail.
+ * Never throws — mail must not fail workspace creation.
+ */
+import { renderWelcomeEmail } from "@uploads/email";
+
+const FROM = { name: "uploads.sh", email: "noreply@uploads.sh" } as const;
+
+type Env = {
+  EMAIL?: {
+    send: (message: {
+      to: string;
+      from: { name: string; email: string };
+      subject: string;
+      text?: string;
+      html?: string;
+    }) => Promise<unknown>;
+  };
+  WEB_ORIGIN?: string;
+};
+
+export async function sendWelcomeEmail(
+  env: Env,
+  args: { to: string; workspaceName?: string },
+): Promise<void> {
+  const { subject, text, html } = renderWelcomeEmail({
+    workspaceName: args.workspaceName,
+    webOrigin: env.WEB_ORIGIN || "https://uploads.sh",
+  });
+
+  if (!env.EMAIL) {
+    console.warn(`[api email] no EMAIL binding — welcome not sent. To: ${args.to}. "${subject}".`);
+    return;
+  }
+
+  try {
+    await env.EMAIL.send({ to: args.to, from: FROM, subject, text, html });
+    console.log(`[api email] sent "${subject}" to ${args.to}`);
+  } catch (err) {
+    console.error(
+      `[api email] welcome send failed for "${subject}" to ${args.to}`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -442,19 +442,36 @@ function buildAuth(
           });
         },
         organizationHooks: {
-          // Notify inviter; sendAuthEmail never throws so accept can't roll back.
+          // Inviter notify + first-membership welcome. sendAuthEmail never
+          // throws so accept can't roll back on mail failure.
           afterAcceptInvitation: async ({ invitation, user, organization: org }) => {
-            if (!invitation.inviterId) return;
-            const [inviter] = await db
-              .select({ email: schema.user.email })
-              .from(schema.user)
-              .where(eq(schema.user.id, invitation.inviterId))
-              .limit(1);
-            if (!inviter?.email || inviter.email.toLowerCase() === user.email.toLowerCase()) return;
+            if (invitation.inviterId) {
+              const [inviter] = await db
+                .select({ email: schema.user.email })
+                .from(schema.user)
+                .where(eq(schema.user.id, invitation.inviterId))
+                .limit(1);
+              if (inviter?.email && inviter.email.toLowerCase() !== user.email.toLowerCase()) {
+                await sendAuthEmail(env, {
+                  to: inviter.email,
+                  template: "member-joined",
+                  context: { organizationName: org.name, memberEmail: user.email },
+                });
+              }
+            }
+
+            // Welcome only on the invitee's first membership.
+            if (!user.email) return;
+            const memberships = await db
+              .select({ id: schema.member.id })
+              .from(schema.member)
+              .where(eq(schema.member.userId, user.id))
+              .limit(2);
+            if (memberships.length !== 1) return;
             await sendAuthEmail(env, {
-              to: inviter.email,
-              template: "member-joined",
-              context: { organizationName: org.name, memberEmail: user.email },
+              to: user.email,
+              template: "welcome",
+              context: { workspaceName: org.name },
             });
           },
         },

--- a/apps/auth/src/email.test.ts
+++ b/apps/auth/src/email.test.ts
@@ -51,7 +51,7 @@ describe("sendAuthEmail", () => {
     expect(args.text).toContain("https://auth.uploads.sh/x");
   });
 
-  it("routes invitation + member-joined through the shared templates", async () => {
+  it("routes invitation + member-joined + welcome through the shared templates", async () => {
     const send = vi.fn().mockResolvedValue({});
     const EMAIL: EmailBinding = { send };
 
@@ -75,6 +75,14 @@ describe("sendAuthEmail", () => {
         context: { organizationName: "buildinternet", memberEmail: "new@example.com" },
       },
     );
+    await sendAuthEmail(
+      { EMAIL, ENVIRONMENT: "production" },
+      {
+        to: "new@example.com",
+        template: "welcome",
+        context: { workspaceName: "acme" },
+      },
+    );
 
     const invite = send.mock.calls[0]?.[0];
     expect(invite.html).toContain("<!doctype html>");
@@ -84,6 +92,12 @@ describe("sendAuthEmail", () => {
     const joined = send.mock.calls[1]?.[0];
     expect(joined.to).toBe("admin@example.com");
     expect(joined.subject).toBe("new@example.com joined buildinternet on uploads.sh");
+
+    const welcome = send.mock.calls[2]?.[0];
+    expect(welcome.to).toBe("new@example.com");
+    expect(welcome.subject).toBe("Welcome to uploads.sh");
+    expect(welcome.html).toContain("uploads install");
+    expect(welcome.html).toContain("acme");
   });
 
   it("never throws when the send fails", async () => {

--- a/apps/auth/src/email.ts
+++ b/apps/auth/src/email.ts
@@ -8,6 +8,7 @@ import {
   renderMagicLinkEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
+  renderWelcomeEmail,
   type RenderedEmail,
 } from "@uploads/email";
 
@@ -40,6 +41,11 @@ export type SendAuthEmailArgs =
       to: string;
       template: "member-joined";
       context: { organizationName: string; memberEmail: string };
+    }
+  | {
+      to: string;
+      template: "welcome";
+      context: { workspaceName?: string };
     };
 
 function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
@@ -50,6 +56,8 @@ function render(args: SendAuthEmailArgs, webOrigin: string): RenderedEmail {
       return renderOrgInvitationEmail({ ...args.context, webOrigin });
     case "member-joined":
       return renderMemberJoinedEmail({ ...args.context, webOrigin });
+    case "welcome":
+      return renderWelcomeEmail({ ...args.context, webOrigin });
   }
 }
 

--- a/apps/web/src/pages/admin/email.astro
+++ b/apps/web/src/pages/admin/email.astro
@@ -13,6 +13,7 @@ const PREVIEW_TYPES = [
   { id: "magic-link", label: "Magic sign-in link", category: "Auth" },
   { id: "org-invitation", label: "Workspace invitation", category: "Auth" },
   { id: "member-joined", label: "Member joined notify", category: "Auth" },
+  { id: "welcome", label: "Welcome / next steps", category: "Auth" },
   { id: "enrollment-invitation", label: "Enrollment invitation", category: "Invites" },
 ] as const;
 

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -12,3 +12,4 @@ export {
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
 } from "./invites";
+export { renderWelcomeEmail } from "./welcome";

--- a/packages/email/src/welcome.ts
+++ b/packages/email/src/welcome.ts
@@ -1,0 +1,89 @@
+import { escapeHtml, renderEmailCard, strong, type RenderedEmail } from "./card";
+
+const GITHUB_APP = "https://github.com/apps/uploads-sh";
+const REPO = "https://github.com/buildinternet/uploads";
+
+const MONO = "ui-monospace,'SF Mono',SFMono-Regular,Menlo,Consolas,monospace";
+const FG = "#ececea";
+
+function code(value: string): string {
+  return `<code style="font-family:${MONO};font-size:13px;color:${FG};">${escapeHtml(value)}</code>`;
+}
+
+function link(href: string, label: string): string {
+  return `<a href="${escapeHtml(href)}" style="color:${FG};text-decoration:underline;">${escapeHtml(label)}</a>`;
+}
+
+function step(n: number, title: string, detailHtml: string): string {
+  return `<strong style="color:${FG};font-weight:600;">${n}. ${escapeHtml(title)}</strong><br>${detailHtml}`;
+}
+
+/**
+ * First-membership welcome: keep momentum with install, GitHub App, docs, star.
+ */
+export function renderWelcomeEmail(ctx: {
+  workspaceName?: string;
+  webOrigin?: string;
+}): RenderedEmail {
+  const origin = (ctx.webOrigin || "https://uploads.sh").replace(/\/$/, "");
+  const docsUrl = `${origin}/docs`;
+  const workspace = ctx.workspaceName?.trim();
+  const where = workspace ? `You're on ${strong(workspace)}.` : "Your uploads.sh account is ready.";
+  const whereText = workspace ? `You're on ${workspace}.` : "Your uploads.sh account is ready.";
+
+  const bodyHtml = [
+    `${where} A few next steps:`,
+    "<br><br>",
+    step(1, "Wire your agent", `Run ${code("uploads install")} — skills + the hosted MCP server.`),
+    "<br><br>",
+    step(
+      2,
+      "Install the GitHub App",
+      `${link(GITHUB_APP, "github.com/apps/uploads-sh")} on repos you attach to — bot comments and live PR titles.`,
+    ),
+    "<br><br>",
+    step(
+      3,
+      "Skim the docs",
+      `${link(docsUrl, "uploads.sh/docs")} when you need a command or flag.`,
+    ),
+    "<br><br>",
+    step(
+      4,
+      "Star the repo",
+      `${link(REPO, "github.com/buildinternet/uploads")} — helps others find it.`,
+    ),
+  ].join("");
+
+  return renderEmailCard({
+    subject: "Welcome to uploads.sh",
+    preheader: "Next: uploads install, the GitHub App, docs — and a star if you like it.",
+    eyebrow: "Welcome",
+    title: "You're in",
+    bodyHtml,
+    text: [
+      "Welcome to uploads.sh",
+      "",
+      whereText,
+      "A few next steps:",
+      "",
+      "1. Wire your agent",
+      "   uploads install",
+      "",
+      "2. Install the GitHub App",
+      `   ${GITHUB_APP}`,
+      "",
+      "3. Skim the docs",
+      `   ${docsUrl}`,
+      "",
+      "4. Star the repo (helps others find it)",
+      `   ${REPO}`,
+      "",
+      "—",
+      "uploads.sh · a Build Internet project",
+    ].join("\n"),
+    cta: { url: docsUrl, label: "Open the docs →" },
+    footNoteHtml: "Already set up? You can ignore this — it's just a nudge.",
+    webOrigin: origin,
+  });
+}

--- a/packages/email/test/invites.test.ts
+++ b/packages/email/test/invites.test.ts
@@ -6,6 +6,7 @@ import {
   renderMagicLinkEmail,
   renderMemberJoinedEmail,
   renderOrgInvitationEmail,
+  renderWelcomeEmail,
 } from "../src/index";
 
 function parseJsonLd(html: string): Record<string, unknown> | null {
@@ -210,5 +211,43 @@ describe("renderMemberJoinedEmail", () => {
     expect(out.html).toContain("buildinternet");
     expect(out.text).toContain("accepted your invitation");
     expect(out.html).not.toContain("application/ld+json");
+  });
+});
+
+describe("renderWelcomeEmail", () => {
+  it("names the workspace, links next steps, and embeds a docs ViewAction", () => {
+    const out = renderWelcomeEmail({
+      workspaceName: "acme",
+      webOrigin: "https://uploads.sh",
+    });
+    expect(out.subject).toBe("Welcome to uploads.sh");
+    expect(out.html).toContain("You&#39;re in");
+    expect(out.html).toContain("acme");
+    expect(out.html).toContain("uploads install");
+    expect(out.html).toContain("https://github.com/apps/uploads-sh");
+    expect(out.html).toContain("https://github.com/buildinternet/uploads");
+    expect(out.html).toContain("https://uploads.sh/docs");
+    expect(out.text).toContain("uploads install");
+    expect(out.text).toContain("github.com/buildinternet/uploads");
+    expect(parseJsonLd(out.html)?.potentialAction).toEqual({
+      "@type": "ViewAction",
+      name: "Open the docs",
+      url: "https://uploads.sh/docs",
+    });
+  });
+
+  it("escapes hostile workspace names", () => {
+    const out = renderWelcomeEmail({
+      workspaceName: `<script>x</script>`,
+      webOrigin: "https://uploads.sh",
+    });
+    expect(out.html).not.toContain("<script>x</script>");
+    expect(out.html).toContain("&lt;script&gt;x&lt;/script&gt;");
+  });
+
+  it("omits the workspace clause when name is empty", () => {
+    const out = renderWelcomeEmail({ webOrigin: "https://uploads.sh" });
+    expect(out.html).toContain("Your uploads.sh account is ready");
+    expect(out.text).toContain("Your uploads.sh account is ready");
   });
 });


### PR DESCRIPTION
## In plain terms

After someone joins their first workspace, send a short welcome email that keeps them moving: wire the agent (`uploads install`), install the GitHub App, open the docs, and star the repo so others can find it.

## What it does

- New `renderWelcomeEmail` template in `@uploads/email` (docs CTA + Gmail ViewAction)
- Sends once on **first membership**:
  - Org invite accept (`afterAcceptInvitation`)
  - First self-serve workspace (`POST /v1/workspaces`)
- Admin email preview: **Welcome / next steps**
- Does **not** re-send on later workspaces or re-invites

## What it is not

- Not a magic-link or invite redesign
- Not a sticky `welcomeEmailedAt` field (first-membership count is enough for now)
- Does not require `@buildinternet/uploads` version bump (private email package only)

## How to try it

From `/admin/email`, send the **Welcome / next steps** preview to yourself.

Or create a first workspace / accept a first invite with Email Sending configured.

## Test plan

- [x] `pnpm --filter @uploads/email test`
- [x] `pnpm --filter @uploads/auth exec vitest run src/email.test.ts`
- [x] `pnpm --filter @uploads/api exec vitest run src/welcome-email.test.ts src/routes/workspaces.test.ts src/admin-email-preview.test.ts`
- [ ] Optional: send live preview from `/admin/email` in prod/staging