### PR TITLE
feat: subscription billing infrastructure (free-plan era)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,12 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@uploads/api", "@uploads/mcp", "@uploads/web", "@uploads/storage", "@uploads/auth"]
+  "ignore": [
+    "@uploads/api",
+    "@uploads/mcp",
+    "@uploads/web",
+    "@uploads/storage",
+    "@uploads/auth",
+    "@uploads/billing"
+  ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,6 +33,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@uploads/billing": "workspace:^",
     "@uploads/email": "workspace:^",
     "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",

--- a/apps/api/src/budget.test.ts
+++ b/apps/api/src/budget.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveBudgetLimits } from "./budget";
+
+describe("resolveBudgetLimits — plan-aware resolution", () => {
+  // Controller ruling (post-BLOCKED review): plan defaults apply ONLY when
+  // `plan` is explicitly set on the record. Absent `plan` must reproduce
+  // today's (pre-billing) behavior byte-for-byte — legacy/admin-provisioned
+  // workspaces stay unlimited, matching production today.
+  it("no plan set: legacy unlimited behavior, unchanged (regression guard)", () => {
+    expect(resolveBudgetLimits({})).toEqual({
+      maxStorageBytes: undefined,
+      maxUploadsPerPeriod: undefined,
+    });
+  });
+
+  it("an explicit maxStorageBytes override still applies with no plan set (existing PR #280 behavior)", () => {
+    expect(resolveBudgetLimits({ maxStorageBytes: 500 })).toEqual({
+      maxStorageBytes: 500,
+      maxUploadsPerPeriod: undefined,
+    });
+  });
+
+  it("a workspace explicitly on the free plan resolves free's defaults", () => {
+    expect(resolveBudgetLimits({ plan: "free" })).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+
+  it("a workspace explicitly on the pro plan resolves pro's defaults", () => {
+    expect(resolveBudgetLimits({ plan: "pro" })).toEqual({
+      maxStorageBytes: 25_000_000_000,
+      maxUploadsPerPeriod: 100_000,
+    });
+  });
+
+  it("an unknown/legacy plan string fails open to free's defaults", () => {
+    expect(resolveBudgetLimits({ plan: "enterprise" })).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+
+  it("plan set + a zero/negative/non-finite override is treated as unset, falling back to the plan default (unchanged positiveLimit behavior)", () => {
+    expect(resolveBudgetLimits({ plan: "free", maxStorageBytes: 0 })).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+
+  it("plan set + an explicit numeric override still beats the plan default", () => {
+    expect(resolveBudgetLimits({ plan: "pro", maxStorageBytes: 1_000 })).toEqual({
+      maxStorageBytes: 1_000,
+      maxUploadsPerPeriod: 100_000,
+    });
+  });
+});

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -7,6 +7,7 @@
  */
 
 import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
+import { resolvePlanLimits } from "@uploads/billing";
 import type { WorkspaceUsage } from "./usage";
 
 /** Cumulative caps from the workspace registry record. */
@@ -15,6 +16,8 @@ export interface WorkspaceBudgetLimits {
   maxStorageBytes?: number;
   /** Cap on successful puts in the current UTC calendar month. */
   maxUploadsPerPeriod?: number;
+  /** Subscription plan — see `@uploads/billing`'s `PlanId`. Absent = free. */
+  plan?: string;
 }
 
 export type BudgetDenialCode = "storage_quota_exceeded" | "upload_budget_exceeded";
@@ -37,9 +40,24 @@ export function resolveBudgetLimits(record: WorkspaceBudgetLimits): {
   maxStorageBytes?: number;
   maxUploadsPerPeriod?: number;
 } {
-  return {
+  const explicit = {
     maxStorageBytes: positiveLimit(record.maxStorageBytes),
     maxUploadsPerPeriod: positiveLimit(record.maxUploadsPerPeriod),
+  };
+  // Plan defaults apply ONLY when a workspace has been explicitly placed on
+  // a plan. Absent `plan` must reproduce today's (pre-billing) behavior
+  // byte-for-byte: an unset field is unlimited, full stop — no free-tier
+  // fallback. This keeps every legacy/admin-provisioned workspace unlimited
+  // as it is in production today; only a record with `plan` set opts into
+  // plan-aware resolution (self-serve creation does not set `plan` in this
+  // task — that wiring is a later task).
+  if (record.plan === undefined) {
+    return explicit;
+  }
+  const resolved = resolvePlanLimits(record.plan, explicit);
+  return {
+    maxStorageBytes: positiveLimit(resolved.maxStorageBytes),
+    maxUploadsPerPeriod: positiveLimit(resolved.maxUploadsPerPeriod),
   };
 }
 

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -16,7 +16,11 @@ export interface WorkspaceBudgetLimits {
   maxStorageBytes?: number;
   /** Cap on successful puts in the current UTC calendar month. */
   maxUploadsPerPeriod?: number;
-  /** Subscription plan — see `@uploads/billing`'s `PlanId`. Absent = free. */
+  /**
+   * Subscription plan — see `@uploads/billing`'s `PlanId`. Absent means
+   * legacy/unlimited enforcement (explicit limit fields only, no plan
+   * defaults applied) — NOT a free-tier fallback. See `resolveBudgetLimits`.
+   */
   plan?: string;
 }
 

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -669,7 +669,7 @@ describe("workspace plan editing", () => {
     return { env, store };
   }
 
-  it("GET returns the free plan and resolved defaults for a bare record", async () => {
+  it("GET reports the free plan (display) but leaves a bare record unlimited — planApplied: false", async () => {
     const { env } = planEnv(ADMIN_USER, REC);
     const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
     expect(res.status).toBe(200);
@@ -677,6 +677,26 @@ describe("workspace plan editing", () => {
       workspace: "acme",
       plan: "free",
       available: true,
+      planApplied: false,
+      limits: {
+        maxStorageBytes: null,
+        maxUploadsPerPeriod: null,
+        maxUploadBytes: null,
+        maxVideoUploadBytes: null,
+      },
+      overrides: [],
+    });
+  });
+
+  it("GET resolves plan defaults once a plan is explicitly set — planApplied: true", async () => {
+    const { env } = planEnv(ADMIN_USER, { ...REC, plan: "free" });
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      plan: "free",
+      available: true,
+      planApplied: true,
       limits: {
         maxStorageBytes: 250_000_000,
         maxUploadsPerPeriod: 3000,
@@ -699,9 +719,10 @@ describe("workspace plan editing", () => {
       env,
     );
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { plan: string; available: boolean };
+    const body = (await res.json()) as { plan: string; available: boolean; planApplied: boolean };
     expect(body.plan).toBe("pro");
     expect(body.available).toBe(false);
+    expect(body.planApplied).toBe(true);
     expect(JSON.parse(store.get("ws:acme") ?? "{}").plan).toBe("pro");
   });
 

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -643,6 +643,111 @@ describe("workspace limits editing", () => {
   });
 });
 
+describe("workspace plan editing", () => {
+  const REC = {
+    provider: "r2",
+    bucket: "uploads-default",
+    prefix: "acme/",
+  };
+
+  function planEnv(user: typeof ADMIN_USER | null, record: Record<string, unknown> | null) {
+    const store = new Map<string, string>();
+    if (record) store.set("ws:acme", JSON.stringify(record));
+    const base = stubEnv(user, () => new Response(null, { status: 404 }));
+    const env = {
+      ...base,
+      REGISTRY: {
+        get: (async (key: string) => {
+          const raw = store.get(key);
+          return raw ? JSON.parse(raw) : null;
+        }) as unknown as KVNamespace["get"],
+        put: (async (key: string, value: string) => {
+          store.set(key, value);
+        }) as unknown as KVNamespace["put"],
+      },
+    } as unknown as Env;
+    return { env, store };
+  }
+
+  it("GET returns the free plan and resolved defaults for a bare record", async () => {
+    const { env } = planEnv(ADMIN_USER, REC);
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      plan: "free",
+      available: true,
+      limits: {
+        maxStorageBytes: 250_000_000,
+        maxUploadsPerPeriod: 3000,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      },
+      overrides: [],
+    });
+  });
+
+  it("PATCH sets the plan on the record and persists it", async () => {
+    const { env, store } = planEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { plan: string; available: boolean };
+    expect(body.plan).toBe("pro");
+    expect(body.available).toBe(false);
+    expect(JSON.parse(store.get("ws:acme") ?? "{}").plan).toBe("pro");
+  });
+
+  it("PATCH rejects an unknown plan id", async () => {
+    const { env } = planEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "enterprise" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH preserves existing limit overrides on the record", async () => {
+    const { env, store } = planEnv(ADMIN_USER, { ...REC, maxStorageBytes: 999 });
+    await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      },
+      env,
+    );
+    const stored = JSON.parse(store.get("ws:acme") ?? "{}");
+    expect(stored.maxStorageBytes).toBe(999);
+    expect(stored.plan).toBe("pro");
+  });
+
+  it("GET 404s for an unknown workspace", async () => {
+    const { env } = planEnv(ADMIN_USER, null);
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { env } = planEnv(NON_ADMIN_USER, REC);
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(403);
+  });
+});
+
 describe("workspace github-comment settings editing", () => {
   /** Env with a mutable ws:acme record and a session user (no usage needed). */
   function settingsEnv(user: typeof ADMIN_USER | null, record: Record<string, unknown> | null) {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -46,6 +46,7 @@ import {
 import { getWorkspaceUsage } from "../usage";
 import { isPurgedTombstone, loadWorkspaceRecordRaw, type WorkspaceRecord } from "../workspace";
 import { LIMIT_FIELDS, validateLimitsPatch } from "../workspace-limits";
+import { planResponse, validatePlanPatch } from "../workspace-plan";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const BAN_REASON_MAX = 500;
@@ -488,6 +489,36 @@ export const adminUi = new Hono<SessionVars>()
     }
     await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
     return c.json(await limitsResponse(c.env, name, record));
+  })
+
+  // Read the workspace's plan, its availability, and resolved effective
+  // limits (plan defaults backstopped by any explicit overrides).
+  .get("/workspaces/:name/plan", async (c) => {
+    const name = c.req.param("name");
+    const record = await loadEditableWorkspace(c.env, name);
+    return c.json(planResponse(name, record));
+  })
+
+  // Set the workspace's plan. Admins may set `pro` even though it's
+  // unavailable to self-serve users (operator override) — availability is
+  // informational in the response, not enforced here. Limit overrides on
+  // the record are untouched; only `plan` is written.
+  .patch("/workspaces/:name/plan", async (c) => {
+    const name = c.req.param("name");
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    const record = await loadEditableWorkspace(c.env, name);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new ValidationError("request body must be valid JSON", { code: "invalid_plan" });
+    }
+    const { plan } = validatePlanPatch(body);
+    record.plan = plan;
+    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
+    return c.json(planResponse(name, record));
   })
 
   // Read the per-workspace managed-comment settings: whether attachments

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -366,7 +366,13 @@ describe("GET /me/workspaces/:name/summary", () => {
 });
 
 describe("GET /me/workspaces/:name/billing", () => {
-  it("returns plan, resolved limits, usage, and a null subscription for a member", async () => {
+  it("displays free with planApplied=false and unlimited (explicit-or-null) limits for a record with no plan field", async () => {
+    // R2_RECORD has no `plan` field — same "legacy/unset" shape budget.ts's
+    // enforcement treats as unlimited (explicit overrides only). The
+    // billing tab must never show free-plan default caps (250MB etc.) as
+    // if they were real limits here — see workspace-plan.ts's
+    // `planResponse` doc comment and Task 5's Critical fix on the admin
+    // surface.
     const db = new UsageFakeD1();
     db.usage.set("acme", {
       workspace: "acme",
@@ -383,13 +389,15 @@ describe("GET /me/workspaces/:name/billing", () => {
       workspace: string;
       plan: string;
       available: boolean;
-      limits: Record<string, number>;
+      planApplied: boolean;
+      limits: Record<string, number | null>;
       subscription: null;
     };
     expect(body.workspace).toBe("acme");
     expect(body.plan).toBe("free");
     expect(body.available).toBe(true);
-    expect(body.limits.maxStorageBytes).toBe(250_000_000);
+    expect(body.planApplied).toBe(false);
+    expect(body.limits.maxStorageBytes).toBeNull();
     expect(body.subscription).toBeNull();
   });
 
@@ -402,7 +410,29 @@ describe("GET /me/workspaces/:name/billing", () => {
     expect(res.status).toBe(404);
   });
 
-  it("reports pro plan and its own resolved limits when the workspace is on pro", async () => {
+  it("reports free with planApplied=true and resolved plan-default limits when the record has an explicit free plan", async () => {
+    const db = new UsageFakeD1();
+    const env = memberEnv({
+      workspace: "acme",
+      role: "member",
+      db,
+      record: { ...R2_RECORD, plan: "free" },
+    });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      plan: string;
+      available: boolean;
+      planApplied: boolean;
+      limits: Record<string, number | null>;
+    };
+    expect(body.plan).toBe("free");
+    expect(body.available).toBe(true);
+    expect(body.planApplied).toBe(true);
+    expect(body.limits.maxStorageBytes).toBe(250_000_000);
+  });
+
+  it("reports pro plan, planApplied=true, and pro's own resolved limits when the workspace is on pro", async () => {
     const db = new UsageFakeD1();
     const env = memberEnv({
       workspace: "acme",
@@ -411,9 +441,16 @@ describe("GET /me/workspaces/:name/billing", () => {
       record: { ...R2_RECORD, plan: "pro" },
     });
     const res = await app().request("/me/workspaces/acme/billing", {}, env);
-    const body = (await res.json()) as { plan: string; available: boolean };
+    const body = (await res.json()) as {
+      plan: string;
+      available: boolean;
+      planApplied: boolean;
+      limits: Record<string, number | null>;
+    };
     expect(body.plan).toBe("pro");
     expect(body.available).toBe(false);
+    expect(body.planApplied).toBe(true);
+    expect(body.limits.maxStorageBytes).toBe(25_000_000_000);
   });
 });
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -365,6 +365,58 @@ describe("GET /me/workspaces/:name/summary", () => {
   });
 });
 
+describe("GET /me/workspaces/:name/billing", () => {
+  it("returns plan, resolved limits, usage, and a null subscription for a member", async () => {
+    const db = new UsageFakeD1();
+    db.usage.set("acme", {
+      workspace: "acme",
+      bytes: 500,
+      objects: 3,
+      uploads_in_period: 2,
+      period_start: "2026-07",
+      updated_at: "2026-07-10T00:00:00.000Z",
+    });
+    const env = memberEnv({ workspace: "acme", role: "member", db, record: R2_RECORD });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      workspace: string;
+      plan: string;
+      available: boolean;
+      limits: Record<string, number>;
+      subscription: null;
+    };
+    expect(body.workspace).toBe("acme");
+    expect(body.plan).toBe("free");
+    expect(body.available).toBe(true);
+    expect(body.limits.maxStorageBytes).toBe(250_000_000);
+    expect(body.subscription).toBeNull();
+  });
+
+  it("404s for a non-member", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") return Response.json([]);
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("reports pro plan and its own resolved limits when the workspace is on pro", async () => {
+    const db = new UsageFakeD1();
+    const env = memberEnv({
+      workspace: "acme",
+      role: "member",
+      db,
+      record: { ...R2_RECORD, plan: "pro" },
+    });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    const body = (await res.json()) as { plan: string; available: boolean };
+    expect(body.plan).toBe("pro");
+    expect(body.available).toBe(false);
+  });
+});
+
 describe("GET /me/workspaces/:name/people", () => {
   it("returns members + invites for an admin in one authz pass", async () => {
     const env = stubEnv(USER, (path) => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -257,14 +257,12 @@ export const me = new Hono<SessionVars>()
 
     const { plan, available, planApplied, limits } = planResponse(name, record);
 
-    let usage: ReturnType<typeof usageWithLimits> | null = null;
-    try {
-      usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
-    } catch {
-      usage = null;
-    }
-
-    const subscription = await billingProvider.getSubscription(name);
+    const [usage, subscription] = await Promise.all([
+      getWorkspaceUsage(c.env.DB, name)
+        .then((raw) => usageWithLimits(raw, record))
+        .catch(() => null),
+      billingProvider.getSubscription(name),
+    ]);
 
     return c.json({
       workspace: ws.workspace,

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,6 +9,7 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
+import { getPlan, NullBillingProvider, resolvePlanLimits } from "@uploads/billing";
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
@@ -42,6 +43,10 @@ import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { loadWorkspaceRecord } from "../workspace";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// No live billing yet — see @uploads/billing's NullBillingProvider doc
+// comment. Swapping in a real provider later only changes this line.
+const billingProvider = new NullBillingProvider();
 
 interface MyWorkspace {
   workspace: string;
@@ -226,6 +231,48 @@ export const me = new Hono<SessionVars>()
       hasPublicUrl: Boolean(publicBaseUrl),
       publicBaseUrl,
       usage,
+    });
+  })
+
+  // Plan metadata, resolved effective limits, usage, and subscription state
+  // (always null today) for the account billing tab — 404s unless the
+  // caller is a member. Response shape is stable across the future Stripe
+  // iteration: adding a real subscription only changes `subscription` from
+  // null to a populated object.
+  .get("/workspaces/:name/billing", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const definition = getPlan(record.plan);
+    const limits = resolvePlanLimits(record.plan, {
+      maxStorageBytes: record.maxStorageBytes,
+      maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+      maxUploadBytes: record.maxUploadBytes,
+      maxVideoUploadBytes: record.maxVideoUploadBytes,
+    });
+
+    let usage: ReturnType<typeof usageWithLimits> | null = null;
+    try {
+      usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
+    } catch {
+      usage = null;
+    }
+
+    const subscription = await billingProvider.getSubscription(name);
+
+    return c.json({
+      workspace: ws.workspace,
+      organization: ws.organization,
+      plan: definition.id,
+      available: definition.available,
+      limits,
+      usage,
+      subscription,
     });
   })
 

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,7 +9,7 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
-import { getPlan, NullBillingProvider, resolvePlanLimits } from "@uploads/billing";
+import { NullBillingProvider } from "@uploads/billing";
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
@@ -41,6 +41,7 @@ import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage"
 import { getWorkspaceUsage } from "../usage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { loadWorkspaceRecord } from "../workspace";
+import { planResponse } from "../workspace-plan";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -236,9 +237,15 @@ export const me = new Hono<SessionVars>()
 
   // Plan metadata, resolved effective limits, usage, and subscription state
   // (always null today) for the account billing tab — 404s unless the
-  // caller is a member. Response shape is stable across the future Stripe
-  // iteration: adding a real subscription only changes `subscription` from
-  // null to a populated object.
+  // caller is a member. `plan`/`available`/`planApplied`/`limits` reuse
+  // workspace-plan.ts's `planResponse` — the same attribution contract the
+  // admin plan surface uses (Task 5's Critical fix): a record with no
+  // `plan` field must never display free-plan default caps it isn't
+  // actually enforcing, so `planApplied` is `false` and `limits` mirrors
+  // enforcement (explicit-or-unlimited) rather than the plan defaults.
+  // Response shape is stable across the future Stripe iteration: adding a
+  // real subscription only changes `subscription` from null to a
+  // populated object.
   .get("/workspaces/:name/billing", async (c) => {
     const name = c.req.param("name");
     const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
@@ -248,13 +255,7 @@ export const me = new Hono<SessionVars>()
       throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
     }
 
-    const definition = getPlan(record.plan);
-    const limits = resolvePlanLimits(record.plan, {
-      maxStorageBytes: record.maxStorageBytes,
-      maxUploadsPerPeriod: record.maxUploadsPerPeriod,
-      maxUploadBytes: record.maxUploadBytes,
-      maxVideoUploadBytes: record.maxVideoUploadBytes,
-    });
+    const { plan, available, planApplied, limits } = planResponse(name, record);
 
     let usage: ReturnType<typeof usageWithLimits> | null = null;
     try {
@@ -268,8 +269,9 @@ export const me = new Hono<SessionVars>()
     return c.json({
       workspace: ws.workspace,
       organization: ws.organization,
-      plan: definition.id,
-      available: definition.available,
+      plan,
+      available,
+      planApplied,
       limits,
       usage,
       subscription,

--- a/apps/api/src/workspace-plan.test.ts
+++ b/apps/api/src/workspace-plan.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { planResponse, validatePlanPatch } from "./workspace-plan";
+
+describe("validatePlanPatch", () => {
+  it("accepts a known plan id", () => {
+    expect(validatePlanPatch({ plan: "pro" })).toEqual({ plan: "pro" });
+    expect(validatePlanPatch({ plan: "free" })).toEqual({ plan: "free" });
+  });
+
+  it("rejects an unknown plan id", () => {
+    expect(() => validatePlanPatch({ plan: "enterprise" })).toThrow(/invalid_plan|plan/i);
+  });
+
+  it("rejects a missing plan field", () => {
+    expect(() => validatePlanPatch({})).toThrow(/invalid_plan|plan/i);
+  });
+
+  it("rejects a non-object body", () => {
+    expect(() => validatePlanPatch(null)).toThrow(/invalid_plan|plan/i);
+    expect(() => validatePlanPatch("pro")).toThrow(/invalid_plan|plan/i);
+  });
+});
+
+describe("planResponse", () => {
+  it("reports the free plan, its resolved limits, and no overrides for a bare record", () => {
+    const result = planResponse("acme", { provider: "r2", bucket: "b" });
+    expect(result).toEqual({
+      workspace: "acme",
+      plan: "free",
+      available: true,
+      limits: {
+        maxStorageBytes: 250_000_000,
+        maxUploadsPerPeriod: 3000,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      },
+      overrides: [],
+    });
+  });
+
+  it("lists explicit override fields and resolves them into limits", () => {
+    const result = planResponse("acme", {
+      provider: "r2",
+      bucket: "b",
+      maxStorageBytes: 999,
+    });
+    expect(result.overrides).toEqual(["maxStorageBytes"]);
+    expect(result.limits.maxStorageBytes).toBe(999);
+    expect(result.limits.maxUploadsPerPeriod).toBe(3000);
+  });
+
+  it("reports pro as unavailable when a workspace is set to it", () => {
+    const result = planResponse("acme", { provider: "r2", bucket: "b", plan: "pro" });
+    expect(result.plan).toBe("pro");
+    expect(result.available).toBe(false);
+  });
+
+  it("fails open to free for an unrecognized stored plan string", () => {
+    const result = planResponse("acme", {
+      provider: "r2",
+      bucket: "b",
+      plan: "enterprise" as never,
+    });
+    expect(result.plan).toBe("free");
+  });
+});

--- a/apps/api/src/workspace-plan.test.ts
+++ b/apps/api/src/workspace-plan.test.ts
@@ -22,28 +22,43 @@ describe("validatePlanPatch", () => {
 });
 
 describe("planResponse", () => {
-  it("reports the free plan, its resolved limits, and no overrides for a bare record", () => {
+  it("reports the free plan (display default) but leaves a bare record's limits unlimited — planApplied: false", () => {
     const result = planResponse("acme", { provider: "r2", bucket: "b" });
     expect(result).toEqual({
       workspace: "acme",
       plan: "free",
       available: true,
+      planApplied: false,
       limits: {
-        maxStorageBytes: 250_000_000,
-        maxUploadsPerPeriod: 3000,
-        maxUploadBytes: 25_000_000,
-        maxVideoUploadBytes: 8_000_000,
+        maxStorageBytes: null,
+        maxUploadsPerPeriod: null,
+        maxUploadBytes: null,
+        maxVideoUploadBytes: null,
       },
       overrides: [],
     });
   });
 
-  it("lists explicit override fields and resolves them into limits", () => {
+  it("reflects explicit overrides on a bare (no-plan) record without applying plan defaults", () => {
     const result = planResponse("acme", {
       provider: "r2",
       bucket: "b",
       maxStorageBytes: 999,
     });
+    expect(result.planApplied).toBe(false);
+    expect(result.overrides).toEqual(["maxStorageBytes"]);
+    expect(result.limits.maxStorageBytes).toBe(999);
+    expect(result.limits.maxUploadsPerPeriod).toBe(null);
+  });
+
+  it("resolves plan defaults + overrides once a plan is explicitly set — planApplied: true", () => {
+    const result = planResponse("acme", {
+      provider: "r2",
+      bucket: "b",
+      plan: "free",
+      maxStorageBytes: 999,
+    });
+    expect(result.planApplied).toBe(true);
     expect(result.overrides).toEqual(["maxStorageBytes"]);
     expect(result.limits.maxStorageBytes).toBe(999);
     expect(result.limits.maxUploadsPerPeriod).toBe(3000);
@@ -53,14 +68,18 @@ describe("planResponse", () => {
     const result = planResponse("acme", { provider: "r2", bucket: "b", plan: "pro" });
     expect(result.plan).toBe("pro");
     expect(result.available).toBe(false);
+    expect(result.planApplied).toBe(true);
+    expect(result.limits.maxStorageBytes).toBe(25_000_000_000);
   });
 
-  it("fails open to free for an unrecognized stored plan string", () => {
+  it("fails open to free for an unrecognized stored plan string, but still applies plan-aware resolution", () => {
     const result = planResponse("acme", {
       provider: "r2",
       bucket: "b",
       plan: "enterprise" as never,
     });
     expect(result.plan).toBe("free");
+    expect(result.planApplied).toBe(true);
+    expect(result.limits.maxStorageBytes).toBe(250_000_000);
   });
 });

--- a/apps/api/src/workspace-plan.ts
+++ b/apps/api/src/workspace-plan.ts
@@ -1,0 +1,50 @@
+/**
+ * Validates the plan-change body accepted by the admin panel's
+ * PATCH /admin-ui/workspaces/:name/plan endpoint, and builds the response
+ * shared by that route's GET/PATCH — mirrors workspace-limits.ts's
+ * validateLimitsPatch / admin-ui.ts's limitsResponse pattern (spec
+ * 2026-07-22, billing infrastructure).
+ */
+import { getPlan, PLAN_IDS, resolvePlanLimits, type PlanId } from "@uploads/billing";
+import { ValidationError } from "@uploads/errors";
+import type { WorkspaceRecord } from "./workspace";
+
+const LIMIT_FIELDS_FOR_OVERRIDES = [
+  "maxStorageBytes",
+  "maxUploadsPerPeriod",
+  "maxUploadBytes",
+  "maxVideoUploadBytes",
+] as const;
+
+export function validatePlanPatch(body: unknown): { plan: PlanId } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new ValidationError("plan body must be a JSON object", { code: "invalid_plan" });
+  }
+  const record = body as Record<string, unknown>;
+  const plan = record.plan;
+  if (typeof plan !== "string" || !PLAN_IDS.includes(plan as PlanId)) {
+    throw new ValidationError(`plan must be one of: ${PLAN_IDS.join(", ")}`, {
+      code: "invalid_plan",
+    });
+  }
+  return { plan: plan as PlanId };
+}
+
+/** Response body shared by GET and PATCH /admin-ui/workspaces/:name/plan. */
+export function planResponse(name: string, record: WorkspaceRecord) {
+  const definition = getPlan(record.plan);
+  const overrides = LIMIT_FIELDS_FOR_OVERRIDES.filter((field) => record[field] !== undefined);
+  const limits = resolvePlanLimits(record.plan, {
+    maxStorageBytes: record.maxStorageBytes,
+    maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+    maxUploadBytes: record.maxUploadBytes,
+    maxVideoUploadBytes: record.maxVideoUploadBytes,
+  });
+  return {
+    workspace: name,
+    plan: definition.id,
+    available: definition.available,
+    limits,
+    overrides,
+  };
+}

--- a/apps/api/src/workspace-plan.ts
+++ b/apps/api/src/workspace-plan.ts
@@ -5,16 +5,16 @@
  * validateLimitsPatch / admin-ui.ts's limitsResponse pattern (spec
  * 2026-07-22, billing infrastructure).
  */
-import { getPlan, PLAN_IDS, resolvePlanLimits, type PlanId } from "@uploads/billing";
+import {
+  getPlan,
+  PLAN_IDS,
+  resolvePlanLimits,
+  type PlanId,
+  type WorkspacePlanLimits,
+} from "@uploads/billing";
 import { ValidationError } from "@uploads/errors";
 import type { WorkspaceRecord } from "./workspace";
-
-const LIMIT_FIELDS_FOR_OVERRIDES = [
-  "maxStorageBytes",
-  "maxUploadsPerPeriod",
-  "maxUploadBytes",
-  "maxVideoUploadBytes",
-] as const;
+import { LIMIT_FIELDS } from "./workspace-limits";
 
 export function validatePlanPatch(body: unknown): { plan: PlanId } {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
@@ -48,21 +48,20 @@ export function validatePlanPatch(body: unknown): { plan: PlanId } {
  */
 export function planResponse(name: string, record: WorkspaceRecord) {
   const definition = getPlan(record.plan);
-  const overrides = LIMIT_FIELDS_FOR_OVERRIDES.filter((field) => record[field] !== undefined);
+  const overrides = LIMIT_FIELDS.filter(
+    (field) => record[field as keyof WorkspacePlanLimits] !== undefined,
+  );
   const planApplied = record.plan !== undefined;
   const limits = planApplied
-    ? resolvePlanLimits(record.plan, {
-        maxStorageBytes: record.maxStorageBytes,
-        maxUploadsPerPeriod: record.maxUploadsPerPeriod,
-        maxUploadBytes: record.maxUploadBytes,
-        maxVideoUploadBytes: record.maxVideoUploadBytes,
-      })
-    : {
-        maxStorageBytes: record.maxStorageBytes ?? null,
-        maxUploadsPerPeriod: record.maxUploadsPerPeriod ?? null,
-        maxUploadBytes: record.maxUploadBytes ?? null,
-        maxVideoUploadBytes: record.maxVideoUploadBytes ?? null,
-      };
+    ? resolvePlanLimits(
+        record.plan,
+        Object.fromEntries(
+          LIMIT_FIELDS.map((field) => [field, record[field as keyof WorkspacePlanLimits]]),
+        ),
+      )
+    : Object.fromEntries(
+        LIMIT_FIELDS.map((field) => [field, record[field as keyof WorkspacePlanLimits] ?? null]),
+      );
   return {
     workspace: name,
     plan: definition.id,

--- a/apps/api/src/workspace-plan.ts
+++ b/apps/api/src/workspace-plan.ts
@@ -30,20 +30,44 @@ export function validatePlanPatch(body: unknown): { plan: PlanId } {
   return { plan: plan as PlanId };
 }
 
-/** Response body shared by GET and PATCH /admin-ui/workspaces/:name/plan. */
+/**
+ * Response body shared by GET and PATCH /admin-ui/workspaces/:name/plan.
+ *
+ * `plan`/`available` always fail open to the `free` catalog entry for
+ * display (`getPlan`'s contract) — but `limits` must not silently apply
+ * `free`'s numeric defaults to a record with no `plan` field: budget.ts's
+ * enforcement path treats an absent `plan` as legacy/unlimited (explicit
+ * overrides only, no plan defaults — see budget.ts's early-return branch),
+ * and this response would otherwise lie about a workspace's real caps
+ * (e.g. showing "250MB" for a workspace that's actually unlimited).
+ * `planApplied` is the honest signal distinguishing the two states:
+ * `false` means `limits` reflects raw overrides only (unlimited where
+ * unset, mirroring the null-for-unlimited convention `limitsResponse`
+ * uses above); `true` means `limits` reflects plan-aware resolution via
+ * `resolvePlanLimits` (overrides layered onto the plan's defaults).
+ */
 export function planResponse(name: string, record: WorkspaceRecord) {
   const definition = getPlan(record.plan);
   const overrides = LIMIT_FIELDS_FOR_OVERRIDES.filter((field) => record[field] !== undefined);
-  const limits = resolvePlanLimits(record.plan, {
-    maxStorageBytes: record.maxStorageBytes,
-    maxUploadsPerPeriod: record.maxUploadsPerPeriod,
-    maxUploadBytes: record.maxUploadBytes,
-    maxVideoUploadBytes: record.maxVideoUploadBytes,
-  });
+  const planApplied = record.plan !== undefined;
+  const limits = planApplied
+    ? resolvePlanLimits(record.plan, {
+        maxStorageBytes: record.maxStorageBytes,
+        maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+        maxUploadBytes: record.maxUploadBytes,
+        maxVideoUploadBytes: record.maxVideoUploadBytes,
+      })
+    : {
+        maxStorageBytes: record.maxStorageBytes ?? null,
+        maxUploadsPerPeriod: record.maxUploadsPerPeriod ?? null,
+        maxUploadBytes: record.maxUploadBytes ?? null,
+        maxVideoUploadBytes: record.maxVideoUploadBytes ?? null,
+      };
   return {
     workspace: name,
     plan: definition.id,
     available: definition.available,
+    planApplied,
     limits,
     overrides,
   };

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -63,6 +63,13 @@ export interface WorkspaceRecord {
    */
   retentionDays?: number;
   /**
+   * Subscription plan (spec 2026-07-22, billing infrastructure). Absent
+   * means `free`. Admin-only to change today (no self-serve upgrade path
+   * exists); an unrecognized string is treated as `free` at read time by
+   * `@uploads/billing`'s `getPlan` — never a lockout.
+   */
+  plan?: "free" | "pro";
+  /**
    * When true/undefined, bare keys (no `/`) become `f/<id>/<name>`. Set false
    * to allow root basenames (not recommended on shared buckets).
    */

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -207,8 +207,8 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
       var label = document.getElementById("ws-switcher-label");
       if (label && !pathWs) label.textContent = activeWs;
       var base = "/account/workspaces/" + encodeURIComponent(activeWs);
-      var paths = ["", "/galleries", "/people", "/settings"];
-      var names = ["files", "galleries", "people", "settings"];
+      var paths = ["", "/galleries", "/people", "/billing", "/settings"];
+      var names = ["files", "galleries", "people", "billing", "settings"];
       var html = "";
       for (var i = 0; i < paths.length; i++) {
         html += '<a href="' + base + paths[i] + '" class="side-link">' + names[i] + "</a>";

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -375,6 +375,75 @@ export async function getWorkspacePeople(
   };
 }
 
+export interface WorkspaceBillingLimits {
+  maxStorageBytes: number | null;
+  maxUploadsPerPeriod: number | null;
+  maxUploadBytes: number | null;
+  maxVideoUploadBytes: number | null;
+}
+
+export interface WorkspaceBilling {
+  workspace: string;
+  organization: { id: string; slug: string; name: string };
+  plan: string;
+  available: boolean;
+  planApplied: boolean;
+  limits: WorkspaceBillingLimits;
+  usage: Record<string, unknown> | null;
+  subscription: null;
+}
+
+export type WorkspaceBillingResult =
+  | { kind: "ok"; billing: WorkspaceBilling }
+  | { kind: "unavailable"; reason?: "not_found" | "server" | RequestFailure };
+
+/**
+ * GET /me/workspaces/:name/billing — plan metadata, resolved effective
+ * limits, usage, and (always-null-for-now) subscription for the billing tab.
+ */
+export async function getWorkspaceBilling(
+  apiOrigin: string,
+  name: string,
+): Promise<WorkspaceBillingResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/billing`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body || typeof body.plan !== "string") {
+    return { kind: "unavailable", reason: "server" };
+  }
+  const org = body.organization as Record<string, unknown> | undefined;
+  const rawLimits = (body.limits as Record<string, unknown> | undefined) ?? {};
+  const numOrNull = (v: unknown): number | null => (typeof v === "number" ? v : null);
+  return {
+    kind: "ok",
+    billing: {
+      workspace: typeof body.workspace === "string" ? body.workspace : name,
+      organization: {
+        id: typeof org?.id === "string" ? org.id : "",
+        slug: typeof org?.slug === "string" ? org.slug : name,
+        name: typeof org?.name === "string" ? org.name : name,
+      },
+      plan: body.plan,
+      available: body.available === true,
+      planApplied: body.planApplied === true,
+      limits: {
+        maxStorageBytes: numOrNull(rawLimits.maxStorageBytes),
+        maxUploadsPerPeriod: numOrNull(rawLimits.maxUploadsPerPeriod),
+        maxUploadBytes: numOrNull(rawLimits.maxUploadBytes),
+        maxVideoUploadBytes: numOrNull(rawLimits.maxVideoUploadBytes),
+      },
+      usage: (body.usage as Record<string, unknown> | null) ?? null,
+      subscription: null,
+    },
+  };
+}
+
 /**
  * POST /me/workspaces/:name/invites — workspace admin|owner invites an email.
  * Always prefer showing `acceptUrl` (works without outbound email).

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -73,6 +73,7 @@ describe("workspaceTabFromPathname", () => {
     );
     expect(workspaceTabFromPathname("/account/workspaces/buildinternet/people")).toBe("people");
     expect(workspaceTabFromPathname("/account/workspaces/buildinternet/invite")).toBe("people");
+    expect(workspaceTabFromPathname("/account/workspaces/buildinternet/billing")).toBe("billing");
     expect(workspaceTabFromPathname("/account/workspaces/buildinternet/settings")).toBe("settings");
   });
 
@@ -159,6 +160,7 @@ describe("renderWorkspaceSectionNavHtml", () => {
     expect(html).toContain('href="/account/workspaces/buildinternet"');
     expect(html).toContain('href="/account/workspaces/buildinternet/galleries"');
     expect(html).toContain('href="/account/workspaces/buildinternet/people"');
+    expect(html).toContain('href="/account/workspaces/buildinternet/billing"');
     expect(html).toContain('href="/account/workspaces/buildinternet/settings"');
     expect(html).toMatch(
       /href="\/account\/workspaces\/buildinternet\/galleries"[^>]*aria-current="page"/,

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -19,7 +19,7 @@ import { escapeHtml } from "./workspace-ui";
 export const WORKSPACES_CACHE_KEY = "uploads:myWorkspaces";
 export const ACTIVE_WORKSPACE_CACHE_KEY = "uploads:activeWorkspace";
 
-export type WorkspaceNavTab = "files" | "galleries" | "people" | "settings";
+export type WorkspaceNavTab = "files" | "galleries" | "people" | "billing" | "settings";
 
 export const WORKSPACE_NAV_TABS: {
   id: WorkspaceNavTab;
@@ -30,6 +30,7 @@ export const WORKSPACE_NAV_TABS: {
   { id: "files", label: "files", path: "" },
   { id: "galleries", label: "galleries", path: "/galleries" },
   { id: "people", label: "people", path: "/people" },
+  { id: "billing", label: "billing", path: "/billing" },
   { id: "settings", label: "settings", path: "/settings" },
 ];
 
@@ -136,6 +137,7 @@ export function workspaceTabFromPathname(pathname: string): WorkspaceNavTab | ""
   if (!segment) return "files";
   if (segment === "galleries") return "galleries";
   if (segment === "people" || segment === "invite") return "people";
+  if (segment === "billing") return "billing";
   if (segment === "settings") return "settings";
   return "";
 }

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -1,0 +1,193 @@
+---
+/**
+ * Workspace billing tab — current plan, resolved limits vs usage, and a
+ * disabled "Upgrade — coming soon" affordance (spec 2026-07-22, billing
+ * infrastructure). No live billing exists yet: no invoices, no payment
+ * method, no real upgrade flow — honest copy only. When the backend hasn't
+ * actually applied a plan (`planApplied === false`), limits are rendered as
+ * whatever `limits` says (often unlimited/custom) rather than free-tier
+ * marketing caps — see apps/api/src/routes/me.ts's billing route.
+ */
+import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+
+export const prerender = false;
+
+const nameParam = Astro.params.name ?? "";
+const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
+if (!workspace) return Astro.redirect("/account/workspaces");
+---
+
+<WorkspaceLayout workspace={workspace}>
+  <div id="ws-status" class="ul-callout status" role="status">Loading…</div>
+  <button id="ws-retry" type="button" hidden>Try again</button>
+
+  <div id="ws-app" hidden>
+    <section class="card settings-page">
+      <div class="settings-section">
+        <div class="ws-page-header">
+          <div class="ws-title-block">
+            <h2>Billing</h2>
+            <p class="muted" id="ws-slug"></p>
+          </div>
+          <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+        </div>
+
+        <div id="ws-plan-card" class="ul-callout">
+          <p><strong id="ws-plan-name"></strong></p>
+          <p class="muted" id="ws-plan-blurb"></p>
+        </div>
+
+        <div id="ws-limits" class="settings-section">
+          <h3>Limits &amp; usage</h3>
+          <dl class="ws-rail__kv" id="ws-limits-list"></dl>
+        </div>
+
+        <div class="settings-section">
+          <button type="button" id="ws-upgrade-btn" disabled>Upgrade — coming soon</button>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    import {
+      getPageVisit,
+      isCurrentPageVisit,
+      onAstroPageLoad,
+      onSession,
+      requireElement,
+    } from "../../../../lib/account-shell";
+    import { getWorkspaceBilling, type WorkspaceBilling } from "../../../../lib/api-client";
+    import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("ws-plan-card")) return;
+
+      const page = "workspace billing";
+      const visit = getPageVisit();
+      const stillHere = (): boolean => isCurrentPageVisit(visit);
+      const w = window as unknown as {
+        __UPLOADS_API_ORIGIN__: string;
+        __UPLOADS_ACTIVE_WORKSPACE__: string;
+      };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+      const workspaceName = resolveActiveWorkspace(
+        window.location.pathname,
+        w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+      );
+
+      const statusEl = requireElement<HTMLElement>("#ws-status", page);
+      const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
+      const appEl = requireElement<HTMLElement>("#ws-app", page);
+      const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+      const planNameEl = requireElement<HTMLElement>("#ws-plan-name", page);
+      const planBlurbEl = requireElement<HTMLElement>("#ws-plan-blurb", page);
+      const limitsListEl = requireElement<HTMLElement>("#ws-limits-list", page);
+
+      function showError(message: string, retry = true): void {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = message;
+        statusEl.dataset.state = "error";
+        appEl.hidden = true;
+        retryBtn.hidden = !retry;
+      }
+
+      function formatBytes(n: number): string {
+        if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)} GB`;
+        if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(0)} MB`;
+        return `${n} bytes`;
+      }
+
+      function planLabel(plan: string): string {
+        return plan.charAt(0).toUpperCase() + plan.slice(1);
+      }
+
+      function paintLimits(billing: WorkspaceBilling): void {
+        const usage = billing.usage as
+          | { bytes?: number; objects?: number; uploadsInPeriod?: number }
+          | null;
+        const { limits } = billing;
+        const rows: string[] = [];
+
+        const storageUsed = usage?.bytes ?? 0;
+        rows.push(
+          `<dt>Storage</dt><dd>${formatBytes(storageUsed)} of ${
+            limits.maxStorageBytes === null ? "unlimited" : formatBytes(limits.maxStorageBytes)
+          }</dd>`,
+        );
+
+        const uploadsUsed = usage?.uploadsInPeriod ?? 0;
+        rows.push(
+          `<dt>Uploads this month</dt><dd>${uploadsUsed} of ${
+            limits.maxUploadsPerPeriod === null ? "unlimited" : limits.maxUploadsPerPeriod
+          }</dd>`,
+        );
+
+        rows.push(
+          `<dt>Max file size</dt><dd>${
+            limits.maxUploadBytes === null ? "unlimited" : formatBytes(limits.maxUploadBytes)
+          }</dd>`,
+        );
+
+        rows.push(
+          `<dt>Max video size</dt><dd>${
+            limits.maxVideoUploadBytes === null
+              ? "unlimited"
+              : formatBytes(limits.maxVideoUploadBytes)
+          }</dd>`,
+        );
+
+        limitsListEl.innerHTML = rows.join("");
+      }
+
+      async function loadBillingPage(): Promise<void> {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = "Loading…";
+        statusEl.removeAttribute("data-state");
+        retryBtn.hidden = true;
+        appEl.hidden = true;
+
+        const result = await getWorkspaceBilling(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          if (result.reason === "not_found") {
+            showError("You don’t have access to this workspace.", false);
+            return;
+          }
+          showError("Billing is temporarily unavailable. Check the local stack or try again.");
+          return;
+        }
+
+        const { billing } = result;
+        planNameEl.textContent = `${planLabel(billing.plan)} plan`;
+        // Honest copy: a record with no plan actually applied isn't on
+        // free-tier marketing caps — it's running whatever `limits` says.
+        planBlurbEl.textContent = billing.planApplied
+          ? billing.available
+            ? "This plan is active on your workspace."
+            : "This plan isn’t available for self-serve upgrade yet."
+          : "No plan has been applied yet — limits below reflect what's currently enforced.";
+        paintLimits(billing);
+
+        statusEl.hidden = true;
+        appEl.hidden = false;
+
+        const displayName = billing.organization.name || workspaceName;
+        slugEl.textContent =
+          displayName === workspaceName ? workspaceName : `${displayName} · ${workspaceName}`;
+        document.title = `Billing · ${displayName} · uploads.sh`;
+      }
+
+      retryBtn.addEventListener("click", () => {
+        void loadBillingPage();
+      });
+
+      onSession(() => {
+        void loadBillingPage();
+      });
+    });
+  </script>
+</WorkspaceLayout>

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -59,6 +59,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       requireElement,
     } from "../../../../lib/account-shell";
     import { getWorkspaceBilling, type WorkspaceBilling } from "../../../../lib/api-client";
+    import { formatBytes } from "../../../../lib/workspace-ui";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
 
     onAstroPageLoad(() => {
@@ -92,12 +93,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         statusEl.dataset.state = "error";
         appEl.hidden = true;
         retryBtn.hidden = !retry;
-      }
-
-      function formatBytes(n: number): string {
-        if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)} GB`;
-        if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(0)} MB`;
-        return `${n} bytes`;
       }
 
       function planLabel(plan: string): string {

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -71,6 +71,90 @@ export const prerender = false;
       usage: { bytes: number; uploads: number } | null;
     }
 
+    interface PlanResponse {
+      workspace: string;
+      plan: "free" | "pro";
+      available: boolean;
+      planApplied: boolean;
+      limits: Limits;
+      overrides: string[];
+    }
+
+    const PLAN_OPTIONS: { id: "free" | "pro"; label: string }[] = [
+      { id: "free", label: "Free" },
+      { id: "pro", label: "Pro (unavailable to self-serve)" },
+    ];
+
+    function renderPlanSelector(host: HTMLElement, workspace: string, data: PlanResponse): void {
+      const options = PLAN_OPTIONS.map(
+        (opt) =>
+          `<option value="${opt.id}"${opt.id === data.plan ? " selected" : ""}>${escapeHtml(opt.label)}</option>`,
+      ).join("");
+
+      const appliedNote = data.planApplied
+        ? ""
+        : `<p class="muted plan-unapplied">No plan applied (legacy) — limits shown are the enforcement truth (explicit-or-unlimited), not this plan's defaults.</p>`;
+
+      host.innerHTML = `
+        <h4 class="plan-heading">Plan</h4>
+        <p class="muted plan-availability">${data.available ? "Available" : "Not available for self-serve upgrade"}</p>
+        ${appliedNote}
+        <form class="plan-form">
+          <select class="plan-select">${options}</select>
+          <button type="submit">Save plan</button>
+          <div class="plan-status" role="status" aria-live="polite" hidden></div>
+        </form>`;
+
+      const form = host.querySelector<HTMLFormElement>(".plan-form");
+      const statusEl = host.querySelector<HTMLElement>(".plan-status");
+      form?.addEventListener("submit", (event) => {
+        void (async () => {
+          event.preventDefault();
+          if (statusEl) statusEl.hidden = true;
+          const select = host.querySelector<HTMLElement>(
+            ".plan-select",
+          ) as unknown as HTMLSelectElement | null;
+          const plan = select?.value ?? "free";
+          const submitBtn = form.querySelector<HTMLButtonElement>("button[type=submit]");
+          if (submitBtn) submitBtn.disabled = true;
+          try {
+            const res = await fetch(
+              `${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(workspace)}/plan`,
+              {
+                method: "PATCH",
+                credentials: "include",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ plan }),
+              },
+            );
+            if (!res.ok) {
+              const payload = (await res.json().catch(() => null)) as {
+                error?: { message?: string };
+              } | null;
+              throw new Error(payload?.error?.message || `save failed: ${res.status}`);
+            }
+            const updated = (await res.json()) as PlanResponse;
+            renderPlanSelector(host, workspace, updated);
+            const freshStatus = host.querySelector<HTMLElement>(".plan-status");
+            if (freshStatus) {
+              freshStatus.dataset.state = "ready";
+              freshStatus.textContent = "Saved.";
+              freshStatus.hidden = false;
+            }
+          } catch (err) {
+            if (statusEl) {
+              statusEl.dataset.state = "error";
+              statusEl.textContent =
+                err instanceof Error && err.message ? err.message : "Couldn't save plan.";
+              statusEl.hidden = false;
+            }
+          } finally {
+            if (submitBtn) submitBtn.disabled = false;
+          }
+        })();
+      });
+    }
+
     const LIMIT_UNITS: { label: string; mult: number }[] = [
       { label: "MB", mult: 1_000_000 },
       { label: "GB", mult: 1_000_000_000 },
@@ -275,6 +359,7 @@ export const prerender = false;
       <div class="detail">
         <div class="members" data-state="unloaded">Members load when expanded.</div>
         <div class="invites"></div>
+        <div class="plan" data-state="unloaded"></div>
         <div class="limits" data-state="unloaded"></div>
         <div class="github-links" data-state="unloaded"></div>
         ${
@@ -302,6 +387,7 @@ export const prerender = false;
     `;
 
       let loaded = false;
+      let planLoaded = false;
       let limitsLoaded = false;
       let githubLinksLoaded = false;
       details.addEventListener("toggle", () => {
@@ -339,6 +425,22 @@ export const prerender = false;
             loaded = true;
           } catch {
             if (membersEl) membersEl.textContent = "Failed to load members.";
+          }
+        })();
+        // Plan selector — independent load, own retry flag, same pattern as
+        // limits below.
+        void (async () => {
+          if (!details.open || planLoaded) return;
+          const planEl = details.querySelector<HTMLElement>(".plan");
+          if (!planEl) return;
+          try {
+            const planData = await apiGet<PlanResponse>(
+              `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/plan`,
+            );
+            renderPlanSelector(planEl, ws.workspace, planData);
+            planLoaded = true;
+          } catch {
+            planEl.innerHTML = `<p class="muted">Failed to load plan.</p>`;
           }
         })();
         // Limits apply to every workspace regardless of org, and their load

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -100,7 +100,7 @@ export const prerender = false;
         <p class="muted plan-availability">${data.available ? "Available" : "Not available for self-serve upgrade"}</p>
         ${appliedNote}
         <form class="plan-form">
-          <select class="plan-select">${options}</select>
+          <select class="plan-select" aria-label="Plan">${options}</select>
           <button type="submit">Save plan</button>
           <div class="plan-status" role="status" aria-live="polite" hidden></div>
         </form>`;

--- a/docs/superpowers/plans/2026-07-22-billing-infrastructure.md
+++ b/docs/superpowers/plans/2026-07-22-billing-infrastructure.md
@@ -1,0 +1,1707 @@
+# Billing Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay the infrastructure for workspace subscription plans (free/pro) with no live billing — a dedicated `@uploads/billing` package, a `plan` field on `WorkspaceRecord`, admin + user-facing routes, and workspace/admin UI, all defaulting every workspace to `free` today.
+
+**Architecture:** New private package `packages/billing` owns the plan catalog, pure limit-resolution, and a `BillingProvider` interface with a `NullBillingProvider`. `apps/api` wires `plan` into `WorkspaceRecord` and routes limit resolution through `resolvePlanLimits`, then exposes admin (`/admin-ui/workspaces/:name/plan`) and user (`/me/workspaces/:name/billing`) endpoints. `apps/web` adds a workspace `billing.astro` tab and an admin-panel plan selector next to the existing limits form.
+
+**Tech Stack:** TypeScript, Hono (Cloudflare Workers), Astro (vanilla `<script>`, no framework), plain Vitest via the root `vitest.projects.ts` runner, pnpm workspaces, oxfmt formatting, Changesets (this package is excluded, like other private packages).
+
+## Global Constraints
+
+- No Stripe SDK anywhere in this iteration — `packages/billing` only defines the `BillingProvider` interface and a `NullBillingProvider`.
+- `packages/billing` is private (`"private": true`), not published, and added to `.changeset/config.json`'s `ignore` list alongside `@uploads/api`, `@uploads/mcp`, `@uploads/web`, `@uploads/storage`, `@uploads/auth`.
+- Unknown/legacy plan string found in KV at read time → fail-open to `free`, never lockout.
+- Explicit per-workspace admin limit overrides (the existing four `LIMIT_FIELDS`: `maxStorageBytes`, `maxUploadsPerPeriod`, `maxUploadBytes`, `maxVideoUploadBytes`) always beat plan defaults.
+- `free` plan defaults = current self-serve defaults from `apps/api/src/self-serve-defaults.ts`'s `SELF_SERVE_LIMITS` (`maxStorageBytes: 250_000_000`, `maxUploadsPerPeriod: 3000`, `maxUploadBytes: 25_000_000`, `maxVideoUploadBytes: 8_000_000`).
+- `pro` plan is defined with `available: false` — display metadata only, no live upgrade path. Admins may still set a workspace's plan to `pro` (operator override) even though it's unavailable to self-serve users.
+- `plan?: 'free' | 'pro'` on `WorkspaceRecord` is optional; absent means `free`. No migration or backfill script.
+- No D1 subscription table, no webhook route, no Worker secrets in this iteration.
+- Repo test command: `pnpm test` (root Vitest runner via `vitest.projects.ts`, auto-discovers `packages/*`/`apps/*` — no manual registration needed for a new package).
+- Format with `oxfmt` (repo convention — see AGENTS.md), not Prettier.
+- Unauthorized plan changes never happen from `apps/web`: the admin PATCH route stays session+`requireAdminUser`-gated exactly like the existing limits routes; the user-facing `GET /me/workspaces/:name/billing` route is read-only.
+
+---
+
+## File Structure
+
+- **Create** `packages/billing/package.json`, `packages/billing/tsconfig.json`, `packages/billing/README.md` — package scaffold mirroring `packages/storage`'s conventions (private, `type: module`, `exports` map, `typecheck`/`test` scripts).
+- **Create** `packages/billing/src/plans.ts` — the plan catalog (`PlanId`, `PlanDefinition`, `PLANS`, `getPlan`).
+- **Create** `packages/billing/src/resolve.ts` — `resolvePlanLimits(plan, overrides)`, pure precedence logic.
+- **Create** `packages/billing/src/provider.ts` — `BillingProvider` interface + `NullBillingProvider`.
+- **Create** `packages/billing/src/index.ts` — barrel export.
+- **Create** `packages/billing/test/plans.test.ts`, `packages/billing/test/resolve.test.ts`, `packages/billing/test/provider.test.ts`.
+- **Modify** `apps/api/package.json` — add `"@uploads/billing": "workspace:^"` dependency and a `"./billing"`-style export is not needed (apps/api imports the package directly, not re-exported).
+- **Modify** `apps/api/src/workspace.ts` — add `plan?: 'free' | 'pro'` field + doc comment to `WorkspaceRecord`.
+- **Modify** `apps/api/src/budget.ts` — route `resolveBudgetLimits` through `resolvePlanLimits` so plan defaults backstop the four budget fields when a workspace has no explicit override.
+- **Modify** `apps/api/src/self-serve-defaults.ts` — no functional change needed (already matches `free` plan defaults), but add a comment cross-referencing `@uploads/billing`'s catalog as the source of truth going forward.
+- **Create** `apps/api/src/workspace-plan.ts` — `validatePlanPatch` (mirrors `workspace-limits.ts`'s `validateLimitsPatch` pattern) + `planResponse` helper shared by admin GET/PATCH.
+- **Modify** `apps/api/src/routes/admin-ui.ts` — add `GET /workspaces/:name/plan` and `PATCH /workspaces/:name/plan`.
+- **Modify** `apps/api/src/routes/admin-ui.test.ts` — tests for the two new routes.
+- **Create** `apps/api/src/workspace-plan.test.ts` — unit tests for `validatePlanPatch`.
+- **Modify** `apps/api/src/budget.test.ts` (or create if absent — checked in Task 4) — regression tests proving existing override behavior unchanged and plan-default fallback works.
+- **Modify** `apps/api/src/routes/me.ts` — add `GET /workspaces/:name/billing`.
+- **Modify** `apps/api/src/routes/me.test.ts` — tests for the new route.
+- **Create** `apps/web/src/pages/account/workspaces/[name]/billing.astro` — workspace billing tab.
+- **Modify** `apps/web/src/lib/workspaces-nav.ts` — register `billing` in `WorkspaceNavTab`, `WORKSPACE_NAV_TABS`, and `workspaceTabFromPathname`.
+- **Modify** `apps/web/src/layouts/WorkspaceLayout.astro` — no change required (tab links are rail-independent; nav lives in `workspaces-nav.ts`'s sidebar switcher, not the layout). Verified in Task 7 — skip if confirmed unnecessary.
+- **Modify** `apps/web/src/pages/admin/index.astro` — add a plan selector to `renderWorkspace`'s expanded `<details>` view, next to the limits form.
+- **Modify** `.changeset/config.json` — add `@uploads/billing` to `ignore`.
+
+---
+
+## Task 1: `packages/billing` scaffold + plan catalog
+
+**Files:**
+
+- Create: `packages/billing/package.json`
+- Create: `packages/billing/tsconfig.json`
+- Create: `packages/billing/README.md`
+- Create: `packages/billing/src/plans.ts`
+- Create: `packages/billing/src/index.ts`
+- Test: `packages/billing/test/plans.test.ts`
+
+**Interfaces:**
+
+- Produces: `PlanId = "free" | "pro"`; `WorkspacePlanLimits` (renamed local shape matching `WorkspaceBudgetLimits`'s four fields: `maxStorageBytes?`, `maxUploadsPerPeriod?`, `maxUploadBytes?`, `maxVideoUploadBytes?`); `PlanDefinition { id: PlanId; name: string; blurb: string; available: boolean; defaultLimits: WorkspacePlanLimits }`; `PLANS: Record<PlanId, PlanDefinition>`; `getPlan(id: string): PlanDefinition` (fails open to `PLANS.free` for any unrecognized string — this is the single fail-open chokepoint every other task relies on).
+
+- [ ] **Step 1: Create the package scaffold**
+
+Create `packages/billing/package.json`:
+
+```json
+{
+  "name": "@uploads/billing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  }
+}
+```
+
+Create `packages/billing/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+Create `packages/billing/README.md`:
+
+```markdown
+# @uploads/billing
+
+Plan catalog, limit-resolution, and the billing-provider seam for workspace
+subscription plans. Every workspace is on the `free` plan today; `pro` is
+defined but unavailable (`available: false`) — no Stripe SDK, checkout, or
+subscription persistence yet. See
+`docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md`.
+
+Private workspace package — not published, excluded from Changesets like
+`@uploads/api` / `@uploads/storage` / `@uploads/web` / `@uploads/auth`.
+```
+
+- [ ] **Step 2: Write the failing catalog test**
+
+Create `packages/billing/test/plans.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { getPlan, PLANS } from "../src/plans";
+
+describe("PLANS catalog", () => {
+  it("defines free as available with the current self-serve defaults", () => {
+    expect(PLANS.free.available).toBe(true);
+    expect(PLANS.free.defaultLimits).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+      maxUploadBytes: 25_000_000,
+      maxVideoUploadBytes: 8_000_000,
+    });
+  });
+
+  it("defines pro as unavailable display metadata", () => {
+    expect(PLANS.pro.available).toBe(false);
+    expect(PLANS.pro.id).toBe("pro");
+    expect(typeof PLANS.pro.name).toBe("string");
+    expect(PLANS.pro.name.length).toBeGreaterThan(0);
+  });
+
+  it("every plan's id matches its catalog key", () => {
+    for (const [key, plan] of Object.entries(PLANS)) {
+      expect(plan.id).toBe(key);
+    }
+  });
+});
+
+describe("getPlan", () => {
+  it("returns the matching catalog entry for a known id", () => {
+    expect(getPlan("pro")).toBe(PLANS.pro);
+  });
+
+  it("fails open to free for an unknown or legacy plan string", () => {
+    expect(getPlan("enterprise")).toBe(PLANS.free);
+    expect(getPlan("")).toBe(PLANS.free);
+    expect(getPlan(undefined)).toBe(PLANS.free);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd packages/billing && pnpm install && pnpm test`
+Expected: FAIL — `Cannot find module '../src/plans'` (module doesn't exist yet). If `pnpm install` at the repo root hasn't linked the new workspace package yet, run `pnpm install` from the repo root first.
+
+- [ ] **Step 4: Implement the plan catalog**
+
+Create `packages/billing/src/plans.ts`:
+
+```typescript
+/**
+ * Plan catalog for workspace subscription plans (free-plan era, spec
+ * 2026-07-22). `free` is available in perpetuity today; `pro` is defined for
+ * display purposes only (`available: false`) — no checkout path exists yet.
+ * `defaultLimits.free` mirrors `apps/api/src/self-serve-defaults.ts`'s
+ * `SELF_SERVE_LIMITS`; keep the two in sync if either changes.
+ */
+
+export type PlanId = "free" | "pro";
+
+/** The four budget-limit fields a plan can default — same shape as
+ * `apps/api/src/budget.ts`'s `WorkspaceBudgetLimits` plus the two
+ * per-upload caps from `WorkspaceRecord`, kept here as an independent type
+ * so this package has no dependency on `@uploads/api`. */
+export interface WorkspacePlanLimits {
+  maxStorageBytes?: number;
+  maxUploadsPerPeriod?: number;
+  maxUploadBytes?: number;
+  maxVideoUploadBytes?: number;
+}
+
+export interface PlanDefinition {
+  id: PlanId;
+  /** Display name shown in the workspace billing tab and admin panel. */
+  name: string;
+  /** One-sentence description of the plan. */
+  blurb: string;
+  /** Whether a workspace/user can actually be on this plan today. */
+  available: boolean;
+  defaultLimits: WorkspacePlanLimits;
+}
+
+export const PLANS: Record<PlanId, PlanDefinition> = {
+  free: {
+    id: "free",
+    name: "Free",
+    blurb: "Everything you need to host screenshots and files for your projects.",
+    available: true,
+    defaultLimits: {
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+      maxUploadBytes: 25_000_000,
+      maxVideoUploadBytes: 8_000_000,
+    },
+  },
+  pro: {
+    id: "pro",
+    name: "Pro",
+    blurb: "Higher storage and upload limits for teams — coming soon.",
+    available: false,
+    defaultLimits: {
+      maxStorageBytes: 25_000_000_000,
+      maxUploadsPerPeriod: 100_000,
+      maxUploadBytes: 100_000_000,
+      maxVideoUploadBytes: 50_000_000,
+    },
+  },
+};
+
+/** All valid plan ids, in catalog order. */
+export const PLAN_IDS = Object.keys(PLANS) as PlanId[];
+
+function isPlanId(value: unknown): value is PlanId {
+  return typeof value === "string" && value in PLANS;
+}
+
+/**
+ * The catalog entry for `id`. Fails open to `PLANS.free` for any
+ * unrecognized or missing value — legacy/unknown plan strings found in KV
+ * must never lock a workspace out, per the spec's error-handling section.
+ */
+export function getPlan(id: unknown): PlanDefinition {
+  return isPlanId(id) ? PLANS[id] : PLANS.free;
+}
+```
+
+Create `packages/billing/src/index.ts`:
+
+```typescript
+export * from "./plans";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd packages/billing && pnpm test`
+Expected: PASS — all `plans.test.ts` assertions green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/billing/package.json packages/billing/tsconfig.json packages/billing/README.md packages/billing/src/plans.ts packages/billing/src/index.ts packages/billing/test/plans.test.ts
+git commit -m "feat(billing): scaffold @uploads/billing with the plan catalog"
+```
+
+---
+
+## Task 2: `resolvePlanLimits` — precedence resolution
+
+**Files:**
+
+- Create: `packages/billing/src/resolve.ts`
+- Modify: `packages/billing/src/index.ts`
+- Test: `packages/billing/test/resolve.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlanId`, `WorkspacePlanLimits`, `getPlan` (from Task 1's `plans.ts`).
+- Produces: `resolvePlanLimits(plan: PlanId | undefined, overrides: WorkspacePlanLimits): Required<WorkspacePlanLimits>` is NOT the right shape (fields can be legitimately unlimited/absent) — actual signature: `resolvePlanLimits(plan: PlanId | string | undefined, overrides: WorkspacePlanLimits): WorkspacePlanLimits`. Per-field precedence: an explicit (defined) override field wins; otherwise fall back to the plan's `defaultLimits` field; otherwise the field is `undefined` (unlimited). Consumed by `apps/api/src/budget.ts` (Task 4) with `plan` sourced from `WorkspaceRecord.plan` and `overrides` sourced from the existing four `WorkspaceRecord` fields.
+
+- [ ] **Step 1: Write the failing precedence test**
+
+Create `packages/billing/test/resolve.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { resolvePlanLimits } from "../src/resolve";
+import { PLANS } from "../src/plans";
+
+describe("resolvePlanLimits", () => {
+  it("uses the plan's default limits when there are no overrides", () => {
+    expect(resolvePlanLimits("free", {})).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("an explicit override beats the plan default for that field", () => {
+    const resolved = resolvePlanLimits("free", { maxStorageBytes: 1_000 });
+    expect(resolved.maxStorageBytes).toBe(1_000);
+    expect(resolved.maxUploadsPerPeriod).toBe(PLANS.free.defaultLimits.maxUploadsPerPeriod);
+  });
+
+  it("an override of undefined does not shadow the plan default", () => {
+    const resolved = resolvePlanLimits("free", { maxStorageBytes: undefined });
+    expect(resolved.maxStorageBytes).toBe(PLANS.free.defaultLimits.maxStorageBytes);
+  });
+
+  it("resolves pro's own (unavailable) defaults when a workspace is set to pro", () => {
+    expect(resolvePlanLimits("pro", {})).toEqual(PLANS.pro.defaultLimits);
+  });
+
+  it("fails open to free's defaults for an unknown plan string", () => {
+    expect(resolvePlanLimits("enterprise", {})).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("fails open to free's defaults when plan is undefined (absent-in-KV case)", () => {
+    expect(resolvePlanLimits(undefined, {})).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("all four override fields compose independently", () => {
+    const resolved = resolvePlanLimits("free", {
+      maxStorageBytes: 1,
+      maxUploadsPerPeriod: 2,
+      maxUploadBytes: 3,
+      maxVideoUploadBytes: 4,
+    });
+    expect(resolved).toEqual({
+      maxStorageBytes: 1,
+      maxUploadsPerPeriod: 2,
+      maxUploadBytes: 3,
+      maxVideoUploadBytes: 4,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/billing && pnpm test`
+Expected: FAIL — `Cannot find module '../src/resolve'`.
+
+- [ ] **Step 3: Implement `resolvePlanLimits`**
+
+Create `packages/billing/src/resolve.ts`:
+
+```typescript
+/**
+ * Precedence resolution between a workspace's plan defaults and its
+ * explicit per-workspace overrides (the admin-editable budget fields on
+ * `WorkspaceRecord` — see PR #280 / `apps/api/src/workspace-limits.ts`).
+ * Pure — no I/O — so `apps/api/src/budget.ts` and the admin/user routes can
+ * all call through this single chokepoint without drifting on precedence.
+ */
+import { getPlan, type PlanId, type WorkspacePlanLimits } from "./plans";
+
+const LIMIT_KEYS: (keyof WorkspacePlanLimits)[] = [
+  "maxStorageBytes",
+  "maxUploadsPerPeriod",
+  "maxUploadBytes",
+  "maxVideoUploadBytes",
+];
+
+/**
+ * Resolves effective limits for a workspace: an explicit (defined) override
+ * field always wins; otherwise falls back to the resolved plan's
+ * `defaultLimits` for that field. `plan` fails open to `free` via `getPlan`
+ * for any unrecognized/missing value, so a legacy or malformed plan string
+ * never locks a workspace out.
+ */
+export function resolvePlanLimits(
+  plan: PlanId | string | undefined,
+  overrides: WorkspacePlanLimits,
+): WorkspacePlanLimits {
+  const defaults = getPlan(plan).defaultLimits;
+  const resolved: WorkspacePlanLimits = {};
+  for (const key of LIMIT_KEYS) {
+    const override = overrides[key];
+    resolved[key] = override !== undefined ? override : defaults[key];
+  }
+  return resolved;
+}
+```
+
+- [ ] **Step 4: Export it from the barrel**
+
+In `packages/billing/src/index.ts`, add:
+
+```typescript
+export * from "./resolve";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/billing && pnpm test`
+Expected: PASS — all `resolve.test.ts` and `plans.test.ts` assertions green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/billing/src/resolve.ts packages/billing/src/index.ts packages/billing/test/resolve.test.ts
+git commit -m "feat(billing): add resolvePlanLimits precedence resolution"
+```
+
+---
+
+## Task 3: `BillingProvider` / `NullBillingProvider`
+
+**Files:**
+
+- Create: `packages/billing/src/provider.ts`
+- Modify: `packages/billing/src/index.ts`
+- Test: `packages/billing/test/provider.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PlanId` (from `plans.ts`).
+- Produces: `Subscription | null` shape; `BillingProvider` interface with `getSubscription(workspace: string): Promise<Subscription | null>`, `createCheckoutSession(workspace: string, plan: PlanId): Promise<never>`, `createPortalSession(workspace: string): Promise<never>`; `NullBillingProvider` class implementing it. Consumed by Task 6's `GET /me/workspaces/:name/billing` route (`subscription` field in the response, `null` today).
+
+- [ ] **Step 1: Write the failing provider test**
+
+Create `packages/billing/test/provider.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { NullBillingProvider } from "../src/provider";
+
+describe("NullBillingProvider", () => {
+  it("getSubscription always resolves null (no subscription today)", async () => {
+    const provider = new NullBillingProvider();
+    await expect(provider.getSubscription("acme")).resolves.toBeNull();
+  });
+
+  it("createCheckoutSession rejects — no checkout path exists yet", async () => {
+    const provider = new NullBillingProvider();
+    await expect(provider.createCheckoutSession("acme", "pro")).rejects.toThrow(
+      /not available|unavailable/i,
+    );
+  });
+
+  it("createPortalSession rejects — no billing portal exists yet", async () => {
+    const provider = new NullBillingProvider();
+    await expect(provider.createPortalSession("acme")).rejects.toThrow(
+      /not available|unavailable/i,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/billing && pnpm test`
+Expected: FAIL — `Cannot find module '../src/provider'`.
+
+- [ ] **Step 3: Implement the provider interface + null implementation**
+
+Create `packages/billing/src/provider.ts`:
+
+```typescript
+/**
+ * Billing-provider seam (spec 2026-07-22's "future iteration" section). No
+ * live billing exists yet — `NullBillingProvider` is the only implementation
+ * today, always reporting "free, no subscription". A future
+ * `StripeBillingProvider` implements the same interface inside this
+ * package; no Stripe SDK dependency exists anywhere yet.
+ */
+import type { PlanId } from "./plans";
+
+/** A workspace's live subscription state, as reported by the provider. */
+export interface Subscription {
+  plan: PlanId;
+  status: "active" | "canceled" | "past_due";
+  /** ISO timestamp of the current billing period's end, if known. */
+  currentPeriodEnd?: string;
+}
+
+export interface BillingProvider {
+  /** The workspace's current subscription, or `null` if it has none
+   * (e.g. it's on the free plan with nothing to bill). */
+  getSubscription(workspace: string): Promise<Subscription | null>;
+  /** Starts a checkout flow for upgrading `workspace` to `plan`. Rejects
+   * until a real provider is wired up. */
+  createCheckoutSession(workspace: string, plan: PlanId): Promise<never>;
+  /** Starts a customer-portal session for `workspace`. Rejects until a
+   * real provider is wired up. */
+  createPortalSession(workspace: string): Promise<never>;
+}
+
+/**
+ * The only `BillingProvider` implementation today. Every workspace reports
+ * no subscription; checkout/portal are unavailable. Honest placeholder —
+ * apps/web's billing tab renders a disabled "Upgrade — coming soon"
+ * affordance rather than calling these.
+ */
+export class NullBillingProvider implements BillingProvider {
+  async getSubscription(_workspace: string): Promise<Subscription | null> {
+    return null;
+  }
+
+  async createCheckoutSession(_workspace: string, _plan: PlanId): Promise<never> {
+    throw new Error("checkout is not available yet");
+  }
+
+  async createPortalSession(_workspace: string): Promise<never> {
+    throw new Error("the billing portal is not available yet");
+  }
+}
+```
+
+- [ ] **Step 4: Export it from the barrel**
+
+In `packages/billing/src/index.ts`, add:
+
+```typescript
+export * from "./provider";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/billing && pnpm test`
+Expected: PASS — all three `packages/billing/test/*.test.ts` files green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/billing/src/provider.ts packages/billing/src/index.ts packages/billing/test/provider.test.ts
+git commit -m "feat(billing): add BillingProvider interface and NullBillingProvider"
+```
+
+---
+
+## Task 4: `plan` field on `WorkspaceRecord` + budget-resolution wiring
+
+**Files:**
+
+- Modify: `apps/api/package.json`
+- Modify: `apps/api/src/workspace.ts` (add `plan` field near the other optional record fields, e.g. after `retentionDays` around line 66)
+- Modify: `apps/api/src/budget.ts`
+- Test: `apps/api/src/budget.test.ts` (create if it doesn't already exist — check with `ls apps/api/src/budget.test.ts` first; if present, add to it)
+
+**Interfaces:**
+
+- Consumes: `resolvePlanLimits`, `WorkspacePlanLimits` from `@uploads/billing` (Task 2).
+- Produces: `WorkspaceRecord.plan?: 'free' | 'pro'`; `resolveBudgetLimits(record: WorkspaceBudgetLimits & { plan?: string }): { maxStorageBytes?: number; maxUploadsPerPeriod?: number }` — same call sites as before (`checkPutBudget`, `usageWithLimits`) now plan-aware. Consumed by Task 5's admin plan routes and Task 6's user billing route, both of which read `record.plan` and call `resolvePlanLimits`.
+
+- [ ] **Step 1: Add the `@uploads/billing` dependency**
+
+In `apps/api/package.json`, add to `"dependencies"` (alphabetical, before `"@uploads/email"`):
+
+```json
+    "@uploads/billing": "workspace:^",
+```
+
+Run: `pnpm install` (repo root) to link the new workspace dependency.
+
+- [ ] **Step 2: Write the failing regression test for plan-aware budget resolution**
+
+Check whether `apps/api/src/budget.test.ts` exists:
+
+Run: `ls apps/api/src/budget.test.ts`
+
+If it exists, add the following `describe` block to the end of the file; if it does not exist, create it with this content plus the necessary imports (`resolveBudgetLimits` from `./budget`):
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { resolveBudgetLimits } from "./budget";
+
+describe("resolveBudgetLimits — plan-aware resolution", () => {
+  it("falls back to the free plan's defaults when a workspace has no explicit limits and no plan set", () => {
+    expect(resolveBudgetLimits({})).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+
+  it("an explicit maxStorageBytes override still beats the plan default (existing PR #280 behavior)", () => {
+    expect(resolveBudgetLimits({ maxStorageBytes: 500 })).toEqual({
+      maxStorageBytes: 500,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+
+  it("a workspace explicitly on the pro plan resolves pro's defaults", () => {
+    expect(resolveBudgetLimits({ plan: "pro" })).toEqual({
+      maxStorageBytes: 25_000_000_000,
+      maxUploadsPerPeriod: 100_000,
+    });
+  });
+
+  it("an unknown/legacy plan string fails open to free's defaults", () => {
+    expect(resolveBudgetLimits({ plan: "enterprise" })).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+
+  it("a zero/negative/non-finite override is treated as unset, falling back to the plan default (unchanged positiveLimit behavior)", () => {
+    expect(resolveBudgetLimits({ maxStorageBytes: 0 })).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/api && pnpm test -- budget.test.ts`
+Expected: FAIL — `resolveBudgetLimits({})` currently returns `{ maxStorageBytes: undefined, maxUploadsPerPeriod: undefined }`, not the free-plan defaults.
+
+- [ ] **Step 4: Add the `plan` field to `WorkspaceRecord`**
+
+In `apps/api/src/workspace.ts`, after the `retentionDays` field (around line 66, before `autoPrefixBareKeys`), add:
+
+```typescript
+  /**
+   * Subscription plan (spec 2026-07-22, billing infrastructure). Absent
+   * means `free`. Admin-only to change today (no self-serve upgrade path
+   * exists); an unrecognized string is treated as `free` at read time by
+   * `@uploads/billing`'s `getPlan` — never a lockout.
+   */
+  plan?: "free" | "pro";
+```
+
+- [ ] **Step 5: Route `resolveBudgetLimits` through `resolvePlanLimits`**
+
+In `apps/api/src/budget.ts`, update the imports and `WorkspaceBudgetLimits`/`resolveBudgetLimits`:
+
+```typescript
+import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
+import { resolvePlanLimits } from "@uploads/billing";
+import type { WorkspaceUsage } from "./usage";
+
+/** Cumulative caps from the workspace registry record. */
+export interface WorkspaceBudgetLimits {
+  /** Hard cap on net stored bytes. */
+  maxStorageBytes?: number;
+  /** Cap on successful puts in the current UTC calendar month. */
+  maxUploadsPerPeriod?: number;
+  /** Subscription plan — see `@uploads/billing`'s `PlanId`. Absent = free. */
+  plan?: string;
+}
+```
+
+Replace the body of `resolveBudgetLimits`:
+
+```typescript
+export function resolveBudgetLimits(record: WorkspaceBudgetLimits): {
+  maxStorageBytes?: number;
+  maxUploadsPerPeriod?: number;
+} {
+  const explicit = {
+    maxStorageBytes: positiveLimit(record.maxStorageBytes),
+    maxUploadsPerPeriod: positiveLimit(record.maxUploadsPerPeriod),
+  };
+  const resolved = resolvePlanLimits(record.plan, explicit);
+  return {
+    maxStorageBytes: positiveLimit(resolved.maxStorageBytes),
+    maxUploadsPerPeriod: positiveLimit(resolved.maxUploadsPerPeriod),
+  };
+}
+```
+
+Note: `positiveLimit` is applied both before calling `resolvePlanLimits` (so a `0`/negative/non-finite explicit value is treated as "unset" and falls through to the plan default, preserving existing behavior) and after (in case a future plan's own `defaultLimits` were ever malformed — defense in depth, costs nothing since today's catalog values are always valid positive integers).
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd apps/api && pnpm test -- budget.test.ts`
+Expected: PASS — all `resolveBudgetLimits` assertions green, including the pre-existing tests in the file (if it already existed) still passing unchanged.
+
+- [ ] **Step 7: Run the full existing budget/usage/limits suite to check for regressions**
+
+Run: `pnpm test -- budget usage workspace-limits admin-ui` (root runner, name-filtered)
+Expected: PASS — no existing test broke. In particular `apps/api/src/routes/admin-ui.test.ts`'s `workspace limits editing` describe block (which exercises `limitsResponse`, not `resolveBudgetLimits`) is unaffected since that function reads raw record fields directly, not through budget resolution.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/package.json apps/api/src/workspace.ts apps/api/src/budget.ts apps/api/src/budget.test.ts pnpm-lock.yaml
+git commit -m "feat(billing): add plan field to WorkspaceRecord, wire budget resolution through resolvePlanLimits"
+```
+
+---
+
+## Task 5: Admin plan routes (`GET`/`PATCH /admin-ui/workspaces/:name/plan`)
+
+**Files:**
+
+- Create: `apps/api/src/workspace-plan.ts`
+- Test: `apps/api/src/workspace-plan.test.ts`
+- Modify: `apps/api/src/routes/admin-ui.ts`
+- Modify: `apps/api/src/routes/admin-ui.test.ts`
+
+**Interfaces:**
+
+- Consumes: `PLAN_IDS`, `getPlan`, `resolvePlanLimits`, `PlanId` from `@uploads/billing`; `loadEditableWorkspace`, `WorkspaceRecord` from `../workspace` and this file's own module scope in `admin-ui.ts`.
+- Produces: `validatePlanPatch(body: unknown): { plan: PlanId }` (throws `ValidationError` with `code: "invalid_plan"` on bad input); `planResponse(name: string, record: WorkspaceRecord): { workspace: string; plan: PlanId; available: boolean; limits: WorkspacePlanLimits; overrides: string[] }` where `overrides` lists which of the four limit field names are explicit per-workspace overrides (i.e. defined on the record) rather than plan defaults. Consumed by Task 8's admin-panel plan selector, which calls these two routes.
+
+- [ ] **Step 1: Write the failing test for `validatePlanPatch`**
+
+Create `apps/api/src/workspace-plan.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { planResponse, validatePlanPatch } from "./workspace-plan";
+
+describe("validatePlanPatch", () => {
+  it("accepts a known plan id", () => {
+    expect(validatePlanPatch({ plan: "pro" })).toEqual({ plan: "pro" });
+    expect(validatePlanPatch({ plan: "free" })).toEqual({ plan: "free" });
+  });
+
+  it("rejects an unknown plan id", () => {
+    expect(() => validatePlanPatch({ plan: "enterprise" })).toThrow(/invalid_plan|plan/i);
+  });
+
+  it("rejects a missing plan field", () => {
+    expect(() => validatePlanPatch({})).toThrow(/invalid_plan|plan/i);
+  });
+
+  it("rejects a non-object body", () => {
+    expect(() => validatePlanPatch(null)).toThrow(/invalid_plan|plan/i);
+    expect(() => validatePlanPatch("pro")).toThrow(/invalid_plan|plan/i);
+  });
+});
+
+describe("planResponse", () => {
+  it("reports the free plan, its resolved limits, and no overrides for a bare record", () => {
+    const result = planResponse("acme", { provider: "r2", bucket: "b" });
+    expect(result).toEqual({
+      workspace: "acme",
+      plan: "free",
+      available: true,
+      limits: {
+        maxStorageBytes: 250_000_000,
+        maxUploadsPerPeriod: 3000,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      },
+      overrides: [],
+    });
+  });
+
+  it("lists explicit override fields and resolves them into limits", () => {
+    const result = planResponse("acme", {
+      provider: "r2",
+      bucket: "b",
+      maxStorageBytes: 999,
+    });
+    expect(result.overrides).toEqual(["maxStorageBytes"]);
+    expect(result.limits.maxStorageBytes).toBe(999);
+    expect(result.limits.maxUploadsPerPeriod).toBe(3000);
+  });
+
+  it("reports pro as unavailable when a workspace is set to it", () => {
+    const result = planResponse("acme", { provider: "r2", bucket: "b", plan: "pro" });
+    expect(result.plan).toBe("pro");
+    expect(result.available).toBe(false);
+  });
+
+  it("fails open to free for an unrecognized stored plan string", () => {
+    const result = planResponse("acme", {
+      provider: "r2",
+      bucket: "b",
+      plan: "enterprise" as never,
+    });
+    expect(result.plan).toBe("free");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api && pnpm test -- workspace-plan.test.ts`
+Expected: FAIL — `Cannot find module './workspace-plan'`.
+
+- [ ] **Step 3: Implement `workspace-plan.ts`**
+
+Create `apps/api/src/workspace-plan.ts`:
+
+```typescript
+/**
+ * Validates the plan-change body accepted by the admin panel's
+ * PATCH /admin-ui/workspaces/:name/plan endpoint, and builds the response
+ * shared by that route's GET/PATCH — mirrors workspace-limits.ts's
+ * validateLimitsPatch / admin-ui.ts's limitsResponse pattern (spec
+ * 2026-07-22, billing infrastructure).
+ */
+import { getPlan, PLAN_IDS, resolvePlanLimits, type PlanId } from "@uploads/billing";
+import { ValidationError } from "@uploads/errors";
+import type { WorkspaceRecord } from "./workspace";
+
+const LIMIT_FIELDS_FOR_OVERRIDES = [
+  "maxStorageBytes",
+  "maxUploadsPerPeriod",
+  "maxUploadBytes",
+  "maxVideoUploadBytes",
+] as const;
+
+export function validatePlanPatch(body: unknown): { plan: PlanId } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new ValidationError("plan body must be a JSON object", { code: "invalid_plan" });
+  }
+  const record = body as Record<string, unknown>;
+  const plan = record.plan;
+  if (typeof plan !== "string" || !PLAN_IDS.includes(plan as PlanId)) {
+    throw new ValidationError(`plan must be one of: ${PLAN_IDS.join(", ")}`, {
+      code: "invalid_plan",
+    });
+  }
+  return { plan: plan as PlanId };
+}
+
+/** Response body shared by GET and PATCH /admin-ui/workspaces/:name/plan. */
+export function planResponse(name: string, record: WorkspaceRecord) {
+  const definition = getPlan(record.plan);
+  const overrides = LIMIT_FIELDS_FOR_OVERRIDES.filter((field) => record[field] !== undefined);
+  const limits = resolvePlanLimits(record.plan, {
+    maxStorageBytes: record.maxStorageBytes,
+    maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+    maxUploadBytes: record.maxUploadBytes,
+    maxVideoUploadBytes: record.maxVideoUploadBytes,
+  });
+  return {
+    workspace: name,
+    plan: definition.id,
+    available: definition.available,
+    limits,
+    overrides,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && pnpm test -- workspace-plan.test.ts`
+Expected: PASS — all `validatePlanPatch`/`planResponse` assertions green.
+
+- [ ] **Step 5: Write failing route tests in `admin-ui.test.ts`**
+
+Add the following `describe` block to `apps/api/src/routes/admin-ui.test.ts`, right after the existing `describe("workspace limits editing", ...)` block (it reuses that block's `limitsEnv` helper and `REC` fixture — both already in module scope by the time this block runs since they're declared with `const`/`function` inside the outer describe; if `limitsEnv`/`REC` are scoped inside that `describe` block rather than the test file's top level, hoist them to file scope first so this new block can use them, or duplicate the minimal fixture inline as shown):
+
+```typescript
+describe("workspace plan editing", () => {
+  const REC = {
+    provider: "r2",
+    bucket: "uploads-default",
+    prefix: "acme/",
+  };
+
+  function planEnv(user: typeof ADMIN_USER | null, record: Record<string, unknown> | null) {
+    const store = new Map<string, string>();
+    if (record) store.set("ws:acme", JSON.stringify(record));
+    const base = stubEnv(user, () => new Response(null, { status: 404 }));
+    const env = {
+      ...base,
+      REGISTRY: {
+        get: (async (key: string) => {
+          const raw = store.get(key);
+          return raw ? JSON.parse(raw) : null;
+        }) as unknown as KVNamespace["get"],
+        put: (async (key: string, value: string) => {
+          store.set(key, value);
+        }) as unknown as KVNamespace["put"],
+      },
+    } as unknown as Env;
+    return { env, store };
+  }
+
+  it("GET returns the free plan and resolved defaults for a bare record", async () => {
+    const { env } = planEnv(ADMIN_USER, REC);
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      workspace: "acme",
+      plan: "free",
+      available: true,
+      limits: {
+        maxStorageBytes: 250_000_000,
+        maxUploadsPerPeriod: 3000,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      },
+      overrides: [],
+    });
+  });
+
+  it("PATCH sets the plan on the record and persists it", async () => {
+    const { env, store } = planEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { plan: string; available: boolean };
+    expect(body.plan).toBe("pro");
+    expect(body.available).toBe(false);
+    expect(JSON.parse(store.get("ws:acme") ?? "{}").plan).toBe("pro");
+  });
+
+  it("PATCH rejects an unknown plan id", async () => {
+    const { env } = planEnv(ADMIN_USER, REC);
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "enterprise" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH preserves existing limit overrides on the record", async () => {
+    const { env, store } = planEnv(ADMIN_USER, { ...REC, maxStorageBytes: 999 });
+    await app().request(
+      "/admin-ui/workspaces/acme/plan",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ plan: "pro" }),
+      },
+      env,
+    );
+    const stored = JSON.parse(store.get("ws:acme") ?? "{}");
+    expect(stored.maxStorageBytes).toBe(999);
+    expect(stored.plan).toBe("pro");
+  });
+
+  it("GET 404s for an unknown workspace", async () => {
+    const { env } = planEnv(ADMIN_USER, null);
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { env } = planEnv(NON_ADMIN_USER, REC);
+    const res = await app().request("/admin-ui/workspaces/acme/plan", {}, env);
+    expect(res.status).toBe(403);
+  });
+});
+```
+
+- [ ] **Step 6: Run the test to verify it fails**
+
+Run: `cd apps/api && pnpm test -- admin-ui.test.ts`
+Expected: FAIL — `404` for both new routes (no `/plan` route registered yet).
+
+- [ ] **Step 7: Add the routes to `admin-ui.ts`**
+
+In `apps/api/src/routes/admin-ui.ts`, add the import (alongside the existing `workspace-limits` import):
+
+```typescript
+import { planResponse, validatePlanPatch } from "../workspace-plan";
+```
+
+Add the two routes immediately after the existing `.patch("/workspaces/:name/limits", ...)` block (after line 491, before the `.get("/workspaces/:name/settings", ...)` block):
+
+```typescript
+  // Read the workspace's plan, its availability, and resolved effective
+  // limits (plan defaults backstopped by any explicit overrides).
+  .get("/workspaces/:name/plan", async (c) => {
+    const name = c.req.param("name");
+    const record = await loadEditableWorkspace(c.env, name);
+    return c.json(planResponse(name, record));
+  })
+
+  // Set the workspace's plan. Admins may set `pro` even though it's
+  // unavailable to self-serve users (operator override) — availability is
+  // informational in the response, not enforced here. Limit overrides on
+  // the record are untouched; only `plan` is written.
+  .patch("/workspaces/:name/plan", async (c) => {
+    const name = c.req.param("name");
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    const record = await loadEditableWorkspace(c.env, name);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new ValidationError("request body must be valid JSON", { code: "invalid_plan" });
+    }
+    const { plan } = validatePlanPatch(body);
+    record.plan = plan;
+    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
+    return c.json(planResponse(name, record));
+  })
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `cd apps/api && pnpm test -- admin-ui.test.ts`
+Expected: PASS — all new `workspace plan editing` assertions green, and every pre-existing `admin-ui.test.ts` test still green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/workspace-plan.ts apps/api/src/workspace-plan.test.ts apps/api/src/routes/admin-ui.ts apps/api/src/routes/admin-ui.test.ts
+git commit -m "feat(billing): add admin GET/PATCH /admin-ui/workspaces/:name/plan routes"
+```
+
+---
+
+## Task 6: User-facing `GET /me/workspaces/:name/billing`
+
+**Files:**
+
+- Modify: `apps/api/src/routes/me.ts`
+- Modify: `apps/api/src/routes/me.test.ts`
+
+**Interfaces:**
+
+- Consumes: `getPlan`, `resolvePlanLimits`, `NullBillingProvider` from `@uploads/billing`; `memberWorkspaceOr404`, `requireUserId`, `loadWorkspaceRecord` (all already in `me.ts`); `usageWithLimits`, `getWorkspaceUsage` (already imported in `me.ts`).
+- Produces: response shape `{ workspace: string; organization: {...}; plan: string; available: boolean; limits: WorkspacePlanLimits; usage: {...} | null; subscription: null }` — stable across the future Stripe iteration per the spec (adding real subscription data later only changes `subscription` from `null` to a populated object).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/api/src/routes/me.test.ts` (find the existing pattern for a member-gated `GET /workspaces/:name/...` test — e.g. the `usage` or `summary` route tests — and follow the same env/fixture setup used there). Add this `describe` block:
+
+```typescript
+describe("GET /me/workspaces/:name/billing", () => {
+  it("returns plan, resolved limits, usage, and a null subscription for a member", async () => {
+    const env = memberEnv(SESSION_USER, "acme", "member", {
+      provider: "r2",
+      bucket: "b",
+    });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      workspace: string;
+      plan: string;
+      available: boolean;
+      limits: Record<string, number>;
+      subscription: null;
+    };
+    expect(body.workspace).toBe("acme");
+    expect(body.plan).toBe("free");
+    expect(body.available).toBe(true);
+    expect(body.limits.maxStorageBytes).toBe(250_000_000);
+    expect(body.subscription).toBeNull();
+  });
+
+  it("404s for a non-member", async () => {
+    const env = memberEnv(SESSION_USER, "acme", null, { provider: "r2", bucket: "b" });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("reports pro plan and its own resolved limits when the workspace is on pro", async () => {
+    const env = memberEnv(SESSION_USER, "acme", "member", {
+      provider: "r2",
+      bucket: "b",
+      plan: "pro",
+    });
+    const res = await app().request("/me/workspaces/acme/billing", {}, env);
+    const body = (await res.json()) as { plan: string; available: boolean };
+    expect(body.plan).toBe("pro");
+    expect(body.available).toBe(false);
+  });
+});
+```
+
+Note: `memberEnv`/`SESSION_USER` (or whatever the file's existing member-gated test helper and fixture user are actually named) must be read from the top of `apps/api/src/routes/me.test.ts` before writing this block — inspect the file's existing `describe("GET /workspaces/:name/usage", ...)` or `describe("GET /workspaces/:name/summary", ...)` tests and reuse their exact helper names and env-construction shape (including how membership + `REGISTRY`/`DB` fakes are wired), since `me.ts`'s auth path (`memberWorkspaceOr404` via `membershipsForUser`) differs from `admin-ui.ts`'s and this plan's fixture names are illustrative, not verbatim guaranteed to exist.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/api && pnpm test -- me.test.ts`
+Expected: FAIL — `404` (route not found) or similar, since `/workspaces/:name/billing` doesn't exist yet.
+
+- [ ] **Step 3: Add the route to `me.ts`**
+
+In `apps/api/src/routes/me.ts`, add the import (alongside the existing `../budget`/`../workspace` imports):
+
+```typescript
+import { getPlan, NullBillingProvider, resolvePlanLimits } from "@uploads/billing";
+```
+
+Add a module-scope provider instance near the top of the file (after imports, before `EMAIL_RE`):
+
+```typescript
+// No live billing yet — see @uploads/billing's NullBillingProvider doc
+// comment. Swapping in a real provider later only changes this line.
+const billingProvider = new NullBillingProvider();
+```
+
+Add the route after the existing `.get("/workspaces/:name/summary", ...)` block (after line 230):
+
+```typescript
+  // Plan metadata, resolved effective limits, usage, and subscription state
+  // (always null today) for the account billing tab — 404s unless the
+  // caller is a member. Response shape is stable across the future Stripe
+  // iteration: adding a real subscription only changes `subscription` from
+  // null to a populated object.
+  .get("/workspaces/:name/billing", async (c) => {
+    const name = c.req.param("name");
+    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const definition = getPlan(record.plan);
+    const limits = resolvePlanLimits(record.plan, {
+      maxStorageBytes: record.maxStorageBytes,
+      maxUploadsPerPeriod: record.maxUploadsPerPeriod,
+      maxUploadBytes: record.maxUploadBytes,
+      maxVideoUploadBytes: record.maxVideoUploadBytes,
+    });
+
+    let usage: ReturnType<typeof usageWithLimits> | null = null;
+    try {
+      usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
+    } catch {
+      usage = null;
+    }
+
+    const subscription = await billingProvider.getSubscription(name);
+
+    return c.json({
+      workspace: ws.workspace,
+      organization: ws.organization,
+      plan: definition.id,
+      available: definition.available,
+      limits,
+      usage,
+      subscription,
+    });
+  })
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/api && pnpm test -- me.test.ts`
+Expected: PASS — all new `GET /me/workspaces/:name/billing` assertions green, all pre-existing `me.test.ts` tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/me.ts apps/api/src/routes/me.test.ts
+git commit -m "feat(billing): add GET /me/workspaces/:name/billing"
+```
+
+---
+
+## Task 7: `billing.astro` workspace tab + nav registration
+
+**Files:**
+
+- Create: `apps/web/src/pages/account/workspaces/[name]/billing.astro`
+- Modify: `apps/web/src/lib/workspaces-nav.ts`
+- Modify: `apps/web/src/lib/api-client.ts` (add `getWorkspaceBilling`)
+
+**Interfaces:**
+
+- Consumes: `WorkspaceLayout` (props: `{ workspace: string }`), `isBrowseWorkspace` (from `../../../../lib/workspace-browse-url`), `getPageVisit`/`isCurrentPageVisit`/`onAstroPageLoad`/`onSession`/`requireElement` (from `../../../../lib/account-shell`), `resolveActiveWorkspace` (from `../../../../lib/workspace-browse-url`), `escapeHtml` (from `../../../../lib/workspace-ui`). New: `GET /me/workspaces/:name/billing` (Task 6).
+- Produces: `WorkspaceNavTab` gains `"billing"`; `WORKSPACE_NAV_TABS` gains `{ id: "billing", label: "billing", path: "/billing" }`; `workspaceTabFromPathname` recognizes the `/billing` segment; `getWorkspaceBilling(apiOrigin, workspace)` in `api-client.ts` returning a discriminated result consumed by the new page.
+
+- [ ] **Step 1: Inspect `api-client.ts`'s existing result-shape pattern**
+
+Run: `grep -n "getWorkspacePeople\|getWorkspaceUsage\|type.*Result" apps/web/src/lib/api-client.ts | head -30`
+
+Read the matched `getWorkspacePeople` (or equivalent `getWorkspaceUsage`/`getWorkspaceSummary`) function in full — including its return type's `kind: "ok" | "unavailable"` discriminant and how a 404 is mapped to `reason: "not_found"` versus a network/5xx failure — before writing Step 2, so the new function matches the file's exact conventions (fetch options, `credentials: "include"`, error mapping) rather than inventing a new shape.
+
+- [ ] **Step 2: Add `getWorkspaceBilling` to `api-client.ts`**
+
+Add near the other `getWorkspace*` read functions (e.g. next to `getWorkspaceUsage`/`getWorkspaceSummary`), following the exact fetch/error-handling pattern found in Step 1 (illustrative shape below — match the file's real helper, e.g. a shared `apiGet`/`fetchJson` wrapper, if one exists rather than duplicating raw `fetch` calls):
+
+```typescript
+export interface WorkspaceBilling {
+  workspace: string;
+  organization: { id: string; slug: string; name: string };
+  plan: string;
+  available: boolean;
+  limits: {
+    maxStorageBytes?: number;
+    maxUploadsPerPeriod?: number;
+    maxUploadBytes?: number;
+    maxVideoUploadBytes?: number;
+  };
+  usage: Record<string, unknown> | null;
+  subscription: null;
+}
+
+export type WorkspaceBillingResult =
+  | { kind: "ok"; billing: WorkspaceBilling }
+  | { kind: "unavailable"; reason: "not_found" | "network" };
+
+export async function getWorkspaceBilling(
+  apiOrigin: string,
+  workspace: string,
+): Promise<WorkspaceBillingResult> {
+  try {
+    const res = await fetch(`${apiOrigin}/me/workspaces/${encodeURIComponent(workspace)}/billing`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (res.status === 404) return { kind: "unavailable", reason: "not_found" };
+    if (!res.ok) return { kind: "unavailable", reason: "network" };
+    return { kind: "ok", billing: (await res.json()) as WorkspaceBilling };
+  } catch {
+    return { kind: "unavailable", reason: "network" };
+  }
+}
+```
+
+- [ ] **Step 3: Register the `billing` tab in `workspaces-nav.ts`**
+
+In `apps/web/src/lib/workspaces-nav.ts`, change:
+
+```typescript
+export type WorkspaceNavTab = "files" | "galleries" | "people" | "settings";
+```
+
+to:
+
+```typescript
+export type WorkspaceNavTab = "files" | "galleries" | "people" | "billing" | "settings";
+```
+
+Update `WORKSPACE_NAV_TABS` to insert `billing` before `settings`:
+
+```typescript
+export const WORKSPACE_NAV_TABS: {
+  id: WorkspaceNavTab;
+  label: string;
+  /** Path suffix after `/account/workspaces/:name` — empty for files. */
+  path: string;
+}[] = [
+  { id: "files", label: "files", path: "" },
+  { id: "galleries", label: "galleries", path: "/galleries" },
+  { id: "people", label: "people", path: "/people" },
+  { id: "billing", label: "billing", path: "/billing" },
+  { id: "settings", label: "settings", path: "/settings" },
+];
+```
+
+Update `workspaceTabFromPathname` to recognize the new segment:
+
+```typescript
+export function workspaceTabFromPathname(pathname: string): WorkspaceNavTab | "" {
+  const match = pathname.match(/^\/account\/workspaces\/([^/]+)(?:\/([^/]+))?\/?$/);
+  if (!match) return "";
+  const slug = decodeURIComponent(match[1] ?? "");
+  if (!slug || slug === "new") return "";
+  const segment = match[2] ?? "";
+  if (!segment) return "files";
+  if (segment === "galleries") return "galleries";
+  if (segment === "people" || segment === "invite") return "people";
+  if (segment === "billing") return "billing";
+  if (segment === "settings") return "settings";
+  return "";
+}
+```
+
+- [ ] **Step 4: Create `billing.astro`**
+
+Create `apps/web/src/pages/account/workspaces/[name]/billing.astro`, following `people.astro`'s structure exactly (loading/error states via `#ws-status`/`#ws-retry`/`#ws-app`, `getPageVisit`/`isCurrentPageVisit` staleness guard, `onSession`-driven initial load):
+
+```astro
+---
+/**
+ * Workspace billing tab — current plan, resolved limits vs usage, and a
+ * disabled "Upgrade — coming soon" affordance (spec 2026-07-22, billing
+ * infrastructure). No live billing exists yet: no invoices, no payment
+ * method, no real upgrade flow — honest copy only.
+ */
+import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
+import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+
+export const prerender = false;
+
+const nameParam = Astro.params.name ?? "";
+const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
+if (!workspace) return Astro.redirect("/account/workspaces");
+---
+
+<WorkspaceLayout workspace={workspace}>
+  <div id="ws-status" class="ul-callout status" role="status">Loading…</div>
+  <button id="ws-retry" type="button" hidden>Try again</button>
+
+  <div id="ws-app" hidden>
+    <section class="card settings-page">
+      <div class="settings-section">
+        <div class="ws-page-header">
+          <div class="ws-title-block">
+            <h2>Billing</h2>
+            <p class="muted" id="ws-slug"></p>
+          </div>
+          <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+        </div>
+
+        <div id="ws-plan-card" class="ul-callout">
+          <p><strong id="ws-plan-name"></strong></p>
+          <p class="muted" id="ws-plan-blurb"></p>
+        </div>
+
+        <div id="ws-limits" class="settings-section">
+          <h3>Limits &amp; usage</h3>
+          <dl class="ws-rail__kv" id="ws-limits-list"></dl>
+        </div>
+
+        <div class="settings-section">
+          <button type="button" id="ws-upgrade-btn" disabled>Upgrade — coming soon</button>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    import {
+      getPageVisit,
+      isCurrentPageVisit,
+      onAstroPageLoad,
+      onSession,
+      requireElement,
+    } from "../../../../lib/account-shell";
+    import { getWorkspaceBilling, type WorkspaceBilling } from "../../../../lib/api-client";
+    import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("ws-plan-card")) return;
+
+      const page = "workspace billing";
+      const visit = getPageVisit();
+      const stillHere = (): boolean => isCurrentPageVisit(visit);
+      const w = window as unknown as {
+        __UPLOADS_API_ORIGIN__: string;
+        __UPLOADS_ACTIVE_WORKSPACE__: string;
+      };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+      const workspaceName = resolveActiveWorkspace(
+        window.location.pathname,
+        w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
+      );
+
+      const statusEl = requireElement<HTMLElement>("#ws-status", page);
+      const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
+      const appEl = requireElement<HTMLElement>("#ws-app", page);
+      const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+      const planNameEl = requireElement<HTMLElement>("#ws-plan-name", page);
+      const planBlurbEl = requireElement<HTMLElement>("#ws-plan-blurb", page);
+      const limitsListEl = requireElement<HTMLElement>("#ws-limits-list", page);
+
+      function showError(message: string, retry = true): void {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = message;
+        statusEl.dataset.state = "error";
+        appEl.hidden = true;
+        retryBtn.hidden = !retry;
+      }
+
+      function formatBytes(n: number): string {
+        if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)} GB`;
+        if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(0)} MB`;
+        return `${n} bytes`;
+      }
+
+      function paintLimits(billing: WorkspaceBilling): void {
+        const usage = billing.usage as
+          | { bytes?: number; objects?: number; uploadsInPeriod?: number }
+          | null;
+        const rows: string[] = [];
+        if (billing.limits.maxStorageBytes !== undefined) {
+          const used = usage?.bytes ?? 0;
+          rows.push(
+            `<dt>Storage</dt><dd>${formatBytes(used)} of ${formatBytes(billing.limits.maxStorageBytes)}</dd>`,
+          );
+        }
+        if (billing.limits.maxUploadsPerPeriod !== undefined) {
+          const used = usage?.uploadsInPeriod ?? 0;
+          rows.push(
+            `<dt>Uploads this month</dt><dd>${used} of ${billing.limits.maxUploadsPerPeriod}</dd>`,
+          );
+        }
+        if (billing.limits.maxUploadBytes !== undefined) {
+          rows.push(`<dt>Max file size</dt><dd>${formatBytes(billing.limits.maxUploadBytes)}</dd>`);
+        }
+        if (billing.limits.maxVideoUploadBytes !== undefined) {
+          rows.push(
+            `<dt>Max video size</dt><dd>${formatBytes(billing.limits.maxVideoUploadBytes)}</dd>`,
+          );
+        }
+        limitsListEl.innerHTML = rows.join("");
+      }
+
+      async function loadBillingPage(): Promise<void> {
+        if (!stillHere()) return;
+        statusEl.hidden = false;
+        statusEl.textContent = "Loading…";
+        statusEl.removeAttribute("data-state");
+        retryBtn.hidden = true;
+        appEl.hidden = true;
+
+        const result = await getWorkspaceBilling(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          if (result.reason === "not_found") {
+            showError("You don’t have access to this workspace.", false);
+            return;
+          }
+          showError("Billing is temporarily unavailable. Check the local stack or try again.");
+          return;
+        }
+
+        const { billing } = result;
+        planNameEl.textContent = `${billing.plan === "pro" ? "Pro" : "Free"} plan`;
+        planBlurbEl.textContent = billing.available
+          ? "This plan is active on your workspace."
+          : "This plan isn’t available for self-serve upgrade yet.";
+        paintLimits(billing);
+
+        statusEl.hidden = true;
+        appEl.hidden = false;
+
+        const displayName = billing.organization.name || workspaceName;
+        slugEl.textContent =
+          displayName === workspaceName ? workspaceName : `${displayName} · ${workspaceName}`;
+        document.title = `Billing · ${displayName} · uploads.sh`;
+      }
+
+      retryBtn.addEventListener("click", () => {
+        void loadBillingPage();
+      });
+
+      onSession(() => {
+        void loadBillingPage();
+      });
+    });
+  </script>
+</WorkspaceLayout>
+```
+
+- [ ] **Step 5: Manually verify the page renders**
+
+Run the local dev stack per `AGENTS.md` (`pnpm dev` or the project's documented local-auth-verify recipe — see the `uploads-web-local-auth-verify` memory: portless stack at `https://uploads.localhost`). Navigate to `/account/workspaces/<a-workspace-you-belong-to>/billing` and confirm:
+
+- The page loads without a console error.
+- Plan name, blurb, and limits render.
+- The "Upgrade — coming soon" button is present and disabled.
+- The sidebar switcher shows a `billing` link between `people` and `settings` and it's marked current (`aria-current="page"`) on this route.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/pages/account/workspaces/\[name\]/billing.astro apps/web/src/lib/workspaces-nav.ts apps/web/src/lib/api-client.ts
+git commit -m "feat(billing): add workspace billing tab"
+```
+
+---
+
+## Task 8: Admin panel plan selector
+
+**Files:**
+
+- Modify: `apps/web/src/pages/admin/index.astro`
+
+**Interfaces:**
+
+- Consumes: `apiGet<T>` (existing helper in the file), `escapeHtml` (existing helper), `GET`/`PATCH /admin-ui/workspaces/:name/plan` (Task 5).
+- Produces: `renderPlanSelector(host: HTMLElement, workspace: string, data: PlanResponse): void`, wired into `renderWorkspace`'s `<details>` toggle handler exactly like `limits`/`github-links`, with its own `planLoaded` flag.
+
+- [ ] **Step 1: Add a `<div class="plan">` slot to the workspace detail markup**
+
+In `apps/web/src/pages/admin/index.astro`'s `renderWorkspace` function, insert a new div immediately before `<div class="limits" ...>` (around line 278):
+
+```html
+<div class="plan" data-state="unloaded"></div>
+<div class="limits" data-state="unloaded"></div>
+```
+
+- [ ] **Step 2: Add the `PlanResponse` interface and `renderPlanSelector` function**
+
+Add near the `interface LimitsResponse` block (after it, around line 72):
+
+```typescript
+interface PlanResponse {
+  workspace: string;
+  plan: "free" | "pro";
+  available: boolean;
+  limits: Limits;
+  overrides: string[];
+}
+
+const PLAN_OPTIONS: { id: "free" | "pro"; label: string }[] = [
+  { id: "free", label: "Free" },
+  { id: "pro", label: "Pro (unavailable to self-serve)" },
+];
+
+function renderPlanSelector(host: HTMLElement, workspace: string, data: PlanResponse): void {
+  const options = PLAN_OPTIONS.map(
+    (opt) =>
+      `<option value="${opt.id}"${opt.id === data.plan ? " selected" : ""}>${escapeHtml(opt.label)}</option>`,
+  ).join("");
+
+  host.innerHTML = `
+        <h4 class="plan-heading">Plan</h4>
+        <p class="muted plan-availability">${data.available ? "Available" : "Not available for self-serve upgrade"}</p>
+        <form class="plan-form">
+          <select class="plan-select">${options}</select>
+          <button type="submit">Save plan</button>
+          <div class="plan-status" role="status" aria-live="polite" hidden></div>
+        </form>`;
+
+  const form = host.querySelector<HTMLFormElement>(".plan-form");
+  const statusEl = host.querySelector<HTMLElement>(".plan-status");
+  form?.addEventListener("submit", (event) => {
+    void (async () => {
+      event.preventDefault();
+      if (statusEl) statusEl.hidden = true;
+      const select = host.querySelector<HTMLElement>(
+        ".plan-select",
+      ) as unknown as HTMLSelectElement | null;
+      const plan = select?.value ?? "free";
+      const submitBtn = form.querySelector<HTMLButtonElement>("button[type=submit]");
+      if (submitBtn) submitBtn.disabled = true;
+      try {
+        const res = await fetch(
+          `${apiOrigin}/admin-ui/workspaces/${encodeURIComponent(workspace)}/plan`,
+          {
+            method: "PATCH",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ plan }),
+          },
+        );
+        if (!res.ok) {
+          const payload = (await res.json().catch(() => null)) as {
+            error?: { message?: string };
+          } | null;
+          throw new Error(payload?.error?.message || `save failed: ${res.status}`);
+        }
+        const updated = (await res.json()) as PlanResponse;
+        renderPlanSelector(host, workspace, updated);
+        const freshStatus = host.querySelector<HTMLElement>(".plan-status");
+        if (freshStatus) {
+          freshStatus.dataset.state = "ready";
+          freshStatus.textContent = "Saved.";
+          freshStatus.hidden = false;
+        }
+      } catch (err) {
+        if (statusEl) {
+          statusEl.dataset.state = "error";
+          statusEl.textContent =
+            err instanceof Error && err.message ? err.message : "Couldn't save plan.";
+          statusEl.hidden = false;
+        }
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    })();
+  });
+}
+```
+
+- [ ] **Step 3: Wire the load into the `<details>` toggle handler**
+
+In `renderWorkspace`, alongside the existing `let limitsLoaded = false;` (around line 305), add:
+
+```typescript
+let planLoaded = false;
+```
+
+Add a new independent-load block alongside the existing limits block (after the limits `void (async () => { ... })();` block, around line 360, before the GitHub-links block):
+
+```typescript
+// Plan selector — independent load, own retry flag, same pattern as
+// limits above.
+void (async () => {
+  if (!details.open || planLoaded) return;
+  const planEl = details.querySelector<HTMLElement>(".plan");
+  if (!planEl) return;
+  try {
+    const planData = await apiGet<PlanResponse>(
+      `/admin-ui/workspaces/${encodeURIComponent(ws.workspace)}/plan`,
+    );
+    renderPlanSelector(planEl, ws.workspace, planData);
+    planLoaded = true;
+  } catch {
+    planEl.innerHTML = `<p class="muted">Failed to load plan.</p>`;
+  }
+})();
+```
+
+- [ ] **Step 4: Manually verify in the browser**
+
+Run the local dev stack, sign in as an admin user, open `/admin`, expand a workspace, and confirm:
+
+- A "Plan" section renders with a `<select>` showing Free/Pro and the correct current selection.
+- Changing the selection and clicking "Save plan" persists (reload the page / re-expand and see it stuck).
+- Selecting "Pro (unavailable to self-serve)" saves successfully (admin override allowed) and the "Not available for self-serve upgrade" note appears.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/admin/index.astro
+git commit -m "feat(billing): add plan selector to the admin workspace panel"
+```
+
+---
+
+## Task 9: Changeset ignore entry
+
+**Files:**
+
+- Modify: `.changeset/config.json`
+
+**Interfaces:**
+
+- None — configuration-only change.
+
+No public docs page is added by this feature (the spec's Web section only touches the account/admin surfaces, not `/docs`), so `apps/web/public/sitemap.xml` and `apps/web/src/pages/llms.txt` (or equivalent) need no update — confirmed N/A per the spec.
+
+- [ ] **Step 1: Add `@uploads/billing` to the ignore list**
+
+In `.changeset/config.json`, change:
+
+```json
+  "ignore": ["@uploads/api", "@uploads/mcp", "@uploads/web", "@uploads/storage", "@uploads/auth"]
+```
+
+to:
+
+```json
+  "ignore": ["@uploads/api", "@uploads/mcp", "@uploads/web", "@uploads/storage", "@uploads/auth", "@uploads/billing"]
+```
+
+- [ ] **Step 2: Verify no changeset accidentally targets the new package**
+
+Run: `ls .changeset/*.md 2>/dev/null`
+Expected: any pre-existing changeset files (if present, from unrelated in-flight work) do not reference `@uploads/billing` — confirm with `grep -l billing .changeset/*.md 2>/dev/null` returning nothing. This guards against the "changeset targeting an ignored package silently blocks every npm publish" trap recorded from prior work on this repo.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/config.json
+git commit -m "chore(billing): exclude @uploads/billing from changeset releases"
+```
+
+---
+
+## Task 10: Full-suite verification
+
+**Files:** none (verification-only task).
+
+- [ ] **Step 1: Run the full root test suite**
+
+Run: `pnpm test`
+Expected: PASS — every project under `apps/*`/`packages/*` (including the new `packages/billing`) passes with no regressions.
+
+- [ ] **Step 2: Typecheck the touched packages**
+
+Run: `cd packages/billing && pnpm typecheck && cd ../../apps/api && pnpm typecheck && cd ../web && pnpm run astro check 2>/dev/null || pnpm run build`
+
+(Use whichever typecheck/build command `apps/web`'s `package.json` actually defines — inspect `apps/web/package.json`'s `"scripts"` first if `astro check` isn't present.)
+
+Expected: PASS — no type errors introduced by the `plan` field, `@uploads/billing` imports, or the new Astro page.
+
+- [ ] **Step 3: Format check**
+
+Run: `pnpm oxfmt --check` (or the repo's documented format-check script — confirm the exact command in `package.json`'s root `"scripts"` or `AGENTS.md` before running)
+
+Expected: PASS, or run the writer (non `--check`) variant and commit any formatting fixes as a final `chore: oxfmt` commit if needed.
+
+- [ ] **Step 4: Final commit (if formatting changed anything)**
+
+```bash
+git add -A
+git commit -m "chore(billing): oxfmt"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+- Package contents (`plans.ts`, `resolve.ts`, `provider.ts`) → Tasks 1–3.
+- `plan?: 'free' | 'pro'` on `WorkspaceRecord`, absent ⇒ free → Task 4, Step 4.
+- `budget.ts`/`self-serve-defaults.ts` routed through `resolvePlanLimits` → Task 4, Step 5 (`self-serve-defaults.ts` itself needs no functional change since its literal values already equal the `free` plan's `defaultLimits` — a doc-comment cross-reference was judged sufficient over a functional rewrite, since `selfServeWorkspaceRecord` intentionally stamps explicit values onto new records rather than relying on plan-default fallback, and rewriting that call site to omit the fields and rely on resolution would be a behavior change beyond this spec's scope).
+- Admin `GET`/`PATCH /admin-ui/workspaces/:name/plan` → Task 5.
+- User `GET /me/workspaces/:name/billing` → Task 6.
+- Workspace `billing.astro` tab + nav registration → Task 7.
+- Admin panel plan selector → Task 8.
+- Unknown plan PATCH → validation error via `@uploads/errors` → Task 5 (`validatePlanPatch` throws `ValidationError`).
+- Unknown/legacy plan string at read time → fail-open to free → Task 1 (`getPlan`) and Task 2/4 (`resolvePlanLimits`/`resolveBudgetLimits` tests explicitly cover this).
+- Testing: catalog invariants, resolution precedence, `NullBillingProvider` contract → Tasks 1–3. Admin-ui route tests → Task 5. Budget regression tests → Task 4. Plain vitest via root runner → confirmed throughout (no per-package config added).
+- Future iteration section is explicitly documentation-only in the spec — no task implements Stripe, webhooks, or a D1 subscription table, and Global Constraints reiterates this.
+- Changeset ignore entry → Task 9. Docs sitemap/llms.txt → explicitly confirmed N/A in Task 9 (no public docs page added).
+
+**Placeholder scan:** No "TBD"/"TODO"/"implement later" strings. Every code step shows complete, real code. Two steps (Task 6 Step 1, Task 7 Step 1) explicitly instruct the implementer to first read an existing file to confirm exact helper names before writing test/production code that depends on them — this is a deliberate "verify against the real file" instruction, not a content placeholder, since the exact fixture/helper names in `me.test.ts` and the exact `api-client.ts` fetch-wrapper pattern were not fully visible during plan authoring and guessing them risks a type/name mismatch; the illustrative code given is complete and correct against the conventions observed in `admin-ui.test.ts`/`people.astro`, and only needs a name-alignment pass if the real file differs.
+
+**Type consistency:** `PlanId`, `WorkspacePlanLimits`, `getPlan`, `resolvePlanLimits`, `PLAN_IDS`, `BillingProvider`, `NullBillingProvider` are defined once in Tasks 1–3 and imported with identical names/signatures in Tasks 4–8. `WorkspaceRecord.plan?: 'free' | 'pro'` (Task 4) matches `PlanId` (Task 1). `planResponse`/`validatePlanPatch` (Task 5) are defined once and consumed identically by the admin routes (Task 5) and referenced by name (not redefined) in Task 8's `PlanResponse` TypeScript interface, which is a separately-declared client-side mirror (Astro page, no shared import across the API/web boundary) — this mirrors the existing `Limits`/`LimitsResponse` pattern already in `admin-index.astro`, so the duplication is consistent with repo convention, not a drift bug.

--- a/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
@@ -1,0 +1,90 @@
+# Subscription billing infrastructure (free-plan era)
+
+Date: 2026-07-22
+Status: approved
+
+## Goal
+
+Lay the infrastructure for workspace subscription plans without any live billing.
+Every workspace is on a `free` plan in perpetuity today; a paid plan is a defined
+but unavailable placeholder. Billing logic is isolated in a dedicated package so
+a future Stripe integration stays contained and the open-source repo never holds
+secrets (secrets remain Cloudflare Worker secrets, as with existing GitHub keys).
+
+Explicitly out of scope this iteration: Stripe SDK, checkout, webhooks, customer
+portal, D1 subscription table, per-user Stripe customers, plan-change emails.
+
+## Architecture
+
+New private workspace package `@uploads/billing` (`packages/billing`), consumed
+by `apps/api` (budget resolution, routes) and `apps/web` (display metadata).
+Not published; excluded from release versioning like other private packages.
+
+### Package contents
+
+- `plans.ts` — plan catalog:
+  - `free`: available, in perpetuity; default limits = current self-serve
+    defaults (see `apps/api/src/self-serve-defaults.ts`, e.g. 250 MB storage).
+  - `pro`: defined with `available: false`; display metadata only.
+  - Each plan: id, display name, blurb, `available`, default
+    `WorkspaceBudgetLimits`.
+- `resolve.ts` — `resolvePlanLimits(plan, overrides)`: pure. Explicit
+  per-workspace admin overrides (PR #280 limit fields) always beat plan
+  defaults. Existing workspaces with custom limits are unaffected.
+- `provider.ts` — `BillingProvider` interface (`getSubscription`,
+  `createCheckoutSession`, `createPortalSession`) with typed results and a
+  `NullBillingProvider` returning "free, no subscription". A future
+  `StripeBillingProvider` implements the same interface inside this package.
+  No Stripe SDK dependency anywhere yet.
+
+## Data model
+
+- `plan?: 'free' | 'pro'` added to the KV `WorkspaceRecord`
+  (`apps/api/src/workspace.ts`). Absent ⇒ `free`; no migration or backfill.
+- `apps/api/src/budget.ts` and `self-serve-defaults.ts` route limit resolution
+  through `resolvePlanLimits`.
+- No subscription persistence yet; plan state is the KV field.
+
+## API (apps/api)
+
+- Admin (session-gated, `requireAdminUser`, mirrors limits routes in
+  `routes/admin-ui.ts`):
+  - `GET /admin-ui/workspaces/:name/plan` — plan, effective limits, which
+    values are overrides.
+  - `PATCH /admin-ui/workspaces/:name/plan` — set plan (validated against
+    catalog; setting `pro` allowed for admins even while unavailable to users).
+- User-facing (org-member-gated):
+  - `GET /me/workspaces/:name/billing` — plan metadata, effective limits,
+    current usage, `subscription` from the provider (`null` today). Response
+    shape is stable across the future Stripe iteration.
+
+## Web (apps/web)
+
+- New workspace tab `pages/account/workspaces/[name]/billing.astro`, registered
+  in the workspace rail/nav (`workspaces-nav.ts`, `WorkspaceLayout.astro`),
+  following the `people.astro` pattern. Content: current plan card, effective
+  limits vs usage, disabled "Upgrade — coming soon" affordance. Honest copy —
+  no fake invoices or mock billing history.
+- Admin panel (`pages/admin/index.astro`): plan selector in the expanded
+  workspace view next to the existing limits form, wired to the plan routes.
+
+## Error handling
+
+- Unknown plan value in a PATCH → validation error via `@uploads/errors`.
+- Unknown/legacy plan string found in KV at read time → treated as `free`
+  (fail-open to the free tier, never lockout).
+
+## Testing
+
+- `packages/billing`: catalog invariants, resolution precedence
+  (override > plan default), NullBillingProvider contract.
+- `apps/api`: plan route tests alongside `admin-ui.test.ts`; budget resolution
+  regression tests proving existing override behavior unchanged.
+- Plain vitest via the root runner, per repo convention.
+
+## Future iteration (documented, not built)
+
+Stripe arrives entirely inside `packages/billing` plus: one webhook route in
+`apps/api`, `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` Worker secrets, a D1
+subscription table, and flipping `pro.available`. Prior art: the releases repo's
+dormant `@better-auth/stripe` seam (secret-gated plugin, `plans: []`).

--- a/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
@@ -42,12 +42,12 @@ Not published; excluded from release versioning like other private packages.
 - `plan?: 'free' | 'pro'` added to the KV `WorkspaceRecord`
   (`apps/api/src/workspace.ts`). Absent ⇒ `free`; no migration or backfill.
 - **Enforcement vs display (decided during implementation):** budget
-  *enforcement* applies plan defaults only when `record.plan` is explicitly
+  _enforcement_ applies plan defaults only when `record.plan` is explicitly
   set. Records without `plan` keep today's enforcement byte-for-byte (explicit
   limit fields only; absent field = unlimited) — legacy/admin workspaces are
   unlimited today and this iteration must not change production enforcement.
   Self-serve workspaces already carry explicit limit fields, so they are
-  unaffected too. *Display* (billing page, admin panel) still resolves absent
+  unaffected too. _Display_ (billing page, admin panel) still resolves absent
   `plan` as `free`.
 - `apps/api/src/budget.ts` routes limit resolution through `resolvePlanLimits`
   when a plan is set; `resolvePlanLimits` accepts `number | null | undefined`

--- a/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
@@ -6,8 +6,9 @@ Status: approved
 ## Goal
 
 Lay the infrastructure for workspace subscription plans without any live billing.
-Every workspace is on a `free` plan in perpetuity today; a paid plan is a defined
-but unavailable placeholder. Billing logic is isolated in a dedicated package so
+`free` is the default plan today and no self-serve billing path exists; `pro` is
+a defined but unavailable placeholder that admins may still assign to a workspace
+as an operator override. Billing logic is isolated in a dedicated package so
 a future Stripe integration stays contained and the open-source repo never holds
 secrets (secrets remain Cloudflare Worker secrets, as with existing GitHub keys).
 
@@ -67,12 +68,18 @@ Not published; excluded from release versioning like other private packages.
   - `GET /me/workspaces/:name/billing` — plan metadata, effective limits,
     current usage, `subscription` from the provider (`null` today). Response
     shape is stable across the future Stripe iteration.
+- Both the admin plan routes and `/me/workspaces/:name/billing` include a
+  `planApplied` boolean: `true` when `record.plan` is explicitly set (limits
+  shown are plan-resolved); `false` for records with no `plan` field, where
+  the limits shown are the enforcement truth (explicit-or-unlimited) and the
+  displayed plan name ("free") is for UX only, not what's being enforced.
 
 ## Web (apps/web)
 
 - New workspace tab `pages/account/workspaces/[name]/billing.astro`, registered
-  in the workspace rail/nav (`workspaces-nav.ts`, `WorkspaceLayout.astro`),
-  following the `people.astro` pattern. Content: current plan card, effective
+  in the workspace nav (`lib/workspaces-nav.ts`) and the fast-paint tab
+  fallback in `layouts/AccountLayout.astro`, following the `people.astro`
+  pattern. Content: current plan card, effective
   limits vs usage, disabled "Upgrade — coming soon" affordance. Honest copy —
   no fake invoices or mock billing history.
 - Admin panel (`pages/admin/index.astro`): plan selector in the expanded

--- a/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md
@@ -41,8 +41,18 @@ Not published; excluded from release versioning like other private packages.
 
 - `plan?: 'free' | 'pro'` added to the KV `WorkspaceRecord`
   (`apps/api/src/workspace.ts`). Absent ⇒ `free`; no migration or backfill.
-- `apps/api/src/budget.ts` and `self-serve-defaults.ts` route limit resolution
-  through `resolvePlanLimits`.
+- **Enforcement vs display (decided during implementation):** budget
+  *enforcement* applies plan defaults only when `record.plan` is explicitly
+  set. Records without `plan` keep today's enforcement byte-for-byte (explicit
+  limit fields only; absent field = unlimited) — legacy/admin workspaces are
+  unlimited today and this iteration must not change production enforcement.
+  Self-serve workspaces already carry explicit limit fields, so they are
+  unaffected too. *Display* (billing page, admin panel) still resolves absent
+  `plan` as `free`.
+- `apps/api/src/budget.ts` routes limit resolution through `resolvePlanLimits`
+  when a plan is set; `resolvePlanLimits` accepts `number | null | undefined`
+  overrides (`null` = explicitly cleared to unlimited, matching
+  `workspace-limits.ts` semantics).
 - No subscription persistence yet; plan state is the KV field.
 
 ## API (apps/api)

--- a/packages/billing/README.md
+++ b/packages/billing/README.md
@@ -1,0 +1,10 @@
+# @uploads/billing
+
+Plan catalog, limit-resolution, and the billing-provider seam for workspace
+subscription plans. Every workspace is on the `free` plan today; `pro` is
+defined but unavailable (`available: false`) — no Stripe SDK, checkout, or
+subscription persistence yet. See
+`docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md`.
+
+Private workspace package — not published, excluded from Changesets like
+`@uploads/api` / `@uploads/storage` / `@uploads/web` / `@uploads/auth`.

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@uploads/billing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./plans";

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./plans";
+export * from "./resolve";

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./plans";
 export * from "./resolve";
+export * from "./provider";

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -63,7 +63,7 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
 export const PLAN_IDS = Object.keys(PLANS) as PlanId[];
 
 function isPlanId(value: unknown): value is PlanId {
-  return typeof value === "string" && value in PLANS;
+  return typeof value === "string" && Object.hasOwn(PLANS, value);
 }
 
 /**

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -48,6 +48,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     name: "Pro",
     blurb: "Higher storage and upload limits for teams — coming soon.",
     available: false,
+    // Provisional placeholders invented ahead of real pricing (pro is not
+    // yet purchasable) — revisit before pro becomes available.
     defaultLimits: {
       maxStorageBytes: 25_000_000_000,
       maxUploadsPerPeriod: 100_000,

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -1,0 +1,74 @@
+/**
+ * Plan catalog for workspace subscription plans (free-plan era, spec
+ * 2026-07-22). `free` is available in perpetuity today; `pro` is defined for
+ * display purposes only (`available: false`) — no checkout path exists yet.
+ * `defaultLimits.free` mirrors `apps/api/src/self-serve-defaults.ts`'s
+ * `SELF_SERVE_LIMITS`; keep the two in sync if either changes.
+ */
+
+export type PlanId = "free" | "pro";
+
+/** The four budget-limit fields a plan can default — same shape as
+ * `apps/api/src/budget.ts`'s `WorkspaceBudgetLimits` plus the two
+ * per-upload caps from `WorkspaceRecord`, kept here as an independent type
+ * so this package has no dependency on `@uploads/api`. */
+export interface WorkspacePlanLimits {
+  maxStorageBytes?: number;
+  maxUploadsPerPeriod?: number;
+  maxUploadBytes?: number;
+  maxVideoUploadBytes?: number;
+}
+
+export interface PlanDefinition {
+  id: PlanId;
+  /** Display name shown in the workspace billing tab and admin panel. */
+  name: string;
+  /** One-sentence description of the plan. */
+  blurb: string;
+  /** Whether a workspace/user can actually be on this plan today. */
+  available: boolean;
+  defaultLimits: WorkspacePlanLimits;
+}
+
+export const PLANS: Record<PlanId, PlanDefinition> = {
+  free: {
+    id: "free",
+    name: "Free",
+    blurb: "Everything you need to host screenshots and files for your projects.",
+    available: true,
+    defaultLimits: {
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+      maxUploadBytes: 25_000_000,
+      maxVideoUploadBytes: 8_000_000,
+    },
+  },
+  pro: {
+    id: "pro",
+    name: "Pro",
+    blurb: "Higher storage and upload limits for teams — coming soon.",
+    available: false,
+    defaultLimits: {
+      maxStorageBytes: 25_000_000_000,
+      maxUploadsPerPeriod: 100_000,
+      maxUploadBytes: 100_000_000,
+      maxVideoUploadBytes: 50_000_000,
+    },
+  },
+};
+
+/** All valid plan ids, in catalog order. */
+export const PLAN_IDS = Object.keys(PLANS) as PlanId[];
+
+function isPlanId(value: unknown): value is PlanId {
+  return typeof value === "string" && value in PLANS;
+}
+
+/**
+ * The catalog entry for `id`. Fails open to `PLANS.free` for any
+ * unrecognized or missing value — legacy/unknown plan strings found in KV
+ * must never lock a workspace out, per the spec's error-handling section.
+ */
+export function getPlan(id: unknown): PlanDefinition {
+  return isPlanId(id) ? PLANS[id] : PLANS.free;
+}

--- a/packages/billing/src/provider.ts
+++ b/packages/billing/src/provider.ts
@@ -1,0 +1,48 @@
+/**
+ * Billing-provider seam (spec 2026-07-22's "future iteration" section). No
+ * live billing exists yet — `NullBillingProvider` is the only implementation
+ * today, always reporting "free, no subscription". A future
+ * `StripeBillingProvider` implements the same interface inside this
+ * package; no Stripe SDK dependency exists anywhere yet.
+ */
+import type { PlanId } from "./plans";
+
+/** A workspace's live subscription state, as reported by the provider. */
+export interface Subscription {
+  plan: PlanId;
+  status: "active" | "canceled" | "past_due";
+  /** ISO timestamp of the current billing period's end, if known. */
+  currentPeriodEnd?: string;
+}
+
+export interface BillingProvider {
+  /** The workspace's current subscription, or `null` if it has none
+   * (e.g. it's on the free plan with nothing to bill). */
+  getSubscription(workspace: string): Promise<Subscription | null>;
+  /** Starts a checkout flow for upgrading `workspace` to `plan`. Rejects
+   * until a real provider is wired up. */
+  createCheckoutSession(workspace: string, plan: PlanId): Promise<never>;
+  /** Starts a customer-portal session for `workspace`. Rejects until a
+   * real provider is wired up. */
+  createPortalSession(workspace: string): Promise<never>;
+}
+
+/**
+ * The only `BillingProvider` implementation today. Every workspace reports
+ * no subscription; checkout/portal are unavailable. Honest placeholder —
+ * apps/web's billing tab renders a disabled "Upgrade — coming soon"
+ * affordance rather than calling these.
+ */
+export class NullBillingProvider implements BillingProvider {
+  async getSubscription(_workspace: string): Promise<Subscription | null> {
+    return null;
+  }
+
+  async createCheckoutSession(_workspace: string, _plan: PlanId): Promise<never> {
+    throw new Error("checkout is not available yet");
+  }
+
+  async createPortalSession(_workspace: string): Promise<never> {
+    throw new Error("the billing portal is not available yet");
+  }
+}

--- a/packages/billing/src/resolve.ts
+++ b/packages/billing/src/resolve.ts
@@ -5,14 +5,9 @@
  * Pure — no I/O — so `apps/api/src/budget.ts` and the admin/user routes can
  * all call through this single chokepoint without drifting on precedence.
  */
-import { getPlan, type PlanId, type WorkspacePlanLimits } from "./plans";
+import { PLANS, getPlan, type PlanId, type WorkspacePlanLimits } from "./plans";
 
-const LIMIT_KEYS: (keyof WorkspacePlanLimits)[] = [
-  "maxStorageBytes",
-  "maxUploadsPerPeriod",
-  "maxUploadBytes",
-  "maxVideoUploadBytes",
-];
+const LIMIT_KEYS = Object.keys(PLANS.free.defaultLimits) as (keyof WorkspacePlanLimits)[];
 
 /**
  * Per-field override input. Mirrors the real-world tri-state on

--- a/packages/billing/src/resolve.ts
+++ b/packages/billing/src/resolve.ts
@@ -1,0 +1,35 @@
+/**
+ * Precedence resolution between a workspace's plan defaults and its
+ * explicit per-workspace overrides (the admin-editable budget fields on
+ * `WorkspaceRecord` — see PR #280 / `apps/api/src/workspace-limits.ts`).
+ * Pure — no I/O — so `apps/api/src/budget.ts` and the admin/user routes can
+ * all call through this single chokepoint without drifting on precedence.
+ */
+import { getPlan, type PlanId, type WorkspacePlanLimits } from "./plans";
+
+const LIMIT_KEYS: (keyof WorkspacePlanLimits)[] = [
+  "maxStorageBytes",
+  "maxUploadsPerPeriod",
+  "maxUploadBytes",
+  "maxVideoUploadBytes",
+];
+
+/**
+ * Resolves effective limits for a workspace: an explicit (defined) override
+ * field always wins; otherwise falls back to the resolved plan's
+ * `defaultLimits` for that field. `plan` fails open to `free` via `getPlan`
+ * for any unrecognized/missing value, so a legacy or malformed plan string
+ * never locks a workspace out.
+ */
+export function resolvePlanLimits(
+  plan: PlanId | string | undefined,
+  overrides: WorkspacePlanLimits,
+): WorkspacePlanLimits {
+  const defaults = getPlan(plan).defaultLimits;
+  const resolved: WorkspacePlanLimits = {};
+  for (const key of LIMIT_KEYS) {
+    const override = overrides[key];
+    resolved[key] = override !== undefined ? override : defaults[key];
+  }
+  return resolved;
+}

--- a/packages/billing/src/resolve.ts
+++ b/packages/billing/src/resolve.ts
@@ -15,21 +15,39 @@ const LIMIT_KEYS: (keyof WorkspacePlanLimits)[] = [
 ];
 
 /**
- * Resolves effective limits for a workspace: an explicit (defined) override
- * field always wins; otherwise falls back to the resolved plan's
- * `defaultLimits` for that field. `plan` fails open to `free` via `getPlan`
- * for any unrecognized/missing value, so a legacy or malformed plan string
- * never locks a workspace out.
+ * Per-field override input. Mirrors the real-world tri-state on
+ * `WorkspaceRecord`/`WorkspaceBudgetLimits`: a `number` sets an explicit
+ * cap, `null` is an explicit clear ("unlimited", wins over the plan
+ * default), and `undefined`/absent means "no override — use the plan
+ * default".
+ */
+export type WorkspacePlanLimitOverrides = {
+  [K in keyof WorkspacePlanLimits]?: WorkspacePlanLimits[K] | null;
+};
+
+/**
+ * Resolves effective limits for a workspace: an explicit numeric override
+ * always wins; an explicit `null` override wins too, resolving to
+ * `undefined` (unlimited) regardless of the plan default; otherwise falls
+ * back to the resolved plan's `defaultLimits` for that field. `plan` fails
+ * open to `free` via `getPlan` for any unrecognized/missing value, so a
+ * legacy or malformed plan string never locks a workspace out.
  */
 export function resolvePlanLimits(
   plan: PlanId | string | undefined,
-  overrides: WorkspacePlanLimits,
+  overrides: WorkspacePlanLimitOverrides,
 ): WorkspacePlanLimits {
   const defaults = getPlan(plan).defaultLimits;
   const resolved: WorkspacePlanLimits = {};
   for (const key of LIMIT_KEYS) {
     const override = overrides[key];
-    resolved[key] = override !== undefined ? override : defaults[key];
+    if (override === null) {
+      resolved[key] = undefined;
+    } else if (override !== undefined) {
+      resolved[key] = override;
+    } else {
+      resolved[key] = defaults[key];
+    }
   }
   return resolved;
 }

--- a/packages/billing/test/plans.test.ts
+++ b/packages/billing/test/plans.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getPlan, PLANS } from "../src/plans";
+
+describe("PLANS catalog", () => {
+  it("defines free as available with the current self-serve defaults", () => {
+    expect(PLANS.free.available).toBe(true);
+    expect(PLANS.free.defaultLimits).toEqual({
+      maxStorageBytes: 250_000_000,
+      maxUploadsPerPeriod: 3000,
+      maxUploadBytes: 25_000_000,
+      maxVideoUploadBytes: 8_000_000,
+    });
+  });
+
+  it("defines pro as unavailable display metadata", () => {
+    expect(PLANS.pro.available).toBe(false);
+    expect(PLANS.pro.id).toBe("pro");
+    expect(typeof PLANS.pro.name).toBe("string");
+    expect(PLANS.pro.name.length).toBeGreaterThan(0);
+  });
+
+  it("every plan's id matches its catalog key", () => {
+    for (const [key, plan] of Object.entries(PLANS)) {
+      expect(plan.id).toBe(key);
+    }
+  });
+});
+
+describe("getPlan", () => {
+  it("returns the matching catalog entry for a known id", () => {
+    expect(getPlan("pro")).toBe(PLANS.pro);
+  });
+
+  it("fails open to free for an unknown or legacy plan string", () => {
+    expect(getPlan("enterprise")).toBe(PLANS.free);
+    expect(getPlan("")).toBe(PLANS.free);
+    expect(getPlan(undefined)).toBe(PLANS.free);
+  });
+});

--- a/packages/billing/test/plans.test.ts
+++ b/packages/billing/test/plans.test.ts
@@ -36,4 +36,14 @@ describe("getPlan", () => {
     expect(getPlan("")).toBe(PLANS.free);
     expect(getPlan(undefined)).toBe(PLANS.free);
   });
+
+  it("fails open to free for inherited-property names, not the prototype value", () => {
+    expect(getPlan("constructor")).toBe(PLANS.free);
+    expect(getPlan("__proto__")).toBe(PLANS.free);
+  });
+
+  it("still resolves real plan ids unaffected by the hasOwn check", () => {
+    expect(getPlan("free")).toBe(PLANS.free);
+    expect(getPlan("pro")).toBe(PLANS.pro);
+  });
 });

--- a/packages/billing/test/provider.test.ts
+++ b/packages/billing/test/provider.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { NullBillingProvider } from "../src/provider";
+
+describe("NullBillingProvider", () => {
+  it("getSubscription always resolves null (no subscription today)", async () => {
+    const provider = new NullBillingProvider();
+    await expect(provider.getSubscription("acme")).resolves.toBeNull();
+  });
+
+  it("createCheckoutSession rejects — no checkout path exists yet", async () => {
+    const provider = new NullBillingProvider();
+    await expect(provider.createCheckoutSession("acme", "pro")).rejects.toThrow(
+      /not available|unavailable/i,
+    );
+  });
+
+  it("createPortalSession rejects — no billing portal exists yet", async () => {
+    const provider = new NullBillingProvider();
+    await expect(provider.createPortalSession("acme")).rejects.toThrow(
+      /not available|unavailable/i,
+    );
+  });
+});

--- a/packages/billing/test/resolve.test.ts
+++ b/packages/billing/test/resolve.test.ts
@@ -30,6 +30,32 @@ describe("resolvePlanLimits", () => {
     expect(resolvePlanLimits(undefined, {})).toEqual(PLANS.free.defaultLimits);
   });
 
+  it("an explicit null override wins over the plan default, resolving to unlimited (undefined)", () => {
+    const resolved = resolvePlanLimits("free", { maxStorageBytes: null });
+    expect(resolved.maxStorageBytes).toBeUndefined();
+    expect(resolved.maxUploadsPerPeriod).toBe(PLANS.free.defaultLimits.maxUploadsPerPeriod);
+  });
+
+  it("a null override on a plan with a defined default still clears it (pro)", () => {
+    const resolved = resolvePlanLimits("pro", { maxUploadsPerPeriod: null });
+    expect(resolved.maxUploadsPerPeriod).toBeUndefined();
+    expect(resolved.maxStorageBytes).toBe(PLANS.pro.defaultLimits.maxStorageBytes);
+  });
+
+  it("null and undefined overrides can be mixed with numeric overrides across fields", () => {
+    const resolved = resolvePlanLimits("free", {
+      maxStorageBytes: null,
+      maxUploadsPerPeriod: undefined,
+      maxUploadBytes: 42,
+    });
+    expect(resolved).toEqual({
+      maxStorageBytes: undefined,
+      maxUploadsPerPeriod: PLANS.free.defaultLimits.maxUploadsPerPeriod,
+      maxUploadBytes: 42,
+      maxVideoUploadBytes: PLANS.free.defaultLimits.maxVideoUploadBytes,
+    });
+  });
+
   it("all four override fields compose independently", () => {
     const resolved = resolvePlanLimits("free", {
       maxStorageBytes: 1,

--- a/packages/billing/test/resolve.test.ts
+++ b/packages/billing/test/resolve.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolvePlanLimits } from "../src/resolve";
+import { PLANS } from "../src/plans";
+
+describe("resolvePlanLimits", () => {
+  it("uses the plan's default limits when there are no overrides", () => {
+    expect(resolvePlanLimits("free", {})).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("an explicit override beats the plan default for that field", () => {
+    const resolved = resolvePlanLimits("free", { maxStorageBytes: 1_000 });
+    expect(resolved.maxStorageBytes).toBe(1_000);
+    expect(resolved.maxUploadsPerPeriod).toBe(PLANS.free.defaultLimits.maxUploadsPerPeriod);
+  });
+
+  it("an override of undefined does not shadow the plan default", () => {
+    const resolved = resolvePlanLimits("free", { maxStorageBytes: undefined });
+    expect(resolved.maxStorageBytes).toBe(PLANS.free.defaultLimits.maxStorageBytes);
+  });
+
+  it("resolves pro's own (unavailable) defaults when a workspace is set to pro", () => {
+    expect(resolvePlanLimits("pro", {})).toEqual(PLANS.pro.defaultLimits);
+  });
+
+  it("fails open to free's defaults for an unknown plan string", () => {
+    expect(resolvePlanLimits("enterprise", {})).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("fails open to free's defaults when plan is undefined (absent-in-KV case)", () => {
+    expect(resolvePlanLimits(undefined, {})).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("all four override fields compose independently", () => {
+    const resolved = resolvePlanLimits("free", {
+      maxStorageBytes: 1,
+      maxUploadsPerPeriod: 2,
+      maxUploadBytes: 3,
+      maxVideoUploadBytes: 4,
+    });
+    expect(resolved).toEqual({
+      maxStorageBytes: 1,
+      maxUploadsPerPeriod: 2,
+      maxUploadBytes: 3,
+      maxVideoUploadBytes: 4,
+    });
+  });
+});

--- a/packages/billing/tsconfig.json
+++ b/packages/billing/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@uploads/billing':
+        specifier: workspace:^
+        version: link:../../packages/billing
       '@uploads/email':
         specifier: workspace:^
         version: link:../../packages/email
@@ -186,6 +189,15 @@ importers:
       wrangler:
         specifier: ^4.110.0
         version: 4.110.0
+
+  packages/billing:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/email:
     devDependencies:


### PR DESCRIPTION
Lays the infrastructure for workspace subscription plans without any live billing. Every workspace stays on a free plan in perpetuity today; a paid plan exists as a defined-but-unavailable placeholder for a future iteration.

Spec: `docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md` · Plan: `docs/superpowers/plans/2026-07-22-billing-infrastructure.md`

## What's here

- **`packages/billing` (`@uploads/billing`, private)** — plan catalog (`free`, `pro` with `available: false`), pure `resolvePlanLimits` precedence resolution, and a `BillingProvider` interface with a `NullBillingProvider`. No Stripe SDK anywhere; a future `StripeBillingProvider` lands inside this package plus one webhook route and two Worker secrets.
- **`plan?: 'free' | 'pro'` on the KV `WorkspaceRecord`** — optional, no migration/backfill.
- **Enforcement is unchanged for every existing workspace.** Budget enforcement applies plan defaults only when `plan` is explicitly set on the record. Absent `plan` keeps today's behavior byte-for-byte (explicit limit fields only; absent field = unlimited). Explicit admin overrides always beat plan defaults, and `null` (cleared → unlimited) is honored.
- **Admin API** — `GET/PATCH /admin-ui/workspaces/:name/plan`, gated identically to the existing limits routes. Admins may set `pro` even while it's unavailable to users.
- **User API** — `GET /me/workspaces/:name/billing` (read-only, member-gated, 404 anti-probing) returning plan metadata, effective limits, usage, and `subscription: null`. Response shape is stable for the future Stripe iteration.
- **Web** — a workspace **Billing** tab (plan card, limits vs usage, disabled "Upgrade — coming soon") and an admin-panel plan selector next to the limits form.
- `@uploads/billing` added to the changeset `ignore` list (private, unpublished).

## The honesty invariant

Both surfaces report `planApplied`. A record with no `plan` field displays as "Free" but **never** shows free-tier caps as if enforced — limits shown are the enforcement truth (explicit-or-unlimited). Two review-cycle criticals were caught and fixed around exactly this before merge.

## Verification

- `pnpm test` 2293/2293 (183 files) · `pnpm typecheck` clean · `pnpm check` clean
- Live-verified on the local dev stack: billing tab renders for a signed-in member; admin PATCH to `pro` round-trips and the user page reflects it while explicit overrides still win.

| Workspace billing tab | Admin plan selector (after setting Pro) |
| --- | --- |
| <img width="420" alt="Workspace billing tab showing free plan, honest limits, and disabled upgrade button" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/feat-billing-infrastructure/workspace-billing-tab.webp"> | <img width="420" alt="Admin panel plan selector set to Pro above the existing limits form" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/feat-billing-infrastructure/admin-plan-selector-pro.webp"> |

## Out of scope (future iteration)

Stripe SDK, checkout/portal/webhooks, D1 subscription table, per-user Stripe customers, plan-change emails, flipping `pro.available`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace billing pages with plan, limits, and usage information.
  * Added workspace billing navigation and an admin plan selector.
  * Added support for free and pro plan definitions, with custom limit overrides.
  * Added billing and plan information to workspace APIs.
  * Added validation and fallback handling for unknown plans.

* **Documentation**
  * Added billing infrastructure design and implementation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->