### PR TITLE
feat: repo comment config (.uploads.yml) with workspace defaults and live preview

### DIFF
--- a/.changeset/repo-comment-config.md
+++ b/.changeset/repo-comment-config.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+gh-fallback comments honor a committed `.uploads.yml` (image width, inline cap, caption fields, note)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@uploads/billing": "workspace:^",
+    "@uploads/comment-config": "workspace:^",
     "@uploads/email": "workspace:^",
     "@uploads/errors": "workspace:^",
     "@uploads/storage": "workspace:^",

--- a/apps/api/src/comment-preview-fixtures.ts
+++ b/apps/api/src/comment-preview-fixtures.ts
@@ -10,34 +10,43 @@
  * `pageUrl: null` throughout — fixtures never claim a real `/f/` file page.
  */
 import type { AttachmentItem } from "./github-comment-render";
+import { webOrigin } from "./web-url";
 
-const FIXTURE_IMAGE_URL = "https://uploads.sh/og/home.png";
-
-export const PREVIEW_FIXTURE_ITEMS: AttachmentItem[] = [
-  {
-    key: "gh/preview/pull/0/dashboard-overview.png",
-    url: FIXTURE_IMAGE_URL,
-    embedUrl: FIXTURE_IMAGE_URL,
-    pageUrl: null,
-  },
-  {
-    key: "gh/preview/pull/0/iphone-checkout.png",
-    url: FIXTURE_IMAGE_URL,
-    embedUrl: FIXTURE_IMAGE_URL,
-    pageUrl: null,
-  },
-  {
-    key: "gh/preview/pull/0/hero-before.png",
-    url: FIXTURE_IMAGE_URL,
-    embedUrl: FIXTURE_IMAGE_URL,
-    pageUrl: null,
-    meta: { state: "before" },
-  },
-  {
-    key: "gh/preview/pull/0/hero-after.png",
-    url: FIXTURE_IMAGE_URL,
-    embedUrl: FIXTURE_IMAGE_URL,
-    pageUrl: null,
-    meta: { state: "after" },
-  },
-];
+/**
+ * Build the fixture items against `env.WEB_ORIGIN` (via `webOrigin`, the
+ * same single source of truth `filePageUrl` uses) instead of a hardcoded
+ * production origin, so the preview's fixture image resolves correctly in
+ * local/staging environments too. `/og/home.png` is the one path — only the
+ * origin varies.
+ */
+export function previewFixtureItems(env: Env): AttachmentItem[] {
+  const fixtureImageUrl = `${webOrigin(env)}/og/home.png`;
+  return [
+    {
+      key: "gh/preview/pull/0/dashboard-overview.png",
+      url: fixtureImageUrl,
+      embedUrl: fixtureImageUrl,
+      pageUrl: null,
+    },
+    {
+      key: "gh/preview/pull/0/iphone-checkout.png",
+      url: fixtureImageUrl,
+      embedUrl: fixtureImageUrl,
+      pageUrl: null,
+    },
+    {
+      key: "gh/preview/pull/0/hero-before.png",
+      url: fixtureImageUrl,
+      embedUrl: fixtureImageUrl,
+      pageUrl: null,
+      meta: { state: "before" },
+    },
+    {
+      key: "gh/preview/pull/0/hero-after.png",
+      url: fixtureImageUrl,
+      embedUrl: fixtureImageUrl,
+      pageUrl: null,
+      meta: { state: "after" },
+    },
+  ];
+}

--- a/apps/api/src/comment-preview-fixtures.ts
+++ b/apps/api/src/comment-preview-fixtures.ts
@@ -1,0 +1,43 @@
+/**
+ * Static fallback items for the comment-settings preview endpoint (issue
+ * #307, Task 6) — used whenever a workspace has no recent `gh/`-prefixed
+ * attachments to render a realistic preview from. All four point at the
+ * same real, always-loadable static asset (`og/home.png`, the site-wide OG
+ * fallback served by apps/web) so the preview never depends on a workspace's
+ * own storage; only the filenames vary, since the renderer's per-item width
+ * heuristic (`attachmentImageWidth`) keys off filename patterns
+ * (landscape/portrait) and the before/after pairing keys off `meta.state`.
+ * `pageUrl: null` throughout — fixtures never claim a real `/f/` file page.
+ */
+import type { AttachmentItem } from "./github-comment-render";
+
+const FIXTURE_IMAGE_URL = "https://uploads.sh/og/home.png";
+
+export const PREVIEW_FIXTURE_ITEMS: AttachmentItem[] = [
+  {
+    key: "gh/preview/pull/0/dashboard-overview.png",
+    url: FIXTURE_IMAGE_URL,
+    embedUrl: FIXTURE_IMAGE_URL,
+    pageUrl: null,
+  },
+  {
+    key: "gh/preview/pull/0/iphone-checkout.png",
+    url: FIXTURE_IMAGE_URL,
+    embedUrl: FIXTURE_IMAGE_URL,
+    pageUrl: null,
+  },
+  {
+    key: "gh/preview/pull/0/hero-before.png",
+    url: FIXTURE_IMAGE_URL,
+    embedUrl: FIXTURE_IMAGE_URL,
+    pageUrl: null,
+    meta: { state: "before" },
+  },
+  {
+    key: "gh/preview/pull/0/hero-after.png",
+    url: FIXTURE_IMAGE_URL,
+    embedUrl: FIXTURE_IMAGE_URL,
+    pageUrl: null,
+    meta: { state: "after" },
+  },
+];

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -286,6 +286,21 @@ describe("attachmentsCommentBody (api copy)", () => {
       },
     ];
 
+    const galleriesWithPreview = [
+      {
+        title: "Design review",
+        url: "https://uploads.sh/g/abc",
+        previews: [
+          {
+            url: "https://uploads.sh/g/abc/i1.png",
+            embedUrl: "https://embed.uploads.sh/g/abc/i1.png",
+            alt: "screen one",
+            itemUrl: "https://uploads.sh/g/abc/i1",
+          },
+        ],
+      },
+    ];
+
     const base = (over: Partial<CommentRenderOptions>): CommentRenderOptions => ({
       ...AUTO_RENDER_OPTIONS,
       ...over,
@@ -316,10 +331,40 @@ describe("attachmentsCommentBody (api copy)", () => {
       expect(body).toContain("<details>");
     });
 
+    it('imageWidth:"full" omits the width attribute on gallery previews too', () => {
+      const body = attachmentsCommentBody(
+        [],
+        galleriesWithPreview,
+        marker,
+        base({ imageWidth: "full" }),
+      );
+      expect(body).not.toMatch(/<img width=/);
+      expect(body).toMatch(/<img alt="screen one"/);
+    });
+
+    it("explicit px overrides the gallery preview's default 320", () => {
+      const body = attachmentsCommentBody(
+        [],
+        galleriesWithPreview,
+        marker,
+        base({ imageWidth: 500 }),
+      );
+      const widths = [...body.matchAll(/<img width="(\d+)"/g)].map((m) => Number(m[1]));
+      expect(widths).toHaveLength(1);
+      expect(widths[0]).toBe(500);
+    });
+
     it("metaPath:false hides path but keeps state in captions", () => {
       const body = attachmentsCommentBody(metaItems, [], marker, base({ metaPath: false }));
       expect(body).not.toContain("apps/web/src");
       expect(body).toContain("after");
+    });
+
+    it("metaState:false hides state but keeps path in captions", () => {
+      const body = attachmentsCommentBody(metaItems, [], marker, base({ metaState: false }));
+      expect(body).toContain("apps/web/src");
+      expect(body).not.toContain("<sub>apps/web/src · after</sub>");
+      expect(body).not.toMatch(/·\s*after/);
     });
 
     it("note renders once, directly after the marker line", () => {

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath, URL as NodeURL } from "node:url";
 import { describe, expect, it } from "vitest";
-import { attachmentsCommentBody } from "./github-comment-render";
+import {
+  attachmentsCommentBody,
+  AUTO_RENDER_OPTIONS,
+  type AttachmentItem,
+  type CommentRenderOptions,
+} from "./github-comment-render";
 
 function loadFixture(name: string) {
   return JSON.parse(
@@ -12,11 +17,21 @@ function loadFixture(name: string) {
   ) as { items: any[]; galleries: any[]; marker?: string; expected: string };
 }
 
+function loadOptionsFixture(name: string) {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new NodeURL(`../../../test/fixtures/${name}`, import.meta.url)),
+      "utf8",
+    ),
+  ) as { cases: { name: string; options: Partial<CommentRenderOptions>; expected: string }[] };
+}
+
 const golden = loadFixture("github-comment-golden.json");
 const goldenCap = loadFixture("github-comment-golden-cap.json");
 const goldenMeta = loadFixture("github-comment-golden-meta.json");
 const goldenVideo = loadFixture("github-comment-golden-video.json");
 const goldenEmpty = loadFixture("github-comment-golden-empty.json");
+const goldenOptions = loadOptionsFixture("github-comment-golden-options.json");
 
 describe("attachmentsCommentBody (api copy)", () => {
   it("renders the golden body byte-for-byte", () => {
@@ -239,6 +254,88 @@ describe("attachmentsCommentBody (api copy)", () => {
         img("gh/acme/web/pull/12/shot.webp", { meta: { path: "/x", state: "after" } }),
       ]);
       expect(body).not.toContain("<table>");
+    });
+  });
+
+  describe("attachmentsCommentBody with options", () => {
+    const items = golden.items as AttachmentItem[];
+    const galleries = golden.galleries;
+    const marker = golden.marker ?? "<!-- uploads.sh:attachments -->";
+
+    const manyImages: AttachmentItem[] = Array.from({ length: 18 }, (_, i) => ({
+      key: `gh/acme/web/pull/12/many-${String(i).padStart(2, "0")}.png`,
+      url: `https://uploads.sh/f/many-${i}.png`,
+      embedUrl: `https://embed.uploads.sh/f/many-${i}.png`,
+      pageUrl: `https://uploads.sh/f/acme/many-${i}.png`,
+    }));
+
+    const metaItems: AttachmentItem[] = [
+      {
+        key: "gh/acme/web/pull/12/meta-a.png",
+        url: "https://uploads.sh/f/meta-a.png",
+        embedUrl: "https://embed.uploads.sh/f/meta-a.png",
+        pageUrl: "https://uploads.sh/f/acme/meta-a.png",
+        meta: { path: "apps/web/src", state: "after" },
+      },
+      {
+        key: "gh/acme/web/pull/12/meta-b.png",
+        url: "https://uploads.sh/f/meta-b.png",
+        embedUrl: "https://embed.uploads.sh/f/meta-b.png",
+        pageUrl: "https://uploads.sh/f/acme/meta-b.png",
+        meta: { path: "apps/web/src", state: "after" },
+      },
+    ];
+
+    const base = (over: Partial<CommentRenderOptions>): CommentRenderOptions => ({
+      ...AUTO_RENDER_OPTIONS,
+      ...over,
+    });
+
+    it("default options render byte-identical to the no-options call", () => {
+      expect(attachmentsCommentBody(items, galleries, marker, AUTO_RENDER_OPTIONS)).toBe(
+        attachmentsCommentBody(items, galleries, marker),
+      );
+    });
+
+    it('imageWidth:"full" omits the width attribute everywhere (inline, pair, poster)', () => {
+      const body = attachmentsCommentBody(items, [], marker, base({ imageWidth: "full" }));
+      expect(body).not.toMatch(/<img width=/);
+      expect(body).toMatch(/<img alt=/);
+    });
+
+    it("explicit px overrides auto sizing and pair/poster constants", () => {
+      const body = attachmentsCommentBody(items, [], marker, base({ imageWidth: 500 }));
+      const widths = [...body.matchAll(/<img width="(\d+)"/g)].map((m) => Number(m[1]));
+      expect(widths.length).toBeGreaterThan(0);
+      expect(widths.every((w) => w === 500)).toBe(true);
+    });
+
+    it("maxInlineImages caps inline embeds; remainder collapses to the details list", () => {
+      const body = attachmentsCommentBody(manyImages, [], marker, base({ maxInlineImages: 2 }));
+      expect([...body.matchAll(/<img /g)]).toHaveLength(2);
+      expect(body).toContain("<details>");
+    });
+
+    it("metaPath:false hides path but keeps state in captions", () => {
+      const body = attachmentsCommentBody(metaItems, [], marker, base({ metaPath: false }));
+      expect(body).not.toContain("apps/web/src");
+      expect(body).toContain("after");
+    });
+
+    it("note renders once, directly after the marker line", () => {
+      const body = attachmentsCommentBody(items, [], marker, base({ note: "Staging only." }));
+      const lines = body.split("\n");
+      expect(lines[0]).toBe(marker);
+      expect(lines[1]).toBe("Staging only.");
+      expect(lines[2]).toBe("");
+    });
+
+    it("matches the shared options golden", () => {
+      for (const c of goldenOptions.cases) {
+        expect(
+          attachmentsCommentBody(items, [], marker, { ...AUTO_RENDER_OPTIONS, ...c.options }),
+        ).toBe(c.expected);
+      }
     });
   });
 });

--- a/apps/api/src/github-comment-render.test.ts
+++ b/apps/api/src/github-comment-render.test.ts
@@ -23,7 +23,16 @@ function loadOptionsFixture(name: string) {
       fileURLToPath(new NodeURL(`../../../test/fixtures/${name}`, import.meta.url)),
       "utf8",
     ),
-  ) as { cases: { name: string; options: Partial<CommentRenderOptions>; expected: string }[] };
+  ) as {
+    cases: {
+      name: string;
+      options: Partial<CommentRenderOptions>;
+      expected: string;
+      // Falls back to the golden suite's shared `items` when a case doesn't
+      // need its own (most cases don't touch item count/meta).
+      items?: AttachmentItem[];
+    }[];
+  };
 }
 
 const golden = loadFixture("github-comment-golden.json");
@@ -375,12 +384,13 @@ describe("attachmentsCommentBody (api copy)", () => {
       expect(lines[2]).toBe("");
     });
 
