### PR TITLE
feat(web): fit/full-width image previews on public file pages

### DIFF
--- a/apps/web/src/components/GalleryReferences.astro
+++ b/apps/web/src/components/GalleryReferences.astro
@@ -96,8 +96,9 @@ const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
     border-radius: var(--radius-lg, 10px);
     background: var(--panel);
   }
-  /* Nested inside the item-page rail — drop the outer card so chips sit like
-     the file share page's gh-chip under the filename. */
+  /* Nested inside the item-page rail — drop the outer card so chips sit flush
+     in the details column (file share page puts the PR as a byline under the
+     filename instead). */
   .refs--inline {
     margin: 0 0 12px;
     padding: 0;

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -1,0 +1,165 @@
+---
+/**
+ * Public image stage with Fit / Full width controls.
+ *
+ * Fit: compact, viewport-capped (photos / wide UI).
+ * Full width: stage grows with the image; page scroll (tall screenshots).
+ * Tall images auto-open full width. Mode resolution: `lib/image-preview-mode.ts`.
+ */
+interface Props {
+  src: string;
+  alt: string;
+}
+
+const { src, alt } = Astro.props;
+---
+
+<div class="media image-preview" data-mode="fit" data-image-preview>
+  <div class="size-toggle" role="group" aria-label="Preview size">
+    <button type="button" data-size="fit" aria-pressed="true">Fit</button>
+    <button type="button" data-size="full" aria-pressed="false">Full width</button>
+  </div>
+  <img src={src} alt={alt} decoding="async" />
+</div>
+
+<script>
+  import {
+    resolvePreviewMode,
+    type ImagePreviewMode,
+  } from "../lib/image-preview-mode";
+
+  function applyMode(root: HTMLElement, mode: ImagePreviewMode): void {
+    root.dataset.mode = mode;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>("button[data-size]")) {
+      btn.setAttribute("aria-pressed", btn.dataset.size === mode ? "true" : "false");
+    }
+  }
+
+  function initPreview(root: HTMLElement): void {
+    if (root.dataset.previewReady === "1") return;
+    root.dataset.previewReady = "1";
+
+    const img = root.querySelector("img");
+    if (!(img instanceof HTMLImageElement)) return;
+
+    // Page-view only — no storage, so the next tall shot still auto-picks full.
+    let override: ImagePreviewMode | null = null;
+
+    const sync = () => {
+      applyMode(
+        root,
+        resolvePreviewMode({
+          override,
+          naturalWidth: img.naturalWidth,
+          naturalHeight: img.naturalHeight,
+        }),
+      );
+    };
+
+    for (const btn of root.querySelectorAll<HTMLButtonElement>("button[data-size]")) {
+      btn.addEventListener("click", () => {
+        const size = btn.dataset.size;
+        if (size !== "fit" && size !== "full") return;
+        override = size;
+        applyMode(root, size);
+      });
+    }
+
+    if (img.complete && img.naturalWidth > 0) sync();
+    else img.addEventListener("load", sync, { once: true });
+  }
+
+  function boot(): void {
+    document.querySelectorAll<HTMLElement>("[data-image-preview]").forEach(initPreview);
+  }
+
+  boot();
+  document.addEventListener("astro:page-load", boot);
+</script>
+
+<style>
+  .image-preview {
+    --preview-max-h: 78vh;
+    position: relative;
+    min-height: 320px;
+    background: var(--bg);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+
+  .size-toggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 2;
+    display: inline-flex;
+    padding: 3px;
+    gap: 2px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    backdrop-filter: blur(8px);
+  }
+
+  .size-toggle button {
+    appearance: none;
+    margin: 0;
+    padding: 5px 11px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font: 11px var(--mono);
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    line-height: 1.2;
+  }
+
+  .size-toggle button:hover,
+  .size-toggle button:focus-visible {
+    color: var(--fg);
+    outline: none;
+  }
+
+  .size-toggle button:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 55%, transparent);
+  }
+
+  .size-toggle button[aria-pressed="true"] {
+    background: color-mix(in srgb, var(--accent) 22%, var(--panel));
+    color: var(--fg);
+  }
+
+  .image-preview img {
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    object-fit: contain;
+  }
+
+  .image-preview[data-mode="fit"] {
+    max-height: var(--preview-max-h);
+  }
+
+  .image-preview[data-mode="fit"] img {
+    max-height: var(--preview-max-h);
+  }
+
+  .image-preview[data-mode="full"] {
+    max-height: none;
+    place-items: start stretch;
+  }
+
+  .image-preview[data-mode="full"] img {
+    width: 100%;
+    max-height: none;
+  }
+
+  @media (max-width: 760px) {
+    .image-preview {
+      min-height: 220px;
+    }
+  }
+</style>

