### PR TITLE
feat(mcp): expose the repo-binding tri-state to hosted MCP agents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,8 @@
     "./gallery-service": "./src/gallery-service.ts",
     "./external-references": "./src/external-references.ts",
     "./uploader-identity": "./src/uploader-identity.ts",
-    "./github-comment-service": "./src/github-comment-service.ts"
+    "./github-comment-service": "./src/github-comment-service.ts",
+    "./github-repo-links": "./src/github-repo-links.ts"
   },
   "scripts": {
     "dev": "wrangler dev",

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -105,6 +105,23 @@ export async function findRepoLink(db: D1Database, repo: string): Promise<RepoLi
   }
 }
 
+/** The tri-state a caller is allowed to learn about someone else's binding (issue #398). */
+export type RepoBinding = "self" | "other" | "none";
+
+/**
+ * Collapses a link record to what the *calling* workspace may know: bound to
+ * me, bound to someone else, or unbound. The point is the deliberate loss of
+ * information — "other" must never carry, or let a caller reconstruct, the
+ * owning workspace's name (see routes/github-link.ts's `/repo-link` for why).
+ * Lives here, beside the record it collapses, so that rule has one home
+ * rather than one copy per surface: the REST route and the hosted MCP
+ * `repo_link_status` tool (issue #422) both call this.
+ */
+export function deriveRepoBinding(link: RepoLink | null, workspaceName: string): RepoBinding {
+  if (link === null) return "none";
+  return link.workspaceName === workspaceName ? "self" : "other";
+}
+
 /**
  * Strict counterpart to `findRepoLink` for callers that must distinguish
  * "no binding" from "D1 is unavailable" (self-serve/admin lookups, issue

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -13,6 +13,7 @@ import { Hono } from "hono";
 import { isEntitledToClaimRepo } from "../github-claim-authz";
 import {
   deleteRepoLinkForWorkspace,
+  deriveRepoBinding,
   findRepoLink,
   findRepoLinkStrict,
   recordRepoLink,
@@ -71,9 +72,7 @@ export const githubLink = new Hono<WorkspaceVars>()
     const repo = parseRepo(c.req.query("repo"));
     const workspaceName = c.get("workspaceName");
     const link = await findRepoLink(c.env.DB, repo);
-    const binding =
-      link === null ? "none" : link.workspaceName === workspaceName ? "self" : "other";
-    return c.json({ binding });
+    return c.json({ binding: deriveRepoBinding(link, workspaceName) });
   })
   .post("/link", writeRateLimit, requireScope("files:write"), async (c) => {
     const repo = parseRepo((await jsonBody(c)).repo);

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -41,7 +41,7 @@ import {
   validateMetadataFilters,
 } from "@uploads/api/file-metadata";
 import { hasGithubTags, uploaderTags } from "@uploads/api/uploader-identity";
-import { findRepoLink } from "@uploads/api/github-repo-links";
+import { deriveRepoBinding, findRepoLink } from "@uploads/api/github-repo-links";
 import {
   addExternalReference,
   addGalleryItem,
@@ -922,9 +922,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         const repo = requiredString(args, "repo");
         if (!validRepoGrammar(repo)) usage("repo must be owner/name");
         const link = await findRepoLink(env.DB, repo);
-        const binding =
-          link === null ? "none" : link.workspaceName === workspaceName ? "self" : "other";
-        return { binding };
+        return { binding: deriveRepoBinding(link, workspaceName) };
       },
     },
     {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -41,6 +41,7 @@ import {
   validateMetadataFilters,
 } from "@uploads/api/file-metadata";
 import { hasGithubTags, uploaderTags } from "@uploads/api/uploader-identity";
+import { findRepoLink } from "@uploads/api/github-repo-links";
 import {
   addExternalReference,
   addGalleryItem,
@@ -899,6 +900,31 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           })),
           cursor: null,
         };
+      },
+    },
+    {
+      name: "repo_link_status",
+      description:
+        'Whether files staged for a repo will auto-attach into that repo\'s PRs from this workspace. Returns a tri-state `binding`: "self" (this repo is bound to this workspace — staged files will auto-attach), "other" (bound to a different workspace — they will not; the owning workspace is deliberately never disclosed), or "none" (unbound).',
+      inputSchema: {
+        type: "object",
+        properties: {
+          repo: {
+            type: "string",
+            description: "GitHub repo as owner/name.",
+          },
+        },
+        required: ["repo"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:read");
+        const repo = requiredString(args, "repo");
+        if (!validRepoGrammar(repo)) usage("repo must be owner/name");
+        const link = await findRepoLink(env.DB, repo);
+        const binding =
+          link === null ? "none" : link.workspaceName === workspaceName ? "self" : "other";
+        return { binding };
       },
     },
     {

--- a/apps/mcp/test/mcp-repo-link-status.test.ts
+++ b/apps/mcp/test/mcp-repo-link-status.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Hosted `repo_link_status` tool (issue #422): the tri-state repo<->workspace
+ * binding check, mirroring `GET /github/repo-link` (apps/api/src/routes/github-link.ts)
+ * via the same lenient `findRepoLink` in-process import. Covers self/other/none,
+ * invalid repo grammar, and the files:read scope gate — and, critically, that
+ * the "other" response never leaks the owning workspace's name anywhere in
+ * the body.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
+import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
+
+const TOKEN = "up_test-ws_legacy-token-value";
+const WS = "test-ws";
+const OTHER_WS = "owner-workspace";
+
+// crypto.subtle.timingSafeEqual is a Workers-runtime extension (used by
+// workspaceAuth) Node's crypto doesn't implement — mirrors mcp.test.ts's polyfill.
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+interface RepoLinkRow {
+  repo_full_name: string;
+  workspace_name: string;
+  installation_id: number | null;
+  source: string;
+  created_at: string;
+}
+
+/** In-memory `github_repo_links` stand-in — mirrors mcp-put-comment.test.ts's RepoLinksTable. */
+class RepoLinksTable {
+  readonly rows = new Map<string, RepoLinkRow>();
+
+  tryFirst(sql: string, args: unknown[]) {
+    if (sql.includes("FROM github_repo_links WHERE repo_full_name")) {
+      const [repo] = args as [string];
+      return this.rows.get(repo) ?? null;
+    }
+    return undefined;
+  }
+}
+
+/**
+ * D1 fake covering just what `findRepoLink` and (for the scope test) the
+ * `auth_tokens` active-token lookup need. By default the token lookup always
+ * misses (legacy token path — full FILE_SCOPES). Pass `scopedToken` to
+ * instead return a D1-tracked row for `TOKEN` carrying exactly those scopes.
+ */
+function makeDb(links: RepoLinksTable, scopedToken?: { tokenHash: string; scopes: string[] }) {
+  return {
+    prepare: (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      let values: unknown[] = [];
+      const stmt = {
+        bind(...next: unknown[]) {
+          values = next;
+          return stmt;
+        },
+        async first<T>() {
+          if (normalized.includes("github_repo_links")) {
+            return (links.tryFirst(normalized, values) ?? null) as T;
+          }
+          if (normalized.startsWith("SELECT id, workspace, token_hash")) {
+            const [, hash] = values as [string, string];
+            if (scopedToken && hash === scopedToken.tokenHash) {
+              return {
+                id: "token-id",
+                workspace: WS,
+                token_hash: hash,
+                label: null,
+                scopes: JSON.stringify(scopedToken.scopes),
+                created_at: "2026-07-13T00:00:00.000Z",
+                expires_at: null,
+                revoked_at: null,
+                minting_user_id: null,
+              } as T;
+            }
+            return null as T;
+          }
+          return null as T;
+        },
+        async run() {
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+        async all<T>() {
+          return { success: true, results: [] as T[], meta: {} };
+        },
+      };
+      return stmt;
+    },
+    async batch(stmts: { run: () => Promise<unknown> }[]) {
+      return Promise.all(stmts.map((s) => s.run()));
+    },
+  };
+}
+
+async function makeEnv(
+  opts: { boundTo?: string; scopes?: string[] } = {},
+): Promise<{ env: Env; links: RepoLinksTable }> {
+  const tokenHash = await sha256Hex(TOKEN);
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "test-bucket",
+    binding: "UPLOADS",
+    publicBaseUrl: "https://storage.example.com",
+    tokenHash,
+  };
+  const bucket = new FakeR2Bucket();
+  const links = new RepoLinksTable();
+  if (opts.boundTo) {
+    links.rows.set("acme/widgets", {
+      repo_full_name: "acme/widgets",
+      workspace_name: opts.boundTo,
+      installation_id: 42,
+      source: "comment",
+      created_at: new Date().toISOString(),
+    });
+  }
+  const scopedToken = opts.scopes ? { tokenHash, scopes: opts.scopes } : undefined;
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    DB: makeDb(links, scopedToken),
+    UPLOADS: bucket,
+  } as unknown as Env;
+  return { env, links };
+}
+
+async function callTool(env: Env, name: string, args: Record<string, unknown>) {
+  const response = await app.request(
+    "/test-ws/mcp",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    },
+    env,
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    result: {
+      isError: boolean;
+      structuredContent?: Record<string, unknown>;
+      content: unknown[];
+    };
+  };
+  return body.result;
+}
+
+describe("repo_link_status", () => {
+  it("returns self when the repo is bound to the calling workspace", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "repo_link_status", { repo: "acme/widgets" });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toEqual({ binding: "self" });
+  });
+
+  it("returns other when the repo is bound to a different workspace, without naming it", async () => {
+    const { env } = await makeEnv({ boundTo: OTHER_WS });
+    const result = await callTool(env, "repo_link_status", { repo: "acme/widgets" });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toEqual({ binding: "other" });
+    const raw = JSON.stringify(result);
+    expect(raw).not.toContain(OTHER_WS);
+    expect(Object.keys(result.structuredContent ?? {})).toEqual(["binding"]);
+  });
+
+  it("returns none when the repo is unbound", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "repo_link_status", { repo: "acme/widgets" });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toEqual({ binding: "none" });
+  });
+
+  it("usage errors on invalid repo grammar", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "repo_link_status", { repo: "not-a-repo" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("repo must be owner/name") },
+    ]);
+  });
+
+  it("requires files:read — a scopeless/other-scoped token is rejected", async () => {
+    const { env } = await makeEnv({ boundTo: WS, scopes: ["files:write"] });
+    const result = await callTool(env, "repo_link_status", { repo: "acme/widgets" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("requires files:read scope") },
+    ]);
+  });
+});

