### PR TITLE
docs: surface screenshot annotations in public materials

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "uploads",
       "source": "./",
-      "description": "Get screenshots, GIFs, recordings, and files into GitHub PRs and issues via uploads.sh. Bundles the github-screenshots + uploads-cli skills, a local MCP server, and the /uploads:attach command.",
+      "description": "Get screenshots, GIFs, recordings, and files into GitHub PRs and issues via uploads.sh. Bundles the github-screenshots, annotate-screenshots, and uploads-cli skills, a local MCP server, and the /uploads:attach command.",
       "version": "0.2.0",
       "author": {
         "name": "Build Internet"
@@ -19,7 +19,11 @@
       "license": "Apache-2.0",
       "keywords": ["uploads", "screenshots", "github", "file-hosting", "images", "mcp"],
       "strict": false,
-      "skills": ["./skills/github-screenshots", "./skills/uploads-cli"],
+      "skills": [
+        "./skills/github-screenshots",
+        "./skills/annotate-screenshots",
+        "./skills/uploads-cli"
+      ],
       "commands": "./plugins/claude/uploads/commands",
       "mcpServers": "./plugins/claude/uploads/.mcp.json",
       "hooks": "./hooks/hooks.json"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -10,6 +10,10 @@
   "repository": "https://github.com/buildinternet/uploads",
   "license": "Apache-2.0",
   "keywords": ["uploads", "screenshots", "github", "file-hosting", "images", "mcp"],
-  "skills": ["./skills/github-screenshots", "./skills/uploads-cli"],
+  "skills": [
+    "./skills/github-screenshots",
+    "./skills/annotate-screenshots",
+    "./skills/uploads-cli"
+  ],
   "hooks": "./hooks/hooks.json"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,15 @@ The path-by-path inventory lives in the README's
 can't drift. `packages/uploads` also ships `uploads mcp`, a stdio MCP server
 mirroring the CLI commands.
 
-Two agent skills are checked in at the repo root so they're installable via
+Three agent skills are checked in at the repo root so they're installable via
 the `npx skills add` convention (and by `uploads install`):
 `skills/github-screenshots` is the thin workflow skill (when a screenshot or
 recording should go into a PR/issue or be shared as a link — the in-repo
 successor to the external `github-screenshots` skill's bundled R2 scripts),
-and `skills/uploads-cli` is the full CLI reference it defers to. Keep both in
-sync when the CLI's commands or flags change.
+`skills/annotate-screenshots` covers callouts and redaction
+(`uploads annotate` / `screenshot --annotate`), and `skills/uploads-cli` is
+the full CLI reference the others defer to. Keep all three in sync when the
+CLI's commands or flags change.
 
 **Screenshots: stage as you go.** If your change is visually observable (web
 UI, email templates, rendered output), capture and stage screenshots at each

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,9 +210,11 @@ Full setup is in [docs/deploy.md](docs/deploy.md); the operator runbook is
   type comes from the bytes, never the client header.
 - **Auth is per-workspace bearer tokens**, hashed and compared in constant time,
   with uniform 401s so workspace names cannot be enumerated.
-- **Keep the two skills in sync** with the CLI. `skills/github-screenshots` is
-  the workflow skill and `skills/uploads-cli` is the full reference; both ship
-  to users, so a new flag belongs in the reference.
+- **Keep the three skills in sync** with the CLI. `skills/github-screenshots` is
+  the workflow skill, `skills/annotate-screenshots` covers callouts and
+  redaction, and `skills/uploads-cli` is the full reference; all three ship to
+  users, so a new flag belongs in the reference (and annotate-related changes
+  also belong in annotate-screenshots).
 - **Docs follow a house style** — active voice, one idea per sentence, one term
   per concept. See [AGENTS.md](AGENTS.md#writing-docs).
 

--- a/README.md
+++ b/README.md
@@ -126,32 +126,42 @@ runtime, without checking anything out:
 npx skills add buildinternet/uploads
 ```
 
-That installs both: `github-screenshots` (visuals → PRs/issues) and
-`uploads-cli` (full CLI reference).
+That installs three skills: `github-screenshots` (visuals → PRs/issues),
+`uploads-cli` (full CLI reference), and `annotate-screenshots` (callouts and
+redaction on a capture).
 
-Full CLI usage — key conventions, stable PR/issue attachments, managed
-comments, and public galleries — lives in [docs/cli.md](docs/cli.md). REST
-routes are in [docs/api.md](docs/api.md).
+Point at what changed before you attach — bake boxes, arrows, labels, or a
+solid redaction into the image:
+
+```bash
+uploads screenshot http://localhost:4321/settings --via local --annotate ./callouts.json
+uploads annotate ./shot.png --spec ./callouts.json --out ./shot.marked.png
+```
+
+Full CLI usage — key conventions, stable PR/issue attachments, annotations,
+managed comments, and public galleries — lives in [docs/cli.md](docs/cli.md).
+REST routes are in [docs/api.md](docs/api.md).
 
 ## What's in this repo
 
-| Path                         | What                                                                                |
-| ---------------------------- | ----------------------------------------------------------------------------------- |
-| `apps/api/`                  | Hono worker — REST API, deploys to `api.uploads.sh`                                 |
-| `apps/auth/`                 | Better Auth worker — sessions, enrollment, device flow                              |
-| `apps/mcp/`                  | Remote MCP server                                                                   |
-| `apps/web/`                  | Astro site — uploads.sh, account and admin UI                                       |
-| `packages/storage/`          | `@uploads/storage` — files-sdk adapter factory                                      |
-| `packages/uploads/`          | `@buildinternet/uploads` — CLI + client, publishes to npm                           |
-| `packages/ui/`               | `@uploads/ui` — shared design system                                                |
-| `packages/billing/`          | `@uploads/billing` — plans and limit resolution                                     |
-| `packages/email/`            | `@uploads/email` — transactional email templates                                    |
-| `packages/errors/`           | `@uploads/errors` — shared error codes and wire format                              |
-| `skills/github-screenshots/` | Workflow skill — visuals into PRs/issues/share links                                |
-| `skills/uploads-cli/`        | Agent skill for driving the CLI                                                     |
-| `hooks/`                     | Shared pre-PR screenshot hook (`uploads hook pre-pr-screenshot`) for Claude + Codex |
-| `plugins/claude/`            | Claude Code plugin config (skills path, MCP, commands)                              |
-| `.codex-plugin/`             | Codex plugin manifest — same skills + shared hook                                   |
+| Path                           | What                                                                                |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| `apps/api/`                    | Hono worker — REST API, deploys to `api.uploads.sh`                                 |
+| `apps/auth/`                   | Better Auth worker — sessions, enrollment, device flow                              |
+| `apps/mcp/`                    | Remote MCP server                                                                   |
+| `apps/web/`                    | Astro site — uploads.sh, account and admin UI                                       |
+| `packages/storage/`            | `@uploads/storage` — files-sdk adapter factory                                      |
+| `packages/uploads/`            | `@buildinternet/uploads` — CLI + client, publishes to npm                           |
+| `packages/ui/`                 | `@uploads/ui` — shared design system                                                |
+| `packages/billing/`            | `@uploads/billing` — plans and limit resolution                                     |
+| `packages/email/`              | `@uploads/email` — transactional email templates                                    |
+| `packages/errors/`             | `@uploads/errors` — shared error codes and wire format                              |
+| `skills/github-screenshots/`   | Workflow skill — visuals into PRs/issues/share links                                |
+| `skills/annotate-screenshots/` | Callouts and redaction — `uploads annotate` / `screenshot --annotate`               |
+| `skills/uploads-cli/`          | Agent skill for driving the CLI                                                     |
+| `hooks/`                       | Shared pre-PR screenshot hook (`uploads hook pre-pr-screenshot`) for Claude + Codex |
+| `plugins/claude/`              | Claude Code plugin config (skills path, MCP, commands)                              |
+| `.codex-plugin/`               | Codex plugin manifest — same skills + shared hook                                   |
 
 The workers and web app are separate deployables. All storage access goes
 through `createStorage()` in `packages/storage` — adding a provider is one new

--- a/VISION.md
+++ b/VISION.md
@@ -68,15 +68,15 @@ so future sessions capture on their own instead of being asked.
 
 One storage layer, reached however the agent (or human) already works:
 
-| Surface                        | What it is                                                                 |
-| ------------------------------ | -------------------------------------------------------------------------- |
-| CLI (`@buildinternet/uploads`) | The canonical interface: put, attach, staged, find, galleries, screenshot  |
-| Local MCP (stdio)              | The CLI's capabilities inside any MCP-capable agent                        |
-| Hosted MCP (agents.uploads.sh) | Remote server behind OAuth 2.1 — no local install at all                   |
-| GitHub App                     | Webhook-driven promotion and comment sync the moment a PR opens            |
-| REST API                       | Everything the CLI does, for anything that speaks HTTP                     |
-| Web (uploads.sh)               | File pages, galleries, workspace settings, admin                           |
-| Skills                         | `github-screenshots` and `uploads-cli`, installable into any agent runtime |
+| Surface                        | What it is                                                                          |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| CLI (`@buildinternet/uploads`) | The canonical interface: put, attach, staged, find, galleries, screenshot, annotate |
+| Local MCP (stdio)              | The CLI's capabilities inside any MCP-capable agent                                 |
+| Hosted MCP (agents.uploads.sh) | Remote server behind OAuth 2.1 — no local install at all                            |
+| GitHub App                     | Webhook-driven promotion and comment sync the moment a PR opens                     |
+| REST API                       | Everything the CLI does, for anything that speaks HTTP                              |
+| Web (uploads.sh)               | File pages, galleries, workspace settings, admin                                    |
+| Skills                         | `github-screenshots`, `annotate-screenshots`, and `uploads-cli`                     |
 
 Discovery is machine-first too: `/.well-known/integrations.json`, OpenAPI,
 OAuth protected-resource metadata. An agent that has never heard of uploads
@@ -131,12 +131,11 @@ these normal.
   tied to code or a deliverable — extends to whatever surface a team reviews
   or ships on. Galleries are the deliberate exploration of that: a curated,
   linkable bundle of evidence that stands on its own, no PR required.
-- **Annotations.** Marking up the evidence itself — callouts, highlights, and
-  notes on a capture — so a screenshot can carry the reviewer's (or the
-  agent's) commentary with it.
 - **Automatic redaction.** Detecting and redacting sensitive content in
   uploads — tokens, emails, personal data caught in a capture — before it
-  ships to a public URL.
+  ships to a public URL. Manual redaction is already shipped (`uploads annotate`
+  / `screenshot --annotate` with a `redact` annotation); automatic detection is
+  the remaining step.
 - **Private hosting.** Hosted files are public today, stated plainly. Scoped,
   private evidence — for teams whose UI can't be on the open web — is on the
   roadmap, not a quiet promise.
@@ -154,8 +153,9 @@ these normal.
 Shipped and running in production: the staging loop, GitHub App promotion,
 before/after pairing, managed-comment self-healing, hosted and local MCP,
 OAuth 2.1, self-serve workspaces, plans and billing, galleries, the screenshot
-renderer, and the agent skills. This repo furnishes its own PRs with the tool
-it ships.
+renderer, screenshot annotations (`uploads annotate` /
+`screenshot --annotate`), and the agent skills. This repo furnishes its own
+PRs with the tool it ships.
 
 Under active development, in the open. APIs (including auth) can still change.
 Feedback is welcome — open an issue.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -8,9 +8,10 @@ Access requires a workspace — create your own with a linked GitHub account, or
 
 - [Home](https://uploads.sh/): product overview and copyable install commands
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
-- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file, capture a screenshot
+- [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file, capture a screenshot, annotate with callouts/redactions
+- [Docs: annotate a screenshot](https://uploads.sh/docs/attach-pull-request-images#annotate): bake boxes, arrows, labels, freeform strokes, and solid redactions into a capture (`uploads screenshot --annotate` or `uploads annotate`)
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): recommended install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
-- [Docs: agents](https://uploads.sh/docs/agents): install the agent skill and MCP server, or the all-in-one Claude Code plugin
+- [Docs: agents](https://uploads.sh/docs/agents): install the agent skills and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Docs: plans & limits](https://uploads.sh/docs/limits): storage/file-size/member caps per plan, behavior at each cap, and the GitHub attachment-cap comparison
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
@@ -20,6 +21,7 @@ Access requires a workspace — create your own with a linked GitHub account, or
 - [API](https://github.com/buildinternet/uploads/blob/main/docs/api.md): REST surface for workspace-scoped files
 - [OpenAPI (summary)](https://uploads.sh/.well-known/openapi.json): machine-readable API surface
 - [CLI skill](https://github.com/buildinternet/uploads/tree/main/skills/uploads-cli): host a file and embed it in a PR/issue (artifact URL is in the skills index)
+- [Annotate skill](https://github.com/buildinternet/uploads/tree/main/skills/annotate-screenshots): JSON annotation spec and workflow for callouts and redaction
 
 ## Install
 

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -94,7 +94,7 @@ it opens (or run: uploads attach --promote once it exists)</pre>
     <div class="cards">
       <a class="card" href="/docs/attach-pull-request-images">
         <h3>Attach &amp; share <span class="go">→</span></h3>
-        <p>Post files to a PR or issue, get a URL for any file, and capture a screenshot.</p>
+        <p>Post files to a PR or issue, get a URL for any file, capture a screenshot, and annotate it.</p>
       </a>
       <a class="card" href="/docs/github-app">
         <h3>GitHub App <span class="go">→</span></h3>
@@ -105,7 +105,7 @@ it opens (or run: uploads attach --promote once it exists)</pre>
       </a>
       <a class="card" href="/docs/agents">
         <h3>Set up your agent <span class="go">→</span></h3>
-        <p>Install the agent skill and the MCP server so your agent uploads on its own.</p>
+        <p>Install the agent skills and the MCP server so your agent uploads on its own.</p>
       </a>
       <a class="card" href="/docs/reference">
         <h3>Reference <span class="go">→</span></h3>

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -15,20 +15,21 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <section class="lead" id="install">
     <h2>One command <a class="anchor" href="#install" aria-label="Link to this section">#</a></h2>
     <p>
-      One command detects your agent runtime and installs both the agent skill and the
-      hosted MCP server:
+      One command detects your agent runtime and installs the agent skills (attach
+      workflow, CLI reference, and screenshot annotations) plus the hosted MCP
+      server:
     </p>
     <div class="cmd">
       <span class="text">uploads install</span>
       <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
     </div>
     <p>
-      Or set up each piece yourself — the skill via <code>npx skills</code>, the MCP
+      Or set up each piece yourself — the skills via <code>npx skills</code>, the MCP
       server with your runtime's MCP registration (shown here for Claude Code):
     </p>
     <div class="cmd">
-      <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
-      <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli" aria-live="polite">copy</button>
+      <span class="text">npx skills add buildinternet/uploads</span>
+      <button type="button" data-copy="npx skills add buildinternet/uploads" aria-live="polite">copy</button>
     </div>
     <div class="cmd">
       <span class="text">claude mcp add --transport http uploads <span class="url">https://agents.uploads.sh/mcp</span></span>
@@ -39,9 +40,10 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <section id="plugin">
     <h2>Claude Code &amp; Codex plugins <a class="anchor" href="#plugin" aria-label="Link to this section">#</a></h2>
     <p>
-      On Claude Code you can install everything as one plugin — both agent skills, an
-      MCP server, an <code>/uploads:attach</code> command, and a pre-PR screenshot
-      reminder hook — from the uploads marketplace. Add the marketplace, then install:
+      On Claude Code you can install everything as one plugin — the agent skills
+      (attach workflow, CLI reference, annotations), an MCP server, an&#32;
+      <code>/uploads:attach</code> command, and a pre-PR screenshot reminder hook —
+      from the uploads marketplace. Add the marketplace, then install:
     </p>
     <div class="cmd slash">
       <span class="text">/plugin marketplace add buildinternet/uploads</span>
@@ -63,12 +65,13 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <section id="skill-vs-mcp">
     <h2>Skill vs. MCP <a class="anchor" href="#skill-vs-mcp" aria-label="Link to this section">#</a></h2>
     <p>
-      The <strong>skill</strong> teaches the agent when and how to use the CLI, for example
-      attaching before/after screenshots to the PR it just opened. The <strong>MCP
-      server</strong> gives agents the same tools (<code>put</code>, <code>attach</code>,&#32;
-      <code>list</code>, <code>delete</code>, and more) over HTTP, using the same token as the
-      CLI. There's also a local stdio variant — register <code>uploads mcp</code> with
-      any MCP client, e.g.:
+      The <strong>skills</strong> teach the agent when and how to use the CLI — for
+      example attaching before/after screenshots to the PR it just opened, or baking
+      callouts onto a capture with <code>uploads screenshot --annotate</code>. The&#32;
+      <strong>MCP server</strong> gives agents the same tools (<code>put</code>,&#32;
+      <code>attach</code>, <code>list</code>, <code>delete</code>, and more) over HTTP,
+      using the same token as the CLI. There's also a local stdio variant — register&#32;
+      <code>uploads mcp</code> with any MCP client, e.g.:
     </p>
     <div class="cmd">
       <span class="text">claude mcp add uploads -- uploads mcp</span>

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -360,14 +360,14 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
     </p>
     <p>A minimal callouts file:</p>
     <div class="block" aria-label="Annotation spec example">
-      <pre>{
+      <pre>{`{
   "version": 1,
   "annotations": [
     { "type": "box", "selector": "#save-button" },
     { "type": "label", "text": "New: bulk save", "selector": "#save-button" },
     { "type": "redact", "selector": "[data-testid=api-key]", "style": "solid" }
   ]
-}</pre>
+}`}</pre>
     </div>
     <p>
       Annotation types: <code>box</code>, <code>arrow</code>, <code>label</code>,

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -1,7 +1,7 @@
 ---
-// uploads.sh — docs / attach & share. The three commands that get media onto
+// uploads.sh — docs / attach & share. The commands that get media onto
 // GitHub or a URL: attach (managed PR/issue comment), put (any file → URL),
-// and screenshot (render + host in one step).
+// screenshot (render + host), and annotate (callouts/redactions on a shot).
 import DocsLayout from "../../layouts/DocsLayout.astro";
 
 const TOC = [
@@ -10,15 +10,16 @@ const TOC = [
   { id: "before-after", label: "Pair a before and after" },
   { id: "put", label: "Get a URL for any file" },
   { id: "screenshot", label: "Capture a screenshot" },
+  { id: "annotate", label: "Annotate a screenshot" },
 ];
 ---
 
 <DocsLayout
   title="Attach & share"
-  description="Attach screenshots and video to GitHub PRs and issues, get a public URL for any file, and capture a screenshot in one step with the uploads CLI."
+  description="Attach screenshots and video to GitHub PRs and issues, get a public URL for any file, capture a screenshot, and bake callouts or redactions onto it with the uploads CLI."
   path="/docs/attach-pull-request-images"
   heading="Attach & share"
-  tagline="The three commands that get media onto a PR, an issue, or a plain URL."
+  tagline="The commands that get media onto a PR, an issue, or a plain URL — capture, annotate, and attach."
   active="attach"
   toc={TOC}
 >
@@ -333,6 +334,54 @@ MARKDOWN: ![app.example](https://storage.uploads.sh/gh/app/example/pull/123/app.
       settle animations. Hide any other overlay with <code>--hide &lt;selector&gt;</code>
       (repeatable), or run setup JS first with <code>--eval &lt;js&gt;</code> /
       <code>--init-script &lt;file&gt;</code> (local backend).
+    </p>
+  </section>
+
+  <section id="annotate">
+    <h2>Annotate a screenshot <a class="anchor" href="#annotate" aria-label="Link to this section">#</a></h2>
+    <p>
+      Point reviewers at what changed — boxes, arrows, labels, freeform strokes,
+      and redactions bake into the image before it is hosted. Two entry points,
+      same JSON spec:
+    </p>
+    <div class="cmd">
+      <span class="text">uploads screenshot http://localhost:4321/settings --via local --annotate ./callouts.json</span>
+      <button type="button" data-copy="uploads screenshot http://localhost:4321/settings --via local --annotate ./callouts.json" aria-live="polite">copy</button>
+    </div>
+    <div class="cmd">
+      <span class="text">uploads annotate ./shot.png --spec ./callouts.json --out ./shot.marked.png</span>
+      <button type="button" data-copy="uploads annotate ./shot.png --spec ./callouts.json --out ./shot.marked.png" aria-live="polite">copy</button>
+    </div>
+    <p>
+      Prefer <code>screenshot --annotate</code> when you control the page: CSS
+      selectors resolve against the live DOM (local capture backend only in v1 —
+      remote rejects selector-bearing specs). Use <code>annotate</code> on an
+      image you already have — pixel coordinates only, no selectors.
+    </p>
+    <p>A minimal callouts file:</p>
+    <div class="block" aria-label="Annotation spec example">
+      <pre>{
+  "version": 1,
+  "annotations": [
+    { "type": "box", "selector": "#save-button" },
+    { "type": "label", "text": "New: bulk save", "selector": "#save-button" },
+    { "type": "redact", "selector": "[data-testid=api-key]", "style": "solid" }
+  ]
+}</pre>
+    </div>
+    <p>
+      Annotation types: <code>box</code>, <code>arrow</code>, <code>label</code>,
+      <code>draw</code>, <code>redact</code>, and <code>svg</code>. House style is
+      fixed (hand-drawn stroke); optional per-annotation <code>color</code> is
+      the only style knob. Use <code>redact</code> with <code>style: "solid"</code>
+      for secrets — hosted files are public, and blurred text can be recoverable.
+    </p>
+    <p>
+      Full spec format, selector vs pixel rules, and workflow notes live in the&#32;
+      <a href="https://github.com/buildinternet/uploads/blob/main/skills/annotate-screenshots/SKILL.md">annotate-screenshots</a>&#32;
+      agent skill (<code>uploads install</code> or&#32;
+      <code>npx skills add buildinternet/uploads</code>). See also&#32;
+      <code>uploads annotate --help</code> and <code>uploads screenshot --help</code>.
     </p>
   </section>
 

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -43,7 +43,10 @@ const REPO = "https://github.com/buildinternet/uploads";
     <ul>
       <li>
         <strong>Hosted files are public.</strong> Anyone with the URL can view them, even
-        media attached to private repositories. Don't upload secrets or sensitive UI.
+        media attached to private repositories. Don't upload secrets or sensitive UI —
+        if a capture shows credentials, solid-redact them first with&#32;
+        <a href="/docs/attach-pull-request-images#annotate"><code>uploads annotate</code></a>&#32;
+        or <code>screenshot --annotate</code> (blurred text can be recoverable).
       </li>
       <li>
         <strong>The visibility toggle unlists — it doesn't lock down bytes.</strong> Marking a

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -34,11 +34,15 @@ const FAQ = [
 	},
 	{
 		q: "How do I set up Claude Code to attach screenshots to its pull requests?",
-		a: "Run `uploads install` once. It installs the uploads-cli agent skill and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads attach <files>` on its own when it changes something visual.",
+		a: "Run `uploads install` once. It installs the agent skills (attach workflow, CLI reference, and annotations) and registers the hosted MCP server with Claude Code. After that, the agent runs `uploads attach <files>` on its own when it changes something visual.",
+	},
+	{
+		q: "Can I mark up a screenshot before attaching it?",
+		a: "Yes. `uploads screenshot --annotate` bakes boxes, arrows, labels, freeform strokes, and redactions into a capture (CSS selectors on a live page). `uploads annotate` does the same on an existing image with pixel coordinates. See the Attach & share docs and the annotate-screenshots skill.",
 	},
 	{
 		q: "Are uploaded files private?",
-		a: "No. Files are public to anyone with the URL, even media attached to private repos. Don't upload secrets or sensitive UI. Uploading itself requires an invite-issued workspace token.",
+		a: "No. Files are public to anyone with the URL, even media attached to private repos. Don't upload secrets or sensitive UI — use a solid redaction (`uploads annotate` / `screenshot --annotate`) when a capture shows credentials. Uploading itself requires an invite-issued workspace token.",
 	},
 ];
 
