### PR TITLE
feat(cli): nudge untargeted put toward --pr/attach when branch context is detectable

### DIFF
--- a/.changeset/bare-put-nudge.md
+++ b/.changeset/bare-put-nudge.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`put` with no `--pr`/`--issue`/`--key` on a non-default git branch now prints a one-line nudge toward `--pr <num>` or `attach --branch`. Human mode writes it to stderr; `--format json` adds an additive `hint` field. Suppress with `--quiet`, `UPLOADS_NO_NUDGE=1`, or config `UPLOADS_NO_NUDGE=1`.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -49,12 +49,15 @@ import {
   resolveRepo,
   resolveCurrentPullRequest,
   resolveCurrentBranch,
+  resolveDefaultBranch,
   classifyGhNumber,
   execRunner,
+  timedExecRunner,
   ghMetadataFromTargetWithTitle,
   upsertAttachmentsComment,
   type CommandRunner,
 } from "./github-gh.js";
+import { deriveRepoFromGit } from "./keys.js";
 import { resolvePutPrefix } from "./destinations.js";
 import {
   optimizeImageForUpload,
@@ -171,6 +174,10 @@ Options:
                         (or UPLOADS_OVERWRITE=1). No effect on --pr/--issue, which always overwrite.
   --dry-run             Print key + public URL without uploading; reports if the key would replace
                         (or, on a strict key, be refused). Not with --comment/--gallery
+
+A bare put (no --pr/--issue/--key) on a non-default git branch prints a one-line
+nudge toward --pr/attach --branch (stderr in human mode, a "hint" field in
+--format json). Suppress with --quiet, UPLOADS_NO_NUDGE=1, or config UPLOADS_NO_NUDGE=1.
 
 Exit codes: 0 ok · 2 usage/token/file · 3 auth/policy · 4 network · 1 other (incl. partial multi-file failure).
 Scripted formats (json|url|markdown) also print failures on stdout.
@@ -1499,6 +1506,84 @@ async function runAttachPromoteOnly(
   return 0;
 }
 
+/** Bounds the best-effort `gh pr view` lookup the put nudge (issue #393) makes
+ * on top of the normal put flow — long enough for a real gh call, short
+ * enough to never be felt as a hang. */
+const PUT_NUDGE_GH_TIMEOUT_MS = 3000;
+
+/**
+ * The bare-put nudge's wording (issue #393): teaches `--pr`/`attach --branch`
+ * as an upgrade from a targetless `put`. `pr` present → names the PR;
+ * otherwise a generic variant that still points at `--pr <num>`. Used
+ * verbatim for both the human-mode stderr line and the JSON `hint` field.
+ */
+function putNudgeText(branch: string, pr: number | undefined): string {
+  const prClause =
+    pr !== undefined ? ` (PR #${pr} open) — rerun with --pr ${pr}` : ` — rerun with --pr <num>`;
+  return (
+    `note: on branch ${branch}${prClause} for a stable key plus a managed comment ` +
+    `that collects this PR's media, or stage pre-PR files with: uploads attach <file> --branch`
+  );
+}
+
+/**
+ * Best-effort bare-put nudge (issue #393): fires only when `put` has no
+ * targeting flag at all (`--pr`/`--issue`/`--key`; `--branch` too, though
+ * `put` doesn't currently accept it — defensive parity with `attach`), is
+ * inside a git repo (reusing `deriveRepoFromGit`, the same detection the
+ * default screenshot key's repo segment uses), and the current branch isn't
+ * the default one. Never throws — any failure (not a repo, detached HEAD,
+ * `gh` missing/unauthenticated/timed out) degrades to "no nudge" or, once a
+ * branch is already known, to the generic no-PR wording. Must never affect
+ * put's exit code, stdout, or upload behavior.
+ */
+function resolvePutNudge(opts: {
+  ctx: CliContext;
+  flags: CommandFlags["flags"];
+  ghTarget: GhTarget | undefined;
+  keyHint: string | undefined;
+  noGit: boolean;
+  defaults: PutDefaults;
+  run: CommandRunner;
+}): string | undefined {
+  const { ctx, flags, ghTarget, keyHint, noGit, defaults, run } = opts;
+  if (ctx.quiet) return undefined;
+  if (defaults.noNudge) return undefined;
+  if (ghTarget || keyHint || noGit) return undefined;
+  if (flags.has("--branch")) return undefined; // not a real put flag today; defensive only
+  try {
+    if (deriveRepoFromGit(run) === undefined) return undefined; // not a (usable) git repo
+    let branch: string;
+    try {
+      branch = resolveCurrentBranch(run);
+    } catch {
+      return undefined; // detached HEAD, or git unavailable
+    }
+    const defaultBranch = resolveDefaultBranch(run);
+    const onDefaultBranch = defaultBranch
+      ? branch === defaultBranch
+      : branch === "main" || branch === "master"; // undetermined: err toward not nudging
+    if (onDefaultBranch) return undefined;
+
+    let pr: number | undefined;
+    try {
+      // Only swap in the bounded runner for the real subprocess path — an
+      // injected `run` (tests, or a future caller) is trusted to already be
+      // fast/fake, and execFileSync's `timeout` option is meaningless
+      // against anything that isn't actually shelling out.
+      const timed = run === execRunner ? timedExecRunner(PUT_NUDGE_GH_TIMEOUT_MS) : run;
+      const repoArg = flagString(flags, "--repo") ?? defaults.repo;
+      const repo = resolveRepo(repoArg, timed);
+      pr = resolveCurrentPullRequest(repo, timed).num;
+    } catch {
+      pr = undefined; // gh missing/unauthenticated/timed out/no open PR — generic wording
+    }
+    return putNudgeText(branch, pr);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function runPut(
   ctx: CliContext,
   args: string[],
@@ -1655,6 +1740,19 @@ export async function runPut(
     }
   }
 
+  // Bare-put nudge (issue #393): computed once, used for both the trailing
+  // stderr line (human mode) and the JSON `hint` field below. Best-effort —
+  // see resolvePutNudge; never affects exit code, stdout, or the upload.
+  const nudge = resolvePutNudge({
+    ctx,
+    flags: parsed.flags,
+    ghTarget,
+    keyHint,
+    noGit,
+    defaults,
+    run,
+  });
+
   const logHuman = !ctx.quiet && format === "human";
   if (logHuman) {
     if (multi) {
@@ -1749,6 +1847,7 @@ export async function runPut(
         failures,
         comment,
         commentError,
+        ...(nudge ? { hint: nudge } : {}),
       });
     } else {
       for (const result of uploads) {
@@ -1785,6 +1884,7 @@ export async function runPut(
           `warning: could not upload ${failure.file}: ${failure.error.message}\n`,
         );
       }
+      if (nudge) process.stderr.write(`${nudge}\n`);
     }
     return failures.length === 0 && !galleryHadError ? 0 : 1;
   }
@@ -1817,6 +1917,7 @@ export async function runPut(
         frame: result.frame,
         gallery,
         ...(dryRun ? { dryRun: true } : {}),
+        ...(nudge ? { hint: nudge } : {}),
       });
       break;
     case "url":
@@ -1841,6 +1942,7 @@ export async function runPut(
       `warning: upload succeeded but adding it to gallery ${gallery.id} failed: ${gallery.error.message}\n`,
     );
   }
