### PR TITLE
feat(cli): note missing GitHub App on gh-fallback comments

### DIFF
--- a/.changeset/gh-fallback-author-note.md
+++ b/.changeset/gh-fallback-author-note.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+When the managed attachments comment falls back to local `gh` (posted under your GitHub account instead of the uploads-sh bot), the comment footer notes that the GitHub App hasn't been installed for the repo yet, with a link to install it.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -43,6 +43,7 @@ import {
   ghMetadataForBranch,
   attachmentsCommentBody,
   attachmentsMarker,
+  GH_FALLBACK_AUTHOR_NOTE,
   type GhTarget,
   type AttachmentItem,
   type GalleryCommentItem,
@@ -786,7 +787,9 @@ export async function syncAttachmentsComment(
   );
 
   const marker = attachmentsMarker(workspace);
-  const body = attachmentsCommentBody(items, previewGalleries, marker);
+  // Append only on the local-gh path: bot posts already carry the uploads-sh
+  // bot identity, so this note would be wrong there.
+  const body = `${attachmentsCommentBody(items, previewGalleries, marker)}\n${GH_FALLBACK_AUTHOR_NOTE}`;
   const count = items.length + previewGalleries.length;
   // Empty (count 0) renders the neutral empty-state body but must not create a
   // comment — it only rewrites one that already exists (`action: "skipped"`

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -597,3 +597,10 @@ export function attachmentsCommentBody(
   );
   return lines.join("\n");
 }
+
+/**
+ * Extra footer line appended only on the local-`gh` fallback path (never on
+ * bot-authored comments). Short note that the App isn't on this repo yet.
+ */
+export const GH_FALLBACK_AUTHOR_NOTE =
+  '<sub><a href="https://github.com/apps/uploads-sh">Install the uploads GitHub App</a> for bot-managed comments.</sub>';

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -88,6 +88,7 @@ export {
 export {
   ATTACHMENTS_MARKER,
   attachmentsCommentBody,
+  GH_FALLBACK_AUTHOR_NOTE,
   ghAttachmentKey,
   ghKeyPrefix,
   ghMetadataFromTarget,

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -7,7 +7,7 @@ import {
   syncAttachmentsComment,
   type CliContext,
 } from "../src/commands.js";
-import { ATTACHMENTS_MARKER, attachmentsMarker } from "../src/github.js";
+import { ATTACHMENTS_MARKER, attachmentsMarker, GH_FALLBACK_AUTHOR_NOTE } from "../src/github.js";
 import type { CommandRunner } from "../src/github-gh.js";
 
 function listClient(
@@ -121,6 +121,23 @@ describe("runComment", () => {
     // uses the namespaced marker (phase 4b).
     expect(create!.input).toContain(attachmentsMarker("test"));
     expect(create!.input).toContain("after.png");
+    // Gh-fallback only: explain why the comment is under a human account.
+    expect(create!.input).toContain(GH_FALLBACK_AUTHOR_NOTE);
+  });
+
+  it("does not append the gh-author note when the bot posts successfully", async () => {
+    const { run, calls } = ghRunner();
+    const client = fakeClient({
+      upsertGithubComment: async () => ({
+        posted: true,
+        action: "created",
+        count: 1,
+      }),
+    });
+    await runComment(ctxWith(client), ["--pr", "5", "--repo", "o/r"], false, run);
+    // Bot path never touches local gh, so no create/patch body is recorded.
+    expect(calls.some((c) => c.args.includes("repos/o/r/issues/5/comments"))).toBe(false);
+    expect(calls.some((c) => c.args.includes("PATCH"))).toBe(false);
   });
 
   it("no-ops (no create) via gh when there are no attachments and no comment exists", async () => {


### PR DESCRIPTION
## Problem

When the GitHub App isn't installed, the managed attachments comment falls back to local `gh` and posts under the human's account. Nothing in that comment explains that the App is missing or how to get bot-managed comments.

## Solution

On the local-`gh` path only, append a one-line footer:

> [Install the uploads GitHub App](https://github.com/apps/uploads-sh) for bot-managed comments.

Bot-authored comments are unchanged — the note would be wrong there.

## How to try it

```bash
# Without the App installed on a repo, any comment sync that falls through to gh:
uploads attach ./shot.png --pr <N> --comment
# or
uploads comment --pr <N>
```

Check the managed attachments comment footer for the install line. With the App installed (bot path), the line must not appear.

## Test plan

- [x] `pnpm --filter @buildinternet/uploads exec vitest run test/commands-comment.test.ts`
- [x] Gh-fallback create includes `GH_FALLBACK_AUTHOR_NOTE`
- [x] Bot success path never hits local `gh` (no note)
- [ ] Manual: attach/comment on a repo without the App; confirm footer + link
- [ ] Manual: same with App installed; footer has no install line

## Risks / follow-ups

- Soft CTA only — no behavior change for bot posts or golden comment bodies.
- Patch changeset included for `@buildinternet/uploads`.