### PR TITLE
chore: commit shared impeccable detector config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,11 @@ worker-configuration.d.ts
 *.log
 pnpm-debug.log*
 coverage/
-.impeccable/
+# Impeccable design-hook state stays local, but the shared detector config
+# (rule suppressions with recorded reasons) is committed so every checkout
+# and worktree agrees on what is intentionally ignored.
+.impeccable/*
+!.impeccable/config.json
 # Local agent notes, private plans, pricing scratch (not for the public repo)
 .context/
 .superpowers/

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -18,9 +18,7 @@
       {
         "rule": "broken-image",
         "value": "*",
-        "files": [
-          "**/packages/uploads/src/**"
-        ],
+        "files": ["**/packages/uploads/src/**"],
         "createdAt": "2026-07-23T18:05:43.111Z",
         "reason": "User confirmed: CLI/MCP source emits GitHub-markdown img templates; src is interpolated at runtime, not a rendered UI surface"
       }

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,29 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [],
+    "ignoreValues": [
+      {
+        "rule": "overused-font",
+        "value": "geist",
+        "createdAt": "2026-07-13T15:21:39.964Z",
+        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist retained deliberately for prose/headings"
+      },
+      {
+        "rule": "overused-font",
+        "value": "geist mono",
+        "createdAt": "2026-07-13T15:21:39.994Z",
+        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist Mono is the brand's base face for a CLI-first product"
+      },
+      {
+        "rule": "broken-image",
+        "value": "*",
+        "files": [
+          "**/packages/uploads/src/**"
+        ],
+        "createdAt": "2026-07-23T18:05:43.111Z",
+        "reason": "User confirmed: CLI/MCP source emits GitHub-markdown img templates; src is interpolated at runtime, not a rendered UI surface"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Commits the shared Impeccable detector config so rule suppressions (with recorded reasons) travel with the repo instead of living per-machine.

- `.gitignore`: `.impeccable/` → `.impeccable/*` + `!.impeccable/config.json`, so the shared config is tracked while local state (`config.local.json`, `hook.cache.json`) stays ignored.
- `.impeccable/config.json`: existing suppressions — Geist/Geist Mono as deliberate brand faces, and `broken-image` scoped to `packages/uploads/src/**`, where CLI/MCP source emits GitHub-markdown `<img>` templates whose `src` is interpolated at runtime (not a rendered UI surface). The scoped ignore also covers git worktrees under the repo directory.

No code changes; no changeset (repo tooling only).
