### PR TITLE
feat: refresh CLI version on account sessions without re-login

### DIFF
--- a/.changeset/session-cli-version.md
+++ b/.changeset/session-cli-version.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Device login now saves a session token and keeps `session.cliVersion` fresh so
+the account Sessions list can show your current CLI version after upgrades
+without re-login.

--- a/apps/auth/migrations/20260723120000_session_cli_version.sql
+++ b/apps/auth/migrations/20260723120000_session_cli_version.sql
@@ -1,0 +1,6 @@
+-- CLI package version on the session row (schema: session.cliVersion).
+-- Written by Better Auth session.additionalFields + CLI POST /update-session
+-- after device login / on throttled CLI heartbeats. Displayed on
+-- /account/profile sessions without re-parsing user_agent.
+
+ALTER TABLE session ADD COLUMN cli_version TEXT;

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -618,6 +618,11 @@ function buildAuth(
       // We only use it for account UX, not high-sensitivity actions — disable.
       freshAge: 0,
       cookieCache: { enabled: true, maxAge: 5 * 60 },
+      // CLI package version — set/refreshed via POST /update-session (not core
+      // userAgent, which Better Auth freezes after create). See account Sessions.
+      additionalFields: {
+        cliVersion: { type: "string", required: false },
+      },
     },
     databaseHooks: {
       session: {

--- a/apps/auth/src/schema.ts
+++ b/apps/auth/src/schema.ts
@@ -64,7 +64,8 @@ export const user = sqliteTable("user", {
  * columns), `migrations/20260712210000_admin_plugin.sql` (`impersonated_by`,
  * written by the `admin` plugin's impersonation feature — Phase 2),
  * `migrations/20260712220000_organization.sql` (`active_organization_id`,
- * written by the `organization` plugin — Phase 3).
+ * written by the `organization` plugin — Phase 3),
+ * `migrations/20260723120000_session_cli_version.sql` (`cli_version`).
  */
 export const session = sqliteTable(
   "session",
@@ -81,6 +82,8 @@ export const session = sqliteTable(
     updatedAt: timestampCol("updated_at"),
     impersonatedBy: text("impersonated_by"),
     activeOrganizationId: text("active_organization_id"),
+    /** Installed `@buildinternet/uploads` version for CLI device sessions. */
+    cliVersion: text("cli_version"),
   },
   (t) => [index("idx_session_user_id").on(t.userId)],
 );

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -50,6 +50,8 @@ export interface AuthSession {
   expiresAt: string | Date;
   ipAddress?: string | null;
   userAgent?: string | null;
+  /** Installed CLI package version (session.additionalFields.cliVersion). */
+  cliVersion?: string | null;
 }
 
 export interface SessionResponse {

--- a/apps/web/src/lib/session-device.test.ts
+++ b/apps/web/src/lib/session-device.test.ts
@@ -21,6 +21,17 @@ describe("deviceLabel", () => {
     expect(deviceLabel("Mozilla/5.0 (Windows NT 10.0) Firefox/128.0")).toBe("Firefox on Windows");
     expect(deviceLabel(null)).toBe("Unknown device");
   });
+
+  it("prefers session.cliVersion over the create-time user-agent version", () => {
+    expect(deviceLabel("@buildinternet/uploads/1.0.0", { cliVersion: "1.9.0" })).toBe(
+      "uploads CLI 1.9.0",
+    );
+    expect(deviceLabel("@buildinternet/uploads", { cliVersion: "2.0.0" })).toBe(
+      "uploads CLI 2.0.0",
+    );
+    // Additional field alone is enough (upgrade path after UA was versionless).
+    expect(deviceLabel(null, { cliVersion: "1.2.3" })).toBe("uploads CLI 1.2.3");
+  });
 });
 
 describe("formatSessionTime", () => {

--- a/apps/web/src/lib/session-device.ts
+++ b/apps/web/src/lib/session-device.ts
@@ -24,13 +24,17 @@ export function isCliUserAgent(ua?: string | null): boolean {
   return Boolean(ua && CLI_USER_AGENT_RE.test(ua));
 }
 
-/** "Chrome on macOS" / "uploads CLI 1.2.3" / "Unknown device". */
-export function deviceLabel(ua?: string | null): string {
-  if (!ua) return "Unknown device";
-  if (isCliUserAgent(ua)) {
-    const version = ua.match(/@buildinternet\/uploads\/([\w.-]+)/i)?.[1];
+/**
+ * "Chrome on macOS" / "uploads CLI 1.2.3" / "Unknown device".
+ * Prefer session.cliVersion when present (refreshed after CLI upgrade).
+ */
+export function deviceLabel(ua?: string | null, opts?: { cliVersion?: string | null }): string {
+  const cliVersion = opts?.cliVersion?.trim();
+  if (cliVersion || isCliUserAgent(ua)) {
+    const version = cliVersion || ua?.match(/@buildinternet\/uploads\/([\w.-]+)/i)?.[1];
     return version ? `uploads CLI ${version}` : "uploads CLI";
   }
+  if (!ua) return "Unknown device";
   const browser = BROWSERS.find(([re]) => re.test(ua))?.[1] ?? "Browser";
   const os = OSES.find(([re]) => re.test(ua))?.[1] ?? "";
   return os ? `${browser} on ${os}` : browser;

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -276,7 +276,7 @@ export const prerender = false;
           return `<li>
             <div class="detail-main">
               <div class="detail-title">
-                <span>${escapeHtml(deviceLabel(s.userAgent))}</span>
+                <span>${escapeHtml(deviceLabel(s.userAgent, { cliVersion: s.cliVersion }))}</span>
                 ${badge}
               </div>
               <div class="detail-meta">${meta}</div>

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -43,6 +43,7 @@ import { runReport } from "./commands/report.js";
 import { runScreenshot } from "./commands/screenshot.js";
 import { packageVersion } from "./package-version.js";
 import { checkForUpdate, maybeHintUpdate } from "./update-check.js";
+import { maybeSyncSessionCliVersion } from "./session-cli-version.js";
 import {
   errorCodeFromUnknown,
   maybeShowFirstRunNotice,
@@ -261,6 +262,11 @@ export async function runCli(argv: string[]): Promise<number> {
     const json = parsed.globals.json ?? false;
     const quiet = parsed.globals.quiet ?? false;
     apiUrl = resolveApiUrl(parsed.globals);
+
+    // Refresh session.cliVersion when the installed package changes (no-op without a session token).
+    if (parsed.command && parsed.command !== "login" && parsed.command !== "logout") {
+      maybeSyncSessionCliVersion({ apiUrl, envFile: parsed.globals.envFile });
+    }
 
     if (parsed.globals.version) {
       process.stdout.write(`${packageVersion()}\n`);

--- a/packages/uploads/src/commands/config.ts
+++ b/packages/uploads/src/commands/config.ts
@@ -31,6 +31,7 @@ Keys:
   UPLOADS_API_URL           API base URL (default: ${DEFAULT_API_URL})
   UPLOADS_WORKSPACE         Workspace / bucket tenant (default: ${DEFAULT_WORKSPACE})
   UPLOADS_TOKEN             Bearer token for the workspace
+  UPLOADS_SESSION_TOKEN     Device-flow session (CLI version on account sessions)
   UPLOADS_DEFAULT_PREFIX    Default key prefix for put/list
   UPLOADS_DEFAULT_REPO      Default repo segment for put
   UPLOADS_DEFAULT_REF       Default ref segment for put
@@ -234,7 +235,11 @@ Examples:
   const path = flagString(parsed.flags, "--path") ?? resolveConfigPath({ envFile: opts.envFile });
   const force = flagBool(parsed.flags, "--force");
   const result = writeConfigKeys(path, { [key]: value }, { force });
-  const payload = { ...result, key, value: key === "UPLOADS_TOKEN" ? redactToken(value) : value };
+  const payload = {
+    ...result,
+    key,
+    value: key === "UPLOADS_TOKEN" || key === "UPLOADS_SESSION_TOKEN" ? redactToken(value) : value,
+  };
 
   if (opts.json) writeJson(payload);
   else process.stdout.write(`set ${key} in ${result.path}\n`);

--- a/packages/uploads/src/commands/login.ts
+++ b/packages/uploads/src/commands/login.ts
@@ -3,8 +3,10 @@ import { createInterface } from "node:readline/promises";
 import { spawn } from "node:child_process";
 import { stdin, stdout } from "node:process";
 import {
+  authUrlFromApi,
   loadConfigFile,
   redactToken,
+  removeConfigKeys,
   resolveConfigPath,
   writeConfigKeys,
   workspaceFromToken,
@@ -22,6 +24,7 @@ import { flagBool, flagString, parseCommandArgs, UsageError } from "../cli-args.
 import { parseScopes } from "./admin-enrollment.js";
 import { writeCommandHelp } from "../cli-style.js";
 import { UploadsError } from "../errors.js";
+import { syncSessionCliVersion } from "../session-cli-version.js";
 
 const HELP = `uploads login [options]
 
@@ -189,16 +192,7 @@ export function resolveAuthUrl(
 ): string {
   const explicit = flagString(parsed.flags, "--auth-url") ?? process.env.UPLOADS_AUTH_URL;
   if (explicit) return explicit.replace(/\/$/, "");
-  try {
-    const url = new URL(apiUrl);
-    if (url.hostname.startsWith("api.")) {
-      url.hostname = `auth.${url.hostname.slice(4)}`;
-      return url.origin;
-    }
-  } catch {
-    // fall through to the default
-  }
-  return "https://auth.uploads.sh";
+  return authUrlFromApi(apiUrl);
 }
 
 /** Best-effort browser open. The URL is always printed too, so failures are silent. */
@@ -285,6 +279,9 @@ interface LoginResult {
   workspace: string;
   token: string;
   apiUrl?: string;
+  /** Device-flow session bearer (absent on enrollment-code path). */
+  sessionToken?: string;
+  authUrl?: string;
 }
 
 /**
@@ -369,7 +366,13 @@ async function runDeviceLogin(
     scopes,
     label,
   }).catch((err) => describeMintFailure(opts.apiUrl, session.accessToken, workspace, err));
-  return { workspace: minted.workspace, token: minted.token, apiUrl: opts.apiUrl };
+  return {
+    workspace: minted.workspace,
+    token: minted.token,
+    apiUrl: opts.apiUrl,
+    sessionToken: session.accessToken,
+    authUrl: opts.authUrl,
+  };
 }
 
 function safeHostname(): string {
@@ -524,6 +527,8 @@ export async function runLogin(
       UPLOADS_API_URL: savedApiUrl,
       UPLOADS_WORKSPACE: result.workspace,
       UPLOADS_TOKEN: result.token,
+      // Device login only — enables throttled session.cliVersion refresh.
+      ...(result.sessionToken ? { UPLOADS_SESSION_TOKEN: result.sessionToken } : {}),
     },
     { force },
   );
@@ -533,6 +538,18 @@ export async function runLogin(
     )
   )
     throw new UsageError("credentials were not fully written; retry with --force");
+  // Enrollment path: drop any stale device session so we don't heartbeat a dead token.
+  if (!result.sessionToken) {
+    removeConfigKeys(path, ["UPLOADS_SESSION_TOKEN"]);
+  } else {
+    // Seed session.cliVersion immediately (don't wait for the next command).
+    await syncSessionCliVersion({
+      sessionToken: result.sessionToken,
+      authUrl: result.authUrl,
+      apiUrl: savedApiUrl,
+      force: true,
+    });
+  }
   const checked = !flagBool(parsed.flags, "--no-check");
   let doctor = { ok: true, error: undefined as string | undefined };
   if (checked) {

--- a/packages/uploads/src/commands/session.ts
+++ b/packages/uploads/src/commands/session.ts
@@ -33,8 +33,9 @@ Examples:
 
 const LOGOUT_HELP = `uploads logout
 
-Remove the saved UPLOADS_TOKEN from the shared config file so this machine is
-no longer signed in for the CLI. Does not revoke the token on the server.
+Remove the saved UPLOADS_TOKEN (and device session token) from the shared
+config file so this machine is no longer signed in for the CLI. Does not
+revoke tokens on the server.
 
 Environment variables (UPLOADS_TOKEN) are not unset — export them yourself if set.
 
@@ -160,7 +161,7 @@ export async function runLogout(
   const path = flagString(parsed.flags, "--path") ?? resolveConfigPath({ envFile: opts.envFile });
   const hadFileToken = Boolean(loadConfigFile(path).UPLOADS_TOKEN);
   const envTokenStillSet = Boolean(process.env.UPLOADS_TOKEN);
-  const result = removeConfigKeys(path, ["UPLOADS_TOKEN"]);
+  const result = removeConfigKeys(path, ["UPLOADS_TOKEN", "UPLOADS_SESSION_TOKEN"]);
 
   const payload = {
     path: result.path,
@@ -175,8 +176,11 @@ export async function runLogout(
     return 0;
   }
 
-  if (result.removed.includes("UPLOADS_TOKEN")) {
-    process.stdout.write(`signed out — removed UPLOADS_TOKEN from ${result.path}\n`);
+  if (
+    result.removed.includes("UPLOADS_TOKEN") ||
+    result.removed.includes("UPLOADS_SESSION_TOKEN")
+  ) {
+    process.stdout.write(`signed out — removed credentials from ${result.path}\n`);
   } else if (!result.existed) {
     process.stdout.write(`no config file at ${result.path} — already signed out\n`);
   } else {

--- a/packages/uploads/src/config-file.ts
+++ b/packages/uploads/src/config-file.ts
@@ -7,6 +7,8 @@ export const UPLOADS_CONFIG_KEYS = [
   "UPLOADS_API_URL",
   "UPLOADS_WORKSPACE",
   "UPLOADS_TOKEN",
+  /** Better Auth device-flow session bearer — keeps session.cliVersion fresh. */
+  "UPLOADS_SESSION_TOKEN",
   "UPLOADS_DEFAULT_PREFIX",
   "UPLOADS_DEFAULT_REPO",
   "UPLOADS_DEFAULT_REF",

--- a/packages/uploads/src/config.ts
+++ b/packages/uploads/src/config.ts
@@ -28,6 +28,20 @@ export interface UploadsClientConfig {
   token: string;
 }
 
+/** Derive auth origin from an API base (`api.` → `auth.`), else production default. */
+export function authUrlFromApi(apiUrl: string): string {
+  try {
+    const url = new URL(apiUrl);
+    if (url.hostname.startsWith("api.")) {
+      url.hostname = `auth.${url.hostname.slice(4)}`;
+      return url.origin;
+    }
+  } catch {
+    // fall through
+  }
+  return "https://auth.uploads.sh";
+}
+
 export const DEFAULT_API_URL = "https://api.uploads.sh";
 export const DEFAULT_WORKSPACE = "default";
 

--- a/packages/uploads/src/session-cli-version.ts
+++ b/packages/uploads/src/session-cli-version.ts
@@ -1,0 +1,102 @@
+/**
+ * Keep Better Auth session.cliVersion in sync with the installed package.
+ *
+ * Device login stores UPLOADS_SESSION_TOKEN; later commands POST
+ * /api/auth/update-session when the local version changes (fire-and-forget).
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { authUrlFromApi } from "./config.js";
+import { loadConfigFile, removeConfigKeys, resolveConfigPath } from "./config-file.js";
+import { packageVersion } from "./package-version.js";
+
+const POST_TIMEOUT_MS = 1500;
+
+function defaultCachePath(): string {
+  const base = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache");
+  return join(base, "uploads", "cli-version-sync");
+}
+
+function readLastSyncedVersion(path: string): string | undefined {
+  try {
+    const v = readFileSync(path, "utf8").trim();
+    return v || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeLastSyncedVersion(path: string, version: string): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, version + "\n", { mode: 0o600 });
+  } catch {
+    // best-effort
+  }
+}
+
+export interface SyncCliVersionOptions {
+  sessionToken?: string;
+  authUrl?: string;
+  apiUrl?: string;
+  envFile?: string;
+  version?: string;
+  /** Skip the local "already synced this version" short-circuit. */
+  force?: boolean;
+  cachePath?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Best-effort POST; never throws. */
+export async function syncSessionCliVersion(opts: SyncCliVersionOptions = {}): Promise<boolean> {
+  const version = opts.version ?? packageVersion();
+  const configPath = resolveConfigPath({ envFile: opts.envFile });
+  const fromFile = loadConfigFile(configPath);
+  const sessionToken = opts.sessionToken ?? fromFile.UPLOADS_SESSION_TOKEN;
+  if (!sessionToken) return false;
+
+  const cachePath = opts.cachePath ?? defaultCachePath();
+  if (!opts.force && readLastSyncedVersion(cachePath) === version) return true;
+
+  const apiUrl = opts.apiUrl ?? fromFile.UPLOADS_API_URL ?? process.env.UPLOADS_API_URL;
+  const authUrl = (
+    opts.authUrl ??
+    process.env.UPLOADS_AUTH_URL ??
+    (apiUrl ? authUrlFromApi(apiUrl) : "https://auth.uploads.sh")
+  ).replace(/\/$/, "");
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
+  try {
+    const fetchImpl = opts.fetchImpl ?? fetch;
+    const res = await fetchImpl(`${authUrl}/api/auth/update-session`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sessionToken}`,
+        "User-Agent": `@buildinternet/uploads/${version} (session-version)`,
+      },
+      body: JSON.stringify({ cliVersion: version }),
+      signal: controller.signal,
+    });
+    if (res.ok) {
+      writeLastSyncedVersion(cachePath, version);
+      return true;
+    }
+    // Stale session: drop it so we stop retrying every command.
+    if (res.status === 401 || res.status === 403) {
+      removeConfigKeys(configPath, ["UPLOADS_SESSION_TOKEN"]);
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Fire-and-forget for CLI command starts. */
+export function maybeSyncSessionCliVersion(opts: SyncCliVersionOptions = {}): void {
+  void syncSessionCliVersion(opts);
+}

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -204,6 +204,7 @@ describe("runLogin device flow", () => {
           201,
         ),
       ) // POST /v1/tokens
+      .mockResolvedValueOnce(response({ session: { cliVersion: "0.0.0" } })) // update-session
       .mockResolvedValueOnce(response({ ok: true })) // doctor health
       .mockResolvedValueOnce(response({ items: [], cursor: null })); // doctor list
     const output = captureOutput();
@@ -223,8 +224,17 @@ describe("runLogin device flow", () => {
     expect(JSON.parse(String((mintCall![1] as RequestInit).body))).toMatchObject({
       grants: [{ workspace: "acme", scopes: ["files:read", "files:write", "files:delete"] }],
     });
-    expect(loadConfigFile(path).UPLOADS_TOKEN).toBe(token);
-    expect(loadConfigFile(path).UPLOADS_WORKSPACE).toBe("acme");
+    const cfg = loadConfigFile(path);
+    expect(cfg.UPLOADS_TOKEN).toBe(token);
+    expect(cfg.UPLOADS_WORKSPACE).toBe("acme");
+    expect(cfg.UPLOADS_SESSION_TOKEN).toBe("sess-tok");
+    const updateCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).endsWith("/api/auth/update-session"),
+    );
+    expect(updateCall).toBeTruthy();
+    expect(JSON.parse(String((updateCall![1] as RequestInit).body))).toMatchObject({
+      cliVersion: expect.any(String),
+    });
     expect(output.out() + output.err()).not.toContain(token);
   });
 

--- a/packages/uploads/test/session-cli-version.test.ts
+++ b/packages/uploads/test/session-cli-version.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { syncSessionCliVersion } from "../src/session-cli-version.js";
+
+describe("syncSessionCliVersion", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs.length = 0;
+    vi.unstubAllEnvs();
+  });
+
+  function tmpConfig(contents: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-cli-ver-"));
+    dirs.push(dir);
+    const path = join(dir, "config");
+    writeFileSync(path, contents);
+    return path;
+  }
+
+  it("no-ops without a session token", async () => {
+    const path = tmpConfig("UPLOADS_API_URL=https://api.uploads.sh\n");
+    const fetchImpl = vi.fn();
+    expect(
+      await syncSessionCliVersion({
+        envFile: path,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        force: true,
+      }),
+    ).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("POSTs update-session and skips when the version is unchanged", async () => {
+    const path = tmpConfig(
+      ["UPLOADS_API_URL=https://api.example.test", "UPLOADS_SESSION_TOKEN=sess_test", ""].join(
+        "\n",
+      ),
+    );
+    const cachePath = join(path, "..", "cache");
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ session: {} }), { status: 200 }),
+    );
+
+    expect(
+      await syncSessionCliVersion({
+        envFile: path,
+        version: "1.2.3",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        cachePath,
+        force: true,
+      }),
+    ).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe("https://auth.example.test/api/auth/update-session");
+    expect(JSON.parse(String(call[1].body))).toEqual({ cliVersion: "1.2.3" });
+    expect(readFileSync(cachePath, "utf8").trim()).toBe("1.2.3");
+
+    expect(
+      await syncSessionCliVersion({
+        envFile: path,
+        version: "1.2.3",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        cachePath,
+      }),
+    ).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    expect(
+      await syncSessionCliVersion({
+        envFile: path,
+        version: "1.2.4",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        cachePath,
+      }),
+    ).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops UPLOADS_SESSION_TOKEN on 401", async () => {
+    const path = tmpConfig(
+      "UPLOADS_SESSION_TOKEN=sess_x\nUPLOADS_API_URL=https://api.uploads.sh\nUPLOADS_TOKEN=up_ws_abc\n",
+    );
+    await syncSessionCliVersion({
+      envFile: path,
+      version: "9.9.9",
+      force: true,
+      fetchImpl: (async () => new Response("{}", { status: 401 })) as unknown as typeof fetch,
+      cachePath: join(path, "..", "cache-401"),
+    });
+    const { loadConfigFile } = await import("../src/config-file.js");
+    const cfg = loadConfigFile(path);
+    expect(cfg.UPLOADS_SESSION_TOKEN).toBeUndefined();
+    expect(cfg.UPLOADS_TOKEN).toBe("up_ws_abc");
+  });
+});


### PR DESCRIPTION
## In plain terms

Account **Sessions** could only show the CLI version captured at login (from User-Agent). After `npm i -g`, the list stayed stale until another `uploads login`. This keeps a small `cliVersion` field on the session and refreshes it from the CLI when the package version changes.

## What it does

- Adds Better Auth `session.additionalFields.cliVersion` (+ D1 migration)
- Device login saves `UPLOADS_SESSION_TOKEN` and immediately sets `cliVersion`
- Later CLI commands fire-and-forget an `update-session` only when the installed version changed (or the local cache is empty)
- Profile sessions prefer `cliVersion` over the create-time User-Agent
- Logout clears the session token; 401/403 from update-session drops a stale session token

## What it is not

- Not an “upgrade available” banner in the web app (still no npm comparison server-side)
- Enrollment-code login has no session token (no heartbeat until a device login)
- Does not rewrite core `userAgent` (Better Auth forbids that on `update-session`)

## How to try it

```bash
uploads login
# Account → Profile → Sessions should show uploads CLI <version>

npm i -g @buildinternet/uploads@latest   # or any newer build
uploads whoami                           # any command triggers a version sync when needed
# Refresh Sessions — version should update without uploads login again
```

## Technical notes

- Auth migration: `apps/auth/migrations/20260723120000_session_cli_version.sql` (apply on auth deploy)
- CLI module: `packages/uploads/src/session-cli-version.ts`
- Changeset: patch for `@buildinternet/uploads`

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @uploads/web test`
- [x] `pnpm --filter @uploads/auth test`
- [ ] Auth D1 migration applied in target env before relying on update-session writes