### PR TITLE
fix(cli): stop the path-meta tip firing when a path was supplied

### DIFF
--- a/.changeset/rotten-rings-warn.md
+++ b/.changeset/rotten-rings-warn.md
@@ -1,0 +1,13 @@
+---
+"@buildinternet/uploads": patch
+---
+
+The "add --meta path=/route" tip no longer fires when a `path` was in fact
+supplied. `put --pr`/`put --issue` and `attach` decided whether to nudge by
+reading the API's put response `metadata` field, which echoes the object's R2
+provenance bag (`client`, `source-name`, `content-sha256`) and never the
+queryable tags — so the tip printed on every image, including ones uploaded
+with an explicit `--meta path=`, and the same text landed in the `hint` field
+of `--format json`. The check now reads the metadata each upload actually sent
+(`--meta` pairs, a `screenshot --out` sidecar manifest, and derived image
+facts), resolved per file.

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -105,6 +105,15 @@ export interface PutResult {
    * non-`gh/` key, existing object, no `replace`) instead of overwriting.
    */
   wouldRefuse?: boolean;
+  /**
+   * The object's R2 **provenance** bag (`client`, `source-name`,
+   * `content-sha256`, `uploaded-at`) — NOT the queryable `--meta` tags this
+   * put sent, which the API does not echo here. Reading it as the latter is
+   * what made the path-meta tip fire on every image (PR #509). To confirm
+   * what landed in the queryable tier, call `getMetadata(key)`
+   * (`GET …/files/:key?metadata=1`); the same field name means the queryable
+   * tags there, on `patchMetadata`, and on `list({ metadata: true })`.
+   */
   metadata?: Record<string, string>;
 }
 
@@ -132,6 +141,7 @@ export interface HeadResult {
   size: number;
   contentType: string;
   uploaded?: string;
+  /** Same R2 provenance bag as `PutResult.metadata` — see the note there. */
   metadata?: Record<string, string>;
 }
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -547,6 +547,13 @@ export interface UploadPreparedImageResult {
   result: PutResult;
   prepared: PreparedUpload;
   markdown: string;
+  /**
+   * The queryable metadata this upload actually sent — `opts.metadata` after
+   * any derived image facts were merged in. Callers that need to reason about
+   * what was stored (see `pathMetaHintFor`) must read this, not
+   * `result.metadata`, which is the API's R2 provenance echo.
+   */
+  sentMetadata?: Record<string, string>;
 }
 
 /**
@@ -607,7 +614,7 @@ export async function uploadPreparedImage(
     alt: opts.alt(prepared),
     width: opts.width,
   });
-  return { result, prepared, markdown };
+  return { result, prepared, markdown, sentMetadata: metadata };
 }
 
 export function frameOptionsFromFlags(flags: CommandFlags["flags"]): {
@@ -886,15 +893,25 @@ Examples:
  * (same tier as `state=`), and unlike `uploads screenshot` (which derives it
  * from the captured URL), a plain `attach`/`put --pr`/`put --issue` of an
  * already-existing image has nothing to derive it from, so it's easy to
- * forget. Fires once per batch (not per file) — checks the metadata the
- * server actually stored (`PutResult.metadata`), not what was requested, so
- * a merge/validation drop still surfaces the gap. Non-image uploads (zips,
+ * forget. Fires once per batch (not per file). Non-image uploads (zips,
  * PDFs, etc.) are exempt — "findable by page" doesn't apply to them.
+ *
+ * Checks the *resolved* metadata each upload actually sent (`--meta` pairs +
+ * sidecar manifest + derived image facts, index-aligned with `uploads`) —
+ * NOT `PutResult.metadata`. That field is the API's echo of the object's R2
+ * provenance bag (`client`, `source-name`, `content-sha256`, `uploaded-at`),
+ * never the queryable D1 tags, so it can't answer this question: reading it
+ * made the tip fire on every image, including ones uploaded with an explicit
+ * `--meta path=` (PR #509).
  */
 export function pathMetaHintFor(
-  uploads: { contentType: string; metadata?: Record<string, string> }[],
+  uploads: readonly { contentType: string }[],
+  /** Index-aligned with `uploads` — see `uploadPuts`/`uploadAttachments`. */
+  sentMetadata: readonly (Record<string, string> | undefined)[],
 ): string | undefined {
-  const missingPath = uploads.some((u) => u.contentType.startsWith("image/") && !u.metadata?.path);
+  const missingPath = uploads.some(
+    (u, i) => u.contentType.startsWith("image/") && !sentMetadata[i]?.path,
+  );
   return missingPath ? "tip: add --meta path=/route so this shot is findable by page" : undefined;
 }
 
@@ -915,6 +932,21 @@ export type AttachFailure = {
   file: string;
   error: { message: string; code?: string; status?: number };
 };
