### PR TITLE
fix(cli): include comment/commentError in single-file put json output

### DIFF
--- a/.changeset/put-json-comment-field.md
+++ b/.changeset/put-json-comment-field.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+`put <file> --pr/--issue --format json` now includes `comment`/`commentError` in the single-file JSON payload, matching the multi-file batch shape (#541).

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2458,6 +2458,8 @@ export async function runPut(
         optimize: result.optimize,
         frame: result.frame,
         gallery,
+        comment,
+        commentError,
         ...(dryRun ? { dryRun: true } : {}),
         ...(jsonHint ? { hint: jsonHint } : {}),
       });

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -373,6 +373,43 @@ describe("runPut managed comment sync (#537)", () => {
       process.stderr.write = write;
     }
   });
+
+  // Issue #541: the single-file `--format json` payload silently dropped
+  // `comment`/`commentError`, unlike the multi-file batch payload — JSON-driven
+  // callers couldn't see the sync outcome.
+  it("includes `comment` in the single-file JSON payload on a successful sync", async () => {
+    const { client } = commentCapableClient();
+    const { run } = ghRunner();
+    const stdout = await captureStdout(() =>
+      runPut(
+        { ...ctxWith(client), quiet: false, json: true },
+        [tmpFile(), "--pr", "5", "--repo", "o/r"],
+        false,
+        run,
+      ),
+    );
+    const payload = JSON.parse(stdout) as {
+      comment?: { action: string; via: string };
+      commentError?: string;
+    };
+    expect(payload.comment).toBeDefined();
+    expect("commentError" in payload).toBe(false);
+  });
+
+  it("surfaces `commentError` in the single-file JSON payload when the sync fails", async () => {
+    const { client } = fakeClient(); // no listAll/findGalleriesByReference stub → sync throws
+    const stdout = await captureStdout(() =>
+      runPut(
+        { ...ctxWith(client), quiet: true, json: true },
+        [tmpFile(), "--pr", "5", "--repo", "o/r"],
+        false,
+        noRun,
+      ),
+    );
+    const payload = JSON.parse(stdout) as { comment?: unknown; commentError?: string };
+    expect(typeof payload.commentError).toBe("string");
+    expect("comment" in payload).toBe(false);
+  });
 });
 
 describe("runPut --name", () => {


### PR DESCRIPTION
Closes #541.

Single-file `put <file> --pr/--issue --format json` now includes `comment`/`commentError` in the JSON payload, matching the multi-file batch shape (which already had them) and `attach`'s single json output. Found while smoke-testing the #537 default sync: the sync ran but JSON-driven callers had no way to see the outcome.

Two new tests cover the success (`comment` present) and failure (`commentError` present) cases; full suite 3419/3419 passing. Patch changeset for `@buildinternet/uploads`.
