### PR TITLE
feat(cli): warn at stage time when the repo isn't bound (#398)

### DIFF
--- a/.changeset/stage-binding-warning.md
+++ b/.changeset/stage-binding-warning.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`attach --branch` now warns at stage time when the repo won't auto-attach staged files at PR open — either because it isn't linked to your workspace yet, or because it's linked to a different workspace. Advisory only: staging always succeeds regardless. Suppressed by `--quiet`, `UPLOADS_NO_NUDGE=1` (env or config), same as the bare-put nudge (#396).

--- a/apps/api/src/routes/github-link-route.test.ts
+++ b/apps/api/src/routes/github-link-route.test.ts
@@ -74,6 +74,16 @@ function get(env: Env, workspace: string, repo: string, token: string) {
   );
 }
 
+function getRepoLink(env: Env, workspace: string, repo: string, token: string) {
+  return app.request(
+    `/v1/${workspace}/github/repo-link?repo=${encodeURIComponent(repo)}`,
+    {
+      headers: { authorization: `Bearer ${token}` },
+    },
+    env,
+  );
+}
+
 function post(env: Env, workspace: string, body: unknown, token: string) {
   return app.request(
     `/v1/${workspace}/github/link`,
@@ -129,6 +139,82 @@ describe("GET /v1/:workspace/github/link", () => {
     const { env } = await seededEnv();
     const res = await app.request(`/v1/${WS}/github/link?repo=${REPO}`, {}, env);
     expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /v1/:workspace/github/repo-link", () => {
+  it("reports 'none' for an unclaimed repo", async () => {
+    const { env } = await seededEnv();
+    const res = await getRepoLink(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ binding: "none" });
+  });
+
+  it("reports 'self' when the repo is bound to the calling workspace", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: WS,
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await getRepoLink(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ binding: "self" });
+  });
+
+  it("reports 'other' when the repo is bound to a different workspace, without naming it", async () => {
+    const { env, db } = await seededEnv();
+    db.repoLinks.set(REPO, {
+      repo_full_name: REPO,
+      workspace_name: "someone-else",
+      installation_id: null,
+      source: "comment",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const res = await getRepoLink(env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ binding: "other" });
+    // Cross-tenant info disclosure guard: the response body must never
+    // contain the other workspace's name, in this field or any other.
+    expect(JSON.stringify(body)).not.toContain("someone-else");
+  });
+
+  it("400s on a malformed repo", async () => {
+    const { env } = await seededEnv();
+    const res = await getRepoLink(env, WS, "not-a-repo", TOKEN);
+    expect(res.status).toBe(400);
+  });
+
+  it("401s with no bearer token", async () => {
+    const { env } = await seededEnv();
+    const res = await app.request(`/v1/${WS}/github/repo-link?repo=${REPO}`, {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("degrades to 'none' (not a 5xx) on a D1 lookup failure — advisory must never hard-fail", async () => {
+    // Only the github_repo_links query fails — auth (auth_tokens) still
+    // resolves normally, so this isolates the lenient findRepoLink fallback
+    // rather than tripping over workspaceAuth's own D1 read.
+    const { env, db } = await seededEnv();
+    const realPrepare = db.prepare;
+    const flakyDb = {
+      prepare: (sql: string) =>
+        sql.includes("github_repo_links")
+          ? {
+              bind: () => ({
+                first: async () => {
+                  throw new Error("d1 unavailable");
+                },
+              }),
+            }
+          : realPrepare(sql),
+    };
+    const res = await getRepoLink({ ...env, DB: flakyDb } as unknown as Env, WS, REPO, TOKEN);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ binding: "none" });
   });
 });
 

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -55,6 +55,26 @@ export const githubLink = new Hono<WorkspaceVars>()
     const link = await findRepoLink(c.env.DB, repo);
     return c.json(linkResponse(repo, link));
   })
