### PR TITLE
feat(web): hide the rail's GitHub App CTA once the workspace has it installed

### DIFF
--- a/apps/api/src/github-install-status.test.ts
+++ b/apps/api/src/github-install-status.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { FakeKv } from "../test/fake-kv";
+import { GITHUB_APP_CFG_ENV as CFG_ENV } from "../test/github-app-env";
+import { UsageFakeD1 } from "../test/usage-fake-d1";
+import { recordRepoLink } from "./github-repo-links";
+import { githubInstallStatus } from "./github-install-status";
+
+function env(db: unknown, kv: FakeKv, cfg = CFG_ENV): Env {
+  return { ...cfg, DB: db, GITHUB_CACHE: kv } as unknown as Env;
+}
+
+/** A fetch that fails the test if called — every case here is cache-served. */
+const noFetch = (() => {
+  throw new Error("unexpected GitHub call");
+}) as unknown as typeof fetch;
+
+describe("githubInstallStatus", () => {
+  it("reports not-configured without touching D1", async () => {
+    const db = {
+      prepare: () => {
+        throw new Error("unexpected D1 query");
+      },
+    };
+    const status = await githubInstallStatus(env(db, new FakeKv(), {} as typeof CFG_ENV), "acme");
+    expect(status).toEqual({ configured: false, installed: false, checkedRepos: 0 });
+  });
+
+  it("reports not-installed for a workspace with no bound repos", async () => {
+    const status = await githubInstallStatus(
+      env(new UsageFakeD1(), new FakeKv(), CFG_ENV),
+      "acme",
+      noFetch,
+    );
+    expect(status).toEqual({ configured: true, installed: false, checkedRepos: 0 });
+  });
+
+  it("reports installed when a bound repo has a cached installation", async () => {
+    const db = new UsageFakeD1();
+    await recordRepoLink(db as unknown as D1Database, "acme/web", "acme", "comment");
+    const kv = new FakeKv();
+    kv.store.set("ghinst:acme/web", { value: "42" });
+    const status = await githubInstallStatus(env(db, kv, CFG_ENV), "acme", noFetch);
+    expect(status).toEqual({ configured: true, installed: true, checkedRepos: 1 });
+  });
+
+  it("reports not-installed when every bound repo is cached as uninstalled", async () => {
+    const db = new UsageFakeD1();
+    await recordRepoLink(db as unknown as D1Database, "acme/web", "acme", "comment");
+    await recordRepoLink(db as unknown as D1Database, "acme/api", "acme", "comment");
+    const kv = new FakeKv();
+    kv.store.set("ghinst:acme/web", { value: "none" });
+    kv.store.set("ghinst:acme/api", { value: "none" });
+    const status = await githubInstallStatus(env(db, kv, CFG_ENV), "acme", noFetch);
+    expect(status).toEqual({ configured: true, installed: false, checkedRepos: 2 });
+  });
+
+  it("ignores repos bound to another workspace", async () => {
+    const db = new UsageFakeD1();
+    await recordRepoLink(db as unknown as D1Database, "other/web", "other", "comment");
+    const kv = new FakeKv();
+    kv.store.set("ghinst:other/web", { value: "42" });
+    const status = await githubInstallStatus(env(db, kv, CFG_ENV), "acme", noFetch);
+    expect(status).toEqual({ configured: true, installed: false, checkedRepos: 0 });
+  });
+
+  it("degrades to not-installed when the link lookup throws", async () => {
+    const db = {
+      prepare: () => ({
+        bind: () => ({
+          all: async () => {
+            throw new Error("D1 unavailable");
+          },
+        }),
+      }),
+    };
+    const status = await githubInstallStatus(env(db, new FakeKv(), CFG_ENV), "acme", noFetch);
+    expect(status).toEqual({ configured: true, installed: false, checkedRepos: 0 });
+  });
+});

