### PR TITLE
feat(cli): sync managed comment on put --pr/--issue by default

### DIFF
--- a/.changeset/put-comment-sync-default.md
+++ b/.changeset/put-comment-sync-default.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`put --pr`/`--issue` now syncs the managed attachments comment by default (same as `attach`), so uploads on a quiet PR show up without a webhook event or `--comment`. Opt out with `--no-comment`; `--comment` is kept as a no-op alias.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ pnpm workspace:limits <name> [--max-storage …] [--max-video-bytes …] \
   [--clear-max-storage] [--clear-allowed-prefixes] […]
 pnpm migrate:d1:local    # apply apps/api/migrations to local D1 (migrate:d1 = remote)
 pnpm uploads put <file> --env-file .env   # monorepo only: builds package first
-pnpm uploads put <file> --pr <num> --comment
+pnpm uploads put <file> --pr <num>
 ```
 
 **CLI examples — installed binary vs monorepo:** product-facing examples
@@ -78,7 +78,7 @@ use the global binary as someone who already installed the CLI would:
 
 ```bash
 uploads put ./shot.png
-uploads put ./after.png --pr 123 --comment
+uploads put ./after.png --pr 123
 ```
 
 Reserve `pnpm uploads …` for **in-repo** development (build-from-source via the

--- a/docs/api.md
+++ b/docs/api.md
@@ -202,7 +202,7 @@ Examples assume the CLI is installed globally (`uploads`); use
 
 ```bash
 uploads put <file>
-uploads put <file> --pr <num> --comment   # PR attachment + managed GitHub comment
+uploads put <file> --pr <num>   # PR attachment + managed GitHub comment by default
 uploads gallery create --title "Release screenshots"
 uploads put <file> --gallery <gallery-id>
 uploads usage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,12 +120,15 @@ uploads put ./after.png --pr 123 --alt "Dashboard after"
 # key: gh/<owner>/<repo>/pull/123/after.webp  (PNG optimized to WebP; extension follows the output)
 ```
 
-**Managed attachments comment** (`--comment`, requires local `gh` auth) creates
-or updates a single comment listing every file attached to that PR or issue. The
-upload still succeeds if `gh` is unavailable:
+**Managed attachments comment** creates or updates a single comment listing
+every file attached to that PR or issue. `put --pr`/`--issue` syncs it by
+default (posts via the GitHub App bot, falling back to local `gh` when the
+App isn't installed); pass `--no-comment` to upload without syncing. The
+upload still succeeds if the comment sync fails:
 
 ```bash