-    it("matches the shared options golden", () => {
-      for (const c of goldenOptions.cases) {
-        expect(
-          attachmentsCommentBody(items, [], marker, { ...AUTO_RENDER_OPTIONS, ...c.options }),
-        ).toBe(c.expected);
-      }
+    it.each(goldenOptions.cases)("matches the options golden: $name", (c) => {
+      expect(
+        attachmentsCommentBody(c.items ?? items, [], marker, {
+          ...AUTO_RENDER_OPTIONS,
+          ...c.options,
+        }),
+      ).toBe(c.expected);
     });
   });
 });

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -76,6 +76,30 @@ export function attachmentsMarker(workspace?: string): string {
  * of images. */
 export const MAX_INLINE_ATTACHMENT_IMAGES = 16;
 
+/**
+ * Per-render knobs for the managed comment (issue #307), sourced from repo
+ * comment config. `imageWidth: "auto"` preserves today's per-item width
+ * heuristics (`attachmentImageWidth`/`posterImageWidth`/pair cap); `"full"`
+ * omits the `width` attribute entirely; a number overrides every width site.
+ */
+export interface CommentRenderOptions {
+  imageWidth: "auto" | "full" | number;
+  maxInlineImages: number;
+  metaPath: boolean;
+  metaState: boolean;
+  note: string | null;
+}
+
+/** Today's behavior, expressed as options — the default for every caller that
+ * hasn't opted into repo comment config. */
+export const AUTO_RENDER_OPTIONS: CommentRenderOptions = {
+  imageWidth: "auto",
+  maxInlineImages: MAX_INLINE_ATTACHMENT_IMAGES,
+  metaPath: true,
+  metaState: true,
+  note: null,
+};
+
 export interface AttachmentItem {
   key: string;
   url: string | null;
@@ -197,18 +221,21 @@ function escapeMarkdownText(s: string): string {
  * alone it is a stray character, and as a prefix next to `state` it is
  * noise. Only exact `/` after trim is suppressed.
  */
-function metaCaptionParts(meta: AttachmentItem["meta"]): string[] {
+function metaCaptionParts(meta: AttachmentItem["meta"], options: CommentRenderOptions): string[] {
   const parts: string[] = [];
   const path = meta?.path?.trim();
-  if (path && path !== "/") parts.push(path);
+  if (options.metaPath && path && path !== "/") parts.push(path);
   const state = meta?.state?.trim();
-  if (state) parts.push(state);
+  if (options.metaState && state) parts.push(state);
   return parts;
 }
 
 /** `<sub>` caption body for an inline image, or null when there is nothing to say. */
-function metaCaptionHtml(meta: AttachmentItem["meta"]): string | null {
-  const parts = metaCaptionParts(meta);
+function metaCaptionHtml(
+  meta: AttachmentItem["meta"],
+  options: CommentRenderOptions,
+): string | null {
+  const parts = metaCaptionParts(meta, options);
   return parts.length > 0 ? parts.map(escapeHtmlText).join(" · ") : null;
 }
 
@@ -217,10 +244,26 @@ function metaCaptionHtml(meta: AttachmentItem["meta"]): string | null {
  * HTML-escapes first, then markdown-escapes: HTML escaping introduces no
  * backslashes or brackets, so the markdown pass cannot corrupt its entities.
  */
-function metaCaptionMarkdown(meta: AttachmentItem["meta"]): string {
-  const parts = metaCaptionParts(meta);
+function metaCaptionMarkdown(meta: AttachmentItem["meta"], options: CommentRenderOptions): string {
+  const parts = metaCaptionParts(meta, options);
   if (parts.length === 0) return "";
   return ` · ${parts.map((p) => escapeMarkdownText(escapeHtmlText(p))).join(" · ")}`;
+}
+
+/** Resolved pixel width for an image site, or `null` meaning "omit the width
+ * attribute". `"auto"` defers to the caller's per-item heuristic (`autoPx`);
+ * `"full"` always omits; a number always wins. */
+function resolvedWidth(autoPx: number, options: CommentRenderOptions): number | null {
+  if (options.imageWidth === "auto") return autoPx;
+  if (options.imageWidth === "full") return null;
+  return options.imageWidth;
+}
+
+/** Every `<img>` tag in the managed comment goes through here so the
+ * omit-width-attribute case ("full") can't drift between call sites. */
+function imgTag(w: number | null, alt: string, src: string): string {
+  const widthAttr = w === null ? "" : ` width="${w}"`;
+  return `<img${widthAttr} alt="${alt}" src="${src}">`;
 }
 
 /** Extract the filename stem's before/after token (issue #419 fallback pairing).
@@ -321,24 +364,33 @@ function pairAttachments(
  * column width (and don't overflow on mobile). */
 export const ATTACHMENT_IMAGE_WIDTH_PAIR = 320;
 
-function renderPairCell(item: AttachmentItem, label: "Before" | "After"): string {
+function renderPairCell(
+  item: AttachmentItem,
+  label: "Before" | "After",
+  options: CommentRenderOptions,
+): string {
   const name = item.key.slice(item.key.lastIndexOf("/") + 1);
   const src = item.embedUrl ?? item.url;
   const link = item.pageUrl ?? item.url;
-  const w = Math.min(attachmentImageWidth(name), ATTACHMENT_IMAGE_WIDTH_PAIR);
+  const autoPx = Math.min(attachmentImageWidth(name), ATTACHMENT_IMAGE_WIDTH_PAIR);
+  const w = resolvedWidth(autoPx, options);
   const alt = escapeHtmlAttr(name);
   const href = escapeHtmlAttr((link ?? src) as string);
   const imgSrc = escapeHtmlAttr(src as string);
-  const caption = metaCaptionHtml(item.meta);
+  const caption = metaCaptionHtml(item.meta, options);
   const captionHtml = caption ? `<br><sub>${caption}</sub>` : "";
-  return `<td align="center"><sub><strong>${label}</strong></sub><br><a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>${captionHtml}</td>`;
+  return `<td align="center"><sub><strong>${label}</strong></sub><br><a href="${href}">${imgTag(w, alt, imgSrc)}</a>${captionHtml}</td>`;
 }
 
 /** One side-by-side before/after row (issue #419): a single HTML table so
  * GitHub renders both images on one line, with `Before`/`After` labels and
  * each side's usual path/state caption preserved underneath. */
-function renderPairRow(beforeItem: AttachmentItem, afterItem: AttachmentItem): string {
-  return `<table><tr>${renderPairCell(beforeItem, "Before")}${renderPairCell(afterItem, "After")}</tr></table>`;
+function renderPairRow(
+  beforeItem: AttachmentItem,
+  afterItem: AttachmentItem,
+  options: CommentRenderOptions,
+): string {
+  return `<table><tr>${renderPairCell(beforeItem, "Before", options)}${renderPairCell(afterItem, "After", options)}</tr></table>`;
 }
 
 /**
@@ -349,6 +401,7 @@ export function attachmentsCommentBody(
   items: AttachmentItem[],
   galleries: GalleryCommentItem[] = [],
   marker: string = ATTACHMENTS_MARKER,
+  options: CommentRenderOptions = AUTO_RENDER_OPTIONS,
 ): string {
   // Non-mutating sort (equivalent to Array#toSorted) — the api worker's
   // tsconfig targets lib ES2022, which predates Array#toSorted (ES2023);
@@ -358,6 +411,7 @@ export function attachmentsCommentBody(
     (a, b) => a.title.localeCompare(b.title) || a.url.localeCompare(b.url),
   );
   const lines: string[] = [marker];
+  if (options.note) lines.push(options.note, "");
   if (sortedGalleries.length > 0) {
     lines.push("### 🖼️ Galleries", "");
     for (const gallery of sortedGalleries) {
@@ -366,8 +420,9 @@ export function attachmentsCommentBody(
       for (const preview of gallery.previews ?? []) {
         const previewHref = preview.itemUrl ? escapeHtmlAttr(preview.itemUrl) : href;
         const previewSrc = escapeHtmlAttr(preview.embedUrl ?? preview.url);
+        const previewW = resolvedWidth(320, options);
         lines.push(
-          `<a href="${previewHref}"><img width="320" alt="${escapeHtmlAttr(preview.alt)}" src="${previewSrc}"></a>`,
+          `<a href="${previewHref}">${imgTag(previewW, escapeHtmlAttr(preview.alt), previewSrc)}</a>`,
         );
       }
       lines.push(`<sub><a href="${href}">Open gallery</a></sub>`, "");
@@ -391,12 +446,12 @@ export function attachmentsCommentBody(
     const partnerIdx = partnerOf.get(idx);
     if (partnerIdx !== undefined) {
       const partner = sorted[partnerIdx];
-      if (inlinedImages + 2 <= MAX_INLINE_ATTACHMENT_IMAGES) {
+      if (inlinedImages + 2 <= options.maxInlineImages) {
         inlinedImages += 2;
         consumedByPair.add(partnerIdx);
         const beforeItem = roleOf.get(idx) === "before" ? item : partner;
         const afterItem = roleOf.get(idx) === "before" ? partner : item;
-        lines.push(renderPairRow(beforeItem, afterItem), "");
+        lines.push(renderPairRow(beforeItem, afterItem, options), "");
         continue;
       }
       // Cap already full for a two-image row — degrade this pair to two
@@ -412,7 +467,7 @@ export function attachmentsCommentBody(
     const isImage = Boolean(src) && inferContentType(name).startsWith("image/");
     const isPosterVideo = Boolean(item.posterUrl) && inferContentType(name).startsWith("video/");
     const inlines = isImage || isPosterVideo;
-    if (inlines && inlinedImages >= MAX_INLINE_ATTACHMENT_IMAGES) {
+    if (inlines && inlinedImages >= options.maxInlineImages) {
       // Cap hit — defer to the collapsed overflow list below rather than
       // embedding every remaining image inline.
       overflowImages.push(item);
@@ -420,10 +475,11 @@ export function attachmentsCommentBody(
     }
     if (isPosterVideo) {
       inlinedImages++;
-      const w = posterImageWidth(item.videoMeta, name);
+      const autoPx = posterImageWidth(item.videoMeta, name);
+      const w = resolvedWidth(autoPx, options);
       const href = escapeHtmlAttr(link ?? (item.posterUrl as string));
       lines.push(
-        `<a href="${href}"><img width="${w}" alt="${escapeHtmlAttr(name)}" src="${escapeHtmlAttr(item.posterUrl as string)}"></a>`,
+        `<a href="${href}">${imgTag(w, escapeHtmlAttr(name), escapeHtmlAttr(item.posterUrl as string))}</a>`,
       );
       // GitHub strips <video>, so a still frame needs an explicit affordance
       // or it reads as a screenshot.
@@ -431,24 +487,25 @@ export function attachmentsCommentBody(
       if (item.videoMeta?.durationSeconds != null) {
         parts.push(formatDuration(item.videoMeta.durationSeconds));
       }
-      parts.push(...metaCaptionParts(item.meta).map(escapeHtmlText));
+      parts.push(...metaCaptionParts(item.meta, options).map(escapeHtmlText));
       lines.push(`<sub>${parts.join(" · ")}</sub>`, "");
     } else if (isImage) {
       inlinedImages++;
       // Markdown ![]() has no width control — phone frames become full-column giants.
       // img src uses embed host when available (Camo revalidates); click-through prefers the file page.
-      const w = attachmentImageWidth(name);
+      const autoPx = attachmentImageWidth(name);
+      const w = resolvedWidth(autoPx, options);
       const alt = escapeHtmlAttr(name);
       const href = escapeHtmlAttr(link ?? (src as string));
       const imgSrc = escapeHtmlAttr(src as string);
-      lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
-      const caption = metaCaptionHtml(item.meta);
+      lines.push(`<a href="${href}">${imgTag(w, alt, imgSrc)}</a>`);
+      const caption = metaCaptionHtml(item.meta, options);
       if (caption) lines.push(`<sub>${caption}</sub>`);
       lines.push("");
     } else if (link) {
-      lines.push(`- [${name}](${link})${metaCaptionMarkdown(item.meta)}`);
+      lines.push(`- [${name}](${link})${metaCaptionMarkdown(item.meta, options)}`);
     } else {
-      lines.push(`- ${name}${metaCaptionMarkdown(item.meta)}`);
+      lines.push(`- ${name}${metaCaptionMarkdown(item.meta, options)}`);
     }
   }
   if (overflowImages.length > 0) {
@@ -457,7 +514,7 @@ export function attachmentsCommentBody(
     for (const item of overflowImages) {
       const name = item.key.slice(item.key.lastIndexOf("/") + 1);
       const link = item.pageUrl ?? item.url;
-      const suffix = metaCaptionMarkdown(item.meta);
+      const suffix = metaCaptionMarkdown(item.meta, options);
       lines.push(link ? `- [${name}](${link})${suffix}` : `- ${name}${suffix}`);
     }
     lines.push("", "</details>", "");

--- a/apps/api/src/github-comment-render.ts
+++ b/apps/api/src/github-comment-render.ts
@@ -260,10 +260,14 @@ function resolvedWidth(autoPx: number, options: CommentRenderOptions): number | 
 }
 
 /** Every `<img>` tag in the managed comment goes through here so the
- * omit-width-attribute case ("full") can't drift between call sites. */
-function imgTag(w: number | null, alt: string, src: string): string {
+ * omit-width-attribute case ("full") can't drift between call sites.
+ *
+ * `escapedAlt`/`escapedSrc` must already be attribute-escaped (via
+ * `escapeHtmlAttr`) by the caller — this function interpolates them as-is
+ * and does not escape them itself. */
+function imgTag(w: number | null, escapedAlt: string, escapedSrc: string): string {
   const widthAttr = w === null ? "" : ` width="${w}"`;
-  return `<img${widthAttr} alt="${alt}" src="${src}">`;
+  return `<img${widthAttr} alt="${escapedAlt}" src="${escapedSrc}">`;
 }
 
 /** Extract the filename stem's before/after token (issue #419 fallback pairing).

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -16,12 +16,15 @@ import { objectPublicUrls, storageConfig } from "./storage";
 import { posterKeyFor } from "./poster";
 import type { WorkspaceRecord } from "./workspace";
 import { githubFetch, githubHeaders, installationToken, type GithubAppConfig } from "./github-app";
+import { resolveRepoCommentOptions } from "./repo-comment-config";
+import type { ResolvedCommentOptions } from "@uploads/comment-config";
 import {
   attachmentsCommentBody,
   attachmentsMarker,
   ghKeyPrefix,
   ATTACHMENTS_MARKER,
   type AttachmentItem,
+  type CommentRenderOptions,
   type GalleryCommentItem,
   type GhTarget,
 } from "./github-comment-render";
@@ -42,18 +45,30 @@ export async function gatherCommentBody(
   workspaceName: string,
   target: GhTarget,
 ): Promise<{ body: string; count: number }> {
+  // Resolve repo `.uploads.yml` (if any) against the workspace's own comment
+  // defaults (issue #307). Never throws — a fetch/App degradation collapses
+  // to workspace-defaults/auto only (see resolveRepoCommentOptions).
+  const { options } = await resolveRepoCommentOptions(env, ws, target.repo);
+
   // Attachments (R2 list) and galleries (D1) are independent reads — overlap
   // them so the request only waits the longer of the two, not their sum.
   const [items, galleries] = await Promise.all([
-    gatherAttachments(env, ws, workspaceName, target),
+    gatherAttachments(env, ws, workspaceName, target, options),
     gatherGalleries(env, ws, workspaceName, target),
   ]);
 
   const count = items.length + galleries.length;
   const marker = attachmentsMarker(workspaceName);
+  const renderOptions: CommentRenderOptions = {
+    imageWidth: options.imageWidth,
+    maxInlineImages: options.maxInlineImages,
+    metaPath: options.metaPath,
+    metaState: options.metaState,
+    note: options.note,
+  };
   // count may be 0 — attachmentsCommentBody renders a neutral empty state.
   // Callers gate create-vs-patch on count (see upsertBotComment createIfMissing).
-  return { body: attachmentsCommentBody(items, galleries, marker), count };
+  return { body: attachmentsCommentBody(items, galleries, marker, renderOptions), count };
 }
 
 /**
@@ -77,13 +92,16 @@ async function gatherAttachments(
   ws: WorkspaceRecord,
   workspaceName: string,
   target: GhTarget,
+  options: ResolvedCommentOptions,
 ): Promise<AttachmentItem[]> {
-  // Per-workspace choice (issue #304): default (undefined/true) links the
-  // managed comment's attachments to their `/f/` file page (issue #301's
+  // Per-workspace/repo choice (issues #304, #307): default (auto/true) links
+  // the managed comment's attachments to their `/f/` file page (issue #301's
   // behavior); `false` links to raw object bytes instead. Attachments only —
   // does not affect gallery `itemUrl` below, which is a separate feature.
-  const linkToFilePage = ws.githubCommentLinkToFilePage !== false;
-  const showMetadata = ws.githubCommentShowMetadata !== false; // issue #365
+  const linkToFilePage = options.linkToFilePage;
+  // issue #365, extended by #307: skip the metadata read entirely when
+  // neither meta field would render anything.
+  const showMetadata = options.metaPath || options.metaState;
   const items: AttachmentItem[] = [];
   let cursor: string | undefined;
   do {

--- a/apps/api/src/repo-comment-config.test.ts
+++ b/apps/api/src/repo-comment-config.test.ts
@@ -235,6 +235,68 @@ describe("fetchRepoCommentConfig", () => {
     }
   });
 
+  it("returns the parsed result even when the cache write rejects (KV quota/transient)", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () =>
+        new Response("comment:\n  imageWidth: full\n", { status: 200 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    kv.failPutWith = new Error("KV quota exceeded");
+    kv.failPutKeyPrefix = "repocfg:";
+    try {
+      const result = await fetchRepoCommentConfig(env, "acme/web");
+      expect(result.found).toBe(true);
+      expect(result.path).toBe(".uploads.yml");
+      expect(result.config?.imageWidth).toBe("full");
+      // The write failed, so nothing landed in the (fake) store either.
+      const cached = await kv.get("repocfg:acme/web", "json");
+      expect(cached).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("degrades to not-found, uncached, when res.text() rejects", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const brokenText = () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new Error("body stream aborted"));
+          },
+        }),
+        { status: 200 },
+      );
+    const { impl, calls } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": brokenText,
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const first = await fetchRepoCommentConfig(env, "acme/web");
+      expect(first.found).toBe(false);
+      const cached = await kv.get("repocfg:acme/web", "json");
+      expect(cached).toBeNull();
+
+      const callsAfterFirst = calls();
+      const second = await fetchRepoCommentConfig(env, "acme/web");
+      expect(second.found).toBe(false);
+      expect(calls()).toBeGreaterThan(callsAfterFirst); // re-fetched, not cached
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("exposes the six candidate paths in spec order", () => {
     expect(REPO_CONFIG_PATHS).toEqual([
       ".uploads.yml",

--- a/apps/api/src/repo-comment-config.test.ts
+++ b/apps/api/src/repo-comment-config.test.ts
@@ -1,0 +1,339 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import {
+  fetchRepoCommentConfig,
+  resolveRepoCommentOptions,
+  workspaceCommentDefaults,
+  REPO_CONFIG_PATHS,
+  REPO_CONFIG_TTL_SECONDS,
+} from "./repo-comment-config";
+import type { WorkspaceRecord } from "./workspace";
+import { FakeKv } from "../test/fake-kv";
+
+/** Generate a throwaway RSA key and return its PKCS#8 PEM (mirrors github-app.test.ts's testKeyPair). */
+async function testPem(): Promise<string> {
+  const pair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      hash: "SHA-256",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const der = (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer;
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = b64.match(/.{1,64}/g)!.join("\n");
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----\n`;
+}
+
+function makeEnv(kv: FakeKv, pem: string): Env {
+  return {
+    GITHUB_CACHE: kv,
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: pem,
+    GITHUB_APP_HOME_INSTALLATION_ID: "9",
+  } as unknown as Env;
+}
+
+/** Counts fetches and answers with route handlers keyed by substring match. */
+function fakeFetch(routes: Record<string, (init: RequestInit) => Response>) {
+  let calls = 0;
+  const impl = (async (url: string, init: RequestInit = {}) => {
+    calls++;
+    for (const [pattern, handler] of Object.entries(routes)) {
+      if (url.includes(pattern)) return handler(init);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+  return { impl, calls: () => calls };
+}
+
+const installationRoute = () => new Response(JSON.stringify({ id: 42 }), { status: 200 });
+const tokenRoute = () => new Response(JSON.stringify({ token: "ghs_test" }), { status: 201 });
+
+describe("fetchRepoCommentConfig", () => {
+  it("finds config at .uploads.yml, parses it, and caches it", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () =>
+        new Response("comment:\n  imageWidth: full\n", { status: 200 }),
+    });
+    // Inject the fetch impl via globalThis.fetch override since the module
+    // uses the ambient `fetch` unless a seam is provided.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const result = await fetchRepoCommentConfig(env, "acme/web");
+      expect(result.found).toBe(true);
+      expect(result.path).toBe(".uploads.yml");
+      expect(result.config?.imageWidth).toBe("full");
+      expect(result.warnings).toEqual([]);
+
+      const cached = await kv.get("repocfg:acme/web", "json");
+      expect(cached).toEqual(result);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls through 404s to .uploads.json and parses as JSON", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.json": () =>
+        new Response(JSON.stringify({ comment: { imageWidth: 320 } }), { status: 200 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const result = await fetchRepoCommentConfig(env, "acme/web");
+      expect(result.found).toBe(true);
+      expect(result.path).toBe(".uploads.json");
+      expect(result.config?.imageWidth).toBe(320);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("caches a negative result when all six candidates 404, and stops fetching on the next call", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl, calls } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      // No /contents/ route registered -> every candidate 404s.
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const first = await fetchRepoCommentConfig(env, "acme/web");
+      expect(first.found).toBe(false);
+      expect(first.path).toBeNull();
+      const callsAfterFirst = calls();
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      const second = await fetchRepoCommentConfig(env, "acme/web");
+      expect(second).toEqual(first);
+      expect(calls()).toBe(callsAfterFirst); // zero additional fetches
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns a cached result with zero fetches on a warm cache (config found)", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl, calls } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () => new Response("comment:\n  note: hello\n", { status: 200 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const first = await fetchRepoCommentConfig(env, "acme/web");
+      const callsAfterFirst = calls();
+      expect(first.found).toBe(true);
+
+      const second = await fetchRepoCommentConfig(env, "acme/web");
+      expect(second).toEqual(first);
+      expect(calls()).toBe(callsAfterFirst);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not cache a transient contents-API failure (500)", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl, calls } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () => new Response("boom", { status: 500 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const first = await fetchRepoCommentConfig(env, "acme/web");
+      expect(first.found).toBe(false);
+      const cached = await kv.get("repocfg:acme/web", "json");
+      expect(cached).toBeNull();
+
+      const callsAfterFirst = calls();
+      const second = await fetchRepoCommentConfig(env, "acme/web");
+      expect(second.found).toBe(false);
+      expect(calls()).toBeGreaterThan(callsAfterFirst); // re-fetched, not cached
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("caches a found-but-unparseable file (found:true, config:null, warning)", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl, calls } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () => new Response("not: valid: yaml: [", { status: 200 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const first = await fetchRepoCommentConfig(env, "acme/web");
+      expect(first.found).toBe(true);
+      expect(first.config).toBeNull();
+      expect(first.warnings.length).toBeGreaterThan(0);
+
+      const callsAfterFirst = calls();
+      const second = await fetchRepoCommentConfig(env, "acme/web");
+      expect(second).toEqual(first);
+      expect(calls()).toBe(callsAfterFirst); // cached, no re-fetch
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("degrades to not-found, uncached, when the App is not configured", async () => {
+    const kv = new FakeKv();
+    const env = { GITHUB_CACHE: kv } as unknown as Env; // no GITHUB_APP_* members
+    const result = await fetchRepoCommentConfig(env, "acme/web");
+    expect(result).toEqual({ found: false, path: null, config: null, warnings: [] });
+    const cached = await kv.get("repocfg:acme/web", "json");
+    expect(cached).toBeNull();
+  });
+
+  it("degrades to not-found, uncached, when the repo has no installation", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl } = fakeFetch({
+      "/installation": () => new Response("nope", { status: 404 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const result = await fetchRepoCommentConfig(env, "acme/web");
+      expect(result.found).toBe(false);
+      const cached = await kv.get("repocfg:acme/web", "json");
+      expect(cached).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("exposes the six candidate paths in spec order", () => {
+    expect(REPO_CONFIG_PATHS).toEqual([
+      ".uploads.yml",
+      ".uploads.yaml",
+      ".uploads.json",
+      ".github/uploads.yml",
+      ".github/uploads.yaml",
+      ".github/uploads.json",
+    ]);
+  });
+
+  it("exposes a 300-second TTL", () => {
+    expect(REPO_CONFIG_TTL_SECONDS).toBe(300);
+  });
+});
+
+describe("workspaceCommentDefaults", () => {
+  it("maps workspace record fields, including both legacy booleans", () => {
+    const ws: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      githubCommentImageWidth: 480,
+      githubCommentMaxInlineImages: 8,
+      githubCommentNote: "hi",
+      githubCommentLinkToFilePage: false,
+      githubCommentShowMetadata: false,
+    } as WorkspaceRecord;
+    const defaults = workspaceCommentDefaults(ws);
+    expect(defaults).toEqual({
+      imageWidth: 480,
+      maxInlineImages: 8,
+      note: "hi",
+      linkToFilePage: false,
+      showMetadata: false,
+    });
+  });
+
+  it("leaves fields absent when the record has none set", () => {
+    const ws: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+    } as WorkspaceRecord;
+    const defaults = workspaceCommentDefaults(ws);
+    expect(defaults).toEqual({});
+  });
+});
+
+describe("resolveRepoCommentOptions", () => {
+  it("resolves end-to-end: repo full-width overrides workspace px default", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () =>
+        new Response("comment:\n  imageWidth: full\n", { status: 200 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const ws: WorkspaceRecord = {
+        provider: "r2",
+        bucket: "shared",
+        binding: "UPLOADS_DEFAULT",
+        prefix: "acme/",
+        githubCommentImageWidth: 320,
+      } as WorkspaceRecord;
+      const {
+        options,
+        source,
+        fetch: fetchResult,
+      } = await resolveRepoCommentOptions(env, ws, "acme/web");
+      expect(options.imageWidth).toBe("full");
+      expect(source.imageWidth).toBe("repo");
+      expect(fetchResult.found).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("degrades to workspace-defaults-only, uncached, when the App is not configured", async () => {
+    const kv = new FakeKv();
+    const env = { GITHUB_CACHE: kv } as unknown as Env;
+    const ws: WorkspaceRecord = {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      githubCommentImageWidth: 320,
+    } as WorkspaceRecord;
+    const { options, source } = await resolveRepoCommentOptions(env, ws, "acme/web");
+    expect(options.imageWidth).toBe(320);
+    expect(source.imageWidth).toBe("workspace");
+    const cached = await kv.get("repocfg:acme/web", "json");
+    expect(cached).toBeNull();
+  });
+});

--- a/apps/api/src/repo-comment-config.test.ts
+++ b/apps/api/src/repo-comment-config.test.ts
@@ -155,6 +155,34 @@ describe("fetchRepoCommentConfig", () => {
     }
   });
 
+  it("shares one cache entry across repo names differing only in case", async () => {
+    const kv = new FakeKv();
+    const pem = await testPem();
+    const env = makeEnv(kv, pem);
+    const { impl, calls } = fakeFetch({
+      "/access_tokens": tokenRoute,
+      "/installation": installationRoute,
+      "/contents/.uploads.yml": () => new Response("comment:\n  note: hello\n", { status: 200 }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = impl;
+    try {
+      const first = await fetchRepoCommentConfig(env, "Acme/Web");
+      expect(first.found).toBe(true);
+      const callsAfterFirst = calls();
+      expect(callsAfterFirst).toBeGreaterThan(0);
+
+      const second = await fetchRepoCommentConfig(env, "acme/web");
+      expect(second).toEqual(first);
+      expect(calls()).toBe(callsAfterFirst); // zero additional fetches
+
+      const cached = await kv.get("repocfg:acme/web", "json");
+      expect(cached).toEqual(first);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("does not cache a transient contents-API failure (500)", async () => {
     const kv = new FakeKv();
     const pem = await testPem();

--- a/apps/api/src/repo-comment-config.ts
+++ b/apps/api/src/repo-comment-config.ts
@@ -87,8 +87,7 @@ export async function fetchRepoCommentConfig(
       res = await githubFetch(fetch, `https://api.github.com/repos/${repo}/contents/${path}`, {
         headers: { ...githubHeaders(token), accept: "application/vnd.github.raw+json" },
       });
-    } catch (e) {
-      console.error("DEBUG fetch error", e);
+    } catch {
       return NOT_FOUND; // transient (network/timeout) — uncached
     }
     if (res.status === 404) continue;

--- a/apps/api/src/repo-comment-config.ts
+++ b/apps/api/src/repo-comment-config.ts
@@ -56,7 +56,9 @@ const NOT_FOUND: RepoConfigFetchResult = {
   warnings: [],
 };
 
-const cacheKeyFor = (repo: string) => `repocfg:${repo}`;
+// GitHub repo names are case-insensitive — lowercase before building the KV
+// key so `Acme/Web` and `acme/web` share one cache entry instead of two.
+const cacheKeyFor = (repo: string) => `repocfg:${repo.toLowerCase()}`;
 
 /** Best-effort KV write — a quota/transient rejection must not surface into the render path. */
 async function cachePut(env: Env, cacheKey: string, result: RepoConfigFetchResult): Promise<void> {

--- a/apps/api/src/repo-comment-config.ts
+++ b/apps/api/src/repo-comment-config.ts
@@ -1,0 +1,149 @@
+/**
+ * Repo-level managed-comment config (`.uploads.yml` / issue #307). Fetches
+ * one of six candidate paths from the repo's default branch via the GitHub
+ * App installation, KV-caches the result (found or not-found alike), and
+ * resolves it against the calling workspace's own defaults into the render
+ * options `attachmentsCommentBody` consumes.
+ *
+ * Cache policy (KV, `repocfg:<repo>`, `REPO_CONFIG_TTL_SECONDS`):
+ * - Found + parsed (even with warnings), or all six candidates 404 → cached.
+ *   A committed-but-broken file shouldn't re-fetch on every render, and a
+ *   repo with no config shouldn't either.
+ * - Anything transient — a non-404 contents-API failure, no App config, no
+ *   installation, a token-mint failure — degrades to "not found", uncached,
+ *   so the next call retries instead of pinning a bad state for the TTL.
+ */
+
+import { parseRepoCommentConfig, resolveCommentOptions } from "@uploads/comment-config";
+import type {
+  OptionSource,
+  RepoCommentConfig,
+  ResolvedCommentOptions,
+  WorkspaceCommentDefaults,
+} from "@uploads/comment-config";
+import {
+  githubAppConfig,
+  githubFetch,
+  githubHeaders,
+  installationForRepo,
+  installationToken,
+} from "./github-app";
+import type { WorkspaceRecord } from "./workspace";
+
+export interface RepoConfigFetchResult {
+  found: boolean;
+  path: string | null; // which candidate matched
+  config: RepoCommentConfig | null;
+  warnings: string[];
+}
+
+export const REPO_CONFIG_TTL_SECONDS = 300;
+
+/** Candidate paths, checked in this order — the first hit wins. */
+export const REPO_CONFIG_PATHS = [
+  ".uploads.yml",
+  ".uploads.yaml",
+  ".uploads.json",
+  ".github/uploads.yml",
+  ".github/uploads.yaml",
+  ".github/uploads.json",
+] as const;
+
+const NOT_FOUND: RepoConfigFetchResult = {
+  found: false,
+  path: null,
+  config: null,
+  warnings: [],
+};
+
+const cacheKeyFor = (repo: string) => `repocfg:${repo}`;
+
+/**
+ * Fetch + KV-cache `repo`'s `.uploads.yml` (or one of its five siblings). See
+ * the module doc-comment for the cache policy. Never throws — any failure to
+ * obtain App credentials or an installation token degrades to `NOT_FOUND`,
+ * uncached.
+ */
+export async function fetchRepoCommentConfig(
+  env: Env,
+  repo: string,
+): Promise<RepoConfigFetchResult> {
+  const cacheKey = cacheKeyFor(repo);
+  const cached = (await env.GITHUB_CACHE.get(cacheKey, "json")) as RepoConfigFetchResult | null;
+  if (cached) return cached;
+
+  const appCfg = githubAppConfig(env);
+  if (!appCfg) return NOT_FOUND; // no App creds configured — fail closed, uncached
+
+  const installationId = await installationForRepo(env, appCfg, repo);
+  if (installationId === null) return NOT_FOUND; // not installed — uncached
+
+  const token = await installationToken(env, appCfg, installationId);
+  if (!token) return NOT_FOUND; // token mint failed — uncached
+
+  for (const path of REPO_CONFIG_PATHS) {
+    let res: Response;
+    try {
+      res = await githubFetch(fetch, `https://api.github.com/repos/${repo}/contents/${path}`, {
+        headers: { ...githubHeaders(token), accept: "application/vnd.github.raw+json" },
+      });
+    } catch (e) {
+      console.error("DEBUG fetch error", e);
+      return NOT_FOUND; // transient (network/timeout) — uncached
+    }
+    if (res.status === 404) continue;
+    if (!res.ok) return NOT_FOUND; // transient (5xx, rate limit, etc.) — uncached
+
+    const text = await res.text();
+    const format = path.endsWith(".json") ? "json" : "yaml";
+    const { config, warnings } = parseRepoCommentConfig(text, format);
+    const result: RepoConfigFetchResult = { found: true, path, config, warnings };
+    await env.GITHUB_CACHE.put(cacheKey, JSON.stringify(result), {
+      expirationTtl: REPO_CONFIG_TTL_SECONDS,
+    });
+    return result;
+  }
+
+  // All six candidates 404 — a real, cacheable "no config" result.
+  await env.GITHUB_CACHE.put(cacheKey, JSON.stringify(NOT_FOUND), {
+    expirationTtl: REPO_CONFIG_TTL_SECONDS,
+  });
+  return NOT_FOUND;
+}
+
+/** Map a workspace record's `githubComment*` fields onto workspace-tier comment defaults. */
+export function workspaceCommentDefaults(ws: WorkspaceRecord): WorkspaceCommentDefaults {
+  const defaults: WorkspaceCommentDefaults = {};
+  if (ws.githubCommentImageWidth !== undefined) defaults.imageWidth = ws.githubCommentImageWidth;
+  if (ws.githubCommentMaxInlineImages !== undefined)
+    defaults.maxInlineImages = ws.githubCommentMaxInlineImages;
+  if (ws.githubCommentShowMetadata !== undefined)
+    defaults.showMetadata = ws.githubCommentShowMetadata;
+  if (ws.githubCommentLinkToFilePage !== undefined)
+    defaults.linkToFilePage = ws.githubCommentLinkToFilePage;
+  if (ws.githubCommentNote !== undefined) defaults.note = ws.githubCommentNote;
+  return defaults;
+}
+
+/**
+ * Fetch `repo`'s config (cached) and resolve it against `ws`'s own defaults
+ * into the final render options. Never throws — a fetch degradation simply
+ * means the resolution proceeds with `config: null` (workspace-defaults/auto
+ * only), matching `fetchRepoCommentConfig`'s own fail-closed behavior.
+ */
+export async function resolveRepoCommentOptions(
+  env: Env,
+  ws: WorkspaceRecord,
+  repo: string,
+): Promise<{
+  options: ResolvedCommentOptions;
+  source: Record<keyof ResolvedCommentOptions, OptionSource>;
+  fetch: RepoConfigFetchResult;
+}> {
+  const fetchResult = await fetchRepoCommentConfig(env, repo);
+  const { options, source } = resolveCommentOptions(
+    fetchResult.config,
+    workspaceCommentDefaults(ws),
+  );
+  return { options, source, fetch: fetchResult };
+}

--- a/apps/api/src/repo-comment-config.ts
+++ b/apps/api/src/repo-comment-config.ts
@@ -58,6 +58,18 @@ const NOT_FOUND: RepoConfigFetchResult = {
 
 const cacheKeyFor = (repo: string) => `repocfg:${repo}`;
 
+/** Best-effort KV write — a quota/transient rejection must not surface into the render path. */
+async function cachePut(env: Env, cacheKey: string, result: RepoConfigFetchResult): Promise<void> {
+  try {
+    await env.GITHUB_CACHE.put(cacheKey, JSON.stringify(result), {
+      expirationTtl: REPO_CONFIG_TTL_SECONDS,
+    });
+  } catch {
+    // Cache write failed (quota, transient KV error, etc.) — the result is
+    // still returned to the caller; the next call just re-fetches.
+  }
+}
+
 /**
  * Fetch + KV-cache `repo`'s `.uploads.yml` (or one of its five siblings). See
  * the module doc-comment for the cache policy. Never throws — any failure to
@@ -93,20 +105,21 @@ export async function fetchRepoCommentConfig(
     if (res.status === 404) continue;
     if (!res.ok) return NOT_FOUND; // transient (5xx, rate limit, etc.) — uncached
 
-    const text = await res.text();
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      return NOT_FOUND; // transient (truncated/aborted body) — uncached
+    }
     const format = path.endsWith(".json") ? "json" : "yaml";
     const { config, warnings } = parseRepoCommentConfig(text, format);
     const result: RepoConfigFetchResult = { found: true, path, config, warnings };
-    await env.GITHUB_CACHE.put(cacheKey, JSON.stringify(result), {
-      expirationTtl: REPO_CONFIG_TTL_SECONDS,
-    });
+    await cachePut(env, cacheKey, result);
     return result;
   }
 
   // All six candidates 404 — a real, cacheable "no config" result.
-  await env.GITHUB_CACHE.put(cacheKey, JSON.stringify(NOT_FOUND), {
-    expirationTtl: REPO_CONFIG_TTL_SECONDS,
-  });
+  await cachePut(env, cacheKey, NOT_FOUND);
   return NOT_FOUND;
 }
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2057,6 +2057,63 @@ describe("workspace comment-settings routes", () => {
   });
 });
 
+describe("GET /me/workspaces/:name/repo-links", () => {
+  const REC = { provider: "r2", bucket: "uploads-default", prefix: "acme/" };
+
+  /** Admin/owner-gated env with a real (SQL-backed) DB for github_repo_links. */
+  function repoLinksEnv(opts: { workspace?: string; role: string; record?: unknown }) {
+    const { workspace = "acme", role, record } = opts;
+    const registry = fakeRegistry(record !== undefined ? { [workspace]: record } : {});
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: workspace,
+            organizationName: workspace,
+            role,
+          },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    const sqlite = new SqliteD1(["migrations/20260720120000_github_repo_links.sql"]);
+    const env = {
+      AUTH: auth,
+      DB: d1FromSqlite(sqlite),
+      REGISTRY: registry,
+    } as unknown as Env;
+    return { env, sqlite };
+  }
+
+  it("403s for a non-admin member", async () => {
+    const { env } = repoLinksEnv({ role: "member", record: REC });
+    const res = await app().request("/me/workspaces/acme/repo-links", {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns an empty list for a workspace with no linked repos", async () => {
+    const { env } = repoLinksEnv({ role: "admin", record: REC });
+    const res = await app().request("/me/workspaces/acme/repo-links", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ repos: [] });
+  });
+
+  it("returns repo names only, most recently linked first", async () => {
+    const { env, sqlite } = repoLinksEnv({ role: "owner", record: REC });
+    const db = d1FromSqlite(sqlite);
+    await recordRepoLink(db, "acme/web", "acme", "comment", null, new Date("2026-01-01"));
+    await recordRepoLink(db, "acme/api", "acme", "comment", null, new Date("2026-01-02"));
+    const res = await app().request("/me/workspaces/acme/repo-links", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ repos: ["acme/api", "acme/web"] });
+  });
+});
+
 describe("GET /me/workspaces/:name/comment-preview", () => {
   const REC = {
     provider: "r2",

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -5,9 +5,11 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
-import { fakeRegistry } from "../../test/fake-kv";
+import { fakeRegistry, FakeKv } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { FakeR2Bucket } from "../../test/fake-r2";
+import { SqliteD1, database as d1FromSqlite } from "../../test/helpers/sqlite-d1";
+import { recordRepoLink } from "../github-repo-links";
 
 const USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
 
@@ -2052,5 +2054,183 @@ describe("workspace comment-settings routes", () => {
     expect(res.status).toBe(200);
     expect(((await res.json()) as { note: unknown }).note).toBe("Hi");
     expect(registry.record<{ githubCommentNote?: unknown }>("acme")?.githubCommentNote).toBe("Hi");
+  });
+});
+
+describe("GET /me/workspaces/:name/comment-preview", () => {
+  const REC = {
+    provider: "r2",
+    bucket: "shared",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+  };
+
+  /** Admin/owner-gated env with a real (SQL-backed) DB for github_repo_links. */
+  function previewEnv(opts: {
+    workspace?: string;
+    role: string;
+    record?: unknown;
+    bucket?: FakeR2Bucket;
+    kv?: FakeKv;
+    githubApp?: boolean;
+  }) {
+    const { workspace = "acme", role, record, bucket, kv, githubApp } = opts;
+    const registry = fakeRegistry(record !== undefined ? { [workspace]: record } : {});
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: workspace,
+            organizationName: workspace,
+            role,
+          },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    const sqlite = new SqliteD1(["migrations/20260720120000_github_repo_links.sql"]);
+    const env = {
+      AUTH: auth,
+      DB: d1FromSqlite(sqlite),
+      REGISTRY: registry,
+      WEB_ORIGIN: "https://uploads.test",
+      ...(bucket ? { UPLOADS_DEFAULT: bucket } : {}),
+      ...(kv ? { GITHUB_CACHE: kv } : {}),
+      ...(githubApp
+        ? {
+            GITHUB_APP_ID: "1",
+            GITHUB_APP_PRIVATE_KEY: "unused",
+            GITHUB_APP_HOME_INSTALLATION_ID: "9",
+          }
+        : {}),
+    } as unknown as Env;
+    return { env, registry, sqlite };
+  }
+
+  it("(a) 403s for a non-admin member", async () => {
+    const { env } = previewEnv({ role: "member", record: REC, bucket: new FakeR2Bucket() });
+    const res = await app().request("/me/workspaces/acme/comment-preview", {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("(b) no repo param -> repoConfig null, body renders, resolved is workspace-defaults", async () => {
+    const { env } = previewEnv({ role: "admin", record: REC, bucket: new FakeR2Bucket() });
+    const res = await app().request("/me/workspaces/acme/comment-preview", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      resolved: { imageWidth: unknown; linkToFilePage: unknown };
+      source: Record<string, string>;
+      repoConfig: unknown;
+      body: string;
+      sample: string;
+    };
+    expect(body.repoConfig).toBeNull();
+    expect(body.resolved).toEqual({
+      imageWidth: "auto",
+      maxInlineImages: 16,
+      metaPath: true,
+      metaState: true,
+      linkToFilePage: true,
+      note: null,
+    });
+    expect(body.source).toMatchObject({ imageWidth: "auto" });
+    expect(typeof body.body).toBe("string");
+    expect(body.body.length).toBeGreaterThan(0);
+  });
+
+  it("(c) recent gh/-prefixed objects in the bucket -> sample recent, body references keys", async () => {
+    const bucket = new FakeR2Bucket();
+    await bucket.put(
+      "acme/gh/o/repo/pull/12/screenshot.png",
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+    );
+    const { env } = previewEnv({ role: "owner", record: REC, bucket });
+    const res = await app().request("/me/workspaces/acme/comment-preview", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sample: string; body: string };
+    expect(body.sample).toBe("recent");
+    expect(body.body).toContain("screenshot.png");
+  });
+
+  it("(d) empty workspace -> sample fixtures, body contains dashboard-overview.png", async () => {
+    const { env } = previewEnv({ role: "admin", record: REC, bucket: new FakeR2Bucket() });
+    const res = await app().request("/me/workspaces/acme/comment-preview", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sample: string; body: string };
+    expect(body.sample).toBe("fixtures");
+    expect(body.body).toContain("dashboard-overview.png");
+  });
+
+  it("(e) repo not linked to this workspace -> 404", async () => {
+    const { env } = previewEnv({ role: "admin", record: REC, bucket: new FakeR2Bucket() });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-preview?repo=other%2Frepo",
+      {},
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect((await res.json()) as { error: { message: string } }).toMatchObject({
+      error: { message: "repo not linked to this workspace" },
+    });
+  });
+
+  it("malformed repo param -> 400", async () => {
+    const { env } = previewEnv({ role: "admin", record: REC, bucket: new FakeR2Bucket() });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-preview?repo=not-a-valid-repo",
+      {},
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("(f) linked repo whose config sets imageWidth: full -> source.imageWidth repo, no width attr", async () => {
+    const kv = new FakeKv();
+    // Pre-populate the installation-id/token cache (mirrors
+    // github-comment-service.test.ts's makeTestEnv): installationForRepo and
+    // installationToken both check GITHUB_CACHE before minting an App JWT,
+    // so a warm cache means the (unusable, "unused") private key is never
+    // actually asked to sign anything.
+    await kv.put("ghinst:acme/web", "42");
+    await kv.put("ghtok:42", "cached-token");
+    const { env, sqlite } = previewEnv({
+      role: "admin",
+      record: REC,
+      bucket: new FakeR2Bucket(),
+      kv,
+      githubApp: true,
+    });
+    await recordRepoLink(d1FromSqlite(sqlite), "acme/web", "acme", "comment", 42);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) => {
+      if (String(url).includes("/contents/.uploads.yml")) {
+        return new Response("comment:\n  imageWidth: full\n", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    try {
+      const res = await app().request(
+        "/me/workspaces/acme/comment-preview?repo=acme%2Fweb",
+        {},
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        source: Record<string, string>;
+        body: string;
+        repoConfig: { found: boolean; path: string | null };
+      };
+      expect(body.source.imageWidth).toBe("repo");
+      expect(body.repoConfig).toMatchObject({ found: true, path: ".uploads.yml" });
+      expect(body.body).not.toMatch(/width=/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
+import { fakeRegistry } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { FakeR2Bucket } from "../../test/fake-r2";
 
@@ -1854,5 +1855,202 @@ describe("GET /me/workspaces/:name/files/facets", () => {
     expect((await res.json()) as { error: { code: string } }).toMatchObject({
       error: { code: "workspace_not_found" },
     });
+  });
+});
+
+describe("workspace comment-settings routes", () => {
+  /** Admin/owner-gated env backed by a real (put-capable) REGISTRY fake. */
+  function commentSettingsEnv(opts: { workspace?: string; role: string; record?: unknown }) {
+    const { workspace = "acme", role, record } = opts;
+    const registry = fakeRegistry(record !== undefined ? { [workspace]: record } : {});
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: workspace,
+            organizationName: workspace,
+            role,
+          },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    const env = {
+      AUTH: auth,
+      DB: new UsageFakeD1(),
+      REGISTRY: registry,
+    } as unknown as Env;
+    return { env, registry };
+  }
+
+  const REC = { provider: "r2", bucket: "uploads-default", prefix: "acme/" };
+
+  it("(a) GET 403s for a non-admin member", async () => {
+    const { env } = commentSettingsEnv({ role: "member", record: REC });
+    const res = await app().request("/me/workspaces/acme/comment-settings", {}, env);
+    expect(res.status).toBe(403);
+  });
+
+  it("(a) PATCH 403s for a non-admin member", async () => {
+    const { env } = commentSettingsEnv({ role: "member", record: REC });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ note: "Hi" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("(b) GET on an untouched workspace returns all nulls", async () => {
+    const { env } = commentSettingsEnv({ role: "admin", record: REC });
+    const res = await app().request("/me/workspaces/acme/comment-settings", {}, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      imageWidth: null,
+      maxInlineImages: null,
+      showMetadata: null,
+      linkToFilePage: null,
+      note: null,
+    });
+  });
+
+  it("(c) PATCH sets fields, echoes the new state, and bumps the KV version", async () => {
+    const { env, registry } = commentSettingsEnv({ role: "owner", record: REC });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ imageWidth: "full", maxInlineImages: 4, note: "Hi" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      imageWidth: "full",
+      maxInlineImages: 4,
+      showMetadata: null,
+      linkToFilePage: null,
+      note: "Hi",
+    });
+
+    // Re-read via GET, independent of the PATCH response, per the brief.
+    const getRes = await app().request("/me/workspaces/acme/comment-settings", {}, env);
+    expect(await getRes.json()).toEqual({
+      imageWidth: "full",
+      maxInlineImages: 4,
+      showMetadata: null,
+      linkToFilePage: null,
+      note: "Hi",
+    });
+
+    const saved = registry.record<{ version?: number }>("acme");
+    expect(saved?.version).toBe(1);
+  });
+
+  it("(d) PATCH rejects an out-of-range imageWidth with 400 and leaves the record untouched", async () => {
+    const { env, registry } = commentSettingsEnv({ role: "admin", record: REC });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ imageWidth: 40 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "invalid_settings" },
+    });
+    expect(registry.record("acme")).toEqual(REC);
+  });
+
+  it("(e) PATCH rejects a note over NOTE_MAX_CHARS with 400", async () => {
+    const { env, registry } = commentSettingsEnv({ role: "admin", record: REC });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ note: "x".repeat(501) }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(registry.record("acme")).toEqual(REC);
+  });
+
+  it("(f) PATCH with an explicit null clears a previously-set field", async () => {
+    const { env, registry } = commentSettingsEnv({
+      role: "admin",
+      record: { ...REC, githubCommentImageWidth: 400 },
+    });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ imageWidth: null }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { imageWidth: unknown }).imageWidth).toBeNull();
+    expect(
+      registry.record<{ githubCommentImageWidth?: unknown }>("acme")?.githubCommentImageWidth,
+    ).toBeUndefined();
+  });
+
+  it("(g) PATCH writes the two legacy booleans", async () => {
+    const { env, registry } = commentSettingsEnv({ role: "admin", record: REC });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ showMetadata: false, linkToFilePage: false }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      imageWidth: null,
+      maxInlineImages: null,
+      showMetadata: false,
+      linkToFilePage: false,
+      note: null,
+    });
+    const saved = registry.record<{
+      githubCommentShowMetadata?: unknown;
+      githubCommentLinkToFilePage?: unknown;
+    }>("acme");
+    expect(saved?.githubCommentShowMetadata).toBe(false);
+    expect(saved?.githubCommentLinkToFilePage).toBe(false);
+  });
+
+  it("PATCH with an unknown key ignores it (matches validateGithubCommentSettingsPatch / validateLimitsPatch precedent) and applies known fields", async () => {
+    const { env, registry } = commentSettingsEnv({ role: "admin", record: REC });
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ bogusField: "nope", note: "Hi" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { note: unknown }).note).toBe("Hi");
+    expect(registry.record<{ githubCommentNote?: unknown }>("acme")?.githubCommentNote).toBe("Hi");
   });
 });

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2201,7 +2201,7 @@ describe("GET /me/workspaces/:name/comment-preview", () => {
     expect(body.body.length).toBeGreaterThan(0);
   });
 
-  it("(c) recent gh/-prefixed objects in the bucket -> sample recent, body references keys", async () => {
+  it("(c) gh/-prefixed objects in the bucket -> sample workspace, body references keys", async () => {
     const bucket = new FakeR2Bucket();
     await bucket.put(
       "acme/gh/o/repo/pull/12/screenshot.png",
@@ -2211,7 +2211,7 @@ describe("GET /me/workspaces/:name/comment-preview", () => {
     const res = await app().request("/me/workspaces/acme/comment-preview", {}, env);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { sample: string; body: string };
-    expect(body.sample).toBe("recent");
+    expect(body.sample).toBe("workspace");
     expect(body.body).toContain("screenshot.png");
   });
 

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1959,6 +1959,25 @@ describe("workspace comment-settings routes", () => {
     expect(saved?.version).toBe(1);
   });
 
+  it("429s when the workspace write limiter is over budget, leaving the record untouched", async () => {
+    const { env: baseEnv, registry } = commentSettingsEnv({ role: "owner", record: REC });
+    const env = {
+      ...baseEnv,
+      WRITE_LIMITER: { limit: async () => ({ success: false }) },
+    } as unknown as Env;
+    const res = await app().request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ note: "Hi" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(429);
+    expect(registry.record("acme")).toEqual(REC);
+  });
+
   it("(d) PATCH rejects an out-of-range imageWidth with 400 and leaves the record untouched", async () => {
     const { env, registry } = commentSettingsEnv({ role: "admin", record: REC });
     const res = await app().request(
@@ -2222,6 +2241,10 @@ describe("GET /me/workspaces/:name/comment-preview", () => {
     const body = (await res.json()) as { sample: string; body: string };
     expect(body.sample).toBe("fixtures");
     expect(body.body).toContain("dashboard-overview.png");
+    // Fixture image origin is derived from WEB_ORIGIN (previewEnv sets
+    // "https://uploads.test"), not hardcoded to production's uploads.sh.
+    expect(body.body).toContain('src="https://uploads.test/og/home.png"');
+    expect(body.body).not.toContain("uploads.sh/og/home.png");
   });
 
   it("(e) repo not linked to this workspace -> 404", async () => {

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -10,6 +10,7 @@
  * for workspace existence any more precisely than for any other workspace.
  */
 import { resolveWorkspaceCreateQuota } from "@uploads/billing";
+import { NOTE_MAX_CHARS } from "@uploads/comment-config";
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
@@ -46,10 +47,157 @@ import { requireSessionUser, sessionAuth, type SessionVars } from "../session-au
 import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
-import { loadWorkspaceRecord } from "../workspace";
+import { loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
+import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** `imageWidth` bounds (issue #307): "full" or an integer clamp width in px. */
+const COMMENT_IMAGE_WIDTH_MIN = 160;
+const COMMENT_IMAGE_WIDTH_MAX = 1000;
+/** `maxInlineImages` bounds (issue #307). */
+const COMMENT_MAX_INLINE_IMAGES_MIN = 1;
+const COMMENT_MAX_INLINE_IMAGES_MAX = 48;
+
+/** The five workspace-level comment-defaults fields (issue #307). */
+const COMMENT_SETTINGS_KEYS = [
+  "imageWidth",
+  "maxInlineImages",
+  "showMetadata",
+  "linkToFilePage",
+  "note",
+] as const;
+type CommentSettingsKey = (typeof COMMENT_SETTINGS_KEYS)[number];
+
+/** Record field each API key writes to. */
+const COMMENT_SETTINGS_RECORD_FIELD: Record<CommentSettingsKey, keyof WorkspaceRecord> = {
+  imageWidth: "githubCommentImageWidth",
+  maxInlineImages: "githubCommentMaxInlineImages",
+  showMetadata: "githubCommentShowMetadata",
+  linkToFilePage: "githubCommentLinkToFilePage",
+  note: "githubCommentNote",
+};
+
+type CommentSettingsValue = string | number | boolean;
+type CommentSettingsPatch = Partial<Record<CommentSettingsKey, CommentSettingsValue | null>>;
+
+/**
+ * Validates a PATCH body for the workspace-level managed-comment defaults
+ * (issue #307). This is the single enforcement point for the bounds the
+ * resolver itself does not clamp (a review finding on the Task 1 parser):
+ * imageWidth "full" or an integer 160–1000, maxInlineImages an integer
+ * 1–48, and note trimmed, non-empty, and at most `NOTE_MAX_CHARS`. Reject-
+ * all-or-apply-all — the whole body is checked before any record mutation,
+ * so an invalid field never partially applies. An omitted key means "leave
+ * unchanged"; an explicit `null` clears the field. Unknown keys are
+ * ignored, mirroring `validateGithubCommentSettingsPatch` (admin-ui.ts) and
+ * `validateLimitsPatch` (workspace-limits.ts), the two sibling workspace-
+ * record PATCH validators in this codebase.
+ */
+function validateCommentSettingsPatch(body: unknown): CommentSettingsPatch {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new ValidationError("request body must be a JSON object", { code: "invalid_settings" });
+  }
+  const record = body as Record<string, unknown>;
+  const patch: CommentSettingsPatch = {};
+
+  if ("imageWidth" in record) {
+    const value = record.imageWidth;
+    if (value === null) {
+      patch.imageWidth = null;
+    } else if (value === "full") {
+      patch.imageWidth = "full";
+    } else if (
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= COMMENT_IMAGE_WIDTH_MIN &&
+      value <= COMMENT_IMAGE_WIDTH_MAX
+    ) {
+      patch.imageWidth = value;
+    } else {
+      throw new ValidationError(
+        `imageWidth must be "full", an integer ${COMMENT_IMAGE_WIDTH_MIN}–${COMMENT_IMAGE_WIDTH_MAX}, or null`,
+        { code: "invalid_settings", details: { field: "imageWidth" } },
+      );
+    }
+  }
+
+  if ("maxInlineImages" in record) {
+    const value = record.maxInlineImages;
+    if (value === null) {
+      patch.maxInlineImages = null;
+    } else if (
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= COMMENT_MAX_INLINE_IMAGES_MIN &&
+      value <= COMMENT_MAX_INLINE_IMAGES_MAX
+    ) {
+      patch.maxInlineImages = value;
+    } else {
+      throw new ValidationError(
+        `maxInlineImages must be an integer ${COMMENT_MAX_INLINE_IMAGES_MIN}–${COMMENT_MAX_INLINE_IMAGES_MAX} or null`,
+        { code: "invalid_settings", details: { field: "maxInlineImages" } },
+      );
+    }
+  }
+
+  if ("showMetadata" in record) {
+    const value = record.showMetadata;
+    if (value !== null && typeof value !== "boolean") {
+      throw new ValidationError("showMetadata must be a boolean or null", {
+        code: "invalid_settings",
+        details: { field: "showMetadata" },
+      });
+    }
+    patch.showMetadata = value;
+  }
+
+  if ("linkToFilePage" in record) {
+    const value = record.linkToFilePage;
+    if (value !== null && typeof value !== "boolean") {
+      throw new ValidationError("linkToFilePage must be a boolean or null", {
+        code: "invalid_settings",
+        details: { field: "linkToFilePage" },
+      });
+    }
+    patch.linkToFilePage = value;
+  }
+
+  if ("note" in record) {
+    const value = record.note;
+    if (value === null) {
+      patch.note = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0 || trimmed.length > NOTE_MAX_CHARS) {
+        throw new ValidationError(`note must be 1–${NOTE_MAX_CHARS} characters after trimming`, {
+          code: "invalid_settings",
+          details: { field: "note" },
+        });
+      }
+      patch.note = trimmed;
+    } else {
+      throw new ValidationError("note must be a string or null", {
+        code: "invalid_settings",
+        details: { field: "note" },
+      });
+    }
+  }
+
+  return patch;
+}
+
+/** Response body shared by GET and PATCH: the workspace-level comment defaults. */
+function commentSettingsResponse(record: WorkspaceRecord) {
+  return {
+    imageWidth: record.githubCommentImageWidth ?? null,
+    maxInlineImages: record.githubCommentMaxInlineImages ?? null,
+    showMetadata: record.githubCommentShowMetadata ?? null,
+    linkToFilePage: record.githubCommentLinkToFilePage ?? null,
+    note: record.githubCommentNote ?? null,
+  };
+}
 
 /** Max characters accepted in a `?name=` filename search term. */
 const SEARCH_NAME_MAX = 128;
@@ -786,4 +934,52 @@ export const me = new Hono<SessionVars>()
     const name = c.req.param("name");
     await memberWorkspaceOr404(c.env, requireUserId(c), name);
     return c.json<GithubInstallStatus>(await githubInstallStatus(c.env, name));
+  })
+
+  // Workspace-level managed-comment defaults (issue #307): image width,
+  // inline-image cap, the two legacy booleans, and a short note. Admin/owner
+  // only — these are workspace-wide defaults every repo comment inherits
+  // unless a repo's `.uploads.yml` overrides them.
+  .get("/workspaces/:name/comment-settings", async (c) => {
+    const name = c.req.param("name");
+    await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    return c.json(commentSettingsResponse(record));
+  })
+
+  // Patch the defaults above. Validated in full before any write (reject-
+  // all-or-apply-all — see `validateCommentSettingsPatch`); an omitted key
+  // leaves the field unchanged, an explicit `null` clears it.
+  .patch("/workspaces/:name/comment-settings", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    await adminWorkspaceOr403(c.env, userId, name);
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new ValidationError("request body must be valid JSON", { code: "invalid_settings" });
+    }
+    const patch = validateCommentSettingsPatch(body);
+    const record = await mutateWorkspaceRecord(
+      c.env,
+      name,
+      (current) => {
+        const next = { ...current };
+        for (const key of COMMENT_SETTINGS_KEYS) {
+          if (!(key in patch)) continue;
+          const field = COMMENT_SETTINGS_RECORD_FIELD[key];
+          const value = patch[key];
+          if (value === null || value === undefined) delete next[field];
+          else (next as Record<string, unknown>)[field] = value;
+        }
+        return next;
+      },
+      { requireServing: true },
+    );
+    return c.json(commentSettingsResponse(record));
   });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -40,7 +40,7 @@ import {
   type AttachmentItem,
 } from "../github-comment-render";
 import { githubInstallStatus, type GithubInstallStatus } from "../github-install-status";
-import { findRepoLink } from "../github-repo-links";
+import { findRepoLink, listRepoLinksForWorkspace } from "../github-repo-links";
 import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-comment-config";
 import { resolveTitles } from "../github-titles";
 import { allowWrite } from "../guards";
@@ -950,6 +950,23 @@ export const me = new Hono<SessionVars>()
     const name = c.req.param("name");
     await memberWorkspaceOr404(c.env, requireUserId(c), name);
     return c.json<GithubInstallStatus>(await githubInstallStatus(c.env, name));
+  })
+
+  // Repos this workspace has linked (issue #307, Task 7) — feeds the comment
+  // settings preview panel's repo picker. Admin/owner-gated like the
+  // comment-settings/preview routes below (same audience: whoever can edit
+  // the defaults is whoever should see which repos they apply to). This is
+  // the session-authed counterpart to admin-ui's operator-only
+  // `/admin-ui/workspaces/:name/github-links` — that route needs
+  // `ADMIN_TOKEN`, which the web app's Better Auth session can't produce.
+  // Repo names only: the web client has no use for installationId/source/
+  // createdAt, and trimming them keeps this from becoming a second surface
+  // to keep in sync with `repoLinkResponse` in admin-ui.ts.
+  .get("/workspaces/:name/repo-links", async (c) => {
+    const name = c.req.param("name");
+    await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    const links = await listRepoLinksForWorkspace(c.env.DB, name);
+    return c.json({ repos: links.map((link) => link.repo) });
   })
 
   // Workspace-level managed-comment defaults (issue #307): image width,

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -10,13 +10,19 @@
  * for workspace existence any more precisely than for any other workspace.
  */
 import { resolveWorkspaceCreateQuota } from "@uploads/billing";
-import { NOTE_MAX_CHARS } from "@uploads/comment-config";
+import {
+  NOTE_MAX_CHARS,
+  resolveCommentOptions,
+  type OptionSource,
+  type ResolvedCommentOptions,
+} from "@uploads/comment-config";
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
+import { PREVIEW_FIXTURE_ITEMS } from "../comment-preview-fixtures";
 import {
   facetKeys,
   facetValues,
@@ -28,7 +34,14 @@ import {
 import { badKey, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { galleryListSummaries } from "../gallery-service";
+import {
+  attachmentsCommentBody,
+  attachmentsMarker,
+  type AttachmentItem,
+} from "../github-comment-render";
 import { githubInstallStatus, type GithubInstallStatus } from "../github-install-status";
+import { findRepoLink } from "../github-repo-links";
+import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-comment-config";
 import { resolveTitles } from "../github-titles";
 import { allowWrite } from "../guards";
 import {
@@ -198,6 +211,9 @@ function commentSettingsResponse(record: WorkspaceRecord) {
     note: record.githubCommentNote ?? null,
   };
 }
+
+/** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
+const REPO_SHAPE_RE = /^[^/\s]+\/[^/\s]+$/;
 
 /** Max characters accepted in a `?name=` filename search term. */
 const SEARCH_NAME_MAX = 128;
@@ -982,4 +998,78 @@ export const me = new Hono<SessionVars>()
       { requireServing: true },
     );
     return c.json(commentSettingsResponse(record));
+  })
+
+  // Preview the production managed-comment body against resolved comment
+  // settings (issue #307). Admin/owner-gated like the settings routes above:
+  // the response includes per-key source attribution ("repo" | "workspace" |
+  // "auto"), which a plain member has no reason to see. With no `repo` query
+  // param, resolution runs against workspace defaults only (`repoConfig:
+  // null`) via the same `resolveCommentOptions(null, ...)` entrypoint
+  // `resolveRepoCommentOptions` wraps. With `repo`, it must already be
+  // linked to THIS workspace (github-repo-links.ts) — otherwise 404, so a
+  // preview can't be used to probe another workspace's repo binding or
+  // `.uploads.yml` contents.
+  //
+  // Renders from the workspace's own most recent `gh/`-prefixed attachments
+  // (first page only, mirrors gatherAttachments's url/pageUrl mapping but
+  // skips the D1 metadata read — the preview needs no per-item meta beyond
+  // what the static fixtures already carry). An empty workspace falls back
+  // to `PREVIEW_FIXTURE_ITEMS` so the preview is never blank.
+  .get("/workspaces/:name/comment-preview", async (c) => {
+    const name = c.req.param("name");
+    await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+
+    const repo = c.req.query("repo");
+    let resolved: ResolvedCommentOptions;
+    let source: Record<keyof ResolvedCommentOptions, OptionSource>;
+    let repoConfig: { found: boolean; path: string | null; warnings: string[] } | null = null;
+
+    if (repo !== undefined) {
+      if (!REPO_SHAPE_RE.test(repo)) {
+        throw new ValidationError("repo must be in owner/name form", { code: "invalid_repo" });
+      }
+      const link = await findRepoLink(c.env.DB, repo);
+      if (!link || link.workspaceName !== name) {
+        throw new NotFoundError("repo not linked to this workspace", { code: "repo_not_linked" });
+      }
+      const resolvedRepo = await resolveRepoCommentOptions(c.env, record, repo);
+      resolved = resolvedRepo.options;
+      source = resolvedRepo.source;
+      repoConfig = {
+        found: resolvedRepo.fetch.found,
+        path: resolvedRepo.fetch.path,
+        warnings: resolvedRepo.fetch.warnings,
+      };
+    } else {
+      const resolvedDefaults = resolveCommentOptions(null, workspaceCommentDefaults(record));
+      resolved = resolvedDefaults.options;
+      source = resolvedDefaults.source;
+    }
+
+    const { items: page } = await listObjects(c.env, record, { prefix: "gh/", limit: 8 });
+    const linkToFilePage = resolved.linkToFilePage;
+    let items: AttachmentItem[] = page.map((o) => ({
+      key: o.key,
+      url: o.url,
+      embedUrl: o.embedUrl,
+      pageUrl: linkToFilePage ? (o.pageUrl ?? null) : null,
+    }));
+    let sample: "recent" | "fixtures" = "recent";
+    if (items.length === 0) {
+      items = PREVIEW_FIXTURE_ITEMS;
+      sample = "fixtures";
+    }
+
+    const body = attachmentsCommentBody(items, [], attachmentsMarker(name), {
+      imageWidth: resolved.imageWidth,
+      maxInlineImages: resolved.maxInlineImages,
+      metaPath: resolved.metaPath,
+      metaState: resolved.metaState,
+      note: resolved.note,
+    });
+
+    return c.json({ resolved, source, repoConfig, body, sample });
   });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1028,11 +1028,13 @@ export const me = new Hono<SessionVars>()
   // preview can't be used to probe another workspace's repo binding or
   // `.uploads.yml` contents.
   //
-  // Renders from the workspace's own most recent `gh/`-prefixed attachments
+  // Renders from a page of the workspace's own `gh/`-prefixed attachments
   // (first page only, mirrors gatherAttachments's url/pageUrl mapping but
   // skips the D1 metadata read — the preview needs no per-item meta beyond
-  // what the static fixtures already carry). An empty workspace falls back
-  // to `PREVIEW_FIXTURE_ITEMS` so the preview is never blank.
+  // what the static fixtures already carry). `listObjects` pages in
+  // lexicographic key order, not upload recency, so this is a representative
+  // sample rather than the "most recent" uploads. An empty workspace falls
+  // back to `PREVIEW_FIXTURE_ITEMS` so the preview is never blank.
   .get("/workspaces/:name/comment-preview", async (c) => {
     const name = c.req.param("name");
     await adminWorkspaceOr403(c.env, requireUserId(c), name);
@@ -1074,7 +1076,7 @@ export const me = new Hono<SessionVars>()
       embedUrl: o.embedUrl,
       pageUrl: linkToFilePage ? (o.pageUrl ?? null) : null,
     }));
-    let sample: "recent" | "fixtures" = "recent";
+    let sample: "workspace" | "fixtures" = "workspace";
     if (items.length === 0) {
       items = PREVIEW_FIXTURE_ITEMS;
       sample = "fixtures";

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -22,7 +22,7 @@ import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
-import { PREVIEW_FIXTURE_ITEMS } from "../comment-preview-fixtures";
+import { previewFixtureItems } from "../comment-preview-fixtures";
 import {
   facetKeys,
   facetValues,
@@ -1034,7 +1034,7 @@ export const me = new Hono<SessionVars>()
   // what the static fixtures already carry). `listObjects` pages in
   // lexicographic key order, not upload recency, so this is a representative
   // sample rather than the "most recent" uploads. An empty workspace falls
-  // back to `PREVIEW_FIXTURE_ITEMS` so the preview is never blank.
+  // back to `previewFixtureItems` so the preview is never blank.
   .get("/workspaces/:name/comment-preview", async (c) => {
     const name = c.req.param("name");
     await adminWorkspaceOr403(c.env, requireUserId(c), name);
@@ -1078,7 +1078,7 @@ export const me = new Hono<SessionVars>()
     }));
     let sample: "workspace" | "fixtures" = "workspace";
     if (items.length === 0) {
-      items = PREVIEW_FIXTURE_ITEMS;
+      items = previewFixtureItems(c.env);
       sample = "fixtures";
     }
 

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -126,6 +126,16 @@ export interface WorkspaceRecord {
    * repos whose visibility uploads.sh does not check.
    */
   githubCommentShowMetadata?: boolean;
+  /** Workspace default for managed-comment image width (issue #307):
+   * "full" omits the width attribute; a number (160–1000) forces that px.
+   * Absent = auto (filename-heuristic sizing). Repo `.uploads.yml` overrides. */
+  githubCommentImageWidth?: "full" | number;
+  /** Workspace default for how many images render inline (1–48) before the
+   * remainder collapse to links. Absent = 16. Repo config overrides. */
+  githubCommentMaxInlineImages?: number;
+  /** Workspace default short markdown note under the comment header.
+   * Trimmed, max 500 chars (validated on PATCH). Repo config overrides. */
+  githubCommentNote?: string;
   /**
    * Per-workspace opt-out for video poster generation (issue #299). Default
    * (undefined/true) generates. The surgical kill switch between "all

--- a/apps/api/test/fake-kv.ts
+++ b/apps/api/test/fake-kv.ts
@@ -1,6 +1,14 @@
 /** In-process KV fake: get/put with recorded TTLs. Mirrors the repo's fake-r2 pattern. */
 export class FakeKv {
   store = new Map<string, { value: string; expirationTtl?: number }>();
+  /**
+   * When set, `put` rejects with this for any key matching `failPutKeyPrefix`
+   * (or every key, if the prefix is left unset) — for exercising best-effort
+   * cache-write paths without also breaking unrelated KV writes (e.g. the
+   * GitHub App's installation/token cache) sharing the same fake instance.
+   */
+  failPutWith: Error | null = null;
+  failPutKeyPrefix = "";
 
   async get(key: string, type?: KvReadType): Promise<unknown> {
     const entry = this.store.get(key);
@@ -9,6 +17,7 @@ export class FakeKv {
   }
 
   async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
+    if (this.failPutWith && key.startsWith(this.failPutKeyPrefix)) throw this.failPutWith;
     this.store.set(key, { value, expirationTtl: opts?.expirationTtl });
   }
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -11,6 +11,7 @@ Access requires a workspace — create your own with a linked GitHub account, or
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file, capture a screenshot, annotate with callouts/redactions
 - [Docs: annotate a screenshot](https://uploads.sh/docs/attach-pull-request-images#annotate): bake boxes, arrows, labels, freeform strokes, and solid redactions into a capture (`uploads screenshot --annotate` or `uploads annotate`)
 - [Docs: GitHub App](https://uploads.sh/docs/github-app): recommended install for bot-posted attachment comments, private-repo PR/issue titles, and zero-CLI promotion of branch-staged screenshots when a PR opens
+- [Docs: comment config](https://uploads.sh/docs/comment-config): commit `.uploads.yml` to a repo to control image width, inline-image caps, caption metadata, the file-page link, and an optional note on the attachments comment; repo config beats the workspace default, which beats automatic behavior
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skills and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Docs: plans & limits](https://uploads.sh/docs/limits): storage/file-size/member caps per plan, behavior at each cap, and the GitHub attachment-cap comparison

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -21,6 +21,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://uploads.sh/docs/comment-config</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://uploads.sh/docs/agents</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -43,6 +43,7 @@ const DOCS_NAV = [
       { slug: "overview", href: "/docs", label: "Overview" },
       { slug: "attach", href: "/docs/attach-pull-request-images", label: "Attach & share" },
       { slug: "github-app", href: "/docs/github-app", label: "GitHub App" },
+      { slug: "comment-config", href: "/docs/comment-config", label: "Comment config" },
       { slug: "agents", href: "/docs/agents", label: "Set up your agent" },
       { slug: "reference", href: "/docs/reference", label: "Reference" },
       { slug: "limits", href: "/docs/limits", label: "Plans & limits" },

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1061,3 +1061,185 @@ export async function listWorkspaceFolder(
     cursor: typeof body.cursor === "string" ? body.cursor : undefined,
   };
 }
+
+/**
+ * Workspace-level managed-comment defaults (issue #307, Task 7 — the
+ * settings-tab block). Mirrors `commentSettingsResponse` in
+ * apps/api/src/routes/me.ts exactly: `null` means "unset/auto" for every
+ * field, never a separate "not configured" state.
+ */
+export interface CommentSettings {
+  imageWidth: "full" | number | null;
+  maxInlineImages: number | null;
+  showMetadata: boolean | null;
+  linkToFilePage: boolean | null;
+  note: string | null;
+}
+
+export type CommentSettingsResult =
+  | { kind: "ok"; settings: CommentSettings }
+  | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
+
+function toCommentSettings(body: unknown): CommentSettings | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  const imageWidth =
+    b.imageWidth === "full" || typeof b.imageWidth === "number" ? b.imageWidth : null;
+  const maxInlineImages = typeof b.maxInlineImages === "number" ? b.maxInlineImages : null;
+  const showMetadata = typeof b.showMetadata === "boolean" ? b.showMetadata : null;
+  const linkToFilePage = typeof b.linkToFilePage === "boolean" ? b.linkToFilePage : null;
+  const note = typeof b.note === "string" ? b.note : null;
+  return { imageWidth, maxInlineImages, showMetadata, linkToFilePage, note };
+}
+
+/** GET /me/workspaces/:name/comment-settings — admin/owner only. */
+export async function getWorkspaceCommentSettings(
+  apiOrigin: string,
+  name: string,
+): Promise<CommentSettingsResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/comment-settings`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const settings = toCommentSettings(await response.json().catch(() => null));
+  if (!settings) return { kind: "unavailable", reason: "server" };
+  return { kind: "ok", settings };
+}
+
+export type CommentSettingsPatchResult =
+  | { kind: "ok"; settings: CommentSettings }
+  | { kind: "invalid"; message: string }
+  | { kind: "unavailable"; reason: RequestFailure | "forbidden" | "not_found" | "server" };
+
+/**
+ * PATCH /me/workspaces/:name/comment-settings. `patch` is partial — an
+ * omitted key leaves the field unchanged server-side, an explicit `null`
+ * clears it. On a 400 the server's `error.message` is surfaced verbatim
+ * (already a complete sentence naming the offending field/bounds) so the
+ * settings form can show it inline without re-deriving it client-side.
+ */
+export async function patchWorkspaceCommentSettings(
+  apiOrigin: string,
+  name: string,
+  patch: Partial<CommentSettings>,
+): Promise<CommentSettingsPatchResult> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/comment-settings`,
+    {
+      method: "PATCH",
+      credentials: "include",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 400) {
+    const body = (await response.json().catch(() => null)) as {
+      error?: { message?: string };
+    } | null;
+    return { kind: "invalid", message: body?.error?.message ?? "That change isn’t allowed." };
+  }
+  if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const settings = toCommentSettings(await response.json().catch(() => null));
+  if (!settings) return { kind: "unavailable", reason: "server" };
+  return { kind: "ok", settings };
+}
+
+/**
+ * GET /me/workspaces/:name/repo-links — repo names this workspace has
+ * linked (issue #307, Task 7's repo picker). Fails open to `[]`: an empty
+ * picker just means "no repo config" is the only option, same as a
+ * workspace that genuinely has no linked repos.
+ */
+export async function getWorkspaceRepoLinks(apiOrigin: string, name: string): Promise<string[]> {
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/repo-links`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable" || !result.response.ok) return [];
+  const body = (await result.response.json().catch(() => null)) as { repos?: unknown } | null;
+  if (!body || !Array.isArray(body.repos)) return [];
+  return body.repos.filter((r): r is string => typeof r === "string");
+}
+
+/** Per-key attribution the preview endpoint returns: which layer supplied the resolved value. */
+export type CommentOptionSource = "repo" | "workspace" | "auto";
+
+export interface CommentPreviewResolved {
+  imageWidth: "auto" | "full" | number;
+  maxInlineImages: number;
+  metaPath: boolean;
+  metaState: boolean;
+  linkToFilePage: boolean;
+  note: string | null;
+}
+
+export interface CommentPreview {
+  resolved: CommentPreviewResolved;
+  source: Record<keyof CommentPreviewResolved, CommentOptionSource>;
+  repoConfig: { found: boolean; path: string | null; warnings: string[] } | null;
+  body: string;
+  sample: "recent" | "fixtures";
+}
+
+export type CommentPreviewResult =
+  | { kind: "ok"; preview: CommentPreview }
+  | {
+      kind: "unavailable";
+      reason: RequestFailure | "forbidden" | "not_found" | "invalid_repo" | "server";
+    };
+
+/**
+ * GET /me/workspaces/:name/comment-preview[?repo=owner/name]. `repo` must
+ * already be linked to this workspace — an unlinked or malformed repo 404s/
+ * 400s server-side, surfaced here as `not_found`/`invalid_repo` so the
+ * preview panel can tell the two apart (a stale picker entry vs. a typo).
+ */
+export async function getWorkspaceCommentPreview(
+  apiOrigin: string,
+  name: string,
+  repo?: string,
+): Promise<CommentPreviewResult> {
+  const qs = repo ? `?repo=${encodeURIComponent(repo)}` : "";
+  const result = await fetchWithTimeout(
+    `${trimOrigin(apiOrigin)}/me/workspaces/${encodeURIComponent(name)}/comment-preview${qs}`,
+    { credentials: "include", cache: "no-store" },
+  );
+  if (result.kind === "unavailable") return result;
+  const { response } = result;
+  if (response.status === 403) return { kind: "unavailable", reason: "forbidden" };
+  if (response.status === 404) return { kind: "unavailable", reason: "not_found" };
+  if (response.status === 400) return { kind: "unavailable", reason: "invalid_repo" };
+  if (!response.ok) return { kind: "unavailable", reason: "server" };
+  const body = (await response.json().catch(() => null)) as Partial<CommentPreview> | null;
+  if (
+    !body ||
+    typeof body.body !== "string" ||
+    !body.resolved ||
+    typeof body.resolved !== "object" ||
+    !body.source ||
+    typeof body.source !== "object" ||
+    (body.sample !== "recent" && body.sample !== "fixtures")
+  ) {
+    return { kind: "unavailable", reason: "server" };
+  }
+  return {
+    kind: "ok",
+    preview: {
+      resolved: body.resolved as CommentPreviewResolved,
+      source: body.source as Record<keyof CommentPreviewResolved, CommentOptionSource>,
+      repoConfig: body.repoConfig ?? null,
+      body: body.body,
+      sample: body.sample,
+    },
+  };
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1188,7 +1188,7 @@ export interface CommentPreview {
   source: Record<keyof CommentPreviewResolved, CommentOptionSource>;
   repoConfig: { found: boolean; path: string | null; warnings: string[] } | null;
   body: string;
-  sample: "recent" | "fixtures";
+  sample: "workspace" | "fixtures";
 }
 
 export type CommentPreviewResult =
@@ -1228,7 +1228,7 @@ export async function getWorkspaceCommentPreview(
     typeof body.resolved !== "object" ||
     !body.source ||
     typeof body.source !== "object" ||
-    (body.sample !== "recent" && body.sample !== "fixtures")
+    (body.sample !== "workspace" && body.sample !== "fixtures")
   ) {
     return { kind: "unavailable", reason: "server" };
   }

--- a/apps/web/src/lib/comment-preview-sanitize.test.ts
+++ b/apps/web/src/lib/comment-preview-sanitize.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeCommentPreviewHtml } from "./comment-preview-sanitize";
+import {
+  formatCommentPreviewBody,
+  renderCommentPreviewHtml,
+  sanitizeCommentPreviewHtml,
+} from "./comment-preview-sanitize";
 
 describe("sanitizeCommentPreviewHtml", () => {
   it("passes through allowed tags with allowed attributes unchanged", () => {
@@ -62,5 +66,105 @@ describe("sanitizeCommentPreviewHtml", () => {
   it("closes disallowed nested tags without corrupting sibling allowed tags", () => {
     const html = "<div><p>text</p></div><p>after</p>";
     expect(sanitizeCommentPreviewHtml(html)).toBe("<p>text</p><p>after</p>");
+  });
+
+  // Embedded tab/newline/CR bypass (browsers strip these before scheme-
+  // sniffing a URL, so a naive `.trim()`-only scheme check can be fooled
+  // into treating `javascript:` as a harmless relative URL).
+  it("rejects a javascript: href with an embedded tab breaking up the scheme", () => {
+    expect(sanitizeCommentPreviewHtml('<a href="java\tscript:alert(1)">x</a>')).toBe("<a>x</a>");
+  });
+
+  it("rejects a javascript: href with an embedded newline breaking up the scheme", () => {
+    expect(sanitizeCommentPreviewHtml('<a href="java\nscript:alert(1)">x</a>')).toBe("<a>x</a>");
+  });
+
+  it("rejects a javascript: href with a leading tab before the scheme", () => {
+    expect(sanitizeCommentPreviewHtml('<a href="\tjavascript:alert(1)">x</a>')).toBe("<a>x</a>");
+  });
+
+  it("rejects a data: src with an embedded newline inside the scheme-adjacent text", () => {
+    expect(sanitizeCommentPreviewHtml('<img src="data:text/html,\nevil">')).toBe("<img>");
+  });
+});
+
+describe("formatCommentPreviewBody", () => {
+  it("strips the hidden managed-comment marker (an HTML comment)", () => {
+    const raw = "<!-- uploads.sh:attachments ws=acme -->\n\nHello";
+    expect(formatCommentPreviewBody(raw)).not.toContain("uploads.sh:attachments");
+    expect(formatCommentPreviewBody(raw)).toBe("<p>Hello</p>");
+  });
+
+  it("strips a multiline HTML comment", () => {
+    const raw = "<!--\nmulti\nline\n-->\nHello";
+    expect(formatCommentPreviewBody(raw)).toBe("<p>Hello</p>");
+  });
+
+  it("converts a line-start ### heading to <h3>", () => {
+    expect(formatCommentPreviewBody("### 📎 Attachments")).toBe("<h3>📎 Attachments</h3>");
+  });
+
+  it("converts a line-start #### heading to <h4>, keeping embedded HTML intact (no double-escaping)", () => {
+    const raw = '#### <a href="https://uploads.sh/g/1">My gallery</a>';
+    expect(formatCommentPreviewBody(raw)).toBe(
+      '<h4><a href="https://uploads.sh/g/1">My gallery</a></h4>',
+    );
+  });
+
+  it("converts a `- [text](url)` line into a real list item link", () => {
+    expect(formatCommentPreviewBody("- [Docs](https://uploads.sh/docs)")).toBe(
+      '<ul><li><a href="https://uploads.sh/docs">Docs</a></li></ul>',
+    );
+  });
+
+  it("groups consecutive list lines into one <ul>", () => {
+    const raw = "- [One](https://a)\n- [Two](https://b)";
+    expect(formatCommentPreviewBody(raw)).toBe(
+      '<ul><li><a href="https://a">One</a></li><li><a href="https://b">Two</a></li></ul>',
+    );
+  });
+
+  it("joins consecutive non-blank lines into one paragraph with <br>, and blank lines separate paragraphs", () => {
+    const raw = "line one\nline two\n\nsecond paragraph";
+    expect(formatCommentPreviewBody(raw)).toBe(
+      "<p>line one<br>line two</p><p>second paragraph</p>",
+    );
+  });
+
+  it("does not double-escape a line that is already an HTML tag", () => {
+    const raw = '<a href="https://uploads.sh/f/x"><img src="https://uploads.sh/x.png"></a>';
+    const out = formatCommentPreviewBody(raw);
+    expect(out).not.toContain("&lt;a");
+    expect(out).toBe(`<p>${raw}</p>`);
+  });
+
+  it("handles an empty string", () => {
+    expect(formatCommentPreviewBody("")).toBe("");
+  });
+});
+
+describe("renderCommentPreviewHtml (format + sanitize combined)", () => {
+  it("renders a realistic managed-comment body: marker gone, heading real, image kept, footer joined", () => {
+    const raw =
+      "<!-- uploads.sh:attachments ws=acme -->\n" +
+      "### 📎 Attachments\n\n" +
+      '<a href="https://uploads.sh/f/x"><img width="400" alt="x.png" src="https://embed.uploads.sh/x.png"></a>\n\n' +
+      "<sub>Maintained by uploads.sh.</sub>\n" +
+      "<sub>Add media: <code>uploads put</code></sub>";
+    const out = renderCommentPreviewHtml(raw);
+    expect(out).not.toContain("uploads.sh:attachments");
+    expect(out).toContain("<h3>📎 Attachments</h3>");
+    expect(out).toContain('<img width="400" alt="x.png" src="https://embed.uploads.sh/x.png">');
+    expect(out).toContain(
+      "<sub>Maintained by uploads.sh.</sub><br><sub>Add media: <code>uploads put</code></sub>",
+    );
+  });
+
+  it("still enforces the tag/attribute allowlist after formatting (script stripped, unsafe href dropped)", () => {
+    const raw = "### Heading\n\n<script>alert(1)</script>\n\n- [Bad](javascript:evil)";
+    const out = renderCommentPreviewHtml(raw);
+    expect(out).not.toContain("<script>");
+    expect(out).not.toContain("javascript:");
+    expect(out).toContain("<h3>Heading</h3>");
   });
 });

--- a/apps/web/src/lib/comment-preview-sanitize.test.ts
+++ b/apps/web/src/lib/comment-preview-sanitize.test.ts
@@ -131,6 +131,19 @@ describe("formatCommentPreviewBody", () => {
     );
   });
 
+  it("escapes a quote-breakout attempt in a `- [text](url)` line's URL so it stays one attribute, safe standalone", () => {
+    // Before the item[2]/item[1] escaping fix, the raw `"` in the URL broke
+    // out of the href attribute here, producing a second, genuine
+    // `onmouseover="foo"` attribute in formatCommentPreviewBody's own
+    // output — exploitable if that output were ever used without the
+    // sanitize pass. Escaping at construction keeps it one href value.
+    const raw = '- [x](javascript:evil" onmouseover="foo)';
+    const out = formatCommentPreviewBody(raw);
+    expect(out).toBe(
+      '<ul><li><a href="javascript:evil&quot; onmouseover=&quot;foo">x</a></li></ul>',
+    );
+  });
+
   it("does not double-escape a line that is already an HTML tag", () => {
     const raw = '<a href="https://uploads.sh/f/x"><img src="https://uploads.sh/x.png"></a>';
     const out = formatCommentPreviewBody(raw);
@@ -166,5 +179,11 @@ describe("renderCommentPreviewHtml (format + sanitize combined)", () => {
     expect(out).not.toContain("<script>");
     expect(out).not.toContain("javascript:");
     expect(out).toContain("<h3>Heading</h3>");
+  });
+
+  it("neutralizes a combined URL-quote-breakout + dangerous-scheme injection in a list-item line", () => {
+    expect(renderCommentPreviewHtml('- [x](javascript:evil" onmouseover="foo)')).not.toContain(
+      "onmouseover",
+    );
   });
 });

--- a/apps/web/src/lib/comment-preview-sanitize.test.ts
+++ b/apps/web/src/lib/comment-preview-sanitize.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCommentPreviewHtml } from "./comment-preview-sanitize";
+
+describe("sanitizeCommentPreviewHtml", () => {
+  it("passes through allowed tags with allowed attributes unchanged", () => {
+    const html =
+      '<p>See <a href="https://uploads.sh/f/abc">this file</a></p>' +
+      '<img src="https://uploads.sh/x.png" alt="screenshot" width="640" align="left">';
+    expect(sanitizeCommentPreviewHtml(html)).toBe(html);
+  });
+
+  it("keeps details/summary and the boolean open attribute", () => {
+    const html = "<details open><summary>More</summary><p>Body</p></details>";
+    expect(sanitizeCommentPreviewHtml(html)).toBe(html);
+  });
+
+  it("keeps table markup and inline formatting tags", () => {
+    const html =
+      "<table><tr><td><strong>Bold</strong> <em>em</em> <sub>sub</sub> <code>code</code></td></tr></table>" +
+      "<h3>H3</h3><h4>H4</h4><ul><li>one</li></ul><br>";
+    expect(sanitizeCommentPreviewHtml(html)).toBe(html);
+  });
+
+  it("strips script tags and their content entirely", () => {
+    const html = "<p>hi</p><script>alert(1)</script><p>bye</p>";
+    expect(sanitizeCommentPreviewHtml(html)).toBe("<p>hi</p><p>bye</p>");
+  });
+
+  it("strips disallowed tags but keeps their text content", () => {
+    const html = "<div>keep me</div><p>ok</p>";
+    expect(sanitizeCommentPreviewHtml(html)).toBe("keep me<p>ok</p>");
+  });
+
+  it("drops disallowed attributes such as onerror and style", () => {
+    const html = '<img src="https://uploads.sh/x.png" onerror="alert(1)" style="x">';
+    expect(sanitizeCommentPreviewHtml(html)).toBe('<img src="https://uploads.sh/x.png">');
+  });
+
+  it("drops javascript: and data: hrefs/srcs, keeps http(s) and relative", () => {
+    expect(sanitizeCommentPreviewHtml('<a href="javascript:alert(1)">x</a>')).toBe("<a>x</a>");
+    expect(sanitizeCommentPreviewHtml('<img src="data:text/html,evil">')).toBe("<img>");
+    expect(sanitizeCommentPreviewHtml('<a href="/f/abc">x</a>')).toBe('<a href="/f/abc">x</a>');
+  });
+
+  it("rejects a non-numeric width and a bogus align value", () => {
+    expect(sanitizeCommentPreviewHtml('<img src="https://a/b.png" width="9999px">')).toBe(
+      '<img src="https://a/b.png">',
+    );
+    expect(sanitizeCommentPreviewHtml('<img src="https://a/b.png" align="evil()">')).toBe(
+      '<img src="https://a/b.png">',
+    );
+  });
+
+  it("escapes stray angle brackets that are not part of a tag", () => {
+    expect(sanitizeCommentPreviewHtml("a < b and c > d")).toBe("a &lt; b and c &gt; d");
+  });
+
+  it("handles an empty string", () => {
+    expect(sanitizeCommentPreviewHtml("")).toBe("");
+  });
+
+  it("closes disallowed nested tags without corrupting sibling allowed tags", () => {
+    const html = "<div><p>text</p></div><p>after</p>";
+    expect(sanitizeCommentPreviewHtml(html)).toBe("<p>text</p><p>after</p>");
+  });
+});

--- a/apps/web/src/lib/comment-preview-sanitize.ts
+++ b/apps/web/src/lib/comment-preview-sanitize.ts
@@ -1,0 +1,156 @@
+/**
+ * Allowlist sanitizer for the workspace comment-settings preview panel
+ * (issue #307, Task 7). The preview endpoint's `body` field is real
+ * managed-comment HTML from `attachmentsCommentBody`
+ * (apps/api/src/github-comment-render.ts) — safe by construction against
+ * *our own* renderer, but it can be influenced by a repo's `.uploads.yml`
+ * (the note text, effectively), so the web client never `innerHTML`s it raw.
+ *
+ * Scoped tightly to the tags/attributes that renderer actually emits — not a
+ * general-purpose HTML sanitizer. If the renderer ever grows a new tag or
+ * attribute, this allowlist needs a matching update or the preview will
+ * silently drop it.
+ */
+
+/** Tags the managed-comment renderer emits (github-comment-render.ts) — see repo-comment-config.ts's task 7 brief for the exact list. */
+const ALLOWED_TAGS = new Set([
+  "a",
+  "img",
+  "sub",
+  "strong",
+  "details",
+  "summary",
+  "table",
+  "tr",
+  "td",
+  "br",
+  "h3",
+  "h4",
+  "code",
+  "em",
+  "p",
+  "ul",
+  "li",
+]);
+
+/** Tags whose content (not just the tag itself) must never reach the DOM. */
+const STRIP_CONTENT_TAGS = new Set([
+  "script",
+  "style",
+  "svg",
+  "iframe",
+  "object",
+  "embed",
+  "template",
+]);
+
+/** Attributes kept per tag — everything else is dropped, never passed through. */
+const ALLOWED_ATTRS_BY_TAG: Record<string, ReadonlySet<string>> = {
+  a: new Set(["href"]),
+  img: new Set(["src", "alt", "width", "align"]),
+  details: new Set(["open"]),
+};
+
+const WIDTH_RE = /^\d{1,4}%?$/;
+const ALIGN_RE = /^[A-Za-z]+$/;
+
+const TAG_RE =
+  /<\/?([a-zA-Z][a-zA-Z0-9]*)((?:\s+[a-zA-Z_:][-a-zA-Z0-9_:.]*(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?)*)\s*\/?>/g;
+const ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+function escapeStrayAngles(text: string): string {
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeAttrValue(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** http(s) or scheme-less (relative/anchor) URLs only — no `javascript:`/`data:`/anything else. */
+function isSafeUrl(value: string): boolean {
+  const match = value.trim().match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  if (!match) return true;
+  const scheme = match[1].toLowerCase();
+  return scheme === "http" || scheme === "https";
+}
+
+function filterAttributes(tagName: string, attrsRaw: string): string {
+  const allowed = ALLOWED_ATTRS_BY_TAG[tagName];
+  if (!allowed || attrsRaw.trim().length === 0) return "";
+
+  let out = "";
+  ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ATTR_RE.exec(attrsRaw))) {
+    const name = m[1].toLowerCase();
+    if (!allowed.has(name)) continue;
+    const value = m[2] ?? m[3] ?? m[4];
+
+    if (name === "open") {
+      out += " open";
+      continue;
+    }
+    if (value === undefined) continue; // every other allowed attribute requires a value
+
+    if ((name === "href" || name === "src") && !isSafeUrl(value)) continue;
+    if (name === "width" && !WIDTH_RE.test(value)) continue;
+    if (name === "align" && !ALIGN_RE.test(value)) continue;
+
+    out += ` ${name}="${escapeAttrValue(value)}"`;
+  }
+  return out;
+}
+
+/**
+ * Sanitize a managed-comment preview body down to the tag/attribute
+ * allowlist above. Disallowed tags are unwrapped (their text content
+ * survives); `script`/`style`/etc. are stripped along with their content.
+ * Text outside any tag has stray `<`/`>` escaped so it can never be
+ * misread as markup once reassembled.
+ */
+export function sanitizeCommentPreviewHtml(html: string): string {
+  if (!html) return html;
+
+  let result = "";
+  let lastIndex = 0;
+  let skipUntilCloseTag: string | null = null;
+
+  TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TAG_RE.exec(html))) {
+    const full = match[0];
+    const tagName = match[1].toLowerCase();
+    const attrsRaw = match[2] ?? "";
+    const isClosing = full.startsWith("</");
+    const textBefore = html.slice(lastIndex, match.index);
+    lastIndex = match.index + full.length;
+
+    if (skipUntilCloseTag) {
+      if (isClosing && tagName === skipUntilCloseTag) skipUntilCloseTag = null;
+      continue;
+    }
+
+    result += escapeStrayAngles(textBefore);
+
+    if (STRIP_CONTENT_TAGS.has(tagName)) {
+      if (!isClosing && !full.endsWith("/>")) skipUntilCloseTag = tagName;
+      continue;
+    }
+
+    if (!ALLOWED_TAGS.has(tagName)) continue; // unwrap: drop the tag, keep surrounding text
+
+    if (isClosing) {
+      result += `</${tagName}>`;
+      continue;
+    }
+
+    result += `<${tagName}${filterAttributes(tagName, attrsRaw)}>`;
+  }
+
+  if (!skipUntilCloseTag) result += escapeStrayAngles(html.slice(lastIndex));
+  return result;
+}

--- a/apps/web/src/lib/comment-preview-sanitize.ts
+++ b/apps/web/src/lib/comment-preview-sanitize.ts
@@ -70,6 +70,21 @@ function escapeAttrValue(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
+/**
+ * Strip ASCII tab/newline/CR *everywhere* in the value, not just the edges.
+ * Browsers do this while parsing `href`/`src` before scheme-sniffing (WHATWG
+ * URL parsing's "remove all ASCII tab or newline" step), so a scheme check
+ * that only `.trim()`s is bypassable: `"java\tscript:alert(1)"` doesn't match
+ * the scheme regex (the embedded tab breaks it), so `isSafeUrl` sees no
+ * scheme at all and treats it as a safe relative URL — while the browser
+ * strips the tab back out at render time and happily executes it. Applying
+ * this to every attribute value (not just href/src) before any per-attribute
+ * check keeps width/align consistent with the same normalization.
+ */
+function stripUrlNoise(value: string): string {
+  return value.replace(/[\t\n\r]/g, "");
+}
+
 /** http(s) or scheme-less (relative/anchor) URLs only — no `javascript:`/`data:`/anything else. */
 function isSafeUrl(value: string): boolean {
   const match = value.trim().match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
@@ -88,13 +103,14 @@ function filterAttributes(tagName: string, attrsRaw: string): string {
   while ((m = ATTR_RE.exec(attrsRaw))) {
     const name = m[1].toLowerCase();
     if (!allowed.has(name)) continue;
-    const value = m[2] ?? m[3] ?? m[4];
+    const rawValue = m[2] ?? m[3] ?? m[4];
 
     if (name === "open") {
       out += " open";
       continue;
     }
-    if (value === undefined) continue; // every other allowed attribute requires a value
+    if (rawValue === undefined) continue; // every other allowed attribute requires a value
+    const value = stripUrlNoise(rawValue);
 
     if ((name === "href" || name === "src") && !isSafeUrl(value)) continue;
     if (name === "width" && !WIDTH_RE.test(value)) continue;
@@ -153,4 +169,95 @@ export function sanitizeCommentPreviewHtml(html: string): string {
 
   if (!skipUntilCloseTag) result += escapeStrayAngles(html.slice(lastIndex));
   return result;
+}
+
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+const H4_LINE_RE = /^####\s+(.*)$/;
+const H3_LINE_RE = /^###\s+(.*)$/;
+/** `- [text](url)` — the one markdown-list shape the renderer's note/gallery text can contain. */
+const LIST_ITEM_LINE_RE = /^-\s+\[([^\]]*)\]\(([^)]*)\)\s*$/;
+
+/**
+ * `attachmentsCommentBody` (apps/api/src/github-comment-render.ts) emits
+ * GitHub-flavored Markdown with embedded HTML — literal `### heading` /
+ * `#### <a>title</a>` lines alongside real `<table>/<a>/<img>` tags, because
+ * GitHub's own renderer understands both together. Nothing in apps/web
+ * understands Markdown, so without this step the preview showed the hidden
+ * `<!-- uploads.sh:attachments ... -->` marker and literal `###`/`####`
+ * text verbatim instead of a heading. This is a *small, scoped* subset of
+ * Markdown — exactly what the renderer's own output shape needs (headings,
+ * one link-list-item form, paragraph/line breaks) — not a general Markdown
+ * parser. It runs BEFORE `sanitizeCommentPreviewHtml`, so nothing it emits
+ * skips the allowlist: an `<a href>` built here still has its `href`
+ * validated the same as one that arrived as raw HTML.
+ */
+export function formatCommentPreviewBody(raw: string): string {
+  const withoutComments = raw.replace(HTML_COMMENT_RE, "");
+  const lines = withoutComments.split(/\r\n|\r|\n/);
+
+  const out: string[] = [];
+  let paragraph: string[] = [];
+  let listItems: string[] = [];
+
+  const flushParagraph = (): void => {
+    if (paragraph.length === 0) return;
+    out.push(`<p>${paragraph.join("<br>")}</p>`);
+    paragraph = [];
+  };
+  const flushList = (): void => {
+    if (listItems.length === 0) return;
+    out.push(`<ul>${listItems.join("")}</ul>`);
+    listItems = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    const h4 = line.match(H4_LINE_RE);
+    if (h4) {
+      flushParagraph();
+      flushList();
+      out.push(`<h4>${h4[1].trim()}</h4>`);
+      continue;
+    }
+
+    const h3 = line.match(H3_LINE_RE);
+    if (h3) {
+      flushParagraph();
+      flushList();
+      out.push(`<h3>${h3[1].trim()}</h3>`);
+      continue;
+    }
+
+    const item = line.match(LIST_ITEM_LINE_RE);
+    if (item) {
+      flushParagraph();
+      listItems.push(`<li><a href="${item[2]}">${item[1]}</a></li>`);
+      continue;
+    }
+
+    flushList();
+    paragraph.push(line);
+  }
+  flushParagraph();
+  flushList();
+
+  return out.join("");
+}
+
+/**
+ * The one entry point the settings-tab preview panel should call: strips
+ * the managed-comment marker, converts the renderer's Markdown-ish shape to
+ * real tags, then sanitizes the result down to the tag/attribute allowlist.
+ * Prefer this over calling `formatCommentPreviewBody`/
+ * `sanitizeCommentPreviewHtml` separately — they're exported individually
+ * only so each transform has its own focused tests.
+ */
+export function renderCommentPreviewHtml(raw: string): string {
+  return sanitizeCommentPreviewHtml(formatCommentPreviewBody(raw));
 }

--- a/apps/web/src/lib/comment-preview-sanitize.ts
+++ b/apps/web/src/lib/comment-preview-sanitize.ts
@@ -237,7 +237,11 @@ export function formatCommentPreviewBody(raw: string): string {
     const item = line.match(LIST_ITEM_LINE_RE);
     if (item) {
       flushParagraph();
-      listItems.push(`<li><a href="${item[2]}">${item[1]}</a></li>`);
+      // Escape at construction — not just relying on the sanitize pass that
+      // runs after — so this transform is safe standalone.
+      const href = escapeAttrValue(item[2]);
+      const text = escapeStrayAngles(item[1]);
+      listItems.push(`<li><a href="${href}">${text}</a></li>`);
       continue;
     }
 

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -49,6 +49,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             id="cs-image-width-px"
             class="ul-input cs-image-width-px"
             step="1"
+            min="160"
+            max="1000"
             placeholder="160–1000"
             hidden
           />
@@ -61,6 +63,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             id="cs-max-inline"
             class="ul-input"
             step="1"
+            min="1"
+            max="48"
             placeholder="Auto (16)"
           />
         </div>
@@ -424,12 +428,21 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         }).join("");
       }
 
+      // Monotonic token guarding against out-of-order responses: each
+      // repo-picker change (or save) starts a new, unsequenced loadPreview
+      // call, and a slower earlier request landing after a faster later one
+      // would render a stale repo's preview. `stillHere()` only guards
+      // against navigating away entirely, not against overlapping preview
+      // requests for the same page visit.
+      let previewSeq = 0;
+
       async function loadPreview(): Promise<void> {
         if (!stillHere()) return;
+        const seq = ++previewSeq;
         previewBodyEl.setAttribute("aria-busy", "true");
         const repo = repoSelect.value || undefined;
         const result = await getWorkspaceCommentPreview(apiOrigin, workspaceName, repo);
-        if (!stillHere()) return;
+        if (!stillHere() || seq !== previewSeq) return;
         previewBodyEl.removeAttribute("aria-busy");
         if (result.kind !== "ok") {
           badgesEl.innerHTML = "";
@@ -499,12 +512,16 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           if (widthSelect.value === "full") {
             patch.imageWidth = "full";
           } else if (widthSelect.value === "custom") {
-            const px = Number(widthPxInput.value);
-            patch.imageWidth = Number.isFinite(px) ? px : null;
+            const raw = widthPxInput.value.trim();
+            const px = Number(raw);
+            patch.imageWidth = raw !== "" && Number.isFinite(px) ? px : null;
           } else {
             patch.imageWidth = null;
           }
-          patch.maxInlineImages = maxInlineInput.value === "" ? null : Number(maxInlineInput.value);
+          {
+            const rawMaxInline = maxInlineInput.value.trim();
+            patch.maxInlineImages = rawMaxInline === "" ? null : Number(rawMaxInline);
+          }
           patch.showMetadata = selectValueToTriState(showMetadataSelect.value);
           patch.linkToFilePage = selectValueToTriState(linkToFilePageSelect.value);
           patch.note = noteInput.value.trim() === "" ? null : noteInput.value;

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -65,14 +65,23 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           />
         </div>
 
-        <label class="cs-checkbox">
-          <input type="checkbox" id="cs-show-metadata" />
-          Show metadata captions
-        </label>
-        <label class="cs-checkbox">
-          <input type="checkbox" id="cs-link-to-file-page" />
-          Link to file pages
-        </label>
+        <div class="cs-field">
+          <label for="cs-show-metadata">Show metadata captions</label>
+          <select id="cs-show-metadata" class="ul-select">
+            <option value="">Auto (on)</option>
+            <option value="true">On</option>
+            <option value="false">Off</option>
+          </select>
+        </div>
+
+        <div class="cs-field">
+          <label for="cs-link-to-file-page">Link to file pages</label>
+          <select id="cs-link-to-file-page" class="ul-select">
+            <option value="">Auto (on)</option>
+            <option value="true">On</option>
+            <option value="false">Off</option>
+          </select>
+        </div>
 
         <div class="cs-field">
           <label for="cs-note">Note</label>
@@ -147,13 +156,6 @@ if (!workspace) return Astro.redirect("/account/workspaces");
     .cs-image-width-px {
       max-width: 10rem;
     }
-    .cs-checkbox {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 13px;
-      cursor: pointer;
-    }
     .cs-actions {
       display: flex;
       align-items: center;
@@ -212,7 +214,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       type CommentPreview,
       type CommentSettings,
     } from "../../../../lib/api-client";
-    import { sanitizeCommentPreviewHtml } from "../../../../lib/comment-preview-sanitize";
+    import { renderCommentPreviewHtml } from "../../../../lib/comment-preview-sanitize";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import { renderDetailsHtml } from "../../../../lib/workspace-rail";
@@ -279,8 +281,20 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       ) as unknown as HTMLSelectElement;
       const widthPxInput = requireElement<HTMLInputElement>("#cs-image-width-px", page);
       const maxInlineInput = requireElement<HTMLInputElement>("#cs-max-inline", page);
-      const showMetadataInput = requireElement<HTMLInputElement>("#cs-show-metadata", page);
-      const linkToFilePageInput = requireElement<HTMLInputElement>("#cs-link-to-file-page", page);
+      // Tri-state (Auto/On/Off) selects, not checkboxes: these fields
+      // resolve `true` when left at "auto" (AUTO_COMMENT_OPTIONS default),
+      // so a two-state checkbox couldn't represent "explicitly off" without
+      // being indistinguishable from "unset" — unchecking would clear an
+      // explicit `false` back to auto (which resolves true), the opposite
+      // of what unchecking should mean.
+      const showMetadataSelect = requireElement<HTMLElement>(
+        "#cs-show-metadata",
+        page,
+      ) as unknown as HTMLSelectElement;
+      const linkToFilePageSelect = requireElement<HTMLElement>(
+        "#cs-link-to-file-page",
+        page,
+      ) as unknown as HTMLSelectElement;
       const noteInput = requireElement<HTMLTextAreaElement>("#cs-note", page);
       const noteCount = requireElement<HTMLElement>("#cs-note-count", page);
       const saveBtn = requireElement<HTMLButtonElement>("#cs-save-btn", page);
@@ -291,6 +305,19 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       ) as unknown as HTMLSelectElement;
       const badgesEl = requireElement<HTMLElement>("#cs-preview-badges", page);
       const previewBodyEl = requireElement<HTMLElement>("#cs-preview-body", page);
+
+      /** `null` -> "" (Auto), `true` -> "true", `false` -> "false" — for the tri-state selects. */
+      function triStateToSelectValue(value: boolean | null): string {
+        if (value === true) return "true";
+        if (value === false) return "false";
+        return "";
+      }
+      /** Inverse of `triStateToSelectValue`, for reading a tri-state select back into a patch. */
+      function selectValueToTriState(value: string): boolean | null {
+        if (value === "true") return true;
+        if (value === "false") return false;
+        return null;
+      }
 
       function applySettingsToForm(settings: CommentSettings): void {
         if (settings.imageWidth === "full") {
@@ -307,8 +334,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         }
         maxInlineInput.value =
           settings.maxInlineImages === null ? "" : String(settings.maxInlineImages);
-        showMetadataInput.checked = settings.showMetadata === true;
-        linkToFilePageInput.checked = settings.linkToFilePage === true;
+        showMetadataSelect.value = triStateToSelectValue(settings.showMetadata);
+        linkToFilePageSelect.value = triStateToSelectValue(settings.linkToFilePage);
         noteInput.value = settings.note ?? "";
         noteCount.textContent = String(noteInput.value.length);
       }
@@ -334,7 +361,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           return;
         }
         renderBadges(result.preview);
-        previewBodyEl.innerHTML = sanitizeCommentPreviewHtml(result.preview.body);
+        previewBodyEl.innerHTML = renderCommentPreviewHtml(result.preview.body);
       }
 
       async function loadRepoPicker(): Promise<void> {
@@ -402,8 +429,8 @@ if (!workspace) return Astro.redirect("/account/workspaces");
             patch.imageWidth = null;
           }
           patch.maxInlineImages = maxInlineInput.value === "" ? null : Number(maxInlineInput.value);
-          patch.showMetadata = showMetadataInput.checked ? true : null;
-          patch.linkToFilePage = linkToFilePageInput.checked ? true : null;
+          patch.showMetadata = selectValueToTriState(showMetadataSelect.value);
+          patch.linkToFilePage = selectValueToTriState(linkToFilePageSelect.value);
           patch.note = noteInput.value.trim() === "" ? null : noteInput.value;
 
           const result = await patchWorkspaceCommentSettings(apiOrigin, workspaceName, patch);

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -1,10 +1,12 @@
 ---
 /**
- * Workspace settings tab — thin stub (design 3A §5.3). The rail already
- * surfaces slug/public-url live; this repeats the same summary in the main
- * column (visible without the rail, e.g. on narrow viewports) via a
- * `<details>` disclosure. No new endpoints — reuses `getMyWorkspaces` +
- * `renderDetailsHtml` from the rail module.
+ * Workspace settings tab — design 3A §5.3's slug/public-url summary, plus
+ * the issue #307 GitHub-comment defaults block + live preview panel (Task
+ * 7). Both new sections start `hidden` and reveal on session (same
+ * progressive-reveal convention as the details `<dl>` below and the
+ * PR #526 account pages) rather than blocking the tab's initial paint —
+ * admin-gated data has nothing to show until the session/role check lands
+ * anyway.
  */
 import WorkspaceLayout from "../../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../../lib/workspace-browse-url";
@@ -23,6 +25,86 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         <summary>Workspace details</summary>
         <dl class="kv" data-ws-settings-details></dl>
       </details>
+    </div>
+
+    <div class="settings-section" id="cs-section" hidden>
+      <h2>GitHub comment</h2>
+      <p class="settings-note muted">
+        Defaults every linked repo's managed comment uses, unless a repo's <code>.uploads.yml</code>
+        overrides them.
+      </p>
+
+      <div id="cs-error" class="ul-callout" data-state="error" role="alert" hidden></div>
+
+      <form class="ws-form cs-form" id="cs-form">
+        <div class="cs-field">
+          <label for="cs-image-width">Image width</label>
+          <select id="cs-image-width" class="ul-select">
+            <option value="auto">Auto</option>
+            <option value="full">Full width</option>
+            <option value="custom">Custom (px)</option>
+          </select>
+          <input
+            type="number"
+            id="cs-image-width-px"
+            class="ul-input cs-image-width-px"
+            step="1"
+            placeholder="160–1000"
+            hidden
+          />
+        </div>
+
+        <div class="cs-field">
+          <label for="cs-max-inline">Max inline images</label>
+          <input
+            type="number"
+            id="cs-max-inline"
+            class="ul-input"
+            step="1"
+            placeholder="Auto (16)"
+          />
+        </div>
+
+        <label class="cs-checkbox">
+          <input type="checkbox" id="cs-show-metadata" />
+          Show metadata captions
+        </label>
+        <label class="cs-checkbox">
+          <input type="checkbox" id="cs-link-to-file-page" />
+          Link to file pages
+        </label>
+
+        <div class="cs-field">
+          <label for="cs-note">Note</label>
+          <textarea
+            id="cs-note"
+            class="ul-input cs-note"
+            maxlength="500"
+            rows="3"
+            placeholder="Optional note appended to every managed comment"></textarea>
+          <p class="ul-field__hint"><span id="cs-note-count">0</span>/500</p>
+        </div>
+
+        <div class="cs-actions">
+          <button type="submit" class="ul-btn ul-btn--solid" id="cs-save-btn">Save</button>
+          <span class="muted" id="cs-save-status" role="status"></span>
+        </div>
+      </form>
+    </div>
+
+    <div class="settings-section" id="cs-preview-section" hidden>
+      <h2>Preview</h2>
+
+      <div class="cs-field">
+        <label for="cs-preview-repo">Repo</label>
+        <select id="cs-preview-repo" class="ul-select">
+          <option value="">No repo config</option>
+        </select>
+      </div>
+
+      <div id="cs-preview-badges" class="cs-badges" aria-live="polite"></div>
+      <div id="cs-preview-body" class="cs-preview-body" aria-busy="true"></div>
+      <p class="settings-note muted">GitHub's own styling may differ slightly.</p>
     </div>
   </section>
 
@@ -44,6 +126,73 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       color: var(--fg);
       outline: none;
     }
+
+    .cs-form {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      max-width: 32rem;
+    }
+    .cs-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .cs-field label {
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+    .cs-image-width-px {
+      max-width: 10rem;
+    }
+    .cs-checkbox {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .cs-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 4px;
+    }
+    #cs-save-status[data-state="error"] {
+      color: var(--red);
+    }
+    #cs-save-status[data-state="ok"] {
+      color: var(--green);
+    }
+
+    .cs-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin: 4px 0 14px;
+    }
+    .cs-preview-body {
+      border: 1px solid var(--line);
+      border-radius: var(--radius-md);
+      padding: 14px 16px;
+      font-size: 13px;
+      line-height: 1.6;
+      overflow-x: auto;
+      max-width: 42rem;
+    }
+    .cs-preview-body img {
+      max-width: 100%;
+      height: auto;
+    }
+    .cs-preview-body table {
+      border-collapse: collapse;
+    }
+    .cs-preview-body td {
+      padding: 4px 8px;
+      vertical-align: top;
+    }
   </style>
 
   <script>
@@ -52,16 +201,48 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       isCurrentPageVisit,
       onAstroPageLoad,
       onSession,
+      requireElement,
     } from "../../../../lib/account-shell";
-    import { getMyWorkspaces } from "../../../../lib/api-client";
+    import {
+      getMyWorkspaces,
+      getWorkspaceCommentSettings,
+      getWorkspaceCommentPreview,
+      getWorkspaceRepoLinks,
+      patchWorkspaceCommentSettings,
+      type CommentPreview,
+      type CommentSettings,
+    } from "../../../../lib/api-client";
+    import { sanitizeCommentPreviewHtml } from "../../../../lib/comment-preview-sanitize";
     import { writeCachedWorkspaces } from "../../../../lib/workspaces-nav";
     import { resolveActiveWorkspace } from "../../../../lib/workspace-browse-url";
     import { renderDetailsHtml } from "../../../../lib/workspace-rail";
+    import { escapeHtml } from "../../../../lib/workspace-ui";
+
+    const SOURCE_LABEL: Record<string, string> = { repo: "repo", workspace: "workspace", auto: "auto" };
+    const SOURCE_BADGE_CLASS: Record<string, string> = {
+      repo: "ul-badge--accent",
+      workspace: "ul-badge--ok",
+      auto: "",
+    };
+    /** Source-badge rows, each paired with the human label + the `source` key it reads. */
+    const BADGE_FIELDS: { label: string; key: keyof CommentPreview["source"] }[] = [
+      { label: "Image width", key: "imageWidth" },
+      { label: "Max inline images", key: "maxInlineImages" },
+      { label: "Metadata path", key: "metaPath" },
+      { label: "Metadata state", key: "metaState" },
+      { label: "Link to file page", key: "linkToFilePage" },
+      { label: "Note", key: "note" },
+    ];
 
     onAstroPageLoad(() => {
       const detailsEl = document.querySelector<HTMLElement>("[data-ws-settings-details]");
-      if (!detailsEl) return;
+      const csSectionEl = document.getElementById("cs-section");
+      if (!detailsEl || !csSectionEl) return;
+      // Narrowed local, not the outer possibly-null binding: TS doesn't carry
+      // the guard above into closures declared further down this function.
+      const csSection = csSectionEl;
 
+      const page = "workspace comment settings";
       const visit = getPageVisit();
       const stillHere = (): boolean => isCurrentPageVisit(visit);
       const w = window as unknown as {
@@ -75,14 +256,179 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         w.__UPLOADS_ACTIVE_WORKSPACE__ || "",
       );
 
+      // Existing "Workspace details" disclosure — unrelated to the comment
+      // settings below, kept exactly as it was.
+      void getMyWorkspaces(apiOrigin).then((result) => {
+        if (!stillHere() || result.kind !== "success") return;
+        writeCachedWorkspaces(result.workspaces);
+        const ws = result.workspaces.find((item) => item.workspace === workspaceName);
+        if (!ws) return;
+        detailsEl.innerHTML = renderDetailsHtml(ws);
+      });
+
+      const csPreviewSection = requireElement<HTMLElement>("#cs-preview-section", page);
+      const errorEl = requireElement<HTMLElement>("#cs-error", page);
+      const form = requireElement<HTMLFormElement>("#cs-form", page);
+      // worker-configuration.d.ts's HTMLRewriter ambient `Element` redeclares
+      // `remove()`, which makes HTMLSelectElement fail requireElement's
+      // `T extends Element` constraint (same workaround as people.astro's
+      // role-select handler) — fetch as HTMLElement and cast.
+      const widthSelect = requireElement<HTMLElement>(
+        "#cs-image-width",
+        page,
+      ) as unknown as HTMLSelectElement;
+      const widthPxInput = requireElement<HTMLInputElement>("#cs-image-width-px", page);
+      const maxInlineInput = requireElement<HTMLInputElement>("#cs-max-inline", page);
+      const showMetadataInput = requireElement<HTMLInputElement>("#cs-show-metadata", page);
+      const linkToFilePageInput = requireElement<HTMLInputElement>("#cs-link-to-file-page", page);
+      const noteInput = requireElement<HTMLTextAreaElement>("#cs-note", page);
+      const noteCount = requireElement<HTMLElement>("#cs-note-count", page);
+      const saveBtn = requireElement<HTMLButtonElement>("#cs-save-btn", page);
+      const saveStatus = requireElement<HTMLElement>("#cs-save-status", page);
+      const repoSelect = requireElement<HTMLElement>(
+        "#cs-preview-repo",
+        page,
+      ) as unknown as HTMLSelectElement;
+      const badgesEl = requireElement<HTMLElement>("#cs-preview-badges", page);
+      const previewBodyEl = requireElement<HTMLElement>("#cs-preview-body", page);
+
+      function applySettingsToForm(settings: CommentSettings): void {
+        if (settings.imageWidth === "full") {
+          widthSelect.value = "full";
+          widthPxInput.hidden = true;
+        } else if (typeof settings.imageWidth === "number") {
+          widthSelect.value = "custom";
+          widthPxInput.hidden = false;
+          widthPxInput.value = String(settings.imageWidth);
+        } else {
+          widthSelect.value = "auto";
+          widthPxInput.hidden = true;
+          widthPxInput.value = "";
+        }
+        maxInlineInput.value =
+          settings.maxInlineImages === null ? "" : String(settings.maxInlineImages);
+        showMetadataInput.checked = settings.showMetadata === true;
+        linkToFilePageInput.checked = settings.linkToFilePage === true;
+        noteInput.value = settings.note ?? "";
+        noteCount.textContent = String(noteInput.value.length);
+      }
+
+      function renderBadges(preview: CommentPreview): void {
+        badgesEl.innerHTML = BADGE_FIELDS.map(({ label, key }) => {
+          const source = preview.source[key] ?? "auto";
+          const cls = SOURCE_BADGE_CLASS[source] ?? "";
+          return `<span class="ul-badge ${cls}">${escapeHtml(label)}: ${escapeHtml(SOURCE_LABEL[source] ?? source)}</span>`;
+        }).join("");
+      }
+
+      async function loadPreview(): Promise<void> {
+        if (!stillHere()) return;
+        previewBodyEl.setAttribute("aria-busy", "true");
+        const repo = repoSelect.value || undefined;
+        const result = await getWorkspaceCommentPreview(apiOrigin, workspaceName, repo);
+        if (!stillHere()) return;
+        previewBodyEl.removeAttribute("aria-busy");
+        if (result.kind !== "ok") {
+          badgesEl.innerHTML = "";
+          previewBodyEl.textContent = "Preview unavailable right now.";
+          return;
+        }
+        renderBadges(result.preview);
+        previewBodyEl.innerHTML = sanitizeCommentPreviewHtml(result.preview.body);
+      }
+
+      async function loadRepoPicker(): Promise<void> {
+        const repos = await getWorkspaceRepoLinks(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        const options = repos
+          .map((repo) => `<option value="${escapeHtml(repo)}">${escapeHtml(repo)}</option>`)
+          .join("");
+        repoSelect.innerHTML = `<option value="">No repo config</option>${options}`;
+      }
+
+      function showFormError(message: string | null): void {
+        if (!message) {
+          errorEl.hidden = true;
+          errorEl.textContent = "";
+          return;
+        }
+        errorEl.hidden = false;
+        errorEl.textContent = message;
+      }
+
+      async function loadCommentSettings(): Promise<void> {
+        if (!stillHere()) return;
+        const result = await getWorkspaceCommentSettings(apiOrigin, workspaceName);
+        if (!stillHere()) return;
+        if (result.kind !== "ok") {
+          // Non-admin members (and any other failure) simply don't get this
+          // block — it stays hidden rather than showing broken empty inputs.
+          return;
+        }
+        csSection.hidden = false;
+        csPreviewSection.hidden = false;
+        applySettingsToForm(result.settings);
+        void loadRepoPicker();
+        void loadPreview();
+      }
+
+      widthSelect.addEventListener("change", () => {
+        widthPxInput.hidden = widthSelect.value !== "custom";
+      });
+
+      noteInput.addEventListener("input", () => {
+        noteCount.textContent = String(noteInput.value.length);
+      });
+
+      repoSelect.addEventListener("change", () => {
+        void loadPreview();
+      });
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        void (async () => {
+          showFormError(null);
+          saveStatus.textContent = "Saving…";
+          saveStatus.removeAttribute("data-state");
+          saveBtn.disabled = true;
+
+          const patch: Partial<CommentSettings> = {};
+          if (widthSelect.value === "full") {
+            patch.imageWidth = "full";
+          } else if (widthSelect.value === "custom") {
+            const px = Number(widthPxInput.value);
+            patch.imageWidth = Number.isFinite(px) ? px : null;
+          } else {
+            patch.imageWidth = null;
+          }
+          patch.maxInlineImages = maxInlineInput.value === "" ? null : Number(maxInlineInput.value);
+          patch.showMetadata = showMetadataInput.checked ? true : null;
+          patch.linkToFilePage = linkToFilePageInput.checked ? true : null;
+          patch.note = noteInput.value.trim() === "" ? null : noteInput.value;
+
+          const result = await patchWorkspaceCommentSettings(apiOrigin, workspaceName, patch);
+          if (!stillHere()) return;
+          saveBtn.disabled = false;
+
+          if (result.kind === "ok") {
+            applySettingsToForm(result.settings);
+            saveStatus.textContent = "Saved.";
+            saveStatus.dataset.state = "ok";
+            void loadPreview();
+            return;
+          }
+          if (result.kind === "invalid") {
+            showFormError(result.message);
+            saveStatus.textContent = "";
+            return;
+          }
+          saveStatus.textContent = "Couldn’t save. Try again.";
+          saveStatus.dataset.state = "error";
+        })();
+      });
+
       onSession(() => {
-        void getMyWorkspaces(apiOrigin).then((result) => {
-          if (!stillHere() || result.kind !== "success") return;
-          writeCachedWorkspaces(result.workspaces);
-          const ws = result.workspaces.find((item) => item.workspace === workspaceName);
-          if (!ws) return;
-          detailsEl.innerHTML = renderDetailsHtml(ws);
-        });
+        void loadCommentSettings();
       });
     });
   </script>

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -112,7 +112,36 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       </div>
 
       <div id="cs-preview-badges" class="cs-badges" aria-live="polite"></div>
-      <div id="cs-preview-body" class="cs-preview-body" aria-busy="true"></div>
+
+      <div class="cs-ghc" role="img" aria-label="Preview of the managed GitHub attachments comment">
+        <div class="cs-ghc-avatar" aria-hidden="true">
+          <svg viewBox="0 0 32 32" shape-rendering="crispEdges">
+            <path d="M4 0H28V4H32V28H28V32H4V28H0V4H4Z" fill="#0d1117" />
+            <g fill="#c27eff">
+              <path d="M14 4h4v4h-4z M10 6h4v4h-4z M18 6h4v4h-4z M6 8h4v4h-4z M22 8h4v4h-4z" />
+              <path
+                opacity=".55"
+                d="M14 12h4v4h-4z M10 14h4v4h-4z M18 14h4v4h-4z M6 16h4v4h-4z M22 16h4v4h-4z"
+              />
+              <path
+                opacity=".28"
+                d="M14 20h4v4h-4z M10 22h4v4h-4z M18 22h4v4h-4z M6 24h4v4h-4z M22 24h4v4h-4z"
+              />
+            </g>
+          </svg>
+        </div>
+        <div class="cs-ghc-bubble">
+          <div class="cs-ghc-head">
+            {/* Name only — the `bot` chip beside it is what GitHub renders, so
+                spelling it "uploads-sh[bot]" here would double-label. */}
+            <span class="cs-ghc-user">uploads-sh</span>
+            <span class="cs-ghc-bot-chip">bot</span>
+            <span>commented just now</span>
+          </div>
+          <div id="cs-preview-body" class="cs-preview-body" aria-busy="true"></div>
+        </div>
+      </div>
+
       <p class="settings-note muted">GitHub's own styling may differ slightly.</p>
     </div>
   </section>
@@ -175,14 +204,61 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       gap: 6px;
       margin: 4px 0 14px;
     }
-    .cs-preview-body {
+
+    /* ---------- GitHub comment chrome ---------- */
+    .cs-ghc {
+      display: grid;
+      grid-template-columns: 40px 1fr;
+      gap: 12px;
+      max-width: 42rem;
+    }
+    .cs-ghc-avatar {
+      width: 40px;
+      height: 40px;
+      border-radius: var(--radius-md);
+      background: var(--panel);
+      border: 1px solid var(--line);
+      display: grid;
+      place-items: center;
+    }
+    .cs-ghc-avatar svg {
+      width: 32px;
+      height: 32px;
+    }
+    .cs-ghc-bubble {
       border: 1px solid var(--line);
       border-radius: var(--radius-md);
+      overflow: hidden;
+    }
+    .cs-ghc-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      background: var(--panel);
+      border-bottom: 1px solid var(--line);
+      padding: 8px 14px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .cs-ghc-user {
+      color: var(--fg);
+      font-weight: 600;
+    }
+    .cs-ghc-bot-chip {
+      font-size: 10px;
+      letter-spacing: 0.02em;
+      color: var(--muted);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 0 6px;
+    }
+
+    .cs-preview-body {
       padding: 14px 16px;
       font-size: 13px;
       line-height: 1.6;
       overflow-x: auto;
-      max-width: 42rem;
     }
     .cs-preview-body img {
       max-width: 100%;

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -292,6 +292,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       getWorkspaceRepoLinks,
       patchWorkspaceCommentSettings,
       type CommentPreview,
+      type CommentPreviewResult,
       type CommentSettings,
     } from "../../../../lib/api-client";
     import { renderCommentPreviewHtml } from "../../../../lib/comment-preview-sanitize";
@@ -428,6 +429,27 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         }).join("");
       }
 
