### PR TITLE
fix(cli): clearer uploads install errors when npx/npm/claude are missing

### DIFF
--- a/.changeset/install-missing-tooling-errors.md
+++ b/.changeset/install-missing-tooling-errors.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`uploads install` handles missing or too-old Node tooling more clearly: one `npx`/`npm` preflight before skill steps, identical failures collapsed to a single `skills:` line, and install guidance (Node 22+ / npm 7+, Claude Code) instead of "run manually: npx …" when the binary is missing. On Windows, `execFile` retries via the shell so npm `.cmd` shims resolve instead of reporting ENOENT.

--- a/packages/uploads/src/commands/install.ts
+++ b/packages/uploads/src/commands/install.ts
@@ -41,9 +41,11 @@ What it does:
 
 What runs under the hood:
   skill   npx -y skills add ${SKILL_SOURCE} --skill <name> -g -y -a '*'
-          (once per skill: ${SKILL_NAMES.join(", ")})
+          (once per skill: ${SKILL_NAMES.join(", ")}; needs Node 22+ / npm 7+
+          with npx on PATH — missing tooling fails once with install guidance)
   mcp     claude mcp add --transport http uploads ${DEFAULT_MCP_URL} \\
             --header "Authorization: Bearer <token>"
+          (needs the Claude Code CLI on PATH)
   hooks   write/merge ~/.grok/hooks/… and ~/.cursor/hooks.json when present
 
 Options:
@@ -68,6 +70,9 @@ export interface StepResult {
   output?: string;
 }
 
