### PR TITLE
feat(billing): wire the Stripe Checkout terms checkbox behind a flag

### DIFF
--- a/apps/auth/src/env.d.ts
+++ b/apps/auth/src/env.d.ts
@@ -30,6 +30,14 @@ interface Env {
   STRIPE_SECRET_KEY?: string;
   STRIPE_WEBHOOK_SECRET?: string;
   STRIPE_PRO_PRICE_ID?: string;
+  /**
+   * Exactly `"true"` makes Stripe Checkout require a Terms of Service
+   * checkbox before it takes payment. Off by default, and deliberately so:
+   * Stripe rejects the session unless a Terms URL is set in the Dashboard
+   * first, which would break every upgrade. See
+   * packages/billing/src/stripe-checkout.ts for the enable order.
+   */
+  STRIPE_CHECKOUT_TOS_CONSENT?: string;
   /** Shared secret for POST /internal/billing/plan (see apps/api's
    * routes/internal-billing.ts and wrangler.jsonc comment there). Fail-closed
    * when unset: billing-bridge.ts no-ops rather than sending an empty header. */

--- a/apps/auth/src/stripe-plugin.test.ts
+++ b/apps/auth/src/stripe-plugin.test.ts
@@ -5,7 +5,12 @@ import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
 import type { AuthEnv } from "./auth";
 import * as schema from "./schema";
-import { desiredPlanForStatus, isOrgBillingAdmin, stripePluginOrNone } from "./stripe-plugin";
+import {
+  checkoutSessionParamsFor,
+  desiredPlanForStatus,
+  isOrgBillingAdmin,
+  stripePluginOrNone,
+} from "./stripe-plugin";
 import { createFakeD1 } from "./test/fake-d1";
 
 type TestEnv = AuthEnv & Pick<Env, "API" | "BILLING_INTERNAL_KEY">;
@@ -65,6 +70,20 @@ describe("stripePluginOrNone", () => {
     const plugins = stripePluginOrNone(env, db);
     expect(plugins).toHaveLength(1);
     expect(plugins[0]?.id).toBe("stripe");
+  });
+});
+
+describe("checkoutSessionParamsFor", () => {
+  it("adds nothing to the checkout session by default", () => {
+    // The paid path must behave exactly as it does today until an operator
+    // sets the Stripe Dashboard Terms URL and flips the flag.
+    expect(checkoutSessionParamsFor({})).toEqual({ params: {} });
+  });
+
+  it("requires the Terms checkbox once the flag is on", () => {
+    expect(checkoutSessionParamsFor({ STRIPE_CHECKOUT_TOS_CONSENT: "true" })).toEqual({
+      params: { consent_collection: { terms_of_service: "required" } },
+    });
   });
 });
 

--- a/apps/auth/src/stripe-plugin.ts
+++ b/apps/auth/src/stripe-plugin.ts
@@ -27,14 +27,20 @@ import { stripe } from "@better-auth/stripe";
 import Stripe from "stripe";
 import { and, eq } from "drizzle-orm";
 import type { drizzle } from "drizzle-orm/d1";
-import { stripePlans } from "@uploads/billing";
+import {
+  checkoutConsentParams,
+  stripePlans,
+  type CheckoutConsentEnv,
+  type CheckoutConsentParams,
+} from "@uploads/billing";
 import * as schema from "./schema";
 import { syncWorkspacePlan } from "./billing-bridge";
 import type { AuthEnv } from "./auth";
 
 type Db = ReturnType<typeof drizzle<typeof schema>>;
 type StripePluginEnv = AuthEnv &
