### PR TITLE
feat(web): ask for terms agreement where accounts get created

### DIFF
--- a/apps/web/src/components/LegalConsent.astro
+++ b/apps/web/src/components/LegalConsent.astro
@@ -1,0 +1,52 @@
+---
+/**
+ * Sign-in-wrap consent notice, shown directly below the sign-in controls on
+ * every surface where an account can be created: /login,
+ * /accept-invitation/[id], and the signed-out branch of /device.
+ *
+ * The Terms rely on this notice. Their opening line ("by using any of these,
+ * you agree") is browsewrap on its own, which is the form least likely to
+ * hold up; putting the same agreement in front of the action that creates the
+ * account is what makes it stick. So this component is a legal surface, not
+ * decoration — keep it visible, keep both links working, and don't move it
+ * away from the buttons it qualifies.
+ *
+ * One home for the copy: all three pages render this rather than repeating
+ * the sentence, so a wording change lands everywhere at once.
+ *
+ * NOT shown on /invite — that page creates no account, it hands off to
+ * `uploads login`, which comes back through /device or /login.
+ */
+---
+
+<p class="legal-consent">
+  By continuing, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>.
+</p>
+
+<style>
+  /* --body, not --muted: this is a disclosure whose legal weight depends on
+     being conspicuous, so it deliberately outranks the footer beneath it
+     (8.9:1 against the panel, vs 5.4:1 for muted). It still reads as
+     secondary — small, centered, and below the button it qualifies. */
+  .legal-consent {
+    margin: 18px 0 0;
+    color: var(--body);
+    font-size: 12px;
+    line-height: 1.55;
+    text-align: center;
+  }
+
+  /* Underlined rather than accent-colored: this should read as a disclosure,
+     not compete with the primary sign-in button above it. */
+  .legal-consent a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .legal-consent a:hover,
+  .legal-consent a:focus-visible {
+    color: var(--fg);
+    text-decoration-color: var(--accent);
+  }
+</style>

--- a/apps/web/src/legal-consent.test.ts
+++ b/apps/web/src/legal-consent.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Guards the sign-in-wrap consent notice (components/LegalConsent.astro).
+ *
+ * Why a source-level test rather than a rendered-DOM one: this app has no
+ * harness that renders `.astro` to HTML in a unit test (see
+ * pages-reachability.test.ts for the same constraint), and the regression
+ * actually worth catching is coarse — someone refactors a sign-in page and
+ * the notice quietly stops rendering. Reading the source catches exactly
+ * that, without a build step.
+ *
+ * The stakes are legal, not cosmetic. The Terms' opening line is browsewrap
+ * on its own; this notice is what puts the agreement in front of the action
+ * that creates the account. If a page below ever stops rendering it, that is
+ * a compliance regression, so the fix is to restore the notice — not to
+ * delete the case from this list.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function source(relativePath: string): string {
+  return readFileSync(fileURLToPath(new NodeURL(relativePath, import.meta.url)), "utf8");
+}
+
+describe("LegalConsent component", () => {
+  const component = source("./components/LegalConsent.astro");
+
+  it("links to both policies", () => {
+    expect(component).toContain('href="/terms"');
+    expect(component).toContain('href="/privacy"');
+  });
+
+  it("states that continuing is the act of agreement", () => {
+    expect(component).toContain("By continuing, you agree to the");
+  });
+
+  it("keeps the links on one source line so Astro does not eat the spaces", () => {
+    // A newline between `the` and `<a href="/terms">` renders as
+    // "the<a>Terms" with no space — the same collapse that has bitten the
+    // legal pages before. Assert the rendered sentence stays intact.
+    const sentence = component.match(
+      /By continuing[^<]*<a[^>]*>[^<]*<\/a>[^<]*<a[^>]*>[^<]*<\/a>\./,
+    );
+    expect(sentence, "consent sentence must be a single unbroken source line").not.toBeNull();
+  });
+});
+
+describe.each([
+  { page: "/login", path: "./pages/login.astro", importPath: "../components/LegalConsent.astro" },
+  {
+    page: "/device",
+    path: "./pages/device.astro",
+    importPath: "../components/LegalConsent.astro",
+  },
+  {
+    page: "/accept-invitation/[id]",
+    path: "./pages/accept-invitation/[id].astro",
+    importPath: "../../components/LegalConsent.astro",
+  },
+])("$page shows the consent notice", ({ path, importPath }) => {
+  const page = source(path);
+
+  it("imports the component", () => {
+    expect(page).toContain(`import LegalConsent from "${importPath}"`);
+  });
+
+  it("renders it", () => {
+    expect(page).toContain("<LegalConsent />");
+  });
+});

--- a/apps/web/src/pages/accept-invitation/[id].astro
+++ b/apps/web/src/pages/accept-invitation/[id].astro
@@ -4,6 +4,7 @@ import { applyAuthSecurityHeaders, authPageCsp } from "../../lib/signed-in-page"
 import BaseHead from "../../components/BaseHead.astro";
 import Brand from "../../components/Brand.astro";
 import Footer from "../../components/Footer.astro";
