### PR TITLE
feat(web): link status.uploads.sh from the site footer

### DIFF
--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -25,6 +25,8 @@ const REPO = "https://github.com/buildinternet/uploads";
 // rel omits "noreferrer" so releases.sh sees the referral traffic (mirrors
 // how its footer links to uploads.sh).
 const RELEASES_URL = "https://releases.sh";
+// Better Stack public status page for the uploads.sh workers + site.
+const STATUS_URL = "https://status.uploads.sh/";
 
 type FooterLink = { label: string; href: string };
 type FooterColumn = { title: string; links: FooterLink[] };
@@ -43,6 +45,7 @@ const COLUMNS: FooterColumn[] = [
     title: "Project",
     links: [
       { label: "GitHub", href: REPO },
+      { label: "Status", href: STATUS_URL },
       { label: "Terms", href: "/terms" },
       { label: "Privacy", href: "/privacy" },
     ],
@@ -55,7 +58,8 @@ const COLUMNS: FooterColumn[] = [
     <footer class="site-footer compact">
       <div class="site-footer__inner">
         a <a href="https://buildinternet.com">Build Internet</a> project · <a href={REPO}>source</a>{" "}
-        · <a href="/docs">docs</a> · <a href="/terms">terms</a> · <a href="/privacy">privacy</a>
+        · <a href="/docs">docs</a> · <a href={STATUS_URL}>status</a> · <a href="/terms">terms</a> ·{" "}
+        <a href="/privacy">privacy</a>
       </div>
     </footer>
   ) : (


### PR DESCRIPTION
## In plain terms

Adds a **Status** link to the site footer that goes to the public Better Stack page at [status.uploads.sh](https://status.uploads.sh/), so anyone can open service health from the product without hunting for a URL.

## What it does

- Full footer: **Status** under the Project column (next to GitHub, Terms, Privacy)
- Compact footer (login / device / invite cards): a matching **status** link in the one-liner

## What it is not

- No new health endpoints or monitor config — only the footer link

## How to try it

After deploy (or `pnpm dev:web` from the monorepo), open any content page and check the footer for **Status** → `https://status.uploads.sh/`. On `/login`, the compact footer should include **status** as well.

## Test plan

- [x] Diff review of `Footer.astro` only
- [ ] Spot-check full footer on homepage / docs
- [ ] Spot-check compact footer on `/login`