--- a/apps/web/src/lib/image-preview-mode.test.ts
+++ b/apps/web/src/lib/image-preview-mode.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { isTallImage, resolvePreviewMode, TALL_ASPECT_RATIO } from "./image-preview-mode";
+
+describe("isTallImage", () => {
+  it("is false for empty or zero dimensions", () => {
+    expect(isTallImage(0, 1000)).toBe(false);
+    expect(isTallImage(800, 0)).toBe(false);
+  });
+
+  it("is false for landscape and roughly square images", () => {
+    expect(isTallImage(1600, 900)).toBe(false);
+    expect(isTallImage(1000, 1000)).toBe(false);
+    expect(isTallImage(1000, 1349)).toBe(false);
+  });
+
+  it("is true at the tall aspect threshold", () => {
+    expect(isTallImage(1000, 1350)).toBe(true);
+    expect(isTallImage(800, 2000)).toBe(true);
+  });
+
+  it("respects a custom ratio", () => {
+    expect(isTallImage(1000, 1500, 2)).toBe(false);
+    expect(isTallImage(1000, 2000, 2)).toBe(true);
+  });
+
+  it("exports a stable default threshold", () => {
+    expect(TALL_ASPECT_RATIO).toBe(1.35);
+  });
+});
+
+describe("resolvePreviewMode", () => {
+  it("prefers an explicit in-page override over aspect ratio", () => {
+    expect(resolvePreviewMode({ override: "fit", naturalWidth: 800, naturalHeight: 2400 })).toBe(
+      "fit",
+    );
+    expect(resolvePreviewMode({ override: "full", naturalWidth: 1600, naturalHeight: 900 })).toBe(
+      "full",
+    );
+  });
+
+  it("auto-selects full for tall images when nothing is overridden", () => {
+    expect(resolvePreviewMode({ override: null, naturalWidth: 900, naturalHeight: 2200 })).toBe(
+      "full",
+    );
+  });
+
+  it("auto-selects fit for wide images when nothing is overridden", () => {
+    expect(resolvePreviewMode({ override: null, naturalWidth: 1600, naturalHeight: 900 })).toBe(
+      "fit",
+    );
+  });
+});

--- a/apps/web/src/lib/image-preview-mode.ts
+++ b/apps/web/src/lib/image-preview-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Fit vs full-width for public image previews.
+ * Tall images (height/width ≥ threshold) default to full so screenshots stay readable.
+ */
+
+export type ImagePreviewMode = "fit" | "full";
+
+/** Height/width at or above this → prefer full width when no override. */
+export const TALL_ASPECT_RATIO = 1.35;
+
+export function isTallImage(
+  naturalWidth: number,
+  naturalHeight: number,
+  ratio = TALL_ASPECT_RATIO,
+): boolean {
+  return naturalWidth > 0 && naturalHeight > 0 && naturalHeight / naturalWidth >= ratio;
+}
+
+/** In-page override wins; otherwise tall → full, else fit. */
+export function resolvePreviewMode(opts: {
+  override: ImagePreviewMode | null;
+  naturalWidth: number;
+  naturalHeight: number;
+}): ImagePreviewMode {
+  if (opts.override) return opts.override;
+  return isTallImage(opts.naturalWidth, opts.naturalHeight) ? "full" : "fit";
+}

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -3,6 +3,7 @@ import BaseHead from "../../../components/BaseHead.astro";
 import Brand from "../../../components/Brand.astro";
 import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
