### PR TITLE
fix(web): don't offer Stripe portal for comped workspaces

### DIFF
--- a/apps/web/src/lib/billing-cta.test.ts
+++ b/apps/web/src/lib/billing-cta.test.ts
@@ -3,23 +3,38 @@ import { resolveBillingCta } from "./billing-cta";
 
 describe("resolveBillingCta", () => {
   it("stays unavailable when pro isn't purchasable yet, regardless of plan", () => {
-    expect(resolveBillingCta({ proAvailable: false, plan: "free" })).toEqual({
+    expect(resolveBillingCta({ proAvailable: false, plan: "free", planSource: "none" })).toEqual({
       kind: "unavailable",
     });
-    expect(resolveBillingCta({ proAvailable: false, plan: "pro" })).toEqual({
+    expect(resolveBillingCta({ proAvailable: false, plan: "pro", planSource: "stripe" })).toEqual({
+      kind: "unavailable",
+    });
+    expect(resolveBillingCta({ proAvailable: false, plan: "pro", planSource: "admin" })).toEqual({
       kind: "unavailable",
     });
   });
 
   it("offers upgrade when pro is available and the workspace isn't on it", () => {
-    expect(resolveBillingCta({ proAvailable: true, plan: "free" })).toEqual({
+    expect(resolveBillingCta({ proAvailable: true, plan: "free", planSource: "none" })).toEqual({
       kind: "upgrade",
     });
   });
 
-  it("offers the billing portal when the workspace is already on pro", () => {
-    expect(resolveBillingCta({ proAvailable: true, plan: "pro" })).toEqual({
+  it("offers the billing portal when a live Stripe subscription backs pro", () => {
+    expect(resolveBillingCta({ proAvailable: true, plan: "pro", planSource: "stripe" })).toEqual({
       kind: "manage",
+    });
+  });
+
+  it("does not offer the Stripe portal for a comped/admin-set pro plan", () => {
+    // A workspace comped to pro has no Stripe customer, so the billing portal
+    // 404s — offer the "comped" state (no portal button) instead of an opaque
+    // error. Covers both derivations of a non-Stripe-backed paid plan.
+    expect(resolveBillingCta({ proAvailable: true, plan: "pro", planSource: "admin" })).toEqual({
+      kind: "comped",
+    });
+    expect(resolveBillingCta({ proAvailable: true, plan: "pro", planSource: "none" })).toEqual({
+      kind: "comped",
     });
   });
 });

--- a/apps/web/src/lib/billing-cta.ts
+++ b/apps/web/src/lib/billing-cta.ts
@@ -15,23 +15,41 @@
  * reading the catalog itself) so the three states are each independently
  * testable without mocking the catalog.
  */
-export type BillingCtaState = { kind: "unavailable" } | { kind: "upgrade" } | { kind: "manage" };
+export type BillingCtaState =
+  | { kind: "unavailable" }
+  | { kind: "upgrade" }
+  | { kind: "manage" }
+  | { kind: "comped" };
 
 /**
  * Resolves which billing-tab CTA to render.
  *
  * - pro not yet available (today): unchanged disabled "coming soon" button.
  * - pro available and the workspace isn't on it: "Upgrade to Pro".
- * - pro available and the workspace is on it: "Manage billing" (portal).
+ * - pro available, on pro, backed by a live Stripe subscription:
+ *   "Manage billing" (opens the Stripe customer portal).
+ * - pro available, on pro, but the plan is comped/admin-set (`planSource`
+ *   is "admin", no Stripe customer behind it): "comped" — NO portal button.
+ *   The Stripe portal 404s for a workspace with no Stripe customer (there's
+ *   nothing to build a portal session from), so offering it would only ever
+ *   produce an opaque error. The "Included with your workspace." status line
+ *   (subscription-copy.ts) already explains the state.
  *
  * Doubles as the plan-comparison cards' state map (billing.astro): "upgrade"
  * and "unavailable" render on the Pro card's CTA when the workspace is on
  * free; "manage" renders as a standalone "Manage billing" button (the
  * downgrade/cancel path lives in the Stripe portal, not a card CTA) shown
- * alongside the Pro card once the workspace is on it.
+ * alongside the Pro card once a real subscription backs it; "comped" renders
+ * neither button, only a clarifying note.
  */
-export function resolveBillingCta(input: { proAvailable: boolean; plan: string }): BillingCtaState {
+export function resolveBillingCta(input: {
+  proAvailable: boolean;
+  plan: string;
+  planSource: "stripe" | "admin" | "none";
+}): BillingCtaState {
   if (!input.proAvailable) return { kind: "unavailable" };
-  if (input.plan === "pro") return { kind: "manage" };
+  if (input.plan === "pro") {
+    return input.planSource === "stripe" ? { kind: "manage" } : { kind: "comped" };
+  }
   return { kind: "upgrade" };
 }

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -50,6 +50,10 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
         <div class="settings-section">
           <button type="button" id="ws-manage-billing-btn" hidden>Manage billing</button>
+          <p class="muted" id="ws-comped-note" hidden>
+            This plan is comped for your workspace, so there’s no self-serve billing to manage.
+            Contact support to make changes.
+          </p>
           <p class="muted" id="ws-billing-error" role="alert" hidden></p>
         </div>
       </div>
@@ -108,6 +112,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const planCardsEl = requireElement<HTMLElement>("#ws-plan-cards", page);
       const manageBillingNoteEl = requireElement<HTMLElement>("#ws-manage-billing-note", page);
       const manageBillingBtn = requireElement<HTMLButtonElement>("#ws-manage-billing-btn", page);
+      const compedNoteEl = requireElement<HTMLElement>("#ws-comped-note", page);
       const subscriptionStatusEl = requireElement<HTMLElement>("#ws-subscription-status", page);
       const billingErrorEl = requireElement<HTMLElement>("#ws-billing-error", page);
 
@@ -236,7 +241,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           (plan) => plan.available || plan.id === currentPlanId,
         );
 
-        const cta = resolveBillingCta({ proAvailable: PLANS.pro.available, plan: billing.plan });
+        const cta = resolveBillingCta({
+          proAvailable: PLANS.pro.available,
+          plan: billing.plan,
+          planSource: billing.planSource,
+        });
 
         const cardsHtml = cardPlans
           .map((plan) => {
@@ -266,10 +275,13 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         planCardsEl.innerHTML = cardsHtml;
 
         // "Manage billing" (also the downgrade/cancel path) only makes sense
-        // once the workspace is actually on a paid plan.
+        // once a live Stripe subscription backs the plan. A comped/admin plan
+        // has no Stripe customer, so the portal 404s — show the comped note
+        // instead of a button that can only error.
         manageBillingBtn.hidden = cta.kind !== "manage";
         manageBillingBtn.disabled = false;
         manageBillingNoteEl.hidden = cta.kind !== "manage";
+        compedNoteEl.hidden = cta.kind !== "comped";
       }
 
       async function handleBillingActionClick(cta: "upgrade" | "manage"): Promise<void> {


### PR DESCRIPTION
## Problem

Clicking **Manage billing** on a comped workspace's billing tab returned a 404 and surfaced only the opaque "couldn't open billing — try again."

A comped/admin-set Pro workspace has `plan: "pro"` but **no Stripe customer** behind it (the API reports `planSource: "admin"`, and the card already reads "Included with your workspace."). `resolveBillingCta` decided the **Manage billing** button off `plan === "pro"` alone, ignoring `planSource`, so the button rendered and its POST to `/api/auth/subscription/billing-portal` 404'd — `@better-auth/stripe` has no customer to build a portal session from.

## Fix

Make the CTA `planSource`-aware. The Stripe portal is only offered when a live Stripe subscription can back it (`planSource === "stripe"`). A comped plan now resolves to a new `"comped"` state that renders **no portal button** and a short clarifying note instead of a control that can only error:

> This plan is comped for your workspace, so there's no self-serve billing to manage. Contact support to make changes.

No server change — we simply stop calling a portal that can't exist for these workspaces. The existing "Included with your workspace." status line is unchanged.

## Testing

- New unit cases in `billing-cta.test.ts` cover both non-Stripe derivations (`admin`, `none`) → `comped`, and Stripe-backed → `manage`. All 358 `apps/web` lib tests pass.
- `astro check`: 0 errors.

Verified via unit tests + typecheck rather than the full local stack, since reproducing a comped Pro org in-browser needs the auth worker plus a seeded comped D1 record.
