### PR TITLE
fix(web): open last workspace after login and flatten the picker

### DIFF
--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -52,8 +52,9 @@ export function writeCachedSessionUser(user: SessionUser): void {
 export function clearCachedSessionUser(): void {
   try {
     sessionStorage.removeItem(SESSION_CACHE_KEY);
-    // Keep in sync with WORKSPACES_CACHE_KEY / ACTIVE_WORKSPACE_CACHE_KEY
-    // in workspaces-nav.ts (avoid importing that module from here).
+    // Keep in sync with WORKSPACES_CACHE_KEY in workspaces-nav.ts
+    // (avoid importing that module from here). Last-used workspace is
+    // localStorage-only so it survives sign-out for the next login.
     sessionStorage.removeItem("uploads:myWorkspaces");
     sessionStorage.removeItem("uploads:activeWorkspace");
   } catch {

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -7,6 +7,7 @@ import {
   readCachedWorkspaces,
   renderSwitcherMenuHtml,
   renderWorkspaceSectionNavHtml,
+  resolveDefaultWorkspace,
   resolveSidebarWorkspace,
   switcherLabel,
   workspaceTabFromPathname,
@@ -16,14 +17,28 @@ import {
 } from "./workspaces-nav";
 import type { MyWorkspace } from "./api-client";
 
-function installStorage() {
+function mapStorage() {
   const values = new Map<string, string>();
-  vi.stubGlobal("sessionStorage", {
-    getItem: (key: string) => values.get(key) ?? null,
-    removeItem: (key: string) => values.delete(key),
-    setItem: (key: string, value: string) => values.set(key, value),
-  });
-  return values;
+  return {
+    values,
+    storage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => {
+        values.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+    },
+  };
+}
+
+function installStorage() {
+  const session = mapStorage();
+  const local = mapStorage();
+  vi.stubGlobal("sessionStorage", session.storage);
+  vi.stubGlobal("localStorage", local.storage);
+  return { session: session.values, local: local.values };
 }
 
 afterEach(() => {
@@ -56,10 +71,10 @@ describe("workspaces cache", () => {
   });
 
   it("drops malformed cache payloads", () => {
-    const values = installStorage();
-    values.set(WORKSPACES_CACHE_KEY, "{not-json");
+    const { session } = installStorage();
+    session.set(WORKSPACES_CACHE_KEY, "{not-json");
     expect(readCachedWorkspaces()).toBeNull();
-    values.set(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces: "nope" }));
+    session.set(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces: "nope" }));
     expect(readCachedWorkspaces()).toBeNull();
   });
 });
@@ -86,13 +101,23 @@ describe("workspaceTabFromPathname", () => {
 });
 
 describe("active workspace cache + resolveSidebarWorkspace", () => {
-  it("round-trips the last-used workspace slug", () => {
-    installStorage();
+  it("persists last-used in localStorage (and clears session leftovers)", () => {
+    const { session, local } = installStorage();
     writeCachedActiveWorkspace("buildinternet");
     expect(readCachedActiveWorkspace()).toBe("buildinternet");
+    expect(local.get(ACTIVE_WORKSPACE_CACHE_KEY)).toBe("buildinternet");
+    expect(session.get(ACTIVE_WORKSPACE_CACHE_KEY)).toBeUndefined();
+
     clearCachedActiveWorkspace();
     expect(readCachedActiveWorkspace()).toBe("");
-    expect(sessionStorage.getItem(ACTIVE_WORKSPACE_CACHE_KEY)).toBeNull();
+    expect(local.get(ACTIVE_WORKSPACE_CACHE_KEY)).toBeUndefined();
+  });
+
+  it("reads a legacy session value so older tabs still resolve", () => {
+    const { session, local } = installStorage();
+    session.set(ACTIVE_WORKSPACE_CACHE_KEY, "buildinternet");
+    expect(local.get(ACTIVE_WORKSPACE_CACHE_KEY)).toBeUndefined();
+    expect(readCachedActiveWorkspace()).toBe("buildinternet");
   });
 
   it("rejects invalid slugs", () => {
@@ -122,6 +147,18 @@ describe("active workspace cache + resolveSidebarWorkspace", () => {
   it("returns empty when nothing is known", () => {
     installStorage();
     expect(resolveSidebarWorkspace("/account/profile", "")).toBe("");
+  });
+});
+
+describe("resolveDefaultWorkspace", () => {
+  const multi = [{ workspace: "buildinternet" }, { workspace: "side" }];
+
+  it("picks the only membership, else a valid last-used, else null", () => {
+    expect(resolveDefaultWorkspace([{ workspace: "solo" }], "other")).toBe("solo");
+    expect(resolveDefaultWorkspace(multi, "side")).toBe("side");
+    expect(resolveDefaultWorkspace(multi, "")).toBeNull();
+    expect(resolveDefaultWorkspace(multi, "gone")).toBeNull();
+    expect(resolveDefaultWorkspace([], "buildinternet")).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -5,17 +5,16 @@
  * workspace"). When a workspace is active, files / galleries / people /
  * settings sit as flat rows underneath.
  *
- * Memberships and last-used workspace are cached in sessionStorage for
- * instant paint (revalidated after session). Last-used keeps personal
- * routes (`/account/profile`, `/account/developers`) from collapsing the
- * workspace section nav.
+ * Memberships live in sessionStorage (instant paint, revalidated after
+ * session). Last-used workspace lives in localStorage so it survives
+ * sign-out and drives the index auto-open after login.
  */
 import { getMyWorkspaces, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
 import { isBrowseWorkspace, workspaceFromPathname } from "./workspace-browse-url";
 import { escapeHtml } from "./workspace-ui";
 
-/** sessionStorage keys — UX only; membership is still enforced server-side. */
+/** Storage keys — UX only; membership is still enforced server-side. */
 export const WORKSPACES_CACHE_KEY = "uploads:myWorkspaces";
 export const ACTIVE_WORKSPACE_CACHE_KEY = "uploads:activeWorkspace";
 
@@ -41,32 +40,32 @@ export type WorkspacesNavOptions = {
 
 type CachePayload = { workspaces: MyWorkspace[] };
 
-function storageGet(key: string): string | null {
+function storeGet(store: Storage, key: string): string | null {
   try {
-    return sessionStorage.getItem(key);
+    return store.getItem(key);
   } catch {
     return null;
   }
 }
 
-function storageSet(key: string, value: string): void {
+function storeSet(store: Storage, key: string, value: string): void {
   try {
-    sessionStorage.setItem(key, value);
+    store.setItem(key, value);
   } catch {
     // Private mode / quota — nav still works without the cache.
   }
 }
 
-function storageRemove(key: string): void {
+function storeRemove(store: Storage, key: string): void {
   try {
-    sessionStorage.removeItem(key);
+    store.removeItem(key);
   } catch {
     // ignore
   }
 }
 
 export function readCachedWorkspaces(): MyWorkspace[] | null {
-  const raw = storageGet(WORKSPACES_CACHE_KEY);
+  const raw = storeGet(sessionStorage, WORKSPACES_CACHE_KEY);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as CachePayload;
@@ -85,24 +84,45 @@ export function readCachedWorkspaces(): MyWorkspace[] | null {
 }
 
 export function writeCachedWorkspaces(workspaces: MyWorkspace[]): void {
-  storageSet(WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces }));
+  storeSet(sessionStorage, WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces }));
 }
 
 export function clearCachedWorkspaces(): void {
-  storageRemove(WORKSPACES_CACHE_KEY);
+  storeRemove(sessionStorage, WORKSPACES_CACHE_KEY);
 }
 
+/** Last-used workspace slug (localStorage; session fallback for older tabs). */
 export function readCachedActiveWorkspace(): string {
-  const raw = storageGet(ACTIVE_WORKSPACE_CACHE_KEY);
+  const raw =
+    storeGet(localStorage, ACTIVE_WORKSPACE_CACHE_KEY) ??
+    storeGet(sessionStorage, ACTIVE_WORKSPACE_CACHE_KEY);
   return raw && isBrowseWorkspace(raw) ? raw : "";
 }
 
 export function writeCachedActiveWorkspace(workspace: string): void {
-  if (isBrowseWorkspace(workspace)) storageSet(ACTIVE_WORKSPACE_CACHE_KEY, workspace);
+  if (!isBrowseWorkspace(workspace)) return;
+  storeSet(localStorage, ACTIVE_WORKSPACE_CACHE_KEY, workspace);
+  // Drop any pre-migration session copy so it can't re-surface later.
+  storeRemove(sessionStorage, ACTIVE_WORKSPACE_CACHE_KEY);
 }
 
 export function clearCachedActiveWorkspace(): void {
-  storageRemove(ACTIVE_WORKSPACE_CACHE_KEY);
+  storeRemove(localStorage, ACTIVE_WORKSPACE_CACHE_KEY);
+  storeRemove(sessionStorage, ACTIVE_WORKSPACE_CACHE_KEY);
+}
+
+/**
+ * Workspace to open from the index after login.
+ * One membership → that workspace. Multi → last-used if still a member.
+ * Otherwise null (show the picker).
+ */
+export function resolveDefaultWorkspace(
+  workspaces: readonly { workspace: string }[],
+  lastActive = "",
+): string | null {
+  if (workspaces.length === 1) return workspaces[0]!.workspace;
+  if (lastActive && workspaces.some((ws) => ws.workspace === lastActive)) return lastActive;
+  return null;
 }
 
 /**

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -2,8 +2,7 @@
 /**
  * Workspaces index.
  * Legacy `?ws=` deep links redirect to `/account/workspaces/<name>`.
- * Single membership auto-opens that workspace; otherwise pick from the list
- * or the sidebar workspace switcher.
+ * Opens the last-used (or only) membership; otherwise shows a flat picker.
  */
 import AccountLayout from "../../layouts/AccountLayout.astro";
 import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
@@ -22,23 +21,27 @@ if (isBrowseWorkspace(legacyWs)) {
 ---
 
 <AccountLayout section="workspaces">
-  <section class="card settings-page">
+  <section class="card settings-page dev-page">
     <div class="settings-section">
       <h2>Workspaces</h2>
       <p class="settings-note muted">
-        Pick one below, use the workspace switcher in the sidebar, or
+        Choose a workspace, or
         <a href="/account/workspaces/new">create one</a>.
       </p>
       <div id="orgs-status" class="ws-status muted">Loading…</div>
       <button id="orgs-retry" type="button" hidden>Try again</button>
-      <ul class="plain" id="orgs-list" hidden></ul>
+      <ul class="dev-links" id="orgs-list" hidden></ul>
     </div>
   </section>
 
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { getMyWorkspaces } from "../../lib/api-client";
-    import { writeCachedWorkspaces } from "../../lib/workspaces-nav";
+    import {
+      readCachedActiveWorkspace,
+      resolveDefaultWorkspace,
+      writeCachedWorkspaces,
+    } from "../../lib/workspaces-nav";
     import { escapeHtml } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
@@ -74,10 +77,10 @@ if (isBrowseWorkspace(legacyWs)) {
           return;
         }
 
-        if (workspaces.length === 1) {
-          const only = workspaces[0]!;
-          status.textContent = `Opening ${only.organization.name || only.workspace}…`;
-          location.replace(`/account/workspaces/${encodeURIComponent(only.workspace)}`);
+        const open = resolveDefaultWorkspace(workspaces, readCachedActiveWorkspace());
+        if (open) {
+          status.textContent = "Opening…";
+          location.replace(`/account/workspaces/${encodeURIComponent(open)}`);
           return;
         }
 
@@ -88,11 +91,9 @@ if (isBrowseWorkspace(legacyWs)) {
             const name = ws.organization.name || ws.workspace;
             const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
             return `<li>
-            <div class="row">
               <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>
               <span class="slug">${escapeHtml(ws.role)}</span>
-            </div>
-          </li>`;
+            </li>`;
           })
           .join("");
       }

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -28,7 +28,7 @@ section.card.settings-page h2 {
   margin-bottom: 0;
 }
 
-/* Developers — flat hairline rows inside the settings surface. */
+/* Developers / workspaces picker — flat hairline rows, not nested boxes. */
 section.card.dev-page {
   padding-bottom: 4px;
 }
@@ -67,6 +67,9 @@ ul.dev-links a:focus-visible {
 ul.dev-links .slug {
   color: var(--muted);
   font-size: 12px;
+}
+.settings-note a {
+  text-underline-offset: 0.15em;
 }
 
 .kv {


### PR DESCRIPTION
## In plain terms

After sign-in, the account shell often dumped multi-workspace users on a nested “pick a workspace” card even when they already had a last-used workspace. This opens that workspace (or the only membership) instead, and only shows a flatter picker when a choice is actually needed.

## What it does

- Auto-open from `/account/workspaces` when there is one membership, or when the last-used workspace is still a membership
- Persist last-used in `localStorage` so it survives sign-out (session still cleared; preference is not)
- Flatten the picker with the existing developers hairline-row styles (no nested boxes)
- Slightly tighten the “create one” note spacing

## What it is not

- No server-side “default workspace” record
- No change to the sidebar switcher or membership APIs
- Users with multiple workspaces and no valid last-used still see the picker once

## How to try it

1. Sign in with an account that has 2+ workspaces
2. Open one workspace (e.g. files)
3. Sign out and sign back in → land in that workspace, not the picker
4. Clear last-used (or use a fresh profile) with multiple memberships → flat picker still appears

## Technical notes

- `resolveDefaultWorkspace()` is pure and unit-tested
- Last-used writes localStorage only; session is a read fallback for older tabs
- Reuses `dev-page` / `dev-links` classes — no new list stylesheet

## Test plan

- [x] `pnpm --filter @uploads/web test`
- [ ] Manual: multi-ws login → last-used open
- [ ] Manual: single-ws login → auto-open
- [ ] Manual: multi-ws, no last-used → flat picker