### PR TITLE
feat(cli): add `uploads update` to upgrade the CLI and refresh agent integrations

### DIFF
--- a/.changeset/uploads-update-command.md
+++ b/.changeset/uploads-update-command.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads update`. It upgrades the globally installed CLI, then re-runs
+`uploads install` so the agent skills and the MCP registration match the new
+version. When the CLI is already current it still refreshes them, because they
+drift on their own. The upgrade step detects npm, pnpm, and bun global
+installs, and refuses to overwrite a workspace checkout or an npx cache. The
+existing update hint and help banner now name `uploads update`.

--- a/apps/web/src/lib/cli-upgrade.test.ts
+++ b/apps/web/src/lib/cli-upgrade.test.ts
@@ -48,7 +48,7 @@ describe("resolveUpgradePrompt", () => {
     expect(resolveUpgradePrompt("0.26.0", "0.27.0")).toMatchObject({
       current: "0.26.0",
       latest: "0.27.0",
-      installCmd: "npm i -g @buildinternet/uploads",
+      installCmd: "uploads update",
     });
     expect(resolveUpgradePrompt("0.27.0", "0.27.0")).toBeNull();
     expect(resolveUpgradePrompt(null, "0.27.0")).toBeNull();

--- a/apps/web/src/lib/cli-upgrade.ts
+++ b/apps/web/src/lib/cli-upgrade.ts
@@ -5,6 +5,8 @@
 
 export const CLI_PACKAGE = "@buildinternet/uploads";
 export const CLI_INSTALL_CMD = `npm i -g ${CLI_PACKAGE}`;
+/** Shown to users who already have the CLI, so it can name the CLI's own verb. */
+export const CLI_UPDATE_CMD = "uploads update";
 /** Session-storage dismiss key prefix; full key includes the latest version. */
 export const CLI_UPGRADE_DISMISS_PREFIX = "uploads:cli-upgrade-dismissed:";
 
@@ -70,8 +72,8 @@ export function resolveUpgradePrompt(
   return {
     current: cur,
     latest: lat,
-    installCmd: CLI_INSTALL_CMD,
-    message: `You’re on CLI ${cur}; ${lat} is available. Update: ${CLI_INSTALL_CMD}`,
+    installCmd: CLI_UPDATE_CMD,
+    message: `You’re on CLI ${cur}; ${lat} is available. Update: ${CLI_UPDATE_CMD}`,
   };
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ and the exit codes, run `uploads help --all` or see
 uploads login          # sign in via browser; saves your workspace token, then runs doctor
 uploads whoami         # show the active workspace + token (alias: uploads status)
 uploads install        # install the agent skills + register the hosted MCP server
+uploads update         # update the CLI, then refresh the skills + MCP registration
 uploads put ./shot.png # stdout: public URL + ready-to-paste markdown; stderr: human summary
 ```
 
@@ -36,6 +37,17 @@ access. Routine agents never receive `ADMIN_TOKEN` and don't need it. See
 For local development, `pnpm workspace:add` prints a bearer token once. Save it
 with `uploads setup --token <token>`, or into `.env` or user config.
 
+Two things go stale independently: the npm package that provides the `uploads`
+binary, and the agent skills plus the MCP registration that `uploads install`
+writes. `uploads update` covers both. It upgrades the global package, then
+re-runs `install` against the new version. When the CLI is already current it
+still refreshes the skills and the MCP registration, because those drift on
+their own. Run `uploads update --dry-run` first to see the plan.
+
+The upgrade step needs a global install. Inside a checkout of this repository,
+or from an `npx` cache, `update` reports the newer version and prints the
+command to run by hand, rather than overwriting your build.
+
 ## Command overview
 
 | Command                 | What it does                                              |
@@ -49,6 +61,7 @@ with `uploads setup --token <token>`, or into `.env` or user config.
 | `delete <key>`          | Delete an object                                          |
 | `usage`                 | Workspace storage / upload counters                       |
 | `install`               | Install the agent skills + register the remote MCP server |
+| `update`                | Update the CLI, then refresh the skills and MCP           |
 | `login` / `logout`      | Sign in (browser or enrollment code) / clear saved token  |
 | `whoami` (`status`)     | Show the active workspace and token                       |
 | `invite`                | Invite a teammate to a workspace (workspace admin)        |

--- a/docs/superpowers/plans/2026-07-23-uploads-update-command.md
+++ b/docs/superpowers/plans/2026-07-23-uploads-update-command.md
@@ -662,7 +662,7 @@ Expected: PASS. If any pre-existing assertion in this file counts commands or sn
 
 - [ ] **Step 6: Verify the command runs end to end**
 
-Run: `pnpm --filter @buildinternet/uploads build && node packages/uploads/dist/cli.js update --dry-run`
+Run: `pnpm --filter @buildinternet/uploads build && node packages/uploads/bin/uploads.js update --dry-run`
 Expected: prints a version line, then `refresh: would run — uploads install`. It must not print a stack trace, and it must not run any command.
 
 - [ ] **Step 7: Run the full package suite**
@@ -858,6 +858,6 @@ git commit -m "docs: document uploads update and add a changeset"
 
 After Task 5, confirm the real behavior outside the test fakes:
 
-- [ ] `node packages/uploads/dist/cli.js update --dry-run` from inside this repository reports that the upgrade is skipped for a workspace checkout, and prints the manual command.
-- [ ] `node packages/uploads/dist/cli.js update --help` renders the help text without a stack trace.
-- [ ] `node packages/uploads/dist/cli.js --help` shows `update` in the essential command list, with the update banner still rendering correctly when a newer version exists.
+- [ ] `node packages/uploads/bin/uploads.js update --dry-run` from inside this repository reports that the upgrade is skipped for a workspace checkout, and prints the manual command.
+- [ ] `node packages/uploads/bin/uploads.js update --help` renders the help text without a stack trace.
+- [ ] `node packages/uploads/bin/uploads.js --help` shows `update` in the essential command list, with the update banner still rendering correctly when a newer version exists.