+import LegalConsent from "../../components/LegalConsent.astro";
 
 export const prerender = false;
 
@@ -74,6 +75,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       <button type="submit" id="magic-submit">Send sign-in link</button>
     </form>
     <div class="ul-callout status" id="signin-error" data-state="error" role="alert" hidden></div>
+    <LegalConsent />
   </div>
 
   <div id="sent-state" hidden>

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -5,6 +5,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
 import GitHubMark from "../components/GitHubMark.astro";
+import LegalConsent from "../components/LegalConsent.astro";
 
 export const prerender = false;
 
@@ -140,6 +141,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
       <button type="submit" id="magic-submit">Send sign-in link</button>
     </form>
     <div class="ul-callout status" id="signin-error" data-state="error" role="alert" hidden></div>
+    <LegalConsent />
   </div>
 
   <div id="sent-state" hidden>

--- a/apps/web/src/pages/login.astro
+++ b/apps/web/src/pages/login.astro
@@ -5,6 +5,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Brand from "../components/Brand.astro";
 import Footer from "../components/Footer.astro";
 import GitHubMark from "../components/GitHubMark.astro";
+import LegalConsent from "../components/LegalConsent.astro";
 
 export const prerender = false;
 
@@ -68,6 +69,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
       <button type="submit" id="magic-submit">Send sign-in link</button>
     </form>
     <div class="ul-callout status" id="error" data-state="error" role="alert" hidden></div>
+    <LegalConsent />
   </div>
 
   <Footer compact />


### PR DESCRIPTION
## In plain terms

Nothing on the sign-in surfaces mentioned the terms. The only links to `/terms`
and `/privacy` lived in the site footer, which left us leaning on the "by using
any of these, you agree" line inside the Terms themselves — browsewrap, the form
least likely to hold up, precisely because nobody has to see it.

This puts the agreement in front of the action that creates the account.

## What it does

Adds a one-line notice directly below the sign-in controls on every surface
where an account can be created:

- `/login`
- `/device` — its signed-out branch, which is where someone running
  `uploads login` with no account signs up
- `/accept-invitation/[id]`

| `/login` | `/device` (signed out) | `/accept-invitation/[id]` |
| --- | --- | --- |
| <img width="250" alt="Consent notice on /login" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/508/consent-login.webp"> | <img width="250" alt="Consent notice on the /device signed-out branch" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/508/consent-device.webp"> | <img width="250" alt="Consent notice on the invitation acceptance page" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/508/consent-accept-invitation.webp"> |

Not `/invite`. That page creates no account — it hands off to `uploads login`,
which comes back through `/device` or `/login`, so the notice would sit next to
nothing it qualifies.

The copy lives in one component, so a wording change lands on all three at once.
It renders at `--body` rather than `--muted`: being conspicuous is what makes
this kind of notice count, so the disclosure deliberately outranks the footer
beneath it (8.9:1 against the panel, vs 5.4:1 for muted) while staying
subordinate to the sign-in button above it.

## What it is not

- **No checkbox.** Notice-only is the developer-tool norm and adds no friction.
  If a liability cap or arbitration clause ever lands in the Terms, revisit —
  those are the clauses where an explicit tick earns its keep.
- **New signups only.** Existing accounts still rely on the Terms'
  continued-use clause. A retroactive acceptance gate was considered and
  deliberately skipped.
- **Does not cover the paid upgrade.** Consent to renewal terms at point of
  purchase is a separate requirement that signup consent does not satisfy, and
  it is still open — see below.

## Still open

Auto-renewal disclosure at checkout remains unaddressed, along with the
liability cap and governing-law clauses flagged during the #507 review. Those
three want a lawyer rather than a diff.

## How to try it

```bash
pnpm --filter @uploads/web dev
```

Open <http://localhost:4321/login>. For the other two, the sign-in block is
behind session state — reveal it in the console with
`document.querySelector('#signed-out').hidden = false`.

## Technical notes

These pages run a strict CSP (`authPageCsp` / `devicePageCsp` in
`apps/web/src/lib/signed-in-page.ts`). Its `style-src` already allows `'self'`
and inline, so the component's scoped style needs no CSP change — verified with
no console violations on all three pages.

`legal-consent.test.ts` reads page source rather than rendered DOM: this app has
no harness that renders `.astro` in a unit test (same constraint noted in
`pages-reachability.test.ts`), and the regression worth catching is coarse —
a refactor silently dropping the notice. One of its cases guards the Astro
whitespace-collapse gotcha, where a newline before `<a>` renders as `the<a>Terms`
with no space; that bug hit the legal pages in #507.

## Test plan

- [x] `pnpm test` — 3011 passed
- [x] `astro check` — 0 errors
- [x] `pnpm lint` — clean on touched files
- [x] Verified the guard actually fails: removed `<LegalConsent />` from
      `/device`, watched that case fail, restored it, watched it pass
- [x] All three pages rendered and read; no console or CSP errors
- [x] Mobile (375px) — wraps cleanly
- [x] Contrast measured in-page at 8.9:1 against the panel
