### PR TITLE
feat(web): gallery item byline and rail spacing

### DIFF
--- a/apps/web/src/components/GalleryReferences.astro
+++ b/apps/web/src/components/GalleryReferences.astro
@@ -2,13 +2,10 @@
 /**
  * Connected work items for public gallery pages.
  *
- * Renders GitHub refs as the same chip shape the public file share page uses
- * for `file.github` (kind icon + optional title + `owner/repo#N`). Non-github
- * providers stay as provider + coordinate.
- *
  * `variant`:
- *   - `panel` (default) — bordered block under the gallery index / full page
- *   - `inline` — chips inside the item-page details rail (no outer card)
+ *   - `panel` (default) — bordered block under the gallery index
+ *   - `header` — under the item-page title: one ref as a byline (matches the
+ *     public file page), several as a compact labeled list (not the details rail)
  */
 import { GH_KIND_PATH, GITHUB_MARK_PATH } from "../lib/brand-icons";
 import { galleryReferenceChip } from "../lib/gallery-reference-chip";
@@ -16,74 +13,107 @@ import type { PublicGalleryReference } from "../lib/public-gallery";
 
 interface Props {
   references: PublicGalleryReference[];
-  variant?: "panel" | "inline";
+  variant?: "panel" | "header";
 }
 
 const { references, variant = "panel" } = Astro.props;
 const chips = references.map(galleryReferenceChip);
