### PR TITLE
chore: Cap free workspace creation at three per user

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -24,6 +24,7 @@ function stubEnv(
   user: typeof USER | null,
   onInternal: (path: string, req: Request) => Response | Promise<Response>,
   db: unknown = new UsageFakeD1(),
+  kvRecords: Record<string, unknown> = {},
 ): Env {
   const auth = stubAuth((req) => {
     const url = new URL(req.url);
@@ -32,7 +33,7 @@ function stubEnv(
     }
     return onInternal(url.pathname, req);
   });
-  return { AUTH: auth, DB: db, REGISTRY: fakeKv({}) } as unknown as Env;
+  return { AUTH: auth, DB: db, REGISTRY: fakeKv(kvRecords) } as unknown as Env;
 }
 
 function fakeKv(records: Record<string, unknown>): Pick<KVNamespace, "get"> {
@@ -130,13 +131,15 @@ describe("GET /me/workspaces", () => {
     memberships: ReturnType<typeof ownedMemberships>,
     records: Record<string, unknown>,
   ): Env {
-    const env = stubEnv(USER, (path) =>
-      path === "/internal/memberships"
-        ? Response.json(memberships)
-        : new Response(null, { status: 404 }),
+    return stubEnv(
+      USER,
+      (path) =>
+        path === "/internal/memberships"
+          ? Response.json(memberships)
+          : new Response(null, { status: 404 }),
+      new UsageFakeD1(),
+      records,
     );
-    (env as unknown as { REGISTRY: Pick<KVNamespace, "get"> }).REGISTRY = fakeKv(records);
-    return env;
   }
 
   async function quotaFor(env: Env) {

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -71,17 +71,15 @@ describe("GET /me/workspaces", () => {
     });
     const res = await app().request("/me/workspaces", {}, env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      workspaces: [
-        {
-          workspace: "acme",
-          organization: { id: "org1", slug: "acme", name: "Acme Inc" },
-          role: "owner",
-          hasPublicUrl: false,
-          plan: "free",
-        },
-      ],
-    });
+    expect(((await res.json()) as { workspaces: unknown[] }).workspaces).toEqual([
+      {
+        workspace: "acme",
+        organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+        role: "owner",
+        hasPublicUrl: false,
+        plan: "free",
+      },
+    ]);
   });
 
   it("flags hasPublicUrl for a workspace whose storage record has a publicBaseUrl", async () => {
@@ -118,6 +116,69 @@ describe("GET /me/workspaces", () => {
     ]);
   });
 
+  /** Memberships payload for `slugs`, all owned unless a role is given. */
+  function ownedMemberships(slugs: [string, string?][]) {
+    return slugs.map(([slug, role], i) => ({
+      organizationId: `org${i + 1}`,
+      organizationSlug: slug,
+      organizationName: slug,
+      role: role ?? "owner",
+    }));
+  }
+
+  function envWithRecords(
+    memberships: ReturnType<typeof ownedMemberships>,
+    records: Record<string, unknown>,
+  ): Env {
+    const env = stubEnv(USER, (path) =>
+      path === "/internal/memberships"
+        ? Response.json(memberships)
+        : new Response(null, { status: 404 }),
+    );
+    (env as unknown as { REGISTRY: Pick<KVNamespace, "get"> }).REGISTRY = fakeKv(records);
+    return env;
+  }
+
+  async function quotaFor(env: Env) {
+    const res = await app().request("/me/workspaces", {}, env);
+    return ((await res.json()) as { workspaceCreate: unknown }).workspaceCreate;
+  }
+
+  it("reports the creation quota as allowed below the cap", async () => {
+    const env = envWithRecords(ownedMemberships([["one"], ["two"]]), {
+      "ws:one": { selfServe: true },
+      "ws:two": { selfServe: true },
+    });
+    expect(await quotaFor(env)).toEqual({ used: 2, cap: 3, allowed: true });
+  });
+
+  it("reports the creation quota as denied at the cap", async () => {
+    const env = envWithRecords(ownedMemberships([["one"], ["two"], ["three"]]), {
+      "ws:one": { selfServe: true },
+      "ws:two": { selfServe: true },
+      "ws:three": { selfServe: true },
+    });
+    expect(await quotaFor(env)).toEqual({ used: 3, cap: 3, allowed: false });
+  });
+
+  it("counts only owned workspaces toward the creation quota", async () => {
+    const env = envWithRecords(ownedMemberships([["one"], ["two", "admin"], ["three", "member"]]), {
+      "ws:one": { selfServe: true },
+      "ws:two": { selfServe: true },
+      "ws:three": { selfServe: true },
+    });
+    expect(await quotaFor(env)).toEqual({ used: 1, cap: 3, allowed: true });
+  });
+
+  it("exempts paid workspaces from the creation quota", async () => {
+    const env = envWithRecords(ownedMemberships([["one"], ["two"], ["three"]]), {
+      "ws:one": { selfServe: true },
+      "ws:two": { selfServe: true },
+      "ws:three": { selfServe: true, plan: "pro" },
+    });
+    expect(await quotaFor(env)).toEqual({ used: 2, cap: 3, allowed: true });
+  });
+
   it("treats a workspace named 'default' as an ordinary workspace", async () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") {
@@ -137,17 +198,15 @@ describe("GET /me/workspaces", () => {
     // than being skipped by a name-based short-circuit.
     const res = await app().request("/me/workspaces", {}, env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
-      workspaces: [
-        {
-          workspace: "default",
-          organization: { id: "org2", slug: "default", name: "Default" },
-          role: "member",
-          hasPublicUrl: false,
-          plan: "free",
-        },
-      ],
-    });
+    expect(((await res.json()) as { workspaces: unknown[] }).workspaces).toEqual([
+      {
+        workspace: "default",
+        organization: { id: "org2", slug: "default", name: "Default" },
+        role: "member",
+        hasPublicUrl: false,
+        plan: "free",
+      },
+    ]);
   });
 
   it("503s when the memberships lookup fails (AUTH outage is not zero memberships)", async () => {
@@ -212,7 +271,7 @@ describe("GET /me/workspaces", () => {
     });
     const res = await app().request("/me/workspaces", {}, env);
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ workspaces: [] });
+    expect(((await res.json()) as { workspaces: unknown[] }).workspaces).toEqual([]);
   });
 });
 

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -9,6 +9,7 @@
  * (`workspace_not_found`) rather than 403ing, so membership can't be probed
  * for workspace existence any more precisely than for any other workspace.
  */
+import { resolveWorkspaceCreateQuota } from "@uploads/billing";
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
@@ -185,20 +186,30 @@ export const me = new Hono<SessionVars>()
     const userId = c.get("sessionUser")?.id;
     if (!userId) throw new NotFoundError("no session user", { code: "workspace_not_found" });
     const workspaces = await myWorkspaces(c.env, userId);
-    const withPublicUrl = await Promise.all(
+    const loaded = await Promise.all(
       workspaces.map(async (ws) => {
         const record = await loadWorkspaceRecord(c.env, ws.workspace);
         const publicBaseUrl = record?.publicBaseUrl;
         const plan = record ? planResponse(ws.workspace, record).plan : "free";
         // `hasPublicUrl` kept alongside the URL itself for existing consumers.
-        return Object.assign({}, ws, {
-          hasPublicUrl: Boolean(publicBaseUrl),
-          publicBaseUrl,
-          plan,
-        });
+        return {
+          record,
+          entry: Object.assign({}, ws, {
+            hasPublicUrl: Boolean(publicBaseUrl),
+            publicBaseUrl,
+            plan,
+          }),
+        };
       }),
     );
-    return c.json({ workspaces: withPublicUrl });
+    // Creation quota (spec 2026-07-24) so the account UI can stop offering a
+    // create affordance the API would refuse. Free rider on the records this
+    // handler already loaded — no extra KV reads. Advisory only: `POST
+    // /v1/workspaces` remains the enforcement point.
+    const quota = resolveWorkspaceCreateQuota(
+      loaded.filter(({ entry }) => entry.role === "owner").map(({ record }) => record),
+    );
+    return c.json({ workspaces: loaded.map(({ entry }) => entry), workspaceCreate: quota });
   })
 
   // Usage + limits for one workspace — 404s unless the caller is a member.

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -224,6 +224,37 @@ describe("POST /v1/workspaces", () => {
     expect(res.status).toBe(201);
   });
 
