### PR TITLE
refactor: Give the communal workspace one home and tell clients about it

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,7 @@
     "@uploads/web",
     "@uploads/storage",
     "@uploads/auth",
-    "@uploads/billing"
+    "@uploads/billing",
+    "@uploads/workspace"
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,6 +40,7 @@
     "@uploads/email": "workspace:^",
     "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",
+    "@uploads/workspace": "workspace:^",
     "hono": "^4.12.28",
     "mediabunny": "^1.50.9"
   },

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,4 +1,5 @@
 import { renderEnrollmentInvitationEmail } from "@uploads/email";
+import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import {
   AppError,
   ConflictError,
@@ -173,7 +174,7 @@ export const admin = new Hono<{ Bindings: Env }>()
     return c.json({ created, existing });
   })
 
-  // Mint a scoped bearer token for an existing workspace (defaults to "default").
+  // Mint a scoped bearer token for an existing workspace (defaults to the communal one).
   // New credentials live in D1; legacy KV credentials remain readable/revocable.
   .post("/tokens", async (c) => {
     const body = await c.req
@@ -192,7 +193,7 @@ export const admin = new Hono<{ Bindings: Env }>()
             expiresInDays?: number;
           },
       );
-    const name = body.workspace?.trim() || "default";
+    const name = body.workspace?.trim() || COMMUNAL_WORKSPACE;
     const label = labelValue(body.label);
     requireWorkspaceName(name);
     requireLabel(label);
@@ -257,7 +258,7 @@ export const admin = new Hono<{ Bindings: Env }>()
             email?: string;
           },
       );
-    const name = body.workspace?.trim() || "default";
+    const name = body.workspace?.trim() || COMMUNAL_WORKSPACE;
     const label = labelValue(body.label);
     requireWorkspaceName(name);
     requireLabel(label);
