### PR TITLE
fix(cli): treat an already-registered MCP server as configured, not failed

### DIFF
--- a/.changeset/pink-eels-invite.md
+++ b/.changeset/pink-eels-invite.md
@@ -1,0 +1,11 @@
+---
+"uploads": patch
+---
+
+`uploads install` no longer reports an already-registered MCP server as a
+failure. `claude mcp add` refuses to overwrite an existing entry and exits
+non-zero, so re-running `install` (or `update`, which re-runs it) ended with a
+raw `Command failed: …` dump and exit 1 for anyone already set up. That case is
+now reported as `mcp: already configured`, exits 0, and prints the
+`claude mcp remove <name>` command needed to re-register with a new token —
+the one thing the existing entry will not pick up on its own.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ and the exit codes, run `uploads help --all` or see
 uploads login          # sign in via browser; saves your workspace token, then runs doctor
 uploads whoami         # show the active workspace + token (alias: uploads status)
 uploads install        # skills + hosted MCP + hooks for Grok/Cursor (Claude/Codex use plugins)
-uploads update         # update the CLI, then refresh skills / MCP / hooks
+uploads update         # update the CLI, then refresh skills / hooks (MCP left as-is)
 uploads put ./shot.png # stdout: public URL + ready-to-paste markdown; stderr: human summary
 ```
 
@@ -41,8 +41,19 @@ Two things go stale independently: the npm package that provides the `uploads`
 binary, and the agent skills plus the MCP registration that `uploads install`
 writes. `uploads update` covers both. It upgrades the global package, then
 re-runs `install` against the new version. When the CLI is already current it
-still refreshes the skills and the MCP registration, because those drift on
-their own. Run `uploads update --dry-run` first to see the plan.
+still refreshes the skills, because those drift on their own. Run
+`uploads update --dry-run` first to see the plan.
+
+Re-running `install` (directly or through `update`) is safe. The skills are
+reinstalled each time; an MCP server already registered under that name is
+reported as `already configured` and left untouched, because `claude mcp add`
+never overwrites an existing entry. That also means a registration keeps the
+bearer token it was created with — after `uploads login` with a new token,
+remove and re-add it:
+
+```bash
+claude mcp remove uploads && uploads install mcp
+```
 
 The upgrade step needs a global install. Inside a checkout of this repository,
 or from an `npx` cache, `update` reports the newer version and prints the

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -25,6 +25,10 @@ infers your workspace from the bearer token, so only the token is needed.
 Claude Code and Codex ship the same reminder via their plugins (same command:
 \`${HOOK_COMMAND}\`) — install those plugins instead of relying on this step.
 
+Safe to re-run. An MCP server already registered under this name is reported
+as \`already configured\` and left as-is — including the token it was created
+with. To point it at a new token: \`claude mcp remove <name>\` first.
+
 Usage:
   uploads install [skill|mcp|hooks|all]     (default: all)
 
@@ -59,7 +63,7 @@ Examples:
 export interface StepResult {
   command: string[];
   ok: boolean;
-  skipped?: "dry-run" | "sign-in";
+  skipped?: "dry-run" | "sign-in" | "already-configured";
   error?: string;
   output?: string;
 }
@@ -90,6 +94,17 @@ export function runStep(run: CommandRunner, command: string[]): StepResult {
 function skillCommand(skill: string): string[] {
   // -g global, -y non-interactive, -a '*' every agent (skips the multi-select TUI)
   return ["npx", "-y", "skills", "add", SKILL_SOURCE, "--skill", skill, "-g", "-y", "-a", "*"];
+}
+
+/**
+ * `claude mcp add` refuses to overwrite an existing entry and exits non-zero
+ * ("MCP server uploads already exists in local config"). That is the steady
+ * state for anyone re-running `uploads install`, not a failure — recognize it
+ * so the run stays green and the footer tells them how to re-add if they want
+ * a fresh token in the header.
+ */
+function alreadyConfigured(result: StepResult): boolean {
+  return !result.ok && /already exists/i.test(result.error ?? "");
 }
 
 function mcpCommand(name: string, url: string, bearer: string): string[] {
@@ -125,6 +140,7 @@ function printHumanSteps(
   results: Record<string, StepResult>,
   redact: (s: string) => string,
   verbose: boolean,
+  mcpName: string,
 ): void {
   for (const [step, r] of Object.entries(results)) {
     const cmd = redact(r.command.join(" "));
@@ -132,6 +148,11 @@ function printHumanSteps(
       process.stdout.write(`${step}: would run — ${cmd}\n`);
     } else if (r.skipped === "sign-in") {
       process.stdout.write(`${step}: skipped — ${redact(r.error ?? "needs sign-in")}\n`);
+    } else if (r.skipped === "already-configured") {
+      process.stdout.write(
+        `${step}: already configured — "${mcpName}" is registered in Claude Code (nothing to do)\n` +
+          `  To re-register (e.g. with a new token): claude mcp remove ${mcpName} && uploads install mcp\n`,
+      );
     } else if (r.ok) {
       process.stdout.write(`${step}: ok\n`);
       if (verbose && r.output) {
@@ -228,7 +249,12 @@ export async function runInstall(
     } else {
       const command = mcpCommand(name, url, token || "<token>");
       if (human) process.stdout.write("Installing MCP server…\n");
-      results.mcp = dryRun ? { command, ok: true, skipped: "dry-run" } : runStep(run, command);
+      const step = dryRun
+        ? { command, ok: true, skipped: "dry-run" as const }
+        : runStep(run, command);
+      results.mcp = alreadyConfigured(step)
+        ? { command, ok: true, skipped: "already-configured", output: step.error }
+        : step;
     }
   }
 
@@ -267,7 +293,7 @@ export async function runInstall(
     return failed ? 1 : 0;
   }
 
-  printHumanSteps(results, redact, verbose);
+  printHumanSteps(results, redact, verbose, name);
   // Path-level detail for hooks (printHumanSteps only shows the synthetic step).
   if (
     (target === "hooks" || target === "all") &&

--- a/packages/uploads/src/commands/update.ts
+++ b/packages/uploads/src/commands/update.ts
@@ -10,9 +10,10 @@ import { runInstall, runStep } from "./install.js";
 const UPDATE_HELP = `uploads update — update the CLI and refresh agent integrations
 
 Upgrades the globally installed npm package, then re-runs \`uploads install\` so
-the agent skills and the MCP registration match the new version. Skills and the
-MCP registration drift on their own, so this refreshes them even when the CLI is
-already current.
+the agent skills match the new version. Skills drift on their own, so this
+refreshes them even when the CLI is already current. An MCP server already
+registered is left as-is (\`already configured\`) — \`claude mcp add\` never
+overwrites an existing entry.
 
 Usage:
   uploads update [options]

--- a/packages/uploads/test/install.test.ts
+++ b/packages/uploads/test/install.test.ts
@@ -246,6 +246,50 @@ describe("uploads install", () => {
     expect(printed).not.toContain("Bearer up_acme");
   });
 
+  it("treats an existing MCP entry as already configured, not a failure", async () => {
+    const run: CommandRunner = (cmd) => {
+      if (cmd === "claude") {
+        throw new Error(
+          "Command failed: claude mcp add --transport http uploads\nMCP server uploads already exists in local config\n",
+        );
+      }
+      return "ok\n";
+    };
+    const { out, err } = captureStreams();
+    const code = await install([], { globals: GLOBALS, runner: run });
+    expect(code).toBe(0);
+    const printed = out.join("");
+    expect(printed).toMatch(/mcp: already configured/);
+    expect(printed).toMatch(/claude mcp remove uploads/);
+    expect(printed).not.toMatch(/mcp: failed/);
+    expect(printed).not.toMatch(/Fix the MCP step above/);
+    expect(err.join("")).toBe("");
+  });
+
+  it("--name is reflected in the already-configured remove hint", async () => {
+    const run: CommandRunner = (cmd) => {
+      if (cmd === "claude") throw new Error("MCP server up already exists in local config");
+      return "ok\n";
+    };
+    const { out } = captureStreams();
+    expect(await install(["mcp", "--name", "up"], { globals: GLOBALS, runner: run })).toBe(0);
+    expect(out.join("")).toMatch(/claude mcp remove up /);
+  });
+
+  it("--json marks an existing MCP entry ok with an already-configured skip", async () => {
+    const run: CommandRunner = (cmd) => {
+      if (cmd === "claude") throw new Error("MCP server uploads already exists in local config");
+      return "ok\n";
+    };
+    const { out } = captureStreams();
+    const code = await install(["mcp"], { globals: GLOBALS, json: true, runner: run });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out.join(""));
+    expect(parsed.ok).toBe(true);
+    expect(parsed.steps.mcp.ok).toBe(true);
+    expect(parsed.steps.mcp.skipped).toBe("already-configured");
+  });
+
   it("rejects unknown targets", async () => {
     const { run } = fakeRunner();
     await expect(install(["nope"], { globals: GLOBALS, runner: run })).rejects.toThrow(


### PR DESCRIPTION
`claude mcp add` refuses to overwrite an existing entry and exits non-zero. That
made every re-run of `uploads install` — and of `uploads update`, which re-runs
it — end in a raw failure dump and exit 1 once the server was registered, which
is the steady state for anyone who has run the command before:

```
mcp: failed — Command failed: claude mcp add --transport http uploads https://agents.uploads.sh/mcp --header Authorization: Bearer ***
MCP server uploads already exists in local config

