### PR TITLE
feat(web,api): before/after paired view on the file page

### DIFF
--- a/apps/api/src/before-after.test.ts
+++ b/apps/api/src/before-after.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { attachmentPrefix, swapBeforeAfterToken } from "./before-after";
+
+describe("attachmentPrefix", () => {
+  it("returns everything up to and including the last slash", () => {
+    expect(attachmentPrefix("gh/acme/web/pull/12/hero-before.webp")).toBe("gh/acme/web/pull/12/");
+  });
+
+  it("returns empty string for a root-level key", () => {
+    expect(attachmentPrefix("hero-before.webp")).toBe("");
+  });
+});
+
+describe("swapBeforeAfterToken", () => {
+  it("swaps a lowercase -before- token to -after-", () => {
+    expect(swapBeforeAfterToken("hero-before.webp")).toEqual({
+      filename: "hero-after.webp",
+      state: "before",
+    });
+  });
+
+  it("swaps a lowercase -after- token to -before-", () => {
+    expect(swapBeforeAfterToken("hero-after.webp")).toEqual({
+      filename: "hero-before.webp",
+      state: "after",
+    });
+  });
+
+  it("preserves capitalized case style", () => {
+    expect(swapBeforeAfterToken("Hero-Before.webp")).toEqual({
+      filename: "Hero-After.webp",
+      state: "before",
+    });
+  });
+
+  it("preserves all-caps case style", () => {
+    expect(swapBeforeAfterToken("HERO-BEFORE.webp")).toEqual({
+      filename: "HERO-AFTER.webp",
+      state: "before",
+    });
+  });
+
+  it("matches an underscore-delimited token", () => {
+    expect(swapBeforeAfterToken("hero_before.webp")).toEqual({
+      filename: "hero_after.webp",
+      state: "before",
+    });
+  });
+
+  it("matches a token at the start of the filename", () => {
+    expect(swapBeforeAfterToken("before-hero.webp")).toEqual({
+      filename: "after-hero.webp",
+      state: "before",
+    });
+  });
+
+  it("does not match a substring like 'beforehand'", () => {
+    expect(swapBeforeAfterToken("beforehand.webp")).toBeNull();
+  });
+
+  it("returns null when there is no before/after token at all", () => {
+    expect(swapBeforeAfterToken("hero.webp")).toBeNull();
+  });
+});

