### PR TITLE
fix(web): billing page price, redundant limits, and copy cleanup

### DIFF
--- a/apps/web/src/lib/plan-prices.test.ts
+++ b/apps/web/src/lib/plan-prices.test.ts
@@ -22,7 +22,7 @@ describe("fetchProPrice", () => {
     });
     expect(fetchMock).toHaveBeenCalledWith(
       "https://auth.uploads.sh/billing/prices",
-      expect.objectContaining({ credentials: "include" }),
+      expect.not.objectContaining({ credentials: "include" }),
     );
   });
 

--- a/apps/web/src/lib/plan-prices.ts
+++ b/apps/web/src/lib/plan-prices.ts
@@ -39,11 +39,17 @@ function isPlanPrice(value: unknown): value is PlanPrice {
  * price, or a thrown fetch (network error, CSP block) — every failure mode
  * collapses to the same "unknown price" state so callers never have to
  * special-case them.
+ *
+ * Deliberately *not* `credentials: "include"` — this endpoint's CORS
+ * (apps/auth/src/index.ts's `billingPricesCors`) is intentionally
+ * non-credentialed (public price info, no cookies involved). Sending
+ * credentials on a non-credentialed CORS response makes the browser reject
+ * it outright, which silently produced this exact "Pro card never shows a
+ * price" bug.
  */
 export async function fetchProPrice(authOrigin: string): Promise<PlanPrice | null> {
   try {
     const res = await fetch(`${authOrigin.replace(/\/$/, "")}/billing/prices`, {
-      credentials: "include",
       cache: "no-store",
     });
     if (!res.ok) return null;

--- a/apps/web/src/lib/subscription-copy.test.ts
+++ b/apps/web/src/lib/subscription-copy.test.ts
@@ -88,10 +88,10 @@ describe("resolveSubscriptionCopy", () => {
     });
   });
 
-  it("renders muted 'applied by an operator' copy for admin-comped plans, ignoring any subscription", () => {
+  it("renders muted 'included with your workspace' copy for admin-comped plans, ignoring any subscription", () => {
     expect(
       resolveSubscriptionCopy({ planSource: "admin", subscription: null, priceText: null }),
-    ).toEqual({ text: "Applied by an operator — no Stripe subscription.", tone: "muted" });
+    ).toEqual({ text: "Included with your workspace.", tone: "muted" });
 
     expect(
       resolveSubscriptionCopy({
@@ -103,7 +103,7 @@ describe("resolveSubscriptionCopy", () => {
         },
         priceText: "$10.00 per month",
       }),
-    ).toEqual({ text: "Applied by an operator — no Stripe subscription.", tone: "muted" });
+    ).toEqual({ text: "Included with your workspace.", tone: "muted" });
   });
 
   it("returns null for an unrecognized status", () => {

--- a/apps/web/src/lib/subscription-copy.ts
+++ b/apps/web/src/lib/subscription-copy.ts
@@ -46,8 +46,8 @@ export function formatDate(iso: string | null): string | null {
  *
  * - No subscription at all (free, or `planSource: "none"`) → `null`, no line.
  * - `planSource: "admin"` (comped paid plan, no Stripe subscription behind
- *   it) → muted "applied by an operator" copy, never a renewal date (there
- *   is nothing to renew).
+ *   it) → muted "included with your workspace" copy, never a renewal date
+ *   (there is nothing to renew).
  * - `status: "past_due"` → alert-toned copy pointing at the billing portal,
  *   regardless of `cancelAtPeriodEnd` (a past-due sub isn't safely "renewing").
  * - `cancelAtPeriodEnd: true` (still active) → honest "ends on <date>" copy
@@ -64,7 +64,7 @@ export function resolveSubscriptionCopy(
   const { planSource, subscription, priceText } = input;
 
   if (planSource === "admin") {
-    return { text: "Applied by an operator — no Stripe subscription.", tone: "muted" };
+    return { text: "Included with your workspace.", tone: "muted" };
   }
 
   if (planSource !== "stripe" || !subscription) return null;

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -36,6 +36,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         <div id="ws-plan-card" class="ul-callout">
           <p><strong id="ws-plan-name"></strong></p>
           <p class="muted" id="ws-plan-blurb"></p>
+          <p class="muted" id="ws-plan-file-limits"></p>
           <p id="ws-subscription-status" role="status" hidden></p>
         </div>
 
@@ -45,11 +46,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           <p class="muted" id="ws-manage-billing-note" hidden>
             To cancel or downgrade, use “Manage billing” below to open the billing portal.
           </p>
-        </div>
-
-        <div id="ws-limits" class="settings-section">
-          <h3>Limits &amp; usage</h3>
-          <dl class="ws-rail__kv" id="ws-limits-list"></dl>
         </div>
 
         <div class="settings-section">
@@ -108,7 +104,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const slugEl = requireElement<HTMLElement>("#ws-slug", page);
       const planNameEl = requireElement<HTMLElement>("#ws-plan-name", page);
       const planBlurbEl = requireElement<HTMLElement>("#ws-plan-blurb", page);
-      const limitsListEl = requireElement<HTMLElement>("#ws-limits-list", page);
+      const planFileLimitsEl = requireElement<HTMLElement>("#ws-plan-file-limits", page);
       const planCardsEl = requireElement<HTMLElement>("#ws-plan-cards", page);
       const manageBillingNoteEl = requireElement<HTMLElement>("#ws-manage-billing-note", page);
       const manageBillingBtn = requireElement<HTMLButtonElement>("#ws-manage-billing-btn", page);
@@ -128,42 +124,27 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         return plan.charAt(0).toUpperCase() + plan.slice(1);
       }
 
-      function paintLimits(billing: WorkspaceBilling): void {
-        const usage = billing.usage as
-          | { bytes?: number; objects?: number; uploadsInPeriod?: number }
-          | null;
+      /**
+       * The current-plan card's one line that isn't already covered by the
+       * workspace rail (which shows storage + uploads-this-month usage) —
+       * the enforced max file/video size, so that information isn't lost
+       * when the standalone "Limits & usage" section is removed.
+       */
+      function paintFileLimits(billing: WorkspaceBilling): void {
         const { limits } = billing;
-        const rows: string[] = [];
+        const parts: string[] = [];
 
-        const storageUsed = usage?.bytes ?? 0;
-        rows.push(
-          `<dt>Storage</dt><dd>${formatBytes(storageUsed)} of ${
-            limits.maxStorageBytes === null ? "unlimited" : formatBytes(limits.maxStorageBytes)
-          }</dd>`,
-        );
+        if (limits.maxUploadBytes !== null) {
+          parts.push(`files up to ${formatBytes(limits.maxUploadBytes)}`);
+        }
+        if (
+          limits.maxVideoUploadBytes !== null &&
+          limits.maxVideoUploadBytes !== limits.maxUploadBytes
+        ) {
+          parts.push(`videos up to ${formatBytes(limits.maxVideoUploadBytes)}`);
+        }
 
-        const uploadsUsed = usage?.uploadsInPeriod ?? 0;
-        rows.push(
-          `<dt>Uploads this month</dt><dd>${uploadsUsed} of ${
-            limits.maxUploadsPerPeriod === null ? "unlimited" : limits.maxUploadsPerPeriod
-          }</dd>`,
-        );
-
-        rows.push(
-          `<dt>Max file size</dt><dd>${
-            limits.maxUploadBytes === null ? "unlimited" : formatBytes(limits.maxUploadBytes)
-          }</dd>`,
-        );
-
-        rows.push(
-          `<dt>Max video size</dt><dd>${
-            limits.maxVideoUploadBytes === null
-              ? "unlimited"
-              : formatBytes(limits.maxVideoUploadBytes)
-          }</dd>`,
-        );
-
-        limitsListEl.innerHTML = rows.join("");
+        planFileLimitsEl.textContent = parts.length ? `Max upload size: ${parts.join(", ")}.` : "";
       }
 
       /** Paints (or hides) the subscription status line inside the
@@ -366,8 +347,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           ? billing.available
             ? "This plan is active on your workspace."
             : "This plan isn’t available for self-serve upgrade yet."
-          : "No plan has been applied yet — limits below reflect what's currently enforced.";
-        paintLimits(billing);
+          : "Your current limits are shown below.";
+        paintFileLimits(billing);
         billingErrorEl.hidden = true;
         billingErrorEl.textContent = "";
         const proPriceCopy = formatPrice(proPrice);


### PR DESCRIPTION
## Summary

Three cleanups to the workspace Billing tab (`apps/web/src/pages/account/workspaces/[name]/billing.astro`), copy/layout only — no `apps/api` changes.

1. **Pro card missing its price.** The client fetch in `plan-prices.ts` sent `credentials: "include"`, but `/billing/prices`' CORS (`apps/auth/src/index.ts`'s `billingPricesCors`) is intentionally non-credentialed. Sending credentials against a non-credentialed CORS response makes the browser reject it outright, so `fetchProPrice` always failed and the Pro card silently showed no price. Dropped `credentials: "include"` from the fetch — this is a client-side, non-credentialed public endpoint by design, so no cookie was ever needed.

2. **Redundant "Limits & usage" section.** Removed the standalone bottom section — storage and uploads-this-month already show in the workspace rail. Max file/video size wasn't shown anywhere else, so that's now a one-line note on the current-plan card instead of a whole duplicate section.

3. **Internal jargon in copy.** `resolveSubscriptionCopy`'s operator-comped-plan line read "Applied by an operator — no Stripe subscription." — now "Included with your workspace." Audited the rest of the tab (CTA labels, error strings, blurbs) for other internal plumbing; the only other "Stripe"/"operator" mentions are in code comments, never rendered.

## Test plan
- [x] `pnpm test` — 223 files / 2824 tests pass
- [x] `pnpm --filter web exec astro check` — no new errors (pre-existing `cloudflare:workers` type-decl errors unrelated to this change, none touching the edited files)
- [x] `oxfmt --check` on changed files
- [ ] Screenshot — skipped; local auth stack setup (portless + TLS + seeded session) was impractical to spin up quickly for a copy/layout change already covered by unit tests
