### PR TITLE
docs: fix staging retention claim, show branch-staged put example

### DIFF
--- a/.changeset/docs-staging-retention-correction.md
+++ b/.changeset/docs-staging-retention-correction.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Correct the README's branch-staging retention claim: staged files are never
+deleted by promotion (copy-and-keep), only skipped by promotion after 30
+days.

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -134,7 +134,26 @@ const TOC = [
       <button type="button" data-copy="uploads put ./shot.png" aria-live="polite">copy</button>
     </div>
     <div class="block" aria-label="Example output">
-      <pre># re-encoded to WebP, then hosted at a stable public URL
+      <pre># on a non-default git branch, bare put stages for that branch
+&gt;&gt; uploading 1 file (staged for branch feat/shot)
+&gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp</span>
+MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp)
+note: staged for branch feat/shot — auto-attaches to this branch's PR when
+it opens (or run: uploads attach --promote once it exists). Use --ref/
+--prefix for a plain dated upload.</pre>
+    </div>
+    <p>
+      That staging behavior is the default for a bare <code>put</code> on any non-default git
+      branch (issue #403) — the same key layout and auto-attach as&#32;
+      <code>attach --branch</code>, above. Any of <code>--pr</code>, <code>--issue</code>,&#32;
+      <code>--key</code>, <code>--ref</code>, <code>--prefix</code>, or&#32;
+      <code>--destination</code> opts out and targets that location instead, as does&#32;
+      <code>--no-git</code>. On the default branch (or detached HEAD, or outside a git repo),&#32;
+      <code>put</code> keeps the classic dated layout shown next.
+    </p>
+    <div class="block" aria-label="Example output">
+      <pre># on the default branch (or --no-git), the classic dated layout applies
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
 URL: <span class="v">https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp</span>
 MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp)</pre>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -135,10 +135,10 @@ const TOC = [
     </div>
     <div class="block" aria-label="Example output">
       <pre># on a non-default git branch, bare put stages for that branch
-&gt;&gt; uploading 1 file (staged for branch feat/shot)
+&gt;&gt; uploading ./shot.png
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
-URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp</span>
-MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp</span>
+MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp)
 note: staged for branch feat/shot — auto-attaches to this branch's PR when
 it opens (or run: uploads attach --promote once it exists). Use --ref/
 --prefix for a plain dated upload.</pre>
@@ -150,7 +150,9 @@ it opens (or run: uploads attach --promote once it exists). Use --ref/
       <code>--key</code>, <code>--ref</code>, <code>--prefix</code>, or&#32;
       <code>--destination</code> opts out and targets that location instead, as does&#32;
       <code>--no-git</code>. On the default branch (or detached HEAD, or outside a git repo),&#32;
-      <code>put</code> keeps the classic dated layout shown next.
+      <code>put</code> keeps the classic dated layout shown next. Notice the staged key has no
+      content-hash suffix, unlike the dated layout below — it's stable per filename, so
+      re-uploading <code>shot.png</code> replaces it in place instead of minting a new URL.
     </p>
     <div class="block" aria-label="Example output">
       <pre># on the default branch (or --no-git), the classic dated layout applies

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -135,7 +135,6 @@ const TOC = [
     </div>
     <div class="block" aria-label="Example output">
       <pre># on a non-default git branch, bare put stages for that branch
-&gt;&gt; uploading ./shot.png
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp</span>
 MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp)
@@ -144,15 +143,9 @@ it opens (or run: uploads attach --promote once it exists). Use --ref/
 --prefix for a plain dated upload.</pre>
     </div>
     <p>
