### PR TITLE
feat(uploads-cli): sidecar manifest carries screenshot metadata into put/attach

### DIFF
--- a/.changeset/screenshot-sidecar-metadata.md
+++ b/.changeset/screenshot-sidecar-metadata.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads screenshot --out` now also writes a sidecar manifest (`<file>.uploads.json`) recording the capture's derived metadata (path/url/env/viewport, plus `--state` if given) with a content hash. A later `uploads put`/`attach` of that exact file automatically picks the metadata back up — explicit `--meta`/`--state` still win, and a regenerated or edited file silently loses its sidecar. Disable with `--no-sidecar`.

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -314,6 +314,12 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
       <code>localhost</code> URLs are only reachable locally.
     </p>
     <p>
+      <code>--out</code> also writes a sidecar, <code>&lt;file&gt;.uploads.json</code>, recording
+      this capture's derived metadata (path/url/env/viewport, plus <code>--state</code> if given)
+      and a content hash. A later <code>put</code> or <code>attach</code> of that same file picks
+      the metadata back up automatically — pass <code>--no-sidecar</code> to skip writing it.
+    </p>
+    <p>
       When you shoot your own dev server, it hides known framework dev toolbars
       (Astro, Next, Nuxt, Vite) automatically (opt out with
       <code>--no-hide-dev-tools</code>) and takes <code>--reduced-motion</code> to

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -74,6 +74,7 @@ export const SCREENSHOT_FLAGS: readonly string[] = [
   "--light",
   "--wait",
   "--out",
+  "--no-sidecar",
   "--no-upload",
   "--destination",
   "--prefix",

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -32,7 +32,7 @@ import { writeJson, writeStdout } from "./io.js";
 import { imageFactsFromBytes } from "./image-facts.js";
 import { parseMetaFlags, validateMetaMap } from "./metadata.js";
 import { mergeDerivedMeta, nearMissMetaWarnings, validateStateValue } from "./metadata-vocab.js";
-import { readSidecarMeta } from "./sidecar.js";
+import { mergeSidecarMeta } from "./sidecar.js";
 import {
   ghAttachmentKey,
   ghBranchAttachmentKey,
@@ -931,14 +931,8 @@ async function uploadAttachmentBatch(
         const sourceName = basename(file);
         const bytes = readFileArg(file);
         // Sidecar manifest from a prior `screenshot --out` of this exact file
-        // (issue #469 lever 2): only merged under whatever metadata this
-        // upload already carries (explicit --meta/--state always win), and
-        // only when the file's current bytes still match the hash recorded
-        // at capture time.
-        const sidecarMeta = readSidecarMeta(file, bytes);
-        const baseMetadata = sidecarMeta
-          ? mergeDerivedMeta(opts.metadata ?? {}, sidecarMeta)
-          : opts.metadata;
+        // (issue #469 lever 2) — see mergeSidecarMeta.
+        const baseMetadata = mergeSidecarMeta(file, bytes, opts.metadata);
         // Same EXIF promotion uploadPreparedImage does; attach keeps its own
         // per-file tail (it builds keys differently), so it opts in here too.
         const metadata = opts.deriveImageFacts
@@ -1143,14 +1137,9 @@ export async function uploadPuts(opts: {
             : basename(file));
         const bytes = readFileArg(file);
         // Sidecar manifest from a prior `screenshot --out` of this exact file
-        // (issue #469 lever 2): only merged under whatever metadata this
-        // upload already carries (explicit --meta/--state always win), and
-        // only when the file's current bytes still match the hash recorded
-        // at capture time. Not applicable to stdin.
-        const sidecarMeta = file !== "-" ? readSidecarMeta(file, bytes) : undefined;
-        const metadata = sidecarMeta
-          ? mergeDerivedMeta(opts.metadata ?? {}, sidecarMeta)
-          : opts.metadata;
+        // (issue #469 lever 2) — see mergeSidecarMeta. Not applicable to stdin.
+        const metadata =
+          file !== "-" ? mergeSidecarMeta(file, bytes, opts.metadata) : opts.metadata;
         const { result, prepared, markdown } = await uploadPreparedImage(
           opts.client,
           bytes,

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -32,6 +32,7 @@ import { writeJson, writeStdout } from "./io.js";
 import { imageFactsFromBytes } from "./image-facts.js";
 import { parseMetaFlags, validateMetaMap } from "./metadata.js";
 import { mergeDerivedMeta, nearMissMetaWarnings, validateStateValue } from "./metadata-vocab.js";
+import { readSidecarMeta } from "./sidecar.js";
 import {
   ghAttachmentKey,
   ghBranchAttachmentKey,
@@ -119,6 +120,12 @@ upload as-is, or --keep-exif when image metadata matters for the discussion.
 
 Optional --frame wraps the image in a device/browser chrome before optimize
 (default off). See: uploads put --help frames
+
+If the file has a sidecar manifest (<file>.uploads.json, written by
+"screenshot --out") and its content hash still matches this file, that
+capture's derived metadata (path/url/env/viewport/state) is merged in
+automatically — explicit --meta/--state always win. A regenerated or edited
+file loses its sidecar silently (hash no longer matches).
 
 Uploads are public. --pr/--issue keys include the repo, number, and filename and
 remain public even for private/internal GitHub repositories. Upload only media
@@ -794,6 +801,12 @@ URL and every embed hot-swap. Human mode prints ">> replaced existing object
 Still images are optimized to WebP by default (same as put). Use --no-optimize
 to upload originals. Optional --frame wraps images in device/browser chrome.
 
+If a file has a sidecar manifest (<file>.uploads.json, written by
+"screenshot --out") and its content hash still matches, that capture's
+derived metadata (path/url/env/viewport/state) is merged in automatically —
+explicit --meta/--state always win. A regenerated or edited file loses its
+sidecar silently (hash no longer matches).
+
 Branch staging (pre-PR): --branch [name] stages files against a git branch
 before a pull request exists, e.g. for a coding agent working a branch that
 hasn't opened a PR yet. Key: gh/<owner>/<repo>/branch/<branch>/<filename>
@@ -917,11 +930,20 @@ async function uploadAttachmentBatch(
       try {
         const sourceName = basename(file);
         const bytes = readFileArg(file);
+        // Sidecar manifest from a prior `screenshot --out` of this exact file
+        // (issue #469 lever 2): only merged under whatever metadata this
+        // upload already carries (explicit --meta/--state always win), and
+        // only when the file's current bytes still match the hash recorded
+        // at capture time.
+        const sidecarMeta = readSidecarMeta(file, bytes);
+        const baseMetadata = sidecarMeta
+          ? mergeDerivedMeta(opts.metadata ?? {}, sidecarMeta)
+          : opts.metadata;
         // Same EXIF promotion uploadPreparedImage does; attach keeps its own
         // per-file tail (it builds keys differently), so it opts in here too.
         const metadata = opts.deriveImageFacts
-          ? await mergeImageFacts(bytes, opts.metadata)
-          : opts.metadata;
+          ? await mergeImageFacts(bytes, baseMetadata)
+          : baseMetadata;
         const prepared = await prepareImageForUpload(bytes, sourceName, {
           ...opts.frame,
           optimize: opts.optimize,
@@ -1119,9 +1141,19 @@ export async function uploadPuts(opts: {
               ? basename(opts.explicitKey)
               : "stdin.bin"
             : basename(file));
+        const bytes = readFileArg(file);
+        // Sidecar manifest from a prior `screenshot --out` of this exact file
+        // (issue #469 lever 2): only merged under whatever metadata this
+        // upload already carries (explicit --meta/--state always win), and
+        // only when the file's current bytes still match the hash recorded
+        // at capture time. Not applicable to stdin.
+        const sidecarMeta = file !== "-" ? readSidecarMeta(file, bytes) : undefined;
+        const metadata = sidecarMeta
+          ? mergeDerivedMeta(opts.metadata ?? {}, sidecarMeta)
+          : opts.metadata;
         const { result, prepared, markdown } = await uploadPreparedImage(
           opts.client,
-          readFileArg(file),
+          bytes,
           sourceName,
           {
             frame: opts.frame,
@@ -1136,7 +1168,7 @@ export async function uploadPuts(opts: {
             contentType: opts.contentType,
             dryRun: opts.dryRun,
             replace: opts.replace,
-            metadata: opts.metadata,
+            metadata,
             deriveImageFacts: opts.deriveImageFacts,
             provenanceClient: opts.provenanceClient,
             alt: () => opts.alt ?? basename(sourceName),

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -36,6 +36,7 @@ import { ghBranchAttachmentKey, ghMetadataForBranch } from "../github.js";
 import { safeCaptureFacts } from "../capture-facts.js";
 import { parseMetaFlags, validateMetaMap } from "../metadata.js";
 import { mergeDerivedMeta } from "../metadata-vocab.js";
+import { writeSidecarMeta } from "../sidecar.js";
 import { writeJson, writeStdout } from "../io.js";
 import {
   assertHideSelector,
@@ -83,7 +84,12 @@ Options:
                             on --via remote — neutralizes animations via injected CSS)
   --eval <js>               Run JS in the page after settle, before capture (--via local only)
   --init-script <file>      Inject a JS file before navigation (--via local only)
-  --out <file>              Also write the PNG to a local file
+  --out <file>              Also write the PNG to a local file. Also writes a sidecar manifest,
+                            <file>.uploads.json, recording this capture's derived metadata
+                            (path/url/env/viewport, plus --state if given) with a content hash; a
+                            later \`put\`/\`attach\` of this exact file picks the metadata back up
+                            automatically (explicit --meta/--state still win). See --no-sidecar.
+  --no-sidecar              Don't write the <file>.uploads.json sidecar alongside --out
   --no-upload                Skip hosting; requires --out (local file only)
   --destination <id>        Typed root: screenshots | gh | f
   --prefix <path>           Key prefix (default: screenshots, or UPLOADS_DEFAULT_PREFIX)
@@ -214,6 +220,8 @@ export async function runScreenshot(
   const outFile = flagString(parsed.flags, "--out");
   const noUpload = flagBool(parsed.flags, "--no-upload");
   if (noUpload && !outFile) throw new UsageError("--no-upload requires --out");
+  const noSidecar = flagBool(parsed.flags, "--no-sidecar");
+  if (noSidecar && !outFile) throw new UsageError("--no-sidecar requires --out");
 
   const keyHint = flagString(parsed.flags, "--key");
   const destFlag = flagString(parsed.flags, "--destination");
@@ -324,6 +332,7 @@ export async function runScreenshot(
   if (outFile) {
     writeFileSync(outFile, captured.png);
     if (logHuman) process.stderr.write(`>> wrote ${outFile}\n`);
+    if (!noSidecar) writeSidecarMeta(outFile, captured.png, withFacts);
   }
 
   if (noUpload) {

--- a/packages/uploads/src/sidecar.ts
+++ b/packages/uploads/src/sidecar.ts
@@ -1,0 +1,116 @@
+/**
+ * Sidecar manifest for `uploads screenshot --out`: derived metadata written
+ * next to a local screenshot file so a later `put`/`attach` of that exact
+ * file can recover the metadata the hosted copy would have gotten at capture
+ * time. See issue #469 lever 2 (the "sidecar manifest" variant — the
+ * alternative, content-hash-keyed server-side inheritance, is out of scope
+ * here).
+ *
+ * File: `<file>.uploads.json` next to `<file>`, e.g. `shot.png.uploads.json`.
+ * Shape: `{ version, sha256, meta }`. `sha256` is the SHA-256 of the exact
+ * bytes written to `<file>` at capture time — read-back compares it against
+ * the file's *current* bytes, so a file that was regenerated or hand-edited
+ * since capture silently loses its sidecar instead of attaching stale
+ * metadata to a different image.
+ *
+ * `meta` is filtered to the closed `CANONICAL_META_KEYS` vocabulary
+ * (metadata-vocab.ts) on both write and read: the sidecar is a plain JSON
+ * file sitting next to the image, so it must never be a channel for
+ * arbitrary metadata even if hand-edited.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { CANONICAL_META_KEYS } from "./metadata-vocab.js";
+
+const SIDECAR_VERSION = 1;
+
+interface SidecarManifest {
+  version: number;
+  sha256: string;
+  meta: Record<string, string>;
+}
+
+/** The sidecar path for a given local file — `<file>.uploads.json`. */
+export function sidecarPath(filePath: string): string {
+  return `${filePath}.uploads.json`;
+}
+
+/** Hex-encoded SHA-256 of `bytes`. */
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Keep only entries whose key is in the closed canonical metadata vocabulary. */
+export function restrictToCanonicalMeta(meta: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of CANONICAL_META_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(meta, key)) out[key] = meta[key]!;
+  }
+  return out;
+}
+
+function isPlainStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  return Object.values(value).every((v) => typeof v === "string");
+}
+
+/**
+ * Write a sidecar manifest next to `filePath`, recording `meta` (restricted
+ * to the canonical vocabulary) and the SHA-256 of `bytes` (the exact bytes
+ * being written to `filePath`). No-ops when `meta` is empty — an image with
+ * no derived metadata gets no sidecar. Best-effort: a write failure (e.g. a
+ * read-only directory) is swallowed, matching the rest of the derived-
+ * metadata pipeline's "never fail the primary operation" contract.
+ */
+export function writeSidecarMeta(
+  filePath: string,
+  bytes: Uint8Array,
+  meta: Record<string, string>,
+): void {
+  const restricted = restrictToCanonicalMeta(meta);
+  if (Object.keys(restricted).length === 0) return;
+  try {
+    const manifest: SidecarManifest = {
+      version: SIDECAR_VERSION,
+      sha256: sha256Hex(bytes),
+      meta: restricted,
+    };
+    writeFileSync(sidecarPath(filePath), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  } catch {
+    // best-effort — never fail the screenshot over a sidecar write
+  }
+}
+
+/**
+ * Read back a sidecar manifest for `filePath`, only when it is present,
+ * well-formed, and its recorded hash matches `bytes` (the file's current
+ * content, as read for the upload in progress). Returns `undefined` on any
+ * absence, parse failure, malformed shape, or hash mismatch — a sidecar is a
+ * best-effort convenience and must never fail or noise an upload. Returned
+ * keys are always a subset of `CANONICAL_META_KEYS`, so a hand-edited
+ * manifest can never inject arbitrary metadata.
+ */
+export function readSidecarMeta(
+  filePath: string,
+  bytes: Uint8Array,
+): Record<string, string> | undefined {
+  const path = sidecarPath(filePath);
+  try {
+    if (!existsSync(path)) return undefined;
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const candidate = parsed as { version?: unknown; sha256?: unknown; meta?: unknown };
+    if (
+      candidate.version !== SIDECAR_VERSION ||
+      typeof candidate.sha256 !== "string" ||
+      !isPlainStringRecord(candidate.meta)
+    ) {
+      return undefined;
+    }
+    if (candidate.sha256 !== sha256Hex(bytes)) return undefined; // stale/regenerated file
+    const restricted = restrictToCanonicalMeta(candidate.meta);
+    return Object.keys(restricted).length > 0 ? restricted : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/uploads/src/sidecar.ts
+++ b/packages/uploads/src/sidecar.ts
@@ -20,7 +20,7 @@
  */
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { CANONICAL_META_KEYS } from "./metadata-vocab.js";
+import { CANONICAL_META_KEYS, mergeDerivedMeta } from "./metadata-vocab.js";
 
 const SIDECAR_VERSION = 1;
 
@@ -113,4 +113,18 @@ export function readSidecarMeta(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Merge `filePath`'s sidecar metadata (if any, per {@link readSidecarMeta})
+ * under `baseMeta` — explicit metadata always wins. Shared by the `put` and
+ * `attach` upload loops (issue #469 lever 2).
+ */
+export function mergeSidecarMeta(
+  filePath: string,
+  bytes: Uint8Array,
+  baseMeta: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const sidecarMeta = readSidecarMeta(filePath, bytes);
+  return sidecarMeta ? mergeDerivedMeta(baseMeta ?? {}, sidecarMeta) : baseMeta;
 }

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -11,6 +11,7 @@ import type {
 import { runAttach, type CliContext } from "../src/commands.js";
 import { UploadsError } from "../src/errors.js";
 import type { CommandRunner } from "../src/github-gh.js";
+import { writeSidecarMeta } from "../src/sidecar.js";
 
 function files(...names: string[]): string[] {
   const dir = mkdtempSync(join(tmpdir(), "uploads-attach-test-"));
@@ -1134,5 +1135,74 @@ describe("attach canonical metadata", () => {
     await runAttach(ctxWith(client), [file, "--no-comment"], false, run);
     const meta = metadataByKey["gh/buildinternet/uploads/pull/123/shot.webp"];
     expect(meta?.viewport).toBe("812x577@2x");
+  });
+});
+
+describe("runAttach sidecar manifest (issue #469)", () => {
+  it("merges a matching sidecar's derived metadata onto the attachment", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-attach-sidecar-"));
+    const file = join(dir, "shot.png");
+    const bytes = Buffer.from("not-really-a-png");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, {
+      path: "/settings",
+      url: "https://app.test/settings",
+      env: "local",
+    });
+    const { client, metadataByKey } = fakeClient();
+    const { run } = ghRunner();
+    await runAttach(ctxWith(client), [file, "--no-comment"], false, run);
+    const meta = metadataByKey["gh/buildinternet/uploads/pull/123/shot.png"];
+    expect(meta).toMatchObject({
+      path: "/settings",
+      url: "https://app.test/settings",
+      env: "local",
+    });
+  });
+
+  it("lets explicit --meta win over the sidecar for the same key", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-attach-sidecar-"));
+    const file = join(dir, "shot.png");
+    const bytes = Buffer.from("not-really-a-png");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, { path: "/from-sidecar" });
+    const { client, metadataByKey } = fakeClient();
+    const { run } = ghRunner();
+    await runAttach(
+      ctxWith(client),
+      [file, "--no-comment", "--meta", "path=/from-flag"],
+      false,
+      run,
+    );
+    const meta = metadataByKey["gh/buildinternet/uploads/pull/123/shot.png"];
+    expect(meta?.path).toBe("/from-flag");
+  });
+
+  it("ignores a sidecar whose hash no longer matches the file (regenerated/edited)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-attach-sidecar-"));
+    const file = join(dir, "shot.png");
+    const original = Buffer.from("original-bytes");
+    writeFileSync(file, original);
+    writeSidecarMeta(file, original, { path: "/stale" });
+    // File changed after the sidecar was written.
+    writeFileSync(file, Buffer.from("different-bytes"));
+    const { client, metadataByKey } = fakeClient();
+    const { run } = ghRunner();
+    await runAttach(ctxWith(client), [file, "--no-comment"], false, run);
+    const meta = metadataByKey["gh/buildinternet/uploads/pull/123/shot.png"];
+    expect(meta?.path).toBeUndefined();
+  });
+
+  it("ignores a malformed sidecar file silently", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "uploads-attach-sidecar-"));
+    const file = join(dir, "shot.png");
+    writeFileSync(file, Buffer.from("bytes"));
+    writeFileSync(`${file}.uploads.json`, "{ not valid json");
+    const { client, metadataByKey } = fakeClient();
+    const { run } = ghRunner();
+    const code = await runAttach(ctxWith(client), [file, "--no-comment"], false, run);
+    expect(code).toBe(0);
+    const meta = metadataByKey["gh/buildinternet/uploads/pull/123/shot.png"];
+    expect(meta?.path).toBeUndefined();
   });
 });

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -4,6 +4,7 @@ import { UploadsError } from "../src/errors.js";
 import type { GithubRepoLinkResult, UploadsClient } from "../src/client.js";
 import { runPut, stateAppMetaFromFlags, type CliContext } from "../src/commands.js";
 import type { CommandRunner } from "../src/github-gh.js";
+import { writeSidecarMeta } from "../src/sidecar.js";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1772,5 +1773,68 @@ describe("put promotes EXIF facts", () => {
     const byName = new Map(puts.map((p) => [p.filename, p.metadata]));
     expect(byName.get("retina.webp")?.viewport).toBe("812x577@2x");
     expect(byName.get("plain.webp")?.viewport).toBeUndefined();
+  });
+});
+
+describe("runPut sidecar manifest (issue #469)", () => {
+  it("merges a matching sidecar's derived metadata onto the upload", async () => {
+    const { client, puts } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-put-sidecar-"));
+    const file = join(dir, "shot.png");
+    const bytes = Buffer.from("not-really-a-png");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, {
+      path: "/settings",
+      url: "https://app.test/settings",
+      env: "local",
+      viewport: "1280x800@2x",
+    });
+    await runPut(ctxWith(client), [file, "--no-git", "--no-auto"], false, noRun);
+    expect(puts[0]?.metadata).toMatchObject({
+      path: "/settings",
+      url: "https://app.test/settings",
+      env: "local",
+      viewport: "1280x800@2x",
+    });
+  });
+
+  it("lets explicit --meta/--state win over the sidecar for the same key", async () => {
+    const { client, puts } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-put-sidecar-"));
+    const file = join(dir, "shot.png");
+    const bytes = Buffer.from("not-really-a-png");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, { path: "/from-sidecar", state: "before" });
+    await runPut(
+      ctxWith(client),
+      [file, "--no-git", "--no-auto", "--meta", "path=/from-flag", "--state", "after"],
+      false,
+      noRun,
+    );
+    expect(puts[0]?.metadata?.path).toBe("/from-flag");
+    expect(puts[0]?.metadata?.state).toBe("after");
+  });
+
+  it("ignores a sidecar whose hash no longer matches the file", async () => {
+    const { client, puts } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-put-sidecar-"));
+    const file = join(dir, "shot.png");
+    const original = Buffer.from("original-bytes");
+    writeFileSync(file, original);
+    writeSidecarMeta(file, original, { path: "/stale" });
+    writeFileSync(file, Buffer.from("different-bytes"));
+    await runPut(ctxWith(client), [file, "--no-git", "--no-auto"], false, noRun);
+    expect(puts[0]?.metadata?.path).toBeUndefined();
+  });
+
+  it("ignores a malformed sidecar file silently", async () => {
+    const { client, puts } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-put-sidecar-"));
+    const file = join(dir, "shot.png");
+    writeFileSync(file, Buffer.from("bytes"));
+    writeFileSync(`${file}.uploads.json`, "{ not valid json");
+    const code = await runPut(ctxWith(client), [file, "--no-git", "--no-auto"], false, noRun);
+    expect(code).toBe(0);
+    expect(puts[0]?.metadata).toBeUndefined();
   });
 });

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -239,6 +239,75 @@ describe("runScreenshot upload tail", () => {
     expect(existsSync(out)).toBe(true);
   });
 
+  it("--out writes a sidecar manifest with derived metadata and a content hash", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const out = join(dir, "shot.png");
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com/settings", "--out", out, "--state", "after"],
+      false,
+      noRun,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    const sidecarPath = `${out}.uploads.json`;
+    expect(existsSync(sidecarPath)).toBe(true);
+    const manifest = JSON.parse(readFileSync(sidecarPath, "utf8"));
+    expect(manifest.version).toBe(1);
+    expect(typeof manifest.sha256).toBe("string");
+    expect(manifest.sha256).toHaveLength(64);
+    expect(manifest.meta).toMatchObject({
+      url: "https://example.com/settings",
+      path: "/settings",
+      state: "after",
+    });
+    expect(manifest.meta.viewport).toBeDefined();
+  });
+
+  it("--no-sidecar skips writing the sidecar manifest", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const out = join(dir, "shot.png");
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com/settings", "--out", out, "--no-sidecar"],
+      false,
+      noRun,
+      fakeCapture("remote"),
+    );
+    expect(code).toBe(0);
+    expect(existsSync(`${out}.uploads.json`)).toBe(false);
+  });
+
+  it("--no-sidecar requires --out", async () => {
+    const { client } = fakeClient();
+    await expect(
+      runScreenshot(
+        ctxWith(client),
+        ["https://example.com", "--no-sidecar"],
+        false,
+        noRun,
+        fakeCapture(),
+      ),
+    ).rejects.toThrow(UsageError);
+  });
+
+  it("does not write a sidecar when there is no derived metadata to store", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-screenshot-"));
+    const out = join(dir, "card.png");
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["./card.html", "--out", out, "--no-auto"],
+      false,
+      noRun,
+      fakeCapture("local"),
+    );
+    void code;
+    expect(existsSync(`${out}.uploads.json`)).toBe(false);
+  });
+
   it("--destination screenshots sets the key prefix", async () => {
     const { client, puts } = fakeClient();
     const code = await runScreenshot(

--- a/packages/uploads/test/sidecar.test.ts
+++ b/packages/uploads/test/sidecar.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readSidecarMeta, sha256Hex, sidecarPath, writeSidecarMeta } from "../src/sidecar.js";
+
+function tmpFile(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "uploads-sidecar-test-"));
+  return join(dir, name);
+}
+
+describe("sidecar manifest (issue #469 lever 2)", () => {
+  it("writes a manifest with version, sha256, and restricted meta", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, {
+      path: "/settings",
+      url: "https://x.test/settings",
+      "not-canonical": "dropped",
+    });
+    const manifest = JSON.parse(readFileSync(sidecarPath(file), "utf8"));
+    expect(manifest.version).toBe(1);
+    expect(manifest.sha256).toBe(sha256Hex(bytes));
+    expect(manifest.meta).toEqual({ path: "/settings", url: "https://x.test/settings" });
+  });
+
+  it("does not write a sidecar when meta has no canonical keys", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, { "not-canonical": "value" });
+    expect(() => readFileSync(sidecarPath(file), "utf8")).toThrow();
+  });
+
+  it("reads back a matching manifest", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, { path: "/settings", state: "after" });
+    expect(readSidecarMeta(file, bytes)).toEqual({ path: "/settings", state: "after" });
+  });
+
+  it("returns undefined when the sidecar is absent", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    expect(readSidecarMeta(file, bytes)).toBeUndefined();
+  });
+
+  it("returns undefined when the hash no longer matches (regenerated/edited file)", () => {
+    const file = tmpFile("shot.png");
+    const original = Buffer.from("original");
+    writeFileSync(file, original);
+    writeSidecarMeta(file, original, { path: "/settings" });
+    const changed = Buffer.from("changed");
+    expect(readSidecarMeta(file, changed)).toBeUndefined();
+  });
+
+  it("returns undefined for malformed JSON", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeFileSync(sidecarPath(file), "not json");
+    expect(readSidecarMeta(file, bytes)).toBeUndefined();
+  });
+
+  it("returns undefined for a manifest with the wrong version", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({ version: 2, sha256: sha256Hex(bytes), meta: { path: "/x" } }),
+    );
+    expect(readSidecarMeta(file, bytes)).toBeUndefined();
+  });
+
+  it("returns undefined when meta is not a plain string record", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({ version: 1, sha256: sha256Hex(bytes), meta: { path: 123 } }),
+    );
+    expect(readSidecarMeta(file, bytes)).toBeUndefined();
+  });
+
+  it("drops non-canonical keys from a hand-edited manifest even when the hash matches", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({
+        version: 1,
+        sha256: sha256Hex(bytes),
+        meta: { path: "/settings", "arbitrary-key": "smuggled" },
+      }),
+    );
+    expect(readSidecarMeta(file, bytes)).toEqual({ path: "/settings" });
+  });
+
+  it("returns undefined when the manifest exists but has no canonical keys", () => {
+    const file = tmpFile("shot.png");
+    const bytes = Buffer.from("bytes");
+    writeFileSync(file, bytes);
+    writeFileSync(
+      sidecarPath(file),
+      JSON.stringify({ version: 1, sha256: sha256Hex(bytes), meta: { "not-canonical": "x" } }),
+    );
+    expect(readSidecarMeta(file, bytes)).toBeUndefined();
+  });
+});

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -50,6 +50,11 @@ uploads screenshot http://localhost:4321 --viewport 1520x960@1x --out home.png -
 uploads screenshot https://uploads.sh --selector main --dark
 ```
 
