### PR TITLE
refactor(api): name the two metadata bags apart on put and head

### DIFF
--- a/.changeset/olive-donuts-tickle.md
+++ b/.changeset/olive-donuts-tickle.md
@@ -1,0 +1,21 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Put and head responses now name the two metadata bags apart. `provenance`
+carries the object's R2 upload labels (`client`, `source-name`,
+`content-sha256`) — the content that used to sit under `metadata` on these two
+endpoints only. `metadata` now means the queryable tags everywhere, matching
+what it already meant on `getMetadata`, `patchMetadata`, and
+`list({ metadata: true })`.
+
+A put echoes the tags it stored, including server-derived pairs the client
+never sent such as `gh.uploader`, so confirming what landed no longer takes a
+second round trip. The field is absent when the put wrote no tags of its own,
+since that case leaves any existing tags untouched. A plain head returns no
+queryable metadata at all — that tier is a separate store and takes a separate
+read, so call `getMetadata(key)`.
+
+`PutResult.provenance` and `HeadResult.provenance` are new; `HeadResult.metadata`
+is gone. Code reading `metadata` off a put or head for provenance must move to
+`provenance`.

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -338,7 +338,18 @@ export async function putObject(
   contentType: string;
   /** True when this put overwrote an existing key (messaging only; no confirm). */
   replaced: boolean;
-  metadata?: ProvenanceMap;
+  /**
+   * The object's R2 provenance bag (`client`, `source-name`, `content-sha256`).
+   * One bag, one name: `metadata` below always means the queryable tier.
+   */
+  provenance?: ProvenanceMap;
+  /**
+   * The queryable metadata (D1 `file_metadata`) this put stored, including any
+   * server-derived pairs the caller did not send (`gh.uploader`). Omitted —
+   * not empty — when the put carried no `metadata` at all, since that case
+   * leaves whatever rows already existed untouched and reads nothing back.
+   */
+  metadata?: Record<string, string>;
   visibility?: Visibility;
 }> {
   const finalKey = finalizeUploadKey(key, ws);
@@ -503,7 +514,8 @@ export async function putObject(
     size: newSize,
     contentType: inspection.contentType,
     replaced,
-    metadata: provenance,
+    provenance,
+    ...(opts?.metadata ? { metadata: opts.metadata } : {}),
     ...(storedVisibility ? { visibility: storedVisibility } : {}),
   };
 }
@@ -634,7 +646,12 @@ function storedMetaJson(meta: { size?: number; type?: string; lastModified?: num
   };
 }
 
-/** Shape HEAD/list-friendly metadata for API JSON. */
+/**
+ * Shape HEAD/list-friendly metadata for API JSON. The object's R2 provenance
+ * comes back as `provenance`; the queryable tier is a separate store and a
+ * separate read, so it is served by `?metadata=1` on the same route rather
+ * than costing every plain HEAD a D1 query.
+ */
 export function headObjectJson(
   key: string,
   meta: {
@@ -653,7 +670,7 @@ export function headObjectJson(
     ...storedMetaJson(meta),
     url,
     embedUrl,
-    ...(provenance ? { metadata: provenance } : {}),
+    ...(provenance ? { provenance } : {}),
     ...(visibility ? { visibility } : {}),
   };
 }

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -312,19 +312,26 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
       },
     });
     expect(res.status).toBe(201);