+  it("does not count paid owned workspaces toward the cap", async () => {
+    const memberships = [
+      { organizationId: "o1", organizationSlug: "one", role: "owner" },
+      { organizationId: "o2", organizationSlug: "two", role: "owner" },
+      { organizationId: "o3", organizationSlug: "three", role: "owner" },
+    ];
+    const kvRecords = {
+      one: { selfServe: true },
+      two: { selfServe: true },
+      // Upgrading frees a slot immediately — the cap is a free-tier gate.
+      three: { selfServe: true, plan: "pro" },
+    };
+    const res = await post(stubEnv({ memberships, kvRecords }), { name: "zachbot" });
+    expect(res.status).toBe(201);
+  });
+
+  it("counts self-serve workspaces the user only belongs to as exempt", async () => {
+    const memberships = [
+      { organizationId: "o1", organizationSlug: "one", role: "owner" },
+      { organizationId: "o2", organizationSlug: "two", role: "admin" },
+      { organizationId: "o3", organizationSlug: "three", role: "member" },
+    ];
+    const kvRecords = {
+      one: { selfServe: true },
+      two: { selfServe: true },
+      three: { selfServe: true },
+    };
+    const res = await post(stubEnv({ memberships, kvRecords }), { name: "zachbot" });
+    expect(res.status).toBe(201);
+  });
+
   it("409s code workspace_name_taken when the KV record exists", async () => {
     const res = await post(stubEnv({ kvRecords: { zachbot: { provider: "r2", bucket: "b" } } }), {
       name: "zachbot",

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -13,6 +13,11 @@ import {
   RateLimitedError,
   ValidationError,
 } from "@uploads/errors";
+import {
+  MAX_SELF_SERVE_WORKSPACES,
+  resolveWorkspaceCreateQuota,
+  workspaceCapMessage,
+} from "@uploads/billing";
 import { Hono, type MiddlewareHandler } from "hono";
 import { adminWorkspaceOr403, isWorkspaceOwner } from "./me";
 import {
@@ -128,7 +133,8 @@ function requireWorkspaceName(name: string): void {
 }
 
 const MAX_BODY_BYTES = 1024;
-export const MAX_SELF_SERVE_WORKSPACES = 3;
+/** Re-exported for existing importers; the cap itself lives in @uploads/billing. */
+export { MAX_SELF_SERVE_WORKSPACES };
 
 export const workspaces = new Hono<SessionVars>().post(
   "/",
@@ -173,17 +179,20 @@ export const workspaces = new Hono<SessionVars>().post(
       });
     }
 
-    // Cap counts only self-serve workspaces the user OWNS — BYO/operator
-    // workspaces (no selfServe flag) never burn the allowance.
+    // Cap counts only FREE self-serve workspaces the user OWNS — BYO/operator
+    // workspaces (no selfServe flag) and paid ones never burn the allowance.
+    // The rule itself lives in @uploads/billing so `/me/workspaces` can tell
+    // the UI whether to offer creation without restating it. This is the only
+    // enforcement point; the UI failing open must never grant a fourth.
     const memberships = await membershipsForUser(c.env, user.id);
     const isFirstMembership = memberships.length === 0;
     const owned = memberships.filter((m) => m.role === "owner");
     const records = await Promise.all(
       owned.map((m) => loadWorkspaceRecord(c.env, m.organizationSlug)),
     );
-    const selfServeCount = records.filter((r) => r?.selfServe === true).length;
-    if (selfServeCount >= MAX_SELF_SERVE_WORKSPACES) {
-      throw new ForbiddenError(`workspace limit reached (${MAX_SELF_SERVE_WORKSPACES})`, {
+    const quota = resolveWorkspaceCreateQuota(records);
+    if (!quota.allowed) {
+      throw new ForbiddenError(workspaceCapMessage(quota.cap), {
         code: "workspace_cap_reached",
       });
     }

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -13,11 +13,7 @@ import {
   RateLimitedError,
   ValidationError,
 } from "@uploads/errors";
-import {
-  MAX_SELF_SERVE_WORKSPACES,
-  resolveWorkspaceCreateQuota,
-  workspaceCapMessage,
-} from "@uploads/billing";
+import { resolveWorkspaceCreateQuota, workspaceCapMessage } from "@uploads/billing";
 import { Hono, type MiddlewareHandler } from "hono";
 import { adminWorkspaceOr403, isWorkspaceOwner } from "./me";
 import {
@@ -133,8 +129,6 @@ function requireWorkspaceName(name: string): void {
 }
 
 const MAX_BODY_BYTES = 1024;
-/** Re-exported for existing importers; the cap itself lives in @uploads/billing. */
-export { MAX_SELF_SERVE_WORKSPACES };
 
 export const workspaces = new Hono<SessionVars>().post(
   "/",

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -30,6 +30,37 @@ describe("getMyWorkspaces", () => {
     });
   });
 
+  it("parses the creation quota when the API sends one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ workspaces: [], workspaceCreate: { used: 3, cap: 3, allowed: false } }),
+      ),
+    );
+
+    const result = await getMyWorkspaces("http://127.0.0.1:8787");
+    expect(result).toMatchObject({ quota: { used: 3, cap: 3, allowed: false } });
+  });
+
+  it("leaves the quota undefined when the API omits or mangles it", async () => {
+    for (const body of [
+      { workspaces: [] },
+      { workspaces: [], workspaceCreate: null },
+      { workspaces: [], workspaceCreate: "nope" },
+      { workspaces: [], workspaceCreate: { used: 3, cap: 3 } },
+      { workspaces: [], workspaceCreate: { used: "3", cap: 3, allowed: false } },
+    ]) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => Response.json(body)),
+      );
+      const result = await getMyWorkspaces("http://127.0.0.1:8787");
+      // Absent means allowed — a stale worker must never lock a user out.
+      expect(result).toMatchObject({ kind: "success" });
+      expect((result as { quota?: unknown }).quota).toBeUndefined();
+    }
+  });
+
   it("does not render an API outage as an empty account", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -69,9 +69,40 @@ function mapMyWorkspace(ws: Omit<MyWorkspace, "hasPublicUrl" | "plan">): MyWorks
   };
 }
 
+/**
+ * Whether this user may create another workspace (spec 2026-07-24). Purely
+ * advisory — `POST /v1/workspaces` is the enforcement point, so the UI is
+ * free to fail open when this is missing.
+ */
+export interface WorkspaceCreateQuota {
+  used: number;
+  cap: number;
+  allowed: boolean;
+}
+
 export type WorkspacesResult =
-  | { kind: "success"; workspaces: MyWorkspace[] }
+  | { kind: "success"; workspaces: MyWorkspace[]; quota?: WorkspaceCreateQuota }
   | { kind: "unavailable"; reason: RequestFailure | "server" | "malformed" };
+
+/**
+ * Parse `workspaceCreate` from a `/me/workspaces` body.
+ *
+ * Returns `undefined` for anything unrecognized — an older API build that
+ * omits the field, a partial response, a garbage value. Every consumer
+ * treats `undefined` as "creation allowed", so a stale worker degrades to
+ * the pre-cap behaviour (create offered, server still refusing at the cap)
+ * rather than locking a user out of a workspace they are entitled to.
+ */
+export function parseWorkspaceCreateQuota(value: unknown): WorkspaceCreateQuota | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const { used, cap, allowed } = raw;
+  if (typeof used !== "number" || typeof cap !== "number" || typeof allowed !== "boolean") {
+    return undefined;
+  }
+  if (!Number.isFinite(used) || !Number.isFinite(cap)) return undefined;
+  return { used, cap, allowed };
+}
 
 /** GET /me/workspaces, preserving an outage rather than rendering it as an empty account. */
 export async function getMyWorkspaces(apiOrigin: string): Promise<WorkspacesResult> {
@@ -83,12 +114,13 @@ export async function getMyWorkspaces(apiOrigin: string): Promise<WorkspacesResu
   const { response } = result;
   if (!response.ok) return { kind: "unavailable", reason: "server" };
   const body = (await response.json().catch(() => undefined)) as
-    | { workspaces?: unknown[] }
+    | { workspaces?: unknown[]; workspaceCreate?: unknown }
     | undefined;
   if (!body || !Array.isArray(body.workspaces)) return { kind: "unavailable", reason: "malformed" };
   return {
     kind: "success",
     workspaces: body.workspaces.filter(isMyWorkspaceCore).map(mapMyWorkspace),
+    quota: parseWorkspaceCreateQuota(body.workspaceCreate),
   };
 }
 

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -206,6 +206,26 @@ describe("resolveDefaultWorkspace", () => {
     ).toBe("one");
   });
 
