### PR TITLE
feat(web): declare integration surfaces for integrations.sh

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -27,8 +27,10 @@ public/sitemap.xml                   Public URL list (landing only)
 public/llms.txt                      Agent-oriented product summary
 public/auth.md                       Agent enrollment / bearer auth + hosted-MCP OAuth
 public/.well-known/api-catalog       RFC 9727 linkset
-public/.well-known/openapi.json      Summary OpenAPI for the REST API
+public/.well-known/integrations.json integrations.sh v3 surface declaration
+public/.well-known/openapi.json      Summary OpenAPI for the REST API (canonical copy)
 public/.well-known/mcp/              MCP server card (points at agents.uploads.sh)
+src/pages/openapi.json.ts            Re-serves the canonical spec at /openapi.json
 src/worker.ts                        Live agent-skills index implementation
 src/entry.ts                         Worker entry (Astro handler + markdown negotiation)
 src/markdown-negotiation.ts          Accept: text/markdown → HTML→Markdown for agents
@@ -67,11 +69,29 @@ rules there.
 | robots.txt      | `/robots.txt`                                                        |
 | sitemap         | `/sitemap.xml` (referenced from robots)                              |
 | Link headers    | homepage `/` via `_headers`                                          |
+| Integrations    | `/.well-known/integrations.json` (integrations.sh v3 declaration)    |
 | API catalog     | `/.well-known/api-catalog`                                           |
+| OpenAPI         | `/.well-known/openapi.json` (canonical) and `/openapi.json` (probe)  |
 | MCP server card | `/.well-known/mcp/server-card.json`                                  |
 | Agent skills    | `/.well-known/agent-skills/index.json`                               |
 | Auth for agents | `/auth.md` (bearer / invite; also documents the hosted-MCP OAuth AS) |
 | oEmbed          | `/oembed?url=…` for public `/f/…` and `/g/…` pages (JSON only)       |
