### PR TITLE
feat: web CLI upgrade callout and plan on usage

### DIFF
--- a/.changeset/cli-upgrade-and-plan.md
+++ b/.changeset/cli-upgrade-and-plan.md
@@ -2,5 +2,6 @@
 "@buildinternet/uploads": patch
 ---
 
-`uploads usage` shows the workspace plan (e.g. Pro) when the API reports a paid
-plan. Additive `plan` field on the usage response.
+`uploads usage` shows the workspace plan (Free or Pro) when the API reports it,
+alongside storage/upload meters. Free is not unlimited — caps appear on the
+meters. Additive `plan` field on the usage response.

--- a/.changeset/cli-upgrade-and-plan.md
+++ b/.changeset/cli-upgrade-and-plan.md
@@ -1,0 +1,6 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads usage` shows the workspace plan (e.g. Pro) when the API reports a paid
+plan. Additive `plan` field on the usage response.

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -1,3 +1,4 @@
+import { getPlan } from "@uploads/billing";
 import { Hono } from "hono";
 import { usageWithLimits } from "../budget";
 import { reconcileWorkspaceUsage } from "../reconcile";
@@ -14,13 +15,17 @@ import { requireScope, type WorkspaceVars } from "../workspace";
 export const usage = new Hono<WorkspaceVars>()
   .get("/", requireScope("files:read"), async (c) => {
     const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
+    const workspace = c.get("workspace");
     // `scopes` reflects the presented credential, not the workspace — doctor
     // uses it to surface a token that can't delete before the user hits a
     // surprise `forbidden`. Legacy tokens report the full file-scope set,
     // which is what they actually have.
+    // `plan` is the catalog id (free|pro) so CLI `uploads usage` can label
+    // paid workspaces without a separate billing round trip.
     return c.json({
-      ...usageWithLimits(snapshot, c.get("workspace")),
+      ...usageWithLimits(snapshot, workspace),
       scopes: c.get("authScopes"),
+      plan: getPlan(workspace.plan).id,
     });
   })
 

--- a/apps/api/test/routes-usage.test.ts
+++ b/apps/api/test/routes-usage.test.ts
@@ -60,6 +60,8 @@ describe("GET /v1/:workspace/usage + put/delete metering", () => {
       periodStart: usagePeriodStart(),
       // Legacy KV-hash token (this suite's TOKEN) → full file-scope set.
       scopes: ["files:read", "files:write", "files:delete"],
+      // Catalog plan id for CLI labeling (free when unset on the record).
+      plan: "free",
     });
   });
 

--- a/apps/web/src/lib/cli-upgrade.test.ts
+++ b/apps/web/src/lib/cli-upgrade.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  bestCliVersion,
+  dismissStorageKey,
+  dismissUpgrade,
+  isNewerVersion,
+  isUpgradeDismissed,
+  parseSemver,
+  resolveUpgradePrompt,
+} from "./cli-upgrade";
+
+describe("parseSemver / isNewerVersion", () => {
+  it("parses and compares", () => {
+    expect(parseSemver("1.2.3")).toEqual([1, 2, 3]);
+    expect(parseSemver("1.2.3-beta.1")).toEqual([1, 2, 3]);
+    expect(isNewerVersion("0.27.0", "0.26.0")).toBe(true);
+    expect(isNewerVersion("0.26.0", "0.26.0")).toBe(false);
+    expect(isNewerVersion("0.25.0", "0.26.0")).toBe(false);
+  });
+});
+
+describe("bestCliVersion", () => {
+  it("prefers cliVersion over UA and the freshest session", () => {
+    expect(
+      bestCliVersion([
+        {
+          userAgent: "@buildinternet/uploads/1.0.0 (device-token)",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          cliVersion: "1.2.0",
+          userAgent: "@buildinternet/uploads/1.1.0 (device-token)",
+          updatedAt: "2026-07-01T00:00:00.000Z",
+        },
+      ]),
+    ).toBe("1.2.0");
+  });
+
+  it("returns null without CLI sessions", () => {
+    expect(bestCliVersion([{ userAgent: "Mozilla/5.0 Chrome/120" }])).toBeNull();
+    expect(bestCliVersion([])).toBeNull();
+    expect(bestCliVersion(null)).toBeNull();
+  });
+});
+
+describe("resolveUpgradePrompt", () => {
+  it("builds a prompt only when latest is newer", () => {
+    expect(resolveUpgradePrompt("0.26.0", "0.27.0")).toMatchObject({
+      current: "0.26.0",
+      latest: "0.27.0",
+      installCmd: "npm i -g @buildinternet/uploads",
+    });
+    expect(resolveUpgradePrompt("0.27.0", "0.27.0")).toBeNull();
+    expect(resolveUpgradePrompt(null, "0.27.0")).toBeNull();
+    expect(resolveUpgradePrompt("0.26.0", null)).toBeNull();
+  });
+});
+
+describe("dismiss helpers", () => {
+  it("reads and writes sessionStorage-style storage", () => {
+    const map = new Map<string, string>();
+    const storage = {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        map.set(k, v);
+      },
+    };
+    expect(isUpgradeDismissed("1.0.0", storage)).toBe(false);
+    dismissUpgrade("1.0.0", storage);
+    expect(map.get(dismissStorageKey("1.0.0"))).toBe("1");
+    expect(isUpgradeDismissed("1.0.0", storage)).toBe(true);
+    expect(isUpgradeDismissed("1.0.1", storage)).toBe(false);
+  });
+
+  it("tolerates storage throwing", () => {
+    const boom = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(isUpgradeDismissed("1.0.0", boom)).toBe(false);
+    expect(() => dismissUpgrade("1.0.0", boom)).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/cli-upgrade.ts
+++ b/apps/web/src/lib/cli-upgrade.ts
@@ -1,0 +1,104 @@
+/**
+ * Account UI: compare session.cliVersion to the published npm latest and
+ * decide whether to show an upgrade callout (issue #459).
+ */
+
+export const CLI_PACKAGE = "@buildinternet/uploads";
+export const CLI_INSTALL_CMD = `npm i -g ${CLI_PACKAGE}`;
+/** Session-storage dismiss key prefix; full key includes the latest version. */
+export const CLI_UPGRADE_DISMISS_PREFIX = "uploads:cli-upgrade-dismissed:";
+
+/** Parse major.minor.patch (ignores pre-release). Same rules as CLI update-check. */
+export function parseSemver(version: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** True when `latest` is strictly greater than `current`. */
+export function isNewerVersion(latest: string, current: string): boolean {
+  const a = parseSemver(latest);
+  const b = parseSemver(current);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i]! > b[i]!) return true;
+    if (a[i]! < b[i]!) return false;
+  }
+  return false;
+}
+
+export type SessionLike = {
+  cliVersion?: string | null;
+  userAgent?: string | null;
+  updatedAt?: string | Date | null;
+};
+
+/** Prefer explicit cliVersion, else parse create-time UA; pick the freshest CLI session. */
+export function bestCliVersion(sessions: SessionLike[] | null | undefined): string | null {
+  if (!sessions?.length) return null;
+  const cli = sessions
+    .map((s) => {
+      const fromField = typeof s.cliVersion === "string" ? s.cliVersion.trim() : "";
+      const fromUa = s.userAgent?.match(/@buildinternet\/uploads\/([\w.-]+)/i)?.[1] ?? "";
+      const version = fromField || fromUa || null;
+      if (!version) return null;
+      const t = s.updatedAt ? new Date(s.updatedAt).getTime() : 0;
+      return { version, t: Number.isFinite(t) ? t : 0 };
+    })
+    .filter((x): x is { version: string; t: number } => x != null);
+  if (!cli.length) return null;
+  cli.sort((a, b) => b.t - a.t);
+  return cli[0]!.version;
+}
+
+export type UpgradePrompt = {
+  current: string;
+  latest: string;
+  installCmd: string;
+  message: string;
+};
+
+/** Null when current is missing, latest is missing, or already up to date. */
+export function resolveUpgradePrompt(
+  current: string | null | undefined,
+  latest: string | null | undefined,
+): UpgradePrompt | null {
+  const cur = current?.trim();
+  const lat = latest?.trim();
+  if (!cur || !lat) return null;
+  if (!isNewerVersion(lat, cur)) return null;
+  return {
+    current: cur,
+    latest: lat,
+    installCmd: CLI_INSTALL_CMD,
+    message: `You’re on CLI ${cur}; ${lat} is available. Update: ${CLI_INSTALL_CMD}`,
+  };
+}
+
+export function dismissStorageKey(latest: string): string {
+  return `${CLI_UPGRADE_DISMISS_PREFIX}${latest.trim()}`;
+}
+
+export function isUpgradeDismissed(
+  latest: string,
+  storage: Pick<Storage, "getItem"> | null | undefined,
+): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(dismissStorageKey(latest)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function dismissUpgrade(
+  latest: string,
+  storage: Pick<Storage, "setItem"> | null | undefined,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(dismissStorageKey(latest), "1");
+  } catch {
+    // private mode / quota — ignore
+  }
+}

--- a/apps/web/src/lib/public-file.test.ts
+++ b/apps/web/src/lib/public-file.test.ts
@@ -239,10 +239,11 @@ describe("fileKind", () => {
 });
 
 describe("formatBytes", () => {
-  it("renders human sizes", () => {
+  it("renders human sizes with decimal SI units", () => {
     expect(formatBytes(512)).toBe("512 B");
-    expect(formatBytes(20480)).toBe("20 KB");
-    expect(formatBytes(1_500_000)).toBe("1.4 MB");
+    expect(formatBytes(20_000)).toBe("20 KB");
+    expect(formatBytes(1_500_000)).toBe("1.5 MB");
+    expect(formatBytes(250_000_000)).toBe("250 MB");
   });
 });
 

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -349,18 +349,21 @@ export async function fetchPublicFile(
   }
 }
 
-/** Human-readable byte size for the metadata block. */
+/**
+ * Human-readable byte size for metadata / file lists (decimal SI).
+ * Matches account/billing meters so a 250 MB free cap never reads as 238 MB.
+ */
 export function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return "—";
-  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1000) return `${Math.round(bytes)} B`;
   const units = ["KB", "MB", "GB", "TB"];
-  let value = bytes / 1024;
+  let value = bytes / 1000;
   let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
     unit += 1;
   }
-  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+  return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
 }
 
 /** Same-day writes within this window share one "Uploaded" chip (R2 mtime noise). */

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatBytes,
   formatMarketedBytes,
   orderOrgsOldestFirst,
   renderInvitesHtml,
@@ -8,13 +9,15 @@ import {
   safeSameOriginPath,
 } from "./workspace-ui";
 
-describe("formatMarketedBytes", () => {
+describe("formatBytes / formatMarketedBytes (decimal SI)", () => {
   it("renders the catalog's round decimal caps exactly as marketed", () => {
     expect(formatMarketedBytes(250_000_000)).toBe("250 MB");
     expect(formatMarketedBytes(25_000_000)).toBe("25 MB");
     expect(formatMarketedBytes(8_000_000)).toBe("8 MB");
     expect(formatMarketedBytes(10_000_000_000)).toBe("10 GB");
     expect(formatMarketedBytes(100_000_000)).toBe("100 MB");
+    // formatBytes is the same SI path (no more binary 238 MB for free).
+    expect(formatBytes(250_000_000)).toBe("250 MB");
   });
 
   it("handles sub-KB and fractional values", () => {
@@ -121,7 +124,7 @@ describe("safeSameOriginPath", () => {
 describe("renderUsageHtml", () => {
   it("falls back to plain text when no quota caps are set", () => {
     const html = renderUsageHtml({
-      bytes: 8_388_608,
+      bytes: 8_000_000,
       objects: 64,
       uploadsInPeriod: 1,
     });

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -39,27 +39,15 @@ export function escapeHtml(value: string): string {
   );
 }
 
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let value = bytes / 1024;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
-}
-
 /**
- * Decimal (SI) byte formatting for *marketed* plan limits, which are defined
- * in plans.ts as round decimal numbers (250 MB, 10 GB, 100 MB). The binary
- * `formatBytes` above stays for measured usage/enforcement figures, but
- * would render those caps as 238 MB / 9.3 GB / 95 MB on the plan cards —
- * contradicting the plan blurb on the same card.
+ * Decimal (SI) human sizes for user-facing UI. Plan catalog caps are defined
+ * as round decimal numbers (250 MB, 10 GB); binary units made Free look like
+ * "238 MB". Used for both measured usage and marketed limits so meters match
+ * plan cards.
  */
-export function formatMarketedBytes(bytes: number): string {
-  if (bytes < 1000) return `${bytes} B`;
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  if (bytes < 1000) return `${Math.round(bytes)} B`;
   const units = ["KB", "MB", "GB", "TB"];
   let value = bytes / 1000;
   let unit = 0;
@@ -68,6 +56,11 @@ export function formatMarketedBytes(bytes: number): string {
     unit += 1;
   }
   return `${value >= 10 ? Math.round(value) : Math.round(value * 10) / 10} ${units[unit]}`;
+}
+
+/** Alias kept for call sites that distinguish plan-card copy; same SI base. */
+export function formatMarketedBytes(bytes: number): string {
+  return formatBytes(bytes);
 }
 
 export type UsageSnapshot = {

--- a/apps/web/src/pages/account/developers.astro
+++ b/apps/web/src/pages/account/developers.astro
@@ -22,6 +22,17 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
     <div id="cli-setup-status" class="ul-callout" data-state="muted" role="status">
       Checking for a CLI sign-in…
     </div>
+    <div id="cli-upgrade" class="ul-callout cli-upgrade" hidden role="status">
+      <span class="ul-callout__title">CLI update</span>
+      <p id="cli-upgrade-msg" class="cli-upgrade__msg"></p>
+      <div class="cli-upgrade__actions">
+        <div class="command">
+          <code id="cli-upgrade-cmd"></code>
+          <button type="button" id="cli-upgrade-copy" data-copy="" aria-live="polite">copy</button>
+        </div>
+        <button type="button" class="text-btn" id="cli-upgrade-dismiss">Dismiss</button>
+      </div>
+    </div>
     <div class="cli-steps" id="cli-steps">
       <div class="command" id="cli-install-cmd">
         <code>npm install -g @buildinternet/uploads</code>
@@ -72,9 +83,36 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
     </div>
   </section>
 
+  <style>
+    .cli-upgrade {
+      margin: 10px 0 0;
+    }
+    .cli-upgrade__msg {
+      margin: 0 0 10px;
+    }
+    .cli-upgrade__actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px 14px;
+    }
+    .cli-upgrade .command {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+    }
+  </style>
+
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
-    import { listSessions } from "../../lib/auth-client";
+    import { listSessions, type AuthSession } from "../../lib/auth-client";
+    import {
+      bestCliVersion,
+      dismissUpgrade,
+      isUpgradeDismissed,
+      resolveUpgradePrompt,
+    } from "../../lib/cli-upgrade";
     import { resolveCliSetupState } from "../../lib/cli-setup-state";
 
     onAstroPageLoad(() => {
@@ -87,12 +125,24 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
         "click",
         (event) => {
           void (async () => {
+            const dismiss = (event.target as HTMLElement).closest<HTMLButtonElement>(
+              "#cli-upgrade-dismiss",
+            );
+            if (dismiss) {
+              const box = requireElement<HTMLElement>("#cli-upgrade", "developers");
+              const latest = box.dataset.latest;
+              if (latest) dismissUpgrade(latest, sessionStorage);
+              box.hidden = true;
+              return;
+            }
             const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
-              "button[data-copy]",
+              "button[data-copy], #cli-upgrade-copy",
             );
             if (!button) return;
+            const text = button.dataset.copy ?? "";
+            if (!text) return;
             try {
-              await navigator.clipboard.writeText(button.dataset.copy ?? "");
+              await navigator.clipboard.writeText(text);
               const previous = button.textContent;
               button.textContent = "copied ✓";
               setTimeout(() => {
@@ -104,6 +154,36 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
           })();
         },
       );
+
+      async function maybeShowCliUpgrade(sessions: AuthSession[] | null): Promise<void> {
+        const box = requireElement<HTMLElement>("#cli-upgrade", "developers");
+        box.hidden = true;
+        if (!sessions?.length) return;
+
+        const current = bestCliVersion(sessions);
+        if (!current) return;
+
+        let latest: string | undefined;
+        try {
+          const res = await fetch("/cli-version.json", { credentials: "same-origin" });
+          if (!res.ok) return;
+          const body = (await res.json()) as { latest?: unknown };
+          if (typeof body.latest === "string") latest = body.latest;
+        } catch {
+          return;
+        }
+
+        const prompt = resolveUpgradePrompt(current, latest);
+        if (!prompt || isUpgradeDismissed(prompt.latest, sessionStorage)) return;
+
+        requireElement<HTMLElement>("#cli-upgrade-msg", "developers").textContent = prompt.message;
+        requireElement<HTMLElement>("#cli-upgrade-cmd", "developers").textContent =
+          prompt.installCmd;
+        requireElement<HTMLButtonElement>("#cli-upgrade-copy", "developers").dataset.copy =
+          prompt.installCmd;
+        box.dataset.latest = prompt.latest;
+        box.hidden = false;
+      }
 
       function applyCliSetup(
         sessions: Awaited<ReturnType<typeof listSessions>>,
@@ -131,6 +211,8 @@ const showConsoleLinks = await resolveShowConsoleLinks(env);
         steps.hidden = kind === "ready";
         installCmd.hidden = kind === "reconnect";
         note.hidden = kind === "ready" || kind === "reconnect";
+
+        if (loaded) void maybeShowCliUpgrade(sessions);
       }
 
       onSession((user) => {

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -26,6 +26,17 @@ export const prerender = false;
 
     <div class="settings-section">
       <h2>Sessions</h2>
+      <div id="cli-upgrade" class="ul-callout cli-upgrade" hidden role="status">
+        <span class="ul-callout__title">CLI update</span>
+        <p id="cli-upgrade-msg" class="cli-upgrade__msg"></p>
+        <div class="cli-upgrade__actions">
+          <div class="command">
+            <code id="cli-upgrade-cmd"></code>
+            <button type="button" id="cli-upgrade-copy" data-copy="" aria-live="polite">copy</button>
+          </div>
+          <button type="button" class="text-btn" id="cli-upgrade-dismiss">Dismiss</button>
+        </div>
+      </div>
       <div id="sessions-status" class="muted detail-status">Loading…</div>
       <ul class="detail-list" id="sessions-list" hidden></ul>
       <div id="sessions-recover" class="sessions-recover" hidden>
@@ -60,6 +71,24 @@ export const prerender = false;
       line-height: 1.55;
       text-wrap: pretty;
     }
+    .cli-upgrade {
+      margin: 0 0 14px;
+    }
+    .cli-upgrade__msg {
+      margin: 0 0 10px;
+    }
+    .cli-upgrade__actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px 14px;
+    }
+    .cli-upgrade .command {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+    }
   </style>
 
   <script>
@@ -71,10 +100,17 @@ export const prerender = false;
       listAccounts,
       listSessions,
       revokeSession,
+      type AuthSession,
       type LinkedAccount,
       type ProviderAccountInfo,
     } from "../../lib/auth-client";
     import { githubMarkSvg } from "../../lib/brand-icons";
+    import {
+      bestCliVersion,
+      dismissUpgrade,
+      isUpgradeDismissed,
+      resolveUpgradePrompt,
+    } from "../../lib/cli-upgrade";
     import { deviceLabel, formatSessionTime, isCliUserAgent } from "../../lib/session-device";
 
     onAstroPageLoad(() => {
@@ -214,15 +250,47 @@ export const prerender = false;
 
     let currentToken: string | undefined;
 
+    async function maybeShowCliUpgrade(sessions: AuthSession[]): Promise<void> {
+      const box = requireElement<HTMLElement>("#cli-upgrade", "account profile");
+      const msg = requireElement<HTMLElement>("#cli-upgrade-msg", "account profile");
+      const cmd = requireElement<HTMLElement>("#cli-upgrade-cmd", "account profile");
+      const copyBtn = requireElement<HTMLButtonElement>("#cli-upgrade-copy", "account profile");
+      box.hidden = true;
+
+      const current = bestCliVersion(sessions);
+      if (!current) return;
+
+      let latest: string | undefined;
+      try {
+        const res = await fetch("/cli-version.json", { credentials: "same-origin" });
+        if (!res.ok) return;
+        const body = (await res.json()) as { latest?: unknown };
+        if (typeof body.latest === "string") latest = body.latest;
+      } catch {
+        return;
+      }
+
+      const prompt = resolveUpgradePrompt(current, latest);
+      if (!prompt || isUpgradeDismissed(prompt.latest, sessionStorage)) return;
+
+      msg.textContent = prompt.message;
+      cmd.textContent = prompt.installCmd;
+      copyBtn.dataset.copy = prompt.installCmd;
+      box.hidden = false;
+      box.dataset.latest = prompt.latest;
+    }
+
     async function loadSessions(): Promise<void> {
       const status = requireElement<HTMLElement>("#sessions-status", "account profile");
       const list = requireElement<HTMLUListElement>("#sessions-list", "account profile");
       const recover = requireElement<HTMLElement>("#sessions-recover", "account profile");
       const reauth = requireElement<HTMLAnchorElement>("#sessions-reauth", "account profile");
       const error = requireElement<HTMLElement>("#sessions-error", "account profile");
+      const upgradeBox = requireElement<HTMLElement>("#cli-upgrade", "account profile");
       error.hidden = true;
       list.hidden = true;
       recover.hidden = true;
+      upgradeBox.hidden = true;
       showStatus(status, "Loading…");
 
       // Point recovery at this page so re-auth lands back on the sessions list.
@@ -285,7 +353,38 @@ export const prerender = false;
           </li>`;
         })
         .join("");
