### PR TITLE
feat(api,cli,mcp): empty-state managed comment + hosted comment tool

### DIFF
--- a/.changeset/empty-state-managed-comment.md
+++ b/.changeset/empty-state-managed-comment.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+The managed attachments comment now shows a neutral empty state when every attachment and gallery is removed from a PR/issue. Deleting the last asset and re-running `uploads comment` (or a `put --comment`) rewrites the existing comment in place to "No attachments are currently associated with this pull request." — it is never deleted (a later upload repopulates it) and is never created just to say it is empty. `uploads comment` reports this as a "cleared" message rather than "updated (0 files)".

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -16,10 +16,17 @@ const golden = loadFixture("github-comment-golden.json");
 const goldenCap = loadFixture("github-comment-golden-cap.json");
 const goldenMeta = loadFixture("github-comment-golden-meta.json");
 const goldenVideo = loadFixture("github-comment-golden-video.json");
+const goldenEmpty = loadFixture("github-comment-golden-empty.json");
 
 describe("attachmentsCommentBody (api copy)", () => {
   it("renders the golden body byte-for-byte", () => {
     expect(attachmentsCommentBody(golden.items, golden.galleries)).toBe(golden.expected);
+  });
+
+  it("renders a neutral empty state when there are no items or galleries", () => {
+    expect(attachmentsCommentBody(goldenEmpty.items, goldenEmpty.galleries)).toBe(
+      goldenEmpty.expected,
+    );
   });
 
   it("renders a video with a poster as a linked image with a play caption", () => {

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -462,6 +462,14 @@ export function attachmentsCommentBody(
     }
     lines.push("", "</details>", "");
   }
+  // Emptied state: a PR/issue whose attachments and galleries were all removed
+  // still keeps its managed comment (a later push can repopulate it) — show a
+  // neutral resting state under the heading rather than a bare heading. Only
+  // the truly-empty case (no attachments, no galleries); a galleries-only
+  // comment has no Attachments heading and must not get this line.
+  if (sorted.length === 0 && sortedGalleries.length === 0) {
+    lines.push("_No attachments are currently associated with this pull request._", "");
+  }
   lines.push(
     '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',
   );

--- a/apps/api/src/github-comment-service.test.ts
+++ b/apps/api/src/github-comment-service.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { postManagedComment } from "./github-comment-service";
+import { attachmentsMarker } from "./github-comment-render";
+import { recordRepoLink } from "./github-repo-links";
+import type { WorkspaceRecord } from "./workspace";
+import { FakeR2Bucket } from "../test/fake-r2";
+import { FakeKv } from "../test/fake-kv";
+import { SqliteD1, database } from "../test/helpers/sqlite-d1";
+
+const MIGRATION = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260720120000_github_repo_links.sql",
+];
+const PRAGMAS = ["PRAGMA foreign_keys = ON"];
+
+/**
+ * A workspace already bound to the repo (via `recordRepoLink`), an installed
+ * App (cached in KV), and a cached installation token — mirrors the route
+ * test's fixture (github-comment-route.test.ts) but exercises
+ * `postManagedComment` directly, without going through HTTP/workspaceAuth.
+ * Pre-binding the repo takes the "already bound to this workspace" branch of
+ * `checkRepoAuthorization`, so these tests aren't about the claim-entitlement
+ * gate — just the empty-state gather/upsert wiring.
+ */
+async function makeTestEnv() {
+  const sqlite = new SqliteD1(MIGRATION, PRAGMAS);
+  const bucket = new FakeR2Bucket();
+  const kv = new FakeKv();
+  kv.store.set("ghinst:acme/web", { value: "42" });
+  kv.store.set("ghtok:42", { value: "cached-token" });
+  const ws: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "shared",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+  };
+  const env = {
+    DB: database(sqlite),
+    WEB_ORIGIN: "https://uploads.test",
+    UPLOADS_DEFAULT: bucket,
+    GITHUB_CACHE: kv,
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "unused",
+    GITHUB_APP_HOME_INSTALLATION_ID: "9",
+  } as unknown as Env;
+  await recordRepoLink(env.DB, "acme/web", "acme", "comment", 42);
+  return { env, ws, workspaceName: "acme", bucket };
+}
+
+function withFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
+  const real = globalThis.fetch;
+  globalThis.fetch = impl;
+  return fn().finally(() => {
+    globalThis.fetch = real;
+  });
+}
+
+describe("postManagedComment empty-state (issue #392 stretch)", () => {
+  it("empties an existing comment (updated, count 0) when all media is removed", async () => {
+    const { env, ws, workspaceName } = await makeTestEnv();
+    // No objects in the bucket and no galleries — gathered.count will be 0 —
+    // but a marker comment already exists on the thread.
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes("/issues/12/comments")) {
+        if (init.method === "POST") throw new Error("must not create");
+        return new Response(
+          JSON.stringify([{ id: 99, body: `${attachmentsMarker("acme")}\nold` }]),
+          { status: 200 },
+        );
+      }
+      if (String(url).includes("/issues/comments/99")) {
+        return new Response(
+          JSON.stringify({ id: 99, html_url: "https://github.com/acme/web/pull/12#c99" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const r = await withFetch(fetchImpl, () =>
+      postManagedComment(env, ws, workspaceName, "user_1", {
+        repo: "acme/web",
+        num: 12,
+        kind: "pull",
+      }),
+    );
+    expect(r).toMatchObject({ posted: true, action: "updated", count: 0 });
+  });
+
+  it("no-ops (skipped) when empty and no comment exists", async () => {
+    const { env, ws, workspaceName } = await makeTestEnv();
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (String(url).includes("/issues/13/comments")) {
+        if (init.method === "POST") throw new Error("must not create");
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const r = await withFetch(fetchImpl, () =>
+      postManagedComment(env, ws, workspaceName, "user_1", {
+        repo: "acme/web",
+        num: 13,
+        kind: "pull",
+      }),
+    );
+    expect(r).toMatchObject({ posted: true, action: "skipped", count: 0 });
+  });
+});

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -108,8 +108,11 @@ export type PostCommentResult =
 /**
  * Gather + upsert the managed comment for `target` on behalf of
  * `workspaceName`. Same ordering as the REST route: app-config, then
- * installation lookup, then the cross-tenant gate, then gather (skip-on-zero),
- * then upsert. On an actual post, best-effort records `target.repo` as bound
+ * installation lookup, then the cross-tenant gate, then gather, then upsert.
+ * Gather always renders a body (the neutral empty state when nothing is
+ * staged); the create-vs-patch decision is the upsert's `createIfMissing`
+ * gate (`count > 0`), so an emptied PR rewrites an existing comment but never
+ * creates one. On an actual post, best-effort records `target.repo` as bound
  * to `workspaceName` (first-claim-wins, never affects the return value).
  */
 export async function postManagedComment(

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -134,9 +134,22 @@ export async function postManagedComment(
   if (decline) return decline;
 
   const gathered = await gatherCommentBody(env, ws, workspaceName, target);
-  if (gathered.skip) return { posted: true, action: "skipped", count: 0 };
 
-  const result = await upsertBotComment(env, cfg, installId, target, gathered.body, workspaceName);
+  // Patch-only when empty: never create a comment just to say "empty" (see
+  // upsertBotComment's createIfMissing). `gathered.body` already renders the
+  // neutral empty state when count is 0.
+  const result = await upsertBotComment(
+    env,
+    cfg,
+    installId,
+    target,
+    gathered.body,
+    workspaceName,
+    fetch,
+    {
+      createIfMissing: gathered.count > 0,
+    },
+  );
   if ("degrade" in result) {
     // A 403 means the App is installed but lacks Issues/PR write (pending org
     // approval). Enrich that one reason with actionable guidance so callers
@@ -146,6 +159,8 @@ export async function postManagedComment(
     if (result.degrade === "forbidden") return forbiddenDecline(target.repo, installId);
     return { posted: false, reason: result.degrade };
   }
+  // Empty + no existing comment: nothing posted, nothing to claim.
+  if (result.action === "skipped") return { posted: true, action: "skipped", count: 0 };
 
   // Implicit claim (phase 3): the comment actually posted, so this
   // workspace has proven authenticated write access to this repo's

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -67,14 +67,15 @@ function fakeFetch(routes: Record<string, (init: RequestInit) => Response>): typ
 }
 
 describe("gatherCommentBody", () => {
-  it("returns skip when the workspace has no attachments and no galleries", async () => {
+  it("returns the empty-state body (no skip) when nothing is staged", async () => {
     const { env, ws, workspaceName } = makeTestEnv();
     const result = await gatherCommentBody(env, ws, workspaceName, {
       repo: "acme/web",
       num: 12,
       kind: "pull",
     });
-    expect(result).toEqual({ skip: true });
+    expect(result.count).toBe(0);
+    expect(result.body).toContain("_No attachments are currently associated");
   });
 
   it("renders the workspace's own attachments under the gh prefix", async () => {
@@ -87,8 +88,6 @@ describe("gatherCommentBody", () => {
       num: 12,
       kind: "pull",
     });
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     expect(result.body.startsWith(attachmentsMarker(workspaceName))).toBe(true);
     expect(result.body).toContain("hero.png");
     expect(result.count).toBe(1);
@@ -104,8 +103,6 @@ describe("gatherCommentBody", () => {
       num: 12,
       kind: "pull",
     });
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     expect(result.body).toContain(`/f/${workspaceName}/`);
   });
 
@@ -120,8 +117,6 @@ describe("gatherCommentBody", () => {
       workspaceName,
       { repo: "acme/web", num: 12, kind: "pull" },
     );
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     expect(result.body).toContain(`/f/${workspaceName}/`);
   });
 
@@ -136,8 +131,6 @@ describe("gatherCommentBody", () => {
       workspaceName,
       { repo: "acme/web", num: 12, kind: "pull" },
     );
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     expect(result.body).not.toContain(`/f/${workspaceName}/`);
     // Falls back to the raw storage url.
     expect(result.body).toContain("storage.uploads.sh");
@@ -186,8 +179,6 @@ describe("gatherCommentBody", () => {
       num: 12,
       kind: "pull",
     });
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     expect(result.body.startsWith(attachmentsMarker(workspaceName))).toBe(true);
     expect(result.body).toContain("Launch media");
     expect(result.body).not.toContain("Not ours");
@@ -211,8 +202,7 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
       kind: "pull",
     });
 
-    expect(result.skip).toBe(false);
-    expect((result as { body: string }).body).toContain("<sub>/settings · before</sub>");
+    expect(result.body).toContain("<sub>/settings · before</sub>");
   });
 
   it("never fetches or renders EXIF-derived keys", async () => {
@@ -229,7 +219,7 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
       kind: "pull",
     });
 
-    const body = (result as { body: string }).body;
+    const body = result.body;
     expect(body).toContain("<sub>/settings</sub>");
     expect(body).not.toContain("iPhone");
     expect(body).not.toContain("Photoshop");
@@ -245,7 +235,7 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
       kind: "pull",
     });
 
-    expect((result as { body: string }).body).not.toContain("<sub>/");
+    expect(result.body).not.toContain("<sub>/");
   });
 
   it("skips the D1 read entirely when githubCommentShowMetadata is false", async () => {
@@ -271,7 +261,7 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
     );
 
     expect(metadataQueries).toBe(0);
-    expect((result as { body: string }).body).not.toContain("<sub>/settings");
+    expect(result.body).not.toContain("<sub>/settings");
   });
 
   it("does not leak another workspace's metadata for the same object key", async () => {
@@ -292,8 +282,7 @@ describe("gatherCommentBody attachment metadata (issue #365)", () => {
       kind: "pull",
     });
 
-    expect(result.skip).toBe(false);
-    const body = (result as { body: string }).body;
+    const body = result.body;
     expect(body).toContain("<sub>/settings · before</sub>");
     expect(body).not.toContain("/intruder-path");
     expect(body).not.toContain("compromised");
@@ -325,8 +314,6 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
       num: 12,
       kind: "pull",
     });
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
 
     const cfg = await storageConfig(env, ws);
     const expectedUrls = objectPublicUrls(env, cfg, posterKeyFor(key));
@@ -348,8 +335,6 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
       num: 12,
       kind: "pull",
     });
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     expect(result.body).not.toContain("_internal/posters");
     expect(result.body).toContain("clip.mp4");
   });
