### PR TITLE
fix: cut D1 full-scan cost and close soft-delete/presign holes

### DIFF
--- a/apps/api/migrations/20260722180000_file_metadata_value_covering_idx.sql
+++ b/apps/api/migrations/20260722180000_file_metadata_value_covering_idx.sql
@@ -1,0 +1,9 @@
+-- Covering index for cross-workspace (meta_key, meta_value) lookups that also
+-- ORDER BY workspace, object_key LIMIT N (staging reaper). The prior
+-- (meta_key, meta_value) index forced a full match-set sort before LIMIT,
+-- billing rows-read proportional to all branch-staged metadata rows.
+
+DROP INDEX IF EXISTS file_metadata_value_lookup_idx;
+
+CREATE INDEX IF NOT EXISTS file_metadata_value_lookup_idx
+  ON file_metadata (meta_key, meta_value, workspace, object_key);

--- a/apps/api/migrations/20260722180100_auth_enrollments_expires_at_idx.sql
+++ b/apps/api/migrations/20260722180100_auth_enrollments_expires_at_idx.sql
@@ -1,6 +1,12 @@
 -- Supports daily observability retention purge on auth_enrollments
--- (expires_at < cutoff OR used_at < cutoff). The existing
--- auth_enrollments_code_idx leads with code_hash and cannot serve a pure
--- expires_at range scan.
+-- (expires_at < cutoff OR (used_at IS NOT NULL AND used_at < cutoff)).
+-- The existing auth_enrollments_code_idx leads with code_hash and cannot
+-- serve a pure expires_at / used_at range scan.
 CREATE INDEX IF NOT EXISTS auth_enrollments_expires_at_idx
   ON auth_enrollments (expires_at);
+
+-- Partial index: only used rows (used_at non-null), so the second OR-leg of
+-- the purge predicate can range-scan without reading unused enrollments.
+CREATE INDEX IF NOT EXISTS auth_enrollments_used_at_idx
+  ON auth_enrollments (used_at)
+  WHERE used_at IS NOT NULL;

--- a/apps/api/migrations/20260722180100_auth_enrollments_expires_at_idx.sql
+++ b/apps/api/migrations/20260722180100_auth_enrollments_expires_at_idx.sql
@@ -1,0 +1,6 @@
+-- Supports daily observability retention purge on auth_enrollments
+-- (expires_at < cutoff OR used_at < cutoff). The existing
+-- auth_enrollments_code_idx leads with code_hash and cannot serve a pure
+-- expires_at range scan.
+CREATE INDEX IF NOT EXISTS auth_enrollments_expires_at_idx
+  ON auth_enrollments (expires_at);

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -356,27 +356,60 @@ export async function replaceFileMetadata(
   await db.batch(statements);
 }
 
+/** Keyset cursor for cross-workspace metadata scans (workspace, object_key). */
+export type MetadataCrossWorkspaceCursor = {
+  workspace: string;
+  key: string;
+};
+
 /**
  * Cross-workspace `(meta_key, meta_value)` lookup (staging reaper: `gh.kind=branch`).
- * Bounded by `limit`; ordered by (workspace, object_key).
- * Needs `file_metadata_value_lookup_idx` — workspace-leading index cannot serve this.
+ * Bounded by `limit`; ordered by (workspace, object_key). Optional keyset
+ * `after` continues past a prior page. `nextAfter` is the last row when the
+ * page was full (caller should resume), or null at end-of-set (reset cursor).
+ *
+ * Served by covering `file_metadata_value_lookup_idx`
+ * `(meta_key, meta_value, workspace, object_key)` — workspace-leading index
+ * cannot serve this.
  */
 export async function findObjectsByMetadataAcrossWorkspaces(
   db: D1Database,
   metaKey: string,
   metaValue: string,
   limit: number,
-): Promise<Array<{ workspace: string; key: string }>> {
-  const result = await db
-    .prepare(
-      `SELECT workspace, object_key FROM file_metadata
-       WHERE meta_key = ? AND meta_value = ?
-       ORDER BY workspace, object_key
-       LIMIT ?`,
-    )
-    .bind(metaKey, metaValue, limit)
-    .all<{ workspace: string; object_key: string }>();
-  return result.results.map((row) => ({ workspace: row.workspace, key: row.object_key }));
+  opts?: { after?: MetadataCrossWorkspaceCursor | null },
+): Promise<{
+  rows: Array<{ workspace: string; key: string }>;
+  /** Null when this page was short (end of set — caller should reset cursor). */
+  nextAfter: MetadataCrossWorkspaceCursor | null;
+}> {
+  const after = opts?.after;
+  const result = after
+    ? await db
+        .prepare(
+          `SELECT workspace, object_key FROM file_metadata
+           WHERE meta_key = ? AND meta_value = ?
+             AND (workspace > ? OR (workspace = ? AND object_key > ?))
+           ORDER BY workspace, object_key
+           LIMIT ?`,
+        )
+        .bind(metaKey, metaValue, after.workspace, after.workspace, after.key, limit)
+        .all<{ workspace: string; object_key: string }>()
+    : await db
+        .prepare(
+          `SELECT workspace, object_key FROM file_metadata
+           WHERE meta_key = ? AND meta_value = ?
+           ORDER BY workspace, object_key
+           LIMIT ?`,
+        )
+        .bind(metaKey, metaValue, limit)
+        .all<{ workspace: string; object_key: string }>();
+
+  const rows = result.results.map((row) => ({ workspace: row.workspace, key: row.object_key }));
+  const last = rows[rows.length - 1];
+  const nextAfter =
+    rows.length === limit && last ? { workspace: last.workspace, key: last.key } : null;
+  return { rows, nextAfter };
 }
 
 const FIND_DEFAULT_LIMIT = 50;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { workspaces } from "./routes/workspaces";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runStagingReaper } from "./staging-reaper";
+import { runObservabilityRetention } from "./observability-retention";
 import { galleries } from "./routes/galleries";
 import { publicGalleries } from "./routes/public-galleries";
 import { publicFiles } from "./routes/public-files";
