### PR TITLE
feat(web): small Pro badge on workspace switcher and workspaces list

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -78,6 +78,7 @@ describe("GET /me/workspaces", () => {
           organization: { id: "org1", slug: "acme", name: "Acme Inc" },
           role: "owner",
           hasPublicUrl: false,
+          plan: "free",
         },
       ],
     });
@@ -143,6 +144,7 @@ describe("GET /me/workspaces", () => {
           organization: { id: "org2", slug: "default", name: "Default" },
           role: "member",
           hasPublicUrl: false,
+          plan: "free",
         },
       ],
     });
@@ -155,6 +157,52 @@ describe("GET /me/workspaces", () => {
     expect((await res.json()) as { error: { code: string } }).toMatchObject({
       error: { code: "auth_lookup_failed" },
     });
+  });
+
+  it("reports plan: 'pro' for a workspace record explicitly on the pro plan (issue #365 follow-up)", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "owner",
+          },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    (env as unknown as { REGISTRY: Pick<KVNamespace, "get"> }).REGISTRY = fakeKv({
+      "ws:acme": { provider: "r2", bucket: "shared", plan: "pro" },
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    const body = (await res.json()) as { workspaces: { workspace: string; plan: string }[] };
+    expect(body.workspaces).toEqual([expect.objectContaining({ workspace: "acme", plan: "pro" })]);
+  });
+
+  it("never reports plan: 'pro' for a legacy record with no plan field applied, even with pro-shaped overrides", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: "acme",
+            organizationName: "Acme Inc",
+            role: "owner",
+          },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    // No `plan` field at all — planApplied is false; `plan` must still fail
+    // open to "free" (getPlan's contract), never leak as "pro".
+    (env as unknown as { REGISTRY: Pick<KVNamespace, "get"> }).REGISTRY = fakeKv({
+      "ws:acme": { provider: "r2", bucket: "shared", maxStorageBytes: null },
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    const body = (await res.json()) as { workspaces: { workspace: string; plan: string }[] };
+    expect(body.workspaces).toEqual([expect.objectContaining({ workspace: "acme", plan: "free" })]);
   });
 
   it("returns an empty list for a user with no memberships", async () => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -170,18 +170,30 @@ export const me = new Hono<SessionVars>()
   // lets the account UI decide, per workspace, whether opening a file should
   // navigate to the public /f/ page (issue #135) or resolve through the
   // signed-URL-capable /file-url endpoint (issue #123) — see
-  // apps/web's AccountFileBrowser. Loaded here (not in `myWorkspaces`, which
-  // every member-gated route calls for authorization) so the extra KV read
-  // per workspace stays confined to this one listing endpoint.
+  // apps/web's AccountFileBrowser. `plan` (issue #365 follow-up, purely
+  // additive) is the same catalog-id string `planResponse` returns for the
+  // billing tab — "free" whenever the record has no plan applied (getPlan's
+  // fail-open-to-free contract), so a legacy/unapplied record can never read
+  // as "pro" here either. Lets the nav/list surfaces show a small Pro badge
+  // without a per-workspace billing round trip. Both fields are loaded here
+  // (not in `myWorkspaces`, which every member-gated route calls for
+  // authorization) so the extra KV read per workspace stays confined to this
+  // one listing endpoint.
   .get("/workspaces", async (c) => {
     const userId = c.get("sessionUser")?.id;
     if (!userId) throw new NotFoundError("no session user", { code: "workspace_not_found" });
     const workspaces = await myWorkspaces(c.env, userId);
     const withPublicUrl = await Promise.all(
       workspaces.map(async (ws) => {
-        const publicBaseUrl = (await loadWorkspaceRecord(c.env, ws.workspace))?.publicBaseUrl;
+        const record = await loadWorkspaceRecord(c.env, ws.workspace);
+        const publicBaseUrl = record?.publicBaseUrl;
+        const plan = record ? planResponse(ws.workspace, record).plan : "free";
         // `hasPublicUrl` kept alongside the URL itself for existing consumers.
-        return Object.assign({}, ws, { hasPublicUrl: Boolean(publicBaseUrl), publicBaseUrl });
+        return Object.assign({}, ws, {
+          hasPublicUrl: Boolean(publicBaseUrl),
+          publicBaseUrl,
+          plan,
+        });
       }),
     );
     return c.json({ workspaces: withPublicUrl });

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -95,6 +95,38 @@ describe("getMyWorkspaces", () => {
       ["byo", false],
     ]);
   });
+
+  it("maps plan through and leaves it undefined when the API omits it (issue #365 follow-up)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          workspaces: [
+            {
+              workspace: "acme",
+              organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+              role: "owner",
+              plan: "pro",
+            },
+            {
+              // Older api response, no plan field at all.
+              workspace: "byo",
+              organization: { id: "org2", slug: "byo", name: "BYO Inc" },
+              role: "member",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await getMyWorkspaces("http://127.0.0.1:8787");
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") throw new Error("expected success");
+    expect(result.workspaces.map((ws) => [ws.workspace, ws.plan])).toEqual([
+      ["acme", "pro"],
+      ["byo", undefined],
+    ]);
+  });
 });
 
 describe("setFileVisibility", () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -26,12 +26,19 @@ export interface MyWorkspace {
   hasPublicUrl: boolean;
   /** The public base URL itself (e.g. `https://storage.uploads.sh`), when configured. */
   publicBaseUrl?: string;
+  /**
+   * Catalog plan id ("free" | "pro" | …) — additive, issue #365 follow-up.
+   * Same fail-open-to-"free" contract as the billing tab's `planResponse`:
+   * a legacy/unapplied workspace record always reads as "free" here, never
+   * "pro". Undefined only against an older api build that omits the field.
+   */
+  plan?: string;
 }
 
-// `hasPublicUrl` is intentionally NOT required here: web and
+// `hasPublicUrl`/`plan` are intentionally NOT required here: web and
 // api deploy independently, so an older api may omit them. We accept the
-// entry and coerce a missing/other value to `false` in the mapper below.
-function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "hasPublicUrl"> {
+// entry and coerce a missing/other value to a safe default in the mapper below.
+function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "hasPublicUrl" | "plan"> {
   if (!value || typeof value !== "object") return false;
   const ws = value as Record<string, unknown>;
   const org = ws.organization as Record<string, unknown> | null | undefined;
@@ -46,10 +53,11 @@ function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "hasPubli
 }
 
 /** Coerce optional/legacy fields; shared by list + summary mappers. */
-function mapMyWorkspace(ws: Omit<MyWorkspace, "hasPublicUrl">): MyWorkspace {
-  const raw = ws as Omit<MyWorkspace, "hasPublicUrl"> & {
+function mapMyWorkspace(ws: Omit<MyWorkspace, "hasPublicUrl" | "plan">): MyWorkspace {
+  const raw = ws as Omit<MyWorkspace, "hasPublicUrl" | "plan"> & {
     hasPublicUrl?: unknown;
     publicBaseUrl?: unknown;
+    plan?: unknown;
   };
   return {
     workspace: raw.workspace,
@@ -57,6 +65,7 @@ function mapMyWorkspace(ws: Omit<MyWorkspace, "hasPublicUrl">): MyWorkspace {
     role: raw.role,
     hasPublicUrl: raw.hasPublicUrl === true,
     publicBaseUrl: typeof raw.publicBaseUrl === "string" ? raw.publicBaseUrl : undefined,
+    plan: typeof raw.plan === "string" ? raw.plan : undefined,
   };
 }
 

--- a/apps/web/src/lib/plan-badge.test.ts
+++ b/apps/web/src/lib/plan-badge.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowProBadge } from "./plan-badge";
+
+describe("shouldShowProBadge", () => {
+  it("shows the badge only for a literal pro plan", () => {
+    expect(shouldShowProBadge("pro")).toBe(true);
+  });
+
+  it("hides the badge for free workspaces", () => {
+    expect(shouldShowProBadge("free")).toBe(false);
+  });
+
+  it("hides the badge for legacy/unapplied plans (undefined)", () => {
+    expect(shouldShowProBadge(undefined)).toBe(false);
+  });
+
+  it("hides the badge for any other/unknown plan id", () => {
+    expect(shouldShowProBadge("enterprise")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/plan-badge.ts
+++ b/apps/web/src/lib/plan-badge.ts
@@ -1,0 +1,15 @@
+/**
+ * Small "Pro" badge shown outside the billing tab (issue #365 follow-up) —
+ * pure logic kept separate from the DOM glue in workspaces-nav.ts and
+ * workspaces.astro, the way billing-cta.ts is split out from billing.astro.
+ *
+ * Free workspaces get no badge at all (absence = free — nothing labels
+ * every row). `plan` here is expected to already carry the fail-open-to-
+ * "free" contract `planResponse`/`getMyWorkspaces` use, so a legacy or
+ * `planApplied === false` workspace record reads as "free" before it ever
+ * reaches this function — this is just the last "is it literally 'pro'?"
+ * check, kept as its own function so callers don't inline a string compare.
+ */
+export function shouldShowProBadge(plan: string | undefined): boolean {
+  return plan === "pro";
+}

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -189,6 +189,22 @@ describe("renderSwitcherMenuHtml", () => {
     expect(html).toContain("+ new workspace");
     expect(html).not.toContain("ws-switcher__sep");
   });
+
+  it("shows a Pro badge only for a pro-plan workspace, never for free/legacy ones", () => {
+    const withPlans: MyWorkspace[] = [
+      { ...sample[0]!, plan: "pro" },
+      { ...sample[1]!, plan: "free" },
+    ];
+    const html = renderSwitcherMenuHtml(withPlans, { active: "buildinternet" });
+    expect(html).toMatch(/buildinternet[\s\S]*?<span class="pro-badge">Pro<\/span>/);
+    const sideItem = html.slice(html.indexOf('href="/account/workspaces/side"'));
+    expect(sideItem).not.toContain("pro-badge");
+  });
+
+  it("omits the badge when plan is absent (older api, legacy workspace)", () => {
+    const html = renderSwitcherMenuHtml(sample, { active: "buildinternet" });
+    expect(html).not.toContain("pro-badge");
+  });
 });
 
 describe("renderWorkspaceSectionNavHtml", () => {

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -12,6 +12,7 @@
 import { getMyWorkspaces, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
 import { isBrowseWorkspace, workspaceFromPathname } from "./workspace-browse-url";
+import { shouldShowProBadge } from "./plan-badge";
 import { escapeHtml } from "./workspace-ui";
 
 /** Storage keys — UX only; membership is still enforced server-side. */
@@ -174,7 +175,8 @@ export function renderSwitcherMenuHtml(
       const current = active === ws.workspace;
       const cls = current ? "ws-switcher__item is-current" : "ws-switcher__item";
       const aria = current ? ' aria-current="true"' : "";
-      return `<a href="${escapeHtml(href)}" class="${cls}"${aria}>${escapeHtml(displayName(ws))}</a>`;
+      const badge = shouldShowProBadge(ws.plan) ? ` <span class="pro-badge">Pro</span>` : "";
+      return `<a href="${escapeHtml(href)}" class="${cls}"${aria}>${escapeHtml(displayName(ws))}${badge}</a>`;
     })
     .join("");
 

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -42,6 +42,7 @@ if (isBrowseWorkspace(legacyWs)) {
       resolveDefaultWorkspace,
       writeCachedWorkspaces,
     } from "../../lib/workspaces-nav";
+    import { shouldShowProBadge } from "../../lib/plan-badge";
     import { escapeHtml } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
@@ -90,8 +91,11 @@ if (isBrowseWorkspace(legacyWs)) {
           .map((ws) => {
             const name = ws.organization.name || ws.workspace;
             const href = `/account/workspaces/${encodeURIComponent(ws.workspace)}`;
+            const badge = shouldShowProBadge(ws.plan)
+              ? ` <span class="pro-badge">Pro</span>`
+              : "";
             return `<li>
-              <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>
+              <a href="${escapeHtml(href)}">${escapeHtml(name)}</a>${badge}
               <span class="slug">${escapeHtml(ws.role)}</span>
             </li>`;
           })

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -34,6 +34,23 @@
   font-size: 15px;
   font-weight: 600;
 }
+
+/* Compact "Pro" marker shown outside the billing tab (issue #365 follow-up)
+   — same uppercase/pill idiom as .plan-card__badge, but a muted accent
+   outline rather than an inverse fg/bg fill so it reads as a small aside
+   next to a workspace name, not a status callout. */
+.pro-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+}
 .plan-card__price {
   margin: 0;
   font-size: 13px;


### PR DESCRIPTION
Workspaces on the Pro plan now show a compact "PRO" pill next to their name, so plan status is visible at a glance outside the billing tab.

- Surfaces: the workspace switcher dropdown and the `/account/workspaces` picker. Free workspaces render nothing (absence = free).
- Plan data rides the existing `GET /me/workspaces` response as an additive `plan` field, computed by the same `planResponse` helper the billing tab uses from the record already loaded per row — no extra KV reads, no N+1.
- Legacy records (`planApplied: false`) fail open to `"free"` via `getPlan`, so they can never show a false Pro badge.
- Styling is a muted accent-outline pill (`.pro-badge`), quieter than the billing tab's inverse "Current plan" badge since this is an ambient marker.

Verified on the local stack with dev-demo admin-set to pro:

<img width="640" alt="Workspace switcher dropdown showing a small PRO pill next to the pro workspace's name" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/449/pro-badge-switcher.webp">

Tests: 2735 passing across the monorepo; typecheck and oxfmt clean.