+      /** Distinct, actionable copy per `CommentPreviewResult`'s `reason` (api-client.ts) — a
+       * blanket "unavailable" message left every failure mode looking the same. */
+      function previewErrorMessage(
+        reason: Extract<CommentPreviewResult, { kind: "unavailable" }>["reason"],
+      ): string {
+        switch (reason) {
+          case "not_found":
+            return "This repo is no longer linked to the workspace.";
+          case "invalid_repo":
+            return "That repo isn't recognized — pick another from the list.";
+          case "forbidden":
+            return "You don't have permission to preview this workspace's comment.";
+          case "timeout":
+            return "Preview timed out — try again.";
+          case "network":
+            return "Couldn't reach the server — check your connection and try again.";
+          default:
+            return "Preview unavailable right now.";
+        }
+      }
+
       // Monotonic token guarding against out-of-order responses: each
       // repo-picker change (or save) starts a new, unsequenced loadPreview
       // call, and a slower earlier request landing after a faster later one
@@ -446,7 +468,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
         previewBodyEl.removeAttribute("aria-busy");
         if (result.kind !== "ok") {
           badgesEl.innerHTML = "";
-          previewBodyEl.textContent = "Preview unavailable right now.";
+          previewBodyEl.textContent = previewErrorMessage(result.reason);
           return;
         }
         renderBadges(result.preview);

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -103,6 +103,10 @@ it opens (or run: uploads attach --promote once it exists)</pre>
           themselves when the PR opens.
         </p>
       </a>
