### PR TITLE
fix(mcp): GitHub App identity vars for the hosted comment path

### DIFF
--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -12,6 +12,14 @@
     // .dev.vars (AUTH_ORIGIN=http://127.0.0.1:8788, matching apps/auth's
     // pinned dev port).
     "AUTH_ORIGIN": "https://auth.uploads.sh",
+    // GitHub App identity for the hosted put/comment path (#392) — the same
+    // App uploads-api uses; postManagedComment runs in-process on this
+    // worker, so it needs its own copy of the config. GITHUB_APP_PRIVATE_KEY
+    // is the only true secret and must be set separately:
+    //   wrangler secret put GITHUB_APP_PRIVATE_KEY --config apps/mcp/wrangler.jsonc
+    // Without all three, comment: true degrades to { reason: "app_unconfigured" }.
+    "GITHUB_APP_ID": "4346270",
+    "GITHUB_APP_HOME_INSTALLATION_ID": "147814297",
   },
   "routes": [
     // Primary domain; mcp.uploads.sh is kept as a working alternate.


### PR DESCRIPTION
The #392 prod e2e (hosted MCP `put` with `pr` + `comment: true` against PR #394) surfaced this: the upload half works (stable `gh/` key written, honest decline returned), but the comment degraded to `app_unconfigured` — `postManagedComment` runs in-process on **uploads-mcp**, and the GitHub App config only existed on **uploads-api**.

This adds the two plain vars (same App identity uploads-api declares). The private key is a secret and must be set once on the worker after merge:

```
wrangler secret put GITHUB_APP_PRIVATE_KEY --config apps/mcp/wrangler.jsonc
```

Until the secret is set, `comment: true` keeps degrading to `app_unconfigured` (upload unaffected, decline honest — the fail-closed path did its job). No changeset (mcp is an ignored package). Typecheck clean.

E2E result that caught it (prod, workspace `default`):

```json
{
  "key": "gh/buildinternet/uploads/pull/394/e2e-hosted-mcp-comment.png",
  "comment": { "posted": false, "reason": "app_unconfigured" }
}
```

Refs #392.
