### PR TITLE
docs: adopt Simplified-English house style for docs and web copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,30 @@ implementers against the same area; use a single implementer or partition
 non-overlapping files explicitly. The root agent remains responsible for final
 integration, tests, and user-facing decisions.
 
+## Writing docs
+
+House style for `docs/`, `README.md`, and web copy. It borrows the grammar
+rules of ASD-STE100 Simplified Technical English — not the controlled
+dictionary — to keep prose clear and free of AI-slop tics:
+
+- **Active voice.** "A public CDN serves hosted files", not "Hosted files are
+  served from a public CDN."
+- **One idea per sentence.** Break anything past ~25 words. A single sentence
+  chaining four clauses with em-dashes is the first thing to split.
+- **Verbs, not nominalizations.** "When the sweep finalizes the delete", not
+  "on the finalization of the delete."
+- **One term per concept.** Never vary a technical name for elegance; call it
+  the same thing every time (`workspace`, not "tenant" then "account").
+- **Keep the article and the connective.** Don't drop "the"/"a"/"that" to
+  sound terse.
+
+But this is the softened form, not literal STE100 conformance: allow compound
+sentences where the flow reads naturally, keep established idioms
+("hash-free keys", "break-glass"), and keep the confident authorial voice
+("Prefer X over Y"). Full one-instruction-per-sentence strictness is for true
+step-by-step procedures (runbooks, setup walkthroughs), not reference or
+rationale prose. Code blocks, tables, and identifiers stay verbatim.
+
 ## Pull requests
 
 Write PR descriptions for humans first, not only for reviewers who already

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -314,7 +314,7 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
       <code>localhost</code> URLs are only reachable locally.
     </p>
     <p>