@@ -181,6 +182,18 @@ export default {
         console.error(
           JSON.stringify({
             message: "staging_reap_failed",
+            error: appErr.message,
+            code: appErr.code,
+          }),
+        );
+      }),
+    );
+    ctx.waitUntil(
+      runObservabilityRetention(env).catch((err) => {
+        const appErr = AppError.from(err);
+        console.error(
+          JSON.stringify({
+            message: "observability_retention_failed",
             error: appErr.message,
             code: appErr.code,
           }),

--- a/apps/api/src/observability-retention.ts
+++ b/apps/api/src/observability-retention.ts
@@ -29,6 +29,39 @@ function placeholders(n: number): string {
   return Array.from({ length: n }, () => "?").join(", ");
 }
 
+/**
+ * Fetch BATCH_SIZE + 1 ids so truncation is grounded in a leftover row, not
+ * “the last batch happened to be full” (exact-cap runs must report truncated=false).
+ */
+async function purgeInBatches(
+  db: D1Database,
+  selectIds: (limit: number) => Promise<string[]>,
+  deleteIds: (ids: string[]) => Promise<void>,
+): Promise<{ deleted: number; truncated: boolean }> {
+  let deleted = 0;
+  const fetchLimit = OBSERVABILITY_RETENTION_BATCH_SIZE + 1;
+
+  for (let batch = 0; batch < OBSERVABILITY_RETENTION_MAX_BATCHES; batch++) {
+    const ids = await selectIds(fetchLimit);
+    if (ids.length === 0) break;
+
+    const toDelete = ids.slice(0, OBSERVABILITY_RETENTION_BATCH_SIZE);
+    await deleteIds(toDelete);
+    deleted += toDelete.length;
+
+    // Fewer than a full batch available → nothing left after this delete.
+    if (ids.length <= OBSERVABILITY_RETENTION_BATCH_SIZE) break;
+
+    // At least one eligible row remains (the +1 lookahead). If this was the
+    // last allowed cycle, report truncation; otherwise continue.
+    if (batch === OBSERVABILITY_RETENTION_MAX_BATCHES - 1) {
+      return { deleted, truncated: true };
+    }
+  }
+
+  return { deleted, truncated: false };
+}
+
 async function purgeTelemetry(
   db: D1Database,
   cutoffMs: number,
@@ -36,33 +69,22 @@ async function purgeTelemetry(
   deleted: number;
   truncated: boolean;
 }> {
-  let deleted = 0;
-  let truncated = false;
-
-  for (let batch = 0; batch < OBSERVABILITY_RETENTION_MAX_BATCHES; batch++) {
-    const { results } = await db
-      .prepare(`SELECT id FROM uploads_telemetry_events WHERE timestamp < ? LIMIT ?`)
-      .bind(cutoffMs, OBSERVABILITY_RETENTION_BATCH_SIZE)
-      .all<{ id: string }>();
-
-    if (!results || results.length === 0) break;
-
-    const ids = results.map((r) => r.id);
-    await db
-      .prepare(`DELETE FROM uploads_telemetry_events WHERE id IN (${placeholders(ids.length)})`)
-      .bind(...ids)
-      .run();
-    deleted += ids.length;
-
-    if (ids.length < OBSERVABILITY_RETENTION_BATCH_SIZE) break;
-
-    // Full batch at the last allowed cycle — more rows may remain.
-    if (batch === OBSERVABILITY_RETENTION_MAX_BATCHES - 1) {
-      truncated = true;
-    }
-  }
-
-  return { deleted, truncated };
+  return purgeInBatches(
+    db,
+    async (limit) => {
+      const { results } = await db
+        .prepare(`SELECT id FROM uploads_telemetry_events WHERE timestamp < ? LIMIT ?`)
+        .bind(cutoffMs, limit)
+        .all<{ id: string }>();
+      return (results ?? []).map((r) => r.id);
+    },
+    async (ids) => {
+      await db
+        .prepare(`DELETE FROM uploads_telemetry_events WHERE id IN (${placeholders(ids.length)})`)
+        .bind(...ids)
+        .run();
+    },
+  );
 }
 
 async function purgeEnrollments(
@@ -72,39 +94,29 @@ async function purgeEnrollments(
   deleted: number;
   truncated: boolean;
 }> {
-  let deleted = 0;
-  let truncated = false;
-
-  for (let batch = 0; batch < OBSERVABILITY_RETENTION_MAX_BATCHES; batch++) {
-    // Never delete unexpired unused enrollments: only rows past the retention
-    // window on expires_at, or used rows whose used_at is past the window.
-    const { results } = await db
-      .prepare(
-        `SELECT id FROM auth_enrollments
-         WHERE expires_at < ?
-            OR (used_at IS NOT NULL AND used_at < ?)
-         LIMIT ?`,
-      )
-      .bind(cutoffIso, cutoffIso, OBSERVABILITY_RETENTION_BATCH_SIZE)
-      .all<{ id: string }>();
-
-    if (!results || results.length === 0) break;
-
-    const ids = results.map((r) => r.id);
-    await db
-      .prepare(`DELETE FROM auth_enrollments WHERE id IN (${placeholders(ids.length)})`)
-      .bind(...ids)
-      .run();
-    deleted += ids.length;
-
-    if (ids.length < OBSERVABILITY_RETENTION_BATCH_SIZE) break;
-
-    if (batch === OBSERVABILITY_RETENTION_MAX_BATCHES - 1) {
-      truncated = true;
-    }
-  }
-
-  return { deleted, truncated };
+  // Never delete unexpired unused enrollments: only rows past the retention
+  // window on expires_at, or used rows whose used_at is past the window.
+  return purgeInBatches(
+    db,
+    async (limit) => {
+      const { results } = await db
+        .prepare(
+          `SELECT id FROM auth_enrollments
+           WHERE expires_at < ?
+              OR (used_at IS NOT NULL AND used_at < ?)
+           LIMIT ?`,
+        )
+        .bind(cutoffIso, cutoffIso, limit)
+        .all<{ id: string }>();
+      return (results ?? []).map((r) => r.id);
+    },
+    async (ids) => {
+      await db
+        .prepare(`DELETE FROM auth_enrollments WHERE id IN (${placeholders(ids.length)})`)
+        .bind(...ids)
+        .run();
+    },
+  );
 }
 
 export async function runObservabilityRetention(

--- a/apps/api/src/observability-retention.ts
+++ b/apps/api/src/observability-retention.ts
@@ -1,0 +1,149 @@
+/**
+ * Daily purge of high-volume observability rows that only ever INSERT/UPDATE:
+ * - uploads_telemetry_events (CLI/MCP command pings)
+ * - auth_enrollments (used or long-expired invite codes)
+ *
+ * Modeled after apps/auth retention-sweep: SELECT ids LIMIT N → DELETE by id →
+ * loop, with a per-table batch cap so a backlog cannot blow the Worker cron
+ * CPU budget. Residual rows clear on subsequent days.
+ */
+
+export const TELEMETRY_RETENTION_DAYS = 30;
+export const ENROLLMENT_RETENTION_DAYS = 7;
+
+/** Rows deleted per SELECT/DELETE cycle. */
+export const OBSERVABILITY_RETENTION_BATCH_SIZE = 500;
+/** Max SELECT/DELETE cycles per table per cron run (~10k rows/table/day). */
+export const OBSERVABILITY_RETENTION_MAX_BATCHES = 20;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface ObservabilityRetentionResult {
+  telemetryDeleted: number;
+  enrollmentsDeleted: number;
+  telemetryTruncated: boolean;
+  enrollmentsTruncated: boolean;
+}
+
+function placeholders(n: number): string {
+  return Array.from({ length: n }, () => "?").join(", ");
+}
+
+async function purgeTelemetry(
+  db: D1Database,
+  cutoffMs: number,
+): Promise<{
+  deleted: number;
+  truncated: boolean;
+}> {
+  let deleted = 0;
+  let truncated = false;
+
+  for (let batch = 0; batch < OBSERVABILITY_RETENTION_MAX_BATCHES; batch++) {
+    const { results } = await db
+      .prepare(`SELECT id FROM uploads_telemetry_events WHERE timestamp < ? LIMIT ?`)
+      .bind(cutoffMs, OBSERVABILITY_RETENTION_BATCH_SIZE)
+      .all<{ id: string }>();
+
+    if (!results || results.length === 0) break;
+
+    const ids = results.map((r) => r.id);
+    await db
+      .prepare(`DELETE FROM uploads_telemetry_events WHERE id IN (${placeholders(ids.length)})`)
+      .bind(...ids)
+      .run();
+    deleted += ids.length;
+
+    if (ids.length < OBSERVABILITY_RETENTION_BATCH_SIZE) break;
+
+    // Full batch at the last allowed cycle — more rows may remain.
+    if (batch === OBSERVABILITY_RETENTION_MAX_BATCHES - 1) {
+      truncated = true;
+    }
+  }
+
+  return { deleted, truncated };
+}
+
+async function purgeEnrollments(
+  db: D1Database,
+  cutoffIso: string,
+): Promise<{
+  deleted: number;
+  truncated: boolean;
+}> {
+  let deleted = 0;
+  let truncated = false;
+
+  for (let batch = 0; batch < OBSERVABILITY_RETENTION_MAX_BATCHES; batch++) {
+    // Never delete unexpired unused enrollments: only rows past the retention
+    // window on expires_at, or used rows whose used_at is past the window.
+    const { results } = await db
+      .prepare(
+        `SELECT id FROM auth_enrollments
+         WHERE expires_at < ?
+            OR (used_at IS NOT NULL AND used_at < ?)
+         LIMIT ?`,
+      )
+      .bind(cutoffIso, cutoffIso, OBSERVABILITY_RETENTION_BATCH_SIZE)
+      .all<{ id: string }>();
+
+    if (!results || results.length === 0) break;
+
+    const ids = results.map((r) => r.id);
+    await db
+      .prepare(`DELETE FROM auth_enrollments WHERE id IN (${placeholders(ids.length)})`)
+      .bind(...ids)
+      .run();
+    deleted += ids.length;
+
+    if (ids.length < OBSERVABILITY_RETENTION_BATCH_SIZE) break;
+
+    if (batch === OBSERVABILITY_RETENTION_MAX_BATCHES - 1) {
+      truncated = true;
+    }
+  }
+
+  return { deleted, truncated };
+}
+
+export async function runObservabilityRetention(
+  env: Env,
+  now = new Date(),
+): Promise<ObservabilityRetentionResult> {
+  if (!env.DB) {
+    return {
+      telemetryDeleted: 0,
+      enrollmentsDeleted: 0,
+      telemetryTruncated: false,
+      enrollmentsTruncated: false,
+    };
+  }
+
+  const cutoffMs = now.getTime() - TELEMETRY_RETENTION_DAYS * MS_PER_DAY;
+  const enrollmentCutoff = new Date(now.getTime() - ENROLLMENT_RETENTION_DAYS * MS_PER_DAY);
+  const cutoffIso = enrollmentCutoff.toISOString();
+
+  const telemetry = await purgeTelemetry(env.DB, cutoffMs);
+  const enrollments = await purgeEnrollments(env.DB, cutoffIso);
+
+  const result: ObservabilityRetentionResult = {
+    telemetryDeleted: telemetry.deleted,
+    enrollmentsDeleted: enrollments.deleted,
+    telemetryTruncated: telemetry.truncated,
+    enrollmentsTruncated: enrollments.truncated,
+  };
+
+  console.log(
+    JSON.stringify({
+      message: "observability_retention",
+      telemetryDeleted: result.telemetryDeleted,
+      enrollmentsDeleted: result.enrollmentsDeleted,
+      ...(result.telemetryTruncated || result.enrollmentsTruncated ? { truncated: true } : {}),
+      ...(result.telemetryTruncated ? { telemetryTruncated: true } : {}),
+      ...(result.enrollmentsTruncated ? { enrollmentsTruncated: true } : {}),
+    }),
+  );
+
+  return result;
+}

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -1,4 +1,9 @@
-import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
+import {
+  ConflictError,
+  NotFoundError,
+  UnsupportedMediaTypeError,
+  ValidationError,
+} from "@uploads/errors";
 import { Hono } from "hono";
 import {
   badKey,
@@ -20,9 +25,20 @@ import {
 import { splitUploadMetaHeaders } from "../provenance";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
-import { checkDeclaredLength, resolveUploadPolicy, writeRateLimit } from "../guards";
+import {
+  checkDeclaredLength,
+  maxBytesForContentType,
+  resolveUploadPolicy,
+  writeRateLimit,
+} from "../guards";
 import { hasGithubTags, uploaderTags } from "../uploader-identity";
 import { sanitizeVisibility } from "../visibility";
+
+/** Normalize a client Content-Type for allowlist compare (type/subtype only, lowercased). */
+function normalizePresignContentType(raw: string): string {
+  const beforeParams = raw.split(";", 1)[0] ?? raw;
+  return beforeParams.trim().toLowerCase();
+}
 
 export const files = new Hono<WorkspaceVars>()
 
@@ -54,11 +70,28 @@ export const files = new Hono<WorkspaceVars>()
     const key = finalizeUploadKey(rawKey, ws);
 
     const policy = resolveUploadPolicy(ws);
-    const ceiling = Math.max(policy.maxBytes, policy.maxVideoBytes);
+
+    // Content-type is required on presign: the direct-to-bucket PUT cannot
+    // magic-byte sniff, so the allowlist must be enforced at mint time.
+    const rawContentType = typeof body.contentType === "string" ? body.contentType : "";
+    if (!rawContentType.trim()) {
+      throw new ValidationError("contentType is required for presign", {
+        code: "content_type_required",
+      });
+    }
+    const contentType = normalizePresignContentType(rawContentType);
+    if (!policy.allowed.has(contentType)) {
+      throw new UnsupportedMediaTypeError("unsupported media type", {
+        code: "unsupported_media_type",
+        details: { allowed: [...policy.allowed] },
+      });
+    }
+
+    const typeCeiling = maxBytesForContentType(policy, contentType);
     const maxSize =
       typeof body.maxSize === "number" && body.maxSize > 0
-        ? Math.min(body.maxSize, ceiling)
-        : ceiling;
+        ? Math.min(body.maxSize, typeCeiling)
+        : typeCeiling;
     const expiresIn =
       typeof body.expiresIn === "number" && body.expiresIn > 0 && body.expiresIn <= 86400
         ? Math.floor(body.expiresIn)
@@ -90,7 +123,7 @@ export const files = new Hono<WorkspaceVars>()
 
       const upload = await store.signedUploadUrl(key, {
         expiresIn,
-        contentType: body.contentType,
+        contentType,
         maxSize,
       });
       const cfg = await storageConfig(c.env, ws);
@@ -106,11 +139,12 @@ export const files = new Hono<WorkspaceVars>()
       });
     } catch (err) {
       if (err instanceof ConflictError) throw err;
+      if (err instanceof ValidationError || err instanceof UnsupportedMediaTypeError) throw err;
       const message = err instanceof Error ? err.message : String(err);
       console.error(JSON.stringify({ message: "presign failed", error: message }));
       throw new ValidationError(
         "presign unavailable for this workspace (needs S3 HTTP credentials; binding-only cannot sign)",
-        { code: "presign_unavailable", details: { detail: message }, cause: err },
+        { code: "presign_unavailable", cause: err },
       );
     }
   })

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -4,7 +4,7 @@ import { downloadResponse } from "../files-core";
 import { listExternalReferences, listGalleryItems, resolvePublicGallery } from "../galleries";
 import { galleryItemFilename, hydratePublicGallery } from "../gallery-service";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
-import { type WorkspaceRecord, type WorkspaceVars } from "../workspace";
+import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 
 /** Runs `action`, mapping any thrown error to the 503 the gallery storage routes commit to. */
 async function withGalleryStorageErrors<T>(action: () => Promise<T>): Promise<T> {
@@ -29,11 +29,12 @@ export const publicGalleries = new Hono<WorkspaceVars>()
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
     }
 
-    const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
-      type: "json",
-      cacheTtl: 60,
-    });
-    if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    // Soft-deleted / purged workspaces collapse to null — same uniform 404 as
+    // missing tenants (matches public-files + authenticated paths).
+    const workspace = await loadWorkspaceRecord(c.env, record.workspace);
+    if (!workspace) {
+      throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    }
 
     const store = await withGalleryStorageErrors(() => storage(c.env, workspace));
     const exists = await withGalleryStorageErrors(() => store.exists(item.object_key));
@@ -59,11 +60,10 @@ export const publicGalleries = new Hono<WorkspaceVars>()
   .get("/:id", async (c) => {
     const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
     if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-    const workspace = await c.env.REGISTRY.get<WorkspaceRecord>(`ws:${record.workspace}`, {
-      type: "json",
-      cacheTtl: 60,
-    });
-    if (!workspace) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    const workspace = await loadWorkspaceRecord(c.env, record.workspace);
+    if (!workspace) {
+      throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    }
     const [items, references] = await Promise.all([
       listGalleryItems(c.env.DB, record.workspace, record.id),
       listExternalReferences(c.env.DB, record.workspace, record.id),

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -23,17 +23,19 @@ export const publicGalleries = new Hono<WorkspaceVars>()
     const record = await resolvePublicGallery(c.env.DB, c.req.param("id"));
     if (!record) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
 
+    // Soft-deleted / purged workspaces collapse to null — same uniform 404 as
+    // missing tenants (matches public-files + authenticated paths). Check
+    // before item lookup so existing and unknown item IDs both yield
+    // gallery_not_found for unavailable workspaces (no item-existence oracle).
+    const workspace = await loadWorkspaceRecord(c.env, record.workspace);
+    if (!workspace) {
+      throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+    }
+
     const items = await listGalleryItems(c.env.DB, record.workspace, record.id);
     const item = items.find((entry) => entry.id === c.req.param("item"));
     if (!item) {
       throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
-    }
-
-    // Soft-deleted / purged workspaces collapse to null — same uniform 404 as
-    // missing tenants (matches public-files + authenticated paths).
-    const workspace = await loadWorkspaceRecord(c.env, record.workspace);
-    if (!workspace) {
-      throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
     }
 
     const store = await withGalleryStorageErrors(() => storage(c.env, workspace));

--- a/apps/api/src/staging-reaper.ts
+++ b/apps/api/src/staging-reaper.ts
@@ -13,12 +13,23 @@
  * Deletion goes through `deleteObject` (files-core.ts) so R2, D1 metadata,
  * and the workspace usage ledger stay consistent — the same path the
  * `/v1/:workspace/files` DELETE route uses.
+ *
+ * Progress: a durable keyset cursor in REGISTRY (`cron:staging-reaper:cursor`)
+ * walks the full candidate set across cron runs so alphabetical head rows
+ * cannot starve later keys. Cursor write failures are best-effort (log only).
  */
 import { deleteObject } from "./files-core";
-import { findObjectsByMetadataAcrossWorkspaces, getMetadataForKeys } from "./file-metadata";
+import {
+  findObjectsByMetadataAcrossWorkspaces,
+  getMetadataForKeys,
+  type MetadataCrossWorkspaceCursor,
+} from "./file-metadata";
 import { loadWorkspaceRecord } from "./workspace";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** REGISTRY KV key for the reaper's keyset progress (not under `ws:`). */
+export const STAGING_REAPER_CURSOR_KEY = "cron:staging-reaper:cursor";
 
 /** `gh.promoted-at` older than this is reaped. */
 export const PROMOTED_MAX_AGE_DAYS = 7;
@@ -37,6 +48,10 @@ export interface StagingReapResult {
   deleted: Array<{ workspace: string; key: string; reason: "promoted" | "abandoned" }>;
   skipped: number;
   errors: Array<{ workspace: string; key: string; error: string }>;
+  /** Cursor used for this scan (null = start of set). */
+  cursor: MetadataCrossWorkspaceCursor | null;
+  /** Cursor to resume from next run (null = end of set, reset). */
+  nextAfter: MetadataCrossWorkspaceCursor | null;
 }
 
 function isOlderThan(iso: string | undefined, maxAgeMs: number, now: number): boolean {
@@ -51,13 +66,59 @@ function looksLikeBranchStagingKey(key: string): boolean {
   return key.startsWith("gh/") && key.includes("/branch/");
 }
 
+function parseCursor(raw: unknown): MetadataCrossWorkspaceCursor | null {
+  if (!raw || typeof raw !== "object") return null;
+  const workspace = (raw as { workspace?: unknown }).workspace;
+  const key = (raw as { key?: unknown }).key;
+  if (typeof workspace !== "string" || typeof key !== "string") return null;
+  if (workspace.length === 0 || key.length === 0) return null;
+  return { workspace, key };
+}
+
+async function loadCursor(env: Env): Promise<MetadataCrossWorkspaceCursor | null> {
+  try {
+    const raw = await env.REGISTRY.get(STAGING_REAPER_CURSOR_KEY, "json");
+    return parseCursor(raw);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "staging_reap_cursor_load_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}
+
+async function storeCursor(
+  env: Env,
+  nextAfter: MetadataCrossWorkspaceCursor | null,
+): Promise<void> {
+  try {
+    if (nextAfter) {
+      await env.REGISTRY.put(STAGING_REAPER_CURSOR_KEY, JSON.stringify(nextAfter));
+    } else {
+      await env.REGISTRY.delete(STAGING_REAPER_CURSOR_KEY);
+    }
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "staging_reap_cursor_store_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
 export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
   const now = Date.now();
-  const candidates = await findObjectsByMetadataAcrossWorkspaces(
+  const cursor = await loadCursor(env);
+  const { rows: candidates, nextAfter } = await findObjectsByMetadataAcrossWorkspaces(
     env.DB,
     "gh.kind",
     "branch",
     STAGING_REAP_SCAN_LIMIT,
+    { after: cursor },
   );
 
   const deleted: StagingReapResult["deleted"] = [];
@@ -134,7 +195,18 @@ export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
     }
   }
 
-  const result: StagingReapResult = { scanned: candidates.length, deleted, skipped, errors };
+  // Persist progress after the pass (even if zero deletes). Best-effort — a
+  // failed put/delete must not undo deletions already done.
+  await storeCursor(env, nextAfter);
+
+  const result: StagingReapResult = {
+    scanned: candidates.length,
+    deleted,
+    skipped,
+    errors,
+    cursor,
+    nextAfter,
+  };
   console.log(
     JSON.stringify({
       message: "staging_reap",
@@ -142,6 +214,8 @@ export async function runStagingReaper(env: Env): Promise<StagingReapResult> {
       deleted: result.deleted.length,
       skipped: result.skipped,
       errors: result.errors.length,
+      cursor: result.cursor,
+      nextAfter: result.nextAfter,
     }),
   );
   return result;

--- a/apps/api/test/observability-retention.test.ts
+++ b/apps/api/test/observability-retention.test.ts
@@ -198,4 +198,36 @@ describe("runObservabilityRetention", () => {
       sqlite.close();
     }
   });
+
+  it("exact daily cap is not reported as truncated", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-07-22T12:00:00.000Z");
+      const oldTs = now.getTime() - (TELEMETRY_RETENTION_DAYS + 5) * MS_PER_DAY;
+      // Exactly MAX_BATCHES full pages — +1 lookahead must not invent leftovers.
+      const exactCap = OBSERVABILITY_RETENTION_BATCH_SIZE * OBSERVABILITY_RETENTION_MAX_BATCHES;
+
+      const insert = sqlite.db.prepare(
+        `INSERT INTO uploads_telemetry_events (
+          id, anon_id, timestamp, surface, client_kind, command, cli_version
+        ) VALUES (?, '11111111-2222-3333-4444-555555555555', ?, 'cli', 'external', 'put', '0.10.0')`,
+      );
+      for (let i = 0; i < exactCap; i++) {
+        insert.run(`tel_exact_${i}`, oldTs);
+      }
+
+      const result = await runObservabilityRetention(env(database(sqlite)), now);
+      expect(result.telemetryDeleted).toBe(exactCap);
+      expect(result.telemetryTruncated).toBe(false);
+
+      const left = (
+        sqlite.db.prepare("SELECT COUNT(*) AS n FROM uploads_telemetry_events").get() as {
+          n: number;
+        }
+      ).n;
+      expect(left).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
 });

--- a/apps/api/test/observability-retention.test.ts
+++ b/apps/api/test/observability-retention.test.ts
@@ -1,0 +1,201 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import {
+  ENROLLMENT_RETENTION_DAYS,
+  OBSERVABILITY_RETENTION_BATCH_SIZE,
+  OBSERVABILITY_RETENTION_MAX_BATCHES,
+  runObservabilityRetention,
+  TELEMETRY_RETENTION_DAYS,
+} from "../src/observability-retention";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260711120000_invite_pages.sql",
+  "migrations/20260715120000_uploads_cli_observability.sql",
+  "migrations/20260722180100_auth_enrollments_expires_at_idx.sql",
+];
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function env(db: D1Database): Env {
+  return { DB: db } as unknown as Env;
+}
+
+function insertTelemetry(
+  sqlite: SqliteD1,
+  row: { id: string; timestamp: number; command?: string },
+) {
+  sqlite.db
+    .prepare(
+      `INSERT INTO uploads_telemetry_events (
+        id, anon_id, timestamp, surface, client_kind, command, cli_version
+      ) VALUES (?, ?, ?, 'cli', 'external', ?, '0.10.0')`,
+    )
+    .run(row.id, "11111111-2222-3333-4444-555555555555", row.timestamp, row.command ?? "put");
+}
+
+function insertEnrollment(
+  sqlite: SqliteD1,
+  row: {
+    id: string;
+    expiresAt: string;
+    usedAt?: string | null;
+    codeHash?: string;
+  },
+) {
+  sqlite.db
+    .prepare(
+      `INSERT INTO auth_enrollments (
+        id, workspace, code_hash, label, scopes, created_at, expires_at, token_expires_at, used_at
+      ) VALUES (?, 'default', ?, NULL, '["files:write"]', ?, ?, ?, ?)`,
+    )
+    .run(
+      row.id,
+      row.codeHash ?? `hash_${row.id}`,
+      row.expiresAt,
+      row.expiresAt,
+      row.expiresAt,
+      row.usedAt ?? null,
+    );
+}
+
+describe("runObservabilityRetention", () => {
+  it("returns zeros when DB is missing", async () => {
+    const result = await runObservabilityRetention({} as Env);
+    expect(result).toEqual({
+      telemetryDeleted: 0,
+      enrollmentsDeleted: 0,
+      telemetryTruncated: false,
+      enrollmentsTruncated: false,
+    });
+  });
+
+  it("deletes old telemetry and keeps recent rows", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-07-22T12:00:00.000Z");
+      const oldTs = now.getTime() - (TELEMETRY_RETENTION_DAYS + 10) * MS_PER_DAY;
+      const freshTs = now.getTime() - 2 * MS_PER_DAY;
+
+      insertTelemetry(sqlite, { id: "tel_old", timestamp: oldTs });
+      insertTelemetry(sqlite, { id: "tel_fresh", timestamp: freshTs });
+
+      const result = await runObservabilityRetention(env(database(sqlite)), now);
+      expect(result.telemetryDeleted).toBe(1);
+      expect(result.telemetryTruncated).toBe(false);
+
+      const remaining = sqlite.db
+        .prepare("SELECT id FROM uploads_telemetry_events ORDER BY id")
+        .all() as Array<{ id: string }>;
+      expect(remaining.map((r) => r.id)).toEqual(["tel_fresh"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("deletes used/expired enrollments past the window and keeps live unused ones", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-07-22T12:00:00.000Z");
+      const past = new Date(
+        now.getTime() - (ENROLLMENT_RETENTION_DAYS + 2) * MS_PER_DAY,
+      ).toISOString();
+      const recentUsed = new Date(now.getTime() - 1 * MS_PER_DAY).toISOString();
+      const liveExpires = new Date(now.getTime() + 2 * MS_PER_DAY).toISOString();
+
+      insertEnrollment(sqlite, {
+        id: "enr_used_old",
+        expiresAt: past,
+        usedAt: past,
+      });
+      insertEnrollment(sqlite, {
+        id: "enr_expired_old",
+        expiresAt: past,
+        usedAt: null,
+      });
+      insertEnrollment(sqlite, {
+        id: "enr_used_recent",
+        expiresAt: liveExpires,
+        usedAt: recentUsed,
+      });
+      insertEnrollment(sqlite, {
+        id: "enr_live_unused",
+        expiresAt: liveExpires,
+        usedAt: null,
+      });
+
+      const result = await runObservabilityRetention(env(database(sqlite)), now);
+      expect(result.enrollmentsDeleted).toBe(2);
+      expect(result.enrollmentsTruncated).toBe(false);
+
+      const remaining = sqlite.db
+        .prepare("SELECT id FROM auth_enrollments ORDER BY id")
+        .all() as Array<{ id: string }>;
+      expect(remaining.map((r) => r.id)).toEqual(["enr_live_unused", "enr_used_recent"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("purges more than one batch of old telemetry", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-07-22T12:00:00.000Z");
+      const oldTs = now.getTime() - (TELEMETRY_RETENTION_DAYS + 5) * MS_PER_DAY;
+      const count = OBSERVABILITY_RETENTION_BATCH_SIZE + 50;
+
+      for (let i = 0; i < count; i++) {
+        insertTelemetry(sqlite, { id: `tel_batch_${i}`, timestamp: oldTs });
+      }
+      insertTelemetry(sqlite, {
+        id: "tel_keep",
+        timestamp: now.getTime() - MS_PER_DAY,
+      });
+
+      const result = await runObservabilityRetention(env(database(sqlite)), now);
+      expect(result.telemetryDeleted).toBe(count);
+      expect(result.telemetryTruncated).toBe(false);
+
+      const remaining = sqlite.db
+        .prepare("SELECT id FROM uploads_telemetry_events")
+        .all() as Array<{ id: string }>;
+      expect(remaining).toEqual([{ id: "tel_keep" }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("caps telemetry deletes at MAX_BATCHES and reports truncation", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const now = new Date("2026-07-22T12:00:00.000Z");
+      const oldTs = now.getTime() - (TELEMETRY_RETENTION_DAYS + 5) * MS_PER_DAY;
+      const cap = OBSERVABILITY_RETENTION_BATCH_SIZE * OBSERVABILITY_RETENTION_MAX_BATCHES;
+      const total = cap + 1;
+
+      const insert = sqlite.db.prepare(
+        `INSERT INTO uploads_telemetry_events (
+          id, anon_id, timestamp, surface, client_kind, command, cli_version
+        ) VALUES (?, '11111111-2222-3333-4444-555555555555', ?, 'cli', 'external', 'put', '0.10.0')`,
+      );
+      for (let i = 0; i < total; i++) {
+        insert.run(`tel_cap_${i}`, oldTs);
+      }
+
+      const result = await runObservabilityRetention(env(database(sqlite)), now);
+      expect(result.telemetryDeleted).toBe(cap);
+      expect(result.telemetryTruncated).toBe(true);
+
+      const left = (
+        sqlite.db.prepare("SELECT COUNT(*) AS n FROM uploads_telemetry_events").get() as {
+          n: number;
+        }
+      ).n;
+      expect(left).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -388,7 +388,7 @@ describe("POST /v1/:workspace/files/sign strict-overwrite gate (review follow-up
       {
         method: "POST",
         headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
-        body: JSON.stringify({ key: "screenshots/shot.png" }),
+        body: JSON.stringify({ key: "screenshots/shot.png", contentType: "image/png" }),
       },
       env,
     );
@@ -407,7 +407,11 @@ describe("POST /v1/:workspace/files/sign strict-overwrite gate (review follow-up
       {
         method: "POST",
         headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
-        body: JSON.stringify({ key: "screenshots/shot.png", replace: true }),
+        body: JSON.stringify({
+          key: "screenshots/shot.png",
+          replace: true,
+          contentType: "image/png",
+        }),
       },
       env,
     );
@@ -425,7 +429,10 @@ describe("POST /v1/:workspace/files/sign strict-overwrite gate (review follow-up
       {
         method: "POST",
         headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
-        body: JSON.stringify({ key: "screenshots/never-uploaded.png" }),
+        body: JSON.stringify({
+          key: "screenshots/never-uploaded.png",
+          contentType: "image/png",
+        }),
       },
       env,
     );
@@ -450,11 +457,143 @@ describe("POST /v1/:workspace/files/sign strict-overwrite gate (review follow-up
       {
         method: "POST",
         headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
-        body: JSON.stringify({ key: "gh/acme/widgets/pull/1/shot.png" }),
+        body: JSON.stringify({
+          key: "gh/acme/widgets/pull/1/shot.png",
+          contentType: "image/png",
+        }),
       },
       env,
     );
     expect(res.status).not.toBe(409);
+  });
+});
+
+describe("POST /v1/:workspace/files/sign content-type policy", () => {
+  it("rejects missing contentType with content_type_required", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ key: "screenshots/a.png" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("content_type_required");
+  });
+
+  it("rejects SVG (and other disallowed types) before storage is called", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "screenshots/evil.svg",
+          contentType: "image/svg+xml",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(415);
+    const json = (await res.json()) as {
+      error: { code: string; type: string; details?: { detail?: string } };
+    };
+    expect(json.error.code).toBe("unsupported_media_type");
+    expect(json.error.type).toBe("unsupported_media_type");
+    // Must not echo provider internals via details.detail (presign_unavailable path).
+    expect(json.error.details?.detail).toBeUndefined();
+  });
+
+  it("rejects text/html", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "screenshots/page.html",
+          contentType: "text/html",
+        }),
+      },
+      env,
+    );
+    expect(res.status).toBe(415);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("unsupported_media_type");
+  });
+
+  it("treats case-insensitive types as allowed (may still fail presign without S3)", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "screenshots/case.png",
+          contentType: "Image/PNG",
+        }),
+      },
+      env,
+    );
+    // Not a content-type rejection — without S3 credentials this is typically
+    // presign_unavailable (400), never 415 / content_type_required.
+    expect(res.status).not.toBe(415);
+    const json = (await res.json()) as { error?: { code: string; details?: { detail?: string } } };
+    expect(json.error?.code).not.toBe("content_type_required");
+    expect(json.error?.code).not.toBe("unsupported_media_type");
+    if (json.error?.code === "presign_unavailable") {
+      expect(json.error.details?.detail).toBeUndefined();
+    }
+  });
+
+  it("accepts image/png without content-type rejection", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "screenshots/ok.png",
+          contentType: "image/png",
+        }),
+      },
+      env,
+    );
+    expect(res.status).not.toBe(415);
+    const json = (await res.json()) as { error?: { code: string } };
+    expect(json.error?.code).not.toBe("unsupported_media_type");
+    expect(json.error?.code).not.toBe("content_type_required");
+  });
+
+  it("does not include raw provider detail on presign_unavailable", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/default/files/sign",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({
+          key: "screenshots/ok.png",
+          contentType: "image/png",
+        }),
+      },
+      env,
+    );
+    // Fake workspace has no S3 HTTP credentials → presign_unavailable.
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as {
+      error: { code: string; details?: { detail?: string } };
+    };
+    expect(json.error.code).toBe("presign_unavailable");
+    expect(json.error.details).toBeUndefined();
   });
 });
 

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath, URL as NodeURL } from "node:url";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { MAX_GALLERY_ITEMS, MAX_GALLERY_REFERENCES } from "../src/galleries";
 import { app } from "../src/index";