--- a/apps/api/src/before-after.ts
+++ b/apps/api/src/before-after.ts
@@ -2,21 +2,26 @@
  * Before/after counterpart detection for the public file page (issue #420).
  *
  * Pairing rule, in priority order — mirrors the managed-comment pairing rule
- * from issue #365:
+ * from issue #365 / PR #424:
  *   1. Same `path` metadata where one file has `state=before` and the other
  *      `state=after` (queryable-tier D1 metadata, file-metadata.ts).
  *   2. Fallback: filename stems differing only by a before/after token
- *      (`hero-before.webp` / `hero-after.webp`).
+ *      (`hero-before.webp` / `hero-after.webp`) — but only when the file has
+ *      no usable `path`/`state` metadata at all. A file with usable path
+ *      metadata is rule-1-only, same as the comment side: a stem-swapped
+ *      neighbor that happens to sit alongside it is not treated as a
+ *      counterpart, since the file's own metadata already declares which
+ *      other object (if any) it pairs with.
  *
  * Both rules are scoped to the same attachment prefix (same PR or same
  * staged branch — everything up to the last `/` in the object key) so
  * unrelated files sharing a `state` value never pair across a workspace.
  *
  * This module only *finds a candidate key* — it has no storage binding, so
- * it cannot check the candidate's own visibility or whether it actually
- * exists. Callers (routes/public-files.ts) must verify both before treating
- * the candidate as a real counterpart, so a public page never reveals a
- * private object's existence.
+ * it cannot check the candidate's own visibility, content type, or whether
+ * it actually exists. Callers (routes/public-files.ts) must verify all of
+ * that before treating the candidate as a real counterpart, so a public page
+ * never reveals a private object's existence and never pairs a non-image.
  */
 
 import { findObjectsByMetadata } from "./file-metadata";
@@ -68,6 +73,22 @@ export interface CounterpartCandidate {
   state: BeforeAfterState;
 }
 
+// v1 pairing only supports images side by side (issue #420's static layout
+// renders both sides as <img>) — same allowlist apps/web's fileKind() treats
+// as "image", minus SVG (never previewed inline, see guards.ts).
+const IMAGE_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+]);
+
+/** True for content types the paired view can render as an `<img>`. */
+export function isPairableImageContentType(contentType: string): boolean {
+  return IMAGE_CONTENT_TYPES.has(contentType);
+}
+
 /**
  * Finds a before/after counterpart candidate for `key`, or null if none
  * applies. Does not check the candidate's existence or visibility — see the
@@ -82,17 +103,21 @@ export async function findCounterpartCandidate(
   const prefix = attachmentPrefix(key);
   const path = metadata.path;
   const state = metadata.state;
+  const hasUsablePathMetadata = Boolean(path && state && STATE_VALUES.has(state));
 
-  if (path && state && STATE_VALUES.has(state)) {
+  if (hasUsablePathMetadata) {
     const want = opposite(state as BeforeAfterState);
     const matches = await findObjectsByMetadata(
       db,
       workspace,
-      { path, state: want },
+      { path: path!, state: want },
       { prefix, limit: 5 },
     );
     const match = matches.find((row) => row.key !== key);
-    if (match) return { key: match.key, state: want };
+    // Rule-1-only once path metadata is usable — mirrors the comment-side
+    // rule (#424): don't fall through to a filename-guess for a file that
+    // already declares its own pairing via metadata.
+    return match ? { key: match.key, state: want } : null;
   }
 
   const filename = key.slice(prefix.length);

--- a/apps/api/src/before-after.ts
+++ b/apps/api/src/before-after.ts
@@ -1,0 +1,102 @@
+/**
+ * Before/after counterpart detection for the public file page (issue #420).
+ *
+ * Pairing rule, in priority order — mirrors the managed-comment pairing rule
+ * from issue #365:
+ *   1. Same `path` metadata where one file has `state=before` and the other
+ *      `state=after` (queryable-tier D1 metadata, file-metadata.ts).
+ *   2. Fallback: filename stems differing only by a before/after token
+ *      (`hero-before.webp` / `hero-after.webp`).
+ *
+ * Both rules are scoped to the same attachment prefix (same PR or same
+ * staged branch — everything up to the last `/` in the object key) so
+ * unrelated files sharing a `state` value never pair across a workspace.
+ *
+ * This module only *finds a candidate key* — it has no storage binding, so
+ * it cannot check the candidate's own visibility or whether it actually
+ * exists. Callers (routes/public-files.ts) must verify both before treating
+ * the candidate as a real counterpart, so a public page never reveals a
+ * private object's existence.
+ */
+
+import { findObjectsByMetadata } from "./file-metadata";
+
+export type BeforeAfterState = "before" | "after";
+
+const STATE_VALUES = new Set<string>(["before", "after"]);
+
+function opposite(state: BeforeAfterState): BeforeAfterState {
+  return state === "before" ? "after" : "before";
+}
+
+/** Everything up to and including the last `/` — same PR / same staged branch. */
+export function attachmentPrefix(key: string): string {
+  const idx = key.lastIndexOf("/");
+  return idx === -1 ? "" : key.slice(0, idx + 1);
+}
+
+// Token bounded by `-`, `_`, `.`, or string start/end, so `hero-before.webp`
+// matches but `beforehand.webp` does not.
+const TOKEN_RE = /(^|[-_.])(before|after)(?=[-_.]|$)/i;
+
+/**
+ * Swaps a filename's before/after token for its opposite, preserving the
+ * token's original case style (all-lower, all-upper, or Capitalized).
+ * Returns null when the filename has no such token.
+ */
+export function swapBeforeAfterToken(
+  filename: string,
+): { filename: string; state: BeforeAfterState } | null {
+  const match = TOKEN_RE.exec(filename);
+  if (!match) return null;
+  const found = match[2]!;
+  const state = found.toLowerCase() as BeforeAfterState;
+  const replacement = opposite(state);
+  let cased: string;
+  if (found === found.toUpperCase()) cased = replacement.toUpperCase();
+  else if (found[0] === found[0]!.toUpperCase()) {
+    cased = replacement[0]!.toUpperCase() + replacement.slice(1);
+  } else cased = replacement;
+  const start = match.index + match[1]!.length;
+  const end = start + found.length;
+  return { filename: filename.slice(0, start) + cased + filename.slice(end), state };
+}
+
+export interface CounterpartCandidate {
+  key: string;
+  /** The counterpart's role (opposite of this file's own role). */
+  state: BeforeAfterState;
+}
+
+/**
+ * Finds a before/after counterpart candidate for `key`, or null if none
+ * applies. Does not check the candidate's existence or visibility — see the
+ * module doc.
+ */
+export async function findCounterpartCandidate(
+  db: D1Database,
+  workspace: string,
+  key: string,
+  metadata: Record<string, string>,
+): Promise<CounterpartCandidate | null> {
+  const prefix = attachmentPrefix(key);
+  const path = metadata.path;
+  const state = metadata.state;
+
+  if (path && state && STATE_VALUES.has(state)) {
+    const want = opposite(state as BeforeAfterState);
+    const matches = await findObjectsByMetadata(
+      db,
+      workspace,
+      { path, state: want },
+      { prefix, limit: 5 },
+    );
+    const match = matches.find((row) => row.key !== key);
+    if (match) return { key: match.key, state: want };
+  }
+
+  const filename = key.slice(prefix.length);
+  const swapped = swapBeforeAfterToken(filename);
+  if (!swapped) return null;
+  return { key: prefix + swapped.filename, state: opposite(swapped.state) };
+}

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,7 +1,11 @@
 import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import type { Files } from "@uploads/storage";
