### PR TITLE
fix(api): drop the dead cross-workspace metadata index

### DIFF
--- a/apps/api/migrations/20260722190000_drop_file_metadata_value_lookup_idx.sql
+++ b/apps/api/migrations/20260722190000_drop_file_metadata_value_lookup_idx.sql
@@ -1,0 +1,12 @@
+-- file_metadata_value_lookup_idx (meta_key, meta_value, workspace, object_key)
+-- existed solely to serve the staging reaper's cross-workspace scan
+-- (WHERE meta_key = ? AND meta_value = ? ORDER BY workspace, object_key).
+-- The reaper and its helper (findObjectsByMetadataAcrossWorkspaces) are gone.
+--
+-- Every remaining file_metadata lookup is workspace-scoped and already
+-- served by file_metadata_lookup_idx (workspace, meta_key, meta_value), so
+-- this index has no remaining query to serve. Every upload writes rows into
+-- this table, so dropping the unused index removes write amplification from
+-- the hottest write path in the system.
+
+DROP INDEX IF EXISTS file_metadata_value_lookup_idx;


### PR DESCRIPTION
Follow-up to #432, which retired the staging reaper and its
`findObjectsByMetadataAcrossWorkspaces` helper.

Stacked on #432 (branch `claude/branch-staging-cleanup-design-cc0ef7`) — merge after that one.

## What this changes

Adds a new forward migration dropping `file_metadata_value_lookup_idx`. Does
not touch the existing `20260722180000_file_metadata_value_covering_idx.sql`
migration (already applied in production).

## Investigation

`file_metadata_value_lookup_idx` was created in
`20260721160000_d1_query_indexes.sql` as `(meta_key, meta_value)` explicitly
to serve the staging reaper's cross-workspace scan (`WHERE meta_key = ? AND
meta_value = ?`, no `workspace` predicate). `20260722180000` widened it to
`(meta_key, meta_value, workspace, object_key)` to also cover the reaper's
`ORDER BY workspace, object_key LIMIT N`.

I grepped every raw SQL statement against `file_metadata` in `apps/` and
`packages/` (excluding tests/fixtures). Every remaining query includes a
`workspace = ?` predicate:

- `findObjectsByMetadata` (`apps/api/src/file-metadata.ts:397`) — `WHERE
  workspace = ? AND meta_key = ? AND meta_value = ?`. Called from
  `apps/api/src/before-after.ts`, `apps/api/src/routes/me.ts`,
  `apps/api/src/routes/files.ts`, and `apps/mcp/src/tools.ts` — always with a
  workspace already resolved.
- `getMetadataForKeys`, the single-key metadata read, and all
  inserts/deletes/upserts — all workspace-scoped.

That means every live query is already served by
`file_metadata_lookup_idx (workspace, meta_key, meta_value)` from
`20260713210559_file_metadata.sql`, which this PR does not touch.
`file_metadata_value_lookup_idx` has no remaining query to serve, so it's
fully dead — this migration drops it.

## Why

Every upload writes `file_metadata` rows, so an index with no query behind
it is pure write amplification on the hottest write path in the system.

## Testing

- `pnpm test` — 206 test files, 2606 tests, all passing
- `pnpm typecheck` — clean across all packages (api, web, mcp, auth), no
  `error TS`

## Not done

- Did not edit the existing `20260722180000` migration — it's already
  applied in production, so this is a new forward migration per the repo
  convention.
- No changeset — `@uploads/api` is in the changeset `ignore` list.