-import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { sha256Hex, stampSoftDelete, type WorkspaceRecord } from "../src/workspace";
 import { FakeR2Bucket } from "./fake-r2";
 
 const TOKEN = "gallery-token";
@@ -806,5 +806,35 @@ describe("GET /public/galleries/:id/items/:item/download", () => {
       env,
     );
     expect(res.status).toBe(404);
+  });
+
+  it("404s public gallery JSON and item download for a soft-deleted workspace", async () => {
+    const gallery = await create();
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+    });
+    expect(added.status).toBe(201);
+    const item = (await added.json()) as { id: string };
+
+    // Soft-delete collapses loadWorkspaceRecord to null — same uniform 404 as
+    // a missing workspace (no deleted-vs-missing signal).
+    records.alpha = stampSoftDelete(records.alpha);
+
+    const publicView = await app.request(`/public/galleries/${gallery.id}`, {}, env);
+    expect(publicView.status).toBe(404);
+    expect(await publicView.json()).toMatchObject({
+      error: { code: "gallery_not_found", type: "not_found" },
+    });
+
+    const download = await app.request(
+      `/public/galleries/${gallery.id}/items/${item.id}/download`,
+      {},
+      env,
+    );
+    expect(download.status).toBe(404);
+    expect(await download.json()).toMatchObject({
+      error: { code: "gallery_not_found", type: "not_found" },
+    });
   });
 });

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -836,5 +836,17 @@ describe("GET /public/galleries/:id/items/:item/download", () => {
     expect(await download.json()).toMatchObject({
       error: { code: "gallery_not_found", type: "not_found" },
     });
+
+    // Unknown item IDs must not leak a different code (item oracle) while the
+    // workspace is soft-deleted — workspace gate runs first.
+    const missingItem = await app.request(
+      `/public/galleries/${gallery.id}/items/item_does_not_exist/download`,
+      {},
+      env,
+    );
+    expect(missingItem.status).toBe(404);
+    expect(await missingItem.json()).toMatchObject({
+      error: { code: "gallery_not_found", type: "not_found" },
+    });
   });
 });