+  it("skips the communal default so an owner there still lands in their own workspace", () => {
+    const roles = [
+      { workspace: "default", role: "owner" },
+      { workspace: "buildinternet", role: "admin" },
+    ];
+    expect(resolveDefaultWorkspace(roles, "")).toBe("buildinternet");
+  });
+
+  it("still opens the communal default when it is the only membership", () => {
+    expect(resolveDefaultWorkspace([{ workspace: "default", role: "owner" }], "")).toBe("default");
+  });
+
+  it("honours an explicit last-used default over the skip", () => {
+    const roles = [
+      { workspace: "default", role: "owner" },
+      { workspace: "buildinternet", role: "admin" },
+    ];
+    expect(resolveDefaultWorkspace(roles, "default")).toBe("default");
+  });
+
   it("returns null only when there are no memberships", () => {
     expect(resolveDefaultWorkspace([], "buildinternet")).toBeNull();
   });

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -5,6 +5,9 @@ import {
   clearCachedWorkspaces,
   readCachedActiveWorkspace,
   readCachedWorkspaces,
+  isManageRequest,
+  loadWorkspaces,
+  MANAGE_WORKSPACES_HREF,
   renderSwitcherMenuHtml,
   renderWorkspaceSectionNavHtml,
   resolveDefaultWorkspace,
@@ -163,6 +166,62 @@ describe("active workspace cache + resolveSidebarWorkspace", () => {
   it("returns empty when nothing is known", () => {
     installStorage();
     expect(resolveSidebarWorkspace("/account/profile", "")).toBe("");
+  });
+});
+
+describe("loadWorkspaces", () => {
+  it("shares one request between concurrent callers and caches the result", async () => {
+    installStorage();
+    const fetchMock = vi.fn(async () =>
+      Response.json({ workspaces: [], workspaceCreate: { used: 3, cap: 3, allowed: false } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const [a, b] = await Promise.all([
+      loadWorkspaces("http://127.0.0.1:8787"),
+      loadWorkspaces("http://127.0.0.1:8787"),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    // Cache written once, so later paints don't need their own fetch.
+    expect(readCachedQuota()).toEqual({ used: 3, cap: 3, allowed: false });
+  });
+
+  it("revalidates on a later call once the first has settled", async () => {
+    installStorage();
+    const fetchMock = vi.fn(async () => Response.json({ workspaces: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await loadWorkspaces("http://127.0.0.1:8787");
+    await loadWorkspaces("http://127.0.0.1:8787");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poison the cache with a failed load", async () => {
+    installStorage();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+    await loadWorkspaces("http://127.0.0.1:8787");
+    expect(readCachedQuota()).toBeUndefined();
+    expect(readCachedWorkspaces()).toBeNull();
+  });
+});
+
+describe("isManageRequest", () => {
+  it("recognizes only the deliberate-list marker", () => {
+    expect(isManageRequest("?manage=1")).toBe(true);
+    expect(isManageRequest("?next=/x&manage=1")).toBe(true);
+    expect(isManageRequest("")).toBe(false);
+    expect(isManageRequest("?manage=0")).toBe(false);
+    expect(isManageRequest("?managed=1")).toBe(false);
+  });
+
+  it("matches the href the switcher renders", () => {
+    expect(isManageRequest(new URL(MANAGE_WORKSPACES_HREF, "https://x").search)).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -12,6 +12,7 @@ import {
   switcherLabel,
   workspaceTabFromPathname,
   writeCachedActiveWorkspace,
+  readCachedQuota,
   writeCachedWorkspaces,
   WORKSPACES_CACHE_KEY,
 } from "./workspaces-nav";
@@ -68,6 +69,21 @@ describe("workspaces cache", () => {
     clearCachedWorkspaces();
     expect(readCachedWorkspaces()).toBeNull();
     expect(sessionStorage.getItem(WORKSPACES_CACHE_KEY)).toBeNull();
+  });
+
+  it("round-trips the creation quota alongside the memberships", () => {
+    installStorage();
+    writeCachedWorkspaces(sample, { used: 3, cap: 3, allowed: false });
+    expect(readCachedQuota()).toEqual({ used: 3, cap: 3, allowed: false });
+    expect(readCachedWorkspaces()).toEqual(sample);
+  });
+
+  it("reads an absent or malformed cached quota as undefined", () => {
+    const { session } = installStorage();
+    writeCachedWorkspaces(sample);
+    expect(readCachedQuota()).toBeUndefined();
+    session.set(WORKSPACES_CACHE_KEY, "{not-json");
+    expect(readCachedQuota()).toBeUndefined();
   });
 
   it("drops malformed cache payloads", () => {
@@ -153,11 +169,44 @@ describe("active workspace cache + resolveSidebarWorkspace", () => {
 describe("resolveDefaultWorkspace", () => {
   const multi = [{ workspace: "buildinternet" }, { workspace: "side" }];
 
-  it("picks the only membership, else a valid last-used, else null", () => {
+  it("picks the only membership, else a valid last-used", () => {
     expect(resolveDefaultWorkspace([{ workspace: "solo" }], "other")).toBe("solo");
     expect(resolveDefaultWorkspace(multi, "side")).toBe("side");
-    expect(resolveDefaultWorkspace(multi, "")).toBeNull();
-    expect(resolveDefaultWorkspace(multi, "gone")).toBeNull();
+  });
+
+  it("falls back to the first owned workspace when no last-used is stored", () => {
+    const roles = [
+      { workspace: "invited", role: "member" },
+      { workspace: "mine", role: "owner" },
+      { workspace: "other", role: "owner" },
+    ];
+    expect(resolveDefaultWorkspace(roles, "")).toBe("mine");
+    // A stale slug the user is no longer a member of takes the same path.
+    expect(resolveDefaultWorkspace(roles, "gone")).toBe("mine");
+  });
+
+  it("prefers an administered workspace when none is owned", () => {
+    const roles = [
+      { workspace: "invited", role: "member" },
+      { workspace: "runs-it", role: "admin" },
+    ];
+    expect(resolveDefaultWorkspace(roles, "")).toBe("runs-it");
+  });
+
+  it("falls back to the first membership when no role qualifies", () => {
+    expect(resolveDefaultWorkspace(multi, "")).toBe("buildinternet");
+    expect(
+      resolveDefaultWorkspace(
+        [
+          { workspace: "one", role: "member" },
+          { workspace: "two", role: "member" },
+        ],
+        "",
+      ),
+    ).toBe("one");
+  });
+
+  it("returns null only when there are no memberships", () => {
     expect(resolveDefaultWorkspace([], "buildinternet")).toBeNull();
   });
 });
@@ -204,6 +253,32 @@ describe("renderSwitcherMenuHtml", () => {
   it("omits the badge when plan is absent (older api, legacy workspace)", () => {
     const html = renderSwitcherMenuHtml(sample, { active: "buildinternet" });
     expect(html).not.toContain("pro-badge");
+  });
+
+  it("swaps the create row for manage workspaces at the cap", () => {
+    const html = renderSwitcherMenuHtml(sample, {
+      active: "buildinternet",
+      quota: { used: 3, cap: 3, allowed: false },
+    });
+    expect(html).toContain('href="/account/workspaces?manage=1"');
+    expect(html).toContain("manage workspaces");
+    expect(html).not.toContain('href="/account/workspaces/new"');
+    expect(html).not.toContain("+ new workspace");
+  });
+
+  it("keeps the create row below the cap", () => {
+    const html = renderSwitcherMenuHtml(sample, {
+      active: "buildinternet",
+      quota: { used: 2, cap: 3, allowed: true },
+    });
+    expect(html).toContain("+ new workspace");
+    expect(html).not.toContain("manage workspaces");
+  });
+
+  it("keeps the create row when the quota is absent (older api)", () => {
+    expect(renderSwitcherMenuHtml(sample, { active: "buildinternet" })).toContain(
+      "+ new workspace",
+    );
   });
 });
 

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -14,6 +14,7 @@ import {
   parseWorkspaceCreateQuota,
   type MyWorkspace,
   type WorkspaceCreateQuota,
+  type WorkspacesResult,
 } from "./api-client";
 import { onSession } from "./account-shell";
 import { isBrowseWorkspace, workspaceFromPathname } from "./workspace-browse-url";
@@ -46,12 +47,53 @@ export type WorkspacesNavOptions = {
   quota?: WorkspaceCreateQuota;
 };
 
+/**
+ * The workspace index normally auto-opens a workspace. This param is how a
+ * link says "the user asked for the list itself" — kept next to the href
+ * that sets it and the predicate that reads it, so the three can't drift.
+ */
+const MANAGE_PARAM = "manage";
+
 /** Where the workspace index is reachable on purpose, without auto-opening. */
-export const MANAGE_WORKSPACES_HREF = "/account/workspaces?manage=1";
+export const MANAGE_WORKSPACES_HREF = `/account/workspaces?${MANAGE_PARAM}=1`;
+
+/** Whether `search` (e.g. `location.search`) asked for the list itself. */
+export function isManageRequest(search: string): boolean {
+  return new URLSearchParams(search).get(MANAGE_PARAM) === "1";
+}
 
 /** Advisory: may this user create another workspace? Absent quota → yes. */
 export function canCreateWorkspace(quota?: WorkspaceCreateQuota): boolean {
   return quota ? quota.allowed : true;
+}
+
+/** In-flight `/me/workspaces` request, shared by everything on the page. */
+let inFlightWorkspaces: Promise<WorkspacesResult> | null = null;
+
+/**
+ * Fetch `/me/workspaces` once per page load, however many surfaces ask.
+ *
+ * The account shell loads this on every page for the switcher, and
+ * individual pages (the index, the create form) need the same payload for
+ * their own rendering. Without this, each surface fired its own request for
+ * a response the others had just received. Concurrent callers share one
+ * promise; the slot clears on settle so a later navigation or an explicit
+ * retry still revalidates.
+ *
+ * Writes the cache on success so callers don't each have to remember to.
+ */
+export function loadWorkspaces(apiOrigin: string): Promise<WorkspacesResult> {
+  if (!inFlightWorkspaces) {
+    inFlightWorkspaces = getMyWorkspaces(apiOrigin)
+      .then((result) => {
+        if (result.kind === "success") writeCachedWorkspaces(result.workspaces, result.quota);
+        return result;
+      })
+      .finally(() => {
+        inFlightWorkspaces = null;
+      });
+  }
+  return inFlightWorkspaces;
 }
 
 type CachePayload = { workspaces: MyWorkspace[]; quota?: WorkspaceCreateQuota };
@@ -80,23 +122,28 @@ function storeRemove(store: Storage, key: string): void {
   }
 }
 
-export function readCachedWorkspaces(): MyWorkspace[] | null {
+/** The cache blob, parsed once. Null for absent or unparseable. */
+function readCachePayload(): CachePayload | null {
   const raw = storeGet(sessionStorage, WORKSPACES_CACHE_KEY);
   if (!raw) return null;
   try {
-    const parsed = JSON.parse(raw) as CachePayload;
-    if (!parsed || !Array.isArray(parsed.workspaces)) return null;
-    return parsed.workspaces.filter(
-      (ws) =>
-        ws &&
-        typeof ws.workspace === "string" &&
-        typeof ws.role === "string" &&
-        ws.organization &&
-        typeof ws.organization.name === "string",
-    );
+    return JSON.parse(raw) as CachePayload;
   } catch {
     return null;
   }
+}
+
+export function readCachedWorkspaces(): MyWorkspace[] | null {
+  const parsed = readCachePayload();
+  if (!parsed || !Array.isArray(parsed.workspaces)) return null;
+  return parsed.workspaces.filter(
+    (ws) =>
+      ws &&
+      typeof ws.workspace === "string" &&
+      typeof ws.role === "string" &&
+      ws.organization &&
+      typeof ws.organization.name === "string",
+  );
 }
 
 export function writeCachedWorkspaces(
@@ -112,13 +159,7 @@ export function writeCachedWorkspaces(
  * payload, garbage) reads as "allowed" everywhere downstream.
  */
 export function readCachedQuota(): WorkspaceCreateQuota | undefined {
-  const raw = storeGet(sessionStorage, WORKSPACES_CACHE_KEY);
-  if (!raw) return undefined;
-  try {
-    return parseWorkspaceCreateQuota((JSON.parse(raw) as CachePayload).quota);
-  } catch {
-    return undefined;
-  }
+  return parseWorkspaceCreateQuota(readCachePayload()?.quota);
 }
 
 export function clearCachedWorkspaces(): void {
@@ -367,9 +408,8 @@ export function initWorkspacesNav(apiOrigin: string, options: WorkspacesNavOptio
   paint(els, readCachedWorkspaces() ?? [], opts);
 
   onSession(() => {
-    void getMyWorkspaces(apiOrigin).then((result) => {
+    void loadWorkspaces(apiOrigin).then((result) => {
       if (result.kind !== "success") return;
-      writeCachedWorkspaces(result.workspaces, result.quota);
       paint(els, result.workspaces, { ...opts, quota: result.quota });
     });
   });

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -9,7 +9,12 @@
  * session). Last-used workspace lives in localStorage so it survives
  * sign-out and drives the index auto-open after login.
  */
-import { getMyWorkspaces, type MyWorkspace } from "./api-client";
+import {
+  getMyWorkspaces,
+  parseWorkspaceCreateQuota,
+  type MyWorkspace,
+  type WorkspaceCreateQuota,
+} from "./api-client";
 import { onSession } from "./account-shell";
 import { isBrowseWorkspace, workspaceFromPathname } from "./workspace-browse-url";
 import { shouldShowProBadge } from "./plan-badge";
@@ -37,9 +42,19 @@ export const WORKSPACE_NAV_TABS: {
 export type WorkspacesNavOptions = {
   active?: string;
   activeTab?: WorkspaceNavTab | "";
+  /** Creation quota; absent means allowed (see `parseWorkspaceCreateQuota`). */
+  quota?: WorkspaceCreateQuota;
 };
 
-type CachePayload = { workspaces: MyWorkspace[] };
+/** Where the workspace index is reachable on purpose, without auto-opening. */
+export const MANAGE_WORKSPACES_HREF = "/account/workspaces?manage=1";
+
+/** Advisory: may this user create another workspace? Absent quota → yes. */
+export function canCreateWorkspace(quota?: WorkspaceCreateQuota): boolean {
+  return quota ? quota.allowed : true;
+}
+
+type CachePayload = { workspaces: MyWorkspace[]; quota?: WorkspaceCreateQuota };
 
 function storeGet(store: Storage, key: string): string | null {
   try {
@@ -84,8 +99,26 @@ export function readCachedWorkspaces(): MyWorkspace[] | null {
   }
 }
 
-export function writeCachedWorkspaces(workspaces: MyWorkspace[]): void {
-  storeSet(sessionStorage, WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces }));
+export function writeCachedWorkspaces(
+  workspaces: MyWorkspace[],
+  quota?: WorkspaceCreateQuota,
+): void {
+  storeSet(sessionStorage, WORKSPACES_CACHE_KEY, JSON.stringify({ workspaces, quota }));
+}
+
+/**
+ * Cached creation quota, so the optimistic first paint doesn't flash the
+ * wrong switcher row before revalidation. `undefined` (no cache, older
+ * payload, garbage) reads as "allowed" everywhere downstream.
+ */
+export function readCachedQuota(): WorkspaceCreateQuota | undefined {
+  const raw = storeGet(sessionStorage, WORKSPACES_CACHE_KEY);
+  if (!raw) return undefined;
+  try {
+    return parseWorkspaceCreateQuota((JSON.parse(raw) as CachePayload).quota);
+  } catch {
+    return undefined;
+  }
 }
 
 export function clearCachedWorkspaces(): void {
@@ -112,18 +145,33 @@ export function clearCachedActiveWorkspace(): void {
   storeRemove(sessionStorage, ACTIVE_WORKSPACE_CACHE_KEY);
 }
 
+/** Role preference for the cold-start fallback below. */
+const FALLBACK_ROLES = ["owner", "admin"];
+
 /**
  * Workspace to open from the index after login.
+ *
  * One membership → that workspace. Multi → last-used if still a member.
- * Otherwise null (show the picker).
+ * Failing both (a fresh browser, cleared storage, a first visit after being
+ * invited), the first workspace the user owns, else the first they
+ * administer, else the first membership — so a signed-in user lands in a
+ * workspace rather than being asked to choose every time. The switcher, not
+ * this page, is how you change workspaces.
+ *
+ * Null only when there are no memberships at all. The index suppresses the
+ * auto-open entirely when it was reached deliberately (`?manage=1`).
  */
 export function resolveDefaultWorkspace(
-  workspaces: readonly { workspace: string }[],
+  workspaces: readonly { workspace: string; role?: string }[],
   lastActive = "",
 ): string | null {
   if (workspaces.length === 1) return workspaces[0]!.workspace;
   if (lastActive && workspaces.some((ws) => ws.workspace === lastActive)) return lastActive;
-  return null;
+  for (const role of FALLBACK_ROLES) {
+    const match = workspaces.find((ws) => ws.role === role);
+    if (match) return match.workspace;
+  }
+  return workspaces[0]?.workspace ?? null;
 }
 
 /**
@@ -180,11 +228,15 @@ export function renderSwitcherMenuHtml(
     })
     .join("");
 
-  return (
-    rows +
-    (rows ? `<div class="ws-switcher__sep"></div>` : "") +
-    `<a href="/account/workspaces/new" class="ws-switcher__item ws-switcher__item--new">+ new workspace</a>`
-  );
+  // One trailing row, never both: the fast path to creating while the user
+  // has an allowance left, and once they're at the cap a link to the index
+  // — which carries the explanation — instead of an offer that would be
+  // refused. Absent quota keeps the create row (fail open).
+  const trailer = canCreateWorkspace(options.quota)
+    ? `<a href="/account/workspaces/new" class="ws-switcher__item ws-switcher__item--new">+ new workspace</a>`
+    : `<a href="${MANAGE_WORKSPACES_HREF}" class="ws-switcher__item ws-switcher__item--manage">manage workspaces</a>`;
+
+  return rows + (rows ? `<div class="ws-switcher__sep"></div>` : "") + trailer;
 }
 
 /** Section links under the switcher. Empty when no workspace is active. */
@@ -231,7 +283,7 @@ function paint(els: SwitcherEls, workspaces: MyWorkspace[], opts: WorkspacesNavO
   const activeTab = opts.activeTab || "";
 
   els.label.textContent = switcherLabel(workspaces, active);
-  els.menu.innerHTML = renderSwitcherMenuHtml(workspaces, { active });
+  els.menu.innerHTML = renderSwitcherMenuHtml(workspaces, { active, quota: opts.quota });
 
   if (active) {
     els.section.hidden = false;
@@ -296,6 +348,7 @@ export function initWorkspacesNav(apiOrigin: string, options: WorkspacesNavOptio
   const opts: WorkspacesNavOptions = {
     active: resolveSidebarWorkspace(location.pathname, options.active ?? ""),
     activeTab: options.activeTab || workspaceTabFromPathname(location.pathname),
+    quota: options.quota ?? readCachedQuota(),
   };
 
   paint(els, readCachedWorkspaces() ?? [], opts);
@@ -303,8 +356,8 @@ export function initWorkspacesNav(apiOrigin: string, options: WorkspacesNavOptio
   onSession(() => {
     void getMyWorkspaces(apiOrigin).then((result) => {
       if (result.kind !== "success") return;
-      writeCachedWorkspaces(result.workspaces);
-      paint(els, result.workspaces, opts);
+      writeCachedWorkspaces(result.workspaces, result.quota);
+      paint(els, result.workspaces, { ...opts, quota: result.quota });
     });
   });
 }

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -149,6 +149,13 @@ export function clearCachedActiveWorkspace(): void {
 const FALLBACK_ROLES = ["owner", "admin"];
 
 /**
+ * The communal workspace. Most accounts are members of it, and many are
+ * `owner` there, so a naive role-first fallback would land almost everyone
+ * in the shared workspace instead of their own. Considered last.
+ */
+const COMMUNAL_WORKSPACE = "default";
+
+/**
  * Workspace to open from the index after login.
  *
  * One membership → that workspace. Multi → last-used if still a member.
@@ -157,6 +164,10 @@ const FALLBACK_ROLES = ["owner", "admin"];
  * administer, else the first membership — so a signed-in user lands in a
  * workspace rather than being asked to choose every time. The switcher, not
  * this page, is how you change workspaces.
+ *
+ * The communal `default` is skipped at every step of that fallback and only
+ * used when it is the sole membership, so a user who happens to be `owner`
+ * there still lands in their own workspace.
  *
  * Null only when there are no memberships at all. The index suppresses the
  * auto-open entirely when it was reached deliberately (`?manage=1`).
@@ -167,11 +178,13 @@ export function resolveDefaultWorkspace(
 ): string | null {
   if (workspaces.length === 1) return workspaces[0]!.workspace;
   if (lastActive && workspaces.some((ws) => ws.workspace === lastActive)) return lastActive;
+
+  const own = workspaces.filter((ws) => ws.workspace !== COMMUNAL_WORKSPACE);
   for (const role of FALLBACK_ROLES) {
-    const match = workspaces.find((ws) => ws.role === role);
+    const match = own.find((ws) => ws.role === role);
     if (match) return match.workspace;
   }
-  return workspaces[0]?.workspace ?? null;
+  return own[0]?.workspace ?? workspaces[0]?.workspace ?? null;
 }
 
 /**

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -24,10 +24,12 @@ if (isBrowseWorkspace(legacyWs)) {
   <section class="card settings-page dev-page">
     <div class="settings-section">
       <h2>Workspaces</h2>
-      <p class="settings-note muted">
-        Choose a workspace, or
-        <a href="/account/workspaces/new">create one</a>.
+      <!-- `&#32;` because Astro collapses the newline between `or` and the
+           link away entirely, rendering `orcreate one`. -->
+      <p class="settings-note muted" id="orgs-intro">
+        Choose a workspace, or&#32;<a href="/account/workspaces/new">create one</a>.
       </p>
+      <p class="settings-note muted" id="orgs-cap" hidden></p>
       <div id="orgs-status" class="ws-status muted">Loading…</div>
       <button id="orgs-retry" type="button" hidden>Try again</button>
       <ul class="dev-links" id="orgs-list" hidden></ul>
@@ -38,10 +40,12 @@ if (isBrowseWorkspace(legacyWs)) {
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
     import { getMyWorkspaces } from "../../lib/api-client";
     import {
+      canCreateWorkspace,
       readCachedActiveWorkspace,
       resolveDefaultWorkspace,
       writeCachedWorkspaces,
     } from "../../lib/workspaces-nav";
+    import { workspaceCapMessage } from "@uploads/billing";
     import { shouldShowProBadge } from "../../lib/plan-badge";
     import { escapeHtml } from "../../lib/workspace-ui";
 
@@ -54,6 +58,13 @@ if (isBrowseWorkspace(legacyWs)) {
       const status = requireElement<HTMLElement>("#orgs-status", page);
       const list = requireElement<HTMLUListElement>("#orgs-list", page);
       const retry = requireElement<HTMLButtonElement>("#orgs-retry", page);
+      const intro = requireElement<HTMLElement>("#orgs-intro", page);
+      const cap = requireElement<HTMLElement>("#orgs-cap", page);
+
+      // `?manage=1` means the user came here on purpose (the switcher's
+      // "manage workspaces" row), so the auto-open below is suppressed and
+      // the list always renders.
+      const managing = new URLSearchParams(location.search).get("manage") === "1";
 
       async function loadIndex(): Promise<void> {
         status.hidden = false;
@@ -69,16 +80,26 @@ if (isBrowseWorkspace(legacyWs)) {
           return;
         }
 
-        const { workspaces } = result;
-        writeCachedWorkspaces(workspaces);
+        const { workspaces, quota } = result;
+        writeCachedWorkspaces(workspaces, quota);
 
+        // At the cap, swap the "or create one" offer for the reason it's
+        // gone. Absent quota (older API, partial response) keeps the offer —
+        // POST /v1/workspaces is the real gate.
+        const canCreate = canCreateWorkspace(quota);
+        intro.hidden = !canCreate;
+        cap.hidden = canCreate;
+        if (!canCreate && quota) cap.textContent = workspaceCapMessage(quota.cap);
+
+        // No memberships means nothing owned, so the cap can't be reached
+        // here — the offer always stands.
         if (!workspaces.length) {
           status.innerHTML =
             'No workspaces yet — <a href="/account/workspaces/new">create one</a>, or accept an invite.';
           return;
         }
 
-        const open = resolveDefaultWorkspace(workspaces, readCachedActiveWorkspace());
+        const open = managing ? null : resolveDefaultWorkspace(workspaces, readCachedActiveWorkspace());
         if (open) {
           status.textContent = "Opening…";
           location.replace(`/account/workspaces/${encodeURIComponent(open)}`);

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -2,7 +2,8 @@
 /**
  * Workspaces index.
  * Legacy `?ws=` deep links redirect to `/account/workspaces/<name>`.
- * Opens the last-used (or only) membership; otherwise shows a flat picker.
+ * Auto-opens a workspace (last-used, else first owned) so a signed-in user
+ * lands somewhere; `?manage=1` asks for the list itself instead.
  */
 import AccountLayout from "../../layouts/AccountLayout.astro";
 import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
@@ -38,12 +39,12 @@ if (isBrowseWorkspace(legacyWs)) {
 
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
-    import { getMyWorkspaces } from "../../lib/api-client";
     import {
       canCreateWorkspace,
+      isManageRequest,
+      loadWorkspaces,
       readCachedActiveWorkspace,
       resolveDefaultWorkspace,
-      writeCachedWorkspaces,
     } from "../../lib/workspaces-nav";
     import { workspaceCapMessage } from "@uploads/billing";
     import { shouldShowProBadge } from "../../lib/plan-badge";
@@ -61,10 +62,10 @@ if (isBrowseWorkspace(legacyWs)) {
       const intro = requireElement<HTMLElement>("#orgs-intro", page);
       const cap = requireElement<HTMLElement>("#orgs-cap", page);
 
-      // `?manage=1` means the user came here on purpose (the switcher's
-      // "manage workspaces" row), so the auto-open below is suppressed and
-      // the list always renders.
-      const managing = new URLSearchParams(location.search).get("manage") === "1";
+      // The switcher's "manage workspaces" row marks the request as
+      // deliberate, which suppresses the auto-open below so the list always
+      // renders.
+      const managing = isManageRequest(location.search);
 
       async function loadIndex(): Promise<void> {
         status.hidden = false;
@@ -72,7 +73,7 @@ if (isBrowseWorkspace(legacyWs)) {
         retry.hidden = true;
         status.textContent = "Loading…";
 
-        const result = await getMyWorkspaces(apiOrigin);
+        const result = await loadWorkspaces(apiOrigin);
         if (result.kind === "unavailable") {
           status.textContent =
             "Workspaces are temporarily unavailable. Check the local stack or try again.";
@@ -81,7 +82,6 @@ if (isBrowseWorkspace(legacyWs)) {
         }
 
         const { workspaces, quota } = result;
-        writeCachedWorkspaces(workspaces, quota);
 
         // At the cap, swap the "or create one" offer for the reason it's
         // gone. Absent quota (older API, partial response) keeps the offer —

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -53,6 +53,11 @@ export const prerender = false;
           <a data-open-workspace href="/account/workspaces">Open this workspace →</a>
         </p>
       </div>
+      <p class="muted cli-note" data-create-cap role="status" hidden>
+        <span data-cap-message></span>&#32;<a href="/account/workspaces?manage=1"
+          >Manage workspaces →</a
+        >
+      </p>
       <p class="muted cli-note" data-create-error role="alert" hidden></p>
       <p class="muted cli-note" data-create-github role="status" hidden>
         Requires a linked GitHub account.
@@ -69,8 +74,13 @@ export const prerender = false;
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
     import { linkGitHub, listAccounts } from "../../../lib/auth-client";
-    import { createWorkspace } from "../../../lib/api-client";
-    import { clearCachedWorkspaces } from "../../../lib/workspaces-nav";
+    import { createWorkspace, getMyWorkspaces } from "../../../lib/api-client";
+    import {
+      canCreateWorkspace,
+      clearCachedWorkspaces,
+      writeCachedWorkspaces,
+    } from "../../../lib/workspaces-nav";
+    import { workspaceCapMessage } from "@uploads/billing";
     import {
       bindCopyButtons,
       createErrorCopy,
@@ -107,6 +117,25 @@ export const prerender = false;
 
     void listAccounts(authOrigin).then((accounts) => {
       if (accounts && !accounts.some((a) => a.providerId === "github")) githubEl.hidden = false;
+    });
+
+    // This page is directly linkable, so it checks the cap itself rather
+    // than trusting that an entry point already did — turning a
+    // submit-then-403 into an up-front explanation. Fails open: an
+    // unreachable API or an older build with no quota leaves the form
+    // enabled, and POST /v1/workspaces still refuses.
+    const capEl = requireElement<HTMLElement>("[data-create-cap]", page);
+    const capMessage = requireElement<HTMLElement>("[data-cap-message]", page);
+    onSession(() => {
+      void getMyWorkspaces(apiOrigin).then((result) => {
+        if (result.kind !== "success") return;
+        writeCachedWorkspaces(result.workspaces, result.quota);
+        if (canCreateWorkspace(result.quota) || !result.quota) return;
+        capMessage.textContent = workspaceCapMessage(result.quota.cap);
+        capEl.hidden = false;
+        input.disabled = true;
+        if (submit) submit.disabled = true;
+      });
     });
 
     if (new URLSearchParams(location.search).get("error")) githubError.hidden = false;

--- a/apps/web/src/pages/account/workspaces/new.astro
+++ b/apps/web/src/pages/account/workspaces/new.astro
@@ -1,5 +1,6 @@
 ---
 import AccountLayout from "../../../layouts/AccountLayout.astro";
+import { MANAGE_WORKSPACES_HREF } from "../../../lib/workspaces-nav";
 
 export const prerender = false;
 ---
@@ -54,7 +55,7 @@ export const prerender = false;
         </p>
       </div>
       <p class="muted cli-note" data-create-cap role="status" hidden>
-        <span data-cap-message></span>&#32;<a href="/account/workspaces?manage=1"
+        <span data-cap-message></span>&#32;<a href={MANAGE_WORKSPACES_HREF}
           >Manage workspaces →</a
         >
       </p>
@@ -74,11 +75,12 @@ export const prerender = false;
   <script>
     import { onAstroPageLoad, onSession, requireElement } from "../../../lib/account-shell";
     import { linkGitHub, listAccounts } from "../../../lib/auth-client";
-    import { createWorkspace, getMyWorkspaces } from "../../../lib/api-client";
+    import { createWorkspace, type WorkspaceCreateQuota } from "../../../lib/api-client";
     import {
       canCreateWorkspace,
       clearCachedWorkspaces,
-      writeCachedWorkspaces,
+      loadWorkspaces,
+      readCachedQuota,
     } from "../../../lib/workspaces-nav";
     import { workspaceCapMessage } from "@uploads/billing";
     import {
@@ -121,20 +123,31 @@ export const prerender = false;
 
     // This page is directly linkable, so it checks the cap itself rather
     // than trusting that an entry point already did — turning a
-    // submit-then-403 into an up-front explanation. Fails open: an
-    // unreachable API or an older build with no quota leaves the form
-    // enabled, and POST /v1/workspaces still refuses.
+    // submit-then-403 into an up-front explanation. Fails open: no quota
+    // (older build, unreachable API) leaves the form enabled, and POST
+    // /v1/workspaces still refuses.
     const capEl = requireElement<HTMLElement>("[data-create-cap]", page);
     const capMessage = requireElement<HTMLElement>("[data-cap-message]", page);
+
+    // Symmetric on purpose: the cached paint below can be stale in either
+    // direction, so revalidation has to be able to LIFT the cap as well as
+    // apply it — otherwise a user who just upgraded stares at a disabled
+    // form until they reload.
+    function applyQuota(quota: WorkspaceCreateQuota | undefined): void {
+      const capped = !!quota && !canCreateWorkspace(quota);
+      if (capped) capMessage.textContent = workspaceCapMessage(quota.cap);
+      capEl.hidden = !capped;
+      input.disabled = capped;
+      if (submit) submit.disabled = capped;
+    }
+
+    // Cached value paints immediately; `loadWorkspaces` then revalidates,
+    // sharing the one request the account shell is already making for the
+    // switcher rather than issuing a second.
+    applyQuota(readCachedQuota());
     onSession(() => {
-      void getMyWorkspaces(apiOrigin).then((result) => {
-        if (result.kind !== "success") return;
-        writeCachedWorkspaces(result.workspaces, result.quota);
-        if (canCreateWorkspace(result.quota) || !result.quota) return;
-        capMessage.textContent = workspaceCapMessage(result.quota.cap);
-        capEl.hidden = false;
-        input.disabled = true;
-        if (submit) submit.disabled = true;
+      void loadWorkspaces(apiOrigin).then((result) => {
+        if (result.kind === "success") applyQuota(result.quota);
       });
     });
 

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -175,7 +175,10 @@
 .account-shell nav.side .ws-switcher__item.is-current {
   color: var(--accent);
 }
-.account-shell nav.side .ws-switcher__item--new {
+/* Trailing switcher row — "+ new workspace", or "manage workspaces" once the
+   creation cap is reached. Same quiet treatment either way. */
+.account-shell nav.side .ws-switcher__item--new,
+.account-shell nav.side .ws-switcher__item--manage {
   color: color-mix(in srgb, var(--muted) 70%, var(--accent));
   font-size: 12px;
 }

--- a/docs/superpowers/specs/2026-07-24-workspace-creation-soft-cap-design.md
+++ b/docs/superpowers/specs/2026-07-24-workspace-creation-soft-cap-design.md
@@ -1,0 +1,228 @@
+# Workspace-creation soft cap
+
+A user may create at most **3 free workspaces**. Paid workspaces do not count
+against the allowance, nor do legacy operator-provisioned ones. Enforced at
+creation only — never retroactively, never a deletion trigger.
+
+Alongside the cap, two adjacent fixes to the workspace index
+(`/account/workspaces`): a whitespace bug in the "create one" link, and a
+wider auto-open fallback so a signed-in user lands in a workspace instead of
+a picker.
+
+## Where the cap already exists
+
+`POST /v1/workspaces` has enforced a cap of 3 since self-serve registration
+shipped: `MAX_SELF_SERVE_WORKSPACES` in `apps/api/src/routes/workspaces.ts`,
+counting owned memberships whose record carries `selfServe === true`, and
+rejecting with `403 workspace_cap_reached`.
+
+Two gaps: it counts paid workspaces against the allowance, and no UI surface
+knows the cap exists, so a user at the limit discovers it only by filling in
+the create form and being refused.
+
+## Scope rule: which workspaces burn a slot
+
+A workspace counts against a user's allowance when **all** hold:
+
+- the user's org role for it is `owner` (not `admin`, not `member`), and
+- the record is `selfServe === true`, and
+- it resolves to the free plan — `getPlan(record.plan).id === "free"`, which
+  fails open to free for an absent or unrecognized plan string.
+
+Everything else is exempt: Pro workspaces, legacy/operator-provisioned
+records (no `selfServe` flag), the communal `default` workspace, and any
+workspace the user merely belongs to. Invitations are unaffected — a user
+may be a member of any number of workspaces.
+
+This mirrors `member-cap.ts`'s reasoning about `selfServe` versus `plan`.
+`plan` is written only by Stripe or an operator; self-serve provisioning
+writes free's numeric limits and no `plan` field. `selfServe` is therefore
+the honest signal for "a free tenant that never had a plan stamped on it",
+and `getPlan`'s fail-open keeps such a record on the free side of the test.
+
+### Consequences, accepted deliberately
+
+- **Upgrading frees a slot immediately.** A user at 3 who takes one to Pro
+  can create a fourth the moment the plan lands on the record.
+- **Downgrading can leave a user over the cap.** Three free workspaces plus
+  a lapsed Pro is four owned free workspaces. Nothing is deleted, disabled,
+  or reclaimed; the user simply cannot create another until they are back
+  under 3. The cap is a creation gate, and only that.
+- **No per-user operator override.** The escape hatch for comping an
+  exception is editing a workspace record (clear `selfServe`, or apply a
+  plan), which is how the adjacent limits are comped today. A dedicated
+  per-user allowance is not worth the surface area at a cap of 3.
+
+## Architecture
+
+### 1. `packages/billing/src/workspace-cap.ts` (new)
+
+Pure, no I/O, so the API guard and any future surface share one answer to
+"may this user create another workspace". Sibling to `member-cap.ts`, which
+it deliberately resembles.
+
+```ts
+export const MAX_SELF_SERVE_WORKSPACES = 3;
+
+/** The subset of a workspace record the cap needs. */
+export interface WorkspaceCapRecord {
+  plan?: string;
+  selfServe?: boolean;
+}
+
+export interface WorkspaceCreateQuota {
+  /** Cap-eligible workspaces the user owns. May exceed `cap` after a downgrade. */
+  used: number;
+  cap: number;
+  allowed: boolean;
+}
+
+export function countCapEligibleWorkspaces(
+  records: readonly (WorkspaceCapRecord | null | undefined)[],
+): number;
+
+export function resolveWorkspaceCreateQuota(
+  ownedRecords: readonly (WorkspaceCapRecord | null | undefined)[],
+): WorkspaceCreateQuota;
+
+/** The note shown at the cap. */
+export function workspaceCapMessage(cap: number): string;
+```
+
+Callers pass records for workspaces the user owns; the role filter stays at
+the call site, where membership data lives. A `null` record (KV miss) does
+not count — it cannot be shown to be cap-eligible, and failing open here
+matches the rest of the module's posture.
+
+### 2. `POST /v1/workspaces`
+
+Drops the local `MAX_SELF_SERVE_WORKSPACES` and the inline
+`records.filter(r => r?.selfServe === true)` count in favour of
+`resolveWorkspaceCreateQuota`. Same 403, same `workspace_cap_reached` code,
+same message shape — now paid-exempt. The re-export of
+`MAX_SELF_SERVE_WORKSPACES` from `apps/api/src/routes/workspaces.ts` is kept
+so existing importers and tests are unaffected.
+
+This remains the **only** enforcement point. Everything below is UI, and the
+UI failing open must never grant a fourth workspace.
+
+### 3. `GET /me/workspaces`
+
+Gains a sibling field to `workspaces`:
+
+```json
+{ "workspaces": [...], "workspaceCreate": { "used": 3, "cap": 3, "allowed": false } }
+```
+
+The handler already loads every membership's record for `plan` and
+`publicBaseUrl`, so the count costs no extra KV reads — it filters the
+records it is already holding down to `role === "owner"` and calls the
+helper.
+
+Purely additive. `api-client.ts` parses it defensively, and **absent means
+allowed**: an older API build, a malformed field, or a partial outage
+degrades to today's behaviour (create affordances shown, server still
+enforcing) rather than locking a user out of something they are entitled to.
+
+The quota rides the existing `sessionStorage` workspace cache
+(`writeCachedWorkspaces`) so the optimistic first paint does not flash the
+wrong dropdown row before revalidation.
+
+## UI
+
+### Switcher dropdown (`renderSwitcherMenuHtml`)
+
+One row, whichever state applies — never both:
+
+- **Under the cap:** `+ new workspace` → `/account/workspaces/new`, as today.
+- **At the cap:** `manage workspaces` → `/account/workspaces?manage=1`.
+
+Keeping create out of the dropdown at the cap is the point: the affordance
+should not sit there permanently offering something that will be refused.
+
+### Workspace index (`/account/workspaces`)
+
+- `?manage=1` suppresses the auto-open (see below) and always renders the
+  list, so "manage workspaces" does not bounce straight back out.
+- **Under the cap:** the existing sentence, "Choose a workspace, or create
+  one."
+- **At the cap:** the create link is replaced by a muted note — "Free
+  accounts include 3 workspaces. Upgrade one to Pro to create another."
+- **Padding fix:** in `workspaces.astro` the word `or` and the following
+  `<a>` sit on separate source lines, and Astro collapses the newline away,
+  rendering `orcreate one` with the underline flush against the preceding
+  word. Fixed with an explicit `&#32;`, not by reflowing to one long line.
+  The empty-state string in the same file already reads correctly and is
+  left alone.
+
+### Create page (`/account/workspaces/new`)
+
+Directly linkable and bookmarkable, so it checks the quota on load rather
+than trusting that no entry point led here. At the cap it renders the form
+disabled with the same note, turning a submit-then-403 into an up-front
+explanation. If the quota is absent or the fetch fails the form stays
+enabled — the server is the backstop.
+
+## Redirect: land in a workspace, not a picker
+
+`resolveDefaultWorkspace` today returns the sole membership, or the
+last-used slug from `localStorage` when it is still a valid membership, and
+otherwise `null` (show the picker). A user with several memberships and no
+stored slug — a fresh browser, cleared storage, a first visit after being
+invited — lands on the picker every time.
+
+New final fallback, applied only when the existing two miss: the first
+membership with role `owner`, else the first with role `admin`, else the
+first entry, in the order `/me/workspaces` returns. `null` is now returned
+only when there are no memberships at all.
+
+Suppressed entirely when `?manage=1` is present, which is what makes the
+index reachable on purpose.
+
+Last-used continues to be recorded by `resolveSidebarWorkspace` on every
+workspace route visit, so the fallback matters only on the first visit; after
+that the stored slug wins.
+
+## Testing
+
+`packages/billing/test/workspace-cap.test.ts`:
+
+- three free self-serve owned records → `allowed: false`, `used: 3`
+- two free + one Pro → `allowed: true`, `used: 2`
+- non-`selfServe` (legacy/operator) records never count
+- absent/unrecognized `plan` on a `selfServe` record counts (fail-open-to-free)
+- four free records after a downgrade → `used: 4`, `allowed: false`, no throw
+- `null` records are skipped
+- boundary: 2 → allowed, 3 → denied
+
+`apps/api/src/routes/workspaces.test.ts`:
+
+- the existing cap test still passes unchanged
+- new: three owned self-serve workspaces where one is Pro → 201, not 403
+- new: owned non-self-serve workspaces do not block creation
+
+`apps/api/src/routes/me.test.ts` (or the nearest existing suite):
+
+- `workspaceCreate` present and correct for a capped and an uncapped user
+- `used` counts only owned workspaces, not every membership
+
+Web unit tests:
+
+- `resolveDefaultWorkspace` — owner-first fallback, admin fallback, first-entry
+  fallback, unchanged single-membership and last-used paths, empty → `null`
+- `renderSwitcherMenuHtml` — create row under the cap, manage row at the cap,
+  never both; absent quota renders the create row
+- `api-client` — `workspaceCreate` parsed, absent field reads as allowed,
+  malformed field reads as allowed
+
+## Docs
+
+`docs/workspaces.md` gains a short section: the cap, the scope rule (owned +
+self-serve + free), that Pro is exempt and upgrading frees a slot, that a
+downgrade can leave a user over the cap without consequence, and that an
+operator comps an exception by editing the workspace record.
+
+The public `/docs/limits` page is deliberately left alone — the cap is a
+per-account creation gate, while that page documents per-workspace limits,
+and mixing the two would muddle a page whose framing is "limits apply per
+workspace, not per user".

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -188,10 +188,26 @@ blocklist itself is not part of this doc).
 
 ### Cap and errors
 
-Each user may own at most **3 self-serve workspaces** (owner-role,
-`selfServe`-flagged records only — BYO-bucket or operator-created workspaces
-you belong to don't count against the cap). Deleting a self-serve workspace,
-like any workspace, remains admin-only.
+Each user may own at most **3 free self-serve workspaces**. A record counts
+against the allowance only when all three hold: the user's role is `owner`,
+the record is `selfServe`-flagged, and it resolves to the free plan. So
+BYO-bucket and operator-created workspaces never count, neither do
+workspaces you merely belong to, and **paid workspaces are exempt**.
+Invitations are unaffected — a user may be a member of any number of
+workspaces. Deleting a self-serve workspace, like any workspace, remains
+admin-only.
+
+The rule lives in `packages/billing/src/workspace-cap.ts`
+(`resolveWorkspaceCreateQuota`), shared by the `POST /v1/workspaces` guard
+and the `workspaceCreate` block on `GET /me/workspaces` that tells the
+account UI whether to offer creation. The POST is the only enforcement
+point; the UI fails open when the field is missing.
+
+Two consequences, both deliberate. Upgrading a workspace to Pro frees a slot
+immediately. A downgrade can leave a user _over_ the cap — nothing is
+deleted, disabled, or reclaimed; they simply can't create another until
+they're back under. To comp an exception, edit the workspace record: clear
+`selfServe`, or apply a plan.
 
 `POST /v1/workspaces` error codes:
 
@@ -200,7 +216,7 @@ like any workspace, remains admin-only.
 | 400    | `invalid_workspace_name`  | Fails the name pattern, or blocklisted                                                                                                   |
 | 400    | `reserved_workspace_name` | Collides with a reserved name                                                                                                            |
 | 403    | `github_required`         | Account has no linked GitHub identity                                                                                                    |
-| 403    | `workspace_cap_reached`   | Caller already owns 3 self-serve workspaces                                                                                              |
+| 403    | `workspace_cap_reached`   | Caller already owns 3 free self-serve workspaces (paid ones exempt)                                                                      |
 | 409    | `workspace_name_taken`    | Name already registered                                                                                                                  |
 | 429    | —                         | Rate-limited (dedicated creation limiter, 3 attempts per minute per user, checked before the GitHub gate — not the shared write limiter) |
 

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -3,4 +3,5 @@ export * from "./member-cap";
 export * from "./plans";
 export * from "./resolve";
 export * from "./subscription-status";
+export * from "./workspace-cap";
 export * from "./stripe-plans";

--- a/packages/billing/src/workspace-cap.ts
+++ b/packages/billing/src/workspace-cap.ts
@@ -1,0 +1,88 @@
+/**
+ * Workspace-creation soft cap (spec 2026-07-24). Pure — no I/O — so the
+ * `POST /v1/workspaces` guard and the `/me/workspaces` listing that tells
+ * the UI whether to offer creation share one answer to "may this user
+ * create another workspace".
+ *
+ * Sibling to `member-cap.ts`, and for the same reason: `plan` is only ever
+ * written by Stripe (`/internal/billing/plan`) or an operator (`PATCH
+ * /admin-ui/workspaces/:name/plan`), while self-serve provisioning writes
+ * free's numeric limits and no `plan` field at all. `selfServe` is the
+ * honest signal for "a free tenant that never had a plan stamped on it",
+ * and `getPlan`'s fail-open-to-free keeps such a record on the free side of
+ * the test.
+ */
+import { getPlan } from "./plans";
+
+/** Free workspaces one user may own at a time. */
+export const MAX_SELF_SERVE_WORKSPACES = 3;
+
+/** The shape the cap needs from a workspace record — a subset of apps/api's
+ * `WorkspaceRecord`, restated here so this package keeps its independence
+ * from `@uploads/api`. */
+export interface WorkspaceCapRecord {
+  /** Subscription plan, when one has been stamped. */
+  plan?: string;
+  /** True for workspaces provisioned by the self-serve flow. */
+  selfServe?: boolean;
+}
+
+export interface WorkspaceCreateQuota {
+  /** Cap-eligible workspaces the user owns. May exceed `cap` after a
+   * downgrade — see `resolveWorkspaceCreateQuota`. */
+  used: number;
+  cap: number;
+  allowed: boolean;
+}
+
+/**
+ * True when this record burns one of the user's free slots: provisioned by
+ * self-serve and still resolving to the free plan.
+ *
+ * Exempt, deliberately: paid workspaces (the whole point of the exemption),
+ * and legacy/operator-provisioned records with no `selfServe` flag, which
+ * keep the unlimited posture they have in production today.
+ */
+function isCapEligible(record: WorkspaceCapRecord | null | undefined): boolean {
+  // A record that could not be loaded cannot be shown to be cap-eligible;
+  // fail open rather than charge a user for a KV miss.
+  if (!record) return false;
+  if (record.selfServe !== true) return false;
+  return getPlan(record.plan).id === "free";
+}
+
+/**
+ * How many of `records` count against the allowance. Callers pass records
+ * for workspaces the user **owns** — the role filter stays at the call
+ * site, where membership data lives.
+ */
+export function countCapEligibleWorkspaces(
+  records: readonly (WorkspaceCapRecord | null | undefined)[],
+): number {
+  return records.filter(isCapEligible).length;
+}
+
+/**
+ * Whether the owner of `ownedRecords` may create another workspace.
+ *
+ * `used` can exceed `cap` — three free workspaces plus a lapsed Pro is four
+ * owned free workspaces. Nothing is deleted, disabled, or reclaimed in that
+ * case; the user simply cannot create another until they are back under the
+ * cap. This is a creation gate, and only that.
+ */
+export function resolveWorkspaceCreateQuota(
+  ownedRecords: readonly (WorkspaceCapRecord | null | undefined)[],
+): WorkspaceCreateQuota {
+  const used = countCapEligibleWorkspaces(ownedRecords);
+  return { used, cap: MAX_SELF_SERVE_WORKSPACES, allowed: used < MAX_SELF_SERVE_WORKSPACES };
+}
+
+/**
+ * The note shown where creation would otherwise be offered. Reads the cap
+ * actually in force rather than hardcoding "3", and names the upgrade path,
+ * which is the one action that frees a slot.
+ */
+export function workspaceCapMessage(cap: number): string {
+  const workspaces = `${cap} workspace${cap === 1 ? "" : "s"}`;
+  return `Free accounts include ${workspaces}. Upgrade one to Pro to create another.`;
+}

--- a/packages/billing/src/workspace-cap.ts
+++ b/packages/billing/src/workspace-cap.ts
@@ -52,18 +52,9 @@ function isCapEligible(record: WorkspaceCapRecord | null | undefined): boolean {
 }
 
 /**
- * How many of `records` count against the allowance. Callers pass records
- * for workspaces the user **owns** — the role filter stays at the call
- * site, where membership data lives.
- */
-export function countCapEligibleWorkspaces(
-  records: readonly (WorkspaceCapRecord | null | undefined)[],
-): number {
-  return records.filter(isCapEligible).length;
-}
-
-/**
- * Whether the owner of `ownedRecords` may create another workspace.
+ * Whether the owner of `ownedRecords` may create another workspace. Callers
+ * pass records for workspaces the user **owns** — the role filter stays at
+ * the call site, where membership data lives.
  *
  * `used` can exceed `cap` — three free workspaces plus a lapsed Pro is four
  * owned free workspaces. Nothing is deleted, disabled, or reclaimed in that
@@ -73,7 +64,7 @@ export function countCapEligibleWorkspaces(
 export function resolveWorkspaceCreateQuota(
   ownedRecords: readonly (WorkspaceCapRecord | null | undefined)[],
 ): WorkspaceCreateQuota {
-  const used = countCapEligibleWorkspaces(ownedRecords);
+  const used = ownedRecords.filter(isCapEligible).length;
   return { used, cap: MAX_SELF_SERVE_WORKSPACES, allowed: used < MAX_SELF_SERVE_WORKSPACES };
 }
 

--- a/packages/billing/test/workspace-cap.test.ts
+++ b/packages/billing/test/workspace-cap.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  countCapEligibleWorkspaces,
   MAX_SELF_SERVE_WORKSPACES,
   resolveWorkspaceCreateQuota,
   workspaceCapMessage,
@@ -13,36 +12,6 @@ const free: WorkspaceCapRecord = { selfServe: true };
 const pro: WorkspaceCapRecord = { selfServe: true, plan: "pro" };
 /** Operator-provisioned, no self-serve flag — exempt. */
 const legacy: WorkspaceCapRecord = {};
-
-describe("countCapEligibleWorkspaces", () => {
-  it("counts free self-serve workspaces", () => {
-    expect(countCapEligibleWorkspaces([free, free, free])).toBe(3);
-  });
-
-  it("exempts paid workspaces", () => {
-    expect(countCapEligibleWorkspaces([free, free, pro])).toBe(2);
-  });
-
-  it("exempts legacy/operator-provisioned workspaces", () => {
-    expect(countCapEligibleWorkspaces([legacy, legacy, free])).toBe(1);
-  });
-
-  it("counts a self-serve record with an explicit free plan", () => {
-    expect(countCapEligibleWorkspaces([{ selfServe: true, plan: "free" }])).toBe(1);
-  });
-
-  it("counts a self-serve record with an unrecognized plan (fails open to free)", () => {
-    expect(countCapEligibleWorkspaces([{ selfServe: true, plan: "enterprise" }])).toBe(1);
-  });
-
-  it("skips records that could not be loaded", () => {
-    expect(countCapEligibleWorkspaces([free, null, undefined, free])).toBe(2);
-  });
-
-  it("counts nothing for a user who owns nothing", () => {
-    expect(countCapEligibleWorkspaces([])).toBe(0);
-  });
-});
 
 describe("resolveWorkspaceCreateQuota", () => {
   it("allows creation below the cap", () => {
@@ -59,6 +28,33 @@ describe("resolveWorkspaceCreateQuota", () => {
       cap: MAX_SELF_SERVE_WORKSPACES,
       allowed: false,
     });
+  });
+
+  it("exempts legacy/operator-provisioned workspaces", () => {
+    expect(resolveWorkspaceCreateQuota([legacy, legacy, legacy, free])).toMatchObject({
+      used: 1,
+      allowed: true,
+    });
+  });
+
+  it("counts a self-serve record whose plan is explicitly free", () => {
+    expect(resolveWorkspaceCreateQuota([{ selfServe: true, plan: "free" }])).toMatchObject({
+      used: 1,
+    });
+  });
+
+  it("counts a self-serve record with an unrecognized plan (fails open to free)", () => {
+    expect(resolveWorkspaceCreateQuota([{ selfServe: true, plan: "enterprise" }])).toMatchObject({
+      used: 1,
+    });
+  });
+
+  it("skips records that could not be loaded", () => {
+    expect(resolveWorkspaceCreateQuota([free, null, undefined, free])).toMatchObject({ used: 2 });
+  });
+
+  it("counts nothing for a user who owns nothing", () => {
+    expect(resolveWorkspaceCreateQuota([])).toMatchObject({ used: 0, allowed: true });
   });
 
   it("frees a slot when one workspace is on a paid plan", () => {

--- a/packages/billing/test/workspace-cap.test.ts
+++ b/packages/billing/test/workspace-cap.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  countCapEligibleWorkspaces,
+  MAX_SELF_SERVE_WORKSPACES,
+  resolveWorkspaceCreateQuota,
+  workspaceCapMessage,
+  type WorkspaceCapRecord,
+} from "../src/workspace-cap";
+
+/** A free self-serve workspace — the only kind that burns a slot. */
+const free: WorkspaceCapRecord = { selfServe: true };
+/** Self-serve, later upgraded — exempt. */
+const pro: WorkspaceCapRecord = { selfServe: true, plan: "pro" };
+/** Operator-provisioned, no self-serve flag — exempt. */
+const legacy: WorkspaceCapRecord = {};
+
+describe("countCapEligibleWorkspaces", () => {
+  it("counts free self-serve workspaces", () => {
+    expect(countCapEligibleWorkspaces([free, free, free])).toBe(3);
+  });
+
+  it("exempts paid workspaces", () => {
+    expect(countCapEligibleWorkspaces([free, free, pro])).toBe(2);
+  });
+
+  it("exempts legacy/operator-provisioned workspaces", () => {
+    expect(countCapEligibleWorkspaces([legacy, legacy, free])).toBe(1);
+  });
+
+  it("counts a self-serve record with an explicit free plan", () => {
+    expect(countCapEligibleWorkspaces([{ selfServe: true, plan: "free" }])).toBe(1);
+  });
+
+  it("counts a self-serve record with an unrecognized plan (fails open to free)", () => {
+    expect(countCapEligibleWorkspaces([{ selfServe: true, plan: "enterprise" }])).toBe(1);
+  });
+
+  it("skips records that could not be loaded", () => {
+    expect(countCapEligibleWorkspaces([free, null, undefined, free])).toBe(2);
+  });
+
+  it("counts nothing for a user who owns nothing", () => {
+    expect(countCapEligibleWorkspaces([])).toBe(0);
+  });
+});
+
+describe("resolveWorkspaceCreateQuota", () => {
+  it("allows creation below the cap", () => {
+    expect(resolveWorkspaceCreateQuota([free, free])).toEqual({
+      used: 2,
+      cap: MAX_SELF_SERVE_WORKSPACES,
+      allowed: true,
+    });
+  });
+
+  it("denies creation at the cap", () => {
+    expect(resolveWorkspaceCreateQuota([free, free, free])).toEqual({
+      used: 3,
+      cap: MAX_SELF_SERVE_WORKSPACES,
+      allowed: false,
+    });
+  });
+
+  it("frees a slot when one workspace is on a paid plan", () => {
+    expect(resolveWorkspaceCreateQuota([free, free, pro])).toEqual({
+      used: 2,
+      cap: MAX_SELF_SERVE_WORKSPACES,
+      allowed: true,
+    });
+  });
+
+  // A lapsed Pro leaves the user over the cap. Nothing is reclaimed — the cap
+  // is a creation gate, so this reports honestly and simply denies creation.
+  it("reports an over-cap count after a downgrade without throwing", () => {
+    expect(resolveWorkspaceCreateQuota([free, free, free, free])).toEqual({
+      used: 4,
+      cap: MAX_SELF_SERVE_WORKSPACES,
+      allowed: false,
+    });
+  });
+});
+
+describe("workspaceCapMessage", () => {
+  it("names the cap in force and points at the upgrade path", () => {
+    expect(workspaceCapMessage(MAX_SELF_SERVE_WORKSPACES)).toBe(
+      "Free accounts include 3 workspaces. Upgrade one to Pro to create another.",
+    );
+  });
+
+  it("reads naturally at a cap of one", () => {
+    expect(workspaceCapMessage(1)).toContain("1 workspace.");
+  });
+});


### PR DESCRIPTION
A user may own at most **3 free workspaces**. Paid workspaces don't count, and
neither do legacy/operator ones or workspaces you were merely invited to.

The cap of 3 has been enforced at `POST /v1/workspaces` since self-serve
registration shipped, but it counted paid workspaces against the allowance and
no UI knew it existed — a user at the limit found out by filling in the create
form and being refused. This makes paid workspaces exempt and teaches the
account surfaces about it.

Spec: `docs/superpowers/specs/2026-07-24-workspace-creation-soft-cap-design.md`

## The rule

Lives in `packages/billing/src/workspace-cap.ts`, sibling to `member-cap.ts` and
keyed on the same `selfServe`-not-`plan` reasoning (self-serve provisioning
writes free's numeric limits and no `plan` field, so a check on `plan === "free"`
alone would bind to almost nobody). A record burns a slot only when all three
hold: role is `owner`, the record is `selfServe`, and it resolves to free.

Two consequences, both deliberate and documented:

- **Upgrading frees a slot immediately.** Take one to Pro and you can create
  another.
- **A downgrade can leave a user over the cap.** Nothing is deleted, disabled,
  or reclaimed — they just can't create another until they're back under. This
  is a creation gate and only that.

To comp an exception, edit the workspace record (clear `selfServe`, or apply a
plan). There's deliberately no per-user override at a cap of 3.

## How the UI knows

`GET /me/workspaces` gained a `workspaceCreate: { used, cap, allowed }` block.
That handler already loads every membership's record for `plan`/`publicBaseUrl`,
so the count costs **no extra KV reads**.

**Absent means allowed** at every layer. An older worker, a malformed field, or
a partial outage degrades to the previous behaviour — create still offered,
server still refusing — rather than locking someone out of a workspace they're
entitled to. `POST /v1/workspaces` remains the only enforcement point.

## At the cap

- The switcher's `+ new workspace` row becomes `manage workspaces` →
  `/account/workspaces?manage=1`. One row either way, never both — the point is
  that creation shouldn't sit there permanently offering something that will be
  refused.
- The index drops the create link for a muted note.
- `/account/workspaces/new` checks the quota itself (it's directly linkable),
  disabling the form rather than letting a submit round-trip into a 403.

## Landing in a workspace

`?manage=1` is what makes the index reachable on purpose; without it, a
signed-in user is auto-opened into a workspace instead of being asked to choose
every time. The fallback order is last-used → first owned → first administered →
first membership.

The communal `default` is skipped at every step of that fallback — most accounts
are `owner` there, so without the skip nearly everyone would land in the shared
workspace on their first visit. It still opens when it's the only membership or
the explicitly stored last-used slug.

## Also

The index's "create one" link was rendering as `orcreate one` — Astro collapses
the newline between `or` and the anchor. Fixed with an explicit `&#32;`.

## Cleanup pass

The account shell fetched `/me/workspaces` for the switcher on every page while
the index and create pages each fetched it again — two or three identical
requests per paint. `loadWorkspaces` now shares one in-flight request between
concurrent callers. Measured on the create page: two requests down to one.

That made the create page's `applyQuota` symmetric out of necessity — a cached
quota can be stale in either direction, so revalidation has to *lift* the cap as
well as apply it, or a user who just upgraded stares at a disabled form until
they reload. Caught by verifying against the running stack, not by the tests.

## Verification

- Full suite: 2977 passing. Lint and typecheck clean.
- Driven against the local stack with a dev session: at-cap index, at-cap
  switcher row, at-cap create form (input + submit disabled), the stale-cache
  lift, the request dedupe (counted), and the whitespace fix in the rendered
  DOM. No console errors.

No changeset — nothing here touches the published CLI.
