### PR TITLE
fix(web): remove the layout shifts on the account settings pages

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,6 +20,9 @@
     "unicorn/no-null": "off",
     "unicorn/no-array-reduce": "off",
     "unicorn/no-await-expression-member": "off",
+    "unicorn/prefer-set-has": "off",
+    "unicorn/no-array-sort": "off",
+    "unicorn/no-array-reverse": "off",
 
     "typescript/await-thenable": "error",
     "typescript/consistent-return": "off",
@@ -93,8 +96,7 @@
       "files": ["**/*.test.ts", "packages/storage/test/**", "packages/uploads/test/**"],
       "rules": {
         "typescript/no-floating-promises": "off",
-        "typescript/await-thenable": "off",
-        "unicorn/no-array-sort": "off"
+        "typescript/await-thenable": "off"
       }
     }
   ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,15 @@ records; any future global secrets go through `wrangler secret put` (prod) or
   / `pnpm format`. CI runs the same gate in the **Lint & Format** job
   (`.github/workflows/ci.yml`), after `pnpm types` so gitignored
   `worker-configuration.d.ts` files exist for type-aware rules.
+- Three `unicorn` rules are off in `.oxlintrc.json` because their **autofixes**
+  are wrong here, not because their advice is: `prefer-set-has` rewrites an
+  array literal to `new Set(...)` without touching the variable's type
+  annotation, which stops compiling; `no-array-sort` and `no-array-reverse`
+  fire on this codebase's `[...arr].sort(...)` idiom, which already copies, so
+  their `toSorted`/`toReversed` rewrite just adds a second copy. oxlint's
+  `--fix` flags are global, so there is no way to keep a rule's diagnostic
+  while suppressing only its fix. If you re-enable any of them, re-check that
+  `pnpm lint:fix` still leaves a clean tree.
 - A Husky pre-commit hook runs `pnpm types` then `lint-staged` (oxlint + oxfmt
   on staged files); it's installed via the `prepare` script on `pnpm install`.
 - TypeScript strict, ESM only, `lib: ["ES2022"]` (no DOM — the Workers types

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -44,7 +44,18 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
           <span class="ws-rail__label">details</span>
           <span class="ws-rail__rule"></span>
         </div>
-        <dl class="ws-rail__kv" data-rail-details set:html={renderDetailsPlaceholderHtml()} />
+        {/* `aria-busy` sits on the <dl> itself, not inside the placeholder like
+            the usage section's does: `innerHTML` replaces this element's
+            children but not the element, so the attribute survives the repaint
+            and `paint()` has to clear it explicitly. Without it the skeleton
+            bars are `aria-hidden`, so a screen reader would meet two empty
+            <dd>s with no indication anything is still loading. */}
+        <dl
+          class="ws-rail__kv"
+          data-rail-details
+          aria-busy="true"
+          set:html={renderDetailsPlaceholderHtml()}
+        />
       </section>
 
       <section class="ws-rail__section">

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -5,6 +5,8 @@
  * Rail data is filled by `initWorkspaceRail` (connected work / usage / details).
  */
 import { GITHUB_APP_INSTALL_URL } from "../lib/github-app";
+import { renderUsagePlaceholderHtml } from "../lib/workspace-ui";
+import { renderDetailsPlaceholderHtml } from "../lib/workspace-rail";
 import AccountLayout from "./AccountLayout.astro";
 
 interface Props {
@@ -34,7 +36,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
           <span class="ws-rail__label">usage</span>
           <span class="ws-rail__rule"></span>
         </div>
-        <div class="ws-rail__usage" data-rail-usage>Loading usage…</div>
+        <div class="ws-rail__usage" data-rail-usage set:html={renderUsagePlaceholderHtml()} />
       </section>
 
       <section class="ws-rail__section">
@@ -42,7 +44,7 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
           <span class="ws-rail__label">details</span>
           <span class="ws-rail__rule"></span>
         </div>
-        <dl class="ws-rail__kv" data-rail-details></dl>
+        <dl class="ws-rail__kv" data-rail-details set:html={renderDetailsPlaceholderHtml()} />
       </section>
 
       <section class="ws-rail__section">

--- a/apps/web/src/lib/account-shell.ts
+++ b/apps/web/src/lib/account-shell.ts
@@ -16,6 +16,7 @@ import {
   type SessionUser,
 } from "./auth-client";
 import { markPageLoad } from "./page-visit";
+import { clearWorkspaceSnapshots } from "./workspace-cache";
 
 export { getPageVisit, isCurrentPageVisit } from "./page-visit";
 
@@ -57,6 +58,7 @@ export function clearCachedSessionUser(): void {
     // localStorage-only so it survives sign-out for the next login.
     sessionStorage.removeItem("uploads:myWorkspaces");
     sessionStorage.removeItem("uploads:activeWorkspace");
+    clearWorkspaceSnapshots();
   } catch {
     // ignore
   }

--- a/apps/web/src/lib/workspace-cache.test.ts
+++ b/apps/web/src/lib/workspace-cache.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearSnapshotsIn,
+  readSnapshotFrom,
+  toWorkspaceSnapshot,
+  workspaceSnapshotKey,
+  writeSnapshotTo,
+  WORKSPACE_SNAPSHOT_TTL_MS,
+  type KeyValueStore,
+  type WorkspaceSnapshot,
+} from "./workspace-cache";
+
+/** Minimal in-memory Storage stand-in — tests run in node, which has none. */
+function fakeStore(
+  seed: Record<string, string> = {},
+): KeyValueStore & { map: Map<string, string> } {
+  const map = new Map(Object.entries(seed));
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    key: (i) => [...map.keys()][i] ?? null,
+    get length() {
+      return map.size;
+    },
+  };
+}
+
+function snapshot(overrides: Partial<WorkspaceSnapshot> = {}): WorkspaceSnapshot {
+  return {
+    slug: "buildinternet",
+    role: "owner",
+    hasPublicUrl: true,
+    publicBaseUrl: "https://media.buildinternet.dev",
+    plan: "free",
+    usage: { bytes: 8_500_000, objects: 78, uploadsInPeriod: 15, maxStorageBytes: 10_000_000_000 },
+    ...overrides,
+  };
+}
+
+describe("workspaceSnapshotKey", () => {
+  // Pins the format the AccountLayout inline boot script and any future
+  // non-importing consumer must hardcode. Changing it is a breaking change.
+  it("namespaces the workspace slug under the uploads:ws: prefix", () => {
+    expect(workspaceSnapshotKey("buildinternet")).toBe("uploads:ws:buildinternet");
+  });
+});
+
+describe("readSnapshotFrom / writeSnapshotTo", () => {
+  it("round-trips a snapshot", () => {
+    const store = fakeStore();
+    writeSnapshotTo(store, "buildinternet", snapshot(), 1000);
+    expect(readSnapshotFrom(store, "buildinternet", 1000)).toEqual(snapshot());
+  });
+
+  it("returns null for a workspace that was never written", () => {
+    expect(readSnapshotFrom(fakeStore(), "missing", 1000)).toBeNull();
+  });
+
+  it("returns null once the entry is older than the TTL", () => {
+    const store = fakeStore();
+    writeSnapshotTo(store, "buildinternet", snapshot(), 1000);
+    expect(
+      readSnapshotFrom(store, "buildinternet", 1000 + WORKSPACE_SNAPSHOT_TTL_MS + 1),
+    ).toBeNull();
+  });
+
+  it("evicts the expired entry rather than leaving it to rot", () => {
+    const store = fakeStore();
+    writeSnapshotTo(store, "buildinternet", snapshot(), 1000);
+    readSnapshotFrom(store, "buildinternet", 1000 + WORKSPACE_SNAPSHOT_TTL_MS + 1);
+    expect(store.map.has("uploads:ws:buildinternet")).toBe(false);
+  });
+
+  it("returns null when the stored schema version is not the current one", () => {
+    const store = fakeStore({
+      "uploads:ws:buildinternet": JSON.stringify({ v: 0, at: 1000, data: snapshot() }),
+    });
+    expect(readSnapshotFrom(store, "buildinternet", 1000)).toBeNull();
+  });
+
+  it("returns null for unparseable JSON instead of throwing", () => {
+    const store = fakeStore({ "uploads:ws:buildinternet": "{not json" });
+    expect(readSnapshotFrom(store, "buildinternet", 1000)).toBeNull();
+  });
+
+  it("returns null when the payload is missing its data object", () => {
+    const store = fakeStore({ "uploads:ws:buildinternet": JSON.stringify({ v: 1, at: 1000 }) });
+    expect(readSnapshotFrom(store, "buildinternet", 1000)).toBeNull();
+  });
+
+  it("swallows a quota-exceeded write so the caller still renders", () => {
+    const store = fakeStore();
+    store.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    expect(() => writeSnapshotTo(store, "buildinternet", snapshot(), 1000)).not.toThrow();
+  });
+});
+
+describe("clearSnapshotsIn", () => {
+  it("removes every workspace snapshot and leaves unrelated keys alone", () => {
+    const store = fakeStore({
+      "uploads:ws:one": JSON.stringify({ v: 1, at: 1, data: snapshot() }),
+      "uploads:ws:two": JSON.stringify({ v: 1, at: 1, data: snapshot() }),
+      "uploads:activeWorkspace": "one",
+      unrelated: "keep",
+    });
+    clearSnapshotsIn(store);
+    expect([...store.map.keys()].sort()).toEqual(["unrelated", "uploads:activeWorkspace"]);
+  });
+});
+
+describe("toWorkspaceSnapshot", () => {
+  it("projects the summary response onto the cached shape", () => {
+    const result = toWorkspaceSnapshot(
+      {
+        workspace: "buildinternet",
+        organization: { id: "org_1", slug: "buildinternet", name: "BuildInternet" },
+        role: "owner",
+        hasPublicUrl: true,
+        publicBaseUrl: "https://media.buildinternet.dev",
+        plan: "free",
+      },
+      {
+        workspace: "buildinternet",
+        bytes: 8_500_000,
+        objects: 78,
+        uploadsInPeriod: 15,
+        periodStart: "2026-07-01",
+        updatedAt: "2026-07-24",
+        maxStorageBytes: 10_000_000_000,
+      },
+    );
+    expect(result).toEqual({
+      slug: "buildinternet",
+      role: "owner",
+      hasPublicUrl: true,
+      publicBaseUrl: "https://media.buildinternet.dev",
+      plan: "free",
+      usage: {
+        bytes: 8_500_000,
+        objects: 78,
+        uploadsInPeriod: 15,
+        maxStorageBytes: 10_000_000_000,
+        maxUploadsPerPeriod: undefined,
+      },
+    });
+  });
+
+  it("omits usage entirely when the summary carried none", () => {
+    const result = toWorkspaceSnapshot(
+      {
+        workspace: "solo",
+        organization: { id: "org_2", slug: "solo", name: "Solo" },
+        role: "member",
+        hasPublicUrl: false,
+      },
+      null,
+    );
+    expect(result.usage).toBeUndefined();
+    expect(result.slug).toBe("solo");
+  });
+});