--- a/docs/superpowers/plans/2026-07-23-uploads-update-command.md
+++ b/docs/superpowers/plans/2026-07-23-uploads-update-command.md
@@ -1,0 +1,863 @@
+# `uploads update` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single `uploads update` command that upgrades the globally installed npm package and then refreshes the agent skills and MCP registration, so users stop having to know those are two separate things.
+
+**Architecture:** One pure function classifies where the running CLI was installed from. One command file orchestrates three steps — check the published version, upgrade the global package, re-run `install`. When an upgrade actually happened, the refresh runs the _new_ binary as a subprocess so the new version's skill list is the one that gets installed; otherwise it calls `runInstall` in process. Existing update notices are repointed at the new command.
+
+**Tech Stack:** TypeScript (ESM, NodeNext), vitest, oxfmt (auto-applied by the pre-commit hook), changesets.
+
+## Global Constraints
+
+- Package name is exactly `@buildinternet/uploads`. It is already exported as `PACKAGE_NAME` from `src/update-check.ts` — import it, never re-type the literal.
+- Every test runs from `packages/uploads`. Test command: `pnpm --filter @buildinternet/uploads test <file>`.
+- A changeset is required. Its header must contain only `"@buildinternet/uploads": minor` — a changeset naming any other package silently blocks all publishing.
+- No confirmation prompt, no `--yes` flag, and no `--format json` in this command. These were deliberately cut.
+- Prose in `docs/` follows the house style in `AGENTS.md` — active voice, one idea per sentence, one term per concept.
+- Do not modify anything under `plugins/` or `.claude-plugin/`. The plugin is out of scope (see issues #487 and #488).
+
+---
+
+### Task 1: Install source detection
+
+A pure function that classifies the path the CLI is running from. This is the safety-critical piece: without it, `pnpm uploads update` inside the monorepo would overwrite the developer's build with the published version.
+
+**Files:**
+
+- Create: `packages/uploads/src/install-source.ts`
+- Test: `packages/uploads/test/install-source.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `detectInstallSource(modulePath: string): InstallSource`, plus the exported types `InstallKind`, `PackageManager`, and `InstallSource`. Task 2 consumes all of these.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/uploads/test/install-source.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { detectInstallSource } from "../src/install-source.js";
+
+describe("detectInstallSource", () => {
+  it("classifies an npm global install", () => {
+    const source = detectInstallSource(
+      "/opt/homebrew/lib/node_modules/@buildinternet/uploads/dist/commands/update.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+    expect(source.upgradeCommand).toEqual([
+      "npm",
+      "install",
+      "-g",
+      "@buildinternet/uploads@latest",
+    ]);
+  });
+
+  it("classifies an nvm-managed npm global install", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.nvm/versions/node/v24.3.0/lib/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+  });
+
+  it("classifies a pnpm global install", () => {
+    const source = detectInstallSource(
+      "/Users/dev/Library/pnpm/global/5/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("pnpm");
+    expect(source.upgradeCommand).toEqual(["pnpm", "add", "-g", "@buildinternet/uploads@latest"]);
+  });
+
+  it("classifies a bun global install", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.bun/install/global/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("bun");
+    expect(source.upgradeCommand).toEqual(["bun", "add", "-g", "@buildinternet/uploads@latest"]);
+  });
+
+  it("classifies an npx cache entry", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.npm/_npx/a1b2c3/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("npx");
+  });
+
+  it("classifies a workspace checkout as workspace, not global", () => {
+    const source = detectInstallSource("/Users/dev/Code/uploads/packages/uploads/dist/cli.js");
+    expect(source.kind).toBe("workspace");
+  });
+
+  it("classifies a local project dependency as unknown", () => {
+    const source = detectInstallSource(
+      "/Users/dev/Code/app/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("unknown");
+  });
+
+  it("prefers the npx marker over the global marker", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.npm/_npx/a1b2c3/lib/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("npx");
+  });
+
+  it("falls back to npm for a non-global kind", () => {
+    const source = detectInstallSource("/Users/dev/Code/uploads/packages/uploads/dist/cli.js");
+    expect(source.manager).toBe("npm");
+  });
+
+  it("normalizes Windows separators", () => {
+    const source = detectInstallSource(
+      "C:\\Users\\dev\\AppData\\Roaming\\npm\\lib\\node_modules\\@buildinternet\\uploads\\dist\\cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @buildinternet/uploads test test/install-source.test.ts`
+Expected: FAIL — `Failed to resolve import "../src/install-source.js"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/uploads/src/install-source.ts`:
+
+```typescript
+/**
+ * Classify where the running CLI was installed from.
+ *
+ * `uploads update` upgrades the global npm package. That is only safe when the
+ * CLI actually came from a global install — upgrading a workspace checkout
+ * would overwrite a developer's build with the published version.
+ *
+ * Pure and path-only: no filesystem or process access, so it is fully testable.
+ */
+import { PACKAGE_NAME } from "./update-check.js";
+
+export type InstallKind = "global" | "workspace" | "npx" | "unknown";
+export type PackageManager = "npm" | "pnpm" | "bun";
+
+export interface InstallSource {
+  kind: InstallKind;
+  /** Falls back to npm for every non-global kind. */
+  manager: PackageManager;
+  /** Upgrades the global install. Only meaningful when kind is "global". */
+  upgradeCommand: string[];
+}
+
+const UPGRADE_COMMANDS: Record<PackageManager, string[]> = {
+  npm: ["npm", "install", "-g", `${PACKAGE_NAME}@latest`],
+  pnpm: ["pnpm", "add", "-g", `${PACKAGE_NAME}@latest`],
+  bun: ["bun", "add", "-g", `${PACKAGE_NAME}@latest`],
+};
+
+function classify(path: string): { kind: InstallKind; manager: PackageManager } {
+  // npx is checked first: a cache entry can also contain a global-looking marker.
+  if (path.includes("/_npx/")) return { kind: "npx", manager: "npm" };
+  if (path.includes("/.bun/install/global/")) return { kind: "global", manager: "bun" };
+  if (path.includes("/pnpm/global/")) return { kind: "global", manager: "pnpm" };
+  if (path.includes("/lib/node_modules/")) return { kind: "global", manager: "npm" };
+  // No node_modules segment at all means we are running out of a source checkout.
+  if (!path.includes("/node_modules/")) return { kind: "workspace", manager: "npm" };
+  return { kind: "unknown", manager: "npm" };
+}
+
+/**
+ * @param modulePath Absolute path of a file inside the installed package,
+ *   normally `realpathSync(fileURLToPath(import.meta.url))`.
+ */
+export function detectInstallSource(modulePath: string): InstallSource {
+  const normalized = modulePath.split("\\").join("/");
+  const { kind, manager } = classify(normalized);
+  return { kind, manager, upgradeCommand: UPGRADE_COMMANDS[manager] };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @buildinternet/uploads test test/install-source.test.ts`
+Expected: PASS — 10 tests.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter @buildinternet/uploads typecheck`
+Expected: no output, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/uploads/src/install-source.ts packages/uploads/test/install-source.test.ts
+git commit -m "feat(cli): classify the CLI's install source"
+```
+
+---
+
+### Task 2: The `update` command
+
+Orchestrates the version check, the upgrade, and the refresh. `runStep` and `StepResult` become exported from `install.ts` so this command reuses them instead of duplicating the runner-and-error shape.
+
+**Files:**
+
+- Create: `packages/uploads/src/commands/update.ts`
+- Modify: `packages/uploads/src/commands/install.ts` (export two existing symbols)
+- Test: `packages/uploads/test/commands-update.test.ts`
+
+**Interfaces:**
+
+- Consumes: `detectInstallSource`, `InstallSource` from Task 1. `runInstall`, `runStep`, `StepResult` from `install.ts`. `checkForUpdate`, `PACKAGE_NAME`, `UpdateStatus` from `update-check.ts`. `CommandRunner`, `execRunner` from `github-gh.ts`.
+- Produces: `runUpdate(args: string[], opts: RunUpdateOptions, help?: boolean): Promise<number>`. Task 3 calls this from `cli.ts`.
+
+- [ ] **Step 1: Export the step helpers from `install.ts`**
+
+In `packages/uploads/src/commands/install.ts`, add the `export` keyword to the existing `StepResult` interface and `runStep` function. Change these two lines only:
+
+```typescript
+export interface StepResult {
+```
+
+```typescript
+export function runStep(run: CommandRunner, command: string[]): StepResult {
+```
+
+Everything else in the file stays as it is.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/uploads/test/commands-update.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandRunner } from "../src/github-gh.js";
+import type { InstallSource } from "../src/install-source.js";
+import { runUpdate } from "../src/commands/update.js";
+
+const GLOBAL_SOURCE: InstallSource = {
+  kind: "global",
+  manager: "npm",
+  upgradeCommand: ["npm", "install", "-g", "@buildinternet/uploads@latest"],
+};
+
+const WORKSPACE_SOURCE: InstallSource = {
+  kind: "workspace",
+  manager: "npm",
+  upgradeCommand: ["npm", "install", "-g", "@buildinternet/uploads@latest"],
+};
+
+const GLOBALS = { apiUrl: "https://x.test", token: "up_acme_secret" };
+
+function fakeRunner(fail?: { onCommand: string; message: string }) {
+  const calls: string[][] = [];
+  const run: CommandRunner = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    if (fail && cmd === fail.onCommand) throw new Error(fail.message);
+    return "ok\n";
+  };
+  return { run, calls };
+}
+
+function captureStreams() {
+  const out: string[] = [];
+  const err: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    out.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    err.push(String(chunk));
+    return true;
+  });
+  return { out, err };
+}
+
+const outdated = async () => ({ current: "0.9.0", latest: "0.10.0", updateAvailable: true });
+const current = async () => ({ current: "0.10.0", latest: "0.10.0", updateAvailable: false });
+
+beforeEach(() => {
+  vi.stubEnv("BUILDINTERNET_CONFIG", "/nonexistent/uploads-update-test-config");
+  vi.stubEnv("UPLOADS_TOKEN", "");
+  vi.stubEnv("UPLOADS_WORKSPACE", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("uploads update", () => {
+  it("upgrades, then refreshes by spawning the new binary", async () => {
+    captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls[0]).toEqual(["npm", "install", "-g", "@buildinternet/uploads@latest"]);
+    expect(calls[1]).toEqual(["uploads", "install"]);
+  });
+
+  it("skips the upgrade when already current but still refreshes in process", async () => {
+    captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: current,
+    });
+    expect(code).toBe(0);
+    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+    // In-process runInstall reaches the same runner with the install steps.
+    expect(calls.some((c) => c[0] === "npx" && c.includes("skills"))).toBe(true);
+    expect(calls).not.toContainEqual(["uploads", "install"]);
+  });
+
+  it("reports the current version when nothing to upgrade", async () => {
+    const { out } = captureStreams();
+    const { run } = fakeRunner();
+    await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: current,
+    });
+    expect(out.join("")).toMatch(/CLI already at 0\.10\.0/);
+  });
+
+  it("refuses the upgrade outside a global install but still refreshes", async () => {
+    const { out } = captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: WORKSPACE_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+    expect(out.join("")).toMatch(/workspace checkout/);
+  });
+
+  it("aborts before the refresh when the upgrade fails", async () => {
+    const { err } = captureStreams();
+    const { run, calls } = fakeRunner({ onCommand: "npm", message: "boom" });
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(1);
+    expect(calls).toEqual([["npm", "install", "-g", "@buildinternet/uploads@latest"]]);
+    expect(err.join("")).toMatch(/npm install -g @buildinternet\/uploads@latest/);
+  });
+
+  it("explains a permissions failure", async () => {
+    const { err } = captureStreams();
+    const { run } = fakeRunner({ onCommand: "npm", message: "EACCES: permission denied" });
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(1);
+    expect(err.join("")).toMatch(/without sudo/);
+  });
+
+  it("--dry-run prints the plan and runs nothing", async () => {
+    const { out } = captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate(["--dry-run"], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls).toEqual([]);
+    expect(out.join("")).toMatch(/would run — npm install -g/);
+    expect(out.join("")).toMatch(/would run — uploads install/);
+  });
+
+  it("--skip-install upgrades only", async () => {
+    captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate(["--skip-install"], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls).toEqual([["npm", "install", "-g", "@buildinternet/uploads@latest"]]);
+  });
+
+  it("rejects an unknown positional", async () => {
+    captureStreams();
+    const { run } = fakeRunner();
+    await expect(
+      runUpdate(["bogus"], {
+        globals: GLOBALS,
+        runner: run,
+        source: GLOBAL_SOURCE,
+        check: current,
+      }),
+    ).rejects.toThrow(/takes no arguments/);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @buildinternet/uploads test test/commands-update.test.ts`
+Expected: FAIL — `Failed to resolve import "../src/commands/update.js"`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `packages/uploads/src/commands/update.ts`:
+
+```typescript
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { flagBool, parseCommandArgs, UsageError, type GlobalFlags } from "../cli-args.js";
+import { execRunner, type CommandRunner } from "../github-gh.js";
+import { writeCommandHelp } from "../cli-style.js";
+import { detectInstallSource, type InstallSource } from "../install-source.js";
+import { checkForUpdate, PACKAGE_NAME, type UpdateStatus } from "../update-check.js";
+import { runInstall, runStep } from "./install.js";
+
+const UPDATE_HELP = `uploads update — update the CLI and refresh agent integrations
+
+Upgrades the globally installed npm package, then re-runs \`uploads install\` so
+the agent skills and the MCP registration match the new version. Skills and the
+MCP registration drift on their own, so this refreshes them even when the CLI is
+already current.
+
+Usage:
+  uploads update [options]
+
+Options:
+  --dry-run        Print the plan without running anything
+  --skip-install   Upgrade the npm package only; leave skills and MCP alone
+  --verbose        Show the output of the underlying commands
+
+Examples:
+  uploads update
+  uploads update --dry-run
+  uploads update --skip-install
+`;
+
+/** Why an upgrade was skipped, phrased for the user. */
+const SKIP_REASON: Record<string, string> = {
+  workspace: "this is a workspace checkout, not a global install",
+  npx: "this ran from an npx cache, which is discarded after the run",
+  unknown: "this is a local project dependency, not a global install",
+};
+
+export interface RunUpdateOptions {
+  globals: GlobalFlags;
+  /** Injected in tests. */
+  runner?: CommandRunner;
+  /** Injected in tests; defaults to detection from this module's path. */
+  source?: InstallSource;
+  /** Injected in tests; defaults to a cache-bypassing registry check. */
+  check?: () => Promise<UpdateStatus>;
+}
+
+function thisModulePath(): string {
+  const path = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function isPermissionError(message: string): boolean {
+  return /EACCES|EPERM|permission denied/i.test(message);
+}
+
+export async function runUpdate(
+  args: string[],
+  opts: RunUpdateOptions,
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(UPDATE_HELP);
+    return 0;
+  }
+  if (parsed.positionals.length > 0) {
+    throw new UsageError(`update takes no arguments (got ${parsed.positionals[0]})`);
+  }
+
+  const dryRun = flagBool(parsed.flags, "--dry-run");
+  const verbose = flagBool(parsed.flags, "--verbose");
+  const skipInstall = flagBool(parsed.flags, "--skip-install");
+  const run = opts.runner ?? execRunner;
+  const source = opts.source ?? detectInstallSource(thisModulePath());
+  // ttlMs 0 bypasses the once-a-day cache: `update` must not trust yesterday's read.
+  const status = await (opts.check ?? (() => checkForUpdate({ ttlMs: 0 })))();
+
+  const willUpgrade = status.updateAvailable && source.kind === "global";
+  const refreshCommand = ["uploads", "install"];
+
+  // --- plan ---
+  if (willUpgrade) {
+    process.stdout.write(`CLI ${status.current} → ${status.latest}\n`);
+  } else if (status.updateAvailable) {
+    process.stdout.write(
+      `CLI ${status.current} is behind ${status.latest}, but the upgrade is skipped — ` +
+        `${SKIP_REASON[source.kind] ?? "the install source is not a global install"}.\n` +
+        `Upgrade by hand with: ${source.upgradeCommand.join(" ")}\n`,
+    );
+  } else {
+    process.stdout.write(`CLI already at ${status.current}\n`);
+  }
+
+  if (dryRun) {
+    if (willUpgrade) {
+      process.stdout.write(`upgrade: would run — ${source.upgradeCommand.join(" ")}\n`);
+    }
+    if (!skipInstall) {
+      process.stdout.write(`refresh: would run — ${refreshCommand.join(" ")}\n`);
+    }
+    return 0;
+  }
+
+  // --- upgrade ---
+  if (willUpgrade) {
+    process.stdout.write("Upgrading the CLI…\n");
+    const result = runStep(run, source.upgradeCommand);
+    if (!result.ok) {
+      const message = result.error ?? "";
+      process.stderr.write(`upgrade: failed — ${message}\n`);
+      if (isPermissionError(message)) {
+        process.stderr.write(
+          "The global install directory is not writable by your user. Fix the ownership " +
+            `of your npm prefix so global installs work without sudo, then re-run \`uploads update\`.\n`,
+        );
+      }
+      process.stderr.write(`Run it by hand: ${source.upgradeCommand.join(" ")}\n`);
+      return 1;
+    }
+    process.stdout.write("upgrade: ok\n");
+    if (verbose && result.output) process.stdout.write(`  ${result.output}\n`);
+  }
+
+  if (skipInstall) return 0;
+
+  // --- refresh ---
+  // After an upgrade the in-process code is the OLD version, so spawn the newly
+  // installed binary. Its skill list is the one that should be installed.
+  if (willUpgrade) {
+    process.stdout.write("Refreshing skills and MCP…\n");
+    const result = runStep(run, refreshCommand);
+    if (!result.ok) {
+      process.stderr.write(`refresh: failed — ${result.error ?? ""}\n`);
+      process.stderr.write("Run it by hand: uploads install\n");
+      return 1;
+    }
+    process.stdout.write(result.output ? `${result.output}\n` : "refresh: ok\n");
+    return 0;
+  }
+
+  // Nothing changed, so the in-process install code is already current.
+  return runInstall([], { globals: opts.globals, runner: run });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @buildinternet/uploads test test/commands-update.test.ts`
+Expected: PASS — 9 tests.
+
+- [ ] **Step 6: Confirm the install tests still pass**
+
+Run: `pnpm --filter @buildinternet/uploads test test/install.test.ts`
+Expected: PASS. The only change to `install.ts` was adding `export` to two declarations.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/uploads/src/commands/update.ts packages/uploads/src/commands/install.ts packages/uploads/test/commands-update.test.ts
+git commit -m "feat(cli): add the uploads update command"
+```
+
+---
+
+### Task 3: Wire the command into the CLI
+
+Registers `update` in the dispatch switch and the command catalog. Shell completion is generated from `ROOT_COMMANDS`, so the catalog entry covers it with no extra file.
+
+**Files:**
+
+- Modify: `packages/uploads/src/cli.ts:38` (import) and `packages/uploads/src/cli.ts:341` (dispatch)
+- Modify: `packages/uploads/src/cli-catalog.ts:198`
+
+**Interfaces:**
+
+- Consumes: `runUpdate` from Task 2.
+- Produces: a working `uploads update` binary path and a `update` entry in `ROOT_COMMANDS`.
+
+- [ ] **Step 1: Add the import**
+
+In `packages/uploads/src/cli.ts`, directly below the existing line 38 `import { runInstall } from "./commands/install.js";`, add:
+
+```typescript
+import { runUpdate } from "./commands/update.js";
+```
+
+- [ ] **Step 2: Add the dispatch case**
+
+In `packages/uploads/src/cli.ts`, directly below the existing `case "install":` block (lines 341-342), add:
+
+```typescript
+      case "update":
+        code = await runUpdate(cmdArgs, { globals: parsed.globals }, showHelp);
+        break;
+```
+
+Note the `install` case above it ends with `break;` — do not remove it.
+
+- [ ] **Step 3: Add the catalog entry**
+
+In `packages/uploads/src/cli-catalog.ts`, insert between the `install` entry and the `login` entry that follows it. The insertion point is the line `  },` that closes the `install` object (line 206), immediately before `  {` opening the `login` object (line 207). Add:
+
+```typescript
+  {
+    name: "update",
+    summary: "Update the CLI, then refresh the agent skills + MCP registration",
+    essential: true,
+  },
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Append to `packages/uploads/test/cli-completion.test.ts`. That file already imports `ROOT_COMMANDS` from `../src/cli-catalog.js` on line 4, so no import change is needed. Add this test inside the outermost `describe` block:
+
+```typescript
+it("includes the update command", () => {
+  expect(ROOT_COMMANDS.map((c) => c.name)).toContain("update");
+});
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `pnpm --filter @buildinternet/uploads test test/cli-completion.test.ts`
+Expected: PASS. If any pre-existing assertion in this file counts commands or snapshots the command list, update that expected value to include `update` — the command list legitimately grew.
+
+- [ ] **Step 6: Verify the command runs end to end**
+
+Run: `pnpm --filter @buildinternet/uploads build && node packages/uploads/dist/cli.js update --dry-run`
+Expected: prints a version line, then `refresh: would run — uploads install`. It must not print a stack trace, and it must not run any command.
+
+- [ ] **Step 7: Run the full package suite**
+
+Run: `pnpm --filter @buildinternet/uploads test`
+Expected: all tests pass. `cli-help` and `cli-style-help` tests may assert on the essential-command list; if one fails because `update` is now present, update that expectation.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/uploads/src/cli.ts packages/uploads/src/cli-catalog.ts packages/uploads/test/cli-completion.test.ts
+git commit -m "feat(cli): register the update command in dispatch and the catalog"
+```
+
+---
+
+### Task 4: Point the existing update notices at the new command
+
+Three places currently tell users to run `npm i -g`. Two of them are shown to people who demonstrably already have the CLI, so they should name the new command instead.
+
+**Files:**
+
+- Modify: `packages/uploads/src/update-check.ts:153`
+- Modify: `packages/uploads/src/cli-brand.ts:193`
+- Modify: `apps/web/src/lib/cli-upgrade.ts:74`
+- Test: `packages/uploads/test/update-check.test.ts`, `packages/uploads/test/cli-brand.test.ts`, `apps/web/src/lib/cli-upgrade.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks. The strings are independent.
+- Produces: nothing consumed later.
+
+- [ ] **Step 1: Update the stderr hint**
+
+In `packages/uploads/src/update-check.ts`, replace the `write(...)` call inside `maybeHintUpdate`:
+
+```typescript
+write(
+  `hint: ${PACKAGE_NAME}@${status.latest} is available (you have ${status.current}). Update: uploads update\n`,
+);
+```
+
+- [ ] **Step 2: Update the help banner**
+
+In `packages/uploads/src/cli-brand.ts`, replace the second line of the `formatUpdateBanner` box:
+
+```typescript
+return boxLines([`Update available  ${options.current} → ${options.latest}`, `uploads update`], {
+  color: options.color,
+  tone: BRAND.accent,
+});
+```
+
+- [ ] **Step 3: Update the account-page callout**
+
+In `apps/web/src/lib/cli-upgrade.ts`, add a command constant beside the existing `CLI_INSTALL_CMD` and use it in the message. `CLI_INSTALL_CMD` stays exported and unchanged, because fresh installs still need it.
+
+```typescript
+export const CLI_INSTALL_CMD = `npm i -g ${CLI_PACKAGE}`;
+/** Shown to users who already have the CLI, so it can name the CLI's own verb. */
+export const CLI_UPDATE_CMD = "uploads update";
+```
+
+Then in `resolveUpgradePrompt`, change the returned object:
+
+```typescript
+return {
+  current: cur,
+  latest: lat,
+  installCmd: CLI_UPDATE_CMD,
+  message: `You’re on CLI ${cur}; ${lat} is available. Update: ${CLI_UPDATE_CMD}`,
+};
+```
+
+- [ ] **Step 4: Update the three assertions**
+
+In `packages/uploads/test/cli-brand.test.ts`, replace the line asserting the npm command (around line 72):
+
+```typescript
+expect(text).toMatch(/uploads update/);
+```
+
+In `packages/uploads/test/update-check.test.ts`, replace line 65:
+
+```typescript
+expect(lines.join("")).toMatch(/Update: uploads update/);
+```
+
+In `apps/web/src/lib/cli-upgrade.test.ts`, change the expectation `installCmd: "npm i -g @buildinternet/uploads"` (around line 51) to:
+
+```typescript
+      installCmd: "uploads update",
+```
+
+- [ ] **Step 5: Run both suites**
+
+Run: `pnpm --filter @buildinternet/uploads test && pnpm --filter @uploads/web test`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/uploads/src/update-check.ts packages/uploads/src/cli-brand.ts packages/uploads/test/update-check.test.ts packages/uploads/test/cli-brand.test.ts apps/web/src/lib/cli-upgrade.ts apps/web/src/lib/cli-upgrade.test.ts
+git commit -m "feat(cli): point update notices at uploads update"
+```
+
+---
+
+### Task 5: Documentation and changeset
+
+**Files:**
+
+- Modify: `docs/cli.md` (the "Getting started" block and the "Command overview" table)
+- Create: `.changeset/uploads-update-command.md`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the command to the getting-started block**
+
+In `docs/cli.md`, inside the fenced `bash` block under `## Getting started`, add this line directly below the `uploads install` line:
+
+```bash
+uploads update         # update the CLI, then refresh the skills + MCP registration
+```
+
+- [ ] **Step 2: Add a paragraph explaining why the command exists**
+
+In `docs/cli.md`, add this paragraph directly above the `## Command overview` heading:
+
+```markdown
+Two things go stale independently: the npm package that provides the `uploads`
+binary, and the agent skills plus the MCP registration that `uploads install`
+writes. `uploads update` covers both. It upgrades the global package, then
+re-runs `install` against the new version. When the CLI is already current it
+still refreshes the skills and the MCP registration, because those drift on
+their own. Run `uploads update --dry-run` first to see the plan.
+
+The upgrade step needs a global install. Inside a checkout of this repository,
+or from an `npx` cache, `update` reports the newer version and prints the
+command to run by hand, rather than overwriting your build.
+```
+
+- [ ] **Step 3: Add the table row**
+
+In `docs/cli.md`, in the `## Command overview` table, add this row directly below the `install` row:
+
+```markdown
+| `update` | Update the CLI, then refresh the skills and MCP |
+```
+
+Column alignment does not need to be hand-perfected — the pre-commit hook runs oxfmt on markdown.
+
+- [ ] **Step 4: Write the changeset**
+
+Create `.changeset/uploads-update-command.md`:
+
+```markdown
+---
+"@buildinternet/uploads": minor
+---
+
+Add `uploads update`. It upgrades the globally installed CLI, then re-runs
+`uploads install` so the agent skills and the MCP registration match the new
+version. When the CLI is already current it still refreshes them, because they
+drift on their own. The upgrade step detects npm, pnpm, and bun global
+installs, and refuses to overwrite a workspace checkout or an npx cache. The
+existing update hint and help banner now name `uploads update`.
+```
+
+- [ ] **Step 5: Verify the changeset header**
+
+Run: `head -4 .changeset/uploads-update-command.md`
+Expected: the header names `"@buildinternet/uploads"` and nothing else. A changeset naming any other package blocks every npm publish.
+
+- [ ] **Step 6: Run the full repository suite**
+
+Run: `pnpm test`
+Expected: all projects pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/cli.md .changeset/uploads-update-command.md
+git commit -m "docs: document uploads update and add a changeset"
+```
+
+---
+
+## Manual verification
+
+After Task 5, confirm the real behavior outside the test fakes:
+
+- [ ] `node packages/uploads/dist/cli.js update --dry-run` from inside this repository reports that the upgrade is skipped for a workspace checkout, and prints the manual command.
+- [ ] `node packages/uploads/dist/cli.js update --help` renders the help text without a stack trace.
+- [ ] `node packages/uploads/dist/cli.js --help` shows `update` in the essential command list, with the update banner still rendering correctly when a newer version exists.

--- a/docs/superpowers/specs/2026-07-23-uploads-update-command-design.md
+++ b/docs/superpowers/specs/2026-07-23-uploads-update-command-design.md
@@ -41,7 +41,9 @@ uploads update [--dry-run] [--skip-install] [--verbose]
 
 The command runs three phases: upgrade the CLI, refresh the skills and MCP
 registration, then report the result. It sits beside `install` and `doctor` in
-the command catalog and is marked `essential`, so it appears in default help.
+the command catalog. It also appears in the short default help. Note that the
+catalog's `essential` flag does not drive that list — `ESSENTIAL_ORDER` in
+`cli-help.ts` does, so a command must be named there to show up.
 
 | Flag             | Effect                                                                                  |
 | ---------------- | --------------------------------------------------------------------------------------- |

--- a/docs/superpowers/specs/2026-07-23-uploads-update-command-design.md
+++ b/docs/superpowers/specs/2026-07-23-uploads-update-command-design.md
@@ -1,0 +1,155 @@
+# `uploads update` command — design
+
+Date: 2026-07-23
+
+## Problem
+
+A user who wanted the newest agent behavior — the pre-PR hooks and the
+branch-staged uploads that the GitHub App posts on PR open — did not know how
+to get it. Their first guess was `uploads update`, which does not exist. Their
+second guess was `npm update` plus `uploads install`, which is correct.
+
+The guess was close to right, so the gap is not that npm is hard. The gap is
+that two separate artifacts go stale, and nothing tells the user that:
+
+1. The npm package that provides the `uploads` binary.
+2. The agent skills and the MCP server registration, which `uploads install`
+   writes.
+
+`uploads update` earns its place as the one verb that covers both. It also
+makes the existing update notice actionable: the hint can name a command the
+user runs directly, instead of a package name they must remember.
+
+## Prior art
+
+Most npm-distributed CLIs do not self-update. `gh`, `wrangler`, `vercel`,
+`netlify`, `supabase`, `stripe`, and `firebase` print a notice and leave the
+upgrade to the package manager. That is what this CLI does today.
+
+Two precedents support adding the command anyway:
+
+- `claude update` is npm-distributed and self-updates. Claude Code is the
+  environment most of our users run in, so the verb is familiar to them.
+- `gh extension upgrade` exists because installed add-ons drift separately
+  from the binary. Our skills and MCP registration have the same problem.
+
+## Command surface
+
+```
+uploads update [--dry-run] [--skip-install] [--verbose]
+```
+
+The command runs three phases: upgrade the CLI, refresh the skills and MCP
+registration, then report the result. It sits beside `install` and `doctor` in
+the command catalog and is marked `essential`, so it appears in default help.
+
+| Flag             | Effect                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------- |
+| `--dry-run`      | Print the plan and exit without running anything.                                       |
+| `--skip-install` | Upgrade the npm package only; do not refresh skills or MCP.                             |
+| `--verbose`      | Show the output of the underlying commands. Errors only by default, matching `install`. |
+
+There is no `--format json`. Nothing consumes machine-readable output from an
+update command.
+
+There is no confirmation prompt and no `--yes` flag. `deno upgrade`,
+`bun upgrade`, `rustup update`, and `claude update` all run without asking.
+`--dry-run` covers the case where a user wants to see the plan first.
+
+## Flow
+
+1. **Detect the install source.** Resolve the real path of the running module
+   and classify it: a global install, an `npx` cache entry, or a workspace
+   checkout.
+2. **Check the version.** Call `checkForUpdate({ ttlMs: 0 })` from
+   `update-check.ts`. The zero TTL forces a fresh registry read, because
+   `update` must not trust the previous day's cache.
+3. **Print the plan.** Every command appears verbatim before anything runs.
+   `--dry-run` stops here.
+4. **Upgrade.** Run the detected package manager's global install. This step
+   is skipped when the CLI is already current, and when the install source is
+   not a global install.
+5. **Refresh.** Re-run the `install` command. When step 4 upgraded the
+   package, this spawns the newly installed binary rather than calling the
+   install code in process, so the new version's skill list is the one that
+   runs. When step 4 was skipped, nothing changed, so the install command runs
+   in process.
+6. **Summarize.** Report what ran and what was skipped.
+
+An already-current CLI is a first-class path, not an early exit. The command
+prints `CLI already at <version>` and still runs the refresh, because the
+skills and the MCP registration drift on their own.
+
+## Install source detection
+
+`detectInstallSource` is a pure function over a resolved path and the
+environment. It returns the install kind and, for global installs, the
+package manager and its upgrade command.
+
+The safety-critical output is the kind, not the manager. Without it,
+`pnpm uploads update` inside this monorepo would overwrite the developer's
+build with the published version. When the source is not a global install, the
+command skips the upgrade, explains why, and still offers the refresh.
+
+Manager detection covers npm, pnpm, and bun. Anything unrecognized falls back
+to npm. Yarn is out of scope, because current yarn versions do not install
+global binaries.
+
+## Error handling
+
+A failed upgrade aborts before the refresh and exits non-zero, printing the
+exact command to run by hand. A refresh that runs against a failed upgrade
+produces a confusing half-applied state, and re-running `uploads update` costs
+the user nothing.
+
+`EACCES` on a global install gets a dedicated message instead of a raw npm
+error dump. A missing `npx` or `claude` binary reuses the `ENOENT` handling
+that `install` already has.
+
+## Files
+
+| File                                          | Change                                                                                             |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `packages/uploads/src/install-source.ts`      | New. Pure `detectInstallSource`.                                                                   |
+| `packages/uploads/src/commands/update.ts`     | New. Orchestration, reusing `install.ts`'s `StepResult`, `runStep`, and `CommandRunner` injection. |
+| `packages/uploads/src/commands/install.ts`    | Export the step logic so `update` calls it instead of duplicating it.                              |
+| `packages/uploads/src/update-check.ts`        | Hint becomes `Update: uploads update`.                                                             |
+| `packages/uploads/src/cli-brand.ts`           | Update banner becomes `uploads update`.                                                            |
+| `packages/uploads/src/cli-catalog.ts`         | Register the command as essential.                                                                 |
+| `packages/uploads/src/commands.ts`            | Wire up the dispatch.                                                                              |
+| `packages/uploads/src/commands/completion.ts` | Add the command.                                                                                   |
+| `docs/cli.md`                                 | Document the command.                                                                              |
+| `apps/web/src/lib/cli-upgrade.ts`             | Account-page callout says `uploads update`.                                                        |
+
+## Testing
+
+The repo uses vitest with in-process fakes.
+
+- Table-driven tests for `detectInstallSource` across npm, pnpm, bun, npx, and
+  workspace paths.
+- Plan-construction tests for three cases: current, outdated, and non-global.
+- Injected-runner tests that assert the exact command sequence, including that
+  the refresh spawns the new binary only after an upgrade ran.
+
+## Out of scope
+
+**The Claude plugin.** The hooks ship only in
+`plugins/claude/uploads/hooks/hooks.json`, which reaches users through the
+plugin marketplace. Neither `npm update` nor `uploads install` installs them.
+`update` does not manage the plugin.
+
+**Website install copy.** The site keeps `npm install -g`, because a user with
+no binary cannot run `uploads update`. The account-page callout is the
+exception: those users demonstrably have the CLI.
+
+**The overlap warning.** The plugin and `uploads install` both provide the same
+two skills, and they register competing MCP servers — local against hosted.
+Detecting that is a health check, so it belongs in `uploads doctor`, not in
+`update`.
+
+## Follow-ups
+
+1. Document the plugin as the only source of the hooks. No page in `docs/`,
+   `README.md`, or the site mentions the plugin install path today.
+2. Decide whether the plugin or `uploads install` is the canonical install
+   path, and add the overlap check to `uploads doctor`.

--- a/packages/uploads/src/cli-brand.ts
+++ b/packages/uploads/src/cli-brand.ts
@@ -189,10 +189,10 @@ export function formatUpdateBanner(options: {
   latest: string;
   color?: boolean;
 }): string {
-  return boxLines(
-    [`Update available  ${options.current} → ${options.latest}`, `npm i -g @buildinternet/uploads`],
-    { color: options.color, tone: BRAND.accent },
-  );
+  return boxLines([`Update available  ${options.current} → ${options.latest}`, `uploads update`], {
+    color: options.color,
+    tone: BRAND.accent,
+  });
 }
 
 export function formatAuthBanner(options: { color?: boolean } = {}): string {

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -205,6 +205,11 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
     ],
   },
   {
+    name: "update",
+    summary: "Update the CLI, then refresh the agent skills + MCP registration",
+    essential: true,
+  },
+  {
     name: "login",
     summary: "Sign in via browser (or an enrollment code) and save credentials",
     essential: true,

--- a/packages/uploads/src/cli-help.ts
+++ b/packages/uploads/src/cli-help.ts
@@ -26,6 +26,7 @@ const ESSENTIAL_ORDER = [
   "delete",
   "doctor",
   "install",
+  "update",
 ] as const;
 
 /** Day-to-day commands shown on bare `uploads` / `uploads help`. */

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -36,6 +36,7 @@ import { runInvite } from "./commands/invite.js";
 import { runAdmin } from "./commands/admin-enrollment.js";
 import { runMcp } from "./commands/mcp.js";
 import { runInstall } from "./commands/install.js";
+import { runUpdate } from "./commands/update.js";
 import { runCompletion } from "./commands/completion.js";
 import { runLogout, runWhoami } from "./commands/session.js";
 import { runTelemetry } from "./commands/telemetry.js";
@@ -340,6 +341,9 @@ export async function runCli(argv: string[]): Promise<number> {
         break;
       case "install":
         code = await runInstall(cmdArgs, { globals: parsed.globals, json }, showHelp);
+        break;
+      case "update":
+        code = await runUpdate(cmdArgs, { globals: parsed.globals }, showHelp);
         break;
       case "completion":
       case "completions":

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -46,7 +46,7 @@ Examples:
   uploads install --dry-run
 `;
 
-interface StepResult {
+export interface StepResult {
   command: string[];
   ok: boolean;
   skipped?: "dry-run" | "sign-in";
@@ -63,7 +63,7 @@ function redactor(token: string | undefined): (text: string) => string {
   };
 }
 
-function runStep(run: CommandRunner, command: string[]): StepResult {
+export function runStep(run: CommandRunner, command: string[]): StepResult {
   try {
     const output = run(command[0], command.slice(1)).trim();
     return { command, ok: true, output: output || undefined };

--- a/packages/uploads/src/commands/update.ts
+++ b/packages/uploads/src/commands/update.ts
@@ -4,7 +4,7 @@ import { flagBool, parseCommandArgs, UsageError, type GlobalFlags } from "../cli
 import { execRunner, type CommandRunner } from "../github-gh.js";
 import { writeCommandHelp } from "../cli-style.js";
 import { detectInstallSource, type InstallSource } from "../install-source.js";
-import { checkForUpdate, PACKAGE_NAME, type UpdateStatus } from "../update-check.js";
+import { checkForUpdate, type UpdateStatus } from "../update-check.js";
 import { runInstall, runStep } from "./install.js";
 
 const UPDATE_HELP = `uploads update — update the CLI and refresh agent integrations

--- a/packages/uploads/src/commands/update.ts
+++ b/packages/uploads/src/commands/update.ts
@@ -1,0 +1,148 @@
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { flagBool, parseCommandArgs, UsageError, type GlobalFlags } from "../cli-args.js";
+import { execRunner, type CommandRunner } from "../github-gh.js";
+import { writeCommandHelp } from "../cli-style.js";
+import { detectInstallSource, type InstallSource } from "../install-source.js";
+import { checkForUpdate, PACKAGE_NAME, type UpdateStatus } from "../update-check.js";
+import { runInstall, runStep } from "./install.js";
+
+const UPDATE_HELP = `uploads update — update the CLI and refresh agent integrations
+
+Upgrades the globally installed npm package, then re-runs \`uploads install\` so
+the agent skills and the MCP registration match the new version. Skills and the
+MCP registration drift on their own, so this refreshes them even when the CLI is
+already current.
+
+Usage:
+  uploads update [options]
+
+Options:
+  --dry-run        Print the plan without running anything
+  --skip-install   Upgrade the npm package only; leave skills and MCP alone
+  --verbose        Show the output of the underlying commands
+
+Examples:
+  uploads update
+  uploads update --dry-run
+  uploads update --skip-install
+`;
+
+/** Why an upgrade was skipped, phrased for the user. */
+const SKIP_REASON: Record<string, string> = {
+  workspace: "this is a workspace checkout, not a global install",
+  npx: "this ran from an npx cache, which is discarded after the run",
+  unknown: "this is a local project dependency, not a global install",
+};
+
+export interface RunUpdateOptions {
+  globals: GlobalFlags;
+  /** Injected in tests. */
+  runner?: CommandRunner;
+  /** Injected in tests; defaults to detection from this module's path. */
+  source?: InstallSource;
+  /** Injected in tests; defaults to a cache-bypassing registry check. */
+  check?: () => Promise<UpdateStatus>;
+}
+
+function thisModulePath(): string {
+  const path = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function isPermissionError(message: string): boolean {
+  return /EACCES|EPERM|permission denied/i.test(message);
+}
+
+export async function runUpdate(
+  args: string[],
+  opts: RunUpdateOptions,
+  help = false,
+): Promise<number> {
+  const parsed = parseCommandArgs(args);
+  if (help || parsed.help) {
+    writeCommandHelp(UPDATE_HELP);
+    return 0;
+  }
+  if (parsed.positionals.length > 0) {
+    throw new UsageError(`update takes no arguments (got ${parsed.positionals[0]})`);
+  }
+
+  const dryRun = flagBool(parsed.flags, "--dry-run");
+  const verbose = flagBool(parsed.flags, "--verbose");
+  const skipInstall = flagBool(parsed.flags, "--skip-install");
+  const run = opts.runner ?? execRunner;
+  const source = opts.source ?? detectInstallSource(thisModulePath());
+  // ttlMs 0 bypasses the once-a-day cache: `update` must not trust yesterday's read.
+  const status = await (opts.check ?? (() => checkForUpdate({ ttlMs: 0 })))();
+
+  const willUpgrade = status.updateAvailable && source.kind === "global";
+  const refreshCommand = ["uploads", "install"];
+
+  // --- plan ---
+  if (willUpgrade) {
+    process.stdout.write(`CLI ${status.current} → ${status.latest}\n`);
+  } else if (status.updateAvailable) {
+    process.stdout.write(
+      `CLI ${status.current} is behind ${status.latest}, but the upgrade is skipped — ` +
+        `${SKIP_REASON[source.kind] ?? "the install source is not a global install"}.\n` +
+        `Upgrade by hand with: ${source.upgradeCommand.join(" ")}\n`,
+    );
+  } else {
+    process.stdout.write(`CLI already at ${status.current}\n`);
+  }
+
+  if (dryRun) {
+    if (willUpgrade) {
+      process.stdout.write(`upgrade: would run — ${source.upgradeCommand.join(" ")}\n`);
+    }
+    if (!skipInstall) {
+      process.stdout.write(`refresh: would run — ${refreshCommand.join(" ")}\n`);
+    }
+    return 0;
+  }
+
+  // --- upgrade ---
+  if (willUpgrade) {
+    process.stdout.write("Upgrading the CLI…\n");
+    const result = runStep(run, source.upgradeCommand);
+    if (!result.ok) {
+      const message = result.error ?? "";
+      process.stderr.write(`upgrade: failed — ${message}\n`);
+      if (isPermissionError(message)) {
+        process.stderr.write(
+          "The global install directory is not writable by your user. Fix the ownership " +
+            `of your npm prefix so global installs work without sudo, then re-run \`uploads update\`.\n`,
+        );
+      }
+      process.stderr.write(`Run it by hand: ${source.upgradeCommand.join(" ")}\n`);
+      return 1;
+    }
+    process.stdout.write("upgrade: ok\n");
+    if (verbose && result.output) process.stdout.write(`  ${result.output}\n`);
+  }
+
+  if (skipInstall) return 0;
+
+  // --- refresh ---
+  // After an upgrade the in-process code is the OLD version, so spawn the newly
+  // installed binary. Its skill list is the one that should be installed.
+  if (willUpgrade) {
+    process.stdout.write("Refreshing skills and MCP…\n");
+    const result = runStep(run, refreshCommand);
+    if (!result.ok) {
+      process.stderr.write(`refresh: failed — ${result.error ?? ""}\n`);
+      process.stderr.write("Run it by hand: uploads install\n");
+      return 1;
+    }
+    process.stdout.write(result.output ? `${result.output}\n` : "refresh: ok\n");
+    return 0;
+  }
+
+  // Nothing changed, so the in-process install code is already current.
+  return runInstall([], { globals: opts.globals, runner: run });
+}

--- a/packages/uploads/src/commands/update.ts
+++ b/packages/uploads/src/commands/update.ts
@@ -81,6 +81,9 @@ export async function runUpdate(
   const status = await (opts.check ?? (() => checkForUpdate({ ttlMs: 0 })))();
 
   const willUpgrade = status.updateAvailable && source.kind === "global";
+  // Resolved through PATH: in the normal single-install case this is the
+  // just-upgraded binary, but with multiple `uploads` binaries on PATH it
+  // could resolve to a different, stale one. Accepted risk, not a guarantee.
   const refreshCommand = ["uploads", "install"];
 
   // --- plan ---
@@ -144,5 +147,5 @@ export async function runUpdate(
   }
 
   // Nothing changed, so the in-process install code is already current.
-  return runInstall([], { globals: opts.globals, runner: run });
+  return runInstall(verbose ? ["--verbose"] : [], { globals: opts.globals, runner: run });
 }

--- a/packages/uploads/src/install-source.ts
+++ b/packages/uploads/src/install-source.ts
@@ -32,6 +32,8 @@ function classify(path: string): { kind: InstallKind; manager: PackageManager } 
   if (path.includes("/.bun/install/global/")) return { kind: "global", manager: "bun" };
   if (path.includes("/pnpm/global/")) return { kind: "global", manager: "pnpm" };
   if (path.includes("/lib/node_modules/")) return { kind: "global", manager: "npm" };
+  // Windows npm globals have no `lib` segment: `<prefix>\npm\node_modules\<pkg>`.
+  if (path.includes("/npm/node_modules/")) return { kind: "global", manager: "npm" };
   // No node_modules segment at all means we are running out of a source checkout.
   if (!path.includes("/node_modules/")) return { kind: "workspace", manager: "npm" };
   return { kind: "unknown", manager: "npm" };

--- a/packages/uploads/src/install-source.ts
+++ b/packages/uploads/src/install-source.ts
@@ -1,0 +1,48 @@
+/**
+ * Classify where the running CLI was installed from.
+ *
+ * `uploads update` upgrades the global npm package. That is only safe when the
+ * CLI actually came from a global install — upgrading a workspace checkout
+ * would overwrite a developer's build with the published version.
+ *
+ * Pure and path-only: no filesystem or process access, so it is fully testable.
+ */
+import { PACKAGE_NAME } from "./update-check.js";
+
+export type InstallKind = "global" | "workspace" | "npx" | "unknown";
+export type PackageManager = "npm" | "pnpm" | "bun";
+
+export interface InstallSource {
+  kind: InstallKind;
+  /** Falls back to npm for every non-global kind. */
+  manager: PackageManager;
+  /** Upgrades the global install. Only meaningful when kind is "global". */
+  upgradeCommand: string[];
+}
+
+const UPGRADE_COMMANDS: Record<PackageManager, string[]> = {
+  npm: ["npm", "install", "-g", `${PACKAGE_NAME}@latest`],
+  pnpm: ["pnpm", "add", "-g", `${PACKAGE_NAME}@latest`],
+  bun: ["bun", "add", "-g", `${PACKAGE_NAME}@latest`],
+};
+
+function classify(path: string): { kind: InstallKind; manager: PackageManager } {
+  // npx is checked first: a cache entry can also contain a global-looking marker.
+  if (path.includes("/_npx/")) return { kind: "npx", manager: "npm" };
+  if (path.includes("/.bun/install/global/")) return { kind: "global", manager: "bun" };
+  if (path.includes("/pnpm/global/")) return { kind: "global", manager: "pnpm" };
+  if (path.includes("/lib/node_modules/")) return { kind: "global", manager: "npm" };
+  // No node_modules segment at all means we are running out of a source checkout.
+  if (!path.includes("/node_modules/")) return { kind: "workspace", manager: "npm" };
+  return { kind: "unknown", manager: "npm" };
+}
+
+/**
+ * @param modulePath Absolute path of a file inside the installed package,
+ *   normally `realpathSync(fileURLToPath(import.meta.url))`.
+ */
+export function detectInstallSource(modulePath: string): InstallSource {
+  const normalized = modulePath.split("\\").join("/");
+  const { kind, manager } = classify(normalized);
+  return { kind, manager, upgradeCommand: UPGRADE_COMMANDS[manager] };
+}

--- a/packages/uploads/src/update-check.ts
+++ b/packages/uploads/src/update-check.ts
@@ -150,7 +150,7 @@ export async function maybeHintUpdate(opts: UpdateCheckOptions = {}): Promise<vo
     if (!status.updateAvailable || !status.latest) return;
     const write = opts.write ?? ((text: string) => process.stderr.write(text));
     write(
-      `hint: ${PACKAGE_NAME}@${status.latest} is available (you have ${status.current}). Update: npm i -g ${PACKAGE_NAME}\n`,
+      `hint: ${PACKAGE_NAME}@${status.latest} is available (you have ${status.current}). Update: uploads update\n`,
     );
   } catch {
     // Never surface update-check failures.

--- a/packages/uploads/test/cli-brand.test.ts
+++ b/packages/uploads/test/cli-brand.test.ts
@@ -69,7 +69,7 @@ describe("banners", () => {
     const text = formatUpdateBanner({ current: "0.9.0", latest: "0.10.0", color: false });
     expect(text).toMatch(/Update available/);
     expect(text).toMatch(/0\.9\.0 → 0\.10\.0/);
-    expect(text).toMatch(/npm i -g @buildinternet\/uploads/);
+    expect(text).toMatch(/uploads update/);
   });
 
   it("auth banner is two lines", () => {

--- a/packages/uploads/test/cli-completion.test.ts
+++ b/packages/uploads/test/cli-completion.test.ts
@@ -67,6 +67,10 @@ describe("generateCompletionScript", () => {
     // put/attach still get their own flags, without screenshot in that group.
     expect(fish).toMatch(/__fish_seen_subcommand_from put attach' -l name/);
   });
+
+  it("includes the update command", () => {
+    expect(ROOT_COMMANDS.map((c) => c.name)).toContain("update");
+  });
 });
 
 describe("runCompletion", () => {

--- a/packages/uploads/test/cli-help.test.ts
+++ b/packages/uploads/test/cli-help.test.ts
@@ -35,6 +35,12 @@ describe("formatRootHelp", () => {
     expect(text).not.toMatch(/BUILDINTERNET_CONFIG/);
   });
 
+  it("includes update in the short essentials list", () => {
+    const text = formatRootHelp({ color: false });
+    expect(text).toMatch(/Essentials:/);
+    expect(text).toMatch(/update/);
+  });
+
   it("shows the full command list with full: true", () => {
     const text = formatRootHelp({ full: true, color: false });
     expect(text).toMatch(/Commands:/);

--- a/packages/uploads/test/commands-update.test.ts
+++ b/packages/uploads/test/commands-update.test.ts
@@ -86,6 +86,22 @@ describe("uploads update", () => {
     expect(calls).not.toContainEqual(["uploads", "install"]);
   });
 
+  it("forwards --verbose to the in-process refresh when already current", async () => {
+    const { out } = captureStreams();
+    const { run } = fakeRunner();
+    const code = await runUpdate(["--verbose"], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: current,
+    });
+    expect(code).toBe(0);
+    // runInstall only prints per-step output when --verbose is forwarded; the
+    // fake runner's "ok" output surfacing here is the observable effect of
+    // --verbose reaching runInstall through the empty-args refresh call.
+    expect(out.join("")).toMatch(/^ {2}ok$/m);
+  });
+
   it("reports the current version when nothing to upgrade", async () => {
     const { out } = captureStreams();
     const { run } = fakeRunner();

--- a/packages/uploads/test/commands-update.test.ts
+++ b/packages/uploads/test/commands-update.test.ts
@@ -70,8 +70,8 @@ describe("uploads update", () => {
     expect(calls[1]).toEqual(["uploads", "install"]);
   });
 
-  it("skips the upgrade when already current but still refreshes in process", async () => {
-    captureStreams();
+  it("skips the upgrade when already current, reports the version, and refreshes in process", async () => {
+    const { out } = captureStreams();
     const { run, calls } = fakeRunner();
     const code = await runUpdate([], {
       globals: GLOBALS,
@@ -80,6 +80,7 @@ describe("uploads update", () => {
       check: current,
     });
     expect(code).toBe(0);
+    expect(out.join("")).toMatch(/CLI already at 0\.10\.0/);
     expect(calls.some((c) => c[0] === "npm")).toBe(false);
     // In-process runInstall reaches the same runner with the install steps.
     expect(calls.some((c) => c[0] === "npx" && c.includes("skills"))).toBe(true);
@@ -100,18 +101,6 @@ describe("uploads update", () => {
     // fake runner's "ok" output surfacing here is the observable effect of
     // --verbose reaching runInstall through the empty-args refresh call.
     expect(out.join("")).toMatch(/^ {2}ok$/m);
-  });
-
-  it("reports the current version when nothing to upgrade", async () => {
-    const { out } = captureStreams();
-    const { run } = fakeRunner();
-    await runUpdate([], {
-      globals: GLOBALS,
-      runner: run,
-      source: GLOBAL_SOURCE,
-      check: current,
-    });
-    expect(out.join("")).toMatch(/CLI already at 0\.10\.0/);
   });
 
   it("refuses the upgrade outside a global install but still refreshes", async () => {

--- a/packages/uploads/test/commands-update.test.ts
+++ b/packages/uploads/test/commands-update.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandRunner } from "../src/github-gh.js";
+import type { InstallSource } from "../src/install-source.js";
+import { runUpdate } from "../src/commands/update.js";
+
+const GLOBAL_SOURCE: InstallSource = {
+  kind: "global",
+  manager: "npm",
+  upgradeCommand: ["npm", "install", "-g", "@buildinternet/uploads@latest"],
+};
+
+const WORKSPACE_SOURCE: InstallSource = {
+  kind: "workspace",
+  manager: "npm",
+  upgradeCommand: ["npm", "install", "-g", "@buildinternet/uploads@latest"],
+};
+
+const GLOBALS = { apiUrl: "https://x.test", token: "up_acme_secret" };
+
+function fakeRunner(fail?: { onCommand: string; message: string }) {
+  const calls: string[][] = [];
+  const run: CommandRunner = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    if (fail && cmd === fail.onCommand) throw new Error(fail.message);
+    return "ok\n";
+  };
+  return { run, calls };
+}
+
+function captureStreams() {
+  const out: string[] = [];
+  const err: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    out.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    err.push(String(chunk));
+    return true;
+  });
+  return { out, err };
+}
+
+const outdated = async () => ({ current: "0.9.0", latest: "0.10.0", updateAvailable: true });
+const current = async () => ({ current: "0.10.0", latest: "0.10.0", updateAvailable: false });
+
+beforeEach(() => {
+  vi.stubEnv("BUILDINTERNET_CONFIG", "/nonexistent/uploads-update-test-config");
+  vi.stubEnv("UPLOADS_TOKEN", "");
+  vi.stubEnv("UPLOADS_WORKSPACE", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("uploads update", () => {
+  it("upgrades, then refreshes by spawning the new binary", async () => {
+    captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls[0]).toEqual(["npm", "install", "-g", "@buildinternet/uploads@latest"]);
+    expect(calls[1]).toEqual(["uploads", "install"]);
+  });
+
+  it("skips the upgrade when already current but still refreshes in process", async () => {
+    captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: current,
+    });
+    expect(code).toBe(0);
+    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+    // In-process runInstall reaches the same runner with the install steps.
+    expect(calls.some((c) => c[0] === "npx" && c.includes("skills"))).toBe(true);
+    expect(calls).not.toContainEqual(["uploads", "install"]);
+  });
+
+  it("reports the current version when nothing to upgrade", async () => {
+    const { out } = captureStreams();
+    const { run } = fakeRunner();
+    await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: current,
+    });
+    expect(out.join("")).toMatch(/CLI already at 0\.10\.0/);
+  });
+
+  it("refuses the upgrade outside a global install but still refreshes", async () => {
+    const { out } = captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: WORKSPACE_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+    expect(out.join("")).toMatch(/workspace checkout/);
+  });
+
+  it("aborts before the refresh when the upgrade fails", async () => {
+    const { err } = captureStreams();
+    const { run, calls } = fakeRunner({ onCommand: "npm", message: "boom" });
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(1);
+    expect(calls).toEqual([["npm", "install", "-g", "@buildinternet/uploads@latest"]]);
+    expect(err.join("")).toMatch(/npm install -g @buildinternet\/uploads@latest/);
+  });
+
+  it("explains a permissions failure", async () => {
+    const { err } = captureStreams();
+    const { run } = fakeRunner({ onCommand: "npm", message: "EACCES: permission denied" });
+    const code = await runUpdate([], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(1);
+    expect(err.join("")).toMatch(/without sudo/);
+  });
+
+  it("--dry-run prints the plan and runs nothing", async () => {
+    const { out } = captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate(["--dry-run"], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls).toEqual([]);
+    expect(out.join("")).toMatch(/would run — npm install -g/);
+    expect(out.join("")).toMatch(/would run — uploads install/);
+  });
+
+  it("--skip-install upgrades only", async () => {
+    captureStreams();
+    const { run, calls } = fakeRunner();
+    const code = await runUpdate(["--skip-install"], {
+      globals: GLOBALS,
+      runner: run,
+      source: GLOBAL_SOURCE,
+      check: outdated,
+    });
+    expect(code).toBe(0);
+    expect(calls).toEqual([["npm", "install", "-g", "@buildinternet/uploads@latest"]]);
+  });
+
+  it("rejects an unknown positional", async () => {
+    captureStreams();
+    const { run } = fakeRunner();
+    await expect(
+      runUpdate(["bogus"], {
+        globals: GLOBALS,
+        runner: run,
+        source: GLOBAL_SOURCE,
+        check: current,
+      }),
+    ).rejects.toThrow(/takes no arguments/);
+  });
+});

--- a/packages/uploads/test/install-source.test.ts
+++ b/packages/uploads/test/install-source.test.ts
@@ -75,7 +75,15 @@ describe("detectInstallSource", () => {
 
   it("normalizes Windows separators", () => {
     const source = detectInstallSource(
-      "C:\\Users\\dev\\AppData\\Roaming\\npm\\lib\\node_modules\\@buildinternet\\uploads\\dist\\cli.js",
+      "C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@buildinternet\\uploads\\dist\\cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+  });
+
+  it("classifies a Windows npm global install", () => {
+    const source = detectInstallSource(
+      "C:/Users/dev/AppData/Roaming/npm/node_modules/@buildinternet/uploads/dist/cli.js",
     );
     expect(source.kind).toBe("global");
     expect(source.manager).toBe("npm");

--- a/packages/uploads/test/install-source.test.ts
+++ b/packages/uploads/test/install-source.test.ts
@@ -73,17 +73,11 @@ describe("detectInstallSource", () => {
     expect(source.manager).toBe("npm");
   });
 
-  it("normalizes Windows separators", () => {
+  // Windows npm installs globally to <prefix>\node_modules with no `lib` segment,
+  // so this covers both the separator normalization and the Windows-only marker.
+  it("classifies a Windows npm global install, normalizing separators", () => {
     const source = detectInstallSource(
       "C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\@buildinternet\\uploads\\dist\\cli.js",
-    );
-    expect(source.kind).toBe("global");
-    expect(source.manager).toBe("npm");
-  });
-
-  it("classifies a Windows npm global install", () => {
-    const source = detectInstallSource(
-      "C:/Users/dev/AppData/Roaming/npm/node_modules/@buildinternet/uploads/dist/cli.js",
     );
     expect(source.kind).toBe("global");
     expect(source.manager).toBe("npm");

--- a/packages/uploads/test/install-source.test.ts
+++ b/packages/uploads/test/install-source.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { detectInstallSource } from "../src/install-source.js";
+
+describe("detectInstallSource", () => {
+  it("classifies an npm global install", () => {
+    const source = detectInstallSource(
+      "/opt/homebrew/lib/node_modules/@buildinternet/uploads/dist/commands/update.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+    expect(source.upgradeCommand).toEqual([
+      "npm",
+      "install",
+      "-g",
+      "@buildinternet/uploads@latest",
+    ]);
+  });
+
+  it("classifies an nvm-managed npm global install", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.nvm/versions/node/v24.3.0/lib/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+  });
+
+  it("classifies a pnpm global install", () => {
+    const source = detectInstallSource(
+      "/Users/dev/Library/pnpm/global/5/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("pnpm");
+    expect(source.upgradeCommand).toEqual(["pnpm", "add", "-g", "@buildinternet/uploads@latest"]);
+  });
+
+  it("classifies a bun global install", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.bun/install/global/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("bun");
+    expect(source.upgradeCommand).toEqual(["bun", "add", "-g", "@buildinternet/uploads@latest"]);
+  });
+
+  it("classifies an npx cache entry", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.npm/_npx/a1b2c3/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("npx");
+  });
+
+  it("classifies a workspace checkout as workspace, not global", () => {
+    const source = detectInstallSource("/Users/dev/Code/uploads/packages/uploads/dist/cli.js");
+    expect(source.kind).toBe("workspace");
+  });
+
+  it("classifies a local project dependency as unknown", () => {
+    const source = detectInstallSource(
+      "/Users/dev/Code/app/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("unknown");
+  });
+
+  it("prefers the npx marker over the global marker", () => {
+    const source = detectInstallSource(
+      "/Users/dev/.npm/_npx/a1b2c3/lib/node_modules/@buildinternet/uploads/dist/cli.js",
+    );
+    expect(source.kind).toBe("npx");
+  });
+
+  it("falls back to npm for a non-global kind", () => {
+    const source = detectInstallSource("/Users/dev/Code/uploads/packages/uploads/dist/cli.js");
+    expect(source.manager).toBe("npm");
+  });
+
+  it("normalizes Windows separators", () => {
+    const source = detectInstallSource(
+      "C:\\Users\\dev\\AppData\\Roaming\\npm\\lib\\node_modules\\@buildinternet\\uploads\\dist\\cli.js",
+    );
+    expect(source.kind).toBe("global");
+    expect(source.manager).toBe("npm");
+  });
+});

--- a/packages/uploads/test/update-check.test.ts
+++ b/packages/uploads/test/update-check.test.ts
@@ -62,7 +62,7 @@ describe("maybeHintUpdate", () => {
     expect(lines.join("")).toMatch(
       /@buildinternet\/uploads@0\.6\.0 is available \(you have 0\.5\.0\)/,
     );
-    expect(lines.join("")).toMatch(/npm i -g @buildinternet\/uploads/);
+    expect(lines.join("")).toMatch(/Update: uploads update/);
     expect(readUpdateCache(path)?.latest).toBe("0.6.0");
   });
 


### PR DESCRIPTION
Adds `uploads update`: one verb that upgrades the CLI and then refreshes the agent skills and MCP registration.

## Why

A user who wanted the newest agent behavior could not work out how to get it. Their first guess was `uploads update`, which did not exist. Their second guess — `npm update` plus `uploads install` — was right.

The guess was close, so the gap is not that npm is hard. The gap is that two artifacts go stale independently, and nothing said so:

1. The npm package that provides the `uploads` binary.
2. The agent skills and the MCP registration that `uploads install` writes.

`uploads update` covers both. It also makes the existing update notice actionable: the hint now names a command you run, instead of a package name you have to remember.

## What it does

```
uploads update [--dry-run] [--skip-install] [--verbose]
```

- Detects where the running CLI was installed from: npm, pnpm, or bun global; an `npx` cache; or a workspace checkout.
- Checks the published version with the once-a-day cache bypassed.
- Upgrades the global package — but only from a global install. Inside this repo or from an `npx` cache it reports the newer version and prints the manual command, rather than overwriting your build.
- Refreshes the skills and MCP registration. After a real upgrade it spawns the newly installed binary, because the in-process code is still the old version.
- When the CLI is already current it still refreshes, because skills and MCP drift on their own.
- A failed upgrade aborts before the refresh and exits non-zero.

```
$ uploads update --dry-run
CLI already at 0.27.0
refresh: would run — uploads install
```

The three existing "new version available" notices now name `uploads update`: the stderr hint, the help banner, and the account-page callout. The website's *install* copy deliberately still says `npm i -g @buildinternet/uploads`, because someone with no binary cannot run `uploads update`.

`update` also appears in the short `uploads --help` list, directly after `install`:

```
  install               Install the agent skills + register the remote MCP server
  update                Update the CLI, then refresh the agent skills + MCP registration
```

## Deliberately not included

- **No confirmation prompt and no `--yes`.** `deno upgrade`, `bun upgrade`, `rustup update`, and `claude update` all run without asking. `--dry-run` covers inspection.
- **No `--format json`.** Nothing consumes machine-readable output from an update command.
- **No plugin management.** See below.

## Known gap this does not close

The pre-PR reminder hooks ship only through the Claude plugin. Neither `npm update` nor `uploads install` installs them, and no page in `docs/`, `README.md`, or the site mentions the plugin install path. So the user who prompted this change still could not have found the hooks.

That is filed separately, along with the overlap between the plugin and `uploads install` (duplicate skills, competing local vs hosted MCP servers):

- #487 — hooks ship only via the Claude plugin, and no doc mentions it
- #488 — decide whether the plugin or `uploads install` is the canonical install path

## Notes for review

- `detectInstallSource` is pure and path-only, so it is fully unit-tested. The safety-critical output is global-vs-not-global: without it, `pnpm uploads update` in this repo would overwrite the developer's build.
- Windows npm globals live at `<prefix>\node_modules` with no `lib` segment, so they need their own marker. Non-default Windows prefixes (nvm-windows, Volta) still classify as `unknown` — that degrades safely, refusing to upgrade and printing the manual command.
- The post-upgrade refresh resolves `uploads` through `PATH`. With several `uploads` binaries on `PATH` that could be a different one; noted in a comment as an accepted risk.
- `runInstall` was already exported and already accepted an injected runner, so `update` reuses it. The only change to `install.ts` is adding `export` to `runStep` and `StepResult`.

Design and plan are on the branch under `docs/superpowers/`.

Full repository suite green: 227 files, 2920 tests.
