### PR TITLE
feat(mcp): hosted put PR/issue targeting + managed comment sync

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,8 @@
     "./galleries": "./src/galleries.ts",
     "./gallery-service": "./src/gallery-service.ts",
     "./external-references": "./src/external-references.ts",
-    "./uploader-identity": "./src/uploader-identity.ts"
+    "./uploader-identity": "./src/uploader-identity.ts",
+    "./github-comment-service": "./src/github-comment-service.ts"
   },
   "scripts": {
     "dev": "wrangler dev",

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared service behind `POST /v1/:workspace/github/comment` (phase 2 PR B)
+ * and the hosted MCP `put`/`comment` tools (issue #392). Workspace-authed
+ * callers only — renders the calling workspace's own attachments + galleries
+ * for a PR/issue and, when the App is installed with write, upserts the
+ * managed comment as the bot. Never throws on an integration failure — a
+ * bot-post problem returns `{ posted: false, reason }` so callers can fall
+ * back (the CLI to its local-gh path; the hosted MCP surfaces the decline).
+ */
+import { gatherCommentBody, upsertBotComment } from "./github-comment";
+import { githubAppConfig, installationForRepo } from "./github-app";
+import { isEntitledToClaimRepo } from "./github-claim-authz";
+import { findRepoLinkStrict, recordRepoLink } from "./github-repo-links";
+import type { GhTarget } from "./github-comment-render";
+import type { WorkspaceRecord } from "./workspace";
+
+/**
+ * Cross-tenant authorization gate (issue #297). The App is installed
+ * org-wide, so every workspace's token can resolve an installation for *any*
+ * org's repo — without this check, workspace A could post/deface
+ * `uploads-sh[bot]` comments on workspace B's repo using A's own uploaded
+ * images under a crafted `gh/<B's org>/...` key prefix, simply by being the
+ * first to call this endpoint for that repo (the implicit-claim call below
+ * has no entitlement check of its own).
+ *
+ * Uses the strict lookup (`findRepoLinkStrict`) deliberately: a D1 failure
+ * here must propagate (5xx via the app's error handler) rather than degrade
+ * to "unbound", which would silently allow posting during an outage.
+ *
+ * - Bound to this workspace → `null` (allowed).
+ * - Bound to a different workspace → decline; never re-checked against
+ *   entitlement (grandfathered — a legitimately-bound repo keeps working even
+ *   if the binder's GitHub link later changes or lapses).
+ * - Unbound → gated by `isEntitledToClaimRepo` (github-claim-authz.ts): only a
+ *   caller whose linked GitHub identity has push/maintain/admin access to
+ *   `repo` may make the first claim. This is also what closes the communal
+ *   `default` workspace's exposure — its tokens have no minting user, so they
+ *   can never claim a new repo (though they can still act on repos already
+ *   bound to `default`).
+ */
+async function checkRepoAuthorization(
+  env: Env,
+  repo: string,
+  workspaceName: string,
+  mintingUserId: string | null,
+  installId: number,
+): Promise<{ posted: false; reason: "not_authorized"; message: string } | null> {
+  const link = await findRepoLinkStrict(env.DB, repo);
+  if (link) {
+    if (link.workspaceName === workspaceName) return null;
+    return {
+      posted: false,
+      reason: "not_authorized",
+      message:
+        `${repo} is bound to a different workspace ("${link.workspaceName}") — this ` +
+        `workspace is not authorized to post the uploads-sh[bot] comment there.`,
+    };
+  }
+  const entitled = await isEntitledToClaimRepo(env, repo, mintingUserId, fetch, installId);
+  if (!entitled) {
+    return {
+      posted: false,
+      reason: "not_authorized",
+      message:
+        `${repo} isn't linked to any workspace yet, and this workspace couldn't be ` +
+        `verified as entitled to claim it. Link a GitHub account with push access ` +
+        `to ${repo}, or ask an operator to bind the repo explicitly.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Actionable body for a `forbidden` (App installed, write not yet approved)
+ * decline. `fixUrl` is the org install's permission-review page — this product
+ * installs on orgs, so the org form is the right target; the message stands on
+ * its own if an install is ever user-owned.
+ */
+function forbiddenDecline(repo: string, installId: number) {
+  const owner = repo.split("/")[0];
+  return {
+    posted: false as const,
+    reason: "forbidden" as const,
+    message:
+      `The uploads.sh GitHub App is installed on ${repo} but needs Issues and ` +
+      `Pull requests write access approved before it can comment as ` +
+      `uploads-sh[bot]. An org admin must approve the updated permissions.`,
+    fixUrl: `https://github.com/organizations/${owner}/settings/installations/${installId}/permissions/update`,
+    required: ["issues:write", "pull_requests:write"],
+  };
+}
+
+export type PostCommentResult =
+  | { posted: false; reason: "app_unconfigured" }
+  | { posted: false; reason: "not_installed" }
+  | { posted: false; reason: "not_authorized"; message: string }
+  | { posted: false; reason: "unavailable" }
+  | {
+      posted: false;
+      reason: "forbidden";
+      message: string;
+      fixUrl: string;
+      required: string[];
+    }
+  | { posted: true; action: "skipped"; count: 0 }
+  | { posted: true; action: "created" | "updated"; count: number; commentUrl: string };
+
+/**
+ * Gather + upsert the managed comment for `target` on behalf of
+ * `workspaceName`. Same ordering as the REST route: app-config, then
+ * installation lookup, then the cross-tenant gate, then gather (skip-on-zero),
+ * then upsert. On an actual post, best-effort records `target.repo` as bound
+ * to `workspaceName` (first-claim-wins, never affects the return value).
+ */
+export async function postManagedComment(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  mintingUserId: string | null,
+  target: GhTarget,
+): Promise<PostCommentResult> {
+  const cfg = githubAppConfig(env);
+  if (!cfg) return { posted: false, reason: "app_unconfigured" };
+  const installId = await installationForRepo(env, cfg, target.repo);
+  if (installId === null) return { posted: false, reason: "not_installed" };
+
+  const decline = await checkRepoAuthorization(
+    env,
+    target.repo,
+    workspaceName,
+    mintingUserId,
+    installId,
+  );
+  if (decline) return decline;
+
+  const gathered = await gatherCommentBody(env, ws, workspaceName, target);
+  if (gathered.skip) return { posted: true, action: "skipped", count: 0 };
+
+  const result = await upsertBotComment(env, cfg, installId, target, gathered.body, workspaceName);
+  if ("degrade" in result) {
+    // A 403 means the App is installed but lacks Issues/PR write (pending org
+    // approval). Enrich that one reason with actionable guidance so callers
+    // can tell the user instead of silently falling back. Mirrors the
+    // IntegrationAuthorizationError vocabulary (@uploads/errors) for the soft,
+    // never-throwing decline path.
+    if (result.degrade === "forbidden") return forbiddenDecline(target.repo, installId);
+    return { posted: false, reason: result.degrade };
+  }
+
+  // Implicit claim (phase 3): the comment actually posted, so this
+  // workspace has proven authenticated write access to this repo's
+  // PR/issue thread — best-effort record it as the repo's bound workspace.
+  // First-claim-wins (recordRepoLink) and never affects this response.
+  await recordRepoLink(env.DB, target.repo, workspaceName, "comment", installId);
+
+  return {
+    posted: true,
+    action: result.action,
+    count: gathered.count,
+    commentUrl: result.commentUrl,
+  };
+}

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -4,13 +4,14 @@
  * the App is installed with write, upserts the managed comment as the bot.
  * Never 5xxs on an integration failure — a bot-post problem returns
  * { posted: false, reason } so the CLI falls back to its local-gh path.
+ *
+ * The actual gather/check/upsert logic lives in `../github-comment-service`
+ * (`postManagedComment`), shared with the hosted MCP server's `put`/`comment`
+ * tools (issue #392) — this route is just the HTTP wrapper.
  */
 import { ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
-import { gatherCommentBody, upsertBotComment } from "../github-comment";
-import { githubAppConfig, installationForRepo } from "../github-app";
-import { isEntitledToClaimRepo } from "../github-claim-authz";
-import { findRepoLinkStrict, recordRepoLink } from "../github-repo-links";
+import { postManagedComment } from "../github-comment-service";
 import type { GhTargetKind } from "../github-comment-render";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
@@ -39,147 +40,19 @@ function parseTarget(body: Record<string, unknown>): {
   return { repo, num, kind };
 }
 
-/**
- * Cross-tenant authorization gate (issue #297). The App is installed
- * org-wide, so every workspace's token can resolve an installation for *any*
- * org's repo — without this check, workspace A could post/deface
- * `uploads-sh[bot]` comments on workspace B's repo using A's own uploaded
- * images under a crafted `gh/<B's org>/...` key prefix, simply by being the
- * first to call this endpoint for that repo (the implicit-claim call below
- * has no entitlement check of its own).
- *
- * Uses the strict lookup (`findRepoLinkStrict`) deliberately: a D1 failure
- * here must propagate (5xx via the app's error handler) rather than degrade
- * to "unbound", which would silently allow posting during an outage.
- *
- * - Bound to this workspace → `null` (allowed).
- * - Bound to a different workspace → decline; never re-checked against
- *   entitlement (grandfathered — a legitimately-bound repo keeps working even
- *   if the binder's GitHub link later changes or lapses).
- * - Unbound → gated by `isEntitledToClaimRepo` (github-claim-authz.ts): only a
- *   caller whose linked GitHub identity has push/maintain/admin access to
- *   `repo` may make the first claim. This is also what closes the communal
- *   `default` workspace's exposure — its tokens have no minting user, so they
- *   can never claim a new repo (though they can still act on repos already
- *   bound to `default`).
- */
-async function checkRepoAuthorization(
-  env: Env,
-  repo: string,
-  workspaceName: string,
-  mintingUserId: string | null,
-  installId: number,
-): Promise<{ posted: false; reason: "not_authorized"; message: string } | null> {
-  const link = await findRepoLinkStrict(env.DB, repo);
-  if (link) {
-    if (link.workspaceName === workspaceName) return null;
-    return {
-      posted: false,
-      reason: "not_authorized",
-      message:
-        `${repo} is bound to a different workspace ("${link.workspaceName}") — this ` +
-        `workspace is not authorized to post the uploads-sh[bot] comment there.`,
-    };
-  }
-  const entitled = await isEntitledToClaimRepo(env, repo, mintingUserId, fetch, installId);
-  if (!entitled) {
-    return {
-      posted: false,
-      reason: "not_authorized",
-      message:
-        `${repo} isn't linked to any workspace yet, and this workspace couldn't be ` +
-        `verified as entitled to claim it. Link a GitHub account with push access ` +
-        `to ${repo}, or ask an operator to bind the repo explicitly.`,
-    };
-  }
-  return null;
-}
-
-/**
- * Actionable body for a `forbidden` (App installed, write not yet approved)
- * decline. `fixUrl` is the org install's permission-review page — this product
- * installs on orgs, so the org form is the right target; the message stands on
- * its own if an install is ever user-owned.
- */
-function forbiddenDecline(repo: string, installId: number) {
-  const owner = repo.split("/")[0];
-  return {
-    posted: false as const,
-    reason: "forbidden" as const,
-    message:
-      `The uploads.sh GitHub App is installed on ${repo} but needs Issues and ` +
-      `Pull requests write access approved before it can comment as ` +
-      `uploads-sh[bot]. An org admin must approve the updated permissions.`,
-    fixUrl: `https://github.com/organizations/${owner}/settings/installations/${installId}/permissions/update`,
-    required: ["issues:write", "pull_requests:write"],
-  };
-}
-
 export const githubComment = new Hono<WorkspaceVars>().post(
   "/comment",
   writeRateLimit,
   requireScope("files:read"),
   async (c) => {
     const target = parseTarget(await jsonBody(c));
-    const workspaceName = c.get("workspaceName");
-
-    // App-configuration/installation checks come before the cross-tenant
-    // gate: they're unconditionally true facts about `target.repo` (not
-    // gated on who's asking), and surfacing them first keeps the more
-    // specific `not_installed`/`app_unconfigured` reasons from being masked
-    // by a generic `not_authorized` when a repo is simply not reachable yet
-    // by any workspace.
-    const cfg = githubAppConfig(c.env);
-    if (!cfg) return c.json({ posted: false, reason: "app_unconfigured" });
-    const installId = await installationForRepo(c.env, cfg, target.repo);
-    if (installId === null) return c.json({ posted: false, reason: "not_installed" });
-
-    const decline = await checkRepoAuthorization(
-      c.env,
-      target.repo,
-      workspaceName,
-      c.get("mintingUserId"),
-      installId,
-    );
-    if (decline) return c.json(decline);
-
-    const gathered = await gatherCommentBody(
+    const result = await postManagedComment(
       c.env,
       c.get("workspace"),
       c.get("workspaceName"),
+      c.get("mintingUserId"),
       target,
     );
-    if (gathered.skip) return c.json({ posted: true, action: "skipped", count: 0 });
-
-    const result = await upsertBotComment(
-      c.env,
-      cfg,
-      installId,
-      target,
-      gathered.body,
-      c.get("workspaceName"),
-    );
-    if ("degrade" in result) {
-      // A 403 means the App is installed but lacks Issues/PR write (pending org
-      // approval). Enrich that one reason with actionable guidance so the CLI
-      // can tell the user instead of silently falling back to gh. Mirrors the
-      // IntegrationAuthorizationError vocabulary (@uploads/errors) for the soft,
-      // never-5xx decline path.
-      if (result.degrade === "forbidden") return c.json(forbiddenDecline(target.repo, installId));
-      return c.json({ posted: false, reason: result.degrade });
-    }
-
-    // Implicit claim (phase 3): the comment actually posted, so this
-    // workspace has proven authenticated write access to this repo's
-    // PR/issue thread — best-effort record it as the repo's bound workspace.
-    // First-claim-wins (recordRepoLink) and never affects this response.
-    await recordRepoLink(c.env.DB, target.repo, c.get("workspaceName"), "comment", installId);
-
-    return c.json({
-      posted: true,
-      action: result.action,
-      count: gathered.count,
-      commentUrl: result.commentUrl,
-    });
+    return c.json(result);
   },
 );

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -563,6 +563,13 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         const target = ghTargetFromArgs(args);
         const wantComment = optBool(args, "comment");
         if (wantComment && !target) usage("comment requires pr or issue");
+        // The comment path's gather reads the workspace's own objects,
+        // metadata, and galleries (github-comment-service.ts's
+        // gatherCommentBody) — the same reason the REST route requires
+        // files:read. Checked up front, alongside the other argument
+        // validation, so a files:write-only token is rejected before any
+        // bytes are written — never after a successful upload.
+        if (wantComment) requireScope("files:read");
 
         const explicitKey = optString(args, "key");
         const prefix = optString(args, "prefix");

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -5,7 +5,13 @@
  * becomes an isError tool result rather than a JSON-RPC error. Tools needing
  * a filesystem or the gh CLI (attach, comment, doctor) stay stdio-only.
  */
-import { buildMarkdown, buildScreenshotKey } from "@buildinternet/uploads";
+import {
+  buildMarkdown,
+  buildScreenshotKey,
+  ghAttachmentKey,
+  ghMetadataFromTarget,
+  type GhTarget,
+} from "@buildinternet/uploads";
 import {
   appProp,
   METADATA_DESCRIPTION,
@@ -25,6 +31,7 @@ import {
 } from "@buildinternet/uploads/mcp";
 import { AppError, NotFoundError } from "@uploads/errors";
 import { badKey } from "@uploads/api/files";
+import { postManagedComment, type PostCommentResult } from "@uploads/api/github-comment-service";
 import {
   findObjectsByMetadata,
   getFileMetadata,
@@ -131,6 +138,34 @@ function optPutFileItems(args: Record<string, unknown>): PutFileItem[] | undefin
   });
 }
 
+// Same owner/name grammar as the REST route's parseTarget (routes/github-comment.ts,
+// now apps/api/src/github-comment-service.ts's caller) — `repo` is interpolated into
+// a server-side api.github.com path via postManagedComment, so a dot-only segment
+// ("..") must be rejected here too, not just the simpler public-files grammar.
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const DOTS_ONLY_RE = /^\.+$/;
+
+function validRepoGrammar(repo: string): boolean {
+  return REPO_RE.test(repo) && !repo.split("/").some((seg) => DOTS_ONLY_RE.test(seg));
+}
+
+/**
+ * Reads `pr`/`issue` (+ `repo`) into a `GhTarget`; undefined when neither is
+ * present. Unlike the stdio tool, `repo` is REQUIRED with a target — there is
+ * no git context on this server to infer it from (deliberate divergence,
+ * documented on the arg itself).
+ */
+function ghTargetFromArgs(args: Record<string, unknown>): GhTarget | undefined {
+  const pr = optPosInt(args, "pr");
+  const issue = optPosInt(args, "issue");
+  if (pr === undefined && issue === undefined) return undefined;
+  if (pr !== undefined && issue !== undefined) usage("pr and issue are mutually exclusive");
+  const repo = optString(args, "repo");
+  if (!repo) usage("repo is required with pr/issue (no git context on the hosted server)");
+  if (!validRepoGrammar(repo)) usage("repo must be owner/name");
+  return { repo, kind: pr !== undefined ? "pull" : "issues", num: (pr ?? issue) as number };
+}
+
 /** Per-item failure detail, same shape as the CLI/stdio `failures[]` entries. */
 function errorDetail(err: unknown): {
   message: string;
@@ -155,6 +190,31 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     // Mirrors the REST API's writeRateLimit middleware (guards.ts): plain
     // Error, not usage() — over-budget is not a caller mistake.
     if (!(await allowWrite(env, workspaceName))) throw new Error("rate limit exceeded");
+  }
+
+  /**
+   * Best-effort managed-comment sync after a successful `put` (issue #392),
+   * reusing the REST route's in-process service. A comment failure — a
+   * decline (not_installed/not_authorized/forbidden/...) is NOT a failure,
+   * it's returned honestly in `comment` — never fails the tool call; a throw
+   * (e.g. an unexpected GitHub API error) is caught into `commentError`, same
+   * shape as the stdio tools' `syncComment`.
+   */
+  async function attachComment(
+    target: GhTarget,
+  ): Promise<{ comment?: PostCommentResult; commentError?: string }> {
+    try {
+      const comment = await postManagedComment(
+        env,
+        workspace,
+        workspaceName,
+        ctx.mintingUserId,
+        target,
+      );
+      return { comment };
+    } catch (err) {
+      return { commentError: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   function requiredString(args: Record<string, unknown>, name: string): string {
@@ -377,7 +437,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "put",
       description:
-        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
+        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). With `pr`/`issue` (+ required `repo`) the key is stable instead (gh/…, always overwrites) and `comment` syncs the managed attachments comment as uploads-sh[bot] — bot-only on this hosted server, no local gh fallback. Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
       inputSchema: {
         type: "object",
         properties: {
@@ -412,7 +472,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               required: ["filename", "contentBase64"],
               additionalProperties: false,
             },
-            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/width/metadata apply to every item. Returns { uploads, failures } with per-item results.`,
+            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/pr/issue/width/metadata apply to every item. Returns { uploads, failures } with per-item results (plus comment/commentError once for the whole batch when comment: true).`,
           },
           key: {
             type: "string",
@@ -425,11 +485,28 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           },
           repo: {
             type: "string",
-            description: "owner/name repo segment for the default key layout (default: misc).",
+            description:
+              "owner/name repo segment for the default key layout (default: misc). REQUIRED (and must be owner/name) with pr/issue — there is no git context on this server to infer it from.",
           },
           ref: {
             type: "string",
-            description: "PR/issue/branch key segment for the default key layout (default: today).",
+            description:
+              "PR/issue/branch key segment for the default key layout (default: today). Cannot be combined with pr/issue.",
+          },
+          pr: {
+            type: "number",
+            description:
+              "Attach to this pull request: uses a stable gh/ key (always overwrites) and stamps canonical gh.* metadata. Mutually exclusive with issue and with key/prefix/ref. Requires repo.",
+          },
+          issue: {
+            type: "number",
+            description:
+              "Attach to this issue: uses a stable gh/ key (always overwrites) and stamps canonical gh.* metadata. Mutually exclusive with pr and with key/prefix/ref. Requires repo.",
+          },
+          comment: {
+            type: "boolean",
+            description:
+              "With pr/issue: after a successful upload, create or update the managed attachments comment via the uploads.sh GitHub App (bot-only on this hosted server — no local gh fallback). Requires pr or issue. A comment failure never fails the upload; see the response's `comment`/`commentError`.",
           },
           alt: {
             type: "string",
@@ -479,6 +556,27 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           if (!filename) usage("filename is required");
         }
 
+        // PR/issue targeting (issue #392): mirrors the stdio put contract, but
+        // `repo` is required here (no git context on this server, enforced by
+        // ghTargetFromArgs). Mutually exclusive with key/prefix/ref — a target
+        // always uses the stable gh/ key layout, never the default one.
+        const target = ghTargetFromArgs(args);
+        const wantComment = optBool(args, "comment");
+        if (wantComment && !target) usage("comment requires pr or issue");
+
+        const explicitKey = optString(args, "key");
+        const prefix = optString(args, "prefix");
+        const repo = optString(args, "repo");
+        const ref = optString(args, "ref");
+        if (target) {
+          if (explicitKey) usage("key cannot be combined with pr/issue");
+          if (prefix) usage("prefix cannot be combined with pr/issue");
+          if (ref) usage("ref cannot be combined with pr/issue");
+        }
+        if (explicitKey && (prefix ?? repo ?? ref) !== undefined) {
+          usage("key cannot be combined with prefix/repo/ref");
+        }
+
         // state/app are explicit input and win over a same-named metadata key.
         // This server cannot derive the EXIF-sourced keys (no image decoding in
         // the Workers runtime), so these two are the whole canonical surface here.
@@ -490,6 +588,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             usage(err instanceof Error ? err.message : String(err));
           }
         }
+        // With a target, stamp the canonical gh.* pairs (parity with the
+        // attach flow, so find/activity-feed/attribution see these uploads).
+        // Canonical keys win over any caller-supplied same-named pair.
+        if (target) metadata = { ...metadata, ...ghMetadataFromTarget(target) };
         // Uploader attribution (issue #345, parity with the REST PUT hook in
         // apps/api/src/routes/files.ts): gh.*-tagged uploads get server-derived
         // `gh.uploader`/`gh.uploader-id` stamped from the OAuth JWT's (or
@@ -504,14 +606,6 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             const merged = { ...metadata, ...uploader };
             if (Object.keys(merged).length <= META_MAX_KEYS) metadata = merged;
           }
-        }
-
-        const explicitKey = optString(args, "key");
-        const prefix = optString(args, "prefix");
-        const repo = optString(args, "repo");
-        const ref = optString(args, "ref");
-        if (explicitKey && (prefix ?? repo ?? ref) !== undefined) {
-          usage("key cannot be combined with prefix/repo/ref");
         }
 
         const policy = resolveUploadPolicy(workspace);
@@ -541,22 +635,25 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               );
             }
           });
