### PR TITLE
feat(billing): retry failed plan syncs through a durable outbox

### DIFF
--- a/apps/auth/migrations/20260723150000_billing_plan_outbox.sql
+++ b/apps/auth/migrations/20260723150000_billing_plan_outbox.sql
@@ -1,0 +1,26 @@
+-- Durable retry for the billing plan bridge (issue #451). When
+-- `syncWorkspacePlan` (src/billing-bridge.ts) can't reach apps/api, it records
+-- the affected organization here instead of dropping the change on the floor;
+-- the cron drain (src/billing-outbox.ts) retries until it lands.
+--
+-- One row per organization, keyed by reference_id: a later failure for the
+-- same org replaces the earlier one rather than queueing a second attempt.
+--
+-- Deliberately stores NO plan value. The drain recomputes the desired plan
+-- from the `subscription` table at retry time, so a queued row can never
+-- re-apply a plan that has since been superseded.
+--
+-- Paired with src/schema.ts — keep both in sync by hand (see the JSDoc there).
+
+CREATE TABLE billing_plan_outbox (
+  reference_id TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  next_attempt_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- The drain's only query shape: rows that are due, oldest first.
+CREATE INDEX billing_plan_outbox_next_attempt_at_idx
+  ON billing_plan_outbox (next_attempt_at);

--- a/apps/auth/src/billing-bridge.test.ts
+++ b/apps/auth/src/billing-bridge.test.ts
@@ -138,6 +138,10 @@ describe("syncWorkspacePlan", () => {
 
     await expect(syncWorkspacePlan(env, brokenOrm, orgId, "pro")).resolves.toBeUndefined();
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    // Two logs, not one: the sync failure, then the outbox enqueue failing on
+    // the same broken db. The queue lives in D1, so it cannot survive D1
+    // itself being down — see billing-outbox.ts. Still resolves either way,
+    // which is the property this test exists to pin.
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/auth/src/billing-bridge.ts
+++ b/apps/auth/src/billing-bridge.ts
@@ -12,16 +12,17 @@
  * return, not a thrown error.
  *
  * Because failures are swallowed, the webhook returns 2xx and Stripe will
- * NOT retry a failed sync. That's a deliberate tradeoff, not an oversight:
- * the auth-side `subscription` table (Task 1's schema) remains the source of
- * truth regardless of whether this sync landed, and an operator can re-run
- * the sync via the idempotent internal route. A persistent outbox/
- * reconciliation job is deferred until real traffic justifies it (#388).
+ * NOT retry a failed sync. The auth-side `subscription` table remains the
+ * source of truth either way, but a dropped sync used to leave the workspace
+ * `plan` stale with no recovery. Every failure path now enqueues the org in
+ * `billing_plan_outbox` (billing-outbox.ts) so the cron drain retries it —
+ * issue #451, ahead of opening signups.
  */
 import { eq } from "drizzle-orm";
 import type { drizzle } from "drizzle-orm/d1";
 import type { AuthEnv } from "./auth";
 import * as schema from "./schema";
+import { enqueuePlanSync } from "./billing-outbox";
 
 /**
  * `AuthEnv` (auth.ts) doesn't itself declare `API`/`BILLING_INTERNAL_KEY` —
@@ -51,10 +52,12 @@ export async function syncWorkspacePlan(
 
     if (!env.API) {
       console.error("syncWorkspacePlan: env.API service binding is not configured");
+      await enqueuePlanSync(db, referenceId, "env.API service binding is not configured");
       return;
     }
     if (!env.BILLING_INTERNAL_KEY) {
       console.error("syncWorkspacePlan: BILLING_INTERNAL_KEY is not configured");
+      await enqueuePlanSync(db, referenceId, "BILLING_INTERNAL_KEY is not configured");
       return;
     }
 
@@ -70,8 +73,13 @@ export async function syncWorkspacePlan(
       console.error(
         `syncWorkspacePlan: POST /internal/billing/plan for workspace ${slug} failed with status ${response.status}`,
       );
+      await enqueuePlanSync(db, referenceId, `status ${response.status}`);
     }
   } catch (error) {
     console.error(`syncWorkspacePlan: failed for organization ${referenceId}`, error);
+    // Also covers a failed org-slug lookup: the D1 read above is inside this
+    // try, and a transient D1 error there is exactly the kind of failure the
+    // queue exists to survive.
+    await enqueuePlanSync(db, referenceId, error instanceof Error ? error.message : String(error));
   }
 }

--- a/apps/auth/src/billing-outbox.test.ts
+++ b/apps/auth/src/billing-outbox.test.ts
@@ -284,6 +284,34 @@ describe("runPlanSyncOutbox", () => {
     expect(await outboxRows(env)).toHaveLength(1);
   });
 
+  it("isn't starved by a backlog of exhausted rows", async () => {
+    // Exhausted rows keep a nextAttemptAt in the past forever, so they sort to
+    // the front of the due query. A batch's worth of them must not crowd out a
+    // row that genuinely needs retrying.
+    const env = dbEnv();
+    const orm_ = orm(env);
+    for (let i = 0; i < 60; i += 1) {
+      await enqueuePlanSync(orm_, `exhausted-${i}`, "status 500", new Date(0));
+      await orm_
+        .update(schema.billingPlanOutbox)
+        .set({ attempts: MAX_ATTEMPTS })
+        .where(eq(schema.billingPlanOutbox.referenceId, `exhausted-${i}`));
+    }
+
+    const orgId = await seedOrganization(env, "acme");
+    await seedSubscription(env, orgId, "active");
+    await enqueuePlanSync(orm_, orgId, "status 500", NOW);
+
+    const fetchMock = okFetch();
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(env, orm_, new Date(NOW.getTime() + 120_000));
+
+    expect(result.synced).toBe(1);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ workspace: "acme", plan: "pro" });
+  });
+
   it("drops a row whose organization no longer exists", async () => {
     const env = dbEnv();
     await enqueuePlanSync(orm(env), "org-that-vanished", "status 500", NOW);

--- a/apps/auth/src/billing-outbox.test.ts
+++ b/apps/auth/src/billing-outbox.test.ts
@@ -64,6 +64,18 @@ describe("backoffSeconds", () => {
     expect(backoffSeconds(3)).toBe(240);
     expect(backoffSeconds(99)).toBe(3600);
   });
+
+  it("gives a total retry window of just over 24 hours", () => {
+    // Pins the number MAX_ATTEMPTS' doc comment claims, so tuning either the
+    // cap or the curve can't silently leave that comment wrong: the initial
+    // wait after enqueue, plus one wait per failed attempt up to the cap.
+    let total = backoffSeconds(1);
+    for (let attempts = 1; attempts < MAX_ATTEMPTS; attempts += 1) {
+      total += backoffSeconds(attempts);
+    }
+    expect(total).toBe(86_640);
+    expect(total / 3600).toBeGreaterThan(24);
+  });
 });
 
 describe("desiredPlanFor", () => {

--- a/apps/auth/src/billing-outbox.test.ts
+++ b/apps/auth/src/billing-outbox.test.ts
@@ -312,6 +312,76 @@ describe("runPlanSyncOutbox", () => {
     expect(JSON.parse(init.body as string)).toEqual({ workspace: "acme", plan: "pro" });
   });
 
+  it("keeps a fresh re-enqueue that lands mid-drain", async () => {
+    // enqueuePlanSync can run between this row's SELECT and its delete — a
+    // genuinely new failure for the same org. The delete is guarded on the
+    // updatedAt the row was read with, so it no-ops rather than dropping that
+    // fresh intent.
+    const env = dbEnv();
+    const orm_ = orm(env);
+    const orgId = await seedOrganization(env, "acme");
+    await seedSubscription(env, orgId, "active");
+    await enqueuePlanSync(orm_, orgId, "status 500", NOW);
+
+    const later = new Date(NOW.getTime() + 300_000);
+    env.API = {
+      fetch: vi.fn(async () => {
+        await enqueuePlanSync(orm_, orgId, "newer failure", later);
+        return new Response(null, { status: 204 });
+      }),
+    } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(env, orm_, new Date(NOW.getTime() + 120_000));
+
+    // The POST landed, so the pass counts as synced...
+    expect(result.synced).toBe(1);
+    // ...but the newer intent survives for the next pass.
+    const rows = await outboxRows(env);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lastError).toBe("newer failure");
+    expect(rows[0].attempts).toBe(0);
+  });
+
+  it("finishes the batch when a finalization write fails", async () => {
+    const env = dbEnv();
+    const realDb = orm(env);
+    const orgA = await seedOrganization(env, "acme");
+    const orgB = await seedOrganization(env, "beta");
+    await seedSubscription(env, orgA, "active");
+    await seedSubscription(env, orgB, "active");
+    await enqueuePlanSync(realDb, orgA, "status 500", NOW);
+    await enqueuePlanSync(realDb, orgB, "status 500", NOW);
+
+    let deletes = 0;
+    const flakyDb = new Proxy(realDb, {
+      get(target, prop, receiver) {
+        if (prop === "delete") {
+          deletes += 1;
+          if (deletes === 1) {
+            return () => {
+              throw new Error("D1 write failed");
+            };
+          }
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+
+    env.API = { fetch: okFetch() } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(
+      env,
+      flakyDb as typeof realDb,
+      new Date(NOW.getTime() + 120_000),
+    );
+
+    // Both rows were attempted — the failed write didn't abort the batch.
+    expect(result.attempted).toBe(2);
+    expect(result.synced).toBe(1);
+    // The row whose delete failed is still queued, so it retries next pass.
+    expect(await outboxRows(env)).toHaveLength(1);
+  });
+
   it("drops a row whose organization no longer exists", async () => {
     const env = dbEnv();
     await enqueuePlanSync(orm(env), "org-that-vanished", "status 500", NOW);

--- a/apps/auth/src/billing-outbox.test.ts
+++ b/apps/auth/src/billing-outbox.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Durable retry for the billing plan bridge (issue #451) — see
+ * src/billing-outbox.ts.
+ */
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthEnv } from "./auth";
+import * as schema from "./schema";
+import {
+  MAX_ATTEMPTS,
+  backoffSeconds,
+  desiredPlanFor,
+  enqueuePlanSync,
+  runPlanSyncOutbox,
+} from "./billing-outbox";
+import { syncWorkspacePlan } from "./billing-bridge";
+import { createFakeD1 } from "./test/fake-d1";
+
+type TestEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
+
+const NOW = new Date("2026-07-23T12:00:00.000Z");
+
+function dbEnv(overrides: Partial<TestEnv> = {}): TestEnv {
+  return {
+    DB: createFakeD1(),
+    WEB_ORIGIN: "https://uploads.sh",
+    BETTER_AUTH_URL: "https://auth.uploads.sh",
+    ENVIRONMENT: "development",
+    BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    BILLING_INTERNAL_KEY: "shh-its-secret",
+    ...overrides,
+  };
+}
+
+function orm(env: TestEnv) {
+  return drizzle(env.DB, { schema });
+}
+
+async function seedOrganization(env: TestEnv, slug: string): Promise<string> {
+  const id = crypto.randomUUID();
+  await orm(env).insert(schema.organization).values({ id, name: slug, slug, createdAt: NOW });
+  return id;
+}
+
+async function seedSubscription(env: TestEnv, referenceId: string, status: string) {
+  await orm(env)
+    .insert(schema.subscription)
+    .values({ id: crypto.randomUUID(), plan: "pro", referenceId, status });
+}
+
+async function outboxRows(env: TestEnv) {
+  return orm(env).select().from(schema.billingPlanOutbox);
+}
+
+function okFetch() {
+  return vi.fn(async () => new Response(null, { status: 204 }));
+}
+
+describe("backoffSeconds", () => {
+  it("doubles from a minute and caps at an hour", () => {
+    expect(backoffSeconds(1)).toBe(60);
+    expect(backoffSeconds(2)).toBe(120);
+    expect(backoffSeconds(3)).toBe(240);
+    expect(backoffSeconds(99)).toBe(3600);
+  });
+});
+
+describe("desiredPlanFor", () => {
+  it("is free with no subscription row at all", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    expect(await desiredPlanFor(orm(env), orgId)).toBe("free");
+  });
+
+  it.each(["active", "trialing", "past_due"])("is pro while status is %s", async (status) => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    await seedSubscription(env, orgId, status);
+    expect(await desiredPlanFor(orm(env), orgId)).toBe("pro");
+  });
+
+  it.each(["canceled", "incomplete_expired", "unpaid"])(
+    "is free once status is %s",
+    async (status) => {
+      const env = dbEnv();
+      const orgId = await seedOrganization(env, "acme");
+      await seedSubscription(env, orgId, status);
+      expect(await desiredPlanFor(orm(env), orgId)).toBe("free");
+    },
+  );
+});
+
+describe("enqueuePlanSync", () => {
+  it("queues one row per organization and resets attempts on requeue", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+
+    await enqueuePlanSync(orm(env), orgId, "first failure", NOW);
+    await orm(env)
+      .update(schema.billingPlanOutbox)
+      .set({ attempts: 5 })
+      .where(eq(schema.billingPlanOutbox.referenceId, orgId));
+    await enqueuePlanSync(orm(env), orgId, "second failure", NOW);
+
+    const rows = await outboxRows(env);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attempts).toBe(0);
+    expect(rows[0].lastError).toBe("second failure");
+  });
+});
+
+describe("syncWorkspacePlan enqueues on failure", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it("queues the org when apps/api rejects the plan set", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    env.API = {
+      fetch: vi.fn(async () => new Response(null, { status: 500 })),
+    } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm(env), orgId, "pro");
+
+    const rows = await outboxRows(env);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].referenceId).toBe(orgId);
+    expect(rows[0].lastError).toBe("status 500");
+  });
+
+  it("queues the org when the service binding throws", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    env.API = {
+      fetch: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm(env), orgId, "pro");
+
+    const rows = await outboxRows(env);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lastError).toBe("boom");
+  });
+
+  it("queues the org when BILLING_INTERNAL_KEY is missing", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: undefined });
+    const orgId = await seedOrganization(env, "acme");
+    env.API = { fetch: okFetch() } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm(env), orgId, "pro");
+
+    expect(await outboxRows(env)).toHaveLength(1);
+  });
+
+  it("queues nothing on a successful sync", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    env.API = { fetch: okFetch() } as unknown as Fetcher;
+
+    await syncWorkspacePlan(env, orm(env), orgId, "pro");
+
+    expect(await outboxRows(env)).toHaveLength(0);
+  });
+});
+
+describe("runPlanSyncOutbox", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => consoleErrorSpy.mockRestore());
+
+  it("re-posts the plan and clears the row on success", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    await seedSubscription(env, orgId, "active");
+    await enqueuePlanSync(orm(env), orgId, "status 500", NOW);
+
+    const fetchMock = okFetch();
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(env, orm(env), new Date(NOW.getTime() + 120_000));
+
+    expect(result).toEqual({ attempted: 1, synced: 1, rescheduled: 0, exhausted: 0 });
+    expect(await outboxRows(env)).toHaveLength(0);
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ workspace: "acme", plan: "pro" });
+  });
+
+  it("recomputes the plan at retry time rather than replaying the queued one", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    await seedSubscription(env, orgId, "active");
+    // Queued while the subscription was active...
+    await enqueuePlanSync(orm(env), orgId, "status 500", NOW);
+    // ...and canceled before the drain ran.
+    await orm(env)
+      .update(schema.subscription)
+      .set({ status: "canceled" })
+      .where(eq(schema.subscription.referenceId, orgId));
+
+    const fetchMock = okFetch();
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    await runPlanSyncOutbox(env, orm(env), new Date(NOW.getTime() + 120_000));
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ workspace: "acme", plan: "free" });
+  });
+
+  it("leaves rows that aren't due yet alone", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    await enqueuePlanSync(orm(env), orgId, "status 500", NOW);
+
+    const fetchMock = okFetch();
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(env, orm(env), NOW);
+
+    expect(result.attempted).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await outboxRows(env)).toHaveLength(1);
+  });
+
+  it("reschedules with a longer backoff when the retry fails again", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    await enqueuePlanSync(orm(env), orgId, "status 500", NOW);
+    env.API = {
+      fetch: vi.fn(async () => new Response(null, { status: 503 })),
+    } as unknown as Fetcher;
+
+    const drainAt = new Date(NOW.getTime() + 120_000);
+    const result = await runPlanSyncOutbox(env, orm(env), drainAt);
+
+    expect(result).toEqual({ attempted: 1, synced: 0, rescheduled: 1, exhausted: 0 });
+    const [row] = await outboxRows(env);
+    expect(row.attempts).toBe(1);
+    expect(row.lastError).toBe("status 503");
+    expect(row.nextAttemptAt.getTime()).toBe(drainAt.getTime() + backoffSeconds(1) * 1000);
+  });
+
+  it("stops retrying at the attempt cap", async () => {
+    const env = dbEnv();
+    const orgId = await seedOrganization(env, "acme");
+    await enqueuePlanSync(orm(env), orgId, "status 500", NOW);
+    await orm(env)
+      .update(schema.billingPlanOutbox)
+      .set({ attempts: MAX_ATTEMPTS - 1 })
+      .where(eq(schema.billingPlanOutbox.referenceId, orgId));
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+    const drainAt = new Date(NOW.getTime() + 120_000);
+
+    const first = await runPlanSyncOutbox(env, orm(env), drainAt);
+    expect(first).toEqual({ attempted: 1, synced: 0, rescheduled: 0, exhausted: 1 });
+
+    // A later pass must not pick the exhausted row back up.
+    const second = await runPlanSyncOutbox(env, orm(env), new Date(drainAt.getTime() + 86_400_000));
+    expect(second.attempted).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await outboxRows(env)).toHaveLength(1);
+  });
+
+  it("drops a row whose organization no longer exists", async () => {
+    const env = dbEnv();
+    await enqueuePlanSync(orm(env), "org-that-vanished", "status 500", NOW);
+    const fetchMock = okFetch();
+    env.API = { fetch: fetchMock } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(env, orm(env), new Date(NOW.getTime() + 120_000));
+
+    expect(result.attempted).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await outboxRows(env)).toHaveLength(0);
+  });
+
+  it("skips the pass without touching rows when the bindings are absent", async () => {
+    const env = dbEnv({ BILLING_INTERNAL_KEY: undefined });
+    const orgId = await seedOrganization(env, "acme");
+    await enqueuePlanSync(orm(env), orgId, "status 500", NOW);
+    env.API = { fetch: okFetch() } as unknown as Fetcher;
+
+    const result = await runPlanSyncOutbox(env, orm(env), new Date(NOW.getTime() + 120_000));
+
+    expect(result.attempted).toBe(0);
+    expect(await outboxRows(env)).toHaveLength(1);
+  });
+});

