### PR TITLE
feat(billing): Stripe phase 2 — @better-auth/stripe org-scoped, dormant until secrets

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -9,6 +9,13 @@
 # If unset, /admin/* rejects every request (fails closed).
 ADMIN_TOKEN=
 
+# Gates POST /internal/billing/plan (Stripe phase 2, task 3): compared
+# timing-safe against the `x-internal-billing-key` header. Any non-empty
+# string works locally. In production set it with:
+#   cd apps/api && pnpm exec wrangler secret put BILLING_INTERNAL_KEY
+# If unset, the route rejects every request (fails closed).
+BILLING_INTERNAL_KEY=
+
 # Optional: encrypt BYO S3 keys in REGISTRY KV (openssl rand -base64 32).
 # Production: wrangler secret put WORKSPACE_SECRETS_KEY
 WORKSPACE_SECRETS_KEY=

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -7,7 +7,7 @@
  */
 
 import { InsufficientStorageError, RateLimitedError } from "@uploads/errors";
-import { resolvePlanLimits } from "@uploads/billing";
+import { resolveEffectiveLimits } from "@uploads/billing";
 import type { WorkspaceUsage } from "./usage";
 
 /** Cumulative caps from the workspace registry record. */
@@ -44,21 +44,29 @@ export function resolveBudgetLimits(record: WorkspaceBudgetLimits): {
   maxStorageBytes?: number;
   maxUploadsPerPeriod?: number;
 } {
-  const explicit = {
+  // Sanitize the record's own fields before handing off to the shared
+  // resolution seam: a zero/negative/non-finite value collapses to
+  // "unset" here (matching the pre-existing `positiveLimit` contract),
+  // *before* `resolveEffectiveLimits` decides whether that counts as an
+  // explicit override or falls back to a plan default. This also
+  // preserves the pre-existing quirk that an explicit `null` on this
+  // record type is indistinguishable from "unset" (both become
+  // `undefined`), unlike the richer null-means-"explicitly cleared"
+  // handling `resolveEffectiveLimits`/`resolvePlanLimits` do for other
+  // callers (e.g. `workspace-plan.ts`'s admin-set fields).
+  const sanitized = {
+    ...record,
     maxStorageBytes: positiveLimit(record.maxStorageBytes),
     maxUploadsPerPeriod: positiveLimit(record.maxUploadsPerPeriod),
   };
   // Plan defaults apply ONLY when a workspace has been explicitly placed on
-  // a plan. Absent `plan` must reproduce today's (pre-billing) behavior
-  // byte-for-byte: an unset field is unlimited, full stop — no free-tier
-  // fallback. This keeps every legacy/admin-provisioned workspace unlimited
-  // as it is in production today; only a record with `plan` set opts into
-  // plan-aware resolution (self-serve creation does not set `plan` in this
-  // task — that wiring is a later task).
-  if (record.plan === undefined) {
-    return explicit;
-  }
-  const resolved = resolvePlanLimits(record.plan, explicit);
+  // a plan — the single `plan === undefined` gate lives in
+  // `resolveEffectiveLimits` (issue #388). Absent `plan` must reproduce
+  // today's (pre-billing) behavior byte-for-byte: an unset field is
+  // unlimited, full stop — no free-tier fallback. This keeps every
+  // legacy/admin-provisioned workspace unlimited as it is in production
+  // today; only a record with `plan` set opts into plan-aware resolution.
+  const resolved = resolveEffectiveLimits(sanitized);
   return {
     maxStorageBytes: positiveLimit(resolved.maxStorageBytes),
     maxUploadsPerPeriod: positiveLimit(resolved.maxUploadsPerPeriod),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -28,6 +28,7 @@ import { githubPromote } from "./routes/github-promote";
 import { githubLink } from "./routes/github-link";
 import { githubHealth } from "./routes/github-health";
 import { githubActivity } from "./routes/github-activity";
+import { internalBilling } from "./routes/internal-billing";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 
 // Lets the browser console on the web origin (and local dev) call the token-
@@ -153,6 +154,11 @@ export const app = new Hono<WorkspaceVars>()
   // Issue #338: recent-PRs-with-media feed, same base path, distinct
   // sub-route "/activity".
   .route("/v1/:workspace/github", githubActivity)
+  // Internal plan-set route (Stripe phase 2, task 3): secret-gated via the
+  // `x-internal-billing-key` header, not session/bearer auth, so it's outside
+  // /v1 and the workspaceAuth guard entirely — same "brings its own auth"
+  // treatment as /v1/github/webhook above. See routes/internal-billing.ts.
+  .route("/internal/billing", internalBilling)
   .onError((err, c) => respondError(c, err))
   .notFound((c) => respondError(c, new NotFoundError()));
 

--- a/apps/api/src/routes/internal-billing.test.ts
+++ b/apps/api/src/routes/internal-billing.test.ts
@@ -1,0 +1,164 @@
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it } from "vitest";
+import { fakeRegistry } from "../../test/fake-kv";
+import { respondError } from "../error-response";
+import { internalBilling } from "./internal-billing";
+
+const SECRET = "shh-internal";
+
+// crypto.subtle.timingSafeEqual is a Workers-only extension absent from this
+// repo's plain-Node vitest runtime — same polyfill as test/routes-key-policy.test.ts
+// et al., needed because the route reuses admin.ts's timing-safe compare pattern.
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/internal/billing", internalBilling)
+    .onError((err, c) => respondError(c, err));
+}
+
+function post(body: unknown, headers: Record<string, string>, env: Env) {
+  return app().request(
+    "/internal/billing/plan",
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json", ...headers },
+    },
+    env,
+  );
+}
+
+function envWith(opts: { secret?: string; record?: Record<string, unknown> } = {}) {
+  const registry = fakeRegistry(opts.record ? { acme: opts.record } : {});
+  const store = registry.store;
+  const env = {
+    REGISTRY: registry,
+    ...(opts.secret !== undefined ? { BILLING_INTERNAL_KEY: opts.secret } : {}),
+  } as unknown as Env;
+  return { env, store };
+}
+
+describe("POST /internal/billing/plan", () => {
+  it("401s when BILLING_INTERNAL_KEY is unset, regardless of the header sent", async () => {
+    const { env } = envWith({ record: { provider: "r2", bucket: "b", prefix: "acme/" } });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": "anything" },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("401s on a wrong key", async () => {
+    const { env } = envWith({
+      secret: SECRET,
+      record: { provider: "r2", bucket: "b", prefix: "acme/" },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": "wrong" },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("401s when the header is missing", async () => {
+    const { env } = envWith({
+      secret: SECRET,
+      record: { provider: "r2", bucket: "b", prefix: "acme/" },
+    });
+    const res = await post({ workspace: "acme", plan: "pro" }, {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("400s an invalid plan value", async () => {
+    const { env } = envWith({
+      secret: SECRET,
+      record: { provider: "r2", bucket: "b", prefix: "acme/" },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "enterprise" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("invalid_plan");
+  });
+
+  it("400s a missing workspace field", async () => {
+    const { env } = envWith({ secret: SECRET });
+    const res = await post({ plan: "pro" }, { "x-internal-billing-key": SECRET }, env);
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error?: { code?: string } };
+    expect(payload.error?.code).toBe("invalid_workspace");
+  });
+
+  it("404s an unknown workspace", async () => {
+    const { env } = envWith({ secret: SECRET });
+    const res = await post(
+      { workspace: "ghost", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("204s and sets the plan on the record", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: { provider: "r2", bucket: "b", prefix: "acme/" },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    expect(JSON.parse(store.get("ws:acme")!).plan).toBe("pro");
+  });
+
+  it("204s and preserves other fields, including explicit limit overrides", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: {
+        provider: "r2",
+        bucket: "b",
+        prefix: "acme/",
+        maxStorageBytes: 123_456,
+        maxUploadsPerPeriod: 42,
+        githubCommentLinkToFilePage: true,
+      },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    const stored = JSON.parse(store.get("ws:acme")!);
+    expect(stored).toMatchObject({
+      provider: "r2",
+      bucket: "b",
+      prefix: "acme/",
+      maxStorageBytes: 123_456,
+      maxUploadsPerPeriod: 42,
+      githubCommentLinkToFilePage: true,
+      plan: "pro",
+    });
+  });
+});

--- a/apps/api/src/routes/internal-billing.ts
+++ b/apps/api/src/routes/internal-billing.ts
@@ -1,0 +1,72 @@
+/**
+ * Internal plan-set route (Stripe phase 2, task 3): `POST /internal/billing/plan`.
+ * Not session/bearer authed like the rest of the API — a shared secret in the
+ * `x-internal-billing-key` header, checked timing-safe against
+ * `env.BILLING_INTERNAL_KEY` the same way `adminAuth` compares `ADMIN_TOKEN`
+ * (see admin.ts): hash both sides with sha256Hex and compare the hashes with
+ * `crypto.subtle.timingSafeEqual` so the raw secret is never compared
+ * directly and unequal-length inputs don't leak via `timingSafeEqual`'s
+ * length check. Fail-closed: an unset `BILLING_INTERNAL_KEY` always 401s,
+ * regardless of what header is sent — this route must be dormant until a
+ * secret is deliberately configured (see wrangler.jsonc).
+ *
+ * Body: `{ workspace: string, plan: "free" | "pro" }`. `plan` reuses
+ * `PLAN_IDS`/`PlanId` from `@uploads/billing`, the same source of truth as
+ * the admin panel's `PATCH /admin-ui/workspaces/:name/plan` (workspace-plan.ts).
+ * Only `plan` is written — `mutateWorkspaceRecord` read-modify-writes the
+ * whole record, so limit overrides, tokens, etc. are preserved untouched.
+ *
+ * `BILLING_INTERNAL_KEY` is read through an intersection type rather than
+ * `Env` directly: it must be added to `worker-configuration.d.ts` (via
+ * `wrangler types`, which reads `.dev.vars`) for the ambient `Env` interface
+ * to carry it, and that's a local/per-deploy secret file this change
+ * deliberately doesn't touch — see the `.dev.vars.example` entry and the
+ * comment in wrangler.jsonc for how to provision it.
+ */
+import { PLAN_IDS, type PlanId } from "@uploads/billing";
+import { UnauthorizedError, ValidationError } from "@uploads/errors";
+import { Hono } from "hono";
+import { jsonBody } from "./json-body";
+import { hexToBytes, sha256Hex } from "../workspace";
+import { mutateWorkspaceRecord } from "../workspace-mutate";
+import type { WorkspaceVars } from "../workspace";
+
+export const internalBilling = new Hono<WorkspaceVars>();
+
+function validatePlanSetBody(body: Record<string, unknown>): { workspace: string; plan: PlanId } {
+  const { workspace, plan } = body;
+  if (typeof workspace !== "string" || workspace.length === 0) {
+    throw new ValidationError("workspace is required", { code: "invalid_workspace" });
+  }
+  if (typeof plan !== "string" || !PLAN_IDS.includes(plan as PlanId)) {
+    throw new ValidationError(`plan must be one of: ${PLAN_IDS.join(", ")}`, {
+      code: "invalid_plan",
+    });
+  }
+  return { workspace, plan: plan as PlanId };
+}
+
+internalBilling.post("/plan", async (c) => {
+  const env = c.env as Env & { BILLING_INTERNAL_KEY?: string };
+  const secret = env.BILLING_INTERNAL_KEY ?? "";
+  const provided = c.req.header("x-internal-billing-key") ?? "";
+
+  const providedHash = await sha256Hex(provided);
+  const expectedHash = secret ? await sha256Hex(secret) : providedHash.replace(/./g, "0");
+  const ok =
+    secret.length > 0 &&
+    provided.length > 0 &&
+    crypto.subtle.timingSafeEqual(hexToBytes(providedHash), hexToBytes(expectedHash));
+  if (!ok) throw new UnauthorizedError();
+
+  const body = await jsonBody(c);
+  const { workspace, plan } = validatePlanSetBody(body);
+
+  // mutateWorkspaceRecord throws NotFoundError for an unknown or
+  // non-serving (soft-deleted) workspace — propagates to respondError as 404.
+  await mutateWorkspaceRecord(c.env, workspace, (record) => ({ ...record, plan }), {
+    requireServing: true,
+  });
+
+  return c.body(null, 204);
+});

--- a/apps/api/src/workspace-limits.ts
+++ b/apps/api/src/workspace-limits.ts
@@ -6,17 +6,15 @@
  * Mirrors set-workspace-limits.mjs's field set and clear semantics, but only
  * the four numeric budget fields (no retention / key-policy). A value is a
  * finite integer >= 1 (set the cap) or null (clear the field -> unlimited).
+ *
+ * The field list itself is canonical in `@uploads/billing` (issue #388,
+ * deferred from PR #386 review) — re-exported here so existing importers
+ * (`routes/admin-ui.ts`, `workspace-plan.ts`) keep working unchanged.
  */
+import { LIMIT_FIELDS, type LimitField } from "@uploads/billing";
 import { ValidationError } from "@uploads/errors";
 
-export const LIMIT_FIELDS = [
-  "maxStorageBytes",
-  "maxUploadsPerPeriod",
-  "maxUploadBytes",
-  "maxVideoUploadBytes",
-] as const;
-
-export type LimitField = (typeof LIMIT_FIELDS)[number];
+export { LIMIT_FIELDS, type LimitField };
 
 export type LimitsPatch = Partial<Record<LimitField, number | null>>;
 

--- a/apps/api/src/workspace-plan.ts
+++ b/apps/api/src/workspace-plan.ts
@@ -8,7 +8,7 @@
 import {
   getPlan,
   PLAN_IDS,
-  resolvePlanLimits,
+  resolveEffectiveLimits,
   type PlanId,
   type WorkspacePlanLimits,
 } from "@uploads/billing";
@@ -44,7 +44,8 @@ export function validatePlanPatch(body: unknown): { plan: PlanId } {
  * `false` means `limits` reflects raw overrides only (unlimited where
  * unset, mirroring the null-for-unlimited convention `limitsResponse`
  * uses above); `true` means `limits` reflects plan-aware resolution via
- * `resolvePlanLimits` (overrides layered onto the plan's defaults).
+ * the shared `resolveEffectiveLimits` seam (overrides layered onto the
+ * plan's defaults — see `@uploads/billing`'s `resolve.ts`; issue #388).
  */
 export function planResponse(name: string, record: WorkspaceRecord) {
   const definition = getPlan(record.plan);
@@ -52,15 +53,11 @@ export function planResponse(name: string, record: WorkspaceRecord) {
     (field) => record[field as keyof WorkspacePlanLimits] !== undefined,
   );
   const planApplied = record.plan !== undefined;
+  const resolved = resolveEffectiveLimits(record);
   const limits = planApplied
-    ? resolvePlanLimits(
-        record.plan,
-        Object.fromEntries(
-          LIMIT_FIELDS.map((field) => [field, record[field as keyof WorkspacePlanLimits]]),
-        ),
-      )
+    ? resolved
     : Object.fromEntries(
-        LIMIT_FIELDS.map((field) => [field, record[field as keyof WorkspacePlanLimits] ?? null]),
+        LIMIT_FIELDS.map((field) => [field, resolved[field as keyof WorkspacePlanLimits] ?? null]),
       );
   return {
     workspace: name,

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -17,6 +17,10 @@
     // token source for public-repo reads.
     "GITHUB_APP_HOME_INSTALLATION_ID": "147814297",
   },
+  // BILLING_INTERNAL_KEY (Stripe phase 2, task 3): shared secret gating
+  // POST /internal/billing/plan (routes/internal-billing.ts), set via
+  // `wrangler secret put` like ADMIN_TOKEN/GITHUB_APP_WEBHOOK_SECRET —
+  // never a plaintext var. Fail-closed: unset means the route always 401s.
   "routes": [
     {
       "pattern": "api.uploads.sh",

--- a/apps/auth/migrations/20260722190000_stripe_subscription.sql
+++ b/apps/auth/migrations/20260722190000_stripe_subscription.sql
@@ -1,0 +1,33 @@
+-- Stripe phase 2: `@better-auth/stripe` schema (see
+-- docs/superpowers/plans/2026-07-22-stripe-phase2-better-auth-plugin.md).
+-- Dormant: the plugin only mounts when STRIPE_SECRET_KEY and
+-- STRIPE_WEBHOOK_SECRET are both set (src/auth.ts), so this table stays
+-- unwritten until then. Field set is mandated by the installed
+-- @better-auth/stripe@1.6.23 plugin (dist/index.mjs `subscriptions` schema
+-- export) — includes cancelAt/canceledAt/endedAt/billingInterval/
+-- stripeScheduleId, which the phase-2 plan's example omits. Paired with
+-- src/schema.ts — keep both in sync by hand (see the JSDoc there).
+
+CREATE TABLE subscription (
+  id TEXT PRIMARY KEY,
+  plan TEXT NOT NULL,
+  reference_id TEXT NOT NULL,
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT,
+  status TEXT DEFAULT 'incomplete',
+  period_start INTEGER,
+  period_end INTEGER,
+  trial_start INTEGER,
+  trial_end INTEGER,
+  cancel_at_period_end INTEGER DEFAULT FALSE,
+  cancel_at INTEGER,
+  canceled_at INTEGER,
+  ended_at INTEGER,
+  seats INTEGER,
+  billing_interval TEXT,
+  stripe_schedule_id TEXT
+);
+
+ALTER TABLE user ADD COLUMN stripe_customer_id TEXT;
+
+ALTER TABLE organization ADD COLUMN stripe_customer_id TEXT;

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "@better-auth/infra": "^0.3.6",
     "@better-auth/oauth-provider": "^1.6.23",
+    "@better-auth/stripe": "^1.6.23",
     "@uploads/email": "workspace:^",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.28"
+    "hono": "^4.12.28",
+    "stripe": "^22.3.2"
   },
   "devDependencies": {
     "@types/node": "^26.1.0",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -16,6 +16,7 @@
     "@better-auth/infra": "^0.3.6",
     "@better-auth/oauth-provider": "^1.6.23",
     "@better-auth/stripe": "^1.6.23",
+    "@uploads/billing": "workspace:^",
     "@uploads/email": "workspace:^",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",

--- a/apps/auth/src/admin-last-guard.test.ts
+++ b/apps/auth/src/admin-last-guard.test.ts
@@ -55,6 +55,7 @@ async function seedUser(
     banReason: overrides.banReason ?? null,
     banExpires: overrides.banExpires ?? null,
     cliOnboardedAt: overrides.cliOnboardedAt ?? null,
+    stripeCustomerId: overrides.stripeCustomerId ?? null,
   };
   await orm.insert(schema.user).values(user);
   return user;

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -24,6 +24,7 @@ import { deviceWorkspacePlugin } from "./device-workspace";
 import { sendAuthEmail } from "./email";
 import { localDemoEnabled, localDemoPlugin } from "./local-demo";
 import * as schema from "./schema";
+import { stripePluginOrNone } from "./stripe-plugin";
 import { authTrustedOrigins, isTrustedOrigin } from "./trusted-origins";
 import {
   applyWorkspaceChoice,
@@ -289,6 +290,13 @@ export type AuthEnv = GitHubCredentialsEnv &
     AUTH_RATE_LIMIT_DISABLED?: string;
     /** Ephemeral flag passed only by `pnpm dev:stack`; never configure in prod. */
     LOCAL_STACK?: string;
+    /** Stripe phase 2 (task 5): gates stripePluginOrNone (src/stripe-plugin.ts)
+     * and feeds this file's memoization key so a rotated secret or a newly
+     * configured price id doesn't keep serving a stale (unmounted/mounted)
+     * instance. See env.d.ts for the ambient Env declarations these mirror. */
+    STRIPE_SECRET_KEY?: string;
+    STRIPE_WEBHOOK_SECRET?: string;
+    STRIPE_PRO_PRICE_ID?: string;
   };
 
 export type BetterAuthInstance = ReturnType<typeof buildAuth>;
@@ -476,6 +484,11 @@ function buildAuth(
           },
         },
       }),
+      // Stripe phase 2 (task 5): dormant unless both STRIPE_SECRET_KEY and
+      // STRIPE_WEBHOOK_SECRET resolve — see src/stripe-plugin.ts. Ordered
+      // right after organization() since it depends on org membership for
+      // authorizeReference and on the org as the billing entity.
+      ...stripePluginOrNone(env, db),
       // Issue #224, Lane A: signs the OAuth provider's access tokens as JWTs
       // and serves JWKS at /api/auth/jwks. MUST precede oauthProvider() below
       // — the plugin looks up the jwt() config at registration time.
@@ -653,6 +666,9 @@ function cacheKey(
     trustedOriginsEnv: env.BETTER_AUTH_TRUSTED_ORIGINS,
     rateLimitDisabled: env.AUTH_RATE_LIMIT_DISABLED,
     localStack: env.LOCAL_STACK,
+    stripeSecretKey: env.STRIPE_SECRET_KEY,
+    stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
+    stripeProPriceId: env.STRIPE_PRO_PRICE_ID,
     signingSecret,
     githubClientId: github?.clientId ?? null,
     githubClientSecret: github?.clientSecret ?? null,

--- a/apps/auth/src/billing-bridge.test.ts
+++ b/apps/auth/src/billing-bridge.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Stripe phase 2, task 4: syncWorkspacePlan — see src/billing-bridge.ts.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthEnv } from "./auth";
+import * as schema from "./schema";
+import { syncWorkspacePlan } from "./billing-bridge";
+import { createFakeD1 } from "./test/fake-d1";
+
+type TestEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
+
+function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://auth.uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+async function seedOrganization(env: TestEnv, slug: string): Promise<string> {
+  const orm = drizzle(env.DB, { schema });
+  const id = crypto.randomUUID();
+  await orm.insert(schema.organization).values({
+    id,
+    name: slug,
+    slug,
+    createdAt: new Date(),
+  });
+  return id;
+}
+
+describe("syncWorkspacePlan", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("resolves org id to slug and POSTs the plan-set contract to env.API", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: "shh-its-secret" });
+    const orgId = await seedOrganization(env, "acme");
+    const orm = drizzle(env.DB, { schema });
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm, orgId, "pro");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://internal/internal/billing/plan");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["x-internal-billing-key"]).toBe(
+      "shh-its-secret",
+    );
+    expect(JSON.parse(init.body as string)).toEqual({ workspace: "acme", plan: "pro" });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-ops with a log for an unknown organization id", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: "shh-its-secret" });
+    const orm = drizzle(env.DB, { schema });
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm, crypto.randomUUID(), "free");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and swallows a non-2xx response", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: "shh-its-secret" });
+    const orgId = await seedOrganization(env, "acme");
+    const orm = drizzle(env.DB, { schema });
+    const fetchMock = vi.fn(async () => new Response(null, { status: 404 }));
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    await expect(syncWorkspacePlan(env, orm, orgId, "pro")).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and swallows a thrown fetch", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: "shh-its-secret" });
+    const orgId = await seedOrganization(env, "acme");
+    const orm = drizzle(env.DB, { schema });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    await expect(syncWorkspacePlan(env, orm, orgId, "free")).resolves.toBeUndefined();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops with a log when env.API is missing", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: "shh-its-secret" });
+    const orgId = await seedOrganization(env, "acme");
+    const orm = drizzle(env.DB, { schema });
+
+    await syncWorkspacePlan(env, orm, orgId, "pro");
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops with a log when BILLING_INTERNAL_KEY is missing", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    const orm = drizzle(env.DB, { schema });
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm, orgId, "free");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/auth/src/billing-bridge.test.ts
+++ b/apps/auth/src/billing-bridge.test.ts
@@ -123,4 +123,21 @@ describe("syncWorkspacePlan", () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("resolves (never rejects) and logs when the org-slug lookup itself throws", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: "shh-its-secret" });
+    const orgId = await seedOrganization(env, "acme");
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    const brokenOrm = {
+      select: () => {
+        throw new Error("D1 is down");
+      },
+    } as unknown as ReturnType<typeof drizzle<typeof schema>>;
+
+    await expect(syncWorkspacePlan(env, brokenOrm, orgId, "pro")).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/auth/src/billing-bridge.ts
+++ b/apps/auth/src/billing-bridge.ts
@@ -6,10 +6,17 @@
  * `x-internal-billing-key` secret.
  *
  * Deliberately never throws: a webhook handler calling this must not 500
- * because the KV bridge hiccuped. Stripe retries the webhook on failure, and
- * the `subscription` table (Task 1's schema) remains the source of truth
- * regardless of whether this sync landed — so every failure path here is
- * `console.error` + return, not a thrown error.
+ * because the KV bridge hiccuped. The entire body — including the org-slug
+ * lookup — runs inside a single try/catch so a D1 failure can't escape as a
+ * rejected promise either. Every failure path here is `console.error` +
+ * return, not a thrown error.
+ *
+ * Because failures are swallowed, the webhook returns 2xx and Stripe will
+ * NOT retry a failed sync. That's a deliberate tradeoff, not an oversight:
+ * the auth-side `subscription` table (Task 1's schema) remains the source of
+ * truth regardless of whether this sync landed, and an operator can re-run
+ * the sync via the idempotent internal route. A persistent outbox/
+ * reconciliation job is deferred until real traffic justifies it (#388).
  */
 import { eq } from "drizzle-orm";
 import type { drizzle } from "drizzle-orm/d1";
@@ -30,27 +37,27 @@ export async function syncWorkspacePlan(
   referenceId: string,
   plan: "free" | "pro",
 ): Promise<void> {
-  const rows = await db
-    .select({ slug: schema.organization.slug })
-    .from(schema.organization)
-    .where(eq(schema.organization.id, referenceId))
-    .limit(1);
-  const slug = rows[0]?.slug;
-  if (!slug) {
-    console.error(`syncWorkspacePlan: unknown organization id ${referenceId}`);
-    return;
-  }
-
-  if (!env.API) {
-    console.error("syncWorkspacePlan: env.API service binding is not configured");
-    return;
-  }
-  if (!env.BILLING_INTERNAL_KEY) {
-    console.error("syncWorkspacePlan: BILLING_INTERNAL_KEY is not configured");
-    return;
-  }
-
   try {
+    const rows = await db
+      .select({ slug: schema.organization.slug })
+      .from(schema.organization)
+      .where(eq(schema.organization.id, referenceId))
+      .limit(1);
+    const slug = rows[0]?.slug;
+    if (!slug) {
+      console.error(`syncWorkspacePlan: unknown organization id ${referenceId}`);
+      return;
+    }
+
+    if (!env.API) {
+      console.error("syncWorkspacePlan: env.API service binding is not configured");
+      return;
+    }
+    if (!env.BILLING_INTERNAL_KEY) {
+      console.error("syncWorkspacePlan: BILLING_INTERNAL_KEY is not configured");
+      return;
+    }
+
     const response = await env.API.fetch("https://internal/internal/billing/plan", {
       method: "POST",
       headers: {
@@ -65,9 +72,6 @@ export async function syncWorkspacePlan(
       );
     }
   } catch (error) {
-    console.error(
-      `syncWorkspacePlan: POST /internal/billing/plan for workspace ${slug} threw`,
-      error,
-    );
+    console.error(`syncWorkspacePlan: failed for organization ${referenceId}`, error);
   }
 }

--- a/apps/auth/src/billing-bridge.ts
+++ b/apps/auth/src/billing-bridge.ts
@@ -1,0 +1,73 @@
+/**
+ * Stripe phase 2, task 4: bridges a subscription-driven plan change (Task 5's
+ * webhook handler, not yet mounted) to the workspace plan record over the
+ * service binding to apps/api — `POST /internal/billing/plan`
+ * (routes/internal-billing.ts), authed with the shared
+ * `x-internal-billing-key` secret.
+ *
+ * Deliberately never throws: a webhook handler calling this must not 500
+ * because the KV bridge hiccuped. Stripe retries the webhook on failure, and
+ * the `subscription` table (Task 1's schema) remains the source of truth
+ * regardless of whether this sync landed — so every failure path here is
+ * `console.error` + return, not a thrown error.
+ */
+import { eq } from "drizzle-orm";
+import type { drizzle } from "drizzle-orm/d1";
+import type { AuthEnv } from "./auth";
+import * as schema from "./schema";
+
+/**
+ * `AuthEnv` (auth.ts) doesn't itself declare `API`/`BILLING_INTERNAL_KEY` —
+ * both are optional secrets that only need to exist on the ambient `Env`
+ * (see env.d.ts) and are read through this intersection, the same pattern
+ * apps/api's routes/internal-billing.ts uses for its own env access.
+ */
+type BillingBridgeEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
+
+export async function syncWorkspacePlan(
+  env: BillingBridgeEnv,
+  db: ReturnType<typeof drizzle<typeof schema>>,
+  referenceId: string,
+  plan: "free" | "pro",
+): Promise<void> {
+  const rows = await db
+    .select({ slug: schema.organization.slug })
+    .from(schema.organization)
+    .where(eq(schema.organization.id, referenceId))
+    .limit(1);
+  const slug = rows[0]?.slug;
+  if (!slug) {
+    console.error(`syncWorkspacePlan: unknown organization id ${referenceId}`);
+    return;
+  }
+
+  if (!env.API) {
+    console.error("syncWorkspacePlan: env.API service binding is not configured");
+    return;
+  }
+  if (!env.BILLING_INTERNAL_KEY) {
+    console.error("syncWorkspacePlan: BILLING_INTERNAL_KEY is not configured");
+    return;
+  }
+
+  try {
+    const response = await env.API.fetch("https://internal/internal/billing/plan", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-internal-billing-key": env.BILLING_INTERNAL_KEY,
+      },
+      body: JSON.stringify({ workspace: slug, plan }),
+    });
+    if (!response.ok) {
+      console.error(
+        `syncWorkspacePlan: POST /internal/billing/plan for workspace ${slug} failed with status ${response.status}`,
+      );
+    }
+  } catch (error) {
+    console.error(
+      `syncWorkspacePlan: POST /internal/billing/plan for workspace ${slug} threw`,
+      error,
+    );
+  }
+}

--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -17,4 +17,21 @@ interface Env {
   BETTER_AUTH_TRUSTED_ORIGINS?: string;
   /** Dev opt-out for Better Auth's fail-closed production rate limiting. */
   AUTH_RATE_LIMIT_DISABLED?: string;
+  /**
+   * Service binding to apps/api (see wrangler.jsonc), used by
+   * src/billing-bridge.ts to POST /internal/billing/plan. Optional: absent
+   * in tests/local dev without both `wrangler dev` sessions running — the
+   * bridge no-ops (logs, doesn't throw) rather than requiring it.
+   */
+  API?: Fetcher;
+  /** Stripe phase 2 secrets (task 5+): unused directly by billing-bridge.ts,
+   * declared here so the webhook handler that will call syncWorkspacePlan
+   * has them typed on Env. */
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
+  STRIPE_PRO_PRICE_ID?: string;
+  /** Shared secret for POST /internal/billing/plan (see apps/api's
+   * routes/internal-billing.ts and wrangler.jsonc comment there). Fail-closed
+   * when unset: billing-bridge.ts no-ops rather than sending an empty header. */
+  BILLING_INTERNAL_KEY?: string;
 }

--- a/apps/auth/src/internal-routes.test.ts
+++ b/apps/auth/src/internal-routes.test.ts
@@ -130,6 +130,7 @@ describe("DB-backed behavior", () => {
       banReason: overrides.banReason ?? null,
       banExpires: overrides.banExpires ?? null,
       cliOnboardedAt: overrides.cliOnboardedAt ?? null,
+      stripeCustomerId: overrides.stripeCustomerId ?? null,
     };
     await orm.insert(schema.user).values(user);
     return user;
@@ -145,6 +146,7 @@ describe("DB-backed behavior", () => {
       logo: overrides.logo ?? null,
       createdAt: overrides.createdAt ?? new Date(),
       metadata: overrides.metadata ?? null,
+      stripeCustomerId: overrides.stripeCustomerId ?? null,
     };
     await orm.insert(schema.organization).values(org);
     return org;

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -49,6 +49,11 @@ export const user = sqliteTable("user", {
   banExpires: integer("ban_expires", { mode: "timestamp" }),
   /** First CLI device-flow session; sticky. */
   cliOnboardedAt: integer("cli_onboarded_at", { mode: "timestamp" }),
+  /** `@better-auth/stripe`'s `user` schema addition (dormant until the
+   * plugin is mounted — see docs/superpowers/plans/2026-07-22-stripe-phase2-
+   * better-auth-plugin.md). Paired migration:
+   * `migrations/20260722190000_stripe_subscription.sql`. */
+  stripeCustomerId: text("stripe_customer_id"),
 });
 
 /**
@@ -165,6 +170,10 @@ export const organization = sqliteTable("organization", {
   logo: text("logo"),
   createdAt: timestampCol("created_at"),
   metadata: text("metadata"),
+  /** `@better-auth/stripe`'s `organization` schema addition (dormant until
+   * the plugin is mounted). Paired migration:
+   * `migrations/20260722190000_stripe_subscription.sql`. */
+  stripeCustomerId: text("stripe_customer_id"),
 });
 
 /**
@@ -409,6 +418,39 @@ export const oauthWorkspaceChoice = sqliteTable("oauth_workspace_choice", {
 });
 
 /**
+ * `@better-auth/stripe`'s `subscription` model (Stripe phase 2, see
+ * docs/superpowers/plans/2026-07-22-stripe-phase2-better-auth-plugin.md).
+ * Dormant: the plugin only mounts when `STRIPE_SECRET_KEY` and
+ * `STRIPE_WEBHOOK_SECRET` are both set (src/auth.ts), so this table stays
+ * unwritten until then. Field set is mandated by the installed plugin
+ * version — reconciled against `@better-auth/stripe@1.6.23`'s
+ * `dist/index.mjs` `subscriptions` schema export, NOT the phase-2 plan's
+ * example (which omits `cancelAt`/`canceledAt`/`endedAt`/`billingInterval`/
+ * `stripeScheduleId`).
+ *
+ * Paired migration: `migrations/20260722190000_stripe_subscription.sql`.
+ */
+export const subscription = sqliteTable("subscription", {
+  id: text("id").primaryKey(),
+  plan: text("plan").notNull(),
+  referenceId: text("reference_id").notNull(),
+  stripeCustomerId: text("stripe_customer_id"),
+  stripeSubscriptionId: text("stripe_subscription_id"),
+  status: text("status").default("incomplete"),
+  periodStart: integer("period_start", { mode: "timestamp" }),
+  periodEnd: integer("period_end", { mode: "timestamp" }),
+  trialStart: integer("trial_start", { mode: "timestamp" }),
+  trialEnd: integer("trial_end", { mode: "timestamp" }),
+  cancelAtPeriodEnd: integer("cancel_at_period_end", { mode: "boolean" }).default(false),
+  cancelAt: integer("cancel_at", { mode: "timestamp" }),
+  canceledAt: integer("canceled_at", { mode: "timestamp" }),
+  endedAt: integer("ended_at", { mode: "timestamp" }),
+  seats: integer("seats"),
+  billingInterval: text("billing_interval"),
+  stripeScheduleId: text("stripe_schedule_id"),
+});
+
+/**
  * Drizzle relations for Better Auth `experimental.joins` (adapter needs these
  * on the same schema object as the tables). No SQL/migration impact.
  *
@@ -486,3 +528,4 @@ export type AuthInvitation = typeof invitation.$inferSelect;
 export type AuthDeviceCode = typeof deviceCode.$inferSelect;
 export type AuthOauthClient = typeof oauthClient.$inferSelect;
 export type AuthOauthWorkspaceChoice = typeof oauthWorkspaceChoice.$inferSelect;
+export type AuthSubscription = typeof subscription.$inferSelect;

--- a/apps/auth/src/stripe-plugin.test.ts
+++ b/apps/auth/src/stripe-plugin.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Stripe phase 2, task 5: stripePluginOrNone — see src/stripe-plugin.ts.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import * as schema from "./schema";
+import { desiredPlanForStatus, isOrgBillingAdmin, stripePluginOrNone } from "./stripe-plugin";
+import { createFakeD1 } from "./test/fake-d1";
+
+type TestEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
+
+function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://auth.uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    ...overrides,
+  };
+}
+
+const BOTH_SECRETS = {
+  STRIPE_SECRET_KEY: "sk_test_123",
+  STRIPE_WEBHOOK_SECRET: "whsec_123",
+};
+
+describe("stripePluginOrNone", () => {
+  it("returns [] when STRIPE_SECRET_KEY is missing", () => {
+    const env = dbEnv({ STRIPE_WEBHOOK_SECRET: "whsec_123" });
+    const db = drizzle(env.DB, { schema });
+    expect(stripePluginOrNone(env, db)).toEqual([]);
+  });
+
+  it("returns [] when STRIPE_WEBHOOK_SECRET is missing", () => {
+    const env = dbEnv({ STRIPE_SECRET_KEY: "sk_test_123" });
+    const db = drizzle(env.DB, { schema });
+    expect(stripePluginOrNone(env, db)).toEqual([]);
+  });
+
+  it("returns [] when both secrets are missing", () => {
+    const env = dbEnv();
+    const db = drizzle(env.DB, { schema });
+    expect(stripePluginOrNone(env, db)).toEqual([]);
+  });
+
+  it("returns exactly one plugin when both secrets are present", () => {
+    const env = dbEnv({ ...BOTH_SECRETS });
+    const db = drizzle(env.DB, { schema });
+    const plugins = stripePluginOrNone(env, db);
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0]?.id).toBe("stripe");
+  });
+});
+
+describe("desiredPlanForStatus", () => {
+  it("keeps pro for active and trialing", () => {
+    expect(desiredPlanForStatus("active")).toBe("pro");
+    expect(desiredPlanForStatus("trialing")).toBe("pro");
+  });
+
+  it("downgrades to free for every other status", () => {
+    for (const status of [
+      "canceled",
+      "incomplete",
+      "incomplete_expired",
+      "past_due",
+      "paused",
+      "unpaid",
+    ]) {
+      expect(desiredPlanForStatus(status)).toBe("free");
+    }
+  });
+});
+
+describe("isOrgBillingAdmin", () => {
+  async function seed(env: TestEnv) {
+    const db = drizzle(env.DB, { schema });
+    const orgId = crypto.randomUUID();
+    await db.insert(schema.organization).values({
+      id: orgId,
+      name: "acme",
+      slug: "acme",
+      createdAt: new Date(),
+    });
+
+    async function seedUser(role: "owner" | "admin" | "member") {
+      const userId = crypto.randomUUID();
+      await db.insert(schema.user).values({
+        id: userId,
+        name: role,
+        email: `${role}@example.com`,
+        emailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await db.insert(schema.member).values({
+        id: crypto.randomUUID(),
+        organizationId: orgId,
+        userId,
+        role,
+        createdAt: new Date(),
+      });
+      return userId;
+    }
+
+    return { db, orgId, seedUser };
+  }
+
+  it("is true for an owner", async () => {
+    const env = dbEnv();
+    const { db, orgId, seedUser } = await seed(env);
+    const userId = await seedUser("owner");
+    expect(await isOrgBillingAdmin(db, userId, orgId)).toBe(true);
+  });
+
+  it("is true for an admin", async () => {
+    const env = dbEnv();
+    const { db, orgId, seedUser } = await seed(env);
+    const userId = await seedUser("admin");
+    expect(await isOrgBillingAdmin(db, userId, orgId)).toBe(true);
+  });
+
+  it("is false for a plain member", async () => {
+    const env = dbEnv();
+    const { db, orgId, seedUser } = await seed(env);
+    const userId = await seedUser("member");
+    expect(await isOrgBillingAdmin(db, userId, orgId)).toBe(false);
+  });
+
+  it("is false for a non-member", async () => {
+    const env = dbEnv();
+    const { db, orgId } = await seed(env);
+    expect(await isOrgBillingAdmin(db, crypto.randomUUID(), orgId)).toBe(false);
+  });
+});

--- a/apps/auth/src/stripe-plugin.test.ts
+++ b/apps/auth/src/stripe-plugin.test.ts
@@ -21,20 +21,22 @@ function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
   };
 }
 
-const BOTH_SECRETS = {
+const ALL_BRIDGE_DEPS = {
   STRIPE_SECRET_KEY: "sk_test_123",
   STRIPE_WEBHOOK_SECRET: "whsec_123",
+  API: { fetch: async () => new Response(null, { status: 204 }) } as unknown as Fetcher,
+  BILLING_INTERNAL_KEY: "shh-its-secret",
 };
 
 describe("stripePluginOrNone", () => {
   it("returns [] when STRIPE_SECRET_KEY is missing", () => {
-    const env = dbEnv({ STRIPE_WEBHOOK_SECRET: "whsec_123" });
+    const env = dbEnv({ ...ALL_BRIDGE_DEPS, STRIPE_SECRET_KEY: undefined });
     const db = drizzle(env.DB, { schema });
     expect(stripePluginOrNone(env, db)).toEqual([]);
   });
 
   it("returns [] when STRIPE_WEBHOOK_SECRET is missing", () => {
-    const env = dbEnv({ STRIPE_SECRET_KEY: "sk_test_123" });
+    const env = dbEnv({ ...ALL_BRIDGE_DEPS, STRIPE_WEBHOOK_SECRET: undefined });
     const db = drizzle(env.DB, { schema });
     expect(stripePluginOrNone(env, db)).toEqual([]);
   });
@@ -45,8 +47,20 @@ describe("stripePluginOrNone", () => {
     expect(stripePluginOrNone(env, db)).toEqual([]);
   });
 
-  it("returns exactly one plugin when both secrets are present", () => {
-    const env = dbEnv({ ...BOTH_SECRETS });
+  it("returns [] when the API service binding is missing", () => {
+    const env = dbEnv({ ...ALL_BRIDGE_DEPS, API: undefined });
+    const db = drizzle(env.DB, { schema });
+    expect(stripePluginOrNone(env, db)).toEqual([]);
+  });
+
+  it("returns [] when BILLING_INTERNAL_KEY is missing", () => {
+    const env = dbEnv({ ...ALL_BRIDGE_DEPS, BILLING_INTERNAL_KEY: undefined });
+    const db = drizzle(env.DB, { schema });
+    expect(stripePluginOrNone(env, db)).toEqual([]);
+  });
+
+  it("returns exactly one plugin when all bridge deps are present", () => {
+    const env = dbEnv({ ...ALL_BRIDGE_DEPS });
     const db = drizzle(env.DB, { schema });
     const plugins = stripePluginOrNone(env, db);
     expect(plugins).toHaveLength(1);

--- a/apps/auth/src/stripe-plugin.ts
+++ b/apps/auth/src/stripe-plugin.ts
@@ -1,0 +1,118 @@
+/**
+ * Stripe phase 2, task 5: mounts `@better-auth/stripe`, gated on both
+ * STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET resolving — until then,
+ * `stripePluginOrNone` returns `[]` and the plugin (and its `subscription`
+ * table writes, webhook route, etc.) is entirely absent from the Better Auth
+ * instance. `stripePlans(env)` (Task 2) itself degrades to `[]` when
+ * STRIPE_PRO_PRICE_ID is unset, so a secrets-only-partial deploy still mounts
+ * a plugin with zero purchasable plans rather than throwing.
+ *
+ * Orgs are the billing entity (workspaces are 1:1 orgs, see schema.ts) —
+ * `organization: { enabled: true }` gives each org its own Stripe customer.
+ * No `createCustomerOnSignUp`: customers are created lazily at first
+ * checkout, since most accounts never buy.
+ *
+ * The plan-sync side effects (subscription complete/update/cancel/deleted →
+ * `syncWorkspacePlan`, Task 4) never throw — see billing-bridge.ts — so a KV/
+ * service-binding hiccup can't turn into a failed webhook response; Stripe's
+ * own retry behavior isn't what's relied on here for correctness, the
+ * `subscription` table row this plugin itself persists is the source of
+ * truth.
+ */
+import { stripe } from "@better-auth/stripe";
+import Stripe from "stripe";
+import { and, eq } from "drizzle-orm";
+import type { drizzle } from "drizzle-orm/d1";
+import { stripePlans } from "@uploads/billing";
+import * as schema from "./schema";
+import { syncWorkspacePlan } from "./billing-bridge";
+import type { AuthEnv } from "./auth";
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+type StripePluginEnv = AuthEnv &
+  Pick<Env, "STRIPE_SECRET_KEY" | "STRIPE_WEBHOOK_SECRET" | "API" | "BILLING_INTERNAL_KEY">;
+
+/**
+ * Downgrade/upgrade decision for a `subscription.update` webhook: `active`
+ * and `trialing` are the only statuses that keep a workspace on `pro`.
+ * Extracted as a pure function so it's directly unit-testable without
+ * standing up the plugin (see stripe-plugin.test.ts).
+ */
+export function desiredPlanForStatus(status: string): "pro" | "free" {
+  return status === "active" || status === "trialing" ? "pro" : "free";
+}
+
+/**
+ * True when `userId` is an `owner` or `admin` member of the org identified
+ * by `referenceId` — the only roles allowed to start/manage a subscription.
+ * Same select-then-check style as auth.ts's other org-role guards
+ * (lastAdminGuardHook). Exported for direct unit testing.
+ */
+export async function isOrgBillingAdmin(
+  db: Db,
+  userId: string,
+  referenceId: string,
+): Promise<boolean> {
+  const [m] = await db
+    .select({ role: schema.member.role })
+    .from(schema.member)
+    .where(and(eq(schema.member.userId, userId), eq(schema.member.organizationId, referenceId)))
+    .limit(1);
+  return m?.role === "owner" || m?.role === "admin";
+}
+
+/**
+ * `[]` unless both `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` resolve —
+ * otherwise a single configured `stripe()` plugin. Spread into auth.ts's
+ * `plugins` array right after `organization()`.
+ */
+export function stripePluginOrNone(env: StripePluginEnv, db: Db) {
+  if (!env.STRIPE_SECRET_KEY || !env.STRIPE_WEBHOOK_SECRET) return [];
+
+  const stripeClient = new Stripe(env.STRIPE_SECRET_KEY, {
+    apiVersion: "2026-06-24.dahlia",
+    // Workers has no Node `http`/`https` module — force the fetch-based
+    // client rather than relying on the SDK's "workerd" export-condition
+    // auto-selection, which isn't guaranteed under every bundler/test
+    // resolution this repo runs (e.g. vitest's default Node resolution).
+    httpClient: Stripe.createFetchHttpClient(),
+  });
+
+  return [
+    stripe({
+      stripeClient,
+      stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET,
+      organization: { enabled: true },
+      subscription: {
+        enabled: true,
+        plans: stripePlans(env),
+        authorizeReference: async ({ user, referenceId }) =>
+          isOrgBillingAdmin(db, user.id, referenceId),
+        onSubscriptionComplete: async ({ subscription }) => {
+          await syncWorkspacePlan(env, db, subscription.referenceId, "pro");
+        },
+        onSubscriptionUpdate: async ({ subscription }) => {
+          await syncWorkspacePlan(
+            env,
+            db,
+            subscription.referenceId,
+            desiredPlanForStatus(subscription.status),
+          );
+        },
+        onSubscriptionCancel: async ({ subscription }) => {
+          // cancel_at_period_end keeps status "active"/"trialing" until the
+          // period actually ends — the eventual `subscription.deleted` event
+          // (onSubscriptionDeleted below) does that downgrade. Only an
+          // immediate (non-period-end) cancel, which lands here with a
+          // terminal status already, downgrades now.
+          if (desiredPlanForStatus(subscription.status) === "free") {
+            await syncWorkspacePlan(env, db, subscription.referenceId, "free");
+          }
+        },
+        onSubscriptionDeleted: async ({ subscription }) => {
+          await syncWorkspacePlan(env, db, subscription.referenceId, "free");
+        },
+      },
+    }),
+  ];
+}

--- a/apps/auth/src/stripe-plugin.ts
+++ b/apps/auth/src/stripe-plugin.ts
@@ -1,9 +1,13 @@
 /**
- * Stripe phase 2, task 5: mounts `@better-auth/stripe`, gated on both
- * STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET resolving — until then,
+ * Stripe phase 2, task 5: mounts `@better-auth/stripe`, gated on ALL of the
+ * bridge's prerequisites resolving — STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET,
+ * the `API` service binding, and BILLING_INTERNAL_KEY. Until then,
  * `stripePluginOrNone` returns `[]` and the plugin (and its `subscription`
  * table writes, webhook route, etc.) is entirely absent from the Better Auth
- * instance. `stripePlans(env)` (Task 2) itself degrades to `[]` when
+ * instance. A checkout that can't sync the resulting plan to the workspace
+ * record (billing-bridge.ts) must not be sellable in the first place — hence
+ * gating on the bridge deps too, not just the two Stripe secrets.
+ * `stripePlans(env)` (Task 2) itself degrades to `[]` when
  * STRIPE_PRO_PRICE_ID is unset, so a secrets-only-partial deploy still mounts
  * a plugin with zero purchasable plans rather than throwing.
  *
@@ -62,12 +66,20 @@ export async function isOrgBillingAdmin(
 }
 
 /**
- * `[]` unless both `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` resolve —
- * otherwise a single configured `stripe()` plugin. Spread into auth.ts's
- * `plugins` array right after `organization()`.
+ * `[]` unless `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, the `API` service
+ * binding, and `BILLING_INTERNAL_KEY` all resolve — otherwise a single
+ * configured `stripe()` plugin. Spread into auth.ts's `plugins` array right
+ * after `organization()`.
  */
 export function stripePluginOrNone(env: StripePluginEnv, db: Db) {
-  if (!env.STRIPE_SECRET_KEY || !env.STRIPE_WEBHOOK_SECRET) return [];
+  if (
+    !env.STRIPE_SECRET_KEY ||
+    !env.STRIPE_WEBHOOK_SECRET ||
+    !env.API ||
+    !env.BILLING_INTERNAL_KEY
+  ) {
+    return [];
+  }
 
   const stripeClient = new Stripe(env.STRIPE_SECRET_KEY, {
     apiVersion: "2026-06-24.dahlia",

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -82,6 +82,19 @@
   // Magic-link delivery. uploads.sh is onboarded for Cloudflare Email Sending;
   // all auth mail comes from noreply@uploads.sh (D7).
   "send_email": [{ "name": "EMAIL", "allowed_sender_addresses": ["noreply@uploads.sh"] }],
+  // Service binding to apps/api (Stripe phase 2, task 4): lets
+  // src/billing-bridge.ts POST /internal/billing/plan over the binding when
+  // a Stripe webhook changes an org's subscription, mirroring apps/api's own
+  // AUTH binding back to this worker. Local-dev caveat: this only resolves
+  // when BOTH `wrangler dev` sessions (apps/auth and apps/api) are running
+  // concurrently — a solo `wrangler dev` here leaves env.API undefined, and
+  // billing-bridge.ts treats that as a no-op (logs, doesn't throw).
+  "services": [
+    {
+      "binding": "API",
+      "service": "uploads-api",
+    },
+  ],
   // Better Auth's own database-backed rate limiter (storage: "database" in
   // src/auth.ts) covers /api/auth/* abuse; this namespace is reserved for a
   // future edge-level limiter in front of it, following apps/api's and

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^14.1.2",
     "@astrojs/react": "^6.0.1",
+    "@uploads/billing": "workspace:^",
     "@uploads/ui": "workspace:*",
     "astro": "^7.0.6",
     "files-sdk": "^2.1.0",

--- a/apps/web/src/lib/auth-client.test.ts
+++ b/apps/web/src/lib/auth-client.test.ts
@@ -9,6 +9,7 @@ import {
   listAccounts,
   listAdminUsers,
   listSessions,
+  openOrganizationBillingPortal,
   revokeSession,
   sendMagicLink,
   getOAuthWorkspaceChoice,
@@ -17,6 +18,7 @@ import {
   startLocalDemoSession,
   submitOAuthConsent,
   unbanUser,
+  upgradeOrganizationSubscription,
 } from "./auth-client";
 import { BROWSER_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "./request";
 
@@ -650,5 +652,121 @@ describe("startLocalDemoSession", () => {
     await expect(
       startLocalDemoSession("http://127.0.0.1:8788", "http://127.0.0.1:4321"),
     ).resolves.toEqual({ kind: "unavailable", reason: "server" });
+  });
+});
+
+describe("upgradeOrganizationSubscription", () => {
+  it("posts the organization upgrade body and returns the checkout url", async () => {
+    const fetcher = vi.fn(async () => Response.json({ url: "https://checkout.stripe.com/x" }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(
+      upgradeOrganizationSubscription("https://auth.uploads.sh", {
+        plan: "pro",
+        referenceId: "org_1",
+        successUrl: "https://uploads.sh/account/workspaces/acme/billing?upgraded=1",
+        cancelUrl: "https://uploads.sh/account/workspaces/acme/billing",
+      }),
+    ).resolves.toEqual({ ok: true, url: "https://checkout.stripe.com/x" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/subscription/upgrade",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plan: "pro",
+          referenceId: "org_1",
+          customerType: "organization",
+          successUrl: "https://uploads.sh/account/workspaces/acme/billing?upgraded=1",
+          cancelUrl: "https://uploads.sh/account/workspaces/acme/billing",
+        }),
+      }),
+    );
+  });
+
+  it("surfaces a server error message, falling back to a generic one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ message: "already subscribed" }, { status: 400 })),
+    );
+    await expect(
+      upgradeOrganizationSubscription("https://auth.uploads.sh", {
+        plan: "pro",
+        referenceId: "org_1",
+        successUrl: "https://uploads.sh/x",
+        cancelUrl: "https://uploads.sh/x",
+      }),
+    ).resolves.toEqual({ ok: false, message: "already subscribed" });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 500 })),
+    );
+    await expect(
+      upgradeOrganizationSubscription("https://auth.uploads.sh", {
+        plan: "pro",
+        referenceId: "org_1",
+        successUrl: "https://uploads.sh/x",
+        cancelUrl: "https://uploads.sh/x",
+      }),
+    ).resolves.toEqual({ ok: false, message: "Something went wrong. Try again." });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    await expect(
+      upgradeOrganizationSubscription("https://auth.uploads.sh", {
+        plan: "pro",
+        referenceId: "org_1",
+        successUrl: "https://uploads.sh/x",
+        cancelUrl: "https://uploads.sh/x",
+      }),
+    ).resolves.toEqual({ ok: false, message: "Couldn't reach the auth service. Try again." });
+  });
+});
+
+describe("openOrganizationBillingPortal", () => {
+  it("posts the organization billing-portal body and returns the portal url", async () => {
+    const fetcher = vi.fn(async () => Response.json({ url: "https://billing.stripe.com/x" }));
+    vi.stubGlobal("fetch", fetcher);
+
+    await expect(
+      openOrganizationBillingPortal("https://auth.uploads.sh", {
+        referenceId: "org_1",
+        returnUrl: "https://uploads.sh/account/workspaces/acme/billing",
+      }),
+    ).resolves.toEqual({ ok: true, url: "https://billing.stripe.com/x" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://auth.uploads.sh/api/auth/subscription/billing-portal",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          referenceId: "org_1",
+          customerType: "organization",
+          returnUrl: "https://uploads.sh/account/workspaces/acme/billing",
+        }),
+      }),
+    );
+  });
+
+  it("returns false-shaped failure on non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ error: { message: "no customer" } }, { status: 404 })),
+    );
+    await expect(
+      openOrganizationBillingPortal("https://auth.uploads.sh", {
+        referenceId: "org_1",
+        returnUrl: "https://uploads.sh/x",
+      }),
+    ).resolves.toEqual({ ok: false, message: "no customer" });
   });
 });

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -747,6 +747,75 @@ export async function revokeSession(origin: string, token: string): Promise<bool
 }
 
 /**
+ * Stripe phase 2, task 6: organization-subscription wrappers for the
+ * workspace billing tab. Plain `fetch()` against the `@better-auth/stripe`
+ * plugin's REST endpoints (`/subscription/upgrade`, `/subscription/billing-
+ * portal`) rather than pulling in `better-auth/client` + `@better-auth/
+ * stripe/client` — this file's top-of-file doc explains why apps/web stays
+ * off the client-bundle SDK, and that reasoning applies here too: two POSTs
+ * with a JSON `{ url }` response don't need a client library. Both
+ * endpoints reply `{ url, redirect }` on success (server never itself
+ * redirects); callers navigate to `url` themselves.
+ */
+export type SubscriptionActionResult = { ok: true; url: string } | { ok: false; message: string };
+
+async function postSubscriptionAction(
+  origin: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<SubscriptionActionResult> {
+  try {
+    const res = await fetch(`${authOrigin(origin)}${path}`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = (await res.json().catch(() => null)) as {
+      url?: string;
+      message?: string;
+      code?: string;
+      error?: { message?: string };
+    } | null;
+    if (!res.ok || typeof data?.url !== "string") {
+      return {
+        ok: false,
+        message: data?.error?.message ?? data?.message ?? "Something went wrong. Try again.",
+      };
+    }
+    return { ok: true, url: data.url };
+  } catch {
+    return { ok: false, message: "Couldn't reach the auth service. Try again." };
+  }
+}
+
+/** POST /api/auth/subscription/upgrade for an organization reference. */
+export function upgradeOrganizationSubscription(
+  origin: string,
+  opts: { plan: string; referenceId: string; successUrl: string; cancelUrl: string },
+): Promise<SubscriptionActionResult> {
+  return postSubscriptionAction(origin, "/api/auth/subscription/upgrade", {
+    plan: opts.plan,
+    referenceId: opts.referenceId,
+    customerType: "organization",
+    successUrl: opts.successUrl,
+    cancelUrl: opts.cancelUrl,
+  });
+}
+
+/** POST /api/auth/subscription/billing-portal for an organization reference. */
+export function openOrganizationBillingPortal(
+  origin: string,
+  opts: { referenceId: string; returnUrl: string },
+): Promise<SubscriptionActionResult> {
+  return postSubscriptionAction(origin, "/api/auth/subscription/billing-portal", {
+    referenceId: opts.referenceId,
+    customerType: "organization",
+    returnUrl: opts.returnUrl,
+  });
+}
+
+/**
  * OAuth AS client metadata (issue #224, Lane B): fields the `/oauth/consent`
  * page reads off `@better-auth/oauth-provider`'s public-client response.
  * `client_uri`/`logo_uri` are attacker-controlled (any registered DCR

--- a/apps/web/src/lib/billing-cta.test.ts
+++ b/apps/web/src/lib/billing-cta.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveBillingCta } from "./billing-cta";
+
+describe("resolveBillingCta", () => {
+  it("stays unavailable when pro isn't purchasable yet, regardless of plan", () => {
+    expect(resolveBillingCta({ proAvailable: false, plan: "free" })).toEqual({
+      kind: "unavailable",
+    });
+    expect(resolveBillingCta({ proAvailable: false, plan: "pro" })).toEqual({
+      kind: "unavailable",
+    });
+  });
+
+  it("offers upgrade when pro is available and the workspace isn't on it", () => {
+    expect(resolveBillingCta({ proAvailable: true, plan: "free" })).toEqual({
+      kind: "upgrade",
+    });
+  });
+
+  it("offers the billing portal when the workspace is already on pro", () => {
+    expect(resolveBillingCta({ proAvailable: true, plan: "pro" })).toEqual({
+      kind: "manage",
+    });
+  });
+});

--- a/apps/web/src/lib/billing-cta.ts
+++ b/apps/web/src/lib/billing-cta.ts
@@ -1,0 +1,31 @@
+/**
+ * Workspace billing tab upgrade/manage CTA — Stripe phase 2, task 6.
+ *
+ * Pure render-state logic, kept separate from billing.astro's DOM glue so
+ * it's unit-testable the way the rest of this app's account-shell modules
+ * are (see workspace-ui.ts / workspaces-nav.ts).
+ *
+ * Gated on `PLANS.pro.available` (the catalog's static "can anyone buy
+ * this today" flag), NOT the `/me/workspaces/:name/billing` response's own
+ * `available` field — that field describes whether the workspace's
+ * *current* plan is still a valid self-serve plan (planResponse in
+ * apps/api/src/workspace-plan.ts), which is `true` for a free workspace
+ * regardless of whether pro is purchasable yet. Callers pass
+ * `PLANS.pro.available` in as `proAvailable` (rather than this module
+ * reading the catalog itself) so the three states are each independently
+ * testable without mocking the catalog.
+ */
+export type BillingCtaState = { kind: "unavailable" } | { kind: "upgrade" } | { kind: "manage" };
+
+/**
+ * Resolves which billing-tab CTA to render.
+ *
+ * - pro not yet available (today): unchanged disabled "coming soon" button.
+ * - pro available and the workspace isn't on it: "Upgrade to Pro".
+ * - pro available and the workspace is on it: "Manage billing" (portal).
+ */
+export function resolveBillingCta(input: { proAvailable: boolean; plan: string }): BillingCtaState {
+  if (!input.proAvailable) return { kind: "unavailable" };
+  if (input.plan === "pro") return { kind: "manage" };
+  return { kind: "upgrade" };
+}

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -45,12 +45,14 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
         <div class="settings-section">
           <button type="button" id="ws-upgrade-btn" disabled>Upgrade — coming soon</button>
+          <p class="muted" id="ws-billing-error" role="alert" hidden></p>
         </div>
       </div>
     </section>
   </div>
 
   <script>
+    import { PLANS } from "@uploads/billing";
     import {
       getPageVisit,
       isCurrentPageVisit,
@@ -59,6 +61,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       requireElement,
     } from "../../../../lib/account-shell";
     import { getWorkspaceBilling, type WorkspaceBilling } from "../../../../lib/api-client";
+    import {
+      openOrganizationBillingPortal,
+      upgradeOrganizationSubscription,
+    } from "../../../../lib/auth-client";
+    import { resolveBillingCta } from "../../../../lib/billing-cta";
     import { formatBytes } from "../../../../lib/workspace-ui";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
 
@@ -70,13 +77,19 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const stillHere = (): boolean => isCurrentPageVisit(visit);
       const w = window as unknown as {
         __UPLOADS_API_ORIGIN__: string;
+        __UPLOADS_AUTH_ORIGIN__: string;
         __UPLOADS_ACTIVE_WORKSPACE__: string;
       };
       const apiOrigin = w.__UPLOADS_API_ORIGIN__;
+      const authOrigin = w.__UPLOADS_AUTH_ORIGIN__;
       const workspaceName = resolveActiveWorkspace(
         window.location.pathname,
         w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
       );
+      // Strip a stray `?upgraded=1` (Stripe checkout successUrl round-trip)
+      // before building the CTA's own successUrl/cancelUrl/returnUrl so a
+      // second upgrade attempt doesn't chain query params.
+      const billingTabUrl = `${window.location.origin}${window.location.pathname}`;
 
       const statusEl = requireElement<HTMLElement>("#ws-status", page);
       const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
@@ -85,6 +98,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const planNameEl = requireElement<HTMLElement>("#ws-plan-name", page);
       const planBlurbEl = requireElement<HTMLElement>("#ws-plan-blurb", page);
       const limitsListEl = requireElement<HTMLElement>("#ws-limits-list", page);
+      const upgradeBtn = requireElement<HTMLButtonElement>("#ws-upgrade-btn", page);
+      const billingErrorEl = requireElement<HTMLElement>("#ws-billing-error", page);
 
       function showError(message: string, retry = true): void {
         if (!stillHere()) return;
@@ -137,6 +152,65 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         limitsListEl.innerHTML = rows.join("");
       }
 
+      let organizationId = "";
+
+      function paintUpgradeButton(billing: WorkspaceBilling): void {
+        organizationId = billing.organization.id;
+        billingErrorEl.hidden = true;
+        billingErrorEl.textContent = "";
+
+        const cta = resolveBillingCta({ proAvailable: PLANS.pro.available, plan: billing.plan });
+        upgradeBtn.dataset.cta = cta.kind;
+        if (cta.kind === "unavailable") {
+          upgradeBtn.textContent = "Upgrade — coming soon";
+          upgradeBtn.disabled = true;
+        } else if (cta.kind === "upgrade") {
+          upgradeBtn.textContent = "Upgrade to Pro";
+          upgradeBtn.disabled = false;
+        } else {
+          upgradeBtn.textContent = "Manage billing";
+          upgradeBtn.disabled = false;
+        }
+      }
+
+      async function handleUpgradeClick(): Promise<void> {
+        const cta = upgradeBtn.dataset.cta;
+        if (cta !== "upgrade" && cta !== "manage") return;
+        if (!organizationId) {
+          billingErrorEl.hidden = false;
+          billingErrorEl.textContent = "upgrade failed — try again";
+          return;
+        }
+
+        billingErrorEl.hidden = true;
+        billingErrorEl.textContent = "";
+        upgradeBtn.disabled = true;
+
+        const result =
+          cta === "upgrade"
+            ? await upgradeOrganizationSubscription(authOrigin, {
+                plan: "pro",
+                referenceId: organizationId,
+                successUrl: `${billingTabUrl}?upgraded=1`,
+                cancelUrl: billingTabUrl,
+              })
+            : await openOrganizationBillingPortal(authOrigin, {
+                referenceId: organizationId,
+                returnUrl: billingTabUrl,
+              });
+
+        if (!stillHere()) return;
+        if (!result.ok) {
+          upgradeBtn.disabled = false;
+          billingErrorEl.hidden = false;
+          billingErrorEl.textContent =
+            cta === "upgrade" ? "upgrade failed — try again" : "couldn’t open billing — try again";
+          return;
+        }
+
+        location.href = result.url;
+      }
+
       async function loadBillingPage(): Promise<void> {
         if (!stillHere()) return;
         statusEl.hidden = false;
@@ -166,6 +240,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             : "This plan isn’t available for self-serve upgrade yet."
           : "No plan has been applied yet — limits below reflect what's currently enforced.";
         paintLimits(billing);
+        paintUpgradeButton(billing);
 
         statusEl.hidden = true;
         appEl.hidden = false;
@@ -178,6 +253,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
       retryBtn.addEventListener("click", () => {
         void loadBillingPage();
+      });
+
+      upgradeBtn.addEventListener("click", () => {
+        void handleUpgradeClick();
       });
 
       onSession(() => {

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./limits";
 export * from "./plans";
 export * from "./resolve";
 export * from "./provider";

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./plans";
 export * from "./resolve";
 export * from "./provider";
+export * from "./stripe-plans";

--- a/packages/billing/src/limits.ts
+++ b/packages/billing/src/limits.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical list of workspace budget-limit fields. Single source of truth
+ * for field names/order — `apps/api/src/workspace-limits.ts` (admin PATCH
+ * validation) and `packages/billing/src/plans.ts` (plan defaults / display)
+ * both derive from this instead of maintaining their own copies (issue
+ * #388, deferred from PR #386 review).
+ */
+export const LIMIT_FIELDS = [
+  "maxStorageBytes",
+  "maxUploadsPerPeriod",
+  "maxUploadBytes",
+  "maxVideoUploadBytes",
+] as const;
+
+export type LimitField = (typeof LIMIT_FIELDS)[number];

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -8,18 +8,18 @@
  * `PLANS.free.defaultLimits` into `SELF_SERVE_LIMITS` (do not re-hardcode).
  */
 
+import type { LimitField } from "./limits";
+
 export type PlanId = "free" | "pro";
 
 /** The four budget-limit fields a plan can default — same shape as
  * `apps/api/src/budget.ts`'s `WorkspaceBudgetLimits` plus the two
  * per-upload caps from `WorkspaceRecord`, kept here as an independent type
- * so this package has no dependency on `@uploads/api`. */
-export interface WorkspacePlanLimits {
-  maxStorageBytes?: number;
-  maxUploadsPerPeriod?: number;
-  maxUploadBytes?: number;
-  maxVideoUploadBytes?: number;
-}
+ * so this package has no dependency on `@uploads/api`. Field set is the
+ * canonical `LIMIT_FIELDS` list from `./limits`. */
+export type WorkspacePlanLimits = {
+  [K in LimitField]?: number;
+};
 
 export interface PlanDefinition {
   id: PlanId;

--- a/packages/billing/src/resolve.ts
+++ b/packages/billing/src/resolve.ts
@@ -5,9 +5,10 @@
  * Pure — no I/O — so `apps/api/src/budget.ts` and the admin/user routes can
  * all call through this single chokepoint without drifting on precedence.
  */
-import { PLANS, getPlan, type PlanId, type WorkspacePlanLimits } from "./plans";
+import { LIMIT_FIELDS } from "./limits";
+import { getPlan, type PlanId, type WorkspacePlanLimits } from "./plans";
 
-const LIMIT_KEYS = Object.keys(PLANS.free.defaultLimits) as (keyof WorkspacePlanLimits)[];
+const LIMIT_KEYS = LIMIT_FIELDS as unknown as (keyof WorkspacePlanLimits)[];
 
 /**
  * Per-field override input. Mirrors the real-world tri-state on
@@ -45,4 +46,44 @@ export function resolvePlanLimits(
     }
   }
   return resolved;
+}
+
+/** Per-field override input plus the optional plan string carried on a
+ * workspace record — the shape `resolveEffectiveLimits` needs from any
+ * caller's record type. */
+export type EffectiveLimitsRecord = WorkspacePlanLimitOverrides & {
+  plan?: PlanId | string;
+};
+
+/**
+ * Single seam for "what are this workspace's effective limits" — the one
+ * place the `plan === undefined` gate lives (issue #388, deferred from PR
+ * #386 review). Both enforcement (`apps/api/src/budget.ts`) and display
+ * (`apps/api/src/workspace-plan.ts`) call through here so they can never
+ * drift on precedence.
+ *
+ * When `record.plan` is absent, this reproduces pre-billing behavior
+ * byte-for-byte: no plan defaults are applied — only the record's own
+ * explicit fields, with `null` (and absence) both resolving to `undefined`
+ * (unlimited). Callers that need to sanitize raw/legacy field values
+ * (e.g. `budget.ts`'s `positiveLimit` filtering) must do so before calling
+ * this function — an absent `plan` here does not consult `resolvePlanLimits`
+ * at all, so no plan-default fallback would apply to a sanitized value
+ * either way.
+ *
+ * When `record.plan` is set (including an unrecognized/legacy string,
+ * which fails open to `free` via `getPlan`), this defers entirely to
+ * `resolvePlanLimits` for precedence between the record's overrides and
+ * the resolved plan's defaults.
+ */
+export function resolveEffectiveLimits(record: EffectiveLimitsRecord): WorkspacePlanLimits {
+  if (record.plan === undefined) {
+    const resolved: WorkspacePlanLimits = {};
+    for (const key of LIMIT_KEYS) {
+      const value = record[key];
+      resolved[key] = value === null ? undefined : value;
+    }
+    return resolved;
+  }
+  return resolvePlanLimits(record.plan, record);
 }

--- a/packages/billing/src/stripe-plans.test.ts
+++ b/packages/billing/src/stripe-plans.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { stripePlans } from "./stripe-plans";
+
+describe("stripePlans", () => {
+  it("returns [] with no price id", () => {
+    expect(stripePlans({})).toEqual([]);
+  });
+  it("maps pro to the configured price", () => {
+    expect(stripePlans({ STRIPE_PRO_PRICE_ID: "price_x" })).toEqual([
+      { name: "pro", priceId: "price_x" },
+    ]);
+  });
+});

--- a/packages/billing/src/stripe-plans.ts
+++ b/packages/billing/src/stripe-plans.ts
@@ -1,0 +1,12 @@
+import type { PlanId } from "./plans";
+
+export interface StripePlan {
+  name: PlanId;
+  priceId: string;
+}
+
+/** Plugin `subscription.plans` for @better-auth/stripe. Only paid plans with
+ * a configured live price id appear; empty array = mounted-but-dormant. */
+export function stripePlans(env: { STRIPE_PRO_PRICE_ID?: string }): StripePlan[] {
+  return env.STRIPE_PRO_PRICE_ID ? [{ name: "pro", priceId: env.STRIPE_PRO_PRICE_ID }] : [];
+}

--- a/packages/billing/test/resolve.test.ts
+++ b/packages/billing/test/resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolvePlanLimits } from "../src/resolve";
+import { resolveEffectiveLimits, resolvePlanLimits } from "../src/resolve";
 import { PLANS } from "../src/plans";
 
 describe("resolvePlanLimits", () => {
@@ -69,5 +69,47 @@ describe("resolvePlanLimits", () => {
       maxUploadBytes: 3,
       maxVideoUploadBytes: 4,
     });
+  });
+});
+
+describe("resolveEffectiveLimits", () => {
+  // Characterization for the single `plan === undefined` gate (issue #388):
+  // both apps/api/src/budget.ts (enforcement) and workspace-plan.ts
+  // (display) call through this seam.
+  it("no plan set: returns the record's own fields, no plan defaults applied", () => {
+    expect(resolveEffectiveLimits({})).toEqual({
+      maxStorageBytes: undefined,
+      maxUploadsPerPeriod: undefined,
+      maxUploadBytes: undefined,
+      maxVideoUploadBytes: undefined,
+    });
+  });
+
+  it("no plan set: an explicit numeric field passes through unchanged", () => {
+    const resolved = resolveEffectiveLimits({ maxStorageBytes: 500 });
+    expect(resolved.maxStorageBytes).toBe(500);
+    expect(resolved.maxUploadsPerPeriod).toBeUndefined();
+  });
+
+  it("no plan set: an explicit null field resolves to undefined (unlimited), same as absent", () => {
+    const resolved = resolveEffectiveLimits({ maxStorageBytes: null });
+    expect(resolved.maxStorageBytes).toBeUndefined();
+  });
+
+  it("plan set: defers to resolvePlanLimits for defaults + override precedence", () => {
+    expect(resolveEffectiveLimits({ plan: "free" })).toEqual(PLANS.free.defaultLimits);
+    const withOverride = resolveEffectiveLimits({ plan: "pro", maxStorageBytes: 1_000 });
+    expect(withOverride.maxStorageBytes).toBe(1_000);
+    expect(withOverride.maxUploadsPerPeriod).toBe(PLANS.pro.defaultLimits.maxUploadsPerPeriod);
+  });
+
+  it("plan set: an unrecognized plan string still fails open to free via resolvePlanLimits", () => {
+    expect(resolveEffectiveLimits({ plan: "enterprise" })).toEqual(PLANS.free.defaultLimits);
+  });
+
+  it("plan set: an explicit null override still wins over the plan default (unlimited)", () => {
+    const resolved = resolveEffectiveLimits({ plan: "free", maxStorageBytes: null });
+    expect(resolved.maxStorageBytes).toBeUndefined();
+    expect(resolved.maxUploadsPerPeriod).toBe(PLANS.free.defaultLimits.maxUploadsPerPeriod);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@26.1.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yaml@2.9.0)
+      '@uploads/billing':
+        specifier: workspace:^
+        version: link:../../packages/billing
       '@uploads/ui':
         specifier: workspace:*
         version: link:../../packages/ui

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@better-auth/oauth-provider':
         specifier: ^1.6.23
         version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))
+      '@better-auth/stripe':
+        specifier: ^1.6.23
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(stripe@22.3.2(@types/node@26.1.0))
       '@uploads/email':
         specifier: workspace:^
         version: link:../../packages/email
@@ -96,6 +99,9 @@ importers:
       hono:
         specifier: ^4.12.28
         version: 4.12.28
+      stripe:
+        specifier: ^22.3.2
+        version: 22.3.2(@types/node@26.1.0)
     devDependencies:
       '@types/node':
         specifier: ^26.1.0
@@ -705,6 +711,14 @@ packages:
         optional: true
       prisma:
         optional: true
+
+  '@better-auth/stripe@1.6.23':
+    resolution: {integrity: sha512-hsMGJQ947k82ZRP5ULWXbNiHLSs57XeVdZ1n2XoWFgRX4ilnvRsQwLTWnwvde4eCIV4x/aT+GEoN8T42t4KlSg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      better-auth: ^1.6.23
+      better-call: 1.3.7
+      stripe: ^18 || ^19 || ^20 || ^21 || ^22
 
   '@better-auth/telemetry@1.6.23':
     resolution: {integrity: sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==}
@@ -4242,6 +4256,15 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  stripe@22.3.2:
+    resolution: {integrity: sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5368,6 +5391,15 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
+
+  '@better-auth/stripe@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(stripe@22.3.2(@types/node@26.1.0))':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0)))
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      stripe: 22.3.2(@types/node@26.1.0)
+      zod: 4.4.3
 
   '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
@@ -8483,6 +8515,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  stripe@22.3.2(@types/node@26.1.0):
+    optionalDependencies:
+      '@types/node': 26.1.0
 
   sucrase@3.35.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@better-auth/stripe':
         specifier: ^1.6.23
         version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(better-auth@1.6.23(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(yaml@2.9.0))))(better-call@1.3.7(zod@4.4.3))(stripe@22.3.2(@types/node@26.1.0))
+      '@uploads/billing':
+        specifier: workspace:^
+        version: link:../../packages/billing
       '@uploads/email':
         specifier: workspace:^
         version: link:../../packages/email


### PR DESCRIPTION
Phase 2 of the billing infrastructure (#388), revised to mount `@better-auth/stripe` on `apps/auth` instead of the hand-rolled webhook route + api-side subscription table the issue originally sketched. Everything is **dormant until secrets are set** — with `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` absent there is provably zero behavior change on any surface (all pre-existing suites pass unchanged).

## What's here

- **apps/auth**: `@better-auth/stripe@1.6.23` mounted org-scoped (orgs are 1:1 with workspaces), gated on both secrets resolving; `authorizeReference` limits checkout/portal to org owner/admin; D1 `subscription` table + `stripeCustomerId` columns (migration `20260722190000`); subscription lifecycle hooks call a new bridge.
- **Bridge**: new `API` service binding (auth→api) + `syncWorkspacePlan` — resolves org→workspace slug and POSTs to the internal route; never throws (webhooks can't 500 on a bridge hiccup; Stripe retries give eventual consistency).
- **apps/api**: `POST /internal/billing/plan`, gated on `BILLING_INTERNAL_KEY` (timing-safe hash compare, fail-closed 401 when unset), writes `plan` via `mutateWorkspaceRecord` (#387's versioned RMW).
- **packages/billing**: `stripePlans()` maps the catalog to the plugin's `plans` config (empty without `STRIPE_PRO_PRICE_ID`); canonical limit-field types moved here; single `resolveEffectiveLimits` seam now shared by enforcement (`budget.ts`) and display (`workspace-plan.ts`) — behavior-neutral, characterization-tested; `planApplied` honesty invariant preserved.
- **apps/web**: billing-tab upgrade CTA + billing portal button, rendered only when `PLANS.pro.available` flips (still `false`, so the tab is unchanged today). Uses the existing zero-dependency plain-fetch auth client; endpoint paths/shapes verified against the installed plugin.

## Not in this PR (Task 8 runbook, gated on operator steps)

Stripe test-mode product/price, webhook endpoint registration (`auth.uploads.sh/api/auth/stripe/webhook`), `STRIPE_WEBHOOK_SECRET`/`STRIPE_PRO_PRICE_ID`/`BILLING_INTERNAL_KEY` secrets, prod D1 migration, test-mode e2e, and the `pro.available` flip.

## Notes for review

- `/internal/billing/plan` is reachable on the public api origin; "internal" is its auth model (shared secret), matching the `/v1/github/webhook` posture.
- `BILLING_INTERNAL_KEY` is typed via a documented `Env` intersection cast pending `worker-configuration.d.ts` regen at deploy (regen reads `.dev.vars`).
- Follow-up minors: narrow the `budget.ts` spread into `resolveEffectiveLimits`; `worker-configuration.d.ts` regen.

Plan: `docs/superpowers/plans/2026-07-22-stripe-phase2-better-auth-plugin.md`. Full sweep: 2677 tests green, typecheck clean across all workers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stripe subscription support for upgrading workspaces and managing billing.
  * Billing pages now show Upgrade, Manage billing, or Coming soon states and provide clearer error handling.
  * Subscription status automatically updates workspace plans.
  * Added support for storing subscription and customer billing information.

* **Bug Fixes**
  * Improved workspace budget-limit resolution, preserving explicit limits and unlimited settings across plan changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->