-  Pick<Env, "STRIPE_SECRET_KEY" | "STRIPE_WEBHOOK_SECRET" | "API" | "BILLING_INTERNAL_KEY">;
+  Pick<Env, "STRIPE_SECRET_KEY" | "STRIPE_WEBHOOK_SECRET" | "API" | "BILLING_INTERNAL_KEY"> &
+  Pick<Env, "STRIPE_CHECKOUT_TOS_CONSENT">;
 
 /**
  * Downgrade/upgrade decision for a `subscription.update` webhook: `active`
@@ -44,6 +50,21 @@ type StripePluginEnv = AuthEnv &
  */
 export function desiredPlanForStatus(status: string): "pro" | "free" {
   return status === "active" || status === "trialing" ? "pro" : "free";
+}
+
+/**
+ * The plugin's `getCheckoutSessionParams` return shape, whose `params` are
+ * merged into `checkout.sessions.create`. Carries only the Terms-checkbox
+ * consent block today, and only when enabled — see
+ * `@uploads/billing`'s stripe-checkout.ts for why that is gated.
+ *
+ * Exported so the wiring is directly testable: the configured plugin object
+ * does not expose its subscription options for inspection.
+ */
+export function checkoutSessionParamsFor(env: CheckoutConsentEnv): {
+  params: CheckoutConsentParams;
+} {
+  return { params: checkoutConsentParams(env) };
 }
 
 /**
@@ -100,6 +121,12 @@ export function stripePluginOrNone(env: StripePluginEnv, db: Db) {
         plans: stripePlans(env),
         authorizeReference: async ({ user, referenceId }) =>
           isOrgBillingAdmin(db, user.id, referenceId),
+        // Merged into `checkout.sessions.create` by the plugin. Empty unless
+        // STRIPE_CHECKOUT_TOS_CONSENT is "true" — see stripe-checkout.ts for
+        // why this is gated rather than simply on (it needs a Dashboard field
+        // set first, or Stripe rejects the session and the upgrade button
+        // dies).
+        getCheckoutSessionParams: () => checkoutSessionParamsFor(env),
         onSubscriptionComplete: async ({ subscription }) => {
           await syncWorkspacePlan(env, db, subscription.referenceId, "pro");
         },

--- a/packages/billing/README.md
+++ b/packages/billing/README.md
@@ -1,10 +1,35 @@
 # @uploads/billing
 
 Plan catalog, limit-resolution, and the billing-provider seam for workspace
-subscription plans. Every workspace is on the `free` plan today; `pro` is
-defined but unavailable (`available: false`) — no Stripe SDK, checkout, or
-subscription persistence yet. See
-`docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md`.
+subscription plans. Both plans are live: `free` is available in perpetuity, and
+`pro` is purchasable through Stripe Checkout, mounted by
+`apps/auth/src/stripe-plugin.ts`. See
+`docs/superpowers/specs/2026-07-22-billing-infrastructure-design.md` for the
+original design.
 
 Private workspace package — not published, excluded from Changesets like
 `@uploads/api` / `@uploads/storage` / `@uploads/web` / `@uploads/auth`.
+
+## Terms checkbox at checkout
+
+Stripe Checkout already shows the price, the currency, and the billing
+interval, and creates the session in subscription mode, so the recurring nature
+is visible to the buyer without any work from us. What it does not do by
+default is collect agreement to _our_ Terms at the moment of purchase.
+
+`checkoutConsentParams` (`src/stripe-checkout.ts`) turns that on, and it is off
+until an operator asks for it. Enabling it out of order breaks the purchase
+path: Stripe rejects a session that requests `consent_collection` when the
+account has no Terms URL, so the upgrade button would fail for everyone.
+
+Enable in this order:
+
+1. In the Stripe Dashboard, set **Settings → Public business information →
+   Terms of service** to `https://uploads.sh/terms`. Do this first.
+2. Set `STRIPE_CHECKOUT_TOS_CONSENT` to exactly `true` on the `uploads-auth`
+   worker.
+3. Run a test-mode checkout and confirm the checkbox renders before you rely
+   on it.
+
+To turn it back off, unset the variable — any value other than `true` leaves
+Checkout as it is today.

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -5,3 +5,4 @@ export * from "./resolve";
 export * from "./subscription-status";
 export * from "./workspace-cap";
 export * from "./stripe-plans";
+export * from "./stripe-checkout";

--- a/packages/billing/src/stripe-checkout.test.ts
+++ b/packages/billing/src/stripe-checkout.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { checkoutConsentParams } from "./stripe-checkout";
+
+describe("checkoutConsentParams", () => {
+  it("is off when the flag is unset", () => {
+    expect(checkoutConsentParams({})).toEqual({});
+  });
+
+  it("requires the Terms checkbox when the flag is exactly 'true'", () => {
+    expect(checkoutConsentParams({ STRIPE_CHECKOUT_TOS_CONSENT: "true" })).toEqual({
+      consent_collection: { terms_of_service: "required" },
+    });
+  });
+
+  // Fail-closed matters more here than convenience. A half-set or typo'd
+  // value must leave checkout working: turning consent_collection on without
+  // a Terms URL in the Stripe Dashboard makes Stripe reject the session, and
+  // that lands on the purchase path.
+  it.each(["", "1", "TRUE", "True", "yes", "false", " true"])(
+    "stays off for %o rather than guessing",
+    (value) => {
+      expect(checkoutConsentParams({ STRIPE_CHECKOUT_TOS_CONSENT: value })).toEqual({});
+    },
+  );
+
+  it("returns a spreadable no-op when off", () => {
+    // The plugin spreads this into checkout.sessions.create, so "off" has to
+    // be an empty object rather than undefined or a null-valued key.
+    const base = { mode: "subscription" };
+    expect({ ...base, ...checkoutConsentParams({}) }).toEqual({ mode: "subscription" });
+  });
+});

--- a/packages/billing/src/stripe-checkout.ts
+++ b/packages/billing/src/stripe-checkout.ts
@@ -1,0 +1,58 @@
+/**
+ * Extra Stripe Checkout Session parameters for the Pro upgrade.
+ *
+ * Today this carries one thing: whether Checkout makes the buyer tick a box
+ * agreeing to our Terms of Service before it will take the payment.
+ *
+ * Stripe already handles the *disclosure* half of a subscription sale on its
+ * own — the checkout page shows the price, the currency, and the billing
+ * interval, and the session is created with `mode: "subscription"`, so the
+ * recurring nature is inherent in what the buyer sees. What Stripe does NOT do
+ * unless asked is collect agreement to *our* terms at the moment of purchase.
+ * That is `consent_collection.terms_of_service`, and it is off by default.
+ *
+ * ## Why this is gated rather than simply on
+ *
+ * `consent_collection: { terms_of_service: "required" }` needs a Terms of
+ * Service URL set in the Stripe Dashboard (Settings → Public business
+ * information). Without it, Stripe rejects the Checkout Session outright — and
+ * that failure lands squarely on the purchase path, which would make the
+ * upgrade button dead for everyone. So the parameter stays off until an
+ * operator turns it on deliberately, after the Dashboard field exists.
+ *
+ * Enabling it, in order:
+ *   1. Set the Terms of service URL in the Stripe Dashboard to
+ *      https://uploads.sh/terms (do this FIRST — step 2 breaks checkout
+ *      without it).
+ *   2. `wrangler secret put STRIPE_CHECKOUT_TOS_CONSENT` on uploads-auth, or
+ *      set the var, to exactly `true`.
+ *   3. Run a test-mode checkout and confirm the checkbox renders.
+ *
+ * Whether the checkbox is legally *required* for us is a question for counsel,
+ * not a default this module should assume — hence off until asked.
+ */
+
+export interface CheckoutConsentEnv {
+  /** Exactly `"true"` enables the Terms checkbox. Any other value, including
+   * unset, leaves Checkout as it is today. */
+  STRIPE_CHECKOUT_TOS_CONSENT?: string;
+}
+
+/** The `consent_collection` block Stripe expects, or nothing. */
+export interface CheckoutConsentParams {
+  consent_collection?: { terms_of_service: "required" };
+}
+
+/**
+ * Extra params to merge into `checkout.sessions.create`. Returns `{}` — a
+ * no-op spread — unless the flag is exactly `"true"`.
+ *
+ * Fail-closed on purpose, matching `OAUTH_CLIENT_REAPER_ENABLED` in
+ * apps/auth: a typo'd or half-set value must leave the paid path working
+ * rather than break every upgrade with a Stripe rejection.
+ */
+export function checkoutConsentParams(env: CheckoutConsentEnv): CheckoutConsentParams {
+  return env.STRIPE_CHECKOUT_TOS_CONSENT === "true"
+    ? { consent_collection: { terms_of_service: "required" } }
+    : {};
+}


