### PR TITLE
fix: require an explicit workspace for admin credential issuance

### DIFF
--- a/.changeset/tidy-moons-invite.md
+++ b/.changeset/tidy-moons-invite.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`uploads admin invite create` now requires `--workspace`. It previously defaulted
+to the communal `default` workspace, so a forgotten flag issued an invite
+granting `files:read`/`files:write` on the shared tenant — and because
+enrollment redemption mints a token without creating an org membership, the
+recipient would not have appeared in any member list while still reading and
+writing that workspace's files. Pass the workspace explicitly; naming `default`
+still works.

--- a/apps/api/src/routes/admin-workspace-required.test.ts
+++ b/apps/api/src/routes/admin-workspace-required.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The four `/admin` token/enrollment routes used to default an omitted
+ * `workspace` to the communal `default` workspace. That made the shared tenant
+ * the silent target of credential issuance: an operator minting a token or an
+ * enrollment code "for a customer" and forgetting the field handed out
+ * files:read/files:write on `default` instead — and because enrollment
+ * redemption mints a token without creating an org membership
+ * (`redeemEnrollment` in auth-db.ts), the recipient would not appear in any
+ * member list while still reading and writing that workspace's objects.
+ *
+ * Requiring the field turns that silent mis-target into a 400. These tests pin
+ * the rule per route so the default cannot be reintroduced one handler at a
+ * time.
+ */
+import { Hono } from "hono";
+import { beforeAll, describe, expect, it } from "vitest";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { respondError } from "../error-response";
+import { admin } from "./admin";
+
+const ADMIN_TOKEN = "test-admin-token";
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+];
+
+const RECORD = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "UPLOADS_DEFAULT",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+beforeAll(() => {
+  if (typeof crypto.subtle.timingSafeEqual !== "function") {
+    (
+      crypto.subtle as unknown as { timingSafeEqual: (a: Uint8Array, b: Uint8Array) => boolean }
+    ).timingSafeEqual = (a: Uint8Array, b: Uint8Array) =>
+      a.length === b.length && a.every((byte, i) => byte === b[i]);
+  }
+});
+
+function appWith(db: SqliteD1) {
+  const app = new Hono<{ Bindings: Env }>()
+    .route("/admin", admin)
+    .onError((err, c) => respondError(c, err));
+  const store = new Map<string, unknown>(
+    Object.entries({ "ws:acme": RECORD, "ws:default": { ...RECORD, prefix: "default/" } }),
+  );
+  const env = {
+    ADMIN_TOKEN,
+    REGISTRY: {
+      get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    },
+    DB: database(db),
+  } as unknown as Env;
+  return { app, env };
+}
+
+function post(path: string, body: unknown) {
+  return new Request(`https://api.uploads.sh${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${ADMIN_TOKEN}`, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** The four routes, each exercised with `workspace` absent. */
+const OMITTED: { name: string; request: () => Request }[] = [
+  {
+    name: "POST /admin/tokens",
+    request: () => post("/admin/tokens", { label: "ci", scopes: ["files:read"] }),
+  },
+  {
+    name: "POST /admin/enrollments",
+    request: () => post("/admin/enrollments", { label: "ci", scopes: ["files:read"] }),
+  },
+  {
+    name: "GET /admin/tokens",
+    request: () =>
+      new Request("https://api.uploads.sh/admin/tokens", {
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }),
+  },
+  {
+    name: "DELETE /admin/tokens",
+    request: () =>
+      new Request("https://api.uploads.sh/admin/tokens", {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ label: "ci" }),
+      }),
+  },
+];
+
+describe("admin routes require an explicit workspace", () => {
+  for (const route of OMITTED) {
+    it(`${route.name} rejects an omitted workspace with 400 workspace_required`, async () => {
+      const { app, env } = appWith(new SqliteD1(MIGRATIONS));
+      const res = await app.request(route.request(), {}, env);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: { code?: string } };
+      expect(body.error?.code).toBe("workspace_required");
+    });
+
+    it(`${route.name} rejects a blank workspace with 400 workspace_required`, async () => {
+      const { app, env } = appWith(new SqliteD1(MIGRATIONS));
+      const original = route.request();
+      const url = new URL(original.url);
+      const blanked =
+        original.method === "GET"
+          ? new Request(`${url.origin}${url.pathname}?workspace=%20%20`, {
+              headers: original.headers,
+            })
+          : new Request(original.url, {
+              method: original.method,
+              headers: original.headers,
+              body: JSON.stringify({
+                ...(JSON.parse(await original.text()) as Record<string, unknown>),
+                workspace: "   ",
+              }),
+            });
+      const res = await app.request(blanked, {}, env);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: { code?: string } };
+      expect(body.error?.code).toBe("workspace_required");
+    });
+  }
+
+  it("a malformed workspace stays invalid_workspace, distinct from omission", async () => {
+    const { app, env } = appWith(new SqliteD1(MIGRATIONS));
+    const res = await app.request(
+      post("/admin/tokens", { workspace: "Not A Slug", label: "ci", scopes: ["files:read"] }),
+      {},
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("invalid_workspace");
+  });
+
+  it("an explicit workspace still works — the gate is on omission, not on the value", async () => {
+    const { app, env } = appWith(new SqliteD1(MIGRATIONS));
+    const res = await app.request(
+      post("/admin/tokens", { workspace: "acme", label: "ci", scopes: ["files:read"] }),
+      {},
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("naming the communal workspace explicitly is still allowed", async () => {
+    const { app, env } = appWith(new SqliteD1(MIGRATIONS));
+    const res = await app.request(
+      post("/admin/tokens", { workspace: "default", label: "ci", scopes: ["files:read"] }),
+      {},
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,5 +1,4 @@
 import { renderEnrollmentInvitationEmail } from "@uploads/email";
-import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import {
   AppError,
   ConflictError,
@@ -85,7 +84,17 @@ function labelValue(value: unknown): string | undefined | null {
   return label.length >= 1 && label.length <= 100 ? label : null;
 }
 
+/**
+ * Omission and malformation are reported separately on purpose. These routes
+ * used to fall back to the communal workspace when `workspace` was absent, so
+ * the failure mode was a credential silently issued against the shared tenant
+ * rather than an error. A distinct `workspace_required` makes "you forgot the
+ * field" legible to an operator instead of reading as a typo'd slug.
+ */
 function requireWorkspaceName(name: string): void {
+  if (!name) {
+    throw new ValidationError("workspace is required", { code: "workspace_required" });
+  }
   if (!WS_NAME_RE.test(name)) {
     throw new ValidationError("invalid workspace", { code: "invalid_workspace" });
   }
@@ -174,7 +183,8 @@ export const admin = new Hono<{ Bindings: Env }>()
     return c.json({ created, existing });
   })
 
-  // Mint a scoped bearer token for an existing workspace (defaults to the communal one).
+  // Mint a scoped bearer token for an existing workspace. `workspace` is
+  // required — see `requireWorkspaceName` for why there is no default.
   // New credentials live in D1; legacy KV credentials remain readable/revocable.
   .post("/tokens", async (c) => {
     const body = await c.req
@@ -193,7 +203,7 @@ export const admin = new Hono<{ Bindings: Env }>()
             expiresInDays?: number;
           },
       );
-    const name = body.workspace?.trim() || COMMUNAL_WORKSPACE;
+    const name = body.workspace?.trim() ?? "";
     const label = labelValue(body.label);
     requireWorkspaceName(name);
     requireLabel(label);
@@ -258,7 +268,7 @@ export const admin = new Hono<{ Bindings: Env }>()
             email?: string;
           },
       );
-    const name = body.workspace?.trim() || COMMUNAL_WORKSPACE;
+    const name = body.workspace?.trim() ?? "";
     const label = labelValue(body.label);
     requireWorkspaceName(name);
     requireLabel(label);
@@ -344,7 +354,7 @@ export const admin = new Hono<{ Bindings: Env }>()
 
   // Lists D1 credentials and legacy KV credentials without exposing secrets.
   .get("/tokens", async (c) => {
-    const name = c.req.query("workspace")?.trim() || COMMUNAL_WORKSPACE;
+    const name = c.req.query("workspace")?.trim() ?? "";
     requireWorkspaceName(name);
     const record = await workspace(c, name);
     if (!record) {
@@ -377,7 +387,7 @@ export const admin = new Hono<{ Bindings: Env }>()
     const body = await c.req
       .json<{ workspace?: string; hashPrefix?: string; label?: string }>()
       .catch(() => ({}) as { workspace?: string; hashPrefix?: string; label?: string });
-    const name = body.workspace?.trim() || COMMUNAL_WORKSPACE;
+    const name = body.workspace?.trim() ?? "";
     const hashPrefix = body.hashPrefix?.trim();
     const label = body.label?.trim();
     requireWorkspaceName(name);

--- a/apps/api/test/routes-auth.test.ts
+++ b/apps/api/test/routes-auth.test.ts
@@ -123,7 +123,7 @@ describe("auth routes", () => {
       {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
-        body: JSON.stringify({ label: "x".repeat(101) }),
+        body: JSON.stringify({ workspace: "default", label: "x".repeat(101) }),
       },
       env(),
     );
@@ -138,6 +138,7 @@ describe("auth routes", () => {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
         body: JSON.stringify({
+          workspace: "default",
           label: "remote-mcp-smoke",
           scopes: ["files:read", "files:write", "files:delete"],
         }),
@@ -157,7 +158,7 @@ describe("auth routes", () => {
       {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
-        body: JSON.stringify({ label: "routine-agent" }),
+        body: JSON.stringify({ workspace: "default", label: "routine-agent" }),
       },
       env(),
     );
@@ -175,7 +176,7 @@ describe("auth routes", () => {
       {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
-        body: JSON.stringify({ email: "adopter@example.com" }),
+        body: JSON.stringify({ workspace: "default", email: "adopter@example.com" }),
       },
       env({ emailOutbox }),
     );
@@ -197,7 +198,7 @@ describe("auth routes", () => {
       {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
-        body: JSON.stringify({ email: "adopter@example.com" }),
+        body: JSON.stringify({ workspace: "default", email: "adopter@example.com" }),
       },
       env({ emailOutbox: [], emailThrows: true }),
     );
@@ -213,7 +214,7 @@ describe("auth routes", () => {
       {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
-        body: JSON.stringify({ email: "not-an-email" }),
+        body: JSON.stringify({ workspace: "default", email: "not-an-email" }),
       },
       env({ emailOutbox: [] }),
     );
@@ -228,7 +229,7 @@ describe("auth routes", () => {
       {
         method: "POST",
         headers: { Authorization: "Bearer admin-secret", "Content-Type": "application/json" },
-        body: JSON.stringify({ email: "Adopter@Example.com" }),
+        body: JSON.stringify({ workspace: "default", email: "Adopter@Example.com" }),
       },
       env({ emailOutbox: [], inviteAllowed: false, inviteKeys }),
     );

--- a/apps/web/src/pages/console.astro
+++ b/apps/web/src/pages/console.astro
@@ -2,7 +2,6 @@
 // Minimal operator console: paste a bearer token, list usage + files via the public API.
 // No server-side secrets — token stays in the browser. Scaffold toward a fuller files-sdk UI.
 import { env } from "cloudflare:workers";
-import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
 import { resolveConsoleMode } from "../lib/console-mode";
 import Brand from "../components/Brand.astro";
 import BaseHead from "../components/BaseHead.astro";
@@ -185,7 +184,7 @@ const authOrigin =
       </label>
       <label>
         Workspace
-        <input id="ws" type="text" value={COMMUNAL_WORKSPACE} autocomplete="off" />
+        <input id="ws" type="text" placeholder="workspace-name" autocomplete="off" required />
       </label>
       <label>
         Bearer token
@@ -260,8 +259,6 @@ const authOrigin =
       });
     </script>
     <script>
-      import { COMMUNAL_WORKSPACE } from "@uploads/workspace";
-
       function el<T extends HTMLElement>(id: string): T {
         const node = document.getElementById(id);
         if (!node) throw new Error(`console page is missing #${id}`);
@@ -315,12 +312,19 @@ const authOrigin =
         out.textContent = "…";
         const email = el<HTMLInputElement>("invite-email").value.trim();
         const label = el<HTMLInputElement>("invite-label").value.trim();
+        // No fallback workspace. An invite grants read/write on whatever
+        // workspace it names, so a blank field must stop here rather than
+        // resolve to a shared default the operator didn't choose.
+        if (!ws) {
+          out.textContent = "Enter a workspace before creating an invite.";
+          return;
+        }
         try {
           const res = await fetch(`${api}/admin/enrollments`, {
             method: "POST",
             headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
             body: JSON.stringify({
-              workspace: ws || COMMUNAL_WORKSPACE,
+              workspace: ws,
               ...(email ? { email } : {}),
               ...(label ? { label } : {}),
             }),
@@ -341,7 +345,7 @@ const authOrigin =
           const emailedNote =
             body.emailed === undefined ? "" : body.emailed ? `\nemailed:  ${email}` : "\nemailed:  send FAILED — share the link yourself";
           out.textContent =
-            `Invite created for "${ws || COMMUNAL_WORKSPACE}" — the link below is shown once. Treat it like a password.\n\n` +
+            `Invite created for "${ws}" — the link below is shown once. Treat it like a password.\n\n` +
             `${inviteLink}\n\nexpires:  ${body.expiresAt ?? "?"}${emailedNote}`;
           copyBtn.hidden = false;
         } catch (e) {

--- a/docs/admin-tokens.md
+++ b/docs/admin-tokens.md
@@ -29,15 +29,7 @@ Direct minting is retained for CI, migration, and break-glass use. Everyday
 setup should use `uploads login` instead (see [enrollment](enrollment.md)) —
 end users mint their own token that way, with no `ADMIN_TOKEN` involved.
 
-Defaults to the `default` workspace:
-
-```bash
-curl -XPOST https://api.uploads.sh/admin/tokens \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-# → { "workspace": "default", "token": "up_default_…", "label": null }
-```
-
-A specific workspace, with an optional label:
+`workspace` is required, with an optional label:
 
 ```bash
 curl -XPOST https://api.uploads.sh/admin/tokens \
@@ -45,6 +37,13 @@ curl -XPOST https://api.uploads.sh/admin/tokens \
   -H "Content-Type: application/json" \
   -d '{"workspace":"acme","label":"ci"}'
 ```
+
+Omitting it is a `400 workspace_required` rather than a fallback. These routes
+used to default to the communal `default` workspace, which meant a forgotten
+field silently issued a credential against the shared tenant — and since
+enrollment redemption mints a token without creating an org membership, the
+recipient would not show up in any member list while still reading and writing
+that workspace's files. Naming `default` explicitly is still allowed.
 
 The token is shown once. Minting appends — a workspace can hold several valid
 tokens.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -261,7 +261,7 @@ scaffold (behind the console-mode flag) uses it internally.
 
 ```bash
 ADMIN_TOKEN=<admin-credential> uploads admin invite create \
-  --workspace default --label early-adopter
+  --workspace acme --label early-adopter
 ```
 
 By default the command prints one **magic link** (`…/invite?id=…#code=…`): the

--- a/packages/uploads/src/commands/admin-enrollment.ts
+++ b/packages/uploads/src/commands/admin-enrollment.ts
@@ -12,7 +12,7 @@ non-secret page URL plus a code you share separately). The legacy
 
 Options:
   --admin-token <token>  Or ADMIN_TOKEN (UPLOADS_ADMIN_TOKEN is a legacy alias)
-  --workspace <name>     Default: default
+  --workspace <name>     Required — the workspace the invite grants access to
   --label <label>
   --expires-in <seconds> Default: server policy
   --token-expires-in <seconds>  Upload token lifetime (default: server policy)
@@ -90,7 +90,15 @@ export async function runAdmin(
   if (!adminToken) throw new UsageError("ADMIN_TOKEN is required for admin enrollment creation");
   const apiUrl = flagString(parsed.flags, "--api-url") ?? opts.apiUrl ?? "https://api.uploads.sh";
   const webUrl = flagString(parsed.flags, "--web-url");
-  const workspace = flagString(parsed.flags, "--workspace") ?? "default";
+  // No default. An invite grants files:read/files:write on the workspace it
+  // names, so omitting the flag used to silently target the shared `default`
+  // workspace — and enrollment redemption mints a token without an org
+  // membership, so the recipient would not appear in any member list while
+  // still reading and writing its files.
+  const workspace = flagString(parsed.flags, "--workspace");
+  if (!workspace) {
+    throw new UsageError("--workspace is required (the workspace the invite grants access to)");
+  }
   const label = flagString(parsed.flags, "--label");
   const email = flagString(parsed.flags, "--email");
   const result = await createEnrollment(apiUrl, adminToken, {

--- a/packages/uploads/test/commands-login.test.ts
+++ b/packages/uploads/test/commands-login.test.ts
@@ -748,6 +748,18 @@ describe("runLogin device flow — browser workspace selection", () => {
 });
 
 describe("admin enrollment", () => {
+  // `--workspace` used to default to the communal `default` workspace, so a
+  // forgotten flag issued an invite granting files:read/files:write on the
+  // shared tenant. Redemption mints a token without an org membership, so the
+  // recipient would not have shown up in any member list either.
+  it("requires --workspace and never falls back to a shared default", async () => {
+    process.env.ADMIN_TOKEN = "admin-secret";
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    captureOutput();
+    await expect(runAdmin(["invite", "create"], {})).rejects.toThrow(/--workspace is required/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("uses ADMIN_TOKEN and sends explicit lifetime and scopes", async () => {
     process.env.ADMIN_TOKEN = "admin-secret";
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
@@ -804,9 +816,9 @@ describe("admin enrollment", () => {
       ),
     );
     captureOutput();
-    await runAdmin(["enrollment", "create"], { json: true });
+    await runAdmin(["enrollment", "create", "--workspace", "acme"], { json: true });
     expect(JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body))).toEqual({
-      workspace: "default",
+      workspace: "acme",
     });
   });
 
@@ -825,7 +837,7 @@ describe("admin enrollment", () => {
     process.env.ADMIN_TOKEN = "admin-secret";
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(enrollmentResponse());
     const output = captureOutput();
-    expect(await runAdmin(["invite", "create"], {})).toBe(0);
+    expect(await runAdmin(["invite", "create", "--workspace", "acme"], {})).toBe(0);
     expect(output.out()).toContain(
       "https://uploads.sh/invite?id=upi_abcdefghijklmnop#code=upe_abcdefghijklmnopqrstuvwxyz012345",
     );
@@ -836,7 +848,9 @@ describe("admin enrollment", () => {
     process.env.ADMIN_TOKEN = "admin-secret";
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(enrollmentResponse());
     const output = captureOutput();
-    expect(await runAdmin(["invite", "create", "--separate-code"], {})).toBe(0);
+    expect(await runAdmin(["invite", "create", "--workspace", "acme", "--separate-code"], {})).toBe(
+      0,
+    );
     expect(output.out()).toContain(
       "Invite page: https://uploads.sh/invite?id=upi_abcdefghijklmnop",
     );
@@ -861,7 +875,12 @@ describe("admin enrollment", () => {
       ),
     );
     const output = captureOutput();
-    expect(await runAdmin(["invite", "create", "--email", "adopter@example.com"], {})).toBe(0);
+    expect(
+      await runAdmin(
+        ["invite", "create", "--workspace", "acme", "--email", "adopter@example.com"],
+        {},
+      ),
+    ).toBe(0);
     expect(JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body))).toMatchObject({
       email: "adopter@example.com",
     });
@@ -885,7 +904,12 @@ describe("admin enrollment", () => {
       ),
     );
     const output = captureOutput();
-    expect(await runAdmin(["invite", "create", "--email", "adopter@example.com"], {})).toBe(0);
+    expect(
+      await runAdmin(
+        ["invite", "create", "--workspace", "acme", "--email", "adopter@example.com"],
+        {},
+      ),
+    ).toBe(0);
     expect(output.err()).toContain("email delivery failed");
     expect(output.out()).toContain("#code=upe_abcdefghijklmnopqrstuvwxyz012345");
   });


### PR DESCRIPTION
Closes the one path that could put unrelated users in the same workspace without anyone choosing it.

## The problem

Four `ADMIN_TOKEN`-gated routes defaulted an omitted `workspace` to the communal `default` workspace, and `uploads admin invite create` hardcoded the same fallback:

| Surface | Old behavior when `workspace` was omitted |
|---|---|
| `POST /admin/tokens` | minted a token for `default` |
| `POST /admin/enrollments` | created an invite granting access to `default` |
| `GET /admin/tokens` | listed `default`'s tokens |
| `DELETE /admin/tokens` | revoked against `default` |
| `uploads admin invite create` | `--workspace` defaulted to `default` |
| `/console` invite form | field prefilled `default`, and blank fell back to it |

So an operator inviting someone "to their workspace" and forgetting the field handed out `files:read`/`files:write` on the shared tenant instead of getting an error.

What makes this worse than a mis-scoped grant: **enrollment redemption mints a token without creating an org membership** (`redeemEnrollment`, `apps/api/src/auth-db.ts`). The recipient could read and write `default`'s objects while appearing in no member list and in no account UI — invisible co-tenancy.

The `DELETE` case fails the other way: intending to revoke in workspace X, omitting it, and revoking in `default` instead — or believing you revoked something when you hadn't.

## The fix

`workspace` is required everywhere. Omitted or blank is now `400 workspace_required`; malformed slugs keep the distinct `invalid_workspace` code, so "you forgot the field" doesn't read as "you typo'd the slug". Naming `default` explicitly still works — this gates omission, not the value.

The CLI change matters independently: because it hardcoded the string `"default"` rather than reading the shared constant, it would have kept sending `default` explicitly and sailed past the API guard.

## Production state

Checked before changing anything (aggregates only):

- `default` has **one** member — the operator.
- Every other workspace has one member, except the team org.
- **Zero** pending invites, **zero** enrollment rows.

No accidental co-tenancy exists today. This closes the path before it gets used rather than cleaning up after it — which is also why there's no migration or backfill here.

## Scope

Deliberately narrow. This does **not** retire the communal workspace, move objects, change any public URL, or touch the `communal` flag / member-cap exemption / reserved slug. Those are the rest of the de-privileging cleanup discussed in #505.

## Verification

- `pnpm test` — 3115/3115 (240 files)
- `pnpm typecheck` — clean
- Changed files format-clean under `oxfmt`

New `apps/api/src/routes/admin-workspace-required.test.ts` pins the rule per route (omitted and blank, both codes) so the default can't be reintroduced one handler at a time, plus a CLI test asserting the guard fires before any network call.

Six tests in `routes-auth.test.ts` relied on the old default while testing scopes and email behavior; each now passes an explicit workspace. One of them (`label` too long) would otherwise have kept passing for the wrong reason — `workspace_required` fires before label validation — so it needed the fix to keep testing what it claims to.

Refs #505.