Skills are installed. Fix the MCP step above, then re-run `uploads install mcp`.
```

Nothing was wrong, and there was nothing to fix.

## After

Real output from this branch (with a stub `claude` that reproduces the error):

```
Installing MCP server…
mcp: already configured — "uploads" is registered in Claude Code (nothing to do)
  To re-register (e.g. with a new token): claude mcp remove uploads && uploads install mcp

Done — mcp ready.
Restart your agent session so it picks up the new skill/server.
```

Exit code `0`.

## What changed

- `alreadyConfigured()` matches `/already exists/i` in the failed step and converts
  it to `ok: true` with `skipped: "already-configured"`. Detection is scoped to the
  MCP step only.
- The human line names the server (honors `--name`) and prints the remove command.
- `--json` reports `steps.mcp.ok: true` with `skipped: "already-configured"`, so the
  overall payload stays `ok: true`.

## Reviewer notes

- **Why a hint instead of auto re-adding.** `claude mcp add` won't update the
  `Authorization` header on an existing entry, so re-running after `uploads login`
  with a new token silently leaves the stale one in place. Removing and re-adding
  automatically would fix that, but it also destroys any manual edits made to that
  entry — so this surfaces the command rather than running it. Worth a second
  opinion if you'd rather it just did the swap.
- **Detection is string-matched** against `claude`'s error text. If that wording
  changes we fall back to the old behavior (a visible failure), not to a silently
  wrong success.
- **Docs correction.** `docs/cli.md` and both `--help` texts claimed `uploads update`
  refreshes the MCP registration. It never did — that claim is exactly what produced
  the confusing failure. Now scoped to skills, with the re-run behavior and the token
  caveat spelled out.

Three tests added; 45 tests across install/update/help pass, typecheck clean.