### PR DESCRIPTION
## In plain terms

Stripe already handles more of the subscription-disclosure job than it looked
like: the checkout page shows the price, the currency, and the billing
interval, and we create the session in subscription mode, so the recurring
nature is in front of the buyer without any work from us. The one thing Stripe
will not do unless asked is collect agreement to *our* Terms at the moment of
purchase.

That is a single Checkout parameter. This wires it, so if counsel says we need
it, turning it on is a config change rather than a build.

## What it does

Adds `checkoutConsentParams()` to `@uploads/billing` and passes it through the
plugin's `getCheckoutSessionParams` hook, which merges into
`checkout.sessions.create`. When enabled, Checkout requires a Terms of Service
checkbox before it will take payment.

**It ships off, and that is the point.** `consent_collection` needs a Terms URL
set in the Stripe Dashboard first — without one, Stripe rejects the session
outright. That rejection lands on the purchase path, so a premature enable
would make the upgrade button dead for every customer. The flag therefore uses
the same fail-closed shape as `OAUTH_CLIENT_REAPER_ENABLED`: exactly `"true"`
turns it on, and anything else — unset, `"1"`, `"TRUE"`, a stray space — leaves
checkout exactly as it is today.

The README carries the enable order, Dashboard field first.

## What it is not

- **Not a legal determination.** Whether the checkbox is required for us is
  still a counsel question. This only makes the answer cheap to act on.