--- a/apps/web/src/lib/workspace-cache.ts
+++ b/apps/web/src/lib/workspace-cache.ts
@@ -1,0 +1,186 @@
+/**
+ * Per-workspace stale-while-revalidate snapshot for the account shell.
+ *
+ * `localStorage`, not `sessionStorage` (which `workspaces-nav.ts` uses for the
+ * membership list): a snapshot exists to make a *returning* tab paint known
+ * values instead of placeholders, and a session-scoped store makes every new
+ * tab a first visit.
+ *
+ * UX affordance only. Membership is enforced server-side on every request, so
+ * a stale — or hand-edited — entry can never widen access. The TTL bounds how
+ * wrong a painted value may be; the schema version invalidates every entry at
+ * once when the shape changes, so there is no migration path to maintain.
+ *
+ * The storage-agnostic `*From`/`*To`/`*In` core is what the tests drive: the
+ * suite runs in a node environment with no `localStorage` at all.
+ */
+import type { MyWorkspace, WorkspaceUsage } from "./api-client";
+import type { UsageSnapshot } from "./workspace-ui";
+
+/** Bump to invalidate every stored snapshot without writing a migration. */
+export const WORKSPACE_SNAPSHOT_VERSION = 1;
+
+/** How stale a painted value may be before we prefer a placeholder. */
+export const WORKSPACE_SNAPSHOT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const KEY_PREFIX = "uploads:ws:";
+
+/**
+ * The slice of `Storage` this module needs. Declaring it explicitly keeps the
+ * core testable from node, where `Storage` does not exist.
+ */
+export interface KeyValueStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  key(index: number): string | null;
+  readonly length: number;
+}
+
+export interface WorkspaceSnapshot {
+  slug: string;
+  role: string;
+  hasPublicUrl: boolean;
+  publicBaseUrl?: string;
+  plan?: string;
+  usage?: UsageSnapshot;
+}
+
+interface StoredSnapshot {
+  v: number;
+  at: number;
+  data: WorkspaceSnapshot;
+}
+
+/**
+ * Storage key for a workspace.
+ *
+ * Keep in sync with any consumer that cannot import this module — inline boot
+ * scripts in layouts can only hardcode the string. `workspace-cache.test.ts`
+ * pins the format so a rename can't drift past review unnoticed.
+ */
+export function workspaceSnapshotKey(workspace: string): string {
+  return `${KEY_PREFIX}${workspace}`;
+}
+
+export function readSnapshotFrom(
+  store: KeyValueStore,
+  workspace: string,
+  now: number = Date.now(),
+): WorkspaceSnapshot | null {
+  const key = workspaceSnapshotKey(workspace);
+  let raw: string | null = null;
+  try {
+    raw = store.getItem(key);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: StoredSnapshot | null = null;
+  try {
+    parsed = JSON.parse(raw) as StoredSnapshot;
+  } catch {
+    parsed = null;
+  }
+
+  const usable =
+    parsed?.v === WORKSPACE_SNAPSHOT_VERSION &&
+    typeof parsed.at === "number" &&
+    !!parsed.data &&
+    now - parsed.at <= WORKSPACE_SNAPSHOT_TTL_MS;
+
+  if (!usable || !parsed) {
+    // Drop anything we refused to use so a stale or malformed entry doesn't
+    // sit there being re-parsed on every navigation.
+    try {
+      store.removeItem(key);
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+  return parsed.data;
+}
+
+export function writeSnapshotTo(
+  store: KeyValueStore,
+  workspace: string,
+  snapshot: WorkspaceSnapshot,
+  now: number = Date.now(),
+): void {
+  const payload: StoredSnapshot = { v: WORKSPACE_SNAPSHOT_VERSION, at: now, data: snapshot };
+  try {
+    store.setItem(workspaceSnapshotKey(workspace), JSON.stringify(payload));
+  } catch {
+    // Private mode / quota — the shell still renders, just without a warm paint.
+  }
+}
+
+export function clearSnapshotsIn(store: KeyValueStore): void {
+  const doomed: string[] = [];
+  try {
+    for (let i = 0; i < store.length; i += 1) {
+      const key = store.key(i);
+      if (key && key.startsWith(KEY_PREFIX)) doomed.push(key);
+    }
+    // Collect first, then delete: removing during iteration reindexes the store.
+    for (const key of doomed) store.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+/** `localStorage` when it exists and is reachable, else null (node, private mode). */
+function browserStore(): KeyValueStore | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readWorkspaceSnapshot(
+  workspace: string,
+  now: number = Date.now(),
+): WorkspaceSnapshot | null {
+  const store = browserStore();
+  return store ? readSnapshotFrom(store, workspace, now) : null;
+}
+
+export function writeWorkspaceSnapshot(
+  workspace: string,
+  snapshot: WorkspaceSnapshot,
+  now: number = Date.now(),
+): void {
+  const store = browserStore();
+  if (store) writeSnapshotTo(store, workspace, snapshot, now);
+}
+
+export function clearWorkspaceSnapshots(): void {
+  const store = browserStore();
+  if (store) clearSnapshotsIn(store);
+}
+
+/** Project a successful `/summary` response onto the cached shape. */
+export function toWorkspaceSnapshot(
+  workspace: MyWorkspace,
+  usage: WorkspaceUsage | null,
+): WorkspaceSnapshot {
+  return {
+    slug: workspace.organization.slug,
+    role: workspace.role,
+    hasPublicUrl: workspace.hasPublicUrl,
+    publicBaseUrl: workspace.publicBaseUrl,
+    plan: workspace.plan,
+    usage: usage
+      ? {
+          bytes: usage.bytes,
+          objects: usage.objects,
+          uploadsInPeriod: usage.uploadsInPeriod,
+          maxStorageBytes: usage.maxStorageBytes,
+          maxUploadsPerPeriod: usage.maxUploadsPerPeriod,
+        }
+      : undefined,
+  };
+}

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { planTitleRepaint, renderConnectedWorkHtml, renderDetailsHtml } from "./workspace-rail";
+import {
+  planTitleRepaint,
+  renderConnectedWorkHtml,
+  renderDetailsHtml,
+  renderDetailsPlaceholderHtml,
+} from "./workspace-rail";
 import type { GhWorkItem } from "./gh-context";
 
 function ghItem(overrides: Partial<GhWorkItem> = {}): GhWorkItem {
@@ -144,6 +149,17 @@ describe("renderDetailsHtml", () => {
     });
     expect(html).not.toContain("<img");
     expect(html).toContain("&lt;img");
+  });
+});
+
+describe("renderDetailsPlaceholderHtml", () => {
+  it("keeps the real details labels and only masks the values", () => {
+    const html = renderDetailsPlaceholderHtml();
+    // Labels are Tier 0 — they are known without any request.
+    expect(html).toContain(">slug<");
+    expect(html).toContain(">base url<");
+    expect(html).toContain("ws-rail__dt");
+    expect(html).toContain("ws-skel");
   });
 });
 

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -200,6 +200,11 @@ export function initWorkspaceRail(
   const usageEl = root.querySelector<HTMLElement>("[data-rail-usage]");
   const githubCtaEl = root.querySelector<HTMLElement>("[data-rail-github-cta]");
 
+  // `data-stale` is a diagnostic marker, not a user-facing affordance: nothing
+  // in the app styles or reads it. It exists so warm-paint behavior (this
+  // file's whole point) can be verified in the browser — inspect the rail
+  // elements after a Tier 1 paint and confirm the attribute is set, then
+  // confirm it clears once Tier 2 repaints with fresh data.
   const paint = (
     details: WorkspaceRailDetails | null,
     usage: UsageSnapshot | undefined,
@@ -208,12 +213,10 @@ export function initWorkspaceRail(
     if (detailsEl && details) {
       detailsEl.innerHTML = renderDetailsHtml(details);
       detailsEl.toggleAttribute("data-stale", stale);
-      detailsEl.removeAttribute("aria-busy");
     }
     if (usageEl && usage) {
       usageEl.innerHTML = renderUsageHtml(usage);
       usageEl.toggleAttribute("data-stale", stale);
-      usageEl.removeAttribute("aria-busy");
     }
   };
 
@@ -255,7 +258,16 @@ export function initWorkspaceRail(
       }
       const ws: MyWorkspace = result.workspace;
       paint(ws, result.usage ?? undefined, false);
-      if (usageEl && !result.usage) usageEl.textContent = "Usage unavailable.";
+      // `result.usage: null` is a genuinely reachable success shape (e.g. a
+      // plan with no usage record yet) — `paint` above already skips the
+      // usage section for it, leaving whatever Tier 1 warm-painted, if
+      // anything, on screen untouched (including its `data-stale`, which
+      // stays honest: the displayed value is still the cached one). Only
+      // fall back to the error string when there was no cached usage to
+      // fall back to, matching the failure branch's same warm-value rule.
+      if (usageEl && !result.usage && !cached?.usage) {
+        usageEl.textContent = "Usage unavailable.";
+      }
     });
   });
 }

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -213,6 +213,11 @@ export function initWorkspaceRail(
     if (detailsEl && details) {
       detailsEl.innerHTML = renderDetailsHtml(details);
       detailsEl.toggleAttribute("data-stale", stale);
+      // The <dl> carries `aria-busy` itself (see WorkspaceLayout.astro) and
+      // survives the innerHTML swap, so it must be cleared by hand. The usage
+      // section needs no equivalent: its `aria-busy` lives on markup the swap
+      // replaces outright.
+      detailsEl.removeAttribute("aria-busy");
     }
     if (usageEl && usage) {
       usageEl.innerHTML = renderUsageHtml(usage);
@@ -257,7 +262,14 @@ export function initWorkspaceRail(
         // `usage: null`). A section with nothing warm to keep must not be
         // left sitting in Tier 0's skeleton (including its `aria-busy="true"`)
         // forever — fall back to the error string there instead.
-        if (!cached && detailsEl) detailsEl.textContent = "Details unavailable.";
+        if (!cached && detailsEl) {
+          detailsEl.textContent = "Details unavailable.";
+          // `textContent` swaps the <dl>'s children, not the <dl>, so its own
+          // `aria-busy` outlives the write — an error that still announces as
+          // loading. The usage section needs no such clear: its `aria-busy`
+          // lives on a child that `textContent` destroys.
+          detailsEl.removeAttribute("aria-busy");
+        }
         if (!cached?.usage && usageEl) usageEl.textContent = "Usage unavailable.";
         return;
       }

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -8,7 +8,9 @@
  *    synchronously, before any network round trip, so a files-tab script that
  *    races ahead of this module's session-gated fetches never calls a
  *    not-yet-defined function;
- *  - fetches `getWorkspaceSummary` → details and usage.
+ *  - paints last-known details/usage from the workspace snapshot cache
+ *    synchronously, then revalidates through the shared `loadWorkspaceSummary`
+ *    request once the session gate resolves.
  *
  * Connected-work hook contract (Task 8's files tab is the only caller):
  *   `window.__uploadsSetConnectedWork(items: GhWorkItem[], titles?: GithubTitleMap): void`
@@ -17,14 +19,11 @@
  * item; an empty array hides it. Non-files tabs never call it, so the section
  * stays hidden by construction.
  */
-import {
-  getGithubInstalled,
-  getWorkspaceSummary,
-  type GithubTitleMap,
-  type MyWorkspace,
-} from "./api-client";
+import { getGithubInstalled, type GithubTitleMap, type MyWorkspace } from "./api-client";
 import { onSession } from "./account-shell";
-import { escapeHtml, renderUsageHtml, skeletonBarHtml } from "./workspace-ui";
+import { escapeHtml, renderUsageHtml, skeletonBarHtml, type UsageSnapshot } from "./workspace-ui";
+import { readWorkspaceSnapshot } from "./workspace-cache";
+import { loadWorkspaceSummary } from "./workspace-summary-source";
 import { githubKindSvg } from "./brand-icons";
 import { applyGhTitles, githubOwnerAvatarUrl, type GhKind, type GhWorkItem } from "./gh-context";
 
@@ -201,6 +200,39 @@ export function initWorkspaceRail(
   const usageEl = root.querySelector<HTMLElement>("[data-rail-usage]");
   const githubCtaEl = root.querySelector<HTMLElement>("[data-rail-github-cta]");
 
+  const paint = (
+    details: WorkspaceRailDetails | null,
+    usage: UsageSnapshot | undefined,
+    stale: boolean,
+  ): void => {
+    if (detailsEl && details) {
+      detailsEl.innerHTML = renderDetailsHtml(details);
+      detailsEl.toggleAttribute("data-stale", stale);
+      detailsEl.removeAttribute("aria-busy");
+    }
+    if (usageEl && usage) {
+      usageEl.innerHTML = renderUsageHtml(usage);
+      usageEl.toggleAttribute("data-stale", stale);
+      usageEl.removeAttribute("aria-busy");
+    }
+  };
+
+  // Tier 1 — last known values, no network. Runs at module-eval time, before
+  // the session gate resolves. The server-rendered placeholders it overwrites
+  // occupy the same height, so this repaint moves nothing on the page.
+  const cached = readWorkspaceSnapshot(workspace);
+  if (cached) {
+    paint(
+      {
+        organization: { slug: cached.slug },
+        hasPublicUrl: cached.hasPublicUrl,
+        publicBaseUrl: cached.publicBaseUrl,
+      },
+      cached.usage,
+      true,
+    );
+  }
+
   onSession(() => {
     // Suppress the install CTA once this workspace has the App (issue #492).
     // One-way: the CTA ships visible and is only ever hidden, so an outage or
@@ -211,17 +243,19 @@ export function initWorkspaceRail(
       });
     }
 
-    void getWorkspaceSummary(apiOrigin, workspace).then((result) => {
+    void loadWorkspaceSummary(apiOrigin, workspace).then((result) => {
       if (result.kind !== "success") {
+        // A warm paint is better than an error string: the values on screen
+        // were true recently, and the failure is already surfaced by whatever
+        // the page body does with the same shared result.
+        if (cached) return;
         if (detailsEl) detailsEl.textContent = "Details unavailable.";
         if (usageEl) usageEl.textContent = "Usage unavailable.";
         return;
       }
       const ws: MyWorkspace = result.workspace;
-      if (detailsEl) detailsEl.innerHTML = renderDetailsHtml(ws);
-      if (usageEl) {
-        usageEl.innerHTML = result.usage ? renderUsageHtml(result.usage) : "Usage unavailable.";
-      }
+      paint(ws, result.usage ?? undefined, false);
+      if (usageEl && !result.usage) usageEl.textContent = "Usage unavailable.";
     });
   });
 }

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -250,10 +250,15 @@ export function initWorkspaceRail(
       if (result.kind !== "success") {
         // A warm paint is better than an error string: the values on screen
         // were true recently, and the failure is already surfaced by whatever
-        // the page body does with the same shared result.
-        if (cached) return;
-        if (detailsEl) detailsEl.textContent = "Details unavailable.";
-        if (usageEl) usageEl.textContent = "Usage unavailable.";
+        // the page body does with the same shared result. But that only holds
+        // per-section — `cached` always carries details when it exists (every
+        // field but `usage` is required), while `cached.usage` can be
+        // undefined on its own (a prior successful response had
+        // `usage: null`). A section with nothing warm to keep must not be
+        // left sitting in Tier 0's skeleton (including its `aria-busy="true"`)
+        // forever — fall back to the error string there instead.
+        if (!cached && detailsEl) detailsEl.textContent = "Details unavailable.";
+        if (!cached?.usage && usageEl) usageEl.textContent = "Usage unavailable.";
         return;
       }
       const ws: MyWorkspace = result.workspace;

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -24,7 +24,7 @@ import {
   type MyWorkspace,
 } from "./api-client";
 import { onSession } from "./account-shell";
-import { escapeHtml, renderUsageHtml } from "./workspace-ui";
+import { escapeHtml, renderUsageHtml, skeletonBarHtml } from "./workspace-ui";
 import { githubKindSvg } from "./brand-icons";
 import { applyGhTitles, githubOwnerAvatarUrl, type GhKind, type GhWorkItem } from "./gh-context";
 
@@ -81,6 +81,17 @@ export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
   return (
     `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${escapeHtml(ws.organization.slug)}</dd>` +
     `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${baseUrlHtml}</dd>`
+  );
+}
+
+/**
+ * Rail details placeholder. The `<dt>` labels are static, so they render for
+ * real; only the `<dd>` values are masked.
+ */
+export function renderDetailsPlaceholderHtml(): string {
+  return (
+    `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${skeletonBarHtml("84px")}</dd>` +
+    `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${skeletonBarHtml("132px")}</dd>`
   );
 }
 

--- a/apps/web/src/lib/workspace-summary-source.test.ts
+++ b/apps/web/src/lib/workspace-summary-source.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { loadWorkspaceSummary, resetInFlightSummaries } from "./workspace-summary-source";
+import type { WorkspaceSummaryResult } from "./api-client";
+
+function successResult(workspace = "buildinternet"): WorkspaceSummaryResult {
+  return {
+    kind: "success",
+    workspace: {
+      workspace,
+      organization: { id: "org_1", slug: workspace, name: "BuildInternet" },
+      role: "owner",
+      hasPublicUrl: false,
+    },
+    usage: null,
+  };
+}
+
+/** A fetcher that never settles until `release` is called. */
+function deferredFetcher() {
+  let release!: (value: WorkspaceSummaryResult) => void;
+  const promise = new Promise<WorkspaceSummaryResult>((resolve) => {
+    release = resolve;
+  });
+  let calls = 0;
+  return {
+    fetcher: () => {
+      calls += 1;
+      return promise;
+    },
+    release,
+    calls: () => calls,
+  };
+}
+
+beforeEach(() => {
+  resetInFlightSummaries();
+});
+
+describe("loadWorkspaceSummary", () => {
+  it("issues one request when two callers ask while it is still in flight", async () => {
+    const d = deferredFetcher();
+    const a = loadWorkspaceSummary("https://api.test", "buildinternet", d.fetcher);
+    const b = loadWorkspaceSummary("https://api.test", "buildinternet", d.fetcher);
+    expect(d.calls()).toBe(1);
+    d.release(successResult());
+    expect(await a).toEqual(await b);
+  });
+
+  it("does not share a request between different workspaces", async () => {
+    let calls = 0;
+    const fetcher = async (_o: string, w: string) => {
+      calls += 1;
+      return successResult(w);
+    };
+    await Promise.all([
+      loadWorkspaceSummary("https://api.test", "one", fetcher),
+      loadWorkspaceSummary("https://api.test", "two", fetcher),
+    ]);
+    expect(calls).toBe(2);
+  });
+
+  it("refetches once the previous request has settled", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return successResult();
+    };
+    await loadWorkspaceSummary("https://api.test", "buildinternet", fetcher);
+    await loadWorkspaceSummary("https://api.test", "buildinternet", fetcher);
+    expect(calls).toBe(2);
+  });
+
+  it("clears the in-flight entry when the request rejects, so a retry can run", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls += 1;
+      throw new Error("network");
+    };
+    await expect(
+      loadWorkspaceSummary("https://api.test", "buildinternet", failing),
+    ).rejects.toThrow("network");
+    await expect(
+      loadWorkspaceSummary("https://api.test", "buildinternet", failing),
+    ).rejects.toThrow("network");
+    expect(calls).toBe(2);
+  });
+
+  it("passes an unavailable result straight through", async () => {
+    const fetcher = async (): Promise<WorkspaceSummaryResult> => ({
+      kind: "unavailable",
+      reason: "not_found",
+    });
+    const result = await loadWorkspaceSummary("https://api.test", "gone", fetcher);
+    expect(result).toEqual({ kind: "unavailable", reason: "not_found" });
+  });
+});

