### PR TITLE
docs(skills): 0.23-era refresh — hosted MCP comment, put nudge, staging story

### DIFF
--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -2,17 +2,22 @@
 name: github-screenshots
 description: >-
   Embed screenshots, images, diagrams, GIFs, and screen recordings in GitHub
-  PRs and issues — or get a durable public link to share a visual with a
+  PRs and issues — or stage them ahead of a PR, collect them into one
+  attachments comment, or get a durable public link to share a visual with a
   person. Use this whenever a visual needs to end up in a PR description,
-  issue body, or PR/issue comment, or in front of a teammate. Triggers include
-  "attach a screenshot to the PR", "add a before/after to the issue", "include
-  a screenshot of …", "share a GIF of the flow", "record the bug and put it in
-  the issue", "get me a link I can paste in Slack", or having just captured or
-  changed something visual that a shot would make clearer. Reach for this
-  instead of drag-and-drop or github.com/user-attachments (agents can't upload
-  there) and instead of hand-rolling cloud-storage uploads. Capture the visual
-  with whatever browser or screenshot tooling you have; this skill covers
-  hosting and embedding it.
+  issue body, or PR/issue comment, in front of a teammate, or saved for a PR
+  that doesn't exist yet. Triggers include "attach a screenshot to the PR",
+  "add a before/after to the issue", "include a screenshot of …", "share a GIF
+  of the flow", "record the bug and put it in the issue", "get me a link I can
+  paste in Slack", "stage screenshots for the PR", "attach this when I open
+  the PR", "save this for the PR", "collect the PR's media", or having just
+  captured or changed something visual that a shot would make clearer — even
+  mid-task, before a PR exists. Also applies when an agent has no local
+  filesystem and is uploading via the hosted MCP (agents.uploads.sh). Reach
+  for this instead of drag-and-drop or github.com/user-attachments (agents
+  can't upload there) and instead of hand-rolling cloud-storage uploads.
+  Capture the visual with whatever browser or screenshot tooling you have;
+  this skill covers hosting and embedding it.
 ---
 
 # Screenshots and recordings in GitHub PRs and issues
@@ -52,6 +57,19 @@ optimizer only rewrites still images (PNG/JPEG → WebP).
 
 ## Step 2 — Host and embed
 
+Two tiers, pick by whether a PR already exists:
+
+- **Simple — a PR/issue already exists.** `uploads put shot.png --pr 123` (or
+  `uploads attach shot.png`, which infers the PR from the current branch) —
+  one call, stable per-PR key, embed URLs back immediately, and the managed
+  comment collects that PR's media as a side effect.
+- **Advanced — stage pre-PR, before there's anything to target.** `uploads
+attach shot.png --branch` (see below) — no PR/issue needed yet; promotion
+  and the comment happen automatically once the PR opens, **but only for a
+  repo already bound to the workspace** (see the caveat below). Reach for the
+  simple tier once the PR exists unless you're deliberately building up a
+  staged set across a longer branch.
+
 **Default loop: stage as you go, from the first visual milestone.** Don't wait
 for a PR to exist. The moment you have something worth capturing — mid-task,
 still on a branch, no PR yet — attach it right then with `uploads attach
@@ -66,6 +84,25 @@ This uploads under stable, branch-keyed paths (no PR/issue target needed, no
 comment yet — there's nothing to comment on until a PR exists). Keep doing
 this at each meaningful visual milestone as you work; don't batch everything
 into one attach at the end.
+
+**Staging only auto-promotes into a bound repo — don't promise it blind.**
+Auto-promotion at PR-open time (webhook or CLI-triggered, below) requires the
+repo already bound to a workspace: any earlier successful attach/comment/
+promote call against that repo binds it implicitly, or `uploads github link`
+binds it explicitly. A repo that's never been bound and only ever staged with
+`--branch` sees **no error and no comment** when the PR opens — it's a silent
+no-op. If you can't confirm the repo is already bound (`uploads github link
+--status`), don't tell the user the screenshot will "just show up" in the PR.
+The zero-setup fallback that works regardless of binding history: once the PR
+exists, run `uploads attach --promote` (or any targeted `uploads attach`
+against that PR) to promote and post explicitly.
+
+**No local filesystem?** An agent driving the hosted MCP
+(`agents.uploads.sh/mcp`, no CLI, no git checkout) can still get a visual into
+a PR in one call: the `put` tool takes `pr`/`issue` (+ required `repo`, since
+there's no git context server-side) plus `comment: true` to post straight to
+the managed attachments comment — see the **uploads-cli** skill for the exact
+tool contract and honest decline reasons.
 
 **Pass `--state before`/`--state after` as a habit.** Before/after is the whole
 point of most PR screenshots, and it's the one thing no tool can infer from the

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: uploads-cli
 description: >-
-  Reference for the uploads CLI — host files on uploads.sh and manage them.
-  Covers put and attach, screenshot capture (local browser or server-side
-  render), stable PR/issue keys, the managed attachments comment, metadata
-  and search, galleries, config defaults, login/doctor, and output formats.
-  Use when driving the `uploads` CLI or its MCP tools, when
-  you need a public URL for a local file ("upload this", "host this image",
-  "give me a public URL for this file"), or when you need exact flags, key
+  Reference for the uploads CLI and its stdio/hosted MCP tools — exact flags,
+  keys, and contracts for put and attach, screenshot capture, stable PR/issue
+  keys, the managed attachments comment, metadata and search, galleries,
+  config defaults, login/doctor, and output formats. Use when driving the
+  `uploads` CLI or its MCP tools (including the hosted MCP at
+  agents.uploads.sh for agents without local filesystem/git access), when you
+  need a public URL for a local file ("upload this", "host this image", "give
+  me a public URL for this file"), when the CLI itself prints a hint or nudge
+  you need to act on (a `hint` field in `--format json`, or the stderr note
+  suggesting `--pr`/`attach --branch`), or when you need exact flags, key
   layouts, or setup and auth details. For the when-and-how of getting a
   screenshot or recording into a GitHub PR or issue, start with the
   github-screenshots skill — it defers here for CLI detail.
@@ -69,6 +72,17 @@ once a PR exists for that branch:
 
 Promotion only applies to PRs, never issues, and both paths degrade silently
 (no error) if the workspace's server doesn't support promotion yet.
+
+**Promotion needs the repo already bound to the workspace.** Both the webhook
+and the CLI-triggered path above rely on the same repo↔workspace binding used
+by the managed comment (see "Repo binding" below) — any earlier successful
+`attach`/`comment`/promote call against that repo binds it implicitly, or
+`uploads github link` claims it explicitly. A repo that has **never** been
+bound and is only ever staged with `--branch` sees no error and no comment —
+promotion is a silent no-op at PR-open time. If you can't confirm the repo is
+already bound, don't promise auto-attach; the zero-setup fallback that works
+regardless of binding history is running `uploads attach --promote` (or any
+targeted `uploads attach`) once the PR exists.
 
 **Comment missing?** First, give it a moment — if the App is installed and
 subscribed to `issue_comment`, a deleted or mangled bot comment self-heals on
@@ -264,6 +278,28 @@ uploads put ./shot.png --format url        # just the URL, for scripting
 uploads put ./shot.png --format markdown   # just the ![]()/<img> snippet
 uploads put ./shot.png --json              # {workspace,key,url,size,markdown}
 ```
+
+**The bare-put nudge (issue #393).** A `put` with no targeting flag at all
+(`--pr`/`--issue`/`--key`) while inside a git repo on a non-default branch
+prints a one-line note teaching the upgrade — human mode writes it to stderr,
+`--format json` adds it as an additive optional `hint` field on the same
+response:
+
+```
+note: on branch fix-header (PR #142 open) — rerun with --pr 142 for a stable
+key plus a managed comment that collects this PR's media, or stage pre-PR
+files with: uploads attach <file> --branch
+```
+
+**If you're an agent and you see this `hint` (or the stderr note), act on
+it** — rerun with `--pr <num>` (or `attach --branch` pre-PR) rather than
+ignoring it; it never changes exit code or upload behavior, so it's easy to
+skip if you're only inspecting `url`/`markdown`, but the suggested command is
+the one that gets a stable key and a managed comment instead of a one-off
+throwaway URL. It's best-effort (a quick `gh pr view` lookup, bounded to 3s) —
+no open PR just widens the wording to a generic `--pr <num>`. Suppress it with
+`--quiet`, `UPLOADS_NO_NUDGE=1` (env), or `UPLOADS_NO_NUDGE=1` in the config
+file (`uploads config set UPLOADS_NO_NUDGE 1`).
 
 ## Capturing a screenshot: `uploads screenshot`
 
@@ -631,7 +667,7 @@ uploads config init --api-url http://localhost:8787 --workspace default --token 
 Recognized keys: `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, `UPLOADS_TOKEN`,
 `UPLOADS_DEFAULT_PREFIX`, `UPLOADS_DEFAULT_REPO`, `UPLOADS_DEFAULT_REF`,
 `UPLOADS_DEFAULT_WIDTH`, `UPLOADS_NO_GIT`, `UPLOADS_NO_OPTIMIZE`, `UPLOADS_KEEP_EXIF`,
-`UPLOADS_NO_AUTO_META`, `UPLOADS_SCREENSHOT_VIA`.
+`UPLOADS_NO_AUTO_META`, `UPLOADS_SCREENSHOT_VIA`, `UPLOADS_NO_NUDGE`.
 Also read (env only, not config-file keys): `UPLOADS_EMBED_PUBLIC_BASE_URL`,
 `UPLOADS_OVERWRITE`.
 
@@ -667,13 +703,35 @@ uploads --api-url http://localhost:8787 doctor
 - **Reports:** only when the user asks — `uploads report "what broke"` or
   `--file ./trace.log`. Never auto-send logs. MCP tool: `report`.
 - **MCP:** `uploads mcp` (stdio) mirrors CLI tools; hosted MCP at
-  `https://agents.uploads.sh/mcp`. Metadata: `get_metadata` / `set_metadata` /
-  `find_files` (same as `meta get` / `meta set` / `find`). Both support
-  multi-file `put` in one call — stdio takes `files` as paths, hosted takes
+  `https://agents.uploads.sh/mcp` — the one to reach for when an agent has no
+  local filesystem or git checkout to shell out from (send base64 content
+  directly). Metadata: `get_metadata` / `set_metadata` / `find_files` (same as
+  `meta get` / `meta set` / `find`). Both support multi-file `put` in one call
+  — stdio takes `files` as paths, hosted takes
   `files: [{ filename, contentBase64, alt? }]` (max 20/call; per-item `alt`
   overrides the top-level one) — returning `{ uploads, failures }` with
   per-item results. `uploads install` sets
   up this skill + hosted MCP (short progress; `--verbose` / `--dry-run` available).
+
+  **Hosted MCP `put` comment parity (issue #392).** The hosted `put` tool
+  accepts `pr`/`issue` (mutually exclusive, mirroring the CLI's `--pr`/
+  `--issue`) plus a required `repo` (`owner/name` — the hosted server has no
+  git context to infer it from) to get the same stable `gh/…` key the CLI
+  produces. Add `comment: true` to post/update the managed `uploads-sh[bot]`
+  attachments comment directly, same as CLI `--comment` — bot-only on this
+  server, no local-`gh` fallback. Prefer `pr`/`issue`/`comment` over just
+  returning a raw `url`/`embedUrl` whenever the caller is going to paste the
+  result into a PR/issue: it gets the stable overwrite-in-place key and
+  (optionally) lands straight in the collected attachments comment instead of
+  a one-off link the caller has to hand-embed. A comment failure never fails
+  the upload — it's returned honestly in the result's `comment` field as one
+  of `not_installed` (App not installed on the repo), `not_authorized` (repo
+  bound to a different workspace, or unbound and this workspace isn't
+  entitled to claim it), or `forbidden` (App installed but Issues/PR write
+  access not yet approved — includes a `fixUrl` to the org's permission-review
+  page), never as a thrown tool error; an unexpected error surfaces
+  separately as `commentError`.
+
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing
   upload/list/delete as AI-SDK tools inside a Worker — only relevant if you're


### PR DESCRIPTION
## Summary

- Fold the 0.23-era shipped changes into the two in-repo agent skills:
  hosted MCP `put`'s comment parity (#392), the bare-put nudge (#393), and
  the simple-vs-staged usage story (`--pr`/`attach` vs `attach --branch`),
  including the repo-binding precondition for auto-promotion and the
  `attach --promote` fallback.
- Tune each skill's `description:` frontmatter for the new trigger
  phrasings (staging/pre-PR, collecting media, hosted MCP, reacting to the
  CLI's nudge output) while keeping the two skills' primary roles
  non-overlapping.

No changeset: `packages/uploads/src/commands/install.ts` fetches both
skills at install time via `npx -y skills add buildinternet/uploads --skill
<name> ...` — pulled directly from this GitHub repo, not bundled into the
`@buildinternet/uploads` npm package. A skills-only change has no npm
surface to version.

## description frontmatter — before/after

**`skills/github-screenshots/SKILL.md`**

Before:
> Embed screenshots, images, diagrams, GIFs, and screen recordings in GitHub
> PRs and issues — or get a durable public link to share a visual with a
> person. Use this whenever a visual needs to end up in a PR description,
> issue body, or PR/issue comment, or in front of a teammate. Triggers include
> "attach a screenshot to the PR", "add a before/after to the issue", "include
> a screenshot of …", "share a GIF of the flow", "record the bug and put it in
> the issue", "get me a link I can paste in Slack", or having just captured or
> changed something visual that a shot would make clearer. Reach for this
> instead of drag-and-drop or github.com/user-attachments (agents can't upload
> there) and instead of hand-rolling cloud-storage uploads. Capture the visual
> with whatever browser or screenshot tooling you have; this skill covers
> hosting and embedding it.

After:
> Embed screenshots, images, diagrams, GIFs, and screen recordings in GitHub
> PRs and issues — or stage them ahead of a PR, collect them into one
> attachments comment, or get a durable public link to share a visual with a
> person. Use this whenever a visual needs to end up in a PR description,
> issue body, or PR/issue comment, in front of a teammate, or saved for a PR
> that doesn't exist yet. Triggers include "attach a screenshot to the PR",
> "add a before/after to the issue", "include a screenshot of …", "share a GIF
> of the flow", "record the bug and put it in the issue", "get me a link I can
> paste in Slack", "stage screenshots for the PR", "attach this when I open
> the PR", "save this for the PR", "collect the PR's media", or having just
> captured or changed something visual that a shot would make clearer — even
> mid-task, before a PR exists. Also applies when an agent has no local
> filesystem and is uploading via the hosted MCP (agents.uploads.sh). Reach
> for this instead of drag-and-drop or github.com/user-attachments (agents
> can't upload there) and instead of hand-rolling cloud-storage uploads.
> Capture the visual with whatever browser or screenshot tooling you have;
> this skill covers hosting and embedding it.

**`skills/uploads-cli/SKILL.md`**

Before:
> Reference for the uploads CLI — host files on uploads.sh and manage them.
> Covers put and attach, screenshot capture (local browser or server-side
> render), stable PR/issue keys, the managed attachments comment, metadata
> and search, galleries, config defaults, login/doctor, and output formats.
> Use when driving the `uploads` CLI or its MCP tools, when
> you need a public URL for a local file ("upload this", "host this image",
> "give me a public URL for this file"), or when you need exact flags, key
> layouts, or setup and auth details. For the when-and-how of getting a
> screenshot or recording into a GitHub PR or issue, start with the
> github-screenshots skill — it defers here for CLI detail.

After:
> Reference for the uploads CLI and its stdio/hosted MCP tools — exact flags,
> keys, and contracts for put and attach, screenshot capture, stable PR/issue
> keys, the managed attachments comment, metadata and search, galleries,
> config defaults, login/doctor, and output formats. Use when driving the
> `uploads` CLI or its MCP tools (including the hosted MCP at
> agents.uploads.sh for agents without local filesystem/git access), when you
> need a public URL for a local file ("upload this", "host this image", "give
> me a public URL for this file"), when the CLI itself prints a hint or nudge
> you need to act on (a `hint` field in `--format json`, or the stderr note
> suggesting `--pr`/`attach --branch`), or when you need exact flags, key
> layouts, or setup and auth details. For the when-and-how of getting a
> screenshot or recording into a GitHub PR or issue, start with the
> github-screenshots skill — it defers here for CLI detail.

## Cross-references checked

Grepped for other copies/mentions of these two skills. Nothing else needed
updating — no factually stale claims (e.g. "comment sync is stdio-only")
found outside the skill files themselves:

- `AGENTS.md` — points at the skills for the full workflow; its own
  short-form summary of auto-promotion doesn't claim anything the update
  contradicts. Left alone.
- `plugins/claude/uploads/README.md`, `plugins/claude/uploads/commands/attach.md`,
  `.claude-plugin/marketplace.json` — generic pointers to the two skills by
  name; no duplicated content to go stale. Left alone.
- `docs/cli.md` — links to the two `SKILL.md` files; no duplicated claims.
  Left alone.
- `docs/superpowers/plans/*`, `docs/superpowers/specs/*` — dated historical
  design docs, not living reference material. Left alone.

## Test plan

- [x] `pnpm test` from repo root — 200 test files / 2467 tests passed
- [x] `oxfmt --check` clean on both edited files (ran via the repo's
      lint-staged hook on commit)
