### PR TITLE
refactor(api): narrow the cross-worker repo-links export to its read slice

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "./external-references": "./src/external-references.ts",
     "./uploader-identity": "./src/uploader-identity.ts",
     "./github-comment-service": "./src/github-comment-service.ts",
-    "./github-repo-links": "./src/github-repo-links.ts"
+    "./github-repo-binding": "./src/github-repo-binding.ts"
   },
   "scripts": {
     "dev": "wrangler dev",

--- a/apps/api/src/github-repo-binding.ts
+++ b/apps/api/src/github-repo-binding.ts
@@ -1,0 +1,21 @@
+/**
+ * The read-only slice of `github-repo-links.ts` that other workers may import
+ * (issue #427). `@uploads/api`'s package exports point at THIS module, not at
+ * `github-repo-links.ts`, so a cross-worker consumer can answer "who is this
+ * repo bound to, relative to me?" without also gaining import-level access to
+ * the mutation side of that module — `setRepoLink` (the operator hard-override
+ * for reassigning someone else's stuck binding), the strict deletes, and the
+ * workspace-scoped listing. Those stay reachable only from inside apps/api,
+ * behind the admin route's auth gate (routes/admin-ui.ts), so a future change
+ * to that gate can't be bypassed by a direct import.
+ *
+ * Same intent as `./github-comment-service`'s narrow surface: export the
+ * function the other worker actually needs, not the module that contains it.
+ * In-package callers keep importing `./github-repo-links` directly.
+ */
+export {
+  deriveRepoBinding,
+  findRepoLink,
+  type RepoBinding,
+  type RepoLink,
+} from "./github-repo-links";

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -41,7 +41,7 @@ import {
   validateMetadataFilters,
 } from "@uploads/api/file-metadata";
 import { hasGithubTags, uploaderTags } from "@uploads/api/uploader-identity";
-import { deriveRepoBinding, findRepoLink } from "@uploads/api/github-repo-links";
+import { deriveRepoBinding, findRepoLink } from "@uploads/api/github-repo-binding";
 import {
   addExternalReference,
   addGalleryItem,


### PR DESCRIPTION
Closes #427. Follow-up to #426.

## Problem

#426 added `"./github-repo-links"` to `@uploads/api`'s exports so the hosted MCP could import `findRepoLink` / `deriveRepoBinding` in-process. That's a whole-module export, so `apps/mcp` also gained import-level access to the mutation side: `setRepoLink` (the operator hard-override for reassigning someone else's stuck binding), the strict deletes, and the workspace-scoped listing.

Nothing called them — this was blast radius, not a live bug. But the surface widens with every new hosted tool, and a direct import would sidestep the admin route's auth gate that those operations are supposed to sit behind.

## Change

Export `github-repo-binding.ts` instead — a read-only re-export of `findRepoLink`, `deriveRepoBinding`, and the two types. This is option 1 from the issue, in its cheapest form: nothing moves between modules, so the seven in-package callers keep importing `./github-repo-links` directly and are untouched. Mirrors the narrow `./github-comment-service` surface #426 was modeled on.

Net: one new file, one exports-map line, one import line in `apps/mcp/src/tools.ts`.

## Verification

The boundary actually closes — a probe file in `apps/mcp` importing `setRepoLink` from the old subpath fails to resolve:

```text
error TS2307: Cannot find module '@uploads/api/github-repo-links' or its corresponding type declarations.
```

(probe was temporary and is not part of the diff)

`pnpm test` — 205 files, 2573 tests passing. `tsc --noEmit` clean for both `apps/api` and `apps/mcp`. `oxfmt --check` clean.

No changeset: `packages/uploads` is untouched, and this is an internal worker-to-worker boundary with no npm-visible effect.
