### PR TITLE
feat(web): surface the GitHub App across footer, agent prompt, rail, and docs

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,19 +1,19 @@
 {
   "detector": {
-    "ignoreRules": [],
+    "ignoreRules": ["single-font", "flat-type-hierarchy"],
     "ignoreFiles": [],
     "ignoreValues": [
       {
         "rule": "overused-font",
         "value": "geist",
-        "createdAt": "2026-07-13T15:21:39.964Z",
-        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist retained deliberately for prose/headings"
+        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist retained deliberately for prose/headings",
+        "createdAt": "2026-07-13T15:21:39.964Z"
       },
       {
         "rule": "overused-font",
         "value": "geist mono",
-        "createdAt": "2026-07-13T15:21:39.994Z",
-        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist Mono is the brand's base face for a CLI-first product"
+        "reason": "Zach confirmed mono-first terminal-native identity 2026-07-13; Geist Mono is the brand's base face for a CLI-first product",
+        "createdAt": "2026-07-13T15:21:39.994Z"
       },
       {
         "rule": "broken-image",
@@ -26,8 +26,8 @@
           "**/*.test.ts",
           "**/*.test.tsx"
         ],
-        "createdAt": "2026-07-23T18:05:43.111Z",
-        "reason": "Waives broken-image for code that EMITS markup as strings rather than rendering it, plus test fixtures — the class this rule cannot distinguish. Covers the CLI/stdio MCP (packages/uploads/src), the hosted MCP worker and the API worker (headless JSON-RPC, no rendered surface; their <img> occurrences are GitHub-comment markdown builders and tool-schema prose), apps/web/src/lib (embed-snippet builders and UI label text, not components), and *.test.ts(x) (notably an XSS fixture, `caption: \"<img onerror=alert(1)>\"`, that must stay malformed). Scoped deliberately rather than disabled globally: the rule stays live on apps/web/src/components/**, apps/web/src/pages/**, and packages/ui/**, which all scan clean today and where a real `<img src=\"\">` would ship a broken box — verified 2026-07-23 that the detector parses .astro and catches that defect."
+        "reason": "Waives broken-image for code that EMITS markup as strings rather than rendering it, plus test fixtures — the class this rule cannot distinguish. Covers the CLI/stdio MCP (packages/uploads/src), the hosted MCP worker and the API worker (headless JSON-RPC, no rendered surface; their <img> occurrences are GitHub-comment markdown builders and tool-schema prose), apps/web/src/lib (embed-snippet builders and UI label text, not components), and *.test.ts(x) (notably an XSS fixture, `caption: \"<img onerror=alert(1)>\"`, that must stay malformed). Scoped deliberately rather than disabled globally: the rule stays live on apps/web/src/components/**, apps/web/src/pages/**, and packages/ui/**, which all scan clean today and where a real `<img src=\"\">` would ship a broken box — verified 2026-07-23 that the detector parses .astro and catches that defect.",
+        "createdAt": "2026-07-23T18:05:43.111Z"
       }
     ]
   }

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -9,7 +9,7 @@ Access requires a workspace — create your own with a linked GitHub account, or
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file, capture a screenshot
-- [Docs: GitHub App](https://uploads.sh/docs/github-app): optional install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
+- [Docs: GitHub App](https://uploads.sh/docs/github-app): recommended install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Docs: plans & limits](https://uploads.sh/docs/limits): storage/file-size/member caps per plan, behavior at each cap, and the GitHub attachment-cap comparison

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -37,6 +37,7 @@ const COLUMNS: FooterColumn[] = [
     title: "Product",
     links: [
       { label: "Docs", href: "/docs" },
+      { label: "GitHub App", href: "/docs/github-app" },
       { label: "Agent guide", href: "/github-screenshots" },
       { label: "Sign in", href: "/login" },
     ],
@@ -44,7 +45,10 @@ const COLUMNS: FooterColumn[] = [
   {
     title: "Project",
     links: [
-      { label: "GitHub", href: REPO },
+      // "Source", not "GitHub" — it sits a column away from "GitHub App" and
+      // the two read as the same destination otherwise. Matches the compact
+      // variant below, which already says "source".
+      { label: "Source", href: REPO },
       { label: "Status", href: STATUS_URL },
       { label: "Terms", href: "/terms" },
       { label: "Privacy", href: "/privacy" },

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -4,6 +4,7 @@
  * Section links live in the sidebar switcher; tab routes only wrap content.
  * Rail data is filled by `initWorkspaceRail` (connected work / usage / details).
  */
+import { GITHUB_APP_INSTALL_URL } from "../lib/github-app";
 import AccountLayout from "./AccountLayout.astro";
 
 interface Props {
@@ -50,6 +51,17 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
           <span class="ws-rail__rule"></span>
         </div>
         <div class="ws-rail__actions">
+          {/* Shown unconditionally — there is no session-authed way to tell
+              whether this workspace already has the App (the health endpoint is
+              workspace-token auth). Kept deliberately light for that reason. */}
+          <a
+            class="ws-rail__cta"
+            href={GITHUB_APP_INSTALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            install github app<span class="ws-rail__cta-go" aria-hidden="true">→</span>
+          </a>
           <a class="ws-rail__invite" href={invitePath}>invite teammate</a>
         </div>
       </section>
@@ -157,7 +169,35 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
   /* Quick actions — server-rendered, static. */
   .ws-rail__actions {
     display: grid;
-    gap: 8px;
+    gap: 10px;
+    justify-items: start;
+  }
+  /* Carries more weight than the plain invite link below it, but stays a rail
+     item rather than a banner — it also shows to workspaces that already
+     installed the App. */
+  .ws-rail__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    color: var(--fg);
+    text-decoration: none;
+    font-size: 12px;
+  }
+  .ws-rail__cta:hover,
+  .ws-rail__cta:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent);
+    outline: none;
+  }
+  .ws-rail__cta-go {
+    color: var(--muted);
+  }
+  .ws-rail__cta:hover .ws-rail__cta-go,
+  .ws-rail__cta:focus-visible .ws-rail__cta-go {
+    color: var(--accent);
   }
   .ws-rail__invite {
     color: var(--muted);

--- a/apps/web/src/lib/github-app.ts
+++ b/apps/web/src/lib/github-app.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonical uploads-sh GitHub App URLs.
+ *
+ * Two of them, because the links mean different things:
+ * - `GITHUB_APP_INSTALL_URL` lands on GitHub's repository picker. Use it
+ *   wherever the label is an imperative ("install …").
+ * - `GITHUB_APP_URL` is the App's public page, which carries the pitch. Use it
+ *   where the link means "learn what this is".
+ *
+ * The footer deliberately uses neither — it links to `/docs/github-app`, which
+ * teaches first and is also the App's configured Setup URL.
+ */
+export const GITHUB_APP_URL = "https://github.com/apps/uploads-sh";
+export const GITHUB_APP_INSTALL_URL = `${GITHUB_APP_URL}/installations/new`;

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -98,7 +98,10 @@ it opens (or run: uploads attach --promote once it exists)</pre>
       </a>
       <a class="card" href="/docs/github-app">
         <h3>GitHub App <span class="go">→</span></h3>
-        <p>Optional install: comments post as uploads-sh[bot] and private-repo titles show up.</p>
+        <p>
+          Recommended. Comments post as the uploads-sh bot and staged screenshots promote
+          themselves when the PR opens.
+        </p>
       </a>
       <a class="card" href="/docs/agents">
         <h3>Set up your agent <span class="go">→</span></h3>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -56,7 +56,8 @@ const TOC = [
       </div>
       <div class="bubble">
         <div class="head">
-          <span class="user">uploads-sh[bot]</span>
+          {/* Name only — the `bot` chip beside it is what GitHub renders. */}
+          <span class="user">uploads-sh</span>
           <span class="bot-chip">bot</span>
           <span>commented just now</span>
           <span class="badge">managed by uploads</span>

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -3,8 +3,7 @@
 // top of the CLI (bot comments, private-repo titles, live title updates), and
 // the post-install landing page (the App's Setup URL points here).
 import DocsLayout from "../../layouts/DocsLayout.astro";
-
-const APP_URL = "https://github.com/apps/uploads-sh";
+import { GITHUB_APP_INSTALL_URL, GITHUB_APP_URL } from "../../lib/github-app";
 
 const TOC = [
   { id: "what-it-adds", label: "What it adds" },
@@ -22,7 +21,7 @@ const TOC = [
   description="Install the uploads-sh GitHub App so attachment comments post as the bot, private-repo PR and issue titles show on file pages, and titles stay current."
   path="/docs/github-app"
   heading="GitHub App"
-  tagline="Optional, but nicer: bot-posted comments and live PR/issue titles."
+  tagline="The recommended setup: bot-posted comments and live PR/issue titles."
   active="github-app"
   toc={TOC}
 >
@@ -35,17 +34,17 @@ const TOC = [
   </aside>
 
   <aside class="callout">
-    <strong>Landed here from a <code>uploads-sh[bot]</code> comment?</strong> That's an
+    <strong>Landed here from an <code>uploads-sh</code> bot comment?</strong> That's an
     auto-updating list of files uploaded for the PR or issue. Anyone with repo access can add
     to it with the <a href="/docs/attach-pull-request-images">uploads CLI</a>. This page
-    covers the optional GitHub App that posts it.
+    covers the GitHub App that posts it.
   </aside>
 
   <section class="lead" id="what-it-adds">
     <h2>What it adds <a class="anchor" href="#what-it-adds" aria-label="Link to this section">#</a></h2>
     <p>
-      Everything in these docs works without the App. Installing&#32;
-      <a href={APP_URL}>the App</a> upgrades four things:
+      Installing <a href={GITHUB_APP_URL}>the App</a> is the recommended setup — it's what
+      makes the staged loop hands-off. Four things change:
     </p>
     <ul>
       <li>
@@ -66,12 +65,16 @@ const TOC = [
         See <a href="#staging">Staging before a PR exists</a>.
       </li>
     </ul>
+    <p>
+      Everything in these docs still works without it — see&#32;
+      <a href="#without-it">Without the App</a>.
+    </p>
   </section>
 
   <section id="install">
     <h2>Install it <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
     <p>
-      Install from <a href={APP_URL}>github.com/apps/uploads-sh</a> and pick the repositories
+      <a href={GITHUB_APP_INSTALL_URL}>Install the App on GitHub</a> and pick the repositories
       you attach files to (add more later in GitHub's settings). That's the whole setup — the
       next <code>uploads attach</code> against an installed repo posts as the bot:
     </p>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -6,6 +6,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Footer from "../components/Footer.astro";
 import GitHubMark from "../components/GitHubMark.astro";
 import SiteHeader from "../components/SiteHeader.astro";
+import { GITHUB_APP_URL } from "../lib/github-app";
 import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
 const pageTitle = "uploads.sh — the missing upload command for coding agents";
@@ -32,6 +33,8 @@ Then get the staged loop working end to end:
 - Open the PR (gh pr create or the GitHub UI) and the staged files promote automatically — the single attachments comment appears with no extra upload command at PR time.
 - Already have an open PR or issue to target directly instead? uploads attach <files> does that immediately.
 - Tag uploads with --meta key=value (e.g. --meta path=/settings) so we can find them again later with uploads find.
+
+Last: tell me to install the GitHub App at ${GITHUB_APP_URL} — you can't, it needs my browser and repo-owner permission. With it, comments post as the \`uploads-sh\` bot and staged screenshots promote themselves when the PR opens.
 
 Finally, update AGENTS.md (or CLAUDE.md) so that whenever UI changes, screenshots get captured at each milestone as you work going forward.
 
@@ -550,7 +553,9 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         </div>
         <div class="bubble">
           <div class="head">
-            <span class="user">uploads-sh[bot]</span>
+            {/* Name only — the `bot` chip beside it is what GitHub renders, so
+                spelling it "uploads-sh[bot]" here would double-label. */}
+            <span class="user">uploads-sh</span>
             <span class="bot-chip">bot</span>
             <span>commented just now</span>
             <span class="badge">managed by uploads.sh</span>

--- a/docs/superpowers/specs/2026-07-23-github-app-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-23-github-app-discoverability-design.md
@@ -1,0 +1,162 @@
+# GitHub App discoverability — design
+
+**Date:** 2026-07-23
+**Status:** approved, ready to plan
+
+## Problem
+
+The `uploads-sh` GitHub App is the recommended way to run uploads.sh — with it, the
+attachments comment posts as the bot rather than under a contributor's own GitHub
+account, and screenshots staged on a branch promote themselves the moment the PR
+opens with no CLI call. Today nothing surfaces it. It has one docs page
+(`/docs/github-app`), reachable only from the docs hub, where it is explicitly
+framed as **optional**. The footer, the homepage agent prompt, and the workspace
+rail never mention it.
+
+## Scope
+
+Copy, markup, and one new constant module. No new API, no logic changes, no
+schema changes.
+
+## 1. Shared URL constant
+
+New `apps/web/src/lib/github-app.ts`:
+
+```ts
+export const GITHUB_APP_URL = "https://github.com/apps/uploads-sh";
+export const GITHUB_APP_INSTALL_URL = `${GITHUB_APP_URL}/installations/new`;
+```
+
+Two URLs because the links mean two different things:
+
+- `GITHUB_APP_INSTALL_URL` (`/installations/new`) lands on GitHub's repo picker.
+  Use it wherever the label is an imperative — the rail CTA, the docs install
+  section.
+- `GITHUB_APP_URL` is the App's public page, which carries the purpose-first
+  pitch. Use it where the link means "learn what this is" — the agent prompt, and
+  the existing "the App" prose links in the docs page.
+
+`apps/web/src/pages/docs/github-app.astro:7` currently hardcodes the app URL; it
+imports the constant instead. The footer consumes neither — it links to the
+internal docs page (§2).
+
+## 2. Footer
+
+`apps/web/src/components/Footer.astro` — add to the `Product` column, between
+Docs and Agent guide:
+
+```ts
+{ label: "GitHub App", href: "/docs/github-app" }
+```
+
+Points at the docs page, not github.com, so the footer teaches before it asks for
+an install. That page is also the App's configured Setup URL, so a user who
+installs from there returns to it and sees the post-install banner.
+
+The adjacent `Project` column already has a link labeled **"GitHub"** (the source
+repo). "GitHub" and "GitHub App" side by side in a 12px mono footer read as the
+same destination, so the repo link is renamed **"Source"** — which is already what
+the compact footer variant calls it.
+
+## 3. Homepage agent prompt
+
+`apps/web/src/pages/index.astro` — the `agentPrompt` string.
+
+An agent cannot install a GitHub App: it needs a browser session and repo-owner
+(often org-admin) permission. So this is not a setup step the agent performs, it
+is a hand-off — the same shape as the existing `uploads login` line ("wait for me
+to approve it").
+
+Appended after the staged-loop block, before the AGENTS.md line:
+
+> Last: tell me to install the GitHub App at https://github.com/apps/uploads-sh —
+> you can't, it needs my browser and repo-owner permission. With it, comments post
+> as the `uploads-sh` bot and staged screenshots promote themselves when the PR
+> opens.
+
+## 4. Workspace rail CTA
+
+`apps/web/src/layouts/WorkspaceLayout.astro` — the `quick actions` section, which
+today holds exactly one muted link (`invite teammate`), becomes:
+
+```
+[ install github app → ]     CTA: bordered, --accent, opens GITHUB_APP_INSTALL_URL
+invite teammate              unchanged muted link
+```
+
+Server-rendered static markup. No `plan` read, no fetch, no client JS. External
+link, so `target="_blank" rel="noopener noreferrer"` — matching the connected-work
+rows above it. Styled in the component's existing scoped `<style>` block against
+`--accent` / `--line`.
+
+Weight: clearly above the invite link, but not a banner. It shows to every
+workspace including ones that already installed, so it must not nag.
+
+### Accepted trade-off: no install detection
+
+There is no session-authenticated way to know whether a workspace has the App
+installed. `GET /v1/:workspace/github/health` is workspace-token auth
+(`workspaceAuth` + `files:read`), and the repo-links listing is admin-only — the
+web app holds a Better Auth session, not a workspace token.
+
+Detection is therefore **out of scope**. The CTA shows unconditionally. A
+follow-up issue covers a session-auth `GET /me/workspaces/:name/github-status`
+(App JWT installation lookup, KV-cached, degrade-to-shown) that would hide it once
+installed.
+
+## 5. Docs reframe: optional → recommended
+
+The honest fallback stays; it just stops being the opening frame.
+
+| Location                                 | Now                                                                                        | After                                                                                                                                                                    |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pages/docs.astro:101` hub card          | "Optional install: comments post as uploads-sh[bot] and private-repo titles show up."      | "Recommended. Comments post as the `uploads-sh` bot and staged screenshots promote themselves when the PR opens."                                                        |
+| `pages/docs/github-app.astro:41` callout | "…covers the optional GitHub App that posts it."                                           | "…covers the GitHub App that posts it."                                                                                                                                  |
+| `pages/docs/github-app.astro:47` lede    | "Everything in these docs works without the App. Installing the App upgrades four things:" | Opens with "Installing the App is the recommended setup." The four-item list is unchanged; "everything still works without it" becomes a one-line note _under_ the list. |
+| `public/llms.txt:12`                     | "optional install for…"                                                                    | "recommended install for…"                                                                                                                                               |
+
+The llms.txt line matters as much as the page — it is the machine-readable index,
+and it must not contradict the prose an agent also reads.
+
+Card order on the `/docs` hub is deliberately **unchanged**.
+
+`README.md` needs no change: it never framed the App as optional (its only
+mention, at line 101, is a neutral conditional about promotion timing).
+
+## 6. Bot-name copy rule
+
+GitHub renders a bot's name as `uploads-sh` with a separate **bot** chip beside
+it. Writing `uploads-sh[bot]` in prose duplicates that chip.
+
+**Rule:** prose says the `uploads-sh` bot.
+
+Two shipped wireframes already double-label — they render `uploads-sh[bot]` _and_
+a sibling `.bot-chip` reading "bot":
+
+- `pages/index.astro:553`
+- `pages/docs/attach-pull-request-images.astro:59`
+
+Both `.user` spans drop to `uploads-sh`. The chip beside them is left alone.
+
+**Unchanged** — these are literal strings, not prose:
+
+- `pages/docs/github-app.astro:84` — a sample of actual CLI stdout.
+- `packages/uploads/CHANGELOG.md`, `skills/uploads-cli/SKILL.md`.
+- The comment renderers, their golden fixtures, and anything comparing against
+  the real GitHub author name.
+
+## Testing & verification
+
+No new unit tests: this is copy, markup, and one constant with no branching.
+
+1. `pnpm typecheck`, `pnpm lint`, `pnpm build` (web).
+2. Existing golden-fixture tests must still pass — proof that the bot-name copy
+   rule did not leak into the renderers.
+3. Browser: workspace rail CTA (target, styling, weight against the invite link);
+   footer at desktop and at the 560px breakpoint where `.cols` reflows.
+4. Screenshot the rail and footer for the PR.
+
+## Follow-ups (filed, not built)
+
+- Session-auth workspace GitHub install status, so the rail CTA can hide once the
+  App is installed.


### PR DESCRIPTION
The GitHub App is the recommended way to run uploads.sh — with it, the attachments
comment posts as the `uploads-sh` bot instead of under a contributor's own account,
and screenshots staged on a branch promote themselves the moment the PR opens with
no CLI call. Nothing outside the docs hub said so, and the docs page that did
mention it called it **optional**.

Four new entry points, plus a framing fix.

## What changed

| Surface | Change |
| --- | --- |
| Footer | `GitHub App` in the Product column; the repo link becomes `Source` |
| Homepage agent prompt | A hand-off step telling the user to install it |
| Workspace rail | `install github app →` CTA in quick actions |
| Docs | optional → recommended (hub card, tagline, callout, lede, llms.txt) |
| `apps/web/src/lib/github-app.ts` | New — both App URLs in one place |

Two URLs, because the links mean different things: the install picker
(`/installations/new`) wherever the label is an imperative, the App's public page
where the link means "learn what this is". The footer uses neither — it points at
`/docs/github-app`, which teaches first and is also the App's configured Setup URL.

## Notes for review

**The agent prompt hands the install back to the user.** An agent can't install a
GitHub App — it needs a browser session and repo-owner (often org-admin)
permission. So it's a hand-off, shaped like the existing `uploads login` line
("wait for me to approve it"), not a step the agent performs.

**The rail CTA shows unconditionally.** There's no session-authenticated way to
tell whether a workspace already has the App: `/v1/:workspace/github/health` is
workspace-token auth and the repo-links listing is admin-only, while the web app
holds a Better Auth session. It's deliberately a light bordered rail item rather
than a banner for exactly that reason. Follow-up: #492.

**Prose now says the `uploads-sh` bot, not `uploads-sh[bot]`.** GitHub already
renders a bot chip beside the name, so the suffix double-labels — two shipped
wireframes were doing this. Literal strings are untouched: the CLI-stdout sample
on the docs page, the CHANGELOG, the skill files, and the comment renderers with
their golden fixtures.

**The impeccable waiver** (`single-font`, `flat-type-hierarchy`, repo-wide) is a
separate commit. Both fire on every page of a deliberately mono-first,
terminal-native brand where hierarchy comes from weight and color rather than size
ratios — consistent with the existing `overused-font` waivers for geist / geist
mono. Rationale is in the commit message, since the admin script stores rule ids
with no reason field.

## Verification

- typecheck 0 errors; lint exits 0 (remaining warnings all pre-existing, none in
  touched files); web build clean
- **2907/2907 tests pass**, including the comment-renderer goldens — the proof the
  bot-name copy rule didn't leak into actual comment output
- In-browser: footer columns and hub card confirmed by DOM read; docs page has no
  "optional" left and its only surviving `uploads-sh[bot]` is the CLI-stdout
  sample; prompt tail and both wireframes correct; footer reflows to two columns at
  375px with no horizontal overflow

One caveat on the rail screenshot: the local auth worker wasn't running, so the
account shell was force-revealed in the DOM to see it (hence "auth unavailable" and
"Loading workspace…"). The CTA is static server-rendered markup with no auth
dependency, so what's pictured is what renders — but it wasn't verified inside a
real session.

Design spec: `docs/superpowers/specs/2026-07-23-github-app-discoverability-design.md`
