### PR TITLE
fix(release): drop the deleted @uploads/workspace from changesets ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,6 @@
     "@uploads/web",
     "@uploads/storage",
     "@uploads/auth",
-    "@uploads/billing",
-    "@uploads/workspace"
+    "@uploads/billing"
   ]
 }


### PR DESCRIPTION
**Unblocks the release pipeline on `main`.** Follow-up to #522.

#522 deleted `packages/workspace`, but left `"@uploads/workspace"` in `.changeset/config.json`'s `ignore` array. Changesets validates that every ignored entry resolves to a real package, so `changeset version` now fails during config parsing — before it does any work:

```
ValidationError: The package or glob expression "@uploads/workspace" is
specified in the `ignore` option but it is not found in the project.
```

That blocks the release PR and every npm publish behind it. My miss on #522: I checked the ignore list to confirm the published package wasn't in it, and didn't consider that deleting a package invalidates its entry.

## Verification

`changeset status` passes and the pending changeset is intact — nothing was lost, the release PR regenerates on the next run:

```
info Packages to be bumped at minor:
- @buildinternet/uploads
```

Also checked the remaining five ignore entries against the actual workspace list; all resolve.

No changeset here — this is release config only and changes nothing about the published package.