### PR TITLE
fix(api): versioned read-modify-write for workspace records

### DIFF
--- a/apps/api/src/reencrypt-registry.ts
+++ b/apps/api/src/reencrypt-registry.ts
@@ -67,38 +67,47 @@ export async function reencryptRegistryCredentials(
       }
 
       try {
-        const resealed = await resealCredentialFields(ring, {
-          accessKeyId: record.accessKeyId,
-          secretAccessKey: record.secretAccessKey,
+        if (dryRun) {
+          const resealed = await resealCredentialFields(ring, {
+            accessKeyId: record.accessKeyId,
+            secretAccessKey: record.secretAccessKey,
+          });
+          if (!resealed.changed) {
+            skipped += 1;
+            workspaces.push({ workspace: name, action: "skipped", reason: "already_current" });
+            continue;
+          }
+          updated += 1;
+          workspaces.push({ workspace: name, action: "would_update" });
+          continue;
+        }
+
+        // Reseal against the freshest record, inside the mutation (issue
+        // #387): this sweep walks every workspace, so an admin edit landing
+        // mid-sweep must not be reverted. The record read above only decides
+        // the cheap missing/no-credentials skips — resealing there too would
+        // pay for the crypto twice on every workspace the sweep rewrites.
+        let changed = false;
+        await mutateWorkspaceRecord(env, name, async (current) => {
+          const resealed = await resealCredentialFields(ring, {
+            accessKeyId: current.accessKeyId,
+            secretAccessKey: current.secretAccessKey,
+          });
+          changed = resealed.changed;
+          if (!changed) return null;
+          return {
+            ...current,
+            accessKeyId: resealed.accessKeyId,
+            secretAccessKey: resealed.secretAccessKey,
+          };
         });
-        if (!resealed.changed) {
+        if (!changed) {
           skipped += 1;
           workspaces.push({ workspace: name, action: "skipped", reason: "already_current" });
           continue;
         }
-        if (!dryRun) {
-          // Re-seal against the freshest record rather than the one read
-          // above (issue #387): this sweep walks every workspace, so an admin
-          // edit landing mid-sweep would otherwise be reverted. The reseal is
-          // recomputed inside the mutation for the same reason.
-          await mutateWorkspaceRecord(env, name, async (current) => {
-            const fresh = await resealCredentialFields(ring, {
-              accessKeyId: current.accessKeyId,
-              secretAccessKey: current.secretAccessKey,
-            });
-            if (!fresh.changed) return null;
-            return {
-              ...current,
-              accessKeyId: fresh.accessKeyId,
-              secretAccessKey: fresh.secretAccessKey,
-            };
-          });
-        }
         updated += 1;
-        workspaces.push({
-          workspace: name,
-          action: dryRun ? "would_update" : "updated",
-        });
+        workspaces.push({ workspace: name, action: "updated" });
       } catch (err) {
         errors.push({
           workspace: name,

--- a/apps/api/src/reencrypt-registry.ts
+++ b/apps/api/src/reencrypt-registry.ts
@@ -6,6 +6,7 @@
  */
 import { resealCredentialFields, secretsKeyRingFromEnv, type SecretsKeyRing } from "./secrets";
 import type { WorkspaceRecord } from "./workspace";
+import { mutateWorkspaceRecord } from "./workspace-mutate";
 
 export interface ReencryptResult {
   dryRun: boolean;
@@ -76,12 +77,22 @@ export async function reencryptRegistryCredentials(
           continue;
         }
         if (!dryRun) {
-          const next: WorkspaceRecord = {
-            ...record,
-            accessKeyId: resealed.accessKeyId,
-            secretAccessKey: resealed.secretAccessKey,
-          };
-          await env.REGISTRY.put(entry.name, JSON.stringify(next));
+          // Re-seal against the freshest record rather than the one read
+          // above (issue #387): this sweep walks every workspace, so an admin
+          // edit landing mid-sweep would otherwise be reverted. The reseal is
+          // recomputed inside the mutation for the same reason.
+          await mutateWorkspaceRecord(env, name, async (current) => {
+            const fresh = await resealCredentialFields(ring, {
+              accessKeyId: current.accessKeyId,
+              secretAccessKey: current.secretAccessKey,
+            });
+            if (!fresh.changed) return null;
+            return {
+              ...current,
+              accessKeyId: fresh.accessKeyId,
+              secretAccessKey: fresh.secretAccessKey,
+            };
+          });
         }
         updated += 1;
         workspaces.push({

--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
+import { fakeRegistry } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { respondError } from "../error-response";
 import { adminUi } from "./admin-ui";
@@ -443,8 +444,8 @@ describe("workspace limits editing", () => {
     record: Record<string, unknown> | null,
     usage: { bytes: number; uploadsInPeriod: number } | null = { bytes: 0, uploadsInPeriod: 0 },
   ) {
-    const store = new Map<string, string>();
-    if (record) store.set("ws:acme", JSON.stringify(record));
+    const registry = fakeRegistry(record ? { acme: record } : {});
+    const store = registry.store;
     const base = stubEnv(user, () => new Response(null, { status: 404 }));
     const db = {
       prepare: () => ({
@@ -466,15 +467,7 @@ describe("workspace limits editing", () => {
     const env = {
       ...base,
       DB: db,
-      REGISTRY: {
-        get: (async (key: string) => {
-          const raw = store.get(key);
-          return raw ? JSON.parse(raw) : null;
-        }) as unknown as KVNamespace["get"],
-        put: (async (key: string, value: string) => {
-          store.set(key, value);
-        }) as unknown as KVNamespace["put"],
-      },
+      REGISTRY: registry,
     } as unknown as Env;
     return { env, store };
   }
@@ -520,6 +513,38 @@ describe("workspace limits editing", () => {
     const saved = JSON.parse(store.get("ws:acme")!);
     expect(saved.maxStorageBytes).toBe(500_000_000);
     expect(saved.maxUploadBytes).toBe(10_000_000);
+    // Written through mutateWorkspaceRecord (issue #387), not a bare put.
+    expect(saved.version).toBe(1);
+  });
+
+  it("PATCH re-applies the edit when a competing write clobbers it", async () => {
+    const { env, store } = limitsEnv(ADMIN_USER, REC);
+    // A competing admin's plan change lands between this request's put and its
+    // verification read. The retry re-applies the limit edit on top of the
+    // competitor's record, so neither change is lost (issue #387).
+    const registry = (env as unknown as { REGISTRY: { get: KVNamespace["get"] } }).REGISTRY;
+    const get = registry.get;
+    let gets = 0;
+    registry.get = (async (key: string, type?: unknown) => {
+      gets += 1;
+      if (gets === 2) store.set("ws:acme", JSON.stringify({ ...REC, plan: "pro", version: 5 }));
+      return get(key as never, type as never);
+    }) as KVNamespace["get"];
+
+    const res = await app().request(
+      "/admin-ui/workspaces/acme/limits",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ maxUploadBytes: 10_000_000 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const saved = JSON.parse(store.get("ws:acme")!);
+    expect(saved.plan).toBe("pro");
+    expect(saved.maxUploadBytes).toBe(10_000_000);
+    expect(saved.version).toBe(6);
   });
 
   it("PATCH with null clears a limit to unlimited", async () => {
@@ -651,20 +676,12 @@ describe("workspace plan editing", () => {
   };
 
   function planEnv(user: typeof ADMIN_USER | null, record: Record<string, unknown> | null) {
-    const store = new Map<string, string>();
-    if (record) store.set("ws:acme", JSON.stringify(record));
+    const registry = fakeRegistry(record ? { acme: record } : {});
+    const store = registry.store;
     const base = stubEnv(user, () => new Response(null, { status: 404 }));
     const env = {
       ...base,
-      REGISTRY: {
-        get: (async (key: string) => {
-          const raw = store.get(key);
-          return raw ? JSON.parse(raw) : null;
-        }) as unknown as KVNamespace["get"],
-        put: (async (key: string, value: string) => {
-          store.set(key, value);
-        }) as unknown as KVNamespace["put"],
-      },
+      REGISTRY: registry,
     } as unknown as Env;
     return { env, store };
   }
@@ -772,20 +789,12 @@ describe("workspace plan editing", () => {
 describe("workspace github-comment settings editing", () => {
   /** Env with a mutable ws:acme record and a session user (no usage needed). */
   function settingsEnv(user: typeof ADMIN_USER | null, record: Record<string, unknown> | null) {
-    const store = new Map<string, string>();
-    if (record) store.set("ws:acme", JSON.stringify(record));
+    const registry = fakeRegistry(record ? { acme: record } : {});
+    const store = registry.store;
     const base = stubEnv(user, () => new Response(null, { status: 404 }));
     const env = {
       ...base,
-      REGISTRY: {
-        get: (async (key: string) => {
-          const raw = store.get(key);
-          return raw ? JSON.parse(raw) : null;
-        }) as unknown as KVNamespace["get"],
-        put: (async (key: string, value: string) => {
-          store.set(key, value);
-        }) as unknown as KVNamespace["put"],
-      },
+      REGISTRY: registry,
     } as unknown as Env;
     return { env, store };
   }

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -45,6 +45,7 @@ import {
 } from "../session-auth";
 import { getWorkspaceUsage } from "../usage";
 import { isPurgedTombstone, loadWorkspaceRecordRaw, type WorkspaceRecord } from "../workspace";
+import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { LIMIT_FIELDS, validateLimitsPatch } from "../workspace-limits";
 import { planResponse, validatePlanPatch } from "../workspace-plan";
 
@@ -470,7 +471,6 @@ export const adminUi = new Hono<SessionVars>()
     if (!(await allowWrite(c.env, name))) {
       throw new RateLimitedError("rate limit exceeded");
     }
-    const record = await loadEditableWorkspace(c.env, name);
     // Distinguish malformed JSON (400) from an intentionally empty object
     // (a no-op patch): swallowing a parse failure into `{}` would silently
     // 200 on a broken request and rewrite the record unchanged.
@@ -481,13 +481,23 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("request body must be valid JSON", { code: "invalid_limit" });
     }
     const patch = validateLimitsPatch(body);
-    for (const field of LIMIT_FIELDS) {
-      if (!(field in patch)) continue;
-      const value = patch[field];
-      if (value === null) delete record[field];
-      else record[field] = value;
-    }
-    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
+    // Body parsing and validation happen before the mutation so the
+    // read-modify-write window stays as short as possible (issue #387).
+    const record = await mutateWorkspaceRecord(
+      c.env,
+      name,
+      (current) => {
+        const next = { ...current };
+        for (const field of LIMIT_FIELDS) {
+          if (!(field in patch)) continue;
+          const value = patch[field];
+          if (value === null) delete next[field];
+          else next[field] = value;
+        }
+        return next;
+      },
+      { requireServing: true },
+    );
     return c.json(await limitsResponse(c.env, name, record));
   })
 
@@ -508,7 +518,6 @@ export const adminUi = new Hono<SessionVars>()
     if (!(await allowWrite(c.env, name))) {
       throw new RateLimitedError("rate limit exceeded");
     }
-    const record = await loadEditableWorkspace(c.env, name);
     let body: unknown;
     try {
       body = await c.req.json();
@@ -516,8 +525,9 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("request body must be valid JSON", { code: "invalid_plan" });
     }
     const { plan } = validatePlanPatch(body);
-    record.plan = plan;
-    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
+    const record = await mutateWorkspaceRecord(c.env, name, (current) => ({ ...current, plan }), {
+      requireServing: true,
+    });
     return c.json(planResponse(name, record));
   })
 
@@ -540,7 +550,6 @@ export const adminUi = new Hono<SessionVars>()
     if (!(await allowWrite(c.env, name))) {
       throw new RateLimitedError("rate limit exceeded");
     }
-    const record = await loadEditableWorkspace(c.env, name);
     let body: unknown;
     try {
       body = await c.req.json();
@@ -548,10 +557,18 @@ export const adminUi = new Hono<SessionVars>()
       throw new ValidationError("request body must be valid JSON", { code: "invalid_settings" });
     }
     const patch = validateGithubCommentSettingsPatch(body);
-    for (const key of GITHUB_COMMENT_SETTING_KEYS) {
-      if (key in patch) record[key] = patch[key];
-    }
-    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(record));
+    const record = await mutateWorkspaceRecord(
+      c.env,
+      name,
+      (current) => {
+        const next = { ...current };
+        for (const key of GITHUB_COMMENT_SETTING_KEYS) {
+          if (key in patch) next[key] = patch[key];
+        }
+        return next;
+      },
+      { requireServing: true },
+    );
     return c.json(githubCommentSettingsResponse(name, record));
   })
 

--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { beforeAll, describe, expect, it } from "vitest";
+import { fakeRegistry } from "../../test/fake-kv";
 import { FakeR2Bucket } from "../../test/fake-r2";
 import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
 import { respondError } from "../error-response";
@@ -38,20 +39,6 @@ const RECORD = {
   publicBaseUrl: "https://storage.uploads.sh",
 };
 
-function fakeKv(records: Record<string, unknown>) {
-  const store = new Map(Object.entries(records));
-  return {
-    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
-    put: (async (key: string, value: string) => {
-      store.set(key, JSON.parse(value));
-    }) as unknown as KVNamespace["put"],
-    delete: (async (key: string) => {
-      store.delete(key);
-    }) as unknown as KVNamespace["delete"],
-    __store: store,
-  };
-}
-
 function appWith(opts: {
   kvRecords?: Record<string, unknown>;
   onDeleteOrg?: (slug: string) => void;
@@ -67,7 +54,7 @@ function appWith(opts: {
     }
     return new Response("not found", { status: 404 });
   });
-  const registry = fakeKv(kvRecords);
+  const registry = fakeRegistry(kvRecords);
   const app = new Hono<{ Bindings: Env }>()
     .route("/admin", admin)
     .onError((err, c) => respondError(c, err));
@@ -184,7 +171,7 @@ describe("DELETE /admin/workspaces/:name", () => {
       // Auth-side org delete was invoked for the right slug.
       expect(deletedOrgSlug).toBe("acme");
       // KV record removed outright — the slug is freed.
-      expect(registry.__store.has("ws:acme")).toBe(false);
+      expect(registry.store.has("ws:acme")).toBe(false);
     } finally {
       sqlite.close();
     }
@@ -210,7 +197,7 @@ describe("DELETE /admin/workspaces/:name", () => {
         14 * 24 * 60 * 60 * 1000,
       );
 
-      const stored = registry.__store.get("ws:acme") as { deletedAt?: string; purgeAt?: string };
+      const stored = registry.record<{ deletedAt?: string; purgeAt?: string }>("acme")!;
       expect(stored.deletedAt).toBe(body.deletedAt);
       expect(stored.purgeAt).toBe(body.purgeAt);
       // Data untouched.
@@ -255,7 +242,7 @@ describe("DELETE /admin/workspaces/:name", () => {
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchObject({ ok: true, workspace: "acme" });
 
-      const stored = registry.__store.get("ws:acme") as { deletedAt?: string; purgeAt?: string };
+      const stored = registry.record<{ deletedAt?: string; purgeAt?: string }>("acme")!;
       expect(stored.deletedAt).toBeUndefined();
       expect(stored.purgeAt).toBeUndefined();
     });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -23,6 +23,7 @@ import {
 import { deriveWebOrigin, inviteLinkUrl as inviteMagicLink } from "../invite-links";
 import { reencryptRegistryCredentials } from "../reencrypt-registry";
 import { storage } from "../storage";
+import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { teardownWorkspace } from "../workspace-teardown";
 import {
   isPastGrace,
@@ -414,9 +415,16 @@ export const admin = new Hono<{ Bindings: Env }>()
     }
 
     const revoked = kvMatches[0];
-    const remaining = kv.filter((token) => token !== revoked);
-    const { tokenHash: _drop, ...rest } = record;
-    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify({ ...rest, tokens: remaining }));
+    // Re-derive the surviving list from the freshest record inside the
+    // mutation (issue #387) — filtering the snapshot read above would restore
+    // a token another request revoked in the meantime.
+    await mutateWorkspaceRecord(c.env, name, (current) => {
+      const { tokenHash: _drop, ...rest } = current;
+      return {
+        ...rest,
+        tokens: legacyTokens(current).filter((token) => token.hash !== revoked.hash),
+      };
+    });
     return c.json({
       workspace: name,
       revoked: { label: revoked.label ?? null, hashPrefix: revoked.hash.slice(0, HASH_PREFIX_LEN) },
@@ -476,15 +484,17 @@ export const admin = new Hono<{ Bindings: Env }>()
     const force = c.req.query("force") === "1" || c.req.query("force") === "true";
 
     if (!hard) {
-      if (record.deletedAt) {
-        throw new ConflictError("workspace is already soft-deleted", {
-          code: "already_deleted",
-          details: { deletedAt: record.deletedAt, purgeAt: record.purgeAt },
-        });
-      }
-
-      const updated = stampSoftDelete(record);
-      await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(updated));
+      // The already-deleted guard lives inside the mutation so it sees the
+      // record actually being overwritten, not the snapshot above (#387).
+      const updated = await mutateWorkspaceRecord(c.env, name, (current) => {
+        if (current.deletedAt) {
+          throw new ConflictError("workspace is already soft-deleted", {
+            code: "already_deleted",
+            details: { deletedAt: current.deletedAt, purgeAt: current.purgeAt },
+          });
+        }
+        return stampSoftDelete(current);
+      });
 
       console.log(
         JSON.stringify({
@@ -524,9 +534,8 @@ export const admin = new Hono<{ Bindings: Env }>()
     // already past) on its next run. Skip if already soft-deleted.
     if (!record.deletedAt) {
       const now = new Date().toISOString();
-      await c.env.REGISTRY.put(
-        `ws:${name}`,
-        JSON.stringify({ ...record, deletedAt: now, purgeAt: now }),
+      await mutateWorkspaceRecord(c.env, name, (current) =>
+        current.deletedAt ? null : { ...current, deletedAt: now, purgeAt: now },
       );
     }
 
@@ -562,20 +571,23 @@ export const admin = new Hono<{ Bindings: Env }>()
     if (!raw || isPurgedTombstone(raw)) {
       throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
     }
-    if (!raw.deletedAt) {
-      throw new ConflictError("workspace is not deleted", { code: "not_deleted" });
-    }
-    if (isPastGrace(raw.purgeAt)) {
-      throw new AppError({
-        type: "conflict",
-        code: "grace_expired",
-        message: "grace period has expired",
-        status: 410,
-      });
-    }
-
-    const rest = stampRestore(raw);
-    await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(rest));
+    // Both guards run against the freshest record inside the mutation (#387):
+    // a restore must not resurrect a workspace whose grace window expired
+    // between this handler's read and its write.
+    await mutateWorkspaceRecord(c.env, name, (current) => {
+      if (!current.deletedAt) {
+        throw new ConflictError("workspace is not deleted", { code: "not_deleted" });
+      }
+      if (isPastGrace(current.purgeAt)) {
+        throw new AppError({
+          type: "conflict",
+          code: "grace_expired",
+          message: "grace period has expired",
+          status: 410,
+        });
+      }
+      return stampRestore(current);
+    });
 
     console.log(JSON.stringify({ event: "workspace_restored", workspace: name }));
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -531,13 +531,11 @@ export const admin = new Hono<{ Bindings: Env }>()
     // Stamp the record non-serving before any destructive step: if teardown
     // crashes partway, the workspace denies access instead of serving a
     // half-wiped state, and the retention sweep finalizes it (purgeAt is
-    // already past) on its next run. Skip if already soft-deleted.
-    if (!record.deletedAt) {
-      const now = new Date().toISOString();
-      await mutateWorkspaceRecord(c.env, name, (current) =>
-        current.deletedAt ? null : { ...current, deletedAt: now, purgeAt: now },
-      );
-    }
+    // already past) on its next run. Already soft-deleted -> nothing to write.
+    const now = new Date().toISOString();
+    await mutateWorkspaceRecord(c.env, name, (current) =>
+      current.deletedAt ? null : { ...current, deletedAt: now, purgeAt: now },
+    );
 
     const result = await teardownWorkspace(c.env, name, record, {
       reason: "admin_hard_delete",

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
+import { fakeRegistry } from "../../test/fake-kv";
 import { SqliteD1 } from "../../test/helpers/sqlite-d1";
 import { createToken } from "../auth-db";
 import { respondError } from "../error-response";
@@ -98,17 +99,13 @@ function stubEnv(opts: EnvOpts = {}): Env {
     return new Response("not found", { status: 404 });
   });
 
-  const puts: [string, string][] = [];
-  const registry = {
-    get: (async (key: string) => {
-      const name = key.startsWith("ws:") ? key.slice(3) : key;
-      return kvRecords[name] ?? null;
-    }) as unknown as KVNamespace["get"],
-    put: (async (key: string, value: string) => {
-      if (putThrows) throw new Error("kv put failed");
-      puts.push([key, value]);
-    }) as unknown as KVNamespace["put"],
-  };
+  const registry = fakeRegistry(kvRecords);
+  const puts = registry.puts;
+  if (putThrows) {
+    registry.put = (async () => {
+      throw new Error("kv put failed");
+    }) as unknown as KVNamespace["put"];
+  }
 
   const wsCreateLimiter =
     wsCreateLimiterAllows === undefined

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -44,6 +44,7 @@ import {
   workspaceGovernanceAuth,
   type GovernanceVars,
 } from "../workspace";
+import { mutateWorkspaceRecord } from "../workspace-mutate";
 
 const HASH_PREFIX_LEN = 8;
 
@@ -285,16 +286,19 @@ workspaces.delete("/:name", sessionAuth, requireSessionUser, async (c) => {
   }
   const user = c.get("sessionUser")!;
 
-  const record = await loadOwnedSelfServeRecord(c, name, user.id);
-  if (record.deletedAt) {
-    throw new ConflictError("workspace is already deleted", {
-      code: "already_deleted",
-      details: { deletedAt: record.deletedAt, purgeAt: record.purgeAt },
-    });
-  }
-
-  const updated = stampSoftDelete(record);
-  await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(updated));
+  // Authorization is settled against the record as read here; the mutable
+  // state check (already-deleted) runs inside the mutation against the
+  // freshest record (issue #387).
+  await loadOwnedSelfServeRecord(c, name, user.id);
+  const updated = await mutateWorkspaceRecord(c.env, name, (current) => {
+    if (current.deletedAt) {
+      throw new ConflictError("workspace is already deleted", {
+        code: "already_deleted",
+        details: { deletedAt: current.deletedAt, purgeAt: current.purgeAt },
+      });
+    }
+    return stampSoftDelete(current);
+  });
 
   console.log(
     JSON.stringify({
@@ -330,21 +334,21 @@ workspaces.post("/:name/restore", sessionAuth, requireSessionUser, async (c) => 
   }
   const user = c.get("sessionUser")!;
 
-  const record = await loadOwnedSelfServeRecord(c, name, user.id);
-  if (!record.deletedAt) {
-    throw new ConflictError("workspace is not deleted", { code: "not_deleted" });
-  }
-  if (isPastGrace(record.purgeAt)) {
-    throw new AppError({
-      type: "conflict",
-      code: "grace_expired",
-      message: "grace period has expired",
-      status: 410,
-    });
-  }
-
-  const rest = stampRestore(record);
-  await c.env.REGISTRY.put(`ws:${name}`, JSON.stringify(rest));
+  await loadOwnedSelfServeRecord(c, name, user.id);
+  await mutateWorkspaceRecord(c.env, name, (current) => {
+    if (!current.deletedAt) {
+      throw new ConflictError("workspace is not deleted", { code: "not_deleted" });
+    }
+    if (isPastGrace(current.purgeAt)) {
+      throw new AppError({
+        type: "conflict",
+        code: "grace_expired",
+        message: "grace period has expired",
+        status: 410,
+      });
+    }
+    return stampRestore(current);
+  });
 
   console.log(
     JSON.stringify({ event: "workspace_restored", workspace: name, actor: "self_serve" }),

--- a/apps/api/src/self-serve-defaults.ts
+++ b/apps/api/src/self-serve-defaults.ts
@@ -24,6 +24,9 @@ export function selfServeWorkspaceRecord(args: {
 }): WorkspaceRecord {
   return {
     name: args.name,
+    // First write of a brand-new record (issue #387); every later mutation
+    // goes through `mutateWorkspaceRecord`, which bumps this.
+    version: 1,
     provider: "r2",
     bucket: "uploads-default",
     binding: "UPLOADS_DEFAULT",

--- a/apps/api/src/workspace-mutate.test.ts
+++ b/apps/api/src/workspace-mutate.test.ts
@@ -1,0 +1,183 @@
+import { AppError } from "@uploads/errors";
+import { describe, expect, it } from "vitest";
+import type { WorkspaceRecord } from "./workspace";
+import {
+  WORKSPACE_MUTATION_ATTEMPTS,
+  mutateWorkspaceRecord,
+  workspaceRecordVersion,
+} from "./workspace-mutate";
+
+const BASE: WorkspaceRecord = { provider: "r2", bucket: "b", binding: "UPLOADS" };
+
+/**
+ * KV fake with a `beforeGet` hook, so a test can simulate another writer's
+ * `put` landing at an exact point in the read-mutate-write cycle.
+ */
+class RacyKv {
+  store = new Map<string, string>();
+  gets = 0;
+  puts = 0;
+  beforeGet: ((gets: number) => void) | undefined;
+
+  constructor(seed: Record<string, unknown> = {}) {
+    for (const [key, value] of Object.entries(seed)) this.store.set(key, JSON.stringify(value));
+  }
+
+  get = async (key: string, opts?: unknown): Promise<unknown> => {
+    this.gets += 1;
+    this.beforeGet?.(this.gets);
+    const raw = this.store.get(key);
+    if (raw === undefined) return null;
+    const json = typeof opts === "object" && opts !== null && "type" in opts;
+    return json || opts === "json" ? JSON.parse(raw) : raw;
+  };
+
+  put = async (key: string, value: string): Promise<void> => {
+    this.puts += 1;
+    this.store.set(key, value);
+  };
+
+  read(name: string): WorkspaceRecord {
+    return JSON.parse(this.store.get(`ws:${name}`)!) as WorkspaceRecord;
+  }
+}
+
+function envFor(kv: RacyKv): Env {
+  return { REGISTRY: kv } as unknown as Env;
+}
+
+describe("workspaceRecordVersion", () => {
+  it("treats a record written before versioning as version 0", () => {
+    expect(workspaceRecordVersion(BASE)).toBe(0);
+    expect(workspaceRecordVersion({ ...BASE, version: 7 })).toBe(7);
+  });
+
+  it("ignores a non-integer version rather than trusting hand-edited JSON", () => {
+    expect(workspaceRecordVersion({ ...BASE, version: 1.5 as number })).toBe(0);
+    expect(workspaceRecordVersion({ ...BASE, version: "3" as unknown as number })).toBe(0);
+  });
+});
+
+describe("mutateWorkspaceRecord", () => {
+  it("reads fresh, applies the mutation, and stamps version 1 on a legacy record", async () => {
+    const kv = new RacyKv({ "ws:acme": BASE });
+    const result = await mutateWorkspaceRecord(envFor(kv), "acme", (record) => ({
+      ...record,
+      maxStorageBytes: 5,
+    }));
+
+    expect(result.maxStorageBytes).toBe(5);
+    expect(result.version).toBe(1);
+    expect(kv.read("acme")).toMatchObject({ maxStorageBytes: 5, version: 1, bucket: "b" });
+  });
+
+  it("increments an existing version", async () => {
+    const kv = new RacyKv({ "ws:acme": { ...BASE, version: 4 } });
+    await mutateWorkspaceRecord(envFor(kv), "acme", (record) => ({ ...record, plan: "pro" }));
+    expect(kv.read("acme").version).toBe(5);
+  });
+
+  it("mutates the freshest record, not a snapshot the caller read earlier", async () => {
+    // The caller's stale view has no plan; another admin set one before the
+    // mutation ran. The mutation must be applied on top of the newer record.
+    const kv = new RacyKv({ "ws:acme": { ...BASE, version: 1, plan: "pro" } });
+    await mutateWorkspaceRecord(envFor(kv), "acme", (record) => ({
+      ...record,
+      maxStorageBytes: 9,
+    }));
+    expect(kv.read("acme")).toMatchObject({ plan: "pro", maxStorageBytes: 9, version: 2 });
+  });
+
+  it("re-applies the mutation when another writer clobbers our put", async () => {
+    const kv = new RacyKv({ "ws:acme": { ...BASE, version: 1 } });
+    // Land a competing write (plan: pro) between our put and the verification
+    // read of the first attempt — the classic lost update.
+    kv.beforeGet = (gets) => {
+      if (gets !== 2) return;
+      kv.store.set("ws:acme", JSON.stringify({ ...BASE, version: 2, plan: "pro" }));
+    };
+
+    const result = await mutateWorkspaceRecord(envFor(kv), "acme", (record) => ({
+      ...record,
+      maxStorageBytes: 3,
+    }));
+
+    // The second attempt reads the competitor's record and layers our change
+    // on top of it: neither update is lost.
+    expect(result).toMatchObject({ plan: "pro", maxStorageBytes: 3, version: 3 });
+    expect(kv.read("acme")).toMatchObject({ plan: "pro", maxStorageBytes: 3, version: 3 });
+    expect(kv.puts).toBe(2);
+  });
+
+  it("409s after the attempt budget when every write keeps losing", async () => {
+    const kv = new RacyKv({ "ws:acme": { ...BASE, version: 1 } });
+    let competing = 100;
+    kv.beforeGet = (gets) => {
+      // Clobber before every verification read (every second get).
+      if (gets % 2 === 0)
+        kv.store.set("ws:acme", JSON.stringify({ ...BASE, version: competing++ }));
+    };
+
+    await expect(
+      mutateWorkspaceRecord(envFor(kv), "acme", (record) => ({ ...record, maxStorageBytes: 3 })),
+    ).rejects.toMatchObject({ status: 409, code: "workspace_record_conflict" });
+    expect(kv.puts).toBe(WORKSPACE_MUTATION_ATTEMPTS);
+  });
+
+  it("skips the write when the mutation returns null", async () => {
+    const kv = new RacyKv({ "ws:acme": { ...BASE, version: 2 } });
+    const result = await mutateWorkspaceRecord(envFor(kv), "acme", () => null);
+    expect(result.version).toBe(2);
+    expect(kv.puts).toBe(0);
+  });
+
+  it("propagates a guard the mutation throws without writing", async () => {
+    const kv = new RacyKv({ "ws:acme": { ...BASE, deletedAt: "2026-01-01T00:00:00.000Z" } });
+    await expect(
+      mutateWorkspaceRecord(envFor(kv), "acme", (record) => {
+        if (record.deletedAt) {
+          throw new AppError({
+            type: "conflict",
+            code: "already_deleted",
+            message: "already deleted",
+            status: 409,
+          });
+        }
+        return record;
+      }),
+    ).rejects.toMatchObject({ code: "already_deleted" });
+    expect(kv.puts).toBe(0);
+  });
+
+  it("404s for an unknown workspace", async () => {
+    const kv = new RacyKv();
+    await expect(
+      mutateWorkspaceRecord(envFor(kv), "ghost", (record) => record),
+    ).rejects.toMatchObject({ status: 404, code: "workspace_not_found" });
+  });
+
+  it("404s for a purged tombstone rather than resurrecting the slug", async () => {
+    const kv = new RacyKv({
+      "ws:gone": { status: "purged", name: "gone", purgedAt: "2026-01-01T00:00:00.000Z" },
+    });
+    await expect(
+      mutateWorkspaceRecord(envFor(kv), "gone", (record) => record),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(kv.puts).toBe(0);
+  });
+
+  it("404s a soft-deleted record only when the caller asks for a serving record", async () => {
+    const kv = new RacyKv({ "ws:acme": { ...BASE, deletedAt: "2026-01-01T00:00:00.000Z" } });
+    await expect(
+      mutateWorkspaceRecord(envFor(kv), "acme", (record) => record, { requireServing: true }),
+    ).rejects.toMatchObject({ status: 404, code: "workspace_not_found" });
+
+    // Without the flag a soft-deleted record is mutable — that's how restore works.
+    const restored = await mutateWorkspaceRecord(
+      envFor(kv),
+      "acme",
+      ({ deletedAt: _, ...rest }) => rest,
+    );
+    expect(restored.deletedAt).toBeUndefined();
+  });
+});

--- a/apps/api/src/workspace-mutate.ts
+++ b/apps/api/src/workspace-mutate.ts
@@ -1,34 +1,20 @@
 /**
- * The single write path for `ws:<name>` workspace records (issue #387).
+ * The single in-worker write path for `ws:<name>` workspace records (#387).
  *
- * Every mutation of a workspace record is a read-modify-write against a KV
- * blob that holds unrelated field groups — budget limits, plan, GitHub-comment
- * settings, tokens, soft-delete stamps. Handlers used to load the record at the
- * top of a request, do slow work (parse the body, validate, hit D1, call the
- * auth worker), then `put` the whole snapshot back. Two concurrent mutations
- * could interleave so the later `put` silently dropped the earlier one's change
- * — an admin's limit edit vanishing because a plan change landed in between.
+ * The record is one KV blob holding unrelated field groups, so every mutation
+ * is a read-modify-write and concurrent ones used to drop each other's changes.
+ * Two mitigations: the read happens here, immediately before the write (slow
+ * per-request work stays outside, shrinking the window to one KV round trip),
+ * and after the `put` the key is read back — if the stored blob isn't the one
+ * we wrote, another writer raced us and the mutation is re-applied on top of
+ * *their* record, surfacing a 409 after `WORKSPACE_MUTATION_ATTEMPTS` losses.
  *
- * Workers KV has no compare-and-swap, so this closes the window rather than
- * eliminating it, in two ways:
- *
- * 1. **The read happens here, immediately before the write.** All the slow
- *    per-request work stays outside, so the vulnerable window shrinks from the
- *    whole handler to one KV round trip. The mutation always sees the freshest
- *    record, so a field group it doesn't touch can't be reverted to a stale value.
- * 2. **Write, verify, retry.** Each record carries a monotonic `version`. After
- *    the `put` we read the key back: if the stored blob isn't the one we just
- *    wrote, another writer raced us, and we re-run the mutation on top of *their*
- *    record instead of leaving our change dropped. After
- *    `WORKSPACE_MUTATION_ATTEMPTS` losses we surface a 409 rather than loop.
- *
- * What remains racy: KV is eventually consistent, so the verification read can
- * in principle return a value that isn't yet globally settled, and two writers
- * can still interleave inside the read-verify window. That is acceptable for
- * this surface — these are admin/owner-initiated, low-concurrency mutations.
- * The durable fix is moving the record to D1 (see issue #387's third option).
+ * KV has no compare-and-swap, so this narrows the lost-update window rather
+ * than closing it. See docs/workspaces.md § "Mutating a workspace record" for
+ * what remains racy and why that's acceptable here; issue #389 tracks the
+ * durable fix (moving the mutable field groups to D1).
  */
-import { AppError, NotFoundError } from "@uploads/errors";
+import { ConflictError, NotFoundError } from "@uploads/errors";
 import { isPurgedTombstone, loadWorkspaceRecordRaw, type WorkspaceRecord } from "./workspace";
 
 /** How many times a mutation is re-applied after losing a write race. */
@@ -42,8 +28,11 @@ export const WORKSPACE_MUTATION_ATTEMPTS = 3;
  * `grace_expired`) belong *inside* the mutation, where they see the record
  * that is actually about to be overwritten.
  *
- * Must be cheap and free of unrelated I/O: it runs inside the window this
- * module exists to keep small, and it may run more than once.
+ * Must be idempotent — a lost write re-runs it — and must not do I/O beyond
+ * what computing the next record needs: it runs inside the window this module
+ * exists to keep small. Deriving a field is fine (the credential re-encrypt
+ * sweep reseals here, deliberately, so it seals the record it is about to
+ * write); fetching unrelated state is not.
  */
 export type WorkspaceMutation = (
   record: WorkspaceRecord,
@@ -67,16 +56,6 @@ export interface MutateWorkspaceOptions {
 export function workspaceRecordVersion(record: WorkspaceRecord): number {
   const { version } = record;
   return typeof version === "number" && Number.isInteger(version) && version >= 0 ? version : 0;
-}
-
-function conflict(name: string): AppError {
-  return new AppError({
-    type: "conflict",
-    code: "workspace_record_conflict",
-    message: "workspace record was modified concurrently; retry",
-    status: 409,
-    details: { workspace: name },
-  });
 }
 
 /**
@@ -121,5 +100,8 @@ export async function mutateWorkspaceRecord(
     );
   }
 
-  throw conflict(name);
+  throw new ConflictError("workspace record was modified concurrently; retry", {
+    code: "workspace_record_conflict",
+    details: { workspace: name },
+  });
 }

--- a/apps/api/src/workspace-mutate.ts
+++ b/apps/api/src/workspace-mutate.ts
@@ -1,0 +1,125 @@
+/**
+ * The single write path for `ws:<name>` workspace records (issue #387).
+ *
+ * Every mutation of a workspace record is a read-modify-write against a KV
+ * blob that holds unrelated field groups — budget limits, plan, GitHub-comment
+ * settings, tokens, soft-delete stamps. Handlers used to load the record at the
+ * top of a request, do slow work (parse the body, validate, hit D1, call the
+ * auth worker), then `put` the whole snapshot back. Two concurrent mutations
+ * could interleave so the later `put` silently dropped the earlier one's change
+ * — an admin's limit edit vanishing because a plan change landed in between.
+ *
+ * Workers KV has no compare-and-swap, so this closes the window rather than
+ * eliminating it, in two ways:
+ *
+ * 1. **The read happens here, immediately before the write.** All the slow
+ *    per-request work stays outside, so the vulnerable window shrinks from the
+ *    whole handler to one KV round trip. The mutation always sees the freshest
+ *    record, so a field group it doesn't touch can't be reverted to a stale value.
+ * 2. **Write, verify, retry.** Each record carries a monotonic `version`. After
+ *    the `put` we read the key back: if the stored blob isn't the one we just
+ *    wrote, another writer raced us, and we re-run the mutation on top of *their*
+ *    record instead of leaving our change dropped. After
+ *    `WORKSPACE_MUTATION_ATTEMPTS` losses we surface a 409 rather than loop.
+ *
+ * What remains racy: KV is eventually consistent, so the verification read can
+ * in principle return a value that isn't yet globally settled, and two writers
+ * can still interleave inside the read-verify window. That is acceptable for
+ * this surface — these are admin/owner-initiated, low-concurrency mutations.
+ * The durable fix is moving the record to D1 (see issue #387's third option).
+ */
+import { AppError, NotFoundError } from "@uploads/errors";
+import { isPurgedTombstone, loadWorkspaceRecordRaw, type WorkspaceRecord } from "./workspace";
+
+/** How many times a mutation is re-applied after losing a write race. */
+export const WORKSPACE_MUTATION_ATTEMPTS = 3;
+
+/**
+ * Applied to the freshest record. Return the record to store, or `null` to
+ * skip the write entirely (a no-op patch, or a sweep that found nothing to
+ * change — no version bump, no wasted KV write). Throwing propagates to the
+ * caller untouched, so state-dependent guards (409 `already_deleted`, 410
+ * `grace_expired`) belong *inside* the mutation, where they see the record
+ * that is actually about to be overwritten.
+ *
+ * Must be cheap and free of unrelated I/O: it runs inside the window this
+ * module exists to keep small, and it may run more than once.
+ */
+export type WorkspaceMutation = (
+  record: WorkspaceRecord,
+) => WorkspaceRecord | null | Promise<WorkspaceRecord | null>;
+
+export interface MutateWorkspaceOptions {
+  /**
+   * Reject soft-deleted records (`deletedAt`) with the same 404 as an unknown
+   * workspace. Set for edits that only make sense on a serving workspace (an
+   * admin can't tune limits on a workspace that no longer serves); leave off
+   * for the delete/restore paths, which mutate exactly those records.
+   */
+  requireServing?: boolean;
+}
+
+/**
+ * A record's optimistic-concurrency counter. Records written before versioning
+ * (and any hand-edited blob with a non-integer `version`) count as 0, so the
+ * first write through this module stamps 1 — no backfill needed.
+ */
+export function workspaceRecordVersion(record: WorkspaceRecord): number {
+  const { version } = record;
+  return typeof version === "number" && Number.isInteger(version) && version >= 0 ? version : 0;
+}
+
+function conflict(name: string): AppError {
+  return new AppError({
+    type: "conflict",
+    code: "workspace_record_conflict",
+    message: "workspace record was modified concurrently; retry",
+    status: 409,
+    details: { workspace: name },
+  });
+}
+
+/**
+ * Read-modify-write `ws:<name>` with the concurrency handling described above.
+ * Returns the stored record (including its new `version`), or the unchanged
+ * record when the mutation returned `null`.
+ */
+export async function mutateWorkspaceRecord(
+  env: Env,
+  name: string,
+  mutate: WorkspaceMutation,
+  opts: MutateWorkspaceOptions = {},
+): Promise<WorkspaceRecord> {
+  const key = `ws:${name}`;
+
+  for (let attempt = 1; attempt <= WORKSPACE_MUTATION_ATTEMPTS; attempt++) {
+    const current = await loadWorkspaceRecordRaw(env, name);
+    if (!current || isPurgedTombstone(current) || (opts.requireServing && current.deletedAt)) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    const mutated = await mutate(current);
+    if (mutated === null) return current;
+
+    const next: WorkspaceRecord = { ...mutated, version: workspaceRecordVersion(current) + 1 };
+    const serialized = JSON.stringify(next);
+    await env.REGISTRY.put(key, serialized);
+
+    // Byte-compare rather than compare versions: two racing writers can land on
+    // the same next version, and only the exact blob proves ours is the one
+    // that stuck.
+    const stored = await env.REGISTRY.get(key, "text");
+    if (stored === serialized) return next;
+
+    console.log(
+      JSON.stringify({
+        event: "workspace_record_write_lost",
+        workspace: name,
+        attempt,
+        attempts: WORKSPACE_MUTATION_ATTEMPTS,
+      }),
+    );
+  }
+
+  throw conflict(name);
+}

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -24,6 +24,14 @@ export interface WorkspaceRecord {
    * records built outside the loaders.
    */
   name?: string;
+  /**
+   * Optimistic-concurrency counter, bumped on every write through
+   * `mutateWorkspaceRecord` (issue #387). Absent on records last written
+   * before versioning — treated as 0, never backfilled. Nothing reads it for
+   * behavior; it exists so a write can tell whether the blob it just stored is
+   * still the one in KV. See `workspace-mutate.ts`.
+   */
+  version?: number;
   provider: StorageProvider;
   bucket: string;
   /** Name of an R2 binding declared in wrangler.jsonc (e.g. "UPLOADS"). When set, I/O uses the binding. */

--- a/apps/api/test/fake-kv.ts
+++ b/apps/api/test/fake-kv.ts
@@ -2,10 +2,10 @@
 export class FakeKv {
   store = new Map<string, { value: string; expirationTtl?: number }>();
 
-  async get(key: string, type?: "text" | "json"): Promise<unknown> {
+  async get(key: string, type?: KvReadType): Promise<unknown> {
     const entry = this.store.get(key);
     if (!entry) return null;
-    return type === "json" ? JSON.parse(entry.value) : entry.value;
+    return wantsJson(type) ? JSON.parse(entry.value) : entry.value;
   }
 
   async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
@@ -15,4 +15,75 @@ export class FakeKv {
   async delete(key: string): Promise<void> {
     this.store.delete(key);
   }
+}
+
+type KvReadType = "text" | "json" | { type?: "text" | "json" } | undefined;
+
+/**
+ * True when a KV read asked for parsed JSON, in either of the two shapes
+ * Workers KV accepts (`get(key, "json")` and `get(key, { type: "json" })`).
+ * A fake that ignores this and always parses is what makes a text read look
+ * like an object — see `fakeRegistry` below.
+ */
+function wantsJson(type: KvReadType): boolean {
+  if (typeof type === "string") return type === "json";
+  return type?.type === "json";
+}
+
+export interface FakeRegistry {
+  get: KVNamespace["get"];
+  put: KVNamespace["put"];
+  delete: KVNamespace["delete"];
+  list: KVNamespace["list"];
+  /** Raw stored blobs, keyed exactly as written (`ws:<name>`). */
+  store: Map<string, string>;
+  /** Every `put`, in order — for tests asserting on what was written. */
+  puts: [string, string][];
+  /** The parsed record stored under `ws:<name>`, or undefined. */
+  record<T = Record<string, unknown>>(name: string): T | undefined;
+}
+
+/**
+ * REGISTRY fake for the workspace-record write path. Unlike the ad-hoc fakes
+ * it replaces, it stores serialized strings and honors the read type, because
+ * `mutateWorkspaceRecord` (issue #387) verifies a write by reading the key
+ * back as text and comparing bytes — against a fake that always returns parsed
+ * JSON, every write would look like it lost a race.
+ *
+ * Seed with plain objects keyed by workspace name; `ws:` is prepended.
+ */
+export function fakeRegistry(records: Record<string, unknown> = {}): FakeRegistry {
+  const store = new Map<string, string>();
+  for (const [name, record] of Object.entries(records)) {
+    store.set(name.startsWith("ws:") ? name : `ws:${name}`, JSON.stringify(record));
+  }
+  const puts: [string, string][] = [];
+
+  return {
+    store,
+    puts,
+    record<T = Record<string, unknown>>(name: string): T | undefined {
+      const raw = store.get(name.startsWith("ws:") ? name : `ws:${name}`);
+      return raw === undefined ? undefined : (JSON.parse(raw) as T);
+    },
+    get: (async (key: string, type?: KvReadType) => {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return wantsJson(type) ? JSON.parse(raw) : raw;
+    }) as unknown as KVNamespace["get"],
+    put: (async (key: string, value: string) => {
+      puts.push([key, value]);
+      store.set(key, value);
+    }) as unknown as KVNamespace["put"],
+    delete: (async (key: string) => {
+      store.delete(key);
+    }) as unknown as KVNamespace["delete"],
+    list: (async (opts?: { prefix?: string }) => ({
+      keys: [...store.keys()]
+        .filter((key) => !opts?.prefix || key.startsWith(opts.prefix))
+        .map((name) => ({ name })),
+      list_complete: true as const,
+      cacheStatus: null,
+    })) as unknown as KVNamespace["list"],
+  };
 }

--- a/apps/api/test/reencrypt-registry.test.ts
+++ b/apps/api/test/reencrypt-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { fakeRegistry } from "./fake-kv";
 import { encryptSecret } from "../src/secrets";
 import { reencryptRegistryCredentials } from "../src/reencrypt-registry";
 import type { WorkspaceRecord } from "../src/workspace";
@@ -10,47 +11,25 @@ describe("reencryptRegistryCredentials", () => {
   it("rewrites credentials sealed with the previous key", async () => {
     const sealedAk = await encryptSecret(PREVIOUS, "AKIA");
     const sealedSk = await encryptSecret(PREVIOUS, "secret");
-    const store = new Map<string, string>([
-      [
-        "ws:byo",
-        JSON.stringify({
-          provider: "r2",
-          bucket: "other",
-          accessKeyId: sealedAk,
-          secretAccessKey: sealedSk,
-        } satisfies WorkspaceRecord),
-      ],
-      [
-        "ws:shared",
-        JSON.stringify({
-          provider: "r2",
-          bucket: "uploads-default",
-          prefix: "shared/",
-        } satisfies WorkspaceRecord),
-      ],
-    ]);
+    const registry = fakeRegistry({
+      byo: {
+        provider: "r2",
+        bucket: "other",
+        accessKeyId: sealedAk,
+        secretAccessKey: sealedSk,
+      } satisfies WorkspaceRecord,
+      shared: {
+        provider: "r2",
+        bucket: "uploads-default",
+        prefix: "shared/",
+      } satisfies WorkspaceRecord,
+    });
+    const store = registry.store;
 
     const env = {
       WORKSPACE_SECRETS_KEY: CURRENT,
       WORKSPACE_SECRETS_KEY_PREVIOUS: PREVIOUS,
-      REGISTRY: {
-        list: async () => ({
-          keys: [...store.keys()].map((name) => ({ name })),
-          list_complete: true as const,
-          cursor: undefined,
-        }),
-        // Honors the read type the way Workers KV does — mutateWorkspaceRecord
-        // verifies its write by reading the key back as text (issue #387).
-        get: async (key: string, type?: "text" | "json" | { type?: string }) => {
-          const raw = store.get(key);
-          if (raw === undefined) return null;
-          const json = typeof type === "string" ? type === "json" : type?.type === "json";
-          return json ? (JSON.parse(raw) as WorkspaceRecord) : raw;
-        },
-        put: async (key: string, value: string) => {
-          store.set(key, value);
-        },
-      },
+      REGISTRY: registry,
     } as unknown as Env;
 
     const dry = await reencryptRegistryCredentials(env, { dryRun: true });

--- a/apps/api/test/reencrypt-registry.test.ts
+++ b/apps/api/test/reencrypt-registry.test.ts
@@ -39,9 +39,13 @@ describe("reencryptRegistryCredentials", () => {
           list_complete: true as const,
           cursor: undefined,
         }),
-        get: async (key: string) => {
+        // Honors the read type the way Workers KV does — mutateWorkspaceRecord
+        // verifies its write by reading the key back as text (issue #387).
+        get: async (key: string, type?: "text" | "json" | { type?: string }) => {
           const raw = store.get(key);
-          return raw ? (JSON.parse(raw) as WorkspaceRecord) : null;
+          if (raw === undefined) return null;
+          const json = typeof type === "string" ? type === "json" : type?.type === "json";
+          return json ? (JSON.parse(raw) as WorkspaceRecord) : raw;
         },
         put: async (key: string, value: string) => {
           store.set(key, value);

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -8,6 +8,25 @@ SHA-256 hashes and metadata for the workspace's tokens (raw tokens are never sto
 
 Nothing in the code treats any workspace as special.
 
+## Mutating a workspace record
+
+The record is one KV blob holding unrelated field groups (limits, plan,
+GitHub-comment settings, tokens, soft-delete stamps), so every writer is a
+read-modify-write of the whole snapshot. **Never `REGISTRY.put("ws:<name>", …)`
+directly** — go through `mutateWorkspaceRecord` in
+`apps/api/src/workspace-mutate.ts`, which reads the freshest record immediately
+before writing, stamps a monotonic `version`, and re-applies the mutation if
+another writer's `put` landed in between (issue #387). Guards that depend on
+mutable state (already-deleted, grace-expired) belong inside the mutation
+callback, not in the handler above it, so they judge the record actually being
+overwritten.
+
+Workers KV has no compare-and-swap, so this narrows the lost-update window
+rather than eliminating it — acceptable for these admin/owner-initiated,
+low-concurrency edits. The exceptions are writes that replace the record
+outright rather than mutating it: self-serve creation (`selfServeWorkspaceRecord`,
+which stamps `version: 1`) and the purged tombstone written by teardown.
+
 ## Usage accounting and budgets
 
 D1 table `workspace_usage` tracks net `bytes` / `objects` and monthly

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -23,7 +23,17 @@ overwritten.
 
 Workers KV has no compare-and-swap, so this narrows the lost-update window
 rather than eliminating it — acceptable for these admin/owner-initiated,
-low-concurrency edits. The exceptions are writes that replace the record
+low-concurrency edits. Issue #389 tracks the durable fix (moving the mutable
+field groups to D1, where transactions exist).
+
+Two caveats on the guarantee. A write landing between our read and our put is
+still lost; the retry only recovers a competitor whose put landed between our
+put and our verification read. And the guarantee covers the **worker only** —
+`pnpm workspace:limits` and `pnpm workspace:add` do their own
+`wrangler kv get` → splice → `wrangler kv put` out of process, so an operator
+running a script while someone edits the same workspace in the admin UI can
+still clobber it, unversioned and unretried. Prefer the admin UI (or the
+`/admin-ui/workspaces/:name/limits` endpoint) for edits to a live workspace. The exceptions are writes that replace the record
 outright rather than mutating it: self-serve creation (`selfServeWorkspaceRecord`,
 which stamps `version: 1`) and the purged tombstone written by teardown.
 


### PR DESCRIPTION
Closes #387.

## The problem

`ws:<name>` is one KV blob holding unrelated field groups — budget limits, plan, GitHub-comment settings, tokens, soft-delete stamps. Every mutation was a read-modify-write of the whole snapshot, and handlers loaded the record at the *top* of the request, did slow work (parse the body, validate, hit D1, call the auth worker), then put it back. Two concurrent mutations could interleave so the later put silently dropped the earlier one's change — an admin's limit edit vanishing because a plan change landed in between.

The issue scoped this to the three admin-ui routes. It's actually nine sites: token revoke, admin and self-serve delete/restore, the pre-teardown stamp, and the credential re-encrypt sweep all do the same thing. A guard on only three of them would be defeated by the other six.

## The fix

New `apps/api/src/workspace-mutate.ts` is the single in-worker write path:

1. **The read moved inside the helper**, immediately before the write. Body parsing, validation, auth and D1 round-trips all happen first, so the vulnerable window shrinks from the whole handler to one KV round trip.
2. **Write → verify → retry.** Each record carries a monotonic `version`; after the put the key is read back and byte-compared. If another writer raced us, the mutation is re-applied on top of *their* record rather than dropped. Three losses → 409 `workspace_record_conflict`.

Byte-compare rather than version-compare because two racing writers can land on the same next version — only the exact blob proves ours stuck.

State-dependent guards (`already_deleted`, `grace_expired`) moved inside the mutation callback so they judge the record actually being overwritten, not a snapshot from the top of the handler. That closes a smaller race of its own: a restore could previously resurrect a workspace whose grace window expired mid-request.

Creation and the purged tombstone *replace* rather than mutate, so they stay direct writes; new self-serve records start at `version: 1`.

## What this does not fix

Stated plainly because the guarantee is easy to overstate, and `docs/workspaces.md` now says the same:

- **A write landing between our read and our put is still lost.** The retry only recovers a competitor whose put landed between our put and our verification read. KV has no compare-and-swap; this narrows the window, it doesn't close it.
- **KV is eventually consistent**, so the verification read can in principle return a value that isn't yet globally settled.
- **Operator scripts bypass the helper entirely.** `pnpm workspace:limits` and `pnpm workspace:add` do their own `wrangler kv get` → splice → `wrangler kv put` out of process. An operator running a script while someone edits the same workspace in the admin UI can still clobber it, unversioned and unretried.

#389 tracks the durable fix: move the mutable field groups to D1, where transactions exist.

## Review notes

- **`version` is observability, not mechanism.** The byte-compare alone would detect a lost write; the counter doesn't add discriminating power. It's kept as an ops signal and as the natural hook for the D1 migration in #389 — but it's a fair thing to argue should go.
- **Handler-level double reads are deliberate.** Delete/restore read once for the ownership check and again inside the mutation (3 GETs + 1 PUT per request, up from 1 + 1). The auth decision has to precede the mutation, and the mutation needs its own fresh read. These are workspace-lifecycle actions, not a hot path.
- **The re-encrypt sweep passes an async callback** that does crypto inside the retry loop, which bends the module's "keep it cheap" contract. It's intentional — the sweep must seal the record it's about to write — and the second commit halves the cost by removing a duplicate reseal. The contract comment was corrected to match.

## Verification

- 2324 tests pass; typecheck and lint clean.
- 12 unit tests on the helper, plus a route-level test in `admin-ui.test.ts` that lands a competing plan change between the put and the verification read. I confirmed it's discriminating — stubbing out the verification makes it fail.
- Four ad-hoc KV test fakes returned parsed JSON for a *text* read, which made every write look lost. Replaced with a shared `fakeRegistry` that honors the read type.

No user-visible CLI/client change, so no changeset.

## Commits

1. `fix(api)` — the helper and the nine call sites.
2. `refactor(api)` — cleanup pass: shared `ConflictError`, half the crypto in the re-encrypt sweep, a redundant guard dropped, doc rationale consolidated into `docs/workspaces.md`.