--- a/apps/api/src/github-install-status.ts
+++ b/apps/api/src/github-install-status.ts
@@ -1,0 +1,78 @@
+/**
+ * "Does this workspace already have the GitHub App?" — the session-authenticated
+ * install signal the workspace rail's `install github app` CTA needs to
+ * self-suppress (issue #492).
+ *
+ * Why this exists at all: `/v1/:workspace/github/health` answers a different
+ * question (is the *App* configured and subscribed to the right events) and is
+ * workspace-token auth, while the repo-links listing is admin-only. The web app
+ * holds a Better Auth session, so neither is reachable from it.
+ *
+ * The answer is derived, not stored: a workspace's bound repos come from
+ * `github_repo_links` (D1), and each repo's installation is the existing App-JWT
+ * lookup, KV-cached under `ghinst:` — so the steady state for a workspace that
+ * has installed (and for one that hasn't) is a D1 read plus KV hits, no GitHub
+ * traffic.
+ *
+ * Every failure degrades to `installed: false`, which shows the CTA. Nagging a
+ * workspace that already installed is a small cost; hiding the CTA from one
+ * that hasn't is the failure that actually matters.
+ */
+
+import { githubAppConfig, installationForRepo } from "./github-app";
+import { listRepoLinksForWorkspace } from "./github-repo-links";
+
+export interface GithubInstallStatus {
+  /** false when the App env isn't configured on this worker — the integration is off entirely. */
+  configured: boolean;
+  /** true only when at least one repo bound to this workspace has the App installed. */
+  installed: boolean;
+  /** How many bound repos were probed (0 means the workspace has claimed no repos yet). */
+  checkedRepos: number;
+}
+
+/**
+ * Most bound repos probed per request. A workspace with dozens of claimed
+ * repos still answers in a bounded number of subrequests, and the answer is a
+ * single boolean — the first installed repo settles it, so the cap only ever
+ * matters for a workspace whose *newest* repos are all uninstalled.
+ */
+export const GITHUB_STATUS_REPO_CAP = 10;
+
+/**
+ * Install status for `workspaceName`. Never throws: a D1 outage, a missing
+ * App config, or a failed installation lookup all report "not installed".
+ */
+export async function githubInstallStatus(
+  env: Env,
+  workspaceName: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<GithubInstallStatus> {
+  const cfg = githubAppConfig(env);
+  if (!cfg) return { configured: false, installed: false, checkedRepos: 0 };
+
+  let repos: string[];
+  try {
+    const links = await listRepoLinksForWorkspace(env.DB, workspaceName);
+    repos = links.slice(0, GITHUB_STATUS_REPO_CAP).map((link) => link.repo);
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        message: "github install status link lookup failed",
+        workspace: workspaceName,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return { configured: true, installed: false, checkedRepos: 0 };
+  }
+
+  // Sequential with an early exit: the common case is one or two bound repos,
+  // and the first hit ends the walk before any further KV/GitHub work.
+  for (const repo of repos) {
+    const installationId = await installationForRepo(env, cfg, repo, fetchImpl);
+    if (installationId !== null) {
+      return { configured: true, installed: true, checkedRepos: repos.length };
+    }
+  }
+  return { configured: true, installed: false, checkedRepos: repos.length };
+}

--- a/apps/api/src/routes/github-status-route.test.ts
+++ b/apps/api/src/routes/github-status-route.test.ts
@@ -1,0 +1,66 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../error-response";
+import { recordRepoLink } from "../github-repo-links";
+import { me } from "./me";
+import { FakeKv } from "../../test/fake-kv";
+import { UsageFakeD1 } from "../../test/usage-fake-d1";
+import { GITHUB_APP_CFG_ENV as CFG_ENV } from "../../test/github-app-env";
+
+const USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+/** Same membership/session scaffolding as github-titles-route.test.ts. */
+function memberEnv({ member, kv, db }: { member: boolean; kv: FakeKv; db: UsageFakeD1 }): Env {
+  const auth = {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const { pathname } = new URL(req.url);
+      if (pathname === "/api/auth/get-session") {
+        return Response.json({ session: {}, user: USER });
+      }
+      if (pathname === "/internal/memberships") {
+        return Response.json(
+          member ? [{ organizationId: "org1", organizationSlug: "acme", role: "member" }] : [],
+        );
+      }
+      if (pathname === "/internal/orgs/acme") {
+        return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme Inc" } });
+      }
+      return new Response(null, { status: 404 });
+    }) as Fetcher["fetch"],
+  };
+  return { AUTH: auth, DB: db, GITHUB_CACHE: kv, ...CFG_ENV } as unknown as Env;
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>().route("/me", me).onError((err, c) => respondError(c, err));
+}
+
+function request(env: Env) {
+  return app().request("/me/workspaces/acme/github-status", { headers: { cookie: "s=1" } }, env);
+}
+
+describe("GET /me/workspaces/:name/github-status", () => {
+  it("404s for a non-member workspace", async () => {
+    const res = await request(
+      memberEnv({ member: false, kv: new FakeKv(), db: new UsageFakeD1() }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("reports installed when a bound repo has the App", async () => {
+    const db = new UsageFakeD1();
+    await recordRepoLink(db as unknown as D1Database, "acme/web", "acme", "comment");
+    const kv = new FakeKv();
+    kv.store.set("ghinst:acme/web", { value: "42" });
+    const res = await request(memberEnv({ member: true, kv, db }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ configured: true, installed: true, checkedRepos: 1 });
+  });
+
+  it("reports not-installed for a workspace with no bindings", async () => {
+    const res = await request(memberEnv({ member: true, kv: new FakeKv(), db: new UsageFakeD1() }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ configured: true, installed: false, checkedRepos: 0 });
+  });
+});

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -23,6 +23,7 @@ import {
 import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { galleryListSummaries } from "../gallery-service";
+import { githubInstallStatus, type GithubInstallStatus } from "../github-install-status";
 import { resolveTitles } from "../github-titles";
 import { allowWrite } from "../guards";
 import {
@@ -671,4 +672,15 @@ export const me = new Hono<SessionVars>()
 
     const titles = await resolveTitles(c.env, [...new Set(normalized)]);
     return c.json({ refs: titles });
+  })
+
+  // Whether this workspace already has the GitHub App installed (issue #492),
+  // so the rail's `install github app` CTA can stop nagging workspaces that
+  // installed it. Member-gated like the sibling `/github-titles`: the answer
+  // is derived from the workspace's repo bindings, which aren't public.
+  // Never fails — see `githubInstallStatus` for the degrade-to-false rule.
+  .get("/workspaces/:name/github-status", async (c) => {
+    const name = c.req.param("name");
+    await memberWorkspaceOr404(c.env, requireUserId(c), name);
+    return c.json<GithubInstallStatus>(await githubInstallStatus(c.env, name));
   });

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -51,11 +51,14 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
           <span class="ws-rail__rule"></span>
         </div>
         <div class="ws-rail__actions">
-          {/* Shown unconditionally — there is no session-authed way to tell
-              whether this workspace already has the App (the health endpoint is
-              workspace-token auth). Kept deliberately light for that reason. */}
+          {/* Server-rendered visible, then hidden by `initWorkspaceRail` when
+              `/me/workspaces/:name/github-status` reports the App installed
+              (issue #492). Shown on every other outcome — a workspace that has
+              it already sees one extra muted link; one that doesn't would
+              otherwise never learn the App exists. */}
           <a
             class="ws-rail__cta"
+            data-rail-github-cta
             href={GITHUB_APP_INSTALL_URL}
             target="_blank"
             rel="noopener noreferrer"
@@ -185,6 +188,11 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     color: var(--fg);
     text-decoration: none;
     font-size: 12px;
+  }
+  /* The class sets `display`, which outranks the UA `[hidden]` rule — without
+     this, the rail's install-status suppression would have no visible effect. */
+  .ws-rail__cta[hidden] {
+    display: none;
   }
   .ws-rail__cta:hover,
   .ws-rail__cta:focus-visible {

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getGithubInstalled,
   getMyWorkspaces,
   getWorkspaceInvites,
   getWorkspaceMembers,
@@ -605,5 +606,44 @@ describe("inviteToWorkspace", () => {
     await expect(inviteToWorkspace("https://api.test", "acme", "new@example.com")).resolves.toEqual(
       { kind: "unavailable", reason: "forbidden" },
     );
+  });
+});
+
+describe("getGithubInstalled", () => {
+  it("reports installed only on an explicit installed:true", async () => {
+    let requested = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        requested = url;
+        return Response.json({ configured: true, installed: true, checkedRepos: 1 });
+      }),
+    );
+
+    await expect(getGithubInstalled("https://api.test", "acme")).resolves.toBe(true);
+    expect(requested).toBe("https://api.test/me/workspaces/acme/github-status");
+  });
+
+  it("keeps the CTA visible when the workspace has no install", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json({ configured: true, installed: false, checkedRepos: 0 })),
+    );
+
+    await expect(getGithubInstalled("https://api.test", "acme")).resolves.toBe(false);
+  });
+
+  it("degrades to shown on an outage, a non-2xx, and a malformed body", async () => {
+    for (const stub of [
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+      vi.fn(async () => new Response(null, { status: 503 })),
+      vi.fn(async () => new Response("not json", { status: 200 })),
+      vi.fn(async () => Response.json({ installed: "yes" })),
+    ]) {
+      vi.stubGlobal("fetch", stub);
+      await expect(getGithubInstalled("https://api.test", "acme")).resolves.toBe(false);
+    }
   });
 });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -802,6 +802,23 @@ export async function getGithubTitles(
   return map as GithubTitleMap;
 }
 
