### PR TITLE
fix(comment): dedupe duplicate managed comments on explicit resync

### DIFF
--- a/.changeset/mean-pugs-invent.md
+++ b/.changeset/mean-pugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads comment` (and the `comment` MCP tool) now always hunts for the managed comment's marker instead of patching its cached comment id, so a duplicate comment left by a create race is collapsed on the next explicit resync rather than surviving until the id cache expires. Attach and screenshot syncs keep the cached-id fast path.

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -18,9 +18,9 @@
       {
         "rule": "broken-image",
         "value": "*",
-        "files": ["**/packages/uploads/src/**"],
+        "files": ["**/packages/uploads/src/**", "**/apps/mcp/src/**"],
         "createdAt": "2026-07-23T18:05:43.111Z",
-        "reason": "User confirmed: CLI/MCP source emits GitHub-markdown img templates; src is interpolated at runtime, not a rendered UI surface"
+        "reason": "User confirmed: CLI/MCP source emits GitHub-markdown img templates; src is interpolated at runtime, not a rendered UI surface. apps/mcp/src added 2026-07-23: the hosted MCP worker is headless JSON-RPC (no rendered surface) and its tool-schema descriptions describe <img> markdown in prose — same class as the CLI, missed by the original packages-only glob."
       }
     ]
   }

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -18,9 +18,16 @@
       {
         "rule": "broken-image",
         "value": "*",
-        "files": ["**/packages/uploads/src/**", "**/apps/mcp/src/**"],
+        "files": [
+          "**/packages/uploads/src/**",
+          "**/apps/mcp/src/**",
+          "**/apps/api/src/**",
+          "**/apps/web/src/lib/**",
+          "**/*.test.ts",
+          "**/*.test.tsx"
+        ],
         "createdAt": "2026-07-23T18:05:43.111Z",
-        "reason": "User confirmed: CLI/MCP source emits GitHub-markdown img templates; src is interpolated at runtime, not a rendered UI surface. apps/mcp/src added 2026-07-23: the hosted MCP worker is headless JSON-RPC (no rendered surface) and its tool-schema descriptions describe <img> markdown in prose — same class as the CLI, missed by the original packages-only glob."
+        "reason": "Waives broken-image for code that EMITS markup as strings rather than rendering it, plus test fixtures — the class this rule cannot distinguish. Covers the CLI/stdio MCP (packages/uploads/src), the hosted MCP worker and the API worker (headless JSON-RPC, no rendered surface; their <img> occurrences are GitHub-comment markdown builders and tool-schema prose), apps/web/src/lib (embed-snippet builders and UI label text, not components), and *.test.ts(x) (notably an XSS fixture, `caption: \"<img onerror=alert(1)>\"`, that must stay malformed). Scoped deliberately rather than disabled globally: the rule stays live on apps/web/src/components/**, apps/web/src/pages/**, and packages/ui/**, which all scan clean today and where a real `<img src=\"\">` would ship a broken box — verified 2026-07-23 that the detector parses .astro and catches that defect."
       }
     ]
   }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "./external-references": "./src/external-references.ts",
     "./uploader-identity": "./src/uploader-identity.ts",
     "./github-comment-service": "./src/github-comment-service.ts",
