### PR TITLE
Add releases.json manifests for releases.sh discovery

### DIFF
--- a/apps/web/public/.well-known/releases.json
+++ b/apps/web/public/.well-known/releases.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://releases.sh/schemas/releases.json",
+  "version": 2,
+  "name": "uploads",
+  "description": "The missing upload command for coding agents — a lightweight file-hosting service that stages screenshots and recordings into agent PRs.",
+  "category": "developer-tools",
+  "tags": ["cli", "developer-tools", "agents", "file-hosting"],
+  "social": { "github": "buildinternet" },
+  "releases": [
+    {
+      "title": "@buildinternet/uploads",
+      "github": "buildinternet/uploads",
+      "canonical": true
+    }
+  ]
+}

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -8,6 +8,7 @@
   Link: </auth.md>; rel="describedby"; type="text/markdown"
   Link: </.well-known/mcp/server-card.json>; rel="alternate"; type="application/json"
   Link: </.well-known/agent-skills/index.json>; rel="alternate"; type="application/json"
+  Link: </.well-known/releases.json>; rel="alternate"; type="application/json"
   Link: <https://api.uploads.sh/.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"
   Link: <https://agents.uploads.sh/.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"
   Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
@@ -86,6 +87,12 @@
   Access-Control-Allow-Origin: *
 
 /.well-known/mcp/server-card.json
+  Content-Type: application/json; charset=utf-8
+  Cache-Control: public, max-age=300
+  Access-Control-Allow-Origin: *
+
+# releases.sh listing — where uploads publishes release notes (GitHub Releases).
+/.well-known/releases.json
   Content-Type: application/json; charset=utf-8
   Cache-Control: public, max-age=300
   Access-Control-Allow-Origin: *

--- a/releases.json
+++ b/releases.json
@@ -2,7 +2,5 @@
   "$schema": "https://releases.sh/schemas/releases.json",
   "version": 2,
   "product": { "name": "uploads", "slug": "uploads" },
-  "releases": [
-    { "github": "self", "canonical": true }
-  ]
+  "releases": [{ "github": "self", "canonical": true }]
 }

--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://releases.sh/schemas/releases.json",
+  "version": 2,
+  "product": { "name": "uploads", "slug": "uploads" },
+  "releases": [
+    { "github": "self", "canonical": true }
+  ]
+}


### PR DESCRIPTION
Declares where uploads publishes release notes, following the [releases.sh listing docs](https://releases.sh/docs/listing), so registries and agents can discover them from the source instead of guessing.

## What's here

- **Domain scope** — `apps/web/public/.well-known/releases.json`, served at `https://uploads.sh/.well-known/releases.json`. Company identity plus a top-level `releases[]` pointing at **GitHub Releases** (`buildinternet/uploads`), which is the canonical release stream for `@buildinternet/uploads` (the `release.yml` workflow cuts `uploads-v*` tags via changesets).
- **Repo scope** — `releases.json` at the repo root, binding this repo to the `uploads` product with `github: "self"`.
- **`_headers`** — serves the well-known file as `application/json` with `Access-Control-Allow-Origin: *` (matching the sibling discovery docs like `openapi.json` / `integrations.json`), and advertises it from the homepage RFC 8288 `Link` set.

## Modeling notes

uploads ships **one product** with **one release stream** (GitHub Releases), so per the skill's guidance this uses a single top-level `releases[]` rather than a `products[]` array of entries that would all share the same changelog. There's no dedicated changelog page on the site, so none is declared — only the real, verified GitHub Releases location. The npm package release notes are the same changeset content surfaced through those GitHub Releases.

## Validation

Both files pass the releases.json **v2** schema validator (domain and repo scope, `at-least-one-locator` / `at-most-one-canonical` / caps all clean).

## After merge

Once deployed, the file is live at `https://uploads.sh/.well-known/releases.json`. releases.sh re-reads it on its regular sweep; no submission step is required. You can optionally preview how it'll be parsed with:

```bash
curl -fsS -X POST https://api.releases.sh/v1/listing/validate \
  -H 'content-type: application/json' -d '{"domain":"uploads.sh"}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAVdqSeUuxwp3fnPJoHJGq)_