--- a/apps/mcp/test/mcp-repo-link-status.test.ts
+++ b/apps/mcp/test/mcp-repo-link-status.test.ts
@@ -9,7 +9,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import app from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
-import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
 
 const TOKEN = "up_test-ws_legacy-token-value";
 const WS = "test-ws";
@@ -55,9 +54,11 @@ class RepoLinksTable {
 
 /**
  * D1 fake covering just what `findRepoLink` and (for the scope test) the
- * `auth_tokens` active-token lookup need. By default the token lookup always
- * misses (legacy token path — full FILE_SCOPES). Pass `scopedToken` to
- * instead return a D1-tracked row for `TOKEN` carrying exactly those scopes.
+ * `auth_tokens` active-token lookup need — `prepare().bind().first()` and
+ * nothing else, because `repo_link_status` is read-only and never writes.
+ * By default the token lookup always misses (legacy token path — full
+ * FILE_SCOPES). Pass `scopedToken` to instead return a D1-tracked row for
+ * `TOKEN` carrying exactly those scopes.
  */
 function makeDb(links: RepoLinksTable, scopedToken?: { tokenHash: string; scopes: string[] }) {
   return {
@@ -92,17 +93,8 @@ function makeDb(links: RepoLinksTable, scopedToken?: { tokenHash: string; scopes
           }
           return null as T;
         },
-        async run() {
-          return { success: true, meta: { changes: 0 }, results: [] };
-        },
-        async all<T>() {
-          return { success: true, results: [] as T[], meta: {} };
-        },
       };
       return stmt;
-    },
-    async batch(stmts: { run: () => Promise<unknown> }[]) {
-      return Promise.all(stmts.map((s) => s.run()));
     },
   };
 }
