### PR TITLE
feat(billing): adopt simplified pro plan limits

### DIFF
--- a/apps/api/src/budget.test.ts
+++ b/apps/api/src/budget.test.ts
@@ -29,7 +29,7 @@ describe("resolveBudgetLimits — plan-aware resolution", () => {
 
   it("a workspace explicitly on the pro plan resolves pro's defaults", () => {
     expect(resolveBudgetLimits({ plan: "pro" })).toEqual({
-      maxStorageBytes: 25_000_000_000,
+      maxStorageBytes: 10_000_000_000,
       maxUploadsPerPeriod: 100_000,
     });
   });

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -450,7 +450,7 @@ describe("GET /me/workspaces/:name/billing", () => {
     expect(body.plan).toBe("pro");
     expect(body.available).toBe(false);
     expect(body.planApplied).toBe(true);
-    expect(body.limits.maxStorageBytes).toBe(25_000_000_000);
+    expect(body.limits.maxStorageBytes).toBe(10_000_000_000);
   });
 });
 

--- a/apps/api/src/workspace-plan.test.ts
+++ b/apps/api/src/workspace-plan.test.ts
@@ -69,7 +69,7 @@ describe("planResponse", () => {
     expect(result.plan).toBe("pro");
     expect(result.available).toBe(false);
     expect(result.planApplied).toBe(true);
-    expect(result.limits.maxStorageBytes).toBe(25_000_000_000);
+    expect(result.limits.maxStorageBytes).toBe(10_000_000_000);
   });
 
   it("fails open to free for an unrecognized stored plan string, but still applies plan-aware resolution", () => {

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -48,15 +48,17 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
   pro: {
     id: "pro",
     name: "Pro",
-    blurb: "Higher storage and upload limits for teams — coming soon.",
+    blurb: "10 GB of storage and files up to 100 MB — coming soon.",
     available: false,
-    // Provisional placeholders invented ahead of real pricing (pro is not
-    // yet purchasable) — revisit before pro becomes available.
+    // Decided 2026-07-22 (first-paid-plan memo): two marketed meters —
+    // storage and one unified file cap (video ceiling = upload ceiling on
+    // pro; only free carves video out). maxUploadsPerPeriod is an internal
+    // abuse guard, not a marketed limit.
     defaultLimits: {
-      maxStorageBytes: 25_000_000_000,
+      maxStorageBytes: 10_000_000_000,
       maxUploadsPerPeriod: 100_000,
       maxUploadBytes: 100_000_000,
-      maxVideoUploadBytes: 50_000_000,
+      maxVideoUploadBytes: 100_000_000,
     },
   },
 };

--- a/packages/billing/test/plans.test.ts
+++ b/packages/billing/test/plans.test.ts
@@ -19,6 +19,15 @@ describe("PLANS catalog", () => {
     expect(PLANS.pro.name.length).toBeGreaterThan(0);
   });
 
+  it("defines pro with the decided simplified limits (2026-07-22)", () => {
+    expect(PLANS.pro.defaultLimits).toEqual({
+      maxStorageBytes: 10_000_000_000,
+      maxUploadsPerPeriod: 100_000,
+      maxUploadBytes: 100_000_000,
+      maxVideoUploadBytes: 100_000_000,
+    });
+  });
+
   it("every plan's id matches its catalog key", () => {
     for (const [key, plan] of Object.entries(PLANS)) {
       expect(plan.id).toBe(key);


### PR DESCRIPTION
Replaces the pro plan's provisional placeholder limits in `@uploads/billing` with the decided values, simplifying the plan shape to two meaningful meters: storage and one unified per-file cap.

## Changes

- `packages/billing/src/plans.ts`: pro `defaultLimits` become 10 GB storage (was 25 GB) and a single 100 MB ceiling for any file — `maxVideoUploadBytes` now matches `maxUploadBytes` (was 50 MB), so only the free plan carves out a separate video ceiling. `maxUploadsPerPeriod` stays at 100k as an internal abuse guard rather than a marketed limit. Blurb updated to match.
- New test pins pro's decided limits the same way free's are pinned; three existing assertions updated (`workspace-plan.test.ts`, `budget.test.ts`, `me.test.ts`).

## Notes

- Pro remains `available: false` — no checkout path until the Stripe phase (#388). This only changes what the Billing tab / admin panel display and what enforcement would resolve for a workspace explicitly set to `pro`.
- Free plan limits are untouched.
- `apps/api/test/workspace-limit-defaults.test.ts` still references 25 GB deliberately — that's the shared/agent admin template profile, not the plan catalog.
- No changeset: `@uploads/billing` and `@uploads/api` are unpublished.

## Testing

- `pnpm --filter @uploads/billing test` — 21/21
- `@uploads/api` vitest run — 1099/1099
