### PR TITLE
fix: harden token compare, unify free limits, bound token lists

### DIFF
--- a/apps/api/src/auth-db.ts
+++ b/apps/api/src/auth-db.ts
@@ -297,12 +297,26 @@ export async function exchangeEnrollment(
   };
 }
 
-export async function listTokens(db: D1Database, workspace: string): Promise<AuthTokenRecord[]> {
+/**
+ * List tokens for a workspace. Active-only by default so list/revoke paths
+ * don't pay D1 rows-read for the full revoke history. Pass
+ * `includeRevoked: true` for admin audit listing.
+ */
+export async function listTokens(
+  db: D1Database,
+  workspace: string,
+  opts?: { includeRevoked?: boolean },
+): Promise<AuthTokenRecord[]> {
+  const includeRevoked = opts?.includeRevoked === true;
   const result = await db
     .prepare(
-      `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
-              minting_user_id
-       FROM auth_tokens WHERE workspace = ? ORDER BY created_at ASC`,
+      includeRevoked
+        ? `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
+                  minting_user_id
+           FROM auth_tokens WHERE workspace = ? ORDER BY created_at ASC`
+        : `SELECT id, workspace, token_hash, label, scopes, created_at, expires_at, revoked_at,
+                  minting_user_id
+           FROM auth_tokens WHERE workspace = ? AND revoked_at IS NULL ORDER BY created_at ASC`,
     )
     .bind(workspace)
     .all<AuthTokenRecord>();
@@ -315,7 +329,8 @@ export async function revokeToken(
   selector: { hashPrefix?: string; label?: string },
   now = new Date(),
 ): Promise<{ match: AuthTokenRecord | null; ambiguous: boolean }> {
-  const tokens = (await listTokens(db, workspace)).filter((token) => token.revoked_at === null);
+  // Active tokens only (listTokens default) — revoked history is irrelevant for revoke.
+  const tokens = await listTokens(db, workspace);
   const matches = tokens.filter((token) =>
     selector.hashPrefix
       ? token.token_hash.startsWith(selector.hashPrefix)

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -349,7 +349,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
     }
 
-    const d1 = (await listTokens(c.env.DB, name)).map((token) => ({
+    const d1 = (await listTokens(c.env.DB, name, { includeRevoked: true })).map((token) => ({
       label: token.label,
       createdAt: token.created_at,
       hashPrefix: token.token_hash.slice(0, HASH_PREFIX_LEN),
@@ -393,10 +393,9 @@ export const admin = new Hono<{ Bindings: Env }>()
     const kvMatches = kv.filter((token) =>
       hashPrefix ? token.hash.startsWith(hashPrefix) : token.label === label,
     );
-    const activeD1 = (await listTokens(c.env.DB, name)).filter(
-      (token) =>
-        token.revoked_at === null &&
-        (hashPrefix ? token.token_hash.startsWith(hashPrefix) : token.label === label),
+    // Active-only list (default) — revoked tokens cannot be re-revoked here.
+    const activeD1 = (await listTokens(c.env.DB, name)).filter((token) =>
+      hashPrefix ? token.token_hash.startsWith(hashPrefix) : token.label === label,
     );
     const count = kvMatches.length + activeD1.length;
     if (count === 0) throw new NotFoundError("no matching token");

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -452,10 +452,9 @@ workspaces.get("/:name/tokens", workspaceManageAuth(), async (c) => {
   requireWorkspaceName(name);
 
   const now = new Date().toISOString();
+  // listTokens is active-only by default; also drop expired actives for UX.
   const tokens = (await listTokens(c.env.DB, name))
-    .filter(
-      (token) => token.revoked_at === null && (token.expires_at === null || token.expires_at > now),
-    )
+    .filter((token) => token.expires_at === null || token.expires_at > now)
     .map((token) => ({
       label: token.label,
       createdAt: token.created_at,

--- a/apps/api/src/self-serve-defaults.test.ts
+++ b/apps/api/src/self-serve-defaults.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { PLANS } from "@uploads/billing";
 import { selfServeWorkspaceRecord, SELF_SERVE_LIMITS } from "./self-serve-defaults";
 
 describe("selfServeWorkspaceRecord", () => {
@@ -18,10 +19,10 @@ describe("selfServeWorkspaceRecord", () => {
       selfServe: true,
       createdByUserId: "u1",
       createdAt: "2026-07-14T00:00:00.000Z",
-      maxStorageBytes: 250_000_000,
-      maxUploadsPerPeriod: 3000,
-      maxUploadBytes: 25_000_000,
-      maxVideoUploadBytes: 8_000_000,
+      maxStorageBytes: PLANS.free.defaultLimits.maxStorageBytes,
+      maxUploadsPerPeriod: PLANS.free.defaultLimits.maxUploadsPerPeriod,
+      maxUploadBytes: PLANS.free.defaultLimits.maxUploadBytes,
+      maxVideoUploadBytes: PLANS.free.defaultLimits.maxVideoUploadBytes,
       allowedKeyPrefixes: ["f", "screenshots", "gh"],
       maxKeyDepth: 8,
     });
@@ -32,8 +33,12 @@ describe("selfServeWorkspaceRecord", () => {
     const b = selfServeWorkspaceRecord({ name: "b", userId: "u", now: new Date(0) });
     expect(a.allowedKeyPrefixes).not.toBe(b.allowedKeyPrefixes);
   });
-  it("limits are 250MB/3000-per-month", () => {
-    expect(SELF_SERVE_LIMITS.maxStorageBytes).toBe(250_000_000);
-    expect(SELF_SERVE_LIMITS.maxUploadsPerPeriod).toBe(3000);
+  it("budget fields match PLANS.free.defaultLimits (single source of truth)", () => {
+    expect({
+      maxStorageBytes: SELF_SERVE_LIMITS.maxStorageBytes,
+      maxUploadsPerPeriod: SELF_SERVE_LIMITS.maxUploadsPerPeriod,
+      maxUploadBytes: SELF_SERVE_LIMITS.maxUploadBytes,
+      maxVideoUploadBytes: SELF_SERVE_LIMITS.maxVideoUploadBytes,
+    }).toEqual(PLANS.free.defaultLimits);
   });
 });

--- a/apps/api/src/self-serve-defaults.ts
+++ b/apps/api/src/self-serve-defaults.ts
@@ -2,17 +2,24 @@
  * Record template for self-serve workspaces (spec 2026-07-14, D3).
  * Deliberately tighter than the operator template in
  * scripts/workspace-limit-defaults.json (25 GB): self-serve tenants start at
- * 250 MB / 3000 uploads per UTC month; raises are admin-only. Uploads are
- * WebP-converted by default, so 250 MB of stored assets holds far more
- * screenshots than the raw byte figure suggests.
+ * free-plan limits from `@uploads/billing` (250 MB / 3000 uploads per UTC
+ * month); raises are admin-only. Uploads are WebP-converted by default, so
+ * 250 MB of stored assets holds far more screenshots than the raw byte
+ * figure suggests.
+ *
+ * Budget numbers come from `PLANS.free.defaultLimits` so plan resolution and
+ * self-serve provisioning cannot drift.
  */
+import { PLANS } from "@uploads/billing";
 import type { WorkspaceRecord } from "./workspace";
 
+const freeLimits = PLANS.free.defaultLimits;
+
 export const SELF_SERVE_LIMITS = {
-  maxStorageBytes: 250_000_000,
-  maxUploadsPerPeriod: 3000,
-  maxUploadBytes: 25_000_000,
-  maxVideoUploadBytes: 8_000_000,
+  maxStorageBytes: freeLimits.maxStorageBytes!,
+  maxUploadsPerPeriod: freeLimits.maxUploadsPerPeriod!,
+  maxUploadBytes: freeLimits.maxUploadBytes!,
+  maxVideoUploadBytes: freeLimits.maxVideoUploadBytes!,
   allowedKeyPrefixes: ["f", "screenshots", "gh"] as const,
   maxKeyDepth: 8,
 } as const;

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  hexToBytes,
   isPurgedTombstone,
+  isSha256Hex,
   loadWorkspaceRecord,
   loadWorkspaceRecordRaw,
   WORKSPACE_DELETE_GRACE_DAYS,
@@ -82,5 +84,21 @@ describe("loadWorkspaceRecord (#247 soft-delete filtering)", () => {
 
   it("grace window constant is 14 days", () => {
     expect(WORKSPACE_DELETE_GRACE_DAYS).toBe(14);
+  });
+});
+
+describe("isSha256Hex / hexToBytes (corrupt token-hash guard)", () => {
+  it("accepts a 64-char hex digest", () => {
+    const hex = "a".repeat(64);
+    expect(isSha256Hex(hex)).toBe(true);
+    expect(hexToBytes(hex).byteLength).toBe(32);
+  });
+
+  it("rejects wrong length or non-hex so timingSafeEqual is never fed unequal buffers", () => {
+    expect(isSha256Hex("deadbeef")).toBe(false);
+    expect(isSha256Hex("z".repeat(64))).toBe(false);
+    expect(isSha256Hex("")).toBe(false);
+    expect(isSha256Hex("a".repeat(63))).toBe(false);
+    expect(isSha256Hex("a".repeat(65))).toBe(false);
   });
 });

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -168,6 +168,19 @@ export type WorkspaceVars = {
  * don't drift from one another. */
 export const WS_NAME_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
 
+/** SHA-256 hex digests are always 64 lowercase/uppercase hex chars (32 bytes). */
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/i;
+
+/** True when `hex` is a well-formed SHA-256 digest (64 hex chars). */
+export function isSha256Hex(hex: string): boolean {
+  return SHA256_HEX_RE.test(hex);
+}
+
+/**
+ * Decode a hex string to bytes. Callers that compare digests with
+ * `timingSafeEqual` must pass only `isSha256Hex` values — unequal lengths
+ * throw in the Workers runtime.
+ */
 export function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);
   for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
@@ -258,13 +271,33 @@ function workspaceAuthWith(
     const providedHash = await sha256Hex(token);
     const providedBytes = hexToBytes(providedHash);
     const candidates = record ? workspaceTokenHashes(record) : [];
-    // Compare against every candidate hash (no early break) so match position isn't timing-visible.
+    // Compare against every *valid* candidate hash (no early break) so match
+    // position isn't timing-visible. Skip corrupt/hand-edited hashes: unequal
+    // lengths make timingSafeEqual throw and would 500 the whole tenant.
     // Note: total work scales with token count — acceptable for this throwaway PoC; a leaked
     // token-count signal goes away with the real auth system.
     const toCheck = candidates.length > 0 ? candidates : [providedHash.replace(/./g, "0")];
     let matched = false;
+    let skippedInvalidHash = false;
     for (const hash of toCheck) {
-      if (crypto.subtle.timingSafeEqual(providedBytes, hexToBytes(hash))) matched = true;
+      if (!isSha256Hex(hash)) {
+        skippedInvalidHash = true;
+        continue;
+      }
+      const candidateBytes = hexToBytes(hash);
+      if (candidateBytes.byteLength !== providedBytes.byteLength) {
+        skippedInvalidHash = true;
+        continue;
+      }
+      if (crypto.subtle.timingSafeEqual(providedBytes, candidateBytes)) matched = true;
+    }
+    if (skippedInvalidHash && record) {
+      console.error(
+        JSON.stringify({
+          message: "workspace_token_hash_invalid",
+          workspace: name ?? null,
+        }),
+      );
     }
     const legacyOk = record !== null && token.length > 0 && candidates.length > 0 && matched;
     // Always pay the D1 round-trip, with dummy inputs when the workspace is

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -2,8 +2,10 @@
  * Plan catalog for workspace subscription plans (free-plan era, spec
  * 2026-07-22). `free` is available in perpetuity today; `pro` is defined for
  * display purposes only (`available: false`) — no checkout path exists yet.
- * `defaultLimits.free` mirrors `apps/api/src/self-serve-defaults.ts`'s
- * `SELF_SERVE_LIMITS`; keep the two in sync if either changes.
+ *
+ * Free `defaultLimits` are the single source of truth for self-serve
+ * provisioning: `apps/api/src/self-serve-defaults.ts` imports
+ * `PLANS.free.defaultLimits` into `SELF_SERVE_LIMITS` (do not re-hardcode).
  */
 
 export type PlanId = "free" | "pro";


### PR DESCRIPTION
## In plain terms

Three small correctness/cost fixes from the improve audit: stop bad stored token hashes from taking down auth, keep free-plan and self-serve limits as one number set, and stop reading every revoked API token on list/revoke paths.

## What it does

- **Token hash compare:** only feed well-formed 64-char SHA-256 hex into `timingSafeEqual`; log `workspace_token_hash_invalid` and continue so a hand-edited KV hash cannot 500 the tenant.
- **Free limits single source:** `SELF_SERVE_LIMITS` budget fields come from `PLANS.free.defaultLimits` in `@uploads/billing` (with a lock test).
- **`listTokens`:** defaults to `revoked_at IS NULL`; admin list passes `includeRevoked: true` for audit history; revoke/self-serve list use active-only.

## What it is not

- Does not hard-delete revoked tokens or change mint/exchange flows.
- Does not set `plan: "free"` on self-serve records (still a later billing step).
- Does not implement presign staging / magic-byte finalize.

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run src/workspace.test.ts src/self-serve-defaults.test.ts test/routes-auth.test.ts src/routes/tokens.test.ts`
- [x] `pnpm --filter @uploads/billing exec vitest run`
- [x] `pnpm --filter @uploads/api typecheck`
- [ ] CI green