### PR TITLE
feat: show GitHub owner avatars on PR/issue surfaces

### DIFF
--- a/apps/api/src/github-avatars.test.ts
+++ b/apps/api/src/github-avatars.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  NEGATIVE_CACHE_CONTROL,
+  POSITIVE_CACHE_CONTROL,
+  githubAvatarProxyUrl,
+  normalizeGithubOwner,
+  ownerFromRepo,
+  resolveGithubAvatar,
+  type AvatarCache,
+} from "./github-avatars";
+
+describe("normalizeGithubOwner", () => {
+  it("accepts common logins and lowercases", () => {
+    expect(normalizeGithubOwner("buildinternet")).toBe("buildinternet");
+    expect(normalizeGithubOwner("BuildInternet")).toBe("buildinternet");
+    expect(normalizeGithubOwner("acme-corp")).toBe("acme-corp");
+  });
+
+  it("rejects invalid logins", () => {
+    expect(normalizeGithubOwner("")).toBeNull();
+    expect(normalizeGithubOwner("-acme")).toBeNull();
+    expect(normalizeGithubOwner("acme-")).toBeNull();
+    expect(normalizeGithubOwner("has space")).toBeNull();
+    expect(normalizeGithubOwner("x".repeat(40))).toBeNull();
+  });
+});
+
+describe("ownerFromRepo", () => {
+  it("parses owner/name", () => {
+    expect(ownerFromRepo("buildinternet/uploads")).toBe("buildinternet");
+    expect(ownerFromRepo("BuildInternet/Uploads")).toBe("buildinternet");
+  });
+
+  it("rejects malformed repos", () => {
+    expect(ownerFromRepo("noshslash")).toBeNull();
+    expect(ownerFromRepo("/uploads")).toBeNull();
+    expect(ownerFromRepo("a/b/c")).toBeNull();
+  });
+});
+
+describe("githubAvatarProxyUrl", () => {
+  it("builds the public proxy URL", () => {
+    expect(githubAvatarProxyUrl("https://api.uploads.sh/", "acme")).toBe(
+      "https://api.uploads.sh/public/github/avatars/acme",
+    );
+  });
+});
+
+function memoryCache(): AvatarCache & { store: Map<string, Response> } {
+  const store = new Map<string, Response>();
+  return {
+    store,
+    async match(request) {
+      return store.get(request.url)?.clone();
+    },
+    async put(request, response) {
+      store.set(request.url, response.clone());
+    },
+  };
+}
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+describe("resolveGithubAvatar", () => {
+  const cacheKeyUrl = "https://api.uploads.sh/public/github/avatars/buildinternet";
+
+  it("returns the upstream image and caches a positive hit", async () => {
+    const cache = memoryCache();
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(PNG, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+    );
+
+    const first = await resolveGithubAvatar("buildinternet", {
+      cacheKeyUrl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      cache,
+    });
+    expect(first.status).toBe(200);
+    expect(first.headers.get("Cache-Control")).toBe(POSITIVE_CACHE_CONTROL);
+    expect(new Uint8Array(await first.arrayBuffer())).toEqual(PNG);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await resolveGithubAvatar("buildinternet", {
+      cacheKeyUrl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      cache,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("negative-caches a 404 from upstream", async () => {
+    const cache = memoryCache();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 404 }));
+    const key = "https://api.uploads.sh/public/github/avatars/missing-org";
+
+    const first = await resolveGithubAvatar("missing-org", {
+      cacheKeyUrl: key,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      cache,
+    });
+    expect(first.status).toBe(404);
+    expect(first.headers.get("Cache-Control")).toBe(NEGATIVE_CACHE_CONTROL);
+
+    await resolveGithubAvatar("missing-org", {
+      cacheKeyUrl: key,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      cache,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-image content types", async () => {
+    const res = await resolveGithubAvatar("buildinternet", {
+      cacheKeyUrl,
+      fetchImpl: vi.fn(
+        async () =>
+          new Response("<html>", { status: 200, headers: { "Content-Type": "text/html" } }),
+      ) as unknown as typeof fetch,
+      cache: null,
+    });
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 when upstream fetch throws", async () => {
+    const res = await resolveGithubAvatar("buildinternet", {
+      cacheKeyUrl,
+      fetchImpl: vi.fn(async () => {
+        throw new Error("network");
+      }) as unknown as typeof fetch,
+      cache: null,
+    });
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/api/src/github-avatars.ts
+++ b/apps/api/src/github-avatars.ts
@@ -1,0 +1,138 @@
+/**
+ * GitHub owner avatar proxy.
+ *
+ * PR/issue surfaces need a first-party image URL for the repo owner from
+ * `gh.repo` (`owner/name`). We proxy `https://github.com/{owner}.png` (edge-
+ * cached) so pages don't hotlink avatars.githubusercontent.com. Display-only:
+ * non-2xx means "no avatar"; never on the upload path.
+ */
+
+/** GitHub login / org slug: 1–39 chars, alphanumeric + mid hyphens only. */
+export const GITHUB_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
+const UPSTREAM_TIMEOUT_MS = 8000;
+const MAX_AVATAR_BYTES = 512 * 1024;
+
+export const POSITIVE_CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
+export const NEGATIVE_CACHE_CONTROL = "public, max-age=3600";
+
+export interface AvatarCache {
+  match(request: Request): Promise<Response | undefined>;
+  put(request: Request, response: Response): Promise<void>;
+}
+
+/** Lowercased login when valid, else null. */
+export function normalizeGithubOwner(raw: string): string | null {
+  const owner = raw.trim();
+  if (!GITHUB_OWNER_RE.test(owner)) return null;
+  return owner.toLowerCase();
+}
+
+/** Owner of `owner/repo`, or null if malformed. */
+export function ownerFromRepo(repo: string): string | null {
+  const slash = repo.indexOf("/");
+  if (slash <= 0 || slash !== repo.lastIndexOf("/") || !repo.slice(slash + 1)) return null;
+  return normalizeGithubOwner(repo.slice(0, slash));
+}
+
+/** Absolute proxy URL (`{apiOrigin}/public/github/avatars/{owner}`). */
+export function githubAvatarProxyUrl(apiOrigin: string, owner: string): string {
+  return `${apiOrigin.replace(/\/$/, "")}/public/github/avatars/${encodeURIComponent(owner)}`;
+}
+
+function avatarResponse(
+  status: number,
+  cacheControl: string,
+  body: BodyInit | null = null,
+  contentType?: string,
+): Response {
+  const headers = new Headers({
+    "Cache-Control": cacheControl,
+    "X-Content-Type-Options": "nosniff",
+  });
+  if (contentType) headers.set("Content-Type", contentType);
+  return new Response(body, { status, headers });
+}
+
+function isImageContentType(value: string | null): boolean {
+  const type = value?.split(";")[0]?.trim().toLowerCase() ?? "";
+  return type.startsWith("image/");
+}
+
+async function putCache(
+  cache: AvatarCache | null | undefined,
+  key: Request,
+  response: Response,
+): Promise<void> {
+  if (!cache) return;
+  await cache.put(key, response.clone());
+}
+
+/**
+ * Cache hit → return; else fetch GitHub's `/{owner}.png`, validate, cache, return.
+ * `cacheKeyUrl` is the normalized public URL for this owner.
+ */
+export async function resolveGithubAvatar(
+  owner: string,
+  opts: {
+    cacheKeyUrl: string;
+    fetchImpl?: typeof fetch;
+    cache?: AvatarCache | null;
+  },
+): Promise<Response> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const cacheKey = new Request(opts.cacheKeyUrl, { method: "GET" });
+
+  const hit = await opts.cache?.match(cacheKey);
+  if (hit) return hit;
+
+  let upstream: Response;
+  try {
+    upstream = await fetchImpl(`https://github.com/${owner}.png`, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+      headers: { accept: "image/*", "user-agent": "uploads.sh" },
+    });
+  } catch {
+    // Network / timeout — don't cache; next request can retry immediately.
+    return avatarResponse(502, NEGATIVE_CACHE_CONTROL);
+  }
+
+  if (!upstream.ok || !isImageContentType(upstream.headers.get("content-type"))) {
+    const status = upstream.status === 404 ? 404 : 502;
+    const negative = avatarResponse(status, NEGATIVE_CACHE_CONTROL);
+    await putCache(opts.cache, cacheKey, negative);
+    return negative;
+  }
+
+  let bytes: ArrayBuffer;
+  try {
+    bytes = await upstream.arrayBuffer();
+  } catch {
+    return avatarResponse(502, NEGATIVE_CACHE_CONTROL);
+  }
+
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_AVATAR_BYTES) {
+    const negative = avatarResponse(502, NEGATIVE_CACHE_CONTROL);
+    await putCache(opts.cache, cacheKey, negative);
+    return negative;
+  }
+
+  const response = avatarResponse(
+    200,
+    POSITIVE_CACHE_CONTROL,
+    bytes,
+    upstream.headers.get("content-type") ?? "image/png",
+  );
+  await putCache(opts.cache, cacheKey, response);
+  return response;
+}
+
+/** Cloudflare Cache API when present; null in unit tests / non-Workers runtimes. */
+export function defaultAvatarCache(): AvatarCache | null {
+  try {
+    return typeof caches !== "undefined" && caches.default ? caches.default : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,6 +16,7 @@ import { runStagingReaper } from "./staging-reaper";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";
+import { publicGithubAvatars } from "./routes/public-github-avatars";
 import { telemetry } from "./routes/telemetry";
 import { reports } from "./routes/reports";
 import { render } from "./routes/render";
@@ -106,6 +107,9 @@ export const app = new Hono<WorkspaceVars>()
   // Public single-object metadata for the file page (#135). Like public
   // galleries, fetched server-side by apps/web; no CORS (not a browser call).
   .route("/public/files", publicFiles)
+  // Public GitHub owner avatar proxy (file byline + connected-work rail).
+  // Edge-cached image bytes; unauthenticated. See github-avatars.ts.
+  .route("/public/github/avatars", publicGithubAvatars)
   // Session-authenticated workspace-token mint (Phase 4). Registered BEFORE the
   // `/v1/:workspace/*` bearer guard: `/v1/tokens` does NOT match that pattern
   // (no trailing segment), so `workspaceAuth` never runs for it — this route

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -3,11 +3,13 @@ import { Hono } from "hono";
 import type { Files } from "@uploads/storage";
 import { badKey, downloadResponse, publicObjectDateFields } from "../files-core";
 import { displayTitle, getFileMetadata, isServerMetaKey } from "../file-metadata";
+import { githubAvatarProxyUrl, ownerFromRepo } from "../github-avatars";
 import { resolveTitles, withPublicTitleBudget } from "../github-titles";
 import { posterKeyFor } from "../poster";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
+import { requestOrigin } from "../well-known";
 
 const POSITIVE_INT_RE_STRICT = /^[1-9][0-9]*$/;
 
@@ -39,6 +41,8 @@ interface GithubContext {
   url: string;
   /** Attach-time stamp and/or live resolveTitles overlay; omitted when unknown. */
   title?: string;
+  /** API proxy for the repo owner avatar; omitted when owner is invalid. */
+  avatarUrl?: string;
 }
 
 // Deliberately permissive (not the full GitHub owner/repo charset) — this only
@@ -196,6 +200,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
 
   // Live title (KV-cached App ladder) wins over stamped gh.title. Failures and
   // budget timeouts never 500 — keep the stamp or omit title entirely.
+  // avatarUrl is pure derivation from gh.repo — no extra network here.
   if (github) {
     const ref = githubRefKey(metadata, github);
     let title = github.title;
@@ -206,8 +211,15 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     } catch {
       // Missing GITHUB_CACHE / App misconfig / transient — keep stamp if any.
     }
-    const { title: _drop, ...base } = github;
-    github = title ? { ...base, title } : base;
+    const owner = ownerFromRepo(github.repo);
+    github = {
+      repo: github.repo,
+      kind: github.kind,
+      number: github.number,
+      url: github.url,
+      ...(title ? { title } : {}),
+      ...(owner ? { avatarUrl: githubAvatarProxyUrl(requestOrigin(c.req.url), owner) } : {}),
+    };
   }
 
   return c.json({

--- a/apps/api/src/routes/public-github-avatars.test.ts
+++ b/apps/api/src/routes/public-github-avatars.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { app } from "../index";
+import { POSITIVE_CACHE_CONTROL } from "../github-avatars";
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9, 8, 7, 6]);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("GET /public/github/avatars/:owner", () => {
+  it("400s on invalid owner without calling GitHub", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await app.request("https://api.uploads.sh/public/github/avatars/-bad");
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("proxies a valid owner avatar from GitHub", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://github.com/buildinternet.png") {
+          return new Response(PNG, {
+            status: 200,
+            headers: { "Content-Type": "image/png" },
+          });
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    const res = await app.request("https://api.uploads.sh/public/github/avatars/BuildInternet");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+    expect(res.headers.get("Cache-Control")).toBe(POSITIVE_CACHE_CONTROL);
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(PNG);
+  });
+
+  it("returns 404 when GitHub has no such user", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 404 })),
+    );
+
+    const res = await app.request("https://api.uploads.sh/public/github/avatars/no-such-user-zzz");
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/public-github-avatars.ts
+++ b/apps/api/src/routes/public-github-avatars.ts
@@ -1,0 +1,27 @@
+/**
+ * `GET /public/github/avatars/:owner` — unauthenticated, edge-cached proxy
+ * for a GitHub user/org avatar (repo owner from `gh.repo`).
+ */
+import { Hono } from "hono";
+import { defaultAvatarCache, normalizeGithubOwner, resolveGithubAvatar } from "../github-avatars";
+import type { WorkspaceVars } from "../workspace";
+
+export const publicGithubAvatars = new Hono<WorkspaceVars>().get("/:owner", async (c) => {
+  const owner = normalizeGithubOwner(c.req.param("owner"));
+  if (!owner) {
+    return new Response(null, {
+      status: 400,
+      headers: { "X-Content-Type-Options": "nosniff" },
+    });
+  }
+
+  // Case-normalize so `BuildInternet` and `buildinternet` share one cache entry.
+  const cacheUrl = new URL(c.req.url);
+  cacheUrl.pathname = `/public/github/avatars/${owner}`;
+  cacheUrl.search = "";
+
+  return resolveGithubAvatar(owner, {
+    cacheKeyUrl: cacheUrl.toString(),
+    cache: defaultAvatarCache(),
+  });
+});

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -246,11 +246,21 @@ describe("GET /public/files/:workspace/:key", () => {
       "X-Uploads-Meta-app": "uploads-cli",
     });
 
-    const res = await app.request("/public/files/default/screenshots/shot.png", {}, env);
+    const res = await app.request(
+      "https://api.uploads.sh/public/files/default/screenshots/shot.png",
+      {},
+      env,
+    );
     expect(res.status).toBe(200);
     const json = (await res.json()) as {
       metadata?: Record<string, string>;
-      github?: { repo: string; kind: string; number: number; url: string };
+      github?: {
+        repo: string;
+        kind: string;
+        number: number;
+        url: string;
+        avatarUrl?: string;
+      };
     };
     expect(json.metadata).toEqual({
       "gh.repo": "buildinternet/uploads",
@@ -263,6 +273,7 @@ describe("GET /public/files/:workspace/:key", () => {
       kind: "pull",
       number: 142,
       url: "https://github.com/buildinternet/uploads/pull/142",
+      avatarUrl: "https://api.uploads.sh/public/github/avatars/buildinternet",
     });
   });
 

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -86,6 +86,15 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     align-items: center;
     gap: 9px;
   }
+  :global(.account-shell) .ws-rail :global(.ws-rail__connected-avatar) {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex: none;
+    background: var(--panel);
+    border: 1px solid var(--line);
+  }
   :global(.account-shell) .ws-rail :global(.ws-rail__connected-icon) {
     width: 14px;
     height: 14px;

--- a/apps/web/src/lib/gh-context.test.ts
+++ b/apps/web/src/lib/gh-context.test.ts
@@ -4,6 +4,8 @@ import {
   connectedWork,
   exactPrMatch,
   githubUrl,
+  githubOwnerAvatarUrl,
+  ownerFromRepo,
   applyGhTitles,
   type GhWorkItem,
 } from "./gh-context";
@@ -22,14 +24,24 @@ const issue = {
 };
 
 describe("gh-context", () => {
-  it("builds a work item with url + labels", () => {
+  it("builds a work item with url + labels + owner", () => {
     expect(ghWorkItemFromMetadata(pr)).toMatchObject({
       ref: "o/uploads#1789",
       kind: "pull",
       kindLabel: "pull request",
       url: "https://github.com/o/uploads/pull/1789",
+      owner: "o",
     });
     expect(ghWorkItemFromMetadata(issue)!.url).toBe("https://github.com/o/uploads/issues/1740");
+  });
+
+  it("ownerFromRepo + avatar URL helpers", () => {
+    expect(ownerFromRepo("buildinternet/uploads")).toBe("buildinternet");
+    expect(ownerFromRepo("BuildInternet/Uploads")).toBe("buildinternet");
+    expect(ownerFromRepo("bad")).toBeNull();
+    expect(githubOwnerAvatarUrl("https://api.uploads.sh/", "buildinternet")).toBe(
+      "https://api.uploads.sh/public/github/avatars/buildinternet",
+    );
   });
   it("returns null when gh.* is absent/partial", () => {
     expect(ghWorkItemFromMetadata(undefined)).toBeNull();

--- a/apps/web/src/lib/gh-context.ts
+++ b/apps/web/src/lib/gh-context.ts
@@ -16,6 +16,9 @@ import type { GithubTitleMap } from "./api-client";
 
 export type GhKind = "pull" | "issue";
 
+/** Mirrors apps/api `GITHUB_OWNER_RE`. */
+const GITHUB_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
 export interface GhWorkItem {
   repo: string;
   kind: GhKind;
@@ -25,12 +28,27 @@ export interface GhWorkItem {
   /** `gh.title` when the CLI resolved one at attach time, else `ref` (e.g. "o/uploads#1789"). */
   label: string;
   kindLabel: "pull request" | "issue";
+  /** Lowercased `owner` from `repo` when it is a valid GitHub login. */
+  owner?: string;
 }
 
 /** `https://github.com/{repo}/{pull|issues}/{number}`. */
 export function githubUrl(repo: string, kind: GhKind, number: string): string {
   const path = kind === "pull" ? "pull" : "issues";
   return `https://github.com/${repo}/${path}/${number}`;
+}
+
+/** Owner of `owner/repo`, lowercased — same rules as the avatar proxy. */
+export function ownerFromRepo(repo: string): string | null {
+  const slash = repo.indexOf("/");
+  if (slash <= 0 || slash !== repo.lastIndexOf("/") || !repo.slice(slash + 1)) return null;
+  const owner = repo.slice(0, slash).trim();
+  return GITHUB_OWNER_RE.test(owner) ? owner.toLowerCase() : null;
+}
+
+/** `{apiOrigin}/public/github/avatars/{owner}`. */
+export function githubOwnerAvatarUrl(apiOrigin: string, owner: string): string {
+  return `${apiOrigin.replace(/\/$/, "")}/public/github/avatars/${encodeURIComponent(owner)}`;
 }
 
 /**
@@ -48,6 +66,7 @@ export function ghWorkItemFromMetadata(
   if (!repo || !kind || !number || !ref) return null;
   if (kind !== "pull" && kind !== "issue") return null;
   const title = meta["gh.title"];
+  const owner = ownerFromRepo(repo) ?? undefined;
   return {
     repo,
     kind,
@@ -56,6 +75,7 @@ export function ghWorkItemFromMetadata(
     url: githubUrl(repo, kind, number),
     label: title ? title : ref,
     kindLabel: kind === "pull" ? "pull request" : "issue",
+    ...(owner ? { owner } : {}),
   };
 }
 

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -93,9 +93,34 @@ describe("isPublicFile", () => {
       kind: "pull",
       number: 142,
       url: "https://github.com/buildinternet/uploads/pull/142",
+      avatarUrl: "https://api.uploads.sh/public/github/avatars/buildinternet",
     } as const;
     const metadata = { "gh.repo": "buildinternet/uploads", "gh.kind": "pull", "gh.number": "142" };
     expect(isPublicFile({ ...file, metadata, github })).toBe(true);
+  });
+
+  it("accepts loopback http avatarUrl for local dev but rejects arbitrary http", () => {
+    const base = {
+      repo: "buildinternet/uploads",
+      kind: "pull" as const,
+      number: 142,
+      url: "https://github.com/buildinternet/uploads/pull/142",
+    };
+    expect(
+      isPublicFile({
+        ...file,
+        github: {
+          ...base,
+          avatarUrl: "http://localhost:8787/public/github/avatars/buildinternet",
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isPublicFile({
+        ...file,
+        github: { ...base, avatarUrl: "http://evil.example/avatar.png" },
+      }),
+    ).toBe(false);
   });
 
   it("rejects malformed metadata maps", () => {

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -13,6 +13,8 @@ export interface GithubContext {
   url: string;
   /** Issue/PR title when the API resolved it; omitted when unavailable. */
   title?: string;
+  /** API proxy URL for the repo owner's avatar; omitted when owner is invalid. */
+  avatarUrl?: string;
 }
 
 /** Allowlisted metadata for one public object, as returned by the API. */
@@ -209,19 +211,28 @@ function isMetadataMap(value: unknown): value is Record<string, string> {
   return entries.every(([key, v]) => META_KEY_RE.test(key) && text(v, META_VALUE_MAX));
 }
 
+/** https always; loopback http for local API (avatar proxy only). */
+function isAvatarUrl(value: unknown): boolean {
+  if (httpsUrl(value)) return true;
+  if (typeof value !== "string" || value.length > 4096) return false;
+  return /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?\//.test(value);
+}
+
 /** Bounded `github` convenience object — mirrors apps/api's `deriveGithubContext` shape. */
 function isGithubContext(value: unknown): value is GithubContext {
   if (typeof value !== "object" || value === null) return false;
   const github = value as Record<string, unknown>;
   const titleOk =
     github.title === undefined || (text(github.title, 512) && (github.title as string).length > 0);
+  const avatarOk = github.avatarUrl === undefined || isAvatarUrl(github.avatarUrl);
   return (
     text(github.repo, 200) &&
     (github.kind === "pull" || github.kind === "issue") &&
     Number.isSafeInteger(github.number) &&
     (github.number as number) > 0 &&
     httpsUrl(github.url) &&
-    titleOk
+    titleOk &&
+    avatarOk
   );
 }
 

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -28,6 +28,18 @@ describe("renderConnectedWorkHtml", () => {
     // The octicon carries the kind (title/aria-label); no repeated word subtitle.
     expect(html).not.toContain("ws-rail__connected-sub");
     expect(html).toContain("<title>pull request</title>");
+    // No apiOrigin → no avatar img (client always passes origin from the rail).
+    expect(html).not.toContain("ws-rail__connected-avatar");
+  });
+
+  it("includes the owner avatar when apiOrigin + item.owner are set", () => {
+    const html = renderConnectedWorkHtml(
+      [ghItem({ owner: "buildinternet" })],
+      "https://api.uploads.sh",
+    );
+    expect(html).toContain('src="https://api.uploads.sh/public/github/avatars/buildinternet"');
+    expect(html).toContain('class="ws-rail__connected-avatar"');
+    expect(html).toContain('alt=""');
   });
 
   it("uses a different icon for issue rows than pull-request rows", () => {

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -21,7 +21,7 @@ import { getWorkspaceSummary, type GithubTitleMap, type MyWorkspace } from "./ap
 import { onSession } from "./account-shell";
 import { escapeHtml, renderUsageHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
-import { applyGhTitles, type GhKind, type GhWorkItem } from "./gh-context";
+import { applyGhTitles, githubOwnerAvatarUrl, type GhKind, type GhWorkItem } from "./gh-context";
 
 /** Optional titles come from the files tab's one listing-scoped title request. */
 export type ConnectedWorkSetter = (items: GhWorkItem[], titles?: GithubTitleMap) => void;
@@ -40,13 +40,17 @@ const CONNECTED_WORK_ICON: Record<GhKind, string> = {
   issue: githubKindSvg("issue", { className: "ws-rail__connected-icon" }),
 };
 
-function connectedWorkRowHtml(item: GhWorkItem): string {
-  return `<div class="ws-rail__connected-item">${CONNECTED_WORK_ICON[item.kind]}<div class="ws-rail__connected-meta"><a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.label)}</a></div></div>`;
+function connectedWorkRowHtml(item: GhWorkItem, apiOrigin?: string): string {
+  const avatar =
+    item.owner && apiOrigin
+      ? `<img class="ws-rail__connected-avatar" src="${escapeHtml(githubOwnerAvatarUrl(apiOrigin, item.owner))}" alt="" width="16" height="16" loading="lazy" decoding="async" />`
+      : "";
+  return `<div class="ws-rail__connected-item">${avatar}${CONNECTED_WORK_ICON[item.kind]}<div class="ws-rail__connected-meta"><a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.label)}</a></div></div>`;
 }
 
 /** Pure row-HTML builder for the rail's "connected work" section. `[]` → `""`. */
-export function renderConnectedWorkHtml(items: GhWorkItem[]): string {
-  return items.map(connectedWorkRowHtml).join("");
+export function renderConnectedWorkHtml(items: GhWorkItem[], apiOrigin?: string): string {
+  return items.map((item) => connectedWorkRowHtml(item, apiOrigin)).join("");
 }
 
 /** Minimal shape `renderDetailsHtml` needs — `MyWorkspace` is a structural superset. */
@@ -99,7 +103,10 @@ export function planTitleRepaint(
   return updated.some((item, i) => item.label !== items[i].label) ? updated : null;
 }
 
-function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter {
+function bindConnectedWorkSetter(
+  root: Document | Element,
+  apiOrigin?: string,
+): ConnectedWorkSetter {
   const section = root.querySelector<HTMLElement>("[data-rail-connected]");
   const list = root.querySelector<HTMLElement>("[data-rail-connected-list]");
   // Whether the user has clicked "show N more" for the current item set. A
@@ -126,7 +133,7 @@ function bindConnectedWorkSetter(root: Document | Element): ConnectedWorkSetter 
       const shown = items.slice(0, limit);
       const hidden = items.length - shown.length;
       list.innerHTML =
-        renderConnectedWorkHtml(shown) +
+        renderConnectedWorkHtml(shown, apiOrigin) +
         (hidden > 0
           ? `<button type="button" class="ws-rail__more" data-rail-more>show ${hidden} more</button>`
           : "");
@@ -171,7 +178,7 @@ export function initWorkspaceRail(
 ): void {
   const root = opts.root ?? document;
 
-  const setConnectedWork = bindConnectedWorkSetter(root);
+  const setConnectedWork = bindConnectedWorkSetter(root, apiOrigin);
   setConnectedWork([]);
 
   const detailsEl = root.querySelector<HTMLElement>("[data-rail-details]");

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -126,8 +126,17 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       .filehead { margin:0 0 16px; min-width:0; }
       .filetitle { margin:0; color:var(--fg); font:600 17px var(--mono); letter-spacing:-.01em; overflow-wrap:anywhere; }
       /* PR/issue under the filename — light byline, not a rail chip. */
-      .gh-byline { display:inline-flex; align-items:baseline; flex-wrap:wrap; column-gap:8px; row-gap:2px; margin-top:6px; max-width:100%; color:var(--muted); font:12.5px/1.45 var(--mono); text-decoration:none; }
+      .gh-byline { display:inline-flex; align-items:center; flex-wrap:wrap; column-gap:8px; row-gap:2px; margin-top:6px; max-width:100%; color:var(--muted); font:12.5px/1.45 var(--mono); text-decoration:none; }
       .gh-byline:hover, .gh-byline:focus-visible { color:var(--accent); outline:none; }
+      .gh-byline-avatar {
+        flex:none;
+        width:16px;
+        height:16px;
+        border-radius:50%;
+        object-fit:cover;
+        background:var(--panel);
+        border:1px solid var(--line);
+      }
       .gh-byline-icon { flex:none; align-self:center; }
       .gh-byline-title { color:var(--body); overflow-wrap:anywhere; }
       .gh-byline:hover .gh-byline-title, .gh-byline:focus-visible .gh-byline-title { color:inherit; }
@@ -183,6 +192,17 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
                 rel="noopener noreferrer"
                 aria-label={ghAriaLabel}
               >
+                {gh.avatarUrl && (
+                  <img
+                    class="gh-byline-avatar"
+                    src={gh.avatarUrl}
+                    alt=""
+                    width="16"
+                    height="16"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                )}
                 <svg
                   class="gh-byline-icon"
                   viewBox="0 0 16 16"


### PR DESCRIPTION
## In plain terms

When a file or workspace is tied to a GitHub PR/issue, we now show the **repo owner’s avatar** next to that work — on the public file byline and in the signed-in connected-work rail — so related GitHub orgs are easier to spot at a glance.

## What it does

- Adds `GET /public/github/avatars/:owner` on the API: proxies `https://github.com/{owner}.png`, validates image bytes, edge-caches positive (1d) and negative (1h) responses
- Enriches public file JSON with `github.avatarUrl` (first-party proxy URL derived from `gh.repo`)
- Renders a 16px circular avatar on the public file share-page byline and connected-work rail rows
- Soft-fails: missing/invalid owner or upstream errors hide the avatar; never blocks uploads

## What it is not

- Not R2 mirroring (proxy + Cache API only for now)
- Not workspace-switcher / settings chrome branding
- Not installation-account avatars (uses repo owner from `gh.repo`)
- No CodeRabbit auto-request

## How to try it

After deploy (or local stack):

1. Open a public file with `gh.repo` metadata → byline shows owner avatar + PR/issue chip
2. Signed-in workspace files tab with GitHub-tagged files → connected-work rows show owner avatars
3. Direct: `curl -I https://api.uploads.sh/public/github/avatars/buildinternet`

## Technical notes

- Worktree: `.worktrees/github-owner-avatars` on `feat/github-owner-avatars`
- Shared helpers in `apps/api/src/github-avatars.ts`; route at `/public/github/avatars`
- Client derives owner + proxy URL for the rail; file page uses DTO `avatarUrl`
- CSP already allows `img-src https:` on public file and signed-in shells

## Test plan

- [x] `pnpm --filter @uploads/api test` (1041)
- [x] `pnpm --filter @uploads/web test` (322)
- [ ] Spot-check file page + rail in local/dev stack with a real `gh.repo`