- **Not a behavior change.** With the flag unset, `checkout.sessions.create`
  receives byte-for-byte what it received before — the added params spread to
  an empty object.
- **Does not cover the post-purchase acknowledgment.** Some auto-renewal
  statutes want a confirmation restating the renewal terms and how to cancel.
  Stripe's receipt covers the payment, not necessarily that. If it is needed it
  belongs in the existing email template.

## How to try it

The default path is the interesting one — confirm nothing changed:

```bash
pnpm --filter @uploads/billing test
pnpm --filter @uploads/auth test stripe-plugin
```

To exercise the enabled path, set the Dashboard Terms URL first (see
`packages/billing/README.md`), then `STRIPE_CHECKOUT_TOS_CONSENT=true` and run a
test-mode checkout.

## Technical notes

`getCheckoutSessionParams` was already exposed by `@better-auth/stripe@1.6.23`;
its return value is destructured at `dist/index.mjs:1007`, which strips `mode`,
`customer`, `success_url`, `cancel_url`, `line_items`, and
`client_reference_id` but passes `consent_collection` through untouched. No
patch or fork needed.

The wiring is extracted as `checkoutSessionParamsFor` rather than inlined in the
config object, because the configured plugin does not expose its subscription
options for inspection — inline, there would be no way to test that the hook is
actually connected.

Also corrects `packages/billing/README.md`, which still described `pro` as
`available: false` with "no Stripe SDK, checkout, or subscription persistence
yet" — all three have shipped since.

## Test plan

- [x] `pnpm test` — 3014 passed (12 new)
- [x] `tsc --noEmit` on `@uploads/auth` — clean
- [x] `pnpm lint` — no new findings
- [x] Off-by-default asserted directly, including that the result is a
      spreadable no-op rather than `undefined`
- [x] Fail-closed asserted for `""`, `"1"`, `"TRUE"`, `"True"`, `"yes"`,
      `"false"`, `" true"`
- [ ] Test-mode checkout with the flag on — needs the Dashboard field, so it
      belongs with whoever enables it
