### PR TITLE
docs(web): correct stale "no self-serve signup" claim

### DIFF
--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -36,10 +36,15 @@ Details: [enrollment docs](https://github.com/buildinternet/uploads/blob/main/do
 
 ## Getting workspace access
 
-An uploads.sh administrator invites your email address to the workspace's
-organization from the session-authenticated `/admin` UI. Accept the
-invitation (GitHub or magic-link sign-in), then run `uploads login` as above.
-There is no self-serve signup.
+Two paths, then `uploads login` as above:
+
+- **Create your own.** Sign in (GitHub or magic link) at
+  <https://uploads.sh/account/workspaces/new> and create a workspace. This
+  requires a linked GitHub account and is capped at three self-serve
+  workspaces per account.
+- **Be invited.** An uploads.sh administrator invites your email address to an
+  existing workspace's organization from the session-authenticated `/admin`
+  UI. Accept the invitation (GitHub or magic-link sign-in).
 
 ## Using the credential
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -2,7 +2,7 @@
 
 > File hosting for agents and humans — hosted CLI, agent skill, and MCP server. Open source for self-hosting.
 
-Access is by invitation. Hosted files are public (including media attached to private repositories). Do not upload secrets or sensitive UI. APIs may change without notice while the project is in active development.
+Access requires a workspace — create your own with a linked GitHub account, or be invited to an existing one. Hosted files are public (including media attached to private repositories). Do not upload secrets or sensitive UI. APIs may change without notice while the project is in active development.
 
 ## Start here
 

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -71,9 +71,9 @@ it opens (or run: uploads attach --promote once it exists)</pre>
     </div>
     <p>
       <code>uploads login</code> opens a browser so you can approve the sign-in (GitHub or a
-      magic link). Access is by invitation. An uploads.sh administrator invites your email to
-      a workspace first. Once approved, the CLI mints a workspace token and saves it, so you
-      only do this once per machine.
+      magic link). You'll need a workspace first — create your own with a linked GitHub account,
+      or get invited to an existing one by an admin. Once approved, the CLI mints a workspace
+      token and saves it, so you only do this once per machine.
     </p>
     <p>Prefer not to install anything? Every command works as a one-off with <code>npx</code>:</p>
     <div class="cmd">

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -62,8 +62,9 @@ const REPO = "https://github.com/buildinternet/uploads";
         <code>GET /oembed?url=&lt;page-url&gt;&amp;format=json</code>.
       </li>
       <li>
-        <strong>Access is by invitation.</strong> There's no self-serve signup right now. If
-        you'd like in, reach out via <a href={REPO}>the GitHub repo</a>.
+        <strong>Getting access.</strong> Sign in and create your own workspace with a linked
+        GitHub account, or get invited to an existing one by a workspace admin. Questions? Reach
+        out via <a href={REPO}>the GitHub repo</a>.
       </li>
       <li>
         <strong>Everything lands in your workspace.</strong> Files are stored under a prefix


### PR DESCRIPTION
Self-serve workspace creation shipped a while ago — `POST /v1/workspaces` (`apps/api/src/routes/workspaces.ts`), GitHub-gated, capped at three workspaces per account — but several agent- and human-facing surfaces still told readers access was invitation-only. Spotted while publishing the integrations.sh discovery files (#434).

Corrects all of them to describe both paths (create your own with a linked GitHub account, or be invited to an existing workspace):

| File | Was | Now |
| --- | --- | --- |
| `public/auth.md` | "There is no self-serve signup." | Two paths: create at `/account/workspaces/new`, or be invited |
| `public/llms.txt` | "Access is by invitation." | "Access requires a workspace — create your own … or be invited" |
| `docs/reference.astro` | "There's no self-serve signup right now." | "Getting access." — both paths |
| `docs.astro` | "Access is by invitation. An admin invites your email first." | Create your own or get invited |

`terms.astro` is intentionally left as-is: its invitation-link / single-use-code language describes a path that still exists, and it's legal copy.

## Verification

- Web build prerenders both docs pages; confirmed the built `dist/` HTML carries the new copy and no "no self-serve" / "access is by invitation" string survives anywhere in the output.
- Screenshotted `/docs/reference` in preview — the "Getting access" bullet reads correctly.

Prose-only edits inside existing elements; no layout or component changes.