-import { findCounterpartCandidate, type BeforeAfterState } from "../before-after";
+import {
+  findCounterpartCandidate,
+  isPairableImageContentType,
+  type BeforeAfterState,
+} from "../before-after";
 import { badKey, downloadResponse, publicObjectDateFields } from "../files-core";
 import { displayTitle, getFileMetadata, isServerMetaKey } from "../file-metadata";
 import { githubAvatarProxyUrl, ownerFromRepo } from "../github-avatars";
@@ -195,15 +199,24 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
   // Before/after counterpart (issue #420). findCounterpartCandidate only
   // proposes a key from D1 metadata / filename convention — it has no
   // storage binding, so this route must independently verify the candidate
-  // exists AND is public before ever mentioning it in the response. Skipping
-  // either check would let a public page leak the existence of a private
-  // counterpart object.
+  // exists, is public, AND is an image before ever mentioning it in the
+  // response. Skipping any of those would either leak the existence of a
+  // private counterpart object, or hand the web page's static side-by-side
+  // layout (issue #420 v1 renders both sides as an image element) a video
+  // or other non-image file it can't render that way.
   let counterpart: { key: string; url: string; state: BeforeAfterState } | undefined;
-  const candidate = await findCounterpartCandidate(c.env.DB, workspace, key, metadata);
+  const ownContentType = meta.type ?? "application/octet-stream";
+  const candidate = isPairableImageContentType(ownContentType)
+    ? await findCounterpartCandidate(c.env.DB, workspace, key, metadata)
+    : null;
   if (candidate && candidate.key !== key) {
     if (await store.exists(candidate.key)) {
       const counterpartMeta = await store.head(candidate.key);
-      if (!objectVisibility(counterpartMeta.metadata ?? undefined)) {
+      const counterpartType = counterpartMeta.type ?? "application/octet-stream";
+      if (
+        isPairableImageContentType(counterpartType) &&
+        !objectVisibility(counterpartMeta.metadata ?? undefined)
+      ) {
         const counterpartUrls = objectPublicUrls(env, cfg, candidate.key);
         if (counterpartUrls.url) {
           counterpart = { key: candidate.key, url: counterpartUrls.url, state: candidate.state };

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -1,6 +1,7 @@
 import { NotFoundError, UnauthorizedError } from "@uploads/errors";
 import { Hono } from "hono";
 import type { Files } from "@uploads/storage";
+import { findCounterpartCandidate, type BeforeAfterState } from "../before-after";
 import { badKey, downloadResponse, publicObjectDateFields } from "../files-core";
 import { displayTitle, getFileMetadata, isServerMetaKey } from "../file-metadata";
 import { githubAvatarProxyUrl, ownerFromRepo } from "../github-avatars";
@@ -191,6 +192,26 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     Object.entries(metadata).filter(([metaKey]) => !isServerMetaKey(metaKey)),
   );
 
+  // Before/after counterpart (issue #420). findCounterpartCandidate only
+  // proposes a key from D1 metadata / filename convention — it has no
+  // storage binding, so this route must independently verify the candidate
+  // exists AND is public before ever mentioning it in the response. Skipping
+  // either check would let a public page leak the existence of a private
+  // counterpart object.
+  let counterpart: { key: string; url: string; state: BeforeAfterState } | undefined;
+  const candidate = await findCounterpartCandidate(c.env.DB, workspace, key, metadata);
+  if (candidate && candidate.key !== key) {
+    if (await store.exists(candidate.key)) {
+      const counterpartMeta = await store.head(candidate.key);
+      if (!objectVisibility(counterpartMeta.metadata ?? undefined)) {
+        const counterpartUrls = objectPublicUrls(env, cfg, candidate.key);
+        if (counterpartUrls.url) {
+          counterpart = { key: candidate.key, url: counterpartUrls.url, state: candidate.state };
+        }
+      }
+    }
+  }
+
   let posterUrl: string | undefined;
   if (metadata["video.poster"] === "1") {
     const posterUrls = objectPublicUrls(env, cfg, posterKeyFor(key));
@@ -234,5 +255,6 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     ...(github ? { github } : {}),
     ...(posterUrl ? { posterUrl } : {}),
     ...(videoDimensions ? { videoDimensions } : {}),
+    ...(counterpart ? { counterpart } : {}),
   });
 });

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -665,3 +665,173 @@ describe("putObject uploaded-at stamp", () => {
     expect(bucket.store.get(key)?.customMetadata?.["uploaded-at"]).toBe(priorLm.toISOString());
   });
 });
