### PR TITLE
feat(cli): read-only `uploads staged` view (#405)

### DIFF
--- a/.changeset/staged-view.md
+++ b/.changeset/staged-view.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+New `uploads staged [--branch <name>] [--repo <owner/name>] [--format json]`: a read-only view of what's staged for a branch (`attach --branch` / bare `put` on a non-default branch) and whether it will auto-attach once a PR opens. One `list` call against the branch staging prefix plus the repo-binding check (files:read only, no new server surface); `--format json` always prints a valid document, even with nothing staged. Also available as the `staged` tool on the local stdio MCP server.

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -131,6 +131,10 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     essential: true,
   },
   {
+    name: "staged",
+    summary: "Show what's staged for a branch, and whether it will auto-attach",
+  },
+  {
     name: "screenshot",
     usage: "screenshot <target>",
     summary: "Capture a URL or .html file and host it (local browser or remote render)",

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -14,6 +14,7 @@ import { colorEnabled, createStyle } from "./cli-style.js";
 import {
   runPut,
   runAttach,
+  runStaged,
   runList,
   runFind,
   runMeta,
@@ -340,6 +341,7 @@ export async function runCli(argv: string[]): Promise<number> {
         break;
       case "attach":
       case "put":
+      case "staged":
       case "screenshot":
       case "gallery":
       case "list":
@@ -359,6 +361,9 @@ export async function runCli(argv: string[]): Promise<number> {
             break;
           case "put":
             code = await runPut(ctx, cmdArgs, showHelp);
+            break;
+          case "staged":
+            code = await runStaged(ctx, cmdArgs, showHelp);
             break;
           case "screenshot":
             code = await runScreenshot(ctx, cmdArgs, showHelp);

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1901,7 +1901,11 @@ export async function runStaged(
     await writeStdout(`${file.filename}  ${size}${staged}  ${file.url ?? "(no url)"}\n`);
   }
   process.stderr.write(`binding: ${result.binding.state} — ${result.binding.message}\n`);
-  process.stderr.write(`once the PR exists: uploads attach --promote\n`);
+  // Promote is pointless advice when the repo belongs to another workspace —
+  // the cross-tenant gate (#297) would reject it from here.
+  if (result.binding.state !== "other") {
+    process.stderr.write(`once the PR exists: uploads attach --promote\n`);
+  }
   return 0;
 }
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -35,6 +35,7 @@ import { mergeDerivedMeta, nearMissMetaWarnings, validateStateValue } from "./me
 import {
   ghAttachmentKey,
   ghBranchAttachmentKey,
+  ghBranchKeyPrefix,
   ghKeyPrefix,
   ghMetadataFromTarget,
   ghMetadataForBranch,
@@ -1479,6 +1480,32 @@ async function runAttachBranch(
 }
 
 /**
+ * One source of truth for the "staged, but not going to auto-attach" advisory
+ * text (issue #398), shared by the `attach --branch`/bare-`put` stage-time
+ * warning below and the `uploads staged` view (issue #405) — both surfaces
+ * must say the exact same thing for the same binding state, verified by
+ * tests on both call sites. Returns undefined for `"self"` (the happy path —
+ * callers each phrase that themselves) and any unrecognized value.
+ */
+export function stagingBindingAdvisory(binding: string, repo: string): string | undefined {
+  switch (binding) {
+    case "none":
+      return (
+        `staged, but ${repo} isn't linked to your workspace yet — staged files only ` +
+        `auto-attach on PR open for linked repos. Link it once with: uploads attach <file> ` +
+        `(on any PR) or uploads github link. After the PR opens: uploads attach --promote`
+      );
+    case "other":
+      return (
+        `staged, but ${repo} is linked to a different workspace — these files won't ` +
+        `auto-attach from here.`
+      );
+    default:
+      return undefined; // "self", or any unrecognized value
+  }
+}
+
+/**
  * Best-effort stage-time binding warning (issue #398): after `attach
  * --branch` stages files, checks whether `repo` is bound to THIS workspace —
  * webhook auto-promotion at PR open only fires for a repo already bound
@@ -1499,21 +1526,8 @@ export async function resolveStageBindingWarning(opts: {
   if (defaults.noNudge) return undefined;
   try {
     const { binding } = await ctx.client.githubRepoLinkStatus(repo);
-    switch (binding) {
-      case "none":
-        return (
-          `note: staged, but ${repo} isn't linked to your workspace yet — staged files only ` +
-          `auto-attach on PR open for linked repos. Link it once with: uploads attach <file> ` +
-          `(on any PR) or uploads github link. After the PR opens: uploads attach --promote`
-        );
-      case "other":
-        return (
-          `note: staged, but ${repo} is linked to a different workspace — these files won't ` +
-          `auto-attach from here.`
-        );
-      default:
-        return undefined; // "self", or any unrecognized value — stay silent
-    }
+    const advisory = stagingBindingAdvisory(binding, repo);
+    return advisory ? `note: ${advisory}` : undefined;
   } catch {
     return undefined; // any failure (network, non-200, older server) — stay silent
   }
@@ -1724,6 +1738,171 @@ export function putStagingNoteText(branch: string): string {
     `note: staged for branch ${branch} — auto-attaches to this branch's PR when it opens ` +
     `(or run: uploads attach --promote once it exists). Use --ref/--prefix for a plain dated upload.`
   );
+}
+
+// --- staged ---
+
+/** One file currently staged for a branch (issue #405). */
+export interface StagedFile {
+  /** Full object key (`gh/<owner>/<repo>/branch/<branch>/<filename>`). */
+  key: string;
+  /** `key` with the staging prefix stripped. */
+  filename: string;
+  size?: number;
+  /** `gh.staged-at` metadata (ISO 8601 UTC), when present. */
+  stagedAt?: string;
+  url: string | null;
+}
+
+/** Tri-state binding, folded into a ready-to-render advisory (issue #405/#398). */
+export interface StagedBinding {
+  state: "self" | "other" | "none" | "unknown";
+  /** True only for "self" — the only state where staged files actually auto-attach. */
+  autoAttach: boolean;
+  message: string;
+}
+
+export interface StagedResult {
+  repo: string;
+  branch: string;
+  files: StagedFile[];
+  binding: StagedBinding;
+}
+
+/**
+ * Binding lookup for `uploads staged`, folded into a renderable `StagedBinding`.
+ * `"none"`/`"other"` reuse `stagingBindingAdvisory` — the exact #398 wording,
+ * one source of truth. `"self"` gets its own message (the #398 warning stays
+ * silent on "self"; this view is the one place that names the happy path
+ * explicitly). Any failure (network, non-200, older server without the
+ * route) degrades to `"unknown"` rather than throwing — this is a read-only
+ * view and a binding check failing must never make it fail outright.
+ */
+async function resolveStagedBinding(client: UploadsClient, repo: string): Promise<StagedBinding> {
+  try {
+    const { binding } = await client.githubRepoLinkStatus(repo);
+    switch (binding) {
+      case "self":
+        return {
+          state: "self",
+          autoAttach: true,
+          message: "these auto-attach when this branch's PR opens",
+        };
+      case "none":
+      case "other":
+        return {
+          state: binding,
+          autoAttach: false,
+          // stagingBindingAdvisory is total for "none"/"other" — never undefined here.
+          message: stagingBindingAdvisory(binding, repo)!,
+        };
+      default:
+        return { state: "unknown", autoAttach: false, message: "binding status unrecognized" };
+    }
+  } catch {
+    return {
+      state: "unknown",
+      autoAttach: false,
+      message: "could not check binding status (offline, or an older server without this route)",
+    };
+  }
+}
+
+/**
+ * Shared core for `uploads staged` (CLI) and the `staged` MCP tool (issue
+ * #405): one `list` call against the branch staging prefix
+ * (`ghBranchKeyPrefix` — never hand-built) plus the #398 binding check. Never
+ * throws on the binding check (see `resolveStagedBinding`); a failed `list`
+ * call still propagates, same as every other read command.
+ */
+export async function resolveStaged(opts: {
+  client: UploadsClient;
+  repo: string;
+  branch: string;
+}): Promise<StagedResult> {
+  const { client, repo, branch } = opts;
+  const prefix = ghBranchKeyPrefix(repo, branch);
+  const [list, binding] = await Promise.all([
+    client.list({ prefix, metadata: true }),
+    resolveStagedBinding(client, repo),
+  ]);
+  const files: StagedFile[] = list.items.map((item) => ({
+    key: item.key,
+    filename: item.key.slice(prefix.length),
+    size: item.size,
+    stagedAt: item.metadata?.["gh.staged-at"],
+    url: item.url,
+  }));
+  return { repo, branch, files, binding };
+}
+
+const STAGED_HELP = `uploads staged [--branch <name>] [--repo <owner/name>] [--format json] [--workspace <name>]
+
+Read-only view of what's staged for a branch (\`attach --branch\` / bare
+\`put\` on a non-default branch, issue #403) and whether it will auto-attach
+once a PR opens. One \`list\` call against the branch staging prefix
+(gh/<owner>/<repo>/branch/<branch>/) plus a binding check — files:read only,
+no new server surface.
+
+Defaults: current git branch (same resolution as \`attach --branch\`, worktree-
+safe), repo from --repo / gh / git remote (same as every other command).
+
+Binding: self means these files auto-attach when this branch's PR opens; none
+or other means they won't (repo unlinked, or linked to a different
+workspace) — same advisory as the attach --branch stage-time warning.
+
+Examples:
+  uploads staged
+  uploads staged --branch feature/thing --repo owner/name
+  uploads staged --format json
+`;
+
+export async function runStaged(
+  ctx: CliContext,
+  args: string[],
+  help = false,
+  run: CommandRunner = execRunner,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(STAGED_HELP);
+    return 0;
+  }
+  const format = ctx.json
+    ? "json"
+    : (() => {
+        const raw = flagString(parsed.flags, "--format");
+        if (!raw || raw === "human") return "human" as const;
+        if (raw === "json") return "json" as const;
+        throw new UsageError(`invalid --format: ${raw} (expected: json)`);
+      })();
+
+  const repo = resolveRepo(flagString(parsed.flags, "--repo"), run);
+  const branch = flagString(parsed.flags, "--branch") ?? resolveCurrentBranch(run);
+
+  const result = await resolveStaged({ client: ctx.client, repo, branch });
+
+  if (format === "json") {
+    // Always a valid JSON document, even with zero files — never empty
+    // stdout (issue #405 explicitly calls out find --format json's empty-
+    // stdout-on-no-matches wart as a wrong pattern to avoid here).
+    await writeJson(result);
+    return 0;
+  }
+
+  if (result.files.length === 0) {
+    await writeStdout(`nothing staged for ${branch} in ${repo}\n`);
+    return 0;
+  }
+
+  for (const file of result.files) {
+    const size = file.size !== undefined ? formatByteSize(file.size) : "? B";
+    const staged = file.stagedAt ? `  staged ${file.stagedAt}` : "";
+    await writeStdout(`${file.filename}  ${size}${staged}  ${file.url ?? "(no url)"}\n`);
+  }
+  process.stderr.write(`binding: ${result.binding.state} — ${result.binding.message}\n`);
+  process.stderr.write(`once the PR exists: uploads attach --promote\n`);
+  return 0;
 }
 
 export async function runPut(

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -11,6 +11,7 @@ import {
   buildDoctorReport,
   makeGhTarget,
   resolvePutStagingTarget,
+  resolveStaged,
   syncAttachmentsComment,
   type AttachmentsCommentResult,
   uploadAttachments,
@@ -33,6 +34,7 @@ import { type OptimizeImageOptions } from "../optimize.js";
 import {
   execRunner,
   ghMetadataFromTargetWithTitle,
+  resolveCurrentBranch,
   resolveCurrentPullRequest,
   resolveRepo,
   type CommandRunner,
@@ -1074,6 +1076,32 @@ export function createUploadsMcpTools(opts: {
           return { items, cursor: null };
         }
         return client.list({ prefix, limit, cursor });
+      },
+    },
+    {
+      name: "staged",
+      description:
+        "Read-only view of what's staged for a git branch (attach --branch / bare put on a non-default branch) and whether it will auto-attach once a PR opens. One list call against the branch staging prefix plus a repo-binding check (files:read only). Returns { repo, branch, files, binding }; binding.state is self/other/none/unknown and binding.autoAttach is true only for self.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          branch: {
+            type: "string",
+            description: "Branch name (default: current git branch, worktree-safe).",
+          },
+          repo: {
+            type: "string",
+            description: "owner/name repo (default: gh/git remote inference).",
+          },
+          workspace: workspaceProp,
+        },
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const { client } = clientFor(args);
+        const repo = resolveRepo(optString(args, "repo"), run);
+        const branch = optString(args, "branch") ?? resolveCurrentBranch(run);
+        return resolveStaged({ client, repo, branch });
       },
     },
     {

--- a/packages/uploads/test/cli-completion.test.ts
+++ b/packages/uploads/test/cli-completion.test.ts
@@ -24,7 +24,7 @@ describe("generateCompletionScript", () => {
   it("bash script registers complete -F and lists root commands", () => {
     const script = generateCompletionScript("bash");
     expect(script).toMatch(/complete -o default -F _uploads uploads/);
-    expect(script).toMatch(/local -a root_cmds=\(attach put screenshot gallery/);
+    expect(script).toMatch(/local -a root_cmds=\(attach put staged screenshot gallery/);
     for (const cmd of ROOT_COMMANDS) {
       expect(script).toContain(cmd.name);
     }

--- a/packages/uploads/test/commands-staged.test.ts
+++ b/packages/uploads/test/commands-staged.test.ts
@@ -255,6 +255,30 @@ describe("runStaged: file listing", () => {
     expect(stderr).toContain("binding: self");
     expect(stderr).toContain("once the PR exists: uploads attach --promote");
   });
+
+  it("human mode omits the promote affordance when the repo is bound to another workspace", async () => {
+    const { client } = fakeClient({
+      items: [
+        {
+          key: "gh/o/r/branch/feature-thing/shot.png",
+          url: "https://x.test/shot.png",
+          size: 2048,
+          metadata: { "gh.staged-at": "2026-07-20T10:00:00Z" },
+        },
+      ],
+      repoLinkStatus: { binding: "other" },
+    });
+    const { stderr } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    expect(stderr).toContain("binding: other");
+    expect(stderr).not.toContain("uploads attach --promote");
+  });
 });
 
 describe("runStaged: binding states", () => {

--- a/packages/uploads/test/commands-staged.test.ts
+++ b/packages/uploads/test/commands-staged.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it, vi } from "vitest";
+import { UsageError } from "../src/cli-args.js";
+import type { GithubRepoLinkResult, ListItem, UploadsClient } from "../src/client.js";
+import {
+  resolveStageBindingWarning,
+  runAttach,
+  runStaged,
+  stagingBindingAdvisory,
+  type CliContext,
+} from "../src/commands.js";
+import type { CommandRunner } from "../src/github-gh.js";
+
+function ctxWith(client: UploadsClient, overrides: Partial<CliContext> = {}): CliContext {
+  return {
+    config: {
+      apiUrl: "https://x.test",
+      workspace: "test",
+      token: "up_test_x",
+      workspaceSource: "override",
+      configPath: "/tmp/uploads-test-config",
+      configExists: false,
+    },
+    client,
+    json: false,
+    quiet: true,
+    ...overrides,
+  };
+}
+
+function fakeClient(opts?: {
+  items?: ListItem[];
+  repoLinkStatus?: GithubRepoLinkResult | Error | ((repo: string) => GithubRepoLinkResult | Error);
+}) {
+  const listCalls: { prefix?: string; metadata?: boolean }[] = [];
+  const client = {
+    list: async (listOpts: { prefix?: string; metadata?: boolean }) => {
+      listCalls.push(listOpts);
+      return { items: opts?.items ?? [], cursor: null };
+    },
+    ...(opts?.repoLinkStatus !== undefined
+      ? {
+          githubRepoLinkStatus: async (repo: string) => {
+            const result =
+              typeof opts.repoLinkStatus === "function"
+                ? opts.repoLinkStatus(repo)
+                : opts.repoLinkStatus!;
+            if (result instanceof Error) throw result;
+            return result;
+          },
+        }
+      : {}),
+  } as unknown as UploadsClient;
+  return { client, listCalls };
+}
+
+const branchRunner =
+  (branch = "feature/thing"): CommandRunner =>
+  (cmd, args) => {
+    if (cmd === "git" && args[0] === "rev-parse") return `${branch}\n`;
+    throw new Error(`unexpected call: ${cmd} ${args.join(" ")}`);
+  };
+
+const noRun: CommandRunner = () => {
+  throw new Error("runner should not be called");
+};
+
+async function withCapturedOutput(fn: () => Promise<void>): Promise<{
+  stdout: string;
+  stderr: string;
+}> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  try {
+    await fn();
+  } finally {
+    vi.restoreAllMocks();
+  }
+  return { stdout: stdout.join(""), stderr: stderr.join("") };
+}
+
+describe("runStaged: branch/repo resolution", () => {
+  it("uses --branch and --repo when given explicitly", async () => {
+    const { client, listCalls } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const code = await runStaged(
+      ctxWith(client),
+      ["--branch", "feature/thing", "--repo", "o/r"],
+      false,
+      noRun,
+    );
+    expect(code).toBe(0);
+    expect(listCalls[0]).toEqual({ prefix: "gh/o/r/branch/feature-thing/", metadata: true });
+  });
+
+  it("defaults --branch to the current git branch (worktree-safe: git rev-parse)", async () => {
+    const { client, listCalls } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const run = branchRunner("main");
+    const code = await runStaged(ctxWith(client), ["--repo", "o/r"], false, run);
+    expect(code).toBe(0);
+    expect(listCalls[0]?.prefix).toBe("gh/o/r/branch/main/");
+  });
+
+  it("resolves --repo via the runner when not given explicitly", async () => {
+    const { client, listCalls } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const run: CommandRunner = (cmd, args) => {
+      if (cmd === "gh" && args[0] === "repo") return "buildinternet/uploads";
+      if (cmd === "git" && args[0] === "rev-parse") return "feature/thing\n";
+      throw new Error(`unexpected call: ${cmd} ${args.join(" ")}`);
+    };
+    const code = await runStaged(ctxWith(client), [], false, run);
+    expect(code).toBe(0);
+    expect(listCalls[0]?.prefix).toBe("gh/buildinternet/uploads/branch/feature-thing/");
+  });
+
+  it("throws UsageError when the current branch cannot be resolved (detached HEAD)", async () => {
+    const { client } = fakeClient();
+    const run: CommandRunner = (cmd, args) => {
+      if (cmd === "git" && args[0] === "rev-parse") return "HEAD\n";
+      throw new Error(`unexpected call: ${cmd} ${args.join(" ")}`);
+    };
+    await expect(runStaged(ctxWith(client), ["--repo", "o/r"], false, run)).rejects.toThrow(
+      UsageError,
+    );
+  });
+});
+
+describe("runStaged: empty staging", () => {
+  it("human mode prints a clean one-line zero-state message", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const { stdout } = await withCapturedOutput(async () => {
+      const code = await runStaged(
+        ctxWith(client),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+      expect(code).toBe(0);
+    });
+    expect(stdout).toBe("nothing staged for feature/thing in o/r\n");
+  });
+
+  it("json mode prints a valid, non-empty JSON document with an empty files array", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const { stdout } = await withCapturedOutput(async () => {
+      const code = await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+      expect(code).toBe(0);
+    });
+    expect(stdout.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({
+      repo: "o/r",
+      branch: "feature/thing",
+      files: [],
+      binding: { state: "self", autoAttach: true, message: expect.any(String) },
+    });
+  });
+
+  it("--format json (without global --json) also prints a valid JSON document", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "none" } });
+    const { stdout } = await withCapturedOutput(async () => {
+      const code = await runStaged(
+        ctxWith(client),
+        ["--branch", "feature/thing", "--repo", "o/r", "--format", "json"],
+        false,
+        noRun,
+      );
+      expect(code).toBe(0);
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.files).toEqual([]);
+    expect(parsed.binding.state).toBe("none");
+  });
+
+  it("rejects an unrecognized --format", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runStaged(
+        ctxWith(client),
+        ["--branch", "feature/thing", "--repo", "o/r", "--format", "yaml"],
+        false,
+        noRun,
+      ),
+    ).rejects.toThrow(UsageError);
+  });
+});
+
+describe("runStaged: file listing", () => {
+  it("maps list items to key/filename/size/stagedAt/url, stripping the staging prefix", async () => {
+    const { client } = fakeClient({
+      items: [
+        {
+          key: "gh/o/r/branch/feature-thing/shot.png",
+          url: "https://x.test/gh/o/r/branch/feature-thing/shot.png",
+          size: 2048,
+          metadata: { "gh.staged-at": "2026-07-20T10:00:00Z", "gh.repo": "o/r" },
+        },
+      ],
+      repoLinkStatus: { binding: "self" },
+    });
+    const { stdout } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.files).toEqual([
+      {
+        key: "gh/o/r/branch/feature-thing/shot.png",
+        filename: "shot.png",
+        size: 2048,
+        stagedAt: "2026-07-20T10:00:00Z",
+        url: "https://x.test/gh/o/r/branch/feature-thing/shot.png",
+      },
+    ]);
+  });
+
+  it("human mode prints one compact line per file plus binding + promote affordance", async () => {
+    const { client } = fakeClient({
+      items: [
+        {
+          key: "gh/o/r/branch/feature-thing/shot.png",
+          url: "https://x.test/shot.png",
+          size: 2048,
+          metadata: { "gh.staged-at": "2026-07-20T10:00:00Z" },
+        },
+      ],
+      repoLinkStatus: { binding: "self" },
+    });
+    const { stdout, stderr } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    expect(stdout).toContain("shot.png");
+    expect(stdout).toContain("2.0 KB");
+    expect(stdout).toContain("https://x.test/shot.png");
+    expect(stderr).toContain("binding: self");
+    expect(stderr).toContain("once the PR exists: uploads attach --promote");
+  });
+});
+
+describe("runStaged: binding states", () => {
+  it("binding self: autoAttach true, own message", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "self" } });
+    const { stdout } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    const { binding } = JSON.parse(stdout);
+    expect(binding).toEqual({
+      state: "self",
+      autoAttach: true,
+      message: "these auto-attach when this branch's PR opens",
+    });
+  });
+
+  it("binding none: autoAttach false, wording matches the #398 stage warning verbatim", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "none" } });
+    const { stdout } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    const { binding } = JSON.parse(stdout);
+    expect(binding.state).toBe("none");
+    expect(binding.autoAttach).toBe(false);
+    expect(binding.message).toBe(stagingBindingAdvisory("none", "o/r"));
+  });
+
+  it("binding other: autoAttach false, wording matches the #398 stage warning verbatim", async () => {
+    const { client } = fakeClient({ repoLinkStatus: { binding: "other" } });
+    const { stdout } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    const { binding } = JSON.parse(stdout);
+    expect(binding.state).toBe("other");
+    expect(binding.autoAttach).toBe(false);
+    expect(binding.message).toBe(stagingBindingAdvisory("other", "o/r"));
+  });
+
+  it("binding unknown on lookup failure (network error) — never throws", async () => {
+    const { client } = fakeClient({ repoLinkStatus: new Error("network down") });
+    const { stdout } = await withCapturedOutput(async () => {
+      const code = await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+      expect(code).toBe(0);
+    });
+    const { binding } = JSON.parse(stdout);
+    expect(binding.state).toBe("unknown");
+    expect(binding.autoAttach).toBe(false);
+  });
+
+  it("binding unknown when the endpoint route is absent (older/self-hosted server)", async () => {
+    const { client } = fakeClient(); // no repoLinkStatus option -> method absent
+    const { stdout } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(client, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    const { binding } = JSON.parse(stdout);
+    expect(binding.state).toBe("unknown");
+  });
+});
+
+describe("wording reuse between `staged` and the #398 attach --branch stage warning", () => {
+  it("shares the exact none/other advisory text via stagingBindingAdvisory", async () => {
+    for (const binding of ["none", "other"] as const) {
+      const stageWarning = await resolveStageBindingWarning({
+        ctx: ctxWith(fakeClient({ repoLinkStatus: { binding } }).client, { quiet: false }),
+        defaults: {} as never,
+        repo: "o/r",
+      });
+      const advisory = stagingBindingAdvisory(binding, "o/r");
+      expect(advisory).toBeDefined();
+      expect(stageWarning).toBe(`note: ${advisory}`);
+
+      const { client } = fakeClient({ repoLinkStatus: { binding } });
+      const { stdout } = await withCapturedOutput(async () => {
+        await runStaged(
+          ctxWith(client, { json: true }),
+          ["--branch", "feature/thing", "--repo", "o/r"],
+          false,
+          noRun,
+        );
+      });
+      const { binding: stagedBinding } = JSON.parse(stdout);
+      expect(stagedBinding.message).toBe(advisory);
+    }
+  });
+
+  it("runAttach --branch's stderr warning is a strict superset (note: + advisory) of what `staged` shows", async () => {
+    // Same fakeClient shape as commands-attach.test.ts's minimal put stub.
+    const puts: string[] = [];
+    const attachClient = {
+      put: async (_body: Uint8Array, putOpts: { key: string }) => {
+        puts.push(putOpts.key);
+        return {
+          workspace: "test",
+          key: putOpts.key,
+          url: `https://x.test/${putOpts.key}`,
+          embedUrl: null,
+          size: 3,
+          contentType: "image/png",
+        };
+      },
+      list: async () => ({ items: [], cursor: null }),
+      listAll: async () => [],
+      findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+      getGallery: async () => ({ items: [] }),
+      githubRepoLinkStatus: async () => ({ binding: "none" }) as GithubRepoLinkResult,
+    } as unknown as UploadsClient;
+
+    const { mkdtempSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "uploads-staged-wording-test-"));
+    const file = join(dir, "shot.png");
+    writeFileSync(file, "shot.png");
+
+    const { stderr: attachStderr } = await withCapturedOutput(async () => {
+      await runAttach(
+        ctxWith(attachClient, { quiet: false }),
+        [file, "--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        branchRunner(),
+      );
+    });
+
+    const advisory = stagingBindingAdvisory("none", "o/r");
+    expect(advisory).toBeDefined();
+    expect(attachStderr).toContain(advisory!);
+
+    const { client: stagedClient } = fakeClient({ repoLinkStatus: { binding: "none" } });
+    const { stdout: stagedJson } = await withCapturedOutput(async () => {
+      await runStaged(
+        ctxWith(stagedClient, { json: true }),
+        ["--branch", "feature/thing", "--repo", "o/r"],
+        false,
+        noRun,
+      );
+    });
+    expect(JSON.parse(stagedJson).binding.message).toBe(advisory);
+  });
+});

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -7,7 +7,9 @@ import type { GlobalFlags } from "../src/cli-args.js";
 import type {
   AddGalleryItemOptions,
   CreateGalleryOptions,
+  GithubRepoLinkResult,
   LinkGalleryExternalReferenceOptions,
+  ListItem,
   UploadsClient,
 } from "../src/client.js";
 import type { UploadsClientConfig } from "../src/config.js";