+  // `/repo-link` (issue #398): a deliberately minimal, cross-tenant-safe
+  // counterpart to `/link` above. `/link` names the owning workspace in its
+  // response — fine for an authenticated inspect/claim flow the caller
+  // initiated for their own repo, but wrong for the `attach --branch` stage
+  // warning, which fires for ANY repo the CLI happens to detect from local
+  // git context. That warning must be able to say "this repo belongs to
+  // someone else" without ever saying to whom, so this route collapses the
+  // full link record down to a tri-state relative to the calling workspace:
+  // "self" (bound to me), "other" (bound, not to me), or "none" (unbound).
+  // Uses the lenient `findRepoLink` (never throws — a D1 blip degrades to
+  // "none", not a 5xx) because this is advisory-only; the CLI already
+  // silences anything but a clean 200.
+  .get("/repo-link", requireScope("files:read"), async (c) => {
+    const repo = parseRepo(c.req.query("repo"));
+    const workspaceName = c.get("workspaceName");
+    const link = await findRepoLink(c.env.DB, repo);
+    const binding =
+      link === null ? "none" : link.workspaceName === workspaceName ? "self" : "other";
+    return c.json({ binding });
+  })
   .post("/link", writeRateLimit, requireScope("files:write"), async (c) => {
     const repo = parseRepo((await jsonBody(c)).repo);
     const workspaceName = c.get("workspaceName");

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -302,6 +302,17 @@ export interface GithubLinkUnlinkResult {
   reason?: "not_linked";
 }
 
+/**
+ * `GET /v1/:workspace/github/repo-link` result (issue #398). Deliberately
+ * minimal relative to `GithubLinkResult`: never names the owning workspace
+ * when it isn't this one — "self"/"other"/"none" is all the stage-time
+ * warning needs, and anything richer would leak cross-tenant info to a
+ * caller that's just probing a repo it detected from local git context.
+ */
+export interface GithubRepoLinkResult {
+  binding: "self" | "other" | "none";
+}
+
 export interface HealthResult {
   ok: boolean;
 }
@@ -1135,6 +1146,20 @@ export function createUploadsClient(config: UploadsClientConfig) {
           body: new TextEncoder().encode(JSON.stringify({ repo })),
           headers: { "Content-Type": "application/json" },
         },
+      );
+    },
+
+    /**
+     * Tri-state binding status for `repo` relative to this workspace (issue
+     * #398, `attach --branch`'s stage-time warning) — never names another
+     * workspace, unlike `githubLinkStatus` above. Throws `UploadsError`
+     * (status 404) on an older/self-hosted server without this route; the
+     * caller (the stage warning) treats ANY failure here as "stay silent".
+     */
+    async githubRepoLinkStatus(repo: string): Promise<GithubRepoLinkResult> {
+      return request<GithubRepoLinkResult>(
+        "GET",
+        `${config.apiUrl}/v1/${encodeURIComponent(config.workspace)}/github/repo-link?repo=${encodeURIComponent(repo)}`,
       );
     },
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1417,8 +1417,19 @@ async function runAttachBranch(
     throw firstError instanceof Error ? firstError : new Error(String(firstError));
   }
 