-      Shooting your own dev server, it hides known framework dev toolbars
+      When you shoot your own dev server, it hides known framework dev toolbars
       (Astro, Next, Nuxt, Vite) automatically (opt out with
       <code>--no-hide-dev-tools</code>) and takes <code>--reduced-motion</code> to
       settle animations. Hide any other overlay with <code>--hide &lt;selector&gt;</code>

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -124,8 +124,8 @@ const TOC = [
       write</strong> — to read titles and state and post the one managed attachments comment.
       It never touches other comments, PR descriptions, or your code. If your org installed
       the App before a permission was added, GitHub holds the upgrade until an org admin
-      approves it; the CLI prints the approval link and posts via <code>gh</code> in the
-      meantime.
+      approves it. In the meantime, the CLI prints the approval link and posts via
+      <code>gh</code>.
     </p>
     <p>
       The App also needs <strong>webhook event subscriptions</strong> (Settings → your App →&#32;

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -99,9 +99,9 @@ const FAQ_JSON_LD = JSON.stringify({
       <button type="button" data-copy="uploads login" aria-live="polite">copy</button>
     </div>
     <p>
-      <code>uploads login</code> trades an invite code for a workspace token and saves it.
-      You do this once per machine. Access is invite-only for now; ask via&#32;
-      <a href={REPO}>the GitHub repo</a>. Check your setup with <code>uploads doctor</code>.
+      <code>uploads login</code> opens a browser sign-in and saves a workspace token. You do
+      this once per machine. Sign in with GitHub or a magic link, then create your own
+      workspace or accept an invite into one. Check your setup with <code>uploads doctor</code>.
     </p>
   </section>
 

--- a/apps/web/src/pages/terms.astro
+++ b/apps/web/src/pages/terms.astro
@@ -20,7 +20,7 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <p>
     uploads.sh is a file-hosting service for agents &amp; humans: you upload files from the
     terminal (or an agent does, on your behalf) and get back public links suitable for embedding
-    in pull requests, issues, and docs. The service is operated by <a href="https://buildinternet.com">Build Internet</a> and is currently invitation-only.
+    in pull requests, issues, and docs. The service is operated by <a href="https://buildinternet.com">Build Internet</a>.
   </p>
   <p>
     The service is provided as-is while it is in active development. We may change, rate-limit,
@@ -128,6 +128,10 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 
   <h2>Revision history</h2>
   <ul>
+    <li>
+      <strong>July 22, 2026</strong> — Corrected a stale description of the service as
+      invitation-only; self-serve workspace creation is available. No change to any term.
+    </li>
     <li><strong>July 11, 2026</strong> — Initial version published.</li>
   </ul>
 </LegalLayout>

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -78,36 +78,37 @@ curl -XDELETE https://api.uploads.sh/admin/tokens \
 Better-auth admins can also mint their own workspace tokens with opt-in
 `operator:read` / `operator:write` scopes via the session-authed `POST /v1/tokens`
 (no `ADMIN_TOKEN` involved). `operator:write` is a superset of `operator:read`.
-Tokens carrying either scope are accepted by `/admin/*` alongside
-`ADMIN_TOKEN`, and are revoked or listed the same way as any other token —
-via the `GET`/`DELETE /admin/tokens` endpoints above. Although an operator
-token is minted against (and stored under) a specific workspace, the
-`operator:read` / `operator:write` scopes themselves grant global operator
-authority across all of `/admin/*` — the same reach as `ADMIN_TOKEN` — not
-just operator access scoped to that one workspace; the workspace only anchors
-where the token is stored and which workspace's token list it appears
-under for revocation.
+`/admin/*` accepts a token carrying either scope alongside `ADMIN_TOKEN`. You
+revoke or list it the same way as any other token, via the
+`GET`/`DELETE /admin/tokens` endpoints above.
 
-Note that a token minted with an operator scope gets **no** file-route access,
-even if file scopes were also requested alongside it — scope parsing on the
-file routes fails the whole scope array when it contains any non-file
-scope. Mint a separate files-only token for file operations and a
-dedicated operator token for `/admin/*`.
+The workspace an operator token is minted against does not bound its authority.
+The `operator:read` / `operator:write` scopes grant global operator authority
+across all of `/admin/*` — the same reach as `ADMIN_TOKEN`. They do not grant
+operator access scoped to that one workspace. The workspace only anchors two
+things: where the token is stored, and which workspace's token list shows it
+for revocation.
+
+A token minted with an operator scope gets **no** file-route access, even if
+you request file scopes alongside it. Scope parsing on the file routes fails
+the whole scope array when it contains any non-file scope. So mint a separate
+files-only token for file operations, and a dedicated operator token for
+`/admin/*`.
 
 ## Workspace-governance scopes
 
-Org admins/owners can also mint tokens with opt-in `workspace:invite` /
-`workspace:manage` scopes via the same session-authed `POST /v1/tokens` —
-requesting either scope requires the minting session user to hold org role
-`admin` or `owner` in the target workspace (platform-admin/operator status
-does not bypass this check); otherwise the mint request is rejected with
+Org admins and owners can also mint tokens with the opt-in `workspace:invite` /
+`workspace:manage` scopes, via the same session-authed `POST /v1/tokens`. To
+request either scope, the minting session user must hold org role `admin` or
+`owner` in the target workspace; platform-admin or operator status does not
+bypass this check. Otherwise the API rejects the mint request with
 `400 invalid_scopes`. Unlike operator scopes, workspace-governance scopes are
 strictly **workspace-bounded**: a token only authorizes actions on the
 workspace embedded in it (`up_<workspace>_…`), never any other workspace.
 
-Like operator tokens, a workspace-governance token gets **zero** file-route
-access, even if file scopes are requested alongside it — scope parsing on the
-file routes fails the whole array when it contains any non-file scope. Mint a
+Like an operator token, a workspace-governance token gets **zero** file-route
+access, even if you request file scopes alongside it. Scope parsing on the file
+routes fails the whole array when it contains any non-file scope. Mint a
 separate files-only token for file operations.
 
 - `workspace:invite` authorizes `POST /v1/workspaces/:name/invites` — sends an

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,10 +71,10 @@ confirmation gate — that hot-swap is intentional so PR/issue embed URLs stay
 stable. Every other key is strict: a `PUT` to an existing non-`gh/` key
 throws `409 Conflict` with `code: "key_exists"` and `details: { key, url,
 embedUrl }` naming the existing object, unless the caller opts in with
-`?replace=1` (or the `X-Uploads-Replace: 1` header). This is enforced in
-`putObject` (`apps/api/src/files-core.ts`) — the one code path shared by the
-REST route and the MCP worker — so both surfaces get the same contract
-without duplicating the check. There is no server-side global escape hatch;
+`?replace=1` (or the `X-Uploads-Replace: 1` header). `putObject`
+(`apps/api/src/files-core.ts`) enforces this — it is the one code path shared by
+the REST route and the MCP worker, so both surfaces get the same contract
+without a duplicated check. There is no server-side global escape hatch;
 `UPLOADS_OVERWRITE=1` is a CLI-side default (see [cli.md](./cli.md)) that
 just sends `replace=1` on the caller's behalf.
 Worker override: optional `EMBED_PUBLIC_BASE_URL` (empty disables; any URL is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,11 +2,11 @@
 
 The `@buildinternet/uploads` package wraps the API for scripting and GitHub
 image embeds. Examples use the global `uploads` binary; install it with
-`npm install -g @buildinternet/uploads`. Inside this monorepo only,
-`pnpm uploads …` builds the package first so you pick up local source.
+`npm install -g @buildinternet/uploads`. Inside this monorepo, `pnpm uploads …`
+builds the package first, so you pick up local source.
 
-This guide covers the everyday flows. For the exhaustive command list, globals,
-and exit codes, run `uploads help --all` or see
+This guide covers the everyday flows. For the full command list, the globals,
+and the exit codes, run `uploads help --all` or see
 [`packages/uploads/README.md`](../packages/uploads/README.md).
 
 ## Getting started
@@ -19,22 +19,22 @@ uploads put ./shot.png # stdout: public URL + ready-to-paste markdown; stderr: h
 ```
 
 `login` opens a browser to authorize this device. The approval page asks which
-workspace to sign in to — pick one, or name a new one if the account has none —
-so `uploads login` needs no flags even when you belong to several workspaces.
-The workspace is settled there, before approval: a workspace your account can't
-reach is refused on the page rather than reported as a success that then fails
-in your terminal.
+workspace to sign in to — pick one, or name a new one if the account has none.
+So `uploads login` needs no flags, even when you belong to several workspaces.
+The browser settles the workspace before you approve the device: if your account
+can't reach a workspace, the page refuses it there, rather than reporting a
+success that then fails in your terminal.
 
-Pass `--workspace <name>` to preselect a workspace in the browser — you can
-still change it there — and `--workspace <name> --create` to provision one by
-name (the one thing the picker can't express). An invitation from a workspace admin also works — `login` trades
-an enrollment code for a saved workspace token, and `logout` removes it.
-`uploads doctor` checks health, auth, and workspace access when something's off.
-Routine agents never receive or need `ADMIN_TOKEN`. See
+Pass `--workspace <name>` to preselect a workspace in the browser; you can still
+change it there. Add `--create` to provision one by name — the one thing the
+picker can't express. An invitation from a workspace admin also works: `login`
+trades an enrollment code for a saved workspace token, and `logout` removes it.
+When something's off, `uploads doctor` checks health, auth, and workspace
+access. Routine agents never receive `ADMIN_TOKEN` and don't need it. See
 [enrollment](enrollment.md).
 
-For local development, `pnpm workspace:add` prints a bearer token once — save it
-with `uploads setup --token <token>` or into `.env` / user config.
+For local development, `pnpm workspace:add` prints a bearer token once. Save it
+with `uploads setup --token <token>`, or into `.env` or user config.
 
 ## Command overview
 
@@ -56,16 +56,17 @@ with `uploads setup --token <token>` or into `.env` / user config.
 | `setup` / `config`      | Inspect and configure CLI settings                        |
 | `mcp`                   | Serve MCP over stdio (tools mirror the CLI)               |
 
-Run `uploads <command> --help` for per-command flags.
+Run `uploads <command> --help` for a command's flags.
 
 ## How keys work
 
-Default `put` lands under `screenshots/…`. Prefer `--destination screenshots`
-(or `gh` with `--pr`/`--issue`) over inventing roots — workspaces may allowlist
-only those destinations. Use `--pr`/`--issue` for stable, hash-free GitHub
-keys; use `--key` only for an exact path under an allowed root.
+By default, `put` lands under `screenshots/…`. Prefer `--destination
+screenshots` (or `gh` with `--pr`/`--issue`) over inventing roots, since a
+workspace may allowlist only those destinations. Use `--pr`/`--issue` for
+stable, hash-free GitHub keys; use `--key` only for an exact path under an
+allowed root.
 
-More output control:
+These flags give you more control over the output:
 
 ```bash
 uploads put ./shot.png --format url
@@ -75,68 +76,67 @@ uploads --version
 uploads doctor
 ```
 
-Globals like `--json`, `--quiet`, and update hints are covered in
+The globals `--json` and `--quiet`, and the update hints, live in
 [`packages/uploads/README.md`](../packages/uploads/README.md).
 
 ## GitHub embeds
 
-GitHub's native image hosting only works through a browser session — agents
+GitHub's native image hosting works only through a browser session, so agents
 and `gh` need a public URL first. The CLI uploads to R2 and returns stable
 markdown you can drop into a PR or issue.
 
-**Stable PR/issue attachments** (`--pr` / `--issue`) use hash-free keys so
-re-uploading the same filename overwrites in place and the URL never changes:
+**Stable PR/issue attachments** (`--pr` / `--issue`) use hash-free keys. So
+re-uploading the same filename overwrites in place, and the URL never changes:
 
 ```bash
 uploads put ./after.png --pr 123 --alt "Dashboard after"
 # key: gh/<owner>/<repo>/pull/123/after.webp  (PNG optimized to WebP; extension follows the output)
 ```
 
-**Managed attachments comment** (`--comment`, requires local `gh` auth)
-creates or updates a single comment listing every file attached to that
-PR/issue — the upload still succeeds if `gh` is unavailable:
+**Managed attachments comment** (`--comment`, requires local `gh` auth) creates
+or updates a single comment listing every file attached to that PR or issue. The
+upload still succeeds if `gh` is unavailable:
 
 ```bash
 uploads put ./after.png --pr 123 --comment
 uploads comment --pr 123   # re-sync without uploading
 ```
 
-`uploads attach` combines the two: it detects the GitHub repository and
-current PR through `gh`, uploads all files, and creates or updates one managed
-attachments comment. Use `--pr <number>` or `--issue <number>` when inference
-is not possible, and `--no-comment` when only the public URLs and Markdown are
-wanted.
+`uploads attach` combines the two: it detects the GitHub repo and current PR
+through `gh`, uploads all the files, then creates or updates one managed
+attachments comment. Pass `--pr <number>` or `--issue <number>` when it can't
+infer the target, and `--no-comment` when you want only the public URLs and
+markdown.
 
-**Re-upload / hot-swap:** overwrite semantics depend on the key (issue #174).
-`attach`, `put --pr`, and `put --issue` always overwrite the object in place
-with no confirmation prompt (agents and re-runs need this) — the public URL
-stays the same so every embed updates after cache revalidation. Human mode
-prints `>> replaced existing object (same URL)` after a real put; JSON
-includes `"replaced": true|false`. Preview first with `uploads put … --dry-run`
-— if the key already exists it reports `>> would replace existing object
-(same URL)` (and `"replaced": true` in JSON) without writing.
+**Re-upload / hot-swap.** Overwrite behavior depends on the key (issue #174).
+`attach`, `put --pr`, and `put --issue` always overwrite the object in place,
+with no confirmation prompt, because agents and re-runs need this. The public
+URL stays the same, so every embed updates after the cache revalidates. Human
+mode prints `>> replaced existing object (same URL)` after a real put; JSON
+includes `"replaced": true|false`. Preview first with `--dry-run`: if the key
+already exists, it reports `>> would replace existing object (same URL)` (and
+`"replaced": true` in JSON) without writing.
 
-Every other key — an explicit `--key`, or the default put path with no
-`--pr`/`--issue` — is **strict**: re-uploading to an existing key refuses with
-a `key_exists` error (the JSON error's `details.url` names the existing
-object) instead of overwriting. Pass `--replace` to opt in for that one call,
-or set `UPLOADS_OVERWRITE=1` to restore always-overwrite behavior for every
-strict-path put. `--dry-run` previews the refusal too, printing `>> would
-refuse: key already exists` instead of writing.
+Every other key is **strict** — an explicit `--key`, or the default put path
+with no `--pr`/`--issue`. Re-uploading to an existing key refuses with a
+`key_exists` error (the JSON error's `details.url` names the existing object)
+instead of overwriting. Pass `--replace` to opt in for that one call, or set
+`UPLOADS_OVERWRITE=1` to restore always-overwrite behavior for every strict put.
+`--dry-run` previews the refusal too, printing `>> would refuse: key already
+exists` without writing.
 
-> **Privacy:** Hosted files are served from a public CDN with no link to GitHub
-> repo visibility. A screenshot on a private PR is still reachable by anyone who
-> knows or guesses the URL — `--pr`/`--issue` keys embed the repo path and
-> filename (`gh/myorg/myapp/pull/123/after.png`), so generic names are easier
-> to guess than hashed keys. Treat uploads as public; don't host secrets or
-> sensitive UI. Tighter access controls for private repos are planned — see
-> [roadmap](roadmap.md).
+> **Privacy:** A public CDN serves hosted files, with no link to GitHub repo
+> visibility. A screenshot on a private PR is still reachable by anyone who knows
+> or guesses the URL. A `--pr`/`--issue` key embeds the repo path and filename
+> (`gh/myorg/myapp/pull/123/after.png`), so generic names are easier to guess
+> than hashed keys. Treat uploads as public; don't host secrets or sensitive UI.
+> Tighter access controls for private repos are planned — see [roadmap](roadmap.md).
 
 ## Custom metadata
 
-Tag uploads with queryable key/value pairs so you can find them later
-(`uploads find`, `uploads list --meta`, the account search UI). Distinct from
-optimize/frame provenance.
+Tag an upload with queryable key/value pairs so you can find it later, via
+`uploads find`, `uploads list --meta`, or the account search UI. This metadata
+is separate from optimize/frame provenance.
 
 Suggested pairs for screenshots:
 
@@ -162,32 +162,36 @@ uploads meta get screenshots/myapp/42/settings.webp
 uploads meta set screenshots/myapp/42/settings.webp page=onboarding --delete path
 ```
 
-Rules: keys `^[a-z][a-z0-9._-]{0,63}$` (lowercase; dots allowed); values 1–512
-printable ASCII; at most 24 pairs per request. Re-upload **with** `--meta`
-replaces the whole metadata set; re-upload **without** `--meta` leaves existing
-pairs alone. `uploads attach` and `put --pr`/`--issue` also stamp `gh.repo` /
-`gh.kind` / `gh.number` / `gh.ref` automatically, plus `gh.title` when the
-PR/issue title is resolvable via local `gh` (best-effort — never blocks the
-upload). Branch staging (`attach --branch`) stamps `gh.status=staged`, flipped
-to `promoted` on promotion — query in-flight files with
-`uploads find gh.status=staged`. Promotion only considers staged files fresh
-enough: past a 30-day window since `gh.staged-at`
-(`FRESHNESS_WINDOW_MS`, `apps/api/src/github-promote.ts`) a staged file stops
-being promotable, but it **keeps serving** — nothing deletes it. There is no
-staging reaper (see `docs/deletion.md`); once a file ages out of the
-promotion window it just sits there, still reachable at its original URL,
-until per-workspace retention or an explicit `files:delete` removes it. On
-gh.\*-tagged uploads the server also
-stamps `gh.uploader` (GitHub login) and `gh.uploader-id` from the user who
-minted the bearer token — attribution only, not access control; a
-client-supplied value of those keys is overridden.
+Rules: keys match `^[a-z][a-z0-9._-]{0,63}$` (lowercase; dots allowed); values
+are 1–512 printable ASCII; at most 24 pairs per request. Re-uploading **with**
+`--meta` replaces the whole metadata set; re-uploading **without** `--meta`
+leaves existing pairs alone.
 
-Non-`gh.*` metadata may appear on the public `/f/…` file page — don't store
+`uploads attach` and `put --pr`/`--issue` also stamp `gh.repo`, `gh.kind`,
+`gh.number`, and `gh.ref` automatically, plus `gh.title` when local `gh` can
+resolve the PR/issue title. Title resolution is best-effort and never blocks the
+upload.
+
+Branch staging (`attach --branch`) stamps `gh.status=staged`, which promotion
+flips to `promoted`. Query in-flight files with `uploads find gh.status=staged`.
+Promotion only accepts a staged file while it's fresh: 30 days after
+`gh.staged-at` (`FRESHNESS_WINDOW_MS`, `apps/api/src/github-promote.ts`) the file
+stops being promotable, but it **keeps serving** — nothing deletes it. There is
+no staging reaper (see `docs/deletion.md`); once a file ages out of the promotion
+window it just sits there, still reachable at its original URL, until
+per-workspace retention or an explicit `files:delete` removes it.
+
+On a `gh.*`-tagged upload, the server also stamps `gh.uploader` (GitHub login)
+and `gh.uploader-id` from the user who minted the bearer token. These are
+attribution only, not access control, and the server overrides any
+client-supplied value for them.
+
+Non-`gh.*` metadata may appear on the public `/f/…` file page, so don't store
 secrets or private notes.
 
 ## Public galleries
 
-Galleries are ordered collections of existing workspace uploads with an opaque
+A gallery is an ordered collection of existing workspace uploads, with an opaque
 public URL. Create one and add uploads with the installed CLI:
 
 ```bash
@@ -198,25 +202,25 @@ uploads gallery link gal_example --github buildinternet/uploads#58
 uploads gallery list --github https://github.com/buildinternet/uploads/pull/58
 ```
 
-Use `uploads gallery link <gallery-id> --github <owner/repo#number>` to record
-an optional GitHub issue or PR reference. `uploads gallery list --github
-<coordinate-or-github-url>` performs an authenticated reverse lookup. The link
-does not change gallery identity or visibility.
+Use `uploads gallery link <gallery-id> --github <owner/repo#number>` to record an
+optional GitHub issue or PR reference. `uploads gallery list --github
+<coordinate-or-github-url>` does an authenticated reverse lookup. The link
+doesn't change gallery identity or visibility.
 
-> **Privacy:** A gallery is public to anyone with its URL; it does not inherit
-> GitHub or repository visibility. Removing or deleting a gallery does not
-> delete its uploaded media or exempt it from retention.
+> **Privacy:** A gallery is public to anyone with its URL; it doesn't inherit
+> GitHub or repository visibility. Removing or deleting a gallery doesn't delete
+> its uploaded media or exempt it from retention.
 
 ## Agent skills
 
-For agent runtimes, install the checked-in skills as well (`uploads install`
-does this for you):
+For agent runtimes, install the checked-in skills too (`uploads install` does
+this for you):
 
 ```bash
 npx skills add buildinternet/uploads
 ```
 
-[`skills/github-screenshots/SKILL.md`](../skills/github-screenshots/SKILL.md)
-is the workflow skill (screenshots/recordings into PRs and issues);
-[`skills/uploads-cli/SKILL.md`](../skills/uploads-cli/SKILL.md) is the full
-CLI reference it defers to. See [api.md](api.md) for REST routes.
+[`skills/github-screenshots/SKILL.md`](../skills/github-screenshots/SKILL.md) is
+the workflow skill — screenshots and recordings into PRs and issues.
+[`skills/uploads-cli/SKILL.md`](../skills/uploads-cli/SKILL.md) is the full CLI
+reference it defers to. See [api.md](api.md) for the REST routes.

--- a/docs/deletion.md
+++ b/docs/deletion.md
@@ -9,10 +9,10 @@ Follow-up to the admin workspace delete (#244) and the soft-delete evaluation
 
 **Member-facing deletes are soft; break-glass and finalization are hard.**
 
-Anything a workspace member (or admin acting routinely) can trigger should be
-reversible for a grace window. Hard deletion happens only as an explicit
-break-glass action or as the automated finalization of an already-expired soft
-delete.
+Any delete a workspace member (or an admin acting routinely) can trigger must be
+reversible for a grace window. A hard delete happens only in two cases: an
+explicit break-glass action, or the automated finalization of an already-expired
+soft delete.
 
 ## Per-surface policy
 
@@ -32,8 +32,8 @@ delete.
 
 - Soft delete stamps `deletedAt` and `purgeAt = deletedAt + 14 days` on the
   workspace KV record.
-- Access denial is immediate at the record layer (lookups treat soft-deleted
-  workspaces as not found), subject to two propagation tails:
+- The record layer denies access immediately (a lookup treats a soft-deleted
+  workspace as not found), subject to two propagation tails:
   - workspace record reads use a 60s KV `cacheTtl`, so token auth may succeed
     for up to a minute after deletion;
   - already-cached public bytes can keep serving from the edge/Camo for up to
@@ -53,11 +53,10 @@ teardown, no ability to free a slug. `DELETE /v1/workspaces/:name` and
 `POST /v1/workspaces/:name/restore` are session-authed and require
 `selfServe === true`; the caller is authorized as either the record creator
 (`createdByUserId`) or the org `owner` (not `admin`) for that workspace
-(#265, extending the original creator-only gate from #249). Org role is resolved via the same membership
-lookup as the #262 governance gates (`isWorkspaceOwner` in
-`apps/api/src/routes/me.ts`); a platform-admin role never bypasses this,
-since operators already have `/admin/workspaces/:name` for break-glass
-deletion. Deliberately session-only: a `workspace:manage`-scoped bearer
+(#265, extending the original creator-only gate from #249). The same membership
+lookup as the #262 governance gates resolves org role (`isWorkspaceOwner` in
+`apps/api/src/routes/me.ts`). A platform-admin role never bypasses this, since
+operators already have `/admin/workspaces/:name` for break-glass deletion. Deliberately session-only: a `workspace:manage`-scoped bearer
 token (see #262) is never accepted here, keeping this destructive action
 attributable to an interactive session. They share the admin path's
 stamp/grace logic (`stampSoftDelete`, `isPastGrace`, `stampRestore` in
@@ -69,9 +68,9 @@ The daily retention sweep (`apps/api/src/retention-sweep.ts`) also lists
 every auth-side org (`GET /internal/orgs` on the auth worker) and deletes
 (force) any whose slug has no `ws:<slug>` KV key at all, or only a purged
 tombstone. A soft-deleted-but-still-in-grace workspace is NOT an orphan —
-restore must bring the org back intact, so it's left alone. An AUTH-fetch
-failure or a per-org delete failure is isolated (logged, sweep continues) rather than
-failing the whole run. Results land in the sweep's `orgsSwept` array and log
+restore must bring the org back intact, so the sweep leaves it alone. The sweep
+isolates an AUTH-fetch failure or a per-org delete failure (logged, sweep
+continues) rather than failing the whole run. Results land in the sweep's `orgsSwept` array and log
 line.
 
 ## Name-reclaim policy (#252)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,9 +1,9 @@
 # Deploy
 
-Works against any Cloudflare account — this repo carries no account-specific
-secrets. Auth either interactively (`wrangler login`) or headlessly by setting
-`CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` in the repo-root `.env`
-(`pnpm deploy` loads it automatically; see `.env.example`).
+This backend works against any Cloudflare account; the repo carries no
+account-specific secrets. Authenticate either interactively (`wrangler login`),
+or headlessly by setting `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` in the
+repo-root `.env` (`pnpm deploy` loads it automatically; see `.env.example`).
 
 Forks: point `routes[0].pattern` in `apps/api/wrangler.jsonc` at your own
 domain, or delete the `routes` block to serve from your `workers.dev`

--- a/docs/enrollment.md
+++ b/docs/enrollment.md
@@ -1,9 +1,9 @@
 # Signing in with `uploads login`
 
-`uploads login` is how people and agents get workspace credentials. Run with
-no flags it opens a browser for a device sign-in (GitHub or a magic link); on
-approval the CLI mints a scoped, expiring workspace token and saves it
-locally. Nobody needs the API's `ADMIN_TOKEN` to sign in.
+`uploads login` is how people and agents get workspace credentials. Run with no
+flags, it opens a browser for a device sign-in (GitHub or a magic link). On
+approval, the CLI mints a scoped, expiring workspace token and saves it locally.
+Nobody needs the API's `ADMIN_TOKEN` to sign in.
 
 ## Everyday login (device flow)
 
@@ -33,13 +33,13 @@ uploads login --workspace acme
 
 The CLI authenticates as the managed official OAuth client `uploads-cli`,
 visible and toggleable by operators in the admin panel at `/admin/oauth`.
-Deleting an official client is blocked server-side (`DELETE` returns 409)
-until an operator first clears its official flag (`PATCH official:false`);
-that two-step is deliberate. The seed migration only runs once (`INSERT OR
-IGNORE`, journaled as applied), so a deleted `uploads-cli` client is not
-automatically re-seeded and would break CLI login fleet-wide until manually
-re-inserted — prefer disabling it over clearing the official flag and
-deleting it.
+The server blocks deleting an official client (`DELETE` returns 409) until an
+operator first clears its official flag (`PATCH official:false`). That two-step
+is deliberate. The seed migration runs only once (`INSERT OR IGNORE`, journaled
+as applied), so the system does not re-seed a deleted `uploads-cli` client
+automatically. A deletion would break CLI login fleet-wide until someone
+re-inserts the row by hand, so prefer disabling the client over clearing its
+official flag and deleting it.
 
 On success, the CLI saves `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and
 `UPLOADS_TOKEN` in the shared buildinternet config and runs `doctor`. It never
@@ -61,10 +61,10 @@ without an invitation or `ADMIN_TOKEN` — `/account/workspaces` has a "Create a
 workspace" form, and `uploads login` offers the same prompt when your account
 has no workspaces yet. Scripted or agent logins can skip the prompt with
 `uploads login --workspace <name> --create`, which provisions the workspace
-during login when the account doesn't already have it (browser device
-approval is still required once). You become the owner of a new organization and a
-`<name>/` prefix on the shared bucket, capped at 3 self-serve workspaces per
-user and with tighter default limits than an operator-provisioned workspace.
+during login when the account doesn't already have it (browser device approval
+is still required once). You become the owner of a new organization and a
+`<name>/` prefix on the shared bucket. Self-serve workspaces are capped at 3 per
+user, with tighter default limits than an operator-provisioned workspace.
 See [workspaces.md#self-serve-workspaces](workspaces.md#self-serve-workspaces)
 for the limits, name rules, and error codes.
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -27,11 +27,11 @@ stack gets stable named `.localhost` origins instead of bare ports:
 | auth    | `https://auth.uploads.localhost` |
 | api     | `https://api.uploads.localhost`  |
 
-The shared `.uploads.localhost` parent is what makes local auth work like
-prod: the Better Auth session cookie set by the auth worker is sent to web
-and api the same way `.uploads.sh` cookies are, so signed-in pages
-(`/account/*`, `/admin/*`) just work in a local browser — including agent
-browser panels. In a linked git worktree, portless prefixes the branch name
+The shared `.uploads.localhost` parent makes local auth work like prod. The
+auth worker sets a Better Auth session cookie, and the browser sends it to web
+and api the same way it sends `.uploads.sh` cookies. So signed-in pages
+(`/account/*`, `/admin/*`) just work in a local browser, including agent browser
+panels. In a linked git worktree, portless prefixes the branch name
 (`fix-ui.uploads.localhost` / `fix-ui.auth.uploads.localhost`); the cookie
 parent still anchors on the last two labels, so nothing else changes.
 `dev:stack` prints the resolved `previewUrl` when ready, and

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -93,19 +93,19 @@ force-deletes any whose slug has no `ws:<slug>` KV key at all, or only a
 purged tombstone — the multi-member orgs left behind by hard/finalized
 workspace teardown (see "Auth org deletion" in `docs/deletion.md`). A
 soft-deleted workspace still inside its grace window is never treated as an
-orphan. An AUTH outage or a single org's delete failure is isolated (logged, sweep
-continues) rather than failing the run. Results roll up into the sweep's
-`orgsSwept` field.
+orphan. The sweep isolates an AUTH outage or a single org's delete failure
+(logged, sweep continues) rather than failing the run. Results roll up into the
+sweep's `orgsSwept` field.
 
 ## Workspace deletion, restore, and finalization
 
 `DELETE /admin/workspaces/:name` is **soft by default** (#247): it stamps
 `deletedAt`/`purgeAt` (14-day grace window, `WORKSPACE_DELETE_GRACE_DAYS`) on
-the KV record and puts it back. Access denies at the record layer — every
-auth/serving path treats a `deletedAt` record as not found — subject to the
-60-second KV `cacheTtl` on workspace reads, so token auth may keep succeeding
-for up to a minute after deletion (see `docs/deletion.md`). R2 objects,
-file metadata, and galleries are untouched. Deleting an already-soft-deleted
+the KV record and puts it back. Access denies at the record layer: every
+auth/serving path treats a `deletedAt` record as not found. This is subject to
+the 60-second KV `cacheTtl` on workspace reads, so token auth may keep
+succeeding for up to a minute after deletion (see `docs/deletion.md`). It leaves
+R2 objects, file metadata, and galleries untouched. Deleting an already-soft-deleted
 workspace 409s `already_deleted` with the existing `purgeAt`.
 
 ```bash
@@ -144,8 +144,8 @@ signed-in owner the same soft-delete/restore surface as the admin path
 above, session-authed (browser cookie) instead of `ADMIN_TOKEN`. Ownership
 gate: the record must have `selfServe === true`, and the caller must be
 either the record creator (`createdByUserId` match) or hold org role
-`owner` (not `admin`) in that workspace's org (#265, via `isWorkspaceOwner`
-— same membership lookup the #262 governance gates use) — anything else
+`owner` (not `admin`) in that workspace's org (#265, via `isWorkspaceOwner` —
+the same membership lookup the #262 governance gates use). Anything else
 403s `not_owner`. Semantics are otherwise identical to the
 admin soft-delete/restore path (409 `already_deleted` / `not_deleted`, 410
 `grace_expired`, never hard, never frees the slug) via a shared stamp helper

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,8 @@
 # Releasing `@buildinternet/uploads`
 
 The CLI/client package is published with **changesets** + npm **trusted
-publishing** (OIDC — no long-lived `NPM_TOKEN`). Published versions are cut by
-the **Release** workflow on `main`.
+publishing** (OIDC — no long-lived `NPM_TOKEN`). The **Release** workflow on
+`main` cuts the published versions.
 
 ## Trusted-publishing configuration
 
@@ -43,7 +43,7 @@ requires npm ≥ 11.5.1 and Node ≥ 22.14).
 **Never hand-edit** `packages/uploads/package.json` `version` for a release —
 `changeset version` owns it.
 
-Private packages (`@uploads/api`, `@uploads/mcp`, …) are ignored by changesets;
+Changesets ignore the private packages (`@uploads/api`, `@uploads/mcp`, …);
 they deploy via Workers Builds.
 
 ## Cut a release

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -11,10 +11,10 @@ Nothing in the code treats any workspace as special.
 ## Mutating a workspace record
 
 The record is one KV blob holding unrelated field groups (limits, plan,
-GitHub-comment settings, tokens, soft-delete stamps), so every writer is a
-read-modify-write of the whole snapshot. **Never `REGISTRY.put("ws:<name>", …)`
-directly** — go through `mutateWorkspaceRecord` in
-`apps/api/src/workspace-mutate.ts`, which reads the freshest record immediately
+GitHub-comment settings, tokens, soft-delete stamps), so every writer must read,
+modify, and write back the whole snapshot. **Never call
+`REGISTRY.put("ws:<name>", …)` directly.** Go through `mutateWorkspaceRecord` in
+`apps/api/src/workspace-mutate.ts`: it reads the freshest record immediately
 before writing, stamps a monotonic `version`, and re-applies the mutation if
 another writer's `put` landed in between (issue #387). Guards that depend on
 mutable state (already-deleted, grace-expired) belong inside the mutation
@@ -26,16 +26,17 @@ rather than eliminating it — acceptable for these admin/owner-initiated,
 low-concurrency edits. Issue #389 tracks the durable fix (moving the mutable
 field groups to D1, where transactions exist).
 
-Two caveats on the guarantee. A write landing between our read and our put is
-still lost; the retry only recovers a competitor whose put landed between our
-put and our verification read. And the guarantee covers the **worker only** —
-`pnpm workspace:limits` and `pnpm workspace:add` do their own
+Two caveats on the guarantee. First, a write landing between our read and our
+put is still lost; the retry only recovers a competitor whose put landed between
+our put and our verification read. Second, the guarantee covers the **worker
+only**. `pnpm workspace:limits` and `pnpm workspace:add` do their own
 `wrangler kv get` → splice → `wrangler kv put` out of process, so an operator
 running a script while someone edits the same workspace in the admin UI can
-still clobber it, unversioned and unretried. Prefer the admin UI (or the
-`/admin-ui/workspaces/:name/limits` endpoint) for edits to a live workspace. The exceptions are writes that replace the record
-outright rather than mutating it: self-serve creation (`selfServeWorkspaceRecord`,
-which stamps `version: 1`) and the purged tombstone written by teardown.
+still clobber it — unversioned and unretried. Prefer the admin UI (or the
+`/admin-ui/workspaces/:name/limits` endpoint) for edits to a live workspace. Two
+writes are exceptions, because they replace the record outright rather than
+mutate it: self-serve creation (`selfServeWorkspaceRecord`, which stamps
+`version: 1`) and the purged tombstone written by teardown.
 
 ## Usage accounting and budgets
 


### PR DESCRIPTION
## In plain terms

A colleague passed along a tip: you can get LLMs to write clearer, less "AI-slop" technical docs by having them follow **ASD-STE100 Simplified Technical English**. We tried it on this repo's docs and it mostly holds up — the useful part is the *grammar rules* (active voice, one idea per sentence, verbs instead of noun-phrases, one term per concept), not the aircraft-manual dictionary.

This PR adopts a **softened** version of those rules as the house style for docs and marketing copy, documents it in `AGENTS.md`, and applies it — cutting the run-on sentences and passive-voice fog where they actually clustered.

## What it does

- **`AGENTS.md` → new "Writing docs" section.** The directive future doc PRs inherit: active voice, one idea per sentence (break >25 words), verbs over nominalizations, one term per concept — but keep compound sentences where they read naturally, keep idioms ("hash-free keys", "break-glass"), and keep the confident authorial voice. Full one-instruction-per-sentence strictness is reserved for step-by-step procedures.
- **Rewrote the worst offenders**, e.g. `cli.md`'s 140-word metadata sentence (now four short paragraphs), the `workspaces.md` version-guard section, the `admin-tokens.md` operator/governance scope paragraphs, and dense finalization notes in `deletion.md` / `ops.md`.
- **Surgical fixes elsewhere** — most docs already largely followed the style, so those got only the genuine passive/run-on fixes rather than manufactured churn.

## What it is *not*

- **Not a full rewrite.** `README.md`, `contract-testing.md`, `roadmap.md`, the homepage (`index.astro`), `docs.astro`, and `docs/agents.astro` were **already compliant** and are deliberately left unchanged — forcing STE100 onto already-good marketing/hero copy only flattens it.
- **Not a dictionary-conformance pass.** Technical terms (`KV`, `Camo`, `compare-and-swap`) stay. Code blocks, tables, and identifiers are verbatim.

## Two correctness fixes (found in passing, not style)

Both pages claimed access is invitation-only. Self-serve registration has been live since #171 (the same stale claim was corrected elsewhere on the web in #435).

1. **`github-screenshots.astro`** said access is "invite-only for now" and that `uploads login` "trades an invite code for a workspace token." Now describes the browser device-login + self-serve-or-invite reality.
2. **`terms.astro`** described the service as "currently invitation-only" — which contradicted its *own* "Access and credentials" section two paragraphs later ("Access comes from creating your own workspace after signing in, or from an invitation to an existing one"). Removed the stale clause rather than restate access twice, and logged it in the revision history.

**On the Terms effective date:** deliberately **not** bumped. No term changed — this is a factual correction, so bumping it would wrongly signal a material change and continued-use re-acceptance under the page's own "Changes to these terms" clause. Flagging for your call at review.

## Test plan

- [x] Pre-commit hook on both commits: `pnpm types` + `oxfmt --write` on staged `.md` (clean)
- [x] Rendered `/terms` on the local Astro dev server — stale claim gone, effective date unchanged, revision history renders newest-first
- [x] Asserted **zero broken in-page anchors** on `/terms` (an earlier draft added a `#access-and-credentials` link; those `<h2>`s have no `id`s and `LegalLayout` has no rehype-slug, so it was removed)
- [x] Confirmed the only remaining "invitation-only" string on `/terms` is inside the revision-history entry describing the correction
- [ ] Prose-only `.astro` edits elsewhere — no live preview (no structural/markup change to render)