+
+/** Shared shape of every prepare + put batch (`uploadPuts`/`uploadAttachments`). */
+export interface UploadBatchResult<T> {
+  uploads: T[];
+  failures: AttachFailure[];
+  /** The original cause of the first failure — for rethrowing single-file CLI paths. */
+  firstError?: unknown;
+  /**
+   * Index-aligned with `uploads`: the queryable metadata each upload actually
+   * sent (flags + sidecar + derived image facts). Kept beside the items rather
+   * than on them so it stays out of the `--format json` upload objects, which
+   * spread the item wholesale. See `pathMetaHintFor`.
+   */
+  sentMetadata: (Record<string, string> | undefined)[];
+}
 
 interface UploadAttachmentBatchOptions {
   client: UploadsClient;
@@ -944,12 +976,14 @@ interface UploadAttachmentBatchOptions {
  */
 async function uploadAttachmentBatch(
   opts: UploadAttachmentBatchOptions,
-): Promise<{ uploads: AttachUploadItem[]; failures: AttachFailure[]; firstError?: unknown }> {
+): Promise<UploadBatchResult<AttachUploadItem>> {
   if (opts.files.some((f) => f === "-")) {
     throw new UsageError("attach does not support stdin; pass one or more file paths");
   }
 
-  type Slot = { ok: true; upload: AttachUploadItem } | { ok: false; file: string; err: unknown };
+  type Slot =
+    | { ok: true; upload: AttachUploadItem; sentMetadata?: Record<string, string> }
+    | { ok: false; file: string; err: unknown };
 
   const slots = await mapBounded(
     opts.files,
@@ -985,6 +1019,7 @@ async function uploadAttachmentBatch(
         });
         return {
           ok: true,
+          sentMetadata: metadata,
           upload: {
             ...result,
             file,
@@ -1008,16 +1043,20 @@ async function uploadAttachmentBatch(
   );
 
   const uploads: AttachUploadItem[] = [];
+  const sentMetadata: (Record<string, string> | undefined)[] = [];
   const failures: AttachFailure[] = [];
   let firstError: unknown;
   for (const slot of slots) {
-    if (slot.ok) uploads.push(slot.upload);
-    else {
+    // Pushed together so the two arrays stay index-aligned across failures.
+    if (slot.ok) {
+      uploads.push(slot.upload);
+      sentMetadata.push(slot.sentMetadata);
+    } else {
       firstError ??= slot.err;
       failures.push({ file: slot.file, error: errorDetail(slot.err) });
     }
   }
-  return { uploads, failures, firstError };
+  return { uploads, failures, firstError, sentMetadata };
 }
 
 /**
@@ -1042,7 +1081,7 @@ export async function uploadAttachments(opts: {
   /** Provenance `client` field (default uploads-cli). */
   provenanceClient?: string;
   concurrency?: number;
-}): Promise<{ uploads: AttachUploadItem[]; failures: AttachFailure[]; firstError?: unknown }> {
+}): Promise<UploadBatchResult<AttachUploadItem>> {
   return uploadAttachmentBatch({
     ...opts,
     keyFor: (filename) => ghAttachmentKey(opts.target, filename),
@@ -1078,7 +1117,7 @@ export async function uploadBranchAttachments(opts: {
   deriveImageFacts?: boolean;
   provenanceClient?: string;
   concurrency?: number;
-}): Promise<{ uploads: AttachUploadItem[]; failures: AttachFailure[]; firstError?: unknown }> {
+}): Promise<UploadBatchResult<AttachUploadItem>> {
   return uploadAttachmentBatch({
     ...opts,
     keyFor: (filename) => ghBranchAttachmentKey(opts.target.repo, opts.target.branch, filename),
@@ -1138,7 +1177,7 @@ export async function uploadPuts(opts: {
   alt?: string;
   width?: number;
   concurrency?: number;
-}): Promise<{ uploads: PutUploadItem[]; failures: AttachFailure[]; firstError?: unknown }> {
+}): Promise<UploadBatchResult<PutUploadItem>> {
   if (opts.files.length > 1 && opts.files.some((f) => f === "-")) {
     throw new UsageError("stdin (-) cannot be combined with multiple file arguments");
   }
@@ -1149,7 +1188,9 @@ export async function uploadPuts(opts: {
     throw new UsageError("--name cannot be combined with multiple files");
   }
 
-  type Slot = { ok: true; upload: PutUploadItem } | { ok: false; file: string; err: unknown };
+  type Slot =
+    | { ok: true; upload: PutUploadItem; sentMetadata?: Record<string, string> }
+    | { ok: false; file: string; err: unknown };
 
   const slots = await mapBounded(
     opts.files,
@@ -1168,7 +1209,7 @@ export async function uploadPuts(opts: {
         // (issue #469 lever 2) — see mergeSidecarMeta. Not applicable to stdin.
         const metadata =
           file !== "-" ? mergeSidecarMeta(file, bytes, opts.metadata) : opts.metadata;
-        const { result, prepared, markdown } = await uploadPreparedImage(
+        const { result, prepared, markdown, sentMetadata } = await uploadPreparedImage(
           opts.client,
           bytes,
           sourceName,
@@ -1194,6 +1235,7 @@ export async function uploadPuts(opts: {
         );
         return {
           ok: true,
+          sentMetadata,
           upload: {
             ...result,
             file,
@@ -1215,16 +1257,20 @@ export async function uploadPuts(opts: {
   );
 
   const uploads: PutUploadItem[] = [];
+  const sentMetadata: (Record<string, string> | undefined)[] = [];
   const failures: AttachFailure[] = [];
   let firstError: unknown;
   for (const slot of slots) {
-    if (slot.ok) uploads.push(slot.upload);
-    else {
+    // Pushed together so the two arrays stay index-aligned across failures.
+    if (slot.ok) {
+      uploads.push(slot.upload);
+      sentMetadata.push(slot.sentMetadata);
+    } else {
       firstError ??= slot.err;
       failures.push({ file: slot.file, error: errorDetail(slot.err) });
     }
   }
-  return { uploads, failures, firstError };
+  return { uploads, failures, firstError, sentMetadata };
 }
 
 /**
@@ -1340,7 +1386,7 @@ export async function runAttach(
     process.stderr.write(`>> uploading ${n} file${n === 1 ? "" : "s"}\n`);
   }
 
-  const { uploads, failures, firstError } = await uploadAttachments({
+  const { uploads, failures, firstError, sentMetadata } = await uploadAttachments({
     client: ctx.client,
     target,
     files: parsed.positionals,
@@ -1392,7 +1438,8 @@ export async function runAttach(
   }
 
   // Lever 3 (issue #469): tip when an image lands here with no `path` meta.
-  const pathHint = uploads.length > 0 && !ctx.quiet ? pathMetaHintFor(uploads) : undefined;
+  const pathHint =
+    uploads.length > 0 && !ctx.quiet ? pathMetaHintFor(uploads, sentMetadata) : undefined;
 
   if (ctx.json) {
     await writeJson({
@@ -2197,7 +2244,7 @@ export async function runPut(
     if (attachedRef) process.stderr.write(`>> attached to ${attachedRef}\n`);
   }
 
-  const { uploads, failures, firstError } = await uploadPuts({
+  const { uploads, failures, firstError, sentMetadata } = await uploadPuts({
     client: ctx.client,
     files,
     nameOverride: nameFlag,
@@ -2236,7 +2283,9 @@ export async function runPut(
   // above (staging/auto/dated) aren't attached to a PR/issue yet, so there's
   // nothing to look up from a page later.
   const pathHint =
-    ghTarget && uploads.length > 0 && !ctx.quiet ? pathMetaHintFor(uploads) : undefined;
+    ghTarget && uploads.length > 0 && !ctx.quiet
+      ? pathMetaHintFor(uploads, sentMetadata)
+      : undefined;
   // One JSON `hint` slot, shared with the #393 nudge (mutually exclusive with
   // it — nudge is undefined whenever staging took over). When staging fires,
   // prefer the more actionable binding warning over the generic staging note

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -68,7 +68,9 @@ function fakeClient(opts?: {
         embedUrl: null,
         size: 3,
         contentType: "image/png",
-        metadata: putOpts.metadata,
+        // Provenance echo, not the queryable pairs that were sent — see the
+        // same note in commands-put.test.ts (PR #509).
+        metadata: { client: "uploads-cli", "content-sha256": "0".repeat(64) },
       };
     },
     list,

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -56,7 +56,10 @@ function fakeClient(opts?: {
         embedUrl: null,
         size: body.byteLength,
         contentType: "image/png",
-        metadata: putOpts.metadata,
+        // The API echoes the object's R2 *provenance* bag here, never the
+        // queryable metadata that was sent (PR #509) — mirroring that is
+        // what keeps the path-meta tip below honest.
+        metadata: { client: "uploads-cli", "content-sha256": "0".repeat(64) },
       };
     },
     list: async () => ({ items: [], cursor: null }),
@@ -1865,6 +1868,62 @@ describe("runPut path-meta tip (issue #469 lever 3)", () => {
       ),
     );
     expect(stderr).not.toContain("tip:");
+  });
+
+  // PR #509: the tip fired on every image because it read the API's put
+  // echo (the R2 provenance bag) instead of the metadata actually sent.
+  it("omits the JSON hint when --meta path= is given", async () => {
+    const { client, puts } = fakeClient();
+    const stdout = await captureStdout(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false, json: true },
+        [tmpFile(), "--pr", "9", "--repo", "o/r", "--meta", "path=/terms", "--state", "after"],
+        false,
+        noRun,
+      ),
+    );
+    // The pair really was sent — the tip is the only thing at issue here.
+    expect(puts[0]?.metadata).toMatchObject({ path: "/terms", state: "after" });
+    const payload = JSON.parse(stdout) as { hint?: string };
+    expect(payload.hint).toBeUndefined();
+  });
+
+  it("does not print the tip when a sidecar manifest supplies the path", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-put-tip-sidecar-"));
+    const file = join(dir, "shot.png");
+    const bytes = Buffer.from("not-really-a-png");
+    writeFileSync(file, bytes);
+    writeSidecarMeta(file, bytes, { path: "/settings" });
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [file, "--pr", "9", "--repo", "o/r"],
+        false,
+        noRun,
+      ),
+    );
+    expect(stderr).not.toContain("tip:");
+  });
+
+  it("still fires when only some files in a batch carry a path", async () => {
+    const { client } = fakeClient();
+    const dir = mkdtempSync(join(tmpdir(), "uploads-put-tip-multi-"));
+    const withPath = join(dir, "a.png");
+    const withoutPath = join(dir, "b.png");
+    const bytes = Buffer.from("a-bytes");
+    writeFileSync(withPath, bytes);
+    writeFileSync(withoutPath, "b-bytes");
+    writeSidecarMeta(withPath, bytes, { path: "/settings" });
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [withPath, withoutPath, "--pr", "9", "--repo", "o/r"],
+        false,
+        noRun,
+      ),
+    );
+    expect(stderr).toContain("tip: add --meta path=/route so this shot is findable by page");
   });
 
   it("is suppressed by --quiet", async () => {


### PR DESCRIPTION
## The bug

`uploads put --pr` and `uploads attach` printed

```
tip: add --meta path=/route so this shot is findable by page
```

on every image — including uploads that passed an explicit `--meta path=` —
and put the same text in the `hint` field of `--format json`. Reproduced
against production:

```bash
uploads put ./shot.png --pr 507 --meta path=/terms --state after --format json
```

returned the hint, while `uploads meta get gh/buildinternet/uploads/pull/507/…`
confirmed `path=/terms` and `state=after` were both stored. Only the
should-I-warn condition was wrong.

## Root cause

`pathMetaHintFor` read `PutResult.metadata`. That field is the API's echo of
the object's **R2 provenance bag** — `client`, `source-name`,
`content-sha256`, `uploaded-at` — set in `files-core.ts` as
`metadata: provenance`. The queryable D1 tags are never in it, so
`metadata?.path` was always `undefined`.

The test fakes hid this. Both echoed `metadata: putOpts.metadata`, returning
the queryable pairs the real server never returns, so the existing "does not
print the tip when `--meta path=` is given" test passed against a fiction.

## The fix

The tip now reads the **resolved metadata each upload actually sent** —
`--meta` pairs, a `screenshot --out` sidecar manifest, and derived image
facts — resolved per file. That set is returned beside the upload items
rather than on them, so it stays out of the `--format json` upload objects
(multi-file put and attach spread each item wholesale).

Both fakes now return a provenance bag like the real API. Stashing the source
fix makes three tests fail, so the regression is genuinely covered.

## Tests

Five cases in `runPut path-meta tip`:

- tip present when no path is given
- absent with `--meta path=`
- JSON `hint` absent with `--meta path=` (the exact repro, asserting the pair really was sent)
- absent when a sidecar manifest supplies the path
- still fires when only some files in a batch carry one

Full suite: 3005 passed across 232 files.

## Verified against production

Dry run, nothing written:

```bash
uploads put ./shot.png --pr 507 --repo buildinternet/uploads --meta path=/terms --state after --dry-run --format json
```

No `hint` field. Dropping `--meta path=` brings it back.

## Follow-up

The response field that invited this misread means two different things
depending on the endpoint:

| Endpoint | `metadata` means |
|---|---|
| `PUT /v1/:ws/files/:key` | R2 provenance |
| `GET /v1/:ws/files/:key` (head) | R2 provenance |
| `GET /v1/:ws/files/:key?metadata=1` | queryable D1 tags |
| `PATCH /v1/:ws/files/:key` | queryable D1 tags |
| `GET /v1/:ws/files?metadata=1` | queryable D1 tags |

A client cannot tell the two bags apart. This PR documents the distinction on
`PutResult` / `HeadResult`, both of which were undocumented. A follow-up PR
splits the names in the API responses.

Fixes a defect found in production; no tracking issue was open for it.