+  if (nudge && format !== "json") process.stderr.write(`${nudge}\n`);
 
   return gallery?.error ? 1 : 0;
 }

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -16,6 +16,7 @@ export const UPLOADS_CONFIG_KEYS = [
   "UPLOADS_KEEP_EXIF",
   "UPLOADS_NO_AUTO_META",
   "UPLOADS_SCREENSHOT_VIA",
+  "UPLOADS_NO_NUDGE",
 ] as const;
 
 export type UploadsConfigKey = (typeof UPLOADS_CONFIG_KEYS)[number];
@@ -34,6 +35,8 @@ export interface PutDefaults {
   keepExif?: boolean;
   /** When true, `put` does NOT auto-resolve/stamp gh.* on the default path. */
   noAutoMeta?: boolean;
+  /** When true, `put` never prints the bare-put --pr/attach nudge (issue #393). */
+  noNudge?: boolean;
 }
 
 const PUT_DEFAULT_KEY_MAP: Record<keyof PutDefaults, UploadsConfigKey> = {
@@ -45,6 +48,7 @@ const PUT_DEFAULT_KEY_MAP: Record<keyof PutDefaults, UploadsConfigKey> = {
   noOptimize: "UPLOADS_NO_OPTIMIZE",
   keepExif: "UPLOADS_KEEP_EXIF",
   noAutoMeta: "UPLOADS_NO_AUTO_META",
+  noNudge: "UPLOADS_NO_NUDGE",
 };
 
 function isTruthyConfigFlag(value: string | undefined): boolean {
@@ -63,6 +67,7 @@ export function putDefaultsToConfigValues(defaults: PutDefaults): UploadsConfigV
   if (defaults.noOptimize) out.UPLOADS_NO_OPTIMIZE = "1";
   if (defaults.keepExif) out.UPLOADS_KEEP_EXIF = "1";
   if (defaults.noAutoMeta) out.UPLOADS_NO_AUTO_META = "1";
+  if (defaults.noNudge) out.UPLOADS_NO_NUDGE = "1";
   return out;
 }
 
@@ -79,6 +84,7 @@ function parsePutDefaultsFromRaw(raw: UploadsConfigValues): PutDefaults {
   if (isTruthyConfigFlag(raw.UPLOADS_NO_OPTIMIZE)) out.noOptimize = true;
   if (isTruthyConfigFlag(raw.UPLOADS_KEEP_EXIF)) out.keepExif = true;
   if (isTruthyConfigFlag(raw.UPLOADS_NO_AUTO_META)) out.noAutoMeta = true;
+  if (isTruthyConfigFlag(raw.UPLOADS_NO_NUDGE)) out.noNudge = true;
   return out;
 }
 
@@ -94,6 +100,7 @@ function parsePutDefaultsFromEnv(): PutDefaults {
   if (process.env.UPLOADS_NO_OPTIMIZE) raw.UPLOADS_NO_OPTIMIZE = process.env.UPLOADS_NO_OPTIMIZE;
   if (process.env.UPLOADS_KEEP_EXIF) raw.UPLOADS_KEEP_EXIF = process.env.UPLOADS_KEEP_EXIF;
   if (process.env.UPLOADS_NO_AUTO_META) raw.UPLOADS_NO_AUTO_META = process.env.UPLOADS_NO_AUTO_META;
+  if (process.env.UPLOADS_NO_NUDGE) raw.UPLOADS_NO_NUDGE = process.env.UPLOADS_NO_NUDGE;
   return parsePutDefaultsFromRaw(raw);
 }
 
@@ -159,6 +166,7 @@ export function mergePutDefaults(...layers: PutDefaults[]): PutDefaults {
     if (layer.noOptimize != null) out.noOptimize = layer.noOptimize;
     if (layer.keepExif != null) out.keepExif = layer.keepExif;
     if (layer.noAutoMeta != null) out.noAutoMeta = layer.noAutoMeta;
+    if (layer.noNudge != null) out.noNudge = layer.noNudge;
   }
   return out;
 }

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -16,6 +16,23 @@ export const execRunner: CommandRunner = (cmd, args, input) =>
   execFileSync(cmd, args, { encoding: "utf8", input, stdio: ["pipe", "pipe", "pipe"] });
 
 /**
+ * A `CommandRunner` bounded by `timeoutMs` (node's native `execFileSync`
+ * `timeout` option). There is no other subprocess-timeout wrapper in this
+ * codebase to reuse, so this is the minimal one: for a best-effort lookup
+ * that must never block its caller for long (e.g. the bare-`put` nudge's `gh
+ * pr view` check, issue #393), pass this instead of the default `execRunner`.
+ */
+export const timedExecRunner =
+  (timeoutMs: number): CommandRunner =>
+  (cmd, args, input) =>
+    execFileSync(cmd, args, {
+      encoding: "utf8",
+      input,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: timeoutMs,
+    });
+
+/**
  * Resolve "owner/name". Order: explicit --repo (validated) → `gh repo view`
  * (fork-aware) → parse the origin remote → UsageError.
  */