+`--out` also drops a `<file>.uploads.json` sidecar next to the PNG — that's a
+working file for a later `put`/`attach` to pick metadata back up from, not
+something to commit, so `.gitignore` it (`*.uploads.json`) or delete it once
+you're done attaching.
+
 Only reach for your harness's browser tools / Playwright / an existing file when
 `uploads screenshot` can't reach the target (e.g. a flow that needs auth or
 interaction first). GIFs and video: capture with any tool and upload as-is — the

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -404,20 +404,21 @@ explicit executable.
 
 Key options (`uploads screenshot --help` for all):
 
-| Flag                                                 | Purpose                                                                                                                                                                                                  |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--via auto\|local\|remote`                          | Capture backend (default: `auto`, or `UPLOADS_SCREENSHOT_VIA`).                                                                                                                                          |
-| `--browser <path>`                                   | Explicit local browser executable (or `UPLOADS_CHROME_PATH` / `CHROME_PATH`).                                                                                                                            |
-| `--cdp <endpoint>`                                   | Attach to a running Chrome via CDP instead of launching one (local backend only).                                                                                                                        |
-| `--viewport <WxH[@Sx]>`                              | Size + device scale factor (default: `1280x800@2`).                                                                                                                                                      |
-| `--selector <css>`                                   | Capture one element instead of the viewport.                                                                                                                                                             |
-| `--full-page`                                        | Capture the full scrollable page.                                                                                                                                                                        |
-| `--dark` / `--light`                                 | Emulate `prefers-color-scheme` (full media-query emulation on `--via local` only — `--via remote` only sets the CSS `color-scheme` property, so a page's own `prefers-color-scheme` queries won't flip). |
-| `--wait <load\|domcontentloaded\|networkidle\|ms>`   | Settle strategy (default: `load`); a millisecond count is local-only.                                                                                                                                    |
-| `--out <file>`                                       | Also write the PNG to a local file.                                                                                                                                                                      |
-| `--no-upload`                                        | Skip hosting; requires `--out` (local file only).                                                                                                                                                        |
-| `--key` / `--pr` / `--issue` / `--comment`           | Same destination and attachment options as `put` (see above); `--pr`/`--issue` also give a stable, hash-free key.                                                                                        |
-| `--frame` / `--no-optimize` / `--gallery` / `--meta` | Same as `put` — reused from the shared upload pipeline.                                                                                                                                                  |
+| Flag                                                 | Purpose                                                                                                                                                                                                                                                                                                                                               |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--via auto\|local\|remote`                          | Capture backend (default: `auto`, or `UPLOADS_SCREENSHOT_VIA`).                                                                                                                                                                                                                                                                                       |
+| `--browser <path>`                                   | Explicit local browser executable (or `UPLOADS_CHROME_PATH` / `CHROME_PATH`).                                                                                                                                                                                                                                                                         |
+| `--cdp <endpoint>`                                   | Attach to a running Chrome via CDP instead of launching one (local backend only).                                                                                                                                                                                                                                                                     |
+| `--viewport <WxH[@Sx]>`                              | Size + device scale factor (default: `1280x800@2`).                                                                                                                                                                                                                                                                                                   |
+| `--selector <css>`                                   | Capture one element instead of the viewport.                                                                                                                                                                                                                                                                                                          |
+| `--full-page`                                        | Capture the full scrollable page.                                                                                                                                                                                                                                                                                                                     |
+| `--dark` / `--light`                                 | Emulate `prefers-color-scheme` (full media-query emulation on `--via local` only — `--via remote` only sets the CSS `color-scheme` property, so a page's own `prefers-color-scheme` queries won't flip).                                                                                                                                              |
+| `--wait <load\|domcontentloaded\|networkidle\|ms>`   | Settle strategy (default: `load`); a millisecond count is local-only.                                                                                                                                                                                                                                                                                 |
+| `--out <file>`                                       | Also write the PNG to a local file, plus a sidecar manifest (`<file>.uploads.json`) with this capture's derived metadata (`path`/`url`/`env`/`viewport`, plus `--state` if given) and a content hash. A later `put`/`attach` of that exact file picks the metadata back up automatically — explicit `--meta`/`--state` still win. See `--no-sidecar`. |
+| `--no-sidecar`                                       | Don't write the `<file>.uploads.json` sidecar alongside `--out`.                                                                                                                                                                                                                                                                                      |
+| `--no-upload`                                        | Skip hosting; requires `--out` (local file only).                                                                                                                                                                                                                                                                                                     |
+| `--key` / `--pr` / `--issue` / `--comment`           | Same destination and attachment options as `put` (see above); `--pr`/`--issue` also give a stable, hash-free key.                                                                                                                                                                                                                                     |
+| `--frame` / `--no-optimize` / `--gallery` / `--meta` | Same as `put` — reused from the shared upload pipeline.                                                                                                                                                                                                                                                                                               |
 
 **Errors and hints:** a local capture with no usable browser fails with
 `BROWSER_NOT_FOUND` (exit `2`) — hint: try `--via remote`, or install a
