### PR TITLE
docs(web): reframe the site around the staged loop, not attach-first

### DIFF
--- a/.changeset/docs-staging-retention-correction.md
+++ b/.changeset/docs-staging-retention-correction.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Correct the README's branch-staging retention claim: staged files are never
+deleted by promotion (copy-and-keep), only skipped by promotion after 30
+days.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -8,7 +8,7 @@ Access is by invitation. Hosted files are public (including media attached to pr
 
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
-- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, get a URL for any file, capture a screenshot
+- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, get a URL for any file, capture a screenshot
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): optional install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -50,7 +50,7 @@ const REPO = "https://github.com/buildinternet/uploads";
       <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
     </div>
     <div class="block" aria-label="Example output">
-      <pre>&gt;&gt; uploading 1 file (staged for branch feat/nav)
+      <pre>&gt;&gt; uploading ./after.png
 note: staged for branch feat/nav — auto-attaches to this branch's PR when
 it opens (or run: uploads attach --promote once it exists)</pre>
     </div>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -39,6 +39,28 @@ const REPO = "https://github.com/buildinternet/uploads";
     </p>
   </section>
 
+  <section id="before-the-pr">
+    <h2>Start before the PR exists <a class="anchor" href="#before-the-pr" aria-label="Link to this section">#</a></h2>
+    <p>
+      You don't need a PR open to start uploading. On a branch, a bare <code>put</code> stages
+      automatically:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads put ./after.png</span>
+      <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
+    </div>
+    <div class="block" aria-label="Example output">
+      <pre>&gt;&gt; uploading 1 file (staged for branch feat/nav)
+note: staged for branch feat/nav — auto-attaches to this branch's PR when
+it opens (or run: uploads attach --promote once it exists)</pre>
+    </div>
+    <p>
+      Keep doing that at each visual milestone, and the PR opens already furnished — no upload
+      command needed at PR time. Check what's queued anytime with <code>uploads staged</code>.
+      Details in <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a>.
+    </p>
+  </section>
+
   <section id="install">
     <h2>Install &amp; sign in <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
     <p>Install the CLI globally, then sign in once:</p>

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -41,10 +41,7 @@ const REPO = "https://github.com/buildinternet/uploads";
 
   <section id="before-the-pr">
     <h2>Start before the PR exists <a class="anchor" href="#before-the-pr" aria-label="Link to this section">#</a></h2>
-    <p>
-      You don't need a PR open to start uploading. On a branch, a bare <code>put</code> stages
-      automatically:
-    </p>
+    <p>You don't need a PR open to start uploading — on a branch, it stages automatically:</p>
     <div class="cmd">
       <span class="text">uploads put ./after.png</span>
       <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
@@ -55,9 +52,9 @@ note: staged for branch feat/nav — auto-attaches to this branch's PR when
 it opens (or run: uploads attach --promote once it exists)</pre>
     </div>
     <p>
-      Keep doing that at each visual milestone, and the PR opens already furnished — no upload
-      command needed at PR time. Check what's queued anytime with <code>uploads staged</code>.
-      Details in <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a>.
+      Keep doing that as you work and the PR opens already furnished — see&#32;
+      <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a> for the staged
+      view that shows what's queued.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -82,10 +82,12 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <section id="stage-as-you-go">
     <h2>Stage screenshots as the agent works <a class="anchor" href="#stage-as-you-go" aria-label="Link to this section">#</a></h2>
     <p>