@@ -94,6 +111,25 @@ export function resolveCurrentBranch(run: CommandRunner = execRunner): string {
     );
   }
   return branch;
+}
+
+/**
+ * Best-effort default-branch name via the local `origin/HEAD` ref (no
+ * network call — just reads the ref git already cached from the last
+ * fetch/clone). Returns undefined when it can't be determined (no origin,
+ * `origin/HEAD` never set, not a git repo) — callers should treat that as
+ * "unknown", not "no default branch exists".
+ */
+export function resolveDefaultBranch(run: CommandRunner = execRunner): string | undefined {
+  try {
+    const out = run("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]).trim();
+    if (!out) return undefined;
+    const slash = out.indexOf("/");
+    const branch = slash === -1 ? out : out.slice(slash + 1);
+    return branch || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/uploads/src/keys.ts
+++ b/packages/uploads/src/keys.ts
@@ -12,9 +12,20 @@ export async function sha256Short(bytes: Uint8Array): Promise<string> {
     .slice(0, 6);
 }
 
-export function deriveRepoFromGit(): string | undefined {
+/**
+ * `run` is optional and structurally matches `CommandRunner` (github-gh.ts)
+ * without importing it — callers that already have an injected runner (e.g.
+ * the put nudge, issue #393) can pass it through for testability; the
+ * default (no `run`) preserves the original direct-`execSync` behavior for
+ * every existing caller.
+ */
+export function deriveRepoFromGit(
+  run?: (cmd: string, args: string[], input?: string) => string,
+): string | undefined {
   try {
-    const url = execSync("git config --get remote.origin.url", { encoding: "utf8" }).trim();
+    const url = run
+      ? run("git", ["config", "--get", "remote.origin.url"]).trim()
+      : execSync("git config --get remote.origin.url", { encoding: "utf8" }).trim();
     const match = url.match(/[/:]([^/]+?)(?:\.git)?$/);
     return match?.[1];
   } catch {

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -942,6 +942,332 @@ describe("runPut canonical metadata flags", () => {
   });
 });
 
+/**
+ * Fake gh/git runner for the bare-put nudge (issue #393). Each stage throws
+ * when its corresponding option is omitted, mirroring the real degrade path
+ * (not a git repo / detached HEAD / gh missing-unauthenticated-no PR).
+ */
+function nudgeRunner(opts: {
+  branch?: string;
+  defaultBranch?: string;
+  originUrl?: string;
+  repo?: string;
+  pr?: number;
+}): CommandRunner {
+  return (cmd, args) => {
+    if (cmd === "git" && args[0] === "config") {
+      if (opts.originUrl === undefined) throw new Error("not a git repo");
+      return `${opts.originUrl}\n`;
+    }
+    if (cmd === "git" && args[0] === "rev-parse") {
+      if (opts.branch === undefined) throw new Error("detached HEAD");
+      return `${opts.branch}\n`;
+    }
+    if (cmd === "git" && args[0] === "symbolic-ref") {
+      if (opts.defaultBranch === undefined) throw new Error("no origin/HEAD");
+      return `origin/${opts.defaultBranch}\n`;
+    }
+    if (cmd === "gh" && args[0] === "repo") {
+      if (opts.repo === undefined) throw new Error("gh unauthenticated");
+      return `${opts.repo}\n`;
+    }
+    if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+      if (opts.pr === undefined) throw new Error("no pull request found");
+      return `${opts.pr}\n`;
+    }
+    throw new Error(`unexpected: ${cmd} ${args.join(" ")}`);
+  };
+}
+
+/** Run `fn` with process.stderr.write captured, returning the concatenated output. */
+async function captureStderr(fn: () => Promise<unknown>): Promise<string> {
+  const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  try {
+    await fn();
+    return writeSpy.mock.calls.map((c) => String(c[0])).join("");
+  } finally {
+    writeSpy.mockRestore();
+  }
+}
+
+/** Run `fn` with process.stdout.write captured, returning the concatenated output. */
+async function captureStdout(fn: () => Promise<unknown>): Promise<string> {
+  const chunks: string[] = [];
+  const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  try {
+    await fn();
+    return chunks.join("");
+  } finally {
+    writeSpy.mockRestore();
+  }
+}
+
+describe("runPut bare-put nudge (issue #393)", () => {
+  const allClear = {
+    branch: "feature/thing",
+    defaultBranch: "main",
+    originUrl: "git@github.com:o/r.git",
+    repo: "o/r",
+    pr: 123,
+  };
+
+  it("fires on stderr for a fully bare put with detectable branch/PR context", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner(allClear),
+      ),
+    );
+    expect(stderr).toContain(
+      "note: on branch feature/thing (PR #123 open) — rerun with --pr 123 for a stable key",
+    );
+    expect(stderr).toContain("uploads attach <file> --branch");
+  });
+
+  it("never writes the nudge to stdout", async () => {
+    const { client } = fakeClient();
+    const stdout = await captureStdout(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner(allClear),
+      ),
+    );
+    expect(stdout).not.toContain("note:");
+  });
+
+  it("includes an additive JSON hint field when it fires", async () => {
+    const { client } = fakeClient();
+    const stdout = await captureStdout(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false, json: true },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner(allClear),
+      ),
+    );
+    const payload = JSON.parse(stdout) as { hint?: string; key: string; url: string };
+    expect(payload.hint).toContain("PR #123 open");
+    expect(payload.key).toBeDefined();
+    expect(payload.url).toBeDefined();
+  });
+
+  it("omits the JSON hint field entirely when the nudge doesn't fire (on the default branch)", async () => {
+    const { client } = fakeClient();
+    const stdout = await captureStdout(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false, json: true },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({ ...allClear, branch: "main" }),
+      ),
+    );
+    const payload = JSON.parse(stdout) as Record<string, unknown>;
+    expect("hint" in payload).toBe(false);
+  });
+
+  it("falls back to generic wording (no PR number) when the gh lookup fails", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({
+          branch: "feature/thing",
+          defaultBranch: "main",
+          originUrl: "git@github.com:o/r.git",
+        }), // no pr
+      ),
+    );
+    expect(stderr).toContain("note: on branch feature/thing — rerun with --pr <num>");
+    expect(stderr).not.toContain("PR #");
+  });
+
+  it("gh timeout falls back to generic wording without changing exit code or upload behavior", async () => {
+    const { client, puts } = fakeClient();
+    const run: CommandRunner = (cmd, args) => {
+      if (cmd === "git" && args[0] === "config") return "git@github.com:o/r.git\n";
+      if (cmd === "git" && args[0] === "rev-parse") return "feature/thing\n";
+      if (cmd === "git" && args[0] === "symbolic-ref") return "origin/main\n";
+      if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+        const err = new Error("ETIMEDOUT");
+        (err as NodeJS.ErrnoException).code = "ETIMEDOUT";
+        throw err;
+      }
+      throw new Error(`unexpected: ${cmd} ${args.join(" ")}`);
+    };
+    const stderr = await captureStderr(async () => {
+      const code = await runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        run,
+      );
+      expect(code).toBe(0);
+    });
+    expect(puts).toHaveLength(1);
+    expect(stderr).toContain("note: on branch feature/thing — rerun with --pr <num>");
+  });
+
+  it("does not nudge with --pr", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--pr", "9", "--repo", "o/r"],
+        false,
+        nudgeRunner(allClear),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge with --issue", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--issue", "9", "--repo", "o/r"],
+        false,
+        nudgeRunner(allClear),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge with an explicit --key", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--key", "screenshots/x.png"],
+        false,
+        nudgeRunner(allClear),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge with --no-git", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r", "--no-git"],
+        false,
+        noRun,
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge in quiet mode", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(ctxWith(client), [tmpFile(), "--repo", "o/r"], false, nudgeRunner(allClear)),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge when UPLOADS_NO_NUDGE=1", async () => {
+    const prev = process.env.UPLOADS_NO_NUDGE;
+    process.env.UPLOADS_NO_NUDGE = "1";
+    try {
+      const { client } = fakeClient();
+      const stderr = await captureStderr(() =>
+        runPut(
+          { ...ctxWith(client), quiet: false },
+          [tmpFile(), "--repo", "o/r"],
+          false,
+          nudgeRunner(allClear),
+        ),
+      );
+      expect(stderr).not.toContain("note:");
+    } finally {
+      if (prev === undefined) delete process.env.UPLOADS_NO_NUDGE;
+      else process.env.UPLOADS_NO_NUDGE = prev;
+    }
+  });
+
+  it("does not nudge on the default branch (remote HEAD resolved)", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({ ...allClear, branch: "main" }),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge on main when the default branch can't be determined (errs toward not nudging)", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({ branch: "main", originUrl: "git@github.com:o/r.git", repo: "o/r", pr: 1 }),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("still nudges on a non-main/master branch when the default branch can't be determined", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({
+          branch: "feature/thing",
+          originUrl: "git@github.com:o/r.git",
+          repo: "o/r",
+          pr: 7,
+        }),
+      ),
+    );
+    expect(stderr).toContain("note: on branch feature/thing (PR #7 open)");
+  });
+
+  it("does not nudge on detached HEAD", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({ defaultBranch: "main", repo: "o/r", pr: 1 }), // no branch → git rev-parse throws
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("does not nudge outside a git repo", async () => {
+    const { client } = fakeClient();
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--repo", "o/r"],
+        false,
+        nudgeRunner({ branch: "feature/thing" }), // no originUrl → deriveRepoFromGit fails
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+});
+
 describe("put promotes EXIF facts", () => {
   async function retinaPng(): Promise<Buffer> {
     const sharp = (await import("sharp")).default;

--- a/packages/uploads/test/config-put-defaults.test.ts
+++ b/packages/uploads/test/config-put-defaults.test.ts
@@ -18,3 +18,27 @@ describe("resolvePutDefaults noAutoMeta", () => {
     expect(resolvePutDefaults({}).noAutoMeta).toBe(true);
   });
 });
+
+describe("resolvePutDefaults noNudge (issue #393)", () => {
+  const prev = process.env.UPLOADS_NO_NUDGE;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.UPLOADS_NO_NUDGE;
+    else process.env.UPLOADS_NO_NUDGE = prev;
+  });
+
+  it("is undefined by default (nudge stays on)", () => {
+    delete process.env.UPLOADS_NO_NUDGE;
+    expect(resolvePutDefaults({}).noNudge).toBeUndefined();
+  });
+
+  it("reads UPLOADS_NO_NUDGE=1 from env", () => {
+    process.env.UPLOADS_NO_NUDGE = "1";
+    expect(resolvePutDefaults({}).noNudge).toBe(true);
+  });
+
+  it("reads UPLOADS_NO_NUDGE=1 from a config/env-file layer (same key, put config path)", () => {
+    delete process.env.UPLOADS_NO_NUDGE;
+    const fromUser = { UPLOADS_NO_NUDGE: "1" } as const;
+    expect(resolvePutDefaults(undefined, { fromEnvFile: {}, fromUser }).noNudge).toBe(true);
+  });
+});

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -6,8 +6,10 @@ import {
   ghMetadataFromTargetWithTitle,
   resolveCurrentBranch,
   resolveCurrentPullRequest,
+  resolveDefaultBranch,
   resolveGhTitle,
   resolveRepo,
+  timedExecRunner,
   upsertAttachmentsComment,
   type CommandRunner,
 } from "../src/github-gh.js";