@@ -481,6 +482,14 @@ uploads find path=/settings state=after        # what it was all for
 - **`uploads put`/`attach`** read the image's own EXIF _before_ the optimizer
   strips it, promoting an allowlist: `viewport` (from pixel dimensions and DPI),
   `device`, `software`, `captured`.
+- **`uploads put`/`attach` also read a sidecar manifest** left by a prior
+  `screenshot --out` of that exact file (`<file>.uploads.json`, content-hash
+  guarded — a regenerated/edited file silently loses it) and merge in its
+  derived metadata. This closes the capture-then-attach gap where a shot is
+  taken before a PR exists: `uploads screenshot ... --out shot.png --state after`
+  now, `uploads attach shot.png --pr 123` later, still gets `path`/`url`/`env`/
+  `viewport`/`state` on the PR-keyed object. Disable writing it with
+  `--no-sidecar`.
 
 `env` is only ever `local`. It is never set to `prod` — inferring that from "not
 localhost" would mislabel every staging and preview URL, and wrong metadata is
@@ -492,8 +501,9 @@ comments. Note the flip side: `device` and `software` were previously discarded
 and now become queryable metadata that renders on the public `/f/` page.
 
 **Precedence:** explicit `--meta`/`--state`/`--app` > screenshot capture facts >
