### PR TITLE
feat(api): content-identical re-uploads inherit derived metadata

### DIFF
--- a/apps/api/migrations/20260724140000_file_content_hash.sql
+++ b/apps/api/migrations/20260724140000_file_content_hash.sql
@@ -1,0 +1,28 @@
+-- Reverse index from an object's stored-body SHA-256 to the object holding it,
+-- so a content-identical re-upload can inherit the earlier object's derived
+-- metadata (issue #479) on paths where the CLI sidecar cannot survive: the
+-- hosted MCP (no local filesystem), CI steps, and second machines.
+--
+-- Deliberately NOT a `file_metadata` row. #511 established that `metadata`
+-- means the user-facing queryable tag tier (`--meta`, `meta get`,
+-- `find --meta`) while the R2 bag responds as `provenance`. `content-sha256`
+-- is server-computed provenance, so storing it as a tag would push it back
+-- into the tier #511 just separated -- a 64-char hash on every file's visible
+-- tags, burning one of the 24 per-file key slots forever.
+--
+-- The primary key is (workspace, object_key), not the hash: an overwrite of the
+-- same key must update that key's hash rather than accumulate a second row.
+-- Many keys may share one hash, which is the whole point of the lookup index.
+CREATE TABLE file_content_hash (
+  workspace      TEXT NOT NULL,
+  object_key     TEXT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  updated_at     TEXT NOT NULL,
+  PRIMARY KEY (workspace, object_key)
+);
+
+-- Donor lookup: workspace + hash, ordered oldest-first for a deterministic
+-- winner when several objects share bytes. `updated_at` and `object_key` are in
+-- the index so that ordering is served without a table scan.
+CREATE INDEX file_content_hash_lookup_idx
+  ON file_content_hash (workspace, content_sha256, updated_at, object_key);

--- a/apps/api/src/content-hash.ts
+++ b/apps/api/src/content-hash.ts
@@ -1,0 +1,164 @@
+/**
+ * Content-identical re-uploads inherit the earlier object's derived metadata
+ * (issue #479).
+ *
+ * #469 closed the capture-then-attach seam two ways: `screenshot` now stages on
+ * a branch (#475), and a sidecar manifest carries derived metadata into a later
+ * `put`/`attach` of the same bytes (#473). Neither reaches a path where the
+ * sidecar cannot exist — the hosted MCP has no local filesystem to write one,
+ * and a CI step or second machine never sees it. This closes that remainder
+ * server-side: when an upload's stored bytes match an object the workspace
+ * already holds, the earlier object's derived tags are copied onto the new one.
+ *
+ * Design: `.context/479-content-hash-inheritance.md`.
+ */
+
+import { isCommunalWorkspace } from "@uploads/workspace";
+import { addMissingFileMetadata, getFileMetadata } from "./file-metadata";
+
+/**
+ * The closed set of keys inheritance may copy — a restatement of
+ * `CANONICAL_META_KEYS` from `packages/uploads/src/metadata-vocab.ts`.
+ *
+ * Restated rather than imported, and deliberately so. The vocabulary lives in
+ * `@buildinternet/uploads`, which is **published** and carries no `@uploads/*`
+ * workspace dependencies — extracting the list to a shared private package (the
+ * `@uploads/workspace` pattern from #504) would make the published package
+ * depend on a private one, and importing the CLI package here would invert the
+ * dependency and drag CLI deps toward a Worker bundle. This follows the other
+ * in-repo precedent instead: `packages/billing/src/workspace-cap.ts`, which
+ * restates the shape it needs to keep its package independent.
+ *
+ * Drift is caught by a parity test (`content-hash-vocab-parity.test.ts`) that
+ * imports the CLI list as a dev-only dependency and asserts the two agree.
+ *
+ * Note what is absent: `gh.*`. A repo/PR association is a claim about *this*
+ * upload's context, not a property of the bytes, so it is not inheritable by
+ * construction — which is also what keeps inherited metadata from minting
+ * phantom PR activity through `recordPrActivityFromMetadata`.
+ */
+export const INHERITABLE_META_KEYS = [
+  "url",
+  "path",
+  "env",
+  "theme",
+  "viewport",
+  "device",
+  "software",
+  "captured",
+  "state",
+  "app",
+] as const;
+
+const INHERITABLE_KEY_SET: ReadonlySet<string> = new Set(INHERITABLE_META_KEYS);
+
+interface HashRow {
+  object_key: string;
+}
+
+/**
+ * Record this object's stored-body hash, replacing any prior hash for the same
+ * key (an overwrite changes the bytes a key points at).
+ *
+ * Never throws: the object is already durably stored by the time this runs, and
+ * a missing index row costs a future inheritance, not correctness.
+ */
+export async function recordContentHash(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  contentSha256: string,
+): Promise<void> {
+  try {
+    await db
+      .prepare(
+        `INSERT INTO file_content_hash (workspace, object_key, content_sha256, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(workspace, object_key)
+         DO UPDATE SET content_sha256 = excluded.content_sha256, updated_at = excluded.updated_at`,
+      )
+      .bind(workspace, objectKey, contentSha256, new Date().toISOString())
+      .run();
+  } catch {
+    // Index maintenance is best-effort by design — see the doc comment.
+  }
+}
+
+/**
+ * Derived metadata to inherit for `contentSha256`, or `{}` when there is
+ * nothing to inherit.
+ *
+ * Returns `{}` unconditionally for the communal workspace. `default` is the one
+ * shared tenant every account belongs to (`packages/workspace`), so
+ * same-workspace — the boundary issue #479 originally proposed — would let one
+ * user's `path=/admin/billing` land on an unrelated user's upload of the same
+ * bytes. Applied in both cloud and self-hosted: inheriting across unrelated
+ * members of a shared tenant is surprising in either deployment, and a
+ * trust rule that differs per deployment is one every future cross-tenant
+ * feature would have to reason about twice.
+ */
+export async function inheritableMetaForHash(
+  db: D1Database,
+  workspace: string,
+  contentSha256: string,
+  selfKey: string,
+): Promise<Record<string, string>> {
+  if (isCommunalWorkspace(workspace)) return {};
+
+  // Fail-soft, deliberately. This runs *after* the bytes are durably stored, so
+  // a D1 blip here must cost the convenience (metadata the caller can re-state)
+  // rather than the upload (bytes the caller would have to re-send). The same
+  // reasoning as recordContentHash, and the opposite of getFileMetadata's
+  // throw-on-error, which serves reads where an empty result would be a lie.
+  try {
+    const row = await db
+      .prepare(
+        `SELECT object_key FROM file_content_hash
+         WHERE workspace = ? AND content_sha256 = ? AND object_key != ?
+         ORDER BY updated_at ASC, object_key ASC
+         LIMIT 1`,
+      )
+      .bind(workspace, contentSha256, selfKey)
+      .first<HashRow>();
+    const donorKey = row?.object_key;
+    if (!donorKey) return {};
+
+    const donorMeta = await getFileMetadata(db, workspace, donorKey);
+    const inheritable: Record<string, string> = {};
+    for (const [key, value] of Object.entries(donorMeta)) {
+      if (INHERITABLE_KEY_SET.has(key)) inheritable[key] = value;
+    }
+    return inheritable;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Apply inheritance for an upload that supplied no explicit metadata.
+ *
+ * A put with no `X-Uploads-Meta-*` headers deliberately leaves an existing
+ * object's tags untouched (see `putObject`), so this must not route through
+ * `replaceFileMetadata` — that is delete-then-insert and would wipe tags the
+ * caller never asked to change. `addMissingFileMetadata` is the additive,
+ * overflow-dropping counterpart.
+ *
+ * Fail-soft for the same reason as the rest of this module: it runs after the
+ * bytes are stored, so a D1 blip must cost the metadata rather than the upload.
+ *
+ * Returns the object's resulting tag set when something was written, else
+ * `undefined` — so the caller can echo what actually landed (#511) without a
+ * second read.
+ */
+export async function applyInheritedMetaAdditively(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  inherited: Record<string, string>,
+): Promise<Record<string, string> | undefined> {
+  try {
+    return await addMissingFileMetadata(db, workspace, objectKey, inherited);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -77,6 +77,59 @@ const VALUE_SAFE_RE = /^[\x20-\x7E]+$/;
 const encoder = new TextEncoder();
 
 /**
+ * Total UTF-8 key+value bytes — the quantity `META_MAX_TOTAL_BYTES` caps.
+ * One implementation so the validator and the cap-aware merge below can never
+ * disagree about what "metadata bytes" means.
+ */
+export function metadataByteLength(meta: Record<string, string>): number {
+  let total = 0;
+  for (const [key, value] of Object.entries(meta)) {
+    total += encoder.encode(key).byteLength + encoder.encode(value).byteLength;
+  }
+  return total;
+}
+
+/** Keys that count against `META_MAX_KEYS` — server-owned keys are exempt. */
+function countableKeys(meta: Record<string, string>): string[] {
+  // Server-owned keys don't consume the user's budget — otherwise every video
+  // upload would silently cost four of their META_MAX_KEYS slots.
+  return Object.keys(meta).filter((key) => !isServerMetaKey(key));
+}
+
+/**
+ * Merge `additions` under `base`, keeping each addition only while the result
+ * still satisfies both caps. `base` keys always win and are never dropped, and
+ * a full budget drops the overflow rather than throwing — a caller merging
+ * *derived* facts must never fail an upload over them.
+ *
+ * Deliberately the same rule as the CLI's `mergeDerivedMeta`
+ * (`packages/uploads/src/metadata-vocab.ts`), which applies it to capture-time
+ * derived metadata. Server-side inheritance (#479) and capture-time derivation
+ * are one feature to a user, so they share an overflow rule rather than each
+ * inventing one.
+ */
+export function mergeWithinMetadataCaps(
+  base: Record<string, string>,
+  additions: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...base };
+  let keyCount = countableKeys(out).length;
+  let bytes = metadataByteLength(out);
+
+  for (const [key, value] of Object.entries(additions)) {
+    if (key in out) continue;
+    const addedKey = isServerMetaKey(key) ? 0 : 1;
+    const addedBytes = encoder.encode(key).byteLength + encoder.encode(value).byteLength;
+    if (keyCount + addedKey > META_MAX_KEYS) continue;
+    if (bytes + addedBytes > META_MAX_TOTAL_BYTES) continue;
+    out[key] = value;
+    keyCount += addedKey;
+    bytes += addedBytes;
+  }
+  return out;
+}
+
+/**
  * Shared validation body for `validateMetadataEntries` and
  * `validateStoredMetadataEntries`: key format, value format/length, the
  * per-map key-count cap, and the total key+value byte cap.
@@ -88,9 +141,7 @@ function validateMetadataEntriesImpl(
   opts: { allowServerKeys?: boolean },
 ): void {
   const keys = Object.keys(meta);
-  // Server-owned keys don't consume the user's budget — otherwise every video
-  // upload would silently cost four of their META_MAX_KEYS slots.
-  const countable = keys.filter((key) => !isServerMetaKey(key));
+  const countable = countableKeys(meta);
   if (countable.length > META_MAX_KEYS) {
     throw new ValidationError(`metadata must have at most ${META_MAX_KEYS} keys.`, {
       code: "file_metadata_limit_exceeded",
@@ -98,7 +149,6 @@ function validateMetadataEntriesImpl(
     });
   }
 
-  let totalBytes = 0;
   for (const key of keys) {
     if (!META_KEY_RE.test(key)) {
       throw new ValidationError(`invalid metadata key: ${key}`, {
@@ -124,9 +174,9 @@ function validateMetadataEntriesImpl(
         details: { key },
       });
     }
-    totalBytes += encoder.encode(key).byteLength + encoder.encode(value).byteLength;
   }
 
+  const totalBytes = metadataByteLength(meta);
   if (totalBytes > META_MAX_TOTAL_BYTES) {
     throw new ValidationError(`metadata exceeds ${META_MAX_TOTAL_BYTES} total bytes.`, {
       code: "file_metadata_limit_exceeded",
@@ -307,6 +357,45 @@ export async function setFileMetadata(
   }
   if (statements.length > 0) await db.batch(statements);
 
+  return next;
+}
+
+/**
+ * Add only the pairs an object does not already carry, dropping any that would
+ * breach the caps (`mergeWithinMetadataCaps`) instead of throwing.
+ *
+ * The additive-and-lossy counterpart to `setFileMetadata`, which merges with
+ * `set` winning and rejects the whole call on overflow. Callers supplying
+ * *derived* pairs — facts the server inferred rather than the user typed — want
+ * neither of those: an inferred value must never overwrite one the user stated,
+ * and must never fail a request it was only decorating.
+ *
+ * One read and one batch: the merge happens here rather than by reading, diffing
+ * outside, and handing the result to `setFileMetadata`, which would read the same
+ * row a second time.
+ *
+ * Returns the object's resulting metadata when something was written, else
+ * `undefined` so a caller can tell "nothing to do" from "wrote an empty map".
+ */
+export async function addMissingFileMetadata(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  candidates: Record<string, string>,
+): Promise<Record<string, string> | undefined> {
+  if (Object.keys(candidates).length === 0) return undefined;
+  validateMetadataEntries(candidates);
+
+  const current = await getFileMetadata(db, workspace, objectKey);
+  const next = mergeWithinMetadataCaps(current, candidates);
+
+  const additions: Record<string, string> = {};
+  for (const key of Object.keys(candidates)) {
+    if (!(key in current) && key in next) additions[key] = next[key]!;
+  }
+  if (Object.keys(additions).length === 0) return undefined;
+
+  await db.batch(upsertStatements(db, workspace, objectKey, additions, new Date().toISOString()));
   return next;
 }
 

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -478,6 +478,9 @@ export async function putObject(
       metadata: storageMetadata,
     });
   } catch (err) {
+    // Settle the in-flight donor lookup so no D1 read outlives the request. It
+    // resolves to `{}` rather than rejecting, so this only discards a result.
+    await inheritedPromise;
     // Nothing was stored — return both reservations to the budget.
     await releaseUploadsSafe(env.DB, workspaceName, 1);
     await releaseStorageBytesSafe(env.DB, workspaceName, reservedBytes);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -17,10 +17,16 @@ import {
 import {
   deleteFileMetadata,
   deleteServerFileMetadataKeys,
+  mergeWithinMetadataCaps,
   replaceFileMetadata,
   setServerFileMetadata,
   validateMetadataEntries,
 } from "./file-metadata";
+import {
+  applyInheritedMetaAdditively,
+  inheritableMetaForHash,
+  recordContentHash,
+} from "./content-hash";
 import { recordPrActivityFromMetadata } from "./github-pr-activity";
 import { DEFAULT_MAX_UPLOAD_BYTES, inspectUpload, resolveUploadPolicy } from "./guards";
 import { checkKeyPolicy, resolveKeyPolicy } from "./key-policy";
@@ -446,9 +452,15 @@ export async function putObject(
   // (never trust a client-supplied hash). Visibility lives alongside provenance
   // in the same custom-metadata bag but is tracked separately (not client-free-form).
   // `uploaded-at` is server-only — set on the final bag, never via sanitizeProvenance.
+  const contentSha256 = await contentSha256Hex(bytes);
+  // Started here rather than where it is consumed, so this D1 read overlaps the
+  // R2 write and usage accounting instead of adding its latency after them. Safe
+  // to leave in flight: inheritableMetaForHash never rejects (it resolves to `{}`
+  // on any failure), so an upload that throws below cannot orphan a rejection.
+  const inheritedPromise = inheritableMetaForHash(env.DB, workspaceName, contentSha256, finalKey);
   const provenance: ProvenanceMap = {
     ...sanitizeProvenance(opts?.provenance, { clientOnly: true }),
-    "content-sha256": await contentSha256Hex(bytes),
+    "content-sha256": contentSha256,
   };
   const storedVisibility = opts?.visibility === "private" ? "private" : undefined;
   const storageMetadata: Record<string, string> = {
@@ -484,14 +496,38 @@ export async function putObject(
     uploads: 0,
   });
 
+  // Derived metadata from a content-identical earlier upload in this workspace
+  // (issue #479) — rescues the paths the CLI sidecar cannot reach: the hosted
+  // MCP, CI, a second machine. Never fires in the communal workspace; see
+  // inheritableMetaForHash. Issued back at the hash, awaited here.
+  const inherited = await inheritedPromise;
+
+  // What actually landed in the queryable tier, echoed on the response (#511).
+  let storedMetadata: Record<string, string> | undefined;
+
   if (opts?.metadata) {
     // Full replace: an overwrite must not inherit a prior put's custom
     // metadata, so clear the row set before (re-)writing this request's, in
     // one atomic batch (replaceFileMetadata) rather than a delete followed
     // by a separate re-read-then-write.
-    await replaceFileMetadata(env.DB, workspaceName, finalKey, opts.metadata);
+    storedMetadata = mergeWithinMetadataCaps(opts.metadata, inherited);
+    await replaceFileMetadata(env.DB, workspaceName, finalKey, storedMetadata);
+    // Explicit metadata only, never the inherited merge: inherited keys
+    // describe the bytes, and letting them reach PR activity would attribute
+    // the donor upload's PR to this one. (`gh.*` is not inheritable, so this
+    // is belt and braces rather than the only guard.)
     await recordPrActivityFromMetadata(env.DB, workspaceName, opts.metadata);
+  } else {
+    // No `X-Uploads-Meta-*` headers: this put deliberately leaves an existing
+    // object's tags alone, so inheritance must be additive rather than a
+    // replace, which would wipe tags the caller never asked to change.
+    storedMetadata = await applyInheritedMetaAdditively(env.DB, workspaceName, finalKey, inherited);
   }
+
+  // Index this object's bytes for future inheritance. Last, and best-effort:
+  // the object is durably stored by now, so a failed index write costs a later
+  // inheritance rather than this upload.
+  await recordContentHash(env.DB, workspaceName, finalKey, contentSha256);
 
   // After the metadata replace, never before: replaceFileMetadata is
   // delete-then-insert and would wipe the server-owned video.* rows.
@@ -515,7 +551,7 @@ export async function putObject(
     contentType: inspection.contentType,
     replaced,
     provenance,
-    ...(opts?.metadata ? { metadata: opts.metadata } : {}),
+    ...(storedMetadata ? { metadata: storedMetadata } : {}),
     ...(storedVisibility ? { visibility: storedVisibility } : {}),
   };
 }

--- a/apps/api/test/content-hash-vocab-parity.test.ts
+++ b/apps/api/test/content-hash-vocab-parity.test.ts
@@ -1,0 +1,56 @@
+/// <reference types="node" />
+
+/**
+ * Drift guard for the one fact this app deliberately duplicates.
+ *
+ * `INHERITABLE_META_KEYS` (apps/api) restates `CANONICAL_META_KEYS`
+ * (packages/uploads) because neither side can import the other: the CLI package
+ * is published and carries no `@uploads/*` workspace deps, so it cannot depend
+ * on a shared private package; and `apps/api` importing the CLI would invert the
+ * dependency and drag CLI deps toward a Worker bundle. Same reasoning as
+ * `packages/billing/src/workspace-cap.ts` restating the record shape it needs.
+ *
+ * The duplication is only safe if drift fails a test. Without this, a key added
+ * to the CLI's canonical vocabulary would silently be non-inheritable
+ * server-side — no compiler error, no failing test, just metadata quietly not
+ * surviving the seam this feature exists to close (#479).
+ *
+ * The vocabulary is read out of the CLI's *source* rather than imported: it is
+ * not in that package's public exports, and its `exports` map points at built
+ * `dist/`, so importing it would make this test depend on a CLI build.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { INHERITABLE_META_KEYS } from "../src/content-hash";
+
+const VOCAB_SOURCE = fileURLToPath(
+  new NodeURL("../../../packages/uploads/src/metadata-vocab.ts", import.meta.url),
+);
+
+/** Pull the `CANONICAL_META_KEYS` array literal out of the CLI source. */
+function readCanonicalKeys(): string[] {
+  const source = readFileSync(VOCAB_SOURCE, "utf8");
+  const match = source.match(/export const CANONICAL_META_KEYS = \[([^\]]*)\] as const;/);
+  if (!match) {
+    throw new Error(
+      `could not find CANONICAL_META_KEYS in ${VOCAB_SOURCE} — if the CLI renamed or reshaped it, update this parity test rather than deleting it`,
+    );
+  }
+  return [...match[1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!);
+}
+
+describe("inheritable vocabulary parity with the CLI", () => {
+  it("finds the canonical vocabulary in the CLI source", () => {
+    expect(readCanonicalKeys().length).toBeGreaterThan(0);
+  });
+
+  it("matches CANONICAL_META_KEYS exactly", () => {
+    // Order-insensitive: the api uses a Set for lookup, so only membership is
+    // load-bearing. A mismatch here means the two lists drifted — add the key
+    // to INHERITABLE_META_KEYS (or, if it must not be inheritable, say why in
+    // a comment there and adjust this expectation deliberately).
+    expect([...INHERITABLE_META_KEYS].sort()).toEqual(readCanonicalKeys().sort());
+  });
+});

--- a/apps/api/test/content-hash.test.ts
+++ b/apps/api/test/content-hash.test.ts
@@ -1,0 +1,292 @@
+import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
+import { describe, expect, it } from "vitest";
+import {
+  applyInheritedMetaAdditively,
+  inheritableMetaForHash,
+  INHERITABLE_META_KEYS,
+  recordContentHash,
+} from "../src/content-hash";
+import {
+  getFileMetadata,
+  META_MAX_KEYS,
+  mergeWithinMetadataCaps,
+  setFileMetadata,
+} from "../src/file-metadata";
+import { database, SqliteD1 } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260724140000_file_content_hash.sql",
+];
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+/** Seed a donor object: its bytes hash, plus the derived tags it carries. */
+async function seedDonor(
+  sqlite: SqliteD1,
+  workspace: string,
+  key: string,
+  hash: string,
+  meta: Record<string, string>,
+): Promise<void> {
+  const db = database(sqlite);
+  await recordContentHash(db, workspace, key, hash);
+  if (Object.keys(meta).length > 0) await setFileMetadata(db, workspace, key, meta);
+}
+
+describe("inheritableMetaForHash", () => {
+  it("returns the donor's derived tags for content-identical bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedDonor(sqlite, "alpha", "f/one.png", HASH_A, {
+        path: "/settings/limits",
+        state: "after",
+      });
+
+      const inherited = await inheritableMetaForHash(
+        database(sqlite),
+        "alpha",
+        HASH_A,
+        "f/two.png",
+      );
+      expect(inherited).toEqual({ path: "/settings/limits", state: "after" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns nothing when no object shares the bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedDonor(sqlite, "alpha", "f/one.png", HASH_A, { path: "/a" });
+      expect(await inheritableMetaForHash(database(sqlite), "alpha", HASH_B, "f/two.png")).toEqual(
+        {},
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never inherits in the communal workspace, even on an exact byte match", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      // `default` is the one shared tenant every account belongs to, so a byte
+      // match there says nothing about the two uploads being related.
+      await seedDonor(sqlite, COMMUNAL_WORKSPACE, "f/one.png", HASH_A, {
+        path: "/admin/billing",
+      });
+
+      expect(
+        await inheritableMetaForHash(database(sqlite), COMMUNAL_WORKSPACE, HASH_A, "f/two.png"),
+      ).toEqual({});
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not cross workspaces", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedDonor(sqlite, "alpha", "f/one.png", HASH_A, { path: "/a" });
+      expect(await inheritableMetaForHash(database(sqlite), "beta", HASH_A, "f/two.png")).toEqual(
+        {},
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not treat the object itself as its own donor on overwrite", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedDonor(sqlite, "alpha", "f/one.png", HASH_A, { path: "/a" });
+      expect(await inheritableMetaForHash(database(sqlite), "alpha", HASH_A, "f/one.png")).toEqual(
+        {},
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns nothing rather than throwing when the lookup fails", async () => {
+    // Only the metadata migration — `file_content_hash` does not exist, standing
+    // in for a D1 blip. This runs after the bytes are durably stored, so the
+    // upload must survive: losing inheritance costs metadata the caller can
+    // re-state, throwing would cost bytes they would have to re-send.
+    const sqlite = new SqliteD1("migrations/20260713210559_file_metadata.sql");
+    try {
+      expect(await inheritableMetaForHash(database(sqlite), "alpha", HASH_A, "f/two.png")).toEqual(
+        {},
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("filters the donor's tags to the inheritable vocabulary", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedDonor(sqlite, "alpha", "f/one.png", HASH_A, {
+        path: "/a",
+        "gh.repo": "owner/repo",
+        "gh.pr": "468",
+        project: "something-custom",
+      });
+
+      const inherited = await inheritableMetaForHash(
+        database(sqlite),
+        "alpha",
+        HASH_A,
+        "f/two.png",
+      );
+      // `gh.*` is a claim about the donor's PR context, not a property of the
+      // bytes — inheriting it would mint phantom PR activity.
+      expect(inherited).toEqual({ path: "/a" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("picks the oldest donor deterministically when several share the bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await seedDonor(sqlite, "alpha", "f/first.png", HASH_A, { path: "/first" });
+      await seedDonor(sqlite, "alpha", "f/second.png", HASH_A, { path: "/second" });
+      // Force a strictly later timestamp on the second donor.
+      await db
+        .prepare(
+          `UPDATE file_content_hash SET updated_at = ? WHERE workspace = ? AND object_key = ?`,
+        )
+        .bind("2999-01-01T00:00:00.000Z", "alpha", "f/second.png")
+        .run();
+
+      const inherited = await inheritableMetaForHash(db, "alpha", HASH_A, "f/third.png");
+      expect(inherited).toEqual({ path: "/first" });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("recordContentHash", () => {
+  it("replaces a key's hash on overwrite rather than accumulating rows", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordContentHash(db, "alpha", "f/one.png", HASH_A);
+      await recordContentHash(db, "alpha", "f/one.png", HASH_B);
+
+      const rows = await db
+        .prepare(`SELECT content_sha256 FROM file_content_hash WHERE workspace = ?`)
+        .bind("alpha")
+        .all<{ content_sha256: string }>();
+      expect(rows.results).toEqual([{ content_sha256: HASH_B }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("mergeWithinMetadataCaps", () => {
+  it("lets explicit keys win over inherited ones", () => {
+    expect(
+      mergeWithinMetadataCaps({ path: "/explicit" }, { path: "/inherited", state: "after" }),
+    ).toEqual({ path: "/explicit", state: "after" });
+  });
+
+  it("drops overflow rather than failing, matching mergeDerivedMeta", () => {
+    // A full explicit budget must never fail an upload — the CLI's
+    // mergeDerivedMeta makes the same call for capture-time derived keys.
+    const explicit: Record<string, string> = {};
+    for (let i = 0; i < META_MAX_KEYS; i += 1) explicit[`k${i}`] = "v";
+
+    const merged = mergeWithinMetadataCaps(explicit, { path: "/a" });
+    expect(Object.keys(merged)).toHaveLength(META_MAX_KEYS);
+    expect(merged.path).toBeUndefined();
+  });
+
+  it("does not let server-owned keys consume the user's key budget", () => {
+    // Same exemption validateMetadataEntries applies: a video upload's four
+    // video.* rows must not cost the user four of their META_MAX_KEYS slots,
+    // and so must not block an inherited key either.
+    const base: Record<string, string> = { "video.poster": "f/p.jpg", "video.width": "1280" };
+    for (let i = 0; i < META_MAX_KEYS - 1; i += 1) base[`k${i}`] = "v";
+
+    const merged = mergeWithinMetadataCaps(base, { path: "/a" });
+    expect(merged.path).toBe("/a");
+  });
+
+  it("adds what fits when only some inherited keys overflow", () => {
+    const explicit: Record<string, string> = {};
+    for (let i = 0; i < META_MAX_KEYS - 1; i += 1) explicit[`k${i}`] = "v";
+
+    const merged = mergeWithinMetadataCaps(explicit, { path: "/a", state: "after" });
+    expect(Object.keys(merged)).toHaveLength(META_MAX_KEYS);
+    expect(merged.path).toBe("/a");
+    expect(merged.state).toBeUndefined();
+  });
+});
+
+describe("applyInheritedMetaAdditively", () => {
+  it("adds inherited keys without disturbing tags already on the object", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await setFileMetadata(db, "alpha", "f/two.png", { "gh.repo": "owner/repo" });
+
+      const stored = await applyInheritedMetaAdditively(db, "alpha", "f/two.png", {
+        path: "/a",
+      });
+
+      expect(stored).toEqual({ "gh.repo": "owner/repo", path: "/a" });
+      expect(await getFileMetadata(db, "alpha", "f/two.png")).toEqual({
+        "gh.repo": "owner/repo",
+        path: "/a",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never overwrites a key the object already carries", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await setFileMetadata(db, "alpha", "f/two.png", { path: "/mine" });
+
+      const stored = await applyInheritedMetaAdditively(db, "alpha", "f/two.png", {
+        path: "/donor",
+      });
+
+      expect(stored).toBeUndefined();
+      expect(await getFileMetadata(db, "alpha", "f/two.png")).toEqual({ path: "/mine" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("writes nothing when there is nothing to inherit", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      expect(await applyInheritedMetaAdditively(db, "alpha", "f/two.png", {})).toBeUndefined();
+      expect(await getFileMetadata(db, "alpha", "f/two.png")).toEqual({});
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("INHERITABLE_META_KEYS", () => {
+  it("excludes gh.* so inherited tags cannot mint phantom PR activity", () => {
+    expect(INHERITABLE_META_KEYS.some((key) => key.startsWith("gh."))).toBe(false);
+  });
+
+  it("excludes reserved server keys", () => {
+    for (const key of ["content-sha256", "visibility", "video.poster"]) {
+      expect((INHERITABLE_META_KEYS as readonly string[]).includes(key)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #479.

## What this does

When an upload's stored bytes match an object the workspace already holds, the earlier object's derived tags (`path`, `url`, `env`, `viewport`, `state`, …) are copied onto the new one.

## Why, given #473 already shipped

#469 closed the capture→attach seam two ways: `screenshot` stages on a branch (#475), and a sidecar manifest carries derived metadata into a later `put`/`attach` of the same bytes (#473). Neither reaches a path where the sidecar cannot exist or does not survive:

- the **hosted MCP** (`agents.uploads.sh`) — no local filesystem, so no sidecar can ever be written;
- a file copied or moved away from its sidecar;
- a CI step, or a second machine, uploading bytes captured elsewhere.

This is a **narrower slice than when #479 was filed** — #475 already covers the dominant capture-then-attach flow. That's worth weighing at review time; see "Cost" below.

## Decisions worth reviewing

**Gated on the communal workspace, not plain same-workspace.** The issue proposed scoping inheritance to the same workspace. That is the wrong boundary: `default` is the one shared tenant every account belongs to, so a byte match there says nothing about two uploads being related. Without the gate, user A's `path=/admin/billing` and `gh.repo=A/private-thing` would land on user B's upload of the same image. Gated in **both** cloud and self-hosted — inheriting across unrelated members of a shared tenant is surprising in either, and a trust rule that varies per deployment is one every future cross-tenant feature has to reason about twice.

Two larger questions this surfaced are split out and do **not** gate this PR: #505 (should cloud keep a communal workspace at all) and #506 (auto-provision a personal workspace from the GitHub username).

**Its own table, not a `file_metadata` row.** The first cut reused `file_metadata_lookup_idx` and shipped no migration. #511 invalidated that: it had just separated the R2 provenance bag (`provenance`) from the user-facing queryable tier (`metadata`), and writing a server-computed `content-sha256` as a tag pushes a 64-char hash straight back into the tier #511 cleaned up — visible in `meta get`, in hydrated listings, in `find --meta`, and burning one of the 24 per-file key slots on every file forever. The migration buys back the clean split, leaves the per-file cap untouched, and removes an ordering hazard (a separate table cannot be wiped by `replaceFileMetadata`, which is delete-then-insert).

**Fail-soft on both index operations.** They run *after* the bytes are durably stored, so an exception would fail a put whose object already exists in R2 — trading a re-upload for metadata the caller could simply re-state. Deliberately the opposite of `getFileMetadata`, which throws because an empty read there would be a lie. This also keeps the feature inert against a database that has not run the migration yet, which matters because the api and its migrations deploy independently.

**A put with no `--meta` cannot use `replaceFileMetadata`.** That path deliberately leaves an existing object's tags untouched, and a replace is delete-then-insert — inheriting through it would wipe tags the caller never asked to change. That branch is additive-only and never overwrites a key the object already carries. This matters because it is the *main* case: a hosted-MCP put with no metadata is exactly what this rescues.

**`gh.*` is not inheritable**, by construction rather than by filter — a repo/PR association is a claim about an upload's context, not a property of its bytes. That is also what stops inherited tags minting phantom PR activity through `recordPrActivityFromMetadata`, which is additionally fed explicit metadata only.

## Refactor carried along

Extracting the merge this needed moved two things into `file-metadata.ts`, beside the caps they enforce: `mergeWithinMetadataCaps` (cap-aware partial merge, explicit wins, overflow dropped rather than thrown — deliberately the same rule as the CLI's `mergeDerivedMeta`, since capture-time derivation and server-side inheritance are one feature to a user) and `metadataByteLength`, now shared with `validateMetadataEntries`.

That closed a real divergence: the validator **exempts server-owned `video.*` keys** from the key-count cap, so a merge that counted them would have silently blocked an inherited key from landing on a video upload. There is a test for it.

`addMissingFileMetadata` is the additive, overflow-dropping counterpart to `setFileMetadata` — one read and one batch, where the first cut read the row, diffed outside, then handed the result to `setFileMetadata`, which read it again.

## Vocabulary duplication

`INHERITABLE_META_KEYS` restates the CLI's `CANONICAL_META_KEYS`. Neither side can import the other: `packages/uploads` is published and carries no `@uploads/*` workspace deps, so it cannot depend on a shared private package, and `apps/api` importing the CLI would invert the dependency and drag CLI deps toward a Worker bundle. This follows the `packages/billing/src/workspace-cap.ts` precedent, with a parity test that reads the CLI source (the vocabulary is not in its public exports, and its `exports` map points at built `dist/`) so drift fails a test rather than silently making a key non-inheritable.

A third option — publishing the vocabulary as its own tiny package — is recorded in the design doc as weighed, not missed. It did not look worth a fourth published package plus release coordination for a 10-entry array, but reviewers may disagree.

## Cost

Every upload now does one extra D1 write (the hash upsert), and every non-communal upload one extra D1 read (the donor lookup). The lookup is issued right after the hash is computed and awaited later, so it overlaps the R2 write rather than stacking on top of it; the upsert stays last on purpose, because writing the hash row after the metadata is what keeps a donor undiscoverable until its tags have landed.

If the verdict is that this is not worth a write on every upload given how much #475 already covers, the honest alternative is closing #479 as covered-enough — that is a legitimate outcome of this review.

## Visible API change

Per #511 a put echoes the tags it stored; inherited keys now appear in that echo, so a client can see what it got without a second round trip.

## Testing

`pnpm test` — 3047 passing (20 new). `pnpm typecheck` — clean. Covers: inheritance on a byte match; never in communal even on an exact match; no cross-workspace; an object is not its own donor on overwrite; vocabulary filtering; deterministic oldest-donor selection; fail-soft when the table is absent; cap overflow dropping rather than failing; the `video.*` exemption; additive merge never overwriting an existing key; and vocabulary parity with the CLI.

No changeset: nothing in `packages/uploads` changed, and a changeset naming an ignored package would block the next npm publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically carries eligible metadata to newly uploaded files with identical content.
  * Preserves existing metadata while applying inherited tags safely within metadata limits.
  * File metadata responses now reflect the metadata actually stored.
  * Metadata inheritance is isolated by workspace and excludes restricted or server-managed fields.

* **Bug Fixes**
  * Prevents metadata overflow from failing uploads by dropping additions that exceed limits.
  * Ensures explicit metadata takes precedence over inherited metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->