### PR TITLE
fix: atomic storage reserve on put; collapse report form until opened

### DIFF
--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -84,6 +84,26 @@ export function uploadBudgetDenial(
   };
 }
 
+/** The 507 storage-quota denial, shared by the read-side check and
+ * the atomic reservation path (usage.ts reserveStorageBytes). */
+export function storageBudgetDenial(
+  usage: WorkspaceUsage,
+  maxStorageBytes: number,
+  deltaBytes: number,
+): BudgetDenial {
+  return {
+    code: "storage_quota_exceeded",
+    status: 507,
+    message: `storage quota exceeded (${usage.bytes} + ${deltaBytes} > ${maxStorageBytes} bytes)`,
+    detail: {
+      bytes: usage.bytes,
+      deltaBytes,
+      maxStorageBytes,
+      objects: usage.objects,
+    },
+  };
+}
+
 /** Map a denial to the thrown error type: 507 storage, 429 upload budget. */
 export function budgetDenialError(
   denial: BudgetDenial,
@@ -113,19 +133,8 @@ export function checkPutBudget(
   }
 
   if (maxStorageBytes !== undefined && delta.bytes > 0) {
-    const next = usage.bytes + delta.bytes;
-    if (next > maxStorageBytes) {
-      return {
-        code: "storage_quota_exceeded",
-        status: 507,
-        message: `storage quota exceeded (${usage.bytes} + ${delta.bytes} > ${maxStorageBytes} bytes)`,
-        detail: {
-          bytes: usage.bytes,
-          deltaBytes: delta.bytes,
-          maxStorageBytes,
-          objects: usage.objects,
-        },
-      };
+    if (usage.bytes + delta.bytes > maxStorageBytes) {
+      return storageBudgetDenial(usage, maxStorageBytes, delta.bytes);
     }
   }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -11,6 +11,7 @@ import {
   budgetDenialError,
   checkPutBudget,
   resolveBudgetLimits,
+  storageBudgetDenial,
   uploadBudgetDenial,
 } from "./budget";
 import {
@@ -37,7 +38,14 @@ import {
   type ProvenanceMap,
 } from "./provenance";
 import { objectPublicUrls, storage, storageConfig } from "./storage";
-import { getWorkspaceUsage, recordUsageSafe, releaseUploadsSafe, reserveUploads } from "./usage";
+import {
+  getWorkspaceUsage,
+  recordUsageSafe,
+  releaseStorageBytesSafe,
+  releaseUploadsSafe,
+  reserveStorageBytes,
+  reserveUploads,
+} from "./usage";
 import { objectVisibility, VISIBILITY_META_KEY, type Visibility } from "./visibility";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
@@ -388,20 +396,40 @@ export async function putObject(
   const uploadedAt = resolveUploadedAtMeta(prior);
 
   const usage = await getWorkspaceUsage(env.DB, workspaceName);
+  // Cheap read-side reject for obviously spent budgets (both caps). Concurrent
+  // puts at the boundary still need the atomic reservations below.
   const denial = checkPutBudget(usage, ws, { bytes: deltaBytes, uploads: 1 });
   if (denial) throw budgetDenialError(denial);
 
-  // The read-side check above handles the storage cap and rejects
-  // obviously-spent budgets cheaply, but it races with concurrent puts at the
-  // upload-cap boundary. Reserve the upload atomically (guarded D1 increment)
-  // before the R2 write; the reservation IS the upload count, so the post-put
-  // recordUsageSafe below must not count it again, and a failed write
-  // releases it.
-  const { maxUploadsPerPeriod } = resolveBudgetLimits(ws);
-  const reservation = await reserveUploads(env.DB, workspaceName, 1, maxUploadsPerPeriod);
-  if (!reservation.ok) {
-    throw budgetDenialError(uploadBudgetDenial(reservation.usage, reservation.maxUploadsPerPeriod));
+  // Atomically reserve monthly upload count AND (when growing) net storage
+  // bytes before the R2 write. Reservations ARE the ledger increments for
+  // those fields, so post-put recordUsageSafe must not count them again; a
+  // failed write releases both.
+  const { maxUploadsPerPeriod, maxStorageBytes } = resolveBudgetLimits(ws);
+  const uploadReservation = await reserveUploads(env.DB, workspaceName, 1, maxUploadsPerPeriod);
+  if (!uploadReservation.ok) {
+    throw budgetDenialError(
+      uploadBudgetDenial(uploadReservation.usage, uploadReservation.maxUploadsPerPeriod),
+    );
   }
+
+  const storageReservation = await reserveStorageBytes(
+    env.DB,
+    workspaceName,
+    deltaBytes,
+    maxStorageBytes,
+  );
+  if (!storageReservation.ok) {
+    await releaseUploadsSafe(env.DB, workspaceName, 1);
+    throw budgetDenialError(
+      storageBudgetDenial(
+        storageReservation.usage,
+        storageReservation.maxStorageBytes,
+        storageReservation.deltaBytes,
+      ),
+    );
+  }
+  const reservedBytes = storageReservation.reservedBytes;
 
   // Client headers first; always attach content-sha256 of the final stored body
   // (never trust a client-supplied hash). Visibility lives alongside provenance
@@ -427,18 +455,20 @@ export async function putObject(
       metadata: storageMetadata,
     });
   } catch (err) {
-    // Nothing was stored, so the reserved upload goes back to the budget.
+    // Nothing was stored — return both reservations to the budget.
     await releaseUploadsSafe(env.DB, workspaceName, 1);
+    await releaseStorageBytesSafe(env.DB, workspaceName, reservedBytes);
     throw err;
   }
 
   // Usage accounting first: the object is already durably stored above, so
   // the ledger must be updated regardless of whether the metadata batch
   // below succeeds — otherwise a metadata failure leaves bytes/objects
-  // stored but under-counted (recordUsageSafe never throws). The upload
-  // itself was already counted by reserveUploads, hence `uploads: 0`.
+  // stored but under-counted (recordUsageSafe never throws). Upload count
+  // and any reserved positive byte delta were already applied at reservation
+  // time; only remaining deltas (objects; shrink/unlimited bytes) land here.
   await recordUsageSafe(env.DB, workspaceName, {
-    bytes: deltaBytes,
+    bytes: reservedBytes > 0 ? 0 : deltaBytes,
     objects: replaced ? 0 : 1,
     uploads: 0,
   });

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -232,6 +232,96 @@ export async function releaseUploadsSafe(
   }
 }
 
+export type StorageReservation =
+  | { ok: true; reservedBytes: number }
+  | { ok: false; usage: WorkspaceUsage; maxStorageBytes: number; deltaBytes: number };
+
+/**
+ * Atomically reserve a positive net-byte delta against `maxStorageBytes`
+ * BEFORE the R2 put. Mirrors `reserveUploads` for the storage cap so
+ * concurrent puts near the quota cannot all pass a read-then-check and
+ * overshoot. No-ops (ok, reservedBytes 0) when `deltaBytes <= 0` or the
+ * workspace is unlimited. Callers must `releaseStorageBytesSafe` on failed
+ * work and must NOT re-count reserved bytes in `recordUsageSafe`.
+ */
+export async function reserveStorageBytes(
+  db: D1Database,
+  workspace: string,
+  deltaBytes: number,
+  maxStorageBytes: number | undefined,
+  now = new Date(),
+): Promise<StorageReservation> {
+  if (deltaBytes <= 0) return { ok: true, reservedBytes: 0 };
+  if (maxStorageBytes === undefined) return { ok: true, reservedBytes: 0 };
+
+  const period = usagePeriodStart(now);
+  const updatedAt = now.toISOString();
+
+  const results = await db.batch([
+    db
+      .prepare(
+        `INSERT OR IGNORE INTO workspace_usage
+           (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+         VALUES (?, 0, 0, 0, ?, ?)`,
+      )
+      .bind(workspace, period, updatedAt),
+    // Distinct predicate fragment (`bytes + ? <= ?`) so fakes/tests can
+    // distinguish this from the upload-count reservation (`uploads… <= ?`).
+    db
+      .prepare(
+        `UPDATE workspace_usage SET
+           bytes = bytes + ?,
+           updated_at = ?
+         WHERE workspace = ?
+           AND bytes + ? <= ?`,
+      )
+      .bind(deltaBytes, updatedAt, workspace, deltaBytes, maxStorageBytes),
+  ]);
+
+  const changes = results[1]?.meta?.changes ?? 0;
+  if (changes > 0) return { ok: true, reservedBytes: deltaBytes };
+  return {
+    ok: false,
+    usage: await getWorkspaceUsage(db, workspace, now),
+    maxStorageBytes,
+    deltaBytes,
+  };
+}
+
+/**
+ * Undo a `reserveStorageBytes` reservation after the R2 write failed.
+ * Best-effort (same rationale as releaseUploadsSafe).
+ */
+export async function releaseStorageBytesSafe(
+  db: D1Database,
+  workspace: string,
+  reservedBytes: number,
+  now = new Date(),
+): Promise<void> {
+  if (reservedBytes <= 0) return;
+  try {
+    await db
+      .prepare(
+        `UPDATE workspace_usage SET
+           bytes = MAX(0, bytes - ?),
+           updated_at = ?
+         WHERE workspace = ?`,
+      )
+      .bind(reservedBytes, now.toISOString(), workspace)
+      .run();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "storage reservation release failed",
+        workspace,
+        reservedBytes,
+        error: message,
+      }),
+    );
+  }
+}
+
 /** Best-effort metering: log and continue if D1 fails. */
 export async function recordUsageSafe(
   db: D1Database,

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -116,6 +116,40 @@ export class UsageFakeD1 {
           return { success: true as const, meta: { changes: 1 }, results: [] };
         }
         if (normalized.startsWith("UPDATE workspace_usage SET")) {
+          // Guarded storage reservation from reserveStorageBytes (check before
+          // the upload-count path — both contain `<= ?`).
+          if (normalized.includes("bytes + ? <=")) {
+            const [deltaBytes, updatedAt, workspace, , max] = values as [
+              number,
+              string,
+              string,
+              number,
+              number,
+            ];
+            const row = this.usage.get(workspace);
+            if (!row) throw new Error(`update before insert for ${workspace}`);
+            if (row.bytes + deltaBytes > max) {
+              return { success: true as const, meta: { changes: 0 }, results: [] };
+            }
+            this.usage.set(workspace, {
+              ...row,
+              bytes: row.bytes + deltaBytes,
+              updated_at: updatedAt,
+            });
+            return { success: true as const, meta: { changes: 1 }, results: [] };
+          }
+          // Storage release from releaseStorageBytesSafe.
+          if (normalized.includes("MAX(0, bytes - ?)")) {
+            const [reservedBytes, updatedAt, workspace] = values as [number, string, string];
+            const row = this.usage.get(workspace);
+            if (!row) return { success: true as const, meta: { changes: 0 }, results: [] };
+            this.usage.set(workspace, {
+              ...row,
+              bytes: Math.max(0, row.bytes - reservedBytes),
+              updated_at: updatedAt,
+            });
+            return { success: true as const, meta: { changes: 1 }, results: [] };
+          }
           // Guarded reservation from reserveUploads: increments
           // uploads_in_period only while within the cap; changes: 0 signals
           // a spent budget. Atomic within a single run(), like D1's UPDATE.

--- a/apps/api/test/usage.test.ts
+++ b/apps/api/test/usage.test.ts
@@ -3,7 +3,9 @@ import {
   applyUsageDelta,
   emptyUsage,
   getWorkspaceUsage,
+  releaseStorageBytesSafe,
   releaseUploadsSafe,
+  reserveStorageBytes,
   reserveUploads,
   usagePeriodStart,
 } from "../src/usage";
@@ -151,5 +153,61 @@ describe("upload reservations", () => {
     );
     expect(results.filter((r) => r.ok)).toHaveLength(2);
     expect((await getWorkspaceUsage(db, "acme", now)).uploadsInPeriod).toBe(2);
+  });
+});
+
+describe("storage byte reservations", () => {
+  const now = new Date("2026-07-10T00:00:00Z");
+
+  it("reserves positive deltas up to the storage cap, then denies", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const a = await reserveStorageBytes(db, "acme", 600, 1000, now);
+    expect(a).toEqual({ ok: true, reservedBytes: 600 });
+    const b = await reserveStorageBytes(db, "acme", 400, 1000, now);
+    expect(b).toEqual({ ok: true, reservedBytes: 400 });
+
+    const denied = await reserveStorageBytes(db, "acme", 1, 1000, now);
+    expect(denied.ok).toBe(false);
+    if (!denied.ok) {
+      expect(denied.usage.bytes).toBe(1000);
+      expect(denied.maxStorageBytes).toBe(1000);
+      expect(denied.deltaBytes).toBe(1);
+    }
+    expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(1000);
+  });
+
+  it("no-ops for non-positive deltas and unlimited workspaces", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    expect(await reserveStorageBytes(db, "acme", 0, 1000, now)).toEqual({
+      ok: true,
+      reservedBytes: 0,
+    });
+    expect(await reserveStorageBytes(db, "acme", -50, 1000, now)).toEqual({
+      ok: true,
+      reservedBytes: 0,
+    });
+    expect(await reserveStorageBytes(db, "acme", 500, undefined, now)).toEqual({
+      ok: true,
+      reservedBytes: 0,
+    });
+    expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(0);
+  });
+
+  it("release returns reserved bytes, clamped at zero", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    await reserveStorageBytes(db, "acme", 200, 1000, now);
+    await releaseStorageBytesSafe(db, "acme", 200, now);
+    expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(0);
+    await releaseStorageBytesSafe(db, "acme", 50, now);
+    expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(0);
+  });
+
+  it("only admits the storage cap under concurrent reservations", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => reserveStorageBytes(db, "acme", 400, 1000, now)),
+    );
+    expect(results.filter((r) => r.ok)).toHaveLength(2);
+    expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(800);
   });
 });