+      <a class="card" href="/docs/comment-config">
+        <h3>Comment config <span class="go">→</span></h3>
+        <p>Commit <code>.uploads.yml</code> to a repo to control image width, inline caps, and a note on its comment.</p>
+      </a>
       <a class="card" href="/docs/agents">
         <h3>Set up your agent <span class="go">→</span></h3>
         <p>Install the agent skills and the MCP server so your agent uploads on its own.</p>

--- a/apps/web/src/pages/docs/agents.astro
+++ b/apps/web/src/pages/docs/agents.astro
@@ -148,7 +148,7 @@ staged files are promoted into the PR's attachments comment automatically.</pre>
   </section>
 
   <nav class="page-nav" aria-label="More docs">
-    <a class="prev" href="/docs/github-app"><span class="dir">← Back</span>GitHub App</a>
+    <a class="prev" href="/docs/comment-config"><span class="dir">← Back</span>Comment config</a>
     <a class="next" href="/docs/reference"><span class="dir">Next →</span>Reference</a>
   </nav>
 </DocsLayout>

--- a/apps/web/src/pages/docs/comment-config.astro
+++ b/apps/web/src/pages/docs/comment-config.astro
@@ -1,0 +1,173 @@
+---
+// uploads.sh — docs / .uploads.yml comment config. A repo-committed file that
+// controls how the managed attachments comment renders for that repo: image
+// width, inline-image cap, caption metadata, the file-page link, and an
+// optional note. Read by both the bot and the CLI's gh-fallback path.
+import DocsLayout from "../../layouts/DocsLayout.astro";
+
+const TOC = [
+  { id: "what-it-controls", label: "What it controls" },
+  { id: "example", label: "Full example" },
+  { id: "file-location", label: "File location" },
+  { id: "precedence", label: "Precedence" },
+  { id: "note", label: "The note field" },
+  { id: "fail-closed", label: "Fail-closed behavior" },
+  { id: "preview", label: "Preview before committing" },
+];
+---
+
+<DocsLayout
+  title="Comment config"
+  description="Reference for .uploads.yml — a repo-committed file that controls image width, inline-image caps, caption metadata, and an optional note on the uploads-sh attachments comment."
+  path="/docs/comment-config"
+  heading="Comment config"
+  tagline="A repo-committed file that shapes how the attachments comment renders."
+  active="comment-config"
+  toc={TOC}
+>
+  <section class="lead" id="what-it-controls">
+    <h2>What it controls <a class="anchor" href="#what-it-controls" aria-label="Link to this section">#</a></h2>
+    <p>
+      Every key is optional and lives under a top-level <code>comment:</code> map. All of
+      it is presentation only — it changes how the attachments comment looks, never what
+      gets uploaded or where.
+    </p>
+    <ul>
+      <li><strong>Image width</strong> for inline images, pair cells, and video posters.</li>
+      <li><strong>How many images</strong> render inline before the rest collapse to links.</li>
+      <li><strong>Caption metadata</strong> — the path and state labels under each image.</li>
+      <li><strong>Whether images link</strong> to the file's share page.</li>
+      <li><strong>A short note</strong> shown under the comment header.</li>
+    </ul>
+    <p>
+      Nothing in the file can change which files get uploaded, where they're hosted, or
+      which repo a workspace can post to — it only reshapes the comment body for a repo
+      that's already allowed to receive one.
+    </p>
+  </section>
+
+  <section id="example">
+    <h2>Full example <a class="anchor" href="#example" aria-label="Link to this section">#</a></h2>
+    <p>Commit this at the repo root as <code>.uploads.yml</code>:</p>
+    <div class="block" aria-label="Example .uploads.yml">
+      <pre>comment:
+  # "auto" (the default filename-based sizing), "full" (natural width up to
+  # the comment column, no fixed attribute), or a pixel number from 160 to
+  # 1000. Applies to inline images, pair cells, and video posters alike;
+  # "full" and an explicit number override their sizing too, "auto" keeps it.
+  imageWidth: auto
+
+  # How many images render inline before the rest collapse to links.
+  # Clamped to 1-48. Default: 16.
+  maxInlineImages: 16
+
+  # Caption metadata under each image. Each key can be forced on or off.
+  # An omitted key follows the workspace default.
+  meta:
+    path: true
+    state: true
+
+  # Whether images link to the file's share page. Overrides the workspace
+  # setting.
+  linkToFilePage: true
+
+  # Optional short markdown shown under the comment header, before the
+  # attachments — repo-specific context, a link to a contributing guide, and
+  # so on. Trimmed, capped at 500 characters, rendered as-is: it's
+  # repo-owner-authored markdown in the owner's own repo, the same trust
+  # level as a PR description. Empty or whitespace-only counts as absent.
+  note: ""</pre>
+    </div>
+    <p class="note">
+      A value outside its valid range doesn't fail the whole file: numbers clamp to their
+      bounds, and an unrecognized value for a key drops just that key while every other
+      key still applies.
+    </p>
+  </section>
+
+  <section id="file-location">
+    <h2>File location <a class="anchor" href="#file-location" aria-label="Link to this section">#</a></h2>
+    <p>
+      The bot and the CLI both check these locations, in order, and use the first one
+      they find:
+    </p>
+    <ul>
+      <li><code>.uploads.yml</code></li>
+      <li><code>.uploads.yaml</code></li>
+      <li><code>.uploads.json</code></li>
+      <li><code>.github/uploads.yml</code></li>
+      <li><code>.github/uploads.yaml</code></li>
+      <li><code>.github/uploads.json</code></li>
+    </ul>
+    <p>
+      Only the file on the repo's default branch is read — config committed on a feature
+      branch or a PR doesn't take effect until it lands on default.
+    </p>
+  </section>
+
+  <section id="precedence">
+    <h2>Precedence <a class="anchor" href="#precedence" aria-label="Link to this section">#</a></h2>
+    <p>Each key resolves independently, in this order:</p>
+    <ol>
+      <li><strong>Repo config</strong> — a value set in <code>.uploads.yml</code>.</li>
+      <li>
+        <strong>Workspace default</strong> — set on the workspace's&#32;
+        <a href="/account">comment settings</a> by a workspace admin.
+      </li>
+      <li><strong>Automatic behavior</strong> — the built-in default when neither is set.</li>
+    </ol>
+    <p>
+      A repo can set some keys and leave others out; the ones it leaves out fall through
+      to the workspace default or the automatic behavior on a per-key basis, not as a
+      single all-or-nothing switch.
+    </p>
+  </section>
+
+  <section id="note">
+    <h2>The note field <a class="anchor" href="#note" aria-label="Link to this section">#</a></h2>
+    <p>
+      <code>note</code> renders directly under the comment header, before the attachments
+      themselves — a good place for "these are staging shots" or a link to a contributing
+      guide. It's capped at 500 characters.
+    </p>
+    <p>
+      A note over the cap is dropped whole, not cut short. Truncating mid-sentence could
+      post a note that reads as a different, unintended message, so the render falls back
+      to no note at all rather than a partial one. Trim the note in the file and it posts
+      normally.
+    </p>
+  </section>
+
+  <section id="fail-closed">
+    <h2>Fail-closed behavior <a class="anchor" href="#fail-closed" aria-label="Link to this section">#</a></h2>
+    <p>
+      A missing, unreadable, or unparseable config file never breaks the comment — it
+      just falls back to the workspace defaults, the same as if no file existed. This
+      applies to the whole file: a YAML syntax error anywhere in it means the whole file
+      is ignored for that render, not just the broken part.
+    </p>
+    <p>
+      The server caches a repo's config for about five minutes, so a commit that changes
+      or removes the file can take up to that long to take effect on the next bot
+      comment. The CLI's <code>gh</code>-fallback path reads the file straight from your
+      local working tree instead, with no cache, so both paths end up honoring the same
+      file.
+    </p>
+  </section>
+
+  <section id="preview">
+    <h2>Preview before committing <a class="anchor" href="#preview" aria-label="Link to this section">#</a></h2>
+    <p>
+      The workspace's <a href="/account">comment settings</a> page includes a live
+      preview: pick a repo the workspace is bound to and it renders the resolved comment
+      body using the same code path the bot uses, with a badge on each setting showing
+      whether it came from the repo config, the workspace default, or automatic
+      behavior. Use it to check a change before committing <code>.uploads.yml</code>.
+    </p>
+  </section>
+
+  <nav class="page-nav" aria-label="More docs">
+    <a class="prev" href="/docs/github-app"><span class="dir">← Back</span>GitHub App</a>
+    <a class="next" href="/docs/agents"><span class="dir">Next →</span>Set up your agent</a>
+  </nav>
+</DocsLayout>