+import ImagePreview from "../../../components/ImagePreview.astro";
 import { GH_KIND_PATH } from "../../../lib/brand-icons";
 import { buildEmbedFormats } from "../../../lib/embed-formats";
 import {
@@ -60,8 +61,8 @@ const ghAriaLabel = gh
   : "";
 const canonical = new URL(file ? filePath(workspace, key) : Astro.url.pathname, Astro.url.origin)
   .href;
-// Generic metadata list excludes `gh.*` pairs — those render as the GitHub
-// chip above via `file.github` instead of duplicating them here.
+// Generic metadata list excludes `gh.*` pairs — those render as the byline
+// under the filename via `file.github` instead of duplicating them here.
 const metadataEntries = file?.metadata
   ? Object.entries(file.metadata)
       .filter(([metaKey]) => !metaKey.startsWith("gh."))
@@ -116,25 +117,32 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       nav.top { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
       .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
+      /* Video / non-image fallbacks only — images use ImagePreview. */
       .media { min-height:320px; max-height:78vh; background:var(--bg); display:grid; place-items:center; overflow:hidden; }
-      img,video { max-width:100%; max-height:78vh; width:auto; height:auto; object-fit:contain; display:block; }
+      .media video { max-width:100%; max-height:78vh; width:auto; height:auto; object-fit:contain; display:block; }
       .fallback { padding:60px 30px; text-align:center; color:var(--muted); font:13px/1.6 var(--mono); }
       .fallback strong { display:block; color:var(--fg); margin-bottom:8px; }
       .fallback a { color:var(--fg); overflow-wrap:anywhere; }
-      .details { padding:18px 20px 22px; border-top:1px solid var(--line); }
-      .filetitle { margin:0 0 16px; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
-      dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:14px 0 0; font:12px var(--mono); }
+      .filehead { margin:0 0 16px; min-width:0; }
+      .filetitle { margin:0; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
+      /* PR/issue under the filename — light byline, not a rail chip. */
+      .gh-byline { display:inline-flex; align-items:baseline; flex-wrap:wrap; column-gap:8px; row-gap:2px; margin-top:6px; max-width:100%; color:var(--muted); font:12.5px/1.45 var(--mono); text-decoration:none; }
+      .gh-byline:hover, .gh-byline:focus-visible { color:var(--accent); outline:none; }
+      .gh-byline-icon { flex:none; align-self:center; }
+      .gh-byline-title { color:var(--body); overflow-wrap:anywhere; }
+      .gh-byline:hover .gh-byline-title, .gh-byline:focus-visible .gh-byline-title { color:inherit; }
+      .gh-byline-sep { opacity:.7; }
+      .gh-byline-ref { overflow-wrap:anywhere; }
+      /* Right rail: account-shell-like section gap; Metadata uses label + rule. */
+      .details { display:flex; flex-direction:column; gap:22px; padding:18px 20px 22px; border-top:1px solid var(--line); }
+      .details > * { min-width:0; }
+      .rail-head { display:flex; align-items:center; gap:10px; margin:0 0 12px; }
+      .rail-label { color:var(--muted); font-size:10.5px; letter-spacing:.14em; text-transform:uppercase; white-space:nowrap; }
+      .rail-rule { flex:1; height:1px; background:var(--line); }
+      dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:0; font:12px var(--mono); }
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
-      .gh-chip { display:inline-flex; align-items:center; gap:6px; margin:10px 0 0; padding:6px 10px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); font:12px var(--mono); text-decoration:none; }
-      .gh-chip:hover, .gh-chip:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
-      .gh-chip-icon { flex:none; }
-      .gh-chip-text { display:flex; flex-direction:column; gap:2px; min-width:0; }
-      .gh-chip-title { overflow-wrap:anywhere; font-weight:600; }
-      .gh-chip-ref { color:var(--muted); font-size:11px; overflow-wrap:anywhere; }
-      .gh-chip-name { overflow-wrap:anywhere; }
-      .section-label { margin:16px 0 0; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font:11px var(--mono); }
-      dl.meta.metadata { margin-top:6px; }
+      .details :global(.actions) { margin-top:0; }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
       .error .signin { display:inline-block; margin-top:18px; padding:9px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--fg); font:12px var(--mono); text-decoration:none; }
