### PR TITLE
feat(billing): make the pro plan available for self-serve upgrade

### DIFF
--- a/apps/api/src/routes/admin-ui.test.ts
+++ b/apps/api/src/routes/admin-ui.test.ts
@@ -738,7 +738,7 @@ describe("workspace plan editing", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { plan: string; available: boolean; planApplied: boolean };
     expect(body.plan).toBe("pro");
-    expect(body.available).toBe(false);
+    expect(body.available).toBe(true);
     expect(body.planApplied).toBe(true);
     expect(JSON.parse(store.get("ws:acme") ?? "{}").plan).toBe("pro");
   });

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -448,7 +448,7 @@ describe("GET /me/workspaces/:name/billing", () => {
       limits: Record<string, number | null>;
     };
     expect(body.plan).toBe("pro");
-    expect(body.available).toBe(false);
+    expect(body.available).toBe(true);
     expect(body.planApplied).toBe(true);
     expect(body.limits.maxStorageBytes).toBe(10_000_000_000);
   });

--- a/apps/api/src/workspace-plan.test.ts
+++ b/apps/api/src/workspace-plan.test.ts
@@ -64,10 +64,10 @@ describe("planResponse", () => {
     expect(result.limits.maxUploadsPerPeriod).toBe(3000);
   });
 
-  it("reports pro as unavailable when a workspace is set to it", () => {
+  it("reports pro as available when a workspace is set to it", () => {
     const result = planResponse("acme", { provider: "r2", bucket: "b", plan: "pro" });
     expect(result.plan).toBe("pro");
-    expect(result.available).toBe(false);
+    expect(result.available).toBe(true);
     expect(result.planApplied).toBe(true);
     expect(result.limits.maxStorageBytes).toBe(10_000_000_000);
   });

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -1,9 +1,9 @@
 ---
 /**
- * Workspace billing tab — current plan, resolved limits vs usage, and a
- * disabled "Upgrade — coming soon" affordance (spec 2026-07-22, billing
- * infrastructure). No live billing exists yet: no invoices, no payment
- * method, no real upgrade flow — honest copy only. When the backend hasn't
+ * Workspace billing tab — current plan, resolved limits vs usage, and the
+ * upgrade/manage-billing CTA (resolveBillingCta). Upgrade goes through
+ * Stripe Checkout via the @better-auth/stripe plugin on apps/auth; "Manage
+ * billing" opens the Stripe customer portal. When the backend hasn't
  * actually applied a plan (`planApplied === false`), limits are rendered as
  * whatever `limits` says (often unlimited/custom) rather than free-tier
  * marketing caps — see apps/api/src/routes/me.ts's billing route.
@@ -44,7 +44,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         </div>
 
         <div class="settings-section">
-          <button type="button" id="ws-upgrade-btn" disabled>Upgrade — coming soon</button>
+          <button type="button" id="ws-upgrade-btn" disabled>Upgrade</button>
           <p class="muted" id="ws-billing-error" role="alert" hidden></p>
         </div>
       </div>

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -1,7 +1,7 @@
 /**
- * Plan catalog for workspace subscription plans (free-plan era, spec
- * 2026-07-22). `free` is available in perpetuity today; `pro` is defined for
- * display purposes only (`available: false`) — no checkout path exists yet.
+ * Plan catalog for workspace subscription plans (spec 2026-07-22). `free`
+ * is available in perpetuity; `pro` is purchasable via Stripe Checkout
+ * through the @better-auth/stripe plugin on apps/auth.
  *
  * Free `defaultLimits` are the single source of truth for self-serve
  * provisioning: `apps/api/src/self-serve-defaults.ts` imports
@@ -48,8 +48,8 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
   pro: {
     id: "pro",
     name: "Pro",
-    blurb: "10 GB of storage and files up to 100 MB — coming soon.",
-    available: false,
+    blurb: "10 GB of storage and files up to 100 MB.",
+    available: true,
     // Decided 2026-07-22 (first-paid-plan memo): two marketed meters —
     // storage and one unified file cap (video ceiling = upload ceiling on
     // pro; only free carves video out). maxUploadsPerPeriod is an internal

--- a/packages/billing/test/plans.test.ts
+++ b/packages/billing/test/plans.test.ts
@@ -12,8 +12,8 @@ describe("PLANS catalog", () => {
     });
   });
 
-  it("defines pro as unavailable display metadata", () => {
-    expect(PLANS.pro.available).toBe(false);
+  it("defines pro as an available paid plan", () => {
+    expect(PLANS.pro.available).toBe(true);
     expect(PLANS.pro.id).toBe("pro");
     expect(typeof PLANS.pro.name).toBe("string");
     expect(PLANS.pro.name.length).toBeGreaterThan(0);


### PR DESCRIPTION
Flips `PLANS.pro.available` to `true` now that the Stripe checkout loop from #443 is verified end-to-end in production (test mode): upgrade → Checkout → webhook → `subscription` row active → workspace record `plan: "pro"` → pro limits resolved.

Changes:

- `packages/billing/src/plans.ts`: `pro.available: true`, blurb drops "coming soon", stale header comment updated
- `apps/web` billing tab: static button text and header comment updated (the CTA logic from #443 already renders the live upgrade/manage-billing buttons once `available` is true)
- Tests updated to the new expectation (billing catalog, workspace-plan, admin-ui, /me billing)

No changeset — none of these packages publish to npm.

Part of #388.