+
+      void maybeShowCliUpgrade(sessions);
     }
+
+    requireElement<HTMLElement>("#cli-upgrade", "account profile").addEventListener(
+      "click",
+      (event) => {
+        void (async () => {
+          const target = event.target as HTMLElement;
+          const dismiss = target.closest<HTMLButtonElement>("#cli-upgrade-dismiss");
+          if (dismiss) {
+            const box = requireElement<HTMLElement>("#cli-upgrade", "account profile");
+            const latest = box.dataset.latest;
+            if (latest) dismissUpgrade(latest, sessionStorage);
+            box.hidden = true;
+            return;
+          }
+          const button = target.closest<HTMLButtonElement>("#cli-upgrade-copy");
+          if (!button?.dataset.copy) return;
+          try {
+            await navigator.clipboard.writeText(button.dataset.copy);
+            const previous = button.textContent;
+            button.textContent = "copied ✓";
+            setTimeout(() => {
+              button.textContent = previous;
+            }, 1500);
+          } catch {
+            // Clipboard blocked.
+          }
+        })();
+      },
+    );
 
     requireElement<HTMLUListElement>("#sessions-list", "account profile").addEventListener(
       "click",

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -204,10 +204,10 @@ export const prerender = false;
       });
     }
 
+    // Decimal SI only — plan caps and display use 1000-based MB/GB (not MiB/GiB).
     const LIMIT_UNITS: { label: string; mult: number }[] = [
       { label: "MB", mult: 1_000_000 },
       { label: "GB", mult: 1_000_000_000 },
-      { label: "GiB", mult: 1024 ** 3 },
     ];
     const LIMIT_FIELDS: { key: keyof Limits; label: string; byte: boolean }[] = [
       { key: "maxStorageBytes", label: "Storage", byte: true },

--- a/apps/web/src/pages/cli-version.json.ts
+++ b/apps/web/src/pages/cli-version.json.ts
@@ -1,0 +1,58 @@
+/**
+ * GET /cli-version.json — published latest for @buildinternet/uploads.
+ *
+ * Account UI uses this (same-origin) instead of calling the npm registry from
+ * the browser, so CORS and ad-blockers don't break the upgrade callout.
+ * Cached briefly at the edge/browser so we don't hammer npm.
+ */
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+const NPM_LATEST =
+  "https://registry.npmjs.org/" + encodeURIComponent("@buildinternet/uploads") + "/latest";
+const FETCH_TIMEOUT_MS = 2500;
+
+export const GET: APIRoute = async () => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(NPM_LATEST, {
+      signal: controller.signal,
+      headers: {
+        accept: "application/json",
+        "user-agent": "uploads.sh-web/cli-version",
+      },
+    });
+    if (!res.ok) {
+      return json({ error: "upstream_unavailable" }, 502);
+    }
+    const body = (await res.json()) as { version?: unknown };
+    if (typeof body.version !== "string" || !body.version.trim()) {
+      return json({ error: "invalid_upstream" }, 502);
+    }
+    return json(
+      {
+        package: "@buildinternet/uploads",
+        latest: body.version.trim(),
+      },
+      200,
+      // Short shared cache: upgrades show up within ~10 minutes without a redeploy.
+      "public, max-age=300, s-maxage=600, stale-while-revalidate=3600",
+    );
+  } catch {
+    return json({ error: "upstream_unavailable" }, 502);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+function json(body: Record<string, unknown>, status: number, cacheControl = "no-store"): Response {
+  return new Response(JSON.stringify(body) + "\n", {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": cacheControl,
+    },
+  });
+}