-          // Keys are deterministic (sanitized name + content hash), so two
+          // Keys are deterministic (sanitized name + content hash for the
+          // default layout, or filename alone under a gh/ target), so two
           // items can collide — e.g. the same file listed twice. Reject
           // before any write: concurrent same-key puts would double-count
           // the usage ledger and report more uploads than stored objects.
-          const keys = await Promise.all(
-            decoded.map((bytes, i) =>
-              buildScreenshotKey({
-                filename: items[i]!.filename,
-                fileBytes: bytes,
-                prefix,
-                repo,
-                ref,
-                deriveRepoFromGit: false,
-              }),
-            ),
-          );
+          const keys = target
+            ? items.map((item) => ghAttachmentKey(target, item.filename))
+            : await Promise.all(
+                decoded.map((bytes, i) =>
+                  buildScreenshotKey({
+                    filename: items[i]!.filename,
+                    fileBytes: bytes,
+                    prefix,
+                    repo,
+                    ref,
+                    deriveRepoFromGit: false,
+                  }),
+                ),
+              );
           const firstIndexByKey = new Map<string, number>();
           keys.forEach((key, i) => {
             const first = firstIndexByKey.get(key);
@@ -608,22 +705,28 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               failures,
             });
           }
-          return { workspace: workspaceName, uploads, failures };
+          // At least one item made it into R2 (issue #392): sync the comment
+          // once for the whole batch, same as the stdio tool syncs once per call.
+          const commentResult =
+            wantComment && target && uploads.length > 0 ? await attachComment(target) : undefined;
+          return { workspace: workspaceName, uploads, failures, ...commentResult };
         }
 
         const bytes = decodeBase64(contentBase64!, maxBytes);
 
         const key =
           explicitKey ??