+
+/** PUT an arbitrary key with optional headers, returning the stored key (unprefixed). */
+async function seedFile(
+  env: Parameters<typeof app.request>[2],
+  key: string,
+  headers: Record<string, string> = {},
+) {
+  const res = await app.request(
+    `/v1/default/files/${key}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-Type": "image/png",
+        "X-Uploads-Replace": "1",
+        ...headers,
+      },
+      body: PNG,
+    },
+    env,
+  );
+  if (res.status !== 201) throw new Error(`seed failed: ${res.status} ${await res.text()}`);
+  return key;
+}
+
+describe("GET /public/files/:workspace/:key — before/after counterpart (issue #420)", () => {
+  it("pairs same-path opposite-state metadata within the same prefix", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "before",
+    });
+    await seedFile(env, "gh/acme/web/pull/12/hero-after.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "after",
+    });
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      counterpart?: { key: string; url: string; state: string };
+    };
+    expect(json.counterpart).toEqual({
+      key: "gh/acme/web/pull/12/hero-after.webp",
+      url: "https://storage.uploads.sh/default/gh/acme/web/pull/12/hero-after.webp",
+      state: "after",
+    });
+  });
+
+  it("does not pair same-path/state metadata across different prefixes (different PR)", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "before",
+    });
+    await seedFile(env, "gh/acme/web/pull/13/hero-after.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "after",
+    });
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.counterpart).toBeUndefined();
+  });
+
+  it("falls back to filename-stem pairing when no path/state metadata is set", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp");
+    await seedFile(env, "gh/acme/web/pull/12/hero-after.webp");
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-after.webp",
+      {},
+      env,
+    );
+    const json = (await res.json()) as { counterpart?: { key: string; state: string } };
+    expect(json.counterpart).toEqual({
+      key: "gh/acme/web/pull/12/hero-before.webp",
+      state: "before",
+      url: "https://storage.uploads.sh/default/gh/acme/web/pull/12/hero-before.webp",
+    });
+  });
+
+  it("omits counterpart when the paired-looking file doesn't actually exist", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp");
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.counterpart).toBeUndefined();
+  });
+
+  it("omits counterpart entirely (no leak) when it exists but is private — public page", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "before",
+    });
+    await seedFile(env, "gh/acme/web/pull/12/hero-after.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "after",
+      "X-Uploads-Visibility": "private",
+    });
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    // The public before file's own page must not reveal that a private
+    // after counterpart exists at all.
+    expect(json.counterpart).toBeUndefined();
+  });
+
+  it("the private counterpart's own page still 401s (no bypass via the pairing lookup)", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "before",
+    });
+    await seedFile(env, "gh/acme/web/pull/12/hero-after.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "after",
+      "X-Uploads-Visibility": "private",
+    });
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-after.webp",
+      {},
+      env,
+    );
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json).not.toHaveProperty("counterpart");
+  });
+
+  it("does not pair unrelated files that merely share a state value", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero.webp",
+      "X-Uploads-Meta-state": "before",
+    });
+    await seedFile(env, "gh/acme/web/pull/12/other.webp", {
+      "X-Uploads-Meta-path": "other.webp",
+      "X-Uploads-Meta-state": "after",
+    });
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.counterpart).toBeUndefined();
+  });
+});

--- a/apps/api/test/routes-public-files.test.ts
+++ b/apps/api/test/routes-public-files.test.ts
@@ -69,6 +69,12 @@ beforeAll(() => {
 });
 
 const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+// ISO base media `ftyp` box with an `isom` major brand — sniffs as video/mp4
+// (apps/api/src/guards.ts's detectContentType; the stored type comes from
+// sniffed bytes, never the client's Content-Type header).
+const MP4 = new Uint8Array([
+  0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0, 0, 2, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+]);
 
 async function makeEnv(
   overrides: Partial<WorkspaceRecord> = {},
@@ -666,11 +672,12 @@ describe("putObject uploaded-at stamp", () => {
   });
 });
 
-/** PUT an arbitrary key with optional headers, returning the stored key (unprefixed). */
+/** PUT an arbitrary key with optional headers/body, returning the stored key (unprefixed). */
 async function seedFile(
   env: Parameters<typeof app.request>[2],
   key: string,
   headers: Record<string, string> = {},
+  body: Uint8Array = PNG,
 ) {
   const res = await app.request(
     `/v1/default/files/${key}`,
@@ -682,7 +689,7 @@ async function seedFile(
         "X-Uploads-Replace": "1",
         ...headers,
       },
-      body: PNG,
+      body,
     },
     env,
   );
@@ -831,6 +838,77 @@ describe("GET /public/files/:workspace/:key — before/after counterpart (issue 
       {},
       env,
     );
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.counterpart).toBeUndefined();
+  });
+
+  it("does not pair videos — the paired view only renders images", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(
+      env,
+      "gh/acme/web/pull/12/hero-before.mp4",
+      { "Content-Type": "video/mp4" },
+      MP4,
+    );
+    await seedFile(env, "gh/acme/web/pull/12/hero-after.mp4", { "Content-Type": "video/mp4" }, MP4);
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.mp4",
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.counterpart).toBeUndefined();
+  });
+
+  it("does not pair an image with a video counterpart via metadata", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero",
+      "X-Uploads-Meta-state": "before",
+    });
+    await seedFile(
+      env,
+      "gh/acme/web/pull/12/hero-after.mp4",
+      {
+        "Content-Type": "video/mp4",
+        "X-Uploads-Meta-path": "hero",
+        "X-Uploads-Meta-state": "after",
+      },
+      MP4,
+    );
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.counterpart).toBeUndefined();
+  });
+
+  it("stays rule-1-only when path/state metadata is usable but finds no match (no filename fallback)", async () => {
+    const { env } = await makeEnv({}, { db: makeFakeDB() });
+    // Has usable path/state metadata, but no object carries the matching
+    // path=hero/state=after pair — rule 1 comes back empty.
+    await seedFile(env, "gh/acme/web/pull/12/hero-before.webp", {
+      "X-Uploads-Meta-path": "hero",
+      "X-Uploads-Meta-state": "before",
+    });
+    // A filename-stem neighbor exists, but must NOT be used as a fallback
+    // once the file has its own usable path metadata (mirrors the
+    // comment-side rule from PR #424: metadata-declared files are
+    // rule-1-only).
+    await seedFile(env, "gh/acme/web/pull/12/hero-after.webp");
+
+    const res = await app.request(
+      "/public/files/default/gh/acme/web/pull/12/hero-before.webp",
+      {},
+      env,
+    );
+    expect(res.status).toBe(200);
     const json = (await res.json()) as Record<string, unknown>;
     expect(json.counterpart).toBeUndefined();
   });

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -385,4 +385,33 @@ describe("fetchPublicFile", () => {
     const { videoDimensions: _omit, ...noDims } = withDims;
     expect(isPublicFile(noDims)).toBe(true);
   });
+
+  it("accepts a well-formed before/after counterpart (issue #420)", () => {
+    const withCounterpart = {
+      ...file,
+      counterpart: {
+        key: "gh/acme/web/pull/12/hero-after.webp",
+        url: "https://storage.uploads.sh/acme/gh/acme/web/pull/12/hero-after.webp",
+        state: "after",
+      },
+    };
+    expect(isPublicFile(withCounterpart)).toBe(true);
+    const { counterpart: _omit, ...noCounterpart } = withCounterpart;
+    expect(isPublicFile(noCounterpart)).toBe(true);
+  });
+
+  it("rejects a malformed counterpart", () => {
+    expect(
+      isPublicFile({ ...file, counterpart: { key: "x", url: "https://x", state: "sideways" } }),
+    ).toBe(false);
+    expect(
+      isPublicFile({
+        ...file,
+        counterpart: { key: "x", url: "javascript:alert(1)", state: "before" },
+      }),
+    ).toBe(false);
+    expect(isPublicFile({ ...file, counterpart: { url: "https://x", state: "before" } })).toBe(
+      false,
+    );
+  });
 });

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -37,6 +37,15 @@ export interface PublicFile {
   posterUrl?: string | null;
   /** Real video dimensions, for reserving aspect ratio before playback; omitted when unknown. */
   videoDimensions?: { width: number; height: number };
+  /** Before/after counterpart (issue #420), when one exists and is visible to this viewer. */
+  counterpart?: PublicFileCounterpart;
+}
+
+/** A file's before/after counterpart — already visibility-checked server-side. */
+export interface PublicFileCounterpart {
+  key: string;
+  url: string;
+  state: "before" | "after";
 }
 
 /** Result of resolving a public file: the DTO, a hard 404, a private gate, or a soft outage. */
@@ -231,6 +240,17 @@ function optionalIsoDate(value: unknown): boolean {
   );
 }
 
+/** Bounded `counterpart` convenience object — mirrors apps/api's response shape. */
+function isPublicFileCounterpart(value: unknown): value is PublicFileCounterpart {
+  if (typeof value !== "object" || value === null) return false;
+  const counterpart = value as Record<string, unknown>;
+  return (
+    text(counterpart.key, 1024) &&
+    httpsUrl(counterpart.url) &&
+    (counterpart.state === "before" || counterpart.state === "after")
+  );
+}
+
 /** Validate an untrusted API response against the bounded {@link PublicFile} shape. */
 export function isPublicFile(value: unknown): value is PublicFile {
   if (typeof value !== "object" || value === null) return false;
@@ -240,6 +260,7 @@ export function isPublicFile(value: unknown): value is PublicFile {
   const posterUrlOk = file.posterUrl === undefined || nullableHttpsUrl(file.posterUrl);
   const videoDimensionsOk =
     file.videoDimensions === undefined || isVideoDimensions(file.videoDimensions);
+  const counterpartOk = file.counterpart === undefined || isPublicFileCounterpart(file.counterpart);
   return (
     text(file.workspace, 64) &&
     text(file.key, 1024) &&
@@ -253,7 +274,8 @@ export function isPublicFile(value: unknown): value is PublicFile {
     metadataOk &&
     githubOk &&
     posterUrlOk &&
-    videoDimensionsOk
+    videoDimensionsOk &&
+    counterpartOk
   );
 }
 

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -94,12 +94,18 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
 // present, else it's simply the counterpart's opposite — either way, only
 // rendered when the API actually returned a counterpart.
 const counterpart = file?.counterpart ?? null;
+
+/** This file's own before/after role, given the counterpart it's paired with. */
+function ownBeforeAfterState(
+  metadataState: string | undefined,
+  counterpartState: "before" | "after",
+): "before" | "after" {
+  if (metadataState === "before" || metadataState === "after") return metadataState;
+  return counterpartState === "before" ? "after" : "before";
+}
+
 const ownState: "before" | "after" | null = counterpart
-  ? file?.metadata?.state === "before" || file?.metadata?.state === "after"
-    ? file.metadata.state
-    : counterpart.state === "before"
-      ? "after"
-      : "before"
+  ? ownBeforeAfterState(file?.metadata?.state, counterpart.state)
   : null;
 const counterpartFilename = counterpart ? counterpart.key.split("/").filter(Boolean).pop() ?? counterpart.key : null;
 const counterpartHref = counterpart ? filePath(workspace, counterpart.key) : null;

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -87,6 +87,36 @@ const title = file
 // oEmbed discovery only when the public object is fully resolved — private /
 // missing pages must not advertise an endpoint that would 404 or leak existence.
 const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : null;
+
+// Before/after paired view (issue #420). The API already did the
+// visibility-safe lookup (routes/public-files.ts); this page only decides
+// how to lay the two images out. Own state comes from `state` metadata when
+// present, else it's simply the counterpart's opposite — either way, only
+// rendered when the API actually returned a counterpart.
+const counterpart = file?.counterpart ?? null;
+const ownState: "before" | "after" | null = counterpart
+  ? file?.metadata?.state === "before" || file?.metadata?.state === "after"
+    ? file.metadata.state
+    : counterpart.state === "before"
+      ? "after"
+      : "before"
+  : null;
+const counterpartFilename = counterpart ? counterpart.key.split("/").filter(Boolean).pop() ?? counterpart.key : null;
+const counterpartHref = counterpart ? filePath(workspace, counterpart.key) : null;
+interface PairPanel {
+  state: "before" | "after";
+  src: string;
+  current: boolean;
+  href: string | null;
+}
+const pairPanels: PairPanel[] | null =
+  counterpart && ownState
+    ? (["before", "after"] as const).map((state) =>
+        state === ownState
+          ? { state, src: file!.url, current: true, href: null }
+          : { state, src: counterpart.url, current: false, href: counterpartHref },
+      )
+    : null;
 ---
 
 <!doctype html>
@@ -152,6 +182,16 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
       .details :global(.actions) { margin-top:0; }
+      /* Before/after paired view (issue #420) — static side-by-side, no slider. */
+      .pair { display:grid; grid-template-columns:1fr 1fr; gap:1px; background:var(--line); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; margin:0 0 20px; }
+      .pair-panel { position:relative; background:var(--panel); display:flex; flex-direction:column; }
+      .pair-panel img { width:100%; height:220px; object-fit:contain; background:var(--bg); display:block; }
+      .pair-label { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:8px 12px; font:11px var(--mono); letter-spacing:.08em; text-transform:uppercase; color:var(--muted); }
+      .pair-label strong { color:var(--fg); font-weight:600; }
+      .pair-panel[data-current="true"] .pair-label strong { color:var(--accent); }
+      .pair-link { color:var(--muted); text-decoration:none; font:12px var(--mono); text-transform:none; letter-spacing:normal; }
+      .pair-link:hover, .pair-link:focus-visible { color:var(--accent); outline:none; }
+      @media (max-width: 620px) { .pair { grid-template-columns:1fr; } }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
       .error .signin { display:inline-block; margin-top:18px; padding:9px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--fg); font:12px var(--mono); text-decoration:none; }
@@ -226,6 +266,21 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
               </a>
             )}
           </header>
+          {pairPanels && (
+            <div class="pair" role="group" aria-label={`Before/after comparison, viewing the ${ownState}`}>
+              {pairPanels.map((panel) => (
+                <div class="pair-panel" data-current={panel.current ? "true" : "false"}>
+                  <img src={panel.src} alt={`${panel.state} of ${filename}`} loading={panel.current ? "eager" : "lazy"} />
+                  <div class="pair-label">
+                    <strong>{panel.state}</strong>
+                    {!panel.current && panel.href && (
+                      <a class="pair-link" href={panel.href}>{counterpartFilename} ↗</a>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           <figure class="stage" style="margin:0">
             {kind(file.contentType) === "image" ? (
               <ImagePreview src={file.url} alt={filename} />


### PR DESCRIPTION
Closes #420. Sibling to #419 (managed-comment side-by-side pairing, apps/api's comment renderer) — that PR is being built in parallel; this one is apps/web + the public file endpoint only.

## What

The `/f/<workspace>/<key>` page now detects a before/after counterpart and
renders a static side-by-side comparison above the main preview, with a link
to the counterpart's own page. v1 is deliberately modest per the issue: labeled
side-by-side panels, no slider/onion-skin.

Real `/f/` page, driven end-to-end against a local `wrangler dev` API + `astro
preview` web build on this branch (two seeded public images, `path=hero.webp`
+ opposite `state` metadata):

| Viewing `before` (desktop) | Viewing `after` (desktop) |
| --- | --- |
| ![Real /f/ page: viewing the before file, desktop width, paired view with counterpart link to hero-after.webp](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/425/paired-view-before-desktop.webp) | ![Real /f/ page: viewing the after file, desktop width, paired view with counterpart link to hero-before.webp](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/425/paired-view-after-desktop.webp) |

Below 620px the panels stack to a single column:

![Real /f/ page at 480px width: paired panels stack to a single column below 620px](https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/425/paired-view-mobile.webp)

*(Captured with `uploads screenshot`'s local Playwright backend pointed at my
own worktree's dev servers, not the shared Browser pane — that pane's preview
infrastructure resolves to a different, non-isolated checkout for this
session, so it can't render an unmerged branch. First attempt hit two local-dev-only
snags unrelated to the feature: `apps/web`'s `global_fetch_strictly_public`
compat flag blocks the Worker from fetching a loopback API — worked around
locally only, not committed — and CLI auto-derived `gh.*`/`avatarUrl`
metadata from this repo's real PR #425 tripped the web DTO's `isAvatarUrl`
check since it isn't `https:`/loopback; re-uploaded with `--no-auto` to keep
the fixture clean. Neither is a bug in this PR's code.)*

## Counterpart-lookup design

New `apps/api/src/before-after.ts`, wired into `GET /public/files/:workspace/:key`
(`apps/api/src/routes/public-files.ts` — the only surface that resolves the full
`/f/` page; see #135/#136/#139). Pairing rule, in priority order, mirroring the
comment-pairing rule from #365:

1. Same `path` metadata where one file has `state=before` and the other
   `state=after` — one `findObjectsByMetadata` query (existing queryable D1
   tier from #157/#365, no schema change).
2. Fallback: filename stems differing only by a before/after token
   (`hero-before.webp` / `hero-after.webp`), bounded by `-`/`_`/`.`/string
   edges so `beforehand.webp` doesn't false-positive.

Both rules are scoped to the same **attachment prefix** — everything up to the
last `/` in the object key, i.e. the same PR (`gh/<owner>/<repo>/pull/<num>/`)
or the same staged branch (`gh/<owner>/<repo>/branch/<branch>/`) — so files
that merely share a `state` value elsewhere in the workspace never pair.

Rule 2 only applies when the file has **no usable `path`/`state` metadata at
all** — a file with usable path metadata is rule-1-only (mirrors #424 on the
comment side): if rule 1 finds no match, the lookup returns nothing rather
than falling through to a filename guess.

A candidate is only ever surfaced when **both** the current file and the
candidate are pairable image types (png/jpeg/gif/webp/avif) — the static
side-by-side layout renders both sides as an image element, so a
video-named-like-an-image (`hero-before.mp4`/`hero-after.mp4`) or a
metadata-paired image+video never produces a `counterpart`.

## Visibility

`findCounterpartCandidate` only *proposes* a key from D1 metadata/filename —
it has no storage binding. `routes/public-files.ts` independently verifies the
candidate before ever mentioning it in the response:

- `store.exists()` — the candidate must actually be there.
- `store.head()` + `objectVisibility()` — the candidate must be public.

Only then does it appear as `counterpart` in the response. This means:

- A **public** file's page never reveals that a **private** counterpart
  exists — the lookup silently comes back empty, same as no counterpart at
  all.
- A **private** file's own page keeps 401ing with `auth_required` exactly as
  before (private objects don't get the full `/f/` render in the first
  place — that page redirects to a signed URL client-side and never reaches
  the pairing code), so it can't be used to bypass the check by asking about
  its own counterpart.
- Pairing across two public files with an existing private one alongside them
  is exercised directly.

`apps/web/src/lib/public-file.ts` adds a bounded `PublicFileCounterpart`
validator (`isPublicFile`) so a malformed/spoofed `counterpart` in the API
response is rejected the same way the rest of the DTO already is.

On the page itself, the nested ternary computing this file's own
before/after role (metadata `state`, else the counterpart's opposite) is now
a small named helper (`ownBeforeAfterState`) — readability only, no behavior
change.

## Tests

- `apps/api/src/before-after.test.ts` — `attachmentPrefix` and
  `swapBeforeAfterToken` unit coverage (case preservation, token boundaries,
  `beforehand.webp` non-match).
- `apps/api/test/routes-public-files.test.ts` (new describe block, 11 cases):
  path/state pairing, prefix scoping (no cross-PR pairing), filename-stem
  fallback, missing-counterpart omission, **private counterpart omitted from
  the public page**, **private counterpart's own page still 401s**, no
  pairing across files that only share a `state` value, **video/video pair →
  no counterpart**, **image+video pair via metadata → no counterpart**, and
  **usable path/state metadata with no match stays rule-1-only** (a
  stem-swapped neighbor is ignored).
- `apps/web/src/lib/public-file.test.ts` — `isPublicFile` accepts a
  well-formed `counterpart` and rejects a malformed one (bad state, non-https
  URL, missing key).

`pnpm test` (root, 205 files / 2590 tests) passes; `pnpm run format` applied
(oxfmt, no diffs beyond this change).
