### PR TITLE
refactor(api): declare BILLING_INTERNAL_KEY on Env, narrow the budget spread

### DIFF
--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -54,8 +54,13 @@ export function resolveBudgetLimits(record: WorkspaceBudgetLimits): {
   // `undefined`), unlike the richer null-means-"explicitly cleared"
   // handling `resolveEffectiveLimits`/`resolvePlanLimits` do for other
   // callers (e.g. `workspace-plan.ts`'s admin-set fields).
+  //
+  // Built field-by-field rather than spread from `record`: enforcement only
+  // consumes the two budget caps, so naming them explicitly keeps a future
+  // field on `WorkspaceBudgetLimits` from silently becoming an override
+  // input to the shared seam.
   const sanitized = {
-    ...record,
+    plan: record.plan,
     maxStorageBytes: positiveLimit(record.maxStorageBytes),
     maxUploadsPerPeriod: positiveLimit(record.maxUploadsPerPeriod),
   };

--- a/apps/api/src/env.d.ts
+++ b/apps/api/src/env.d.ts
@@ -2,6 +2,13 @@
 // so `wrangler types` does not generate them. Augment Env here.
 interface Env {
   ADMIN_TOKEN?: string;
+  /**
+   * Shared secret gating POST /internal/billing/plan, sent by apps/auth's
+   * billing bridge as x-internal-billing-key. Set via `wrangler secret put` on
+   * both workers (the values must match). Unset/empty means the route 401s
+   * every request.
+   */
+  BILLING_INTERNAL_KEY?: string;
   /** Current AES master for BYO credentials at rest in KV (optional). */
   WORKSPACE_SECRETS_KEY?: string;
   /**

--- a/apps/api/src/routes/internal-billing.ts
+++ b/apps/api/src/routes/internal-billing.ts
@@ -16,12 +16,11 @@
  * Only `plan` is written — `mutateWorkspaceRecord` read-modify-writes the
  * whole record, so limit overrides, tokens, etc. are preserved untouched.
  *
- * `BILLING_INTERNAL_KEY` is read through an intersection type rather than
- * `Env` directly: it must be added to `worker-configuration.d.ts` (via
- * `wrangler types`, which reads `.dev.vars`) for the ambient `Env` interface
- * to carry it, and that's a local/per-deploy secret file this change
- * deliberately doesn't touch — see the `.dev.vars.example` entry and the
- * comment in wrangler.jsonc for how to provision it.
+ * `BILLING_INTERNAL_KEY` is declared optional on `Env` in `src/env.d.ts`
+ * alongside the other `wrangler secret put` secrets — not left to the
+ * generated `worker-configuration.d.ts`, which is git-ignored and regenerated
+ * in CI without `.dev.vars`. See the `.dev.vars.example` entry and the comment
+ * in wrangler.jsonc for how to provision it.
  */
 import { PLAN_IDS, type PlanId } from "@uploads/billing";
 import { UnauthorizedError, ValidationError } from "@uploads/errors";
@@ -47,8 +46,7 @@ function validatePlanSetBody(body: Record<string, unknown>): { workspace: string
 }
 
 internalBilling.post("/plan", async (c) => {
-  const env = c.env as Env & { BILLING_INTERNAL_KEY?: string };
-  const secret = env.BILLING_INTERNAL_KEY ?? "";
+  const secret = c.env.BILLING_INTERNAL_KEY ?? "";
   const provided = c.req.header("x-internal-billing-key") ?? "";
 
   const providedHash = await sha256Hex(provided);


### PR DESCRIPTION
Two small follow-ups deferred from the billing phase 2 review, now that
billing is live. Both were checkboxes on #388 (closed) and are carried in
#451; this clears them so #451 is purely the reconciliation sweep.

## `BILLING_INTERNAL_KEY` on `Env`

`POST /internal/billing/plan` read its shared secret through an
`as Env & { BILLING_INTERNAL_KEY?: string }` cast, with a note to drop the
cast once the key reached `.dev.vars` and `wrangler types` regenerated
`worker-configuration.d.ts`.

That prescription would not have worked: `worker-configuration.d.ts` is
git-ignored and CI regenerates it with no `.dev.vars`, so the ambient `Env`
would lack the field there and the CI typecheck would fail. The key is
declared in `apps/api/src/env.d.ts` instead — the file that exists for
exactly this, and where `ADMIN_TOKEN` and `GITHUB_APP_WEBHOOK_SECRET`
already live for the same documented reason.

Route behavior is untouched: still fail-closed (unset means every request
401s) with the timing-safe hash comparison.

## `resolveBudgetLimits` input built field-by-field

`resolveBudgetLimits` spread the whole record into the shared
`resolveEffectiveLimits` seam. Enforcement consumes only the two budget
caps, so the fields are now named explicitly, which keeps a future field on
`WorkspaceBudgetLimits` from silently becoming an override input.

No behavior change — `resolveEffectiveLimits` reads only `plan` and the
limit fields, and the sanitize-then-resolve ordering is unchanged.

## Verification

- `tsc --noEmit` on `@uploads/api` passes with the cast removed
- 56 tests pass across `budget`, `internal-billing`, `workspace-plan`, and
  `packages/billing`
- `pnpm lint` clean (no new warnings)

No changeset: `@uploads/api` is in the changesets ignore list.