-      That staging behavior is the default for a bare <code>put</code> on any non-default git
-      branch (issue #403) — the same key layout and auto-attach as&#32;
-      <code>attach --branch</code>, above. Any of <code>--pr</code>, <code>--issue</code>,&#32;
-      <code>--key</code>, <code>--ref</code>, <code>--prefix</code>, or&#32;
-      <code>--destination</code> opts out and targets that location instead, as does&#32;
-      <code>--no-git</code>. On the default branch (or detached HEAD, or outside a git repo),&#32;
-      <code>put</code> keeps the classic dated layout shown next. Notice the staged key has no
-      content-hash suffix, unlike the dated layout below — it's stable per filename, so
-      re-uploading <code>shot.png</code> replaces it in place instead of minting a new URL.
+      On a branch, a bare <code>put</code> stages the file for that branch's future PR — same
+      behavior as <code>attach</code>, above. Everywhere else it keeps the plain dated path
+      shown next.
     </p>
     <div class="block" aria-label="Example output">
       <pre># on the default branch (or --no-git), the classic dated layout applies
@@ -190,6 +183,13 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
       supports <a href="https://oembed.com/">oEmbed</a> — so chat apps, notes tools, and
       other unfurlers can embed the image when you paste the page link. Details are in&#32;
       <a href="/docs/reference#good-to-know">Reference</a>.
+    </p>
+    <p class="note">
+      Details: any of <code>--pr</code>, <code>--issue</code>, <code>--key</code>,&#32;
+      <code>--ref</code>, <code>--prefix</code>, or <code>--destination</code> opts a bare&#32;
+      <code>put</code> out of branch staging, as does <code>--no-git</code>. Staged keys have
+      no content-hash suffix (unlike the dated layout above) — they're stable per filename, so
+      re-uploading the same file replaces it in place instead of minting a new URL.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -104,13 +104,10 @@ const TOC = [
       (<code>--no-promote</code> skips it).
     </p>
     <p>
-      Promotion is copy-and-keep: the staged original stays in place, so any URL you've
-      already embedded (in a PR body, a comment, wherever) keeps serving — promotion never
-      deletes it. Staged objects follow the same per-workspace retention as any other file,
-      plus explicit deletes; there's no separate staging cleanup. Promotion itself does have
-      a 30-day freshness window: files staged more than 30 days before a PR opens are skipped
-      by both the App's automatic promotion and <code>uploads attach --promote</code> — they
-      stay right where they are, just no longer auto-promoted.
+      Promotion copies — it never deletes the staged original, so URLs you've already
+      embedded keep working. Staged files stick around under the same rules as anything else
+      in your workspace. The one caveat: a file staged more than 30 days before its PR opens
+      won't auto-promote (it's still there, just not attached automatically).
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -104,8 +104,13 @@ const TOC = [
       (<code>--no-promote</code> skips it).
     </p>
     <p>
-      Staging cleans itself up: promoted files drop out after ~7 days, abandoned ones after
-      ~30.
+      Promotion is copy-and-keep: the staged original stays in place, so any URL you've
+      already embedded (in a PR body, a comment, wherever) keeps serving — promotion never
+      deletes it. Staged objects follow the same per-workspace retention as any other file,
+      plus explicit deletes; there's no separate staging cleanup. Promotion itself does have
+      a 30-day freshness window: files staged more than 30 days before a PR opens are skipped
+      by both the App's automatic promotion and <code>uploads attach --promote</code> — they
+      stay right where they are, just no longer auto-promoted.
     </p>
   </section>
 

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -91,8 +91,12 @@ attachments when one opens: automatically via the
 [GitHub App](https://uploads.sh/docs/github-app) webhook, or on the first
 `attach` after the PR exists (`--promote` forces it with no new files,
 `--no-promote` opts out). `uploads github link` inspects or claims the
-workspace↔repo binding the webhook path uses. Promoted staging is cleaned up
-server-side after ~7 days (~30 for branches that never got a PR).
+workspace↔repo binding the webhook path uses. Promotion is copy-and-keep —
+the staged original is never deleted, so any URL already embedded keeps
+serving — and staged objects follow only normal per-workspace retention and
+explicit deletes. Promotion (auto or `--promote`) does skip files staged
+more than 30 days before the PR opens, though; they're still there, just no
+longer auto-promoted.
 
 **Bare `put` stages too, by default (issue #403):** on a non-default git
 branch, a `put` with none of


### PR DESCRIPTION
## Summary

Two docs corrections, no code changes:

- `docs/attach-pull-request-images.astro` — the `put` section's example output
  showed the classic dated key. Since 0.24.0 (issue #403), a bare `put` on a
  non-default git branch stages by default (same key/behavior as
  `attach --branch`), printing a staging note. Updated the example to show
  that as the branch-context default, kept the dated example for the
  default-branch / opt-out case, and listed the opt-out flags
  (`--pr`/`--issue`/`--key`/`--ref`/`--prefix`/`--destination`, `--no-git`).
- `docs/github-app.astro` and `packages/uploads/README.md` both claimed
  staging is cleaned up server-side after ~7/~30 days. That's false — no such
  cleanup exists. Promotion is copy-and-keep (see `docs/deletion.md`,
  "Branch-staged attachments after promotion"): the staged original is never
  deleted by promotion, so an already-embedded URL keeps serving. Staged
  objects follow only normal per-workspace retention and explicit deletes.
  The real time bound is promotion's 30-day freshness window
  (`apps/api/src/github-promote.ts` `FRESHNESS_WINDOW_MS`) — files staged
  more than 30 days before a PR opens are skipped by promotion (auto or
  `attach --promote`), not deleted.

Added a `patch` changeset for `@buildinternet/uploads` only (the README fix).

## Test plan

- [x] `pnpm test` — 204 files / 2568 tests pass
- [x] `pnpm typecheck` — 0 errors across all workspaces
- [x] `pnpm run format:check` — clean