-      Any agent that can run a shell command can capture at each visual milestone, run&#32;
-      <code>uploads attach --branch --state before|after</code>, and let the PR comment
-      assemble itself once a PR opens — via the GitHub App webhook, or the next&#32;
-      <code>uploads attach</code> (or <code>uploads attach --promote</code>) without the
+      Any agent that can run a shell command can capture at each visual milestone and run a
+      bare <code>uploads put ./shot.png --state before|after</code> — on a branch it stages
+      automatically (issue #403), no <code>--branch</code> flag required. <code>--state</code>
+      is still worth keeping as a habit; it's the one thing no tool can infer from the image.
+      Let the PR comment assemble itself once a PR opens — via the GitHub App webhook, or the
+      next <code>uploads attach</code> (or <code>uploads attach --promote</code>) without the
       App. See the <a href="/github-screenshots">stage-as-you-go walkthrough</a>&#32;
       for the full loop.
     </p>
@@ -103,9 +105,10 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 When a change is visually observable (UI, layout, styling), capture it as you
 go — don't wait until the PR is open. After each meaningful visual change:
 
-  uploads attach ./shot.png --branch --state before   # or --state after
+  uploads put ./shot.png --state before   # or --state after
 
-Stage before/after pairs where it makes sense. No need to open the PR first —
+On a branch, that stages automatically — no --branch flag needed. Stage
+before/after pairs where it makes sense. No need to open the PR first —
 staged files are promoted into the PR's attachments comment automatically.</pre>
     </div>
     <p>
@@ -128,16 +131,15 @@ staged files are promoted into the PR's attachments comment automatically.</pre>
 # Run before `gh pr create` (wrapper, or your agent's pre-command hook).
 # Fails open: any error here just skips the reminder, never blocks the PR.
 set -u
-branch=$(git branch --show-current 2>/dev/null) || exit 0
-[ -n "$branch" ] || exit 0
-# gh.branch metadata is stored lowercased
-branch_key=$(printf '%s' "$branch" | tr '[:upper:]' '[:lower:]')
-
-staged=$(uploads find "gh.branch=$branch_key" 2>/dev/null) || exit 0
-if [ -z "$staged" ]; then
-  echo "note: no screenshots staged for branch '$branch' — if this PR" >&2
-  echo "touches UI, consider 'uploads attach ./shot.png --branch' first" >&2
-fi
+# --format json always prints a valid document, even with zero files staged —
+# no empty-stdout special case to handle here.
+staged=$(uploads staged --format json 2>/dev/null) || exit 0
+case "$staged" in
+  *'"files": []'*)
+    echo "note: nothing staged for this branch — if this PR touches UI," >&2
+    echo "consider 'uploads put ./shot.png' first" >&2
+    ;;
+esac
 exit 0</pre>
     </div>
     <p>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -137,7 +137,7 @@ const TOC = [
       <button type="button" data-copy="uploads staged" aria-live="polite">copy</button>
     </div>
     <div class="block" aria-label="Example output">
-      <pre>after.webp  94.2 KB  staged 2026-07-22T14:00:00Z  https://storage.uploads.sh/gh/you/app/branch/feat/nav/after.webp
+      <pre>after.webp  94.2 KB  staged 2026-07-22T14:00:00Z  https://storage.uploads.sh/gh/you/app/branch/feat-nav/after.webp
 binding: self — these auto-attach when this branch's PR opens
 once the PR exists: uploads attach --promote</pre>
     </div>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -6,6 +6,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 
 const TOC = [
   { id: "attach", label: "Attach files to a PR" },
+  { id: "staging", label: "Stage before a PR exists" },
   { id: "put", label: "Get a URL for any file" },
   { id: "screenshot", label: "Capture a screenshot" },
 ];
@@ -106,20 +107,56 @@ const TOC = [
       <span class="text">uploads attach ./shot.png --no-comment <span class="cm"># print URLs, post nothing</span></span>
       <button type="button" data-copy="uploads attach ./shot.png --no-comment" aria-live="polite">copy</button>
     </div>
+  </section>
+
+  <section id="staging">
+    <h2>Stage before a PR exists <a class="anchor" href="#staging" aria-label="Link to this section">#</a></h2>
     <p>
-      No PR yet? <code>--branch</code> stages files against your current branch instead, so
-      you can attach screenshots while you work:
+      Don't wait for a PR to capture something. As of issue #403, a bare <code>put</code> on a
+      non-default git branch already stages by default — no <code>--branch</code> flag needed:
     </p>
     <div class="cmd">
-      <span class="text">uploads attach --branch ./shot.png</span>
-      <button type="button" data-copy="uploads attach --branch ./shot.png" aria-live="polite">copy</button>
+      <span class="text">uploads put ./after.png</span>
+      <button type="button" data-copy="uploads put ./after.png" aria-live="polite">copy</button>
     </div>
     <p>
-      Once the PR opens, the next <code>attach</code> promotes those staged files onto it
+      <code>attach --branch</code> is the explicit, multi-file form of the same thing — reach
+      for it to upload several files at once with shared flags, or to force staging outside a
+      bare <code>put</code>:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads attach --branch ./before.png ./after.png</span>
+      <button type="button" data-copy="uploads attach --branch ./before.png ./after.png" aria-live="polite">copy</button>
+    </div>
+    <p>
+      See what's queued for the current branch, and whether it'll actually auto-attach, with&#32;
+      <code>uploads staged</code>:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads staged</span>
+      <button type="button" data-copy="uploads staged" aria-live="polite">copy</button>
+    </div>
+    <div class="block" aria-label="Example output">
+      <pre>after.webp  94.2 KB  staged 2026-07-22T14:00:00Z  https://storage.uploads.sh/gh/you/app/branch/feat/nav/after.webp
+binding: self — these auto-attach when this branch's PR opens
+once the PR exists: uploads attach --promote</pre>
+    </div>
+    <p>
+      The <code>binding</code> line is the thing worth reading: <code>self</code> means these
+      files will actually auto-attach when the PR opens; <code>none</code> or <code>other</code>&#32;
+      means they won't (the repo isn't linked to this workspace, or it's linked to a different
+      one), and <code>unknown</code> means the check itself couldn't run. Pass&#32;
+      <code>--format json</code> for a machine-readable version — it always prints a valid
+      document, even with zero files staged. See&#32;
+      <a href="/docs/github-app#staging">GitHub App: staging before a PR exists</a> for what
+      each binding state means and how to fix it.
+    </p>
+    <p>
+      Once the PR opens, the next <code>attach</code> against it promotes those staged files
       automatically — or run <code>uploads attach --promote</code> with no files to do it
-      explicitly (<code>--no-promote</code> opts out). See&#32;
-      <a href="/docs/github-app#staging">GitHub App: staging before a PR exists</a> for how
-      this works with zero CLI involvement.
+      explicitly (<code>--no-promote</code> opts out). Promotion is copy-and-keep: the staged
+      original is never deleted, so a URL you already embedded (in the PR body, say, before it
+      was even opened) keeps serving.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -122,7 +122,7 @@ const TOC = [
     <p>
       <code>attach --branch</code> is the explicit, multi-file form of the same thing — reach
       for it to upload several files at once with shared flags, or to force staging outside a
-      bare <code>put</code>:
+      plain upload:
     </p>
     <div class="cmd">
       <span class="text">uploads attach --branch ./before.png ./after.png</span>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -134,7 +134,26 @@ const TOC = [
       <button type="button" data-copy="uploads put ./shot.png" aria-live="polite">copy</button>
     </div>
     <div class="block" aria-label="Example output">
-      <pre># re-encoded to WebP, then hosted at a stable public URL
+      <pre># on a non-default git branch, bare put stages for that branch
+&gt;&gt; uploading 1 file (staged for branch feat/shot)
+&gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp</span>
+MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp)
+note: staged for branch feat/shot — auto-attaches to this branch's PR when
+it opens (or run: uploads attach --promote once it exists). Use --ref/
+--prefix for a plain dated upload.</pre>
+    </div>
+    <p>
+      That staging behavior is the default for a bare <code>put</code> on any non-default git
+      branch (issue #403) — the same key layout and auto-attach as&#32;
+      <code>attach --branch</code>, above. Any of <code>--pr</code>, <code>--issue</code>,&#32;
+      <code>--key</code>, <code>--ref</code>, <code>--prefix</code>, or&#32;
+      <code>--destination</code> opts out and targets that location instead, as does&#32;
+      <code>--no-git</code>. On the default branch (or detached HEAD, or outside a git repo),&#32;
+      <code>put</code> keeps the classic dated layout shown next.
+    </p>
+    <div class="block" aria-label="Example output">
+      <pre># on the default branch (or --no-git), the classic dated layout applies
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
 URL: <span class="v">https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp</span>
 MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot-9f2c1a.webp)</pre>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -135,10 +135,10 @@ const TOC = [
     </div>
     <div class="block" aria-label="Example output">
       <pre># on a non-default git branch, bare put stages for that branch
-&gt;&gt; uploading 1 file (staged for branch feat/shot)
+&gt;&gt; uploading ./shot.png
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
-URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp</span>
-MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat/shot/shot-9f2c1a.webp)
+URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp</span>
+MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp)
 note: staged for branch feat/shot — auto-attaches to this branch's PR when
 it opens (or run: uploads attach --promote once it exists). Use --ref/
 --prefix for a plain dated upload.</pre>
@@ -150,7 +150,9 @@ it opens (or run: uploads attach --promote once it exists). Use --ref/
       <code>--key</code>, <code>--ref</code>, <code>--prefix</code>, or&#32;
       <code>--destination</code> opts out and targets that location instead, as does&#32;
       <code>--no-git</code>. On the default branch (or detached HEAD, or outside a git repo),&#32;
-      <code>put</code> keeps the classic dated layout shown next.
+      <code>put</code> keeps the classic dated layout shown next. Notice the staged key has no
+      content-hash suffix, unlike the dated layout below — it's stable per filename, so
+      re-uploading <code>shot.png</code> replaces it in place instead of minting a new URL.
     </p>
     <div class="block" aria-label="Example output">
       <pre># on the default branch (or --no-git), the classic dated layout applies

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -135,7 +135,6 @@ const TOC = [
     </div>
     <div class="block" aria-label="Example output">
       <pre># on a non-default git branch, bare put stages for that branch
-&gt;&gt; uploading ./shot.png
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp</span>
 MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp)
@@ -144,15 +143,9 @@ it opens (or run: uploads attach --promote once it exists). Use --ref/
 --prefix for a plain dated upload.</pre>
     </div>
     <p>
-      That staging behavior is the default for a bare <code>put</code> on any non-default git
-      branch (issue #403) — the same key layout and auto-attach as&#32;
-      <code>attach --branch</code>, above. Any of <code>--pr</code>, <code>--issue</code>,&#32;
-      <code>--key</code>, <code>--ref</code>, <code>--prefix</code>, or&#32;
-      <code>--destination</code> opts out and targets that location instead, as does&#32;
-      <code>--no-git</code>. On the default branch (or detached HEAD, or outside a git repo),&#32;
-      <code>put</code> keeps the classic dated layout shown next. Notice the staged key has no
-      content-hash suffix, unlike the dated layout below — it's stable per filename, so
-      re-uploading <code>shot.png</code> replaces it in place instead of minting a new URL.
+      On a branch, a bare <code>put</code> stages the file for that branch's future PR — same
+      behavior as <code>attach</code>, above. Everywhere else it keeps the plain dated path
+      shown next.
     </p>
     <div class="block" aria-label="Example output">
       <pre># on the default branch (or --no-git), the classic dated layout applies
@@ -190,6 +183,13 @@ MARKDOWN: ![shot.png](https://storage.uploads.sh/screenshots/app/2026-07-12/shot
       supports <a href="https://oembed.com/">oEmbed</a> — so chat apps, notes tools, and
       other unfurlers can embed the image when you paste the page link. Details are in&#32;
       <a href="/docs/reference#good-to-know">Reference</a>.
+    </p>
+    <p class="note">
+      Details: any of <code>--pr</code>, <code>--issue</code>, <code>--key</code>,&#32;
+      <code>--ref</code>, <code>--prefix</code>, or <code>--destination</code> opts a bare&#32;
+      <code>put</code> out of branch staging, as does <code>--no-git</code>. Staged keys have
+      no content-hash suffix (unlike the dated layout above) — they're stable per filename, so
+      re-uploading the same file replaces it in place instead of minting a new URL.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -104,13 +104,10 @@ const TOC = [
       (<code>--no-promote</code> skips it).
     </p>
     <p>
-      Promotion is copy-and-keep: the staged original stays in place, so any URL you've
-      already embedded (in a PR body, a comment, wherever) keeps serving — promotion never
-      deletes it. Staged objects follow the same per-workspace retention as any other file,
-      plus explicit deletes; there's no separate staging cleanup. Promotion itself does have
-      a 30-day freshness window: files staged more than 30 days before a PR opens are skipped
-      by both the App's automatic promotion and <code>uploads attach --promote</code> — they
-      stay right where they are, just no longer auto-promoted.
+      Promotion copies — it never deletes the staged original, so URLs you've already
+      embedded keep working. Staged files stick around under the same rules as anything else
+      in your workspace. The one caveat: a file staged more than 30 days before its PR opens
+      won't auto-promote (it's still there, just not attached automatically).
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -104,8 +104,13 @@ const TOC = [
       (<code>--no-promote</code> skips it).
     </p>
     <p>
-      Staging cleans itself up: promoted files drop out after ~7 days, abandoned ones after
-      ~30.
+      Promotion is copy-and-keep: the staged original stays in place, so any URL you've
+      already embedded (in a PR body, a comment, wherever) keeps serving — promotion never
+      deletes it. Staged objects follow the same per-workspace retention as any other file,
+      plus explicit deletes; there's no separate staging cleanup. Promotion itself does have
+      a 30-day freshness window: files staged more than 30 days before a PR opens are skipped
+      by both the App's automatic promotion and <code>uploads attach --promote</code> — they
+      stay right where they are, just no longer auto-promoted.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -29,6 +29,10 @@ const REPO = "https://github.com/buildinternet/uploads";
       <button type="button" data-copy="uploads usage" aria-live="polite">copy</button>
     </div>
     <div class="cmd">
+      <span class="text">uploads staged <span class="cm"># what's queued for this branch</span></span>
+      <button type="button" data-copy="uploads staged" aria-live="polite">copy</button>
+    </div>
+    <div class="cmd">
       <span class="text">uploads --help <span class="cm"># everything else</span></span>
       <button type="button" data-copy="uploads --help" aria-live="polite">copy</button>
     </div>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -21,12 +21,14 @@ Setup:
 2. Authenticate: uploads login (opens a browser sign-in — wait for me to approve it)
 3. Wire it into you: uploads install (adds the agent skill + MCP server so future sessions know how to use it)
 
-Then get one attachment working end to end:
-- From a branch with an open PR, capture a screenshot of something that changed. uploads screenshot <url> captures and hosts in one step if that's easier.
-- Run uploads attach <files> from that branch — it creates or updates the single attachments comment on the PR.
+Then get the staged loop working end to end:
+- While you're still working, before there's a PR, capture a screenshot at each visual milestone and run uploads put <file> --state before (or --state after). On a branch, a bare put stages it automatically — no --branch flag, no PR needed yet. uploads screenshot <url> captures and hosts in one step if that's easier.
+- Check what's queued anytime with uploads staged.
+- Open the PR (gh pr create or the GitHub UI) and the staged files promote automatically — the single attachments comment appears with no extra upload command at PR time.
+- Already have an open PR or issue to target directly instead? uploads attach <files> does that immediately.
 - Tag uploads with --meta key=value (e.g. --meta path=/settings) so we can find them again later with uploads find.
 
-Finally, update AGENTS.md (or CLAUDE.md) so that whenever UI changes, before/after screenshots get attached to the PR going forward.
+Finally, update AGENTS.md (or CLAUDE.md) so that whenever UI changes, screenshots get captured at each milestone as you work going forward.
 
 Docs: https://uploads.sh/docs
 Agent guide: https://uploads.sh/github-screenshots
@@ -39,7 +41,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <title>uploads.sh — the missing upload command for coding agents</title>
     <meta
       name="description"
-      content="GitHub has no real way for an agent to show their work. uploads attach puts screenshots and screen recordings on the PR in one tidy comment — plus one-command captures, device frames, and tags you can search later. Open source — CLI, agent skill, and MCP server."
+      content="GitHub has no real way for an agent to show their work. Capture as you go — uploads put stages screenshots on a branch automatically, so the PR opens already furnished with one tidy comment. uploads attach targets an existing PR or issue directly. Open source — CLI, agent skill, and MCP server."
     />
     <link rel="canonical" href="https://uploads.sh/" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
@@ -48,13 +50,13 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <meta property="og:title" content="uploads.sh — the missing upload command for coding agents" />
     <meta
       property="og:description"
-      content="GitHub has no real way for an agent to show their work. uploads attach puts screenshots and screen recordings on the PR in one tidy comment — plus one-command captures, device frames, and tags you can search later."
+      content="GitHub has no real way for an agent to show their work. Capture as you go — uploads put stages screenshots on a branch automatically, so the PR opens already furnished with one tidy comment."
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="uploads.sh — the missing upload command for coding agents" />
     <meta
       name="twitter:description"
-      content="GitHub has no real way for an agent to show their work. uploads attach puts screenshots and screen recordings on the PR in one tidy comment."
+      content="Capture as you go — uploads put stages screenshots on a branch automatically, so the PR opens already furnished with one tidy comment."
     />
     <style>
       * { box-sizing: border-box; }
@@ -472,9 +474,11 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <main>
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
       <p class="lede">
-        GitHub has no real way for an agent to show their work. <code>uploads attach</code> puts
-        screenshots and screen recordings on the PR in one tidy comment — and it comes with the
-        rest of the kit: one-command captures, device frames, and tags you can search later.
+        GitHub has no real way for an agent to show their work. Capture screenshots as you go —
+        a bare <code>uploads put</code> on a branch stages them automatically — and by the time
+        the PR opens, it's already furnished with one tidy, update-in-place comment. Point&#32;
+        <code>uploads attach</code> at an existing PR or issue anytime you'd rather target it
+        directly.
       </p>
 
       <div class="cmdrow hero-install">
@@ -492,17 +496,19 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           <span>bash</span>
         </div>
         <div class="screen">
-          <p class="line out"># attach media to the PR for this branch</p>
-          <p class="line"><span class="prompt">$</span> <span class="cmd">uploads attach ./before.png ./after.png</span></p>
-          <p class="line out hidden">&gt;&gt; uploading ./before.png</p>
-          <p class="line out hidden">&gt;&gt; uploading ./after.png</p>
-          <p class="line hidden"><span class="ok">&gt;&gt; attachments comment updated</span></p>
+          <p class="line out"># capture as you work — no PR yet</p>
+          <p class="line"><span class="prompt">$</span> <span class="cmd">uploads put ./after.png</span></p>
+          <p class="line out hidden">&gt;&gt; uploading 1 file (staged for branch feat/nav)</p>
+          <p class="line out hidden">note: staged — auto-attaches when this branch's PR opens</p>
+          <div class="gap hidden"></div>
+          <p class="line hidden"><span class="prompt">$</span> <span class="cmd">gh pr create</span></p>
+          <p class="line out hidden"><span class="ok">&gt;&gt; https://github.com/you/app/pull/123</span></p>
           <div class="gap"></div>
           <p class="line hidden"><span class="prompt">$</span> <span class="cursor" aria-hidden="true"></span></p>
         </div>
       </section>
 
-      <p class="flow-note"><span class="arrow">└─▶</span> And on your pull request:</p>
+      <p class="flow-note"><span class="arrow">└─▶</span> your PR opens already furnished:</p>
 
       <section
         class="ghc"
@@ -583,11 +589,11 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         <h2 class="sect-head later"># what else it does</h2>
         <div class="grid">
           <div class="feature">
-            <h3>update-in-place comments</h3>
+            <h3>stage as you go</h3>
             <p>
-              <code>attach</code> keeps a single attachments comment per PR or issue. Run it
-              again and the same comment updates — no comment spam. Agents can manually link
-              visuals too, of course.
+              A bare <code>put</code> on a branch stages automatically — no <code>--branch</code>&#32;
+              flag needed. <code>uploads staged</code> shows what's queued and whether it'll
+              auto-attach. Promotion never breaks a URL you already embedded.
             </p>
           </div>
           <div class="feature">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -498,8 +498,8 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         <div class="screen">
           <p class="line out"># capture as you work — no PR yet</p>
           <p class="line"><span class="prompt">$</span> <span class="cmd">uploads put ./after.png</span></p>
-          <p class="line out hidden">&gt;&gt; uploading 1 file (staged for branch feat/nav)</p>
-          <p class="line out hidden">note: staged — auto-attaches when this branch's PR opens</p>
+          <p class="line out hidden">&gt;&gt; uploading ./after.png</p>
+          <p class="line out hidden">note: staged for branch feat/nav — auto-attaches to this branch's PR when it opens…</p>
           <div class="gap hidden"></div>
           <p class="line hidden"><span class="prompt">$</span> <span class="cmd">gh pr create</span></p>
           <p class="line out hidden"><span class="ok">&gt;&gt; https://github.com/you/app/pull/123</span></p>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -41,7 +41,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <title>uploads.sh — the missing upload command for coding agents</title>
     <meta
       name="description"
-      content="GitHub has no real way for an agent to show their work. Capture as you go — uploads put stages screenshots on a branch automatically, so the PR opens already furnished with one tidy comment. uploads attach targets an existing PR or issue directly. Open source — CLI, agent skill, and MCP server."
+      content="GitHub has no real way for an agent to show their work. Capture screenshots as you go and they're staged for the branch automatically, so the PR opens already furnished with one tidy comment. Open source — CLI, agent skill, and MCP server."
     />
     <link rel="canonical" href="https://uploads.sh/" />
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
@@ -50,13 +50,13 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <meta property="og:title" content="uploads.sh — the missing upload command for coding agents" />
     <meta
       property="og:description"
-      content="GitHub has no real way for an agent to show their work. Capture as you go — uploads put stages screenshots on a branch automatically, so the PR opens already furnished with one tidy comment."
+      content="GitHub has no real way for an agent to show their work. Capture screenshots as you go and they're staged for the branch automatically, so the PR opens already furnished with one tidy comment."
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="uploads.sh — the missing upload command for coding agents" />
     <meta
       name="twitter:description"
-      content="Capture as you go — uploads put stages screenshots on a branch automatically, so the PR opens already furnished with one tidy comment."
+      content="Capture screenshots as you go — they're staged for the branch automatically, so the PR opens already furnished with one tidy comment."
     />
     <style>
       * { box-sizing: border-box; }
@@ -474,11 +474,9 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <main>
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
       <p class="lede">
-        GitHub has no real way for an agent to show their work. Capture screenshots as you go —
-        a bare <code>uploads put</code> on a branch stages them automatically — and by the time
-        the PR opens, it's already furnished with one tidy, update-in-place comment. Point&#32;
-        <code>uploads attach</code> at an existing PR or issue anytime you'd rather target it
-        directly.
+        GitHub has no real way for an agent to show their work. Capture screenshots as you go
+        — they're staged for the branch automatically — and by the time the PR opens, it's
+        already furnished with one tidy comment.
       </p>
 
       <div class="cmdrow hero-install">
@@ -591,16 +589,17 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           <div class="feature">
             <h3>stage as you go</h3>
             <p>
-              A bare <code>put</code> on a branch stages automatically — no <code>--branch</code>&#32;
-              flag needed. <code>uploads staged</code> shows what's queued and whether it'll
-              auto-attach. Promotion never breaks a URL you already embedded.
+              A plain upload on a branch stages automatically — no extra flag needed. A staged
+              view (<code>uploads staged</code>) shows what's queued and whether it'll
+              auto-attach, and re-running it later updates the same comment instead of adding
+              a new one. Promotion never breaks a URL you've already embedded.
             </p>
           </div>
           <div class="feature">
             <h3>device frames</h3>
             <p>
-              <code>--frame phone</code>, <code>browser</code>, or <code>iphone-16-pro</code>&#32;
-              puts a raw screenshot inside device chrome.
+              Wrap a raw screenshot in device chrome — phone, browser, or a specific iPhone —
+              with <code>--frame</code>.
             </p>
           </div>
           <div class="feature">

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -91,8 +91,12 @@ attachments when one opens: automatically via the
 [GitHub App](https://uploads.sh/docs/github-app) webhook, or on the first
 `attach` after the PR exists (`--promote` forces it with no new files,
 `--no-promote` opts out). `uploads github link` inspects or claims the
-workspace↔repo binding the webhook path uses. Promoted staging is cleaned up
-server-side after ~7 days (~30 for branches that never got a PR).
+workspace↔repo binding the webhook path uses. Promotion is copy-and-keep —
+the staged original is never deleted, so any URL already embedded keeps
+serving — and staged objects follow only normal per-workspace retention and
+explicit deletes. Promotion (auto or `--promote`) does skip files staged
+more than 30 days before the PR opens, though; they're still there, just no
+longer auto-promoted.
 
 **Bare `put` stages too, by default (issue #403):** on a non-default git
 branch, a `put` with none of


### PR DESCRIPTION
Stacked on #416 (`docs/staging-correctness`) — merge that one first. This
branch is based on it, so the diff here is scoped to the story reframe.

## Summary

The site told an attach-first story ("have a PR, run attach"). Since 0.24.0
(#403 bare `put` stages by default on a branch; #405 `uploads staged`), the
actual differentiator is the inverted loop: upload while you work → it's
already staged for the branch → the PR opens already furnished, with zero
upload commands at PR time. This reframes the site around that loop, matching
the story already told in `docs/deletion.md`,
`skills/github-screenshots/SKILL.md`, and `skills/uploads-cli/SKILL.md`.

- **Homepage** (`index.astro`): hero terminal now walks `uploads put` (staged,
  no PR yet) → `gh pr create` → "your PR opens already furnished" → the same
  wireframe comment. Lede, `<meta>` description, og/twitter descriptions
  updated to lead with the loop while still naming `uploads attach` as the
  explicit form. The features grid swaps "update-in-place comments" for a
  "stage as you go" card (`uploads staged`, binding, copy-and-keep); the
  update-in-place fact moved into the lede. `agentPrompt` (the copyable agent
  setup prompt) now teaches the staged loop end to end.
- **Docs hub** (`docs.astro`): new "Start before the PR exists" beat right
  after the two-command overview.
- **Attach & share** (`attach-pull-request-images.astro`): staging promoted
  from a "No PR yet?" aside to a first-class section (own TOC entry) —
  `attach --branch` as the explicit multi-file form, `uploads staged`
  (`--branch`, `--format json`), the binding states (self/none/other/unknown,
  linked to the GitHub App page), and the durability sentence (copy-and-keep).
- **Agents guide** (`agents.astro`): stage-as-you-go section and the
  AGENTS.md snippet drop the now-unnecessary `--branch` flag from a bare
  `put`; the `find gh.branch=…` shell backstop is replaced with
  `uploads staged --format json` (always a valid document, even at zero
  files).
- **Reference** (`reference.astro`): added `uploads staged` to the command
  list.
- `llms.txt`'s "Docs: attach & share" line now mentions staging.

No new solid CTAs; existing width tokens and `&#32;` whitespace pattern kept
as-is.

## Screenshots

Homepage hero, before vs. after, attached below via `uploads attach` (see the
managed 📎 Attachments comment). Captured locally: a static server over the
built `dist/client` for "after", the shared dev server (still on `main`'s
copy at the time) for "before", both via
`uploads screenshot --no-upload --out` + `uploads attach`. This environment's
shared preview infrastructure serves from the main checkout rather than this
worktree, so the dev-server route to the "after" state wasn't usable — the
static-server workaround above stood in for it.

## Test plan

- [x] `pnpm --filter @uploads/web build` — succeeds, verified rendered output
      in `dist/client/index.html` for the new copy
- [x] `pnpm test` — 204 files / 2568 tests pass
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm run format:check` — clean
- [x] Visual check via local screenshots (above)