--- a/apps/web/src/components/ReportAbuse.astro
+++ b/apps/web/src/components/ReportAbuse.astro
@@ -180,6 +180,14 @@ const REASONS = [
     border-radius: var(--radius-md);
     background: var(--bg);
   }
+  /* `display: flex` above would override the HTML `hidden` attribute's
+     UA `display: none` — keep the form collapsed until "Report a problem". */
+  .report-form[hidden],
+  .report-done[hidden],
+  .report-status[hidden],
+  .report-toggle[hidden] {
+    display: none;
+  }
   .report-lead {
     margin: 0;
     color: var(--muted);


### PR DESCRIPTION
## In plain terms

Two unrelated fixes: storage quotas can no longer be overshot by concurrent uploads (the same race we already fixed for monthly upload counts), and the public file page no longer shows the full abuse form until you click **Report a problem**.

## What it does

- **Storage TOCTOU:** `reserveStorageBytes` / `releaseStorageBytesSafe` on the put path, guarded by `bytes + delta <= maxStorageBytes`. Reserved bytes are not double-counted after a successful put. Shrink/unlimited paths unchanged.
- **Report form:** CSS was setting `.report-form { display: flex }`, which overrode the HTML `hidden` attribute so the form always looked open. Explicit `[hidden] { display: none }` for toggle/form/status/done.

## What it is not

- Presign still has no post-upload magic-byte path or budget reservation at mint time.
- No operator abuse triage UI.

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run test/usage.test.ts test/budget.test.ts src/budget.test.ts`
- [x] `pnpm --filter @uploads/api typecheck`
- [ ] Visual: public file page shows only “Report a problem” link until click
- [ ] CI green