--- a/apps/api/test/staging-reaper.test.ts
+++ b/apps/api/test/staging-reaper.test.ts
@@ -4,6 +4,7 @@ import {
   PROMOTED_MAX_AGE_DAYS,
   runStagingReaper,
   STAGING_REAP_SCAN_LIMIT,
+  STAGING_REAPER_CURSOR_KEY,
 } from "../src/staging-reaper";
 import { getFileMetadata, replaceFileMetadata } from "../src/file-metadata";
 import type { WorkspaceRecord } from "../src/workspace";
@@ -14,6 +15,9 @@ const MIGRATIONS = [
   "migrations/20260711180000_galleries.sql",
   "migrations/20260713210559_file_metadata.sql",
   "migrations/20260710140000_workspace_usage.sql",
+  // Covering (meta_key, meta_value, workspace, object_key) index for the reaper
+  // scan. DROP IF EXISTS is a no-op when the short lookup index was never applied.
+  "migrations/20260722180000_file_metadata_value_covering_idx.sql",
 ];
 
 const WS = "acme";
@@ -27,10 +31,18 @@ const RECORD: WorkspaceRecord = {
 const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]);
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/** Fake REGISTRY: get/put/delete over an in-memory Map (workspace records + reaper cursor). */
 function fakeRegistry(records: Record<string, unknown>) {
   const store = new Map(Object.entries(records));
   return {
+    store,
     get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    put: (async (key: string, value: string) => {
+      store.set(key, JSON.parse(value));
+    }) as unknown as KVNamespace["put"],
+    delete: (async (key: string) => {
+      store.delete(key);
+    }) as unknown as KVNamespace["delete"],
   };
 }
 
