### PR TITLE
fix(api,cli): self-heal duplicate managed comments; re-sync after meta set

### DIFF
--- a/.changeset/duplicate-comment-dedupe-meta-resync.md
+++ b/.changeset/duplicate-comment-dedupe-meta-resync.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`meta set` refreshes the managed PR/issue comment when it changes `path` or `state` on a `gh/…`-keyed attachment, so backfilled metadata shows up without waiting for the next attach. If the bot endpoint is unavailable it prints a `uploads comment` hint instead of failing the write. The server side also self-heals duplicate managed comments left by a create race: the oldest is kept and updated, extras are deleted on the next sync (issue #470).

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -780,6 +780,184 @@ describe("upsertBotComment", () => {
     expect(await kv.get("ghcomment:other-ws:acme/web#12")).toBe("66");
   });
 
+  it("collapses duplicate marker comments: patches the oldest, deletes the extras (issue #470)", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const deleted: string[] = [];
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/12/comments")) {
+        return new Response(
+          JSON.stringify([
+            { id: 7, body: `${attachmentsMarker("acme")}\nfirst` },
+            { id: 8, body: `${attachmentsMarker("acme")}\nduplicate` },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (init.method === "DELETE") {
+        deleted.push(url);
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes("/issues/comments/7") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 7, html_url: "https://github.com/acme/web/pull/12#c7" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+    expect(deleted).toEqual(["https://api.github.com/repos/acme/web/issues/comments/8"]);
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("7");
+  });
+
+  it("collects duplicates across pages, keeping the oldest", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fullPage = [
+      { id: 7, body: `${attachmentsMarker("acme")}\nfirst` },
+      ...Array.from({ length: 99 }, (_, i) => ({ id: 100 + i, body: "noise" })),
+    ];
+    const deleted: string[] = [];
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("&page=1")) return new Response(JSON.stringify(fullPage), { status: 200 });
+      if (url.includes("&page=2")) {
+        return new Response(
+          JSON.stringify([{ id: 900, body: `${attachmentsMarker("acme")}\nduplicate` }]),
+          { status: 200 },
+        );
+      }
+      if (init.method === "DELETE") {
+        deleted.push(url);
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes("/issues/comments/7") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 7, html_url: "https://github.com/acme/web/pull/12#c7" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+    expect(deleted).toEqual(["https://api.github.com/repos/acme/web/issues/comments/900"]);
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("7");
+  });
+
+  it("still reports updated when deleting a duplicate fails", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/12/comments")) {
+        return new Response(
+          JSON.stringify([
+            { id: 7, body: `${attachmentsMarker("acme")}\nfirst` },
+            { id: 8, body: `${attachmentsMarker("acme")}\nduplicate` },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (init.method === "DELETE") return new Response("no", { status: 403 });
+      if (url.includes("/issues/comments/7") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 7, html_url: "https://github.com/acme/web/pull/12#c7" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+  });
+
+  it("never deletes another workspace's legacy marker comment while deduping", async () => {
+    const { env } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/12/comments")) {
+        return new Response(
+          JSON.stringify([
+            { id: 1, body: `${ATTACHMENTS_MARKER}\nsomeone else's legacy comment` },
+            { id: 7, body: `${attachmentsMarker("acme")}\nours` },
+            { id: 8, body: `${attachmentsMarker("acme")}\nour duplicate` },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (init.method === "DELETE") {
+        if (url.includes("/issues/comments/1")) throw new Error("deleted a legacy comment");
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes("/issues/comments/7") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 7, html_url: "https://github.com/acme/web/pull/12#c7" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+  });
+
   it("patches an existing comment to empty when createIfMissing is false", async () => {
     const { env } = makeTestEnv();
     const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -289,6 +289,21 @@ export async function upsertBotComment(
     : await write(`${base}/issues/${target.num}/comments`, "POST");
   if (!r.ok) return { degrade: degradeFor(r.status) };
 
+  // Self-healing dedupe (issue #470): a create race can leave two marker
+  // comments on the thread; the extras would drift stale forever since the
+  // hunt keeps only the oldest. Delete them best-effort — a failed delete
+  // must never fail the caller's request, and the next sync retries anyway.
+  for (const extra of found.extras ?? []) {
+    try {
+      await githubFetch(fetchImpl, `${base}/issues/comments/${extra.id}`, {
+        method: "DELETE",
+        headers: jsonHeaders,
+      });
+    } catch {
+      // Best effort only.
+    }
+  }
+
   const id = existing?.id ?? r.id;
   if (id !== undefined) {
     await env.GITHUB_CACHE.put(cacheKey, String(id), { expirationTtl: COMMENT_ID_TTL });
@@ -308,6 +323,12 @@ export async function upsertBotComment(
  * adopted and migrated in place. When `marker` IS the legacy marker (no
  * workspace to namespace with) this collapses to a single hunt, unchanged
  * from pre-4b behavior.
+ *
+ * Collects EVERY comment carrying `marker` (a create race can leave more than
+ * one — issue #470): the oldest is `comment`, the rest come back as `extras`
+ * for the caller to delete. Only exact-`marker` hits are ever extras — a
+ * legacy (unnamespaced) comment may belong to a different workspace, so it is
+ * adopted at most, never deleted.
  */
 async function findMarkerComment(
   fetchImpl: typeof fetch,
@@ -315,9 +336,10 @@ async function findMarkerComment(
   base: string,
   num: number,
   marker: string,
-): Promise<{ comment?: GhComment; degrade?: "forbidden" | "unavailable" }> {
+): Promise<{ comment?: GhComment; extras?: GhComment[]; degrade?: "forbidden" | "unavailable" }> {
   const MAX_PAGES = 20; // 2000 comments.
   let legacyHit: GhComment | undefined;
+  const hits: GhComment[] = [];
   for (let page = 1; page <= MAX_PAGES; page++) {
     let res: Response;
     try {
@@ -334,17 +356,16 @@ async function findMarkerComment(
     if (res.status === 403) return { degrade: "forbidden" };
     if (!res.ok) return { degrade: "unavailable" };
     const comments = (await res.json().catch(() => [])) as GhComment[];
-    if (!Array.isArray(comments)) return { comment: legacyHit };
-    const namespacedHit = comments.find(
-      (c) => typeof c.body === "string" && c.body.includes(marker),
-    );
-    if (namespacedHit) return { comment: namespacedHit };
+    if (!Array.isArray(comments)) break;
+    hits.push(...comments.filter((c) => typeof c.body === "string" && c.body.includes(marker)));
     if (!legacyHit && marker !== ATTACHMENTS_MARKER) {
       legacyHit = comments.find(
         (c) => typeof c.body === "string" && c.body.includes(ATTACHMENTS_MARKER),
       );
     }
-    if (comments.length < 100) return { comment: legacyHit }; // last page reached.
+    if (comments.length < 100) break; // last page reached.
   }
-  return { comment: legacyHit }; // page cap hit — best effort, still adopt a legacy hit if seen.
+  // Comments list oldest-first, so hits[0] is the oldest marker comment.
+  if (hits.length > 0) return { comment: hits[0], extras: hits.slice(1) };
+  return { comment: legacyHit }; // best effort — adopt a legacy hit if seen.
 }

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -38,6 +38,7 @@ import {
   ghBranchKeyPrefix,
   ghKeyPrefix,
   ghMetadataFromTarget,
+  parseGhKey,
   ghMetadataForBranch,
   attachmentsCommentBody,
   attachmentsMarker,
@@ -2712,10 +2713,53 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
       });
       if (ctx.json) await writeJson(result);
       else for (const [k, v] of Object.entries(result.metadata)) await writeStdout(`${k}=${v}\n`);
+      await resyncCommentAfterMetaSet(ctx, key, [...Object.keys(set ?? {}), ...del]);
       return 0;
     }
     default:
       throw new UsageError(`unknown meta command: ${action}`);
+  }
+}
+
+/** The metadata keys the managed comment renders (path/state, PR #370). */
+const COMMENT_RENDERED_META_KEYS = ["path", "state"];
+
+/**
+ * Best-effort managed-comment refresh after `meta set` touches a
+ * display-relevant key on a PR/issue-keyed object (issue #470) — without
+ * this, backfilled `path=`/`state=` never reaches the rendered comment until
+ * an unrelated attach fires. Bot endpoint only (no gh fallback — this is a
+ * metadata tweak, not an explicit comment command); any failure degrades to
+ * a stderr hint instead of failing the metadata write that already landed.
+ */
+async function resyncCommentAfterMetaSet(
+  ctx: CliContext,
+  key: string,
+  touchedKeys: string[],
+): Promise<void> {
+  if (!touchedKeys.some((k) => COMMENT_RENDERED_META_KEYS.includes(k))) return;
+  const target = parseGhKey(key);
+  if (!target) return;
+  try {
+    const bot = await ctx.client.upsertGithubComment({
+      repo: target.repo,
+      num: target.num,
+      kind: target.kind,
+    });
+    if (bot.posted) {
+      if (!ctx.quiet && !ctx.json) {
+        process.stderr.write(`refreshed the managed comment on ${target.repo}#${target.num}\n`);
+      }
+      return;
+    }
+  } catch {
+    // Fall through to the hint.
+  }
+  if (!ctx.quiet && !ctx.json) {
+    const flag = target.kind === "pull" ? "--pr" : "--issue";
+    process.stderr.write(
+      `tip: run \`uploads comment ${flag} ${target.num}\` to refresh the PR comment\n`,
+    );
   }
 }
 

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -73,6 +73,18 @@ export function normalizeGithubCoordinate(value: string): GithubCoordinate | und
   };
 }
 
+/**
+ * Inverse of `ghKeyPrefix`: parse the PR/issue coordinate back out of a
+ * stable attachment key (`gh/<owner>/<name>/<kind>/<num>/<filename>`), or
+ * undefined for any other key shape.
+ */
+export function parseGhKey(key: string): GhTarget | undefined {
+  const match = /^gh\/([^/]+)\/([^/]+)\/(pull|issues)\/([1-9][0-9]*)\/./.exec(key);
+  if (!match) return undefined;
+  const [, owner, name, kind, num] = match;
+  return { repo: `${owner}/${name}`, kind: kind as GhTargetKind, num: Number(num) };
+}
+
 export function ghKeyPrefix(target: GhTarget): string {
   const [owner, name] = target.repo.split("/");
   return `gh/${sanitizeKeySegment(owner)}/${sanitizeKeySegment(name)}/${target.kind}/${target.num}/`;

--- a/packages/uploads/test/commands-meta.test.ts
+++ b/packages/uploads/test/commands-meta.test.ts
@@ -140,6 +140,75 @@ describe("runMeta set", () => {
   });
 });
 
+describe("runMeta set comment re-sync (issue #470)", () => {
+  function syncClient(opts: { fail?: boolean } = {}) {
+    const upsertCalls: { repo: string; num: number; kind: string }[] = [];
+    const client = {
+      patchMetadata: async (_key: string, o: { set?: Record<string, string> }) => ({
+        metadata: { ...o.set },
+      }),
+      upsertGithubComment: async (o: { repo: string; num: number; kind: string }) => {
+        upsertCalls.push(o);
+        if (opts.fail) throw new Error("endpoint unreachable");
+        return { posted: true, action: "updated", count: 1 };
+      },
+    } as unknown as UploadsClient;
+    return { client, upsertCalls };
+  }
+
+  it("re-syncs the managed comment when path/state changes on a gh-keyed object", async () => {
+    const { client, upsertCalls } = syncClient();
+    const code = await runMeta(
+      ctxWith(client),
+      ["set", "gh/acme/web/pull/12/shot.png", "path=/docs/limits"],
+      false,
+    );
+    expect(code).toBe(0);
+    expect(upsertCalls).toEqual([{ repo: "acme/web", num: 12, kind: "pull" }]);
+  });
+
+  it("re-syncs when a display-relevant key is deleted", async () => {
+    const { client, upsertCalls } = syncClient();
+    await runMeta(
+      ctxWith(client),
+      ["set", "gh/acme/web/issues/7/shot.png", "--delete", "state"],
+      false,
+    );
+    expect(upsertCalls).toEqual([{ repo: "acme/web", num: 7, kind: "issues" }]);
+  });
+
+  it("does not sync when the touched keys are not rendered in the comment", async () => {
+    const { client, upsertCalls } = syncClient();
+    await runMeta(ctxWith(client), ["set", "gh/acme/web/pull/12/shot.png", "app=myapp"], false);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  it("does not sync for a non-gh key", async () => {
+    const { client, upsertCalls } = syncClient();
+    await runMeta(ctxWith(client), ["set", "screenshots/a.png", "path=/settings"], false);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  it("prints a refresh hint instead of failing when the sync errors", async () => {
+    const { client } = syncClient({ fail: true });
+    const ctx = { ...ctxWith(client), quiet: false };
+    const stderr: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    try {
+      expect(await runMeta(ctx, ["set", "gh/acme/web/pull/12/shot.png", "path=/x"], false)).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(stderr.join("")).toContain("uploads comment --pr 12");
+  });
+});
+
 describe("runMeta unknown command", () => {
   it("rejects an unrecognized subcommand", async () => {
     const { client } = fakeClient();


### PR DESCRIPTION
Closes #470.

## What

**1. Self-healing dedupe of the managed bot comment (server).** `upsertBotComment`'s marker hunt now collects *every* comment carrying the workspace's namespaced marker instead of stopping at the first. The oldest is kept and PATCHed; extras are DELETEd best-effort (a failed delete never fails the caller — the next sync retries). This makes the webhook-vs-CLI create race that duplicated the comment on PR #468 retroactively harmless: the next sync on an affected thread collapses the duplicates. Legacy (unnamespaced) marker comments are only ever adopted, never deleted, since they may belong to another workspace.

**2. `meta set` refreshes the comment (CLI).** `uploads meta set` on a `gh/…`-keyed object that touches a rendered key (`path`/`state`, per #370) now triggers a best-effort bot comment refresh; if the endpoint is unavailable it prints a `tip: run uploads comment --pr N` stderr hint instead of failing the metadata write. Untouched for non-gh keys and non-rendered keys.

## Notes

- The hunt now pages the whole thread when it runs (to collect duplicates) rather than early-returning on the first hit; it still runs at most ~once per comment thanks to the KV id cache.
- Hosted-MCP `set_metadata` has the same re-sync gap; left for the #392 comment-parity work.
- TDD: new tests in `apps/api/src/github-comment.test.ts` and `packages/uploads/test/commands-meta.test.ts`; full suite (2842 tests) and typecheck pass.