+/**
+ * Whether this workspace already has the GitHub App installed (issue #492) —
+ * `true` only on an explicit `installed: true`. Every other outcome (outage,
+ * non-2xx, malformed body, App not configured) is `false`, which keeps the
+ * rail's install CTA visible: nagging an installed workspace is cheaper than
+ * hiding the CTA from one that never installed.
+ */
+export async function getGithubInstalled(apiOrigin: string, name: string): Promise<boolean> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/github-status`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return false;
+  const body = (await result.response.json().catch(() => null)) as { installed?: unknown } | null;
+  return body?.installed === true;
+}
+
 export interface WorkspaceFolderFile {
   key: string;
   url: string | null;

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -17,7 +17,12 @@
  * item; an empty array hides it. Non-files tabs never call it, so the section
  * stays hidden by construction.
  */
-import { getWorkspaceSummary, type GithubTitleMap, type MyWorkspace } from "./api-client";
+import {
+  getGithubInstalled,
+  getWorkspaceSummary,
+  type GithubTitleMap,
+  type MyWorkspace,
+} from "./api-client";
 import { onSession } from "./account-shell";
 import { escapeHtml, renderUsageHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
@@ -183,8 +188,18 @@ export function initWorkspaceRail(
 
   const detailsEl = root.querySelector<HTMLElement>("[data-rail-details]");
   const usageEl = root.querySelector<HTMLElement>("[data-rail-usage]");
+  const githubCtaEl = root.querySelector<HTMLElement>("[data-rail-github-cta]");
 
   onSession(() => {
+    // Suppress the install CTA once this workspace has the App (issue #492).
+    // One-way: the CTA ships visible and is only ever hidden, so an outage or
+    // a slow response leaves the markup as server-rendered.
+    if (githubCtaEl) {
+      void getGithubInstalled(apiOrigin, workspace).then((installed) => {
+        if (installed) githubCtaEl.hidden = true;
+      });
+    }
+
     void getWorkspaceSummary(apiOrigin, workspace).then((result) => {
       if (result.kind !== "success") {
         if (detailsEl) detailsEl.textContent = "Details unavailable.";


### PR DESCRIPTION
Closes #492.

The workspace rail's `install github app` quick action showed unconditionally, including to workspaces that already installed the App — deliberate, because nothing session-authenticated could tell the difference (`/v1/:workspace/github/health` is workspace-token auth, repo-links listing is admin-only, and the web app holds a Better Auth session).

## What's here

**`GET /me/workspaces/:name/github-status`** (`apps/api/src/github-install-status.ts`, mounted in `routes/me.ts`) — member-gated exactly like the sibling `/github-titles`, since the answer is derived from the workspace's repo bindings and those aren't public. It returns `{ configured, installed, checkedRepos }`.

The answer is derived, not stored: bound repos come from `github_repo_links`, and each repo's installation is the existing App-JWT lookup already KV-cached under `ghinst:`. Steady state is one indexed D1 read plus KV hits — no GitHub traffic on a normal page load. Repos are probed newest-first with an early exit on the first hit and a 10-repo per-request cap.

**Rail suppression** — `WorkspaceLayout.astro`'s CTA gains a `data-rail-github-cta` hook and `initWorkspaceRail` hides it when the endpoint reports installed. The suppression is one-way: the CTA ships server-rendered visible and is only ever hidden, so a slow response or an outage leaves the markup as rendered.

## Degrade-to-shown, everywhere

No App config, a D1 outage, a failed installation lookup, a non-2xx, a malformed body, a network failure — all report "not installed" and keep the CTA. Nagging a workspace that already installed costs one extra muted link; hiding the CTA from one that never installed means it never learns the App exists.

## Verification

`pnpm test` (2940 tests), `pnpm lint`, `pnpm typecheck` all pass. New coverage: install-status resolution (configured/unbound/installed/uninstalled/other-workspace/D1-throws), the route (404 for non-members, installed, no-bindings), and the client's degrade paths.

Checked in the browser against the local dev server: the CTA renders with the hook, `hidden` collapses it to `display: none` (the class sets `display`, so the CSS needs the explicit `[hidden]` rule — added), and with the API unreachable the rail's session block runs and leaves the CTA visible.

Not screenshotted: the installed state only differs by the CTA's absence, and reproducing it needs a signed-in stack with a bound repo and live App credentials.

## Notes

- No changeset — `@uploads/api` and `@uploads/web` are both in the changesets ignore list.
- The design doc's §4 "Accepted trade-off: no install detection" is the point-in-time record of why this shipped unconditional; it's left as written.
