### PR TITLE
fix(release): correct the package name in the install changeset

### DIFF
--- a/.changeset/pink-eels-invite.md
+++ b/.changeset/pink-eels-invite.md
@@ -1,5 +1,5 @@
 ---
-"uploads": patch
+"@buildinternet/uploads": patch
 ---
 
 `uploads install` no longer reports an already-registered MCP server as a


### PR DESCRIPTION
The changeset added in #518 names `uploads`, but the package is `@buildinternet/uploads`. Changesets treats an unknown name as a hard error:

```
🦋  error Error: Found changeset pink-eels-invite for package uploads which is not in the workspace
```

That failed the Release run on the #518 merge commit ([run 30119500009](https://github.com/buildinternet/uploads/actions/runs/30119500009)), so no version PR was opened and publishing is blocked until this lands. My error in #518 — the release job is the only place it surfaces, since nothing validates changeset package names at PR time.

`npx changeset status` on this branch now resolves it cleanly:

```
🦋  info Packages to be bumped at patch:
🦋  - @buildinternet/uploads
```

Content of the changeset is unchanged.