### PR TITLE
feat(web): galleries page explainer, create command, and table view

### DIFF
--- a/apps/api/src/galleries.ts
+++ b/apps/api/src/galleries.ts
@@ -382,6 +382,57 @@ export async function listGalleryItems(
   return result.results;
 }
 
+/** Item counts for many galleries in one query (avoids N+1 on the account list). */
+export async function countItemsForGalleries(
+  db: D1Database,
+  workspace: string,
+  galleryIds: string[],
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  if (!galleryIds.length) return counts;
+  const placeholders = galleryIds.map(() => "?").join(", ");
+  const result = await db
+    .prepare(
+      `SELECT i.gallery_id AS gallery_id, COUNT(*) AS n
+       FROM gallery_items i
+       JOIN galleries g ON g.id = i.gallery_id
+       WHERE g.workspace = ? AND g.deleted_at IS NULL AND i.gallery_id IN (${placeholders})
+       GROUP BY i.gallery_id`,
+    )
+    .bind(workspace, ...galleryIds)
+    .all<{ gallery_id: string; n: number }>();
+  for (const row of result.results) counts.set(row.gallery_id, Number(row.n) || 0);
+  return counts;
+}
+
+/** External references for many galleries in one query, ordered by created_at. */
+export async function listExternalReferencesForGalleries(
+  db: D1Database,
+  workspace: string,
+  galleryIds: string[],
+): Promise<Map<string, GalleryExternalReferenceRecord[]>> {
+  const byGallery = new Map<string, GalleryExternalReferenceRecord[]>();
+  if (!galleryIds.length) return byGallery;
+  const placeholders = galleryIds.map(() => "?").join(", ");
+  const result = await db
+    .prepare(
+      `SELECT r.id, r.gallery_id, r.provider, r.resource_type, r.normalized_key, r.locator_json,
+              r.canonical_url, r.created_at, r.updated_at
+       FROM gallery_external_references r
+       JOIN galleries g ON g.id = r.gallery_id
+       WHERE g.workspace = ? AND g.deleted_at IS NULL AND r.gallery_id IN (${placeholders})
+       ORDER BY r.created_at, r.id`,
+    )
+    .bind(workspace, ...galleryIds)
+    .all<GalleryExternalReferenceRecord>();
+  for (const row of result.results) {
+    const list = byGallery.get(row.gallery_id) ?? [];
+    list.push(row);
+    byGallery.set(row.gallery_id, list);
+  }
+  return byGallery;
+}
+
 /** Persistence primitive: callers must first verify objectKey exists and has a public URL. */
 export async function addGalleryItem(
   db: D1Database,

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -13,6 +13,8 @@ import {
   type GalleryRecord,
   type MutationResult,
   type PublicGallery,
+  countItemsForGalleries,
+  listExternalReferencesForGalleries,
   projectPublicGallery,
 } from "./galleries";
 import { resolveTitles, withPublicTitleBudget, type TitleInfo } from "./github-titles";
@@ -88,6 +90,12 @@ export interface GallerySummaryDto {
   version: number;
   createdAt: string;
   updatedAt: string;
+}
+
+/** List-row summary: base fields plus item count and linked PR/issue refs. */
+export interface GalleryListSummaryDto extends GallerySummaryDto {
+  itemCount: number;
+  references: ExternalReferenceDto[];
 }
 export type PublicGalleryDto = PublicGallery & {
   items: PublicGalleryItemDto[];
@@ -319,6 +327,25 @@ export function gallerySummary(env: Env, record: GalleryRecord): GallerySummaryD
     createdAt: record.created_at,
     updatedAt: record.updated_at,
   };
+}
+
+/** Attach item counts and external refs via two batch queries. */
+export async function galleryListSummaries(
+  env: Env,
+  workspace: string,
+  records: GalleryRecord[],
+): Promise<GalleryListSummaryDto[]> {
+  if (!records.length) return [];
+  const ids = records.map((record) => record.id);
+  const [itemCounts, refsByGallery] = await Promise.all([
+    countItemsForGalleries(env.DB, workspace, ids),
+    listExternalReferencesForGalleries(env.DB, workspace, ids),
+  ]);
+  return records.map((record) => ({
+    ...gallerySummary(env, record),
+    itemCount: itemCounts.get(record.id) ?? 0,
+    references: (refsByGallery.get(record.id) ?? []).map(referenceDto),
+  }));
 }
 
 export async function hydrateOwnerGallery(

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -952,6 +952,53 @@ describe("GET /me/workspaces/:name/galleries", () => {
           version: 1,
           createdAt: "2026-07-01T00:00:00.000Z",
           updatedAt: "2026-07-01T00:00:00.000Z",
+          itemCount: 0,
+          references: [],
+        },
+      ],
+    });
+  });
+
+  it("includes item counts and linked PR/issue references on each row", async () => {
+    const db = galleriesDb();
+    db.exec(
+      `INSERT INTO galleries
+         (id, workspace, title, description, visibility, cover_item_id, version, created_at, updated_at, deleted_at)
+       VALUES
+         ('gal_bbbbbbbbbbbbbbbbbbbbbb', 'acme', 'PR screenshots', NULL, 'public', NULL, 1,
+          '2026-07-02T00:00:00.000Z', '2026-07-03T00:00:00.000Z', NULL);
+       INSERT INTO gallery_items
+         (id, gallery_id, object_key, position, caption, alt_text, created_at)
+       VALUES
+         ('item_1', 'gal_bbbbbbbbbbbbbbbbbbbbbb', 'screenshots/a.png', 1, NULL, NULL, '2026-07-02T00:00:00.000Z'),
+         ('item_2', 'gal_bbbbbbbbbbbbbbbbbbbbbb', 'screenshots/b.png', 2, NULL, NULL, '2026-07-02T00:01:00.000Z');
+       INSERT INTO gallery_external_references
+         (id, gallery_id, provider, resource_type, normalized_key, locator_json, canonical_url, created_at, updated_at)
+       VALUES
+         ('ref_1', 'gal_bbbbbbbbbbbbbbbbbbbbbb', 'github', 'item',
+          'github:buildinternet/uploads#58',
+          '{"owner":"buildinternet","repository":"uploads","number":58}',
+          'https://github.com/buildinternet/uploads/pull/58',
+          '2026-07-02T00:00:00.000Z', '2026-07-02T00:00:00.000Z')`,
+    );
+    const env = memberEnv({ workspace: "acme", db: new SQLiteD1(db) });
+    const res = await app().request("/me/workspaces/acme/galleries", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      galleries: Array<{
+        id: string;
+        itemCount: number;
+        references: Array<{ coordinate: string; canonicalUrl: string | null }>;
+      }>;
+    };
+    expect(body.galleries).toHaveLength(1);
+    expect(body.galleries[0]).toMatchObject({
+      id: "gal_bbbbbbbbbbbbbbbbbbbbbb",
+      itemCount: 2,
+      references: [
+        {
+          coordinate: "buildinternet/uploads#58",
+          canonicalUrl: "https://github.com/buildinternet/uploads/pull/58",
         },
       ],
     });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -22,7 +22,7 @@ import {
 } from "../file-metadata";
 import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
-import { gallerySummary } from "../gallery-service";
+import { galleryListSummaries } from "../gallery-service";
 import { resolveTitles } from "../github-titles";
 import { allowWrite } from "../guards";
 import {
@@ -339,7 +339,7 @@ export const me = new Hono<SessionVars>()
     await memberWorkspaceOr404(c.env, requireUserId(c), name);
     const page = await listGalleries(c.env.DB, name, { limit: 50 });
     return c.json({
-      galleries: page.galleries.map((gallery) => gallerySummary(c.env, gallery)),
+      galleries: await galleryListSummaries(c.env, name, page.galleries),
     });
   })
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -187,6 +187,13 @@ async function fetchWorkspaceList<T>(
   return Array.isArray(list) ? list.filter(isValid) : [];
 }
 
+export interface GalleryReferenceSummary {
+  provider: string;
+  resourceType: string;
+  coordinate: string;
+  canonicalUrl: string | null;
+}
+
 export interface GallerySummary {
   id: string;
   url: string;
@@ -195,12 +202,35 @@ export interface GallerySummary {
   coverItemId: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Omitted on older API deployments. */
+  itemCount?: number;
+  references?: GalleryReferenceSummary[];
+}
+
+function isGalleryReferenceSummary(value: unknown): value is GalleryReferenceSummary {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.provider === "string" &&
+    typeof r.resourceType === "string" &&
+    typeof r.coordinate === "string" &&
+    (r.canonicalUrl === null || typeof r.canonicalUrl === "string")
+  );
 }
 
 function isGallerySummary(value: unknown): value is GallerySummary {
   if (!value || typeof value !== "object") return false;
   const g = value as Record<string, unknown>;
-  return typeof g.id === "string" && typeof g.url === "string" && typeof g.title === "string";
+  if (typeof g.id !== "string" || typeof g.url !== "string" || typeof g.title !== "string") {
+    return false;
+  }
+  if (g.itemCount !== undefined && typeof g.itemCount !== "number") return false;
+  if (g.references !== undefined) {
+    if (!Array.isArray(g.references) || !g.references.every(isGalleryReferenceSummary)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /** GET /me/workspaces/:name/galleries. See {@link fetchWorkspaceList}. */

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatGalleryDate,
   formatMarketedBytes,
   orderOrgsOldestFirst,
+  renderGalleriesTableHtml,
   renderInvitesHtml,
   renderMembersHtml,
   renderUsageHtml,
@@ -193,5 +195,75 @@ describe("orderOrgsOldestFirst", () => {
     const copy = [...orgs];
     orderOrgsOldestFirst(orgs);
     expect(orgs).toEqual(copy);
+  });
+});
+
+describe("renderGalleriesTableHtml", () => {
+  it("returns empty string for no galleries", () => {
+    expect(renderGalleriesTableHtml([])).toBe("");
+  });
+
+  it("renders name, items, linked refs, and updated date", () => {
+    const html = renderGalleriesTableHtml([
+      {
+        url: "https://uploads.sh/g/gal_1",
+        title: "Launch media",
+        description: "Ship shots",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        itemCount: 2,
+        references: [
+          {
+            coordinate: "buildinternet/uploads#58",
+            canonicalUrl: "https://github.com/buildinternet/uploads/pull/58",
+          },
+        ],
+      },
+    ]);
+    expect(html).toContain("Launch media");
+    expect(html).toContain("Ship shots");
+    expect(html).toContain('href="https://uploads.sh/g/gal_1"');
+    expect(html).toContain(">2<");
+    expect(html).toContain("buildinternet/uploads#58");
+    expect(html).toContain("https://github.com/buildinternet/uploads/pull/58");
+    expect(html).toContain(formatGalleryDate("2026-07-03T00:00:00.000Z"));
+  });
+
+  it("escapes title/description and shows em dash when nothing is linked", () => {
+    const html = renderGalleriesTableHtml([
+      {
+        url: "https://uploads.sh/g/gal_2",
+        title: "<img src=x onerror=alert(1)>",
+        description: "<b>x</b>",
+        updatedAt: "not-a-date",
+        itemCount: 0,
+        references: [],
+      },
+    ]);
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("<b>");
+    expect(html).toContain("&lt;img");
+    expect(html).toContain("—");
+    expect(html).toContain("not-a-date");
+  });
+
+  it("caps linked refs at three and shows a +N remainder", () => {
+    const refs = [1, 2, 3, 4, 5].map((n) => ({
+      coordinate: `org/repo#${n}`,
+      canonicalUrl: `https://github.com/org/repo/pull/${n}`,
+    }));
+    const html = renderGalleriesTableHtml([
+      {
+        url: "https://uploads.sh/g/gal_3",
+        title: "Many links",
+        description: null,
+        updatedAt: "2026-07-01T00:00:00.000Z",
+        itemCount: 1,
+        references: refs,
+      },
+    ]);
+    expect(html).toContain("org/repo#1");
+    expect(html).toContain("org/repo#3");
+    expect(html).not.toContain("org/repo#4");
+    expect(html).toContain("+2");
   });
 });

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -251,6 +251,81 @@ export function createErrorCopy(code: string): string {
   }
 }
 
+/** Fields the account galleries table needs (extra API fields are fine). */
+export interface GalleryTableRow {
+  url: string;
+  title: string;
+  description: string | null;
+  updatedAt: string;
+  itemCount?: number;
+  references?: Array<{ coordinate: string; canonicalUrl: string | null }>;
+}
+
+/** Short table-cell date (e.g. "Jul 3, 2026"). Invalid ISO falls back to the raw string. */
+export function formatGalleryDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+
+const EMPTY_CELL = `<span class="muted">—</span>`;
+
+/** Up to three linked PR/issue coordinates; remainder as "+N". */
+function renderGalleryLinksHtml(
+  references: Array<{ coordinate: string; canonicalUrl: string | null }>,
+): string {
+  if (!references.length) return EMPTY_CELL;
+  const shown = references.slice(0, 3);
+  const extra = references.length - shown.length;
+  const chips = shown
+    .map((ref) => {
+      const label = escapeHtml(ref.coordinate);
+      if (ref.canonicalUrl) {
+        return `<a class="ws-gallery-link" href="${escapeHtml(ref.canonicalUrl)}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+      }
+      return `<span class="ws-gallery-link ws-gallery-link--plain">${label}</span>`;
+    })
+    .join("");
+  const more = extra > 0 ? `<span class="muted ws-gallery-link-more">+${extra}</span>` : "";
+  return `<div class="ws-gallery-links">${chips}${more}</div>`;
+}
+
+/** Account galleries table HTML. Empty list → "" (caller paints the empty state). */
+export function renderGalleriesTableHtml(galleries: GalleryTableRow[]): string {
+  if (!galleries.length) return "";
+  const rows = galleries
+    .map((g) => {
+      const itemsCell =
+        typeof g.itemCount === "number" ? escapeHtml(String(g.itemCount)) : EMPTY_CELL;
+      const desc = g.description?.trim()
+        ? `<div class="muted ws-gallery-desc">${escapeHtml(g.description.trim())}</div>`
+        : "";
+      return `<tr>
+  <td>
+    <a class="ws-gallery-title" href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a>
+    ${desc}
+  </td>
+  <td class="num">${itemsCell}</td>
+  <td>${renderGalleryLinksHtml(g.references ?? [])}</td>
+  <td class="muted ws-gallery-updated">${escapeHtml(formatGalleryDate(g.updatedAt))}</td>
+</tr>`;
+    })
+    .join("");
+  return `<div class="ws-table-wrap">
+<table class="ws-table" aria-label="Galleries">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col" class="num">Items</th>
+      <th scope="col">Linked</th>
+      <th scope="col">Updated</th>
+    </tr>
+  </thead>
+  <tbody>${rows}</tbody>
+</table>
+</div>`;
+}
+
 /**
  * Copy-to-clipboard via event delegation under `root`.
  *

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -1,9 +1,7 @@
 ---
 /**
- * Workspace galleries tab — lifted verbatim (fetch + render) from the old
- * combined `[name].astro` page as part of the 3A workspace-tab overhaul (Task
- * 9; see `.superpowers/sdd/task-9-brief.md`). `[name].astro` keeps its own
- * copy until Task 8's rewrite lands and drops it on that side.
+ * Workspace galleries tab: explainer, create command, and table (name, items,
+ * linked PR/issues, updated) from GET /me/workspaces/:name/galleries.
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
@@ -13,6 +11,8 @@ export const prerender = false;
 const nameParam = Astro.params.name ?? "";
 const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
+
+const createCmd = 'uploads gallery create --title "Release screenshots"';
 ---
 
 <WorkspaceLayout workspace={workspace}>
@@ -20,9 +20,28 @@ if (!workspace) return Astro.redirect("/account/workspaces");
   <button id="ws-retry" type="button" hidden>Try again</button>
 
   <div id="ws-app" hidden>
-    <section class="card ws-page-card">
-      <div class="ws-block" id="ws-galleries-card">
-        <h2 class="ws-section-head">Galleries</h2>
+    <section class="card settings-page">
+      <div class="settings-section" id="ws-galleries-card">
+        <div class="ws-page-header">
+          <div class="ws-title-block">
+            <h2>Galleries</h2>
+            <p class="settings-note muted">
+              Ordered sets of screenshots and media with one public link. Link a gallery to
+              pull requests or issues so a managed comment can surface the whole set.
+            </p>
+          </div>
+        </div>
+
+        <div class="command">
+          <code>{createCmd}</code>
+          <button type="button" data-copy={createCmd} aria-live="polite">copy</button>
+        </div>
+        <p class="muted cli-note">
+          Add files with <code>uploads put ./shot.png --gallery &lt;id&gt;</code> or
+          <code>uploads gallery add &lt;id&gt; &lt;key&gt;</code>. Link a PR with
+          <code>uploads gallery link &lt;id&gt; --github owner/repo#123</code>.
+        </p>
+
         <div id="ws-galleries"><p class="ws-empty">Loading…</p></div>
       </div>
     </section>
@@ -36,14 +55,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       onSession,
       requireElement,
     } from "../../../../lib/account-shell";
-    import {
-      getMyWorkspaces,
-      getMyWorkspaceGalleries,
-      type GallerySummary,
-    } from "../../../../lib/api-client";
+    import { getMyWorkspaces, getMyWorkspaceGalleries, type GallerySummary } from "../../../../lib/api-client";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
-    import { escapeHtml } from "../../../../lib/workspace-ui";
+    import {
+      bindCopyButtons,
+      renderGalleriesTableHtml,
+    } from "../../../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("ws-galleries")) return;
@@ -69,6 +87,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const galleriesCard = requireElement<HTMLElement>("#ws-galleries-card", page);
       const galleriesEl = requireElement<HTMLElement>("#ws-galleries", page);
 
+      bindCopyButtons(galleriesCard);
+
       function showError(message: string, retry = true): void {
         if (!stillHere()) return;
         statusEl.hidden = false;
@@ -81,15 +101,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       function renderGalleries(galleries: GallerySummary[]): void {
         if (!stillHere()) return;
         if (!galleries.length) {
-          galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet.</p>`;
+          galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet. Create one with the command above.</p>`;
           return;
         }
-        galleriesEl.innerHTML = `<ul class="ws-items">${galleries
-          .map(
-            (g) =>
-              `<li><a href="${escapeHtml(g.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(g.title)}</a></li>`,
-          )
-          .join("")}</ul>`;
+        galleriesEl.innerHTML = renderGalleriesTableHtml(galleries);
       }
 
       async function loadGalleries(): Promise<void> {

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -622,6 +622,93 @@ section.card .ws-note {
 section.card .ws-note {
   color: var(--body);
 }
+
+/* Compact list tables (account galleries). */
+.ws-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-top: 16px;
+}
+.ws-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.ws-table th {
+  text-align: left;
+  font: 500 11px var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0 12px 10px 0;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+}
+.ws-table th:last-child,
+.ws-table td:last-child {
+  padding-right: 0;
+}
+.ws-table th.num,
+.ws-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-left: 16px;
+}
+.ws-table tbody > tr > td {
+  padding: 12px 12px 12px 0;
+  border-bottom: 1px solid var(--line);
+  color: var(--body);
+  vertical-align: middle;
+}
+.ws-table tbody > tr:last-child > td {
+  border-bottom: 0;
+}
+.ws-table .ws-gallery-title {
+  color: var(--fg);
+  font-weight: 600;
+  text-decoration: none;
+}
+.ws-table .ws-gallery-title:hover,
+.ws-table .ws-gallery-title:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+.ws-table .ws-gallery-desc {
+  margin-top: 3px;
+  font-size: 12px;
+  max-width: 28rem;
+}
+.ws-gallery-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+}
+.ws-gallery-link {
+  color: var(--fg);
+  font-size: 12px;
+  font-family: var(--mono);
+  text-decoration: none;
+  text-underline-offset: 0.15em;
+}
+.ws-gallery-link:hover,
+.ws-gallery-link:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+  outline: none;
+}
+.ws-gallery-link--plain {
+  color: var(--muted);
+}
+.ws-gallery-link-more {
+  font-size: 12px;
+}
+.ws-table .ws-gallery-updated {
+  white-space: nowrap;
+  font-size: 12px;
+}
 /* Search bar breathing room above the file list. */
 .ws-page-card .ws-search-bar {
   margin: 0;


### PR DESCRIPTION
## In plain terms

The workspace **Galleries** tab was a bare list of titles. It now explains what galleries are, shows a copyable create command, and lists galleries in a table with useful columns (item count, linked PRs/issues, last updated).

## What it does

- Short explainer + `uploads gallery create --title "…"` (copy button), plus add/link CLI hints
- Table: **Name**, **Items**, **Linked**, **Updated**
- Enriches `GET /me/workspaces/:name/galleries` with `itemCount` and `references` (two batch queries, no N+1)
- Empty state points back at the create command

## What it is not

- No change to the token-scoped CLI list endpoint (`GET /v1/:workspace/galleries`)
- No in-product create form (CLI-only for now)

## How to try it

1. Open `/account/workspaces/<workspace>/galleries` while signed in
2. Confirm the explainer + create command
3. With at least one gallery, check item counts and linked PR/issue coordinates

## Technical notes

- Batch helpers: `countItemsForGalleries`, `listExternalReferencesForGalleries`
- Table HTML: `renderGalleriesTableHtml` in `workspace-ui`

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run src/routes/me.test.ts -t "GET /me/workspaces/:name/galleries"`
- [x] `pnpm --filter @uploads/web exec vitest run src/lib/workspace-ui.test.ts`
- [ ] Manual: signed-in galleries tab with 0 / 1+ galleries and a linked PR