-          // deriveRepoFromGit: false — no git (or child_process) on a worker.
-          (await buildScreenshotKey({
-            filename: filename!,
-            fileBytes: bytes,
-            prefix,
-            repo,
-            ref,
-            deriveRepoFromGit: false,
-          }));
+          (target
+            ? ghAttachmentKey(target, filename!)
+            : // deriveRepoFromGit: false — no git (or child_process) on a worker.
+              await buildScreenshotKey({
+                filename: filename!,
+                fileBytes: bytes,
+                prefix,
+                repo,
+                ref,
+                deriveRepoFromGit: false,
+              }));
 
         // Key/body validation and the size/type guardrails live in putObject,
         // shared with the REST API — the stored content type is sniffed there.
@@ -637,7 +740,8 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
                 alt: alt ?? filename!,
                 width,
               });
-        return { workspace: workspaceName, ...result, markdown };
+        const commentResult = wantComment && target ? await attachComment(target) : undefined;
+        return { workspace: workspaceName, ...result, markdown, ...commentResult };
       },
     },
     {

--- a/apps/mcp/test/mcp-put-comment.test.ts
+++ b/apps/mcp/test/mcp-put-comment.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Hosted `put` PR/issue targeting + managed comment sync (issue #392). The
+ * gather/check/upsert logic itself is exercised end-to-end by
+ * apps/api/src/routes/github-comment-route.test.ts (now via
+ * `postManagedComment`, apps/api/src/github-comment-service.ts) — these tests
+ * cover only the hosted MCP `put` tool's new surface: targeting args, the
+ * `comment` opt-in, and that a decline/failure never fails the upload.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
+import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
+
+const TOKEN = "up_test-ws_legacy-token-value";
+const WS = "test-ws";
+
+// crypto.subtle.timingSafeEqual is a Workers-runtime extension (used by
+// workspaceAuth) Node's crypto doesn't implement — mirrors mcp.test.ts's polyfill.
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+const GITHUB_APP_CFG_ENV = {
+  GITHUB_APP_ID: "12345",
+  GITHUB_APP_PRIVATE_KEY: "unused",
+  GITHUB_APP_HOME_INSTALLATION_ID: "777",
+  WEB_ORIGIN: "https://uploads.sh",
+};
+
+/** In-process KV fake: get/put with recorded TTLs — mirrors apps/api/test/fake-kv.ts. */
+class FakeKv {
+  store = new Map<string, { value: string; expirationTtl?: number }>();
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key)?.value ?? null;
+  }
+  async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
+    this.store.set(key, { value, expirationTtl: opts?.expirationTtl });
+  }
+}
+
+interface RepoLinkRow {
+  repo_full_name: string;
+  workspace_name: string;
+  installation_id: number | null;
+  source: string;
+  created_at: string;
+}
+
+/** In-memory `github_repo_links` stand-in — mirrors apps/api/test/helpers/fake-repo-links-table.ts. */
+class RepoLinksTable {
+  readonly rows = new Map<string, RepoLinkRow>();
+
+  tryRun(sql: string, args: unknown[]) {
+    if (sql.startsWith("INSERT OR IGNORE INTO github_repo_links")) {
+      const [repo, workspace, installationId, source, createdAt] = args as [
+        string,
+        string,
+        number | null,
+        string,
+        string,
+      ];
+      if (this.rows.has(repo)) return { success: true, meta: { changes: 0 }, results: [] };
+      this.rows.set(repo, {
+        repo_full_name: repo,
+        workspace_name: workspace,
+        installation_id: installationId,
+        source,
+        created_at: createdAt,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    return undefined;
+  }
+
+  tryFirst(sql: string, args: unknown[]) {
+    if (sql.includes("FROM github_repo_links WHERE repo_full_name")) {
+      const [repo] = args as [string];
+      return this.rows.get(repo) ?? null;
+    }
+    return undefined;
+  }
+}
+
+/**
+ * Combines the file_metadata fake (gh.* stamping on `putObject`) with a
+ * `github_repo_links` table and a not-found `auth_tokens` lookup (legacy
+ * token auth only — every test here uses `TOKEN`, never a D1-tracked one, so
+ * `mintingUserId` is always null; the entitlement/claim path is covered by
+ * the route-level tests instead).
+ */
+function makeDb(links: RepoLinksTable, metadata: Map<string, Map<string, string>>) {
+  const scopeKey = (ws: string, objectKey: string) => `${ws} ${objectKey}`;
+  return {
+    prepare: (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      let values: unknown[] = [];
+      const stmt = {
+        bind(...next: unknown[]) {
+          values = next;
+          return stmt;
+        },
+        async first<T>() {
+          if (normalized.includes("github_repo_links")) {
+            return (links.tryFirst(normalized, values) ?? null) as T;
+          }
+          // auth_tokens active-token lookup: always miss (legacy token path).
+          return null as T;
+        },
+        async run() {
+          if (normalized.includes("github_repo_links")) {
+            return (
+              links.tryRun(normalized, values) ?? {
+                success: true,
+                meta: { changes: 0 },
+                results: [],
+              }
+            );
+          }
+          if (normalized.startsWith("INSERT INTO file_metadata")) {
+            const [ws, objectKey, key, value] = values as [string, string, string, string];
+            const map = metadata.get(scopeKey(ws, objectKey)) ?? new Map<string, string>();
+            map.set(key, value);
+            metadata.set(scopeKey(ws, objectKey), map);
+          } else if (normalized.startsWith("DELETE FROM file_metadata")) {
+            const [ws, objectKey] = values as [string, string];
+            metadata.delete(scopeKey(ws, objectKey));
+          }
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+        async all<T>() {
+          if (normalized.startsWith("SELECT meta_key, meta_value FROM file_metadata")) {
+            const [ws, objectKey] = values as [string, string];
+            const map = metadata.get(scopeKey(ws, objectKey)) ?? new Map<string, string>();
+            return {
+              success: true,
+              results: [...map.entries()].map(([meta_key, meta_value]) => ({
+                meta_key,
+                meta_value,
+              })) as T[],
+              meta: {},
+            };
+          }
+          return { success: true, results: [] as T[], meta: {} };
+        },
+      };
+      return stmt;
+    },
+    async batch(stmts: { run: () => Promise<unknown> }[]) {
+      return Promise.all(stmts.map((s) => s.run()));
+    },
+  };
+}
+
+async function makeEnv(
+  opts: { boundTo?: string } = {},
+): Promise<{ env: Env; bucket: FakeR2Bucket; links: RepoLinksTable; githubCache: FakeKv }> {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "test-bucket",
+    binding: "UPLOADS",
+    publicBaseUrl: "https://storage.example.com",
+    tokenHash: await sha256Hex(TOKEN),
+  };
+  const bucket = new FakeR2Bucket();
+  const links = new RepoLinksTable();
+  if (opts.boundTo) {
+    links.rows.set("acme/widgets", {
+      repo_full_name: "acme/widgets",
+      workspace_name: opts.boundTo,
+      installation_id: 42,
+      source: "comment",
+      created_at: new Date().toISOString(),
+    });
+  }
+  const metadata = new Map<string, Map<string, string>>();
+  const githubCache = new FakeKv();
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    DB: makeDb(links, metadata),
+    UPLOADS: bucket,
+    GITHUB_CACHE: githubCache,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, bucket, links, githubCache };
+}
+
+async function callTool(env: Env, name: string, args: Record<string, unknown>) {
+  const response = await app.request(
+    "/test-ws/mcp",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    },
+    env,
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    result: {
+      isError: boolean;
+      structuredContent?: Record<string, unknown>;
+      content: unknown[];
+    };
+  };
+  return body.result;
+}
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+const PNG_B64 = btoa(String.fromCharCode(...PNG_BYTES));
+
+function stubGithubFetch(
+  handler: (url: string, init: RequestInit) => Response | Promise<Response>,
+) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init: RequestInit = {}) =>
+    handler(String(url), init)) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+describe("hosted put: pr/issue targeting", () => {
+  it("uses a stable gh/ key and stamps canonical gh.* metadata", async () => {
+    const { env, bucket } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      key: "gh/acme/widgets/pull/12/hero.png",
+      url: "https://storage.example.com/gh/acme/widgets/pull/12/hero.png",
+    });
+    expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
+  });
+
+  it("uses the issues kind for `issue`", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      issue: 7,
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      key: "gh/acme/widgets/issues/7/hero.png",
+    });
+  });
+
+  it("always overwrites a gh/ target key without replace: true (issue #174 has no effect here)", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const first = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(first.isError).toBe(false);
+    expect(first.structuredContent).toMatchObject({ replaced: false });
+
+    const second = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(second.isError).toBe(false);
+    expect(second.structuredContent).toMatchObject({ replaced: true });
+  });
+
+  it("usage errors: comment without pr/issue", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      key: "shots/hero.png",
+      comment: true,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("comment requires pr or issue") },
+    ]);
+  });
+
+  it("usage errors: pr without repo", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("repo is required") },
+    ]);
+  });
+
+  it("usage errors: pr + key are mutually exclusive", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+      key: "shots/hero.png",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("key cannot be combined with pr/issue") },
+    ]);
+  });
+
+  it("usage errors: pr + issue are mutually exclusive", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      issue: 7,
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("mutually exclusive") },
+    ]);
+  });
+});
+
+describe("hosted put: comment sync (issue #392)", () => {
+  it("posts the managed comment and records a repo link on a bound repo", async () => {
+    const { env, links, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/acme/widgets/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "put", {
+        contentBase64: PNG_B64,
+        filename: "hero.png",
+        pr: 12,
+        repo: "acme/widgets",
+        comment: true,
+      });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent?.comment).toEqual({
+        posted: true,
+        action: "created",
+        count: 1,
+        commentUrl: "https://github.com/acme/widgets/pull/12#c5",
+      });
+      expect(result.structuredContent?.commentError).toBeUndefined();
+      expect(links.rows.get("acme/widgets")).toMatchObject({
+        workspace_name: WS,
+        source: "comment",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("uploads successfully and returns an honest not_installed decline (never a tool error)", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "none" });
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+      comment: true,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent?.key).toBe("gh/acme/widgets/pull/12/hero.png");
+    expect(result.structuredContent?.comment).toEqual({ posted: false, reason: "not_installed" });
+  });
+
+  it("declines not_authorized for a repo bound to a different workspace, without a GitHub write", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: "other-ws" });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    let sawGithubCall = false;
+    const restore = stubGithubFetch(() => {
+      sawGithubCall = true;
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "put", {
+        contentBase64: PNG_B64,
+        filename: "hero.png",
+        pr: 12,
+        repo: "acme/widgets",
+        comment: true,
+      });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent?.comment).toMatchObject({
+        posted: false,
+        reason: "not_authorized",
+      });
+      expect(sawGithubCall).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns a forbidden decline with fixUrl + required when the App lacks write", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const restore = stubGithubFetch((url) =>
+      url.includes("/issues/12/comments")
+        ? new Response("no", { status: 403 })
+        : new Response("nf", { status: 404 }),
+    );
+    try {
+      const result = await callTool(env, "put", {
+        contentBase64: PNG_B64,
+        filename: "hero.png",
+        pr: 12,
+        repo: "acme/widgets",
+        comment: true,
+      });
+      expect(result.isError).toBe(false);
+      const comment = result.structuredContent?.comment as {
+        posted: boolean;
+        reason: string;
+        fixUrl: string;
+        required: string[];
+      };
+      expect(comment.posted).toBe(false);
+      expect(comment.reason).toBe("forbidden");
+      expect(comment.fixUrl).toBe(
+        "https://github.com/organizations/acme/settings/installations/42/permissions/update",
+      );
+      expect(comment.required).toEqual(["issues:write", "pull_requests:write"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not attach a comment when comment is not requested", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent?.comment).toBeUndefined();
+    expect(result.structuredContent?.commentError).toBeUndefined();
+  });
+});