+  // Stage-time binding warning (issue #398): only worth checking once staging
+  // actually produced something to warn about. Best-effort — see
+  // resolveStageBindingWarning; never affects exit code or the upload itself.
+  const bindingWarning =
+    uploads.length > 0 ? await resolveStageBindingWarning({ ctx, defaults, repo }) : undefined;
+
   if (ctx.json) {
-    await writeJson({ target, uploads, failures });
+    await writeJson({
+      target,
+      uploads,
+      failures,
+      ...(bindingWarning ? { hint: bindingWarning } : {}),
+    });
   } else {
     for (const result of uploads) {
       if (logHuman) {
@@ -1444,8 +1455,50 @@ async function runAttachBranch(
           `(or run \`uploads attach --promote\` after opening)\n`,
       );
     }
+    if (bindingWarning) process.stderr.write(`${bindingWarning}\n`);
   }
   return failures.length === 0 ? 0 : 1;
+}
+
+/**
+ * Best-effort stage-time binding warning (issue #398): after `attach
+ * --branch` stages files, checks whether `repo` is bound to THIS workspace —
+ * webhook auto-promotion at PR open only fires for a repo already bound
+ * (#297), and staging alone never binds one. Fires only for `binding: "none"`
+ * (unbound) or `"other"` (bound elsewhere); `"self"` and any failure
+ * (network, non-200, older server without the route, `binding: "unknown"`)
+ * are silent — this is advisory only and must never make staging look like
+ * it failed. Same suppression as the #393 put nudge: `--quiet`,
+ * `UPLOADS_NO_NUDGE=1` (env or config).
+ */
+async function resolveStageBindingWarning(opts: {
+  ctx: CliContext;
+  defaults: PutDefaults;
+  repo: string;
+}): Promise<string | undefined> {
+  const { ctx, defaults, repo } = opts;
+  if (ctx.quiet) return undefined;
+  if (defaults.noNudge) return undefined;
+  try {
+    const { binding } = await ctx.client.githubRepoLinkStatus(repo);
+    switch (binding) {
+      case "none":
+        return (
+          `note: staged, but ${repo} isn't linked to your workspace yet — staged files only ` +
+          `auto-attach on PR open for linked repos. Link it once with: uploads attach <file> ` +
+          `(on any PR) or uploads github link. After the PR opens: uploads attach --promote`
+        );
+      case "other":
+        return (
+          `note: staged, but ${repo} is linked to a different workspace — these files won't ` +
+          `auto-attach from here.`
+        );
+      default:
+        return undefined; // "self", or any unrecognized value — stay silent
+    }
+  } catch {
+    return undefined; // any failure (network, non-200, older server) — stay silent
+  }
 }
 
 /**

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
-import type { PromoteBranchAttachmentsResult, UploadsClient } from "../src/client.js";
+import type {
+  GithubRepoLinkResult,
+  PromoteBranchAttachmentsResult,
+  UploadsClient,
+} from "../src/client.js";
 import { runAttach, type CliContext } from "../src/commands.js";
 import { UploadsError } from "../src/errors.js";
 import type { CommandRunner } from "../src/github-gh.js";
@@ -26,6 +30,12 @@ function fakeClient(opts?: {
     num: number;
     branch: string;
   }) => Promise<PromoteBranchAttachmentsResult> | PromoteBranchAttachmentsResult;
+  /**
+   * `client.githubRepoLinkStatus` behavior (issue #398 stage-time binding
+   * warning): a `GithubRepoLinkResult`, a thrown error, or omitted (method
+   * absent — simulates an older server without the route).
+   */
+  repoLinkStatus?: GithubRepoLinkResult | Error | ((repo: string) => GithubRepoLinkResult | Error);
 }) {
   const puts: string[] = [];
   const metadataByKey: Record<string, Record<string, string> | undefined> = {};
@@ -66,6 +76,18 @@ function fakeClient(opts?: {
     },
     findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
     getGallery: async () => ({ items: [] }),
+    ...(opts?.repoLinkStatus !== undefined
+      ? {
+          githubRepoLinkStatus: async (repo: string) => {
+            const result =
+              typeof opts.repoLinkStatus === "function"
+                ? opts.repoLinkStatus(repo)
+                : opts.repoLinkStatus!;
+            if (result instanceof Error) throw result;
+            return result;
+          },
+        }
+      : {}),
     ...(opts?.promote
       ? {
           promoteBranchAttachments: async (promoteOpts: {
@@ -516,6 +538,225 @@ describe("runAttach --branch (branch-staged, pre-PR)", () => {
         expect(puts.length).toBe(1);
       },
     );
+  });
+});
+
+describe("runAttach --branch stage-time binding warning (issue #398)", () => {
+  const branchRunner =
+    (branch = "feature/thing"): CommandRunner =>
+    (cmd, args) => {
+      if (cmd === "git" && args[0] === "rev-parse") return `${branch}\n`;
+      throw new Error(`unexpected call: ${cmd} ${args.join(" ")}`);
+    };
+
+  /** Run `fn` with stderr captured and stdout swallowed. */
+  async function withCapturedStderr(fn: () => Promise<unknown>): Promise<string> {
+    const stderr: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    try {
+      await fn();
+    } finally {
+      vi.restoreAllMocks();
+    }
+    return stderr.join("");
+  }
+
+  it("warns when the repo is unbound (binding: none)", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "none" } });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr = await withCapturedStderr(() =>
+      runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      ),
+    );
+    expect(stderr).toContain(
+      "note: staged, but o/r isn't linked to your workspace yet — staged files only auto-attach on PR open for linked repos. " +
+        "Link it once with: uploads attach <file> (on any PR) or uploads github link. " +
+        "After the PR opens: uploads attach --promote",
+    );
+  });
+
+  it("warns when the repo is bound to a different workspace (binding: other)", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "other" } });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr = await withCapturedStderr(() =>
+      runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      ),
+    );
+    expect(stderr).toContain(
+      "note: staged, but o/r is linked to a different workspace — these files won't auto-attach from here.",
+    );
+  });
+
+  it("is silent when the repo is bound to this workspace (binding: self)", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr = await withCapturedStderr(() =>
+      runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("is silent on an unrecognized binding value (server-side 'unknown')", async () => {
+    const { client } = fakeClient({
+      repoLinkStatus: { binding: "unknown" } as unknown as GithubRepoLinkResult,
+    });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr = await withCapturedStderr(() =>
+      runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("is silent when the endpoint call fails (network error)", async () => {
+    const { client } = fakeClient({ repoLinkStatus: new Error("network down") });
+    const ctx = { ...ctxWith(client), quiet: false };
+    let code: number | undefined;
+    const stderr = await withCapturedStderr(async () => {
+      code = await runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      );
+    });
+    expect(stderr).not.toContain("note:");
+    expect(code).toBe(0); // staging itself still succeeded
+  });
+
+  it("is silent when the endpoint route is absent (older/self-hosted server)", async () => {
+    const { client } = fakeClient(); // no repoLinkStatus option → method absent
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr = await withCapturedStderr(() =>
+      runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("is silent in quiet mode even when unbound", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "none" } });
+    const stderr = await withCapturedStderr(() =>
+      runAttach(
+        ctxWith(client), // quiet: true (default)
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      ),
+    );
+    expect(stderr).not.toContain("note:");
+  });
+
+  it("is silent when UPLOADS_NO_NUDGE=1", async () => {
+    const prev = process.env.UPLOADS_NO_NUDGE;
+    process.env.UPLOADS_NO_NUDGE = "1";
+    try {
+      const { client } = fakeClient({ repoLinkStatus: { binding: "none" } });
+      const ctx = { ...ctxWith(client), quiet: false };
+      const stderr = await withCapturedStderr(() =>
+        runAttach(
+          ctx,
+          [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+          false,
+          branchRunner(),
+        ),
+      );
+      expect(stderr).not.toContain("note:");
+    } finally {
+      if (prev === undefined) delete process.env.UPLOADS_NO_NUDGE;
+      else process.env.UPLOADS_NO_NUDGE = prev;
+    }
+  });
+
+  it("never writes the warning to stdout", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "none" } });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    vi.spyOn(process.stderr, "write").mockImplementation(
+      (() => true) as typeof process.stderr.write,
+    );
+    try {
+      await runAttach(
+        ctx,
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      );
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(stdout.join("")).not.toContain("note:");
+  });
+
+  it("includes an additive JSON hint field when it fires, absent otherwise", async () => {
+    const unbound = fakeClient({ repoLinkStatus: { binding: "none" } }).client;
+    const stdoutUnbound: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdoutUnbound.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      await runAttach(
+        { ...ctxWith(unbound), quiet: false, json: true },
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      );
+    } finally {
+      vi.restoreAllMocks();
+    }
+    const payloadUnbound = JSON.parse(stdoutUnbound.join("")) as { hint?: string };
+    expect(payloadUnbound.hint).toContain("isn't linked to your workspace yet");
+
+    const bound = fakeClient({ repoLinkStatus: { binding: "self" } }).client;
+    const stdoutBound: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdoutBound.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      await runAttach(
+        { ...ctxWith(bound), quiet: false, json: true },
+        [...files("shot.png"), "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      );
+    } finally {
+      vi.restoreAllMocks();
+    }
+    const payloadBound = JSON.parse(stdoutBound.join("")) as Record<string, unknown>;
+    expect("hint" in payloadBound).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #398

## Problem

Webhook auto-promotion only fires for repos already bound to a workspace (#297), and `attach --branch` staging never binds one. In a never-bound repo, stage-only work silently no-ops at PR open — the one silent failure mode in the "stage pre-PR, comment appears at PR open" flow.

## What this does

`attach --branch` now checks the repo's binding right after a successful stage and prints one advisory line when the staged files won't auto-attach. No auto-binding — this is advisory only; staging always succeeds regardless of binding state.

**Server** — `GET /v1/:workspace/github/repo-link?repo=owner/name` (`apps/api/src/routes/github-link.ts`):
- Workspace-authed, `requireScope("files:read")`
- Same owner/name grammar + dots-only-segment guard as `routes/github-comment.ts`
- Returns only `{ binding: "self" | "other" | "none" }` — deliberately minimal vs. the existing `/github/link`, which does name the owning workspace. This route never does, closing the cross-tenant info-disclosure gap for a check that fires for any repo the CLI happens to detect from local git context.
- Uses the lenient `findRepoLink` (never throws) so a D1 blip degrades to `"none"`, not a 5xx — an advisory endpoint must not hard-fail.

**CLI** — after `attach --branch` stages at least one file (`packages/uploads/src/commands.ts`), a best-effort call to the new endpoint:
- `none` → `note: staged, but <repo> isn't linked to your workspace yet — staged files only auto-attach on PR open for linked repos. Link it once with: uploads attach <file> (on any PR) or uploads github link. After the PR opens: uploads attach --promote`
- `other` → `note: staged, but <repo> is linked to a different workspace — these files won't auto-attach from here.`
- `self`, any unrecognized `binding` value, or any failure (network, non-200, older server without the route) → completely silent
- Suppressed by `--quiet` and `UPLOADS_NO_NUDGE=1` (env or config `PutDefaults.noNudge`), matching the #396 put-nudge conventions exactly: stderr-only, never stdout, and an additive `hint` field on the `--format json` staging output (absent when the warning doesn't fire)

## Deviation from the issue text

The issue's server section floated returning `binding: "unknown"` for a lookup failure if only a strict helper existed. `github-repo-links.ts` already has `findRepoLink` (lenient — never throws, returns `null` on a D1 error), so the endpoint uses that directly and a D1 blip just looks like `"none"`. The CLI still treats an unrecognized `binding` value as silent (defensive parity with a hypothetical future `"unknown"`), but the server can't currently produce one.

## Test evidence

```
$ pnpm --filter @uploads/api test -- github-link-route
 Test Files  94 passed (94)
      Tests  1047 passed (1047)

$ pnpm --filter @buildinternet/uploads typecheck
$ tsc --noEmit && tsc --noEmit -p test
(clean)

$ pnpm --filter @uploads/api typecheck
(clean)

$ pnpm test   # root, full workspace
 Test Files  200 passed (200)
      Tests  2483 passed (2483)
```

New coverage:
- **Server** (`apps/api/src/routes/github-link-route.test.ts`): tri-state for bound-to-self / bound-to-other / unbound, no owner name in the `other` response body, grammar rejection (400), 401 with no token, D1-lookup-failure → `{ binding: "none" }` (not a 5xx).
- **CLI** (`packages/uploads/test/commands-attach.test.ts`): warning text per state (`none`/`other`), silence for `self`/unrecognized-value/network-error/route-absent, suppression via quiet mode and `UPLOADS_NO_NUDGE=1`, stderr-only (never stdout), additive JSON `hint` field present when firing and absent otherwise, staging still exits 0 in every case.

## Conventions followed

- oxfmt (ran on all touched files)
- Changeset: minor, `@buildinternet/uploads` only (nothing for `apps/api` — ignored package)
- No `.env` files touched
- `worker-configuration.d.ts` regenerated by the pre-commit hook as usual but produced no diff