-    const json = (await res.json()) as { metadata?: Record<string, string> };
-    expect(json.metadata).toMatchObject({
+    const json = (await res.json()) as {
+      provenance?: Record<string, string>;
+      metadata?: Record<string, string>;
+    };
+    expect(json.provenance).toMatchObject({
       client: "uploads-cli",
       "client-version": "0.3.0",
       optimized: "1",
       frame: "phone",
     });
-    expect(json.metadata?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
-    expect(json.metadata?.["content-sha256"]).not.toBe("0".repeat(64));
+    expect(json.provenance?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(json.provenance?.["content-sha256"]).not.toBe("0".repeat(64));
+    // The two bags never mix: the non-allowlisted header is queryable
+    // metadata, and no provenance key leaks into it.
+    expect(json.metadata).toEqual({ secret: "custom-not-provenance" });
+    expect(json.metadata).not.toHaveProperty("client");
     // R2 bag is provenance plus server-only keys (uploaded-at); put/head JSON
     // still returns the allowlisted provenance subset only.
     const storedMeta = bucket.store.get("default/screenshots/shot.png")?.customMetadata;
-    expect(storedMeta).toMatchObject(json.metadata!);
+    expect(storedMeta).toMatchObject(json.provenance!);
     expect(storedMeta?.["uploaded-at"]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
     const head = await app.request(
@@ -335,13 +342,16 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     expect(head.status).toBe(200);
     const headJson = (await head.json()) as {
       contentType: string;
+      provenance?: Record<string, string>;
       metadata?: Record<string, string>;
       key: string;
     };
     expect(headJson.key).toBe("screenshots/shot.png");
     expect(headJson.contentType).toBe("image/png");
-    expect(headJson.metadata).toEqual(json.metadata);
-    expect(headJson.metadata).not.toHaveProperty("uploaded-at");
+    expect(headJson.provenance).toEqual(json.provenance);
+    expect(headJson.provenance).not.toHaveProperty("uploaded-at");
+    // A plain head reads R2 only — the queryable tier needs `?metadata=1`.
+    expect(headJson).not.toHaveProperty("metadata");
   });
 
   it("stores private visibility from the upload header and surfaces it on authed head", async () => {
@@ -372,8 +382,8 @@ describe("PUT /v1/:workspace/files upload guardrails", () => {
     const { env } = await makeEnv();
     const res = await putShot(env);
     expect(res.status).toBe(201);
-    const json = (await res.json()) as { metadata?: Record<string, string> };
-    expect(json.metadata?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
+    const json = (await res.json()) as { provenance?: Record<string, string> };
+    expect(json.provenance?.["content-sha256"]).toMatch(/^[0-9a-f]{64}$/);
   });
 });
 
@@ -605,9 +615,15 @@ describe("PUT /v1/:workspace/files custom metadata capture + cascade", () => {
     });
     expect(res.status).toBe(201);
 
-    const json = (await res.json()) as { metadata?: Record<string, string> };
-    expect(json.metadata?.client).toBe("cli");
-    expect(json.metadata?.app).toBeUndefined();
+    const json = (await res.json()) as {
+      provenance?: Record<string, string>;
+      metadata?: Record<string, string>;
+    };
+    expect(json.provenance?.client).toBe("cli");
+    expect(json.provenance?.app).toBeUndefined();
+    // The echo names the tier each pair landed in — `app` is queryable, not provenance.
+    expect(json.metadata?.app).toBe("web");
+    expect(json.metadata?.client).toBeUndefined();
     expect(bucket.store.get("default/screenshots/shot.png")?.customMetadata?.app).toBeUndefined();
 
     await expect(
@@ -680,8 +696,8 @@ describe("PUT /v1/:workspace/files custom metadata capture + cascade", () => {
     const { env, bucket } = await makeEnv();
     const res = await putShot(env, { headers: { "X-Uploads-Meta-Client": "" } });
     expect(res.status).toBe(201);
-    const json = (await res.json()) as { metadata?: Record<string, string> };
-    expect(json.metadata?.client).toBeUndefined();
+    const json = (await res.json()) as { provenance?: Record<string, string> };
+    expect(json.provenance?.client).toBeUndefined();
     expect(bucket.store.has("default/screenshots/shot.png")).toBe(true);
   });
 
@@ -1346,6 +1362,10 @@ describe("PUT /v1/:workspace/files uploader attribution (issue #340)", () => {
       expect(meta["gh.uploader"]).toBe("octocat");
       expect(meta["gh.uploader-id"]).toBe("user-1");
       expect(meta["gh.repo"]).toBe("acme/web");
+      // The put echo reports the stored set, so a client learns the
+      // server-derived identity without a second round trip.
+      const json = (await res.json()) as { metadata?: Record<string, string> };
+      expect(json.metadata).toEqual(meta);
     } finally {
       restore();
     }

--- a/apps/web/public/.well-known/openapi.json
+++ b/apps/web/public/.well-known/openapi.json
@@ -79,7 +79,9 @@
           }
         },
         "responses": {
-          "200": { "description": "Uploaded; body includes key, url, size, contentType" },
+          "200": {
+            "description": "Uploaded; body includes key, url, size, contentType, provenance (R2 upload labels), and metadata (the queryable tags this put stored, when it stored any)"
+          },
           "401": { "description": "Missing or invalid workspace token" },
           "413": { "description": "Payload too large" }
         }
@@ -89,7 +91,9 @@
         "summary": "Object metadata",
         "security": [{ "bearerAuth": [] }],
         "responses": {
-          "200": { "description": "Metadata JSON (includes public url when configured)" },
+          "200": {
+            "description": "Object metadata JSON (includes public url when configured, and provenance; add ?metadata=1 for the queryable tags instead)"
+          },
           "401": { "description": "Missing or invalid workspace token" },
           "404": { "description": "Not found" }
         }

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,9 +132,23 @@ Never send tokens, workspace secrets, or PII.
 **Server-only:** every put also stores `content-sha256` (lowercase hex SHA-256 of
 the **final stored body**). Client-supplied `content-sha256` headers are ignored.
 
-Put and head responses always include `metadata` with at least `content-sha256`.
-The CLI/`uploads mcp` set the client fields automatically from optimize/frame
-options.
+Put and head responses always include `provenance` with at least
+`content-sha256`. The CLI/`uploads mcp` set the client fields automatically from
+optimize/frame options.
+
+**Two bags, two names.** `provenance` is this R2 bag. `metadata` always means
+the queryable tier described below — on put, on `?metadata=1`, on `PATCH`, and
+on a `?metadata=1` listing. Before this split, put and head called the
+provenance bag `metadata`, which no client could tell apart from the queryable
+tags. Read `provenance` for the upload's own labels and `metadata` for the tags
+you set.
+
+A put response reports `metadata` only when that put wrote tags: a put with no
+`X-Uploads-Meta-*` header of its own leaves any existing tags untouched, so the
+server omits the field rather than implying an empty set. The reported set
+includes server-derived pairs the client never sent, such as `gh.uploader`. A
+plain head returns no `metadata` at all — the queryable tier is a separate
+store, so it takes a separate read (`?metadata=1`).
 
 ### Usage ledger and budgets
 

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -106,13 +106,22 @@ export interface PutResult {
    */
   wouldRefuse?: boolean;
   /**
-   * The object's R2 **provenance** bag (`client`, `source-name`,
-   * `content-sha256`, `uploaded-at`) — NOT the queryable `--meta` tags this
-   * put sent, which the API does not echo here. Reading it as the latter is
-   * what made the path-meta tip fire on every image (PR #509). To confirm
-   * what landed in the queryable tier, call `getMetadata(key)`
-   * (`GET …/files/:key?metadata=1`); the same field name means the queryable
-   * tags there, on `patchMetadata`, and on `list({ metadata: true })`.
+   * The object's R2 provenance bag (`client`, `source-name`,
+   * `content-sha256`) — what the upload was made *by*, not the tags it was
+   * tagged *with*. Absent on a dry run, and on API deployments older than the
+   * split that gave this bag its own name.
+   */
+  provenance?: Record<string, string>;
+  /**
+   * The queryable metadata (D1) this put stored, including server-derived
+   * pairs the client never sent (`gh.uploader`). Absent when the put carried
+   * no metadata — that case leaves any existing tags untouched, so the server
+   * reports nothing rather than implying an empty set. Means the same thing
+   * on `getMetadata`, `patchMetadata`, and `list({ metadata: true })`.
+   *
+   * An API older than the split returns the provenance bag here instead, so a
+   * client that must work against both reads `path`-style tags defensively —
+   * see `pathMetaHintFor` in commands.ts, which prefers what it sent.
    */
   metadata?: Record<string, string>;
 }
@@ -141,8 +150,12 @@ export interface HeadResult {
   size: number;
   contentType: string;
   uploaded?: string;
-  /** Same R2 provenance bag as `PutResult.metadata` — see the note there. */
-  metadata?: Record<string, string>;
+  /**
+   * The object's R2 provenance bag — see `PutResult.provenance`. A plain head
+   * returns no queryable metadata at all: that tier lives in a separate store
+   * and takes a separate read, so call `getMetadata(key)` for it.
+   */
+  provenance?: Record<string, string>;
 }
 
 export interface DeleteResult {
@@ -927,6 +940,7 @@ export function createUploadsClient(config: UploadsClientConfig) {
         size: number;
         contentType: string;
         replaced?: boolean;
+        provenance?: Record<string, string>;
         metadata?: Record<string, string>;
       }>("PUT", `${filesBase(config)}/${encodeKeyPath(key)}`, {
         body,

--- a/packages/uploads/test/commands-attach.test.ts
+++ b/packages/uploads/test/commands-attach.test.ts
@@ -68,9 +68,9 @@ function fakeClient(opts?: {
         embedUrl: null,
         size: 3,
         contentType: "image/png",
-        // Provenance echo, not the queryable pairs that were sent — see the
-        // same note in commands-put.test.ts (PR #509).
-        metadata: { client: "uploads-cli", "content-sha256": "0".repeat(64) },
+        // Two bags, two names — see the same note in commands-put.test.ts.
+        provenance: { client: "uploads-cli", "content-sha256": "0".repeat(64) },
+        ...(putOpts.metadata ? { metadata: putOpts.metadata } : {}),
       };
     },
     list,

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -56,10 +56,13 @@ function fakeClient(opts?: {
         embedUrl: null,
         size: body.byteLength,
         contentType: "image/png",
-        // The API echoes the object's R2 *provenance* bag here, never the
-        // queryable metadata that was sent (PR #509) — mirroring that is
-        // what keeps the path-meta tip below honest.
-        metadata: { client: "uploads-cli", "content-sha256": "0".repeat(64) },
+        // Two bags, two names, as the API now returns them: `provenance` for
+        // the R2 upload labels, `metadata` for the queryable tags this put
+        // stored. Before the split both endpoints called provenance
+        // `metadata`, and a fake that echoed the sent tags there instead is
+        // what let the path-meta tip below ship broken.
+        provenance: { client: "uploads-cli", "content-sha256": "0".repeat(64) },
+        ...(putOpts.metadata ? { metadata: putOpts.metadata } : {}),
       };
     },
     list: async () => ({ items: [], cursor: null }),
@@ -1899,6 +1902,29 @@ describe("runPut path-meta tip (issue #469 lever 3)", () => {
       runPut(
         { ...ctxWith(client), quiet: false },
         [file, "--pr", "9", "--repo", "o/r"],
+        false,
+        noRun,
+      ),
+    );
+    expect(stderr).not.toContain("tip:");
+  });
+
+  // A self-hosted worker older than the provenance/metadata split answers a
+  // put with the provenance bag under `metadata` and no `provenance` at all.
+  // The tip reads what it sent, so it stays right on both server generations.
+  it("does not print the tip against a pre-split API response shape", async () => {
+    const { client } = fakeClient();
+    const modern = client.put.bind(client);
+    client.put = async (body, putOpts) => {
+      const { provenance: _dropped, ...rest } = (await modern(body, putOpts)) as Awaited<
+        ReturnType<typeof modern>
+      > & { provenance?: Record<string, string> };
+      return { ...rest, metadata: { client: "uploads-cli", "content-sha256": "0".repeat(64) } };
+    };
+    const stderr = await captureStderr(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false },
+        [tmpFile(), "--pr", "9", "--repo", "o/r", "--meta", "path=/settings"],
         false,
         noRun,
       ),


### PR DESCRIPTION
Follow-up to #509, which fixed a CLI tip that fired on every image. The
underlying cause was an API response field that means two different things.

## The problem

| Endpoint | `metadata` meant |
|---|---|
| `PUT /v1/:ws/files/:key` | R2 provenance |
| `GET /v1/:ws/files/:key` (head) | R2 provenance |
| `GET /v1/:ws/files/:key?metadata=1` | queryable D1 tags |
| `PATCH /v1/:ws/files/:key` | queryable D1 tags |
| `GET /v1/:ws/files?metadata=1` | queryable D1 tags |

Same word, two bags, split only by a query parameter on the same route. The
user-facing vocabulary — `--meta`, `meta get`, `find --meta` — uses "metadata"
for the queryable tags only, so put and head were the outliers. A client
reading `metadata` off a put has no way to know it is holding provenance.

## The change

Put and head return `provenance` for the R2 bag. `metadata` now means the
queryable tier everywhere.

A put also echoes the tags it stored. This costs no extra read — `putObject`
already holds the set after `replaceFileMetadata` — and it surfaces
server-derived pairs the client never sent, such as the `gh.uploader` and
`gh.uploader-id` stamped from the bearer token's minting user. Confirming what
landed no longer takes a second round trip.

Two deliberate absences:

- A put reports `metadata` only when it wrote tags. A put with no
  `X-Uploads-Meta-*` header of its own leaves existing tags untouched, so the
  server omits the field rather than implying an empty set.
- A plain head returns no queryable metadata at all. That tier is a separate
  store, and serving it here would cost every head a D1 query. `?metadata=1`
  still answers it.

## Breaking

`HeadResult.metadata` is gone and `PutResult.metadata` changes meaning;
`provenance` is new on both. Anything reading `metadata` off a put or head for
provenance moves to `provenance`.

In-repo, the blast radius is small: the CLI's `head()` has no callers, the web
app reads metadata only from `/public/files` and hydrated listings (both
already the queryable tier), and the hosted MCP `put` tool spreads the result
straight through, so its output gains both fields.

The API is pre-1.0 and the CLI is 0.22.x, so this is one clean break rather
than a deprecation window that would leave two names for the same thing.

## Tests

`routes-files.test.ts` now pins the split rather than the old name: the two
bags never mix (a non-allowlisted header lands in `metadata`, no provenance key
leaks into it), a plain head carries `provenance` and no `metadata`, and the
attribution test asserts the put echo equals what `getFileMetadata` reads back
— the round trip the echo is meant to save.

Full suite: 3002 passed across 232 files. `pnpm typecheck` and `pnpm check`
clean.

## Rebased on #509

#509 has merged and this branch is rebased onto it. The one expected conflict
was the `PutResult` / `HeadResult` JSDoc in `client.ts`; #511's version wins,
since #509 documented the meaning this PR removes.

The rebase also left #509's test fakes describing a server that no longer
exists — they echoed the provenance bag under `metadata`. They now return both
bags under their own names. A self-hosted worker older than the split still
answers the old way, so a new case pins the tip against that shape too: it
stays correct on both generations because it reads the metadata it sent, not
the server's echo.

Optional follow-on, deliberately not in this PR: now that a put reports the
tags it stored, the tip could treat that echo as authoritative and fall back to
what it sent, restoring its original intent of catching a server-side
validation drop.