@@ -370,8 +355,6 @@ describe("gatherCommentBody poster hydration (issue #299)", () => {
       num: 12,
       kind: "pull",
     });
-    expect(result.skip).toBe(false);
-    if (result.skip) return;
     // formatDuration(14) === "0:14" (github-comment-render.ts / poster.ts).
     // Task 11's caption format: "▶ Play video · 0:14 · ...". Dimensions feed
     // display width selection rather than appearing verbatim, so duration is
@@ -795,5 +778,62 @@ describe("upsertBotComment", () => {
       commentUrl: "https://github.com/other-ws/web/pull/12#c66",
     });
     expect(await kv.get("ghcomment:other-ws:acme/web#12")).toBe("66");
+  });
+
+  it("patches an existing comment to empty when createIfMissing is false", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": (init) => {
+        if (init.method === "POST") throw new Error("must not create");
+        return new Response(
+          JSON.stringify([{ id: 99, body: `${attachmentsMarker("acme")}\nold body` }]),
+          { status: 200 },
+        );
+      },
+      "/issues/comments/99": () =>
+        new Response(
+          JSON.stringify({ id: 99, html_url: "https://github.com/acme/web/pull/12#c99" }),
+          { status: 200 },
+        ),
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "EMPTY BODY",
+      "acme",
+      fetchImpl,
+      { createIfMissing: false },
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c99",
+    });
+  });
+
+  it("no-ops (skipped) when createIfMissing is false and no comment exists", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = fakeFetch({
+      "/access_tokens": () => new Response(JSON.stringify({ token: "t" }), { status: 201 }),
+      "/issues/12/comments": (init) => {
+        if (init.method === "POST") throw new Error("must not create");
+        return new Response(JSON.stringify([]), { status: 200 });
+      },
+    });
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "EMPTY BODY",
+      "acme",
+      fetchImpl,
+      { createIfMissing: false },
+    );
+    expect(res).toEqual({ action: "skipped" });
   });
 });

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -41,7 +41,7 @@ export async function gatherCommentBody(
   ws: WorkspaceRecord,
   workspaceName: string,
   target: GhTarget,
-): Promise<{ skip: true } | { skip: false; body: string; count: number }> {
+): Promise<{ body: string; count: number }> {
   // Attachments (R2 list) and galleries (D1) are independent reads — overlap
   // them so the request only waits the longer of the two, not their sum.
   const [items, galleries] = await Promise.all([
@@ -50,9 +50,10 @@ export async function gatherCommentBody(
   ]);
 
   const count = items.length + galleries.length;
-  if (count === 0) return { skip: true };
   const marker = attachmentsMarker(workspaceName);
-  return { skip: false, body: attachmentsCommentBody(items, galleries, marker), count };
+  // count may be 0 — attachmentsCommentBody renders a neutral empty state.
+  // Callers gate create-vs-patch on count (see upsertBotComment createIfMissing).
+  return { body: attachmentsCommentBody(items, galleries, marker), count };
 }
 
 /**
@@ -232,9 +233,13 @@ export async function upsertBotComment(
   body: string,
   workspaceName: string,
   fetchImpl: typeof fetch = fetch,
+  opts: { createIfMissing?: boolean } = {},
 ): Promise<
-  { action: "created" | "updated"; commentUrl: string } | { degrade: "forbidden" | "unavailable" }
+  | { action: "created" | "updated"; commentUrl: string }
+  | { action: "skipped" }
+  | { degrade: "forbidden" | "unavailable" }
 > {
+  const createIfMissing = opts.createIfMissing ?? true;
   const token = await installationToken(env, cfg, installationId, fetchImpl);
   if (!token) return { degrade: "unavailable" };
   const base = `https://api.github.com/repos/${target.repo}`;
@@ -278,6 +283,7 @@ export async function upsertBotComment(
   if (found.degrade) return { degrade: found.degrade };
   const existing = found.comment;
 
+  if (!existing && !createIfMissing) return { action: "skipped" };
   const r = existing
     ? await write(`${base}/issues/comments/${existing.id}`, "PATCH")
     : await write(`${base}/issues/${target.num}/comments`, "POST");

--- a/apps/api/src/github-webhook-auto-promote.test.ts
+++ b/apps/api/src/github-webhook-auto-promote.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { handleWebhook } from "./github-webhook";
+import { attachmentsMarker } from "./github-comment-render";
 import { recordRepoLink } from "./github-repo-links";
 import { replaceFileMetadata } from "./file-metadata";
 import { sha256Hex, type WorkspaceRecord } from "./workspace";
@@ -189,14 +190,21 @@ describe("handleWebhook pull_request auto-promotion", () => {
     expect(bucket.store.has(`${PREFIX}${destKey("hero.png")}`)).toBe(true);
   });
 
-  it("does not post a comment when nothing is staged and nothing pre-exists", async () => {
+  it("does not create a comment on a bound PR that never had one", async () => {
     const { env } = await baseEnv();
     await recordRepoLink(env.DB, REPO, WS, "promote");
 
-    let fetchCalled = false;
+    // Empty gather (nothing staged, no galleries) + no existing marker
+    // comment (the list call returns []) — patch-only-when-empty must never
+    // create a comment just to say "empty".
+    const calls: { method: string; url: string }[] = [];
     const realFetch = globalThis.fetch;
-    globalThis.fetch = (async () => {
-      fetchCalled = true;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      const method = init.method ?? "GET";
+      calls.push({ method, url: String(url) });
+      if (String(url).includes(`/issues/${NUM}/comments`) && method === "GET") {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
       return new Response("nf", { status: 404 });
     }) as unknown as typeof fetch;
     try {
@@ -204,7 +212,44 @@ describe("handleWebhook pull_request auto-promotion", () => {
     } finally {
       globalThis.fetch = realFetch;
     }
-    expect(fetchCalled).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("patches the comment to empty when the last attachment is removed on a bound PR", async () => {
+    const { env } = await baseEnv();
+    await recordRepoLink(env.DB, REPO, WS, "promote");
+
+    // Empty gather (nothing staged, no galleries) but a marker comment
+    // already exists on the thread — it must be rewritten to the empty
+    // state, not left stale and not deleted.
+    const calls: { method: string; url: string; body?: string }[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      const method = init.method ?? "GET";
+      const body = typeof init.body === "string" ? init.body : undefined;
+      calls.push({ method, url: String(url), body });
+      if (String(url).includes(`/issues/${NUM}/comments`) && method === "GET") {
+        return new Response(JSON.stringify([{ id: 9, body: `${attachmentsMarker(WS)}\nold` }]), {
+          status: 200,
+        });
+      }
+      if (String(url).includes("/issues/comments/9") && method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 9, html_url: `https://github.com/${REPO}/pull/${NUM}#c9` }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await handleWebhook(env, "pull_request", prPayload());
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    expect(
+      calls.some((c) => c.method === "PATCH" && c.body?.includes("_No attachments") === true),
+    ).toBe(true);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
   });
 
   it("ignores actions outside the promote set (e.g. closed)", async () => {

--- a/apps/api/src/github-webhook.ts
+++ b/apps/api/src/github-webhook.ts
@@ -134,13 +134,15 @@ async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Prom
   }
 
   const gathered = await gatherCommentBody(env, ws, link.workspaceName, target);
-  if (gathered.skip) return; // nothing staged and nothing pre-existing — no empty comment.
 
   const cfg = githubAppConfig(env);
   if (!cfg) return;
   const installId = link.installationId ?? (await installationForRepo(env, cfg, target.repo));
   if (installId === null) return;
 
+  // Patch-only when empty: a fully-cleared PR keeps/updates an existing
+  // comment to the empty state, but we never create one just to say "empty"
+  // (this path fires on every pull_request event for a bound repo).
   const result = await upsertBotComment(
     env,
     cfg,
@@ -148,6 +150,8 @@ async function gatherAndUpsert(env: Env, link: RepoLink, target: GhTarget): Prom
     target,
     gathered.body,
     link.workspaceName,
+    fetch,
+    { createIfMissing: gathered.count > 0 },
   );
   if ("degrade" in result) {
     console.error(

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -329,7 +329,7 @@ describe("POST /v1/:workspace/github/comment implicit repo-link claim", () => {
     }
   });
 
-  it("does not record a link when gathering skips (nothing to post)", async () => {
+  it("does not record a link when there is nothing to post (empty, no existing comment)", async () => {
     const { db, links } = claimTestDb("user-1");
     const hash = await sha256Hex(TOKEN);
     const record: WorkspaceRecord = {
@@ -356,10 +356,16 @@ describe("POST /v1/:workspace/github/comment implicit repo-link claim", () => {
       ...GITHUB_APP_CFG_ENV,
     } as unknown as Env;
     const realFetch = globalThis.fetch;
-    globalThis.fetch = (async (url: string) =>
-      String(url).includes("/collaborators/octocat/permission")
-        ? new Response(JSON.stringify({ permission: "write" }), { status: 200 })
-        : new Response("nf", { status: 404 })) as unknown as typeof fetch;
+    globalThis.fetch = (async (url: string) => {
+      const u = String(url);
+      if (u.includes("/collaborators/octocat/permission"))
+        return new Response(JSON.stringify({ permission: "write" }), { status: 200 });
+      // Empty PR: the create-vs-patch discovery lists the thread's comments and
+      // finds no managed comment (an empty list, not a 404) — so nothing is
+      // created and the result is `skipped`.
+      if (u.includes("/issues/12/comments")) return new Response("[]", { status: 200 });
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
     try {
       const res = await post(env, { repo: "acme/web", num: 12, kind: "pull" });
       expect(res.status).toBe(200);

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -800,6 +800,39 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       },
     },
     {
+      name: "comment",
+      description:
+        "Create or update the managed attachments comment on a GitHub PR or issue, listing everything this workspace has uploaded for it. Refreshes the comment WITHOUT re-uploading — use after deleting media to re-sync (e.g. it will show a neutral empty state once the last attachment is removed). Posts as uploads-sh[bot] via the uploads.sh GitHub App — bot-only on this hosted server, no local gh fallback; if the App isn't installed/authorized the decline is returned honestly. Requires repo (owner/name — no git context on this server) and exactly one of pr/issue.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          repo: {
+            type: "string",
+            description:
+              "owner/name repo segment. REQUIRED (owner/name) — there is no git context on this server to infer it from.",
+          },
+          pr: {
+            type: "number",
+            description: "Pull request number. Mutually exclusive with issue.",
+          },
+          issue: { type: "number", description: "Issue number. Mutually exclusive with pr." },
+        },
+        required: ["repo"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        // Reading the workspace's own objects/metadata/galleries to render the
+        // body is a files:read operation (mirrors the REST route + put
+        // --comment); no workspace bytes are written, but the App write it
+        // triggers is still rate-limited like the other mutating tools.
+        requireScope("files:read");
+        await requireWriteBudget();
+        const target = ghTargetFromArgs(args);
+        if (!target) usage("comment requires pr or issue");
+        return postManagedComment(env, workspace, workspaceName, ctx.mintingUserId, target);
+      },
+    },
+    {
       name: "get_metadata",
       description:
         "Read an object's queryable custom metadata (D1 key-value pairs, not R2 provenance). Returns `{ metadata }` (empty when none). Object must exist. Same as `uploads meta get`.",

--- a/apps/mcp/test/mcp-put-comment.test.ts
+++ b/apps/mcp/test/mcp-put-comment.test.ts
@@ -529,3 +529,154 @@ describe("hosted put: comment sync (issue #392)", () => {
     expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
   });
 });
+
+/**
+ * Standalone hosted `comment` tool (issue #392 stretch) — refreshes the
+ * managed comment without re-uploading, e.g. after a hosted `delete`. Bot-only
+ * (delegates to the same `postManagedComment` service as `put --comment` and
+ * the REST route), so it reuses this file's fake-D1 + stubbed api.github.com
+ * harness rather than inventing a new one.
+ */
+describe("hosted comment tool (issue #392 stretch)", () => {
+  it("posts the managed comment via the bot for an already-attached file", async () => {
+    const { env, links, githubCache } = await makeEnv({ boundTo: WS });
+    // Seed one attachment first (no comment requested) — the standalone
+    // `comment` tool only refreshes, it never uploads.
+    const seeded = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(seeded.isError).toBe(false);
+
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/acme/widgets/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12 });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent).toEqual({
+        posted: true,
+        action: "created",
+        count: 1,
+        commentUrl: "https://github.com/acme/widgets/pull/12#c5",
+      });
+      expect(links.rows.get("acme/widgets")).toMatchObject({
+        workspace_name: WS,
+        source: "comment",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces not_installed as an honest decline, never a tool error", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "none" });
+    const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12 });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toEqual({ posted: false, reason: "not_installed" });
+  });
+
+  it("declines not_authorized for a repo bound to a different workspace, without a GitHub write", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: "other-ws" });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    let sawGithubCall = false;
+    const restore = stubGithubFetch(() => {
+      sawGithubCall = true;
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12 });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent).toMatchObject({
+        posted: false,
+        reason: "not_authorized",
+      });
+      expect(sawGithubCall).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns a forbidden decline with fixUrl + required when the App lacks write", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    const seeded = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      pr: 12,
+      repo: "acme/widgets",
+    });
+    expect(seeded.isError).toBe(false);
+
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const restore = stubGithubFetch((url) =>
+      url.includes("/issues/12/comments")
+        ? new Response("no", { status: 403 })
+        : new Response("nf", { status: 404 }),
+    );
+    try {
+      const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12 });
+      expect(result.isError).toBe(false);
+      const comment = result.structuredContent as {
+        posted: boolean;
+        reason: string;
+        fixUrl: string;
+        required: string[];
+      };
+      expect(comment.posted).toBe(false);
+      expect(comment.reason).toBe("forbidden");
+      expect(comment.fixUrl).toBe(
+        "https://github.com/organizations/acme/settings/installations/42/permissions/update",
+      );
+      expect(comment.required).toEqual(["issues:write", "pull_requests:write"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("requires a pr or issue target", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "comment", { repo: "acme/widgets" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("pr or issue") },
+    ]);
+  });
+
+  it("requires repo", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "comment", { pr: 12 });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: expect.stringContaining("repo") }]);
+  });
+
+  it("rejects pr and issue together", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12, issue: 5 });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("mutually exclusive") },
+    ]);
+  });
+
+  it("requires files:read scope", async () => {
+    const { env } = await makeEnv({ boundTo: WS, scopes: ["files:write"] });
+    const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12 });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([{ type: "text", text: expect.stringContaining("files:read") }]);
+  });
+});