@@ -360,6 +362,7 @@ describe("tools/list", () => {
       "screenshot",
       "attach",
       "list",
+      "staged",
       "delete",
       "get_metadata",
       "set_metadata",
@@ -1220,5 +1223,138 @@ describe("canonical metadata params reach the upload", () => {
       arguments: { file, metadata: { state: "before" }, state: "after" },
     });
     expect(puts[0]?.metadata?.state).toBe("after");
+  });
+});
+
+describe("staged tool (issue #405)", () => {
+  function stagedFactory(opts: {
+    items?: ListItem[];
+    repoLinkStatus?: GithubRepoLinkResult | Error;
+  }) {
+    const listCalls: { prefix?: string; metadata?: boolean }[] = [];
+    const factory = (): UploadsClient =>
+      ({
+        list: async (listOpts: { prefix?: string; metadata?: boolean }) => {
+          listCalls.push(listOpts);
+          return { items: opts.items ?? [], cursor: null };
+        },
+        ...(opts.repoLinkStatus !== undefined
+          ? {
+              githubRepoLinkStatus: async () => {
+                if (opts.repoLinkStatus instanceof Error) throw opts.repoLinkStatus;
+                return opts.repoLinkStatus!;
+              },
+            }
+          : {}),
+      }) as unknown as UploadsClient;
+    return { factory, listCalls };
+  }
+
+  function branchRunner(branch = "feature/thing"): CommandRunner {
+    return (cmd, args) => {
+      if (cmd === "git" && args[0] === "rev-parse") return `${branch}\n`;
+      throw new Error(`unexpected call: ${cmd} ${args.join(" ")}`);
+    };
+  }
+
+  it("is registered and mirrors the CLI (repo/branch args, files + binding)", async () => {
+    const { factory, listCalls } = stagedFactory({
+      items: [
+        {
+          key: "gh/o/r/branch/feature-thing/shot.png",
+          url: "https://x.test/shot.png",
+          size: 10,
+          metadata: { "gh.staged-at": "2026-07-20T10:00:00Z" },
+        },
+      ],
+      repoLinkStatus: { binding: "self" },
+    });
+    const server = createMcpServer({
+      serverInfo: { name: "uploads", version: "0.0.0-test" },
+      tools: createUploadsMcpTools({
+        globals: { apiUrl: "https://x.test", token: "up_test_x" },
+        runner: noRun,
+        clientFactory: factory,
+      }),
+    });
+    const res = await rpc(server, "tools/call", {
+      name: "staged",
+      arguments: { branch: "feature/thing", repo: "o/r" },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(listCalls[0]).toEqual({ prefix: "gh/o/r/branch/feature-thing/", metadata: true });
+    expect(res.result.structuredContent).toEqual({
+      repo: "o/r",
+      branch: "feature/thing",
+      files: [
+        {
+          key: "gh/o/r/branch/feature-thing/shot.png",
+          filename: "shot.png",
+          size: 10,
+          stagedAt: "2026-07-20T10:00:00Z",
+          url: "https://x.test/shot.png",
+        },
+      ],
+      binding: {
+        state: "self",
+        autoAttach: true,
+        message: "these auto-attach when this branch's PR opens",
+      },
+    });
+  });
+
+  it("defaults branch to the current git branch when omitted", async () => {
+    const { factory, listCalls } = stagedFactory({ repoLinkStatus: { binding: "none" } });
+    const server = createMcpServer({
+      serverInfo: { name: "uploads", version: "0.0.0-test" },
+      tools: createUploadsMcpTools({
+        globals: { apiUrl: "https://x.test", token: "up_test_x" },
+        runner: branchRunner("main"),
+        clientFactory: factory,
+      }),
+    });
+    const res = await rpc(server, "tools/call", {
+      name: "staged",
+      arguments: { repo: "o/r" },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(listCalls[0]?.prefix).toBe("gh/o/r/branch/main/");
+  });
+
+  it("empty staging returns a valid empty files array (never an error, never empty)", async () => {
+    const { factory } = stagedFactory({ repoLinkStatus: { binding: "none" } });
+    const server = createMcpServer({
+      serverInfo: { name: "uploads", version: "0.0.0-test" },
+      tools: createUploadsMcpTools({
+        globals: { apiUrl: "https://x.test", token: "up_test_x" },
+        runner: noRun,
+        clientFactory: factory,
+      }),
+    });
+    const res = await rpc(server, "tools/call", {
+      name: "staged",
+      arguments: { branch: "feature/thing", repo: "o/r" },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent.files).toEqual([]);
+    expect(res.result.structuredContent.binding.state).toBe("none");
+  });
+
+  it("binding degrades to unknown when the lookup route is absent (older server)", async () => {
+    const { factory } = stagedFactory({}); // no repoLinkStatus -> method absent
+    const server = createMcpServer({
+      serverInfo: { name: "uploads", version: "0.0.0-test" },
+      tools: createUploadsMcpTools({
+        globals: { apiUrl: "https://x.test", token: "up_test_x" },
+        runner: noRun,
+        clientFactory: factory,
+      }),
+    });
+    const res = await rpc(server, "tools/call", {
+      name: "staged",
+      arguments: { branch: "feature/thing", repo: "o/r" },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(res.result.structuredContent.binding.state).toBe("unknown");
   });
 });

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -57,6 +57,42 @@ the token's minting user) on gh.\*-tagged uploads, so
 `uploads find gh.status=staged gh.uploader=<login>` narrows to one
 contributor's in-flight files.
 
+**Check what's staged: `uploads staged`.** A dedicated read-only view —
+"what's staged for this branch, and will it auto-attach?" — instead of
+hand-building the `find`/`list` query above:
+
+```bash
+uploads staged                                  # current branch, repo from gh/git remote
+uploads staged --branch feature/thing --repo owner/name
+uploads staged --format json
+```
+
+Same branch/repo resolution as `attach --branch` (current git branch by
+default, worktree-safe). Human mode prints one compact line per staged file
+(filename, size, `gh.staged-at`, public URL), then a `binding:` line and
+`once the PR exists: uploads attach --promote`. Nothing staged prints a
+single zero-state line. `--format json` (or global `--json`) always emits a
+valid document — `{ repo, branch, files, binding }` — even with zero files;
+`files` is `[]`, never empty stdout.
+
+`binding` folds in the same repo↔workspace check the stage-time warning uses
+(see "Repo binding" below), so you don't have to separately reason about it:
+
+| `binding.state` | `binding.autoAttach` | Meaning                                                                                                      |
+| --------------- | -------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `self`          | `true`               | Repo is bound to this workspace — staged files auto-attach on PR open.                                       |
+| `none`          | `false`              | Repo isn't linked yet — link it (`uploads github link`) or nothing auto-attaches.                            |
+| `other`         | `false`              | Repo is linked to a **different** workspace — these files won't auto-attach from here.                       |
+| `unknown`       | `false`              | Binding check failed (offline, or an older server without the route) — advisory only, never blocks the view. |
+
+The `none`/`other` wording is the exact same advisory text as the
+`attach --branch` stage-time warning (issue #398) — one source of truth, so
+the two surfaces never drift.
+
+Local stdio MCP mirrors this as the `staged` tool (`branch`/`repo` args,
+same `{ repo, branch, files, binding }` shape). The hosted MCP has no
+dedicated tool for this — see "Hosted MCP: checking what's staged" below.
+
 Getting those files into the PR's attachments comment needs no extra step
 once a PR exists for that branch:
 
@@ -643,6 +679,11 @@ title updates, self-healing) seems to be silently doing nothing.
 comment --body-file` over inline HEREDOCs.
 - The host is agnostic — the same URLs work in issues, PR comments, discussions, and
   plain markdown docs.
+- **Prefer short, compressed clips (or an animated capture) over large raw
+  video files** when attaching to PRs. Per-file and workspace storage caps
+  apply underneath, and a multi-minute uncompressed recording is a poor PR
+  embed regardless — trim to the relevant seconds and compress before
+  uploading.
 
 ## Managing uploads
 
@@ -751,6 +792,25 @@ uploads --api-url http://localhost:8787 doctor
   access not yet approved — includes a `fixUrl` to the org's permission-review
   page), never as a thrown tool error; an unexpected error surfaces
   separately as `commentError`.
+
+  **Hosted MCP: checking what's staged (issue #405).** There's no dedicated
+  `staged` tool on the hosted server — it has no local git context to default
+  `branch` from, so it always needs the caller's own `repo`/`branch`. Answer
+  "what's staged?" with the existing tools instead:
+
+  ```text
+  list  { prefix: "gh/<owner>/<repo>/branch/<branch>/" }
+  # or
+  find_files  { filters: { "gh.branch": "<branch>" } }
+  ```
+
+  `find_files` returns each match's metadata inline, so `gh.staged-at` gives
+  recency without a second call; add `"gh.repo": "<owner>/<repo>"` to the
+  filters when branch names aren't unique across repos you're working in. For
+  the binding question ("will these auto-attach?"), there's no hosted-MCP
+  tool for the repo-link check either — fall back to the CLI's `uploads
+github link --status --repo <owner/name>`, or just try `attach --promote`
+  once the PR exists and read its result.
 
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -70,7 +70,9 @@ uploads staged --format json
 Same branch/repo resolution as `attach --branch` (current git branch by
 default, worktree-safe). Human mode prints one compact line per staged file
 (filename, size, `gh.staged-at`, public URL), then a `binding:` line and
-`once the PR exists: uploads attach --promote`. Nothing staged prints a
+`once the PR exists: uploads attach --promote` (the promote line is omitted
+for `binding: other` — promoting from a non-owning workspace would be
+rejected by the cross-tenant gate). Nothing staged prints a
 single zero-state line. `--format json` (or global `--json`) always emits a
 valid document — `{ repo, branch, files, binding }` — even with zero files;
 `files` is `[]`, never empty stdout.


### PR DESCRIPTION
## Summary

- New `uploads staged [--branch <name>] [--repo <owner/name>] [--format json]`: a read-only view of what's staged for a branch and whether it will auto-attach once a PR opens. One `list` call against the branch staging prefix (`ghBranchKeyPrefix`, never hand-built) plus the #398 repo-binding check (`files:read` only, no new server surface).
- Human mode: one compact line per staged file (filename, size, `gh.staged-at`, public URL), a `binding: <state> — <message>` line, and `once the PR exists: uploads attach --promote`. Empty staging prints a single zero-state line.
- `--format json` / `--json`: always a valid document — `{ repo, branch, files, binding }` — even with zero files (`files: []`, never empty stdout, unlike `find --format json`'s known wart).
- Binding is folded into `{ state: self|other|none|unknown, autoAttach, message }`. `none`/`other` reuse the exact #398 stage-warning wording via a new shared `stagingBindingAdvisory` helper (the existing `resolveStageBindingWarning` now calls it too) — one source of truth, verified by test that both surfaces produce identical text for the same binding state.
- Local stdio MCP: new `staged` tool mirroring the CLI (shared `resolveStaged` core). Hosted MCP gets no new tool — it has no git context to default `branch`/`repo` from — documented as a `list`/`find_files` recipe in the skill instead.
- `skills/uploads-cli/SKILL.md`: documents the new command (flags, output, binding table, JSON shape), the hosted-MCP recipe, and a short video-size guidance line for PR embeds.
- Changeset: minor, `@buildinternet/uploads` only.

## Test plan

- [x] `pnpm test` — 204 files / 2567 tests pass (new `test/commands-staged.test.ts`, plus additions to `test/mcp.test.ts` and `test/cli-completion.test.ts`)
- [x] `pnpm --filter @buildinternet/uploads run build` (tsc) and `pnpm -r typecheck` — clean
- [x] `pnpm run format:check` — clean (oxfmt)
- [x] Manual: `uploads staged --help`, `uploads help --all` lists `staged`
- [x] Test matrix per the issue: branch/repo resolution (explicit flags, current-branch default via `git rev-parse`, detached-HEAD error), empty staging (human zero-state line + JSON `files: []`, both `--json` and `--format json`), all four binding states (self/other/none/unknown incl. network failure and older-server-without-route), JSON schema, and wording-reuse parity against `attach --branch`'s #398 warning

Closes #405