--- a/apps/mcp/test/mcp-put-comment.test.ts
+++ b/apps/mcp/test/mcp-put-comment.test.ts
@@ -94,12 +94,18 @@ class RepoLinksTable {
 
 /**
  * Combines the file_metadata fake (gh.* stamping on `putObject`) with a
- * `github_repo_links` table and a not-found `auth_tokens` lookup (legacy
- * token auth only — every test here uses `TOKEN`, never a D1-tracked one, so
- * `mintingUserId` is always null; the entitlement/claim path is covered by
- * the route-level tests instead).
+ * `github_repo_links` table and an `auth_tokens` lookup. By default the
+ * active-token lookup always misses (legacy token path — full FILE_SCOPES,
+ * `mintingUserId` null; the entitlement/claim path is covered by the
+ * route-level tests instead). Pass `scopedToken` to instead return a
+ * D1-tracked row for `TOKEN` carrying exactly those scopes, for the
+ * files:read-required-for-comment scope test.
  */
-function makeDb(links: RepoLinksTable, metadata: Map<string, Map<string, string>>) {
+function makeDb(
+  links: RepoLinksTable,
+  metadata: Map<string, Map<string, string>>,
+  scopedToken?: { tokenHash: string; scopes: string[] },
+) {
   const scopeKey = (ws: string, objectKey: string) => `${ws} ${objectKey}`;
   return {
     prepare: (sql: string) => {
@@ -113,6 +119,23 @@ function makeDb(links: RepoLinksTable, metadata: Map<string, Map<string, string>
         async first<T>() {
           if (normalized.includes("github_repo_links")) {
             return (links.tryFirst(normalized, values) ?? null) as T;
+          }
+          if (normalized.startsWith("SELECT id, workspace, token_hash")) {
+            const [, hash] = values as [string, string];
+            if (scopedToken && hash === scopedToken.tokenHash) {
+              return {
+                id: "token-id",
+                workspace: WS,
+                token_hash: hash,
+                label: null,
+                scopes: JSON.stringify(scopedToken.scopes),
+                created_at: "2026-07-13T00:00:00.000Z",
+                expires_at: null,
+                revoked_at: null,
+                minting_user_id: null,
+              } as T;
+            }
+            return null as T;
           }
           // auth_tokens active-token lookup: always miss (legacy token path).
           return null as T;
@@ -163,14 +186,15 @@ function makeDb(links: RepoLinksTable, metadata: Map<string, Map<string, string>
 }
 
 async function makeEnv(
-  opts: { boundTo?: string } = {},
+  opts: { boundTo?: string; scopes?: string[] } = {},
 ): Promise<{ env: Env; bucket: FakeR2Bucket; links: RepoLinksTable; githubCache: FakeKv }> {
+  const tokenHash = await sha256Hex(TOKEN);
   const record: WorkspaceRecord = {
     provider: "r2",
     bucket: "test-bucket",
     binding: "UPLOADS",
     publicBaseUrl: "https://storage.example.com",
-    tokenHash: await sha256Hex(TOKEN),
+    tokenHash,
   };
   const bucket = new FakeR2Bucket();
   const links = new RepoLinksTable();
@@ -185,9 +209,10 @@ async function makeEnv(
   }
   const metadata = new Map<string, Map<string, string>>();
   const githubCache = new FakeKv();
+  const scopedToken = opts.scopes ? { tokenHash, scopes: opts.scopes } : undefined;
   const env = {
     REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
-    DB: makeDb(links, metadata),
+    DB: makeDb(links, metadata, scopedToken),
     UPLOADS: bucket,
     GITHUB_CACHE: githubCache,
     ...GITHUB_APP_CFG_ENV,
@@ -475,5 +500,32 @@ describe("hosted put: comment sync (issue #392)", () => {
     expect(result.isError).toBe(false);
     expect(result.structuredContent?.comment).toBeUndefined();
     expect(result.structuredContent?.commentError).toBeUndefined();
+  });
+
+  it("requires files:read for comment: true — a files:write-only token is rejected before any write", async () => {
+    const { env, bucket } = await makeEnv({ boundTo: WS, scopes: ["files:write"] });
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+      comment: true,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: expect.stringContaining("files:read") }]);
+    // Rejected up front — no object written, not even a partial upload.
+    expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(false);
+  });
+
+  it("the same files:write-only token can still put without comment", async () => {
+    const { env, bucket } = await makeEnv({ boundTo: WS, scopes: ["files:write"] });
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(false);
+    expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #392

## Summary

The hosted MCP server (`apps/mcp`) can now target a PR/issue on `put` and opt in to syncing the managed attachments comment, reusing the REST route's logic in-process. The trust model is unchanged.

**Extraction (apps/api).** `apps/api/src/routes/github-comment.ts`'s handler body moved verbatim into `apps/api/src/github-comment-service.ts` as `postManagedComment(env, ws, workspaceName, mintingUserId, target)`, exported as a new `@uploads/api/github-comment-service` package entry. The route is now just parse + `writeRateLimit` + `requireScope("files:read")` + the service call. Ordering is unchanged: `githubAppConfig` → `installationForRepo` → the cross-tenant gate (`checkRepoAuthorization`, issue #297) → `gatherCommentBody` (skip-on-zero) → `upsertBotComment` (with the `forbidden` enrichment) → the implicit `recordRepoLink` claim on success.

**Hosted `put` (apps/mcp/src/tools.ts).** New args `pr`/`issue` (mutually exclusive with each other and with `key`/`prefix`/`ref`) and `comment` (opt-in boolean). With a target, `repo` becomes required — there is no git context on a Worker to infer it from, unlike the stdio tool; this divergence is documented on the arg description. Keys use `ghAttachmentKey` (stable, always overwrites via `putObject`'s existing gh/-key handling — `replace: false` has no effect there) and canonical `gh.*` metadata is stamped via `ghMetadataFromTarget`, merged under any caller-supplied metadata so the canonical keys win — this gives the same find/activity-feed/attribution parity attach uploads get.

After a successful upload (or a batch with at least one success) with `comment: true`, the tool calls `postManagedComment` in-process and attaches the result as `comment` on the tool response. A comment failure (thrown error) is caught into `commentError` and never fails the tool call; a decline (`not_installed`, `not_authorized`, `forbidden` with `fixUrl`/`required`) is returned honestly — there's no `gh` fallback in a Worker.

**Stretch tool:** not included — the diff was already sized to cover the required surface, so the standalone `comment` tool was skipped per the brief's guidance.

## Test evidence

Full suite from repo root:
```
 Test Files  197 passed (197)
      Tests  2422 passed (2422)
```

`apps/api` and `apps/mcp` typecheck (`wrangler types && tsc --noEmit`) clean.

`apps/mcp/test/mcp-put-comment.test.ts` (new, 12 tests) covers: stable gh/ key + `gh.*` metadata stamping, pull vs issue kind, gh/-key overwrite unaffected by `replace: false`, all five usage-error cases (`comment` without a target, `pr` without `repo`, `pr`+`key`, `pr`+`issue`), a successful comment post with repo-link recording, an honest `not_installed` decline on a successful upload, a cross-tenant `not_authorized` decline with no GitHub API call made, and a `forbidden` decline carrying `fixUrl`/`required`.

`apps/api/src/routes/github-comment-route.test.ts` and `apps/api/src/github-comment.test.ts` pass unchanged (42 tests) — the regression proof that the extraction is faithful.

## Deviations

- `repo` required alongside `pr`/`issue` on the hosted tool (spec'd divergence, no git context server-side).
- Standalone `comment` tool (stretch) not added.