+/** npm 7+ for `npx -y`. Node 22 ships npm 10+; this catches ancient/system npm. */
+export const MIN_NPM_MAJOR_FOR_SKILLS = 7;
+
 /** Mask Bearer credentials and the configured token in any printed text. */
 function redactor(token: string | undefined): (text: string) => string {
   return (text) => {
@@ -77,17 +82,73 @@ function redactor(token: string | undefined): (text: string) => string {
   };
 }
 
+function isEnoent(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
+/** Install guidance when a host binary is missing (not "run manually: <same binary>"). */
+export function missingBinaryHint(binary: string): string {
+  switch (binary) {
+    case "npx":
+    case "npm":
+      return (
+        `${binary} not found on PATH — skill install needs Node.js (npm includes npx). ` +
+        `Install Node 22+ from https://nodejs.org (or your package manager), open a new shell, ` +
+        `confirm \`${binary} --version\` works, then re-run \`uploads install skill\`.`
+      );
+    case "claude":
+      return (
+        `claude not found on PATH — MCP install needs the Claude Code CLI. ` +
+        `Install it from https://docs.anthropic.com/en/docs/claude-code, ensure \`claude\` is on PATH, ` +
+        `then re-run \`uploads install mcp\`. Skills and hooks still work without Claude Code.`
+      );
+    default:
+      return `${binary} not found on PATH — install it and ensure it is available in this shell.`;
+  }
+}
+
+export function npmTooOldHint(version: string): string {
+  return (
+    `npm ${version} is too old for skill install (need npm ${MIN_NPM_MAJOR_FOR_SKILLS}+ for \`npx -y\`). ` +
+    `Upgrade Node/npm (Node 22+ recommended: https://nodejs.org), confirm \`npm --version\`, ` +
+    `then re-run \`uploads install skill\`.`
+  );
+}
+
+/**
+ * Probe npx/npm once before the per-skill loop. Returns an error string when
+ * tooling is missing/too old; undefined means skill steps should proceed.
+ * Non-ENOENT npx failures are left for the real `skills add` to surface.
+ */
+export function probeSkillTooling(run: CommandRunner): string | undefined {
+  try {
+    run("npx", ["--version"]);
+  } catch (err) {
+    return isEnoent(err) ? missingBinaryHint("npx") : undefined;
+  }
+  try {
+    const out = run("npm", ["--version"]).trim();
+    const major = Number.parseInt(out.split(".")[0] ?? "", 10);
+    if (Number.isFinite(major) && major < MIN_NPM_MAJOR_FOR_SKILLS) {
+      return npmTooOldHint(out);
+    }
+  } catch (err) {
+    if (isEnoent(err)) return missingBinaryHint("npm");
+  }
+  return undefined;
+}
+
 export function runStep(run: CommandRunner, command: string[]): StepResult {
   try {
     const output = run(command[0], command.slice(1)).trim();
     return { command, ok: true, output: output || undefined };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const hint =
-      (err as NodeJS.ErrnoException).code === "ENOENT"
-        ? `${command[0]} not found on PATH — install it, or run manually: ${command.join(" ")}`
-        : message;
-    return { command, ok: false, error: hint };
+    return {
+      command,
+      ok: false,
+      error: isEnoent(err) ? missingBinaryHint(command[0]) : message,
+    };
   }
 }
 
@@ -136,32 +197,70 @@ function peekToken(globals: GlobalFlags): string | undefined {
   }
 }
 
+function printOneHumanStep(
+  step: string,
+  r: StepResult,
+  redact: (s: string) => string,
+  verbose: boolean,
+  mcpName: string,
+): void {
+  const cmd = redact(r.command.join(" "));
+  if (r.skipped === "dry-run") {
+    process.stdout.write(`${step}: would run — ${cmd}\n`);
+  } else if (r.skipped === "sign-in") {
+    process.stdout.write(`${step}: skipped — ${redact(r.error ?? "needs sign-in")}\n`);
+  } else if (r.skipped === "already-configured") {
+    process.stdout.write(
+      `${step}: already configured — "${mcpName}" is registered in Claude Code (nothing to do)\n` +
+        `  To re-register (e.g. with a new token): claude mcp remove ${mcpName} && uploads install mcp\n`,
+    );
+  } else if (r.ok) {
+    process.stdout.write(`${step}: ok\n`);
+    if (verbose && r.output) {
+      process.stdout.write(`  ${redact(r.output).split("\n").join("\n  ")}\n`);
+    }
+  } else {
+    process.stderr.write(`${step}: failed — ${redact(r.error ?? "")}\n`);
+    if (verbose) process.stderr.write(`  command: ${cmd}\n`);
+  }
+}
+
+/** Shared error when every skill step failed identically; otherwise undefined. */
+function identicalSkillFailure(skillEntries: [string, StepResult][]): string | undefined {
+  if (skillEntries.length < 2) return undefined;
+  const error = skillEntries[0]?.[1].error;
+  if (!error) return undefined;
+  const allSame = skillEntries.every(([, r]) => !r.ok && !r.skipped && r.error === error);
+  return allSame ? error : undefined;
+}
+
+/** Collapse identical skill failures to one `skills:` line (missing npx, old npm, …). */
 function printHumanSteps(
   results: Record<string, StepResult>,
   redact: (s: string) => string,
   verbose: boolean,
   mcpName: string,
 ): void {
-  for (const [step, r] of Object.entries(results)) {
-    const cmd = redact(r.command.join(" "));
-    if (r.skipped === "dry-run") {
-      process.stdout.write(`${step}: would run — ${cmd}\n`);
-    } else if (r.skipped === "sign-in") {
-      process.stdout.write(`${step}: skipped — ${redact(r.error ?? "needs sign-in")}\n`);
-    } else if (r.skipped === "already-configured") {
-      process.stdout.write(
-        `${step}: already configured — "${mcpName}" is registered in Claude Code (nothing to do)\n` +
-          `  To re-register (e.g. with a new token): claude mcp remove ${mcpName} && uploads install mcp\n`,
-      );
-    } else if (r.ok) {
-      process.stdout.write(`${step}: ok\n`);
-      if (verbose && r.output) {
-        process.stdout.write(`  ${redact(r.output).split("\n").join("\n  ")}\n`);
+  const entries = Object.entries(results);
+  const skillEntries = entries.filter(([step]) => step.startsWith("skill:"));
+  const sharedError = identicalSkillFailure(skillEntries);
+
+  if (sharedError !== undefined) {
+    process.stderr.write(`skills: failed — ${redact(sharedError)}\n`);
+    if (verbose) {
+      for (const [step, r] of skillEntries) {
+        process.stderr.write(`  ${step}: ${redact(r.command.join(" "))}\n`);
       }
-    } else {
-      process.stderr.write(`${step}: failed — ${redact(r.error ?? "")}\n`);
-      if (verbose) process.stderr.write(`  command: ${cmd}\n`);
     }
+  } else {
+    for (const [step, r] of skillEntries) {
+      printOneHumanStep(step, r, redact, verbose, mcpName);
+    }
+  }
+
+  for (const [step, r] of entries) {
+    if (step.startsWith("skill:")) continue;
+    printOneHumanStep(step, r, redact, verbose, mcpName);
   }
 }
 
@@ -230,11 +329,16 @@ export async function runInstall(
 
   if (target === "skill" || target === "all") {
     if (human) process.stdout.write("Installing skills…\n");
+    const toolingError = dryRun ? undefined : probeSkillTooling(run);
     for (const skill of SKILL_NAMES) {
       const command = skillCommand(skill);
-      results[`skill:${skill}`] = dryRun
-        ? { command, ok: true, skipped: "dry-run" }
-        : runStep(run, command);
+      if (dryRun) {
+        results[`skill:${skill}`] = { command, ok: true, skipped: "dry-run" };
+      } else if (toolingError) {
+        results[`skill:${skill}`] = { command, ok: false, error: toolingError };
+      } else {
+        results[`skill:${skill}`] = runStep(run, command);
+      }
     }
   }
 
@@ -314,15 +418,26 @@ export async function runInstall(
     ];
     printSuccessFooter(stepLabels, signedIn);
   } else if (failed && !dryRun && skillsOk && results.mcp && !results.mcp.ok) {
-    const next =
-      results.mcp.skipped === "sign-in"
-        ? "Sign in with `uploads login`, then re-run `uploads install mcp`."
-        : "Fix the MCP step above, then re-run `uploads install mcp`.";
+    let next: string;
+    if (results.mcp.skipped === "sign-in") {
+      next = "Sign in with `uploads login`, then re-run `uploads install mcp`.";
+    } else if (results.mcp.error?.includes("not found on PATH")) {
+      next = "Install the Claude Code CLI (or skip MCP), then re-run `uploads install mcp`.";
+    } else {
+      next = "Fix the MCP step above, then re-run `uploads install mcp`.";
+    }
     process.stdout.write(`\nSkills are installed. ${next}\n`);
   } else if (failed && !dryRun && skillsFailed) {
-    // Mixed or total skill failure used to print only per-step lines (#191).
+    // Closing guidance when skills fail (issue #191: used to be per-step only).
+    const skillErrText = skillResults.map((r) => r.error ?? "").join("\n");
+    const toolingMissing = /npx not found|npm not found|too old for skill install/i.test(
+      skillErrText,
+    );
     process.stdout.write(
-      "\nSkill install incomplete. Fix the errors above, then re-run `uploads install skill`.\n",
+      toolingMissing
+        ? "\nSkill install needs a working Node.js toolchain (npx + npm 7+ on PATH). " +
+            "Fix that, then re-run `uploads install skill`.\n"
+        : "\nSkill install incomplete. Fix the errors above, then re-run `uploads install skill`.\n",
     );
   }
 

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -12,8 +12,34 @@ import { META_VALUE_MAX, isMetaValueSafe } from "./metadata.js";
 /** Runs a command and returns stdout; throws on non-zero exit. Injectable for tests. */
 export type CommandRunner = (cmd: string, args: string[], input?: string) => string;
 
+type ExecFileOpts = {
+  encoding: "utf8";
+  input?: string;
+  stdio: ["pipe", "pipe", "pipe"];
+  timeout?: number;
+};
+
+/**
+ * Windows npm shims are `.cmd`/`.bat`; bare `execFileSync` ENOENTs them.
+ * Retry once with `shell: true` so PATHEXT resolves the shim. Other platforms
+ * and non-ENOENT errors stay on the no-shell path. Args are from our CLI, not
+ * free-form shell strings.
+ */
+function execFileSyncCompat(cmd: string, args: string[], opts: ExecFileOpts): string {
+  try {
+    return execFileSync(cmd, args, opts);
+  } catch (err) {
+    const isWinShim =
+      process.platform === "win32" &&
+      (err as NodeJS.ErrnoException).code === "ENOENT" &&
+      !/\.(cmd|bat|exe|com)$/i.test(cmd);
+    if (isWinShim) return execFileSync(cmd, args, { ...opts, shell: true });
+    throw err;
+  }
+}
+
 export const execRunner: CommandRunner = (cmd, args, input) =>
-  execFileSync(cmd, args, { encoding: "utf8", input, stdio: ["pipe", "pipe", "pipe"] });
+  execFileSyncCompat(cmd, args, { encoding: "utf8", input, stdio: ["pipe", "pipe", "pipe"] });
 
 /**
  * A `CommandRunner` bounded by `timeoutMs` (node's native `execFileSync`
@@ -25,7 +51,7 @@ export const execRunner: CommandRunner = (cmd, args, input) =>
 export const timedExecRunner =
   (timeoutMs: number): CommandRunner =>
   (cmd, args, input) =>
-    execFileSync(cmd, args, {
+    execFileSyncCompat(cmd, args, {
       encoding: "utf8",
       input,
       stdio: ["pipe", "pipe", "pipe"],

--- a/packages/uploads/test/commands-update.test.ts
+++ b/packages/uploads/test/commands-update.test.ts
@@ -81,8 +81,8 @@ describe("uploads update", () => {
     });
     expect(code).toBe(0);
     expect(out.join("")).toMatch(/CLI already at 0\.10\.0/);
-    expect(calls.some((c) => c[0] === "npm")).toBe(false);
-    // In-process runInstall reaches the same runner with the install steps.
+    // Skill preflight may call `npm --version`; only the package upgrade is forbidden.
+    expect(calls.some((c) => c[0] === "npm" && c.includes("install"))).toBe(false);
     expect(calls.some((c) => c[0] === "npx" && c.includes("skills"))).toBe(true);
     expect(calls).not.toContainEqual(["uploads", "install"]);
   });
@@ -113,7 +113,8 @@ describe("uploads update", () => {
       check: outdated,
     });
     expect(code).toBe(0);
-    expect(calls.some((c) => c[0] === "npm")).toBe(false);
+    // No package upgrade when the source isn't a global install.
+    expect(calls.some((c) => c[0] === "npm" && c.includes("install"))).toBe(false);
     expect(out.join("")).toMatch(/workspace checkout/);
   });
 

--- a/packages/uploads/test/install.test.ts
+++ b/packages/uploads/test/install.test.ts
@@ -3,15 +3,41 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommandRunner } from "../src/github-gh.js";
-import { runInstall, DEFAULT_MCP_URL } from "../src/commands/install.js";
+import {
+  runInstall,
+  DEFAULT_MCP_URL,
+  missingBinaryHint,
+  npmTooOldHint,
+  probeSkillTooling,
+} from "../src/commands/install.js";
+
+/** Answer skill preflight version checks so custom runners reach `skills add`. */
+function skillProbeOk(cmd: string, args: string[]): string | undefined {
+  if (cmd === "npx" && args[0] === "--version") return "10.9.0\n";
+  if (cmd === "npm" && args[0] === "--version") return "10.9.0\n";
+  return undefined;
+}
+
+function makeEnoent(message: string): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
 
 function fakeRunner() {
   const calls: string[][] = [];
   const run: CommandRunner = (cmd, args) => {
     calls.push([cmd, ...args]);
-    return "installed\nwith multi-line child output\n";
+    return skillProbeOk(cmd, args) ?? "installed\nwith multi-line child output\n";
   };
   return { run, calls };
+}
+
+/** Drop skill preflight (`npx/npm --version`) from call logs. */
+function withoutSkillProbe(calls: string[][]): string[][] {
+  return calls.filter(
+    (c) => !(c[0] === "npx" && c[1] === "--version") && !(c[0] === "npm" && c[1] === "--version"),
+  );
 }
 
 function captureStreams() {
@@ -59,7 +85,9 @@ describe("uploads install", () => {
     const { run, calls } = fakeRunner();
     const code = await install([], { globals: GLOBALS, runner: run });
     expect(code).toBe(0);
-    expect(calls).toEqual([
+    expect(calls[0]).toEqual(["npx", "--version"]);
+    expect(calls[1]).toEqual(["npm", "--version"]);
+    expect(withoutSkillProbe(calls)).toEqual([
       [
         "npx",
         "-y",
@@ -144,8 +172,9 @@ describe("uploads install", () => {
   it("install skill runs only the skills step", async () => {
     const { run, calls } = fakeRunner();
     expect(await install(["skill"], { globals: GLOBALS, runner: run })).toBe(0);
-    expect(calls).toHaveLength(3);
-    expect(calls.every((c) => c[0] === "npx")).toBe(true);
+    const skillAdds = withoutSkillProbe(calls);
+    expect(skillAdds).toHaveLength(3);
+    expect(skillAdds.every((c) => c[0] === "npx" && c.includes("skills"))).toBe(true);
   });
 
   it("skill-only success still nudges login when unsigned", async () => {
@@ -218,8 +247,9 @@ describe("uploads install", () => {
       runner: run,
     });
     expect(code).toBe(1);
-    expect(calls).toHaveLength(3);
-    expect(calls.every((c) => c[0] === "npx")).toBe(true);
+    const skillAdds = withoutSkillProbe(calls);
+    expect(skillAdds).toHaveLength(3);
+    expect(skillAdds.every((c) => c[0] === "npx" && c.includes("skills"))).toBe(true);
     expect(out.join("")).toMatch(/skill:uploads-cli: ok/);
     expect(out.join("")).toMatch(/skill:github-screenshots: ok/);
     expect(out.join("")).toMatch(/skill:annotate-screenshots: ok/);
@@ -230,20 +260,86 @@ describe("uploads install", () => {
     expect(err.join("")).not.toMatch(/error:/i);
   });
 
-  it("reports a missing binary with a manual-command hint, redacted, and exits 1", async () => {
+  it("reports a missing claude binary with install guidance, redacted, and exits 1", async () => {
     const enoent: CommandRunner = () => {
-      const err = new Error("spawn claude ENOENT") as NodeJS.ErrnoException;
-      err.code = "ENOENT";
-      throw err;
+      throw makeEnoent("spawn claude ENOENT");
     };
     const { err } = captureStreams();
     const code = await install(["mcp"], { globals: GLOBALS, runner: enoent });
     expect(code).toBe(1);
     const printed = err.join("");
     expect(printed).toContain("claude not found on PATH");
+    expect(printed).toMatch(/Claude Code CLI/i);
+    expect(printed).toMatch(/uploads install mcp/);
     expect(printed).not.toContain("up_acme_secret");
-    // Full command (with token) only with --verbose; still redacted if shown.
     expect(printed).not.toContain("Bearer up_acme");
+    expect(printed).not.toMatch(/run manually:/i);
+  });
+
+  it("missing npx short-circuits all skills with one collapsed human error", async () => {
+    const calls: string[][] = [];
+    const run: CommandRunner = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (cmd === "npx") throw makeEnoent("spawn npx ENOENT");
+      return "ok\n";
+    };
+    const { out, err } = captureStreams();
+    const code = await install(["skill"], { globals: GLOBALS, runner: run });
+    expect(code).toBe(1);
+    expect(calls).toEqual([["npx", "--version"]]);
+    const stderr = err.join("");
+    expect(stderr).toMatch(/skills: failed —/);
+    expect(stderr).toContain("npx not found on PATH");
+    expect(stderr).toMatch(/nodejs\.org/i);
+    expect(stderr).not.toMatch(/skill:uploads-cli: failed/);
+    expect(stderr).not.toMatch(/skill:github-screenshots: failed/);
+    expect(stderr).not.toMatch(/run manually:/i);
+    expect(out.join("")).toMatch(/working Node\.js toolchain/);
+    expect(out.join("")).toMatch(/uploads install skill/);
+  });
+
+  it("old npm version blocks skill install before skills add", async () => {
+    const calls: string[][] = [];
+    const run: CommandRunner = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (cmd === "npx" && args[0] === "--version") return "6.14.18\n";
+      if (cmd === "npm" && args[0] === "--version") return "6.14.18\n";
+      return "ok\n";
+    };
+    const { err, out } = captureStreams();
+    const code = await install(["skill"], { globals: GLOBALS, runner: run });
+    expect(code).toBe(1);
+    expect(calls).toEqual([
+      ["npx", "--version"],
+      ["npm", "--version"],
+    ]);
+    expect(err.join("")).toMatch(/skills: failed —/);
+    expect(err.join("")).toContain(npmTooOldHint("6.14.18"));
+    expect(out.join("")).toMatch(/npm 7\+/);
+  });
+
+  it("probeSkillTooling and missingBinaryHint are stable for agents/tests", () => {
+    expect(missingBinaryHint("npx")).toMatch(/npx not found/);
+    expect(missingBinaryHint("claude")).toMatch(/Claude Code CLI/);
+    expect(
+      probeSkillTooling(() => {
+        throw makeEnoent("ENOENT");
+      }),
+    ).toBe(missingBinaryHint("npx"));
+    expect(
+      probeSkillTooling((cmd) => {
+        if (cmd === "npx") return "10.0.0";
+        if (cmd === "npm") return "6.0.0";
+        return "";
+      }),
+    ).toBe(npmTooOldHint("6.0.0"));
+    expect(
+      probeSkillTooling((cmd) => {
+        if (cmd === "npx") return "10.0.0";
+        if (cmd === "npm") return "10.0.0";
+        return "";
+      }),
+    ).toBeUndefined();
   });
 
   it("treats an existing MCP entry as already configured, not a failure", async () => {
@@ -312,11 +408,13 @@ describe("uploads install", () => {
   });
 
   it("mixed skill success/failure prints closing guidance (issue #191)", async () => {
-    let skillCalls = 0;
-    const run: CommandRunner = (cmd) => {
+    let skillAddCalls = 0;
+    const run: CommandRunner = (cmd, args) => {
+      const probe = skillProbeOk(cmd, args);
+      if (probe !== undefined) return probe;
       if (cmd === "npx") {
-        skillCalls += 1;
-        if (skillCalls === 2) throw new Error("skills add failed for github-screenshots");
+        skillAddCalls += 1;
+        if (skillAddCalls === 2) throw new Error("skills add failed for github-screenshots");
         return "ok\n";
       }
       return "mcp ok\n";
@@ -328,5 +426,21 @@ describe("uploads install", () => {
     expect(err.join("")).toMatch(/skill:github-screenshots: failed/);
     expect(out.join("")).toMatch(/Skill install incomplete/);
     expect(out.join("")).toMatch(/uploads install skill/);
+  });
+
+  it("missing claude after successful skills points at Claude Code install", async () => {
+    const run: CommandRunner = (cmd, args) => {
+      const probe = skillProbeOk(cmd, args);
+      if (probe !== undefined) return probe;
+      if (cmd === "claude") throw makeEnoent("spawn claude ENOENT");
+      return "ok\n";
+    };
+    const { out, err } = captureStreams();
+    const code = await install([], { globals: GLOBALS, runner: run });
+    expect(code).toBe(1);
+    expect(out.join("")).toMatch(/skill:uploads-cli: ok/);
+    expect(err.join("")).toMatch(/claude not found on PATH/);
+    expect(out.join("")).toMatch(/Skills are installed/);
+    expect(out.join("")).toMatch(/Claude Code CLI/);
   });
 });


### PR DESCRIPTION
## In plain terms

When `uploads install` runs on a machine without `npx`, an ancient npm, or the Claude Code CLI, it used to spam three identical “not found” skill lines and suggest “run manually: npx …” — useless when the binary itself is missing. It now fails once with install guidance, and on Windows it no longer treats npm `.cmd` shims as missing.

## What it does / what it is not

- **Does:** probe `npx`/`npm` once before skill steps; require npm 7+ for `npx -y`
- **Does:** collapse identical skill failures into one `skills:` line (JSON still reports each skill key)
- **Does:** point at Node 22+ / Claude Code install steps instead of re-running a missing binary
- **Does:** retry Windows `execFile` via the shell so npm batch shims resolve
- **Does not:** install Node or Claude Code for you, or change successful install behavior
- **Does not:** auto-request CodeRabbit

## How to try it

```bash
# Simulate missing tooling (PATH without node/npx), or use a clean shell:
uploads install skill
# Expect one skills: failed line + Node install guidance, not three skill:* lines

uploads install mcp
# Without Claude Code: mcp: failed with Claude Code install guidance
```

## Technical notes

- Preflight lives in `probeSkillTooling`; human collapse in `identicalSkillFailure` / `printHumanSteps`
- Windows fix is in shared `execFileSyncCompat` used by `execRunner` / `timedExecRunner` (also helps `gh` etc.)

## Test plan

- [x] `pnpm exec vitest run test/install.test.ts test/commands-update.test.ts test/github-gh.test.ts` in `packages/uploads` (69 tests)
- [x] `pnpm exec tsc --noEmit` in `packages/uploads`
- [x] Pre-commit lint-staged (oxlint + oxfmt) on commit
- [ ] CI on this PR