### PR TITLE
docs(billing): say the checkout terms checkbox is live

### DIFF
--- a/packages/billing/README.md
+++ b/packages/billing/README.md
@@ -17,19 +17,24 @@ interval, and creates the session in subscription mode, so the recurring nature
 is visible to the buyer without any work from us. What it does not do by
 default is collect agreement to _our_ Terms at the moment of purchase.
 
-`checkoutConsentParams` (`src/stripe-checkout.ts`) turns that on, and it is off
-until an operator asks for it. Enabling it out of order breaks the purchase
-path: Stripe rejects a session that requests `consent_collection` when the
-account has no Terms URL, so the upgrade button would fail for everyone.
+`checkoutConsentParams` (`src/stripe-checkout.ts`) turns that on. **Production
+has it on** — `apps/auth/wrangler.jsonc` is the source of truth for which
+environments do. The code default stays off, so any environment that does not
+set the var behaves as it always did.
 
-Enable in this order:
+**The two halves have an order, and reversing it breaks the purchase path.**
+Stripe rejects a session requesting `consent_collection` when the account has
+no Terms URL, and that rejection surfaces as a dead upgrade button for every
+customer. So:
 
 1. In the Stripe Dashboard, set **Settings → Public business information →
-   Terms of service** to `https://uploads.sh/terms`. Do this first.
+   Terms of service** to `https://uploads.sh/terms`. Always first. (Done for
+   the live account on 2026-07-24.)
 2. Set `STRIPE_CHECKOUT_TOS_CONSENT` to exactly `true` on the `uploads-auth`
    worker.
-3. Run a test-mode checkout and confirm the checkbox renders before you rely
-   on it.
+3. Run a checkout and confirm the checkbox renders.
 
-To turn it back off, unset the variable — any value other than `true` leaves
-Checkout as it is today.
+The same order applies in reverse. If that Dashboard field is ever cleared,
+remove the var in the same change — leaving the var set against an account with
+no Terms URL is the broken state. To disable deliberately, drop the var; any
+value other than `true` leaves Checkout as it was.


### PR DESCRIPTION
## In plain terms

I wrote the billing README while the checkout Terms checkbox was still off, so
it says the feature is off "until an operator asks for it" and then lists enable
steps. #512 turned it on. As written, the page now tells a future operator the
opposite of what is true.

## What it does

- States that production has it on, and points at `apps/auth/wrangler.jsonc` as
  the source of truth for which environments set the var. One home for the fact
  rather than a second copy that can drift.
- Keeps the ordering rule, and adds the reverse case: clearing the Stripe
  Dashboard Terms URL while the var is still set is the state that breaks
  checkout, so those two move together in both directions.
- Notes the code default is still off, so any environment that does not set the
  var is unaffected.

Docs only — no code, no behavior change.

## Test plan

- [x] `pnpm lint` / format clean (markdown only)