-uploads put ./after.png --pr 123 --comment
+uploads put ./after.png --pr 123
+uploads put ./after.png --pr 123 --no-comment   # upload only
 uploads comment --pr 123   # re-sync without uploading
 ```
 

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -173,9 +173,13 @@ Options:
   --format human|url|markdown|json
   --pr <num>            Attach to a pull request: key gh/<owner>/<repo>/pull/<num>/<name> (stable URL, no hash)
   --issue <num>         Attach to an issue: key gh/<owner>/<repo>/issues/<num>/<name>
-  --comment             With --pr/--issue: update one managed comment with
-                        attachments and linked galleries. Posts as uploads-sh[bot]
-                        when the GitHub App is installed; otherwise via local gh.
+  --comment             With --pr/--issue, the managed comment sync runs by
+                        default; --comment is accepted as a no-op for
+                        back-compat (kept redundant with the default).
+  --no-comment          With --pr/--issue: skip updating the managed comment
+                        with attachments and linked galleries. Otherwise it
+                        posts as uploads-sh[bot] when the GitHub App is
+                        installed, or via local gh as a fallback.
   --gallery <id>         Add the uploaded object(s) to this public gallery
   --meta <k=v>          Queryable custom metadata (repeatable; value may contain "="): key ^[a-z][a-z0-9._-]{0,63}$, value 1-512 printable ASCII, max 24 pairs
                         Re-uploading to an existing key WITH --meta replaces that file's
@@ -186,7 +190,7 @@ Options:
   --replace             Allow overwriting an existing object on a strict (--key/default) key
                         (or UPLOADS_OVERWRITE=1). No effect on --pr/--issue, which always overwrite.
   --dry-run             Print key + public URL without uploading; reports if the key would replace
-                        (or, on a strict key, be refused). Not with --comment/--gallery
+                        (or, on a strict key, be refused). Not with --gallery
 
 A bare put (no --pr/--issue/--key) on a non-default git branch prints a one-line
 nudge toward --pr/attach --branch (stderr in human mode, a "hint" field in
@@ -2079,7 +2083,10 @@ export async function runPut(
   const destFlag = flagString(parsed.flags, "--destination");
   const prefixFlag = flagString(parsed.flags, "--prefix");
   const ghTarget = ghTargetFromFlags(parsed.flags, run);
-  const wantComment = parsed.flags.has("--comment");
+  // Comment sync runs by default with --pr/--issue (matches `attach`); opt
+  // out with --no-comment. --comment is accepted as a redundant no-op for
+  // back-compat with scripts written before this default flipped (#537).
+  const wantComment = !parsed.flags.has("--no-comment");
   const galleryId = flagString(parsed.flags, "--gallery");
   const nameFlag = flagString(parsed.flags, "--name");
   const dryRun = flagBool(parsed.flags, "--dry-run");
@@ -2097,8 +2104,11 @@ export async function runPut(
     validateMetaMap(merged);
     return merged;
   })();
-  if (wantComment && typeof parsed.flags.get("--comment") === "string") {
+  if (parsed.flags.has("--comment") && typeof parsed.flags.get("--comment") === "string") {
     throw new UsageError("--comment takes no value — place it after the file argument");
+  }
+  if (parsed.flags.has("--no-comment") && typeof parsed.flags.get("--no-comment") === "string") {
+    throw new UsageError("--no-comment takes no value");
   }
   if (parsed.flags.has("--auto") && typeof parsed.flags.get("--auto") === "string") {
     throw new UsageError("--auto takes no value");
@@ -2106,7 +2116,9 @@ export async function runPut(
   if (parsed.flags.has("--no-auto") && typeof parsed.flags.get("--no-auto") === "string") {
     throw new UsageError("--no-auto takes no value");
   }
-  if (wantComment && !ghTarget) throw new UsageError("--comment requires --pr or --issue");
+  if (parsed.flags.has("--no-comment") && !ghTarget) {
+    throw new UsageError("--no-comment requires --pr or --issue");
+  }
   if (multi) {
     if (keyHint) throw new UsageError("--key cannot be combined with multiple files");
     if (nameFlag !== undefined)
@@ -2132,10 +2144,7 @@ export async function runPut(
     }
     if (keyHint) throw new UsageError("--name cannot be combined with --key");
   }
-  if (dryRun) {
-    if (wantComment) throw new UsageError("--dry-run cannot be combined with --comment");
-    if (galleryId) throw new UsageError("--dry-run cannot be combined with --gallery");
-  }
+  if (dryRun && galleryId) throw new UsageError("--dry-run cannot be combined with --gallery");
   let resolvedPrefix: string | undefined;
   try {
     resolvedPrefix = resolvePutPrefix({
@@ -2350,7 +2359,7 @@ export async function runPut(
 
   let comment: AttachmentsCommentResult | undefined;
   let commentError: string | undefined;
-  if (wantComment && ghTarget && uploads.length > 0) {
+  if (wantComment && ghTarget && !dryRun && uploads.length > 0) {
     try {
       comment = await syncAttachmentsComment(ctx.client, ghTarget, run, ctx.config.workspace);
       if (logHuman)

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -281,6 +281,100 @@ describe("runPut --pr/--issue", () => {
   });
 });
 
+describe("runPut managed comment sync (#537)", () => {
+  /** gh CommandRunner fake: records calls, resolves repo/pr and posts the comment. */
+  function ghRunner() {
+    const calls: string[][] = [];
+    const run: CommandRunner = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      if (args[1]?.includes("per_page=100")) return "[]";
+      return JSON.stringify({ id: 9 });
+    };
+    return { run, calls };
+  }
+
+  /** Extends the base fakeClient with the methods syncAttachmentsComment needs
+   * for the gh-fallback path (no `upsertGithubComment` stub, so the bot call
+   * is absent and it falls through, same as commands-attach.test.ts). */
+  function commentCapableClient() {
+    const { client, puts } = fakeClient();
+    // At least one item so the sync has something to report — an empty
+    // listing means "skipped" (no comment created), which would defeat the
+    // point of these tests.
+    (client as unknown as { listAll: UploadsClient["listAll"] }).listAll = async () => [
+      { key: "gh/o/r/pull/5/shot.png", url: "https://x.test/shot.png" },
+    ];
+    (
+      client as unknown as { findGalleriesByReference: UploadsClient["findGalleriesByReference"] }
+    ).findGalleriesByReference = async () => ({ galleries: [], nextCursor: null });
+    return { client, puts };
+  }
+
+  it("syncs the managed comment by default with --pr (posts via gh fallback)", async () => {
+    const { client } = commentCapableClient();
+    const { run, calls } = ghRunner();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "5", "--repo", "o/r"],
+      false,
+      run,
+    );
+    expect(code).toBe(0);
+    expect(calls.some((call) => call.includes("repos/o/r/issues/5/comments"))).toBe(true);
+  });
+
+  it("--no-comment suppresses the sync (no comment call)", async () => {
+    const { client } = commentCapableClient();
+    const { run, calls } = ghRunner();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "5", "--repo", "o/r", "--no-comment"],
+      false,
+      run,
+    );
+    expect(code).toBe(0);
+    expect(calls.some((call) => call.includes("comments"))).toBe(false);
+  });
+
+  it("bare put (no --pr/--issue) never attempts the comment sync", async () => {
+    const { client } = commentCapableClient();
+    const code = await runPut(ctxWith(client), [tmpFile()], false, noRun);
+    expect(code).toBe(0);
+  });
+
+  it("accepts --comment as a redundant no-op alongside the default sync", async () => {
+    const { client } = commentCapableClient();
+    const { run, calls } = ghRunner();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "5", "--repo", "o/r", "--comment"],
+      false,
+      run,
+    );
+    expect(code).toBe(0);
+    expect(calls.some((call) => call.includes("repos/o/r/issues/5/comments"))).toBe(true);
+  });
+
+  it("a comment-sync failure degrades with a stderr warning and still exits 0", async () => {
+    const { client, puts } = fakeClient(); // no listAll/findGalleriesByReference stub → sync throws
+    const stderr: string[] = [];
+    const write = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const ctx = { ...ctxWith(client), quiet: false };
+      const code = await runPut(ctx, [tmpFile(), "--pr", "5", "--repo", "o/r"], false, noRun);
+      expect(code).toBe(0);
+      expect(puts).toHaveLength(1); // upload still succeeded
+      expect(stderr.join("")).toContain("warning: upload succeeded but the GitHub comment failed");
+    } finally {
+      process.stderr.write = write;
+    }
+  });
+});
+
 describe("runPut --name", () => {
   it("overrides the key leaf while keeping the stable --pr path", async () => {
     const { client, puts } = fakeClient();
@@ -372,10 +466,21 @@ describe("runPut --dry-run", () => {
     }
   });
 
-  it("rejects --dry-run with --comment", async () => {
+  it("skips the comment sync on --dry-run even with --pr (no run calls)", async () => {
+    const { client } = fakeClient();
+    const code = await runPut(
+      ctxWith(client),
+      [tmpFile(), "--pr", "5", "--repo", "o/r", "--dry-run"],
+      false,
+      noRun, // would throw if the comment sync (or anything else) called the runner
+    );
+    expect(code).toBe(0);
+  });
+
+  it("rejects --no-comment without --pr/--issue", async () => {
     const { client } = fakeClient();
     await expect(
-      runPut(ctxWith(client), [tmpFile(), "--pr", "5", "--dry-run", "--comment"], false, noRun),
+      runPut(ctxWith(client), [tmpFile(), "--no-comment"], false, noRun),
     ).rejects.toThrow(UsageError);
   });
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -258,29 +258,29 @@ capture them. Use `-` as the file to read from stdin.
 
 Key options (`uploads put --help` for all):
 
-| Flag                                  | Purpose                                                                                                                                                               |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                                                                                      |
-| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                                                                                      |
-| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                                                                                        |
-| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                                                                                              |
-| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                                                                                           |
-| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                                                                                     |
-| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                                                                                           |
-| `--name <leaf>`                       | Clean filename for the key's leaf + default alt (no `/`); keeps the `--pr`/default path. Not with `--key`.                                                            |
-| `--replace`                           | Allow overwriting an existing object on a strict key (`--key`/default path). No effect on `--pr`/`--issue` (or `UPLOADS_OVERWRITE=1`).                                |
-| `--dry-run`                           | Resolve + print the key and final public URL without uploading; reports if the key would replace (or, on a strict key, be refused). Not with `--comment`/`--gallery`. |
-| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body).                                                                    |
-| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                                                                                   |
-| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                                                                                               |
-| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                                                                                     |
-| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.                                                                       |
-| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                                                                                        |
-| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                                                                                           |
-| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.                                                                         |
-| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                                                                                    |
-| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                                                                                        |
-| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                                                                                               |
+| Flag                                  | Purpose                                                                                                                                                                                                              |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--alt <text>`                        | Alt text for the markdown (default: filename). Always write meaningful alt text.                                                                                                                                     |
+| `--width <px>`                        | Emit sized `<img width=…>` HTML instead of `![]()` (markdown can't size images).                                                                                                                                     |
+| `--repo <owner/repo>`                 | Repo segment of the auto key (default: git remote, or `UPLOADS_DEFAULT_REPO`).                                                                                                                                       |
+| `--ref <id>`                          | PR/issue/branch/date segment (default: today, or `UPLOADS_DEFAULT_REF`).                                                                                                                                             |
+| `--destination <id>`                  | Typed root: `screenshots` \| `gh` \| `f` (sets key prefix).                                                                                                                                                          |
+| `--prefix <path>`                     | Key prefix (default: `screenshots`, or `UPLOADS_DEFAULT_PREFIX`).                                                                                                                                                    |
+| `--key <key>`                         | Set the object key explicitly; skips the auto-naming below.                                                                                                                                                          |
+| `--name <leaf>`                       | Clean filename for the key's leaf + default alt (no `/`); keeps the `--pr`/default path. Not with `--key`.                                                                                                           |
+| `--replace`                           | Allow overwriting an existing object on a strict key (`--key`/default path). No effect on `--pr`/`--issue` (or `UPLOADS_OVERWRITE=1`).                                                                               |
+| `--dry-run`                           | Resolve + print the key and final public URL without uploading; reports if the key would replace (or, on a strict key, be refused). Not with `--gallery`; skips the managed comment sync even with `--pr`/`--issue`. |
+| `--content-type <mime>`               | Override the content type (else inferred from extension; ignored when optimize rewrites the body).                                                                                                                   |
+| `--frame <id>`                        | Opt-in chrome before optimize: `phone`, `browser`, `iphone-16-pro`.                                                                                                                                                  |
+| `--frame-url <url>`                   | Address bar text for `--frame browser`.                                                                                                                                                                              |
+| `--frame-fit cover\|contain`          | How the shot fills the screen (default: `cover`).                                                                                                                                                                    |
+| `--no-optimize`                       | Skip client-side image optimization (default: still images → WebP). Or `UPLOADS_NO_OPTIMIZE=1`.                                                                                                                      |
+| `--optimize-max-edge <px>`            | Max long edge when optimizing (default: 2400).                                                                                                                                                                       |
+| `--optimize-quality <1-100>`          | WebP quality when optimizing (default: 85).                                                                                                                                                                          |
+| `--keep-exif`                         | Keep EXIF/XMP/ICC when optimizing (default: **strip** for privacy). Or `UPLOADS_KEEP_EXIF=1`.                                                                                                                        |
+| `--no-git`                            | Don't derive `--repo` from the git remote (or `UPLOADS_NO_GIT=1`).                                                                                                                                                   |
+| `--format human\|url\|markdown\|json` | Control stdout. `--json` (global) forces json.                                                                                                                                                                       |
+| `-w, --workspace <name>`              | Override workspace (wins over env and token inference).                                                                                                                                                              |
 
 **Image optimization (default on):** PNG/JPEG and similar still images are re-encoded to
 WebP (long edge capped at 2400px, quality 85) before upload so PR/issue embeds stay
@@ -661,13 +661,15 @@ to the target's own `gh.*` values. It also stamps `gh.title` with the real
 PR/issue title when resolvable via local `gh` (best-effort; omitted rather
 than failing the upload if `gh` can't resolve one).
 
-### Option B — managed attachments comment (`--comment` / `comment`)
+### Option B — managed attachments comment (default with `--pr`/`--issue`, or `comment`)
 
-Add `--comment` to upload **and** create/update a single marker-owned comment on the PR/issue. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. It finds its own prior comment via a hidden marker and edits it in place — it never touches the description or other comments:
+`put --pr`/`--issue` (like `attach`) uploads **and** creates/updates a single marker-owned comment on the PR/issue by default — no separate flag needed. It keeps loose `gh/...` attachments and every public gallery linked to that PR/issue in clearly separate sections, with up to three available gallery images inline. It finds its own prior comment via a hidden marker and edits it in place — it never touches the description or other comments:
 
 ```bash
-uploads put ./after.png --pr 123 --comment
+uploads put ./after.png --pr 123
 ```
+
+Pass `--no-comment` to skip the sync (upload only), matching `attach --no-comment`. `--comment` is still accepted on `put` as a no-op — it's redundant now that the sync is the default, kept only for scripts written before this changed (#537).
 
 The upload is authoritative; the comment is best-effort — if `gh` is missing or
 unauthenticated, the upload still succeeds and you get a warning. To (re)sync the


### PR DESCRIPTION
Closes #537.

`put --pr`/`put --issue` now runs the same managed-comment sync `attach` does by default, so an upload on a quiet PR shows up in the attachments comment immediately instead of waiting for the next webhook event (open/reopen/synchronize). On PR #534 a bare `put --pr` stayed invisible for ~25 minutes until the next push fired a sync; on a PR with no further pushes it would never appear.

This is option 1 from the issue: fix the put/attach asymmetry at the client.

**Flag semantics**
- `--no-comment` opts out (matches `attach`); requires `--pr`/`--issue`.
- `--comment` is kept as a redundant no-op for existing scripts.
- `--dry-run` skips the sync (nothing was uploaded); the old `--dry-run` + `--comment` usage error is gone.
- Bare `put` (no gh key) is unchanged.

**Implementation**
- Reuses `syncAttachmentsComment` as-is — bot/gh-fallback parity and marker-hunt dedupe are untouched; a failed sync still degrades to a stderr warning without failing the upload.
- Docs (`docs/cli.md`, `docs/api.md`, `AGENTS.md`, `skills/uploads-cli/SKILL.md`) updated; changeset adds a minor bump for `@buildinternet/uploads`.

**Tests**
- New coverage: default sync, `--no-comment` suppression, bare put untouched, `--comment` no-op, sync-failure degrade, `--dry-run` skip.
- `pnpm test`: 3416/3416 passing; lint and typecheck clean.