+
+### Integration surfaces (`/.well-known/integrations.json`)
+
+One self-contained v3 document declaring every way an agent can integrate: the
+REST API (`api.uploads.sh`), the hosted MCP server (`agents.uploads.sh/mcp`,
+streamable-http only), and the CLI (`@buildinternet/uploads`). Credentials are
+defined once in the top-level `credentials` map and referenced by id from each
+surface's `auth`; the hosted MCP lists two entries because a workspace bearer
+token **or** an OAuth 2.1 token both work.
+
+Read by [integrations.sh](https://integrations.sh/uploads.sh/), which silently
+ignores the file if it fails to parse or match the schema — so
+`src/integrations-manifest.test.ts` asserts the shape (v3, credential ids
+resolve, every `basis.source` is this origin's canonical URL). Only declare
+surfaces that exist: no GraphQL, no agent card, and `storage.uploads.sh` is
+raw hosted bytes rather than an API.
 
 ### Agent skills — always track GitHub `main`
 

--- a/apps/web/public/.well-known/integrations.json
+++ b/apps/web/public/.well-known/integrations.json
@@ -1,0 +1,146 @@
+{
+  "version": 3,
+  "summary": "File hosting for agents and humans — upload a file, get a public URL, embed it in GitHub pull requests and issues. Workspace-scoped REST API, hosted MCP server, and a CLI. Open source for self-hosting.",
+  "credentials": {
+    "workspace-token": {
+      "type": "bearer",
+      "label": "uploads.sh workspace token",
+      "generateUrl": "https://uploads.sh/account/developers",
+      "setup": "Sign in at https://uploads.sh/login (GitHub or email magic link). You need access to a workspace: create one at https://uploads.sh/account/workspaces/new (requires a linked GitHub account) or accept an invitation from a workspace admin. Then:\n\n```bash\nnpm install -g @buildinternet/uploads\nuploads login\n```\n\n`uploads login` runs a browser device-authorization flow and saves `UPLOADS_TOKEN` (with `UPLOADS_API_URL` and `UPLOADS_WORKSPACE`) to the shared config file; the raw token is never printed. Pass `--workspace <name>` if the account can reach more than one. Tokens look like `up_<workspace>_…`, are scoped to a single workspace, carry `files:read` and `files:write` by default (`files:delete` must be granted by an admin), and expire after 90 days. Full details: https://uploads.sh/auth.md",
+      "fields": {
+        "UPLOADS_TOKEN": {
+          "secret": true,
+          "description": "Workspace bearer token (up_<workspace>_…). Sent as `Authorization: Bearer <token>`; also read from the environment by the CLI."
+        }
+      }
+    },
+    "mcp-oauth": {
+      "type": "oauth2",
+      "label": "uploads.sh OAuth 2.1 (hosted MCP only)",
+      "setup": "Applies only to https://agents.uploads.sh/mcp — the REST API does not accept OAuth tokens in v1. The authorization server is https://auth.uploads.sh (issuer https://auth.uploads.sh/api/auth). It supports PKCE and dynamic client registration (RFC 7591), so an MCP client can register itself with no manual setup, and it is discoverable from the MCP endpoint via RFC 9728:\n\n```bash\ncurl -s https://agents.uploads.sh/.well-known/oauth-protected-resource\ncurl -s https://auth.uploads.sh/.well-known/oauth-authorization-server\n```\n\nA human signs in and grants scopes (`files:read`, `files:write`, `files:delete`) at https://uploads.sh/oauth/consent. Each grant is scoped to exactly one workspace, carried in the token's `workspace` claim; a token minted without one is refused with a `workspace_required` error. There is no OIDC surface. Full details: https://uploads.sh/auth.md"
+    }
+  },
+  "surfaces": [
+    {
+      "type": "http",
+      "slug": "uploads-api",
+      "name": "uploads.sh REST API",
+      "url": "https://api.uploads.sh",
+      "spec": "https://uploads.sh/openapi.json",
+      "docs": "https://github.com/buildinternet/uploads/blob/main/docs/api.md",
+      "basis": {
+        "via": "declared",
+        "source": "https://uploads.sh/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "workspace-token",
+                "mechanics": {
+                  "source": "http",
+                  "in": "header",
+                  "headerName": "Authorization",
+                  "scheme": "Bearer"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://uploads.sh/.well-known/integrations.json"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "mcp",
+      "slug": "uploads-mcp",
+      "name": "uploads.sh hosted MCP server",
+      "url": "https://agents.uploads.sh/mcp",
+      "transports": ["streamable-http"],
+      "docs": "https://uploads.sh/docs/agents",
+      "basis": {
+        "via": "declared",
+        "source": "https://uploads.sh/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "workspace-token",
+                "mechanics": {
+                  "source": "http",
+                  "in": "header",
+                  "headerName": "Authorization",
+                  "scheme": "Bearer"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://uploads.sh/.well-known/integrations.json"
+            }
+          },
+          {
+            "use": [
+              {
+                "id": "mcp-oauth",
+                "mechanics": {
+                  "source": "well-known"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://uploads.sh/.well-known/integrations.json"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "cli",
+      "slug": "uploads-cli",
+      "name": "uploads CLI",
+      "command": "uploads",
+      "packages": [
+        {
+          "registryType": "npm",
+          "identifier": "@buildinternet/uploads",
+          "runtimeHint": "npx"
+        }
+      ],
+      "docs": "https://uploads.sh/docs",
+      "basis": {
+        "via": "declared",
+        "source": "https://uploads.sh/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "workspace-token",
+                "mechanics": {
+                  "source": "cli",
+                  "command": "uploads login",
+                  "env": ["UPLOADS_TOKEN"]
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://uploads.sh/.well-known/integrations.json"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,6 +1,7 @@
 # Homepage — RFC 8288 Link discovery for agents
 /
   Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"
+  Link: </.well-known/integrations.json>; rel="alternate"; type="application/json"
   Link: </.well-known/openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"
   Link: <https://github.com/buildinternet/uploads/blob/main/docs/api.md>; rel="service-doc"; type="text/markdown"
   Link: </llms.txt>; rel="describedby"; type="text/plain"
@@ -67,6 +68,20 @@
 
 /.well-known/openapi.json
   Content-Type: application/vnd.oai.openapi+json;version=3.1
+  Cache-Control: public, max-age=300
+  Access-Control-Allow-Origin: *
+
+# Conventional probe path for the same document (src/pages/openapi.json.ts).
+# Plain application/json here — crawlers that probe this path match on the
+# extension, not the OpenAPI media type.
+/openapi.json
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=300
+  Access-Control-Allow-Origin: *
+
+# integrations.sh surface declaration (v3) — credentials + surfaces inline.
+/.well-known/integrations.json
+  Content-Type: application/json; charset=utf-8
   Cache-Control: public, max-age=300
   Access-Control-Allow-Origin: *
 

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -61,17 +61,18 @@ inferred from the `up_<workspace>_…` token form).
 
 ## Discovery documents
 
-| Resource               | URL                                                            |
-| ---------------------- | -------------------------------------------------------------- |
-| This file              | https://uploads.sh/auth.md                                     |
-| Agent summary          | https://uploads.sh/llms.txt                                    |
-| API catalog (RFC 9727) | https://uploads.sh/.well-known/api-catalog                     |
-| OpenAPI (summary)      | https://uploads.sh/.well-known/openapi.json                    |
-| MCP server card        | https://uploads.sh/.well-known/mcp/server-card.json            |
-| Agent skills index     | https://uploads.sh/.well-known/agent-skills/index.json         |
-| Narrative API docs     | https://github.com/buildinternet/uploads/blob/main/docs/api.md |
-| API health             | https://api.uploads.sh/health                                  |
-| MCP health             | https://agents.uploads.sh/health                               |
+| Resource               | URL                                                              |
+| ---------------------- | ---------------------------------------------------------------- |
+| This file              | https://uploads.sh/auth.md                                       |
+| Agent summary          | https://uploads.sh/llms.txt                                      |
+| Integration surfaces   | https://uploads.sh/.well-known/integrations.json                 |
+| API catalog (RFC 9727) | https://uploads.sh/.well-known/api-catalog                       |
+| OpenAPI (summary)      | https://uploads.sh/.well-known/openapi.json (also /openapi.json) |
+| MCP server card        | https://uploads.sh/.well-known/mcp/server-card.json              |
+| Agent skills index     | https://uploads.sh/.well-known/agent-skills/index.json           |
+| Narrative API docs     | https://github.com/buildinternet/uploads/blob/main/docs/api.md   |
+| API health             | https://api.uploads.sh/health                                    |
+| MCP health             | https://agents.uploads.sh/health                                 |
 
 ## OAuth for the hosted MCP
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -51,7 +51,9 @@ Claude Code plugin (bundles the skills, the hosted MCP server, and the /uploads:
 
 ## Machine-readable discovery
 
+- Integration surfaces (API, MCP, CLI + how each authenticates): https://uploads.sh/.well-known/integrations.json
 - API catalog: https://uploads.sh/.well-known/api-catalog
+- OpenAPI (summary): https://uploads.sh/openapi.json
 - MCP server card: https://uploads.sh/.well-known/mcp/server-card.json
 - Agent skills index: https://uploads.sh/.well-known/agent-skills/index.json
 - robots / sitemap: https://uploads.sh/robots.txt · https://uploads.sh/sitemap.xml

--- a/apps/web/src/integrations-manifest.test.ts
+++ b/apps/web/src/integrations-manifest.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Shape coverage for `public/.well-known/integrations.json`.
+ *
+ * integrations.sh silently ignores a declaration that fails to parse or match
+ * the v3 shape — there is no error surface to notice. A typo would just make
+ * uploads.sh look like it has no integration surfaces at all, so the invariants
+ * that would fail silently in production are asserted here instead:
+ *
+ *   - it is strict JSON at version 3;
+ *   - every credential referenced by a surface's auth exists in `credentials`;
+ *   - every `basis.source` points at this document's own canonical URL;
+ *   - declared surfaces stay in sync with what the repo actually ships
+ *     (no GraphQL, MCP is streamable-http only — see apps/mcp/src/index.ts).
+ *
+ * The `/openapi.json` case guards the other half of the discovery change:
+ * src/pages/openapi.json.ts re-serves the canonical `.well-known` spec, so the
+ * two paths must never diverge.
+ */
+import { describe, expect, it } from "vitest";
+import manifest from "../public/.well-known/integrations.json";
+import canonicalSpec from "../public/.well-known/openapi.json";
+import { GET } from "./pages/openapi.json";
+
+const CANONICAL_SOURCE = "https://uploads.sh/.well-known/integrations.json";
+
+type Basis = { via: string; source: string };
+type Mechanics = Record<string, unknown> & { source: string };
+type AuthEntry = { use: { id: string; mechanics: Mechanics }[]; basis: Basis };
+type Surface = {
+  type: string;
+  slug: string;
+  name: string;
+  docs?: string;
+  basis: Basis;
+  auth: { status: string; entries?: AuthEntry[]; basis?: Basis };
+  [key: string]: unknown;
+};
+
+const surfaces = manifest.surfaces as unknown as Surface[];
+const credentials = manifest.credentials as unknown as Record<
+  string,
+  { type: string; setup: string }
+>;
+
+/** Every `basis` object anywhere in the document, surface- and auth-level alike. */
+function allBases(): Basis[] {
+  const found: Basis[] = [];
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (node === null || typeof node !== "object") return;
+    const record = node as Record<string, unknown>;
+    if (typeof record.via === "string" && typeof record.source === "string") {
+      found.push(record as unknown as Basis);
+    }
+    Object.values(record).forEach(walk);
+  };
+  walk(manifest);
+  return found;
+}
+
+describe("integrations.json (v3)", () => {
+  it("declares version 3 with a summary", () => {
+    expect(manifest.version).toBe(3);
+    expect(manifest.summary).toBeTruthy();
+  });
+
+  it("references only credentials defined in the top-level map", () => {
+    const declared = Object.keys(credentials);
+    expect(declared.length).toBeGreaterThan(0);
+    const referenced = surfaces.flatMap((surface) =>
+      (surface.auth.entries ?? []).flatMap((entry) => entry.use.map((use) => use.id)),
+    );
+    expect(referenced.length).toBeGreaterThan(0);
+    for (const id of referenced) {
+      expect(declared).toContain(id);
+    }
+    // No orphans either — an unreferenced credential is dead weight agents act on.
+    for (const id of declared) {
+      expect(referenced).toContain(id);
+    }
+  });
+
+  it("gives every credential a label and setup instructions", () => {
+    for (const [id, credential] of Object.entries(credentials)) {
+      expect(credential.type, id).toBeTruthy();
+      expect(credential.setup, id).toBeTruthy();
+    }
+  });
+
+  it("points every basis at this document's canonical URL", () => {
+    const bases = allBases();
+    // 3 surfaces + 4 auth entries.
+    expect(bases).toHaveLength(7);
+    for (const basis of bases) {
+      expect(basis.via).toBe("declared");
+      expect(basis.source).toBe(CANONICAL_SOURCE);
+    }
+  });
+
+  it("declares each auth entry with concrete mechanics", () => {
+    for (const surface of surfaces) {
+      expect(surface.auth.status, surface.slug).toBe("required");
+      for (const entry of surface.auth.entries ?? []) {
+        expect(entry.use.length, surface.slug).toBeGreaterThan(0);
+        for (const use of entry.use) {
+          expect(use.mechanics.source, surface.slug).not.toBe("unknown");
+        }
+      }
+    }
+  });
+
+  it("declares the three surfaces this repo actually ships", () => {
+    expect(surfaces.map((s) => `${s.type}:${s.slug}`)).toEqual([
+      "http:uploads-api",
+      "mcp:uploads-mcp",
+      "cli:uploads-cli",
+    ]);
+  });
+
+  it("advertises the API base URL and spec the OpenAPI document agrees with", () => {
+    const api = surfaces.find((s) => s.type === "http")!;
+    expect(api.url).toBe(canonicalSpec.servers[0].url);
+    expect(api.spec).toBe("https://uploads.sh/openapi.json");
+  });
+
+  it("advertises the hosted MCP endpoint as streamable-http only", () => {
+    const mcp = surfaces.find((s) => s.type === "mcp")!;
+    expect(mcp.url).toBe("https://agents.uploads.sh/mcp");
+    // apps/mcp is stateless with no SSE stream — see apps/mcp/src/index.ts.
+    expect(mcp.transports).toEqual(["streamable-http"]);
+    // Workspace bearer OR OAuth: two alternatives, not one AND'd pair.
+    expect(mcp.auth.entries).toHaveLength(2);
+  });
+
+  it("advertises the published CLI binary and npm package", () => {
+    const cli = surfaces.find((s) => s.type === "cli")!;
+    expect(cli.command).toBe("uploads");
+    expect(cli.packages).toEqual([
+      { registryType: "npm", identifier: "@buildinternet/uploads", runtimeHint: "npx" },
+    ]);
+  });
+});
+
+describe("/openapi.json", () => {
+  it("serves the canonical .well-known spec verbatim", async () => {
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(await response.json()).toEqual(canonicalSpec);
+  });
+});

--- a/apps/web/src/pages/openapi.json.ts
+++ b/apps/web/src/pages/openapi.json.ts
@@ -1,0 +1,21 @@
+/**
+ * `/openapi.json` — the conventional path agent-facing crawlers probe for an
+ * OpenAPI document (integrations.sh checks it before `/swagger.json`,
+ * `/api/openapi.json`, …). The canonical file stays at
+ * `public/.well-known/openapi.json` (referenced from the RFC 9727 api-catalog,
+ * llms.txt, and auth.md); this route re-serves those same bytes so both paths
+ * resolve without a second copy drifting out of date.
+ *
+ * Prerendered: Astro emits `dist/openapi.json` at build time, so it is served
+ * off the ASSETS binding like the rest of the discovery documents. Response
+ * headers come from `public/_headers`.
+ */
+import type { APIRoute } from "astro";
+import spec from "../../public/.well-known/openapi.json";
+
+export const prerender = true;
+
+export const GET: APIRoute = () =>
+  new Response(`${JSON.stringify(spec, null, 2)}\n`, {
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });


### PR DESCRIPTION
Makes uploads.sh discoverable on [integrations.sh](https://integrations.sh/uploads.sh/) by publishing the surface declaration it reads, plus the one open-standard path we were still missing.

## What's new

**`/.well-known/integrations.json`** — a v3 declaration with everything inline: a shared `credentials` map plus a `surfaces` list covering every way an agent can integrate.

| Surface | Endpoint | Auth |
| --- | --- | --- |
| `http:uploads-api` | `https://api.uploads.sh` | `Authorization: Bearer up_<workspace>_…` |
| `mcp:uploads-mcp` | `https://agents.uploads.sh/mcp` (streamable-http) | workspace bearer **or** OAuth 2.1 |
| `cli:uploads-cli` | `uploads` / `@buildinternet/uploads` | `uploads login` → `UPLOADS_TOKEN` |

The MCP surface carries two auth entries because either credential genuinely works. The OAuth one uses `{"source": "well-known"}`, which resolves for real — `agents.uploads.sh` already serves RFC 9728 metadata with `authorization_servers`.

**`/openapi.json`** — the conventional path agent crawlers probe, which returned 404 until now. The canonical document stays at `/.well-known/openapi.json` (referenced from the api-catalog, llms.txt, and auth.md); a prerendered Astro route re-serves those same bytes, so a second copy can't drift.

## Already published, unchanged

The RFC 9727 api-catalog, MCP server card, `llms.txt`, agent-skills index, and RFC 9728 `oauth-protected-resource` on both `api.` and `agents.` were already live. Five of the seven standards needed nothing.

## Deliberately not published

- **agent-card.json** — no agent-facing identity surface exists.
- **GraphQL** — none in the repo.
- **`storage.uploads.sh`** — raw hosted bytes, not an API with operations.
- **stdio MCP** (`uploads mcp`) — ships inside the CLI package, and the v3 `mcp` shape only expresses `url` + streamable-http/sse.

## Tests

integrations.sh **silently ignores** a declaration that fails to parse or match the schema — a typo would just make uploads.sh look like it has no integration surfaces, with no error anywhere. `apps/web/src/integrations-manifest.test.ts` asserts the invariants that would otherwise fail unnoticed: version 3, credential ids resolve in both directions (no dangling references, no orphans), every `basis.source` is the canonical URL, no `unknown` mechanics, declared surfaces match what the repo ships, and `/openapi.json` is byte-identical to the canonical spec.

Verified locally against the built Workers asset server — all six discovery paths return 200 with the right content types, and the homepage `Link` header advertises the new document.

No changeset: `@uploads/web` is on the changesets ignore list.

## After merge

```bash
curl -sS -D- -o/dev/null https://uploads.sh/.well-known/integrations.json
curl -sS https://uploads.sh/.well-known/integrations.json | jq .
curl -sS -D- -o/dev/null https://uploads.sh/openapi.json
```

Then open https://integrations.sh/uploads.sh/ and click "Map integration surface" to publish the listing.

## Follow-up spotted, not fixed here

`apps/web/public/auth.md` still says "There is no self-serve signup," but `POST /v1/workspaces` does self-serve creation for GitHub-linked accounts. The `setup` text in this PR covers both paths; correcting auth.md is a separate change.
