### PR TITLE
docs(web): Plans & limits docs page

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -12,6 +12,7 @@ Access requires a workspace — create your own with a linked GitHub account, or
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): optional install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
+- [Docs: plans & limits](https://uploads.sh/docs/limits): storage/file-size/member caps per plan, behavior at each cap, and the GitHub attachment-cap comparison
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
 - [Auth for agents](https://uploads.sh/auth.md): self-serve and invitation enrollment, bearer tokens, and the hosted-MCP OAuth authorization server
 - [Source & docs](https://github.com/buildinternet/uploads): repository, roadmap, and operator docs

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -31,6 +31,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://uploads.sh/docs/limits</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://uploads.sh/github-screenshots</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -45,6 +45,7 @@ const DOCS_NAV = [
       { slug: "github-app", href: "/docs/github-app", label: "GitHub App" },
       { slug: "agents", href: "/docs/agents", label: "Set up your agent" },
       { slug: "reference", href: "/docs/reference", label: "Reference" },
+      { slug: "limits", href: "/docs/limits", label: "Plans & limits" },
     ],
   },
   {
@@ -262,6 +263,23 @@ const fullTitle = `${title} · uploads.sh`;
       .doc h3 { font: 600 15px/1.4 var(--sans); margin: 22px 0 6px; color: var(--fg); }
       .doc p, .doc li { color: var(--body); }
       .doc strong { color: var(--fg); }
+
+      /* plain data table (used by the plans & limits page) */
+      .doc table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 16px 0;
+        font-size: 14px;
+      }
+      .doc table th,
+      .doc table td {
+        text-align: left;
+        padding: 8px 12px;
+        border: 1px solid var(--line);
+        color: var(--body);
+      }
+      .doc table thead th { background: var(--panel); color: var(--fg); font-weight: 600; }
+      .doc table tbody th[scope="row"] { color: var(--fg); font-weight: 600; white-space: nowrap; }
 
       /* FAQ definition list (used by the agent guide) */
       .doc .faq { margin: 0; }

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -108,6 +108,10 @@ it opens (or run: uploads attach --promote once it exists)</pre>
         <h3>Reference <span class="go">→</span></h3>
         <p>List, delete, and check usage, plus the things worth knowing before you rely on it.</p>
       </a>
+      <a class="card" href="/docs/limits">
+        <h3>Plans &amp; limits <span class="go">→</span></h3>
+        <p>Storage and file-size caps per plan, and how they compare with GitHub's.</p>
+      </a>
       <a class="card" href="/github-screenshots">
         <h3>Agent walkthrough <span class="go">→</span></h3>
         <p>A guided setup for getting a coding agent to upload screenshots and video to GitHub.</p>

--- a/apps/web/src/pages/docs/limits.astro
+++ b/apps/web/src/pages/docs/limits.astro
@@ -1,0 +1,148 @@
+---
+// uploads.sh — docs / plans & limits. What each plan includes, what happens
+// when you hit a cap, and how the limits compare with GitHub's own
+// attachment caps. Numbers come from the plan catalog (`@uploads/billing`
+// PLANS) at build time so this page cannot drift from what the API enforces.
+import { PLANS } from "@uploads/billing";
+import DocsLayout from "../../layouts/DocsLayout.astro";
+
+const REPO = "https://github.com/buildinternet/uploads";
+
+// Marketed byte values are clean decimal numbers (250 MB, 10 GB), so a
+// simple unit walk formats them exactly.
+function formatBytes(bytes: number): string {
+  if (bytes >= 1_000_000_000) return `${bytes / 1_000_000_000} GB`;
+  return `${bytes / 1_000_000} MB`;
+}
+
+const free = PLANS.free.defaultLimits;
+const pro = PLANS.pro.defaultLimits;
+
+const TOC = [
+  { id: "plans", label: "Plan limits" },
+  { id: "at-the-cap", label: "When you hit a cap" },
+  { id: "github", label: "Compared with GitHub" },
+];
+---
+
+<DocsLayout
+  title="Plans & limits"
+  description="Storage, file size, and member limits for uploads.sh free and pro workspaces, and how they compare with GitHub's own attachment caps."
+  path="/docs/limits"
+  heading="Plans & limits"
+  tagline="What each plan includes, and what happens when you reach a cap."
+  active="limits"
+  toc={TOC}
+>
+  <div class="callout">
+    <strong>Hosted service only.</strong> These limits apply to the cloud-hosted uploads.sh
+    service, not to self-hosted deployments, which set their own limits.
+  </div>
+
+  <section class="lead" id="plans">
+    <h2>Plan limits <a class="anchor" href="#plans" aria-label="Link to this section">#</a></h2>
+    <p>
+      Limits apply per workspace, not per user. Everyone in a workspace shares the same
+      storage and the same caps.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>{PLANS.free.name}</th>
+          <th>{PLANS.pro.name}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Storage</th>
+          <td>{formatBytes(free.maxStorageBytes!)}</td>
+          <td>{formatBytes(pro.maxStorageBytes!)}</td>
+        </tr>
+        <tr>
+          <th scope="row">Max file size</th>
+          <td>{formatBytes(free.maxUploadBytes!)}</td>
+          <td>{formatBytes(pro.maxUploadBytes!)}</td>
+        </tr>
+        <tr>
+          <th scope="row">Max video size</th>
+          <td>{formatBytes(free.maxVideoUploadBytes!)}</td>
+          <td>{formatBytes(pro.maxVideoUploadBytes!)}</td>
+        </tr>
+        <tr>
+          <th scope="row">Members</th>
+          <td>{free.maxMembers}</td>
+          <td>Unlimited</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      On {PLANS.pro.name} there is one file cap: videos get the
+      same {formatBytes(pro.maxUploadBytes!)} ceiling as everything else.
+      Only {PLANS.free.name} carves videos out with a smaller cap.
+    </p>
+    <p class="note">
+      Both plans also carry internal rate guards against automated abuse. Normal use — even
+      heavy agent-driven use — does not reach them.
+    </p>
+  </section>
+
+  <section id="at-the-cap">
+    <h2>When you hit a cap <a class="anchor" href="#at-the-cap" aria-label="Link to this section">#</a></h2>
+    <ul>
+      <li>
+        <strong>Oversized file.</strong> The upload is rejected before any bytes land, with an
+        error that names the cap. Nothing counts against your storage.
+      </li>
+      <li>
+        <strong>Storage full.</strong> New uploads are rejected until you free space. Existing
+        files keep serving. Run <code>uploads list</code> and <code>uploads delete</code> to
+        clear room, or check <code>uploads usage</code> to see where you stand.
+      </li>
+      <li>
+        <strong>Member cap (free).</strong> Invites beyond the cap are refused, pending invites
+        included. Upgrade the workspace or revoke an unused invite.
+      </li>
+    </ul>
+    <p>
+      Workspace admins can see current usage on the workspace's billing tab, and upgrade
+      to {PLANS.pro.name} from there.
+    </p>
+  </section>
+
+  <section id="github">
+    <h2>Compared with GitHub <a class="anchor" href="#github" aria-label="Link to this section">#</a></h2>
+    <p>
+      GitHub caps files you attach directly to an issue or pull request:
+      10&nbsp;MB for images and GIFs on every plan, 25&nbsp;MB for other files, and videos at
+      10&nbsp;MB on free plans (100&nbsp;MB on paid plans). Files hosted on uploads.sh don't
+      go through that path — the CLI embeds a URL, so GitHub's attachment caps never apply.
+    </p>
+    <ul>
+      <li>
+        <strong>Images:</strong> up to {formatBytes(free.maxUploadBytes!)} on free
+        ({formatBytes(pro.maxUploadBytes!)} on {PLANS.pro.name}), vs GitHub's 10&nbsp;MB on
+        every GitHub plan.
+      </li>
+      <li>
+        <strong>Videos:</strong> {formatBytes(pro.maxVideoUploadBytes!)} on {PLANS.pro.name},
+        even when the repository is on a free GitHub plan where direct attachments stop at
+        10&nbsp;MB.
+      </li>
+      <li>
+        <strong>Any file type.</strong> GitHub restricts attachments to an allowlist of
+        extensions. uploads.sh hosts whatever your workflow produces.
+      </li>
+    </ul>
+    <p class="note">
+      One difference to know: GitHub renders inline video players only for its own uploads.
+      Videos hosted on uploads.sh appear in comments as a poster image that links to the
+      file's share page, where the video plays.
+    </p>
+  </section>
+
+  <nav class="page-nav" aria-label="More docs">
+    <a class="prev" href="/docs/reference"><span class="dir">← Back</span>Reference</a>
+    <a class="next" href="/docs"><span class="dir">Docs →</span>Overview</a>
+  </nav>
+</DocsLayout>

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -86,6 +86,6 @@ const REPO = "https://github.com/buildinternet/uploads";
 
   <nav class="page-nav" aria-label="More docs">
     <a class="prev" href="/docs/agents"><span class="dir">← Back</span>Set up your agent</a>
-    <a class="next" href="/docs"><span class="dir">Docs →</span>Overview</a>
+    <a class="next" href="/docs/limits"><span class="dir">Next →</span>Plans &amp; limits</a>
   </nav>
 </DocsLayout>


### PR DESCRIPTION
## What

Adds a **Plans & limits** docs page at `/docs/limits`.

- Every number is imported from the `@uploads/billing` `PLANS` catalog at build time, so the page cannot drift from what the API enforces. Marketed limits only — per-period upload counts and pro's member ceiling stay internal, matching the plan catalog's abuse-guard framing.
- A callout at the top scopes the limits to the cloud-hosted service; self-hosted deployments set their own.
- Covers what happens at each cap (oversized file, storage full, member cap) and an honest comparison with GitHub's own attachment caps (10 MB images on every GitHub plan; 10 MB video on free repos), including the caveat that our videos render as poster-image links, not inline players.
- Wired into the DocsLayout nav (plus new `.doc table` styles), docs hub cards, the Reference page's next-link, `sitemap.xml`, and `llms.txt`.

## Screenshot

![Plans & limits docs page](https://embed.uploads.sh/default/screenshots/uploads/2026-07-23/localhost-docs-limits-b4676b.webp)

## Related

Decision context: keep the pro cap at 100 MB rather than advertising a higher one — the Cloudflare edge body limit and the buffer-everything upload path pin it. The >100 MB / direct-to-R2 design sketch is filed as #467 (low priority).