--- a/apps/web/src/pages/docs/github-app.astro
+++ b/apps/web/src/pages/docs/github-app.astro
@@ -223,7 +223,7 @@ const TOC = [
 
   <nav class="page-nav" aria-label="More docs">
     <a class="prev" href="/docs/attach-pull-request-images"><span class="dir">← Back</span>Attach &amp; share</a>
-    <a class="next" href="/docs/agents"><span class="dir">Next →</span>Set up your agent</a>
+    <a class="next" href="/docs/comment-config"><span class="dir">Next →</span>Comment config</a>
   </nav>
 </DocsLayout>
 

--- a/packages/comment-config/package.json
+++ b/packages/comment-config/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@uploads/comment-config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "yaml": "^2.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/comment-config/package.json
+++ b/packages/comment-config/package.json
@@ -14,6 +14,7 @@
     "yaml": "^2.6.0"
   },
   "devDependencies": {
+    "@types/node": "^26.1.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   }

--- a/packages/comment-config/src/index.test.ts
+++ b/packages/comment-config/src/index.test.ts
@@ -1,5 +1,44 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { AUTO_COMMENT_OPTIONS, parseRepoCommentConfig, resolveCommentOptions } from "./index";
+import {
+  AUTO_COMMENT_OPTIONS,
+  parseRepoCommentConfig,
+  resolveCommentOptions,
+  type RepoCommentConfig,
+  type WorkspaceCommentDefaults,
+} from "./index";
+
+/**
+ * Parity fixture (issue #307) shared with the CLI copy
+ * (packages/uploads/test/comment-config.test.ts) — see the module doc
+ * comment in ./index.ts and packages/uploads/src/comment-config.ts for the
+ * cross-reference. Generated from THIS (canonical) package; asserted from
+ * both sides so the two copies can never drift silently.
+ */
+function loadGolden() {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL("../../../test/fixtures/comment-config-golden.json", import.meta.url)),
+      "utf8",
+    ),
+  ) as {
+    parseCases: {
+      name: string;
+      text: string;
+      format: "yaml" | "json";
+      expected: { config: RepoCommentConfig | null; warnings: string[] };
+    }[];
+    resolveCases: {
+      name: string;
+      repo: RepoCommentConfig | null;
+      workspace: WorkspaceCommentDefaults | null;
+      expected: ReturnType<typeof resolveCommentOptions>;
+    }[];
+  };
+}
+
+const golden = loadGolden();
 
 describe("parseRepoCommentConfig", () => {
   it("parses a full valid yaml config", () => {
@@ -112,5 +151,15 @@ describe("resolveCommentOptions", () => {
     const { options } = resolveCommentOptions({ metaPath: true }, { showMetadata: false });
     expect(options.metaPath).toBe(true);
     expect(options.metaState).toBe(false);
+  });
+});
+
+describe("comment-config-golden.json parity (canonical side)", () => {
+  it.each(golden.parseCases)("parse: $name", ({ text, format, expected }) => {
+    expect(parseRepoCommentConfig(text, format)).toEqual(expected);
+  });
+
+  it.each(golden.resolveCases)("resolve: $name", ({ repo, workspace, expected }) => {
+    expect(resolveCommentOptions(repo, workspace)).toEqual(expected);
   });
 });

--- a/packages/comment-config/src/index.test.ts
+++ b/packages/comment-config/src/index.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { AUTO_COMMENT_OPTIONS, parseRepoCommentConfig, resolveCommentOptions } from "./index";
+
+describe("parseRepoCommentConfig", () => {
+  it("parses a full valid yaml config", () => {
+    const { config, warnings } = parseRepoCommentConfig(
+      `comment:\n  imageWidth: full\n  maxInlineImages: 8\n  meta:\n    path: false\n    state: true\n  linkToFilePage: false\n  note: "Staging shots only."\n`,
+      "yaml",
+    );
+    expect(warnings).toEqual([]);
+    expect(config).toEqual({
+      imageWidth: "full",
+      maxInlineImages: 8,
+      metaPath: false,
+      metaState: true,
+      linkToFilePage: false,
+      note: "Staging shots only.",
+    });
+  });
+  it("parses json format", () => {
+    const { config } = parseRepoCommentConfig(
+      JSON.stringify({ comment: { imageWidth: 640 } }),
+      "json",
+    );
+    expect(config).toEqual({ imageWidth: 640 });
+  });
+  it("clamps numeric imageWidth to 160–1000", () => {
+    expect(parseRepoCommentConfig("comment:\n  imageWidth: 40\n", "yaml").config).toEqual({
+      imageWidth: 160,
+    });
+    expect(parseRepoCommentConfig("comment:\n  imageWidth: 5000\n", "yaml").config).toEqual({
+      imageWidth: 1000,
+    });
+  });
+  it("clamps maxInlineImages to 1–48", () => {
+    expect(parseRepoCommentConfig("comment:\n  maxInlineImages: 0\n", "yaml").config).toEqual({
+      maxInlineImages: 1,
+    });
+    expect(parseRepoCommentConfig("comment:\n  maxInlineImages: 99\n", "yaml").config).toEqual({
+      maxInlineImages: 48,
+    });
+  });
+  it("drops an invalid key with a warning, keeps the rest", () => {
+    const { config, warnings } = parseRepoCommentConfig(
+      "comment:\n  imageWidth: enormous\n  maxInlineImages: 4\n",
+      "yaml",
+    );
+    expect(config).toEqual({ maxInlineImages: 4 });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("imageWidth");
+  });
+  it("ignores unknown keys silently", () => {
+    const { config, warnings } = parseRepoCommentConfig(
+      "comment:\n  banana: true\n  linkToFilePage: false\nother: 1\n",
+      "yaml",
+    );
+    expect(config).toEqual({ linkToFilePage: false });
+    expect(warnings).toEqual([]);
+  });
+  it("drops an over-500-char note whole, with a warning — never truncates", () => {
+    const { config, warnings } = parseRepoCommentConfig(
+      `comment:\n  note: "${"x".repeat(501)}"\n`,
+      "yaml",
+    );
+    expect(config).toEqual({});
+    expect(warnings[0]).toContain("note");
+  });
+  it("treats empty/whitespace note as absent", () => {
+    expect(parseRepoCommentConfig('comment:\n  note: "   "\n', "yaml").config).toEqual({});
+  });
+  it("returns null config + warning for unparseable yaml", () => {
+    const { config, warnings } = parseRepoCommentConfig("comment: [unclosed", "yaml");
+    expect(config).toBeNull();
+    expect(warnings).toHaveLength(1);
+  });
+  it("returns null config for a non-object root or missing comment key", () => {
+    expect(parseRepoCommentConfig("- a\n- b\n", "yaml").config).toBeNull();
+    expect(parseRepoCommentConfig("other: 1\n", "yaml").config).toBeNull();
+  });
+  it("never throws on hostile input", () => {
+    for (const text of ["", "\0", "!!js/function 'x'", "{", "comment: 3"]) {
+      expect(() => parseRepoCommentConfig(text, "yaml")).not.toThrow();
+    }
+  });
+});
+
+describe("resolveCommentOptions", () => {
+  it("returns AUTO options with all-auto sources for null inputs", () => {
+    const { options, source } = resolveCommentOptions(null, null);
+    expect(options).toEqual(AUTO_COMMENT_OPTIONS);
+    expect(Object.values(source).every((s) => s === "auto")).toBe(true);
+  });
+  it("applies per-key precedence repo > workspace > auto", () => {
+    const { options, source } = resolveCommentOptions(
+      { imageWidth: "full" },
+      { imageWidth: 640, maxInlineImages: 4 },
+    );
+    expect(options.imageWidth).toBe("full");
+    expect(source.imageWidth).toBe("repo");
+    expect(options.maxInlineImages).toBe(4);
+    expect(source.maxInlineImages).toBe("workspace");
+    expect(options.metaPath).toBe(true);
+    expect(source.metaPath).toBe("auto");
+  });
+  it("maps workspace showMetadata:false to both meta fields", () => {
+    const { options, source } = resolveCommentOptions(null, { showMetadata: false });
+    expect(options.metaPath).toBe(false);
+    expect(options.metaState).toBe(false);
+    expect(source.metaPath).toBe("workspace");
+  });
+  it("repo meta override beats workspace showMetadata", () => {
+    const { options } = resolveCommentOptions({ metaPath: true }, { showMetadata: false });
+    expect(options.metaPath).toBe(true);
+    expect(options.metaState).toBe(false);
+  });
+});

--- a/packages/comment-config/src/index.ts
+++ b/packages/comment-config/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * Repo-level managed-comment config parser/resolver (issue #307). The
+ * published CLI (`@buildinternet/uploads`) cannot import this private
+ * workspace package, so it carries its own byte-for-byte COPY at
+ * packages/uploads/src/comment-config.ts. Kept in sync by
+ * test/fixtures/comment-config-golden.json, asserted from both sides
+ * (this package's index.test.ts and the CLI's comment-config.test.ts) —
+ * change both copies together.
+ */
 import { parse as parseYaml } from "yaml";
 
 export interface RepoCommentConfig {

--- a/packages/comment-config/src/index.ts
+++ b/packages/comment-config/src/index.ts
@@ -1,0 +1,166 @@
+import { parse as parseYaml } from "yaml";
+
+export interface RepoCommentConfig {
+  imageWidth?: "auto" | "full" | number;
+  maxInlineImages?: number;
+  metaPath?: boolean;
+  metaState?: boolean;
+  linkToFilePage?: boolean;
+  note?: string;
+}
+export interface WorkspaceCommentDefaults {
+  imageWidth?: "full" | number;
+  maxInlineImages?: number;
+  showMetadata?: boolean; // maps to BOTH metaPath and metaState
+  linkToFilePage?: boolean;
+  note?: string;
+}
+export interface ResolvedCommentOptions {
+  imageWidth: "auto" | "full" | number;
+  maxInlineImages: number;
+  metaPath: boolean;
+  metaState: boolean;
+  linkToFilePage: boolean;
+  note: string | null;
+}
+export type OptionSource = "repo" | "workspace" | "auto";
+
+export const AUTO_COMMENT_OPTIONS: ResolvedCommentOptions = {
+  imageWidth: "auto",
+  maxInlineImages: 16, // MAX_INLINE_ATTACHMENT_IMAGES — renderer copies own the constant
+  metaPath: true,
+  metaState: true,
+  linkToFilePage: true,
+  note: null,
+};
+
+export const NOTE_MAX_CHARS = 500;
+const WIDTH_MIN = 160;
+const WIDTH_MAX = 1000;
+const MAX_INLINE_MIN = 1;
+const MAX_INLINE_MAX = 48;
+
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, Math.round(n)));
+
+export function parseRepoCommentConfig(
+  text: string,
+  format: "yaml" | "json",
+): { config: RepoCommentConfig | null; warnings: string[] } {
+  const warnings: string[] = [];
+  let root: unknown;
+  try {
+    root = format === "json" ? JSON.parse(text) : parseYaml(text);
+  } catch {
+    return { config: null, warnings: ["config file could not be parsed; ignoring it"] };
+  }
+  if (typeof root !== "object" || root === null || Array.isArray(root)) {
+    return { config: null, warnings };
+  }
+  const comment = (root as Record<string, unknown>).comment;
+  if (typeof comment !== "object" || comment === null || Array.isArray(comment)) {
+    return { config: null, warnings };
+  }
+  const c = comment as Record<string, unknown>;
+  const config: RepoCommentConfig = {};
+
+  // imageWidth: "auto" | "full" | finite number (clamped)
+  if ("imageWidth" in c) {
+    const v = c.imageWidth;
+    if (v === "auto" || v === "full") config.imageWidth = v;
+    else if (typeof v === "number" && Number.isFinite(v))
+      config.imageWidth = clamp(v, WIDTH_MIN, WIDTH_MAX);
+    else warnings.push(`imageWidth: expected "auto", "full", or a number; dropped`);
+  }
+
+  // maxInlineImages: finite number (clamped)
+  if ("maxInlineImages" in c) {
+    const v = c.maxInlineImages;
+    if (typeof v === "number" && Number.isFinite(v))
+      config.maxInlineImages = clamp(v, MAX_INLINE_MIN, MAX_INLINE_MAX);
+    else warnings.push(`maxInlineImages: expected a number; dropped`);
+  }
+
+  // linkToFilePage: boolean
+  if ("linkToFilePage" in c) {
+    const v = c.linkToFilePage;
+    if (typeof v === "boolean") config.linkToFilePage = v;
+    else warnings.push(`linkToFilePage: expected a boolean; dropped`);
+  }
+
+  // meta.path / meta.state: booleans nested under `meta`
+  if ("meta" in c) {
+    const v = c.meta;
+    if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+      const meta = v as Record<string, unknown>;
+      if ("path" in meta) {
+        if (typeof meta.path === "boolean") config.metaPath = meta.path;
+        else warnings.push(`meta.path: expected a boolean; dropped`);
+      }
+      if ("state" in meta) {
+        if (typeof meta.state === "boolean") config.metaState = meta.state;
+        else warnings.push(`meta.state: expected a boolean; dropped`);
+      }
+    } else {
+      warnings.push(`meta: expected an object; dropped`);
+    }
+  }
+
+  // note: non-empty trimmed string, max NOTE_MAX_CHARS (never truncated)
+  if ("note" in c) {
+    const v = c.note;
+    if (typeof v === "string") {
+      const trimmed = v.trim();
+      if (trimmed.length === 0) {
+        // empty/whitespace note is treated as absent
+      } else if (trimmed.length > NOTE_MAX_CHARS) {
+        warnings.push(`note: longer than ${NOTE_MAX_CHARS} characters; dropped (not truncated)`);
+      } else {
+        config.note = trimmed;
+      }
+    } else {
+      warnings.push(`note: expected a string; dropped`);
+    }
+  }
+
+  return { config, warnings };
+}
+
+export function resolveCommentOptions(
+  repo: RepoCommentConfig | null,
+  ws: WorkspaceCommentDefaults | null,
+): { options: ResolvedCommentOptions; source: Record<keyof ResolvedCommentOptions, OptionSource> } {
+  const wsAsRepo: RepoCommentConfig = {
+    ...(ws?.imageWidth !== undefined ? { imageWidth: ws.imageWidth } : {}),
+    ...(ws?.maxInlineImages !== undefined ? { maxInlineImages: ws.maxInlineImages } : {}),
+    ...(ws?.showMetadata !== undefined
+      ? { metaPath: ws.showMetadata, metaState: ws.showMetadata }
+      : {}),
+    ...(ws?.linkToFilePage !== undefined ? { linkToFilePage: ws.linkToFilePage } : {}),
+    ...(ws?.note ? { note: ws.note } : {}),
+  };
+  const options = { ...AUTO_COMMENT_OPTIONS };
+  const source = Object.fromEntries(
+    Object.keys(AUTO_COMMENT_OPTIONS).map((k) => [k, "auto"]),
+  ) as Record<keyof ResolvedCommentOptions, OptionSource>;
+  const apply = (cfg: RepoCommentConfig, from: OptionSource) => {
+    for (const key of [
+      "imageWidth",
+      "maxInlineImages",
+      "metaPath",
+      "metaState",
+      "linkToFilePage",
+    ] as const) {
+      if (cfg[key] !== undefined && source[key] === "auto") {
+        (options as Record<string, unknown>)[key] = cfg[key];
+        source[key] = from;
+      }
+    }
+    if (cfg.note !== undefined && source.note === "auto") {
+      options.note = cfg.note;
+      source.note = from;
+    }
+  };
+  if (repo) apply(repo, "repo");
+  apply(wsAsRepo, "workspace");
+  return { options, source };
+}

--- a/packages/comment-config/tsconfig.json
+++ b/packages/comment-config/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/comment-config/tsconfig.json
+++ b/packages/comment-config/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -68,7 +68,8 @@
     "opentype.js": "^2.0.0",
     "perfect-freehand": "^1.2.3",
     "roughjs": "^4.6.6",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "yaml": "^2.6.0"
   },
   "optionalDependencies": {
     "playwright-core": "^1.61.1"

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -26,6 +26,7 @@ import {
   type ResolvedConfig,
 } from "./config.js";
 import { buildMarkdown } from "./embed.js";
+import { readLocalRepoCommentConfig, resolveCommentOptions } from "./comment-config.js";
 import { urlForGithubEmbed } from "./public-urls.js";
 import { UploadsError } from "./errors.js";
 import { writeJson, writeStdout } from "./io.js";
@@ -43,7 +44,9 @@ import {
   ghMetadataForBranch,
   attachmentsCommentBody,
   attachmentsMarker,
+  AUTO_RENDER_OPTIONS,
   GH_FALLBACK_AUTHOR_NOTE,
+  type CommentRenderOptions,
   type GhTarget,
   type AttachmentItem,
   type GalleryCommentItem,
@@ -787,9 +790,30 @@ export async function syncAttachmentsComment(
   );
 
   const marker = attachmentsMarker(workspace);
+  // Honor a committed .uploads.yml on the working tree (issue #307). This CLI
+  // process has no server-side WorkspaceRecord in scope (see the note above),
+  // so it resolves against `null` workspace defaults — a documented
+  // divergence from the bot path (commands.ts:728 / apps/api's
+  // resolveRepoCommentOptions, which also layers the workspace's own
+  // githubComment* fields).
+  let renderOptions: CommentRenderOptions = AUTO_RENDER_OPTIONS;
+  try {
+    const root = run("git", ["rev-parse", "--show-toplevel"]).trim();
+    const { config } = readLocalRepoCommentConfig(root);
+    const { options } = resolveCommentOptions(config, null);
+    renderOptions = {
+      imageWidth: options.imageWidth,
+      maxInlineImages: options.maxInlineImages,
+      metaPath: options.metaPath,
+      metaState: options.metaState,
+      note: options.note,
+    };
+  } catch {
+    // Not a git repo, or the config file couldn't be read — fall back to auto.
+  }
   // Append only on the local-gh path: bot posts already carry the uploads-sh
   // bot identity, so this note would be wrong there.
-  const body = `${attachmentsCommentBody(items, previewGalleries, marker)}\n${GH_FALLBACK_AUTHOR_NOTE}`;
+  const body = `${attachmentsCommentBody(items, previewGalleries, marker, renderOptions)}\n${GH_FALLBACK_AUTHOR_NOTE}`;
   const count = items.length + previewGalleries.length;
   // Empty (count 0) renders the neutral empty-state body but must not create a
   // comment — it only rewrites one that already exists (`action: "skipped"`

--- a/packages/uploads/src/comment-config.ts
+++ b/packages/uploads/src/comment-config.ts
@@ -1,0 +1,221 @@
+/**
+ * Published-CLI COPY of the workspace parser/resolver (issue #307)
+ * (packages/comment-config/src/index.ts). The published CLI imports no
+ * @uploads/* package, so that private package cannot be shared here — its
+ * parser/resolver is copied verbatim below. Kept in sync by hand; there is no
+ * golden-fixture cross-check like github-comment-render.ts's, so change both
+ * copies together. `readLocalRepoCommentConfig` below is CLI-only: it reads
+ * the six candidate config paths off the working tree (the server instead
+ * fetches them from GitHub's contents API — apps/api/src/repo-comment-config.ts).
+ */
+
+import fs from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export interface RepoCommentConfig {
+  imageWidth?: "auto" | "full" | number;
+  maxInlineImages?: number;
+  metaPath?: boolean;
+  metaState?: boolean;
+  linkToFilePage?: boolean;
+  note?: string;
+}
+export interface WorkspaceCommentDefaults {
+  imageWidth?: "full" | number;
+  maxInlineImages?: number;
+  showMetadata?: boolean; // maps to BOTH metaPath and metaState
+  linkToFilePage?: boolean;
+  note?: string;
+}
+export interface ResolvedCommentOptions {
+  imageWidth: "auto" | "full" | number;
+  maxInlineImages: number;
+  metaPath: boolean;
+  metaState: boolean;
+  linkToFilePage: boolean;
+  note: string | null;
+}
+export type OptionSource = "repo" | "workspace" | "auto";
+
+export const AUTO_COMMENT_OPTIONS: ResolvedCommentOptions = {
+  imageWidth: "auto",
+  maxInlineImages: 16, // MAX_INLINE_ATTACHMENT_IMAGES — renderer copies own the constant
+  metaPath: true,
+  metaState: true,
+  linkToFilePage: true,
+  note: null,
+};
+
+export const NOTE_MAX_CHARS = 500;
+const WIDTH_MIN = 160;
+const WIDTH_MAX = 1000;
+const MAX_INLINE_MIN = 1;
+const MAX_INLINE_MAX = 48;
+
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, Math.round(n)));
+
+export function parseRepoCommentConfig(
+  text: string,
+  format: "yaml" | "json",
+): { config: RepoCommentConfig | null; warnings: string[] } {
+  const warnings: string[] = [];
+  let root: unknown;
+  try {
+    root = format === "json" ? JSON.parse(text) : parseYaml(text);
+  } catch {
+    return { config: null, warnings: ["config file could not be parsed; ignoring it"] };
+  }
+  if (typeof root !== "object" || root === null || Array.isArray(root)) {
+    return { config: null, warnings };
+  }
+  const comment = (root as Record<string, unknown>).comment;
+  if (typeof comment !== "object" || comment === null || Array.isArray(comment)) {
+    return { config: null, warnings };
+  }
+  const c = comment as Record<string, unknown>;
+  const config: RepoCommentConfig = {};
+
+  // imageWidth: "auto" | "full" | finite number (clamped)
+  if ("imageWidth" in c) {
+    const v = c.imageWidth;
+    if (v === "auto" || v === "full") config.imageWidth = v;
+    else if (typeof v === "number" && Number.isFinite(v))
+      config.imageWidth = clamp(v, WIDTH_MIN, WIDTH_MAX);
+    else warnings.push(`imageWidth: expected "auto", "full", or a number; dropped`);
+  }
+
+  // maxInlineImages: finite number (clamped)
+  if ("maxInlineImages" in c) {
+    const v = c.maxInlineImages;
+    if (typeof v === "number" && Number.isFinite(v))
+      config.maxInlineImages = clamp(v, MAX_INLINE_MIN, MAX_INLINE_MAX);
+    else warnings.push(`maxInlineImages: expected a number; dropped`);
+  }
+
+  // linkToFilePage: boolean
+  if ("linkToFilePage" in c) {
+    const v = c.linkToFilePage;
+    if (typeof v === "boolean") config.linkToFilePage = v;
+    else warnings.push(`linkToFilePage: expected a boolean; dropped`);
+  }
+
+  // meta.path / meta.state: booleans nested under `meta`
+  if ("meta" in c) {
+    const v = c.meta;
+    if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+      const meta = v as Record<string, unknown>;
+      if ("path" in meta) {
+        if (typeof meta.path === "boolean") config.metaPath = meta.path;
+        else warnings.push(`meta.path: expected a boolean; dropped`);
+      }
+      if ("state" in meta) {
+        if (typeof meta.state === "boolean") config.metaState = meta.state;
+        else warnings.push(`meta.state: expected a boolean; dropped`);
+      }
+    } else {
+      warnings.push(`meta: expected an object; dropped`);
+    }
+  }
+
+  // note: non-empty trimmed string, max NOTE_MAX_CHARS (never truncated)
+  if ("note" in c) {
+    const v = c.note;
+    if (typeof v === "string") {
+      const trimmed = v.trim();
+      if (trimmed.length === 0) {
+        // empty/whitespace note is treated as absent
+      } else if (trimmed.length > NOTE_MAX_CHARS) {
+        warnings.push(`note: longer than ${NOTE_MAX_CHARS} characters; dropped (not truncated)`);
+      } else {
+        config.note = trimmed;
+      }
+    } else {
+      warnings.push(`note: expected a string; dropped`);
+    }
+  }
+
+  return { config, warnings };
+}
+
+export function resolveCommentOptions(
+  repo: RepoCommentConfig | null,
+  ws: WorkspaceCommentDefaults | null,
+): { options: ResolvedCommentOptions; source: Record<keyof ResolvedCommentOptions, OptionSource> } {
+  const wsAsRepo: RepoCommentConfig = {
+    ...(ws?.imageWidth !== undefined ? { imageWidth: ws.imageWidth } : {}),
+    ...(ws?.maxInlineImages !== undefined ? { maxInlineImages: ws.maxInlineImages } : {}),
+    ...(ws?.showMetadata !== undefined
+      ? { metaPath: ws.showMetadata, metaState: ws.showMetadata }
+      : {}),
+    ...(ws?.linkToFilePage !== undefined ? { linkToFilePage: ws.linkToFilePage } : {}),
+    ...(ws?.note ? { note: ws.note } : {}),
+  };
+  const options = { ...AUTO_COMMENT_OPTIONS };
+  const source = Object.fromEntries(
+    Object.keys(AUTO_COMMENT_OPTIONS).map((k) => [k, "auto"]),
+  ) as Record<keyof ResolvedCommentOptions, OptionSource>;
+  const apply = (cfg: RepoCommentConfig, from: OptionSource) => {
+    for (const key of [
+      "imageWidth",
+      "maxInlineImages",
+      "metaPath",
+      "metaState",
+      "linkToFilePage",
+    ] as const) {
+      if (cfg[key] !== undefined && source[key] === "auto") {
+        (options as Record<string, unknown>)[key] = cfg[key];
+        source[key] = from;
+      }
+    }
+    if (cfg.note !== undefined && source.note === "auto") {
+      options.note = cfg.note;
+      source.note = from;
+    }
+  };
+  if (repo) apply(repo, "repo");
+  apply(wsAsRepo, "workspace");
+  return { options, source };
+}
+
+/**
+ * Candidate paths, checked in this order — the first hit wins. Must match
+ * the server's REPO_CONFIG_PATHS exactly (apps/api/src/repo-comment-config.ts)
+ * so a committed config resolves identically whether the bot or the local
+ * gh fallback renders the comment.
+ */
+export const REPO_CONFIG_PATHS = [
+  ".uploads.yml",
+  ".uploads.yaml",
+  ".uploads.json",
+  ".github/uploads.yml",
+  ".github/uploads.yaml",
+  ".github/uploads.json",
+] as const;
+
+/**
+ * Read the repo's comment config off the local working tree — the CLI has no
+ * GitHub App installation token to fetch via the contents API, so this reads
+ * `rootDir` directly. Returns the first candidate that exists (readable or
+ * not); an unreadable file (permissions, or a directory at that path) is
+ * treated as absent and the search continues to the next candidate, matching
+ * a 404 in the server-side fetch.
+ */
+export function readLocalRepoCommentConfig(rootDir: string): {
+  config: RepoCommentConfig | null;
+  path: string | null;
+  warnings: string[];
+} {
+  for (const candidate of REPO_CONFIG_PATHS) {
+    let text: string;
+    try {
+      text = fs.readFileSync(join(rootDir, candidate), "utf8");
+    } catch {
+      continue;
+    }
+    const format = candidate.endsWith(".json") ? "json" : "yaml";
+    const { config, warnings } = parseRepoCommentConfig(text, format);
+    return { config, path: candidate, warnings };
+  }
+  return { config: null, path: null, warnings: [] };
+}