-const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
+const single = chips.length === 1 ? chips[0]! : null;
+const isHeader = variant === "header";
+const isByline = isHeader && single != null;
+const isHeaderMulti = isHeader && chips.length > 1;
+const refsClass = isByline ? "refs refs--byline" : isHeaderMulti ? "refs refs--header" : "refs";
 ---
 
 {
   chips.length > 0 && (
     <aside class={refsClass}>
-      <h2>Connected work items</h2>
-      <ul>
-        {chips.map((chip) => (
-          <li>
-            {chip.href ? (
-              <a
-                class="gh-chip"
-                href={chip.href}
-                rel="noopener noreferrer"
-                aria-label={chip.ariaLabel}
-              >
-                {chip.glyph === "kind" && chip.kind && (
-                  <svg
-                    class="gh-chip-icon"
-                    viewBox="0 0 16 16"
-                    width="14"
-                    height="14"
-                    aria-hidden="true"
-                    focusable="false"
-                  >
-                    <title>{chip.kindLabel}</title>
-                    <path fill="currentColor" d={GH_KIND_PATH[chip.kind]} />
-                  </svg>
-                )}
-                {chip.glyph === "github-mark" && (
-                  <svg
-                    class="gh-chip-icon"
-                    viewBox="0 0 24 24"
-                    width="14"
-                    height="14"
-                    aria-hidden="true"
-                    focusable="false"
-                  >
-                    <path fill="currentColor" d={GITHUB_MARK_PATH} />
-                  </svg>
-                )}
-                {chip.glyph === "provider" && <span class="provider">{chip.provider}</span>}
-                <span class="gh-chip-text">
-                  {chip.title ? (
-                    <>
-                      <span class="gh-chip-title">{chip.title}</span>
-                      <span class="gh-chip-ref">{chip.coordinate}</span>
-                    </>
-                  ) : (
-                    <span class="gh-chip-name">{chip.coordinate}</span>
-                  )}
-                </span>
-              </a>
-            ) : (
-              <span class="gh-chip gh-chip--static">
-                <span class="provider">{chip.provider}</span>
-                <span class="gh-chip-name">{chip.coordinate}</span>
-              </span>
+      {isHeaderMulti && (
+        <div class="rail-head">
+          <span class="rail-label">Connected work</span>
+          <span class="rail-rule" aria-hidden="true"></span>
+        </div>
+      )}
+      {!isHeader && <h2>Connected work items</h2>}
+
+      {isByline && single ? (
+        single.href ? (
+          <a class="gh-byline" href={single.href} rel="noopener noreferrer" aria-label={single.ariaLabel}>
+            {single.glyph === "kind" && single.kind && (
+              <svg class="gh-byline-icon" viewBox="0 0 16 16" width="13" height="13" aria-hidden="true" focusable="false">
+                <title>{single.kindLabel}</title>
+                <path fill="currentColor" d={GH_KIND_PATH[single.kind]} />
+              </svg>
             )}
-          </li>
-        ))}
-      </ul>
+            {single.glyph === "github-mark" && (
+              <svg class="gh-byline-icon" viewBox="0 0 24 24" width="13" height="13" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d={GITHUB_MARK_PATH} />
+              </svg>
+            )}
+            {single.glyph === "provider" && <span class="provider">{single.provider}</span>}
+            {single.title ? (
+              <>
+                <span class="gh-byline-title">{single.title}</span>
+                <span class="gh-byline-sep" aria-hidden="true">·</span>
+                <span class="gh-byline-ref">{single.coordinate}</span>
+              </>
+            ) : (
+              <span class="gh-byline-ref">{single.coordinate}</span>
+            )}
+          </a>
+        ) : (
+          <span class="gh-byline gh-byline--static">
+            {single.glyph === "provider" && <span class="provider">{single.provider}</span>}
+            {single.title ? (
+              <>
+                <span class="gh-byline-title">{single.title}</span>
+                <span class="gh-byline-sep" aria-hidden="true">·</span>
+                <span class="gh-byline-ref">{single.coordinate}</span>
+              </>
+            ) : (
+              <span class="gh-byline-ref">{single.coordinate}</span>
+            )}
+          </span>
+        )
+      ) : (
+        <ul>
+          {chips.map((chip) => (
+            <li>
+              {chip.href ? (
+                <a class="gh-chip" href={chip.href} rel="noopener noreferrer" aria-label={chip.ariaLabel}>
+                  {chip.glyph === "kind" && chip.kind && (
+                    <svg class="gh-chip-icon" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" focusable="false">
+                      <title>{chip.kindLabel}</title>
+                      <path fill="currentColor" d={GH_KIND_PATH[chip.kind]} />
+                    </svg>
+                  )}
+                  {chip.glyph === "github-mark" && (
+                    <svg class="gh-chip-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false">
+                      <path fill="currentColor" d={GITHUB_MARK_PATH} />
+                    </svg>
+                  )}
+                  {chip.glyph === "provider" && <span class="provider">{chip.provider}</span>}
+                  <span class="gh-chip-text">
+                    {chip.title ? (
+                      <>
+                        <span class="gh-chip-title">{chip.title}</span>
+                        <span class="gh-chip-ref">{chip.coordinate}</span>
+                      </>
+                    ) : (
+                      <span class="gh-chip-name">{chip.coordinate}</span>
+                    )}
+                  </span>
+                </a>
+              ) : (
+                <span class="gh-chip gh-chip--static">
+                  <span class="provider">{chip.provider}</span>
+                  <span class="gh-chip-name">{chip.coordinate}</span>
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </aside>
   )
 }
@@ -96,16 +126,26 @@ const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
     border-radius: var(--radius-lg, 10px);
     background: var(--panel);
   }
-  /* Nested inside the item-page rail — drop the outer card so chips sit flush
-     in the details column (file share page puts the PR as a byline under the
-     filename instead). */
-  .refs--inline {
-    margin: 0 0 12px;
+
+  /* Multi-ref header: flush under the filename, no outer card.
+     Bottom spacing comes from the page `.filehead` margin. */
+  .refs--header {
+    margin: 8px 0 0;
     padding: 0;
     border: none;
     border-radius: 0;
     background: transparent;
   }
+
+  /* Single-ref byline: no card, no heading. */
+  .refs--byline {
+    margin: 6px 0 0;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+  }
+
   .refs h2 {
     margin: 0 0 10px;
     color: var(--muted);
@@ -114,10 +154,28 @@ const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
     text-transform: uppercase;
     font-weight: 600;
   }
-  .refs--inline h2 {
-    margin: 0 0 8px;
-    letter-spacing: 0.08em;
+
+  .rail-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 0 10px;
   }
+
+  .rail-label {
+    color: var(--muted);
+    font-size: 10.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .rail-rule {
+    flex: 1;
+    height: 1px;
+    background: var(--line);
+  }
+
   .refs ul {
     margin: 0;
     padding: 0;
@@ -127,6 +185,58 @@ const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
     gap: 8px;
     align-items: flex-start;
   }
+
+  .refs--header ul {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .gh-byline {
+    display: inline-flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    column-gap: 8px;
+    row-gap: 2px;
+    max-width: 100%;
+    color: var(--muted);
+    font: 12.5px / 1.45 var(--mono);
+    text-decoration: none;
+  }
+
+  a.gh-byline:hover,
+  a.gh-byline:focus-visible {
+    color: var(--accent);
+    outline: none;
+  }
+
+  .gh-byline-icon {
+    flex: none;
+    align-self: center;
+  }
+
+  .gh-byline-title {
+    color: var(--body);
+    overflow-wrap: anywhere;
+  }
+
+  a.gh-byline:hover .gh-byline-title,
+  a.gh-byline:focus-visible .gh-byline-title {
+    color: inherit;
+  }
+
+  .gh-byline-sep {
+    opacity: 0.7;
+  }
+
+  .gh-byline-ref {
+    overflow-wrap: anywhere;
+  }
+
+  .gh-byline--static {
+    color: var(--body);
+  }
+
   .gh-chip {
     display: inline-flex;
     align-items: center;
@@ -140,36 +250,44 @@ const refsClass = variant === "inline" ? "refs refs--inline" : "refs";
     text-decoration: none;
     max-width: 100%;
   }
+
   a.gh-chip:hover,
   a.gh-chip:focus-visible {
     border-color: var(--accent);
     color: var(--accent);
     outline: none;
   }
+
   .gh-chip--static {
     color: var(--body);
   }
+
   .gh-chip-icon {
     flex: none;
   }
+
   .gh-chip-text {
     display: flex;
     flex-direction: column;
     gap: 2px;
     min-width: 0;
   }
+
   .gh-chip-title {
     overflow-wrap: anywhere;
     font-weight: 600;
   }
+
   .gh-chip-ref {
     color: var(--muted);
     font-size: 11px;
     overflow-wrap: anywhere;
   }
+
   .gh-chip-name {
     overflow-wrap: anywhere;
   }
+
   .provider {
     color: var(--muted);
     font: 11px var(--mono);

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -108,7 +108,8 @@ const sizeLabel =
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
       .crumbs { margin-bottom:12px; color:var(--muted); font:13px var(--mono); overflow-wrap:anywhere; }
       .crumbs .count { color:var(--muted); }
-      .filetitle { margin:0 0 16px; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
+      .filehead { margin:0 0 16px; min-width:0; }
+      .filetitle { margin:0; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
       .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
       /* Video / non-image fallbacks only — images use ImagePreview. */
       .media { min-height:320px; max-height:78vh; background:var(--bg); display:grid; place-items:center; overflow:hidden; }
@@ -116,11 +117,14 @@ const sizeLabel =
       .fallback { padding:60px 30px; text-align:center; color:var(--muted); font:13px/1.6 var(--mono); }
       .fallback strong { display:block; color:var(--fg); margin-bottom:8px; }
       .fallback a { color:var(--fg); overflow-wrap:anywhere; }
-      .details { padding:18px 20px 22px; border-top:1px solid var(--line); }
-      .caption { margin:0 0 12px; color:var(--body); font-size:15px; line-height:1.6; white-space:pre-wrap; }
-      dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:0 0 4px; font:12px var(--mono); }
+      /* Right rail: same section gap as the public file page. */
+      .details { display:flex; flex-direction:column; gap:22px; padding:18px 20px 22px; border-top:1px solid var(--line); }
+      .details > * { min-width:0; }
+      .caption { margin:0; color:var(--body); font-size:15px; line-height:1.6; white-space:pre-wrap; }
+      dl.meta { display:grid; grid-template-columns:auto 1fr; gap:6px 16px; margin:0; font:12px var(--mono); }
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
+      .details :global(.actions) { margin-top:0; }
       .pager { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:22px 0 0; font:13px var(--mono); }
       .pager a, .pager span.disabled { display:inline-block; padding:10px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); text-decoration:none; }
       .pager a:hover, .pager a:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
@@ -155,7 +159,10 @@ const sizeLabel =
       {gallery && item ? (
         <>
           <div class="crumbs"><a href={listPath}>{gallery.title}</a> · <span class="count">{index + 1} of {items.length}</span></div>
-          <h1 class="filetitle">{item.filename}</h1>
+          <header class="filehead">
+            <h1 class="filetitle">{item.filename}</h1>
+            <GalleryReferences references={gallery.references} variant="header" />
+          </header>
           <figure class="stage" style="margin:0">
             {kind(item) === "image" && item.url ? (
               <ImagePreview src={item.url} alt={item.altText ?? item.caption ?? item.filename} />
@@ -168,7 +175,6 @@ const sizeLabel =
               </div>
             )}
             <figcaption class="details" id="item-caption">
-              <GalleryReferences references={gallery.references} variant="inline" />
               {item.caption && <div class="caption">{item.caption}</div>}
               {(sizeLabel || uploadedLabel || modifiedLabel) && (
                 <dl class="meta">


### PR DESCRIPTION
## In plain terms

Gallery item pages still kept connected PRs in the right rail and stacked caption/meta/actions without breathing room. They now match the public file page: related work under the title, and a clearer details column.

## What it does

- **Connected work under the header** (not the details rail)
  - **One** reference → inline byline (same pattern as file pages)
  - **Several** → compact “Connected work” label + chips under the filename
- **Rail spacing** on gallery items: 22px gaps between caption, meta, and actions
- Gallery **index** still uses the existing panel under the grid (unchanged)

## What it is not

- No change to Fit/Full width (already shared via `ImagePreview` from #383)
- Does not move index-page connected work into the header

## How to try it

1. Open a gallery item with one GitHub reference — expect a byline under the filename
2. Open an item in a gallery with multiple references — expect a compact list under the title
3. Confirm the right rail only has caption / size / copy actions with even spacing

## Test plan

- [x] `pnpm --filter @uploads/web exec vitest run src/lib/gallery-reference-chip.test.ts`
- [ ] Manual: single-ref gallery item byline
- [ ] Manual: multi-ref gallery item header list
- [ ] Manual: gallery index panel still at bottom