### PR TITLE
docs(readme): add a GitHub App badge to the header row

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ provider-agnostic (R2 today; any files-sdk adapter later).
   <a href="https://skills.sh/buildinternet/uploads"><img alt="skills.sh" src="https://skills.sh/b/buildinternet/uploads"></a>
   <a href="https://github.com/buildinternet/uploads/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/buildinternet/uploads/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/@buildinternet/uploads"><img alt="npm (CLI)" src="https://img.shields.io/npm/v/@buildinternet/uploads?color=cb3837&label=%40buildinternet%2Fuploads&logo=npm"></a>
+  <a href="https://github.com/apps/uploads-sh"><img alt="GitHub App: uploads-sh" src="https://img.shields.io/badge/GitHub%20App-uploads--sh-181717?logo=github&logoColor=white"></a>
   <a href="https://deepwiki.com/buildinternet/uploads"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
   <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue"></a>
 </p>


### PR DESCRIPTION
The README mentioned the GitHub App only once, mid-page, in a conditional
aside ("instantly if the GitHub App is installed"). Nothing at the top said the
App exists.

Adds a badge to the header row, between npm and DeepWiki:

`GitHub App | uploads-sh` → https://github.com/apps/uploads-sh

It links to the App's public page rather than the `/installations/new` picker,
following the convention documented in `apps/web/src/lib/github-app.ts`:
imperative labels ("install …") get the install URL, noun labels get the App
page. A badge label is a noun.

The existing prose reference is unchanged — it already explains what installing
the App buys you and points at `/docs/github-app`.

Verified the shields.io image (200, `image/svg+xml`) and the App URL (200)
both resolve.