@@ -114,8 +118,8 @@ const FAQ_JSON_LD = JSON.stringify({
     </div>
     <ul>
       <li>
-        The <strong>agent skill</strong> teaches the agent when to attach screenshots,
-        like before/after shots on a PR it just opened.
+        The <strong>agent skills</strong> teach when to attach screenshots (and when to
+        annotate them with callouts or redactions), plus the full CLI reference.
       </li>
       <li>
         The <strong>MCP server</strong> offers the same tools
@@ -125,8 +129,8 @@ const FAQ_JSON_LD = JSON.stringify({
     </ul>
     <p>Or set up each piece yourself, for other agent runtimes:</p>
     <div class="cmd">
-      <span class="text">npx skills add buildinternet/uploads --skill uploads-cli</span>
-      <button type="button" data-copy="npx skills add buildinternet/uploads --skill uploads-cli" aria-live="polite">copy</button>
+      <span class="text">npx skills add buildinternet/uploads</span>
+      <button type="button" data-copy="npx skills add buildinternet/uploads" aria-live="polite">copy</button>
     </div>
     <div class="cmd">
       <span class="text">claude mcp add --transport http uploads <span class="url">https://agents.uploads.sh/mcp</span></span>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -25,10 +25,11 @@ uploads.sh is the missing upload command for coding agents: one CLI that hosts s
 Setup:
 1. Install the CLI: npm install -g @buildinternet/uploads
 2. Authenticate: uploads login (opens a browser sign-in — wait for me to approve it)
-3. Wire it into you: uploads install (adds the agent skill + MCP server so future sessions know how to use it)
+3. Wire it into you: uploads install (adds the agent skills + MCP server so future sessions know how to use it)
 
 Then get the staged loop working end to end:
 - While you're still working, before there's a PR, capture a screenshot at each visual milestone and run uploads put <file> --state before (or --state after). On a branch, a bare put stages it automatically — no --branch flag, no PR needed yet. uploads screenshot <url> captures and hosts in one step if that's easier.
+- Need to point at what changed? uploads screenshot <url> --via local --annotate ./callouts.json bakes boxes, arrows, labels, or solid redactions into the capture (or uploads annotate on an existing image).
 - Check what's queued anytime with uploads staged.
 - Open the PR (gh pr create or the GitHub UI) and the staged files promote automatically — the single attachments comment appears with no extra upload command at PR time.
 - Already have an open PR or issue to target directly instead? uploads attach <files> does that immediately.
@@ -634,6 +635,14 @@ Source (and where to look if something breaks): https://github.com/buildinternet
             </p>
           </div>
           <div class="feature">
+            <h3>annotations</h3>
+            <p>
+              Bake hand-drawn boxes, arrows, labels, and solid redactions into a capture with&#32;
+              <code>screenshot --annotate</code> or <code>uploads annotate</code> — so reviewers
+              see what changed without hunting.
+            </p>
+          </div>
+          <div class="feature">
             <h3>shareable galleries</h3>
             <p>
               Group uploads into a gallery that can live across multiple PRs — one link for the
@@ -653,7 +662,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           </div>
           <div class="cmdrow">
             <span class="tag">agents</span>
-            <span class="cmdtext">uploads install <span class="comment"># skill + mcp</span></span>
+            <span class="cmdtext">uploads install <span class="comment"># skills + mcp</span></span>
             <button type="button" data-copy="uploads install" aria-live="polite">copy</button>
           </div>
           <div class="cmdrow">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,25 +61,27 @@ command to run by hand, rather than overwriting your build.
 
 ## Command overview
 
-| Command                 | What it does                                                            |
-| ----------------------- | ----------------------------------------------------------------------- |
-| `attach <file…>`        | Attach media to the current PR (stable URLs + comment)                  |
-| `put <file>`            | Upload one file → public URL + GitHub markdown                          |
-| `comment`               | Create/update a PR/issue attachments comment (via `gh`)                 |
-| `list` / `find k=v`     | List objects, optionally filtered by queryable metadata                 |
-| `meta get` / `meta set` | Read or merge-set an object's queryable metadata                        |
-| `gallery …`             | Create and organize public media galleries                              |
-| `delete <key>`          | Delete an object                                                        |
-| `usage`                 | Workspace storage / upload counters                                     |
-| `install`               | Skills + remote MCP + hooks (Grok/Cursor); see plugins for Claude/Codex |
-| `hook`                  | Agent harness handlers (e.g. pre-PR screenshot reminder)                |
-| `update`                | Update the CLI, then refresh skills / MCP / hooks                       |
-| `login` / `logout`      | Sign in (browser or enrollment code) / clear saved token                |
-| `whoami` (`status`)     | Show the active workspace and token                                     |
-| `invite`                | Invite a teammate to a workspace (workspace admin)                      |
-| `doctor` / `health`     | Health + auth + workspace checks / API liveness                         |
-| `setup` / `config`      | Inspect and configure CLI settings                                      |
-| `mcp`                   | Serve MCP over stdio (tools mirror the CLI)                             |
+| Command                  | What it does                                                            |
+| ------------------------ | ----------------------------------------------------------------------- |
+| `attach <file…>`         | Attach media to the current PR (stable URLs + comment)                  |
+| `put <file>`             | Upload one file → public URL + GitHub markdown                          |
+| `screenshot <url\|html>` | Capture a page (or local HTML) and host it in one step                  |
+| `annotate <image>`       | Bake boxes, arrows, labels, strokes, and redactions onto an image       |
+| `comment`                | Create/update a PR/issue attachments comment (via `gh`)                 |
+| `list` / `find k=v`      | List objects, optionally filtered by queryable metadata                 |
+| `meta get` / `meta set`  | Read or merge-set an object's queryable metadata                        |
+| `gallery …`              | Create and organize public media galleries                              |
+| `delete <key>`           | Delete an object                                                        |
+| `usage`                  | Workspace storage / upload counters                                     |
+| `install`                | Skills + remote MCP + hooks (Grok/Cursor); see plugins for Claude/Codex |
+| `hook`                   | Agent harness handlers (e.g. pre-PR screenshot reminder)                |
+| `update`                 | Update the CLI, then refresh skills / MCP / hooks                       |
+| `login` / `logout`       | Sign in (browser or enrollment code) / clear saved token                |
+| `whoami` (`status`)      | Show the active workspace and token                                     |
+| `invite`                 | Invite a teammate to a workspace (workspace admin)                      |
+| `doctor` / `health`      | Health + auth + workspace checks / API liveness                         |
+| `setup` / `config`       | Inspect and configure CLI settings                                      |
+| `mcp`                    | Serve MCP over stdio (tools mirror the CLI)                             |
 
 Run `uploads <command> --help` for a command's flags.
 
@@ -156,6 +158,32 @@ exists` without writing.
 > (`gh/myorg/myapp/pull/123/after.png`), so generic names are easier to guess
 > than hashed keys. Treat uploads as public; don't host secrets or sensitive UI.
 > Tighter access controls for private repos are planned — see [roadmap](roadmap.md).
+
+## Annotating screenshots
+
+Bake hand-drawn callouts into a capture so reviewers see what changed without
+hunting through the image. Two commands share one JSON spec format:
+
+```bash
+# Capture and annotate in one pass (CSS selectors resolve on the live page;
+# local capture backend only for selector-bearing specs)
+uploads screenshot http://localhost:3000 --via local --annotate ./callouts.json
+
+# Annotate an existing PNG/JPEG (pixel coordinates only — no selectors)
+uploads annotate ./shot.png --spec ./callouts.json --out ./shot.marked.png
+```
+
+A spec is `{ "version": 1, "annotations": [ … ] }`. Supported types: `box`,
+`arrow`, `label`, `draw`, `redact`, and `svg`. Prefer selectors with
+`screenshot --annotate` whenever a live page is available; fall back to pixel
+geometry with `annotate` when you only have the image. Use `redact` with
+`style: "solid"` for secrets before anything is uploaded — hosted URLs are
+public.
+
+Full format, worked examples, and redaction guidance:
+[`skills/annotate-screenshots/SKILL.md`](../skills/annotate-screenshots/SKILL.md).
+Public walkthrough:
+[uploads.sh/docs/attach-pull-request-images#annotate](https://uploads.sh/docs/attach-pull-request-images#annotate).
 
 ## Custom metadata
 
@@ -249,7 +277,10 @@ npx skills add buildinternet/uploads
 [`skills/github-screenshots/SKILL.md`](../skills/github-screenshots/SKILL.md) is
 the workflow skill — screenshots and recordings into PRs and issues.
 [`skills/uploads-cli/SKILL.md`](../skills/uploads-cli/SKILL.md) is the full CLI
-reference it defers to. See [api.md](api.md) for the REST routes.
+reference it defers to.
+[`skills/annotate-screenshots/SKILL.md`](../skills/annotate-screenshots/SKILL.md)
+covers callouts and redaction (`uploads annotate` /
+`uploads screenshot --annotate`). See [api.md](api.md) for the REST routes.
 
 The same install step also wires a fail-open pre-PR screenshot reminder for
 **Grok** and **Cursor** when those tools are present. **Claude Code** and

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -17,6 +17,8 @@ uploads --version
 uploads attach ./before.png ./after.png
 uploads screenshot https://app.example --pr 123 --comment   # capture + host in one step
 uploads screenshot ./report.html --dark --selector "main"
+uploads screenshot http://localhost:3000 --via local --annotate ./callouts.json
+uploads annotate ./shot.png --spec ./callouts.json --out ./shot.marked.png
 uploads put ./shot.png
 uploads put ./shot.png --destination screenshots
 uploads put ./shot.png --no-optimize

--- a/plugins/claude/uploads/README.md
+++ b/plugins/claude/uploads/README.md
@@ -6,13 +6,14 @@ with `source: "./"`, so the whole repo is a one-plugin marketplace.
 
 ## What it bundles
 
-| Component                   | Invocation                    | Purpose                                                                     |
-| --------------------------- | ----------------------------- | --------------------------------------------------------------------------- |
-| github-screenshots skill    | `/uploads:github-screenshots` | Capture + host + embed a visual in a PR/issue                               |
-| uploads-cli skill           | `/uploads:uploads-cli`        | Full `uploads` CLI reference                                                |
-| attach command              | `/uploads:attach`             | Explicit host / attach entry point                                          |
-| uploads MCP server          | (tools)                       | Hosted `https://agents.uploads.sh/mcp`                                      |
-| PR screenshot reminder hook | (automatic)                   | Advisory nudge before `gh pr create` on a UI-touching branch with no stages |
+| Component                   | Invocation                      | Purpose                                                                     |
+| --------------------------- | ------------------------------- | --------------------------------------------------------------------------- |
+| github-screenshots skill    | `/uploads:github-screenshots`   | Capture + host + embed a visual in a PR/issue                               |
+| annotate-screenshots skill  | `/uploads:annotate-screenshots` | Bake boxes, arrows, labels, and redactions onto a capture                   |
+| uploads-cli skill           | `/uploads:uploads-cli`          | Full `uploads` CLI reference                                                |
+| attach command              | `/uploads:attach`               | Explicit host / attach entry point                                          |
+| uploads MCP server          | (tools)                         | Hosted `https://agents.uploads.sh/mcp`                                      |
+| PR screenshot reminder hook | (automatic)                     | Advisory nudge before `gh pr create` on a UI-touching branch with no stages |
 
 Plugin skills and commands are namespaced (`/uploads:…`).
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -4,8 +4,8 @@
   "groupings": [
     {
       "title": "GitHub screenshots & file hosting",
-      "description": "Start with github-screenshots — it gets screenshots, GIFs, and recordings into PRs and issues. uploads-cli is the full CLI reference it defers to.",
-      "skills": ["github-screenshots", "uploads-cli"]
+      "description": "Start with github-screenshots — it gets screenshots, GIFs, and recordings into PRs and issues. annotate-screenshots bakes callouts and redactions onto a capture; uploads-cli is the full CLI reference the others defer to.",
+      "skills": ["github-screenshots", "annotate-screenshots", "uploads-cli"]
     }
   ]
 }


### PR DESCRIPTION
## In plain terms

Screenshot annotations (`uploads annotate` / `screenshot --annotate`) already ship in the CLI and the annotate-screenshots skill, but most public surfaces still described a two-skill product and never mentioned callouts or redaction. This PR documents the feature where people discover it and registers the third skill in the Claude and Codex plugins.

## What it does / what it is not

- Adds an **Annotate a screenshot** section on the Attach & share docs page (examples, selector vs pixel, sample JSON, solid redaction note).
- Documents annotate in `docs/cli.md`, the root README, package README examples, `llms.txt`, and the landing-page “what else it does” grid.
- Updates agents/walkthrough/reference copy so skill install wording matches all three skills.
- Ships `annotate-screenshots` from the Claude marketplace and Codex plugin manifests (install already included it).
- Marks annotations as shipped in `VISION.md` (automatic redaction remains roadmap).
- Does **not** change CLI behavior, the annotation renderer, or the API.

## How to try it

```bash
# already shipped — docs only point here
uploads screenshot http://localhost:4321 --via local --annotate ./callouts.json
uploads annotate ./shot.png --spec ./callouts.json --out ./shot.marked.png
```

Browse `/docs/attach-pull-request-images#annotate` after the web deploy, or read the skill at `skills/annotate-screenshots/SKILL.md`.

## Technical notes

Full annotation format stays in the agent skill (same design as before). Public pages stay short and link out for the complete contract.

## Test plan

- [x] Pre-commit types + lint-staged clean
- [ ] Spot-check Attach & share annotate section and home “annotations” tile after web deploy
- [ ] Confirm Claude/Codex plugin skill lists include annotate-screenshots after install refresh