@@ -166,54 +174,61 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       <nav class="top"><Brand /><span class="public">public file</span></nav>
       {file ? (
         <>
-          <h1 class="filetitle">{filename}</h1>
-          <figure class="stage" style="margin:0">
-            <div class="media">
-              {kind(file.contentType) === "image" && <img src={file.url} alt={filename} decoding="async" />}
-              {kind(file.contentType) === "video" && <video src={file.url} controls playsinline preload="metadata">Your browser cannot play this video.</video>}
-              {kind(file.contentType) === "file" && <div class="fallback"><strong>Preview unavailable</strong><a href={file.url} rel="noopener noreferrer">Open {filename}</a></div>}
-              {kind(file.contentType) === "unsupported" && <div class="fallback"><strong>Unsupported media type</strong><span>This file cannot be previewed inline.</span></div>}
-            </div>
-            <figcaption class="details">
-              {gh && (
-                <a
-                  class="gh-chip"
-                  href={gh.url}
-                  rel="noopener noreferrer"
-                  aria-label={ghAriaLabel}
+          <header class="filehead">
+            <h1 class="filetitle">{filename}</h1>
+            {gh && (
+              <a
+                class="gh-byline"
+                href={gh.url}
+                rel="noopener noreferrer"
+                aria-label={ghAriaLabel}
+              >
+                <svg
+                  class="gh-byline-icon"
+                  viewBox="0 0 16 16"
+                  width="13"
+                  height="13"
+                  aria-hidden="true"
+                  focusable="false"
                 >
-                  <svg
-                    class="gh-chip-icon"
-                    viewBox="0 0 16 16"
-                    width="14"
-                    height="14"
-                    aria-hidden="true"
-                    focusable="false"
-                  >
-                    <title>{gh.kind === "pull" ? "pull request" : "issue"}</title>
-                    <path fill="currentColor" d={GH_KIND_PATH[gh.kind]} />
-                  </svg>
-                  <span class="gh-chip-text">
-                    {gh.title ? (
-                      <>
-                        <span class="gh-chip-title">{gh.title}</span>
-                        <span class="gh-chip-ref">{ghRef}</span>
-                      </>
-                    ) : (
-                      <span class="gh-chip-name">{ghRef}</span>
-                    )}
-                  </span>
-                </a>
-              )}
+                  <title>{gh.kind === "pull" ? "pull request" : "issue"}</title>
+                  <path fill="currentColor" d={GH_KIND_PATH[gh.kind]} />
+                </svg>
+                {gh.title ? (
+                  <>
+                    <span class="gh-byline-title">{gh.title}</span>
+                    <span class="gh-byline-sep" aria-hidden="true">·</span>
+                    <span class="gh-byline-ref">{ghRef}</span>
+                  </>
+                ) : (
+                  <span class="gh-byline-ref">{ghRef}</span>
+                )}
+              </a>
+            )}
+          </header>
+          <figure class="stage" style="margin:0">
+            {kind(file.contentType) === "image" ? (
+              <ImagePreview src={file.url} alt={filename} />
+            ) : (
+              <div class="media">
+                {kind(file.contentType) === "video" && <video src={file.url} controls playsinline preload="metadata">Your browser cannot play this video.</video>}
+                {kind(file.contentType) === "file" && <div class="fallback"><strong>Preview unavailable</strong><a href={file.url} rel="noopener noreferrer">Open {filename}</a></div>}
+                {kind(file.contentType) === "unsupported" && <div class="fallback"><strong>Unsupported media type</strong><span>This file cannot be previewed inline.</span></div>}
+              </div>
+            )}
+            <figcaption class="details">
               <dl class="meta">
                 <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
                 {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
                 {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}
               </dl>
               {metadataEntries.length > 0 && (
-                <>
-                  <div class="section-label">Metadata</div>
-                  <dl class="meta metadata">
+                <div>
+                  <div class="rail-head">
+                    <span class="rail-label">Metadata</span>
+                    <span class="rail-rule" aria-hidden="true"></span>
+                  </div>
+                  <dl class="meta">
                     {metadataEntries.map(([metaKey, metaValue]) => (
                       <>
                         <dt>{metaKey}</dt>
@@ -221,7 +236,7 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
                       </>
                     ))}
                   </dl>
-                </>
+                </div>
               )}
               <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
                 {kind(file.contentType) !== "unsupported" && (

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -4,6 +4,7 @@ import Brand from "../../../components/Brand.astro";
 import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
 import GalleryReferences from "../../../components/GalleryReferences.astro";
+import ImagePreview from "../../../components/ImagePreview.astro";
 import { buildEmbedFormats, type EmbedFormatOption } from "../../../lib/embed-formats";
 import {
   formatBytes,
@@ -109,8 +110,9 @@ const sizeLabel =
       .crumbs .count { color:var(--muted); }
       .filetitle { margin:0 0 16px; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
       .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
+      /* Video / non-image fallbacks only — images use ImagePreview. */
       .media { min-height:320px; max-height:78vh; background:var(--bg); display:grid; place-items:center; overflow:hidden; }
-      img,video { max-width:100%; max-height:78vh; width:auto; height:auto; object-fit:contain; display:block; }
+      .media video { max-width:100%; max-height:78vh; width:auto; height:auto; object-fit:contain; display:block; }
       .fallback { padding:60px 30px; text-align:center; color:var(--muted); font:13px/1.6 var(--mono); }
       .fallback strong { display:block; color:var(--fg); margin-bottom:8px; }
       .fallback a { color:var(--fg); overflow-wrap:anywhere; }
@@ -155,13 +157,16 @@ const sizeLabel =
           <div class="crumbs"><a href={listPath}>{gallery.title}</a> · <span class="count">{index + 1} of {items.length}</span></div>
           <h1 class="filetitle">{item.filename}</h1>
           <figure class="stage" style="margin:0">
-            <div class="media">
-              {kind(item) === "image" && <img src={item.url!} alt={item.altText ?? item.caption ?? item.filename} decoding="async" />}
-              {kind(item) === "video" && <video src={item.url!} controls playsinline preload="metadata" aria-describedby="item-caption">Your browser cannot play this video.</video>}
-              {kind(item) === "file" && <div class="fallback"><strong>Preview unavailable</strong><a href={item.url!} rel="noopener noreferrer">Open {item.filename}</a></div>}
-              {kind(item) === "unsupported" && <div class="fallback"><strong>Unsupported media type</strong><span>This item cannot be opened inline.</span></div>}
-              {kind(item) === "missing" && <div class="fallback"><strong>Removed or expired</strong><span>This item remains in the gallery to preserve its place.</span></div>}
-            </div>
+            {kind(item) === "image" && item.url ? (
+              <ImagePreview src={item.url} alt={item.altText ?? item.caption ?? item.filename} />
+            ) : (
+              <div class="media">
+                {kind(item) === "video" && <video src={item.url!} controls playsinline preload="metadata" aria-describedby="item-caption">Your browser cannot play this video.</video>}
+                {kind(item) === "file" && <div class="fallback"><strong>Preview unavailable</strong><a href={item.url!} rel="noopener noreferrer">Open {item.filename}</a></div>}
+                {kind(item) === "unsupported" && <div class="fallback"><strong>Unsupported media type</strong><span>This item cannot be opened inline.</span></div>}
+                {kind(item) === "missing" && <div class="fallback"><strong>Removed or expired</strong><span>This item remains in the gallery to preserve its place.</span></div>}
+              </div>
+            )}
             <figcaption class="details" id="item-caption">
               <GalleryReferences references={gallery.references} variant="inline" />
               {item.caption && <div class="caption">{item.caption}</div>}


### PR DESCRIPTION
## In plain terms

Tall agent/docs screenshots on the public file page were squeezed into a short viewport, so you couldn’t read the UI without opening the original. The preview can now grow to full width (page scroll), and the PR link sits under the filename instead of eating the sidebar.

## What it does

- **Fit / Full width** control on image previews (public file + gallery item pages)
- Tall images (height/width ≥ 1.35) **auto-open Full width** so the stage grows with the image; normal page scroll, no inner scrollport
- Fit keeps the previous compact ~78vh stage for photos / wide shots
- Move linked PR/issue to an **inline byline under the filename**
- Right rail: clearer **section spacing** and a **Metadata** label + rule (account-rail style) so it doesn’t look like another key-value row

## What it is not

- Not a lightbox / zoom viewer (can follow later)
- No persisted preference across pages — override is per page view so the next tall shot still auto-picks full width

## How to try it

1. Open a tall screenshot file page, e.g. a full-page agents docs capture under `/f/default/gh/...`
2. Confirm it loads in **Full width** and the block expands; scroll the page to read the bottom
3. Toggle **Fit** to return to the compact stage
4. Confirm the PR byline under the filename and Metadata spacing in the rail

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/image-preview-mode.test.ts`
- [x] Pre-commit types + lint-staged
- [ ] Manual: tall vs wide image on `/f/...` and gallery item page
- [ ] Manual: PR byline + metadata section spacing on a GH-attached file