### PR TITLE
docs: describe the Pro plan in Terms and Privacy

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -61,7 +61,7 @@ Claude Code plugin (bundles the skills, the hosted MCP server, and the /uploads:
 
 ## Legal
 
-- [Terms of Service](https://uploads.sh/terms): access, acceptable use, and takedowns
+- [Terms of Service](https://uploads.sh/terms): access, plans and payment, acceptable use, and takedowns
 - [Privacy Policy](https://uploads.sh/privacy): what data the service collects and retains
 - Operated by [Build Internet](https://buildinternet.com)
 

--- a/apps/web/src/pages/privacy.astro
+++ b/apps/web/src/pages/privacy.astro
@@ -4,11 +4,11 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 
 <LegalLayout
   title="Privacy Policy"
-  description="How uploads.sh handles data from the API, CLI, MCP server, invitations, and website."
+  description="How uploads.sh handles data from the API, CLI, MCP server, invitations, payments, and website."
   path="/privacy"
 >
   <h1>Privacy Policy</h1>
-  <p class="effective">Effective July 11, 2026</p>
+  <p class="effective">Effective July 24, 2026</p>
 
   <p>
     This page explains what data uploads.sh collects when you use the website, the API, the <a href="https://github.com/buildinternet/uploads">open-source CLI</a>, or the MCP server, and
@@ -19,17 +19,32 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 
   <h3>Website</h3>
   <p>
-    The site does not run analytics scripts, does not use advertising trackers, and does not set
-    cookies. The invitation page reads its one-time code from the URL fragment, which your browser
-    never sends to a server.
+    The site does not run analytics scripts, does not use advertising trackers, and loads no
+    third-party scripts. Fonts are served from our own domain. The site sets one cookie: your
+    session cookie, once you sign in. That cookie is shared across the uploads.sh subdomains, so a
+    single sign-in covers the website, the API, and the auth service. It is strictly necessary to
+    keep you signed in, we do not use it to track you, and signing out clears it.
+  </p>
+  <p>
+    The invitation page reads its one-time code from the URL fragment, which your browser never
+    sends to a server.
+  </p>
+
+  <h3>Accounts</h3>
+  <p>
+    You sign in with a magic link sent to your email address, or with GitHub. We store your email
+    address, your display name, and your avatar URL. Connecting GitHub also stores your GitHub
+    account identity, which is what lets the service attribute uploads and post pull-request
+    comments on your behalf. We never use your email address for marketing.
   </p>
 
   <h3>Invitations</h3>
   <p>
-    If an administrator invites you by email, your email address is used to deliver the invitation
-    and to rate-limit invitation sending. It appears in short-lived operational logs but is not
-    stored in the service's database, and we never use it for marketing. Invitation emails are sent
-    through Cloudflare's email-sending service.
+    If an administrator invites you to a workspace by email, we store your email address on the
+    invitation record, together with the role you were offered, the invitation's status, and its
+    expiry. We use the address to deliver the invitation and to rate-limit invitation sending, and
+    never for marketing. Revoking a pending invitation deletes its record. Invitation emails are
+    sent through Cloudflare's email-sending service.
   </p>
 
   <h3>Workspaces and tokens</h3>
@@ -41,6 +56,28 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <p>
     Invitation codes are single-use, short-lived, and redeemed atomically; the service stores what
     it needs to validate and expire them, never the plaintext secrets.
+  </p>
+
+  <h3>Plans and payment</h3>
+  <p>
+    Card details never reach our servers. When you upgrade a workspace, we send you to Stripe's own
+    checkout page, and Stripe collects your payment method and billing details there. What we store
+    on our side is the subscription record behind your plan:
+  </p>
+  <ul>
+    <li>The Stripe customer id for your workspace, and for you as the buyer.</li>
+    <li>
+      The plan, the subscription's status and billing interval, and the dates that go with it —
+      period start and end, and any trial, cancellation, or end date.
+    </li>
+  </ul>
+  <p>
+    Stripe holds the payment method, the billing address, any tax details the sale requires, and
+    the invoice history. Stripe uses that data as its own controller for payment processing, fraud
+    prevention, and its legal obligations, under <a href="https://stripe.com/privacy">Stripe's
+    privacy policy</a>. You can reach your invoices
+    and payment method through <strong>Manage billing</strong> in the workspace's billing tab, which
+    opens the Stripe customer portal.
   </p>
 
   <h3>Uploaded files</h3>
@@ -70,6 +107,7 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <ul>
     <li>To store and serve the files you upload.</li>
     <li>To deliver invitations and authenticate workspace tokens.</li>
+    <li>To take payment for a paid plan and manage the subscription behind it.</li>
     <li>To enforce rate limits and prevent abuse.</li>
     <li>To diagnose errors and operate the service.</li>
     <li>To respond to your questions and takedown requests.</li>
@@ -85,6 +123,15 @@ import LegalLayout from "../layouts/LegalLayout.astro";
       <strong>Cloudflare</strong> — hosts the API, MCP server, and website; stores the database
       and uploaded files (R2); and sends invitation email. Request metadata passes through
       Cloudflare as part of normal routing and logging.
+    </li>
+    <li>
+      <strong>Stripe</strong> — processes payments for paid plans, hosts the checkout page and the
+      billing portal, and stores your payment method and billing details. We send Stripe the
+      workspace and account identifiers needed to attach a subscription to your workspace.
+    </li>
+    <li>
+      <strong>GitHub</strong> — authenticates you if you sign in with GitHub or connect a GitHub
+      account, under GitHub's own privacy policy.
     </li>
     <li>
       <strong>Your own storage</strong> — workspaces can bring their own bucket (for example an
@@ -107,12 +154,19 @@ import LegalLayout from "../layouts/LegalLayout.astro";
     <li>Workspace and token records: kept while the workspace is active; tokens expire and can be revoked.</li>
     <li>Invitation codes: expire automatically (hours, not days) and are unusable after redemption.</li>
     <li>Request and delivery logs: short-lived, retained for operational purposes only.</li>
+    <li>
+      Billing and tax records: kept after a workspace is deleted, for as long as tax and accounting
+      law requires. Stripe retains the invoice history on its side under its own schedule.
+    </li>
   </ul>
 
   <h2>Your rights</h2>
   <p>
     To delete your files, use the CLI or API. To delete a workspace and the records tied to it, or
     to ask what data we hold about you, email <a href="mailto:privacy@uploads.sh">privacy@uploads.sh</a>.
+    Cancel a paid plan first, through <strong>Manage billing</strong> in the workspace's billing
+    tab. Deleting a workspace does not clear the billing and tax records described under
+    <strong>Retention</strong>.
   </p>
 
   <h2>Changes</h2>
@@ -130,6 +184,12 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 
   <h2>Revision history</h2>
   <ul>
+    <li>
+      <strong>July 24, 2026</strong> — Described payment data and named Stripe as a service
+      provider, for the Pro plan. Added an accounts section. Corrected two statements that had
+      gone stale: the site does set a session cookie, and an invitation record does store the
+      invited email address.
+    </li>
     <li><strong>July 11, 2026</strong> — Initial version published.</li>
   </ul>
 </LegalLayout>

--- a/apps/web/src/pages/terms.astro
+++ b/apps/web/src/pages/terms.astro
@@ -4,11 +4,11 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 
 <LegalLayout
   title="Terms of Service"
-  description="Access, acceptable use, content rules, and takedown policy for the uploads.sh API, CLI, MCP server, and website."
+  description="Access, plans and payment, acceptable use, content rules, and takedown policy for the uploads.sh API, CLI, MCP server, and website."
   path="/terms"
 >
   <h1>Terms of Service</h1>
-  <p class="effective">Effective July 11, 2026</p>
+  <p class="effective">Effective July 24, 2026</p>
 
   <p>
     These terms cover use of the uploads.sh website, the API, the remote MCP server, and the
@@ -24,16 +24,19 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   </p>
   <p>
     The service is provided as-is while it is in active development. We may change, rate-limit,
-    suspend, or discontinue any part of it at any time, and we reserve the right to introduce
-    paid plans or change what is included at any tier of access.
+    suspend, or discontinue any part of it at any time, and we may change what is included at any
+    tier of access. If we discontinue something a paid plan includes, the <strong>Plans and
+    payment</strong> section below covers what happens to the period you already paid for.
   </p>
 
   <h2>Access and credentials</h2>
   <ul>
     <li>
-      Access comes from creating your own workspace after signing in, or from an invitation to
-      an existing one. An invitation link contains a single-use code — treat it like a
-      password. Either way, sign-in issues a scoped, expiring workspace token.
+      You sign in with a magic link sent to your email address, or with GitHub. Access then comes
+      from creating your own workspace, or from an invitation to an existing one. Creating a
+      workspace also requires a connected GitHub account. An invitation link contains a
+      single-use code — treat it like a password. Either way, sign-in issues a scoped, expiring
+      workspace token.
     </li>
     <li>
       You are responsible for keeping your invitation links and workspace tokens confidential,
@@ -45,6 +48,50 @@ import LegalLayout from "../layouts/LegalLayout.astro";
       users, or for violations of these terms.
     </li>
   </ul>
+
+  <h2>Plans and payment</h2>
+  <p>
+    The free plan is available in perpetuity. Pro is a paid subscription that raises your
+    workspace's storage and file-size limits. An owner or admin of the workspace can subscribe
+    from the workspace's billing tab.
+  </p>
+  <ul>
+    <li>
+      <strong>A subscription renews automatically.</strong> You pay the price shown at checkout
+      for each billing period. The subscription renews at that price every period until you
+      cancel it. We add tax where we are required to collect it.
+    </li>
+    <li>
+      <strong>Stripe processes payments.</strong> You enter your card details on Stripe's own
+      checkout page. We never receive or store your card number.
+    </li>
+    <li>
+      <strong>You can cancel at any time.</strong> Use <strong>Manage billing</strong> in the
+      workspace's billing tab, which opens the Stripe customer portal. The cancellation takes
+      effect at the end of the period you already paid for. Your workspace stays on Pro until
+      then. We don't refund the remainder of a period you cancel partway through.
+    </li>
+    <li>
+      <strong>A failed payment downgrades the workspace.</strong> If a renewal payment doesn't go
+      through, we mark the subscription past due and ask you to update your payment method. The
+      workspace returns to the free plan if the payment isn't resolved.
+    </li>
+    <li>
+      <strong>We give notice before a price change.</strong> A new price applies from your next
+      renewal, never to a period you are already in.
+    </li>
+  </ul>
+  <p>
+    <strong>A downgrade never deletes your files.</strong> Whether you cancel or a payment fails,
+    your files stay where they are and their links keep working. If the workspace holds more than
+    the free plan's storage limit, we refuse new uploads until you delete enough to get back
+    under it.
+  </p>
+  <p>
+    If we discontinue Pro, or materially reduce what it includes, your workspace keeps its current
+    plan and limits until the end of the period you already paid for. We do not refund fees if we
+    terminate your access for a violation of these terms.
+  </p>
 
   <h2>Your content</h2>
   <p>
@@ -84,14 +131,14 @@ import LegalLayout from "../layouts/LegalLayout.astro";
   <p>
     Uploads and other mutating operations are rate-limited per workspace, and upload size and
     content-type limits apply. Agents and integrations should handle rate-limit responses with
-    exponential backoff. If you need higher limits for a legitimate use, email <a href="mailto:hi@uploads.sh">hi@uploads.sh</a>.
+    exponential backoff. The Pro plan raises the storage and file-size limits. If you need more
+    than it offers for a legitimate use, email <a href="mailto:hi@uploads.sh">hi@uploads.sh</a>.
   </p>
 
   <h2>Takedowns</h2>
   <p>
     If content hosted on uploads.sh infringes your rights or otherwise shouldn't be here, use
-    <strong>Report a problem</strong> on the public file page, or email
-    <a href="mailto:abuse@uploads.sh">abuse@uploads.sh</a> with the file URL, your relationship to
+    <strong>Report a problem</strong> on the public file page, or email <a href="mailto:abuse@uploads.sh">abuse@uploads.sh</a> with the file URL, your relationship to
     the content, and a brief reason. We review takedown requests and honor reasonable ones, even
     when not legally required to.
   </p>
@@ -128,6 +175,11 @@ import LegalLayout from "../layouts/LegalLayout.astro";
 
   <h2>Revision history</h2>
   <ul>
+    <li>
+      <strong>July 24, 2026</strong> — Added <strong>Plans and payment</strong> for the Pro
+      subscription: renewal, cancellation, refunds, and what a downgrade does to your files.
+      Described how you sign in.
+    </li>
     <li>
       <strong>July 22, 2026</strong> — Corrected a stale description of the service as
       invitation-only; self-serve workspace creation is available. No change to any term.


### PR DESCRIPTION
## In plain terms

Both legal pages were written before we sold anything, and Pro has been live
since yesterday. Terms still told people we "reserve the right to introduce
paid plans," and Privacy never mentioned Stripe even though it receives account
data every time someone upgrades. This brings both pages in line with what the
code actually does today.

## What it does

**Terms** gains a **Plans and payment** section: automatic renewal, Stripe as
the processor, cancellation through the billing portal, the past-due downgrade,
and price-change notice.

Two things it commits to in writing, both matching existing behavior:

- **A downgrade never deletes files.** Going over the free storage limit blocks
  new uploads and nothing else — that is what `budget.ts` already does, and it
  is worth saying out loud rather than leaving people to guess.
- **No prorated refunds, in either direction.** Cancel mid-cycle and you keep
  Pro to the end of the period you paid for, with no refund of the remainder.
  If we discontinue Pro, the remedy is the same shape — your plan and limits run
  out the paid term — rather than a pro-rata refund.

**Privacy** gains **Accounts** and **Plans and payment** sections, names Stripe
and GitHub as service providers, and adds a billing/tax retention carve-out so
the retention list no longer contradicts the workspace-deletion promise.

While in these files, two claims that had already gone stale before this change
are corrected: the site *does* set a session cookie (cross-subdomain, from Better
Auth), and an invitation record *does* store the invited email address — the old
text said it was not stored in the database. Effective dates bumped on both
pages, since this is substantive rather than a factual fix.

| Terms — Plans and payment | Privacy — Plans and payment |
| --- | --- |
| <img width="380" alt="Terms of Service: the new Plans and payment section" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/507/terms-plans-and-payment.webp"> | <img width="380" alt="Privacy Policy: the new Plans and payment section" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/507/privacy-plans-and-payment.webp"> |

## What it is not

This is the accuracy pass only. Three clauses are deliberately left alone
because they want a lawyer rather than a diff:

1. Formal auto-renewal disclosure wording (state auto-renewal laws) and the
   consent flow at point of purchase. The plain factual statement is here; the
   compliance wording is not.
2. A liability cap. The "as is" disclaimer covers indirect damages only —
   direct damages are uncapped and there is no statutory-rights savings clause.
3. Governing law and dispute resolution, absent from Terms entirely.

No code, config, or CLI changes — no changeset needed.

## How to try it

```bash
pnpm --filter @uploads/web dev
```

Then read <http://localhost:4321/terms> and <http://localhost:4321/privacy>.

## Technical notes

Reviewing this means checking prose against behavior, so here is where each
claim comes from:

| Claim in the docs | Source |
| --- | --- |
| Over-limit blocks uploads, deletes nothing | `apps/api/src/budget.ts` |
| Cancel keeps Pro until period end | `desiredPlanForStatus` + `onSubscriptionDeleted`, `apps/auth/src/stripe-plugin.ts` |
| Only an owner or admin can subscribe | `isOrgBillingAdmin`, same file |
| Card details never reach our servers | Checkout and portal are full redirects; no Stripe.js anywhere in `apps/web` |
| We store customer id + subscription record | `apps/auth/migrations/20260722190000_stripe_subscription.sql` |
| The site sets a session cookie | `crossSubDomainCookies`, `apps/auth/src/auth.ts` |
| Invitations store the invited email | `invitation` table, `apps/auth/src/schema.ts` |

Three whitespace-collapse bugs turned up while verifying the rendered output —
a newline between `</strong>` and the next word renders with no space in Astro.
Two were mine; the third was pre-existing in the Takedowns section and is fixed
here too.

## Test plan

- [x] `astro check` — 0 errors
- [x] `pnpm lint` — no new findings
- [x] Both pages rendered and read end to end against the dev server
- [x] Verified no remaining whitespace collapses in the served HTML
- [ ] Legal review of the three deferred clauses above
