### PR TITLE
fix(cli): derive short-help essentials from the command catalog

### DIFF
--- a/.changeset/plain-badgers-shave.md
+++ b/.changeset/plain-badgers-shave.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Short `uploads --help` now lists every command the catalog marks essential.
+Membership had two sources of truth — the `essential` flag in the command
+catalog and a separate hardcoded array in the help renderer — and they had
+drifted, so `screenshot` was flagged essential but never appeared. The catalog
+is now the only source of truth; the array orders the list and nothing more,
+and a mismatch in either direction fails loudly instead of silently hiding a
+command.

--- a/packages/uploads/src/cli-help.ts
+++ b/packages/uploads/src/cli-help.ts
@@ -16,10 +16,18 @@ function toRow(c: (typeof ROOT_COMMANDS)[number]): CmdRow {
   return [c.usage ?? c.name, c.summary];
 }
 
-/** Preferred order for the short essentials help (subset of ROOT_COMMANDS). */
+/**
+ * Display order for the short essentials help. Membership is *not* declared
+ * here — it comes from `essential: true` in cli-catalog.ts, the one source of
+ * truth (issue #491: this array used to decide membership too, and had already
+ * drifted, silently keeping `screenshot` out of short help). This list only
+ * says what order the essential commands appear in; the check below fails the
+ * build-time module load if the two ever disagree in either direction.
+ */
 const ESSENTIAL_ORDER = [
   "put",
   "attach",
+  "screenshot",
   "login",
   "whoami",
   "list",
@@ -30,11 +38,25 @@ const ESSENTIAL_ORDER = [
 ] as const;
 
 /** Day-to-day commands shown on bare `uploads` / `uploads help`. */
-const ESSENTIALS: CmdRow[] = ESSENTIAL_ORDER.map((name) => {
-  const cmd = ROOT_COMMANDS.find((c) => c.name === name);
-  if (!cmd) throw new Error(`cli-catalog missing essential command: ${name}`);
-  return toRow(cmd);
-});
+const ESSENTIALS: CmdRow[] = (() => {
+  const essential = ROOT_COMMANDS.filter((c) => c.essential);
+  const rank = new Map<string, number>(ESSENTIAL_ORDER.map((name, i) => [name, i]));
+  const unordered = essential.filter((c) => !rank.has(c.name));
+  if (unordered.length > 0) {
+    throw new Error(
+      `cli-help ESSENTIAL_ORDER missing essential command(s): ${unordered.map((c) => c.name).join(", ")}`,
+    );
+  }
+  const names = new Set(essential.map((c) => c.name));
+  const stale = ESSENTIAL_ORDER.filter((name) => !names.has(name));
+  if (stale.length > 0) {
+    throw new Error(`cli-help ESSENTIAL_ORDER names non-essential command(s): ${stale.join(", ")}`);
+  }
+  return essential
+    .slice()
+    .sort((a, b) => rank.get(a.name)! - rank.get(b.name)!)
+    .map(toRow);
+})();
 
 /** Full catalog (same surface as before, still discoverable via help --all). */
 const ALL_COMMANDS: CmdRow[] = ROOT_COMMANDS.map(toRow);

--- a/packages/uploads/test/cli-help.test.ts
+++ b/packages/uploads/test/cli-help.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseArgv } from "../src/cli-args.js";
+import { ROOT_COMMANDS } from "../src/cli-catalog.js";
 import { formatRootHelp, wantsFullHelp } from "../src/cli-help.js";
 import { colorEnabled, createStyle } from "../src/cli-style.js";
 import { runCli } from "../src/cli.js";
@@ -39,6 +40,20 @@ describe("formatRootHelp", () => {
     const text = formatRootHelp({ color: false });
     expect(text).toMatch(/Essentials:/);
     expect(text).toMatch(/update/);
+  });
+
+  // Issue #491: membership used to be declared twice (the catalog's
+  // `essential` flag and cli-help's own array) and had drifted — `screenshot`
+  // was flagged essential but never rendered. The catalog is now the only
+  // source of truth; this asserts the rendered output actually agrees with it.
+  it("renders every command the catalog flags essential", () => {
+    const text = formatRootHelp({ color: false });
+    const essentials = text.slice(text.indexOf("Essentials:"));
+    const flagged = ROOT_COMMANDS.filter((c) => c.essential).map((c) => c.name);
+    expect(flagged).toContain("screenshot");
+    for (const name of flagged) {
+      expect(essentials).toMatch(new RegExp(`^\\s+${name}\\b`, "m"));
+    }
   });
 
   it("shows the full command list with full: true", () => {


### PR DESCRIPTION
Closes #491.

## Problem

Which commands appear in the short `uploads --help` list was declared in two
independent places, and they had already drifted:

- `packages/uploads/src/cli-catalog.ts` marks ten root commands `essential: true`.
- `packages/uploads/src/cli-help.ts` built the rendered list from its own
  hardcoded `ESSENTIAL_ORDER` array, naming nine.

The array was what actually governed rendering; nothing read the flag. So
`screenshot` carried `essential: true` and never showed up in short help — it
appeared only under `uploads help --all`.

## Change

The catalog flag is now the single source of truth for *membership*.
`ESSENTIAL_ORDER` declares *display order* and nothing else, and the module
throws at load time if the two disagree in either direction — an essential
command missing from the order, or an ordered name that is no longer
essential. That turns a silent omission into a loud failure.

`screenshot` takes its place after `attach`, next to the other two commands
that put a file somewhere.

## After

```
Essentials:
  put <file...>         Upload (+ URL + markdown for GitHub)
  attach <file...>      Attach media to the current PR (stable URLs + managed comment)
  screenshot <target>   Capture a URL or .html file and host it (local browser or remote render)
  login                 Sign in via browser (or an enrollment code) and save credentials
  whoami                Show active workspace and token (alias: status)
  list                  List objects (--meta k=v filters by queryable metadata)
  delete <key>          Delete object
  doctor                Health + auth + workspace checks
  install               Install the agent skills + register the remote MCP server
  update                Update the CLI, then refresh the agent skills + MCP registration
```

## Verification

- New test asserts the *rendered* short help contains every command the catalog
  flags essential, so this cannot drift back silently.
- Full CLI suite: 908/908 passing. `pnpm typecheck` clean, lint clean.
- Confirmed the rendered output above by dumping `formatRootHelp` directly, not
  by trusting the test alone.

Patch changeset included.
