### PR TITLE
chore(auth): turn on the Stripe Checkout terms checkbox

### DIFF
--- a/apps/auth/wrangler.jsonc
+++ b/apps/auth/wrangler.jsonc
@@ -18,6 +18,13 @@
     // email template both derive from this.
     "WEB_ORIGIN": "https://uploads.sh",
     "ENVIRONMENT": "production",
+    // Makes Stripe Checkout require a Terms of Service checkbox before it
+    // takes payment. Safe only because the Stripe Dashboard's Terms of
+    // service URL is set (confirmed 2026-07-24) — Stripe rejects the whole
+    // Checkout Session without it, which would break every upgrade. If that
+    // Dashboard field is ever cleared, remove this var in the same change.
+    // See packages/billing/src/stripe-checkout.ts.
+    "STRIPE_CHECKOUT_TOS_CONSENT": "true",
   },
   "routes": [
     {


### PR DESCRIPTION
## In plain terms

Turns on the Stripe Checkout Terms checkbox that #510 wired. Buyers now tick a
box agreeing to the Terms before Stripe takes payment.

One line, so reverting is one line if checkout misbehaves.

## Merge #510 first

These two are inert apart and only do something together:

- **#510 alone** — the code reads the flag, the flag is unset, checkout behaves
  exactly as it does today.
- **This PR alone** — the var exists, nothing reads it.

Merging this before #510 is harmless, just pointless. Merging #510 first is the
intended order.

## Why this is safe now, and wasn't before

`consent_collection` requires a Terms of service URL on the Stripe account.
Without one Stripe rejects the entire Checkout Session, and that failure lands
on the purchase path — the upgrade button would die for every customer. That is
why #510 shipped off.

That Dashboard field is now set to `https://uploads.sh/terms` (confirmed
2026-07-24), so the prerequisite is met. The wrangler comment records the
dependency, so anyone clearing that Dashboard field knows to remove this var in
the same change.

## After merging

Watch the first real upgrade, or run a test-mode checkout, and confirm the
checkbox renders and the session completes. The failure mode if something is
wrong with the Dashboard field is loud and immediate — Stripe refuses to create
the session — so it will not fail quietly.

## Test plan

- [x] `wrangler types` regenerates cleanly, picking up the var
- [ ] Post-deploy: a checkout session renders the Terms checkbox and completes