--- a/packages/ui/src/FileBrowser.tsx
+++ b/packages/ui/src/FileBrowser.tsx
@@ -34,11 +34,19 @@ export interface FileBrowserProps {
   ) => React.ReactNode;
 }
 
+/** Decimal SI sizes — matches account/billing and CLI (250 MB free, not 238 MB). */
 const formatBytes = (bytes: number): string => {
-  if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1000) return `${Math.round(bytes)} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1000;
+  let unit = 0;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
+    unit += 1;
+  }
+  const rounded = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unit]}`;
 };
 
 const crumbsOf = (prefix: string, delimiter: string) => {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -347,6 +347,11 @@ export interface UsageResult {
   uploadsRemaining?: number;
   /** File scopes of the presented token (servers ≥ this field's release). */
   scopes?: Array<TokenScope>;
+  /**
+   * Workspace plan catalog id (`free` | `pro`). Present on API workers that
+   * ship plan-aware usage; omitted on older servers.
+   */
+  plan?: string;
 }
 
 export interface ReconcileResult {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3010,10 +3010,10 @@ const USAGE_HELP = `uploads usage [--workspace <name>]
 Show workspace storage and monthly upload counters.
 
 When the API reports workspace quotas (typical on uploads.sh cloud /
-self-serve plans), human output includes progress bars toward those caps.
-Paid workspaces also show their plan (e.g. Pro). Self-hosted or unlimited
-operator workspaces get usage totals only, plus a short unmetered note —
-no invented limits.
+self-serve Free and Pro), human output includes the plan name and progress
+bars toward those caps. Free is not unlimited — storage and monthly upload
+limits show on the meters. Self-hosted or unlimited operator workspaces get
+usage totals only, plus a short unmetered note — no invented limits.
 
 Examples:
   uploads --env-file .env usage

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -3011,8 +3011,9 @@ Show workspace storage and monthly upload counters.
 
 When the API reports workspace quotas (typical on uploads.sh cloud /
 self-serve plans), human output includes progress bars toward those caps.
-Self-hosted or unlimited operator workspaces get usage totals only, plus a
-short unmetered note — no invented limits.
+Paid workspaces also show their plan (e.g. Pro). Self-hosted or unlimited
+operator workspaces get usage totals only, plus a short unmetered note —
+no invented limits.
 
 Examples:
   uploads --env-file .env usage

--- a/packages/uploads/src/format-bytes.ts
+++ b/packages/uploads/src/format-bytes.ts
@@ -1,5 +1,5 @@
 /**
- * Human-readable size for CLI notes (1024-based).
+ * Human-readable size for measured file/usage bytes (1024-based).
  * files-sdk has no size formatter — only raw `size` on head/upload results.
  */
 export function formatByteSize(bytes: number): string {
@@ -7,4 +7,24 @@ export function formatByteSize(bytes: number): string {
   const units = ["B", "KB", "MB", "GB", "TB"] as const;
   const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+}
+
+/**
+ * Decimal (SI) sizes for *marketed* plan limits, which are defined in
+ * `@uploads/billing` as round decimal numbers (250 MB, 10 GB, 100 MB).
+ * Binary `formatByteSize` would render those as 238.4 MB / 9.3 GB and
+ * contradict the plan blurb — same split as apps/web `formatMarketedBytes`.
+ */
+export function formatMarketedBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1000) return `${Math.round(bytes)} B`;
+  const units = ["KB", "MB", "GB", "TB"] as const;
+  let value = bytes / 1000;
+  let unit = 0;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
+    unit += 1;
+  }
+  const rounded = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[unit]}`;
 }

--- a/packages/uploads/src/format-bytes.ts
+++ b/packages/uploads/src/format-bytes.ts
@@ -1,21 +1,10 @@
 /**
- * Human-readable size for measured file/usage bytes (1024-based).
- * files-sdk has no size formatter — only raw `size` on head/upload results.
+ * Decimal (SI) human sizes for CLI output. Plan catalog caps are round decimal
+ * numbers (250 MB free, 10 GB pro); binary units made Free look like 238.4 MB.
+ * Used for usage meters, list sizes, optimize notes, and doctor — same base
+ * as apps/web `formatBytes` / `formatMarketedBytes`.
  */
 export function formatByteSize(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"] as const;
-  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`;
-}
-
-/**
- * Decimal (SI) sizes for *marketed* plan limits, which are defined in
- * `@uploads/billing` as round decimal numbers (250 MB, 10 GB, 100 MB).
- * Binary `formatByteSize` would render those as 238.4 MB / 9.3 GB and
- * contradict the plan blurb — same split as apps/web `formatMarketedBytes`.
- */
-export function formatMarketedBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
   if (bytes < 1000) return `${Math.round(bytes)} B`;
   const units = ["KB", "MB", "GB", "TB"] as const;
@@ -27,4 +16,9 @@ export function formatMarketedBytes(bytes: number): string {
   }
   const rounded = value >= 10 ? Math.round(value) : Math.round(value * 10) / 10;
   return `${rounded} ${units[unit]}`;
+}
+
+/** Alias for call sites that want plan-cap wording; same SI formatter. */
+export function formatMarketedBytes(bytes: number): string {
+  return formatByteSize(bytes);
 }

--- a/packages/uploads/src/format-usage.ts
+++ b/packages/uploads/src/format-usage.ts
@@ -21,6 +21,8 @@ export type UsageSnapshotLike = {
   storageRemainingBytes?: number;
   maxUploadsPerPeriod?: number;
   uploadsRemaining?: number;
+  /** Catalog plan id when the API reports it (`free` | `pro`). */
+  plan?: string;
 };
 
 export type FormatUsageOptions = {
@@ -116,6 +118,14 @@ export function formatUsageTimestamp(iso: string, timeZone?: string): string {
   }
 }
 
+/** Display label for a paid plan id; free/unknown stay hidden. */
+export function paidPlanLabel(plan: string | undefined): string | null {
+  if (!plan || plan === "free") return null;
+  if (plan === "pro") return "Pro";
+  // Future paid tiers: title-case the id rather than hiding them.
+  return plan.charAt(0).toUpperCase() + plan.slice(1);
+}
+
 /** Human-readable lines for `uploads usage` (not JSON). */
 export function formatUsageHuman(
   result: UsageSnapshotLike,
@@ -125,6 +135,9 @@ export function formatUsageHuman(
   const color = opts.color === true;
   const metered = isUsageMetered(result);
   const lines: string[] = [`workspace: ${result.workspace}`];
+
+  const planLabel = paidPlanLabel(result.plan);
+  if (planLabel) lines.push(`plan:      ${planLabel}`);
 
   const storagePct = usagePct(result.bytes, result.maxStorageBytes);
   if (storagePct !== null && result.maxStorageBytes != null) {

--- a/packages/uploads/src/format-usage.ts
+++ b/packages/uploads/src/format-usage.ts
@@ -118,13 +118,20 @@ export function formatUsageTimestamp(iso: string, timeZone?: string): string {
   }
 }
 
-/** Display label for a paid plan id; free/unknown stay hidden. */
-export function paidPlanLabel(plan: string | undefined): string | null {
-  if (!plan || plan === "free") return null;
+/**
+ * Display label for a plan catalog id. Free is shown too — free workspaces
+ * still have quotas (storage / monthly uploads) that usage meters report.
+ */
+export function planLabel(plan: string | undefined): string | null {
+  if (!plan) return null;
+  if (plan === "free") return "Free";
   if (plan === "pro") return "Pro";
-  // Future paid tiers: title-case the id rather than hiding them.
+  // Future tiers: title-case the id rather than hiding them.
   return plan.charAt(0).toUpperCase() + plan.slice(1);
 }
+
+/** @deprecated use planLabel — kept as an alias for any external importers. */
+export const paidPlanLabel = planLabel;
 
 /** Human-readable lines for `uploads usage` (not JSON). */
 export function formatUsageHuman(
@@ -136,8 +143,8 @@ export function formatUsageHuman(
   const metered = isUsageMetered(result);
   const lines: string[] = [`workspace: ${result.workspace}`];
 
-  const planLabel = paidPlanLabel(result.plan);
-  if (planLabel) lines.push(`plan:      ${planLabel}`);
+  const label = planLabel(result.plan);
+  if (label) lines.push(`plan:      ${label}`);
 
   const storagePct = usagePct(result.bytes, result.maxStorageBytes);
   if (storagePct !== null && result.maxStorageBytes != null) {
@@ -169,8 +176,16 @@ export function formatUsageHuman(
   lines.push(`updated:   ${formatUsageTimestamp(result.updatedAt, opts.timeZone)}`);
 
   if (!metered) {
-    // Self-host / operator unlimited: report usage without implying a plan.
-    lines.push("note:      unmetered — no storage or upload quotas on this workspace");
+    // Self-host / operator unlimited, or a plan without reported caps.
+    // Free self-serve normally reports maxStorageBytes / maxUploadsPerPeriod;
+    // when those are missing, say so explicitly rather than implying unlimited free.
+    if (result.plan === "free") {
+      lines.push(
+        "note:      free plan — no quotas reported for this workspace (limits may still apply server-side)",
+      );
+    } else {
+      lines.push("note:      unmetered — no storage or upload quotas on this workspace");
+    }
   }
 
   return lines;

--- a/packages/uploads/src/format-usage.ts
+++ b/packages/uploads/src/format-usage.ts
@@ -7,7 +7,7 @@
  * and operator workspaces usually omit them (unlimited). Progress bars only
  * appear for fields that have a positive cap — never invent a budget.
  */
-import { formatByteSize } from "./format-bytes.js";
+import { formatByteSize, formatMarketedBytes } from "./format-bytes.js";
 import { BRAND, type Rgb } from "./cli-brand.js";
 
 export type UsageSnapshotLike = {
@@ -148,10 +148,13 @@ export function formatUsageHuman(
 
   const storagePct = usagePct(result.bytes, result.maxStorageBytes);
   if (storagePct !== null && result.maxStorageBytes != null) {
+    // Caps (and remaining-against-cap) use SI marketed formatting so Free's
+    // 250_000_000 reads as "250 MB", not binary "238.4 MB". Used bytes share
+    // the same base on this line so the three numbers stay coherent.
     const detail =
-      `${formatByteSize(result.bytes)} / ${formatByteSize(result.maxStorageBytes)}` +
+      `${formatMarketedBytes(result.bytes)} / ${formatMarketedBytes(result.maxStorageBytes)}` +
       (result.storageRemainingBytes != null
-        ? ` (${formatByteSize(result.storageRemainingBytes)} free)`
+        ? ` (${formatMarketedBytes(result.storageRemainingBytes)} free)`
         : "");
     const bar = formatProgressBar(storagePct, { width, color });
     lines.push(`storage:   ${bar}  ${detail}`);

--- a/packages/uploads/test/commands-staged.test.ts
+++ b/packages/uploads/test/commands-staged.test.ts
@@ -250,7 +250,7 @@ describe("runStaged: file listing", () => {
       );
     });
     expect(stdout).toContain("shot.png");
-    expect(stdout).toContain("2.0 KB");
+    expect(stdout).toContain("2 KB");
     expect(stdout).toContain("https://x.test/shot.png");
     expect(stderr).toContain("binding: self");
     expect(stderr).toContain("once the PR exists: uploads attach --promote");

--- a/packages/uploads/test/format-bytes.test.ts
+++ b/packages/uploads/test/format-bytes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatByteSize } from "../src/format-bytes.js";
+import { formatByteSize, formatMarketedBytes } from "../src/format-bytes.js";
 
 describe("formatByteSize", () => {
   it("keeps small values in bytes", () => {
@@ -8,16 +8,33 @@ describe("formatByteSize", () => {
     expect(formatByteSize(1023)).toBe("1023 B");
   });
 
-  it("formats KB and MB with one decimal", () => {
+  it("formats KB and MB with one decimal (1024-based)", () => {
     expect(formatByteSize(1024)).toBe("1.0 KB");
     expect(formatByteSize(96412)).toBe("94.2 KB");
     expect(formatByteSize(421337)).toBe("411.5 KB");
     expect(formatByteSize(1024 * 1024)).toBe("1.0 MB");
     expect(formatByteSize(1.5 * 1024 * 1024)).toBe("1.5 MB");
+    // Plan free cap would look wrong with binary units:
+    expect(formatByteSize(250_000_000)).toBe("238.4 MB");
   });
 
   it("handles non-finite input", () => {
     expect(formatByteSize(Number.NaN)).toBe("0 B");
     expect(formatByteSize(-1)).toBe("0 B");
+  });
+});
+
+describe("formatMarketedBytes", () => {
+  it("renders plan catalog caps as round decimal units", () => {
+    expect(formatMarketedBytes(250_000_000)).toBe("250 MB");
+    expect(formatMarketedBytes(25_000_000)).toBe("25 MB");
+    expect(formatMarketedBytes(8_000_000)).toBe("8 MB");
+    expect(formatMarketedBytes(10_000_000_000)).toBe("10 GB");
+    expect(formatMarketedBytes(100_000_000)).toBe("100 MB");
+  });
+
+  it("handles sub-KB and fractional values", () => {
+    expect(formatMarketedBytes(500)).toBe("500 B");
+    expect(formatMarketedBytes(1_500_000)).toBe("1.5 MB");
   });
 });

--- a/packages/uploads/test/format-bytes.test.ts
+++ b/packages/uploads/test/format-bytes.test.ts
@@ -5,17 +5,16 @@ describe("formatByteSize", () => {
   it("keeps small values in bytes", () => {
     expect(formatByteSize(0)).toBe("0 B");
     expect(formatByteSize(512)).toBe("512 B");
-    expect(formatByteSize(1023)).toBe("1023 B");
+    expect(formatByteSize(999)).toBe("999 B");
   });
 
-  it("formats KB and MB with one decimal (1024-based)", () => {
-    expect(formatByteSize(1024)).toBe("1.0 KB");
-    expect(formatByteSize(96412)).toBe("94.2 KB");
-    expect(formatByteSize(421337)).toBe("411.5 KB");
-    expect(formatByteSize(1024 * 1024)).toBe("1.0 MB");
-    expect(formatByteSize(1.5 * 1024 * 1024)).toBe("1.5 MB");
-    // Plan free cap would look wrong with binary units:
-    expect(formatByteSize(250_000_000)).toBe("238.4 MB");
+  it("formats KB and MB with decimal SI units", () => {
+    expect(formatByteSize(1000)).toBe("1 KB");
+    expect(formatByteSize(1500)).toBe("1.5 KB");
+    expect(formatByteSize(1_500_000)).toBe("1.5 MB");
+    expect(formatByteSize(1_000_000)).toBe("1 MB");
+    // Free plan cap must read as marketed 250 MB, not binary 238.4 MB.
+    expect(formatByteSize(250_000_000)).toBe("250 MB");
   });
 
   it("handles non-finite input", () => {

--- a/packages/uploads/test/format-usage.test.ts
+++ b/packages/uploads/test/format-usage.test.ts
@@ -148,4 +148,35 @@ describe("formatUsageHuman", () => {
       "note:      unmetered — no storage or upload quotas on this workspace",
     ]);
   });
+
+  it("shows plan on paid workspaces only", () => {
+    const pro = formatUsageHuman(
+      {
+        workspace: "acme",
+        bytes: 10,
+        objects: 1,
+        uploadsInPeriod: 2,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+        plan: "pro",
+      },
+      { timeZone: "UTC" },
+    );
+    expect(pro[0]).toBe("workspace: acme");
+    expect(pro[1]).toBe("plan:      Pro");
+
+    const free = formatUsageHuman(
+      {
+        workspace: "acme",
+        bytes: 10,
+        objects: 1,
+        uploadsInPeriod: 2,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+        plan: "free",
+      },
+      { timeZone: "UTC" },
+    );
+    expect(free.some((l) => l.startsWith("plan:"))).toBe(false);
+  });
 });

--- a/packages/uploads/test/format-usage.test.ts
+++ b/packages/uploads/test/format-usage.test.ts
@@ -97,8 +97,9 @@ describe("formatUsageHuman", () => {
       { timeZone: "America/New_York" },
     );
     expect(lines[0]).toBe("workspace: default");
+    // Caps use SI marketed units (2.5 GB, not binary ~2.3 GB).
     expect(lines[1]).toMatch(
-      /^storage:   \[█░░░░░░░░░░░░░░░░░░░\]\s+0\.1%\s+1\.5 MB \/ 2\.3 GB \(2\.3 GB free\)$/,
+      /^storage:   \[█░░░░░░░░░░░░░░░░░░░\]\s+0\.1%\s+1\.6 MB \/ 2\.5 GB \(2\.5 GB free\)$/,
     );
     expect(lines[2]).toBe("objects:   63");
     expect(lines[3]).toMatch(
@@ -187,8 +188,8 @@ describe("formatUsageHuman", () => {
       { timeZone: "UTC" },
     );
     expect(free[1]).toBe("plan:      Free");
-    expect(free.find((l) => l.startsWith("storage:"))).toMatch(/\[/);
-    expect(free.find((l) => l.startsWith("storage:"))).toMatch(/MB/);
+    // Marketed free cap is 250_000_000 → "250 MB", not binary "238.4 MB".
+    expect(free.find((l) => l.startsWith("storage:"))).toMatch(/1 MB \/ 250 MB \(249 MB free\)/);
     expect(free.some((l) => l.startsWith("note:"))).toBe(false);
   });
 

--- a/packages/uploads/test/format-usage.test.ts
+++ b/packages/uploads/test/format-usage.test.ts
@@ -149,7 +149,7 @@ describe("formatUsageHuman", () => {
     ]);
   });
 
-  it("shows plan on paid workspaces only", () => {
+  it("shows Free and Pro plan labels (free still has quotas when metered)", () => {
     const pro = formatUsageHuman(
       {
         workspace: "acme",
@@ -159,15 +159,43 @@ describe("formatUsageHuman", () => {
         periodStart: "2026-07",
         updatedAt: "2026-07-11T00:00:00.000Z",
         plan: "pro",
+        maxStorageBytes: 10_000_000_000,
+        storageRemainingBytes: 9_999_999_990,
+        maxUploadsPerPeriod: 100_000,
+        uploadsRemaining: 99_998,
       },
       { timeZone: "UTC" },
     );
     expect(pro[0]).toBe("workspace: acme");
     expect(pro[1]).toBe("plan:      Pro");
+    expect(pro.find((l) => l.startsWith("storage:"))).toMatch(/\[/);
 
     const free = formatUsageHuman(
       {
         workspace: "acme",
+        bytes: 1_000_000,
+        objects: 3,
+        uploadsInPeriod: 10,
+        periodStart: "2026-07",
+        updatedAt: "2026-07-11T00:00:00.000Z",
+        plan: "free",
+        maxStorageBytes: 250_000_000,
+        storageRemainingBytes: 249_000_000,
+        maxUploadsPerPeriod: 3000,
+        uploadsRemaining: 2990,
+      },
+      { timeZone: "UTC" },
+    );
+    expect(free[1]).toBe("plan:      Free");
+    expect(free.find((l) => l.startsWith("storage:"))).toMatch(/\[/);
+    expect(free.find((l) => l.startsWith("storage:"))).toMatch(/MB/);
+    expect(free.some((l) => l.startsWith("note:"))).toBe(false);
+  });
+
+  it("notes free when the plan is free but no quotas were reported", () => {
+    const lines = formatUsageHuman(
+      {
+        workspace: "legacy",
         bytes: 10,
         objects: 1,
         uploadsInPeriod: 2,
@@ -177,6 +205,7 @@ describe("formatUsageHuman", () => {
       },
       { timeZone: "UTC" },
     );
-    expect(free.some((l) => l.startsWith("plan:"))).toBe(false);
+    expect(lines[1]).toBe("plan:      Free");
+    expect(lines.some((l) => l.includes("no quotas reported"))).toBe(true);
   });
 });


### PR DESCRIPTION
## In plain terms

When your CLI session is on an older package than the published latest, the account UI can say so and offer a copyable update command. Separately, `uploads usage` names the plan when the workspace is on a paid tier (Pro) instead of only showing meters.

## What it does

### Web (closes #459)
- Compares the freshest CLI session version (`cliVersion` / UA) to npm latest
- Same-origin `GET /cli-version.json` (short-cached proxy to the registry)
- Calm, dismissible callout on **Profile → Sessions** and **Developers**
- Dismiss is per-latest-version in `sessionStorage` so a new release can prompt again
- Network/upstream failures stay silent

### CLI / API
- `GET /v1/:workspace/usage` includes additive `plan` (`free` | `pro`)
- Human `uploads usage` prints `plan: Pro` only when paid; free stays quiet
- `whoami` stays offline (no API call); plan lives on usage where the workspace is already loaded

## What it is not

- Not email/push nagging
- Not forcing re-login
- Not changing the CLI stderr upgrade hint
- Not a full billing dump on `whoami`

## How to try it

```bash
# Paid plan label
uploads usage
# → plan:      Pro   (on a pro workspace)

# Upgrade callout (after a device login with an older cliVersion)
# Open /account/profile or /account/developers while signed in
```

## Technical notes

- Helpers: `apps/web/src/lib/cli-upgrade.ts`
- Builds on #458 (`session.cliVersion`)
- Changeset: patch for `@buildinternet/uploads`

## Test plan

- [x] `pnpm --filter @buildinternet/uploads test`
- [x] `pnpm --filter @uploads/api test`
- [x] `pnpm --filter @uploads/web test`
- [ ] Manual: account pages with an outdated CLI session show the callout; Dismiss hides it for that latest version