### PR TITLE
feat(mcp): sync managed comment on hosted put with pr/issue by default

### DIFF
--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -438,7 +438,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "put",
       description:
-        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). With `pr`/`issue` (+ required `repo`) the key is stable instead (gh/…, always overwrites) and `comment` syncs the managed attachments comment as uploads-sh[bot] — bot-only on this hosted server, no local gh fallback. Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
+        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). With `pr`/`issue` (+ required `repo`) the key is stable instead (gh/…, always overwrites) and the managed attachments comment is synced by default as uploads-sh[bot] (bot-only on this hosted server, no local gh fallback) — pass `comment: false` to skip it. Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
       inputSchema: {
         type: "object",
         properties: {
@@ -473,7 +473,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               required: ["filename", "contentBase64"],
               additionalProperties: false,
             },
-            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/pr/issue/width/metadata apply to every item. Returns { uploads, failures } with per-item results (plus comment/commentError once for the whole batch when comment: true).`,
+            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/pr/issue/width/metadata apply to every item. Returns { uploads, failures } with per-item results (plus comment/commentError once for the whole batch when the comment sync runs).`,
           },
           key: {
             type: "string",
@@ -507,7 +507,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           comment: {
             type: "boolean",
             description:
-              "With pr/issue: after a successful upload, create or update the managed attachments comment via the uploads.sh GitHub App (bot-only on this hosted server — no local gh fallback). Requires pr or issue. A comment failure never fails the upload; see the response's `comment`/`commentError`.",
+              "With pr/issue: after a successful upload, create or update the managed attachments comment via the uploads.sh GitHub App (bot-only on this hosted server — no local gh fallback). Defaults to true when pr/issue is given (requires the files:read scope; a write-only token skips the sync unless comment is explicitly true); pass false to skip. Requires pr or issue. A comment failure never fails the upload; see the response's `comment`/`commentError`.",
           },
           alt: {
             type: "string",
@@ -562,15 +562,25 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         // ghTargetFromArgs). Mutually exclusive with key/prefix/ref — a target
         // always uses the stable gh/ key layout, never the default one.
         const target = ghTargetFromArgs(args);
-        const wantComment = optBool(args, "comment");
-        if (wantComment && !target) usage("comment requires pr or issue");
+        // optBool collapses "absent" to false, but absent vs explicit false
+        // matters here (absent → default-on with pr/issue), so gate on the
+        // raw arg first.
+        const commentArg = args.comment == null ? undefined : optBool(args, "comment");
+        if (commentArg && !target) usage("comment requires pr or issue");
         // The comment path's gather reads the workspace's own objects,
         // metadata, and galleries (github-comment-service.ts's
         // gatherCommentBody) — the same reason the REST route requires
         // files:read. Checked up front, alongside the other argument
         // validation, so a files:write-only token is rejected before any
         // bytes are written — never after a successful upload.
-        if (wantComment) requireScope("files:read");
+        if (commentArg === true) requireScope("files:read");
+        // With pr/issue the sync runs by default (parity with CLI put, #537);
+        // comment: false opts out. The default-on case additionally requires
+        // files:read on the token — a write-only token keeps its pre-#537
+        // ability to upload by silently skipping the sync, and only an
+        // explicit comment: true turns that missing scope into an error.
+        const wantComment =
+          commentArg ?? (target !== undefined && ctx.authScopes.includes("files:read"));
 
         const explicitKey = optString(args, "key");
         const prefix = optString(args, "prefix");

--- a/apps/mcp/test/mcp-put-comment.test.ts
+++ b/apps/mcp/test/mcp-put-comment.test.ts
@@ -4,7 +4,8 @@
  * apps/api/src/routes/github-comment-route.test.ts (now via
  * `postManagedComment`, apps/api/src/github-comment-service.ts) — these tests
  * cover only the hosted MCP `put` tool's new surface: targeting args, the
- * `comment` opt-in, and that a decline/failure never fails the upload.
+ * default comment sync with pr/issue (#537 parity; `comment: false` opts
+ * out), and that a decline/failure never fails the upload.
  */
 import { beforeAll, describe, expect, it } from "vitest";
 import app from "../src/index";
@@ -490,13 +491,48 @@ describe("hosted put: comment sync (issue #392)", () => {
     }
   });
 
-  it("does not attach a comment when comment is not requested", async () => {
+  it("syncs the comment by default when pr/issue is given (#537 parity)", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/acme/widgets/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "put", {
+        contentBase64: PNG_B64,
+        filename: "hero.png",
+        pr: 12,
+        repo: "acme/widgets",
+      });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent?.comment).toEqual({
+        posted: true,
+        action: "created",
+        count: 1,
+        commentUrl: "https://github.com/acme/widgets/pull/12#c5",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not attach a comment with comment: false", async () => {
     const { env } = await makeEnv({ boundTo: WS });
     const result = await callTool(env, "put", {
       contentBase64: PNG_B64,
       filename: "hero.png",
       pr: 12,
       repo: "acme/widgets",
+      comment: false,
     });
     expect(result.isError).toBe(false);
     expect(result.structuredContent?.comment).toBeUndefined();
@@ -518,7 +554,7 @@ describe("hosted put: comment sync (issue #392)", () => {
     expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(false);
   });
 
-  it("the same files:write-only token can still put without comment", async () => {
+  it("a files:write-only token still puts to a pr: the default sync is skipped, not an error", async () => {
     const { env, bucket } = await makeEnv({ boundTo: WS, scopes: ["files:write"] });
     const result = await callTool(env, "put", {
       contentBase64: PNG_B64,
@@ -528,6 +564,10 @@ describe("hosted put: comment sync (issue #392)", () => {
     });
     expect(result.isError).toBe(false);
     expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
+    // The default-on sync requires files:read — silently skipped here rather
+    // than turning a previously-valid write-only upload into an error.
+    expect(result.structuredContent?.comment).toBeUndefined();
+    expect(result.structuredContent?.commentError).toBeUndefined();
   });
 });
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -863,12 +863,15 @@ uploads --api-url http://localhost:8787 doctor
   accepts `pr`/`issue` (mutually exclusive, mirroring the CLI's `--pr`/
   `--issue`) plus a required `repo` (`owner/name` — the hosted server has no
   git context to infer it from) to get the same stable `gh/…` key the CLI
-  produces. Add `comment: true` to post/update the managed `uploads-sh[bot]`
-  attachments comment directly, same as CLI `--comment` — bot-only on this
-  server, no local-`gh` fallback. Prefer `pr`/`issue`/`comment` over just
+  produces. With `pr`/`issue` the managed `uploads-sh[bot]` attachments
+  comment is posted/updated by default, same as CLI `put --pr` (#537) — pass
+  `comment: false` to skip it. Bot-only on this server, no local-`gh`
+  fallback; the default sync needs the `files:read` scope and is silently
+  skipped on a write-only token (explicit `comment: true` errors instead).
+  Prefer `pr`/`issue` over just
   returning a raw `url`/`embedUrl` whenever the caller is going to paste the
   result into a PR/issue: it gets the stable overwrite-in-place key and
-  (optionally) lands straight in the collected attachments comment instead of
+  lands straight in the collected attachments comment instead of
   a one-off link the caller has to hand-embed. A comment failure never fails
   the upload — it's returned honestly in the result's `comment` field as one
   of `not_installed` (App not installed on the repo), `not_authorized` (repo


### PR DESCRIPTION
Follow-up to #539 (issue #537): brings the hosted MCP `put` tool to the same default as CLI `put --pr/--issue` — with `pr`/`issue`, the managed attachments comment now syncs by default instead of requiring `comment: true`.

**Semantics**
- `comment` defaults to true when `pr`/`issue` is given; `comment: false` opts out; explicit `comment: true` stays accepted.
- The sync path needs the `files:read` scope. A default-on sync on a write-only token is silently skipped (so tokens that could upload before keep working); an explicit `comment: true` still errors on the missing scope, unchanged.
- Failure handling unchanged: declines and errors land in `comment`/`commentError`, never failing the upload.
- One helper wrinkle: `optBool` collapses "absent" to `false`, so the handler now distinguishes an absent `comment` (default-on) from an explicit `false` before calling it.

Tool descriptions and the `uploads-cli` skill reference updated. No changeset — `apps/mcp` is a deploy target outside the publish set.

**Tests**: new cases for default sync, `comment: false` opt-out, and write-only-token skip; full suite 3417/3417 passing.
