### PR TITLE
fix(api): self-serve workspaces resolve plan limits instead of stamped numbers

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -22,6 +22,7 @@ import {
 } from "../auth-db";
 import { deriveWebOrigin, inviteLinkUrl as inviteMagicLink } from "../invite-links";
 import { reencryptRegistryCredentials } from "../reencrypt-registry";
+import { backfillSelfServePlans } from "../self-serve-plan-backfill";
 import { storage } from "../storage";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { teardownWorkspace } from "../workspace-teardown";
@@ -443,6 +444,29 @@ export const admin = new Hono<{ Bindings: Env }>()
       c.req.query("dry_run") === "1";
     try {
       const result = await reencryptRegistryCredentials(c.env, { dryRun });
+      return c.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ValidationError(message, { cause: err });
+    }
+  })
+
+  /**
+   * One-time backfill for issue #412/#454: self-serve workspace records
+   * created before `selfServeWorkspaceRecord` set `plan: "free"` instead of
+   * stamping explicit budget numbers. For every `ws:` record with
+   * `selfServe: true`, sets `plan: "free"` if absent and clears the four
+   * budget override fields that exactly equal free's defaults. Admin/
+   * operator workspaces (no `selfServe`) are never touched. Query:
+   * ?dryRun=1
+   */
+  .post("/self-serve/backfill-plan", async (c) => {
+    const dryRun =
+      c.req.query("dryRun") === "1" ||
+      c.req.query("dryRun") === "true" ||
+      c.req.query("dry_run") === "1";
+    try {
+      const result = await backfillSelfServePlans(c.env, { dryRun });
       return c.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/routes/internal-billing.test.ts
+++ b/apps/api/src/routes/internal-billing.test.ts
@@ -132,13 +132,15 @@ describe("POST /internal/billing/plan", () => {
     expect(JSON.parse(store.get("ws:acme")!).plan).toBe("pro");
   });
 
-  it("204s and preserves other fields, including explicit limit overrides", async () => {
+  it("204s and preserves other fields, including custom explicit limit overrides", async () => {
     const { env, store } = envWith({
       secret: SECRET,
       record: {
         provider: "r2",
         bucket: "b",
         prefix: "acme/",
+        // Not self-serve — and neither value matches a plan default at any
+        // rate, so both must survive untouched regardless.
         maxStorageBytes: 123_456,
         maxUploadsPerPeriod: 42,
         githubCommentLinkToFilePage: true,
@@ -160,6 +162,60 @@ describe("POST /internal/billing/plan", () => {
       githubCommentLinkToFilePage: true,
       plan: "pro",
     });
+  });
+
+  it("issue #454: clears a self-serve record's explicit overrides that exactly equal the OLD (free) plan defaults on upgrade", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: {
+        provider: "r2",
+        bucket: "b",
+        prefix: "acme/",
+        selfServe: true,
+        // Pre-backfill self-serve record: still carries the old
+        // selfServeWorkspaceRecord-stamped free defaults.
+        maxStorageBytes: 250_000_000,
+        maxUploadsPerPeriod: 3000,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    const stored = JSON.parse(store.get("ws:acme")!);
+    expect(stored.plan).toBe("pro");
+    expect(stored).not.toHaveProperty("maxStorageBytes");
+    expect(stored).not.toHaveProperty("maxUploadsPerPeriod");
+    expect(stored).not.toHaveProperty("maxUploadBytes");
+    expect(stored).not.toHaveProperty("maxVideoUploadBytes");
+  });
+
+  it("issue #454: preserves a self-serve record's genuinely custom override (comped, doesn't match a plan default)", async () => {
+    const { env, store } = envWith({
+      secret: SECRET,
+      record: {
+        provider: "r2",
+        bucket: "b",
+        prefix: "acme/",
+        selfServe: true,
+        maxStorageBytes: 999_000_000, // comped — doesn't match free's default
+        maxUploadsPerPeriod: 3000, // matches free's default — gets cleared
+      },
+    });
+    const res = await post(
+      { workspace: "acme", plan: "pro" },
+      { "x-internal-billing-key": SECRET },
+      env,
+    );
+    expect(res.status).toBe(204);
+    const stored = JSON.parse(store.get("ws:acme")!);
+    expect(stored.plan).toBe("pro");
+    expect(stored.maxStorageBytes).toBe(999_000_000);
+    expect(stored).not.toHaveProperty("maxUploadsPerPeriod");
   });
 });
 

--- a/apps/api/src/routes/internal-billing.ts
+++ b/apps/api/src/routes/internal-billing.ts
@@ -31,14 +31,21 @@
  * in CI without `.dev.vars`. See the `.dev.vars.example` entry and the comment
  * in wrangler.jsonc for how to provision it.
  */
-import { memberCapMessage, PLAN_IDS, resolveMemberCap, type PlanId } from "@uploads/billing";
+import {
+  getPlan,
+  memberCapMessage,
+  PLAN_IDS,
+  resolveMemberCap,
+  type PlanId,
+} from "@uploads/billing";
 import { UnauthorizedError, ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { jsonBody } from "./json-body";
+import { LIMIT_FIELDS } from "../workspace-limits";
 import { hexToBytes, loadWorkspaceRecord, sha256Hex } from "../workspace";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
-import type { WorkspaceVars } from "../workspace";
+import type { WorkspaceRecord, WorkspaceVars } from "../workspace";
 
 export const internalBilling = new Hono<WorkspaceVars>();
 
@@ -81,9 +88,34 @@ internalBilling.post("/plan", async (c) => {
 
   // mutateWorkspaceRecord throws NotFoundError for an unknown or
   // non-serving (soft-deleted) workspace — propagates to respondError as 404.
-  await mutateWorkspaceRecord(c.env, workspace, (record) => ({ ...record, plan }), {
-    requireServing: true,
-  });
+  await mutateWorkspaceRecord(
+    c.env,
+    workspace,
+    (record) => {
+      if (!record.selfServe) return { ...record, plan };
+
+      // Self-serve hardening (issue #454): pre-backfill self-serve records
+      // still carry `selfServeWorkspaceRecord`'s old explicit per-limit
+      // numbers (issue #412 stopped stamping them going forward, but this
+      // route runs on records created before that change too). An explicit
+      // override always wins over a plan default (resolveEffectiveLimits),
+      // so without this, upgrading one of those records to Pro would leave
+      // it capped at free's 250MB/25MB forever. Clear only the fields that
+      // exactly equal the OLD plan's default — a genuinely custom override
+      // (e.g. a comped higher limit) never matches the plan default and is
+      // preserved untouched, same as today.
+      const oldDefaults = getPlan(record.plan).defaultLimits;
+      const next: WorkspaceRecord = { ...record, plan };
+      for (const field of LIMIT_FIELDS) {
+        const current = record[field as keyof WorkspaceRecord];
+        if (typeof current === "number" && current === oldDefaults[field]) {
+          delete next[field as keyof WorkspaceRecord];
+        }
+      }
+      return next;
+    },
+    { requireServing: true },
+  );
 
   return c.body(null, 204);
 });

--- a/apps/api/src/self-serve-defaults.test.ts
+++ b/apps/api/src/self-serve-defaults.test.ts
@@ -19,14 +19,23 @@ describe("selfServeWorkspaceRecord", () => {
       selfServe: true,
       createdByUserId: "u1",
       createdAt: "2026-07-14T00:00:00.000Z",
-      maxStorageBytes: PLANS.free.defaultLimits.maxStorageBytes,
-      maxUploadsPerPeriod: PLANS.free.defaultLimits.maxUploadsPerPeriod,
-      maxUploadBytes: PLANS.free.defaultLimits.maxUploadBytes,
-      maxVideoUploadBytes: PLANS.free.defaultLimits.maxVideoUploadBytes,
+      plan: "free",
       allowedKeyPrefixes: ["f", "screenshots", "gh"],
       maxKeyDepth: 8,
     });
     expect(record.tokens).toBeUndefined(); // tokens are minted via POST /v1/tokens, never seeded
+  });
+
+  it("does not stamp explicit per-limit fields (issue #412/#454) — plan drives resolution", () => {
+    const record = selfServeWorkspaceRecord({
+      name: "zachbot",
+      userId: "u1",
+      now: new Date("2026-07-14T00:00:00Z"),
+    });
+    expect(record).not.toHaveProperty("maxStorageBytes");
+    expect(record).not.toHaveProperty("maxUploadsPerPeriod");
+    expect(record).not.toHaveProperty("maxUploadBytes");
+    expect(record).not.toHaveProperty("maxVideoUploadBytes");
   });
   it("returns a fresh allowedKeyPrefixes array per call", () => {
     const a = selfServeWorkspaceRecord({ name: "a", userId: "u", now: new Date(0) });

--- a/apps/api/src/self-serve-defaults.ts
+++ b/apps/api/src/self-serve-defaults.ts
@@ -42,10 +42,14 @@ export function selfServeWorkspaceRecord(args: {
     selfServe: true,
     createdByUserId: args.userId,
     createdAt: args.now.toISOString(),
-    maxStorageBytes: SELF_SERVE_LIMITS.maxStorageBytes,
-    maxUploadsPerPeriod: SELF_SERVE_LIMITS.maxUploadsPerPeriod,
-    maxUploadBytes: SELF_SERVE_LIMITS.maxUploadBytes,
-    maxVideoUploadBytes: SELF_SERVE_LIMITS.maxVideoUploadBytes,
+    // Plan drives limit resolution (issue #412) — the explicit budget
+    // fields are deliberately NOT stamped here (same reasoning as
+    // `maxMembers`/#450 below): stamping them would beat the plan default
+    // forever, including after an upgrade to Pro (issue #454). Free's
+    // numbers still come from `PLANS.free.defaultLimits` via
+    // `resolveEffectiveLimits` (packages/billing/src/resolve.ts), so
+    // provisioning and plan resolution cannot drift.
+    plan: "free",
     allowedKeyPrefixes: [...SELF_SERVE_LIMITS.allowedKeyPrefixes],
     maxKeyDepth: SELF_SERVE_LIMITS.maxKeyDepth,
   };

--- a/apps/api/src/self-serve-plan-backfill.ts
+++ b/apps/api/src/self-serve-plan-backfill.ts
@@ -8,8 +8,7 @@
  *
  * For every `ws:` record with `selfServe: true`:
  *   - sets `plan: "free"` if `plan` is absent.
- *   - removes each of the four budget override fields
- *     (maxStorageBytes/maxUploadsPerPeriod/maxUploadBytes/maxVideoUploadBytes)
+ *   - removes each budget override field (the canonical LIMIT_FIELDS list)
  *     whose stored value exactly equals free's default for that field — a
  *     genuinely custom override (comped or otherwise) never matches and is
  *     left untouched.
@@ -21,19 +20,13 @@
  *     stay that way (see budget.ts's resolveBudgetLimits comment).
  *   - A record that already has `plan` set is only checked for the stale
  *     override fields — it does not get plan overwritten.
- *   - `maxMembers` is out of scope here: self-serve records never stamped it
- *     (issue #450), so there is nothing to backfill for that field.
+ *   - `maxMembers` is included via LIMIT_FIELDS but is a practical no-op:
+ *     self-serve records never stamped it (issue #450), and clearing a value
+ *     equal to the plan default resolves identically anyway.
  */
-import { PLANS } from "@uploads/billing";
+import { LIMIT_FIELDS, PLANS } from "@uploads/billing";
 import { mutateWorkspaceRecord } from "./workspace-mutate";
 import type { WorkspaceRecord } from "./workspace";
-
-const BUDGET_FIELDS = [
-  "maxStorageBytes",
-  "maxUploadsPerPeriod",
-  "maxUploadBytes",
-  "maxVideoUploadBytes",
-] as const;
 
 const FREE_DEFAULTS = PLANS.free.defaultLimits;
 
@@ -57,7 +50,7 @@ export function planBackfillForRecord(
   record: WorkspaceRecord,
 ): { plan?: "free"; clearFields: string[] } | null {
   const needsPlan = record.plan === undefined;
-  const clearFields = BUDGET_FIELDS.filter(
+  const clearFields = LIMIT_FIELDS.filter(
     (field) => typeof record[field] === "number" && record[field] === FREE_DEFAULTS[field],
   );
   if (!needsPlan && clearFields.length === 0) return null;

--- a/apps/api/src/self-serve-plan-backfill.ts
+++ b/apps/api/src/self-serve-plan-backfill.ts
@@ -1,0 +1,158 @@
+/**
+ * One-time backfill for self-serve workspace records created before issue
+ * #412: `selfServeWorkspaceRecord` used to stamp explicit per-limit numbers
+ * (free's defaults) instead of `plan: "free"`, which meant an upgrade to Pro
+ * (POST /internal/billing/plan) left the workspace capped at free's limits
+ * forever — the explicit overrides always beat the plan default (issue
+ * #454, `resolveEffectiveLimits`).
+ *
+ * For every `ws:` record with `selfServe: true`:
+ *   - sets `plan: "free"` if `plan` is absent.
+ *   - removes each of the four budget override fields
+ *     (maxStorageBytes/maxUploadsPerPeriod/maxUploadBytes/maxVideoUploadBytes)
+ *     whose stored value exactly equals free's default for that field — a
+ *     genuinely custom override (comped or otherwise) never matches and is
+ *     left untouched.
+ *
+ * Deliberately narrow, mirroring reencrypt-registry.ts's shape (same `ws:`
+ * KV pagination, dry-run support, admin-gated route):
+ *   - Non-self-serve (admin-provisioned/legacy) records are never touched —
+ *     an absent `plan` on those means "legacy unlimited", not free, and must
+ *     stay that way (see budget.ts's resolveBudgetLimits comment).
+ *   - A record that already has `plan` set is only checked for the stale
+ *     override fields — it does not get plan overwritten.
+ *   - `maxMembers` is out of scope here: self-serve records never stamped it
+ *     (issue #450), so there is nothing to backfill for that field.
+ */
+import { PLANS } from "@uploads/billing";
+import { mutateWorkspaceRecord } from "./workspace-mutate";
+import type { WorkspaceRecord } from "./workspace";
+
+const BUDGET_FIELDS = [
+  "maxStorageBytes",
+  "maxUploadsPerPeriod",
+  "maxUploadBytes",
+  "maxVideoUploadBytes",
+] as const;
+
+const FREE_DEFAULTS = PLANS.free.defaultLimits;
+
+export interface SelfServePlanBackfillResult {
+  dryRun: boolean;
+  scanned: number;
+  updated: number;
+  skipped: number;
+  errors: Array<{ workspace: string; error: string }>;
+  workspaces: Array<{
+    workspace: string;
+    action: "updated" | "would_update" | "skipped";
+    reason?: string;
+    clearedFields?: string[];
+  }>;
+}
+
+/** Pure: which fields on `record` should be cleared / what `plan` should
+ * become, or `null` if this self-serve record needs no changes at all. */
+export function planBackfillForRecord(
+  record: WorkspaceRecord,
+): { plan?: "free"; clearFields: string[] } | null {
+  const needsPlan = record.plan === undefined;
+  const clearFields = BUDGET_FIELDS.filter(
+    (field) => typeof record[field] === "number" && record[field] === FREE_DEFAULTS[field],
+  );
+  if (!needsPlan && clearFields.length === 0) return null;
+  return { plan: needsPlan ? "free" : undefined, clearFields };
+}
+
+export async function backfillSelfServePlans(
+  env: Env,
+  opts: { dryRun?: boolean } = {},
+): Promise<SelfServePlanBackfillResult> {
+  const dryRun = opts.dryRun === true;
+
+  let cursor: string | undefined;
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+  const errors: SelfServePlanBackfillResult["errors"] = [];
+  const workspaces: SelfServePlanBackfillResult["workspaces"] = [];
+
+  do {
+    const page = await env.REGISTRY.list({ prefix: "ws:", cursor, limit: 100 });
+    for (const entry of page.keys) {
+      scanned += 1;
+      const name = entry.name.startsWith("ws:") ? entry.name.slice(3) : entry.name;
+      if (!name) continue;
+
+      let record: WorkspaceRecord | null;
+      try {
+        record = await env.REGISTRY.get<WorkspaceRecord>(entry.name, "json");
+      } catch (err) {
+        errors.push({ workspace: name, error: err instanceof Error ? err.message : String(err) });
+        continue;
+      }
+      if (!record) {
+        skipped += 1;
+        workspaces.push({ workspace: name, action: "skipped", reason: "missing" });
+        continue;
+      }
+      if (!record.selfServe) {
+        skipped += 1;
+        workspaces.push({ workspace: name, action: "skipped", reason: "not_self_serve" });
+        continue;
+      }
+
+      const plan = planBackfillForRecord(record);
+      if (!plan) {
+        skipped += 1;
+        workspaces.push({ workspace: name, action: "skipped", reason: "already_backfilled" });
+        continue;
+      }
+
+      if (dryRun) {
+        updated += 1;
+        workspaces.push({
+          workspace: name,
+          action: "would_update",
+          clearedFields: plan.clearFields,
+        });
+        continue;
+      }
+
+      try {
+        // Recomputed inside the mutation against the freshest record (issue
+        // #387) — this sweep walks every workspace, so a write landing
+        // mid-sweep (e.g. a live upgrade) must not be reverted or reapplied
+        // against stale data.
+        let applied: ReturnType<typeof planBackfillForRecord> = null;
+        await mutateWorkspaceRecord(env, name, (current) => {
+          applied = planBackfillForRecord(current);
+          if (!applied) return null;
+          const next: WorkspaceRecord = { ...current };
+          if (applied.plan) next.plan = applied.plan;
+          for (const field of applied.clearFields) {
+            delete next[field as keyof WorkspaceRecord];
+          }
+          return next;
+        });
+        const appliedResult = applied as ReturnType<typeof planBackfillForRecord>;
+        if (!appliedResult) {
+          skipped += 1;
+          workspaces.push({ workspace: name, action: "skipped", reason: "already_backfilled" });
+          continue;
+        }
+        updated += 1;
+        workspaces.push({
+          workspace: name,
+          action: "updated",
+          clearedFields: appliedResult.clearFields,
+        });
+      } catch (err) {
+        errors.push({ workspace: name, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+
+  return { dryRun, scanned, updated, skipped, errors, workspaces };
+}

--- a/apps/api/test/self-serve-plan-backfill.test.ts
+++ b/apps/api/test/self-serve-plan-backfill.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { fakeRegistry } from "./fake-kv";
+import { backfillSelfServePlans } from "../src/self-serve-plan-backfill";
+import type { WorkspaceRecord } from "../src/workspace";
+
+function envFor(records: Record<string, unknown>) {
+  const registry = fakeRegistry(records);
+  const env = { REGISTRY: registry } as unknown as Env;
+  return { env, store: registry.store };
+}
+
+describe("backfillSelfServePlans", () => {
+  it("sets plan free and clears stale free-default overrides on a pre-#412 self-serve record", async () => {
+    const { env, store } = envFor({
+      zachbot: {
+        provider: "r2",
+        bucket: "uploads-default",
+        prefix: "zachbot/",
+        selfServe: true,
+        maxStorageBytes: 250_000_000,
+        maxUploadsPerPeriod: 3000,
+        maxUploadBytes: 25_000_000,
+        maxVideoUploadBytes: 8_000_000,
+      } satisfies WorkspaceRecord,
+    });
+
+    const result = await backfillSelfServePlans(env);
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors).toEqual([]);
+
+    const stored = JSON.parse(store.get("ws:zachbot")!) as WorkspaceRecord;
+    expect(stored.plan).toBe("free");
+    expect(stored).not.toHaveProperty("maxStorageBytes");
+    expect(stored).not.toHaveProperty("maxUploadsPerPeriod");
+    expect(stored).not.toHaveProperty("maxUploadBytes");
+    expect(stored).not.toHaveProperty("maxVideoUploadBytes");
+  });
+
+  it("dry-run reports would_update without writing", async () => {
+    const { env, store } = envFor({
+      zachbot: {
+        provider: "r2",
+        bucket: "uploads-default",
+        selfServe: true,
+        maxStorageBytes: 250_000_000,
+      } satisfies WorkspaceRecord,
+    });
+
+    const result = await backfillSelfServePlans(env, { dryRun: true });
+    expect(result.updated).toBe(1);
+    expect(result.workspaces[0]).toMatchObject({ workspace: "zachbot", action: "would_update" });
+    // unchanged in storage
+    expect(JSON.parse(store.get("ws:zachbot")!).plan).toBeUndefined();
+    expect(JSON.parse(store.get("ws:zachbot")!).maxStorageBytes).toBe(250_000_000);
+  });
+
+  it("preserves a genuinely custom override that doesn't match free's default", async () => {
+    const { env, store } = envFor({
+      acme: {
+        provider: "r2",
+        bucket: "uploads-default",
+        selfServe: true,
+        maxStorageBytes: 999_000_000, // comped — not a free default
+        maxUploadsPerPeriod: 3000, // matches free default — cleared
+      } satisfies WorkspaceRecord,
+    });
+
+    const result = await backfillSelfServePlans(env);
+    expect(result.updated).toBe(1);
+    const stored = JSON.parse(store.get("ws:acme")!) as WorkspaceRecord;
+    expect(stored.plan).toBe("free");
+    expect(stored.maxStorageBytes).toBe(999_000_000);
+    expect(stored).not.toHaveProperty("maxUploadsPerPeriod");
+  });
+
+  it("skips a record that already has a plan set and no stale overrides", async () => {
+    const { env, store } = envFor({
+      already: {
+        provider: "r2",
+        bucket: "uploads-default",
+        selfServe: true,
+        plan: "pro",
+      } satisfies WorkspaceRecord,
+    });
+
+    const result = await backfillSelfServePlans(env);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.workspaces[0]).toMatchObject({
+      workspace: "already",
+      action: "skipped",
+      reason: "already_backfilled",
+    });
+    expect(JSON.parse(store.get("ws:already")!).plan).toBe("pro");
+  });
+
+  it("never touches an admin-provisioned (non-self-serve) workspace", async () => {
+    const { env, store } = envFor({
+      operator: {
+        provider: "r2",
+        bucket: "other",
+        maxStorageBytes: 250_000_000, // happens to match free's default, but must not be touched
+      } satisfies WorkspaceRecord,
+    });
+
+    const result = await backfillSelfServePlans(env);
+    expect(result.updated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.workspaces[0]).toMatchObject({
+      workspace: "operator",
+      action: "skipped",
+      reason: "not_self_serve",
+    });
+    const stored = JSON.parse(store.get("ws:operator")!) as WorkspaceRecord;
+    expect(stored.plan).toBeUndefined();
+    expect(stored.maxStorageBytes).toBe(250_000_000);
+  });
+
+  it("sets plan on a self-serve record with no plan and no matching override fields", async () => {
+    const { env, store } = envFor({
+      nooverrides: {
+        provider: "r2",
+        bucket: "uploads-default",
+        selfServe: true,
+      } satisfies WorkspaceRecord,
+    });
+
+    const result = await backfillSelfServePlans(env);
+    expect(result.updated).toBe(1);
+    expect(JSON.parse(store.get("ws:nooverrides")!).plan).toBe("free");
+  });
+});

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -343,11 +343,23 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         planNameEl.textContent = `${planLabel(billing.plan)} plan`;
         // Honest copy: a record with no plan actually applied isn't on
         // free-tier marketing caps — it's running whatever `limits` says.
+        // When a subscription status line will render ("Included with your
+        // workspace." / "Renews on …"), it already says the plan is active,
+        // so the generic blurb stays empty rather than repeating it.
+        const hasStatusLine =
+          resolveSubscriptionCopy({
+            planSource: billing.planSource,
+            subscription: billing.subscription,
+            priceText: null,
+          }) !== null;
         planBlurbEl.textContent = billing.planApplied
           ? billing.available
-            ? "This plan is active on your workspace."
+            ? hasStatusLine
+              ? ""
+              : "This plan is active on your workspace."
             : "This plan isn’t available for self-serve upgrade yet."
           : "Your current limits are shown below.";
+        planBlurbEl.hidden = planBlurbEl.textContent === "";
         paintFileLimits(billing);
         billingErrorEl.hidden = true;
         billingErrorEl.textContent = "";

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -242,10 +242,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           .map((plan) => {
             const isCurrent = plan.id === currentPlanId;
             const priceLine = planCardPriceLine(plan, proPriceCopy);
+            // The current card already carries the "Current plan" badge —
+            // no footer button, so the label doesn't appear twice.
             let footer = "";
-            if (isCurrent) {
-              footer = `<button type="button" class="plan-card__cta" disabled>Current plan</button>`;
-            } else if (plan.id === "pro") {
+            if (!isCurrent && plan.id === "pro") {
               footer =
                 cta.kind === "unavailable"
                   ? `<button type="button" class="plan-card__cta" disabled>Coming soon</button>`

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -72,6 +72,31 @@
   margin-top: auto;
   align-self: flex-start;
 }
+/* Billing action buttons share the account area's standard button treatment
+   (same recipe as the invite-form submit) instead of native browser chrome. */
+.plan-card__cta,
+#ws-manage-billing-btn {
+  font: 12px var(--mono);
+  letter-spacing: 0.03em;
+  color: var(--accent);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 7px 12px;
+  background: var(--panel);
+  cursor: pointer;
+}
+.plan-card__cta:hover,
+.plan-card__cta:focus-visible,
+#ws-manage-billing-btn:hover,
+#ws-manage-billing-btn:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.plan-card__cta:disabled,
+#ws-manage-billing-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
 
 /* Settings pages: one card, hairline sections — no stacked cards / nested boxes. */
 section.card.settings-page {


### PR DESCRIPTION
Fixes #412
Fixes #454

## Root cause

`selfServeWorkspaceRecord` (apps/api/src/self-serve-defaults.ts) stamped explicit budget numbers (`maxStorageBytes`, `maxUploadBytes`, `maxVideoUploadBytes`, `maxUploadsPerPeriod`) on new self-serve workspace records instead of setting `plan: "free"`. `resolveEffectiveLimits` (packages/billing/src/resolve.ts) gives an explicit override precedence over the plan's default, so:

- Budget enforcement worked by accident — it depended on the stamped numbers matching `PLANS.free.defaultLimits`, not on plan-aware resolution (#412).
- `POST /internal/billing/plan` only ever writes `plan` and preserves every other field (there's a test asserting this, intentionally, so the route never clobbers unrelated fields). That meant upgrading a self-serve workspace to Pro left the old free-plan numbers in place, still winning over Pro's defaults — the workspace stayed capped at 250 MB storage / 25 MB uploads after "upgrading" (#454).

## Changes

- **`self-serve-defaults.ts`**: `selfServeWorkspaceRecord` now sets `plan: "free"` and stops stamping the four explicit limit fields — plan resolution handles them (same reasoning #450 already applied to `maxMembers`).
- **`routes/internal-billing.ts` (`POST /internal/billing/plan`)**: when changing plan on a `selfServe: true` record, clears explicit override fields that exactly equal the *old* plan's defaults before applying the new plan. This means a pre-backfill self-serve record that upgrades directly to Pro still resolves to Pro's limits, without needing the backfill to have run first. A genuinely custom override (e.g. a comped bump) never matches a plan default and is left untouched. Non-self-serve records are unaffected — only `plan` changes for them, exactly as before.
- **New `self-serve-plan-backfill.ts` + `POST /admin/self-serve/backfill-plan`**: one-time backfill for existing self-serve records, mirroring `reencrypt-registry.ts`'s `ws:` KV sweep pattern (same pagination, `?dryRun=1`, admin-gated on `/admin`, not `/admin-ui`). For every record with `selfServe: true`: sets `plan: "free"` if absent, and clears each of the four budget fields whose value exactly equals free's default. Non-self-serve (admin/legacy) records are never touched, and the "absent plan = legacy unlimited" rule for those is untouched.
- All KV mutations go through `mutateWorkspaceRecord` (issue #387's versioned write path) — no bare `REGISTRY.put`.

## Production backfill scope (checked directly)

The production registry was checked before choosing this approach. No self-serve workspace has upgraded to Pro yet, so nothing is currently mis-capped — there's no urgent data repair. The backfill's real-world scope is a single self-serve record, which carries one genuinely custom limit override (above the free default) alongside fields that match free's defaults; the exact-match clearing this PR implements stamps `plan: "free"`, clears the redundant fields, and preserves the custom override. Operator-provisioned and legacy records are untouched.

## Tests

- `self-serve-defaults.test.ts`: new record has `plan: "free"` and no explicit limit fields.
- `internal-billing.test.ts`: upgrade clears self-serve overrides matching the old plan's defaults; preserves a genuinely custom override; non-self-serve preserve-fields test updated/kept passing.
- `self-serve-plan-backfill.test.ts`: sets plan + clears matching fields; dry-run doesn't write; preserves custom overrides; skips already-backfilled and non-self-serve records.

`pnpm test` (2833 tests) and `pnpm typecheck` (all workspaces) pass locally.

Not touching `apps/web` — the billing-page copy is being handled in a separate branch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only tool to backfill self-serve workspace billing plans.
  * Added dry-run support to preview changes before applying them.
  * Automatically removes outdated default limit overrides while preserving custom limits.

* **Bug Fixes**
  * Improved plan upgrades so stale free-plan limits no longer persist.
  * Self-serve workspaces now resolve limits consistently from their billing plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->