-EXIF > unset. Derived keys are also dropped first if the 24-key cap is reached —
-your own keys are never dropped, and a full key budget never fails an upload.
+sidecar manifest > EXIF > unset. Derived keys are also dropped first if the
+24-key cap is reached — your own keys are never dropped, and a full key
+budget never fails an upload.
 
 Turn the whole derived tier off with `--no-auto` or `UPLOADS_NO_AUTO_META=1`.
 


### PR DESCRIPTION
## What

Lever 2 of #469, implemented as the sidecar-manifest variant (the other option in the issue — copying derived metadata onto content-identical re-uploads server-side — is out of scope here; noted as a possible follow-up below).

`uploads screenshot <url> --out file.png` now also writes `file.png.uploads.json` next to it, recording:
- this capture's derived metadata: `path`/`url`/`env`/`viewport` (whatever `captureFacts` produced), plus `state` if `--state` was passed
- a SHA-256 of the exact bytes written to `file.png`

A later `uploads put file.png` or `uploads attach file.png --pr N` detects the sidecar, verifies the file's current bytes still hash-match the manifest, and merges the sidecar's metadata onto the upload — explicit `--meta`/`--state` always win over sidecar values.

This closes the exact gap in the issue's motivating trace: capture early with `--out`, open the PR later, `attach` still gets `path`/`state`/etc. on the PR-keyed object.