--- a/packages/uploads/src/comment-config.ts
+++ b/packages/uploads/src/comment-config.ts
@@ -2,11 +2,13 @@
  * Published-CLI COPY of the workspace parser/resolver (issue #307)
  * (packages/comment-config/src/index.ts). The published CLI imports no
  * @uploads/* package, so that private package cannot be shared here — its
- * parser/resolver is copied verbatim below. Kept in sync by hand; there is no
- * golden-fixture cross-check like github-comment-render.ts's, so change both
- * copies together. `readLocalRepoCommentConfig` below is CLI-only: it reads
- * the six candidate config paths off the working tree (the server instead
- * fetches them from GitHub's contents API — apps/api/src/repo-comment-config.ts).
+ * parser/resolver is copied verbatim below. Kept in sync by
+ * test/fixtures/comment-config-golden.json, asserted from both sides (this
+ * package's comment-config.test.ts and the canonical package's
+ * index.test.ts) — change both copies together. `readLocalRepoCommentConfig`
+ * below is CLI-only: it reads the six candidate config paths off the working
+ * tree (the server instead fetches them from GitHub's contents API —
+ * apps/api/src/repo-comment-config.ts).
  */
 
 import fs from "node:fs";

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -198,6 +198,30 @@ export function attachmentsMarker(workspace?: string): string {
  * of images. */
 export const MAX_INLINE_ATTACHMENT_IMAGES = 16;
 
+/**
+ * Per-render knobs for the managed comment (issue #307), sourced from repo
+ * comment config. `imageWidth: "auto"` preserves today's per-item width
+ * heuristics (`attachmentImageWidth`/`posterImageWidth`/pair cap); `"full"`
+ * omits the `width` attribute entirely; a number overrides every width site.
+ */
+export interface CommentRenderOptions {
+  imageWidth: "auto" | "full" | number;
+  maxInlineImages: number;
+  metaPath: boolean;
+  metaState: boolean;
+  note: string | null;
+}
+
+/** Today's behavior, expressed as options — the default for every caller that
+ * hasn't opted into repo comment config. */
+export const AUTO_RENDER_OPTIONS: CommentRenderOptions = {
+  imageWidth: "auto",
+  maxInlineImages: MAX_INLINE_ATTACHMENT_IMAGES,
+  metaPath: true,
+  metaState: true,
+  note: null,
+};
+
 export interface AttachmentItem {
   key: string;
   url: string | null;
@@ -319,18 +343,21 @@ function escapeMarkdownText(s: string): string {
  * alone it is a stray character, and as a prefix next to `state` it is
  * noise. Only exact `/` after trim is suppressed.
  */
-function metaCaptionParts(meta: AttachmentItem["meta"]): string[] {
+function metaCaptionParts(meta: AttachmentItem["meta"], options: CommentRenderOptions): string[] {
   const parts: string[] = [];
   const path = meta?.path?.trim();
-  if (path && path !== "/") parts.push(path);
+  if (options.metaPath && path && path !== "/") parts.push(path);
   const state = meta?.state?.trim();
-  if (state) parts.push(state);
+  if (options.metaState && state) parts.push(state);
   return parts;
 }
 
 /** `<sub>` caption body for an inline image, or null when there is nothing to say. */
-function metaCaptionHtml(meta: AttachmentItem["meta"]): string | null {
-  const parts = metaCaptionParts(meta);
+function metaCaptionHtml(
+  meta: AttachmentItem["meta"],
+  options: CommentRenderOptions,
+): string | null {
+  const parts = metaCaptionParts(meta, options);
   return parts.length > 0 ? parts.map(escapeHtmlText).join(" · ") : null;
 }
 
@@ -339,10 +366,26 @@ function metaCaptionHtml(meta: AttachmentItem["meta"]): string | null {
  * HTML-escapes first, then markdown-escapes: HTML escaping introduces no
  * backslashes or brackets, so the markdown pass cannot corrupt its entities.
  */
-function metaCaptionMarkdown(meta: AttachmentItem["meta"]): string {
-  const parts = metaCaptionParts(meta);
+function metaCaptionMarkdown(meta: AttachmentItem["meta"], options: CommentRenderOptions): string {
+  const parts = metaCaptionParts(meta, options);
   if (parts.length === 0) return "";
   return ` · ${parts.map((p) => escapeMarkdownText(escapeHtmlText(p))).join(" · ")}`;
+}
+
+/** Resolved pixel width for an image site, or `null` meaning "omit the width
+ * attribute". `"auto"` defers to the caller's per-item heuristic (`autoPx`);
+ * `"full"` always omits; a number always wins. */
+function resolvedWidth(autoPx: number, options: CommentRenderOptions): number | null {
+  if (options.imageWidth === "auto") return autoPx;
+  if (options.imageWidth === "full") return null;
+  return options.imageWidth;
+}
+
+/** Every `<img>` tag in the managed comment goes through here so the
+ * omit-width-attribute case ("full") can't drift between call sites. */
+function imgTag(w: number | null, alt: string, src: string): string {
+  const widthAttr = w === null ? "" : ` width="${w}"`;
+  return `<img${widthAttr} alt="${alt}" src="${src}">`;
 }
 
 /** Extract the filename stem's before/after token (issue #419 fallback pairing).
@@ -443,24 +486,33 @@ function pairAttachments(
  * column width (and don't overflow on mobile). */
 export const ATTACHMENT_IMAGE_WIDTH_PAIR = 320;
 
-function renderPairCell(item: AttachmentItem, label: "Before" | "After"): string {
+function renderPairCell(
+  item: AttachmentItem,
+  label: "Before" | "After",
+  options: CommentRenderOptions,
+): string {
   const name = item.key.slice(item.key.lastIndexOf("/") + 1);
   const src = item.embedUrl ?? item.url;
   const link = item.pageUrl ?? item.url;
-  const w = Math.min(attachmentImageWidth(name), ATTACHMENT_IMAGE_WIDTH_PAIR);
+  const autoPx = Math.min(attachmentImageWidth(name), ATTACHMENT_IMAGE_WIDTH_PAIR);
+  const w = resolvedWidth(autoPx, options);
   const alt = escapeHtmlAttr(name);
   const href = escapeHtmlAttr((link ?? src) as string);
   const imgSrc = escapeHtmlAttr(src as string);
-  const caption = metaCaptionHtml(item.meta);
+  const caption = metaCaptionHtml(item.meta, options);
   const captionHtml = caption ? `<br><sub>${caption}</sub>` : "";
-  return `<td align="center"><sub><strong>${label}</strong></sub><br><a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>${captionHtml}</td>`;
+  return `<td align="center"><sub><strong>${label}</strong></sub><br><a href="${href}">${imgTag(w, alt, imgSrc)}</a>${captionHtml}</td>`;
 }
 
 /** One side-by-side before/after row (issue #419): a single HTML table so
  * GitHub renders both images on one line, with `Before`/`After` labels and
  * each side's usual path/state caption preserved underneath. */
-function renderPairRow(beforeItem: AttachmentItem, afterItem: AttachmentItem): string {
-  return `<table><tr>${renderPairCell(beforeItem, "Before")}${renderPairCell(afterItem, "After")}</tr></table>`;
+function renderPairRow(
+  beforeItem: AttachmentItem,
+  afterItem: AttachmentItem,
+  options: CommentRenderOptions,
+): string {
+  return `<table><tr>${renderPairCell(beforeItem, "Before", options)}${renderPairCell(afterItem, "After", options)}</tr></table>`;
 }
 
 /**
@@ -471,12 +523,14 @@ export function attachmentsCommentBody(
   items: AttachmentItem[],
   galleries: GalleryCommentItem[] = [],
   marker: string = ATTACHMENTS_MARKER,
+  options: CommentRenderOptions = AUTO_RENDER_OPTIONS,
 ): string {
   const sorted = items.toSorted((a, b) => a.key.localeCompare(b.key));
   const sortedGalleries = galleries.toSorted(
     (a, b) => a.title.localeCompare(b.title) || a.url.localeCompare(b.url),
   );
   const lines: string[] = [marker];
+  if (options.note) lines.push(options.note, "");
   if (sortedGalleries.length > 0) {
     lines.push("### 🖼️ Galleries", "");
     for (const gallery of sortedGalleries) {
@@ -485,8 +539,9 @@ export function attachmentsCommentBody(
       for (const preview of gallery.previews ?? []) {
         const previewHref = preview.itemUrl ? escapeHtmlAttr(preview.itemUrl) : href;
         const previewSrc = escapeHtmlAttr(preview.embedUrl ?? preview.url);
+        const previewW = resolvedWidth(320, options);
         lines.push(
-          `<a href="${previewHref}"><img width="320" alt="${escapeHtmlAttr(preview.alt)}" src="${previewSrc}"></a>`,
+          `<a href="${previewHref}">${imgTag(previewW, escapeHtmlAttr(preview.alt), previewSrc)}</a>`,
         );
       }
       lines.push(`<sub><a href="${href}">Open gallery</a></sub>`, "");
@@ -510,12 +565,12 @@ export function attachmentsCommentBody(
     const partnerIdx = partnerOf.get(idx);
     if (partnerIdx !== undefined) {
       const partner = sorted[partnerIdx];
-      if (inlinedImages + 2 <= MAX_INLINE_ATTACHMENT_IMAGES) {
+      if (inlinedImages + 2 <= options.maxInlineImages) {
         inlinedImages += 2;
         consumedByPair.add(partnerIdx);
         const beforeItem = roleOf.get(idx) === "before" ? item : partner;
         const afterItem = roleOf.get(idx) === "before" ? partner : item;
-        lines.push(renderPairRow(beforeItem, afterItem), "");
+        lines.push(renderPairRow(beforeItem, afterItem, options), "");
         continue;
       }
       // Cap already full for a two-image row — degrade this pair to two
@@ -531,7 +586,7 @@ export function attachmentsCommentBody(
     const isImage = Boolean(src) && inferContentType(name).startsWith("image/");
     const isPosterVideo = Boolean(item.posterUrl) && inferContentType(name).startsWith("video/");
     const inlines = isImage || isPosterVideo;
-    if (inlines && inlinedImages >= MAX_INLINE_ATTACHMENT_IMAGES) {
+    if (inlines && inlinedImages >= options.maxInlineImages) {
       // Cap hit — defer to the collapsed overflow list below rather than
       // embedding every remaining image inline.
       overflowImages.push(item);
@@ -539,10 +594,11 @@ export function attachmentsCommentBody(
     }
     if (isPosterVideo) {
       inlinedImages++;
-      const w = posterImageWidth(item.videoMeta, name);
+      const autoPx = posterImageWidth(item.videoMeta, name);
+      const w = resolvedWidth(autoPx, options);
       const href = escapeHtmlAttr(link ?? (item.posterUrl as string));
       lines.push(
-        `<a href="${href}"><img width="${w}" alt="${escapeHtmlAttr(name)}" src="${escapeHtmlAttr(item.posterUrl as string)}"></a>`,
+        `<a href="${href}">${imgTag(w, escapeHtmlAttr(name), escapeHtmlAttr(item.posterUrl as string))}</a>`,
       );
       // GitHub strips <video>, so a still frame needs an explicit affordance
       // or it reads as a screenshot.
@@ -550,24 +606,25 @@ export function attachmentsCommentBody(
       if (item.videoMeta?.durationSeconds != null) {
         parts.push(formatDuration(item.videoMeta.durationSeconds));
       }
-      parts.push(...metaCaptionParts(item.meta).map(escapeHtmlText));
+      parts.push(...metaCaptionParts(item.meta, options).map(escapeHtmlText));
       lines.push(`<sub>${parts.join(" · ")}</sub>`, "");
     } else if (isImage) {
       inlinedImages++;
       // Markdown ![]() has no width control — phone frames become full-column giants.
       // img src uses embed host when available (Camo revalidates); click-through prefers the file page.
-      const w = attachmentImageWidth(name);
+      const autoPx = attachmentImageWidth(name);
+      const w = resolvedWidth(autoPx, options);
       const alt = escapeHtmlAttr(name);
       const href = escapeHtmlAttr(link ?? (src as string));
       const imgSrc = escapeHtmlAttr(src as string);
-      lines.push(`<a href="${href}"><img width="${w}" alt="${alt}" src="${imgSrc}"></a>`);
-      const caption = metaCaptionHtml(item.meta);
+      lines.push(`<a href="${href}">${imgTag(w, alt, imgSrc)}</a>`);
+      const caption = metaCaptionHtml(item.meta, options);
       if (caption) lines.push(`<sub>${caption}</sub>`);
       lines.push("");
     } else if (link) {
-      lines.push(`- [${name}](${link})${metaCaptionMarkdown(item.meta)}`);
+      lines.push(`- [${name}](${link})${metaCaptionMarkdown(item.meta, options)}`);
     } else {
-      lines.push(`- ${name}${metaCaptionMarkdown(item.meta)}`);
+      lines.push(`- ${name}${metaCaptionMarkdown(item.meta, options)}`);
     }
   }
   if (overflowImages.length > 0) {
@@ -576,7 +633,7 @@ export function attachmentsCommentBody(
     for (const item of overflowImages) {
       const name = item.key.slice(item.key.lastIndexOf("/") + 1);
       const link = item.pageUrl ?? item.url;
-      const suffix = metaCaptionMarkdown(item.meta);
+      const suffix = metaCaptionMarkdown(item.meta, options);
       lines.push(link ? `- [${name}](${link})${suffix}` : `- ${name}${suffix}`);
     }
     lines.push("", "</details>", "");

--- a/packages/uploads/src/github.ts
+++ b/packages/uploads/src/github.ts
@@ -382,10 +382,14 @@ function resolvedWidth(autoPx: number, options: CommentRenderOptions): number | 
 }
 
 /** Every `<img>` tag in the managed comment goes through here so the
- * omit-width-attribute case ("full") can't drift between call sites. */
-function imgTag(w: number | null, alt: string, src: string): string {
+ * omit-width-attribute case ("full") can't drift between call sites.
+ *
+ * `escapedAlt`/`escapedSrc` must already be attribute-escaped (via
+ * `escapeHtmlAttr`) by the caller — this function interpolates them as-is
+ * and does not escape them itself. */
+function imgTag(w: number | null, escapedAlt: string, escapedSrc: string): string {
   const widthAttr = w === null ? "" : ` width="${w}"`;
-  return `<img${widthAttr} alt="${alt}" src="${src}">`;
+  return `<img${widthAttr} alt="${escapedAlt}" src="${escapedSrc}">`;
 }
 
 /** Extract the filename stem's before/after token (issue #419 fallback pairing).

--- a/packages/uploads/test/commands-comment.test.ts
+++ b/packages/uploads/test/commands-comment.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { UsageError } from "../src/cli-args.js";
 import type { UploadsClient } from "../src/client.js";
 import {
@@ -373,5 +376,48 @@ describe("syncAttachmentsComment", () => {
     expect(result).toEqual({ action: "skipped", count: 0, via: "gh" });
     expect(calls.some((c) => c.args.includes("PATCH"))).toBe(false);
     expect(calls.some((c) => c.args.includes("repos/acme/web/issues/12/comments"))).toBe(false);
+  });
+
+  describe("repo comment config (.uploads.yml)", () => {
+    let dirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of dirs) fs.rmSync(dir, { recursive: true, force: true });
+      dirs = [];
+    });
+
+    function tmpRepoWithConfig(yaml: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-commands-comment-"));
+      dirs.push(dir);
+      fs.writeFileSync(path.join(dir, ".uploads.yml"), yaml);
+      return dir;
+    }
+
+    it("caps inline images at maxInlineImages from a committed .uploads.yml", async () => {
+      const root = tmpRepoWithConfig("comment:\n  maxInlineImages: 1\n");
+      const client = fakeClient({
+        upsertGithubComment: async () => ({ posted: false, reason: "not_installed" }),
+        listAll: async () => [
+          { key: "gh/acme/web/pull/12/a.png", url: "https://x.test/a.png", embedUrl: null },
+          { key: "gh/acme/web/pull/12/b.png", url: "https://x.test/b.png", embedUrl: null },
+        ],
+        findGalleriesByReference: async () => ({ galleries: [], nextCursor: null }),
+      });
+      let posted = "";
+      // gh+git runner: `git rev-parse --show-toplevel` resolves to the temp
+      // repo root; gh calls find no marker and create.
+      const run: CommandRunner = (cmd, args, input) => {
+        if (cmd === "git" && args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+          return `${root}\n`;
+        }
+        if (cmd !== "gh") throw new Error(`unexpected command: ${cmd}`);
+        if (args[1]?.includes("per_page=100")) return "[]";
+        if (input) posted = input;
+        return JSON.stringify({ id: 9 });
+      };
+      await syncAttachmentsComment(client, { repo: "acme/web", num: 12, kind: "pull" }, run);
+      expect(posted.match(/<img/g)?.length).toBe(1);
+      expect(posted).toContain("<details>");
+    });
   });
 });

--- a/packages/uploads/test/comment-config.test.ts
+++ b/packages/uploads/test/comment-config.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AUTO_COMMENT_OPTIONS,
+  parseRepoCommentConfig,
+  readLocalRepoCommentConfig,
+  resolveCommentOptions,
+} from "../src/comment-config.js";
+
+let dirs: string[] = [];
+
+function tmpRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "uploads-comment-config-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of dirs) fs.rmSync(dir, { recursive: true, force: true });
+  dirs = [];
+});
+
+describe("readLocalRepoCommentConfig", () => {
+  it("prefers .uploads.yml at root over .github/uploads.yml", () => {
+    const root = tmpRepo();
+    fs.writeFileSync(path.join(root, ".uploads.yml"), "comment:\n  imageWidth: full\n");
+    fs.mkdirSync(path.join(root, ".github"));
+    fs.writeFileSync(path.join(root, ".github", "uploads.yml"), "comment:\n  imageWidth: 640\n");
+    const { config, path: matched, warnings } = readLocalRepoCommentConfig(root);
+    expect(matched).toBe(".uploads.yml");
+    expect(config).toEqual({ imageWidth: "full" });
+    expect(warnings).toEqual([]);
+  });
+
+  it("parses .uploads.json as JSON", () => {
+    const root = tmpRepo();
+    fs.writeFileSync(
+      path.join(root, ".uploads.json"),
+      JSON.stringify({ comment: { maxInlineImages: 4 } }),
+    );
+    const { config, path: matched } = readLocalRepoCommentConfig(root);
+    expect(matched).toBe(".uploads.json");
+    expect(config).toEqual({ maxInlineImages: 4 });
+  });
+
+  it("falls back to .github/uploads.yaml when no root-level file exists", () => {
+    const root = tmpRepo();
+    fs.mkdirSync(path.join(root, ".github"));
+    fs.writeFileSync(
+      path.join(root, ".github", "uploads.yaml"),
+      "comment:\n  linkToFilePage: false\n",
+    );
+    const { config, path: matched } = readLocalRepoCommentConfig(root);
+    expect(matched).toBe(".github/uploads.yaml");
+    expect(config).toEqual({ linkToFilePage: false });
+  });
+
+  it("returns config: null, path: null when no candidate file exists", () => {
+    const root = tmpRepo();
+    const { config, path: matched, warnings } = readLocalRepoCommentConfig(root);
+    expect(config).toBeNull();
+    expect(matched).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns config: null with one warning for malformed YAML", () => {
+    const root = tmpRepo();
+    fs.writeFileSync(path.join(root, ".uploads.yml"), "comment: [unclosed");
+    const { config, path: matched, warnings } = readLocalRepoCommentConfig(root);
+    expect(config).toBeNull();
+    expect(matched).toBe(".uploads.yml");
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("treats an unreadable file as absent and continues", () => {
+    const root = tmpRepo();
+    // A directory at the candidate path fails a utf8 read (EISDIR) — treat
+    // as absent and move on to the next candidate rather than throwing.
+    fs.mkdirSync(path.join(root, ".uploads.yml"));
+    fs.writeFileSync(path.join(root, ".uploads.json"), JSON.stringify({ comment: { note: "hi" } }));
+    const { config, path: matched } = readLocalRepoCommentConfig(root);
+    expect(matched).toBe(".uploads.json");
+    expect(config).toEqual({ note: "hi" });
+  });
+});
+
+// Smoke subset of the parser/resolver cases (full coverage lives in
+// packages/comment-config/src/index.test.ts — this is a byte-copy).
+describe("parseRepoCommentConfig / resolveCommentOptions (smoke)", () => {
+  it("clamps numeric imageWidth to 160-1000", () => {
+    expect(parseRepoCommentConfig("comment:\n  imageWidth: 40\n", "yaml").config).toEqual({
+      imageWidth: 160,
+    });
+  });
+
+  it("drops an over-500-char note whole, with a warning", () => {
+    const { config, warnings } = parseRepoCommentConfig(
+      `comment:\n  note: "${"x".repeat(501)}"\n`,
+      "yaml",
+    );
+    expect(config).toEqual({});
+    expect(warnings[0]).toContain("note");
+  });
+
+  it("returns AUTO options with all-auto sources for null inputs", () => {
+    const { options, source } = resolveCommentOptions(null, null);
+    expect(options).toEqual(AUTO_COMMENT_OPTIONS);
+    expect(Object.values(source).every((s) => s === "auto")).toBe(true);
+  });
+});

--- a/packages/uploads/test/comment-config.test.ts
+++ b/packages/uploads/test/comment-config.test.ts
@@ -1,13 +1,47 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   AUTO_COMMENT_OPTIONS,
   parseRepoCommentConfig,
   readLocalRepoCommentConfig,
   resolveCommentOptions,
+  type RepoCommentConfig,
+  type WorkspaceCommentDefaults,
 } from "../src/comment-config.js";
+
+/**
+ * Parity fixture (issue #307) shared with the canonical package
+ * (packages/comment-config/src/index.test.ts) — see the header comment in
+ * ../src/comment-config.ts for the cross-reference. Generated from the
+ * canonical package; asserted here too so the two copies can never drift
+ * silently.
+ */
+function loadGolden() {
+  return JSON.parse(
+    fs.readFileSync(
+      fileURLToPath(new URL("../../../test/fixtures/comment-config-golden.json", import.meta.url)),
+      "utf8",
+    ),
+  ) as {
+    parseCases: {
+      name: string;
+      text: string;
+      format: "yaml" | "json";
+      expected: { config: RepoCommentConfig | null; warnings: string[] };
+    }[];
+    resolveCases: {
+      name: string;
+      repo: RepoCommentConfig | null;
+      workspace: WorkspaceCommentDefaults | null;
+      expected: ReturnType<typeof resolveCommentOptions>;
+    }[];
+  };
+}
+
+const golden = loadGolden();
 
 let dirs: string[] = [];
 
@@ -108,5 +142,15 @@ describe("parseRepoCommentConfig / resolveCommentOptions (smoke)", () => {
     const { options, source } = resolveCommentOptions(null, null);
     expect(options).toEqual(AUTO_COMMENT_OPTIONS);
     expect(Object.values(source).every((s) => s === "auto")).toBe(true);
+  });
+});
+
+describe("comment-config-golden.json parity (CLI copy)", () => {
+  it.each(golden.parseCases)("parse: $name", ({ text, format, expected }) => {
+    expect(parseRepoCommentConfig(text, format)).toEqual(expected);
+  });
+
+  it.each(golden.resolveCases)("resolve: $name", ({ repo, workspace, expected }) => {
+    expect(resolveCommentOptions(repo, workspace)).toEqual(expected);
   });
 });

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -280,6 +280,21 @@ describe("attachmentsCommentBody (CLI copy)", () => {
       },
     ];
 
+    const galleriesWithPreview = [
+      {
+        title: "Design review",
+        url: "https://uploads.sh/g/abc",
+        previews: [
+          {
+            url: "https://uploads.sh/g/abc/i1.png",
+            embedUrl: "https://embed.uploads.sh/g/abc/i1.png",
+            alt: "screen one",
+            itemUrl: "https://uploads.sh/g/abc/i1",
+          },
+        ],
+      },
+    ];
+
     const base = (over: Partial<CommentRenderOptions>): CommentRenderOptions => ({
       ...AUTO_RENDER_OPTIONS,
       ...over,
@@ -310,10 +325,40 @@ describe("attachmentsCommentBody (CLI copy)", () => {
       expect(body).toContain("<details>");
     });
 
+    it('imageWidth:"full" omits the width attribute on gallery previews too', () => {
+      const body = attachmentsCommentBody(
+        [],
+        galleriesWithPreview,
+        marker,
+        base({ imageWidth: "full" }),
+      );
+      expect(body).not.toMatch(/<img width=/);
+      expect(body).toMatch(/<img alt="screen one"/);
+    });
+
+    it("explicit px overrides the gallery preview's default 320", () => {
+      const body = attachmentsCommentBody(
+        [],
+        galleriesWithPreview,
+        marker,
+        base({ imageWidth: 500 }),
+      );
+      const widths = [...body.matchAll(/<img width="(\d+)"/g)].map((m) => Number(m[1]));
+      expect(widths).toHaveLength(1);
+      expect(widths[0]).toBe(500);
+    });
+
     it("metaPath:false hides path but keeps state in captions", () => {
       const body = attachmentsCommentBody(metaItems, [], marker, base({ metaPath: false }));
       expect(body).not.toContain("apps/web/src");
       expect(body).toContain("after");
+    });
+
+    it("metaState:false hides state but keeps path in captions", () => {
+      const body = attachmentsCommentBody(metaItems, [], marker, base({ metaState: false }));
+      expect(body).toContain("apps/web/src");
+      expect(body).not.toContain("<sub>apps/web/src · after</sub>");
+      expect(body).not.toMatch(/·\s*after/);
     });
 
     it("note renders once, directly after the marker line", () => {

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -17,7 +17,16 @@ function loadFixture(name: string) {
 function loadOptionsFixture(name: string) {
   return JSON.parse(
     readFileSync(fileURLToPath(new URL(`../../../test/fixtures/${name}`, import.meta.url)), "utf8"),
-  ) as { cases: { name: string; options: Partial<CommentRenderOptions>; expected: string }[] };
+  ) as {
+    cases: {
+      name: string;
+      options: Partial<CommentRenderOptions>;
+      expected: string;
+      // Falls back to the golden suite's shared `items` when a case doesn't
+      // need its own (most cases don't touch item count/meta).
+      items?: AttachmentItem[];
+    }[];
+  };
 }
 
 const golden = loadFixture("github-comment-golden.json");
@@ -369,12 +378,13 @@ describe("attachmentsCommentBody (CLI copy)", () => {
       expect(lines[2]).toBe("");
     });
 
-    it("matches the shared options golden", () => {
-      for (const c of goldenOptions.cases) {
-        expect(
-          attachmentsCommentBody(items, [], marker, { ...AUTO_RENDER_OPTIONS, ...c.options }),
-        ).toBe(c.expected);
-      }
+    it.each(goldenOptions.cases)("matches the options golden: $name", (c) => {
+      expect(
+        attachmentsCommentBody(c.items ?? items, [], marker, {
+          ...AUTO_RENDER_OPTIONS,
+          ...c.options,
+        }),
+      ).toBe(c.expected);
     });
   });
 });

--- a/packages/uploads/test/github-render-golden.test.ts
+++ b/packages/uploads/test/github-render-golden.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { attachmentsCommentBody } from "../src/github.js";
+import {
+  attachmentsCommentBody,
+  AUTO_RENDER_OPTIONS,
+  type AttachmentItem,
+  type CommentRenderOptions,
+} from "../src/github.js";
 
 function loadFixture(name: string) {
   return JSON.parse(
@@ -9,11 +14,18 @@ function loadFixture(name: string) {
   ) as { items: any[]; galleries: any[]; marker?: string; expected: string };
 }
 
+function loadOptionsFixture(name: string) {
+  return JSON.parse(
+    readFileSync(fileURLToPath(new URL(`../../../test/fixtures/${name}`, import.meta.url)), "utf8"),
+  ) as { cases: { name: string; options: Partial<CommentRenderOptions>; expected: string }[] };
+}
+
 const golden = loadFixture("github-comment-golden.json");
 const goldenCap = loadFixture("github-comment-golden-cap.json");
 const goldenMeta = loadFixture("github-comment-golden-meta.json");
 const goldenVideo = loadFixture("github-comment-golden-video.json");
 const goldenEmpty = loadFixture("github-comment-golden-empty.json");
+const goldenOptions = loadOptionsFixture("github-comment-golden-options.json");
 
 describe("attachmentsCommentBody (CLI copy)", () => {
   it("renders the golden body byte-for-byte", () => {
@@ -236,6 +248,88 @@ describe("attachmentsCommentBody (CLI copy)", () => {
         img("gh/acme/web/pull/12/shot.webp", { meta: { path: "/x", state: "after" } }),
       ]);
       expect(body).not.toContain("<table>");
+    });
+  });
+
+  describe("attachmentsCommentBody with options", () => {
+    const items = golden.items as AttachmentItem[];
+    const galleries = golden.galleries;
+    const marker = golden.marker ?? "<!-- uploads.sh:attachments -->";
+
+    const manyImages: AttachmentItem[] = Array.from({ length: 18 }, (_, i) => ({
+      key: `gh/acme/web/pull/12/many-${String(i).padStart(2, "0")}.png`,
+      url: `https://uploads.sh/f/many-${i}.png`,
+      embedUrl: `https://embed.uploads.sh/f/many-${i}.png`,
+      pageUrl: `https://uploads.sh/f/acme/many-${i}.png`,
+    }));
+
+    const metaItems: AttachmentItem[] = [
+      {
+        key: "gh/acme/web/pull/12/meta-a.png",
+        url: "https://uploads.sh/f/meta-a.png",
+        embedUrl: "https://embed.uploads.sh/f/meta-a.png",
+        pageUrl: "https://uploads.sh/f/acme/meta-a.png",
+        meta: { path: "apps/web/src", state: "after" },
+      },
+      {
+        key: "gh/acme/web/pull/12/meta-b.png",
+        url: "https://uploads.sh/f/meta-b.png",
+        embedUrl: "https://embed.uploads.sh/f/meta-b.png",
+        pageUrl: "https://uploads.sh/f/acme/meta-b.png",
+        meta: { path: "apps/web/src", state: "after" },
+      },
+    ];
+
+    const base = (over: Partial<CommentRenderOptions>): CommentRenderOptions => ({
+      ...AUTO_RENDER_OPTIONS,
+      ...over,
+    });
+
+    it("default options render byte-identical to the no-options call", () => {
+      expect(attachmentsCommentBody(items, galleries, marker, AUTO_RENDER_OPTIONS)).toBe(
+        attachmentsCommentBody(items, galleries, marker),
+      );
+    });
+
+    it('imageWidth:"full" omits the width attribute everywhere (inline, pair, poster)', () => {
+      const body = attachmentsCommentBody(items, [], marker, base({ imageWidth: "full" }));
+      expect(body).not.toMatch(/<img width=/);
+      expect(body).toMatch(/<img alt=/);
+    });
+
+    it("explicit px overrides auto sizing and pair/poster constants", () => {
+      const body = attachmentsCommentBody(items, [], marker, base({ imageWidth: 500 }));
+      const widths = [...body.matchAll(/<img width="(\d+)"/g)].map((m) => Number(m[1]));
+      expect(widths.length).toBeGreaterThan(0);
+      expect(widths.every((w) => w === 500)).toBe(true);
+    });
+
+    it("maxInlineImages caps inline embeds; remainder collapses to the details list", () => {
+      const body = attachmentsCommentBody(manyImages, [], marker, base({ maxInlineImages: 2 }));
+      expect([...body.matchAll(/<img /g)]).toHaveLength(2);
+      expect(body).toContain("<details>");
+    });
+
+    it("metaPath:false hides path but keeps state in captions", () => {
+      const body = attachmentsCommentBody(metaItems, [], marker, base({ metaPath: false }));
+      expect(body).not.toContain("apps/web/src");
+      expect(body).toContain("after");
+    });
+
+    it("note renders once, directly after the marker line", () => {
+      const body = attachmentsCommentBody(items, [], marker, base({ note: "Staging only." }));
+      const lines = body.split("\n");
+      expect(lines[0]).toBe(marker);
+      expect(lines[1]).toBe("Staging only.");
+      expect(lines[2]).toBe("");
+    });
+
+    it("matches the shared options golden", () => {
+      for (const c of goldenOptions.cases) {
+        expect(
+          attachmentsCommentBody(items, [], marker, { ...AUTO_RENDER_OPTIONS, ...c.options }),
+        ).toBe(c.expected);
+      }
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,19 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
 
+  packages/comment-config:
+    dependencies:
+      yaml:
+        specifier: ^2.6.0
+        version: 2.9.0
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
+
   packages/email:
     devDependencies:
       typescript:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
         specifier: ^2.6.0
         version: 2.9.0
     devDependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@uploads/billing':
         specifier: workspace:^
         version: link:../../packages/billing
+      '@uploads/comment-config':
+        specifier: workspace:^
+        version: link:../../packages/comment-config
       '@uploads/email':
         specifier: workspace:^
         version: link:../../packages/email

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@26.1.0)
+      yaml:
+        specifier: ^2.6.0
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.0

--- a/test/fixtures/comment-config-golden.json
+++ b/test/fixtures/comment-config-golden.json
@@ -1,0 +1,292 @@
+{
+  "parseCases": [
+    {
+      "name": "valid full yaml config",
+      "text": "comment:\n  imageWidth: full\n  maxInlineImages: 8\n  meta:\n    path: false\n    state: true\n  linkToFilePage: false\n  note: \"Staging shots only.\"\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "imageWidth": "full",
+          "maxInlineImages": 8,
+          "linkToFilePage": false,
+          "metaPath": false,
+          "metaState": true,
+          "note": "Staging shots only."
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "json format",
+      "text": "{\"comment\":{\"imageWidth\":640}}",
+      "format": "json",
+      "expected": {
+        "config": {
+          "imageWidth": 640
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "clamps numeric imageWidth low (below 160)",
+      "text": "comment:\n  imageWidth: 40\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "imageWidth": 160
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "clamps numeric imageWidth high (above 1000)",
+      "text": "comment:\n  imageWidth: 5000\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "imageWidth": 1000
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "clamps maxInlineImages low (below 1)",
+      "text": "comment:\n  maxInlineImages: 0\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "maxInlineImages": 1
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "clamps maxInlineImages high (above 48)",
+      "text": "comment:\n  maxInlineImages: 99\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "maxInlineImages": 48
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "drops an invalid key with a warning, keeps the rest",
+      "text": "comment:\n  imageWidth: enormous\n  maxInlineImages: 4\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "maxInlineImages": 4
+        },
+        "warnings": ["imageWidth: expected \"auto\", \"full\", or a number; dropped"]
+      }
+    },
+    {
+      "name": "ignores unknown keys silently",
+      "text": "comment:\n  banana: true\n  linkToFilePage: false\nother: 1\n",
+      "format": "yaml",
+      "expected": {
+        "config": {
+          "linkToFilePage": false
+        },
+        "warnings": []
+      }
+    },
+    {
+      "name": "drops an over-500-char note whole, with a warning — never truncates",
+      "text": "comment:\n  note: \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\n",
+      "format": "yaml",
+      "expected": {
+        "config": {},
+        "warnings": ["note: longer than 500 characters; dropped (not truncated)"]
+      }
+    },
+    {
+      "name": "treats empty/whitespace note as absent",
+      "text": "comment:\n  note: \"   \"\n",
+      "format": "yaml",
+      "expected": {
+        "config": {},
+        "warnings": []
+      }
+    },
+    {
+      "name": "returns null config + warning for unparseable yaml",
+      "text": "comment: [unclosed",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": ["config file could not be parsed; ignoring it"]
+      }
+    },
+    {
+      "name": "returns null config for a non-object root",
+      "text": "- a\n- b\n",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": []
+      }
+    },
+    {
+      "name": "returns null config for a missing comment key",
+      "text": "other: 1\n",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": []
+      }
+    },
+    {
+      "name": "hostile input: empty string",
+      "text": "",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": []
+      }
+    },
+    {
+      "name": "hostile input: NUL byte",
+      "text": "\u0000",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": []
+      }
+    },
+    {
+      "name": "hostile input: yaml function tag",
+      "text": "!!js/function 'x'",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": []
+      }
+    },
+    {
+      "name": "hostile input: unclosed brace",
+      "text": "{",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": ["config file could not be parsed; ignoring it"]
+      }
+    },
+    {
+      "name": "hostile input: comment key is a scalar, not an object",
+      "text": "comment: 3",
+      "format": "yaml",
+      "expected": {
+        "config": null,
+        "warnings": []
+      }
+    }
+  ],
+  "resolveCases": [
+    {
+      "name": "returns AUTO options with all-auto sources for null inputs",
+      "repo": null,
+      "workspace": null,
+      "expected": {
+        "options": {
+          "imageWidth": "auto",
+          "maxInlineImages": 16,
+          "metaPath": true,
+          "metaState": true,
+          "linkToFilePage": true,
+          "note": null
+        },
+        "source": {
+          "imageWidth": "auto",
+          "maxInlineImages": "auto",
+          "metaPath": "auto",
+          "metaState": "auto",
+          "linkToFilePage": "auto",
+          "note": "auto"
+        }
+      }
+    },
+    {
+      "name": "applies per-key precedence repo > workspace > auto",
+      "repo": {
+        "imageWidth": "full"
+      },
+      "workspace": {
+        "imageWidth": 640,
+        "maxInlineImages": 4
+      },
+      "expected": {
+        "options": {
+          "imageWidth": "full",
+          "maxInlineImages": 4,
+          "metaPath": true,
+          "metaState": true,
+          "linkToFilePage": true,
+          "note": null
+        },
+        "source": {
+          "imageWidth": "repo",
+          "maxInlineImages": "workspace",
+          "metaPath": "auto",
+          "metaState": "auto",
+          "linkToFilePage": "auto",
+          "note": "auto"
+        }
+      }
+    },
+    {
+      "name": "maps workspace showMetadata:false to both meta fields",
+      "repo": null,
+      "workspace": {
+        "showMetadata": false
+      },
+      "expected": {
+        "options": {
+          "imageWidth": "auto",
+          "maxInlineImages": 16,
+          "metaPath": false,
+          "metaState": false,
+          "linkToFilePage": true,
+          "note": null
+        },
+        "source": {
+          "imageWidth": "auto",
+          "maxInlineImages": "auto",
+          "metaPath": "workspace",
+          "metaState": "workspace",
+          "linkToFilePage": "auto",
+          "note": "auto"
+        }
+      }
+    },
+    {
+      "name": "repo meta override beats workspace showMetadata",
+      "repo": {
+        "metaPath": true
+      },
+      "workspace": {
+        "showMetadata": false
+      },
+      "expected": {
+        "options": {
+          "imageWidth": "auto",
+          "maxInlineImages": 16,
+          "metaPath": true,
+          "metaState": false,
+          "linkToFilePage": true,
+          "note": null
+        },
+        "source": {
+          "imageWidth": "auto",
+          "maxInlineImages": "auto",
+          "metaPath": "repo",
+          "metaState": "workspace",
+          "linkToFilePage": "auto",
+          "note": "auto"
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/github-comment-golden-options.json
+++ b/test/fixtures/github-comment-golden-options.json
@@ -1,0 +1,39 @@
+{
+  "cases": [
+    {
+      "name": "full",
+      "options": {
+        "imageWidth": "full"
+      },
+      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+    },
+    {
+      "name": "px500",
+      "options": {
+        "imageWidth": 500
+      },
+      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"500\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+    },
+    {
+      "name": "cap2",
+      "options": {
+        "maxInlineImages": 2
+      },
+      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+    },
+    {
+      "name": "metaPathOff",
+      "options": {
+        "metaPath": false
+      },
+      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+    },
+    {
+      "name": "note",
+      "options": {
+        "note": "Staging only."
+      },
+      "expected": "<!-- uploads.sh:attachments -->\nStaging only.\n\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+    }
+  ]
+}

--- a/test/fixtures/github-comment-golden-options.json
+++ b/test/fixtures/github-comment-golden-options.json
@@ -19,14 +19,46 @@
       "options": {
         "maxInlineImages": 2
       },
-      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/checkout.png\"><img width=\"400\" alt=\"checkout.png\" src=\"https://embed.uploads.sh/f/checkout.png\"></a>\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/dashboard.png\"><img width=\"640\" alt=\"dashboard.png\" src=\"https://embed.uploads.sh/f/dashboard.png\"></a>\n\n<details><summary>1 more attachment</summary>\n\n- [hero.png](https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png)\n\n</details>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>",
+      "items": [
+        {
+          "key": "gh/acme/web/pull/12/hero.png",
+          "url": "https://uploads.sh/f/hero.png",
+          "embedUrl": "https://embed.uploads.sh/f/hero.png",
+          "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png"
+        },
+        {
+          "key": "gh/acme/web/pull/12/dashboard.png",
+          "url": "https://uploads.sh/f/dashboard.png",
+          "embedUrl": "https://embed.uploads.sh/f/dashboard.png",
+          "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/dashboard.png"
+        },
+        {
+          "key": "gh/acme/web/pull/12/checkout.png",
+          "url": "https://uploads.sh/f/checkout.png",
+          "embedUrl": "https://embed.uploads.sh/f/checkout.png",
+          "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/checkout.png"
+        }
+      ]
     },
     {
       "name": "metaPathOff",
       "options": {
         "metaPath": false
       },
-      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n- [build.log](https://uploads.sh/f/acme/gh/acme/web/pull/12/build.log)\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/hero.png\"><img width=\"400\" alt=\"hero.png\" src=\"https://embed.uploads.sh/f/hero.png\"></a>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>"
+      "expected": "<!-- uploads.sh:attachments -->\n### 📎 Attachments\n\n<a href=\"https://uploads.sh/f/acme/gh/acme/web/pull/12/meta-a.png\"><img width=\"400\" alt=\"meta-a.png\" src=\"https://embed.uploads.sh/f/meta-a.png\"></a>\n<sub>after</sub>\n\n<sub>Maintained by <a href=\"https://uploads.sh\">uploads.sh</a> — re-uploading a file with the same name updates it everywhere it is embedded.</sub>\n<sub>Add media: <code>uploads put &lt;file&gt; --pr &lt;N&gt; --comment</code> (or <code>--issue &lt;N&gt;</code>) · <a href=\"https://uploads.sh/docs/github-app\">docs</a></sub>",
+      "items": [
+        {
+          "key": "gh/acme/web/pull/12/meta-a.png",
+          "url": "https://uploads.sh/f/meta-a.png",
+          "embedUrl": "https://embed.uploads.sh/f/meta-a.png",
+          "pageUrl": "https://uploads.sh/f/acme/gh/acme/web/pull/12/meta-a.png",
+          "meta": {
+            "path": "apps/web/src",
+            "state": "after"
+          }
+        }
+      ]
     },
     {
       "name": "note",


### PR DESCRIPTION
Closes #307.

Repo owners can now control how the managed attachments comment renders via a committed `.uploads.yml`, and workspace admins get editable defaults plus a live preview in workspace settings.

## What's in here

**Repo config file** — `.uploads.yml` (also `.uploads.yaml`/`.uploads.json`, root or `.github/`, first found wins, default branch only):

```yaml
comment:
  imageWidth: full        # auto | full | 160–1000 px
  maxInlineImages: 8      # 1–48
  meta: { path: true, state: true }
  linkToFilePage: false   # the original #307 knob
  note: "Screenshots from CI."   # ≤500 chars, shown under the header
```

Resolved per key: repo config > workspace default > auto. Fail-closed everywhere — a missing, unreadable, or broken file falls back to workspace defaults and never breaks the comment. Server fetches via the GitHub App and caches per repo for 5 minutes (negative results cached; transient errors not). The CLI gh-fallback path reads the same file from the local working tree, so both comment paths honor it.

**Workspace defaults + preview** — new `GET/PATCH /me/workspaces/:name/comment-settings` (admin-gated, validated bounds, reject-all-or-apply-all) and a settings block on the workspace settings tab. The preview panel renders the output of the real `attachmentsCommentBody` (recent attachments when the workspace has any, canned fixtures otherwise) with per-knob source badges (repo / workspace / auto), backed by `GET /me/workspaces/:name/comment-preview` and a small session-authed `repo-links` endpoint for the picker.

**Parity discipline** — the parser/resolver lives in a new private `@uploads/comment-config` package; the published CLI carries a synced copy guarded by a new shared golden (`test/fixtures/comment-config-golden.json`) asserted from both sides, same mechanism as the renderer copies. Renderer changes are byte-identical for default options: zero churn to pre-existing goldens.

**Docs** — `/docs/comment-config` reference page, wired into the hub, sitemap, and llms.txt.

<img width="700" alt="Workspace settings: GitHub comment block with tri-state controls, and live preview with source badges" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/534/task-7-preview.webp">

<img width="700" alt="Preview panel wrapped in GitHub comment chrome: bot avatar, author header, comment bubble" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/534/preview-chrome.webp">

## Notes for review

- The preview body is sanitized with a per-tag attribute allowlist; review caught and fixed a control-character `javascript:` URL bypass (`java\tscript:`) with regression tests.
- `showMetadata`/`linkToFilePage` are tri-state (auto/on/off) in the UI — an explicit Off is distinct from unset and survives saves.
- One changeset: `@buildinternet/uploads` minor (gh-fallback honors `.uploads.yml`).
- Follow-up candidates: operator admin-ui coverage of the three new workspace fields; hosted-MCP awareness of repo config.

Tests: 3396 passing across 250 files; typecheck clean; settings + preview verified live in the browser on the local stack.
