### PR TITLE
docs: document comment self-heal dedupe and meta set re-sync (#471 follow-up)

### DIFF
--- a/.changeset/docs-471-comment-resync-followup.md
+++ b/.changeset/docs-471-comment-resync-followup.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Docs: document the managed-comment self-heal dedupe and the `meta set`
+comment re-sync (path/state) added in #471, in the CLI README, the
+uploads-cli skill, and the GitHub App docs page.

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -194,6 +194,13 @@ const TOC = [
       (see <a href="#permissions">Permissions &amp; events</a>). A briefly missing comment is
       expected and not a reason to repost one manually.
     </p>
+    <p>
+      Duplicate marker comments — the occasional webhook-vs-CLI race that creates two — are
+      collapsed the same way: the next sync keeps the oldest, updates it, and deletes the
+      extras. And <code>uploads meta set</code> on a <code>gh/…</code>-keyed object refreshes
+      the comment automatically whenever it changes <code>path</code> or <code>state</code>,
+      so backfilled metadata shows up without waiting on the next <code>attach</code>.
+    </p>
   </section>
 
   <section id="without-it">

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -98,6 +98,11 @@ explicit deletes. Promotion (auto or `--promote`) does skip files staged
 more than 30 days before the PR opens, though; they're still there, just no
 longer auto-promoted.
 
+**Metadata edits re-sync the comment too:** `uploads meta set` on a `gh/…`-keyed
+object refreshes the managed comment automatically when it touches `path` or
+`state` — best-effort, so backfilled metadata shows up without waiting on the
+next `attach`.
+
 **Bare `put` stages too, by default (issue #403):** on a non-default git
 branch, a `put` with none of
 `--pr`/`--issue`/`--key`/`--ref`/`--prefix`/`--destination` set

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -507,6 +507,13 @@ request; a value may itself contain `=` (only the first `=` splits key from valu
 visibility gate, respectively). `uploads attach` writes its own `gh.*`
 reserved-by-convention keys automatically — see below.
 
+`meta set` on a `gh/…`-keyed object also refreshes the managed PR/issue comment
+whenever the write touches a rendered key (`path`/`state`) — best-effort, after
+the metadata write already lands. On success it prints
+`refreshed the managed comment on <repo>#<num>` to stderr; if the bot endpoint
+is unavailable it prints `tip: run \`uploads comment --pr <num>\` to refresh
+the PR comment` instead, and either way the metadata write itself never fails.
+
 ```bash
 uploads meta get screenshots/myapp/42/settings.webp
 uploads meta set screenshots/myapp/42/settings.webp path=/onboarding --delete url


### PR DESCRIPTION
Closes three docs gaps left by #471 (self-heal comment dedupe + `meta set` re-sync, see #470):

- `skills/uploads-cli/SKILL.md` — "Rules and reserved keys" now documents that `meta set` touching `path`/`state` on a `gh/…` key refreshes the managed comment, plus the success/fallback stderr lines.
- `apps/web/src/pages/docs/github-app.astro` — "Self-healing comments" now covers duplicate marker comments being collapsed (oldest kept, extras removed) alongside the existing deleted/edited case, and mentions the `meta set` re-sync.
- `packages/uploads/README.md` — a short callout near "Branch staging (pre-PR)" noting the same `meta set` re-sync behavior.

Docs only, no behavior changes. Added a patch changeset since `packages/uploads/README.md` ships with the npm package (matches the convention from #184/#316/#416).