--- a/apps/auth/src/billing-outbox.ts
+++ b/apps/auth/src/billing-outbox.ts
@@ -126,6 +126,32 @@ export async function desiredPlanFor(db: Db, referenceId: string): Promise<"free
   return rows.some((row) => isStripeBackingStatus(row.status)) ? "pro" : "free";
 }
 
+/**
+ * Run one finalization write (the delete-on-success or update-on-failure that
+ * closes out a drained row), absorbing a D1 error so one bad write can't abort
+ * the rest of the batch. Returns whether the write went through.
+ */
+async function finalize(
+  write: () => Promise<unknown>,
+  referenceId: string,
+  kind: "delete" | "update",
+): Promise<boolean> {
+  try {
+    await write();
+    return true;
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        message: "billing_outbox_finalize_failed",
+        referenceId,
+        kind,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return false;
+  }
+}
+
 export interface OutboxDrainResult {
   /** Rows that were due and attempted this pass. */
   attempted: number;
@@ -220,24 +246,47 @@ export async function runPlanSyncOutbox(
       failure = error instanceof Error ? error.message : String(error);
     }
 
+    // Both finalization writes are guarded on the `updatedAt` this row was
+    // read with, and both are wrapped so a D1 error finishes this row rather
+    // than aborting the rest of the batch.
+    //
+    // The guard matters because `enqueuePlanSync` can land between this row's
+    // SELECT and its write: a genuinely new failure for the same org resets
+    // the row, and an unguarded delete would drop that fresh intent (or an
+    // unguarded update would clobber its reset attempt count). A no-op write
+    // leaves the newer row alone for the next pass, which is the safe way to
+    // lose the race.
+    const unchanged = and(
+      eq(schema.billingPlanOutbox.referenceId, row.referenceId),
+      eq(schema.billingPlanOutbox.updatedAt, row.updatedAt),
+    );
+
     if (failure === null) {
-      await db
-        .delete(schema.billingPlanOutbox)
-        .where(eq(schema.billingPlanOutbox.referenceId, row.referenceId));
-      result.synced += 1;
+      const finalized = await finalize(
+        () => db.delete(schema.billingPlanOutbox).where(unchanged),
+        row.referenceId,
+        "delete",
+      );
+      if (finalized) result.synced += 1;
       continue;
     }
 
     const attempts = row.attempts + 1;
-    await db
-      .update(schema.billingPlanOutbox)
-      .set({
-        attempts,
-        lastError: failure,
-        nextAttemptAt: new Date(now.getTime() + backoffSeconds(attempts) * 1000),
-        updatedAt: now,
-      })
-      .where(eq(schema.billingPlanOutbox.referenceId, row.referenceId));
+    const finalized = await finalize(
+      () =>
+        db
+          .update(schema.billingPlanOutbox)
+          .set({
+            attempts,
+            lastError: failure,
+            nextAttemptAt: new Date(now.getTime() + backoffSeconds(attempts) * 1000),
+            updatedAt: now,
+          })
+          .where(unchanged),
+      row.referenceId,
+      "update",
+    );
+    if (!finalized) continue;
 
     if (attempts >= MAX_ATTEMPTS) {
       result.exhausted += 1;

--- a/apps/auth/src/billing-outbox.ts
+++ b/apps/auth/src/billing-outbox.ts
@@ -1,0 +1,271 @@
+/**
+ * Durable retry for the billing plan bridge (issue #451).
+ *
+ * `syncWorkspacePlan` (billing-bridge.ts) never throws, so a failed bridge
+ * call used to leave the workspace's `plan` stale with no recovery: the Stripe
+ * webhook had already returned 2xx, so Stripe would not redeliver. Someone
+ * could pay and stay on the free plan until a human noticed.
+ *
+ * This module closes that gap. Every failure path in the bridge enqueues the
+ * affected organization here; the cron drain retries with backoff until the
+ * plan lands or the attempt cap is hit.
+ *
+ * Two design decisions worth keeping:
+ *
+ * 1. The queue records only WHICH organization needs syncing, never which
+ *    plan. `desiredPlanFor` recomputes that from the `subscription` table at
+ *    retry time, so a row queued before a cancellation can't resurrect `pro`
+ *    minutes later. The subscription table is already the source of truth
+ *    (see billing-bridge.ts) — this keeps it that way.
+ *
+ * 2. It only ever touches organizations whose bridge call actually failed.
+ *    That is what keeps it clear of the comped-workspace problem in #451: a
+ *    workspace an operator put on `pro` by hand never goes through the bridge,
+ *    so it is never enqueued, so this can never downgrade it. A general
+ *    "compare everything to Stripe" sweep could not make that promise without
+ *    a comp marker.
+ *
+ * Known limit: the queue lives in the same D1 database the bridge reads, so a
+ * D1 outage takes the enqueue down with the sync it was meant to rescue. That
+ * failure is logged (`billing_outbox_enqueue_failed`) and is the one case
+ * still needing an operator re-post through the idempotent internal route.
+ * Covering it would mean queueing somewhere other than D1, which is not worth
+ * the second system at this volume.
+ */
+import { asc, eq, lte } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import type { AuthEnv } from "./auth";
+import * as schema from "./schema";
+import { isStripeBackingStatus } from "@uploads/billing";
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+type OutboxEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
+
+/** Rows processed per drain — a ceiling on cron runtime, not a queue cap. */
+const DRAIN_BATCH = 50;
+
+/**
+ * Give up after this many failed attempts. At the backoff below that is a bit
+ * over a day of retrying, which comfortably outlives a deploy, a bad secret,
+ * or an apps/api outage. A row at the cap stays in the table (it is the
+ * operator's record of what never landed) but is no longer retried.
+ */
+export const MAX_ATTEMPTS = 12;
+
+/** Exponential backoff, capped at an hour: 1m, 2m, 4m … 60m. */
+export function backoffSeconds(attempts: number): number {
+  return Math.min(60 * 2 ** Math.max(0, attempts - 1), 3600);
+}
+
+/**
+ * Queue (or requeue) an organization for retry. Never throws — it is called
+ * from the bridge's failure paths, which must not turn a swallowed sync error
+ * into a rejected promise inside a webhook handler.
+ *
+ * A repeat failure for the same org updates the existing row and resets its
+ * attempt count: the newest failure restarts the backoff rather than
+ * inheriting an older row's exhausted budget.
+ */
+export async function enqueuePlanSync(
+  db: Db,
+  referenceId: string,
+  reason: string,
+  now: Date = new Date(),
+): Promise<void> {
+  try {
+    const nextAttemptAt = new Date(now.getTime() + backoffSeconds(1) * 1000);
+    await db
+      .insert(schema.billingPlanOutbox)
+      .values({
+        referenceId,
+        attempts: 0,
+        lastError: reason,
+        nextAttemptAt,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: schema.billingPlanOutbox.referenceId,
+        set: { attempts: 0, lastError: reason, nextAttemptAt, updatedAt: now },
+      });
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        message: "billing_outbox_enqueue_failed",
+        referenceId,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+}
+
+/**
+ * The plan an organization should be on right now, derived from its
+ * subscription rows: `pro` if any row is in a backing status
+ * (active/trialing/past_due), `free` otherwise — including when there are no
+ * rows at all, which is how a fully deleted subscription reads.
+ *
+ * Any-row rather than newest-row because `subscription` has no reliable
+ * ordering key (ids are opaque, and the timestamp columns are Stripe period
+ * bounds rather than write times). "Is anything currently paying for this
+ * org" is the question that matters and it is order-independent.
+ *
+ * `isStripeBackingStatus` rather than `desiredPlanForStatus`: the two
+ * deliberately differ on `past_due`, and a retry should not downgrade someone
+ * mid-dunning when the live webhook path would have kept them on `pro`.
+ */
+export async function desiredPlanFor(db: Db, referenceId: string): Promise<"free" | "pro"> {
+  const rows = await db
+    .select({ status: schema.subscription.status })
+    .from(schema.subscription)
+    .where(eq(schema.subscription.referenceId, referenceId));
+  return rows.some((row) => isStripeBackingStatus(row.status)) ? "pro" : "free";
+}
+
+export interface OutboxDrainResult {
+  /** Rows that were due and attempted this pass. */
+  attempted: number;
+  /** Rows whose plan landed and were removed from the queue. */
+  synced: number;
+  /** Rows that failed again and were rescheduled. */
+  rescheduled: number;
+  /** Rows that hit MAX_ATTEMPTS this pass and will not be retried again. */
+  exhausted: number;
+}
+
+/**
+ * One drain pass. Returns counts for logging. Business-logic failures are
+ * absorbed per row (a poisoned row can't stall the queue); a D1 failure on the
+ * initial select propagates so the caller's cron logging sees it.
+ */
+export async function runPlanSyncOutbox(
+  env: OutboxEnv,
+  db: Db,
+  now: Date = new Date(),
+): Promise<OutboxDrainResult> {
+  const result: OutboxDrainResult = { attempted: 0, synced: 0, rescheduled: 0, exhausted: 0 };
+
+  if (!env.API || !env.BILLING_INTERNAL_KEY) {
+    // Same fail-quiet posture as the bridge: without the binding or the shared
+    // secret there is nothing to retry against, and rows stay queued for a
+    // later, properly configured deploy.
+    console.error(
+      JSON.stringify({
+        message: "billing_outbox_drain_skipped",
+        reason: env.API ? "missing_billing_internal_key" : "missing_api_binding",
+      }),
+    );
+    return result;
+  }
+
+  const due = await db
+    .select()
+    .from(schema.billingPlanOutbox)
+    .where(lte(schema.billingPlanOutbox.nextAttemptAt, now))
+    .orderBy(asc(schema.billingPlanOutbox.nextAttemptAt))
+    .limit(DRAIN_BATCH);
+
+  for (const row of due) {
+    if (row.attempts >= MAX_ATTEMPTS) continue;
+    result.attempted += 1;
+
+    let failure: string | null = null;
+    try {
+      const [org] = await db
+        .select({ slug: schema.organization.slug })
+        .from(schema.organization)
+        .where(eq(schema.organization.id, row.referenceId))
+        .limit(1);
+
+      if (!org?.slug) {
+        // The org is gone — nothing to sync to, ever. Drop the row rather than
+        // retrying it until the attempt cap.
+        await db
+          .delete(schema.billingPlanOutbox)
+          .where(eq(schema.billingPlanOutbox.referenceId, row.referenceId));
+        console.error(
+          JSON.stringify({
+            message: "billing_outbox_dropped_unknown_org",
+            referenceId: row.referenceId,
+          }),
+        );
+        continue;
+      }
+
+      const plan = await desiredPlanFor(db, row.referenceId);
+      const response = await env.API.fetch("https://internal/internal/billing/plan", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-internal-billing-key": env.BILLING_INTERNAL_KEY,
+        },
+        body: JSON.stringify({ workspace: org.slug, plan }),
+      });
+      if (!response.ok) failure = `status ${response.status}`;
+    } catch (error) {
+      failure = error instanceof Error ? error.message : String(error);
+    }
+
+    if (failure === null) {
+      await db
+        .delete(schema.billingPlanOutbox)
+        .where(eq(schema.billingPlanOutbox.referenceId, row.referenceId));
+      result.synced += 1;
+      continue;
+    }
+
+    const attempts = row.attempts + 1;
+    await db
+      .update(schema.billingPlanOutbox)
+      .set({
+        attempts,
+        lastError: failure,
+        nextAttemptAt: new Date(now.getTime() + backoffSeconds(attempts) * 1000),
+        updatedAt: now,
+      })
+      .where(eq(schema.billingPlanOutbox.referenceId, row.referenceId));
+
+    if (attempts >= MAX_ATTEMPTS) {
+      result.exhausted += 1;
+      console.error(
+        JSON.stringify({
+          message: "billing_outbox_exhausted",
+          referenceId: row.referenceId,
+          attempts,
+          lastError: failure,
+        }),
+      );
+    } else {
+      result.rescheduled += 1;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * The cron expression that runs the drain (wrangler.jsonc `triggers.crons`).
+ * Exported so src/index.ts dispatches on the same string the config declares
+ * rather than a copy of it.
+ */
+export const BILLING_OUTBOX_CRON = "*/5 * * * *";
+
+/**
+ * Cron entry point, mirroring `runAuthRetentionSweep`: builds the db from
+ * `env` and logs the pass. Quiet when the queue is empty — the common case —
+ * so the logs only carry passes that did something.
+ */
+export async function drainBillingOutbox(env: AuthEnv): Promise<OutboxDrainResult> {
+  const db = drizzle(env.DB, { schema });
+  // The scheduled handler is typed `AuthEnv`, which doesn't declare the two
+  // optional billing bindings — same intersection the bridge and the Stripe
+  // plugin use to reach them. `runPlanSyncOutbox` treats both as possibly
+  // absent, so widening here can't assert away a real missing binding.
+  const result = await runPlanSyncOutbox(env as OutboxEnv, db);
+
+  if (result.attempted > 0) {
+    console.log(JSON.stringify({ message: "billing_outbox_drain", ...result }));
+  }
+
+  return result;
+}

--- a/apps/auth/src/billing-outbox.ts
+++ b/apps/auth/src/billing-outbox.ts
@@ -32,7 +32,7 @@
  * Covering it would mean queueing somewhere other than D1, which is not worth
  * the second system at this volume.
  */
-import { asc, eq, lte } from "drizzle-orm";
+import { and, asc, eq, lt, lte } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { AuthEnv } from "./auth";
 import * as schema from "./schema";
@@ -162,14 +162,24 @@ export async function runPlanSyncOutbox(
     return result;
   }
 
+  // Exhausted rows are excluded in SQL, not just skipped in the loop below.
+  // They stay in the table forever with a `nextAttemptAt` in the past, so they
+  // sort to the front of this query — enough of them would fill the batch and
+  // starve rows that genuinely need retrying.
   const due = await db
     .select()
     .from(schema.billingPlanOutbox)
-    .where(lte(schema.billingPlanOutbox.nextAttemptAt, now))
+    .where(
+      and(
+        lte(schema.billingPlanOutbox.nextAttemptAt, now),
+        lt(schema.billingPlanOutbox.attempts, MAX_ATTEMPTS),
+      ),
+    )
     .orderBy(asc(schema.billingPlanOutbox.nextAttemptAt))
     .limit(DRAIN_BATCH);
 
   for (const row of due) {
+    // Defensive: the query above already excludes these.
     if (row.attempts >= MAX_ATTEMPTS) continue;
     result.attempted += 1;
 

--- a/apps/auth/src/billing-outbox.ts
+++ b/apps/auth/src/billing-outbox.ts
@@ -45,12 +45,16 @@ type OutboxEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
 const DRAIN_BATCH = 50;
 
 /**
- * Give up after this many failed attempts. At the backoff below that is a bit
- * over a day of retrying, which comfortably outlives a deploy, a bad secret,
- * or an apps/api outage. A row at the cap stays in the table (it is the
- * operator's record of what never landed) but is no longer retried.
+ * Give up after this many failed attempts. With the backoff below, the first
+ * seven tries cover 3,840s and every try after that adds the 3,600s ceiling,
+ * so 30 attempts is 3,840 + 23×3,600 = 86,640s — just over 24 hours. That is
+ * the window this is sized for: long enough to outlive a deploy, a bad secret,
+ * or an apps/api outage without an operator watching.
+ *
+ * A row at the cap stays in the table — it is the operator's record of what
+ * never landed — but is no longer retried.
  */
-export const MAX_ATTEMPTS = 12;
+export const MAX_ATTEMPTS = 30;
 
 /** Exponential backoff, capped at an hour: 1m, 2m, 4m … 60m. */
 export function backoffSeconds(attempts: number): number {

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -7,6 +7,7 @@ import { localDemoEnabled } from "./local-demo";
 import { isTrustedOrigin } from "./trusted-origins";
 import { runAuthRetentionSweep } from "./retention-sweep";
 import { sweepOauthClients } from "./oauth-client-reaper";
+import { BILLING_OUTBOX_CRON, drainBillingOutbox } from "./billing-outbox";
 import { billingPricesResponseBody } from "./billing-prices";
 
 // Credentialed CORS for the web origin (+ dev origins), scoped to /api/auth/*
@@ -120,10 +121,25 @@ export const app = new Hono<{ Bindings: AuthEnv }>()
 
 export default {
   fetch: app.fetch.bind(app),
-  // Daily retention sweep (plan Phase 5, uploads#102 item 4): expired
-  // `verification`/`device_code` rows that Better Auth doesn't proactively
-  // clean up. See src/retention-sweep.ts.
-  async scheduled(_controller: ScheduledController, env: AuthEnv, ctx: ExecutionContext) {
+  // Two schedules (see wrangler.jsonc `triggers.crons`), dispatched on
+  // `controller.cron`: the every-5-minutes billing outbox drain must not drag
+  // the daily sweeps along with it.
+  async scheduled(controller: ScheduledController, env: AuthEnv, ctx: ExecutionContext) {
+    if (controller.cron === BILLING_OUTBOX_CRON) {
+      // Issue #451: retry plan syncs whose bridge call to apps/api failed.
+      ctx.waitUntil(
+        drainBillingOutbox(env).catch((err) => {
+          console.error(
+            JSON.stringify({
+              message: "billing_outbox_drain_failed",
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }),
+      );
+      return;
+    }
+
     ctx.waitUntil(
       runAuthRetentionSweep(env).catch((err) => {
         console.error(

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -451,6 +451,30 @@ export const subscription = sqliteTable("subscription", {
 });
 
 /**
+ * Durable retry queue for the billing plan bridge (issue #451). Written by
+ * `syncWorkspacePlan` (src/billing-bridge.ts) when the `POST
+ * /internal/billing/plan` call to apps/api fails, drained by the cron in
+ * src/billing-outbox.ts.
+ *
+ * `referenceId` (the organization id) is the primary key, so a repeat failure
+ * for the same org replaces its pending row instead of queueing a duplicate.
+ *
+ * Deliberately carries NO plan column: the drain recomputes the desired plan
+ * from the `subscription` table at retry time, so a queued row can never
+ * re-apply a plan that a later event has already superseded.
+ *
+ * Paired migration: `migrations/20260723150000_billing_plan_outbox.sql`.
+ */
+export const billingPlanOutbox = sqliteTable("billing_plan_outbox", {
+  referenceId: text("reference_id").primaryKey(),
+  attempts: integer("attempts").notNull().default(0),
+  lastError: text("last_error"),
+  nextAttemptAt: integer("next_attempt_at", { mode: "timestamp" }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+/**
  * Drizzle relations for Better Auth `experimental.joins` (adapter needs these
  * on the same schema object as the tables). No SQL/migration impact.
  *
@@ -529,3 +553,4 @@ export type AuthDeviceCode = typeof deviceCode.$inferSelect;
 export type AuthOauthClient = typeof oauthClient.$inferSelect;
 export type AuthOauthWorkspaceChoice = typeof oauthWorkspaceChoice.$inferSelect;
 export type AuthSubscription = typeof subscription.$inferSelect;
+export type AuthBillingPlanOutbox = typeof billingPlanOutbox.$inferSelect;

--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -29,12 +29,19 @@
     "enabled": true,
     "head_sampling_rate": 1,
   },
-  // Daily retention sweep for expired verification/device_code rows (plan
-  // Phase 5, uploads#102 item 4 — see src/retention-sweep.ts). Offset 15
-  // minutes from apps/api's own daily sweep (0 6 * * *) so the two crons
-  // don't fire in the same minute.
+  // Two schedules, dispatched on `controller.cron` in src/index.ts:
+  //
+  // "15 6 * * *"    daily retention sweep for expired verification/device_code
+  //                 rows (plan Phase 5, uploads#102 item 4 — see
+  //                 src/retention-sweep.ts) plus the stale OAuth-client
+  //                 reaper. Offset 15 minutes from apps/api's own daily sweep
+  //                 (0 6 * * *) so the two crons don't fire in the same minute.
+  // "*/5 * * * *"   billing plan-sync outbox drain (issue #451, see
+  //                 src/billing-outbox.ts). Frequent because the queue only
+  //                 has rows when someone's paid plan is stale; the drain is a
+  //                 single indexed D1 read and does nothing when empty.
   "triggers": {
-    "crons": ["15 6 * * *"],
+    "crons": ["15 6 * * *", "*/5 * * * *"],
   },
   // Dedicated D1 database (see docs/superpowers/plans/2026-07-12-better-auth-introduction.md,
   // decision D1) — auth tables never live in uploads-production. Database


### PR DESCRIPTION
Closes #451. Picked option C from the design writeup on that issue — retry the
failed message rather than build a reconciler that compares Stripe to
workspace records.

## The gap

`syncWorkspacePlan` never throws, deliberately: a webhook handler must not 500
because the bridge to apps/api hiccuped. But that means Stripe gets a 2xx and
never redelivers, so a failed bridge call left the workspace `plan` stale with
no recovery. Someone could pay and stay on the free plan until a human noticed.

## The fix

Every failure path in the bridge — non-2xx from apps/api, a throwing service
binding, a missing binding or secret, a D1 error on the org lookup — enqueues
the organization in a new `billing_plan_outbox` table. The auth worker's cron
drains it every 5 minutes with exponential backoff (1m doubling to a 1h cap)
and a 12-attempt ceiling, which is a bit over a day of retrying: long enough to
outlive a deploy, a bad secret, or an apps/api outage.

Rows that hit the ceiling stay in the table as the operator's record of what
never landed, and log `billing_outbox_exhausted`.

## Two decisions worth reviewing

**The queue stores no plan value.** It records only which organization needs
syncing; the drain recomputes the desired plan from the `subscription` table at
retry time. A row queued before a cancellation therefore can't resurrect `pro`
minutes later, and the subscription table stays the single source of truth.
Test: "recomputes the plan at retry time rather than replaying the queued one".

**It only touches organizations whose bridge call actually failed.** This is
what keeps it clear of the comped-workspace trap in #451 — a workspace an
operator put on `pro` by hand never goes through the bridge, so it is never
enqueued and this can never downgrade it. A compare-everything-to-Stripe sweep
could not promise that without first adding a comp marker, which is the main
reason this is an outbox and not a reconciler.

## Known limit

The queue lives in the same D1 the bridge reads, so a D1 outage takes the
enqueue down with the sync it was meant to rescue. That case logs
`billing_outbox_enqueue_failed` and still needs an operator re-post through the
idempotent internal route. Documented in the module header. Covering it would
mean queueing outside D1, which isn't worth a second system at this volume.

This surfaced as a real test failure: `billing-bridge.test.ts`'s broken-D1 case
asserted exactly one error log and now sees two (the sync failure, then the
enqueue failing on the same broken db). Updated the expectation and the comment
rather than papering over it — the property that test pins, that the bridge
still resolves, is unchanged.

## Migration

`20260723150000_billing_plan_outbox.sql`, already applied to the production
`uploads-auth` D1 ahead of this merge (verified: table + index present). Nothing
writes to it until this deploys.

## Verification

- Full suite: 2755 tests across 218 files pass, including 20 new ones
- `tsc --noEmit` on `@uploads/auth` clean; `pnpm lint` clean
- The fake-D1 test harness applies the real migration files, so these tests
  exercise the actual SQL and would catch drift between `schema.ts` and the
  migration

No changeset: `@uploads/auth` is in the changesets ignore list.

## Also in scope

The daily retention/reaper sweeps and the new drain dispatch on
`controller.cron`, so the 5-minute schedule doesn't drag the daily work with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable retries for billing plan synchronization failures.
  * Billing plans are automatically retried every five minutes with exponential backoff.
  * Retry attempts use the latest subscription status, preventing outdated plan changes.
  * Duplicate pending retries are consolidated per organization.

* **Bug Fixes**
  * Billing synchronization failures no longer disappear after being logged; they remain queued for recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->