### PR TITLE
fix(api,cli): align comment stem-token fallback with file page rule

### DIFF
--- a/.changeset/align-stem-token-fallback.md
+++ b/.changeset/align-stem-token-fallback.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Align the managed comment's filename-stem before/after fallback with the file page: a delimiter-bounded token anywhere in the stem now pairs (not just at the start or end).

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -147,6 +147,25 @@ describe("attachmentsCommentBody (api copy)", () => {
       expect(body).not.toContain("<table>");
     });
 
+    it("pairs a delimiter-bounded before/after token in the middle of the stem", () => {
+      const body = attachmentsCommentBody([
+        img("gh/acme/web/pull/12/paired-view-after-desktop.webp"),
+        img("gh/acme/web/pull/12/paired-view-before-desktop.webp"),
+      ]);
+      const beforeIdx = body.indexOf("paired-view-before-desktop.webp");
+      const afterIdx = body.indexOf("paired-view-after-desktop.webp");
+      expect(beforeIdx).toBeGreaterThan(-1);
+      expect(beforeIdx).toBeLessThan(afterIdx);
+    });
+
+    it("does not treat 'before'/'after' as a token when not delimiter-bounded", () => {
+      const body = attachmentsCommentBody([
+        img("gh/acme/web/pull/12/beforehand.webp"),
+        img("gh/acme/web/pull/12/aftermath.webp"),
+      ]);
+      expect(body).not.toContain("<table>");
+    });
+
     it("leaves an unpaired attachment (including error/loading state) rendered as today", () => {
       const body = attachmentsCommentBody([
         img("gh/acme/web/pull/12/lonely-before.webp"),

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -228,18 +228,27 @@ function metaCaptionMarkdown(meta: AttachmentItem["meta"]): string {
  * carries no recognizable before/after token. Requires a separator (`-`, `_`,
  * or `.`) between the token and the rest of the name — except when the token
  * IS the whole stem (`before.png`) — so `beforehand.png` doesn't false-match. */
+// Token bounded by `-`, `_`, `.`, or stem start/end, so `hero-before.webp`
+// and `paired-view-before-desktop.webp` match but `beforehand.webp` does
+// not. Mirrors before-after.ts's TOKEN_RE (file page), applied to the stem.
+const STEM_TOKEN_RE = /(^|[-_.])(before|after)($|[-_.])/i;
+
 function filenameStemToken(name: string): { base: string; state: "before" | "after" } | null {
   const dot = name.lastIndexOf(".");
   const stem = dot > 0 ? name.slice(0, dot) : name;
-  const lower = stem.toLowerCase();
-  if (lower === "before" || lower === "after") {
-    return { base: "", state: lower as "before" | "after" };
-  }
-  let m = /^(.+?)[-_.](before|after)$/i.exec(stem);
-  if (m) return { base: m[1].toLowerCase(), state: m[2].toLowerCase() as "before" | "after" };
-  m = /^(before|after)[-_.](.+)$/i.exec(stem);
-  if (m) return { base: m[2].toLowerCase(), state: m[1].toLowerCase() as "before" | "after" };
-  return null;
+  const m = STEM_TOKEN_RE.exec(stem);
+  if (!m) return null;
+  const state = m[2]!.toLowerCase() as "before" | "after";
+  const tokenStart = m.index + m[1]!.length;
+  const tokenEnd = tokenStart + m[2]!.length;
+  // Base = stem with the token and one adjoining delimiter removed, so
+  // `paired-view-before-desktop` and `paired-view-after-desktop` both
+  // collapse to `paired-view-desktop` and group together.
+  const base =
+    m[1]!.length > 0
+      ? stem.slice(0, m.index) + stem.slice(tokenEnd)
+      : stem.slice(tokenEnd + m[3]!.length);
+  return { base: base.toLowerCase(), state };
 }
 
 /**

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -338,18 +338,27 @@ function metaCaptionMarkdown(meta: AttachmentItem["meta"]): string {
  * carries no recognizable before/after token. Requires a separator (`-`, `_`,
  * or `.`) between the token and the rest of the name — except when the token
  * IS the whole stem (`before.png`) — so `beforehand.png` doesn't false-match. */
+// Token bounded by `-`, `_`, `.`, or stem start/end, so `hero-before.webp`
+// and `paired-view-before-desktop.webp` match but `beforehand.webp` does
+// not. Mirrors before-after.ts's TOKEN_RE (file page), applied to the stem.
+const STEM_TOKEN_RE = /(^|[-_.])(before|after)($|[-_.])/i;
+
 function filenameStemToken(name: string): { base: string; state: "before" | "after" } | null {
   const dot = name.lastIndexOf(".");
   const stem = dot > 0 ? name.slice(0, dot) : name;
-  const lower = stem.toLowerCase();
-  if (lower === "before" || lower === "after") {
-    return { base: "", state: lower as "before" | "after" };
-  }
-  let m = /^(.+?)[-_.](before|after)$/i.exec(stem);
-  if (m) return { base: m[1].toLowerCase(), state: m[2].toLowerCase() as "before" | "after" };
-  m = /^(before|after)[-_.](.+)$/i.exec(stem);
-  if (m) return { base: m[2].toLowerCase(), state: m[1].toLowerCase() as "before" | "after" };
-  return null;
+  const m = STEM_TOKEN_RE.exec(stem);
+  if (!m) return null;
+  const state = m[2]!.toLowerCase() as "before" | "after";
+  const tokenStart = m.index + m[1]!.length;
+  const tokenEnd = tokenStart + m[2]!.length;
+  // Base = stem with the token and one adjoining delimiter removed, so
+  // `paired-view-before-desktop` and `paired-view-after-desktop` both
+  // collapse to `paired-view-desktop` and group together.
+  const base =
+    m[1]!.length > 0
+      ? stem.slice(0, m.index) + stem.slice(tokenEnd)
+      : stem.slice(tokenEnd + m[3]!.length);
+  return { base: base.toLowerCase(), state };
 }
 
 /**

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -144,6 +144,25 @@ describe("attachmentsCommentBody (CLI copy)", () => {
       expect(body).not.toContain("<table>");
     });
 
+    it("pairs a delimiter-bounded before/after token in the middle of the stem", () => {
+      const body = attachmentsCommentBody([
+        img("gh/acme/web/pull/12/paired-view-after-desktop.webp"),
+        img("gh/acme/web/pull/12/paired-view-before-desktop.webp"),
+      ]);
+      const beforeIdx = body.indexOf("paired-view-before-desktop.webp");
+      const afterIdx = body.indexOf("paired-view-after-desktop.webp");
+      expect(beforeIdx).toBeGreaterThan(-1);
+      expect(beforeIdx).toBeLessThan(afterIdx);
+    });
+
+    it("does not treat 'before'/'after' as a token when not delimiter-bounded", () => {
+      const body = attachmentsCommentBody([
+        img("gh/acme/web/pull/12/beforehand.webp"),
+        img("gh/acme/web/pull/12/aftermath.webp"),
+      ]);
+      expect(body).not.toContain("<table>");
+    });
+
     it("leaves an unpaired attachment (including error/loading state) rendered as today", () => {
       const body = attachmentsCommentBody([
         img("gh/acme/web/pull/12/lonely-before.webp"),


### PR DESCRIPTION
Fixes #429.

`filenameStemToken` (managed comment) only matched a before/after token at the
start or end of the filename stem, while `swapBeforeAfterToken` (file page,
`apps/api/src/before-after.ts`) already allowed a delimiter-bounded token
anywhere in the stem. This aligns `filenameStemToken` to the same
delimiter-bounded rule (`-`/`_`/`.` or stem start/end), so a real-world case
like `paired-view-before-desktop.webp` / `paired-view-after-desktop.webp` now
pairs in the comment the same way it already pairs on the file page, while
`beforehand.webp` / `aftermath.webp` still never match. The pair base is the
stem with the matched token and one adjoining delimiter removed, lowercased,
so both sides of a pair collapse to the same grouping key.

`filenameStemToken` exists as two byte-identical copies
(`apps/api/src/github-comment-render.ts` and `packages/uploads/src/github.ts`
for the CLI package) — both were updated in lockstep and diffed to confirm
they stayed identical.

## Tests
- Extended the pairing test blocks in both
  `apps/api/src/github-comment-render.test.ts` and
  `packages/uploads/test/github-render-golden.test.ts`: mid-stem pairing
  (`paired-view-before-desktop.webp` / `paired-view-after-desktop.webp`) and a
  non-match check (`beforehand.webp` / `aftermath.webp`) alongside the
  existing prefix/suffix cases.
- Checked `test/fixtures/*.json` for mid-stem-token filenames that would now
  legitimately pair — none found, so no goldens needed regeneration.
- `pnpm test` — 206 files / 2617 tests passed.
- `pnpm run format:check` (oxfmt) — clean.
- `npx changeset status` — resolves to exactly `@buildinternet/uploads`.