## Design decisions

- **Sidecar filename**: `<file>.uploads.json` (e.g. `docs-limits.png.uploads.json`) — sits next to the image, obviously associated, doesn't collide with the image extension.
- **Format**: `{ version: 1, sha256: "<hex>", meta: { ... } }`. `meta` is filtered to the closed `CANONICAL_META_KEYS` vocabulary (`metadata-vocab.ts`) on both write and read, so a hand-edited or malicious sidecar can never smuggle arbitrary keys into an upload — only `path`/`url`/`env`/`theme`/`viewport`/`state`/etc., the same vocabulary `find` already relies on.
- **Hash**: full SHA-256 (not the existing truncated `sha256Short` used for key generation) of the file's raw bytes at write time, compared against the file's current bytes at read time. A regenerated or hand-edited screenshot silently loses its sidecar instead of attaching stale/wrong metadata to a different image.
- **Default-on, with `--no-sidecar` to opt out** — matches the existing `--no-optimize`/`--no-upload`/`--no-git` flag convention. The sidecar is inert extra output; the read side is equally silent (never fails or noises an upload on absence/malformed/hash-mismatch — at most it's just a no-op).
- Read-side wiring lives in the two shared per-file loops (`uploadPuts`, `uploadAttachmentBatch`) that already have both a file path and its bytes, using `mergeDerivedMeta` (same helper the EXIF/capture-facts tiers use) so sidecar values only fill gaps and still go through the standard metadata validators before the request is sent.

## Left out / follow-ups

- The content-hash server-side inheritance alternative from the issue (copying derived metadata onto a content-identical re-upload without a local sidecar file) — coordinator decision, out of scope for this PR.
- Lever 1 from #469 (`screenshot` participating in branch staging like `put --branch` does) is a separate, larger change and not part of this PR.
- Lever 3 (nudge at the point of loss) is likewise separate.

## Test evidence

- New `packages/uploads/test/sidecar.test.ts`: unit coverage for `writeSidecarMeta`/`readSidecarMeta` — write/read round-trip, canonical-key filtering, hash-mismatch rejection, malformed JSON, wrong version, non-string values.
- `commands-screenshot.test.ts`: `--out` writes a well-formed sidecar with derived metadata + `--state`; `--no-sidecar` skips it; `--no-sidecar` requires `--out`; no sidecar written when there's no derived metadata.
- `commands-put.test.ts` / `commands-attach.test.ts`: sidecar metadata merges onto the upload; explicit `--meta`/`--state` wins over sidecar; a byte-changed file's sidecar is ignored; malformed sidecar JSON is ignored silently.
- Full suite: `pnpm test` at repo root — 225 files / 2855 tests passing. `pnpm typecheck` passing (root + package).

Closes part of #469.