@@ -343,7 +344,7 @@ export const admin = new Hono<{ Bindings: Env }>()
 
   // Lists D1 credentials and legacy KV credentials without exposing secrets.
   .get("/tokens", async (c) => {
-    const name = c.req.query("workspace")?.trim() || "default";
+    const name = c.req.query("workspace")?.trim() || COMMUNAL_WORKSPACE;
     requireWorkspaceName(name);
     const record = await workspace(c, name);
     if (!record) {
@@ -376,7 +377,7 @@ export const admin = new Hono<{ Bindings: Env }>()
     const body = await c.req
       .json<{ workspace?: string; hashPrefix?: string; label?: string }>()
       .catch(() => ({}) as { workspace?: string; hashPrefix?: string; label?: string });
-    const name = body.workspace?.trim() || "default";
+    const name = body.workspace?.trim() || COMMUNAL_WORKSPACE;
     const hashPrefix = body.hashPrefix?.trim();
     const label = body.label?.trim();
     requireWorkspaceName(name);

--- a/apps/api/src/routes/internal-billing.test.ts
+++ b/apps/api/src/routes/internal-billing.test.ts
@@ -1,3 +1,4 @@
+import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import { Hono } from "hono";
 import { beforeAll, describe, expect, it } from "vitest";
 import { fakeRegistry } from "../../test/fake-kv";
@@ -280,12 +281,12 @@ describe("GET /internal/billing/member-cap", () => {
     expect(body.message).toBeNull();
   });
 
-  it("exempts the communal default workspace even if a plan is stamped on it", async () => {
+  it("exempts the communal workspace even if a plan is stamped on it", async () => {
     const registry = fakeRegistry({
-      default: { provider: "r2", bucket: "b", plan: "free", selfServe: true },
+      [COMMUNAL_WORKSPACE]: { provider: "r2", bucket: "b", plan: "free", selfServe: true },
     });
     const env = { REGISTRY: registry, BILLING_INTERNAL_KEY: SECRET } as unknown as Env;
-    const res = await get("default", { "x-internal-billing-key": SECRET }, env);
+    const res = await get(COMMUNAL_WORKSPACE, { "x-internal-billing-key": SECRET }, env);
     expect(res.status).toBe(200);
     expect((await res.json()) as { cap: number | null }).toMatchObject({ cap: null });
   });

--- a/apps/api/src/routes/internal-billing.ts
+++ b/apps/api/src/routes/internal-billing.ts
@@ -39,6 +39,7 @@ import {
   type PlanId,
 } from "@uploads/billing";
 import { UnauthorizedError, ValidationError } from "@uploads/errors";
+import { isCommunalWorkspace } from "@uploads/workspace";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { jsonBody } from "./json-body";
@@ -121,15 +122,6 @@ internalBilling.post("/plan", async (c) => {
 });
 
 /**
- * The communal `default` workspace is exempt from the member cap, the same
- * way it's already exempt from the other member flows (see slug-policy.ts).
- * Today it also resolves to unlimited on its own — it's operator-provisioned,
- * so it has neither a `plan` nor `selfServe` — but naming it here means an
- * operator stamping a plan on it can't accidentally cap the shared workspace.
- */
-const MEMBER_CAP_EXEMPT_WORKSPACES = new Set(["default"]);
-
-/**
  * `GET /internal/billing/member-cap?workspace=<name>` — the cap the auth
  * worker enforces at invite creation (issue #450).
  *
@@ -151,7 +143,13 @@ internalBilling.get("/member-cap", async (c) => {
     throw new ValidationError("workspace is required", { code: "invalid_workspace" });
   }
 
-  const record = MEMBER_CAP_EXEMPT_WORKSPACES.has(workspace)
+  // The communal workspace is exempt from the member cap, the same way it's
+  // already exempt from the other member flows (see slug-policy.ts). Today it
+  // also resolves to unlimited on its own — it's operator-provisioned, so it
+  // has neither a `plan` nor `selfServe` — but skipping the lookup means an
+  // operator stamping a plan on it can't accidentally cap the shared
+  // workspace.
+  const record = isCommunalWorkspace(workspace)
     ? null
     : await loadWorkspaceRecord(c.env, workspace);
   const cap = record ? resolveMemberCap(record) : null;

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { fileURLToPath, URL as NodeURL } from "node:url";
+import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
@@ -77,9 +78,30 @@ describe("GET /me/workspaces", () => {
         workspace: "acme",
         organization: { id: "org1", slug: "acme", name: "Acme Inc" },
         role: "owner",
+        communal: false,
         hasPublicUrl: false,
         plan: "free",
       },
+    ]);
+  });
+
+  it("marks the communal workspace so the account UI doesn't infer it from the slug", async () => {
+    const env = stubEnv(USER, (path) => {
+      if (path === "/internal/memberships") {
+        return Response.json(
+          ownedMemberships([
+            [COMMUNAL_WORKSPACE, "owner"],
+            ["acme", "owner"],
+          ]),
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+    const res = await app().request("/me/workspaces", {}, env);
+    const body = (await res.json()) as { workspaces: { workspace: string; communal: boolean }[] };
+    expect(body.workspaces.map((ws) => [ws.workspace, ws.communal])).toEqual([
+      [COMMUNAL_WORKSPACE, true],
+      ["acme", false],
     ]);
   });
 
@@ -182,7 +204,7 @@ describe("GET /me/workspaces", () => {
     expect(await quotaFor(env)).toEqual({ used: 2, cap: 3, allowed: true });
   });
 
-  it("treats a workspace named 'default' as an ordinary workspace", async () => {
+  it("loads the communal workspace's record like any other — the flag is not a short-circuit", async () => {
     const env = stubEnv(USER, (path) => {
       if (path === "/internal/memberships") {
         return Response.json([
@@ -206,6 +228,7 @@ describe("GET /me/workspaces", () => {
         workspace: "default",
         organization: { id: "org2", slug: "default", name: "Default" },
         role: "member",
+        communal: true,
         hasPublicUrl: false,
         plan: "free",
       },

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -12,6 +12,7 @@
 import { resolveWorkspaceCreateQuota } from "@uploads/billing";
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
+import { isCommunalWorkspace } from "@uploads/workspace";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { throwForInviteError } from "../invite-error";
@@ -52,11 +53,20 @@ interface MyWorkspace {
   workspace: string;
   organization: { id: string; slug: string; name: string };
   role: string;
+  /**
+   * True for the shared tenant every account belongs to. Sent so clients
+   * don't have to re-derive a privileged-workspace rule from the slug: the
+   * account UI skips the communal workspace when picking which workspace to
+   * auto-open, and that is a server-owned fact, not a naming convention the
+   * browser should be pattern-matching. Free to compute — no extra lookup.
+   */
+  communal: boolean;
 }
 
 function myWorkspaceFromMembership(membership: Membership, workspace: string): MyWorkspace {
   return {
     workspace,
+    communal: isCommunalWorkspace(workspace),
     organization: {
       id: membership.organizationId,
       slug: membership.organizationSlug,
@@ -181,7 +191,9 @@ export const me = new Hono<SessionVars>()
   // without a per-workspace billing round trip. Both fields are loaded here
   // (not in `myWorkspaces`, which every member-gated route calls for
   // authorization) so the extra KV read per workspace stays confined to this
-  // one listing endpoint.
+  // one listing endpoint. `communal` rides along from `myWorkspaces` — it
+  // costs no lookup, and it's what keeps the account UI from inferring the
+  // shared-tenant rule from the slug.
   .get("/workspaces", async (c) => {
     const userId = c.get("sessionUser")?.id;
     if (!userId) throw new NotFoundError("no session user", { code: "workspace_not_found" });
@@ -250,6 +262,7 @@ export const me = new Hono<SessionVars>()
       workspace: ws.workspace,
       organization: ws.organization,
       role: ws.role,
+      communal: ws.communal,
       hasPublicUrl: Boolean(publicBaseUrl),
       publicBaseUrl,
       usage,

--- a/apps/api/src/slug-policy.ts
+++ b/apps/api/src/slug-policy.ts
@@ -1,24 +1,25 @@
+import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import { WS_NAME_RE } from "./workspace";
 import { SLUG_BLOCKLIST, SLUG_BLOCKLIST_ALLOW } from "./slug-blocklist";
 
 /**
  * Names that collide with routes or subdomains.
  *
- * `default` is redundant with the existing-name check today (the built-in
- * `default` workspace is always registered, so self-serve registration
- * would already 409 `workspace_name_taken` without this entry) — but it
- * stays reserved deliberately, not just for symmetry. Hard-delete is the
- * only path that ever frees a slug (see docs/deletion.md), and `default` is
- * uniquely privileged: it's the communal/agent workspace exempted from the
- * reaper and referenced by ops tooling, docs, and bootstrap scripts by
- * name. If it were ever hard-deleted (accidentally or deliberately) and
- * this entry were removed, self-serve registration would let any signed-in
- * user reclaim the `default` slug for an unrelated, non-communal workspace
- * — a name-squatting/confusion risk this list exists to close for the
- * other entries. Keeping it here costs nothing and closes that latent gap.
+ * `COMMUNAL_WORKSPACE` is redundant with the existing-name check today (the
+ * built-in communal workspace is always registered, so self-serve
+ * registration would already 409 `workspace_name_taken` without this entry)
+ * — but it stays reserved deliberately, not just for symmetry. Hard-delete is
+ * the only path that ever frees a slug (see docs/deletion.md), and the
+ * communal workspace is uniquely privileged: it's the communal/agent
+ * workspace exempted from the reaper and referenced by ops tooling, docs, and
+ * bootstrap scripts by name. If it were ever hard-deleted (accidentally or
+ * deliberately) and this entry were removed, self-serve registration would
+ * let any signed-in user reclaim the slug for an unrelated, non-communal
+ * workspace — a name-squatting/confusion risk this list exists to close for
+ * the other entries. Keeping it here costs nothing and closes that latent gap.
  */
 export const RESERVED_WORKSPACE_NAMES: ReadonlySet<string> = new Set([
-  "default",
+  COMMUNAL_WORKSPACE,
   "admin",
   "api",
   "www",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@astrojs/react": "^6.0.1",
     "@uploads/billing": "workspace:^",
     "@uploads/ui": "workspace:*",
+    "@uploads/workspace": "workspace:^",
     "astro": "^7.0.6",
     "files-sdk": "^2.1.0",
     "markdown-for-agents": "^1.3.4",

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -160,6 +160,48 @@ describe("getMyWorkspaces", () => {
       ["byo", undefined],
     ]);
   });
+
+  it("trusts the api's communal flag and falls back to the slug only when it is absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          workspaces: [
+            {
+              workspace: "acme",
+              organization: { id: "org1", slug: "acme", name: "Acme Inc" },
+              role: "owner",
+              communal: true,
+            },
+            {
+              // The api's own answer wins even for the communal slug.
+              workspace: "default",
+              organization: { id: "org2", slug: "default", name: "default" },
+              role: "member",
+              communal: false,
+            },
+            {
+              // Older api response, no communal field: fall back to the slug
+              // so the auto-open skip can't silently stop working.
+              workspace: "default",
+              organization: { id: "org3", slug: "default", name: "default" },
+              role: "member",
+            },
+            {
+              workspace: "byo",
+              organization: { id: "org4", slug: "byo", name: "BYO Inc" },
+              role: "member",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await getMyWorkspaces("http://127.0.0.1:8787");
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") throw new Error("expected success");
+    expect(result.workspaces.map((ws) => ws.communal)).toEqual([true, false, true, false]);
+  });
 });
 
 describe("setFileVisibility", () => {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -6,6 +6,7 @@
  * rather than rendering an outage as an empty account; less central detail
  * helpers retain their defensive null/[] fallbacks.
  */
+import { isCommunalWorkspace } from "@uploads/workspace";
 import { fetchWithTimeout, type RequestFailure } from "./request";
 import { buildSearchQuery, type MetaFilter } from "./workspace-search-url";
 
@@ -33,12 +34,24 @@ export interface MyWorkspace {
    * "pro". Undefined only against an older api build that omits the field.
    */
   plan?: string;
+  /**
+   * True for the shared/communal tenant every account belongs to. Server-
+   * supplied (`/me/workspaces`) so the UI reads a business rule rather than
+   * matching a slug; `mapMyWorkspace` falls back to the slug only for an
+   * older api build that predates the field.
+   */
+  communal: boolean;
 }
 
-// `hasPublicUrl`/`plan` are intentionally NOT required here: web and
-// api deploy independently, so an older api may omit them. We accept the
-// entry and coerce a missing/other value to a safe default in the mapper below.
-function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "hasPublicUrl" | "plan"> {
+/**
+ * The fields every api build has always sent. `hasPublicUrl`/`plan`/`communal`
+ * are deliberately excluded: web and api deploy independently, so an older api
+ * may omit them — the entry is still accepted and `mapMyWorkspace` coerces each
+ * missing value to a safe default.
+ */
+type MyWorkspaceCore = Omit<MyWorkspace, "hasPublicUrl" | "plan" | "communal">;
+
+function isMyWorkspaceCore(value: unknown): value is MyWorkspaceCore {
   if (!value || typeof value !== "object") return false;
   const ws = value as Record<string, unknown>;
   const org = ws.organization as Record<string, unknown> | null | undefined;
@@ -52,12 +65,23 @@ function isMyWorkspaceCore(value: unknown): value is Omit<MyWorkspace, "hasPubli
   );
 }
 
-/** Coerce optional/legacy fields; shared by list + summary mappers. */
-function mapMyWorkspace(ws: Omit<MyWorkspace, "hasPublicUrl" | "plan">): MyWorkspace {
-  const raw = ws as Omit<MyWorkspace, "hasPublicUrl" | "plan"> & {
+/**
+ * Coerce optional/legacy fields; shared by list + summary mappers.
+ *
+ * `communal` is the one field with a non-constant fallback: it is a rule the
+ * api owns, but an api build older than the field would omit it, and reading
+ * that absence as "not communal" would silently un-skip the shared workspace
+ * in `resolveDefaultWorkspace`. So a missing flag — and only a missing flag —
+ * falls back to the shared slug constant. This is the sole place in the web
+ * app that knows the communal slug at all; everything downstream reads the
+ * boolean.
+ */
+function mapMyWorkspace(ws: MyWorkspaceCore): MyWorkspace {
+  const raw = ws as MyWorkspaceCore & {
     hasPublicUrl?: unknown;
     publicBaseUrl?: unknown;
     plan?: unknown;
+    communal?: unknown;
   };
   return {
     workspace: raw.workspace,
@@ -66,6 +90,7 @@ function mapMyWorkspace(ws: Omit<MyWorkspace, "hasPublicUrl" | "plan">): MyWorks
     hasPublicUrl: raw.hasPublicUrl === true,
     publicBaseUrl: typeof raw.publicBaseUrl === "string" ? raw.publicBaseUrl : undefined,
     plan: typeof raw.plan === "string" ? raw.plan : undefined,
+    communal: typeof raw.communal === "boolean" ? raw.communal : isCommunalWorkspace(raw.workspace),
   };
 }
 

--- a/apps/web/src/lib/workspace-file-row.test.ts
+++ b/apps/web/src/lib/workspace-file-row.test.ts
@@ -170,6 +170,7 @@ function mkWorkspace(workspace: string, overrides: Partial<MyWorkspace> = {}): M
     organization: { id: "1", slug: workspace, name: workspace },
     role: "member",
     hasPublicUrl: false,
+    communal: false,
     ...overrides,
   };
 }

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -55,12 +55,14 @@ const sample: MyWorkspace[] = [
     organization: { id: "1", slug: "buildinternet", name: "buildinternet" },
     role: "admin",
     hasPublicUrl: true,
+    communal: false,
   },
   {
     workspace: "side",
     organization: { id: "2", slug: "side", name: "Side Project" },
     role: "member",
     hasPublicUrl: false,
+    communal: false,
   },
 ];
 
@@ -226,18 +228,21 @@ describe("isManageRequest", () => {
 });
 
 describe("resolveDefaultWorkspace", () => {
-  const multi = [{ workspace: "buildinternet" }, { workspace: "side" }];
+  const multi = [
+    { workspace: "buildinternet", communal: false },
+    { workspace: "side", communal: false },
+  ];
 
   it("picks the only membership, else a valid last-used", () => {
-    expect(resolveDefaultWorkspace([{ workspace: "solo" }], "other")).toBe("solo");
+    expect(resolveDefaultWorkspace([{ workspace: "solo", communal: false }], "other")).toBe("solo");
     expect(resolveDefaultWorkspace(multi, "side")).toBe("side");
   });
 
   it("falls back to the first owned workspace when no last-used is stored", () => {
     const roles = [
-      { workspace: "invited", role: "member" },
-      { workspace: "mine", role: "owner" },
-      { workspace: "other", role: "owner" },
+      { workspace: "invited", role: "member", communal: false },
+      { workspace: "mine", role: "owner", communal: false },
+      { workspace: "other", role: "owner", communal: false },
     ];
     expect(resolveDefaultWorkspace(roles, "")).toBe("mine");
     // A stale slug the user is no longer a member of takes the same path.
@@ -246,8 +251,8 @@ describe("resolveDefaultWorkspace", () => {
 
   it("prefers an administered workspace when none is owned", () => {
     const roles = [
-      { workspace: "invited", role: "member" },
-      { workspace: "runs-it", role: "admin" },
+      { workspace: "invited", role: "member", communal: false },
+      { workspace: "runs-it", role: "admin", communal: false },
     ];
     expect(resolveDefaultWorkspace(roles, "")).toBe("runs-it");
   });
@@ -257,32 +262,43 @@ describe("resolveDefaultWorkspace", () => {
     expect(
       resolveDefaultWorkspace(
         [
-          { workspace: "one", role: "member" },
-          { workspace: "two", role: "member" },
+          { workspace: "one", role: "member", communal: false },
+          { workspace: "two", role: "member", communal: false },
         ],
         "",
       ),
     ).toBe("one");
   });
 
-  it("skips the communal default so an owner there still lands in their own workspace", () => {
-    const roles = [
-      { workspace: "default", role: "owner" },
-      { workspace: "buildinternet", role: "admin" },
-    ];
-    expect(resolveDefaultWorkspace(roles, "")).toBe("buildinternet");
+  // The skip keys off the server-supplied `communal` flag, never the slug —
+  // these fixtures name the workspace "shared" precisely to prove that.
+  const communalPair = [
+    { workspace: "shared", role: "owner", communal: true },
+    { workspace: "buildinternet", role: "admin", communal: false },
+  ];
+
+  it("skips a communal workspace so an owner there still lands in their own workspace", () => {
+    expect(resolveDefaultWorkspace(communalPair, "")).toBe("buildinternet");
   });
 
-  it("still opens the communal default when it is the only membership", () => {
-    expect(resolveDefaultWorkspace([{ workspace: "default", role: "owner" }], "")).toBe("default");
+  it("still opens the communal workspace when it is the only membership", () => {
+    expect(
+      resolveDefaultWorkspace([{ workspace: "shared", role: "owner", communal: true }], ""),
+    ).toBe("shared");
   });
 
-  it("honours an explicit last-used default over the skip", () => {
+  it("honours an explicit last-used communal workspace over the skip", () => {
+    expect(resolveDefaultWorkspace(communalPair, "shared")).toBe("shared");
+  });
+
+  it("does not skip the communal slug when the flag says otherwise", () => {
+    // An entry named `default` that the api did not mark communal is an
+    // ordinary workspace here — the client no longer reads the slug.
     const roles = [
-      { workspace: "default", role: "owner" },
-      { workspace: "buildinternet", role: "admin" },
+      { workspace: "default", role: "owner", communal: false },
+      { workspace: "buildinternet", role: "member", communal: false },
     ];
-    expect(resolveDefaultWorkspace(roles, "default")).toBe("default");
+    expect(resolveDefaultWorkspace(roles, "")).toBe("default");
   });
 
   it("returns null only when there are no memberships", () => {

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -190,13 +190,6 @@ export function clearCachedActiveWorkspace(): void {
 const FALLBACK_ROLES = ["owner", "admin"];
 
 /**
- * The communal workspace. Most accounts are members of it, and many are
- * `owner` there, so a naive role-first fallback would land almost everyone
- * in the shared workspace instead of their own. Considered last.
- */
-const COMMUNAL_WORKSPACE = "default";
-
-/**
  * Workspace to open from the index after login.
  *
  * One membership → that workspace. Multi → last-used if still a member.
@@ -206,21 +199,27 @@ const COMMUNAL_WORKSPACE = "default";
  * workspace rather than being asked to choose every time. The switcher, not
  * this page, is how you change workspaces.
  *
- * The communal `default` is skipped at every step of that fallback and only
- * used when it is the sole membership, so a user who happens to be `owner`
- * there still lands in their own workspace.
+ * A communal workspace (`communal`, set by the api — most accounts belong to
+ * the shared one and many are `owner` there, so a naive role-first fallback
+ * would land almost everyone in it) is skipped at every step of that fallback
+ * and only used when it is the sole membership, so a user who happens to be
+ * `owner` there still lands in their own workspace. The flag comes from the
+ * server precisely so this file doesn't encode which slug that is.
  *
  * Null only when there are no memberships at all. The index suppresses the
  * auto-open entirely when it was reached deliberately (`?manage=1`).
  */
 export function resolveDefaultWorkspace(
-  workspaces: readonly { workspace: string; role?: string }[],
+  // `communal` is required, not optional: an optional flag would let a future
+  // caller omit it and silently un-skip the shared workspace with no type
+  // error — exactly the drift this stopped inferring from the slug to avoid.
+  workspaces: readonly { workspace: string; role?: string; communal: boolean }[],
   lastActive = "",
 ): string | null {
   if (workspaces.length === 1) return workspaces[0]!.workspace;
   if (lastActive && workspaces.some((ws) => ws.workspace === lastActive)) return lastActive;
 
-  const own = workspaces.filter((ws) => ws.workspace !== COMMUNAL_WORKSPACE);
+  const own = workspaces.filter((ws) => !ws.communal);
   for (const role of FALLBACK_ROLES) {
     const match = own.find((ws) => ws.role === role);
     if (match) return match.workspace;

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -2,6 +2,7 @@
 // Minimal operator console: paste a bearer token, list usage + files via the public API.
 // No server-side secrets — token stays in the browser. Scaffold toward a fuller files-sdk UI.
 import { env } from "cloudflare:workers";
+import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import { resolveConsoleMode } from "../lib/console-mode";
 import Brand from "../components/Brand.astro";
 import BaseHead from "../components/BaseHead.astro";
@@ -184,7 +185,7 @@ const authOrigin =
       </label>
       <label>
         Workspace
-        <input id="ws" type="text" value="default" autocomplete="off" />
+        <input id="ws" type="text" value={COMMUNAL_WORKSPACE} autocomplete="off" />
       </label>
       <label>
         Bearer token
@@ -259,6 +260,8 @@ const authOrigin =
       });
     </script>
     <script>
+      import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
+
       function el<T extends HTMLElement>(id: string): T {
         const node = document.getElementById(id);
         if (!node) throw new Error(`console page is missing #${id}`);
@@ -317,7 +320,7 @@ const authOrigin =
             method: "POST",
             headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
             body: JSON.stringify({
-              workspace: ws || "default",
+              workspace: ws || COMMUNAL_WORKSPACE,
               ...(email ? { email } : {}),
               ...(label ? { label } : {}),
             }),
@@ -338,7 +341,7 @@ const authOrigin =
           const emailedNote =
             body.emailed === undefined ? "" : body.emailed ? `\nemailed:  ${email}` : "\nemailed:  send FAILED — share the link yourself";
           out.textContent =
-            `Invite created for "${ws || "default"}" — the link below is shown once. Treat it like a password.\n\n` +
+            `Invite created for "${ws || COMMUNAL_WORKSPACE}" — the link below is shown once. Treat it like a password.\n\n` +
             `${inviteLink}\n\nexpires:  ${body.expiresAt ?? "?"}${emailedNote}`;
           copyBtn.hidden = false;
         } catch (e) {

--- a/packages/email/src/invites.ts
+++ b/packages/email/src/invites.ts
@@ -1,3 +1,4 @@
+import { isCommunalWorkspace } from "@uploads/workspace";
 import { escapeHtml, renderEmailCard, strong, type RenderedEmail } from "./card";
 
 const CTA = "Accept invitation →";
@@ -38,7 +39,7 @@ export function renderOrgInvitationEmail(ctx: {
 
 /**
  * Token enrollment invite (console / CLI → /invite#code).
- * "default" is framed as access to uploads.sh itself.
+ * The communal workspace is framed as access to uploads.sh itself.
  */
 export function renderEnrollmentInvitationEmail(ctx: {
   workspaceName: string;
@@ -54,7 +55,7 @@ export function renderEnrollmentInvitationEmail(ctx: {
     timeZone: "UTC",
     timeZoneName: "short",
   });
-  const isDefault = ctx.workspaceName === "default";
+  const isDefault = isCommunalWorkspace(ctx.workspaceName);
   const invitedTo = isDefault
     ? "You've been given access to uploads.sh"
     : `You've been invited to the ${ctx.workspaceName} workspace on uploads.sh`;

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1,0 +1,14 @@
+# @uploads/workspace
+
+Workspace identity facts that more than one worker has to agree on — today,
+which slug is the communal workspace (`COMMUNAL_WORKSPACE`,
+`isCommunalWorkspace`). Enforcement lives with the rules it belongs to
+(slug reservation in `apps/api/src/slug-policy.ts`, the member-cap exemption in
+`apps/api/src/routes/internal-billing.ts`); this package only says which
+workspace they are all talking about.
+
+Clients are told, not left to infer: `/me/workspaces` stamps `communal` on each
+membership entry, so `apps/web` reads a flag instead of matching a slug.
+
+Private workspace package — not published, excluded from Changesets like
+`@uploads/api` / `@uploads/billing` / `@uploads/web` / `@uploads/auth`.

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,14 +1,10 @@
 {
-  "name": "@uploads/email",
+  "name": "@uploads/workspace",
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "sideEffects": false,
   "exports": {
     ".": "./src/index.ts"
-  },
-  "dependencies": {
-    "@uploads/workspace": "workspace:^"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/workspace/src/communal.ts
+++ b/packages/workspace/src/communal.ts
@@ -1,0 +1,27 @@
+/**
+ * Identity of the communal workspace — the one shared tenant every account
+ * belongs to, as opposed to the workspaces a user creates or is invited to.
+ *
+ * It is privileged in several unrelated places: its slug is reserved against
+ * self-serve registration (`slug-policy.ts`), it is exempt from the free-plan
+ * member cap (`routes/internal-billing.ts`) and from the workspace reaper, and
+ * the account UI skips it when choosing which workspace to open. Those rules
+ * are enforced in different workers, so the slug itself lives here — one home
+ * that both `apps/api` and `apps/web` can import — rather than being spelled
+ * out at each site where a rename would have to be applied in lockstep with no
+ * compiler help.
+ *
+ * Note the distinction this package does *not* erase: server code may compare
+ * against the slug, but clients should be *told* whether a workspace is
+ * communal (`/me/workspaces` stamps `communal` on each entry) instead of
+ * re-deriving a business rule from a naming convention. The one client-side
+ * comparison left is `apps/web`'s `mapMyWorkspace`, which falls back to the
+ * slug only when the field is absent — i.e. against an api build older than
+ * the flag, since web and api deploy independently.
+ */
+export const COMMUNAL_WORKSPACE = "default";
+
+/** Whether `name` is the communal workspace. */
+export function isCommunalWorkspace(name: string): boolean {
+  return name === COMMUNAL_WORKSPACE;
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./communal";

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@uploads/storage':
         specifier: workspace:^
         version: link:../../packages/storage
+      '@uploads/workspace':
+        specifier: workspace:^
+        version: link:../../packages/workspace
       hono:
         specifier: ^4.12.28
         version: 4.12.28
@@ -167,6 +170,9 @@ importers:
       '@uploads/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@uploads/workspace':
+        specifier: workspace:^
+        version: link:../../packages/workspace
       astro:
         specifier: ^7.0.6
         version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
@@ -215,6 +221,10 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
 
   packages/email:
+    dependencies:
+      '@uploads/workspace':
+        specifier: workspace:^
+        version: link:../workspace
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -313,6 +323,15 @@ importers:
       playwright-core:
         specifier: ^1.61.1
         version: 1.61.1
+
+  packages/workspace:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
 
   scripts/demos:
     dependencies:


### PR DESCRIPTION
Follow-up to the cleanup review on #503, deferred there because the fix reaches
well outside that diff.

## The problem

The communal workspace slug `"default"` was spelled out independently in four
places, none importing from the others:

| Site | Rule it enforces |
| --- | --- |
| `apps/api/src/slug-policy.ts` | reserved against self-serve registration |
| `apps/api/src/routes/internal-billing.ts` | exempt from the free-plan member cap |
| `apps/web/src/lib/workspaces-nav.ts` | skipped by the account index auto-open |
| `packages/email/src/invites.ts` | invite framed as access to uploads.sh itself |

A rename would have needed four coordinated edits with no compiler help. Worse,
the web copy meant the browser was inferring a business rule from a naming
convention — the deeper problem behind the duplication.

## The fix

**One home: `@uploads/workspace`** — a private source-only package (same shape
as `@uploads/billing`) exporting `COMMUNAL_WORKSPACE` and
`isCommunalWorkspace`. All four sites now import it, as do the four operator
`admin.ts` token/enrollment routes and `console.astro`, which had the same slug
as their "workspace the operator meant when they didn't say" default.

`@uploads/billing` was considered and rejected: a workspace slug is not a
billing concern, even though `apps/web` already depends on that package.

**The web half is fixed at the contract level, not just by sharing a
constant.** `GET /me/workspaces` (and `/summary`) now stamps a `communal`
boolean on each membership entry — computed in `myWorkspaceFromMembership`, so
it costs a string comparison and no extra lookup — and `resolveDefaultWorkspace`
filters on that flag. Its parameter type requires `communal`, so a future caller
can't omit it and silently un-skip the shared workspace.

The one slug comparison left in `apps/web` is `mapMyWorkspace`'s fallback for an
api build older than the field. web and api deploy independently (the same
contract already documented for `hasPublicUrl`/`plan`), and reading an absent
flag as "not communal" would quietly un-skip the shared workspace during the
rollout window.

`packages/uploads` keeps its own `DEFAULT_WORKSPACE`: that is the CLI's default
*target*, a different fact that happens to share a value, and a published
package can't depend on a private one.

## Behaviour

Unchanged. The three cases `resolveDefaultWorkspace` guarantees — skip the
communal workspace in the fallback chain, still open it when it's the sole
membership, still honour it as an explicit last-used slug — all hold, and their
tests now assert the *flag*: the fixtures name the communal workspace `shared`
so a slug-matching regression fails. Added coverage for an entry named `default`
that the api marks non-communal, and for the mapper's flag-vs-fallback matrix.

## Verification

`pnpm test` 3002 passed / 232 files · `pnpm lint` no errors · `pnpm typecheck`
clean incl. `astro check` · `pnpm format:check` clean.

Smoke-tested in a real browser against `astro dev`, not just vitest:

- `/console` renders and its inline script bundles with the new import; with the
  workspace field left blank the enrollment request still posts
  `{"workspace":"default"}` — byte-identical to before.
- Driving the shipped `getMyWorkspaces` + `resolveDefaultWorkspace` modules
  against a stubbed response: a **new** api payload (`communal` present) flags
  `shared: true`/`acme: false` and auto-opens `acme`, while last-used `shared`
  still wins; an **older** payload (field absent) falls back to the slug, flags
  `default: true`, and still auto-opens `acme`; a sole communal membership opens
  it.

No screenshot: nothing visual changed — the console's workspace field renders
the same string, now sourced from the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