--- a/apps/web/src/lib/workspace-summary-source.ts
+++ b/apps/web/src/lib/workspace-summary-source.ts
@@ -1,0 +1,54 @@
+/**
+ * One `/me/workspaces/:name/summary` request per workspace per page load.
+ *
+ * Before this existed, a workspace tab issued three overlapping requests for
+ * the same authorization fact: the page fetched the whole membership list to
+ * run a `.find()` over it, the rail fetched this workspace's summary, and the
+ * sidebar fetched the list again for the switcher. The page's list fetch was
+ * pure duplication — the summary endpoint answers "am I a member of this
+ * workspace" in one round trip — and the rail's copy of it can be shared.
+ *
+ * Callers that arrive while a request is still in flight join it. Once it
+ * settles the entry is dropped, so a later navigation revalidates rather than
+ * serving a stale promise for the life of the tab.
+ *
+ * A successful response also refreshes the workspace snapshot, which is what
+ * makes the *next* visit paint without waiting on the network at all.
+ */
+import { getWorkspaceSummary, type WorkspaceSummaryResult } from "./api-client";
+import { toWorkspaceSnapshot, writeWorkspaceSnapshot } from "./workspace-cache";
+
+export type SummaryFetcher = (
+  apiOrigin: string,
+  workspace: string,
+) => Promise<WorkspaceSummaryResult>;
+
+const inFlight = new Map<string, Promise<WorkspaceSummaryResult>>();
+
+export function loadWorkspaceSummary(
+  apiOrigin: string,
+  workspace: string,
+  fetcher: SummaryFetcher = getWorkspaceSummary,
+): Promise<WorkspaceSummaryResult> {
+  const existing = inFlight.get(workspace);
+  if (existing) return existing;
+
+  const request = fetcher(apiOrigin, workspace)
+    .then((result) => {
+      if (result.kind === "success") {
+        writeWorkspaceSnapshot(workspace, toWorkspaceSnapshot(result.workspace, result.usage));
+      }
+      return result;
+    })
+    .finally(() => {
+      inFlight.delete(workspace);
+    });
+
+  inFlight.set(workspace, request);
+  return request;
+}
+
+/** Drop memoized requests. Tests use this; production never needs it. */
+export function resetInFlightSummaries(): void {
+  inFlight.clear();
+}

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -8,6 +8,7 @@ import {
   renderGalleriesTableHtml,
   renderInvitesHtml,
   renderMembersHtml,
+  renderMembersPlaceholderHtml,
   renderUsageHtml,
   renderUsagePlaceholderHtml,
   safeSameOriginPath,
@@ -326,5 +327,14 @@ describe("skeleton placeholders", () => {
 
   it("defaults to three placeholder rows", () => {
     expect(renderGalleriesPlaceholderHtml().match(/<tr>/g)).toHaveLength(4);
+  });
+
+  it("mirrors the real member row's two-column structure", () => {
+    const html = renderMembersPlaceholderHtml(2);
+    expect(html.match(/class="member-row"/g)).toHaveLength(2);
+    // Both halves present, or the flex row collapses and the swap rearranges.
+    expect(html).toContain("member-row__who");
+    expect(html).toContain("member-row__name");
+    expect(html).toContain("member-row__role");
   });
 });

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -4,11 +4,15 @@ import {
   formatGalleryDate,
   formatMarketedBytes,
   orderOrgsOldestFirst,
+  renderDetailsPlaceholderHtml,
+  renderGalleriesPlaceholderHtml,
   renderGalleriesTableHtml,
   renderInvitesHtml,
   renderMembersHtml,
   renderUsageHtml,
+  renderUsagePlaceholderHtml,
   safeSameOriginPath,
+  skeletonBarHtml,
 } from "./workspace-ui";
 
 describe("formatBytes / formatMarketedBytes (decimal SI)", () => {
@@ -268,5 +272,62 @@ describe("renderGalleriesTableHtml", () => {
     expect(html).toContain("org/repo#3");
     expect(html).not.toContain("org/repo#4");
     expect(html).toContain("+2");
+  });
+});
+
+describe("skeleton placeholders", () => {
+  it("marks bars decorative so screen readers skip them", () => {
+    const html = skeletonBarHtml("60%");
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain("ws-skel");
+    expect(html).toContain("--ws-skel-w:60%");
+  });
+
+  it("drops a width that is not a plain CSS length", () => {
+    // The value lands in a style attribute — a CSS context, where HTML
+    // escaping would not help. Anything unrecognised falls back to the default.
+    const html = skeletonBarHtml('60px;background:url("http://evil.test")');
+    expect(html).toContain("--ws-skel-w:100%");
+    expect(html).not.toContain("evil.test");
+  });
+
+  it("builds the usage placeholder from the same meter chrome as real usage", () => {
+    const html = renderUsagePlaceholderHtml();
+    // Same wrapper + row + track classes renderUsageHtml emits, so the swap
+    // to real data cannot change the section's height.
+    expect(html).toContain("ul-progress");
+    expect(html).toContain("ul-progress__row");
+    expect(html).toContain("ul-progress__track");
+    // Two meters, matching renderUsageHtml's storage + uploads pair.
+    expect(html.match(/ul-progress__row/g)).toHaveLength(2);
+    // Empty track: no width to animate from a wrong starting point.
+    expect(html).toContain("width:0%");
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  it("keeps the real details labels and only masks the values", () => {
+    const html = renderDetailsPlaceholderHtml();
+    // Labels are Tier 0 — they are known without any request.
+    expect(html).toContain(">slug<");
+    expect(html).toContain(">base url<");
+    expect(html).toContain("ws-rail__dt");
+    expect(html).toContain("ws-skel");
+  });
+
+  it("builds a galleries placeholder with the real table chrome", () => {
+    const html = renderGalleriesPlaceholderHtml(3);
+    expect(html).toContain("ws-table-wrap");
+    expect(html).toContain('class="ws-table"');
+    // Same four column headers renderGalleriesTableHtml emits.
+    expect(html).toContain(">Name<");
+    expect(html).toContain(">Items<");
+    expect(html).toContain(">Linked<");
+    expect(html).toContain(">Updated<");
+    expect(html.match(/<tr>/g)).toHaveLength(4); // 1 head + 3 body
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  it("defaults to three placeholder rows", () => {
+    expect(renderGalleriesPlaceholderHtml().match(/<tr>/g)).toHaveLength(4);
   });
 });

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  escapeHtml,
   formatBytes,
   formatGalleryDate,
   formatMarketedBytes,
   orderOrgsOldestFirst,
+  renderGalleriesEmptyHtml,
   renderGalleriesPlaceholderHtml,
   renderGalleriesTableHtml,
   renderInvitesHtml,
@@ -336,5 +338,31 @@ describe("skeleton placeholders", () => {
     expect(html).toContain("member-row__who");
     expect(html).toContain("member-row__name");
     expect(html).toContain("member-row__role");
+  });
+});
+
+describe("renderGalleriesEmptyHtml", () => {
+  const cmd = 'uploads gallery create --title "Release screenshots"';
+
+  it("leads with the state, not with instructions", () => {
+    const html = renderGalleriesEmptyHtml(cmd);
+    const headlineAt = html.indexOf("No galleries yet");
+    const commandAt = html.indexOf("ws-empty__command");
+    expect(headlineAt).toBeGreaterThanOrEqual(0);
+    expect(commandAt).toBeGreaterThan(headlineAt);
+  });
+
+  it("carries the create command as the single primary action", () => {
+    const html = renderGalleriesEmptyHtml(cmd);
+    // `cmd` embeds double quotes (`--title "..."`), so the *safe* HTML must
+    // entity-escape them — left raw, `data-copy="${cmd}"` would terminate at
+    // the first embedded quote and corrupt the attribute. Assert on the
+    // escaped form rather than the raw string.
+    expect(html).toContain(escapeHtml(cmd));
+    expect(html.match(/data-copy=/g)).toHaveLength(1);
+  });
+
+  it("escapes a command containing markup", () => {
+    expect(renderGalleriesEmptyHtml('a<b>"c"')).not.toContain("<b>");
   });
 });

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -4,7 +4,6 @@ import {
   formatGalleryDate,
   formatMarketedBytes,
   orderOrgsOldestFirst,
-  renderDetailsPlaceholderHtml,
   renderGalleriesPlaceholderHtml,
   renderGalleriesTableHtml,
   renderInvitesHtml,
@@ -305,13 +304,11 @@ describe("skeleton placeholders", () => {
     expect(html).toContain('aria-busy="true"');
   });
 
-  it("keeps the real details labels and only masks the values", () => {
-    const html = renderDetailsPlaceholderHtml();
-    // Labels are Tier 0 — they are known without any request.
-    expect(html).toContain(">slug<");
-    expect(html).toContain(">base url<");
-    expect(html).toContain("ws-rail__dt");
-    expect(html).toContain("ws-skel");
+  it("emits as many meter rows as the caller's `meters` guess", () => {
+    // A caller expecting the workspace to land on the capless single-meter
+    // shape (or any other guess) can say so instead of always assuming two.
+    expect(renderUsagePlaceholderHtml(1).match(/ul-progress__row/g)).toHaveLength(1);
+    expect(renderUsagePlaceholderHtml(3).match(/ul-progress__row/g)).toHaveLength(3);
   });
 
   it("builds a galleries placeholder with the real table chrome", () => {

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -178,6 +178,27 @@ export function renderMembersHtml(members: MemberRow[], opts: MemberRowOptions =
 }
 
 /**
+ * Member-list placeholder.
+ *
+ * Mirrors `renderMembersHtml`'s two-part row — `.member-row` is a flex with
+ * `justify-content: space-between`, so a single child would collapse to one
+ * column and the swap to real rows would visibly rearrange, not just repaint.
+ * The nested `__name` and `__role` spans also carry the font sizes the row's
+ * `align-items: baseline` height is derived from.
+ */
+export function renderMembersPlaceholderHtml(rows = 2): string {
+  const widths = ["124px", "96px"];
+  return Array.from(
+    { length: rows },
+    (_, i) =>
+      `<div class="member-row">` +
+      `<span class="member-row__who"><span class="member-row__name">${skeletonBarHtml(widths[i % widths.length])}</span></span>` +
+      `<span class="member-row__role">${skeletonBarHtml("42px")}</span>` +
+      `</div>`,
+  ).join("");
+}
+
+/**
  * Pending invites as people-list rows (same `.member-row` surface as members).
  * Status badge + revoke. `[]` → `""` (caller omits the block).
  */

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -165,7 +165,7 @@ export function renderMembersHtml(members: MemberRow[], opts: MemberRowOptions =
       const sub = m.name ? `<span class="member-row__email">${escapeHtml(m.email)}</span>` : "";
       const controls = canManageMemberRow(m, opts)
         ? `<span class="member-row__actions">` +
-          `<select class="member-row__role-select" data-member-id="${escapeHtml(m.id!)}" aria-label="Role for ${escapeHtml(m.email)}">` +
+          `<select class="member-row__role-select ul-select ul-select--sm" data-member-id="${escapeHtml(m.id!)}" aria-label="Role for ${escapeHtml(m.email)}">` +
           `<option value="member"${m.role === "member" ? " selected" : ""}>member</option>` +
           `<option value="admin"${m.role === "admin" ? " selected" : ""}>admin</option>` +
           `</select>` +

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -354,3 +354,86 @@ export function bindCopyButtons(root: Node, selector = "button[data-copy]"): voi
     })();
   });
 }
+
+/**
+ * Loading placeholders.
+ *
+ * These live beside the real builders on purpose. Their whole job is to
+ * occupy the *exact* height the real markup will occupy, so when data lands
+ * nothing on the page moves — and the only way to keep that true over time is
+ * for both versions of a given block to be edited in the same file, in view of
+ * each other. A placeholder that drifts from its counterpart is worse than no
+ * placeholder at all, because it reintroduces the shift it was added to remove.
+ *
+ * Deliberately unanimated: a placeholder is only ever seen on a first visit to
+ * a workspace, and a pulse at that moment reads as noise rather than progress.
+ */
+
+/**
+ * One masked bar. `width` drives `--ws-skel-w`.
+ *
+ * The value lands in a `style` attribute, which is a CSS context — HTML
+ * escaping would not make an attacker-controlled value safe there. Every call
+ * site passes a literal, so rather than rely on that staying true, anything
+ * that isn't a plain CSS length is dropped for the default.
+ */
+const CSS_LENGTH = /^\d+(\.\d+)?(px|%|em|rem|ch)$/;
+
+export function skeletonBarHtml(width: string): string {
+  const safe = CSS_LENGTH.test(width) ? width : "100%";
+  return `<span class="ws-skel" aria-hidden="true" style="--ws-skel-w:${safe}"></span>`;
+}
+
+/** Empty meter chrome for the rail, matching `renderUsageHtml`'s two meters. */
+export function renderUsagePlaceholderHtml(): string {
+  const row = (labelWidth: string, valueWidth: string): string => `<div class="ul-progress__row">
+    <div class="ul-progress__head">
+      <span class="ul-progress__label">${skeletonBarHtml(labelWidth)}</span>
+      <span class="ul-progress__value">${skeletonBarHtml(valueWidth)}</span>
+    </div>
+    <div class="ul-progress__track">
+      <div class="ul-progress__fill" style="width:0%"></div>
+    </div>
+  </div>`;
+  return `<div class="ul-progress" aria-busy="true">${row("52px", "96px")}${row("108px", "78px")}</div><div class="usage-meta">${skeletonBarHtml("64px")}</div>`;
+}
+
+/**
+ * Rail details placeholder. The `<dt>` labels are static, so they render for
+ * real; only the `<dd>` values are masked.
+ */
+export function renderDetailsPlaceholderHtml(): string {
+  return (
+    `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${skeletonBarHtml("84px")}</dd>` +
+    `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${skeletonBarHtml("132px")}</dd>`
+  );
+}
+
+/** Galleries table placeholder — same chrome as `renderGalleriesTableHtml`. */
+export function renderGalleriesPlaceholderHtml(rows = 3): string {
+  // Varying widths so the block reads as a list of distinct rows rather than
+  // a solid slab.
+  const widths = ["68%", "54%", "76%"];
+  const body = Array.from({ length: rows }, (_, i) => {
+    const w = widths[i % widths.length];
+    return `<tr>
+  <td>${skeletonBarHtml(w)}</td>
+  <td class="num">${skeletonBarHtml("24px")}</td>
+  <td>${skeletonBarHtml("92px")}</td>
+  <td class="ws-gallery-updated">${skeletonBarHtml("72px")}</td>
+</tr>`;
+  }).join("");
+  return `<div class="ws-table-wrap" aria-busy="true">
+<table class="ws-table" aria-label="Galleries">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col" class="num">Items</th>
+      <th scope="col">Linked</th>
+      <th scope="col">Updated</th>
+    </tr>
+  </thead>
+  <tbody>${body}</tbody>
+</table>
+</div>`;
+}

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -403,9 +403,12 @@ const USAGE_METER_WIDTHS: Array<{ label: string; value: string }> = [
  * A workspace with no caps (plan never applied) still collapses once, from
  * these meters down to the one-line text, on its first visit — that shift is
  * not eliminated by this change, only made no worse than the two-meter
- * assumption already was. It happens exactly once: every later visit paints
- * from the cached snapshot instead of this placeholder, so the collapse
- * cannot recur for that workspace.
+ * assumption already was. Most later visits paint from the cached snapshot
+ * (`workspace-cache.ts`) instead of this placeholder, so the collapse is
+ * uncommon after the first — but it is bounded, not impossible: the cache
+ * expires (`WORKSPACE_SNAPSHOT_TTL_MS`, 24h), gets invalidated wholesale on a
+ * `WORKSPACE_SNAPSHOT_VERSION` bump, and is cleared on sign-out
+ * (`clearWorkspaceSnapshots`), any of which sends the next visit back here.
  */
 export function renderUsagePlaceholderHtml(meters = 2): string {
   const row = (labelWidth: string, valueWidth: string): string => `<div class="ul-progress__row">

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -448,6 +448,25 @@ export function renderUsagePlaceholderHtml(meters = 2): string {
   return `<div class="ul-progress" aria-busy="true">${rows}</div><div class="usage-meta">${skeletonBarHtml("64px")}</div>`;
 }
 
+/**
+ * Galleries empty state.
+ *
+ * Built as the page's primary element rather than a muted footnote: when a
+ * workspace has no galleries, "you have none, here is how to make one" *is*
+ * the content, and burying it under a command block inverted the hierarchy.
+ */
+export function renderGalleriesEmptyHtml(createCmd: string): string {
+  const safe = escapeHtml(createCmd);
+  return `<div class="ws-empty-state">
+  <p class="ws-empty-state__title">No galleries yet</p>
+  <p class="ws-empty-state__body">A gallery collects screenshots behind one public link you can drop in a pull request.</p>
+  <div class="command ws-empty__command">
+    <code>${safe}</code>
+    <button type="button" data-copy="${safe}" aria-live="polite">copy</button>
+  </div>
+</div>`;
+}
+
 /** Galleries table placeholder — same chrome as `renderGalleriesTableHtml`. */
 export function renderGalleriesPlaceholderHtml(rows = 3): string {
   // Varying widths so the block reads as a list of distinct rows rather than

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -384,8 +384,30 @@ export function skeletonBarHtml(width: string): string {
   return `<span class="ws-skel" aria-hidden="true" style="--ws-skel-w:${safe}"></span>`;
 }
 
-/** Empty meter chrome for the rail, matching `renderUsageHtml`'s two meters. */
-export function renderUsagePlaceholderHtml(): string {
+/** Label/value skeleton widths for each meter row, cycled when `meters` runs past this table. */
+const USAGE_METER_WIDTHS: Array<{ label: string; value: string }> = [
+  { label: "52px", value: "96px" }, // "Storage"
+  { label: "108px", value: "78px" }, // "Uploads this month"
+];
+
+/**
+ * Empty meter chrome for the rail, guessing at `renderUsageHtml`'s shape.
+ *
+ * The real shape is unknowable before the first response lands: depending on
+ * which caps the workspace's plan actually sets, `renderUsageHtml` renders
+ * two meters, one meter, or — when no caps are set at all — a structurally
+ * different single-line `usage-text` block. This placeholder can only guess;
+ * `meters` (default 2, the common case of both caps set) lets a caller
+ * express its best guess, same as `renderGalleriesPlaceholderHtml(rows)`.
+ *
+ * A workspace with no caps (plan never applied) still collapses once, from
+ * these meters down to the one-line text, on its first visit — that shift is
+ * not eliminated by this change, only made no worse than the two-meter
+ * assumption already was. It happens exactly once: every later visit paints
+ * from the cached snapshot instead of this placeholder, so the collapse
+ * cannot recur for that workspace.
+ */
+export function renderUsagePlaceholderHtml(meters = 2): string {
   const row = (labelWidth: string, valueWidth: string): string => `<div class="ul-progress__row">
     <div class="ul-progress__head">
       <span class="ul-progress__label">${skeletonBarHtml(labelWidth)}</span>
@@ -395,18 +417,11 @@ export function renderUsagePlaceholderHtml(): string {
       <div class="ul-progress__fill" style="width:0%"></div>
     </div>
   </div>`;
-  return `<div class="ul-progress" aria-busy="true">${row("52px", "96px")}${row("108px", "78px")}</div><div class="usage-meta">${skeletonBarHtml("64px")}</div>`;
-}
-
-/**
- * Rail details placeholder. The `<dt>` labels are static, so they render for
- * real; only the `<dd>` values are masked.
- */
-export function renderDetailsPlaceholderHtml(): string {
-  return (
-    `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${skeletonBarHtml("84px")}</dd>` +
-    `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${skeletonBarHtml("132px")}</dd>`
-  );
+  const rows = Array.from({ length: meters }, (_, i) => {
+    const w = USAGE_METER_WIDTHS[i % USAGE_METER_WIDTHS.length];
+    return row(w.label, w.value);
+  }).join("");
+  return `<div class="ul-progress" aria-busy="true">${rows}</div><div class="usage-meta">${skeletonBarHtml("64px")}</div>`;
 }
 
 /** Galleries table placeholder — same chrome as `renderGalleriesTableHtml`. */

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -10,6 +10,7 @@
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+import { skeletonBarHtml } from "../../../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -19,46 +20,44 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 ---
 
 <WorkspaceLayout workspace={workspace}>
-  <div id="ws-status" class="ul-callout status" role="status">Loading…</div>
+  <div id="ws-status" class="ul-callout status" role="status" hidden></div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 
-  <div id="ws-app" hidden>
-    <section class="card settings-page">
-      <div class="settings-section">
-        <div class="ws-page-header">
-          <div class="ws-title-block">
-            <h2>Billing</h2>
-            <p class="muted" id="ws-slug"></p>
-          </div>
-          <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+  <section class="card settings-page">
+    <div class="settings-section">
+      <div class="ws-page-header">
+        <div class="ws-title-block">
+          <h2>Billing</h2>
+          <p class="muted" id="ws-slug"></p>
         </div>
-
-        <div id="ws-plan-card" class="ul-callout">
-          <p><strong id="ws-plan-name"></strong></p>
-          <p class="muted" id="ws-plan-blurb"></p>
-          <p class="muted" id="ws-plan-file-limits"></p>
-          <p id="ws-subscription-status" role="status" hidden></p>
-        </div>
-
-        <div class="settings-section">
-          <h3>Plans</h3>
-          <div id="ws-plan-cards" class="plan-cards"></div>
-          <p class="muted" id="ws-manage-billing-note" hidden>
-            To cancel or downgrade, use “Manage billing” below to open the billing portal.
-          </p>
-        </div>
-
-        <div class="settings-section">
-          <button type="button" id="ws-manage-billing-btn" hidden>Manage billing</button>
-          <p class="muted" id="ws-comped-note" hidden>
-            This plan is comped for your workspace, so there’s no self-serve billing to manage.
-            Contact support to make changes.
-          </p>
-          <p class="muted" id="ws-billing-error" role="alert" hidden></p>
-        </div>
+        <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
       </div>
-    </section>
-  </div>
+
+      <div id="ws-plan-card" class="ul-callout" aria-busy="true">
+        <p><strong id="ws-plan-name" set:html={skeletonBarHtml("72px")} /></p>
+        <p class="muted" id="ws-plan-blurb" set:html={skeletonBarHtml("80%")} />
+        <p class="muted" id="ws-plan-file-limits" set:html={skeletonBarHtml("60%")} />
+        <p id="ws-subscription-status" role="status" hidden></p>
+      </div>
+
+      <div class="settings-section">
+        <h3>Plans</h3>
+        <div id="ws-plan-cards" class="plan-cards"></div>
+        <p class="muted" id="ws-manage-billing-note" hidden>
+          To cancel or downgrade, use “Manage billing” below to open the billing portal.
+        </p>
+      </div>
+
+      <div class="settings-section">
+        <button type="button" id="ws-manage-billing-btn" hidden>Manage billing</button>
+        <p class="muted" id="ws-comped-note" hidden>
+          This plan is comped for your workspace, so there’s no self-serve billing to manage.
+          Contact support to make changes.
+        </p>
+        <p class="muted" id="ws-billing-error" role="alert" hidden></p>
+      </div>
+    </div>
+  </section>
 
   <script>
     import { PLANS, type PlanDefinition } from "@uploads/billing";
@@ -79,6 +78,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     import { resolveSubscriptionCopy } from "../../../../lib/subscription-copy";
     import { escapeHtml, formatBytes, formatMarketedBytes } from "../../../../lib/workspace-ui";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
+    import { loadWorkspaceSummary } from "../../../../lib/workspace-summary-source";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("ws-plan-card")) return;
@@ -104,8 +104,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
       const statusEl = requireElement<HTMLElement>("#ws-status", page);
       const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
-      const appEl = requireElement<HTMLElement>("#ws-app", page);
       const slugEl = requireElement<HTMLElement>("#ws-slug", page);
+      const planCardEl = requireElement<HTMLElement>("#ws-plan-card", page);
       const planNameEl = requireElement<HTMLElement>("#ws-plan-name", page);
       const planBlurbEl = requireElement<HTMLElement>("#ws-plan-blurb", page);
       const planFileLimitsEl = requireElement<HTMLElement>("#ws-plan-file-limits", page);
@@ -121,7 +121,25 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         statusEl.hidden = false;
         statusEl.textContent = message;
         statusEl.dataset.state = "error";
-        appEl.hidden = true;
+        // The card stays on screen — the heading and back link aren't
+        // invalidated by a failed billing fetch, so only the plan card's own
+        // data is cleared (same "own region" rule as the people/galleries
+        // pages). `aria-busy` lives on the surviving `#ws-plan-card`
+        // container, not on markup an innerHTML swap would discard, so it's
+        // cleared here too: loading has concluded, even though it failed.
+        planCardEl.removeAttribute("aria-busy");
+        planNameEl.textContent = "";
+        planBlurbEl.textContent = "";
+        planBlurbEl.hidden = true;
+        planFileLimitsEl.textContent = "";
+        subscriptionStatusEl.hidden = true;
+        subscriptionStatusEl.textContent = "";
+        planCardsEl.innerHTML = "";
+        manageBillingBtn.hidden = true;
+        manageBillingNoteEl.hidden = true;
+        compedNoteEl.hidden = true;
+        billingErrorEl.hidden = true;
+        billingErrorEl.textContent = "";
         retryBtn.hidden = !retry;
       }
 
@@ -326,14 +344,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         location.href = result.url;
       }
 
-      async function loadBillingPage(): Promise<void> {
+      async function loadPlan(): Promise<void> {
         if (!stillHere()) return;
-        statusEl.hidden = false;
-        statusEl.textContent = "Loading…";
-        statusEl.removeAttribute("data-state");
-        retryBtn.hidden = true;
-        appEl.hidden = true;
-
         // The price fetch never throws (see plan-prices.ts) and its failure
         // must never block the rest of the page from rendering.
         const [result, proPrice] = await Promise.all([
@@ -378,14 +390,41 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         const proPriceCopy = formatPrice(proPrice);
         renderPlanCards(billing, proPriceCopy);
         paintSubscriptionStatus(billing, proPriceCopy);
+        // Unlike the innerHTML-based regions on the galleries/people pages,
+        // the plan card's fields are painted field-by-field above rather
+        // than replaced wholesale, so `#ws-plan-card`'s own `aria-busy`
+        // never gets discarded along with placeholder markup — it has to be
+        // cleared explicitly once real data lands.
+        planCardEl.removeAttribute("aria-busy");
+      }
 
+      async function loadBillingPage(): Promise<void> {
+        if (!stillHere()) return;
         statusEl.hidden = true;
-        appEl.hidden = false;
+        statusEl.removeAttribute("data-state");
+        retryBtn.hidden = true;
 
-        const displayName = billing.organization.name || workspaceName;
+        const result = await loadWorkspaceSummary(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          // `not_found` from /summary is the not-a-member case: the endpoint
+          // answers membership and existence together, so a 404 here means
+          // "not yours" and is not worth a retry button.
+          if (result.reason === "not_found") {
+            showError("You don’t have access to this workspace.", false);
+            return;
+          }
+          showError("Billing is temporarily unavailable. Check the local stack or try again.");
+          return;
+        }
+
+        const ws = result.workspace;
+        const displayName = ws.organization.name || workspaceName;
         slugEl.textContent =
           displayName === workspaceName ? workspaceName : `${displayName} · ${workspaceName}`;
         document.title = `Billing · ${displayName} · uploads.sh`;
+
+        void loadPlan();
       }
 
       retryBtn.addEventListener("click", () => {

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -26,23 +26,24 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
         <div class="ws-title-block">
           <h2>Galleries</h2>
           <p class="settings-note muted">
-            Ordered sets of screenshots and media with one public link. Link a gallery to
-            pull requests or issues so a managed comment can surface the whole set.
+            Ordered sets of media behind one public link, linkable to a pull request or issue.
           </p>
         </div>
       </div>
 
-      <div class="command">
-        <code>{createCmd}</code>
-        <button type="button" data-copy={createCmd} aria-live="polite">copy</button>
-      </div>
-      <p class="muted cli-note">
-        Add files with <code>uploads put ./shot.png --gallery &lt;id&gt;</code> or
-        <code>uploads gallery add &lt;id&gt; &lt;key&gt;</code>. Link a PR with
-        <code>uploads gallery link &lt;id&gt; --github owner/repo#123</code>.
-      </p>
-
       <div id="ws-galleries" set:html={renderGalleriesPlaceholderHtml()} />
+
+      <details class="ws-gallery-help">
+        <summary>Working with galleries</summary>
+        <div class="command">
+          <code>{createCmd}</code>
+          <button type="button" data-copy={createCmd} aria-live="polite">copy</button>
+        </div>
+        <p class="muted cli-note">
+          Add files with <code>uploads put ./shot.png --gallery &lt;id&gt;</code>. Link a PR with
+          <code>uploads gallery link &lt;id&gt; --github owner/repo#123</code>.
+        </p>
+      </details>
     </div>
   </section>
 
@@ -59,6 +60,7 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
     import { loadWorkspaceSummary } from "../../../../lib/workspace-summary-source";
     import {
       bindCopyButtons,
+      renderGalleriesEmptyHtml,
       renderGalleriesTableHtml,
     } from "../../../../lib/workspace-ui";
 
@@ -108,7 +110,9 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
         // is no separate busy flag to clear on `galleriesEl` itself (it never
         // carried the attribute; the placeholder's child did).
         if (!galleries.length) {
-          galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet. Create one with the command above.</p>`;
+          galleriesEl.innerHTML = renderGalleriesEmptyHtml(
+            'uploads gallery create --title "Release screenshots"',
+          );
           return;
         }
         galleriesEl.innerHTML = renderGalleriesTableHtml(galleries);

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -5,6 +5,7 @@
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+import { renderGalleriesPlaceholderHtml } from "../../../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -16,36 +17,34 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
 ---
 
 <WorkspaceLayout workspace={workspace}>
-  <div id="ws-status" class="ul-callout status" role="status">Loading…</div>
+  <div id="ws-status" class="ul-callout status" role="status" hidden></div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 
-  <div id="ws-app" hidden>
-    <section class="card settings-page">
-      <div class="settings-section" id="ws-galleries-card">
-        <div class="ws-page-header">
-          <div class="ws-title-block">
-            <h2>Galleries</h2>
-            <p class="settings-note muted">
-              Ordered sets of screenshots and media with one public link. Link a gallery to
-              pull requests or issues so a managed comment can surface the whole set.
-            </p>
-          </div>
+  <section class="card settings-page">
+    <div class="settings-section" id="ws-galleries-card">
+      <div class="ws-page-header">
+        <div class="ws-title-block">
+          <h2>Galleries</h2>
+          <p class="settings-note muted">
+            Ordered sets of screenshots and media with one public link. Link a gallery to
+            pull requests or issues so a managed comment can surface the whole set.
+          </p>
         </div>
-
-        <div class="command">
-          <code>{createCmd}</code>
-          <button type="button" data-copy={createCmd} aria-live="polite">copy</button>
-        </div>
-        <p class="muted cli-note">
-          Add files with <code>uploads put ./shot.png --gallery &lt;id&gt;</code> or
-          <code>uploads gallery add &lt;id&gt; &lt;key&gt;</code>. Link a PR with
-          <code>uploads gallery link &lt;id&gt; --github owner/repo#123</code>.
-        </p>
-
-        <div id="ws-galleries"><p class="ws-empty">Loading…</p></div>
       </div>
-    </section>
-  </div>
+
+      <div class="command">
+        <code>{createCmd}</code>
+        <button type="button" data-copy={createCmd} aria-live="polite">copy</button>
+      </div>
+      <p class="muted cli-note">
+        Add files with <code>uploads put ./shot.png --gallery &lt;id&gt;</code> or
+        <code>uploads gallery add &lt;id&gt; &lt;key&gt;</code>. Link a PR with
+        <code>uploads gallery link &lt;id&gt; --github owner/repo#123</code>.
+      </p>
+
+      <div id="ws-galleries" set:html={renderGalleriesPlaceholderHtml()} />
+    </div>
+  </section>
 
   <script>
     import {
@@ -55,9 +54,9 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
       onSession,
       requireElement,
     } from "../../../../lib/account-shell";
-    import { getMyWorkspaces, getMyWorkspaceGalleries, type GallerySummary } from "../../../../lib/api-client";
-    import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
+    import { getMyWorkspaceGalleries, type GallerySummary } from "../../../../lib/api-client";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
+    import { loadWorkspaceSummary } from "../../../../lib/workspace-summary-source";
     import {
       bindCopyButtons,
       renderGalleriesTableHtml,
@@ -83,7 +82,6 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
 
       const statusEl = requireElement<HTMLElement>("#ws-status", page);
       const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
-      const appEl = requireElement<HTMLElement>("#ws-app", page);
       const galleriesCard = requireElement<HTMLElement>("#ws-galleries-card", page);
       const galleriesEl = requireElement<HTMLElement>("#ws-galleries", page);
 
@@ -94,12 +92,21 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
         statusEl.hidden = false;
         statusEl.textContent = message;
         statusEl.dataset.state = "error";
-        appEl.hidden = true;
+        // The card stays on screen. A failed galleries fetch does not
+        // invalidate the heading, the explainer or the create command, and
+        // blanking them was the single largest shift on this page. This
+        // innerHTML assignment also discards the placeholder's `aria-busy`
+        // wrapper wholesale, so there is nothing left to un-busy.
+        galleriesEl.innerHTML = "";
         retryBtn.hidden = !retry;
       }
 
       function renderGalleries(galleries: GallerySummary[]): void {
         if (!stillHere()) return;
+        // Same as `showError`: the assignment below replaces the placeholder
+        // markup — including its `aria-busy` wrapper — in one step, so there
+        // is no separate busy flag to clear on `galleriesEl` itself (it never
+        // carried the attribute; the placeholder's child did).
         if (!galleries.length) {
           galleriesEl.innerHTML = `<p class="ws-empty">No galleries yet. Create one with the command above.</p>`;
           return;
@@ -109,32 +116,27 @@ const createCmd = 'uploads gallery create --title "Release screenshots"';
 
       async function loadGalleries(): Promise<void> {
         if (!stillHere()) return;
-        statusEl.hidden = false;
-        statusEl.textContent = "Loading…";
+        statusEl.hidden = true;
         statusEl.removeAttribute("data-state");
         retryBtn.hidden = true;
-        appEl.hidden = true;
 
-        const result = await getMyWorkspaces(apiOrigin);
+        const result = await loadWorkspaceSummary(apiOrigin, workspaceName);
         if (!stillHere()) return;
         if (result.kind === "unavailable") {
+          // `not_found` from /summary is the not-a-member case: the endpoint
+          // answers membership and existence together, so a 404 here means
+          // "not yours" and is not worth a retry button.
+          if (result.reason === "not_found") {
+            showError("You don’t have access to this workspace.", false);
+            return;
+          }
           showError("Workspaces are temporarily unavailable. Check the local stack or try again.");
           return;
         }
 
-        writeCachedWorkspaces(result.workspaces);
-
-        const ws = result.workspaces.find((item) => item.workspace === workspaceName);
-        if (!ws) {
-          showError("You don’t have access to this workspace.", false);
-          return;
-        }
-
-        statusEl.hidden = true;
-        appEl.hidden = false;
+        const ws = result.workspace;
         document.title = `Galleries · ${ws.organization.name || ws.workspace} · uploads.sh`;
 
-        galleriesCard.hidden = false;
         void getMyWorkspaceGalleries(apiOrigin, ws.workspace).then(renderGalleries);
       }
 

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -6,6 +6,7 @@
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
+import { renderMembersPlaceholderHtml } from "../../../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -15,49 +16,45 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 ---
 
 <WorkspaceLayout workspace={workspace}>
-  <div id="ws-status" class="ul-callout status" role="status">Loading…</div>
+  <div id="ws-status" class="ul-callout status" role="status" hidden></div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 
-  <div id="ws-app" hidden>
-    <section class="card settings-page">
-      <div class="settings-section">
-        <div class="ws-page-header">
-          <div class="ws-title-block">
-            <h2>People</h2>
-            <p class="muted" id="ws-slug"></p>
-          </div>
-          <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
+  <section class="card settings-page">
+    <div class="settings-section">
+      <div class="ws-page-header">
+        <div class="ws-title-block">
+          <h2>People</h2>
+          <p class="muted" id="ws-slug"></p>
         </div>
-        <div id="ws-members" class="member-list">
-          <p class="muted" id="ws-members-status" role="status">Loading people…</p>
-        </div>
+        <a class="text-btn" id="ws-back" href={`/account/workspaces/${workspace}`}>← Workspace</a>
       </div>
+      <div id="ws-members" class="member-list" aria-busy="true" set:html={renderMembersPlaceholderHtml()} />
+    </div>
 
-      <div class="settings-section" id="ws-invite-section">
-        <h2>Invite</h2>
-        <p class="settings-note muted">Accept link, then <code>uploads login</code>.</p>
-        <form class="ws-form" id="ws-invite-form">
-          <div class="input-group">
-            <label class="input-group__field">
-              <span class="sr-only">Email</span>
-              <input
-                type="email"
-                name="email"
-                required
-                autocomplete="email"
-                placeholder="teammate@example.com"
-              />
-            </label>
-            <button type="submit" class="input-group__action">Invite</button>
-          </div>
-        </form>
-        <div class="ws-messages">
-          <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
-          <p class="muted cli-note" id="ws-invite-link" hidden></p>
+    <div class="settings-section" id="ws-invite-section" hidden>
+      <h2>Invite</h2>
+      <p class="settings-note muted">Accept link, then <code>uploads login</code>.</p>
+      <form class="ws-form" id="ws-invite-form">
+        <div class="input-group">
+          <label class="input-group__field">
+            <span class="sr-only">Email</span>
+            <input
+              type="email"
+              name="email"
+              required
+              autocomplete="email"
+              placeholder="teammate@example.com"
+            />
+          </label>
+          <button type="submit" class="input-group__action">Invite</button>
         </div>
+      </form>
+      <div class="ws-messages">
+        <p class="muted cli-note" id="ws-invite-status" role="status" hidden></p>
+        <p class="muted cli-note" id="ws-invite-link" hidden></p>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
 
   <script>
     import {
@@ -76,6 +73,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       type ManageResult,
     } from "../../../../lib/api-client";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
+    import { loadWorkspaceSummary } from "../../../../lib/workspace-summary-source";
     import {
       escapeHtml,
       isWorkspaceAdminRole,
@@ -103,7 +101,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 
       const statusEl = requireElement<HTMLElement>("#ws-status", page);
       const retryBtn = requireElement<HTMLButtonElement>("#ws-retry", page);
-      const appEl = requireElement<HTMLElement>("#ws-app", page);
       const slugEl = requireElement<HTMLElement>("#ws-slug", page);
       const inviteStatus = requireElement<HTMLElement>("#ws-invite-status", page);
       const inviteLink = requireElement<HTMLElement>("#ws-invite-link", page);
@@ -123,7 +120,16 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         statusEl.hidden = false;
         statusEl.textContent = message;
         statusEl.dataset.state = "error";
-        appEl.hidden = true;
+        // The card stays on screen. A failed fetch does not invalidate the
+        // heading or the invite section's own permission-gated visibility —
+        // it just has nothing to show, so the members region is cleared and
+        // the invite section (permission unknown) stays hidden. `aria-busy`
+        // lives on `membersEl` itself, not on markup this assignment
+        // replaces, so it's cleared explicitly too: loading has concluded,
+        // even though it failed.
+        membersEl.innerHTML = "";
+        membersEl.removeAttribute("aria-busy");
+        inviteSection.hidden = true;
         retryBtn.hidden = !retry;
       }
 
@@ -136,6 +142,11 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           memberOpts.canManage && invites.length ? renderInvitesHtml(invites) : "";
         const html = memberHtml + inviteHtml;
         membersEl.innerHTML = html || '<p class="muted">Just you so far.</p>';
+        // Unlike the innerHTML assignments above, `aria-busy` here lives on
+        // `membersEl` itself, not on markup the assignment replaces — the
+        // placeholder puts it directly on the surviving container, so it has
+        // to be cleared explicitly once real content lands.
+        membersEl.removeAttribute("aria-busy");
       }
 
       function applyMemberOpts(result: {
@@ -149,14 +160,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         };
       }
 
-      async function loadInvitePage(): Promise<void> {
+      async function loadPeople(): Promise<void> {
         if (!stillHere()) return;
-        statusEl.hidden = false;
-        statusEl.textContent = "Loading…";
-        statusEl.removeAttribute("data-state");
-        retryBtn.hidden = true;
-        appEl.hidden = true;
-
         // One combined people payload (authz + members + invites).
         const result = await getWorkspacePeople(apiOrigin, workspaceName);
         if (!stillHere()) return;
@@ -174,15 +179,36 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         inviteSection.hidden = !canInvite;
         inviteForm.hidden = !canInvite;
         applyMemberOpts(result);
-
-        statusEl.hidden = true;
-        appEl.hidden = false;
         paintPeopleList(result.members, result.invites);
+      }
 
-        const displayName = result.organization.name || workspaceName;
+      async function loadInvitePage(): Promise<void> {
+        if (!stillHere()) return;
+        statusEl.hidden = true;
+        statusEl.removeAttribute("data-state");
+        retryBtn.hidden = true;
+
+        const result = await loadWorkspaceSummary(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind === "unavailable") {
+          // `not_found` from /summary is the not-a-member case: the endpoint
+          // answers membership and existence together, so a 404 here means
+          // "not yours" and is not worth a retry button.
+          if (result.reason === "not_found") {
+            showError("You don’t have access to this workspace.", false);
+            return;
+          }
+          showError("People are temporarily unavailable. Check the local stack or try again.");
+          return;
+        }
+
+        const ws = result.workspace;
+        const displayName = ws.organization.name || workspaceName;
         slugEl.textContent =
           displayName === workspaceName ? workspaceName : `${displayName} · ${workspaceName}`;
         document.title = `People · ${displayName} · uploads.sh`;
+
+        void loadPeople();
       }
 
       async function refreshPeopleLists(): Promise<void> {

--- a/apps/web/src/pages/admin/index.astro
+++ b/apps/web/src/pages/admin/index.astro
@@ -149,7 +149,7 @@ export const prerender = false;
         ${subscriptionLine}
         ${appliedNote}
         <form class="plan-form">
-          <select class="plan-select" aria-label="Plan">${options}</select>
+          <select class="plan-select ul-select ul-select--sm" aria-label="Plan">${options}</select>
           <button type="submit">Save plan</button>
           <div class="plan-status" role="status" aria-live="polite" hidden></div>
         </form>`;
@@ -244,7 +244,7 @@ export const prerender = false;
             <div class="limit-row" data-field="${f.key}" data-byte="1">
               <label>${f.label}</label>
               <input type="number" min="1" step="1" class="limit-value" value="${split.value}" ${unlimited ? "disabled" : ""} />
-              <select class="limit-unit" ${unlimited ? "disabled" : ""}>${options}</select>
+              <select class="limit-unit ul-select ul-select--sm" ${unlimited ? "disabled" : ""}>${options}</select>
               <label class="limit-unlimited"><input type="checkbox" class="limit-unlim" ${unlimited ? "checked" : ""} /> Unlimited</label>
             </div>`;
         }
@@ -426,7 +426,7 @@ export const prerender = false;
                 ? `<form class="invite-form admin-inline-form admin-detail-block" data-workspace="${escapeHtml(ws.workspace)}">
                     <label>Email<input type="email" required class="invite-email" placeholder="you@example.com" /></label>
                     <label>Role
-                      <select class="invite-role">
+                      <select class="invite-role ul-select ul-select--sm">
                         <option value="member">member</option>
                         <option value="admin">admin</option>
                       </select>

--- a/apps/web/src/pages/device.astro
+++ b/apps/web/src/pages/device.astro
@@ -50,20 +50,6 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
       text-transform: uppercase;
       margin-bottom: 6px;
     }
-    .ws select {
-      width: 100%;
-      font: 14px var(--mono);
-      color: var(--fg);
-      background: var(--bg);
-      border: 1px solid var(--line);
-      border-radius: var(--radius-sm);
-      padding: 9px 11px;
-      appearance: none;
-    }
-    .ws select:focus-visible {
-      border-color: var(--accent);
-      outline: none;
-    }
     .ws .fixed {
       font: 14px var(--mono);
       color: var(--fg);
@@ -154,7 +140,7 @@ applyAuthSecurityHeaders(Astro.response.headers, devicePageCsp(authOrigin, apiOr
 
     <div class="ws" id="ws-block" hidden>
       <label for="ws-select">Workspace</label>
-      <select id="ws-select"></select>
+      <select id="ws-select" class="ul-select"></select>
       <div class="fixed" id="ws-fixed" hidden></div>
       <p class="note" id="ws-note" hidden></p>
       <div class="ws-new" id="ws-new" hidden>

--- a/apps/web/src/pages/oauth/consent.astro
+++ b/apps/web/src/pages/oauth/consent.astro
@@ -32,8 +32,6 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     .client-host :global(a){color:inherit}
     .workspace-picker{margin:0 0 20px}
     .workspace-picker label{display:block;color:var(--muted);font-size:11px;letter-spacing:.08em;text-transform:uppercase;margin-bottom:6px}
-    .workspace-picker select{width:100%;font:14px var(--mono);color:var(--fg);background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-sm);padding:9px 11px;appearance:none}
-    .workspace-picker select:focus-visible{border-color:var(--accent);outline:none}
     .scopes{list-style:none;margin:0 0 22px;padding:0;display:grid;gap:10px}
     .scopes :global(li){display:flex;align-items:baseline;gap:10px;padding:10px 12px;background:var(--bg);border:1px solid var(--line);border-radius:var(--radius-md)}
     .scopes :global(.dot){width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none;margin-top:6px}
@@ -104,7 +102,7 @@ applyAuthSecurityHeaders(Astro.response.headers, authPageCsp(authOrigin));
     <div class="client-host" id="client-host" hidden></div>
     <div class="workspace-picker" id="workspace-picker" hidden>
       <label for="workspace-select">Workspace</label>
-      <select id="workspace-select"></select>
+      <select id="workspace-select" class="ul-select"></select>
     </div>
     <ul class="scopes" id="scope-list"></ul>
     <div class="actions">

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1595,3 +1595,48 @@ button.wft-card__name:focus-visible {
   font-weight: 500;
   color: var(--muted);
 }
+
+/* Galleries empty state — the primary element when a workspace has none. */
+.ws-empty-state {
+  display: grid;
+  gap: 10px;
+  justify-items: start;
+  padding: 20px 0 8px;
+}
+.ws-empty-state__title {
+  margin: 0;
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 600;
+}
+.ws-empty-state__body {
+  margin: 0;
+  max-width: 46ch;
+  color: var(--muted);
+  font-size: 13px;
+}
+.ws-empty-state .command {
+  width: 100%;
+}
+
+/* Reference commands, demoted out of the primary reading path. */
+.ws-gallery-help {
+  margin-top: 20px;
+}
+.ws-gallery-help summary {
+  cursor: pointer;
+  list-style: none;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+.ws-gallery-help summary::-webkit-details-marker {
+  display: none;
+}
+.ws-gallery-help summary:hover,
+.ws-gallery-help summary:focus-visible {
+  color: var(--fg);
+  outline: none;
+}

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1553,12 +1553,15 @@ button.wft-card__name:focus-visible {
 }
 /* A row's height must not depend on which of three shapes its role cell
    happens to render: a plain label (read-only viewer), a <select>
-   (manageable viewer), or, via .member-row__actions below, a Remove/Revoke
-   .text-btn (also a manageable/pending viewer). .member-row__role mirrors
-   .text-btn's own box (font/padding/border, account-content.css:513) rather
-   than a measured number, so the label converges on whatever that rule
-   computes to and stays correct if it ever changes. letter-spacing/
-   text-transform/color stay label-specific — neither affects box height. */
+   (manageable viewer, styled via .ul-select--sm below), or, via
+   .member-row__actions below, a Remove/Revoke .text-btn (also a
+   manageable/pending viewer). .member-row__role mirrors .text-btn's own box
+   (font/padding/border, account-content.css:513) — the same box
+   .ul-select--sm mirrors — rather than a measured number, so all three
+   converge on whatever that rule computes to and stay correct if it ever
+   changes. letter-spacing/text-transform/color stay label-specific — neither
+   affects box height. Can't just apply .ul-select--sm here: this is a plain
+   <span>, not a <select>, so the caret/background-image would be wrong. */
 .member-row__role {
   flex: none;
   font: 12px var(--mono);
@@ -1595,23 +1598,19 @@ button.wft-card__name:focus-visible {
   align-items: center;
   gap: 8px;
 }
+/* Styling now comes from .ul-select .ul-select--sm (markup in workspace-ui.ts)
+   — that primitive's `appearance: none` takes full control of the box, which
+   turns out to be exactly what removes the old <select>-vs-<button> height
+   quirk (a previous attempt pinned `height: 27.5px` here because plain
+   box-matching CSS left a <select> rendering 2px taller than a <button> no
+   matter how closely font/padding/border/line-height/box-sizing were copied;
+   `appearance: none` plus a drawn-in caret doesn't have that quirk — see
+   packages/ui/src/styles.css). `.member-row__role-select` itself is now only
+   a JS hook (people.astro); the one thing it still needs is `width: auto` —
+   .ul-select defaults to 100% for stacked fields, but this select sits in the
+   flex .member-row__actions row next to the Remove button. */
 .member-row__role-select {
-  /* Same box-convergence rule as .member-row__role above — mirrors
-     .text-btn's font/padding/border rather than a measured number. That
-     alone isn't sufficient for <select>, though: measured live with every
-     other property byte-identical to .text-btn (font, padding, border,
-     line-height "normal", box-sizing border-box), a <select> still renders
-     2px taller than a <button> (29.5px vs. 27.5px) — a browser form-control
-     quirk in how "auto" height is computed for the two elements, not
-     anything expressible via matching CSS declarations. `height` pins it
-     to .text-btn's own measured 27.5px so the row's height genuinely can't
-     depend on the viewer's permission; re-measure this value if .text-btn's
-     box (account-content.css:513) or --mono ever changes. */
-  font: 12px var(--mono);
-  padding: 5px 9px;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  height: 27.5px;
+  width: auto;
 }
 .member-row__role--pending {
   color: var(--accent);

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1551,10 +1551,21 @@ button.wft-card__name:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* A row's height must not depend on which of three shapes its role cell
+   happens to render: a plain label (read-only viewer), a <select>
+   (manageable viewer), or, via .member-row__actions below, a Remove/Revoke
+   .text-btn (also a manageable/pending viewer). .member-row__role mirrors
+   .text-btn's own box (font/padding/border, account-content.css:513) rather
+   than a measured number, so the label converges on whatever that rule
+   computes to and stays correct if it ever changes. letter-spacing/
+   text-transform/color stay label-specific — neither affects box height. */
 .member-row__role {
   flex: none;
+  font: 12px var(--mono);
+  padding: 5px 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
   color: var(--muted);
-  font-size: 10.5px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -1585,8 +1596,22 @@ button.wft-card__name:focus-visible {
   gap: 8px;
 }
 .member-row__role-select {
-  font: inherit;
-  padding: 2px 6px;
+  /* Same box-convergence rule as .member-row__role above — mirrors
+     .text-btn's font/padding/border rather than a measured number. That
+     alone isn't sufficient for <select>, though: measured live with every
+     other property byte-identical to .text-btn (font, padding, border,
+     line-height "normal", box-sizing border-box), a <select> still renders
+     2px taller than a <button> (29.5px vs. 27.5px) — a browser form-control
+     quirk in how "auto" height is computed for the two elements, not
+     anything expressible via matching CSS declarations. `height` pins it
+     to .text-btn's own measured 27.5px so the row's height genuinely can't
+     depend on the viewer's permission; re-measure this value if .text-btn's
+     box (account-content.css:513) or --mono ever changes. */
+  font: 12px var(--mono);
+  padding: 5px 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  height: 27.5px;
 }
 .member-row__role--pending {
   color: var(--accent);

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -273,3 +273,18 @@
     display: none;
   }
 }
+
+/* Loading placeholder. Sized by `--ws-skel-w` from the builder so one class
+   covers every call site. `min-height: 1em` plus `vertical-align: middle`
+   makes a bar occupy exactly the line box its text will occupy, which is what
+   keeps the swap to real content free of layout shift. */
+.ws-skel {
+  display: inline-block;
+  width: var(--ws-skel-w, 100%);
+  min-height: 1em;
+  vertical-align: middle;
+  border-radius: 3px;
+  background: var(--panel);
+  /* Purely decorative and aria-hidden — nothing here should be selectable. */
+  user-select: none;
+}

--- a/apps/web/src/styles/admin-workspaces.css
+++ b/apps/web/src/styles/admin-workspaces.css
@@ -13,9 +13,7 @@
   gap: 8px;
   align-items: center;
 }
-.workspace .plan-select,
-.workspace .limit-value,
-.workspace .limit-unit {
+.workspace .limit-value {
   background: var(--bg);
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
@@ -23,8 +21,18 @@
   padding: 4px 6px;
   font: 12px var(--mono);
 }
-.workspace .plan-select {
-  padding: 7px 9px;
+/* .plan-select, .limit-unit, and .invite-role are styled by .ul-select
+   .ul-select--sm (markup in admin/index.astro) instead of bespoke box CSS.
+   All three need width: auto — .ul-select defaults to 100% for a stacked
+   field, but each of these sits in a flex row (.plan-form next to "Save
+   plan"; the invite-role <label> inside the flex-wrap .admin-inline-form)
+   or, for .limit-unit, reads clearer pinned to content width like the
+   sibling .limit-value input even though its 70px grid column would also
+   work with the 100% default. */
+.workspace .plan-select,
+.workspace .limit-unit,
+.workspace .invite-role {
+  width: auto;
 }
 .workspace .plan-status,
 .workspace .limit-status,
@@ -62,8 +70,8 @@
   font-size: 13px;
   color: var(--body);
 }
-.workspace .limit-value:disabled,
-.workspace .limit-unit:disabled {
+/* .limit-unit's disabled treatment now comes from .ul-select:disabled. */
+.workspace .limit-value:disabled {
   opacity: 0.5;
 }
 .workspace .limit-unlimited {

--- a/apps/web/src/styles/admin.css
+++ b/apps/web/src/styles/admin.css
@@ -342,12 +342,18 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
+/*
+ * `select` deliberately dropped from these lists: .invite-role (the only
+ * <select> in an .admin-inline-form) is now styled by .ul-select
+ * .ul-select--sm, and a class+type rule here would out-specificity
+ * .ul-select's own declarations (background/border/padding/font) and clobber
+ * them. No .admin-stack-form <select> exists today either — leaving `select`
+ * out of both lists keeps the box available for .ul-select if one shows up.
+ */
 .admin-inline-form input,
-.admin-inline-form select,
 .admin-stack-form input[type="text"],
 .admin-stack-form input[type="url"],
 .admin-stack-form textarea,
-.admin-stack-form select,
 .users-ban-form input {
   background: var(--bg);
   border: 1px solid var(--line);
@@ -360,15 +366,12 @@
 }
 .admin-stack-form input[type="text"],
 .admin-stack-form input[type="url"],
-.admin-stack-form textarea,
-.admin-stack-form select {
+.admin-stack-form textarea {
   background: var(--panel);
 }
 .admin-inline-form input:focus-visible,
-.admin-inline-form select:focus-visible,
 .admin-stack-form input:focus-visible,
 .admin-stack-form textarea:focus-visible,
-.admin-stack-form select:focus-visible,
 .users-ban-form input:focus-visible {
   outline: none;
   border-color: var(--accent);

--- a/packages/ui/src/Field.tsx
+++ b/packages/ui/src/Field.tsx
@@ -21,6 +21,24 @@ export function Input({ className, ...rest }: InputProps) {
   return <input className={["ul-input", className].filter(Boolean).join(" ")} {...rest} />;
 }
 
+export interface SelectProps extends ComponentPropsWithoutRef<"select"> {}
+
+/**
+ * A single dark `<select>` in the monospace console idiom — same box as `Input`,
+ * with a drawn caret standing in for native browser chrome. Usually composed
+ * inside `Field`, but valid on its own. Pass `className="ul-select--sm"` for
+ * the compact variant used in dense rows and tables.
+ *
+ * @example
+ * <Select defaultValue="member">
+ *   <option value="member">member</option>
+ *   <option value="admin">admin</option>
+ * </Select>
+ */
+export function Select({ className, ...rest }: SelectProps) {
+  return <select className={["ul-select", className].filter(Boolean).join(" ")} {...rest} />;
+}
+
 export interface LabelProps extends ComponentPropsWithoutRef<"label"> {
   children?: ReactNode;
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,8 +17,8 @@ export type { ButtonProps } from "./Button";
 export { Panel } from "./Panel";
 export type { PanelProps } from "./Panel";
 
-export { Field, Input, Label } from "./Field";
-export type { FieldProps, InputProps, LabelProps } from "./Field";
+export { Field, Input, Label, Select } from "./Field";
+export type { FieldProps, InputProps, LabelProps, SelectProps } from "./Field";
 
 export { Callout } from "./Callout";
 export type { CalloutProps } from "./Callout";

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -281,6 +281,51 @@
   opacity: 0.55;
   cursor: default;
 }
+/*
+ * `appearance: none` hands us the whole box — that's also what makes the
+ * `<select>`-vs-`<button>` height mismatch disappear (a browser form-control
+ * quirk in "auto" height for the two elements otherwise). We draw the caret
+ * ourselves as a background-image data URI so the box stays pixel-identical
+ * to `.ul-input`. CSP: pages that ship `img-src data:` (signed-in, auth,
+ * device) allow this — `background-image` is governed by `img-src`, and we
+ * never fetch the caret from a URL. The stroke is `--muted`'s literal hex
+ * (#8a8a83), not a live `var()` — the SVG renders as an external resource
+ * with its own document scope, so it can't resolve the host page's custom
+ * properties; baking in the value keeps it in the same idiom instead.
+ */
+.ul-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: var(--bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M2.75 4.5L6 7.75L9.25 4.5' stroke='%238a8a83' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 12px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--fg);
+  padding: 10px 34px 10px 12px;
+  font: 14px var(--mono);
+  width: 100%;
+}
+.ul-select:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.ul-select:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+/* Compact variant — matches .text-btn's box (account-content.css) so a
+   member row's height converges on its own Remove button without a pin. */
+.ul-select--sm {
+  font: 12px var(--mono);
+  padding: 5px 22px 5px 9px;
+  border-radius: 6px;
+  background-position: right 8px center;
+  background-size: 10px 10px;
+}
 .ul-field__hint {
   color: var(--muted);
   font: 11px var(--mono);

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -44,6 +44,9 @@
   /* Text */
   --fg: #ececea; /* headings / high-emphasis */
   --body: #b3b3ad; /* body copy */
+  /* Changing this? `.ul-select`'s caret in styles.css bakes in this literal
+     hex — a data-URI SVG renders in its own document scope and cannot resolve
+     custom properties, so the two only stay in sync by hand. */
   --muted: #8a8a83; /* metadata, footnotes, placeholders */
 
   /* Accents */


### PR DESCRIPTION
Navigating `/account/*` produced a run of layout shifts: explicit "Loading…" text, then the whole page flickering in at once, then the right rail swapping "Loading usage…" for a taller meter block.

The cause was not asset delivery — Astro already serves hashed JS/CSS with long cache headers. Every shift came from the data waterfall, and from static chrome being gated behind it.

## What was happening

Every workspace tab hid its entire card behind `<div id="ws-app" hidden>` until two network round trips finished:

```
HTML paints    →  #ws-app hidden, "Loading…" is the only content
module JS      →  RT1: GET auth/session
onSession      →  RT2: GET /me/workspaces   ← the whole list, only to check membership
               →  unhide #ws-app            ← SHIFT A: entire card appears at once
               →  RT3: GET .../galleries    ← SHIFT B: "Loading…" swaps to a table
rail (own gate)→  RT4: .../github-status
               →  RT5: .../summary          ← SHIFT C: text swaps to a meter
```

Shift A was self-inflicted: the heading, explainer and CLI command need no data at all. And RT2 was redundant — `initWorkspacesNav` already fetched and cached that same list, and the rail separately fetched the same workspace.

## Approach

A three-tier loading model, applied across the rail and all three gated tabs.

- **Tier 0 — static chrome, in server HTML, never hidden.** Headings, explainers, command blocks, table headers, rail labels. The `#ws-app` gate is gone.
- **Tier 1 — cached data, no network.** A per-workspace `localStorage` snapshot store warm-paints last-known values at module-eval time.
- **Tier 2 — genuinely unknown, so a skeleton.** Dim bars at `--panel`, sized to the *exact* geometry of what replaces them.

Errors are now section-scoped rather than page-replacing. The one exception stays page-level: no access to the workspace, where the rest of the page is meaningless.

The membership check moved from a `.find()` over the workspace list to the `/summary` endpoint the rail already called, sharing one in-flight promise — so the page and the rail now issue **one** request where there were three.

## Result

Measured in the browser, placeholder vs. real content:

| Region | Placeholder | Real content | Delta |
|---|---|---|---|
| Galleries table | 153.586px | 153.586px | 0 |
| Billing plan card | 106.445px | 106.445px | 0 |
| People list — read-only viewer | — | — | 0 |
| People list — owner/admin | — | — | 0 |
| People list — pending invite | — | — | 0 |

The three People variants and the placeholder were measured together and all
four agree exactly; the absolute figure is omitted because it was captured in a
different measurement context from the two rows above it, and reconciling the
two bases would not change the result that matters — the delta is zero.

No `id="ws-app"` remains, and no literal "Loading…" / "Loading usage…" ships in the HTML for these routes.

## Galleries tab, restructured

The hierarchy was inverted: the CLI command was the loudest element on the page but it is *instructions*, while the actual state — that the workspace has no galleries — was the quietest thing there, muted, at the bottom, under a paragraph carrying three more commands.

Now the table region comes first, the explainer is one sentence instead of two, the commands sit in a closed disclosure, and the empty state leads with "No galleries yet". `uploads gallery add` is dropped from the page — `uploads put --gallery` already does that job, and listing both invited a choice that does not matter.

## A design-system gap this turned up

Fixing the People-tab shift meant styling a `<select>` by hand, which raised a fair question: why hand-roll a control at all?

Because the DS had no select primitive — not as a React component, not as a CSS class. `@uploads/ui` ships `Field` / `Input` / `Label` and `.ul-field` / `.ul-label` / `.ul-input`, but nothing for `<select>`. So all six selects in the web app styled themselves independently, and three of them (`.invite-role` on admin, `#ws-select` on device login, `#workspace-select` on OAuth consent) had **no CSS at all** — raw browser chrome inside a dark mono-token UI.

This adds `.ul-select` (plus a compact `.ul-select--sm`) beside `.ul-input`, and a matching React `Select` export for parity, then adopts it at all six call sites and deletes the superseded bespoke CSS.

The primitive sets `appearance: none` and draws its own caret as a data-URI SVG, which is also what retires the magic number: with full control of the box, a `<select>` and a `<button>` compute to the same 28px, so the member row's height converges on its own Remove button with no pinned height. That was measured, not assumed — an A/B against the previous commit put all four People-row variants at an identical height before and after.

One tradeoff worth naming: the caret's stroke is `--muted`'s literal hex rather than a live `var()`, because a data-URI SVG renders in its own document scope and cannot resolve the host page's custom properties. Both the rule and the token definition carry a note about the coupling.

## Also worth a reviewer's attention

**Member rows are taller for everyone**, by roughly the difference between the old read-only and manageable variants. A row's height used to depend on whether *you* could manage members, because the manageable variant carries a select and a Remove button. No placeholder can be right for both when permission isn't known at first paint, so the row now reserves one height for all three variants.

**One commit here is unrelated to the rest.** `fix(lint): disable three unicorn rules whose autofixes corrupt the tree` — `pnpm lint:fix` rewrote 13 files across four packages, and `apps/web/src/lib/console-mode.ts` stopped compiling: `prefer-set-has` converts an array literal to `new Set(...)` without touching the `readonly ConsoleMode[]` annotation. `no-array-sort`/`no-array-reverse` fire on this repo's `[...arr].sort(...)` idiom, which already copies, so their rewrite just adds a second copy. oxlint's `--fix` flags are global, so a rule's diagnostic cannot be kept while suppressing only its fix. The pre-commit hook was never affected — lint-staged runs `oxlint` without `--fix`.

## Known limits, accepted deliberately

- Galleries rows carrying a description line are 19.8px taller than the placeholder reserves. That variance is content-dependent — identical for every viewer — which is a different class from the permission-dependent variance fixed above.
- An uncapped workspace (plan never applied) still collapses once from two meters to a one-line text on its *first* visit. Bounded, not eliminated: later visits paint from the cached snapshot, until the 24h TTL, a schema-version bump, or sign-out.
- `data-stale` is set on warm-painted sections as a diagnostic marker; it has no visual treatment, deliberately.

## Testing

`pnpm test` 3170/3170 · `pnpm types` exit 0 · all changed files oxfmt-clean · no changeset (`@uploads/web` is changeset-ignored).

New unit coverage for the cache (TTL, version mismatch, malformed entries, quota), the request de-dupe (including that a rejection clears the in-flight entry so retries work), and every placeholder builder. Astro page scripts and DOM boot code stay uncovered — the suite runs in node with no jsdom — so those were verified in the browser instead.

`pnpm check` exits 1 on `.claude/settings.local.json`, an untracked gitignored local file unrelated to this branch.