@@ -334,5 +336,38 @@ describe("classifyGhNumber", () => {
   it("returns undefined on unexpected output", () => {
     const run: CommandRunner = () => "weird\n";
     expect(classifyGhNumber("o/r", 1, run)).toBeUndefined();
+  });
+});
+
+describe("resolveDefaultBranch (issue #393)", () => {
+  it("parses the short branch name from origin/HEAD", () => {
+    const { run } = fakeRunner({ git: () => "origin/main\n" });
+    expect(resolveDefaultBranch(run)).toBe("main");
+  });
+
+  it("handles a bare ref with no remote prefix", () => {
+    const { run } = fakeRunner({ git: () => "main\n" });
+    expect(resolveDefaultBranch(run)).toBe("main");
+  });
+
+  it("returns undefined when origin/HEAD isn't set (no remote, not a repo, etc.)", () => {
+    const { run } = fakeRunner({
+      git: () => {
+        throw new Error("fatal: ref refs/remotes/origin/HEAD is not a symbolic ref");
+      },
+    });
+    expect(resolveDefaultBranch(run)).toBeUndefined();
+  });
+});
+
+describe("timedExecRunner (issue #393)", () => {
+  it("runs a fast command and returns its stdout, like execRunner", () => {
+    const run = timedExecRunner(5000);
+    expect(run(process.execPath, ["-e", "process.stdout.write('ok')"])).toBe("ok");
+  });
+
+  it("kills and throws when the command outlives the timeout", () => {
+    const run = timedExecRunner(150);
+    expect(() => run(process.execPath, ["-e", "setTimeout(() => {}, 5000)"])).toThrow();
   });
 });