+    "./github-comment-render": "./src/github-comment-render.ts",
     "./github-repo-binding": "./src/github-repo-binding.ts"
   },
   "scripts": {

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -114,6 +114,12 @@ export type PostCommentResult =
  * gate (`count > 0`), so an emptied PR rewrites an existing comment but never
  * creates one. On an actual post, best-effort records `target.repo` as bound
  * to `workspaceName` (first-claim-wins, never affects the return value).
+ *
+ * `opts.resync` marks the call as an explicit "make the comment state
+ * correct" request (the `uploads comment` command and its MCP equivalents)
+ * rather than a background sync: it forces the marker hunt, and with it the
+ * duplicate-comment dedupe, instead of trusting the cached comment id (issue
+ * #480). Costs one extra listing, so ordinary attach/promote syncs leave it off.
  */
 export async function postManagedComment(
   env: Env,
@@ -121,6 +127,7 @@ export async function postManagedComment(
   workspaceName: string,
   mintingUserId: string | null,
   target: GhTarget,
+  opts: { resync?: boolean } = {},
 ): Promise<PostCommentResult> {
   const cfg = githubAppConfig(env);
   if (!cfg) return { posted: false, reason: "app_unconfigured" };
@@ -151,6 +158,7 @@ export async function postManagedComment(
     fetch,
     {
       createIfMissing: gathered.count > 0,
+      forceHunt: opts.resync === true,
     },
   );
   if ("degrade" in result) {

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -958,6 +958,90 @@ describe("upsertBotComment", () => {
     });
   });
 
+  it("forceHunt ignores a warm cached id so a duplicate is collapsed (issue #480)", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    // Warm cache pointing at the NEWER of two marker comments — exactly the
+    // state that left #468's duplicate untouched for a cache lifetime.
+    await kv.put("ghcomment:acme:acme/web#12", "8");
+    const deleted: string[] = [];
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/12/comments")) {
+        return new Response(
+          JSON.stringify([
+            { id: 7, body: `${attachmentsMarker("acme")}\nfirst` },
+            { id: 8, body: `${attachmentsMarker("acme")}\nduplicate` },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (init.method === "DELETE") {
+        deleted.push(url);
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes("/issues/comments/7") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 7, html_url: "https://github.com/acme/web/pull/12#c7" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+      { forceHunt: true },
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c7",
+    });
+    expect(deleted).toEqual(["https://api.github.com/repos/acme/web/issues/comments/8"]);
+    // The cache now points at the surviving (oldest) comment.
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("7");
+  });
+
+  it("leaves the cached-id fast path alone without forceHunt", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    await kv.put("ghcomment:acme:acme/web#12", "8");
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/12/comments")) throw new Error("listed on cache hit");
+      if (url.includes("/issues/comments/8") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 8, html_url: "https://github.com/acme/web/pull/12#c8" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+      { forceHunt: false },
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c8",
+    });
+  });
+
   it("patches an existing comment to empty when createIfMissing is false", async () => {
     const { env } = makeTestEnv();
     const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -224,6 +224,13 @@ const degradeFor = (status: number): "forbidden" | "unavailable" =>
  * PATCH with no listing. The id is only an optimization — the marker in the
  * body stays authoritative, so a stale/deleted id (404) drops the cache and
  * falls back to the marker hunt, which pages through the whole thread.
+ *
+ * `forceHunt` skips that fast path and always hunts (issue #480). The dedupe
+ * below only runs on the hunt, so while the cache is warm a race-created
+ * duplicate would otherwise survive until the id expires (30 days). Callers
+ * whose whole intent is "make the comment state correct" — the explicit
+ * `uploads comment` resync — pay one listing to bound a duplicate's lifetime
+ * to the next such call. High-frequency attach/promote syncs keep the fast path.
  */
 export async function upsertBotComment(
   env: Env,
@@ -233,7 +240,7 @@ export async function upsertBotComment(
   body: string,
   workspaceName: string,
   fetchImpl: typeof fetch = fetch,
-  opts: { createIfMissing?: boolean } = {},
+  opts: { createIfMissing?: boolean; forceHunt?: boolean } = {},
 ): Promise<
   | { action: "created" | "updated"; commentUrl: string }
   | { action: "skipped" }
@@ -264,7 +271,10 @@ export async function upsertBotComment(
   };
 
   // Fast path: a cached id lets us PATCH the comment directly, no listing.
-  const cachedId = (await env.GITHUB_CACHE.get(cacheKey)) as string | null;
+  // Skipped entirely under `forceHunt` — the caller wants the dedupe pass.
+  const cachedId = opts.forceHunt
+    ? null
+    : ((await env.GITHUB_CACHE.get(cacheKey)) as string | null);
   if (cachedId) {
     const r = await write(`${base}/issues/comments/${cachedId}`, "PATCH");
     if (r.ok) return { action: "updated", commentUrl: r.commentUrl };

--- a/apps/api/src/routes/github-comment-route.test.ts
+++ b/apps/api/src/routes/github-comment-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { app } from "../index";
+import { attachmentsMarker } from "../github-comment-render";
 import { sha256Hex, type WorkspaceRecord } from "../workspace";
 import { FakeKv } from "../../test/fake-kv";
 import { FakeR2Bucket } from "../../test/fake-r2";
@@ -174,6 +175,90 @@ describe("POST /v1/:workspace/github/comment", () => {
         count: 1,
         commentUrl: "https://github.com/acme/web/pull/12#c5",
       });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("400s on a non-boolean resync", async () => {
+    const env = await seededEnv();
+    const res = await post(env, { repo: "acme/web", num: 12, kind: "pull", resync: "yes" });
+    expect(res.status).toBe(400);
+  });
+
+  it("resync:true hunts past the warm comment-id cache and collapses a duplicate (issue #480)", async () => {
+    const hash = await sha256Hex(TOKEN);
+    const record: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "b",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokens: [{ hash, createdAt: new Date().toISOString() }],
+    };
+    const registry = {
+      get: (async (key: string) =>
+        key === `ws:${WS}` ? record : null) as unknown as KVNamespace["get"],
+    };
+    const githubCache = new FakeKv();
+    githubCache.store.set("ghinst:acme/web", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    githubCache.store.set("ghlogin:user-1", { value: "octocat" });
+    // Warm cache pointing at the NEWER of the two marker comments — the state
+    // that used to leave the duplicate untouched for the id's whole lifetime.
+    githubCache.store.set("ghcomment:acme:acme/web#12", { value: "8" });
+    const bucket = new FakeR2Bucket();
+    await bucket.put("acme/gh/acme/web/pull/12/hero.png", new Uint8Array([0x89, 0x50]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+    const { db } = claimTestDb("user-1");
+    const env = {
+      REGISTRY: registry,
+      DB: db,
+      GITHUB_CACHE: githubCache,
+      UPLOADS_DEFAULT: bucket,
+      ...GITHUB_APP_CFG_ENV,
+    } as unknown as Env;
+
+    const marker = attachmentsMarker(WS);
+    const deleted: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string, init: RequestInit = {}) => {
+      const u = String(url);
+      if (u.includes("/collaborators/octocat/permission")) {
+        return new Response(JSON.stringify({ permission: "write" }), { status: 200 });
+      }
+      if (u.includes("/issues/12/comments")) {
+        return new Response(
+          JSON.stringify([
+            { id: 7, body: `${marker}\nfirst` },
+            { id: 8, body: `${marker}\nduplicate` },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (init.method === "DELETE") {
+        deleted.push(u);
+        return new Response(null, { status: 204 });
+      }
+      if (u.includes("/issues/comments/7") && init.method === "PATCH") {
+        return new Response(
+          JSON.stringify({ id: 7, html_url: "https://github.com/acme/web/pull/12#c7" }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await post(env, { repo: "acme/web", num: 12, kind: "pull", resync: true });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        posted: true,
+        action: "updated",
+        count: 1,
+        commentUrl: "https://github.com/acme/web/pull/12#c7",
+      });
+      expect(deleted).toEqual(["https://api.github.com/repos/acme/web/issues/comments/8"]);
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -27,6 +27,7 @@ function parseTarget(body: Record<string, unknown>): {
   repo: string;
   num: number;
   kind: GhTargetKind;
+  resync: boolean;
 } {
   const repo = typeof body.repo === "string" ? body.repo : "";
   const num = typeof body.num === "number" ? body.num : NaN;
@@ -37,7 +38,12 @@ function parseTarget(body: Record<string, unknown>): {
     throw new ValidationError("num must be a positive integer.");
   if (kind !== "pull" && kind !== "issues")
     throw new ValidationError('kind must be "pull" or "issues".');
-  return { repo, num, kind };
+  // Optional (older clients omit it): marks an explicit resync, which forces
+  // the marker hunt + duplicate dedupe instead of the cached-id fast path
+  // (issue #480).
+  if (body.resync !== undefined && typeof body.resync !== "boolean")
+    throw new ValidationError("resync must be a boolean.");
+  return { repo, num, kind, resync: body.resync === true };
 }
 
 export const githubComment = new Hono<WorkspaceVars>().post(
@@ -45,13 +51,14 @@ export const githubComment = new Hono<WorkspaceVars>().post(
   writeRateLimit,
   requireScope("files:read"),
   async (c) => {
-    const target = parseTarget(await jsonBody(c));
+    const { resync, ...target } = parseTarget(await jsonBody(c));
     const result = await postManagedComment(
       c.env,
       c.get("workspace"),
       c.get("workspaceName"),
       c.get("mintingUserId"),
       target,
+      { resync },
     );
     return c.json(result);
   },

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -829,7 +829,12 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         await requireWriteBudget();
         const target = ghTargetFromArgs(args);
         if (!target) usage("comment requires pr or issue");
-        return postManagedComment(env, workspace, workspaceName, ctx.mintingUserId, target);
+        // Explicit resync (issue #480): hunt for the marker instead of
+        // trusting the cached comment id, so a duplicate gets collapsed here
+        // rather than waiting on a cache miss.
+        return postManagedComment(env, workspace, workspaceName, ctx.mintingUserId, target, {
+          resync: true,
+        });
       },
     },
     {

--- a/apps/mcp/test/mcp-put-comment.test.ts
+++ b/apps/mcp/test/mcp-put-comment.test.ts
@@ -9,6 +9,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import app from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
+import { attachmentsMarker } from "@uploads/api/github-comment-render";
 import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
 
 const TOKEN = "up_test-ws_legacy-token-value";
@@ -682,15 +683,23 @@ describe("hosted comment tool (issue #392 stretch)", () => {
 
   it("rewrites an existing comment to the empty state once every attachment is gone", async () => {
     // No attachment seeded → the workspace has nothing under the PR prefix, so
-    // the gathered body is the neutral empty state (count 0). A cached comment
-    // id makes upsertBotComment PATCH the existing comment directly — the empty
-    // body rewrites it in place; it is never deleted, and no new one is created.
+    // the gathered body is the neutral empty state (count 0). The empty body
+    // rewrites the existing comment in place; it is never deleted, and no new
+    // one is created. The `comment` tool is an explicit resync, so it hunts for
+    // the marker rather than trusting the cached id (issue #480) — the cache is
+    // still seeded here to prove the hunt wins.
     const { env, githubCache } = await makeEnv({ boundTo: WS });
     githubCache.store.set("ghinst:acme/widgets", { value: "42" });
     githubCache.store.set("ghtok:42", { value: "cached-token" });
     githubCache.store.set("ghcomment:test-ws:acme/widgets#12", { value: "5" });
     let patchedBody: string | undefined;
     const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/12/comments") && init.method !== "POST") {
+        return new Response(
+          JSON.stringify([{ id: 5, body: `${attachmentsMarker(WS)}\nold body` }]),
+          { status: 200 },
+        );
+      }
       if (url.includes("/issues/comments/5") && init.method === "PATCH") {
         patchedBody = JSON.parse(String(init.body)).body as string;
         return new Response(

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -1092,10 +1092,18 @@ export function createUploadsClient(config: UploadsClientConfig) {
       return request<GalleryListResult>("GET", galleriesBase(config) + "/by-reference?" + params);
     },
 
+    /**
+     * Upsert the managed attachments comment. `resync: true` marks an
+     * explicit "make the comment state correct" call (`uploads comment`), so
+     * the server hunts for the marker — and collapses any duplicate — instead
+     * of patching its cached comment id (issue #480). Older servers ignore
+     * the field.
+     */
     async upsertGithubComment(opts: {
       repo: string;
       num: number;
       kind: "pull" | "issues";
+      resync?: boolean;
     }): Promise<GithubCommentResult> {
       return request<GithubCommentResult>(
         "POST",

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -667,11 +667,19 @@ export function commentViaSuffix(via: AttachmentsCommentResult["via"]): string {
  */
 export class GithubCommentAuthorizationError extends Error {}
 
+/**
+ * `opts.resync` marks an explicit `uploads comment` invocation rather than a
+ * background sync (attach, screenshot, put --comment). It costs the server one
+ * extra comment listing and in exchange collapses any duplicate managed
+ * comment (issue #480) — worth it on the rare, explicitly-asked-for resync,
+ * not on every attach.
+ */
 export async function syncAttachmentsComment(
   client: UploadsClient,
   target: GhTarget,
   run: CommandRunner,
   workspace?: string,
+  opts: { resync?: boolean } = {},
 ): Promise<AttachmentsCommentResult> {
   let bot: GithubCommentResult | undefined;
   try {
@@ -679,6 +687,7 @@ export async function syncAttachmentsComment(
       repo: target.repo,
       num: target.num,
       kind: target.kind,
+      ...(opts.resync ? { resync: true } : {}),
     });
   } catch {
     // Endpoint absent/unreachable (self-hosted, network, older worker) — fall
@@ -2809,6 +2818,7 @@ async function resyncCommentAfterMetaSet(
       repo: target.repo,
       num: target.num,
       kind: target.kind,
+      resync: true,
     });
     if (bot.posted) {
       if (!ctx.quiet && !ctx.json) {
@@ -2895,7 +2905,9 @@ export async function runComment(
   const target = ghTargetFromFlags(parsed.flags, run);
   if (!target) throw new UsageError("comment requires --pr or --issue");
 
-  const result = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace);
+  const result = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace, {
+    resync: true,
+  });
   if (ctx.json) {
     await writeJson({ ...target, ...result });
   } else if (!ctx.quiet) {

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -1290,7 +1290,10 @@ export function createUploadsMcpTools(opts: {
         const target = ghTargetFromArgs(args, run);
         if (!target) usage("comment requires pr or issue");
         const { config, client } = clientFor(args);
-        const result = await syncAttachmentsComment(client, target, run, config.workspace);
+        // Explicit resync, same as `uploads comment` (issue #480).
+        const result = await syncAttachmentsComment(client, target, run, config.workspace, {
+          resync: true,
+        });
         return { ...target, ...result };
       },
     },

--- a/packages/uploads/test/commands-meta.test.ts
+++ b/packages/uploads/test/commands-meta.test.ts
@@ -164,7 +164,7 @@ describe("runMeta set comment re-sync (issue #470)", () => {
       false,
     );
     expect(code).toBe(0);
-    expect(upsertCalls).toEqual([{ repo: "acme/web", num: 12, kind: "pull" }]);
+    expect(upsertCalls).toEqual([{ repo: "acme/web", num: 12, kind: "pull", resync: true }]);
   });
 
   it("re-syncs when a display-relevant key is deleted", async () => {
@@ -174,7 +174,7 @@ describe("runMeta set comment re-sync (issue #470)", () => {
       ["set", "gh/acme/web/issues/7/shot.png", "--delete", "state"],
       false,
     );
-    expect(upsertCalls).toEqual([{ repo: "acme/web", num: 7, kind: "issues" }]);
+    expect(upsertCalls).toEqual([{ repo: "acme/web", num: 7, kind: "issues", resync: true }]);
   });
 
   it("does not sync when the touched keys are not rendered in the comment", async () => {


### PR DESCRIPTION
Closes #480.

## The gap

PR #471 added self-healing dedupe (patch the oldest marker comment, delete the extras), but it only runs on the marker *hunt*. `upsertBotComment`'s fast path PATCHes the KV-cached comment id with no listing, so while the cache is warm — `COMMENT_ID_TTL` is 30 days, refreshed on every hunt — a race-created duplicate sits untouched. Verified live on #468: the duplicate only collapsed after forcing a cache miss.

## The fix

Add `forceHunt` to `upsertBotComment` (skip the cached-id read, always hunt) and plumb it through as `resync`:

- `postManagedComment(…, { resync })` — apps/api/src/github-comment-service.ts
- `POST /v1/:workspace/github/comment` accepts an optional `resync` boolean (older clients omit it; a non-boolean 400s)
- `client.upsertGithubComment({ …, resync })` and `syncAttachmentsComment(…, { resync })` in the CLI

Callers that opt in are the ones whose whole intent is "make the comment state correct", and which run rarely:

- `uploads comment`
- the stdio MCP `comment` tool and the hosted MCP `comment` tool
- the `meta set` comment refresh

Attach, screenshot, `put --comment`, and the webhook auto-promote path keep the cached-id fast path. The `issue_comment` reconcile path already forced a hunt (it deletes the cache key first), so it was already covered.

Net effect: a duplicate's lifetime is bounded by "the next `uploads comment`" instead of "the next cache miss".

## Tests

- `upsertBotComment`: `forceHunt` ignores a warm cached id pointing at the *newer* duplicate, patches the oldest, deletes the extra, and repoints the cache
- `upsertBotComment`: without `forceHunt`, the fast path still short-circuits (the listing stub throws if it's hit)
- Route: `resync: true` end-to-end over a warm cache collapses the duplicate; non-boolean `resync` 400s
- Updated the hosted-MCP empty-state test and the `meta set` resync assertions for the new call shape

Full suite green: 2901 passed. `pnpm typecheck` and `pnpm lint` clean.
## Also: impeccable broken-image waiver

PR #477's `broken-image` waiver was scoped to `**/packages/uploads/src/**` only, so the hosted MCP worker kept flagging the `<img width=…>` prose in its `put` tool-schema description. A repo-wide `--no-config` scan found 11 more latent findings queued to fire on unrelated edits:

| Area | Findings | What they are |
|---|---|---|
| `apps/api/src` | 7 | `github-comment-render.ts`, `before-after.ts`, `poster.ts`, `file-metadata.ts` — comment-markdown builders |
| `apps/web/src/lib` | 4 | `embed-formats.ts` snippet strings + label text; one is an XSS test fixture (`caption: "<img onerror=alert(1)>"`) |
| `apps/mcp/src` | 1 | the finding that started this |

Rather than keep patching per-directory, this waives the class the rule can't distinguish — code that *emits* markup as strings, plus test fixtures.

Deliberately **not** disabled globally: every genuine UI surface (`components/**`, `pages/**`, `packages/ui/**`) scans clean today, and the detector does parse `.astro` and does catch a real defect there. Verified both directions — those four areas report zero with the config, and a planted `<img src="">` in a component, a page, and a UI package is still reported.