@@ -43,7 +55,7 @@ function makeEnv(opts: { db: SqliteD1; bucket?: FakeR2Bucket; workspaces?: strin
     BUCKET: bucket,
     DB: database(db),
   } as unknown as Env;
-  return { env, bucket };
+  return { env, bucket, registry };
 }
 
 function branchKey(workspace: string, branch: string, filename: string): string {
@@ -291,6 +303,79 @@ describe("runStagingReaper", () => {
 
       const meta = await getFileMetadata(database(sqlite), WS, key);
       expect(meta).toEqual({});
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("advances a keyset cursor so later pages can reap past a young alphabetical head", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      // Young (non-reapable) keys that sort *before* one old abandoned object.
+      // A single run without a cursor only sees the young head; the second run
+      // must resume via the stored cursor to reach the old key.
+      for (let i = 0; i < STAGING_REAP_SCAN_LIMIT; i++) {
+        const key = branchKey(WS, "aaa", `shot-${String(i).padStart(3, "0")}.png`);
+        await seed(sqlite, bucket, WS, key, {
+          "gh.kind": "branch",
+          "gh.staged-at": daysAgo(1),
+        });
+      }
+      const oldKey = branchKey(WS, "zzz", "old.png");
+      await seed(sqlite, bucket, WS, oldKey, {
+        "gh.kind": "branch",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+      const { env, registry } = makeEnv({ db: sqlite, bucket });
+
+      const first = await runStagingReaper(env);
+      expect(first.scanned).toBe(STAGING_REAP_SCAN_LIMIT);
+      expect(first.deleted).toEqual([]);
+      expect(first.nextAfter).toEqual({
+        workspace: WS,
+        key: branchKey(
+          WS,
+          "aaa",
+          `shot-${String(STAGING_REAP_SCAN_LIMIT - 1).padStart(3, "0")}.png`,
+        ),
+      });
+      expect(registry.store.get(STAGING_REAPER_CURSOR_KEY)).toEqual(first.nextAfter);
+      expect(bucket.store.has(oldKey)).toBe(true);
+
+      const second = await runStagingReaper(env);
+      expect(second.cursor).toEqual(first.nextAfter);
+      expect(second.deleted).toEqual([{ workspace: WS, key: oldKey, reason: "abandoned" }]);
+      expect(bucket.store.has(oldKey)).toBe(false);
+      // Short final page → cursor cleared so the next run restarts from the head.
+      expect(second.nextAfter).toBeNull();
+      expect(registry.store.has(STAGING_REAPER_CURSOR_KEY)).toBe(false);
+
+      const third = await runStagingReaper(env);
+      expect(third.cursor).toBeNull();
+      expect(third.scanned).toBe(STAGING_REAP_SCAN_LIMIT);
+      expect(third.deleted).toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("treats a corrupt cursor in KV as start-of-set", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const { env, bucket, registry } = makeEnv({ db: sqlite });
+      const key = branchKey(WS, "feat-y", "shot.png");
+      await seed(sqlite, bucket, WS, key, {
+        "gh.kind": "branch",
+        "gh.staged-at": daysAgo(ABANDONED_MAX_AGE_DAYS + 1),
+      });
+      // Corrupt blob — not { workspace, key } strings.
+      registry.store.set(STAGING_REAPER_CURSOR_KEY, { workspace: 1, key: null });
+
+      const result = await runStagingReaper(env);
+
+      expect(result.cursor).toBeNull();
+      expect(result.deleted).toEqual([{ workspace: WS, key, reason: "abandoned" }]);
     } finally {
       sqlite.close();
     }

--- a/apps/auth/migrations/20260722180000_retention_expires_at_idx.sql
+++ b/apps/auth/migrations/20260722180000_retention_expires_at_idx.sql
@@ -1,0 +1,9 @@
+-- Nightly runAuthRetentionSweep: WHERE expires_at < ? LIMIT 500
+-- (apps/auth/src/retention-sweep.ts). Without these indexes each batch is a
+-- full table scan (D1 rows-read).
+
+CREATE INDEX IF NOT EXISTS idx_verification_expires_at
+  ON verification (expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_device_code_expires_at
+  ON device_code (expires_at);

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -113,7 +113,9 @@ export const account = sqliteTable(
  * Single-use verification records — magic-link tokens (`storeToken: "hashed"`,
  * see src/auth.ts) live here.
  *
- * Paired migration: `migrations/20260712200000_better_auth_core.sql`.
+ * Paired migrations: `migrations/20260712200000_better_auth_core.sql`,
+ * `migrations/20260722180000_retention_expires_at_idx.sql`
+ * (`idx_verification_expires_at` for nightly retention sweep).
  */
 export const verification = sqliteTable(
   "verification",
@@ -125,7 +127,11 @@ export const verification = sqliteTable(
     createdAt: timestampCol("created_at"),
     updatedAt: timestampCol("updated_at"),
   },
-  (t) => [index("idx_verification_identifier").on(t.identifier)],
+  (t) => [
+    index("idx_verification_identifier").on(t.identifier),
+    // Retention sweep: expires_at < now. Migration: 20260722180000_retention_expires_at_idx.sql
+    index("idx_verification_expires_at").on(t.expiresAt),
+  ],
 );
 
 /**
@@ -229,7 +235,9 @@ export const invitation = sqliteTable(
  * is snake_case but the drizzle-adapter schema KEY must stay the camelCase
  * model name `deviceCode`.
  *
- * Paired migration: `migrations/20260712230000_device_code.sql`.
+ * Paired migrations: `migrations/20260712230000_device_code.sql`,
+ * `migrations/20260722180000_retention_expires_at_idx.sql`
+ * (`idx_device_code_expires_at` for nightly retention sweep).
  */
 export const deviceCode = sqliteTable(
   "device_code",
@@ -251,6 +259,8 @@ export const deviceCode = sqliteTable(
   (t) => [
     index("idx_device_code_device_code").on(t.deviceCode),
     index("idx_device_code_user_code").on(t.userCode),
+    // Retention sweep: expires_at < now. Migration: 20260722180000_retention_expires_at_idx.sql
+    index("idx_device_code_expires_at").on(t.expiresAt),
   ],
 );
 


### PR DESCRIPTION
## In plain terms

Daily D1 work and a couple of hot request paths were either reading more rows than they needed or missing isolation/policy checks that the rest of the product already enforces. This PR batches those fixes into one change: cheaper, progress-safe crons; public galleries that disappear with a soft-deleted workspace; and presign that cannot mint disallowed content types (or leak provider errors).

## What it does

- **Staging reaper (D1):** covering index on `(meta_key, meta_value, workspace, object_key)` so `ORDER BY … LIMIT` does not full-sort every branch-staged row; keyset cursor in REGISTRY so alphabetical head rows cannot starve later candidates.
- **Auth retention (D1):** `expires_at` indexes on `verification` and `device_code` for the nightly purge.
- **API observability retention:** daily batched purge of telemetry (30d) and stale enrollments (7d), with a per-run batch cap.
- **Public galleries:** resolve workspace via `loadWorkspaceRecord` so soft-deleted tenants get a uniform 404 (matches public files).
- **Presign:** require + allowlist `contentType`, cap size with per-type policy, drop provider error `details.detail` from the client response.

## What it is not

- Does **not** reserve budget/usage on `/sign` (still a known follow-up).
- Does **not** magic-byte sniff direct-to-bucket uploads (impossible without a post-upload path).
- Does **not** change retention age thresholds for staging reaper promoted/abandoned rules.

## How to try it

Presign without a type (API, installed client with a workspace token that has S3-capable credentials if you want a full mint success):

```bash
# missing contentType → 400 content_type_required
curl -sS -X POST "$UPLOADS_API_URL/v1/$UPLOADS_WORKSPACE/files/sign" \
  -H "Authorization: Bearer $UPLOADS_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"key":"screenshots/try.png"}'

# SVG → 415 unsupported_media_type
curl -sS -X POST "$UPLOADS_API_URL/v1/$UPLOADS_WORKSPACE/files/sign" \
  -H "Authorization: Bearer $UPLOADS_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"key":"screenshots/try.svg","contentType":"image/svg+xml"}'
```

Migrations apply on the next API/auth deploy (`migrate:d1` before `wrangler deploy` for API; auth package migrate path as usual).

## Technical notes

- API migrations: `20260722180000_file_metadata_value_covering_idx.sql`, `20260722180100_auth_enrollments_expires_at_idx.sql`
- Auth migration: `20260722180000_retention_expires_at_idx.sql` (+ Drizzle `schema.ts` mirror)
- New module: `apps/api/src/observability-retention.ts` (third daily `waitUntil` on the API worker)
- Staging reaper cursor KV key: `cron:staging-reaper:cursor`

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run test/staging-reaper.test.ts test/routes-galleries.test.ts test/observability-retention.test.ts test/routes-files.test.ts test/telemetry.test.ts`
- [x] `pnpm --filter @uploads/auth exec vitest run src/retention-sweep.test.ts`
- [x] `pnpm --filter @uploads/api typecheck` / `pnpm --filter @uploads/auth typecheck`
- [ ] CI green on this PR
- [ ] After merge: confirm remote D1 migrations applied for api + auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload signing now requires an approved content type and handles case variations consistently.
  * Background cleanup now removes aged observability and authentication data automatically.
  * Stale staged attachments are processed more reliably across scheduled runs.

* **Bug Fixes**
  * Public galleries now return a consistent not-found response for unavailable or removed galleries.
  * Cross-workspace metadata searches provide more reliable pagination and improved performance.

* **Tests**
  * Added coverage for upload validation, gallery availability, retention cleanup, and staged attachment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->