@@ -118,7 +110,6 @@ async function makeEnv(
     publicBaseUrl: "https://storage.example.com",
     tokenHash,
   };
-  const bucket = new FakeR2Bucket();
   const links = new RepoLinksTable();
   if (opts.boundTo) {
     links.rows.set("acme/widgets", {
@@ -133,7 +124,7 @@ async function makeEnv(
   const env = {
     REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
     DB: makeDb(links, scopedToken),
-    UPLOADS: bucket,
+    // No UPLOADS binding on purpose: this tool never touches storage.
   } as unknown as Env;
   return { env, links };
 }

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -550,6 +550,7 @@ describe("mcp worker", () => {
       "purge_expired",
       "put",
       "reconcile",
+      "repo_link_status",
       "set_metadata",
       "usage",
     ]);

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -809,10 +809,18 @@ uploads --api-url http://localhost:8787 doctor
   `find_files` returns each match's metadata inline, so `gh.staged-at` gives
   recency without a second call; add `"gh.repo": "<owner>/<repo>"` to the
   filters when branch names aren't unique across repos you're working in. For
-  the binding question ("will these auto-attach?"), there's no hosted-MCP
-  tool for the repo-link check either — fall back to the CLI's `uploads
-github link --status --repo <owner/name>`, or just try `attach --promote`
-  once the PR exists and read its result.
+  the binding question ("will these auto-attach?"), use the hosted `repo_link_status`
+  tool (issue #422):
+
+  ```text
+  repo_link_status  { repo: "<owner>/<repo>" }
+  ```
+
+  It returns `{ binding: "self" | "other" | "none" }`: `"self"` means this
+  repo is bound to this workspace and staged files will auto-attach,
+  `"other"` means it's bound to a different workspace and they won't —
+  deliberately without ever naming that workspace — and `"none"` means the
+  repo is unbound.
 
 - **Agents on the Worker side:** the package also exports
   `createUploadsWorkerFileTools()` from `@buildinternet/uploads/agent` for exposing


### PR DESCRIPTION
Closes #422.

Hosted-MCP agents could already see what's staged for a branch (the `list` / `find_files` recipes from #405), but not the question that decides whether it matters: *will these auto-attach at PR open?* The skill's answer was to shell out to the CLI — no help to an agent that only has the hosted server.

## What's here

A `repo_link_status` tool on the hosted MCP tool set, returning the #398 tri-state:

```text
repo_link_status  { repo: "acme/widgets" }  ->  { binding: "self" | "other" | "none" }
```

It reuses `findRepoLink` from the API in-process — the same pattern #394 used for `postManagedComment` — so there's no second source of truth for the binding. The lenient variant is deliberate: a D1 blip degrades to `"none"` rather than a 5xx, matching `GET /github/repo-link`, because this is advisory-only. `files:read`, and `repo` is required (the hosted server has no git context to infer it from, same divergence already documented for `pr`/`issue`).

## Cross-tenant disclosure

`{ binding }` is the entire response. For `"other"` the owning workspace is never named, hinted at, or reconstructible — that's the whole reason `/repo-link` exists separately from `/link`, which does name the owner. A test asserts both that the response has exactly one key and that the other workspace's name appears nowhere in the serialized result.

Since that rule is a security invariant, the second commit pulls the tri-state derivation into `deriveRepoBinding()` in `github-repo-links.ts`, beside the record it collapses, and points both the REST route and the new tool at it — one home for the rule instead of a copy per surface.

## Notes

- Hosted MCP only. The local stdio MCP is a separate tool set and is untouched.
- No changeset: nothing in `packages/uploads` changes, so there's nothing to publish.
- Docs: the SKILL.md hosted-MCP section's CLI-fallback paragraph is replaced with the tool. The nearby "no dedicated tool for this" line stays — it refers to the `staged` tool, which still doesn't exist.

## Verification

`pnpm test` — 205 files, 2573 tests passing. `pnpm check` clean (only pre-existing warnings in untouched files); `tsc --noEmit` clean for `apps/mcp` and `apps/api`.