--- a/apps/mcp/test/mcp-put-comment.test.ts
+++ b/apps/mcp/test/mcp-put-comment.test.ts
@@ -679,4 +679,39 @@ describe("hosted comment tool (issue #392 stretch)", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toEqual([{ type: "text", text: expect.stringContaining("files:read") }]);
   });
+
+  it("rewrites an existing comment to the empty state once every attachment is gone", async () => {
+    // No attachment seeded → the workspace has nothing under the PR prefix, so
+    // the gathered body is the neutral empty state (count 0). A cached comment
+    // id makes upsertBotComment PATCH the existing comment directly — the empty
+    // body rewrites it in place; it is never deleted, and no new one is created.
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    githubCache.store.set("ghcomment:test-ws:acme/widgets#12", { value: "5" });
+    let patchedBody: string | undefined;
+    const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/comments/5") && init.method === "PATCH") {
+        patchedBody = JSON.parse(String(init.body)).body as string;
+        return new Response(
+          JSON.stringify({ id: 5, html_url: "https://github.com/acme/widgets/pull/12#c5" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "comment", { repo: "acme/widgets", pr: 12 });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent).toEqual({
+        posted: true,
+        action: "updated",
+        count: 0,
+        commentUrl: "https://github.com/acme/widgets/pull/12#c5",
+      });
+      expect(patchedBody).toContain("_No attachments are currently associated");
+    } finally {
+      restore();
+    }
+  });
 });

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -537,6 +537,7 @@ describe("mcp worker", () => {
       result: { tools: { name: string }[] };
     };
     expect(body.result.tools.map((tool) => tool.name).sort()).toEqual([
+      "comment",
       "delete",
       "find_files",
       "gallery_add",

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -763,17 +763,14 @@ export async function syncAttachmentsComment(
 
   const marker = attachmentsMarker(workspace);
   const body = attachmentsCommentBody(items, previewGalleries, marker);
-  const empty = items.length === 0 && previewGalleries.length === 0;
-  const { created, patched } = upsertAttachmentsComment(target, body, run, marker, {
-    createIfMissing: !empty,
+  const count = items.length + previewGalleries.length;
+  // Empty (count 0) renders the neutral empty-state body but must not create a
+  // comment — it only rewrites one that already exists (`action: "skipped"`
+  // when none does).
+  const { action } = upsertAttachmentsComment(target, body, run, marker, {
+    createIfMissing: count > 0,
   });
-  // Empty + nothing to patch → no comment ever existed; leave it a no-op.
-  if (empty && !patched) return { action: "skipped", count: 0, via: "gh" };
-  return {
-    action: created ? "created" : "updated",
-    count: items.length + previewGalleries.length,
-    via: "gh",
-  };
+  return { action, count, via: "gh" };
 }
 
 // --- attach ---
@@ -2795,12 +2792,15 @@ export async function runComment(
     await writeJson({ ...target, ...result });
   } else if (!ctx.quiet) {
     const via = commentViaSuffix(result.via);
-    const line =
-      result.action === "skipped"
-        ? `no attachments under ${ghKeyPrefix(target)} — nothing to do\n`
-        : result.count === 0
-          ? `cleared attachments comment on ${target.repo}#${target.num} — no files remaining${via}\n`
-          : `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})${via}\n`;
+    let line: string;
+    if (result.action === "skipped") {
+      line = `no attachments under ${ghKeyPrefix(target)} — nothing to do\n`;
+    } else if (result.count === 0) {
+      // An existing comment rewritten to the empty state (every file removed).
+      line = `cleared attachments comment on ${target.repo}#${target.num} — no files remaining${via}\n`;
+    } else {
+      line = `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})${via}\n`;
+    }
     process.stderr.write(line);
   }
   return 0;

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -761,12 +761,14 @@ export async function syncAttachmentsComment(
     }),
   );
 
-  if (items.length === 0 && previewGalleries.length === 0)
-    return { action: "skipped", count: 0, via: "gh" };
-
   const marker = attachmentsMarker(workspace);
   const body = attachmentsCommentBody(items, previewGalleries, marker);
-  const { created } = upsertAttachmentsComment(target, body, run, marker);
+  const empty = items.length === 0 && previewGalleries.length === 0;
+  const { created, patched } = upsertAttachmentsComment(target, body, run, marker, {
+    createIfMissing: !empty,
+  });
+  // Empty + nothing to patch → no comment ever existed; leave it a no-op.
+  if (empty && !patched) return { action: "skipped", count: 0, via: "gh" };
   return {
     action: created ? "created" : "updated",
     count: items.length + previewGalleries.length,
@@ -2793,11 +2795,13 @@ export async function runComment(
     await writeJson({ ...target, ...result });
   } else if (!ctx.quiet) {
     const via = commentViaSuffix(result.via);
-    process.stderr.write(
+    const line =
       result.action === "skipped"
         ? `no attachments under ${ghKeyPrefix(target)} — nothing to do\n`
-        : `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})${via}\n`,
-    );
+        : result.count === 0
+          ? `cleared attachments comment on ${target.repo}#${target.num} — no files remaining${via}\n`
+          : `${result.action} attachments comment on ${target.repo}#${target.num} (${result.count} file${result.count === 1 ? "" : "s"})${via}\n`;
+    process.stderr.write(line);
   }
   return 0;
 }

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -260,7 +260,7 @@ export function upsertAttachmentsComment(
   run: CommandRunner = execRunner,
   marker: string = ATTACHMENTS_MARKER,
   opts: { createIfMissing?: boolean } = {},
-): { created: boolean; patched: boolean } {
+): { action: "created" | "updated" | "skipped" } {
   const createIfMissing = opts.createIfMissing ?? true;
   const existing = findManagedComment(target, run, marker);
   if (existing) {
@@ -276,9 +276,11 @@ export function upsertAttachmentsComment(
       ],
       body,
     );
-    return { created: false, patched: true };
+    return { action: "updated" };
   }
-  if (!createIfMissing) return { created: false, patched: false };
+  // Patch-only (createIfMissing false, i.e. an empty body) with no existing
+  // comment: nothing to do — never create one just to say it's empty.
+  if (!createIfMissing) return { action: "skipped" };
   run("gh", ["api", `repos/${target.repo}/issues/${target.num}/comments`, "-F", "body=@-"], body);
-  return { created: true, patched: false };
+  return { action: "created" };
 }

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -259,7 +259,9 @@ export function upsertAttachmentsComment(
   body: string,
   run: CommandRunner = execRunner,
   marker: string = ATTACHMENTS_MARKER,
-): { created: boolean } {
+  opts: { createIfMissing?: boolean } = {},
+): { created: boolean; patched: boolean } {
+  const createIfMissing = opts.createIfMissing ?? true;
   const existing = findManagedComment(target, run, marker);
   if (existing) {
     run(
@@ -274,8 +276,9 @@ export function upsertAttachmentsComment(
       ],
       body,
     );
-    return { created: false };
+    return { created: false, patched: true };
   }
+  if (!createIfMissing) return { created: false, patched: false };
   run("gh", ["api", `repos/${target.repo}/issues/${target.num}/comments`, "-F", "body=@-"], body);
-  return { created: true };
+  return { created: true, patched: false };
 }

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -569,6 +569,14 @@ export function attachmentsCommentBody(
     }
     lines.push("", "</details>", "");
   }
+  // Emptied state: a PR/issue whose attachments and galleries were all removed
+  // still keeps its managed comment (a later push can repopulate it) — show a
+  // neutral resting state under the heading rather than a bare heading. Only
+  // the truly-empty case (no attachments, no galleries); a galleries-only
+  // comment has no Attachments heading and must not get this line.
+  if (sorted.length === 0 && sortedGalleries.length === 0) {
+    lines.push("_No attachments are currently associated with this pull request._", "");
+  }
   lines.push(
     '<sub>Maintained by <a href="https://uploads.sh">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>',
   );

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -68,14 +68,7 @@ function ctxWith(client: UploadsClient): CliContext {
 
 /** gh runner that reports no existing comments and records the create call. */
 function ghRunner() {
-  const calls: { args: string[]; input?: string }[] = [];
-  const run: CommandRunner = (cmd, args, input) => {
-    if (cmd !== "gh") throw new Error(`unexpected command: ${cmd}`);
-    calls.push({ args, input });
-    if (args[1]?.includes("per_page=100")) return "[]";
-    return JSON.stringify({ id: 9 });
-  };
-  return { run, calls };
+  return ghRunnerWithExisting(null);
 }
 
 /**

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -7,7 +7,7 @@ import {
   syncAttachmentsComment,
   type CliContext,
 } from "../src/commands.js";
-import { attachmentsMarker } from "../src/github.js";
+import { ATTACHMENTS_MARKER, attachmentsMarker } from "../src/github.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
 function listClient(
@@ -78,6 +78,37 @@ function ghRunner() {
   return { run, calls };
 }
 
+/**
+ * gh runner for the empty-state path: reports either an existing managed
+ * comment (`existingCommentId`) or none (`null`) on the marker hunt, and
+ * records every call so a test can assert whether PATCH/create ever fired.
+ */
+function ghRunnerWithExisting(existingCommentId: number | null) {
+  const calls: { args: string[]; input?: string }[] = [];
+  const run: CommandRunner = (cmd, args, input) => {
+    if (cmd !== "gh") throw new Error(`unexpected command: ${cmd}`);
+    calls.push({ args, input });
+    if (args[1]?.includes("per_page=100")) {
+      return existingCommentId === null
+        ? "[]"
+        : JSON.stringify([{ id: existingCommentId, body: `${ATTACHMENTS_MARKER}\nold` }]);
+    }
+    return JSON.stringify({ id: existingCommentId ?? 9 });
+  };
+  return { run, calls };
+}
+
+/** Run `fn` with process.stderr.write captured, returning the concatenated output. */
+async function captureStderr(fn: () => Promise<unknown>): Promise<string> {
+  const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  try {
+    await fn();
+    return writeSpy.mock.calls.map((c) => String(c[0])).join("");
+  } finally {
+    writeSpy.mockRestore();
+  }
+}
+
 describe("runComment", () => {
   it("requires --pr or --issue", async () => {
     const { run } = ghRunner();
@@ -99,7 +130,10 @@ describe("runComment", () => {
     expect(create!.input).toContain("after.png");
   });
 
-  it("skips gh entirely when there are no attachments", async () => {
+  it("no-ops (no create) via gh when there are no attachments and no comment exists", async () => {
+    // Patch-only-when-empty still hunts for an existing marker comment (one
+    // gh call), it just never creates one — this is the "never create just
+    // to say empty" safety property, not a full skip of gh.
     const { run, calls } = ghRunner();
     const code = await runComment(
       ctxWith(listClient([])),
@@ -108,7 +142,22 @@ describe("runComment", () => {
       run,
     );
     expect(code).toBe(0);
-    expect(calls.length).toBe(0);
+    expect(calls.some((c) => c.args.includes("PATCH"))).toBe(false);
+    expect(calls.some((c) => c.args.includes("repos/o/r/issues/5/comments"))).toBe(false);
+  });
+
+  it("prints a cleared message when the comment is emptied", async () => {
+    const { run } = ghRunnerWithExisting(7);
+    const err = await captureStderr(() =>
+      runComment(
+        { ...ctxWith(listClient([])), quiet: false },
+        ["--pr", "12", "--repo", "o/r"],
+        false,
+        run,
+      ),
+    );
+    expect(err).toContain("cleared attachments comment");
+    expect(err).not.toContain("(0 files)");
   });
   it("renders available gallery images inline and falls back for missing media", async () => {
     const { run, calls } = ghRunner();
@@ -284,5 +333,35 @@ describe("syncAttachmentsComment", () => {
     expect(posted).toContain("<sub>/settings · before</sub>");
     expect(posted).not.toContain("iPhone");
     expect(posted).not.toContain("Photoshop");
+  });
+
+  const clientWithNothing = fakeClient({
+    upsertGithubComment: async () => ({ posted: false, reason: "not_installed" }),
+    listAll: async () => [],
+    findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+  });
+
+  it("empties an existing managed comment via gh when nothing is left", async () => {
+    const { run, calls } = ghRunnerWithExisting(7);
+    const result = await syncAttachmentsComment(
+      clientWithNothing,
+      { repo: "acme/web", num: 12, kind: "pull" },
+      run,
+    );
+    expect(result).toEqual({ action: "updated", count: 0, via: "gh" });
+    expect(calls.some((c) => c.args.includes("PATCH"))).toBe(true);
+    expect(calls.some((c) => c.args.includes("repos/acme/web/issues/12/comments"))).toBe(false);
+  });
+
+  it("no-ops via gh when nothing is left and no comment exists", async () => {
+    const { run, calls } = ghRunnerWithExisting(null);
+    const result = await syncAttachmentsComment(
+      clientWithNothing,
+      { repo: "acme/web", num: 12, kind: "pull" },
+      run,
+    );
+    expect(result).toEqual({ action: "skipped", count: 0, via: "gh" });
+    expect(calls.some((c) => c.args.includes("PATCH"))).toBe(false);
+    expect(calls.some((c) => c.args.includes("repos/acme/web/issues/12/comments"))).toBe(false);
   });
 });

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -147,7 +147,7 @@ describe("upsertAttachmentsComment", () => {
       },
     });
     const result = upsertAttachmentsComment(target, `${ATTACHMENTS_MARKER}\nbody`, run);
-    expect(result.created).toBe(true);
+    expect(result).toEqual({ action: "created" });
     // The lookup paginates so the marker is found past the first 100 comments.
     expect(calls[0].args).toContain("--paginate");
     const post = calls[1];
@@ -169,7 +169,7 @@ describe("upsertAttachmentsComment", () => {
       },
     });
     const result = upsertAttachmentsComment(target, `${ATTACHMENTS_MARKER}\nnew body`, run);
-    expect(result.created).toBe(false);
+    expect(result).toEqual({ action: "updated" });
     const patch = calls[1];
     expect(patch.args).toContain("repos/o/r/issues/comments/42");
     expect(patch.args).toContain("PATCH");
@@ -190,7 +190,7 @@ describe("upsertAttachmentsComment", () => {
       },
     });
     const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
-    expect(result.created).toBe(false);
+    expect(result).toEqual({ action: "updated" });
     const patch = calls[1];
     expect(patch.args).toContain("repos/o/r/issues/comments/2");
   });
@@ -208,7 +208,7 @@ describe("upsertAttachmentsComment", () => {
     // The namespaced marker is already the first line of the new body —
     // patching the legacy comment with it migrates the comment in place.
     const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
-    expect(result.created).toBe(false);
+    expect(result).toEqual({ action: "updated" });
     const patch = calls[1];
     expect(patch.args).toContain("repos/o/r/issues/comments/7");
     expect(patch.input).toContain(marker);
@@ -226,7 +226,7 @@ describe("upsertAttachmentsComment", () => {
     const result = upsertAttachmentsComment(target, "EMPTY BODY", run, undefined, {
       createIfMissing: false,
     });
-    expect(result).toEqual({ created: false, patched: false });
+    expect(result).toEqual({ action: "skipped" });
     expect(calls).toHaveLength(1); // only the marker hunt — no create call.
   });
 
@@ -242,7 +242,7 @@ describe("upsertAttachmentsComment", () => {
     const result = upsertAttachmentsComment(target, "EMPTY BODY", run, undefined, {
       createIfMissing: false,
     });
-    expect(result).toEqual({ created: false, patched: true });
+    expect(result).toEqual({ action: "updated" });
     const patch = calls[1];
     expect(patch.args).toContain("repos/o/r/issues/comments/42");
     expect(patch.args).toContain("PATCH");

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -213,6 +213,40 @@ describe("upsertAttachmentsComment", () => {
     expect(patch.args).toContain("repos/o/r/issues/comments/7");
     expect(patch.input).toContain(marker);
   });
+
+  it("does not create a comment when createIfMissing is false and none exists", () => {
+    const { run, calls } = fakeRunner({
+      gh: (args) => {
+        if (args[1]?.includes("/comments?per_page=100")) {
+          return JSON.stringify([{ id: 1, body: "unrelated comment" }]);
+        }
+        throw new Error("must not create");
+      },
+    });
+    const result = upsertAttachmentsComment(target, "EMPTY BODY", run, undefined, {
+      createIfMissing: false,
+    });
+    expect(result).toEqual({ created: false, patched: false });
+    expect(calls).toHaveLength(1); // only the marker hunt — no create call.
+  });
+
+  it("patches an existing comment when createIfMissing is false", () => {
+    const { run, calls } = fakeRunner({
+      gh: (args) => {
+        if (args[1]?.includes("/comments?per_page=100")) {
+          return JSON.stringify([{ id: 42, body: `${ATTACHMENTS_MARKER}\nold body` }]);
+        }
+        return JSON.stringify({ id: 42 });
+      },
+    });
+    const result = upsertAttachmentsComment(target, "EMPTY BODY", run, undefined, {
+      createIfMissing: false,
+    });
+    expect(result).toEqual({ created: false, patched: true });
+    const patch = calls[1];
+    expect(patch.args).toContain("repos/o/r/issues/comments/42");
+    expect(patch.args).toContain("PATCH");
+  });
 });
 
 describe("resolveGhTitle", () => {

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -13,10 +13,17 @@ const golden = loadFixture("github-comment-golden.json");
 const goldenCap = loadFixture("github-comment-golden-cap.json");
 const goldenMeta = loadFixture("github-comment-golden-meta.json");
 const goldenVideo = loadFixture("github-comment-golden-video.json");
+const goldenEmpty = loadFixture("github-comment-golden-empty.json");
 
 describe("attachmentsCommentBody (CLI copy)", () => {
   it("renders the golden body byte-for-byte", () => {
     expect(attachmentsCommentBody(golden.items, golden.galleries)).toBe(golden.expected);
+  });
+
+  it("renders a neutral empty state when there are no items or galleries", () => {
+    expect(attachmentsCommentBody(goldenEmpty.items, goldenEmpty.galleries)).toBe(
+      goldenEmpty.expected,
+    );
   });
 
   it("renders a video with a poster as a linked image with a play caption", () => {

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -169,6 +169,12 @@ and subscribed to the `issue_comment` event, a deleted or edited-out managed
 comment self-heals automatically on the next webhook delivery — no need to
 run `comment`/`attach` again just to bring it back.
 
+**Removed the wrong screenshots?** `delete` the object(s) and re-run
+`comment` (or the hosted `comment` tool) to re-sync. Once the last attachment
+is gone the comment is rewritten in place to a neutral empty state — it stays
+on the PR (a later upload repopulates it) rather than leaving stale entries
+that point at deleted files.
+
 **Bot comment not showing up at all?** The managed comment needs a
 repo↔workspace binding (normally created implicitly by the first
 comment/promote call, or by installing the GitHub App). If a comment you

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -615,6 +615,17 @@ uploads comment --pr 123
 uploads comment --issue 45 --repo buildinternet/uploads
 ```
 
+Removed the wrong screenshots? `delete` the object(s) and re-run `comment` to
+re-sync. When the **last** attachment and gallery are gone, the managed comment
+is rewritten in place to a neutral empty state (`No attachments are currently
+associated with this pull request.`) — it is never deleted (a later upload
+repopulates it) and never created just to say it's empty:
+
+```bash
+uploads delete gh/owner/name/pull/123/after.png   # remove the asset
+uploads comment --pr 123                           # comment now shows the empty state
+```
+
 Past 16 inline images, the comment collapses the rest into a `<details>` link
 list so a heavily-screenshotted PR stays readable. Each workspace gets its own
 managed comment on a shared repo (namespaced under the hood) instead of
@@ -794,6 +805,15 @@ uploads --api-url http://localhost:8787 doctor
   access not yet approved — includes a `fixUrl` to the org's permission-review
   page), never as a thrown tool error; an unexpected error surfaces
   separately as `commentError`.
+
+  **Hosted MCP standalone `comment` tool.** The hosted server also has a
+  `comment` tool (`{ repo, pr | issue }`, `repo` required for the same
+  no-git-context reason) that refreshes the managed comment **without
+  re-uploading** — the hosted equivalent of CLI `uploads comment`. Use it to
+  re-sync after deleting an asset: `delete` the `gh/…` key, then call `comment`.
+  When the last attachment and gallery are gone the comment is rewritten in
+  place to a neutral empty state (never deleted, never created empty). It is
+  bot-only with the same honest declines as `put`'s comment field.
 
   **Hosted MCP: checking what's staged (issue #405).** There's no dedicated
   `staged` tool on the hosted server — it has no local git context to default

--- a/test/fixtures/github-comment-golden-empty.json
+++ b/test/fixtures/github-comment-golden-empty.json
@@ -1,0 +1,5 @@
+{
+  "items": [],
+  "galleries": [],
+  "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n_No attachments are currently associated with this pull request._\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+}


### PR DESCRIPTION
## Why

An agent (or a person) can already remove an asset from a PR/branch with `uploads delete <key>` or the hosted MCP `delete` tool. What it couldn't do was make the managed attachments comment reflect that removal: every publish path took a skip-on-zero branch and wrote nothing, so the previous non-empty comment survived on the PR listing files that now 404. And a hosted MCP agent had no way to re-sync the comment at all without re-uploading.

This makes emptying honest, and gives hosted agents the missing refresh tool.

## What

**Empty-state managed comment (api + cli).** When the last attachment and gallery are removed from a PR/issue, the existing managed comment is **rewritten in place** to a neutral empty state — never deleted (a later upload repopulates it) and never created just to say it's empty:

```
### 📎 Attachments

_No attachments are currently associated with this pull request._

<sub>Maintained by uploads.sh — re-uploading a file with the same name updates it everywhere it is embedded.</sub>
<sub>Add media: uploads put <file> --pr <N> --comment (or --issue <N>) · docs</sub>
```

The core rule is **patch-only-when-empty**: emptiness rewrites an existing comment but never posts a new one. This matters because the webhook gathers on every `pull_request` event for a bound repo — create-on-empty would spray "no attachments" comments across every PR. The rule lives in one place, the upsert primitives (`upsertBotComment` / `upsertAttachmentsComment`), gated by `createIfMissing: count > 0`; `gatherCommentBody` now always renders a body (empty when count 0) and all four call sites (service route, webhook auto-promote, CLI local-gh) inherit the behavior.

Outward contract folds into the existing enum — emptying reports `action: "updated"` with `count: 0`, empty-with-no-comment stays `skipped`. No new value.

**Hosted MCP `comment` tool.** The deferred stretch of #392: a standalone `comment` tool (`{ repo, pr | issue }`) that refreshes the managed comment without re-uploading — the hosted equivalent of `uploads comment`. Delegates to the already-extracted `postManagedComment`; bot-only with the same honest declines as `put`'s comment field. Closes the hosted delete → refresh loop.

## The delete → refresh loop, end to end

```bash
uploads delete gh/owner/name/pull/123/after.png   # remove the asset
uploads comment --pr 123                           # comment now shows the empty state
```
(or the hosted MCP `delete` + `comment` tools)

## Tests

- Dual-renderer empty-state golden (`test/fixtures/github-comment-golden-empty.json`) asserted in both the api and cli render suites (kept byte-identical).
- `gatherCommentBody` / `upsertBotComment` create-vs-patch, `postManagedComment` + webhook empty cases (patch existing, never create), CLI `syncAttachmentsComment` / `upsertAttachmentsComment` / `runComment` "cleared" message.
- Hosted `comment` tool: post, declines (`not_installed`, cross-tenant `not_authorized`, `forbidden` + `fixUrl`), usage errors, scope, and the empty-state rewrite integration case.

Full monorepo suite green: **2627 tests**. Includes a simplification pass (unified the CLI upsert result shape with its api twin, de-duplicated a test helper, refreshed a stale docstring).

## Notes

- `@uploads/api` / `@uploads/mcp` are `ignore`d in changesets (Workers-deployed, not npm-published), so the changeset targets only `@buildinternet/uploads` (the CLI, whose local-gh comment path changed).
- Follow-up worth a separate perf ticket: for a bound repo whose PRs never carry attachments, the webhook now issues a comment-list GET on each event (to discover whether a comment exists to empty) that previously short-circuited. Inherent to the feature; a negative-result cache would remove the steady-state cost.