--- a/packages/uploads/test/keys.test.ts
+++ b/packages/uploads/test/keys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { deriveRepoFromGit } from "../src/keys.js";
+
+describe("deriveRepoFromGit (injectable run, issue #393)", () => {
+  it("parses the repo name from an SSH remote via an injected runner", () => {
+    const run = (cmd: string, args: string[]) => {
+      expect(cmd).toBe("git");
+      expect(args).toEqual(["config", "--get", "remote.origin.url"]);
+      return "git@github.com:buildinternet/uploads.git\n";
+    };
+    expect(deriveRepoFromGit(run)).toBe("uploads");
+  });
+
+  it("returns undefined when the injected runner throws (not a git repo / no origin)", () => {
+    const run = () => {
+      throw new Error("fatal: not a git repository");
+    };
+    expect(deriveRepoFromGit(run)).toBeUndefined();
+  });
+
+  it("returns undefined when the remote URL doesn't match the expected shape", () => {
+    const run = () => "not-a-url\n";
+    expect(deriveRepoFromGit(run)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #393.

A bare `uploads put` (no `--pr`/`--issue`/`--key`, not `--no-git`) on a non-default git branch now prints a one-line nudge toward `--pr <num>` or `attach --branch`. Detection reuses existing plumbing (`resolveCurrentBranch`, `resolveRepo`, `resolveCurrentPullRequest`) and never changes what or where the put actually uploads — suggestion only.

### Before / after (human mode)

```
$ uploads put shot.png
URL: https://uploads.sh/screenshots/uploads/2026-07-22/shot-a1b2c3.webp
MARKDOWN: ![shot.png](https://uploads.sh/screenshots/uploads/2026-07-22/shot-a1b2c3.webp)
note: on branch feat/393-bare-put-nudge (PR #401 open) — rerun with --pr 401 for a stable key plus a managed comment that collects this PR's media, or stage pre-PR files with: uploads attach <file> --branch
```

The note goes to stderr, after the normal output — stdout (`URL:`/`MARKDOWN:`/etc.) is unchanged.

Generic variant (no open PR resolvable, or `gh` missing/unauthenticated/timed out):

```
note: on branch feat/393-bare-put-nudge — rerun with --pr <num> for a stable key plus a managed comment that collects this PR's media, or stage pre-PR files with: uploads attach <file> --branch
```

### JSON mode

`--format json` gets an additive, optional top-level `hint` field with the same content — absent whenever the nudge doesn't fire, every existing field unchanged:

```json
{
  "workspace": "acme",
  "key": "screenshots/uploads/2026-07-22/shot-a1b2c3.webp",
  "url": "https://uploads.sh/...",
  "...": "...",
  "hint": "note: on branch feat/393-bare-put-nudge (PR #401 open) — rerun with --pr 401 for a stable key plus a managed comment that collects this PR's media, or stage pre-PR files with: uploads attach <file> --branch"
}
```

This is the half that matters most per the issue — agents read structured stdout and drop stderr.

### Suppression

- `--quiet`
- `UPLOADS_NO_NUDGE=1` (env var)
- `UPLOADS_NO_NUDGE=1` in the shared config file / `--env-file` (same key as the env var, following the existing `UPLOADS_NO_GIT`/`UPLOADS_NO_AUTO_META` pattern in `config-file.ts`)
- Any targeting flag (`--pr`, `--issue`, `--key`) or `--no-git`
- Being on the repo's default branch (best-effort `origin/HEAD`; when undetermined, errs toward *not* nudging on `main`/`master`)

### Detection

- No `--pr`/`--issue`/`--key` (also checks `--branch`, defensively, though `put` doesn't currently accept that flag)
- Inside a git repo — `keys.ts`'s `deriveRepoFromGit` (used for the default screenshot key's repo segment), now accepting an optional injectable runner for testability while keeping its original `execSync` default for every existing caller
- Not on the default branch
- PR number resolution is best-effort via `resolveRepo`/`resolveCurrentPullRequest` (the same lookup `attach` uses), bounded by a new `timedExecRunner` (native `execFileSync` `timeout`) when running the real subprocess path — any failure or timeout degrades to the generic wording, never fails the put, never changes its exit code or upload behavior

## Test plan

- [x] `pnpm test` (root, all packages) — 197 files / 2438 tests passed
- [x] `pnpm --filter @buildinternet/uploads run typecheck`
- [x] `pnpm run format:check` (oxfmt)
- [x] Detection matrix: `--pr`, `--issue`, `--key`, `--no-git`, quiet, `UPLOADS_NO_NUDGE=1`, default branch (resolved and undetermined-on-main/master), detached HEAD, and "not a git repo" each independently suppress the nudge; the all-clear case fires it (`packages/uploads/test/commands-put.test.ts`)
- [x] `gh` lookup failure/timeout falls back to generic wording without changing stdout, exit code, or upload behavior
- [x] JSON mode: `hint` present when firing, absent otherwise, no other field touched
- [x] Human mode: nudge asserted on stderr, asserted absent from stdout
- [x] New unit coverage for the supporting plumbing: `resolveDefaultBranch`, `timedExecRunner` (`packages/uploads/test/github-gh.test.ts`), injectable `deriveRepoFromGit` (`packages/uploads/test/keys.test.ts`), and `UPLOADS_NO_NUDGE` config resolution (`packages/uploads/test/config-put-defaults.test.ts`)
- [x] Changeset added for `@buildinternet/uploads` only (minor)
