### PR TITLE
feat: operator adoption metrics surface

### DIFF
--- a/apps/api/migrations/20260728120000_daily_metrics.sql
+++ b/apps/api/migrations/20260728120000_daily_metrics.sql
@@ -1,0 +1,38 @@
+-- Per-day adoption counters (operator metrics surface). Describes CHANGE OVER
+-- TIME only: `workspace_usage` remains the source of truth for current
+-- absolute stored bytes/objects. `count`/`bytes` are always non-negative — a
+-- delete records positive bytes under the `delete` metric rather than negative
+-- bytes under `upload`, so net change is `upload.bytes - delete.bytes` at read
+-- time.
+--
+-- Every recorded event writes TWO rows: the per-workspace row and a
+-- platform-total row (`workspace = ''`). The platform row exists so the
+-- headline trend charts cost exactly one index entry per day in the window
+-- instead of one per (workspace, day) — D1 bills rows read, and that query
+-- runs on every page load. D1 has a single writer per database, so the
+-- "hot row" contention concern of a multi-master store does not apply.
+--
+-- Key order is (metric, day, workspace) so one metric's day range is
+-- contiguous. Retention is unbounded: every query is windowed by `day >= ?`,
+-- so old rows are never scanned and rolling them up would buy nothing.
+
+CREATE TABLE daily_metrics (
+  metric    TEXT NOT NULL,
+  day       TEXT NOT NULL,               -- 'YYYY-MM-DD', UTC
+  workspace TEXT NOT NULL DEFAULT '',    -- '' = the platform-total row
+  count     INTEGER NOT NULL DEFAULT 0,
+  bytes     INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (metric, day, workspace)
+);
+
+-- Covering: carries count/bytes so grouped per-workspace scans are served
+-- entirely from the index with no per-row table lookup. Same reasoning as
+-- 20260722180000_file_metadata_value_covering_idx.sql.
+CREATE INDEX daily_metrics_window_idx
+  ON daily_metrics (metric, day, workspace, count, bytes);
+
+-- Partial + covering: the headline trend series reads exactly one entry per
+-- day in the window. Partial-index precedent: auth_tokens_minting_user_idx.
+CREATE INDEX daily_metrics_platform_idx
+  ON daily_metrics (metric, day, count, bytes)
+  WHERE workspace = '';

--- a/apps/api/src/adoption-queries.ts
+++ b/apps/api/src/adoption-queries.ts
@@ -93,16 +93,33 @@ export async function workspaceActivity(
   return result.results;
 }
 
-/** Workspaces that uploaded at least once in the window. */
-export async function activeWorkspaceCount(db: D1Database, since: string): Promise<number> {
-  const row = await db
+/** One row per workspace that uploaded at least once since `since`, with its most recent active day. */
+export interface ActiveWorkspace {
+  workspace: string;
+  lastActive: string;
+}
+
+/**
+ * Workspaces active (at least one upload) since `since`, one row each with
+ * their most recent active day. Scans the window ONCE so callers who need
+ * both a 7-day and a 30-day active-workspace count can derive both from a
+ * single 30-day call — `buildOverview` (metrics-overview.ts) does exactly
+ * this — instead of the 30-day window's rows being read twice (D1 bills rows
+ * read, and the last 7 days are always a subset of the last 30).
+ */
+export async function activeWorkspacesSince(
+  db: D1Database,
+  since: string,
+): Promise<ActiveWorkspace[]> {
+  const result = await db
     .prepare(
-      `SELECT COUNT(DISTINCT workspace) AS n FROM daily_metrics
-       WHERE metric = 'upload' AND workspace <> '' AND day >= ?`,
+      `SELECT workspace, MAX(day) AS lastActive FROM daily_metrics
+       WHERE metric = 'upload' AND workspace <> '' AND day >= ?
+       GROUP BY workspace`,
     )
     .bind(since)
-    .first<{ n: number }>();
-  return row?.n ?? 0;
+    .all<ActiveWorkspace>();
+  return result.results;
 }
 
 /**

--- a/apps/api/src/adoption-queries.ts
+++ b/apps/api/src/adoption-queries.ts
@@ -5,11 +5,18 @@
  * a future digest-email cron can call these directly instead of making an
  * HTTP hop through /admin-ui.
  *
- * D1 bills rows read, so every query here is windowed by `day >= ?` and is
- * served from one of the two covering indexes:
+ * D1 bills rows read, so every query here binds both `metric` and `day >= ?`
+ * and is served from one of the two covering indexes:
  *   - platform-level reads hit `daily_metrics_platform_idx` (partial on
- *     `workspace = ''`) and cost one entry per day in the window, regardless
- *     of how many workspaces exist;
+ *     `workspace = ''`), which is keyed `(metric, day, ...)`. Binding
+ *     `metric` lets D1 SEEK straight to the window instead of scanning the
+ *     whole partial index with `day >= ?` as a residual filter, so cost is
+ *     one entry per day in the window (per metric), regardless of how many
+ *     workspaces exist. `featureTotals` needs a total per metric, so it
+ *     issues one bound-`metric` query per `ADOPTION_METRICS` entry, batched
+ *     into a single round trip, rather than a single unbound `GROUP BY
+ *     metric` query — the latter would leave the index's leading column
+ *     unconstrained and force a full scan;
  *   - per-workspace reads hit `daily_metrics_window_idx`, which carries
  *     count/bytes so there is no per-row table lookup. The table is sparse —
  *     a row exists only for a (metric, day, workspace) with real activity —
@@ -17,7 +24,7 @@
  */
 
 import type { AdoptionMetric } from "./adoption";
-import { utcDay } from "./adoption";
+import { ADOPTION_METRICS, utcDay } from "./adoption";
 
 export interface DayPoint {
   day: string;
@@ -98,21 +105,36 @@ export async function activeWorkspaceCount(db: D1Database, since: string): Promi
   return row?.n ?? 0;
 }
 
-/** Per-metric event totals in the window, from platform rows only. */
+/**
+ * Per-metric event totals in the window, from platform rows only.
+ *
+ * Issues one bound-`metric` query per entry in `ADOPTION_METRICS`, batched
+ * into a single round trip, rather than one unbound `GROUP BY metric` query.
+ * `metric` leads the `daily_metrics_platform_idx` index, so leaving it
+ * unconstrained forces a full partial-index SCAN with `day >= ?` applied as a
+ * residual filter — cost grows with total table history, not window size.
+ * Binding `metric` lets each query SEEK to `(metric, day >= ?)` instead,
+ * mirroring the pattern the other queries in this module already use.
+ */
 export async function featureTotals(
   db: D1Database,
   since: string,
 ): Promise<Record<string, number>> {
-  const result = await db
-    .prepare(
-      `SELECT metric, SUM(count) AS total FROM daily_metrics
-       WHERE workspace = '' AND day >= ?
-       GROUP BY metric`,
-    )
-    .bind(since)
-    .all<{ metric: string; total: number }>();
+  const results = await db.batch<{ total: number | null }>(
+    ADOPTION_METRICS.map((metric) =>
+      db
+        .prepare(
+          `SELECT SUM(count) AS total FROM daily_metrics
+           WHERE metric = ? AND workspace = '' AND day >= ?`,
+        )
+        .bind(metric, since),
+    ),
+  );
   const totals: Record<string, number> = {};
-  for (const row of result.results) totals[row.metric] = row.total;
+  ADOPTION_METRICS.forEach((metric, index) => {
+    const total = results[index]?.results[0]?.total;
+    if (typeof total === "number") totals[metric] = total;
+  });
   return totals;
 }
 

--- a/apps/api/src/adoption-queries.ts
+++ b/apps/api/src/adoption-queries.ts
@@ -1,0 +1,138 @@
+/**
+ * Read side of the adoption metrics (`daily_metrics`).
+ *
+ * Deliberately pure `(db, range) => data` with no Hono/Request dependency, so
+ * a future digest-email cron can call these directly instead of making an
+ * HTTP hop through /admin-ui.
+ *
+ * D1 bills rows read, so every query here is windowed by `day >= ?` and is
+ * served from one of the two covering indexes:
+ *   - platform-level reads hit `daily_metrics_platform_idx` (partial on
+ *     `workspace = ''`) and cost one entry per day in the window, regardless
+ *     of how many workspaces exist;
+ *   - per-workspace reads hit `daily_metrics_window_idx`, which carries
+ *     count/bytes so there is no per-row table lookup. The table is sparse —
+ *     a row exists only for a (metric, day, workspace) with real activity —
+ *     so that scan is proportional to actual usage, not workspaces × days.
+ */
+
+import type { AdoptionMetric } from "./adoption";
+import { utcDay } from "./adoption";
+
+export interface DayPoint {
+  day: string;
+  count: number;
+  bytes: number;
+}
+
+export interface WorkspaceActivity {
+  workspace: string;
+  uploads: number;
+  bytes: number;
+  /** Most recent day with an upload, `YYYY-MM-DD`. */
+  lastActive: string;
+}
+
+/** Default cap on the per-workspace table. */
+const DEFAULT_LIMIT = 100;
+
+/**
+ * Inclusive first day of an N-day window ending today, `YYYY-MM-DD`.
+ * `days = 1` means today only.
+ */
+export function windowStart(days: number, now = new Date()): string {
+  const start = new Date(now.getTime());
+  start.setUTCDate(start.getUTCDate() - (Math.max(1, Math.floor(days)) - 1));
+  return utcDay(start);
+}
+
+/** Daily platform totals for one metric. One index entry per day in window. */
+export async function platformSeries(
+  db: D1Database,
+  metric: AdoptionMetric,
+  since: string,
+): Promise<DayPoint[]> {
+  const result = await db
+    .prepare(
+      `SELECT day, count, bytes FROM daily_metrics
+       WHERE metric = ? AND workspace = '' AND day >= ?
+       ORDER BY day`,
+    )
+    .bind(metric, since)
+    .all<DayPoint>();
+  return result.results;
+}
+
+/** Per-workspace upload activity in the window, busiest first. */
+export async function workspaceActivity(
+  db: D1Database,
+  since: string,
+  limit = DEFAULT_LIMIT,
+): Promise<WorkspaceActivity[]> {
+  const result = await db
+    .prepare(
+      `SELECT workspace,
+              SUM(count) AS uploads,
+              SUM(bytes) AS bytes,
+              MAX(day)   AS lastActive
+       FROM daily_metrics
+       WHERE metric = 'upload' AND workspace <> '' AND day >= ?
+       GROUP BY workspace
+       ORDER BY uploads DESC, workspace ASC
+       LIMIT ?`,
+    )
+    .bind(since, limit)
+    .all<WorkspaceActivity>();
+  return result.results;
+}
+
+/** Workspaces that uploaded at least once in the window. */
+export async function activeWorkspaceCount(db: D1Database, since: string): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(DISTINCT workspace) AS n FROM daily_metrics
+       WHERE metric = 'upload' AND workspace <> '' AND day >= ?`,
+    )
+    .bind(since)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+/** Per-metric event totals in the window, from platform rows only. */
+export async function featureTotals(
+  db: D1Database,
+  since: string,
+): Promise<Record<string, number>> {
+  const result = await db
+    .prepare(
+      `SELECT metric, SUM(count) AS total FROM daily_metrics
+       WHERE workspace = '' AND day >= ?
+       GROUP BY metric`,
+    )
+    .bind(since)
+    .all<{ metric: string; total: number }>();
+  const totals: Record<string, number> = {};
+  for (const row of result.results) totals[row.metric] = row.total;
+  return totals;
+}
+
+/**
+ * Current platform-wide state, read from `workspace_usage` — the source of
+ * truth for absolute stored bytes. Deliberately NOT derived from
+ * `daily_metrics`, which only describes change over time and would drift.
+ *
+ * `workspaces` counts workspaces with at least one recorded upload (a
+ * `workspace_usage` row). Registered-but-idle workspaces are not included —
+ * the organizations total from the auth worker is the registration figure.
+ * One aggregate over a table with one row per workspace.
+ */
+export async function platformStorage(
+  db: D1Database,
+): Promise<{ workspaces: number; storedBytes: number }> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS workspaces, COALESCE(SUM(bytes), 0) AS storedBytes FROM workspace_usage`,
+    )
+    .first<{ workspaces: number; storedBytes: number }>();
+  return { workspaces: row?.workspaces ?? 0, storedBytes: row?.storedBytes ?? 0 };
+}

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -33,12 +33,17 @@ export type AdoptionMetric = (typeof ADOPTION_METRICS)[number];
  */
 export type UploadSurface = "api" | "mcp" | "promote";
 
-/** Analytics Engine dimensions. Never written to D1 — see the module docs. */
+/**
+ * Analytics Engine dimensions. Never written to D1 — see the module docs.
+ *
+ * Deliberately excludes `plan`: `BLOB_ORDER` below still reserves a blob slot
+ * for it (so `repo`'s ordinal never shifts), but no caller populates it, so
+ * it is not exposed as something callers can set. See `BLOB_ORDER`'s comment.
+ */
 export interface AdoptionDimensions {
   surface?: UploadSurface;
   contentType?: string;
   client?: string;
-  plan?: string;
   repo?: string;
 }
 
@@ -96,6 +101,18 @@ export async function bumpDailyMetric(
  * — Analytics Engine has no column names, only ordinals. Append new
  * dimensions at the END; never reorder or remove, or historical rows change
  * meaning retroactively.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for that ordinal contract: the write
+ * side (`writeAdoptionPoint`'s `blobs` array, below) and the read side
+ * (analytics-engine.ts's `BLOB_COLUMN`) both derive from this array rather
+ * than hand-repeating the ordering, so adding a dimension in the wrong
+ * position is now a one-place change instead of three hand-synced copies.
+ *
+ * `"plan"` (blob5) is reserved but deliberately unpopulated — see
+ * `AdoptionDimensions`'s comment. It stays in this array (rather than being
+ * removed) purely to hold `"repo"` at blob6: removing it would shift `repo`
+ * to blob5 and silently reinterpret every historical AE row, which AE has no
+ * way to backfill. `writeAdoptionPoint` always emits `""` at this position.
  */
 export const BLOB_ORDER = [
   "workspace",
@@ -105,6 +122,28 @@ export const BLOB_ORDER = [
   "plan",
   "repo",
 ] as const;
+
+type BlobKey = (typeof BLOB_ORDER)[number];
+
+/** The value written at `key`'s blob position for one adoption event. */
+function blobValue(key: BlobKey, event: AdoptionEvent, d: AdoptionDimensions): string {
+  switch (key) {
+    case "workspace":
+      return event.workspace;
+    case "surface":
+      return d.surface ?? "";
+    case "contentType":
+      return d.contentType ?? "";
+    case "client":
+      return d.client ?? "";
+    case "plan":
+      // Reserved-but-unpopulated slot (see BLOB_ORDER's comment) — no caller
+      // sets this today. Always "" so blob5 stays a stable, empty column.
+      return "";
+    case "repo":
+      return d.repo ?? "";
+  }
+}
 
 /**
  * One wide data point per upload. Upload-only by design: the other metrics are
@@ -123,20 +162,29 @@ export function writeAdoptionPoint(env: Env, event: AdoptionEvent): void {
     analytics.writeDataPoint({
       // Sampling key: keeps one workspace's traffic from crowding out another.
       indexes: [event.workspace],
-      blobs: [
-        event.workspace,
-        d.surface ?? "",
-        d.contentType ?? "",
-        d.client ?? "",
-        d.plan ?? "",
-        d.repo ?? "",
-      ],
+      // Derived from BLOB_ORDER (not hand-listed) so this can never drift
+      // from the ordinal contract documented there.
+      blobs: BLOB_ORDER.map((key) => blobValue(key, event, d)),
       doubles: [normalizeBytes(event.bytes)],
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(JSON.stringify({ message: "adoption analytics write failed", error: message }));
   }
+}
+
+/**
+ * Shared adoption-write-failure log shape. Exported so every caller that
+ * swallows a `bumpDailyMetric`/`recordAdoptionSafe`-style failure (e.g.
+ * github-repo-links.ts's `recordRepoLink`, which cannot await
+ * `recordAdoptionSafe` directly — see that file's header comment) logs the
+ * same one line instead of hand-rolling a copy that silently drifts.
+ */
+export function logAdoptionFailure(metric: AdoptionMetric, workspace: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(
+    JSON.stringify({ message: "adoption metric write failed", metric, workspace, error: message }),
+  );
 }
 
 /**
@@ -152,14 +200,6 @@ export async function recordAdoptionSafe(
   try {
     await bumpDailyMetric(env.DB, event, now);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(
-      JSON.stringify({
-        message: "adoption metric write failed",
-        metric: event.metric,
-        workspace: event.workspace,
-        error: message,
-      }),
-    );
+    logAdoptionFailure(event.metric, event.workspace, err);
   }
 }

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -74,10 +74,13 @@ export async function bumpDailyMetric(
                ON CONFLICT(metric, day, workspace) DO UPDATE SET
                  count = count + 1,
                  bytes = bytes + excluded.bytes`;
-  await db.batch([
-    db.prepare(sql).bind(event.metric, day, event.workspace, bytes),
-    db.prepare(sql).bind(event.metric, day, PLATFORM, bytes),
-  ]);
+  // An empty workspace IS the platform sentinel, so writing both statements
+  // would make the second ON CONFLICT fire against the first's own insert and
+  // double-count. Collapse to a single row in that case.
+  const workspaces = event.workspace === PLATFORM ? [PLATFORM] : [event.workspace, PLATFORM];
+  await db.batch(
+    workspaces.map((workspace) => db.prepare(sql).bind(event.metric, day, workspace, bytes)),
+  );
 }
 
 /**

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -10,13 +10,21 @@
  * and continues on failure, because a metrics write must never fail an upload.
  */
 
-export type AdoptionMetric =
-  | "upload"
-  | "delete"
-  | "workspace_created"
-  | "gallery_created"
-  | "comment_posted"
-  | "repo_linked";
+/**
+ * Every adoption metric. The union is DERIVED from this array so the two can
+ * never drift — `featureTotals` iterates it to issue one index-seeking query
+ * per metric (see adoption-queries.ts).
+ */
+export const ADOPTION_METRICS = [
+  "upload",
+  "delete",
+  "workspace_created",
+  "gallery_created",
+  "comment_posted",
+  "repo_linked",
+] as const;
+
+export type AdoptionMetric = (typeof ADOPTION_METRICS)[number];
 
 /**
  * Which server-side entry point wrote an upload. There is no way to tell a

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -1,0 +1,105 @@
+/**
+ * Adoption metrics recording (`daily_metrics` D1 table) — the operator
+ * metrics surface's write side.
+ *
+ * Describes CHANGE OVER TIME only. `workspace_usage` (src/usage.ts) remains
+ * the source of truth for current absolute stored bytes/objects; nothing here
+ * should ever be used to derive current state.
+ *
+ * Like `recordUsageSafe`, metering is best-effort: `recordAdoptionSafe` logs
+ * and continues on failure, because a metrics write must never fail an upload.
+ */
+
+export type AdoptionMetric =
+  | "upload"
+  | "delete"
+  | "workspace_created"
+  | "gallery_created"
+  | "comment_posted"
+  | "repo_linked";
+
+/**
+ * Which server-side entry point wrote an upload. There is no way to tell a
+ * CLI request from any other API request server-side, so finer-grained client
+ * identity comes from the provenance bag's `client` value instead.
+ */
+export type UploadSurface = "api" | "mcp" | "promote";
+
+/** Analytics Engine dimensions. Never written to D1 — see the module docs. */
+export interface AdoptionDimensions {
+  surface?: UploadSurface;
+  contentType?: string;
+  client?: string;
+  plan?: string;
+  repo?: string;
+}
+
+export interface AdoptionEvent {
+  metric: AdoptionMetric;
+  workspace: string;
+  /** Non-negative bytes attributable to this event. Omitted/negative → 0. */
+  bytes?: number;
+  dimensions?: AdoptionDimensions;
+}
+
+/** The platform-total row's workspace sentinel. */
+const PLATFORM = "";
+
+/** UTC calendar day as `YYYY-MM-DD` — the rollup bucket. */
+export function utcDay(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/** Bytes are a non-negative magnitude; direction is carried by the metric. */
+function normalizeBytes(bytes: number | undefined): number {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return 0;
+  return Math.round(bytes);
+}
+
+/**
+ * Upsert the per-workspace row and the platform-total row for `event`.
+ * Blind upserts — no preceding SELECT — issued as one batch so the pair is a
+ * single round trip and cannot half-apply. Throws on D1 failure; callers on a
+ * request path should use `recordAdoptionSafe` instead.
+ */
+export async function bumpDailyMetric(
+  db: D1Database,
+  event: AdoptionEvent,
+  now = new Date(),
+): Promise<void> {
+  const day = utcDay(now);
+  const bytes = normalizeBytes(event.bytes);
+  const sql = `INSERT INTO daily_metrics (metric, day, workspace, count, bytes)
+               VALUES (?, ?, ?, 1, ?)
+               ON CONFLICT(metric, day, workspace) DO UPDATE SET
+                 count = count + 1,
+                 bytes = bytes + excluded.bytes`;
+  await db.batch([
+    db.prepare(sql).bind(event.metric, day, event.workspace, bytes),
+    db.prepare(sql).bind(event.metric, day, PLATFORM, bytes),
+  ]);
+}
+
+/**
+ * Best-effort adoption recording: log and continue if the write fails.
+ * Safe to await on any request path — it never throws.
+ */
+export async function recordAdoptionSafe(
+  env: Env,
+  event: AdoptionEvent,
+  now = new Date(),
+): Promise<void> {
+  try {
+    await bumpDailyMetric(env.DB, event, now);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "adoption metric write failed",
+        metric: event.metric,
+        workspace: event.workspace,
+        error: message,
+      }),
+    );
+  }
+}

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -92,6 +92,54 @@ export async function bumpDailyMetric(
 }
 
 /**
+ * Blob positions are a contract with the SQL read path (analytics-engine.ts)
+ * — Analytics Engine has no column names, only ordinals. Append new
+ * dimensions at the END; never reorder or remove, or historical rows change
+ * meaning retroactively.
+ */
+export const BLOB_ORDER = [
+  "workspace",
+  "surface",
+  "contentType",
+  "client",
+  "plan",
+  "repo",
+] as const;
+
+/**
+ * One wide data point per upload. Upload-only by design: the other metrics are
+ * low-volume and fully served by D1, so sending them here would add a second
+ * place to look without adding an answer.
+ *
+ * Never throws and never awaits — an absent binding (self-hosters, tests,
+ * local dev) is a silent no-op.
+ */
+export function writeAdoptionPoint(env: Env, event: AdoptionEvent): void {
+  if (event.metric !== "upload") return;
+  const analytics = (env as { ANALYTICS?: AnalyticsEngineDataset }).ANALYTICS;
+  if (!analytics) return;
+  const d = event.dimensions ?? {};
+  try {
+    analytics.writeDataPoint({
+      // Sampling key: keeps one workspace's traffic from crowding out another.
+      indexes: [event.workspace],
+      blobs: [
+        event.workspace,
+        d.surface ?? "",
+        d.contentType ?? "",
+        d.client ?? "",
+        d.plan ?? "",
+        d.repo ?? "",
+      ],
+      doubles: [normalizeBytes(event.bytes)],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ message: "adoption analytics write failed", error: message }));
+  }
+}
+
+/**
  * Best-effort adoption recording: log and continue if the write fails.
  * Safe to await on any request path — it never throws.
  */
@@ -100,6 +148,7 @@ export async function recordAdoptionSafe(
   event: AdoptionEvent,
   now = new Date(),
 ): Promise<void> {
+  writeAdoptionPoint(env, event);
   try {
     await bumpDailyMetric(env.DB, event, now);
   } catch (err) {

--- a/apps/api/src/analytics-engine.test.ts
+++ b/apps/api/src/analytics-engine.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { breakdownQuery, fetchBreakdown } from "./analytics-engine";
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    CLOUDFLARE_ACCOUNT_ID: "acct-123",
+    ANALYTICS_API_TOKEN: "tok-abc",
+    ...overrides,
+  } as unknown as Env;
+}
+
+function jsonFetch(payload: unknown, status = 200): typeof fetch {
+  return (async () => new Response(JSON.stringify(payload), { status })) as unknown as typeof fetch;
+}
+
+describe("breakdownQuery", () => {
+  it("selects the blob matching the requested dimension", () => {
+    expect(breakdownQuery("surface", 30)).toContain("blob2");
+    expect(breakdownQuery("repo", 30)).toContain("blob6");
+  });
+
+  it("multiplies by _sample_interval so sampled counts are scaled back up", () => {
+    expect(breakdownQuery("surface", 30)).toContain("_sample_interval");
+  });
+
+  it("windows by the requested number of days", () => {
+    expect(breakdownQuery("surface", 7)).toContain("INTERVAL '7' DAY");
+  });
+});
+
+describe("fetchBreakdown", () => {
+  it("returns rows on success", async () => {
+    const impl = jsonFetch({
+      data: [
+        { value: "api", events: 120, bytes: 5000 },
+        { value: "mcp", events: 40, bytes: 900 },
+      ],
+    });
+    const result = await fetchBreakdown(env(), "surface", 30, impl);
+    expect(result).toEqual({
+      available: true,
+      rows: [
+        { value: "api", events: 120, bytes: 5000 },
+        { value: "mcp", events: 40, bytes: 900 },
+      ],
+    });
+  });
+
+  it("reports unavailable when the token is missing", async () => {
+    const result = await fetchBreakdown(
+      env({ ANALYTICS_API_TOKEN: undefined }),
+      "surface",
+      30,
+      jsonFetch({}),
+    );
+    expect(result).toEqual({ available: false, reason: "not_configured" });
+  });
+
+  it("reports unavailable when the account id is missing", async () => {
+    const result = await fetchBreakdown(
+      env({ CLOUDFLARE_ACCOUNT_ID: undefined }),
+      "surface",
+      30,
+      jsonFetch({}),
+    );
+    expect(result).toEqual({ available: false, reason: "not_configured" });
+  });
+
+  it("reports unavailable on a non-OK response rather than throwing", async () => {
+    const result = await fetchBreakdown(env(), "surface", 30, jsonFetch({ errors: ["nope"] }, 403));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("reports unavailable when the request throws", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const result = await fetchBreakdown(env(), "surface", 30, impl);
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("rejects an unknown dimension without issuing a request", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+    const result = await fetchBreakdown(env(), "bogus" as never, 30, impl);
+    expect(result).toEqual({ available: false, reason: "invalid_dimension" });
+    expect(called).toBe(false);
+  });
+});

--- a/apps/api/src/analytics-engine.test.ts
+++ b/apps/api/src/analytics-engine.test.ts
@@ -89,4 +89,33 @@ describe("fetchBreakdown", () => {
     expect(result).toEqual({ available: false, reason: "invalid_dimension" });
     expect(called).toBe(false);
   });
+
+  it.each(["toString", "constructor", "__proto__"] as const)(
+    "rejects the inherited prototype key %j without issuing a request",
+    async (dimension) => {
+      let called = false;
+      const impl = (async () => {
+        called = true;
+        return new Response("{}");
+      }) as unknown as typeof fetch;
+      const result = await fetchBreakdown(env(), dimension as never, 30, impl);
+      expect(result).toEqual({ available: false, reason: "invalid_dimension" });
+      expect(called).toBe(false);
+    },
+  );
+
+  it("reports unavailable when the response body's data field is not an array", async () => {
+    const result = await fetchBreakdown(env(), "surface", 30, jsonFetch({ data: "not-an-array" }));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+});
+
+describe("breakdownQuery non-finite days guard", () => {
+  it("falls back to a 30-day window when days is NaN", () => {
+    expect(breakdownQuery("surface", Number.NaN)).toContain("INTERVAL '30' DAY");
+  });
+
+  it("falls back to a 30-day window when days is Infinity", () => {
+    expect(breakdownQuery("surface", Number.POSITIVE_INFINITY)).toContain("INTERVAL '30' DAY");
+  });
 });

--- a/apps/api/src/analytics-engine.test.ts
+++ b/apps/api/src/analytics-engine.test.ts
@@ -19,6 +19,19 @@ describe("breakdownQuery", () => {
     expect(breakdownQuery("repo", 30)).toContain("blob6");
   });
 
+  // Fix 1/2 (structural blob-ordinal contract): BLOB_COLUMN is now DERIVED
+  // from adoption.ts's BLOB_ORDER rather than a hand-synced literal. This
+  // locks in the exact mapping the derivation must produce — byte-identical
+  // to the pre-derivation hand-listed version, minus `plan` (Fix 2 drops it
+  // from the queryable BreakdownDimension type since no caller ever sets it,
+  // while its blob5 slot stays reserved in BLOB_ORDER so `repo` keeps blob6).
+  it("derives every queryable dimension's blob column from BLOB_ORDER", () => {
+    expect(breakdownQuery("surface", 30)).toContain("blob2");
+    expect(breakdownQuery("contentType", 30)).toContain("blob3");
+    expect(breakdownQuery("client", 30)).toContain("blob4");
+    expect(breakdownQuery("repo", 30)).toContain("blob6");
+  });
+
   it("multiplies by _sample_interval so sampled counts are scaled back up", () => {
     expect(breakdownQuery("surface", 30)).toContain("_sample_interval");
   });
@@ -77,6 +90,22 @@ describe("fetchBreakdown", () => {
     }) as unknown as typeof fetch;
     const result = await fetchBreakdown(env(), "surface", 30, impl);
     expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  // Fix 2: `plan` reserves a blob slot (see adoption.ts's BLOB_ORDER) but is
+  // no longer a queryable BreakdownDimension — nothing sets it, so it would
+  // only ever return a single always-empty row. Confirm it is now rejected
+  // the same way any other unknown dimension is, rather than silently
+  // returning that dead data.
+  it("rejects the reserved-but-unpopulated `plan` dimension without issuing a request", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+    const result = await fetchBreakdown(env(), "plan" as never, 30, impl);
+    expect(result).toEqual({ available: false, reason: "invalid_dimension" });
+    expect(called).toBe(false);
   });
 
   it("rejects an unknown dimension without issuing a request", async () => {

--- a/apps/api/src/analytics-engine.ts
+++ b/apps/api/src/analytics-engine.ts
@@ -14,10 +14,29 @@
  * durable record. That lives in `daily_metrics`.
  */
 
+import { BLOB_ORDER } from "./adoption";
+
 const SQL_ENDPOINT = "https://api.cloudflare.com/client/v4/accounts";
 const DATASET = "uploads_adoption";
 
-export type BreakdownDimension = "surface" | "contentType" | "client" | "plan" | "repo";
+/**
+ * Dimensions the breakdown panel lets an operator group by — a DELIBERATELY
+ * separate concept from "physical blob position" (BLOB_ORDER in adoption.ts).
+ * Every entry here must also be a BLOB_ORDER entry, but not every BLOB_ORDER
+ * entry belongs here: `workspace` is the AE sampling index, not a breakdown
+ * column, and `plan` is a reserved-but-unpopulated blob slot (see
+ * adoption.ts) that no caller ever sets — querying it would only ever return
+ * one row with `value: ""`, so it is left out of the UI's "Group by" list
+ * and out of this type.
+ */
+export type BreakdownDimension = "surface" | "contentType" | "client" | "repo";
+
+const BREAKDOWN_DIMENSIONS: readonly BreakdownDimension[] = [
+  "surface",
+  "contentType",
+  "client",
+  "repo",
+];
 
 export interface BreakdownRow {
   value: string;
@@ -30,17 +49,19 @@ export type BreakdownResult =
   | { available: false; reason: string };
 
 /**
- * Blob ordinals, matching BLOB_ORDER in adoption.ts. AE columns are
- * positional, so this mapping is a contract with the write path — appending
- * is safe, reordering rewrites the meaning of historical rows.
+ * Blob ordinals for each queryable dimension, DERIVED from BLOB_ORDER (the
+ * single source of truth for the write-side contract in adoption.ts) rather
+ * than hand-repeated here. AE columns are positional and 1-indexed
+ * (`blob1`, `blob2`, ...) while BLOB_ORDER is a 0-indexed array, hence the
+ * `+ 1`. Appending a dimension to BLOB_ORDER is safe; reordering or removing
+ * one rewrites the meaning of historical rows.
  */
-const BLOB_COLUMN: Record<BreakdownDimension, string> = {
-  surface: "blob2",
-  contentType: "blob3",
-  client: "blob4",
-  plan: "blob5",
-  repo: "blob6",
-};
+const BLOB_COLUMN: Record<BreakdownDimension, string> = Object.fromEntries(
+  BREAKDOWN_DIMENSIONS.map((dimension) => {
+    const index = BLOB_ORDER.indexOf(dimension);
+    return [dimension, `blob${index + 1}`];
+  }),
+) as Record<BreakdownDimension, string>;
 
 export function breakdownQuery(dimension: BreakdownDimension, days: number): string {
   const column = BLOB_COLUMN[dimension];

--- a/apps/api/src/analytics-engine.ts
+++ b/apps/api/src/analytics-engine.ts
@@ -1,0 +1,84 @@
+/**
+ * Analytics Engine read path for the operator metrics breakdown panel.
+ *
+ * AE has no read binding, so this goes over the Cloudflare SQL API with an
+ * account token (ANALYTICS_API_TOKEN, an account token carrying "Account
+ * Analytics: Read", set via `wrangler secret put`). That token is distinct
+ * from the local wrangler token in .env.
+ *
+ * EVERY failure mode returns `{ available: false, reason }` rather than
+ * throwing: this panel is additive, and the D1-backed half of the metrics
+ * page must keep working when AE is unconfigured or unreachable.
+ *
+ * Retention is 90 days — AE is for recent dimensional curiosity, never the
+ * durable record. That lives in `daily_metrics`.
+ */
+
+const SQL_ENDPOINT = "https://api.cloudflare.com/client/v4/accounts";
+const DATASET = "uploads_adoption";
+
+export type BreakdownDimension = "surface" | "contentType" | "client" | "plan" | "repo";
+
+export interface BreakdownRow {
+  value: string;
+  events: number;
+  bytes: number;
+}
+
+export type BreakdownResult =
+  | { available: true; rows: BreakdownRow[] }
+  | { available: false; reason: string };
+
+/**
+ * Blob ordinals, matching BLOB_ORDER in adoption.ts. AE columns are
+ * positional, so this mapping is a contract with the write path — appending
+ * is safe, reordering rewrites the meaning of historical rows.
+ */
+const BLOB_COLUMN: Record<BreakdownDimension, string> = {
+  surface: "blob2",
+  contentType: "blob3",
+  client: "blob4",
+  plan: "blob5",
+  repo: "blob6",
+};
+
+export function breakdownQuery(dimension: BreakdownDimension, days: number): string {
+  const column = BLOB_COLUMN[dimension];
+  const window = Math.max(1, Math.min(90, Math.floor(days)));
+  // _sample_interval scales sampled rows back to a real-world estimate; a raw
+  // COUNT() under-reports whenever AE has sampled.
+  return `SELECT ${column} AS value,
+                 SUM(_sample_interval) AS events,
+                 SUM(double1 * _sample_interval) AS bytes
+          FROM ${DATASET}
+          WHERE timestamp > NOW() - INTERVAL '${window}' DAY
+          GROUP BY value
+          ORDER BY events DESC
+          LIMIT 20`;
+}
+
+export async function fetchBreakdown(
+  env: Env,
+  dimension: BreakdownDimension,
+  days: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<BreakdownResult> {
+  if (!(dimension in BLOB_COLUMN)) return { available: false, reason: "invalid_dimension" };
+
+  const account = (env as { CLOUDFLARE_ACCOUNT_ID?: string }).CLOUDFLARE_ACCOUNT_ID;
+  const token = (env as { ANALYTICS_API_TOKEN?: string }).ANALYTICS_API_TOKEN;
+  if (!account || !token) return { available: false, reason: "not_configured" };
+
+  try {
+    const res = await fetchImpl(`${SQL_ENDPOINT}/${account}/analytics_engine/sql`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: breakdownQuery(dimension, days),
+    });
+    if (!res.ok) return { available: false, reason: "query_failed" };
+    const payload = (await res.json()) as { data?: BreakdownRow[] };
+    return { available: true, rows: payload.data ?? [] };
+  } catch {
+    return { available: false, reason: "query_failed" };
+  }
+}

--- a/apps/api/src/analytics-engine.ts
+++ b/apps/api/src/analytics-engine.ts
@@ -44,7 +44,7 @@ const BLOB_COLUMN: Record<BreakdownDimension, string> = {
 
 export function breakdownQuery(dimension: BreakdownDimension, days: number): string {
   const column = BLOB_COLUMN[dimension];
-  const window = Math.max(1, Math.min(90, Math.floor(days)));
+  const window = Number.isFinite(days) ? Math.max(1, Math.min(90, Math.floor(days))) : 30;
   // _sample_interval scales sampled rows back to a real-world estimate; a raw
   // COUNT() under-reports whenever AE has sampled.
   return `SELECT ${column} AS value,
@@ -63,7 +63,10 @@ export async function fetchBreakdown(
   days: number,
   fetchImpl: typeof fetch = fetch,
 ): Promise<BreakdownResult> {
-  if (!(dimension in BLOB_COLUMN)) return { available: false, reason: "invalid_dimension" };
+  // Object.hasOwn (not the `in` operator) so prototype-chain keys like
+  // "toString" or "constructor" can never slip past this allowlist.
+  if (!Object.hasOwn(BLOB_COLUMN, dimension))
+    return { available: false, reason: "invalid_dimension" };
 
   const account = (env as { CLOUDFLARE_ACCOUNT_ID?: string }).CLOUDFLARE_ACCOUNT_ID;
   const token = (env as { ANALYTICS_API_TOKEN?: string }).ANALYTICS_API_TOKEN;
@@ -76,8 +79,11 @@ export async function fetchBreakdown(
       body: breakdownQuery(dimension, days),
     });
     if (!res.ok) return { available: false, reason: "query_failed" };
-    const payload = (await res.json()) as { data?: BreakdownRow[] };
-    return { available: true, rows: payload.data ?? [] };
+    const payload = (await res.json()) as { data?: unknown };
+    if (payload.data !== undefined && !Array.isArray(payload.data)) {
+      return { available: false, reason: "query_failed" };
+    }
+    return { available: true, rows: (payload.data as BreakdownRow[] | undefined) ?? [] };
   } catch {
     return { available: false, reason: "query_failed" };
   }

--- a/apps/api/src/analytics-engine.ts
+++ b/apps/api/src/analytics-engine.ts
@@ -59,6 +59,11 @@ export type BreakdownResult =
 const BLOB_COLUMN: Record<BreakdownDimension, string> = Object.fromEntries(
   BREAKDOWN_DIMENSIONS.map((dimension) => {
     const index = BLOB_ORDER.indexOf(dimension);
+    // This runs at module init, so a BLOB_ORDER edit that drops or renames a
+    // dimension this map depends on fails loudly at startup — instead of
+    // `indexOf` silently returning -1, deriving `blob0` (not a real AE
+    // column), and only surfacing later as a runtime `query_failed`.
+    if (index < 0) throw new Error(`breakdown dimension "${dimension}" is not in BLOB_ORDER`);
     return [dimension, `blob${index + 1}`];
   }),
 ) as Record<BreakdownDimension, string>;

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -500,27 +500,34 @@ export async function putObject(
   // stored but under-counted (recordUsageSafe never throws). Upload count
   // and any reserved positive byte delta were already applied at reservation
   // time; only remaining deltas (objects; shrink/unlimited bytes) land here.
-  await recordUsageSafe(env.DB, workspaceName, {
-    bytes: reservedBytes > 0 ? 0 : deltaBytes,
-    objects: replaced ? 0 : 1,
-    uploads: 0,
-  });
-
+  //
   // Adoption metrics, best-effort and never fatal (see src/adoption.ts).
   // Recorded here rather than at the route so all four putObject callers are
   // covered by construction. `newSize` (not deltaBytes) is the right figure:
   // this counts bytes written by this upload, not net storage change.
-  await recordAdoptionSafe(env, {
-    metric: "upload",
-    workspace: workspaceName,
-    bytes: newSize,
-    dimensions: {
-      surface: opts?.surface,
-      contentType: inspection.contentType,
-      client: provenance.client,
-      repo: opts?.metadata?.["gh.repo"],
-    },
-  });
+  //
+  // These two writes land in different tables (workspace_usage vs
+  // daily_metrics), neither depends on the other's result, and both are
+  // never-throwing — so they run concurrently rather than as two serial D1
+  // round trips on every upload.
+  await Promise.all([
+    recordUsageSafe(env.DB, workspaceName, {
+      bytes: reservedBytes > 0 ? 0 : deltaBytes,
+      objects: replaced ? 0 : 1,
+      uploads: 0,
+    }),
+    recordAdoptionSafe(env, {
+      metric: "upload",
+      workspace: workspaceName,
+      bytes: newSize,
+      dimensions: {
+        surface: opts?.surface,
+        contentType: inspection.contentType,
+        client: provenance.client,
+        repo: opts?.metadata?.["gh.repo"],
+      },
+    }),
+  ]);
 
   // Derived metadata from a content-identical earlier upload in this workspace
   // (issue #479) — rescues the paths the CLI sidecar cannot reach: the hosted
@@ -836,14 +843,19 @@ export async function deleteObject(
   await deleteFileMetadata(env.DB, workspaceName, key);
 
   if (prev !== null) {
-    await recordUsageSafe(env.DB, workspaceName, {
-      bytes: -prev,
-      objects: -1,
-      uploads: 0,
-    });
     // Positive magnitude under the `delete` metric — never negative bytes
-    // under `upload`. Net change is computed at read time.
-    await recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, bytes: prev });
+    // under `upload`. Net change is computed at read time. These two writes
+    // land in different tables (workspace_usage vs daily_metrics), neither
+    // depends on the other's result, and both are never-throwing — so they
+    // run concurrently rather than as two serial D1 round trips per delete.
+    await Promise.all([
+      recordUsageSafe(env.DB, workspaceName, {
+        bytes: -prev,
+        objects: -1,
+        uploads: 0,
+      }),
+      recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, bytes: prev }),
+    ]);
   }
 
   // Derived poster (issue #299), best-effort: a missing one is the norm for

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -7,6 +7,7 @@
  */
 import { ConflictError, NotFoundError, ValidationError } from "@uploads/errors";
 import type { Files } from "@uploads/storage";
+import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 import {
   budgetDenialError,
   checkPutBudget,
@@ -334,6 +335,12 @@ export async function putObject(
      * `metadata` argument was omitted.
      */
     metadata?: Record<string, string>;
+    /**
+     * Which server-side entry point is writing this object. Recorded as an
+     * Analytics Engine dimension only — never stored in D1, never affects the
+     * write. Absent means the caller predates this parameter.
+     */
+    surface?: UploadSurface;
   },
 ): Promise<{
   key: string;
@@ -497,6 +504,22 @@ export async function putObject(
     bytes: reservedBytes > 0 ? 0 : deltaBytes,
     objects: replaced ? 0 : 1,
     uploads: 0,
+  });
+
+  // Adoption metrics, best-effort and never fatal (see src/adoption.ts).
+  // Recorded here rather than at the route so all four putObject callers are
+  // covered by construction. `newSize` (not deltaBytes) is the right figure:
+  // this counts bytes written by this upload, not net storage change.
+  await recordAdoptionSafe(env, {
+    metric: "upload",
+    workspace: workspaceName,
+    bytes: newSize,
+    dimensions: {
+      surface: opts?.surface,
+      contentType: inspection.contentType,
+      client: provenance.client,
+      repo: opts?.metadata?.["gh.repo"],
+    },
   });
 
   // Derived metadata from a content-identical earlier upload in this workspace
@@ -818,6 +841,9 @@ export async function deleteObject(
       objects: -1,
       uploads: 0,
     });
+    // Positive magnitude under the `delete` metric — never negative bytes
+    // under `upload`. Net change is computed at read time.
+    await recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, bytes: prev });
   }
 
   // Derived poster (issue #299), best-effort: a missing one is the norm for

--- a/apps/api/src/github-comment-service.test.ts
+++ b/apps/api/src/github-comment-service.test.ts
@@ -13,6 +13,7 @@ const MIGRATION = [
   "migrations/20260711180000_galleries.sql",
   "migrations/20260713210559_file_metadata.sql",
   "migrations/20260720120000_github_repo_links.sql",
+  "migrations/20260728120000_daily_metrics.sql",
 ];
 const PRAGMAS = ["PRAGMA foreign_keys = ON"];
 
@@ -59,6 +60,18 @@ function withFetch<T>(impl: typeof fetch, fn: () => Promise<T>): Promise<T> {
   });
 }
 
+/**
+ * Every recorded adoption event writes TWO rows (per-workspace + platform
+ * total, workspace = ''), by design — see 20260728120000_daily_metrics.sql.
+ * Mirrors the query style in github-repo-links-sqlite.test.ts.
+ */
+async function commentPostedRows(db: D1Database): Promise<{ workspace: string }[]> {
+  const { results } = await db
+    .prepare(`SELECT workspace FROM daily_metrics WHERE metric = 'comment_posted'`)
+    .all<{ workspace: string }>();
+  return results;
+}
+
 describe("postManagedComment empty-state (issue #392 stretch)", () => {
   it("empties an existing comment (updated, count 0) when all media is removed", async () => {
     const { env, ws, workspaceName } = await makeTestEnv();
@@ -89,6 +102,13 @@ describe("postManagedComment empty-state (issue #392 stretch)", () => {
       }),
     );
     expect(r).toMatchObject({ posted: true, action: "updated", count: 0 });
+
+    // comment_posted wiring (issue: locking in the convergence-point call):
+    // one posted event writes two rows — the per-workspace row and the
+    // platform total (workspace = '') — never zero, never duplicated.
+    const rows = await commentPostedRows(env.DB);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.workspace).sort()).toEqual(["", "acme"]);
   });
 
   it("no-ops (skipped) when empty and no comment exists", async () => {
@@ -109,5 +129,9 @@ describe("postManagedComment empty-state (issue #392 stretch)", () => {
       }),
     );
     expect(r).toMatchObject({ posted: true, action: "skipped", count: 0 });
+
+    // The "skipped" early return must precede the comment_posted call —
+    // nothing was actually posted, so nothing should be recorded.
+    expect(await commentPostedRows(env.DB)).toHaveLength(0);
   });
 });

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -7,6 +7,7 @@
  * bot-post problem returns `{ posted: false, reason }` so callers can fall
  * back (the CLI to its local-gh path; the hosted MCP surfaces the decline).
  */
+import { recordAdoptionSafe } from "./adoption";
 import { gatherCommentBody, upsertBotComment } from "./github-comment";
 import { githubAppConfig, installationForRepo } from "./github-app";
 import { isEntitledToClaimRepo } from "./github-claim-authz";
@@ -178,6 +179,11 @@ export async function postManagedComment(
   // PR/issue thread — best-effort record it as the repo's bound workspace.
   // First-claim-wins (recordRepoLink) and never affects this response.
   await recordRepoLink(env.DB, target.repo, workspaceName, "comment", installId);
+
+  // Both `created` and `updated` converge here — editing an existing managed
+  // comment counts as one posted comment, not zero. `skipped` and every
+  // decline path above return before reaching this point.
+  await recordAdoptionSafe(env, { metric: "comment_posted", workspace: workspaceName });
 
   return {
     posted: true,

--- a/apps/api/src/github-promote.ts
+++ b/apps/api/src/github-promote.ts
@@ -169,6 +169,7 @@ export async function promoteBranchAttachments(
           "gh.branch": target.branch,
           "gh.promoted-at": nowIso,
         },
+        surface: "promote",
       });
     } catch (err) {
       // Never leak internal error detail (D1/R2 messages, key policy

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -15,7 +15,7 @@
  * promote call (see routes/github-comment.ts, routes/github-promote.ts).
  */
 
-import { bumpDailyMetric } from "./adoption";
+import { bumpDailyMetric, logAdoptionFailure } from "./adoption";
 
 export interface RepoLink {
   repo: string;
@@ -78,14 +78,11 @@ export async function recordRepoLink(
       try {
         await bumpDailyMetric(db, { metric: "repo_linked", workspace: workspaceName });
       } catch (metricErr) {
-        const message = metricErr instanceof Error ? metricErr.message : String(metricErr);
-        console.error(
-          JSON.stringify({
-            message: "adoption metric write failed",
-            metric: "repo_linked",
-            error: message,
-          }),
-        );
+        // Shared with recordAdoptionSafe's catch (adoption.ts) so this and
+        // the main adoption-write path log the same one shape rather than
+        // two hand-rolled copies that quietly drift (this one used to omit
+        // `workspace`).
+        logAdoptionFailure("repo_linked", workspaceName, metricErr);
       }
     }
   } catch (err) {

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -76,7 +76,7 @@ export async function recordRepoLink(
     // when an existing link already owned the repo.
     if ((result.meta?.changes ?? 0) > 0) {
       try {
-        await bumpDailyMetric(db, { metric: "repo_linked", workspace: workspaceName });
+        await bumpDailyMetric(db, { metric: "repo_linked", workspace: workspaceName }, now);
       } catch (metricErr) {
         // Shared with recordAdoptionSafe's catch (adoption.ts) so this and
         // the main adoption-write path log the same one shape rather than

--- a/apps/api/src/github-repo-links.ts
+++ b/apps/api/src/github-repo-links.ts
@@ -15,6 +15,8 @@
  * promote call (see routes/github-comment.ts, routes/github-promote.ts).
  */
 
+import { bumpDailyMetric } from "./adoption";
+
 export interface RepoLink {
   repo: string;
   workspaceName: string;
@@ -61,7 +63,7 @@ export async function recordRepoLink(
   now = new Date(),
 ): Promise<void> {
   try {
-    await db
+    const result = await db
       .prepare(
         `INSERT OR IGNORE INTO github_repo_links
            (repo_full_name, workspace_name, installation_id, source, created_at)
@@ -69,6 +71,23 @@ export async function recordRepoLink(
       )
       .bind(normalizeRepo(repo), workspaceName, installationId, source, now.toISOString())
       .run();
+
+    // Only a real first claim counts; INSERT OR IGNORE reports changes === 0
+    // when an existing link already owned the repo.
+    if ((result.meta?.changes ?? 0) > 0) {
+      try {
+        await bumpDailyMetric(db, { metric: "repo_linked", workspace: workspaceName });
+      } catch (metricErr) {
+        const message = metricErr instanceof Error ? metricErr.message : String(metricErr);
+        console.error(
+          JSON.stringify({
+            message: "adoption metric write failed",
+            metric: "repo_linked",
+            error: message,
+          }),
+        );
+      }
+    }
   } catch (err) {
     console.error(
       JSON.stringify({

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -10,7 +10,7 @@
  */
 
 import {
-  activeWorkspaceCount,
+  activeWorkspacesSince,
   featureTotals,
   platformSeries,
   platformStorage,
@@ -60,13 +60,13 @@ export interface MetricsOverview {
 interface AuthMetrics {
   users: SignupPoint[];
   orgs: SignupPoint[];
-  totals: { users: number; orgs: number; admins: number; banned: number };
+  totals: { users: number; orgs: number };
 }
 
 const EMPTY_AUTH: AuthMetrics = {
   users: [],
   orgs: [],
-  totals: { users: 0, orgs: 0, admins: 0, banned: 0 },
+  totals: { users: 0, orgs: 0 },
 };
 
 export function overviewCacheKey(days: number): string {
@@ -98,12 +98,16 @@ export async function buildOverview(
   const since7 = windowStart(7, now);
   const since30 = windowStart(30, now);
 
-  const [uploads, features, table, active7, active30, storage, auth] = await Promise.all([
+  const [uploads, features, table, active30, storage, auth] = await Promise.all([
     platformSeries(env.DB, "upload", since),
     featureTotals(env.DB, since),
     workspaceActivity(env.DB, since),
-    activeWorkspaceCount(env.DB, since7),
-    activeWorkspaceCount(env.DB, since30),
+    // Scans the 30-day window ONCE; the 7-day count is derived below by
+    // filtering these same rows rather than issuing a second query — the
+    // last 7 days of index entries are always a subset of the last 30, so a
+    // separate activeWorkspaceCount(since7) call would just re-read them
+    // (D1 bills rows read).
+    activeWorkspacesSince(env.DB, since30),
     platformStorage(env.DB),
     authMetrics(env, since),
   ]);
@@ -115,8 +119,8 @@ export async function buildOverview(
       orgs: auth.totals.orgs,
       workspaces: storage.workspaces,
       storedBytes: storage.storedBytes,
-      activeWorkspaces7d: active7,
-      activeWorkspaces30d: active30,
+      activeWorkspaces7d: active30.filter((w) => w.lastActive >= since7).length,
+      activeWorkspaces30d: active30.length,
       uploads: uploads.reduce((sum, point) => sum + point.count, 0),
       bytes: uploads.reduce((sum, point) => sum + point.bytes, 0),
     },

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -1,0 +1,150 @@
+/**
+ * Composes the operator metrics overview from the D1 rollups (this worker)
+ * and signup history (the auth worker, over the AUTH service binding — never
+ * a direct cross-database read).
+ *
+ * Cached in KV because D1 bills rows read: the TTL bounds cost by elapsed
+ * time rather than by page loads. Cache keys live under the `metrics:` prefix
+ * and are NOT workspace records, so the `mutateWorkspaceRecord` discipline
+ * that governs `ws:` keys does not apply here.
+ */
+
+import {
+  activeWorkspaceCount,
+  featureTotals,
+  platformSeries,
+  platformStorage,
+  windowStart,
+  workspaceActivity,
+  type DayPoint,
+  type WorkspaceActivity,
+} from "./adoption-queries";
+
+export const OVERVIEW_CACHE_TTL = 600;
+
+/** Windows the UI offers. Anything else is rejected, so the cache stays small. */
+export const ALLOWED_WINDOWS = [7, 30, 90] as const;
+
+export interface SignupPoint {
+  day: string;
+  count: number;
+}
+
+export interface MetricsOverview {
+  window: { days: number; since: string };
+  totals: {
+    /** All-time, from the auth worker. */
+    users: number;
+    /** All-time registered organizations, from the auth worker. */
+    orgs: number;
+    /** Workspaces with at least one recorded upload (not registrations). */
+    workspaces: number;
+    /** Current absolute stored bytes, from `workspace_usage`. */
+    storedBytes: number;
+    activeWorkspaces7d: number;
+    activeWorkspaces30d: number;
+    /** Uploads within the selected window. */
+    uploads: number;
+    /** Bytes uploaded within the selected window — not stored bytes. */
+    bytes: number;
+  };
+  series: {
+    uploads: DayPoint[];
+    users: SignupPoint[];
+    orgs: SignupPoint[];
+  };
+  features: Record<string, number>;
+  workspaces: WorkspaceActivity[];
+}
+
+interface AuthMetrics {
+  users: SignupPoint[];
+  orgs: SignupPoint[];
+  totals: { users: number; orgs: number; admins: number; banned: number };
+}
+
+const EMPTY_AUTH: AuthMetrics = {
+  users: [],
+  orgs: [],
+  totals: { users: 0, orgs: 0, admins: 0, banned: 0 },
+};
+
+export function overviewCacheKey(days: number): string {
+  return `metrics:overview:v1:${days}`;
+}
+
+/**
+ * Signup history from the auth worker. Degrades to zeros rather than failing
+ * the page: the D1-backed half of the overview is still worth showing.
+ */
+async function authMetrics(env: Env, since: string): Promise<AuthMetrics> {
+  try {
+    const res = await env.AUTH.fetch(`https://auth.internal/internal/metrics?since=${since}`);
+    if (!res.ok) return EMPTY_AUTH;
+    return (await res.json()) as AuthMetrics;
+  } catch {
+    return EMPTY_AUTH;
+  }
+}
+
+export async function buildOverview(
+  env: Env,
+  days: number,
+  now = new Date(),
+): Promise<MetricsOverview> {
+  const since = windowStart(days, now);
+  const since7 = windowStart(7, now);
+  const since30 = windowStart(30, now);
+
+  const [uploads, features, table, active7, active30, storage, auth] = await Promise.all([
+    platformSeries(env.DB, "upload", since),
+    featureTotals(env.DB, since),
+    workspaceActivity(env.DB, since),
+    activeWorkspaceCount(env.DB, since7),
+    activeWorkspaceCount(env.DB, since30),
+    platformStorage(env.DB),
+    authMetrics(env, since),
+  ]);
+
+  return {
+    window: { days, since },
+    totals: {
+      users: auth.totals.users,
+      orgs: auth.totals.orgs,
+      workspaces: storage.workspaces,
+      storedBytes: storage.storedBytes,
+      activeWorkspaces7d: active7,
+      activeWorkspaces30d: active30,
+      uploads: uploads.reduce((sum, point) => sum + point.count, 0),
+      bytes: uploads.reduce((sum, point) => sum + point.bytes, 0),
+    },
+    series: { uploads, users: auth.users, orgs: auth.orgs },
+    features,
+    workspaces: table,
+  };
+}
+
+/** Cached read. Cache failures fall through to a live build, never a 500. */
+export async function cachedOverview(
+  env: Env,
+  days: number,
+  fresh: boolean,
+  now = new Date(),
+): Promise<MetricsOverview> {
+  const key = overviewCacheKey(days);
+  if (!fresh) {
+    try {
+      const hit = await env.REGISTRY.get(key);
+      if (hit) return JSON.parse(hit) as MetricsOverview;
+    } catch {
+      // fall through to a live build
+    }
+  }
+  const overview = await buildOverview(env, days, now);
+  try {
+    await env.REGISTRY.put(key, JSON.stringify(overview), { expirationTtl: OVERVIEW_CACHE_TTL });
+  } catch {
+    // caching is an optimization, never a requirement
+  }
+  return overview;
+}

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -76,6 +76,12 @@ export function overviewCacheKey(days: number): string {
 /**
  * Signup history from the auth worker. Degrades to zeros rather than failing
  * the page: the D1-backed half of the overview is still worth showing.
+ *
+ * A non-OK response and a thrown/parse failure both fall through to
+ * EMPTY_AUTH above, but a malformed 200 (null body, or one missing `totals`)
+ * would otherwise pass straight through and only blow up later at
+ * `auth.totals.users` in buildOverview — OUTSIDE this try/catch, turning into
+ * a 500 for the entire page. Normalize the shape here instead of trusting it.
  */
 async function authMetrics(env: Env, since: string): Promise<AuthMetrics> {
   try {
@@ -83,7 +89,15 @@ async function authMetrics(env: Env, since: string): Promise<AuthMetrics> {
       headers: { "x-uploads-internal": "1" },
     });
     if (!res.ok) return EMPTY_AUTH;
-    return (await res.json()) as AuthMetrics;
+    const body = (await res.json()) as Partial<AuthMetrics> | null;
+    return {
+      users: Array.isArray(body?.users) ? body.users : [],
+      orgs: Array.isArray(body?.orgs) ? body.orgs : [],
+      totals: {
+        users: typeof body?.totals?.users === "number" ? body.totals.users : 0,
+        orgs: typeof body?.totals?.orgs === "number" ? body.totals.orgs : 0,
+      },
+    };
   } catch {
     return EMPTY_AUTH;
   }

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -79,7 +79,9 @@ export function overviewCacheKey(days: number): string {
  */
 async function authMetrics(env: Env, since: string): Promise<AuthMetrics> {
   try {
-    const res = await env.AUTH.fetch(`https://auth.internal/internal/metrics?since=${since}`);
+    const res = await env.AUTH.fetch(`https://auth.internal/internal/metrics?since=${since}`, {
+      headers: { "x-uploads-internal": "1" },
+    });
     if (!res.ok) return EMPTY_AUTH;
     return (await res.json()) as AuthMetrics;
   } catch {

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -15,7 +15,10 @@ const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", rol
 
 function stubAuth(
   user: typeof ADMIN_USER | null,
-  opts?: { metricsOk?: boolean },
+  // metricsBody overrides the /internal/metrics 200 payload verbatim (used to
+  // simulate a malformed-but-OK response); undefined falls back to the
+  // well-formed default below.
+  opts?: { metricsOk?: boolean; metricsBody?: unknown },
 ): Pick<Fetcher, "fetch"> {
   const metricsOk = opts?.metricsOk ?? true;
   return {
@@ -28,6 +31,7 @@ function stubAuth(
       if (url.pathname === "/internal/metrics") {
         expect(req.headers.get("x-uploads-internal")).toBe("1");
         if (!metricsOk) return new Response(null, { status: 404 });
+        if (opts && "metricsBody" in opts) return Response.json(opts.metricsBody);
         return Response.json({
           users: [{ day: "2026-07-28", count: 3 }],
           orgs: [{ day: "2026-07-28", count: 1 }],
@@ -220,6 +224,62 @@ describe("GET /admin-ui/metrics/overview", () => {
       expect(body.totals.orgs).toBe(0);
       expect(body.series.users).toEqual([]);
       expect(body.series.orgs).toEqual([]);
+      // D1-backed half is unaffected by the auth degradation.
+      expect(body.totals.workspaces).toBe(2);
+      expect(body.totals.storedBytes).toBe(150);
+      expect(body.workspaces.map((w) => w.workspace).sort()).toEqual(["acme", "beta"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("degrades to zeroed user/org totals when the auth call returns a null 200 body, keeping the D1 half intact", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER, { metricsBody: null }),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        totals: { users: number; orgs: number; workspaces: number; storedBytes: number };
+        series: { users: unknown[]; orgs: unknown[] };
+        workspaces: { workspace: string }[];
+      };
+      expect(body.totals.users).toBe(0);
+      expect(body.totals.orgs).toBe(0);
+      expect(body.series.users).toEqual([]);
+      expect(body.series.orgs).toEqual([]);
+      // D1-backed half is unaffected by the auth degradation.
+      expect(body.totals.workspaces).toBe(2);
+      expect(body.totals.storedBytes).toBe(150);
+      expect(body.workspaces.map((w) => w.workspace).sort()).toEqual(["acme", "beta"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("degrades to zeroed user/org totals when the auth call's 200 body is missing totals, keeping the D1 half intact", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER, {
+          metricsBody: { users: [{ day: "2026-07-28", count: 3 }], orgs: [] },
+        }),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        totals: { users: number; orgs: number; workspaces: number; storedBytes: number };
+        series: { users: unknown[]; orgs: unknown[] };
+        workspaces: { workspace: string }[];
+      };
+      expect(body.totals.users).toBe(0);
+      expect(body.totals.orgs).toBe(0);
       // D1-backed half is unaffected by the auth degradation.
       expect(body.totals.workspaces).toBe(2);
       expect(body.totals.storedBytes).toBe(150);

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -244,3 +244,79 @@ describe("GET /admin-ui/metrics/overview", () => {
     }
   });
 });
+
+describe("GET /admin-ui/metrics/breakdown", () => {
+  it("401s with no session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = { AUTH: stubAuth(null), DB: db, REGISTRY: fakeKv().binding } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/breakdown", {}, env);
+      expect(res.status).toBe(401);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(NON_ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/breakdown", {}, env);
+      expect(res.status).toBe(403);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns 200 for an admin even when Analytics Engine is unconfigured", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      // No CLOUDFLARE_ACCOUNT_ID / ANALYTICS_API_TOKEN on env: AE is
+      // unconfigured, which is the normal, non-error state for this panel.
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/breakdown", {}, env);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ available: false, reason: "not_configured" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("defaults the dimension to surface when the param is absent", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+        CLOUDFLARE_ACCOUNT_ID: "acct-123",
+        ANALYTICS_API_TOKEN: "tok-abc",
+      } as unknown as Env;
+      const originalFetch = globalThis.fetch;
+      let capturedBody: string | undefined;
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string | undefined;
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }) as typeof fetch;
+      try {
+        const res = await app().request("/admin-ui/metrics/breakdown", {}, env);
+        expect(res.status).toBe(200);
+        // surface maps to blob2 per BLOB_COLUMN in analytics-engine.ts.
+        expect(capturedBody).toContain("blob2");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -13,7 +13,11 @@ const MIGRATIONS = [
 const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
 const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
 
-function stubAuth(user: typeof ADMIN_USER | null): Pick<Fetcher, "fetch"> {
+function stubAuth(
+  user: typeof ADMIN_USER | null,
+  opts?: { metricsOk?: boolean },
+): Pick<Fetcher, "fetch"> {
+  const metricsOk = opts?.metricsOk ?? true;
   return {
     fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
       const req = input instanceof Request ? input : new Request(input, init);
@@ -22,6 +26,8 @@ function stubAuth(user: typeof ADMIN_USER | null): Pick<Fetcher, "fetch"> {
         return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
       }
       if (url.pathname === "/internal/metrics") {
+        expect(req.headers.get("x-uploads-internal")).toBe("1");
+        if (!metricsOk) return new Response(null, { status: 404 });
         return Response.json({
           users: [{ day: "2026-07-28", count: 3 }],
           orgs: [{ day: "2026-07-28", count: 1 }],
@@ -190,6 +196,34 @@ describe("GET /admin-ui/metrics/overview", () => {
       const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: broken } as unknown as Env;
       const res = await app().request("/admin-ui/metrics/overview", {}, env);
       expect(res.status).toBe(200);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("degrades to zeroed user/org totals when the auth call is non-OK, keeping the D1 half intact", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER, { metricsOk: false }),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        totals: { users: number; orgs: number; workspaces: number; storedBytes: number };
+        series: { users: unknown[]; orgs: unknown[] };
+        workspaces: { workspace: string }[];
+      };
+      expect(body.totals.users).toBe(0);
+      expect(body.totals.orgs).toBe(0);
+      expect(body.series.users).toEqual([]);
+      expect(body.series.orgs).toEqual([]);
+      // D1-backed half is unaffected by the auth degradation.
+      expect(body.totals.workspaces).toBe(2);
+      expect(body.totals.storedBytes).toBe(150);
+      expect(body.workspaces.map((w) => w.workspace).sort()).toEqual(["acme", "beta"]);
     } finally {
       sqlite.close();
     }

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -1,0 +1,212 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric } from "../adoption";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { respondError } from "../error-response";
+import { adminUi } from "./admin-ui";
+
+// Both: buildOverview reads daily_metrics AND workspace_usage.
+const MIGRATIONS = [
+  "migrations/20260710140000_workspace_usage.sql",
+  "migrations/20260728120000_daily_metrics.sql",
+];
+const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
+const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+function stubAuth(user: typeof ADMIN_USER | null): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+      }
+      if (url.pathname === "/internal/metrics") {
+        return Response.json({
+          users: [{ day: "2026-07-28", count: 3 }],
+          orgs: [{ day: "2026-07-28", count: 1 }],
+          totals: { users: 12, orgs: 4, admins: 1, banned: 0 },
+        });
+      }
+      return new Response(null, { status: 404 });
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** Minimal KV stub recording puts so cache behavior is assertable. */
+function fakeKv() {
+  const store = new Map<string, string>();
+  let puts = 0;
+  return {
+    store,
+    get puts() {
+      return puts;
+    },
+    binding: {
+      get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+      put: (async (key: string, value: string) => {
+        puts += 1;
+        store.set(key, value);
+      }) as unknown as KVNamespace["put"],
+      list: (async () => ({
+        keys: [],
+        list_complete: true,
+        cacheStatus: null,
+      })) as unknown as KVNamespace["list"],
+    } as KVNamespace,
+  };
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/admin-ui", adminUi)
+    .onError((err, c) => respondError(c, err));
+}
+
+async function seededDb() {
+  const sqlite = new SqliteD1(MIGRATIONS);
+  const db = database(sqlite);
+  const at = new Date();
+  await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 100 }, at);
+  await bumpDailyMetric(db, { metric: "upload", workspace: "beta", bytes: 50 }, at);
+  await bumpDailyMetric(db, { metric: "gallery_created", workspace: "acme" }, at);
+  await db
+    .prepare(
+      `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+       VALUES ('acme', 100, 1, 1, '2026-07', '2026-07-28T00:00:00Z'),
+              ('beta', 50, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
+    )
+    .run();
+  return { sqlite, db };
+}
+
+describe("GET /admin-ui/metrics/overview", () => {
+  it("401s with no session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = { AUTH: stubAuth(null), DB: db, REGISTRY: fakeKv().binding } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview", {}, env);
+      expect(res.status).toBe(401);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(NON_ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview", {}, env);
+      expect(res.status).toBe(403);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns totals, series and the workspace table for an admin", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        window: { days: number; since: string };
+        totals: {
+          users: number;
+          orgs: number;
+          workspaces: number;
+          storedBytes: number;
+          uploads: number;
+          bytes: number;
+          activeWorkspaces30d: number;
+        };
+        series: { uploads: unknown[]; users: unknown[] };
+        features: Record<string, number>;
+        workspaces: { workspace: string; uploads: number }[];
+      };
+      expect(body.window.days).toBe(30);
+      expect(body.totals.users).toBe(12);
+      expect(body.totals.orgs).toBe(4);
+      expect(body.totals.workspaces).toBe(2);
+      expect(body.totals.storedBytes).toBe(150);
+      expect(body.totals.uploads).toBe(2);
+      expect(body.totals.bytes).toBe(150);
+      expect(body.totals.activeWorkspaces30d).toBe(2);
+      expect(body.features.gallery_created).toBe(1);
+      expect(body.workspaces.map((w) => w.workspace).sort()).toEqual(["acme", "beta"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("serves the second request from cache without recomputing", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const kv = fakeKv();
+      const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: kv.binding } as unknown as Env;
+      await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(kv.puts).toBe(1);
+      expect(kv.store.has("metrics:overview:v1:30")).toBe(true);
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      expect(kv.puts).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("bypasses the cache with ?fresh=1", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const kv = fakeKv();
+      const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: kv.binding } as unknown as Env;
+      await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      await app().request("/admin-ui/metrics/overview?days=30&fresh=1", {}, env);
+      expect(kv.puts).toBe(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still answers when the cache read throws", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const broken = {
+        get: (async () => {
+          throw new Error("KV down");
+        }) as unknown as KVNamespace["get"],
+        put: (async () => {
+          throw new Error("KV down");
+        }) as unknown as KVNamespace["put"],
+      } as KVNamespace;
+      const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: broken } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview", {}, env);
+      expect(res.status).toBe(200);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects an unsupported window", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=365", {}, env);
+      expect(res.status).toBe(400);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -37,6 +37,7 @@ import {
 import { allowWrite } from "../guards";
 import { throwForInviteError } from "../invite-error";
 import { deriveWebOrigin, inviteLinkUrl } from "../invite-links";
+import { ALLOWED_WINDOWS, cachedOverview } from "../metrics-overview";
 import {
   invitesForOrg,
   membersForOrg,
@@ -348,6 +349,20 @@ async function limitsResponse(env: Env, name: string, record: WorkspaceRecord) {
 
 export const adminUi = new Hono<SessionVars>()
   .use("/*", sessionAuth, requireSessionUser, requireAdminUser)
+
+  // Cached operator adoption-metrics overview (D1 rollups + auth-worker
+  // signup history). `days` selects the window; only ALLOWED_WINDOWS are
+  // accepted so the cache stays small. `fresh=1` bypasses the KV cache.
+  .get("/metrics/overview", async (c) => {
+    const raw = c.req.query("days");
+    const days = raw === undefined ? 30 : Number(raw);
+    if (!ALLOWED_WINDOWS.includes(days as (typeof ALLOWED_WINDOWS)[number])) {
+      throw new ValidationError(`days must be one of ${ALLOWED_WINDOWS.join(", ")}`, {
+        code: "invalid_window",
+      });
+    }
+    return c.json(await cachedOverview(c.env, days, c.req.query("fresh") === "1"));
+  })
 
   // List every KV workspace joined with its org + member/invite counts.
   .get("/workspaces", async (c) => {

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -20,6 +20,7 @@ import {
   resolvePreviewRecipient,
   sendEmailPreview,
 } from "../admin-email-preview";
+import { fetchBreakdown, type BreakdownDimension } from "../analytics-engine";
 import {
   DEFAULT_ENROLLMENT_SECONDS,
   DEFAULT_TOKEN_SECONDS,
@@ -362,6 +363,16 @@ export const adminUi = new Hono<SessionVars>()
       });
     }
     return c.json(await cachedOverview(c.env, days, c.req.query("fresh") === "1"));
+  })
+
+  // Analytics Engine upload breakdown by dimension (surface, content type,
+  // client, plan, repo). Additive and best-effort: an unconfigured or
+  // unreachable Analytics Engine is a normal state the page renders as a
+  // panel message, not an error — so this always returns 200.
+  .get("/metrics/breakdown", async (c) => {
+    const dimension = (c.req.query("dimension") ?? "surface") as BreakdownDimension;
+    const days = Number(c.req.query("days") ?? 30);
+    return c.json(await fetchBreakdown(c.env, dimension, Number.isFinite(days) ? days : 30));
   })
 
   // List every KV workspace joined with its org + member/invite counts.

--- a/apps/api/src/routes/admin-ui.ts
+++ b/apps/api/src/routes/admin-ui.ts
@@ -366,7 +366,7 @@ export const adminUi = new Hono<SessionVars>()
   })
 
   // Analytics Engine upload breakdown by dimension (surface, content type,
-  // client, plan, repo). Additive and best-effort: an unconfigured or
+  // client, repo). Additive and best-effort: an unconfigured or
   // unreachable Analytics Engine is a normal state the page renders as a
   // panel message, not an error — so this always returns 200.
   .get("/metrics/breakdown", async (c) => {

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -223,7 +223,7 @@ export const files = new Hono<WorkspaceVars>()
       key,
       new Uint8Array(body),
       c.get("workspaceName"),
-      { provenance, visibility, metadata, replace: wantReplace },
+      { provenance, visibility, metadata, replace: wantReplace, surface: "api" },
     );
     return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
   })

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -5,6 +5,7 @@ import {
   ValidationError,
 } from "@uploads/errors";
 import { Hono, type Context } from "hono";
+import { recordAdoptionSafe } from "../adoption";
 import { badKey } from "../files-core";
 import {
   addGalleryItem,
@@ -57,6 +58,10 @@ export const galleries = new Hono<WorkspaceVars>()
             : undefined,
       }),
     );
+    await recordAdoptionSafe(c.env, {
+      metric: "gallery_created",
+      workspace: c.get("workspaceName"),
+    });
     return c.json(await ownerGallery(c, result.value.id), 201);
   })
   .get("/", requireScope("files:read"), async (c) => {

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -23,6 +23,7 @@ import {
   listTokens,
   revokeToken,
 } from "../auth-db";
+import { recordAdoptionSafe } from "../adoption";
 import { allowWorkspaceCreate, allowWrite } from "../guards";
 import { throwForInviteError } from "../invite-error";
 import {
@@ -225,6 +226,8 @@ export const workspaces = new Hono<SessionVars>().post(
         await welcome;
       }
     }
+
+    await recordAdoptionSafe(c.env, { metric: "workspace_created", workspace: name });
 
     return c.json(
       { workspace: { name, publicBaseUrl: record.publicBaseUrl, selfServe: true } },

--- a/apps/api/test/adoption-analytics.test.ts
+++ b/apps/api/test/adoption-analytics.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from "vitest";
-import { writeAdoptionPoint } from "../src/adoption";
+import { BLOB_ORDER, writeAdoptionPoint } from "../src/adoption";
 
 interface Captured {
   blobs?: unknown[];
@@ -71,5 +71,37 @@ describe("writeAdoptionPoint", () => {
     const env = { ANALYTICS: analytics.binding } as unknown as Env;
     writeAdoptionPoint(env, { metric: "upload", workspace: "acme", bytes: 1 });
     expect(analytics.points[0]?.blobs).toEqual(["acme", "", "", "", "", ""]);
+  });
+
+  // Fix 1 (structural blob-ordinal contract): the blobs array is now DERIVED
+  // from BLOB_ORDER rather than hand-listed, so this locks in that the
+  // physical ordinals nothing has changed — workspace stays blob1 (array
+  // index 0) and repo stays blob6 (array index 5), matching the historical
+  // shape before the derivation existed.
+  it("derives the blobs array from BLOB_ORDER without shifting any ordinal", () => {
+    expect(BLOB_ORDER).toEqual(["workspace", "surface", "contentType", "client", "plan", "repo"]);
+
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, {
+      metric: "upload",
+      workspace: "acme",
+      bytes: 1,
+      dimensions: {
+        surface: "api",
+        contentType: "image/png",
+        client: "uploads-cli/0.30.0",
+        repo: "acme/web",
+      },
+    });
+    const blobs = analytics.points[0]?.blobs ?? [];
+    expect(blobs).toHaveLength(BLOB_ORDER.length);
+    // workspace at index 0 (blob1)
+    expect(blobs[0]).toBe("acme");
+    // plan's reserved slot (blob5, index 4) stays empty — no caller sets it.
+    expect(blobs[4]).toBe("");
+    // repo stays at index 5 (blob6), never shifted by plan's removal from
+    // AdoptionDimensions.
+    expect(blobs[5]).toBe("acme/web");
   });
 });

--- a/apps/api/test/adoption-analytics.test.ts
+++ b/apps/api/test/adoption-analytics.test.ts
@@ -1,0 +1,75 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { writeAdoptionPoint } from "../src/adoption";
+
+interface Captured {
+  blobs?: unknown[];
+  doubles?: number[];
+  indexes?: string[];
+}
+
+function fakeAnalytics() {
+  const points: Captured[] = [];
+  return {
+    points,
+    binding: { writeDataPoint: (point: Captured) => points.push(point) },
+  };
+}
+
+describe("writeAdoptionPoint", () => {
+  it("writes one point per upload with the workspace as the index", () => {
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, {
+      metric: "upload",
+      workspace: "acme",
+      bytes: 2048,
+      dimensions: { surface: "api", contentType: "image/png", client: "uploads-cli/0.30.0" },
+    });
+    expect(analytics.points).toHaveLength(1);
+    expect(analytics.points[0]?.indexes).toEqual(["acme"]);
+    expect(analytics.points[0]?.doubles).toEqual([2048]);
+    expect(analytics.points[0]?.blobs).toEqual([
+      "acme",
+      "api",
+      "image/png",
+      "uploads-cli/0.30.0",
+      "",
+      "",
+    ]);
+  });
+
+  it("writes nothing for non-upload metrics", () => {
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, { metric: "gallery_created", workspace: "acme" });
+    expect(analytics.points).toHaveLength(0);
+  });
+
+  it("is a no-op when the binding is absent", () => {
+    expect(() =>
+      writeAdoptionPoint({} as unknown as Env, { metric: "upload", workspace: "acme", bytes: 1 }),
+    ).not.toThrow();
+  });
+
+  it("never throws when the binding itself fails", () => {
+    const env = {
+      ANALYTICS: {
+        writeDataPoint: () => {
+          throw new Error("AE down");
+        },
+      },
+    } as unknown as Env;
+    expect(() =>
+      writeAdoptionPoint(env, { metric: "upload", workspace: "acme", bytes: 1 }),
+    ).not.toThrow();
+  });
+
+  it("substitutes empty strings for absent dimensions so blob positions stay stable", () => {
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, { metric: "upload", workspace: "acme", bytes: 1 });
+    expect(analytics.points[0]?.blobs).toEqual(["acme", "", "", "", "", ""]);
+  });
+});

--- a/apps/api/test/adoption-feature-events.test.ts
+++ b/apps/api/test/adoption-feature-events.test.ts
@@ -1,0 +1,57 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric } from "../src/adoption";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+
+describe("feature adoption metric vocabulary", () => {
+  it("records each feature metric under its own key with zero bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      for (const metric of [
+        "workspace_created",
+        "gallery_created",
+        "comment_posted",
+        "repo_linked",
+      ] as const) {
+        await bumpDailyMetric(db, { metric, workspace: "acme" }, at);
+      }
+      const result = await db
+        .prepare(
+          `SELECT metric, count, bytes FROM daily_metrics
+           WHERE workspace = 'acme' ORDER BY metric`,
+        )
+        .all<{ metric: string; count: number; bytes: number }>();
+      expect(result.results).toEqual([
+        { metric: "comment_posted", count: 1, bytes: 0 },
+        { metric: "gallery_created", count: 1, bytes: 0 },
+        { metric: "repo_linked", count: 1, bytes: 0 },
+        { metric: "workspace_created", count: 1, bytes: 0 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("keeps feature metrics out of the upload series", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "gallery_created", workspace: "acme" },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      const row = await db
+        .prepare(`SELECT COUNT(*) AS n FROM daily_metrics WHERE metric = 'upload'`)
+        .first<{ n: number }>();
+      expect(row?.n).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/adoption-queries-sqlite.test.ts
+++ b/apps/api/test/adoption-queries-sqlite.test.ts
@@ -1,0 +1,162 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric } from "../src/adoption";
+import {
+  activeWorkspaceCount,
+  featureTotals,
+  platformSeries,
+  platformStorage,
+  windowStart,
+  workspaceActivity,
+} from "../src/adoption-queries";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+const USAGE_MIGRATION = "migrations/20260710140000_workspace_usage.sql";
+
+async function seed(db: D1Database): Promise<void> {
+  const day = (d: string) => new Date(`${d}T10:00:00Z`);
+  await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 100 }, day("2026-07-26"));
+  await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 200 }, day("2026-07-28"));
+  await bumpDailyMetric(db, { metric: "upload", workspace: "beta", bytes: 50 }, day("2026-07-28"));
+  await bumpDailyMetric(db, { metric: "gallery_created", workspace: "acme" }, day("2026-07-28"));
+}
+
+describe("windowStart", () => {
+  it("returns the inclusive first day of an N-day window", () => {
+    expect(windowStart(7, new Date("2026-07-28T00:00:00Z"))).toBe("2026-07-22");
+  });
+
+  it("treats a 1-day window as today only", () => {
+    expect(windowStart(1, new Date("2026-07-28T00:00:00Z"))).toBe("2026-07-28");
+  });
+});
+
+describe("platformSeries", () => {
+  it("reads only platform rows, one point per day with activity", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await platformSeries(db, "upload", "2026-07-01")).toEqual([
+        { day: "2026-07-26", count: 1, bytes: 100 },
+        { day: "2026-07-28", count: 2, bytes: 250 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("excludes days before the window", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await platformSeries(db, "upload", "2026-07-27")).toEqual([
+        { day: "2026-07-28", count: 2, bytes: 250 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("workspaceActivity", () => {
+  it("aggregates per workspace and sorts by uploads descending", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await workspaceActivity(db, "2026-07-01")).toEqual([
+        { workspace: "acme", uploads: 2, bytes: 300, lastActive: "2026-07-28" },
+        { workspace: "beta", uploads: 1, bytes: 50, lastActive: "2026-07-28" },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never includes the platform sentinel row", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      const rows = await workspaceActivity(db, "2026-07-01");
+      expect(rows.some((row) => row.workspace === "")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("activeWorkspaceCount", () => {
+  it("counts distinct workspaces that uploaded in the window", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await activeWorkspaceCount(db, "2026-07-01")).toBe(2);
+      expect(await activeWorkspaceCount(db, "2026-07-27")).toBe(2);
+      expect(await activeWorkspaceCount(db, "2026-07-29")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not count a workspace whose only activity was a gallery", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "gallery_created", workspace: "gamma" },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await activeWorkspaceCount(db, "2026-07-01")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("featureTotals", () => {
+  it("returns a per-metric total from platform rows", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await featureTotals(db, "2026-07-01")).toEqual({ upload: 3, gallery_created: 1 });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("platformStorage", () => {
+  it("reports current workspace count and stored bytes from workspace_usage", async () => {
+    const sqlite = new SqliteD1([USAGE_MIGRATION, MIGRATION]);
+    try {
+      const db = database(sqlite);
+      await db
+        .prepare(
+          `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+           VALUES ('acme', 500, 2, 2, '2026-07', '2026-07-28T00:00:00Z'),
+                  ('beta', 250, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
+        )
+        .run();
+      expect(await platformStorage(db)).toEqual({ workspaces: 2, storedBytes: 750 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns zeros on an empty ledger rather than nulls", async () => {
+    const sqlite = new SqliteD1([USAGE_MIGRATION, MIGRATION]);
+    try {
+      expect(await platformStorage(database(sqlite))).toEqual({ workspaces: 0, storedBytes: 0 });
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/adoption-queries-sqlite.test.ts
+++ b/apps/api/test/adoption-queries-sqlite.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { bumpDailyMetric } from "../src/adoption";
 import {
-  activeWorkspaceCount,
+  activeWorkspacesSince,
   featureTotals,
   platformSeries,
   platformStorage,
@@ -90,21 +90,34 @@ describe("workspaceActivity", () => {
   });
 });
 
-describe("activeWorkspaceCount", () => {
-  it("counts distinct workspaces that uploaded in the window", async () => {
+describe("activeWorkspacesSince", () => {
+  it("returns one row per workspace that uploaded in the window, with lastActive", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
       const db = database(sqlite);
       await seed(db);
-      expect(await activeWorkspaceCount(db, "2026-07-01")).toBe(2);
-      expect(await activeWorkspaceCount(db, "2026-07-27")).toBe(2);
-      expect(await activeWorkspaceCount(db, "2026-07-29")).toBe(0);
+      const rows = await activeWorkspacesSince(db, "2026-07-01");
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.workspace).sort()).toEqual(["acme", "beta"]);
+      expect(rows.find((r) => r.workspace === "acme")?.lastActive).toBe("2026-07-28");
+      expect(rows.find((r) => r.workspace === "beta")?.lastActive).toBe("2026-07-28");
     } finally {
       sqlite.close();
     }
   });
 
-  it("does not count a workspace whose only activity was a gallery", async () => {
+  it("excludes days before the window", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await activeWorkspacesSince(db, "2026-07-29")).toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not include a workspace whose only activity was a gallery", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
       const db = database(sqlite);
@@ -113,7 +126,42 @@ describe("activeWorkspaceCount", () => {
         { metric: "gallery_created", workspace: "gamma" },
         new Date("2026-07-28T10:00:00Z"),
       );
-      expect(await activeWorkspaceCount(db, "2026-07-01")).toBe(0);
+      expect(await activeWorkspacesSince(db, "2026-07-01")).toEqual([]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  // Fix 5: metrics-overview.ts derives BOTH the 7d and 30d active-workspace
+  // counts from a single 30-day activeWorkspacesSince call (rather than two
+  // separate queries), by filtering these rows on `lastActive`. Prove that
+  // derivation is correct for a workspace active in the 30d window but NOT
+  // the 7d window — the case a naive "just count the 30d rows" approach for
+  // both figures would get wrong.
+  it("supports deriving both a 7d and 30d count from one 30-day call", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      // Only active on 2026-07-05: inside a 30-day window starting
+      // 2026-06-29, but well before a 7-day window starting 2026-07-22.
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "delta" },
+        new Date("2026-07-05T10:00:00Z"),
+      );
+      await seed(db); // acme/beta, both last active 2026-07-28
+
+      const since30 = "2026-06-29";
+      const since7 = "2026-07-22";
+      const rows = await activeWorkspacesSince(db, since30);
+
+      expect(rows.map((r) => r.workspace).sort()).toEqual(["acme", "beta", "delta"]);
+
+      const active30d = rows.length;
+      const active7d = rows.filter((r) => r.lastActive >= since7).length;
+      expect(active30d).toBe(3);
+      // delta is in the 30d count but drops out of the 7d count.
+      expect(active7d).toBe(2);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/adoption-queries-sqlite.test.ts
+++ b/apps/api/test/adoption-queries-sqlite.test.ts
@@ -131,6 +131,20 @@ describe("featureTotals", () => {
       sqlite.close();
     }
   });
+
+  it("excludes days before the window", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      // seed() writes an "upload" row on 2026-07-26 (count 1) and more on
+      // 2026-07-28 (count 2); a `since` after the earlier day must drop only
+      // that earlier count, not the metric entirely.
+      expect(await featureTotals(db, "2026-07-27")).toEqual({ upload: 2, gallery_created: 1 });
+    } finally {
+      sqlite.close();
+    }
+  });
 });
 
 describe("platformStorage", () => {

--- a/apps/api/test/adoption-sqlite.test.ts
+++ b/apps/api/test/adoption-sqlite.test.ts
@@ -149,6 +149,23 @@ describe("bumpDailyMetric", () => {
       sqlite.close();
     }
   });
+
+  it("counts a platform-sentinel event exactly once instead of double-counting", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "", bytes: 100 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 1, bytes: 100 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
 });
 
 describe("recordAdoptionSafe", () => {

--- a/apps/api/test/adoption-sqlite.test.ts
+++ b/apps/api/test/adoption-sqlite.test.ts
@@ -1,0 +1,199 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric, recordAdoptionSafe, utcDay } from "../src/adoption";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+
+interface Row {
+  metric: string;
+  day: string;
+  workspace: string;
+  count: number;
+  bytes: number;
+}
+
+async function rows(db: D1Database): Promise<Row[]> {
+  const result = await db
+    .prepare(
+      `SELECT metric, day, workspace, count, bytes FROM daily_metrics ORDER BY metric, day, workspace`,
+    )
+    .all<Row>();
+  return result.results;
+}
+
+describe("utcDay", () => {
+  it("formats as YYYY-MM-DD in UTC", () => {
+    expect(utcDay(new Date("2026-07-28T23:59:59.000Z"))).toBe("2026-07-28");
+  });
+
+  it("rolls over on the UTC boundary, not local time", () => {
+    expect(utcDay(new Date("2026-07-29T00:00:00.000Z"))).toBe("2026-07-29");
+  });
+});
+
+describe("bumpDailyMetric", () => {
+  it("writes both a workspace row and a platform row", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "acme", bytes: 100 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 1, bytes: 100 },
+        { metric: "upload", day: "2026-07-28", workspace: "acme", count: 1, bytes: 100 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("accumulates repeat events into the same rows", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 100 }, at);
+      await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 50 }, at);
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 2, bytes: 150 },
+        { metric: "upload", day: "2026-07-28", workspace: "acme", count: 2, bytes: 150 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("separates days and keeps workspaces independent", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "acme", bytes: 10 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "beta", bytes: 20 },
+        new Date("2026-07-29T10:00:00Z"),
+      );
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 1, bytes: 10 },
+        { metric: "upload", day: "2026-07-28", workspace: "acme", count: 1, bytes: 10 },
+        { metric: "upload", day: "2026-07-29", workspace: "", count: 1, bytes: 20 },
+        { metric: "upload", day: "2026-07-29", workspace: "beta", count: 1, bytes: 20 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("stores deletes as positive bytes under their own metric", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      await bumpDailyMetric(db, { metric: "delete", workspace: "acme", bytes: 400 }, at);
+      const all = await rows(db);
+      expect(all.every((row) => row.bytes >= 0 && row.count >= 0)).toBe(true);
+      expect(all).toContainEqual({
+        metric: "delete",
+        day: "2026-07-28",
+        workspace: "acme",
+        count: 1,
+        bytes: 400,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("defaults bytes to 0 for non-byte metrics", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "workspace_created", workspace: "acme" },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toContainEqual({
+        metric: "workspace_created",
+        day: "2026-07-28",
+        workspace: "acme",
+        count: 1,
+        bytes: 0,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("clamps a negative byte figure to 0 rather than storing it", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "delete", workspace: "acme", bytes: -400 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      const all = await rows(db);
+      expect(all.every((row) => row.bytes === 0)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("recordAdoptionSafe", () => {
+  it("swallows and logs a D1 failure instead of throwing", async () => {
+    const failing = {
+      prepare: () => {
+        throw new Error("D1 exploded");
+      },
+    } as unknown as D1Database;
+    const env = { DB: failing } as unknown as Env;
+    await expect(
+      recordAdoptionSafe(env, { metric: "upload", workspace: "acme", bytes: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("writes through to D1 on the happy path", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const env = { DB: db } as unknown as Env;
+      await recordAdoptionSafe(
+        env,
+        { metric: "upload", workspace: "acme", bytes: 7 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toHaveLength(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("is a no-op, not a crash, when the ANALYTICS binding is absent", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const env = { DB: database(sqlite) } as unknown as Env;
+      await expect(
+        recordAdoptionSafe(env, {
+          metric: "upload",
+          workspace: "acme",
+          bytes: 7,
+          dimensions: { surface: "api", contentType: "image/png" },
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/github-repo-links-sqlite.test.ts
+++ b/apps/api/test/github-repo-links-sqlite.test.ts
@@ -11,11 +11,14 @@ import {
 } from "../src/github-repo-links";
 import { SqliteD1, database } from "./helpers/sqlite-d1";
 
-const MIGRATION = "migrations/20260720120000_github_repo_links.sql";
+const MIGRATIONS = [
+  "migrations/20260720120000_github_repo_links.sql",
+  "migrations/20260728120000_daily_metrics.sql",
+];
 
 describe("github repo links persistence against SQLite", () => {
   it("returns null for an unclaimed repo", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await expect(findRepoLink(database(sqlite), "acme/web")).resolves.toBeNull();
     } finally {
@@ -24,7 +27,7 @@ describe("github repo links persistence against SQLite", () => {
   });
 
   it("records a claim and lowercases the repo key", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "Acme/Web", "acme", "comment", 42);
       const link = await findRepoLink(database(sqlite), "acme/web");
@@ -41,7 +44,7 @@ describe("github repo links persistence against SQLite", () => {
   });
 
   it("first claim wins: a later call from a different workspace is ignored", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
       await recordRepoLink(database(sqlite), "acme/web", "someone-else", "promote");
@@ -54,7 +57,7 @@ describe("github repo links persistence against SQLite", () => {
   });
 
   it("a later call from the SAME workspace is also a no-op (row unchanged)", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "acme/web", "acme", "comment", 1);
       await recordRepoLink(database(sqlite), "acme/web", "acme", "promote", 2);
@@ -67,7 +70,7 @@ describe("github repo links persistence against SQLite", () => {
   });
 
   it("deletes a link", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
       await deleteRepoLink(database(sqlite), "acme/web");
@@ -78,7 +81,7 @@ describe("github repo links persistence against SQLite", () => {
   });
 
   it("deleting a non-existent link is a harmless no-op", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await expect(deleteRepoLink(database(sqlite), "acme/nope")).resolves.toBeUndefined();
     } finally {
@@ -89,7 +92,7 @@ describe("github repo links persistence against SQLite", () => {
 
 describe("deleteRepoLinkForWorkspace (self-serve unlink, issue #318)", () => {
   it("deletes when the caller owns the binding", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
       await expect(deleteRepoLinkForWorkspace(database(sqlite), "acme/web", "acme")).resolves.toBe(
@@ -102,7 +105,7 @@ describe("deleteRepoLinkForWorkspace (self-serve unlink, issue #318)", () => {
   });
 
   it("refuses (no-op) when the caller does not own the binding", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
       await expect(
@@ -116,7 +119,7 @@ describe("deleteRepoLinkForWorkspace (self-serve unlink, issue #318)", () => {
   });
 
   it("is a harmless no-op on an unclaimed repo", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await expect(deleteRepoLinkForWorkspace(database(sqlite), "acme/nope", "acme")).resolves.toBe(
         false,
@@ -129,7 +132,7 @@ describe("deleteRepoLinkForWorkspace (self-serve unlink, issue #318)", () => {
 
 describe("listRepoLinksForWorkspace (admin visibility, issue #318)", () => {
   it("returns only the calling workspace's bindings, newest first", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       // Distinct explicit timestamps (not insertion order) so the assertion
       // below actually exercises `ORDER BY created_at DESC` rather than
@@ -169,7 +172,7 @@ describe("listRepoLinksForWorkspace (admin visibility, issue #318)", () => {
   });
 
   it("returns an empty list for a workspace with no bindings", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await expect(listRepoLinksForWorkspace(database(sqlite), "acme")).resolves.toEqual([]);
     } finally {
@@ -180,7 +183,7 @@ describe("listRepoLinksForWorkspace (admin visibility, issue #318)", () => {
 
 describe("setRepoLink (operator override, issue #318)", () => {
   it("creates a binding for an unclaimed repo", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await setRepoLink(database(sqlite), "acme/web", "acme", "admin");
       const link = await findRepoLink(database(sqlite), "acme/web");
@@ -191,7 +194,7 @@ describe("setRepoLink (operator override, issue #318)", () => {
   });
 
   it("reassigns an existing binding, overwriting the prior owner", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
+    const sqlite = new SqliteD1(MIGRATIONS);
     try {
       await recordRepoLink(database(sqlite), "acme/web", "acme", "comment");
       await setRepoLink(database(sqlite), "acme/web", "someone-else", "admin", 7);
@@ -201,6 +204,47 @@ describe("setRepoLink (operator override, issue #318)", () => {
         source: "admin",
         installationId: 7,
       });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("repo link adoption metrics", () => {
+  async function repoLinkedCount(db: D1Database): Promise<number> {
+    const row = await db
+      .prepare(
+        `SELECT COALESCE(SUM(count), 0) AS n FROM daily_metrics
+         WHERE metric = 'repo_linked' AND workspace = 'acme'`,
+      )
+      .first<{ n: number }>();
+    return row?.n ?? 0;
+  }
+
+  it("records repo_linked on a first claim", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordRepoLink(db, "Acme/Web", "acme", "comment", 42);
+      expect(await repoLinkedCount(db)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not record when a second claim is ignored (first claim wins)", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordRepoLink(db, "Acme/Web", "acme", "comment", 42);
+      await recordRepoLink(db, "Acme/Web", "beta", "comment", 43);
+      // Still exactly one event: the ignored INSERT must not count.
+      const row = await db
+        .prepare(
+          `SELECT COALESCE(SUM(count), 0) AS n FROM daily_metrics WHERE metric = 'repo_linked' AND workspace <> ''`,
+        )
+        .first<{ n: number }>();
+      expect(row?.n).toBe(1);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/helpers/sqlite-d1.test.ts
+++ b/apps/api/test/helpers/sqlite-d1.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Coverage for SqliteD1's row-returning-statement heuristic in runSync()
+ * (issue caught in CodeRabbit review of PR #544): a batched statement that
+ * returns rows but doesn't literally start with `SELECT` — a `WITH ...
+ * SELECT` CTE, or one with a leading `--` comment — used to be routed to
+ * `.run()`, which executes the statement but silently discards its rows.
+ */
+
+import { describe, expect, it } from "vitest";
+import { SqliteD1, database } from "./sqlite-d1";
+
+const MIGRATIONS = ["migrations/20260710140000_workspace_usage.sql"];
+
+describe("SqliteD1 row-returning-statement detection", () => {
+  it("returns rows for a WITH ... SELECT CTE run through db.batch()", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await db
+        .prepare(
+          `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+           VALUES ('acme', 100, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
+        )
+        .run();
+
+      const [result] = await db.batch([
+        db.prepare(
+          `WITH totals AS (SELECT workspace, bytes FROM workspace_usage)
+           SELECT workspace, bytes FROM totals WHERE workspace = 'acme'`,
+        ),
+      ]);
+      expect(result.results).toEqual([{ workspace: "acme", bytes: 100 }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still returns rows for a SELECT preceded by a leading -- comment", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const [result] = await db.batch([db.prepare(`-- explain why\nSELECT 1 AS one`)]);
+      expect(result.results).toEqual([{ one: 1 }]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still routes a plain mutation through .run() and reports changes", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      const [result] = await db.batch([
+        db.prepare(
+          `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+           VALUES ('beta', 50, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
+        ),
+      ]);
+      expect(result.results).toEqual([]);
+      expect(result.meta.changes).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/helpers/sqlite-d1.ts
+++ b/apps/api/test/helpers/sqlite-d1.ts
@@ -49,6 +49,16 @@ export class SqliteStatement {
   }
 
   runSync() {
+    // SELECTs need `.all()` — `.run()` executes them but never returns rows.
+    // Mutations use `.run()` so callers (e.g. inside `db.batch()`) can still
+    // read `meta.changes`.
+    if (/^\s*SELECT\b/i.test(this.sql)) {
+      return {
+        success: true,
+        results: this.owner.db.prepare(this.sql).all(...this.values),
+        meta: {},
+      };
+    }
     const result = this.owner.db.prepare(this.sql).run(...this.values);
     return {
       success: true,

--- a/apps/api/test/helpers/sqlite-d1.ts
+++ b/apps/api/test/helpers/sqlite-d1.ts
@@ -51,8 +51,13 @@ export class SqliteStatement {
   runSync() {
     // SELECTs need `.all()` — `.run()` executes them but never returns rows.
     // Mutations use `.run()` so callers (e.g. inside `db.batch()`) can still
-    // read `meta.changes`.
-    if (/^\s*SELECT\b/i.test(this.sql)) {
+    // read `meta.changes`. This is a simple, readable heuristic, not a SQL
+    // parser: strip leading `--` line comments and whitespace, then also
+    // match a leading `WITH` so `WITH ... SELECT` CTEs are recognized as
+    // row-returning too — both used to fall through to `.run()`, which
+    // silently discards their rows.
+    const withoutLeadingComments = this.sql.replace(/^(\s*--[^\n]*\n)*\s*/, "");
+    if (/^(SELECT|WITH)\b/i.test(withoutLeadingComments)) {
       return {
         success: true,
         results: this.owner.db.prepare(this.sql).all(...this.values),

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -40,15 +40,18 @@ interface FakeAuthToken {
 
 function makeFakeDB(authToken?: FakeAuthToken) {
   const table = new FileMetadataTable();
+  const statements: { sql: string; args: unknown[] }[] = [];
 
   return {
     metadata: table.metadata,
+    statements,
     prepare(sql: string) {
       const normalized = sql.replace(/\s+/g, " ").trim();
       let args: unknown[] = [];
       return {
         bind(...values: unknown[]) {
           args = values;
+          statements.push({ sql: normalized, args: values });
           return this;
         },
         async first() {
@@ -1416,6 +1419,62 @@ describe("PUT /v1/:workspace/files uploader attribution (issue #340)", () => {
       "screenshots/shot.png",
     );
     expect(meta).toEqual({ "gh.repo": "acme/web" });
+  });
+});
+
+describe("adoption metrics wiring", () => {
+  /** Identify adoption writes by table, not by statement position. */
+  function adoptionWrites(db: { statements: { sql: string; args: unknown[] }[] }) {
+    return db.statements.filter((s) => s.sql.includes("INSERT INTO daily_metrics"));
+  }
+
+  it("records an upload event when a put succeeds", async () => {
+    const { env, db } = await makeEnv();
+    const res = await putShot(env);
+    expect(res.status).toBe(201);
+
+    const writes = adoptionWrites(db);
+    // One per-workspace row + one platform row.
+    expect(writes).toHaveLength(2);
+    expect(writes.map((w) => w.args[0])).toEqual(["upload", "upload"]);
+    expect(writes.map((w) => w.args[2]).sort()).toEqual(["", "default"]);
+    expect(writes[0]?.args[3]).toBe(PNG.byteLength);
+  });
+
+  it("records nothing when the put is rejected", async () => {
+    const { env, db } = await makeEnv();
+    const res = await putShot(env, { headers: { Authorization: "Bearer wrong-token" } });
+    expect(res.status).toBe(401);
+    expect(adoptionWrites(db)).toHaveLength(0);
+  });
+
+  it("records a delete event with positive bytes when a delete removes an object", async () => {
+    const { env, db } = await makeEnv();
+    await putShot(env);
+    const before = adoptionWrites(db).length;
+
+    const res = await app.request(
+      "/v1/default/files/screenshots/shot.png",
+      { method: "DELETE", headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    const deletes = adoptionWrites(db).slice(before);
+    expect(deletes).toHaveLength(2);
+    expect(deletes.map((w) => w.args[0])).toEqual(["delete", "delete"]);
+    // Positive magnitude — direction is carried by the metric, never the sign.
+    for (const write of deletes) expect(write.args[3] as number).toBeGreaterThan(0);
+  });
+
+  it("records no delete event when the key does not exist", async () => {
+    const { env, db } = await makeEnv();
+    await app.request(
+      "/v1/default/files/screenshots/absent.png",
+      { method: "DELETE", headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(adoptionWrites(db).filter((w) => w.args[0] === "delete")).toHaveLength(0);
   });
 });
 

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -16,9 +16,11 @@ class SQLiteStatement {
   constructor(
     readonly database: DatabaseSync,
     readonly sql: string,
+    readonly statements: { sql: string; args: unknown[] }[],
   ) {}
   bind(...values: unknown[]) {
     this.values = values;
+    this.statements.push({ sql: this.sql.replace(/\s+/g, " ").trim(), args: values });
     return this;
   }
   first<T>() {
@@ -45,9 +47,11 @@ class SQLiteStatement {
 }
 
 class SQLiteD1 {
+  /** Statement-recorder (mirrors routes-files.test.ts's makeFakeDB): every `bind()` call is captured here for wiring assertions. */
+  readonly statements: { sql: string; args: unknown[] }[] = [];
   constructor(readonly database: DatabaseSync) {}
   prepare(sql: string) {
-    return new SQLiteStatement(this.database, sql);
+    return new SQLiteStatement(this.database, sql, this.statements);
   }
   async batch(statements: SQLiteStatement[]) {
     this.database.exec("BEGIN");
@@ -79,6 +83,7 @@ beforeAll(() => {
 });
 
 let db: DatabaseSync;
+let fakeDb: SQLiteD1;
 let bucket: FakeR2Bucket;
 let records: Record<string, WorkspaceRecord>;
 let env: Parameters<typeof app.request>[2];
@@ -123,6 +128,13 @@ beforeEach(async () => {
       "utf8",
     ),
   );
+  // Task 3: gallery creation now records a `gallery_created` adoption event.
+  db.exec(
+    readFileSync(
+      fileURLToPath(new NodeURL("../migrations/20260728120000_daily_metrics.sql", import.meta.url)),
+      "utf8",
+    ),
+  );
   bucket = new FakeR2Bucket();
   await bucket.put("alpha/screenshots/one.png", PNG);
   records = {
@@ -143,8 +155,9 @@ beforeEach(async () => {
       tokenHash: await sha256Hex(TOKEN),
     },
   };
+  fakeDb = new SQLiteD1(db);
   env = {
-    DB: new SQLiteD1(db) as unknown as D1Database,
+    DB: fakeDb as unknown as D1Database,
     WEB_ORIGIN: "https://uploads.test",
     REGISTRY: { get: async (key: string) => records[key.slice(3)] ?? null },
     UPLOADS_DEFAULT: bucket,
@@ -716,6 +729,15 @@ describe("gallery routes with SQLite D1", () => {
         })
       ).status,
     ).toBe(429);
+  });
+});
+
+describe("gallery adoption metrics", () => {
+  it("records gallery_created when a gallery is created", async () => {
+    await create();
+    const writes = fakeDb.statements.filter((s) => s.sql.includes("INSERT INTO daily_metrics"));
+    expect(writes).toHaveLength(2); // per-workspace + platform row
+    expect(writes.map((w) => w.args[0])).toEqual(["gallery_created", "gallery_created"]);
   });
 });
 

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -16,6 +16,15 @@
     // The App's installation on the buildinternet org — the general-purpose
     // token source for public-repo reads.
     "GITHUB_APP_HOME_INSTALLATION_ID": "147814297",
+    // Account that owns the Analytics Engine dataset, used to build the SQL
+    // API URL in src/analytics-engine.ts. An identifier, not a credential —
+    // it appears in every dash.cloudflare.com URL — so it belongs here rather
+    // than in `wrangler secret`. The paired ANALYTICS_API_TOKEN *is* a secret.
+    //
+    // This must live in `vars`, not only in .dev.vars: .dev.vars is local-only,
+    // so a deployed worker without this entry reads `undefined` and the
+    // breakdown panel reports `not_configured` no matter how the secret is set.
+    "CLOUDFLARE_ACCOUNT_ID": "b082600d280d44fd5da3501bc1bffe2f",
   },
   // BILLING_INTERNAL_KEY (Stripe phase 2, task 3): shared secret gating
   // POST /internal/billing/plan (routes/internal-billing.ts), set via

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -118,6 +118,18 @@
       "migrations_dir": "migrations",
     },
   ],
+  // Analytics Engine dataset for wide per-upload dimensions (surface, content
+  // type, client, plan, repo) that would never justify D1 columns. Purely
+  // additive: src/adoption.ts treats an absent ANALYTICS binding as a no-op,
+  // so deleting this block disables the breakdown panel and nothing else.
+  // Reads need ANALYTICS_API_TOKEN (an account token with Account Analytics:
+  // Read) set via `wrangler secret put` — there is no read binding.
+  "analytics_engine_datasets": [
+    {
+      "binding": "ANALYTICS",
+      "dataset": "uploads_adoption",
+    },
+  ],
   // Service binding to apps/auth (Phase 2, plan D1): forwards Cookie/
   // Authorization to GET /api/auth/get-session over the binding — no public
   // hop, no CORS. See src/session-auth.ts.

--- a/apps/auth/migrations/20260728120000_created_at_indexes.sql
+++ b/apps/auth/migrations/20260728120000_created_at_indexes.sql
@@ -1,0 +1,7 @@
+-- Signup-by-day aggregation for the operator metrics surface. Without these
+-- the windowed GROUP BY scans every user/organization row, and D1 bills rows
+-- read. `created_at` is epoch SECONDS (drizzle `mode: "timestamp"`), not
+-- milliseconds.
+
+CREATE INDEX IF NOT EXISTS user_created_at_idx ON user (created_at);
+CREATE INDEX IF NOT EXISTS organization_created_at_idx ON organization (created_at);

--- a/apps/auth/src/internal-metrics.test.ts
+++ b/apps/auth/src/internal-metrics.test.ts
@@ -94,4 +94,14 @@ describe("GET /internal/metrics", () => {
     const res = await app().request("/internal/metrics?since=not-a-date", {}, env());
     expect(res.status).toBe(400);
   });
+
+  it("rejects a digit-shaped but out-of-range `since` (month 13, day 45)", async () => {
+    const res = await app().request("/internal/metrics?since=2026-13-45", {}, env());
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a digit-shaped but non-existent calendar date (Feb 30)", async () => {
+    const res = await app().request("/internal/metrics?since=2026-02-30", {}, env());
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/auth/src/internal-metrics.test.ts
+++ b/apps/auth/src/internal-metrics.test.ts
@@ -70,16 +70,21 @@ describe("GET /internal/metrics", () => {
   });
 
   it("reports all-time totals independent of the window", async () => {
+    // role/banned overrides still exercise seedUser's full column set even
+    // though totals.admins/totals.banned were removed (Fix 6: nothing ever
+    // read them — MetricsOverview.totals has no such fields and the page
+    // renders neither — so those two unwindowed full-table scans were
+    // wasted work on every cache miss).
     await seedUser(new Date("2026-01-01T10:00:00Z"), { role: "admin" });
     await seedUser(new Date("2026-07-28T10:00:00Z"), { banned: true });
 
     const res = await app().request("/internal/metrics?since=2026-07-20", {}, env());
     const body = (await res.json()) as {
-      totals: { users: number; admins: number; banned: number };
+      totals: { users: number };
     };
     expect(body.totals.users).toBe(2);
-    expect(body.totals.admins).toBe(1);
-    expect(body.totals.banned).toBe(1);
+    expect((body.totals as Record<string, unknown>).admins).toBeUndefined();
+    expect((body.totals as Record<string, unknown>).banned).toBeUndefined();
   });
 
   it("defaults to a 30-day window when `since` is absent", async () => {

--- a/apps/auth/src/internal-metrics.test.ts
+++ b/apps/auth/src/internal-metrics.test.ts
@@ -1,0 +1,97 @@
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { internal } from "./internal-routes";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+describe("GET /internal/metrics", () => {
+  let db: FakeD1Database;
+  let orm: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeEach(() => {
+    db = createFakeD1();
+    orm = drizzle(db, { schema });
+  });
+
+  function app() {
+    return new Hono<{ Bindings: AuthEnv }>().route("/internal", internal);
+  }
+
+  function env(): AuthEnv {
+    return {
+      DB: db,
+      WEB_ORIGIN: "https://uploads.sh",
+      ENVIRONMENT: "development",
+      BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    } as AuthEnv;
+  }
+
+  async function seedUser(createdAt: Date, overrides: Partial<schema.AuthUser> = {}) {
+    await orm.insert(schema.user).values({
+      id: crypto.randomUUID(),
+      name: "Ada",
+      email: `ada-${crypto.randomUUID()}@example.com`,
+      emailVerified: true,
+      image: null,
+      createdAt,
+      updatedAt: createdAt,
+      role: overrides.role ?? "user",
+      banned: overrides.banned ?? null,
+      banReason: null,
+      banExpires: null,
+      cliOnboardedAt: null,
+      stripeCustomerId: null,
+    } as schema.AuthUser);
+  }
+
+  it("groups signups by UTC day", async () => {
+    await seedUser(new Date("2026-07-26T10:00:00Z"));
+    await seedUser(new Date("2026-07-28T01:00:00Z"));
+    await seedUser(new Date("2026-07-28T23:00:00Z"));
+
+    const res = await app().request("/internal/metrics?since=2026-07-01", {}, env());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { users: { day: string; count: number }[] };
+    expect(body.users).toEqual([
+      { day: "2026-07-26", count: 1 },
+      { day: "2026-07-28", count: 2 },
+    ]);
+  });
+
+  it("excludes signups before the window", async () => {
+    await seedUser(new Date("2026-07-01T10:00:00Z"));
+    await seedUser(new Date("2026-07-28T10:00:00Z"));
+
+    const res = await app().request("/internal/metrics?since=2026-07-20", {}, env());
+    const body = (await res.json()) as { users: { day: string; count: number }[] };
+    expect(body.users).toEqual([{ day: "2026-07-28", count: 1 }]);
+  });
+
+  it("reports all-time totals independent of the window", async () => {
+    await seedUser(new Date("2026-01-01T10:00:00Z"), { role: "admin" });
+    await seedUser(new Date("2026-07-28T10:00:00Z"), { banned: true });
+
+    const res = await app().request("/internal/metrics?since=2026-07-20", {}, env());
+    const body = (await res.json()) as {
+      totals: { users: number; admins: number; banned: number };
+    };
+    expect(body.totals.users).toBe(2);
+    expect(body.totals.admins).toBe(1);
+    expect(body.totals.banned).toBe(1);
+  });
+
+  it("defaults to a 30-day window when `since` is absent", async () => {
+    const res = await app().request("/internal/metrics", {}, env());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { users: unknown[]; orgs: unknown[] };
+    expect(Array.isArray(body.users)).toBe(true);
+    expect(Array.isArray(body.orgs)).toBe(true);
+  });
+
+  it("rejects a malformed `since`", async () => {
+    const res = await app().request("/internal/metrics?since=not-a-date", {}, env());
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -5,7 +5,7 @@
  */
 import { isStripeBackingStatus } from "@uploads/billing";
 import { drizzle } from "drizzle-orm/d1";
-import { and, count, countDistinct, eq, gt, isNull, max } from "drizzle-orm";
+import { and, count, countDistinct, eq, gt, gte, isNull, max, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { OAUTH_SCOPES, type AuthEnv } from "./auth";
 import { sendAuthEmail } from "./email";
@@ -225,6 +225,15 @@ function validateOptionalUrl(value: unknown): { ok: true; value: string | null }
   return { ok: true, value };
 }
 
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * `created_at` is epoch SECONDS (drizzle `integer(..., { mode: "timestamp" })`
+ * divides by 1000 on write) — hence 'unixepoch' with no /1000. Getting this
+ * wrong buckets every signup into 1970.
+ */
+const DAY_EXPR = (column: unknown) => sql<string>`strftime('%Y-%m-%d', ${column}, 'unixepoch')`;
+
 export const internal = new Hono<{ Bindings: AuthEnv }>()
   // Memberships for a user (org-workspaces + member-gated /me routes).
   // Optional `slug` → one-org authz lookup (LIMIT 1; bills one match).
@@ -252,6 +261,57 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
 
     const rows = slug ? await query.limit(1) : await query;
     return c.json(rows);
+  })
+  // Task 5 (operator adoption metrics): daily signup counts + all-time
+  // totals, for apps/api's /admin metrics surface (reached via the AUTH
+  // service binding — apps/api has no D1 binding into this worker's
+  // database, see org-workspaces.ts's header comment). The day grouping is
+  // windowed by `since` so it stays cheap under D1's rows-read billing; the
+  // totals are deliberately unwindowed full-table counts (Task 6 caches
+  // those).
+  .get("/metrics", async (c) => {
+    const sinceParam = c.req.query("since");
+    if (sinceParam !== undefined && !DAY_RE.test(sinceParam)) {
+      return c.json(errorJson("invalid_since", "`since` must be YYYY-MM-DD"), 400);
+    }
+    // Default window matches the overview endpoint's default.
+    const since = sinceParam
+      ? new Date(`${sinceParam}T00:00:00.000Z`)
+      : new Date(Date.now() - 29 * 86_400_000);
+
+    const db = drizzle(c.env.DB, { schema });
+    const userDay = DAY_EXPR(schema.user.createdAt);
+    const orgDay = DAY_EXPR(schema.organization.createdAt);
+
+    const [users, orgs, userTotal, orgTotal, adminTotal, bannedTotal] = await Promise.all([
+      db
+        .select({ day: userDay, count: count() })
+        .from(schema.user)
+        .where(gte(schema.user.createdAt, since))
+        .groupBy(userDay)
+        .orderBy(userDay),
+      db
+        .select({ day: orgDay, count: count() })
+        .from(schema.organization)
+        .where(gte(schema.organization.createdAt, since))
+        .groupBy(orgDay)
+        .orderBy(orgDay),
+      db.select({ n: count() }).from(schema.user),
+      db.select({ n: count() }).from(schema.organization),
+      db.select({ n: count() }).from(schema.user).where(eq(schema.user.role, "admin")),
+      db.select({ n: count() }).from(schema.user).where(eq(schema.user.banned, true)),
+    ]);
+
+    return c.json({
+      users,
+      orgs,
+      totals: {
+        users: userTotal[0]?.n ?? 0,
+        orgs: orgTotal[0]?.n ?? 0,
+        admins: adminTotal[0]?.n ?? 0,
+        banned: bannedTotal[0]?.n ?? 0,
+      },
+    });
   })
   // Phase 3 (plan scope A): admin-provisioned org creation, idempotent on
   // slug — the backfill script (apps/api/scripts/backfill-orgs.mjs) and

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -268,7 +268,11 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
   // database, see org-workspaces.ts's header comment). The day grouping is
   // windowed by `since` so it stays cheap under D1's rows-read billing; the
   // totals are deliberately unwindowed full-table counts (Task 6 caches
-  // those).
+  // those). Only `users`/`orgs` totals are computed — this used to also run
+  // unwindowed full-table `role='admin'`/`banned=1` scans, but nothing
+  // downstream ever read those (MetricsOverview.totals has no admins/banned
+  // fields, and the page renders neither), so they were two wasted full
+  // scans on every cache miss. Removed rather than left dead.
   .get("/metrics", async (c) => {
     const sinceParam = c.req.query("since");
     if (sinceParam !== undefined && !DAY_RE.test(sinceParam)) {
@@ -296,7 +300,7 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     const userDay = DAY_EXPR(schema.user.createdAt);
     const orgDay = DAY_EXPR(schema.organization.createdAt);
 
-    const [users, orgs, userTotal, orgTotal, adminTotal, bannedTotal] = await Promise.all([
+    const [users, orgs, userTotal, orgTotal] = await Promise.all([
       db
         .select({ day: userDay, count: count() })
         .from(schema.user)
@@ -311,8 +315,6 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
         .orderBy(orgDay),
       db.select({ n: count() }).from(schema.user),
       db.select({ n: count() }).from(schema.organization),
-      db.select({ n: count() }).from(schema.user).where(eq(schema.user.role, "admin")),
-      db.select({ n: count() }).from(schema.user).where(eq(schema.user.banned, true)),
     ]);
 
     return c.json({
@@ -321,8 +323,6 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
       totals: {
         users: userTotal[0]?.n ?? 0,
         orgs: orgTotal[0]?.n ?? 0,
-        admins: adminTotal[0]?.n ?? 0,
-        banned: bannedTotal[0]?.n ?? 0,
       },
     });
   })

--- a/apps/auth/src/internal-routes.ts
+++ b/apps/auth/src/internal-routes.ts
@@ -278,6 +278,19 @@ export const internal = new Hono<{ Bindings: AuthEnv }>()
     const since = sinceParam
       ? new Date(`${sinceParam}T00:00:00.000Z`)
       : new Date(Date.now() - 29 * 86_400_000);
+    // A digit-shaped but non-calendar date is either Invalid Date (e.g.
+    // month 2026-13-45, whose NaN bind would silently match nothing) or, for
+    // an out-of-range day-of-month, silently overflows into the next month
+    // (e.g. 2026-02-30 parses as 2026-03-02) instead of failing to parse.
+    // Round-tripping back to YYYY-MM-DD catches both — a dashboard should
+    // never show a confident "zero" for a question that was never validly
+    // asked.
+    if (
+      Number.isNaN(since.getTime()) ||
+      (sinceParam !== undefined && since.toISOString().slice(0, 10) !== sinceParam)
+    ) {
+      return c.json(errorJson("invalid_since", "`since` must be YYYY-MM-DD"), 400);
+    }
 
     const db = drizzle(c.env.DB, { schema });
     const userDay = DAY_EXPR(schema.user.createdAt);

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -638,7 +638,9 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         // layout) — putObject always allows overwrite on gh/-prefixed keys.
         const replaceArg = optBool(args, "replace") === true;
         const putOpts =
-          metadata !== undefined || replaceArg ? { metadata, replace: replaceArg } : undefined;
+          metadata !== undefined || replaceArg
+            ? { metadata, replace: replaceArg, surface: "mcp" as const }
+            : { surface: "mcp" as const };
 
         if (multi) {
           // Decode (and size-gate) every item before any write, so a

--- a/apps/web/src/layouts/AdminLayout.astro
+++ b/apps/web/src/layouts/AdminLayout.astro
@@ -21,7 +21,7 @@ import ViewTransitions from "../components/ViewTransitions.astro";
 import "../styles/signed-in-shell.css";
 import "../styles/admin.css";
 
-export type AdminSection = "workspaces" | "users" | "oauth" | "email";
+export type AdminSection = "workspaces" | "metrics" | "users" | "oauth" | "email";
 
 interface Props {
   section: AdminSection;
@@ -31,6 +31,7 @@ const { section } = Astro.props;
 
 const titles: Record<AdminSection, string> = {
   workspaces: "Admin",
+  metrics: "Metrics · Admin",
   users: "Users · Admin",
   oauth: "OAuth apps · Admin",
   email: "Email · Admin",
@@ -44,6 +45,7 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
 
 const nav: { href: string; section: AdminSection; label: string }[] = [
   { href: "/admin", section: "workspaces", label: "Workspaces" },
+  { href: "/admin/metrics", section: "metrics", label: "Metrics" },
   { href: "/admin/users", section: "users", label: "Users" },
   { href: "/admin/oauth", section: "oauth", label: "OAuth apps" },
   { href: "/admin/email", section: "email", label: "Email" },

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -161,6 +161,23 @@ export const prerender = false;
         return niceFrac * base;
       }
 
+      /**
+       * Y-axis tick values for a [0, niceMax] scale: 0, the midpoint, and
+       * niceMax. The midpoint is dropped when rounding it for display would
+       * collide with either endpoint's rounded label — routine for
+       * niceMax === 1 (niceCeil's floor), where midpoint 0.5 rounds up to
+       * 1 and duplicates the top label. Endpoints are always kept so the
+       * axis still spans the full plotted range.
+       */
+      function buildYTicks(niceMax: number): number[] {
+        const raw = [0, niceMax / 2, niceMax];
+        const rounded = raw.map((t) => Math.round(t));
+        if (rounded[1] === rounded[0] || rounded[1] === rounded[2]) {
+          return [raw[0], raw[2]];
+        }
+        return raw;
+      }
+
       /** Evenly spaced x-axis label indices, capped so labels never crowd. */
       function pickLabelIndices(n: number, max = 6): Set<number> {
         const step = Math.max(1, Math.ceil(n / max));
@@ -196,6 +213,7 @@ export const prerender = false;
         elementId: string,
         points: { day: string; value: number }[],
         label: string,
+        windowDays: number,
       ): void {
         const container = document.getElementById(elementId);
         if (!container) return;
@@ -221,7 +239,7 @@ export const prerender = false;
         const barWidth = Math.max(1, Math.min(24, bandWidth - gap));
         const labelIdx = pickLabelIndices(points.length);
 
-        const yTicks = [0, niceMax / 2, niceMax];
+        const yTicks = buildYTicks(niceMax);
         const gridlines = yTicks
           .map((t) => {
             const y = baseline - (t / niceMax) * plotH;
@@ -261,7 +279,12 @@ export const prerender = false;
           })
           .join("");
 
-        const svg = `<svg class="metrics-chart" viewBox="0 0 ${W} ${H}" role="img" aria-label="${escapeHtml(label)}, last ${points.length} days">
+        // windowDays is the selected time window (overview.window.days from
+        // the API), not points.length — the series only includes days that
+        // have rows, so a sparse window would otherwise undercount (and
+        // mangle the grammar) in the accessible name.
+        const windowLabel = `last ${windowDays} day${windowDays === 1 ? "" : "s"}`;
+        const svg = `<svg class="metrics-chart" viewBox="0 0 ${W} ${H}" role="img" aria-label="${escapeHtml(label)}, ${windowLabel}">
             <line x1="${marginLeft}" y1="${baseline}" x2="${W - marginRight}" y2="${baseline}" class="metrics-axis-line" />
             ${gridlines}
             ${bars}
@@ -393,11 +416,13 @@ export const prerender = false;
           "chart-uploads",
           overview.series.uploads.map((p) => ({ day: p.day, value: p.count })),
           "Uploads per day",
+          overview.window.days,
         );
         drawChart(
           "chart-signups",
           overview.series.users.map((p) => ({ day: p.day, value: p.count })),
           "Signups per day",
+          overview.window.days,
         );
       }
 

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -1,0 +1,439 @@
+---
+/**
+ * Operator adoption-metrics overview — GET /admin-ui/metrics/overview
+ * (Task 6). Session-authenticated + admin-gated server-side; this page's
+ * gating is a UX affordance only, same disclaimer as every other /admin/*
+ * page (see AdminLayout.astro).
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-metrics.css";
+
+export const prerender = false;
+---
+
+<AdminLayout section="metrics">
+  <section class="admin-page">
+    <header class="admin-page-header">
+      <h2>Adoption</h2>
+      <p>Signup, upload, and workspace activity across the platform over a rolling window.</p>
+    </header>
+
+    <div class="metrics-range" role="group" aria-label="Time window">
+      <button type="button" class="admin-btn" data-days="7" aria-pressed="false">7 days</button>
+      <button type="button" class="admin-btn" data-days="30" aria-pressed="true">30 days</button>
+      <button type="button" class="admin-btn" data-days="90" aria-pressed="false">90 days</button>
+    </div>
+
+    <div id="metrics-status" class="admin-status">Loading…</div>
+
+    <div id="metrics-content">
+      <dl class="metrics-tiles" id="metrics-tiles">
+        <div class="metrics-tile">
+          <dt>Users</dt>
+          <dd id="tile-users">—</dd>
+        </div>
+        <div class="metrics-tile">
+          <dt>Organizations</dt>
+          <dd id="tile-orgs">—</dd>
+        </div>
+        <div class="metrics-tile">
+          <dt>Workspaces with uploads</dt>
+          <dd id="tile-workspaces">—</dd>
+        </div>
+        <div class="metrics-tile">
+          <dt>Stored bytes</dt>
+          <dd id="tile-stored">—</dd>
+        </div>
+        <div class="metrics-tile">
+          <dt>Active, 7d</dt>
+          <dd id="tile-active-7">—</dd>
+        </div>
+        <div class="metrics-tile">
+          <dt>Active, 30d</dt>
+          <dd id="tile-active-30">—</dd>
+        </div>
+        <div class="metrics-tile">
+          <dt>Uploads in window</dt>
+          <dd id="tile-uploads">—</dd>
+        </div>
+      </dl>
+
+      <section class="metrics-section">
+        <h3>Uploads per day</h3>
+        <div id="chart-uploads"></div>
+      </section>
+
+      <section class="metrics-section">
+        <h3>Signups per day</h3>
+        <div id="chart-signups"></div>
+      </section>
+
+      <section class="metrics-section">
+        <h3>Workspace activity</h3>
+        <div class="metrics-table-wrap">
+          <table class="admin-table" id="workspace-activity" aria-label="Workspace activity">
+          </table>
+        </div>
+      </section>
+    </div>
+  </section>
+
+  <script>
+    import { onAstroPageLoad, onSession, requireElement } from "../../lib/account-shell";
+    import { escapeHtml } from "../../lib/admin-ui";
+    import { formatBytes } from "../../lib/workspace-ui";
+
+    onAstroPageLoad(() => {
+      if (!document.getElementById("metrics-tiles")) return;
+
+      const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
+      const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
+      const status = requireElement<HTMLElement>("#metrics-status", "admin metrics");
+      const content = requireElement<HTMLElement>("#metrics-content", "admin metrics");
+
+      interface DayPoint {
+        day: string;
+        count: number;
+        bytes: number;
+      }
+      interface SignupPoint {
+        day: string;
+        count: number;
+      }
+      interface WorkspaceRow {
+        workspace: string;
+        uploads: number;
+        bytes: number;
+        lastActive: string;
+      }
+      // Mirrors apps/api/src/metrics-overview.ts's MetricsOverview exactly.
+      // `totals.workspaces` is workspaces with >=1 recorded upload — not the
+      // registration count (idle workspaces have no workspace_usage row).
+      // `totals.orgs` is the registration figure. `totals.storedBytes` is
+      // current absolute stored bytes; `totals.bytes` is bytes uploaded
+      // within the selected window, not stored bytes.
+      interface Overview {
+        window: { days: number; since: string };
+        totals: {
+          users: number;
+          orgs: number;
+          workspaces: number;
+          storedBytes: number;
+          activeWorkspaces7d: number;
+          activeWorkspaces30d: number;
+          uploads: number;
+          bytes: number;
+        };
+        series: { uploads: DayPoint[]; users: SignupPoint[]; orgs: SignupPoint[] };
+        features: Record<string, number>;
+        workspaces: WorkspaceRow[];
+      }
+
+      let days = 30;
+
+      const num = (input: unknown): string => {
+        const parsed = Number(input);
+        return Number.isFinite(parsed) ? parsed.toLocaleString() : "0";
+      };
+
+      const bytes = (input: unknown): string => {
+        const parsed = Number(input);
+        return Number.isFinite(parsed) ? formatBytes(parsed) : "0 B";
+      };
+
+      const formatDay = (day: string): string => {
+        const date = new Date(`${day}T00:00:00Z`);
+        if (Number.isNaN(date.getTime())) return day;
+        return new Intl.DateTimeFormat("en-US", {
+          month: "short",
+          day: "numeric",
+          timeZone: "UTC",
+        }).format(date);
+      };
+
+      /** Round a positive max up to a "clean" axis ceiling (1/2/5/10 * 10^n). */
+      function niceCeil(value: number): number {
+        if (!Number.isFinite(value) || value <= 0) return 1;
+        const exp = Math.floor(Math.log10(value));
+        const base = 10 ** exp;
+        const frac = value / base;
+        const niceFrac = frac <= 1 ? 1 : frac <= 2 ? 2 : frac <= 5 ? 5 : 10;
+        return niceFrac * base;
+      }
+
+      /** Evenly spaced x-axis label indices, capped so labels never crowd. */
+      function pickLabelIndices(n: number, max = 6): Set<number> {
+        const step = Math.max(1, Math.ceil(n / max));
+        const idx = new Set<number>();
+        for (let i = 0; i < n; i += step) idx.add(i);
+        idx.add(n - 1);
+        return idx;
+      }
+
+      /** A rect path rounded only at the top — square at the baseline. */
+      function roundedTopRectPath(
+        x: number,
+        y: number,
+        barW: number,
+        h: number,
+        r: number,
+      ): string {
+        if (h <= 0 || barW <= 0) return "";
+        const radius = Math.min(r, barW / 2, h);
+        return `M${x},${y + h} V${y + radius} Q${x},${y} ${x + radius},${y} H${x + barW - radius} Q${x + barW},${y} ${x + barW},${y + radius} V${y + h} Z`;
+      }
+
+      /**
+       * Single-series inline SVG bar chart with a hover/focus tooltip and a
+       * visually-hidden data table as the accessible alternative (dataviz
+       * skill: form = bar for daily counts; a lone series takes one hue
+       * (var(--accent)) and needs no legend box — the heading names it;
+       * y-axis ticks round to clean numbers; hover lifts the hovered bar and
+       * every value stays reachable without hovering, via the sr-only
+       * table).
+       */
+      function drawChart(
+        elementId: string,
+        points: { day: string; value: number }[],
+        label: string,
+      ): void {
+        const container = document.getElementById(elementId);
+        if (!container) return;
+        if (!points.length) {
+          container.innerHTML = `<p class="muted">No data yet.</p>`;
+          return;
+        }
+
+        const values = points.map((p) => Math.max(0, Number(p.value) || 0));
+        const niceMax = niceCeil(Math.max(1, ...values));
+
+        const W = 480;
+        const H = 200;
+        const marginLeft = 36;
+        const marginRight = 8;
+        const marginTop = 10;
+        const marginBottom = 26;
+        const plotW = W - marginLeft - marginRight;
+        const plotH = H - marginTop - marginBottom;
+        const baseline = marginTop + plotH;
+        const bandWidth = plotW / points.length;
+        const gap = Math.min(6, Math.max(2, bandWidth * 0.25));
+        const barWidth = Math.max(1, Math.min(24, bandWidth - gap));
+        const labelIdx = pickLabelIndices(points.length);
+
+        const yTicks = [0, niceMax / 2, niceMax];
+        const gridlines = yTicks
+          .map((t) => {
+            const y = baseline - (t / niceMax) * plotH;
+            return (
+              `<line x1="${marginLeft}" y1="${y}" x2="${W - marginRight}" y2="${y}" class="metrics-gridline" />` +
+              `<text x="${marginLeft - 6}" y="${y}" class="metrics-axis-label" text-anchor="end" dominant-baseline="middle">${escapeHtml(Math.round(t).toLocaleString())}</text>`
+            );
+          })
+          .join("");
+
+        const bars = points
+          .map((point, i) => {
+            const value = values[i];
+            const barHeight = (value / niceMax) * plotH;
+            const x = marginLeft + i * bandWidth + (bandWidth - barWidth) / 2;
+            const y = baseline - barHeight;
+            const path = roundedTopRectPath(x, y, barWidth, barHeight, 4);
+            const dayLabel = escapeHtml(formatDay(point.day));
+            const xLabel = labelIdx.has(i)
+              ? `<text x="${x + barWidth / 2}" y="${H - 8}" class="metrics-axis-label" text-anchor="middle">${dayLabel}</text>`
+              : "";
+            return `<g class="metrics-bar" data-index="${i}">
+                ${path ? `<path d="${path}" class="metrics-bar-fill" />` : ""}
+                <rect
+                  class="metrics-bar-hit"
+                  data-index="${i}"
+                  x="${x - gap / 2}"
+                  y="${marginTop}"
+                  width="${barWidth + gap}"
+                  height="${plotH}"
+                  tabindex="0"
+                  role="img"
+                  aria-label="${dayLabel}: ${escapeHtml(value.toLocaleString())} ${escapeHtml(label.toLowerCase())}"
+                />
+                ${xLabel}
+              </g>`;
+          })
+          .join("");
+
+        const svg = `<svg class="metrics-chart" viewBox="0 0 ${W} ${H}" role="img" aria-label="${escapeHtml(label)}, last ${points.length} days">
+            <line x1="${marginLeft}" y1="${baseline}" x2="${W - marginRight}" y2="${baseline}" class="metrics-axis-line" />
+            ${gridlines}
+            ${bars}
+          </svg>`;
+
+        const tableRows = points
+          .map(
+            (point, i) =>
+              `<tr><td>${escapeHtml(point.day)}</td><td class="num">${escapeHtml(values[i].toLocaleString())}</td></tr>`,
+          )
+          .join("");
+
+        container.innerHTML = `
+          <div class="metrics-chart-wrap">
+            ${svg}
+            <div class="metrics-chart-tooltip" data-visible="false" role="presentation"></div>
+          </div>
+          <table class="sr-only">
+            <caption>${escapeHtml(label)}, by day</caption>
+            <thead><tr><th scope="col">Day</th><th scope="col">Value</th></tr></thead>
+            <tbody>${tableRows}</tbody>
+          </table>`;
+
+        const wrap = container.querySelector<HTMLElement>(".metrics-chart-wrap");
+        const tooltip = container.querySelector<HTMLElement>(".metrics-chart-tooltip");
+        let liftedFill: SVGElement | null = null;
+
+        function setLift(index: number | null): void {
+          if (liftedFill) {
+            liftedFill.removeAttribute("style");
+            liftedFill = null;
+          }
+          if (index === null) return;
+          const fill = wrap?.querySelector<SVGElement>(
+            `.metrics-bar[data-index="${index}"] .metrics-bar-fill`,
+          );
+          if (fill) {
+            fill.setAttribute("style", "opacity:0.8");
+            liftedFill = fill;
+          }
+        }
+
+        function show(index: number): void {
+          const point = points[index];
+          if (!point || !tooltip) return;
+          const value = values[index];
+          const barHeight = (value / niceMax) * plotH;
+          const x = marginLeft + index * bandWidth + bandWidth / 2;
+          const y = baseline - barHeight;
+          tooltip.style.left = `${(x / W) * 100}%`;
+          tooltip.style.top = `${(y / H) * 100}%`;
+          tooltip.innerHTML = "";
+          const dayEl = document.createElement("span");
+          dayEl.className = "day";
+          dayEl.textContent = formatDay(point.day);
+          const valueEl = document.createElement("span");
+          valueEl.className = "value";
+          valueEl.textContent = value.toLocaleString();
+          // Not tooltip.append(...): worker-configuration.d.ts's HTMLRewriter
+          // ambient `Element` redeclares append() with a Cloudflare-specific
+          // signature that shadows the DOM lib overload (same drift noted in
+          // admin/index.astro re: Element.remove()). appendChild is unaffected.
+          tooltip.appendChild(dayEl);
+          tooltip.appendChild(valueEl);
+          tooltip.dataset.visible = "true";
+          setLift(index);
+        }
+
+        function hide(): void {
+          if (tooltip) tooltip.dataset.visible = "false";
+          setLift(null);
+        }
+
+        function indexFromEvent(event: Event): number | null {
+          const el = (event.target as Element | null)?.closest("[data-index]");
+          const raw = el?.getAttribute("data-index");
+          const idx = raw === null || raw === undefined ? NaN : Number(raw);
+          return Number.isNaN(idx) ? null : idx;
+        }
+
+        wrap?.addEventListener("pointermove", (event) => {
+          const idx = indexFromEvent(event);
+          if (idx !== null) show(idx);
+        });
+        wrap?.addEventListener("pointerleave", hide);
+        wrap?.addEventListener("focusin", (event) => {
+          const idx = indexFromEvent(event);
+          if (idx !== null) show(idx);
+        });
+        wrap?.addEventListener("focusout", hide);
+      }
+
+      function render(overview: Overview): void {
+        const tile = (id: string, value: string) => {
+          const el = document.getElementById(id);
+          if (el) el.textContent = value;
+        };
+        tile("tile-users", num(overview.totals.users));
+        tile("tile-orgs", num(overview.totals.orgs));
+        tile("tile-workspaces", num(overview.totals.workspaces));
+        tile("tile-stored", bytes(overview.totals.storedBytes));
+        tile("tile-active-7", num(overview.totals.activeWorkspaces7d));
+        tile("tile-active-30", num(overview.totals.activeWorkspaces30d));
+        tile("tile-uploads", num(overview.totals.uploads));
+
+        const table = requireElement<HTMLElement>("#workspace-activity", "admin metrics");
+        // tr.admin-row: .admin-table's cell padding/border rules are scoped
+        // to tr.admin-row (see admin.css) — a bare <tr> falls through to
+        // unstyled browser-default cell padding, same convention oauth.astro
+        // uses for its plain (non-expandable) rows.
+        const rows = overview.workspaces.length
+          ? overview.workspaces
+              .map(
+                (row) =>
+                  `<tr class="admin-row"><td>${escapeHtml(row.workspace)}</td><td class="num">${num(row.uploads)}</td><td class="num">${bytes(row.bytes)}</td><td>${escapeHtml(row.lastActive)}</td></tr>`,
+              )
+              .join("")
+          : `<tr class="admin-row"><td colspan="4" class="muted">No workspace activity in this window.</td></tr>`;
+        // th.keep: this table is only 4 narrow columns, so all of them stay
+        // visible at the .admin-table mobile breakpoint instead of the
+        // wider workspaces table's "hide the optional ones" collapse — a
+        // bare `th` (no `keep`) is dropped there, which would leave the
+        // data row without column labels.
+        table.innerHTML =
+          `<thead><tr><th class="keep" scope="col">Workspace</th><th class="keep num" scope="col">Uploads</th><th class="keep num" scope="col">Bytes</th><th class="keep" scope="col">Last active</th></tr></thead>` +
+          `<tbody>${rows}</tbody>`;
+
+        drawChart(
+          "chart-uploads",
+          overview.series.uploads.map((p) => ({ day: p.day, value: p.count })),
+          "Uploads per day",
+        );
+        drawChart(
+          "chart-signups",
+          overview.series.users.map((p) => ({ day: p.day, value: p.count })),
+          "Signups per day",
+        );
+      }
+
+      async function load(): Promise<void> {
+        status.hidden = false;
+        status.textContent = "Loading…";
+        content.dataset.loading = "true";
+        try {
+          const res = await fetch(`${apiOrigin}/admin-ui/metrics/overview?days=${days}`, {
+            credentials: "include",
+            cache: "no-store",
+          });
+          if (!res.ok) throw new Error(`request failed: ${res.status}`);
+          render((await res.json()) as Overview);
+          status.hidden = true;
+        } catch {
+          status.hidden = false;
+          status.textContent = "Could not load metrics. Try again.";
+        } finally {
+          content.dataset.loading = "false";
+        }
+      }
+
+      for (const button of document.querySelectorAll<HTMLButtonElement>("[data-days]")) {
+        button.addEventListener("click", () => {
+          days = Number(button.dataset.days);
+          for (const other of document.querySelectorAll<HTMLButtonElement>("[data-days]")) {
+            other.setAttribute("aria-pressed", other === button ? "true" : "false");
+          }
+          void load();
+        });
+      }
+
+      onSession(() => {
+        void load();
+      });
+    });
+  </script>
+</AdminLayout>

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -190,14 +190,20 @@ export const prerender = false;
         return Number.isFinite(parsed) ? formatBytes(parsed) : "0 B";
       };
 
+      // Hoisted out of formatDay: constructing an Intl.DateTimeFormat is
+      // comparatively expensive, and formatDay runs up to ~180 times per
+      // chart render plus once per hover/focus move — one shared formatter
+      // instance is reused instead of building a fresh one every call.
+      const DAY_FORMATTER = new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+
       const formatDay = (day: string): string => {
         const date = new Date(`${day}T00:00:00Z`);
         if (Number.isNaN(date.getTime())) return day;
-        return new Intl.DateTimeFormat("en-US", {
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        }).format(date);
+        return DAY_FORMATTER.format(date);
       };
 
       /** Round a positive max up to a "clean" axis ceiling (1/2/5/10 * 10^n). */
@@ -362,20 +368,36 @@ export const prerender = false;
         const tooltip = container.querySelector<HTMLElement>(".metrics-chart-tooltip");
         let liftedFill: SVGElement | null = null;
 
+        // Precomputed once per draw rather than a `.metrics-bar-fill`
+        // querySelector per hover: pointermove can fire 60-120 times/sec, and
+        // a bar with zero height renders no path (see roundedTopRectPath), so
+        // this map simply has no entry for those indices — same as the old
+        // querySelector returning null.
+        const fillByIndex = new Map<number, SVGElement>();
+        wrap?.querySelectorAll<HTMLElement>(".metrics-bar[data-index]").forEach((bar) => {
+          const idx = Number(bar.getAttribute("data-index"));
+          const fill = bar.querySelector<SVGElement>(".metrics-bar-fill");
+          if (!Number.isNaN(idx) && fill) fillByIndex.set(idx, fill);
+        });
+
         function setLift(index: number | null): void {
           if (liftedFill) {
             liftedFill.removeAttribute("style");
             liftedFill = null;
           }
           if (index === null) return;
-          const fill = wrap?.querySelector<SVGElement>(
-            `.metrics-bar[data-index="${index}"] .metrics-bar-fill`,
-          );
+          const fill = fillByIndex.get(index);
           if (fill) {
             fill.setAttribute("style", "opacity:0.8");
             liftedFill = fill;
           }
         }
+
+        // The index the tooltip currently reflects, so repeated pointermove
+        // events over the same bar (dozens per second) can no-op instead of
+        // re-running show()'s DOM teardown/rebuild on every event. Reset to
+        // null on hide() so the next show() of that same index still works.
+        let lastShownIndex: number | null = null;
 
         function show(index: number): void {
           const point = points[index];
@@ -401,11 +423,13 @@ export const prerender = false;
           tooltip.appendChild(valueEl);
           tooltip.dataset.visible = "true";
           setLift(index);
+          lastShownIndex = index;
         }
 
         function hide(): void {
           if (tooltip) tooltip.dataset.visible = "false";
           setLift(null);
+          lastShownIndex = null;
         }
 
         function indexFromEvent(event: Event): number | null {
@@ -417,7 +441,7 @@ export const prerender = false;
 
         wrap?.addEventListener("pointermove", (event) => {
           const idx = indexFromEvent(event);
-          if (idx !== null) show(idx);
+          if (idx !== null && idx !== lastShownIndex) show(idx);
         });
         wrap?.addEventListener("pointerleave", hide);
         wrap?.addEventListener("focusin", (event) => {

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -24,7 +24,7 @@ export const prerender = false;
       <button type="button" class="admin-btn" data-days="90" aria-pressed="false">90 days</button>
     </div>
 
-    <div id="metrics-status" class="admin-status">Loading…</div>
+    <div id="metrics-status" class="admin-status" role="status">Loading…</div>
 
     <div id="metrics-content">
       <dl class="metrics-tiles" id="metrics-tiles">
@@ -109,7 +109,7 @@ export const prerender = false;
           <option value="client">Client</option>
           <option value="repo">Repository</option>
         </select>
-        <div id="breakdown-status" class="admin-status" hidden></div>
+        <div id="breakdown-status" class="admin-status" role="status" hidden></div>
         <div class="metrics-table-wrap">
           <table class="admin-table" id="breakdown-table" aria-label="Upload breakdown"></table>
         </div>
@@ -169,6 +169,17 @@ export const prerender = false;
       }
 
       let days = 30;
+
+      // Monotonic request tokens (same shape as `previewSeq` in
+      // account/workspaces/[name]/settings.astro): each loader is
+      // re-invoked directly from user input (range buttons, the dimension
+      // select) with no way to cancel an in-flight fetch, so whichever
+      // response RESOLVES last would otherwise win over whichever was
+      // REQUESTED last — a slow 7-day response rendering over an
+      // already-selected 90-day window. One counter per loader since they
+      // run independently.
+      let loadSeq = 0;
+      let breakdownSeq = 0;
 
       // The four genuine feature-adoption metrics (excludes `upload`/
       // `delete`, already shown elsewhere) mapped to their tile element ids.
@@ -526,14 +537,22 @@ export const prerender = false;
         ) as unknown as HTMLSelectElement;
         const panelStatus = requireElement<HTMLElement>("#breakdown-status", "admin");
         const table = requireElement<HTMLElement>("#breakdown-table", "admin");
+        const seq = ++breakdownSeq;
         try {
           const res = await fetch(
             `${apiOrigin}/admin-ui/metrics/breakdown?dimension=${select.value}&days=90`,
             { credentials: "include", cache: "no-store" },
           );
+          if (seq !== breakdownSeq) return;
+          // Checked before res.json(): a 401/5xx response carries an
+          // AppError body, not the {available, ...} shape below, and parsing
+          // it as such would misreport it to the user as "Breakdown is
+          // temporarily unavailable" instead of falling into the catch block.
+          if (!res.ok) throw new Error(`request failed: ${res.status}`);
           const body = (await res.json()) as
             | { available: true; rows: { value: string; events: number; bytes: number }[] }
             | { available: false; reason: string };
+          if (seq !== breakdownSeq) return;
           if (!body.available) {
             table.innerHTML = "";
             panelStatus.hidden = false;
@@ -561,12 +580,14 @@ export const prerender = false;
               .join("") +
             `</tbody>`;
         } catch {
+          if (seq !== breakdownSeq) return;
           panelStatus.hidden = false;
           panelStatus.textContent = "Breakdown is temporarily unavailable.";
         }
       }
 
       async function load(): Promise<void> {
+        const seq = ++loadSeq;
         status.hidden = false;
         status.textContent = "Loading…";
         content.dataset.loading = "true";
@@ -575,15 +596,19 @@ export const prerender = false;
             credentials: "include",
             cache: "no-store",
           });
+          if (seq !== loadSeq) return;
           if (!res.ok) throw new Error(`request failed: ${res.status}`);
-          render((await res.json()) as Overview);
+          const overview = (await res.json()) as Overview;
+          if (seq !== loadSeq) return;
+          render(overview);
           status.hidden = true;
           void loadBreakdown();
         } catch {
+          if (seq !== loadSeq) return;
           status.hidden = false;
           status.textContent = "Could not load metrics. Try again.";
         } finally {
-          content.dataset.loading = "false";
+          if (seq === loadSeq) content.dataset.loading = "false";
         }
       }
 

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -242,10 +242,11 @@ export const prerender = false;
         const yTicks = buildYTicks(niceMax);
         const gridlines = yTicks
           .map((t) => {
-            const y = baseline - (t / niceMax) * plotH;
+            const labelValue = Math.round(t);
+            const y = baseline - (labelValue / niceMax) * plotH;
             return (
               `<line x1="${marginLeft}" y1="${y}" x2="${W - marginRight}" y2="${y}" class="metrics-gridline" />` +
-              `<text x="${marginLeft - 6}" y="${y}" class="metrics-axis-label" text-anchor="end" dominant-baseline="middle">${escapeHtml(Math.round(t).toLocaleString())}</text>`
+              `<text x="${marginLeft - 6}" y="${y}" class="metrics-axis-label" text-anchor="end" dominant-baseline="middle">${escapeHtml(labelValue.toLocaleString())}</text>`
             );
           })
           .join("");

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -76,6 +76,29 @@ export const prerender = false;
         </div>
       </section>
 
+      <section class="metrics-section" id="features-panel">
+        <h3>Feature adoption</h3>
+        <p class="admin-hint">Counts within the selected window, not all-time totals.</p>
+        <dl class="metrics-tiles" id="feature-tiles">
+          <div class="metrics-tile">
+            <dt>Workspaces created</dt>
+            <dd id="tile-feature-workspace_created">—</dd>
+          </div>
+          <div class="metrics-tile">
+            <dt>Galleries created</dt>
+            <dd id="tile-feature-gallery_created">—</dd>
+          </div>
+          <div class="metrics-tile">
+            <dt>PR comments posted</dt>
+            <dd id="tile-feature-comment_posted">—</dd>
+          </div>
+          <div class="metrics-tile">
+            <dt>Repos linked</dt>
+            <dd id="tile-feature-repo_linked">—</dd>
+          </div>
+        </dl>
+      </section>
+
       <section class="metrics-section" id="breakdown-panel">
         <h3>Upload breakdown</h3>
         <p class="admin-hint">Last 90 days, from Analytics Engine. Sampled and approximate.</p>
@@ -146,6 +169,16 @@ export const prerender = false;
       }
 
       let days = 30;
+
+      // The four genuine feature-adoption metrics (excludes `upload`/
+      // `delete`, already shown elsewhere) mapped to their tile element ids.
+      // Keys mirror ADOPTION_METRICS in apps/api/src/adoption.ts.
+      const FEATURE_TILES: [string, string][] = [
+        ["workspace_created", "tile-feature-workspace_created"],
+        ["gallery_created", "tile-feature-gallery_created"],
+        ["comment_posted", "tile-feature-comment_posted"],
+        ["repo_linked", "tile-feature-repo_linked"],
+      ];
 
       const num = (input: unknown): string => {
         const parsed = Number(input);
@@ -406,6 +439,18 @@ export const prerender = false;
         tile("tile-active-7", num(overview.totals.activeWorkspaces7d));
         tile("tile-active-30", num(overview.totals.activeWorkspaces30d));
         tile("tile-uploads", num(overview.totals.uploads));
+
+        // `upload`/`delete` are deliberately excluded — they're already the
+        // "Uploads in window" tile and the uploads chart above; repeating
+        // them here would double-report the headline number under a
+        // "feature adoption" label. A metric absent from `overview.features`
+        // means zero activity in the window (adoption-queries.ts's
+        // featureTotals only sets keys with a real SUM), not "unknown" — so
+        // it renders as 0, same as any other zero count, rather than being
+        // dropped from the tile row.
+        for (const [key, id] of FEATURE_TILES) {
+          tile(id, num(overview.features[key] ?? 0));
+        }
 
         const table = requireElement<HTMLElement>("#workspace-activity", "admin metrics");
         // tr.admin-row: .admin-table's cell padding/border rules are scoped

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -75,6 +75,22 @@ export const prerender = false;
           </table>
         </div>
       </section>
+
+      <section class="metrics-section" id="breakdown-panel">
+        <h3>Upload breakdown</h3>
+        <p class="admin-hint">Last 90 days, from Analytics Engine. Sampled and approximate.</p>
+        <label for="breakdown-dimension">Group by</label>
+        <select id="breakdown-dimension" class="ul-select">
+          <option value="surface">Surface</option>
+          <option value="contentType">Content type</option>
+          <option value="client">Client</option>
+          <option value="repo">Repository</option>
+        </select>
+        <div id="breakdown-status" class="admin-status" hidden></div>
+        <div class="metrics-table-wrap">
+          <table class="admin-table" id="breakdown-table" aria-label="Upload breakdown"></table>
+        </div>
+      </section>
     </div>
   </section>
 
@@ -427,6 +443,60 @@ export const prerender = false;
         );
       }
 
+      // Analytics Engine upload breakdown (Task 9). Loaded separately from
+      // the D1-backed overview above so an unconfigured/unreachable AE never
+      // blocks the tiles/charts/table from rendering.
+      async function loadBreakdown(): Promise<void> {
+        // Not requireElement<HTMLSelectElement>: worker-configuration.d.ts's
+        // HTMLRewriter ambient `Element` redeclares `remove()`, which makes
+        // HTMLSelectElement fail the `T extends Element` constraint. Fetch as
+        // HTMLElement and cast instead (same pattern as oauth/consent.astro).
+        const select = requireElement<HTMLElement>(
+          "#breakdown-dimension",
+          "admin",
+        ) as unknown as HTMLSelectElement;
+        const panelStatus = requireElement<HTMLElement>("#breakdown-status", "admin");
+        const table = requireElement<HTMLElement>("#breakdown-table", "admin");
+        try {
+          const res = await fetch(
+            `${apiOrigin}/admin-ui/metrics/breakdown?dimension=${select.value}&days=90`,
+            { credentials: "include", cache: "no-store" },
+          );
+          const body = (await res.json()) as
+            | { available: true; rows: { value: string; events: number; bytes: number }[] }
+            | { available: false; reason: string };
+          if (!body.available) {
+            table.innerHTML = "";
+            panelStatus.hidden = false;
+            panelStatus.textContent =
+              body.reason === "not_configured"
+                ? "Analytics Engine is not configured. Set ANALYTICS_API_TOKEN to enable this panel."
+                : "Breakdown is temporarily unavailable.";
+            return;
+          }
+          panelStatus.hidden = true;
+          // Every interpolated field is either escaped or coerced to a
+          // number. `value` carries client-supplied data (content type,
+          // client string, repo name) that reached AE straight from upload
+          // requests, so escapeHtml is load-bearing here, not decorative.
+          // The numeric columns are typed `number` but arrive as untyped
+          // JSON from an external API, so they are coerced rather than
+          // trusted.
+          table.innerHTML =
+            `<thead><tr><th class="keep" scope="col">Value</th><th class="keep num" scope="col">Uploads</th><th class="keep num" scope="col">Bytes</th></tr></thead><tbody>` +
+            body.rows
+              .map(
+                (row) =>
+                  `<tr class="admin-row"><td>${escapeHtml(row.value || "(none)")}</td><td class="num">${num(row.events)}</td><td class="num">${bytes(row.bytes)}</td></tr>`,
+              )
+              .join("") +
+            `</tbody>`;
+        } catch {
+          panelStatus.hidden = false;
+          panelStatus.textContent = "Breakdown is temporarily unavailable.";
+        }
+      }
+
       async function load(): Promise<void> {
         status.hidden = false;
         status.textContent = "Loading…";
@@ -439,6 +509,7 @@ export const prerender = false;
           if (!res.ok) throw new Error(`request failed: ${res.status}`);
           render((await res.json()) as Overview);
           status.hidden = true;
+          void loadBreakdown();
         } catch {
           status.hidden = false;
           status.textContent = "Could not load metrics. Try again.";
@@ -446,6 +517,14 @@ export const prerender = false;
           content.dataset.loading = "false";
         }
       }
+
+      const breakdownSelect = requireElement<HTMLElement>(
+        "#breakdown-dimension",
+        "admin",
+      ) as unknown as HTMLSelectElement;
+      breakdownSelect.addEventListener("change", () => {
+        void loadBreakdown();
+      });
 
       for (const button of document.querySelectorAll<HTMLButtonElement>("[data-days]")) {
         button.addEventListener("click", () => {

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -1,0 +1,155 @@
+/*
+ * Operator metrics surface (/admin/metrics). Follows the per-page CSS
+ * convention used by admin-workspaces.css / admin-oauth.css — design-system
+ * tokens only, no hard-coded colors, so light and dark both work.
+ *
+ * Token names verified against packages/ui/src/tokens.css and
+ * apps/web/src/styles/admin.css: this repo has no "--space-", "--font-size-"
+ * or "--color-" prefixed custom properties in active use anywhere under
+ * apps/web/src, so spacing here matches admin.css's raw-px convention (its
+ * numbers are all literal px, not a token scale) and colors read the real
+ * tokens — var(--line), var(--fg), var(--body), var(--muted), var(--accent),
+ * var(--panel), var(--bg), var(--mono), var(--radius-sm), var(--radius-md).
+ */
+
+.metrics-tiles {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  margin: 0;
+  padding: 0;
+}
+
+.metrics-tile {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+}
+
+.metrics-tile dt {
+  margin: 0;
+  color: var(--muted);
+  font: 11px var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.metrics-tile dd {
+  margin: 6px 0 0;
+  color: var(--fg);
+  font-size: 20px;
+  font-weight: 600;
+  /* Tabular figures so the numbers don't jitter on refresh. */
+  font-variant-numeric: tabular-nums;
+}
+
+.metrics-range {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* .admin-btn is the shared admin button look; the pressed state here is
+   the same pattern as .wft-view__btn[aria-pressed="true"] in
+   account-content.css — a filled accent chip instead of an outline. */
+.metrics-range .admin-btn[aria-pressed="true"] {
+  color: var(--bg);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.metrics-section h3 {
+  margin: 0 0 10px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg);
+}
+
+.metrics-chart-wrap {
+  position: relative;
+}
+
+.metrics-chart {
+  display: block;
+  inline-size: 100%;
+  block-size: auto;
+}
+
+.metrics-chart .metrics-axis-line,
+.metrics-chart .metrics-gridline {
+  stroke: var(--line);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.metrics-chart .metrics-axis-label {
+  fill: var(--muted);
+  font: 9px var(--mono);
+}
+
+.metrics-chart .metrics-bar-fill {
+  fill: var(--accent);
+  transition: opacity 0.1s ease;
+}
+
+.metrics-chart .metrics-bar-hit {
+  fill: transparent;
+  cursor: pointer;
+}
+
+.metrics-chart .metrics-bar-hit:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Data-point tooltip, positioned in JS as a percentage of the chart's
+   rendered box (computed from SVG viewBox coordinates, so it tracks the
+   chart at any responsive width). */
+.metrics-chart-tooltip {
+  position: absolute;
+  transform: translate(-50%, -100%) translateY(-6px);
+  pointer-events: none;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+  z-index: 1;
+}
+
+.metrics-chart-tooltip[data-visible="true"] {
+  opacity: 1;
+}
+
+.metrics-chart-tooltip .value {
+  color: var(--fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.metrics-chart-tooltip .day {
+  color: var(--muted);
+  margin-right: 4px;
+}
+
+/* Wide content scrolls inside its own container; the page body never
+   scrolls horizontally. */
+.metrics-table-wrap {
+  overflow-x: auto;
+}
+
+/* Reduced opacity while a range change is refetching, so the previous
+   render holds instead of flashing to empty. */
+#metrics-content {
+  transition: opacity 0.15s ease;
+}
+
+#metrics-content[data-loading="true"] {
+  opacity: 0.6;
+}

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -153,3 +153,24 @@
 #metrics-content[data-loading="true"] {
   opacity: 0.6;
 }
+
+/* Small explanatory line under a section heading — same treatment as
+   .admin-page-header p, scoped to this page since no other /admin/* section
+   currently needs one. */
+.admin-hint {
+  margin: 0 0 10px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+#breakdown-panel label {
+  display: inline-block;
+  margin: 0 8px 10px 0;
+  font-size: 13px;
+  color: var(--body);
+}
+
+#breakdown-panel #breakdown-status {
+  margin: 8px 0;
+}

--- a/docs/superpowers/plans/2026-07-28-operator-adoption-metrics.md
+++ b/docs/superpowers/plans/2026-07-28-operator-adoption-metrics.md
@@ -1,0 +1,2662 @@
+# Operator Adoption Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an operator-only `/admin/metrics` page showing registrations, uploads per day, active workspaces, and feature adoption, backed by a D1 daily-rollup table plus an optional Analytics Engine breakdown.
+
+**Architecture:** A new `daily_metrics` table in `uploads-production` accumulates per-day counters, written from a single never-throwing helper hooked into the existing accounting choke points. Reads go through pure query functions (reusable by a future digest-email cron) behind a KV-cached `/admin-ui/metrics/overview` endpoint. Signup history comes from the auth worker's own D1 over the `AUTH` service binding. Analytics Engine is layered on last and is additive-only.
+
+**Tech Stack:** Cloudflare Workers, Hono, D1 (raw SQL in apps/api, drizzle-orm in apps/auth), KV, Analytics Engine, Astro (apps/web), Vitest with `node:sqlite`-backed fake D1.
+
+Spec: `docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md`
+
+## Global Constraints
+
+Every task's requirements implicitly include these.
+
+- **A metrics failure must never fail an upload.** All recording is wrapped and logged as structured JSON, following `recordUsageSafe` in `apps/api/src/usage.ts`.
+- **`count` and `bytes` are always non-negative.** A delete records positive bytes under the `delete` metric, never negative bytes under `upload`.
+- **`daily_metrics` describes change over time only.** `workspace_usage` remains the source of truth for current absolute state. Never derive current stored bytes from `daily_metrics`.
+- **The `ANALYTICS` binding is optional everywhere.** An absent binding is a silent no-op — self-hosters, tests, and local dev must work without it.
+- **The Analytics Engine read path fails soft.** Missing token, missing account id, or an API error returns `{ available: false, reason }`; the rest of the page is unaffected.
+- **apps/api never reads the auth D1 directly.** All auth data comes over the `AUTH` service binding, per the ownership note atop `apps/api/src/org-workspaces.ts`.
+- **KV cache keys live under the `metrics:` prefix only**, never colliding with `ws:` records. The `mutateWorkspaceRecord` discipline governs `ws:` keys and does not apply here.
+- **Auth `created_at` columns are epoch SECONDS**, not milliseconds — drizzle `integer(..., { mode: "timestamp" })` divides by 1000 on write. Grouping SQL uses `strftime('%Y-%m-%d', created_at, 'unixepoch')` with no `/1000`.
+- **Formatting is oxfmt, linting is oxlint** (not prettier/eslint). The pre-commit hook runs both plus `wrangler types`.
+- Run the full suite with `pnpm test` from the repo root, or a single file with `pnpm vitest run <path>`.
+
+---
+
+### Task 1: `daily_metrics` table and the recording helper
+
+**Files:**
+
+- Create: `apps/api/migrations/20260728120000_daily_metrics.sql`
+- Create: `apps/api/src/adoption.ts`
+- Test: `apps/api/test/adoption-sqlite.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `type AdoptionMetric = "upload" | "delete" | "workspace_created" | "gallery_created" | "comment_posted" | "repo_linked"`
+  - `type UploadSurface = "api" | "mcp" | "promote"`
+  - `interface AdoptionDimensions { surface?: UploadSurface; contentType?: string; client?: string; plan?: string; repo?: string }`
+  - `interface AdoptionEvent { metric: AdoptionMetric; workspace: string; bytes?: number; dimensions?: AdoptionDimensions }`
+  - `function utcDay(now?: Date): string`
+  - `function bumpDailyMetric(db: D1Database, event: AdoptionEvent, now?: Date): Promise<void>` — throws on D1 failure
+  - `function recordAdoptionSafe(env: Env, event: AdoptionEvent, now?: Date): Promise<void>` — never throws
+
+> **Naming note:** the spec sketched `recordAdoption(env, event, ctx?)`. This plan uses `recordAdoptionSafe` and drops the `ExecutionContext` parameter, so the helper matches the established `recordUsageSafe` shape and is awaited on paths that already await D1. A floating un-awaited promise risks cancellation when the response returns; one extra `db.batch` on a path already doing several is the cheaper trade.
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/api/migrations/20260728120000_daily_metrics.sql`:
+
+```sql
+-- Per-day adoption counters (operator metrics surface). Describes CHANGE OVER
+-- TIME only: `workspace_usage` remains the source of truth for current
+-- absolute stored bytes/objects. `count`/`bytes` are always non-negative — a
+-- delete records positive bytes under the `delete` metric rather than negative
+-- bytes under `upload`, so net change is `upload.bytes - delete.bytes` at read
+-- time.
+--
+-- Every recorded event writes TWO rows: the per-workspace row and a
+-- platform-total row (`workspace = ''`). The platform row exists so the
+-- headline trend charts cost exactly one index entry per day in the window
+-- instead of one per (workspace, day) — D1 bills rows read, and that query
+-- runs on every page load. D1 has a single writer per database, so the
+-- "hot row" contention concern of a multi-master store does not apply.
+--
+-- Key order is (metric, day, workspace) so one metric's day range is
+-- contiguous. Retention is unbounded: every query is windowed by `day >= ?`,
+-- so old rows are never scanned and rolling them up would buy nothing.
+
+CREATE TABLE daily_metrics (
+  metric    TEXT NOT NULL,
+  day       TEXT NOT NULL,               -- 'YYYY-MM-DD', UTC
+  workspace TEXT NOT NULL DEFAULT '',    -- '' = the platform-total row
+  count     INTEGER NOT NULL DEFAULT 0,
+  bytes     INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (metric, day, workspace)
+);
+
+-- Covering: carries count/bytes so grouped per-workspace scans are served
+-- entirely from the index with no per-row table lookup. Same reasoning as
+-- 20260722180000_file_metadata_value_covering_idx.sql.
+CREATE INDEX daily_metrics_window_idx
+  ON daily_metrics (metric, day, workspace, count, bytes);
+
+-- Partial + covering: the headline trend series reads exactly one entry per
+-- day in the window. Partial-index precedent: auth_tokens_minting_user_idx.
+CREATE INDEX daily_metrics_platform_idx
+  ON daily_metrics (metric, day, count, bytes)
+  WHERE workspace = '';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/api/test/adoption-sqlite.test.ts`:
+
+```ts
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric, recordAdoptionSafe, utcDay } from "../src/adoption";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+
+interface Row {
+  metric: string;
+  day: string;
+  workspace: string;
+  count: number;
+  bytes: number;
+}
+
+async function rows(db: D1Database): Promise<Row[]> {
+  const result = await db
+    .prepare(
+      `SELECT metric, day, workspace, count, bytes FROM daily_metrics ORDER BY metric, day, workspace`,
+    )
+    .all<Row>();
+  return result.results;
+}
+
+describe("utcDay", () => {
+  it("formats as YYYY-MM-DD in UTC", () => {
+    expect(utcDay(new Date("2026-07-28T23:59:59.000Z"))).toBe("2026-07-28");
+  });
+
+  it("rolls over on the UTC boundary, not local time", () => {
+    expect(utcDay(new Date("2026-07-29T00:00:00.000Z"))).toBe("2026-07-29");
+  });
+});
+
+describe("bumpDailyMetric", () => {
+  it("writes both a workspace row and a platform row", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "acme", bytes: 100 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 1, bytes: 100 },
+        { metric: "upload", day: "2026-07-28", workspace: "acme", count: 1, bytes: 100 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("accumulates repeat events into the same rows", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 100 }, at);
+      await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 50 }, at);
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 2, bytes: 150 },
+        { metric: "upload", day: "2026-07-28", workspace: "acme", count: 2, bytes: 150 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("separates days and keeps workspaces independent", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "acme", bytes: 10 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "beta", bytes: 20 },
+        new Date("2026-07-29T10:00:00Z"),
+      );
+      expect(await rows(db)).toEqual([
+        { metric: "upload", day: "2026-07-28", workspace: "", count: 1, bytes: 10 },
+        { metric: "upload", day: "2026-07-28", workspace: "acme", count: 1, bytes: 10 },
+        { metric: "upload", day: "2026-07-29", workspace: "", count: 1, bytes: 20 },
+        { metric: "upload", day: "2026-07-29", workspace: "beta", count: 1, bytes: 20 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("stores deletes as positive bytes under their own metric", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      await bumpDailyMetric(db, { metric: "delete", workspace: "acme", bytes: 400 }, at);
+      const all = await rows(db);
+      expect(all.every((row) => row.bytes >= 0 && row.count >= 0)).toBe(true);
+      expect(all).toContainEqual({
+        metric: "delete",
+        day: "2026-07-28",
+        workspace: "acme",
+        count: 1,
+        bytes: 400,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("defaults bytes to 0 for non-byte metrics", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "workspace_created", workspace: "acme" },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toContainEqual({
+        metric: "workspace_created",
+        day: "2026-07-28",
+        workspace: "acme",
+        count: 1,
+        bytes: 0,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("clamps a negative byte figure to 0 rather than storing it", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "delete", workspace: "acme", bytes: -400 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      const all = await rows(db);
+      expect(all.every((row) => row.bytes === 0)).toBe(true);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("recordAdoptionSafe", () => {
+  it("swallows and logs a D1 failure instead of throwing", async () => {
+    const failing = {
+      prepare: () => {
+        throw new Error("D1 exploded");
+      },
+    } as unknown as D1Database;
+    const env = { DB: failing } as unknown as Env;
+    await expect(
+      recordAdoptionSafe(env, { metric: "upload", workspace: "acme", bytes: 1 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("writes through to D1 on the happy path", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const env = { DB: db } as unknown as Env;
+      await recordAdoptionSafe(
+        env,
+        { metric: "upload", workspace: "acme", bytes: 7 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await rows(db)).toHaveLength(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("is a no-op, not a crash, when the ANALYTICS binding is absent", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const env = { DB: database(sqlite) } as unknown as Env;
+      await expect(
+        recordAdoptionSafe(env, {
+          metric: "upload",
+          workspace: "acme",
+          bytes: 7,
+          dimensions: { surface: "api", contentType: "image/png" },
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/test/adoption-sqlite.test.ts`
+Expected: FAIL — `Failed to resolve import "../src/adoption"`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `apps/api/src/adoption.ts`:
+
+```ts
+/**
+ * Adoption metrics recording (`daily_metrics` D1 table) — the operator
+ * metrics surface's write side.
+ *
+ * Describes CHANGE OVER TIME only. `workspace_usage` (src/usage.ts) remains
+ * the source of truth for current absolute stored bytes/objects; nothing here
+ * should ever be used to derive current state.
+ *
+ * Like `recordUsageSafe`, metering is best-effort: `recordAdoptionSafe` logs
+ * and continues on failure, because a metrics write must never fail an upload.
+ */
+
+export type AdoptionMetric =
+  | "upload"
+  | "delete"
+  | "workspace_created"
+  | "gallery_created"
+  | "comment_posted"
+  | "repo_linked";
+
+/**
+ * Which server-side entry point wrote an upload. There is no way to tell a
+ * CLI request from any other API request server-side, so finer-grained client
+ * identity comes from the provenance bag's `client` value instead.
+ */
+export type UploadSurface = "api" | "mcp" | "promote";
+
+/** Analytics Engine dimensions. Never written to D1 — see the module docs. */
+export interface AdoptionDimensions {
+  surface?: UploadSurface;
+  contentType?: string;
+  client?: string;
+  plan?: string;
+  repo?: string;
+}
+
+export interface AdoptionEvent {
+  metric: AdoptionMetric;
+  workspace: string;
+  /** Non-negative bytes attributable to this event. Omitted/negative → 0. */
+  bytes?: number;
+  dimensions?: AdoptionDimensions;
+}
+
+/** The platform-total row's workspace sentinel. */
+const PLATFORM = "";
+
+/** UTC calendar day as `YYYY-MM-DD` — the rollup bucket. */
+export function utcDay(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/** Bytes are a non-negative magnitude; direction is carried by the metric. */
+function normalizeBytes(bytes: number | undefined): number {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return 0;
+  return Math.round(bytes);
+}
+
+/**
+ * Upsert the per-workspace row and the platform-total row for `event`.
+ * Blind upserts — no preceding SELECT — issued as one batch so the pair is a
+ * single round trip and cannot half-apply. Throws on D1 failure; callers on a
+ * request path should use `recordAdoptionSafe` instead.
+ */
+export async function bumpDailyMetric(
+  db: D1Database,
+  event: AdoptionEvent,
+  now = new Date(),
+): Promise<void> {
+  const day = utcDay(now);
+  const bytes = normalizeBytes(event.bytes);
+  const sql = `INSERT INTO daily_metrics (metric, day, workspace, count, bytes)
+               VALUES (?, ?, ?, 1, ?)
+               ON CONFLICT(metric, day, workspace) DO UPDATE SET
+                 count = count + 1,
+                 bytes = bytes + excluded.bytes`;
+  await db.batch([
+    db.prepare(sql).bind(event.metric, day, event.workspace, bytes),
+    db.prepare(sql).bind(event.metric, day, PLATFORM, bytes),
+  ]);
+}
+
+/**
+ * Best-effort adoption recording: log and continue if the write fails.
+ * Safe to await on any request path — it never throws.
+ */
+export async function recordAdoptionSafe(
+  env: Env,
+  event: AdoptionEvent,
+  now = new Date(),
+): Promise<void> {
+  try {
+    await bumpDailyMetric(env.DB, event, now);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "adoption metric write failed",
+        metric: event.metric,
+        workspace: event.workspace,
+        error: message,
+      }),
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run apps/api/test/adoption-sqlite.test.ts`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/migrations/20260728120000_daily_metrics.sql apps/api/src/adoption.ts apps/api/test/adoption-sqlite.test.ts
+git commit -m "feat(api): add daily_metrics table and adoption recording helper"
+```
+
+---
+
+### Task 2: Record upload and delete events
+
+**Files:**
+
+- Modify: `apps/api/src/files-core.ts` (the `putObject` `opts` type, the post-`recordUsageSafe` hook in `putObject`, and the `recordUsageSafe` call in the delete path)
+- Modify: `apps/api/src/routes/files.ts:220` (pass `surface`)
+- Modify: `apps/api/src/github-promote.ts:154` (pass `surface`)
+- Modify: `apps/mcp/src/tools.ts:691` and `apps/mcp/src/tools.ts:753` (pass `surface`)
+- Test: `apps/api/test/adoption-hooks.test.ts`
+
+**Interfaces:**
+
+- Consumes: `recordAdoptionSafe`, `AdoptionEvent`, `UploadSurface` from Task 1.
+- Produces: `putObject`'s `opts` gains `surface?: UploadSurface`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/test/adoption-hooks.test.ts`:
+
+```ts
+/// <reference types="node" />
+
+import { describe, expect, it, vi } from "vitest";
+import { bumpDailyMetric } from "../src/adoption";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+
+/**
+ * These assert the CONTRACT the hooks must satisfy, independent of the large
+ * putObject integration surface: an upload records one `upload` event with the
+ * stored byte size, and a delete records one `delete` event with a positive
+ * byte figure.
+ */
+describe("upload and delete recording contract", () => {
+  it("an upload of N bytes records count 1 and bytes N", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "upload", workspace: "acme", bytes: 2048, dimensions: { surface: "api" } },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      const row = await db
+        .prepare(
+          `SELECT count, bytes FROM daily_metrics WHERE metric = 'upload' AND workspace = 'acme'`,
+        )
+        .first<{ count: number; bytes: number }>();
+      expect(row).toEqual({ count: 1, bytes: 2048 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("a delete of N bytes records the delete metric with positive bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "delete", workspace: "acme", bytes: 2048 },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      const row = await db
+        .prepare(
+          `SELECT count, bytes FROM daily_metrics WHERE metric = 'delete' AND workspace = 'acme'`,
+        )
+        .first<{ count: number; bytes: number }>();
+      expect(row).toEqual({ count: 1, bytes: 2048 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("net stored change for a day is upload.bytes minus delete.bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 5000 }, at);
+      await bumpDailyMetric(db, { metric: "delete", workspace: "acme", bytes: 2000 }, at);
+      const row = await db
+        .prepare(
+          `SELECT
+             SUM(CASE WHEN metric = 'upload' THEN bytes ELSE 0 END)
+           - SUM(CASE WHEN metric = 'delete' THEN bytes ELSE 0 END) AS net
+           FROM daily_metrics WHERE workspace = 'acme' AND day = '2026-07-28'`,
+        )
+        .first<{ net: number }>();
+      expect(row?.net).toBe(3000);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("putObject surface plumbing", () => {
+  it("accepts a surface option without altering the result contract", async () => {
+    // Guard against the opts type regressing: this must typecheck.
+    const opts: { surface?: "api" | "mcp" | "promote" } = { surface: "mcp" };
+    expect(opts.surface).toBe("mcp");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/test/adoption-hooks.test.ts`
+Expected: PASS for the contract tests only if Task 1 landed — they exercise `bumpDailyMetric` directly. If Task 1 is present these already pass; the real verification for this task is Step 5's typecheck plus the full suite. Proceed to Step 3.
+
+- [ ] **Step 3: Add `surface` to the `putObject` options type**
+
+In `apps/api/src/files-core.ts`, inside the `opts?:` object literal of `putObject`'s signature, after the `metadata?: Record<string, string>;` member, add:
+
+```ts
+    /**
+     * Which server-side entry point is writing this object. Recorded as an
+     * Analytics Engine dimension only — never stored in D1, never affects the
+     * write. Absent means the caller predates this parameter.
+     */
+    surface?: UploadSurface;
+```
+
+Add to the imports at the top of `files-core.ts`:
+
+```ts
+import { recordAdoptionSafe, type UploadSurface } from "./adoption";
+```
+
+- [ ] **Step 4: Hook the upload event**
+
+In `apps/api/src/files-core.ts`, immediately after the `await recordUsageSafe(env.DB, workspaceName, { bytes: reservedBytes > 0 ? 0 : deltaBytes, objects: replaced ? 0 : 1, uploads: 0 });` call inside `putObject`, add:
+
+```ts
+// Adoption metrics, best-effort and never fatal (see src/adoption.ts).
+// Recorded here rather than at the route so all four putObject callers are
+// covered by construction. `newSize` (not deltaBytes) is the right figure:
+// this counts bytes written by this upload, not net storage change.
+await recordAdoptionSafe(env, {
+  metric: "upload",
+  workspace: workspaceName,
+  bytes: newSize,
+  dimensions: {
+    surface: opts?.surface,
+    contentType: inspection.contentType,
+    client: provenance.client,
+    repo: opts?.metadata?.["gh.repo"],
+  },
+});
+```
+
+- [ ] **Step 5: Hook the delete event**
+
+In `apps/api/src/files-core.ts`, in the delete path, immediately after the existing
+
+```ts
+if (prev !== null) {
+  await recordUsageSafe(env.DB, workspaceName, {
+    bytes: -prev,
+    objects: -1,
+    uploads: 0,
+  });
+}
+```
+
+add inside the same `if` block, after the `recordUsageSafe` call:
+
+```ts
+// Positive magnitude under the `delete` metric — never negative bytes
+// under `upload`. Net change is computed at read time.
+await recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, bytes: prev });
+```
+
+Do **not** add a hook to the poster-cleanup delete below it: derived posters are an implementation detail, and counting them would inflate the delete series with events no operator initiated.
+
+- [ ] **Step 6: Pass `surface` from each caller**
+
+In `apps/api/src/routes/files.ts`, change the `putObject` options argument from
+
+```ts
+      { provenance, visibility, metadata, replace: wantReplace },
+```
+
+to
+
+```ts
+      { provenance, visibility, metadata, replace: wantReplace, surface: "api" },
+```
+
+In `apps/api/src/github-promote.ts`, add `surface: "promote"` to the options object passed to `putObject`.
+
+In `apps/mcp/src/tools.ts`, add `surface: "mcp"` to the options object at the first `putObject` call, and add `surface: "mcp"` to the `putOpts` object used by the second.
+
+- [ ] **Step 7: Typecheck and run the suite**
+
+```bash
+pnpm types && pnpm test
+```
+
+Expected: types clean; full suite PASS. Existing `files-core` tests continue to pass because `recordAdoptionSafe` never throws even when the test env has no real `daily_metrics` table.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/files-core.ts apps/api/src/routes/files.ts apps/api/src/github-promote.ts apps/mcp/src/tools.ts apps/api/test/adoption-hooks.test.ts
+git commit -m "feat(api): record upload and delete adoption events"
+```
+
+---
+
+### Task 3: Record feature-adoption events
+
+**Files:**
+
+- Modify: `apps/api/src/routes/workspaces.ts` (self-serve create, after the workspace record is durably written)
+- Modify: `apps/api/src/routes/galleries.ts` (gallery create handler)
+- Modify: `apps/api/src/github-comment-service.ts` (after a managed comment is successfully posted)
+- Modify: `apps/api/src/github-repo-links.ts` (after `recordRepoLink` actually creates a link)
+- Test: `apps/api/test/adoption-feature-events.test.ts`
+
+**Interfaces:**
+
+- Consumes: `recordAdoptionSafe` from Task 1.
+- Produces: no new exported symbols.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/test/adoption-feature-events.test.ts`:
+
+```ts
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric } from "../src/adoption";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+
+describe("feature adoption metrics", () => {
+  it("records each feature metric under its own key with zero bytes", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      for (const metric of [
+        "workspace_created",
+        "gallery_created",
+        "comment_posted",
+        "repo_linked",
+      ] as const) {
+        await bumpDailyMetric(db, { metric, workspace: "acme" }, at);
+      }
+      const result = await db
+        .prepare(
+          `SELECT metric, count, bytes FROM daily_metrics
+           WHERE workspace = 'acme' ORDER BY metric`,
+        )
+        .all<{ metric: string; count: number; bytes: number }>();
+      expect(result.results).toEqual([
+        { metric: "comment_posted", count: 1, bytes: 0 },
+        { metric: "gallery_created", count: 1, bytes: 0 },
+        { metric: "repo_linked", count: 1, bytes: 0 },
+        { metric: "workspace_created", count: 1, bytes: 0 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("keeps feature metrics out of the upload series", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      const at = new Date("2026-07-28T10:00:00Z");
+      await bumpDailyMetric(db, { metric: "gallery_created", workspace: "acme" }, at);
+      const row = await db
+        .prepare(`SELECT COUNT(*) AS n FROM daily_metrics WHERE metric = 'upload'`)
+        .first<{ n: number }>();
+      expect(row?.n).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/test/adoption-feature-events.test.ts`
+Expected: PASS (it exercises Task 1's helper directly). This file is the regression guard for the metric vocabulary; the wiring below is verified by the full suite in Step 4.
+
+- [ ] **Step 3: Add the four call sites**
+
+In each file, import the helper:
+
+```ts
+import { recordAdoptionSafe } from "../adoption";
+```
+
+(use `"./adoption"` in `apps/api/src/github-comment-service.ts` and `apps/api/src/github-repo-links.ts`, which sit at `src/` level; `github-repo-links.ts` receives a bare `D1Database` rather than `Env`, so import `bumpDailyMetric` there and wrap the call in its own try/catch — see below).
+
+**`apps/api/src/routes/workspaces.ts`** — in the self-serve create handler, after the workspace record write succeeds and before the success response is returned:
+
+```ts
+await recordAdoptionSafe(c.env, { metric: "workspace_created", workspace: name });
+```
+
+The handler already binds the validated slug to a local `const name` — reuse it rather than introducing a new variable.
+
+**`apps/api/src/routes/galleries.ts`** — in the create handler, after `createGallery(c.env.DB, …)` resolves and immediately before the existing `return c.json(await ownerGallery(c, result.value.id), 201);`:
+
+```ts
+await recordAdoptionSafe(c.env, { metric: "gallery_created", workspace: c.get("workspaceName") });
+```
+
+**`apps/api/src/github-comment-service.ts`** — after a managed comment is successfully created or patched, on the success path only:
+
+```ts
+await recordAdoptionSafe(env, { metric: "comment_posted", workspace: workspaceName });
+```
+
+Place it where both the create and the patch outcome converge, so an edit of an existing comment counts as one posted comment, not zero. A failed post must not record.
+
+**`apps/api/src/github-repo-links.ts`** — `recordRepoLink` takes a bare `D1Database`, so record only when the `INSERT OR IGNORE` actually inserted (first claim wins — a no-op second claim must not count):
+
+```ts
+// Only a real first claim counts; INSERT OR IGNORE reports changes === 0
+// when an existing link already owned the repo.
+if ((result.meta?.changes ?? 0) > 0) {
+  try {
+    await bumpDailyMetric(db, { metric: "repo_linked", workspace: workspaceName });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "adoption metric write failed",
+        metric: "repo_linked",
+        error: message,
+      }),
+    );
+  }
+}
+```
+
+Bind `result` to the existing `INSERT OR IGNORE` statement's `.run()` return value if it is not already captured.
+
+- [ ] **Step 4: Typecheck and run the suite**
+
+```bash
+pnpm types && pnpm test
+```
+
+Expected: types clean; full suite PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/workspaces.ts apps/api/src/routes/galleries.ts apps/api/src/github-comment-service.ts apps/api/src/github-repo-links.ts apps/api/test/adoption-feature-events.test.ts
+git commit -m "feat(api): record workspace, gallery, comment and repo-link adoption events"
+```
+
+---
+
+### Task 4: Read-side query functions
+
+**Files:**
+
+- Create: `apps/api/src/adoption-queries.ts`
+- Test: `apps/api/test/adoption-queries-sqlite.test.ts`
+
+**Interfaces:**
+
+- Consumes: the `daily_metrics` schema from Task 1.
+- Produces:
+  - `interface DayPoint { day: string; count: number; bytes: number }`
+  - `interface WorkspaceActivity { workspace: string; uploads: number; bytes: number; lastActive: string }`
+  - `function windowStart(days: number, now?: Date): string`
+  - `function platformSeries(db: D1Database, metric: AdoptionMetric, since: string): Promise<DayPoint[]>`
+  - `function workspaceActivity(db: D1Database, since: string, limit?: number): Promise<WorkspaceActivity[]>`
+  - `function activeWorkspaceCount(db: D1Database, since: string): Promise<number>`
+  - `function featureTotals(db: D1Database, since: string): Promise<Record<string, number>>`
+  - `function platformStorage(db: D1Database): Promise<{ workspaces: number; storedBytes: number }>`
+
+These are pure `(db, range) => data` with no Hono or `Request` dependency — that is the seam a future digest-email cron calls directly, with no HTTP hop.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/test/adoption-queries-sqlite.test.ts`:
+
+```ts
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric } from "../src/adoption";
+import {
+  activeWorkspaceCount,
+  featureTotals,
+  platformSeries,
+  windowStart,
+  workspaceActivity,
+} from "../src/adoption-queries";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+
+async function seed(db: D1Database): Promise<void> {
+  const day = (d: string) => new Date(`${d}T10:00:00Z`);
+  await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 100 }, day("2026-07-26"));
+  await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 200 }, day("2026-07-28"));
+  await bumpDailyMetric(db, { metric: "upload", workspace: "beta", bytes: 50 }, day("2026-07-28"));
+  await bumpDailyMetric(db, { metric: "gallery_created", workspace: "acme" }, day("2026-07-28"));
+}
+
+describe("windowStart", () => {
+  it("returns the inclusive first day of an N-day window", () => {
+    expect(windowStart(7, new Date("2026-07-28T00:00:00Z"))).toBe("2026-07-22");
+  });
+
+  it("treats a 1-day window as today only", () => {
+    expect(windowStart(1, new Date("2026-07-28T00:00:00Z"))).toBe("2026-07-28");
+  });
+});
+
+describe("platformSeries", () => {
+  it("reads only platform rows, one point per day with activity", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await platformSeries(db, "upload", "2026-07-01")).toEqual([
+        { day: "2026-07-26", count: 1, bytes: 100 },
+        { day: "2026-07-28", count: 2, bytes: 250 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("excludes days before the window", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await platformSeries(db, "upload", "2026-07-27")).toEqual([
+        { day: "2026-07-28", count: 2, bytes: 250 },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("workspaceActivity", () => {
+  it("aggregates per workspace and sorts by uploads descending", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await workspaceActivity(db, "2026-07-01")).toEqual([
+        { workspace: "acme", uploads: 2, bytes: 300, lastActive: "2026-07-28" },
+        { workspace: "beta", uploads: 1, bytes: 50, lastActive: "2026-07-28" },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("never includes the platform sentinel row", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      const rows = await workspaceActivity(db, "2026-07-01");
+      expect(rows.some((row) => row.workspace === "")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("activeWorkspaceCount", () => {
+  it("counts distinct workspaces that uploaded in the window", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await activeWorkspaceCount(db, "2026-07-01")).toBe(2);
+      expect(await activeWorkspaceCount(db, "2026-07-27")).toBe(2);
+      expect(await activeWorkspaceCount(db, "2026-07-29")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not count a workspace whose only activity was a gallery", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await bumpDailyMetric(
+        db,
+        { metric: "gallery_created", workspace: "gamma" },
+        new Date("2026-07-28T10:00:00Z"),
+      );
+      expect(await activeWorkspaceCount(db, "2026-07-01")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("featureTotals", () => {
+  it("returns a per-metric total from platform rows", async () => {
+    const sqlite = new SqliteD1(MIGRATION);
+    try {
+      const db = database(sqlite);
+      await seed(db);
+      expect(await featureTotals(db, "2026-07-01")).toEqual({ upload: 3, gallery_created: 1 });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("platformStorage", () => {
+  it("reports current workspace count and stored bytes from workspace_usage", async () => {
+    const sqlite = new SqliteD1([USAGE_MIGRATION, MIGRATION]);
+    try {
+      const db = database(sqlite);
+      await db
+        .prepare(
+          `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+           VALUES ('acme', 500, 2, 2, '2026-07', '2026-07-28T00:00:00Z'),
+                  ('beta', 250, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
+        )
+        .run();
+      expect(await platformStorage(db)).toEqual({ workspaces: 2, storedBytes: 750 });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns zeros on an empty ledger rather than nulls", async () => {
+    const sqlite = new SqliteD1([USAGE_MIGRATION, MIGRATION]);
+    try {
+      expect(await platformStorage(database(sqlite))).toEqual({ workspaces: 0, storedBytes: 0 });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+```
+
+Add the second migration constant and the import at the top of the file:
+
+```ts
+const USAGE_MIGRATION = "migrations/20260710140000_workspace_usage.sql";
+```
+
+and extend the `adoption-queries` import to include `platformStorage`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/test/adoption-queries-sqlite.test.ts`
+Expected: FAIL — `Failed to resolve import "../src/adoption-queries"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/adoption-queries.ts`:
+
+```ts
+/**
+ * Read side of the adoption metrics (`daily_metrics`).
+ *
+ * Deliberately pure `(db, range) => data` with no Hono/Request dependency, so
+ * a future digest-email cron can call these directly instead of making an
+ * HTTP hop through /admin-ui.
+ *
+ * D1 bills rows read, so every query here is windowed by `day >= ?` and is
+ * served from one of the two covering indexes:
+ *   - platform-level reads hit `daily_metrics_platform_idx` (partial on
+ *     `workspace = ''`) and cost one entry per day in the window, regardless
+ *     of how many workspaces exist;
+ *   - per-workspace reads hit `daily_metrics_window_idx`, which carries
+ *     count/bytes so there is no per-row table lookup. The table is sparse —
+ *     a row exists only for a (metric, day, workspace) with real activity —
+ *     so that scan is proportional to actual usage, not workspaces × days.
+ */
+
+import type { AdoptionMetric } from "./adoption";
+import { utcDay } from "./adoption";
+
+export interface DayPoint {
+  day: string;
+  count: number;
+  bytes: number;
+}
+
+export interface WorkspaceActivity {
+  workspace: string;
+  uploads: number;
+  bytes: number;
+  /** Most recent day with an upload, `YYYY-MM-DD`. */
+  lastActive: string;
+}
+
+/** Default cap on the per-workspace table. */
+const DEFAULT_LIMIT = 100;
+
+/**
+ * Inclusive first day of an N-day window ending today, `YYYY-MM-DD`.
+ * `days = 1` means today only.
+ */
+export function windowStart(days: number, now = new Date()): string {
+  const start = new Date(now.getTime());
+  start.setUTCDate(start.getUTCDate() - (Math.max(1, Math.floor(days)) - 1));
+  return utcDay(start);
+}
+
+/** Daily platform totals for one metric. One index entry per day in window. */
+export async function platformSeries(
+  db: D1Database,
+  metric: AdoptionMetric,
+  since: string,
+): Promise<DayPoint[]> {
+  const result = await db
+    .prepare(
+      `SELECT day, count, bytes FROM daily_metrics
+       WHERE metric = ? AND workspace = '' AND day >= ?
+       ORDER BY day`,
+    )
+    .bind(metric, since)
+    .all<DayPoint>();
+  return result.results;
+}
+
+/** Per-workspace upload activity in the window, busiest first. */
+export async function workspaceActivity(
+  db: D1Database,
+  since: string,
+  limit = DEFAULT_LIMIT,
+): Promise<WorkspaceActivity[]> {
+  const result = await db
+    .prepare(
+      `SELECT workspace,
+              SUM(count) AS uploads,
+              SUM(bytes) AS bytes,
+              MAX(day)   AS lastActive
+       FROM daily_metrics
+       WHERE metric = 'upload' AND workspace <> '' AND day >= ?
+       GROUP BY workspace
+       ORDER BY uploads DESC, workspace ASC
+       LIMIT ?`,
+    )
+    .bind(since, limit)
+    .all<WorkspaceActivity>();
+  return result.results;
+}
+
+/** Workspaces that uploaded at least once in the window. */
+export async function activeWorkspaceCount(db: D1Database, since: string): Promise<number> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(DISTINCT workspace) AS n FROM daily_metrics
+       WHERE metric = 'upload' AND workspace <> '' AND day >= ?`,
+    )
+    .bind(since)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+/** Per-metric event totals in the window, from platform rows only. */
+export async function featureTotals(
+  db: D1Database,
+  since: string,
+): Promise<Record<string, number>> {
+  const result = await db
+    .prepare(
+      `SELECT metric, SUM(count) AS total FROM daily_metrics
+       WHERE workspace = '' AND day >= ?
+       GROUP BY metric`,
+    )
+    .bind(since)
+    .all<{ metric: string; total: number }>();
+  const totals: Record<string, number> = {};
+  for (const row of result.results) totals[row.metric] = row.total;
+  return totals;
+}
+
+/**
+ * Current platform-wide state, read from `workspace_usage` — the source of
+ * truth for absolute stored bytes. Deliberately NOT derived from
+ * `daily_metrics`, which only describes change over time and would drift.
+ *
+ * `workspaces` counts workspaces with at least one recorded upload (a
+ * `workspace_usage` row). Registered-but-idle workspaces are not included —
+ * the organizations total from the auth worker is the registration figure.
+ * One aggregate over a table with one row per workspace.
+ */
+export async function platformStorage(
+  db: D1Database,
+): Promise<{ workspaces: number; storedBytes: number }> {
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS workspaces, COALESCE(SUM(bytes), 0) AS storedBytes FROM workspace_usage`,
+    )
+    .first<{ workspaces: number; storedBytes: number }>();
+  return { workspaces: row?.workspaces ?? 0, storedBytes: row?.storedBytes ?? 0 };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run apps/api/test/adoption-queries-sqlite.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/adoption-queries.ts apps/api/test/adoption-queries-sqlite.test.ts
+git commit -m "feat(api): add adoption metrics query functions"
+```
+
+---
+
+### Task 5: Signup metrics from the auth worker
+
+**Files:**
+
+- Create: `apps/auth/migrations/20260728120000_created_at_indexes.sql`
+- Modify: `apps/auth/src/internal-routes.ts` (add `GET /internal/metrics`)
+- Test: `apps/auth/src/internal-metrics.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `GET /internal/metrics?since=YYYY-MM-DD` returning
+
+```ts
+{
+  users: {
+    day: string;
+    count: number;
+  }
+  [];
+  orgs: {
+    day: string;
+    count: number;
+  }
+  [];
+  totals: {
+    users: number;
+    orgs: number;
+    admins: number;
+    banned: number;
+  }
+}
+```
+
+- [ ] **Step 1: Write the migration**
+
+Create `apps/auth/migrations/20260728120000_created_at_indexes.sql`:
+
+```sql
+-- Signup-by-day aggregation for the operator metrics surface. Without these
+-- the windowed GROUP BY scans every user/organization row, and D1 bills rows
+-- read. `created_at` is epoch SECONDS (drizzle `mode: "timestamp"`), not
+-- milliseconds.
+
+CREATE INDEX IF NOT EXISTS user_created_at_idx ON user (created_at);
+CREATE INDEX IF NOT EXISTS organization_created_at_idx ON organization (created_at);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/auth/src/internal-metrics.test.ts`:
+
+```ts
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthEnv } from "./auth";
+import { internal } from "./internal-routes";
+import * as schema from "./schema";
+import { createFakeD1, type FakeD1Database } from "./test/fake-d1";
+
+describe("GET /internal/metrics", () => {
+  let db: FakeD1Database;
+  let orm: ReturnType<typeof drizzle<typeof schema>>;
+
+  beforeEach(() => {
+    db = createFakeD1();
+    orm = drizzle(db, { schema });
+  });
+
+  function app() {
+    return new Hono<{ Bindings: AuthEnv }>().route("/internal", internal);
+  }
+
+  function env(): AuthEnv {
+    return {
+      DB: db,
+      WEB_ORIGIN: "https://uploads.sh",
+      ENVIRONMENT: "development",
+      BETTER_AUTH_SECRET_DEV: "test-signing-secret-at-least-32-chars-long",
+    } as AuthEnv;
+  }
+
+  async function seedUser(createdAt: Date, overrides: Partial<schema.AuthUser> = {}) {
+    await orm.insert(schema.user).values({
+      id: crypto.randomUUID(),
+      name: "Ada",
+      email: `ada-${crypto.randomUUID()}@example.com`,
+      emailVerified: true,
+      image: null,
+      createdAt,
+      updatedAt: createdAt,
+      role: overrides.role ?? "user",
+      banned: overrides.banned ?? null,
+      banReason: null,
+      banExpires: null,
+      cliOnboardedAt: null,
+      stripeCustomerId: null,
+    } as schema.AuthUser);
+  }
+
+  it("groups signups by UTC day", async () => {
+    await seedUser(new Date("2026-07-26T10:00:00Z"));
+    await seedUser(new Date("2026-07-28T01:00:00Z"));
+    await seedUser(new Date("2026-07-28T23:00:00Z"));
+
+    const res = await app().request("/internal/metrics?since=2026-07-01", {}, env());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { users: { day: string; count: number }[] };
+    expect(body.users).toEqual([
+      { day: "2026-07-26", count: 1 },
+      { day: "2026-07-28", count: 2 },
+    ]);
+  });
+
+  it("excludes signups before the window", async () => {
+    await seedUser(new Date("2026-07-01T10:00:00Z"));
+    await seedUser(new Date("2026-07-28T10:00:00Z"));
+
+    const res = await app().request("/internal/metrics?since=2026-07-20", {}, env());
+    const body = (await res.json()) as { users: { day: string; count: number }[] };
+    expect(body.users).toEqual([{ day: "2026-07-28", count: 1 }]);
+  });
+
+  it("reports all-time totals independent of the window", async () => {
+    await seedUser(new Date("2026-01-01T10:00:00Z"), { role: "admin" });
+    await seedUser(new Date("2026-07-28T10:00:00Z"), { banned: true });
+
+    const res = await app().request("/internal/metrics?since=2026-07-20", {}, env());
+    const body = (await res.json()) as {
+      totals: { users: number; admins: number; banned: number };
+    };
+    expect(body.totals.users).toBe(2);
+    expect(body.totals.admins).toBe(1);
+    expect(body.totals.banned).toBe(1);
+  });
+
+  it("defaults to a 30-day window when `since` is absent", async () => {
+    const res = await app().request("/internal/metrics", {}, env());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { users: unknown[]; orgs: unknown[] };
+    expect(Array.isArray(body.users)).toBe(true);
+    expect(Array.isArray(body.orgs)).toBe(true);
+  });
+
+  it("rejects a malformed `since`", async () => {
+    const res = await app().request("/internal/metrics?since=not-a-date", {}, env());
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/auth/src/internal-metrics.test.ts`
+Expected: FAIL — 404 responses, because `/internal/metrics` does not exist yet.
+
+- [ ] **Step 4: Add the route**
+
+In `apps/auth/src/internal-routes.ts`, extend the drizzle import to include `gte` and `sql`:
+
+```ts
+import { and, count, countDistinct, eq, gt, gte, isNull, max, sql } from "drizzle-orm";
+```
+
+Add this helper above the router definition:
+
+```ts
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * `created_at` is epoch SECONDS (drizzle `integer(..., { mode: "timestamp" })`
+ * divides by 1000 on write) — hence 'unixepoch' with no /1000. Getting this
+ * wrong buckets every signup into 1970.
+ */
+const DAY_EXPR = (column: unknown) => sql<string>`strftime('%Y-%m-%d', ${column}, 'unixepoch')`;
+```
+
+Add the route to the `internal` chain, placed alongside the other `GET` handlers:
+
+```ts
+  .get("/metrics", async (c) => {
+    const sinceParam = c.req.query("since");
+    if (sinceParam !== undefined && !DAY_RE.test(sinceParam)) {
+      return c.json(errorJson("invalid_since", "`since` must be YYYY-MM-DD"), 400);
+    }
+    // Default window matches the overview endpoint's default.
+    const since = sinceParam
+      ? new Date(`${sinceParam}T00:00:00.000Z`)
+      : new Date(Date.now() - 29 * 86_400_000);
+
+    const db = drizzle(c.env.DB, { schema });
+    const userDay = DAY_EXPR(schema.user.createdAt);
+    const orgDay = DAY_EXPR(schema.organization.createdAt);
+
+    const [users, orgs, userTotal, orgTotal, adminTotal, bannedTotal] = await Promise.all([
+      db
+        .select({ day: userDay, count: count() })
+        .from(schema.user)
+        .where(gte(schema.user.createdAt, since))
+        .groupBy(userDay)
+        .orderBy(userDay),
+      db
+        .select({ day: orgDay, count: count() })
+        .from(schema.organization)
+        .where(gte(schema.organization.createdAt, since))
+        .groupBy(orgDay)
+        .orderBy(orgDay),
+      db.select({ n: count() }).from(schema.user),
+      db.select({ n: count() }).from(schema.organization),
+      db.select({ n: count() }).from(schema.user).where(eq(schema.user.role, "admin")),
+      db.select({ n: count() }).from(schema.user).where(eq(schema.user.banned, true)),
+    ]);
+
+    return c.json({
+      users,
+      orgs,
+      totals: {
+        users: userTotal[0]?.n ?? 0,
+        orgs: orgTotal[0]?.n ?? 0,
+        admins: adminTotal[0]?.n ?? 0,
+        banned: bannedTotal[0]?.n ?? 0,
+      },
+    });
+  })
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run apps/auth/src/internal-metrics.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/auth/migrations/20260728120000_created_at_indexes.sql apps/auth/src/internal-routes.ts apps/auth/src/internal-metrics.test.ts
+git commit -m "feat(auth): add /internal/metrics signup aggregation"
+```
+
+---
+
+### Task 6: The `/admin-ui/metrics/overview` endpoint
+
+**Files:**
+
+- Create: `apps/api/src/metrics-overview.ts`
+- Modify: `apps/api/src/routes/admin-ui.ts` (add the route)
+- Test: `apps/api/src/routes/admin-ui-metrics.test.ts`
+
+**Interfaces:**
+
+- Consumes: `platformSeries`, `workspaceActivity`, `activeWorkspaceCount`, `featureTotals`, `windowStart` (Task 4); `GET /internal/metrics` (Task 5).
+- Produces:
+  - `const OVERVIEW_CACHE_TTL = 600`
+  - `function overviewCacheKey(days: number): string` → `metrics:overview:v1:<days>`
+  - `function buildOverview(env: Env, days: number, now?: Date): Promise<MetricsOverview>`
+  - `interface MetricsOverview { window: { days: number; since: string }; totals: { users: number; orgs: number; workspaces: number; storedBytes: number; activeWorkspaces7d: number; activeWorkspaces30d: number; uploads: number; bytes: number }; series: { uploads: DayPoint[]; users: SignupPoint[]; orgs: SignupPoint[] }; features: Record<string, number>; workspaces: WorkspaceActivity[] }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/routes/admin-ui-metrics.test.ts`:
+
+```ts
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { bumpDailyMetric } from "../adoption";
+import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
+import { respondError } from "../error-response";
+import { adminUi } from "./admin-ui";
+
+// Both: buildOverview reads daily_metrics AND workspace_usage.
+const MIGRATIONS = [
+  "migrations/20260710140000_workspace_usage.sql",
+  "migrations/20260728120000_daily_metrics.sql",
+];
+const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
+const NON_ADMIN_USER = { id: "u-plain", email: "plain@b.com", name: "Plain", role: "user" };
+
+function stubAuth(user: typeof ADMIN_USER | null): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify(user ? { session: {}, user } : null), { status: 200 });
+      }
+      if (url.pathname === "/internal/metrics") {
+        return Response.json({
+          users: [{ day: "2026-07-28", count: 3 }],
+          orgs: [{ day: "2026-07-28", count: 1 }],
+          totals: { users: 12, orgs: 4, admins: 1, banned: 0 },
+        });
+      }
+      return new Response(null, { status: 404 });
+    }) as Fetcher["fetch"],
+  };
+}
+
+/** Minimal KV stub recording puts so cache behavior is assertable. */
+function fakeKv() {
+  const store = new Map<string, string>();
+  let puts = 0;
+  return {
+    store,
+    get puts() {
+      return puts;
+    },
+    binding: {
+      get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+      put: (async (key: string, value: string) => {
+        puts += 1;
+        store.set(key, value);
+      }) as unknown as KVNamespace["put"],
+      list: (async () => ({
+        keys: [],
+        list_complete: true,
+        cacheStatus: null,
+      })) as unknown as KVNamespace["list"],
+    } as KVNamespace,
+  };
+}
+
+function app() {
+  return new Hono<{ Bindings: Env }>()
+    .route("/admin-ui", adminUi)
+    .onError((err, c) => respondError(c, err));
+}
+
+async function seededDb() {
+  const sqlite = new SqliteD1(MIGRATIONS);
+  const db = database(sqlite);
+  const at = new Date();
+  await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 100 }, at);
+  await bumpDailyMetric(db, { metric: "upload", workspace: "beta", bytes: 50 }, at);
+  await bumpDailyMetric(db, { metric: "gallery_created", workspace: "acme" }, at);
+  await db
+    .prepare(
+      `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+       VALUES ('acme', 100, 1, 1, '2026-07', '2026-07-28T00:00:00Z'),
+              ('beta', 50, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
+    )
+    .run();
+  return { sqlite, db };
+}
+
+describe("GET /admin-ui/metrics/overview", () => {
+  it("401s with no session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = { AUTH: stubAuth(null), DB: db, REGISTRY: fakeKv().binding } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview", {}, env);
+      expect(res.status).toBe(401);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("403s for a non-admin session", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(NON_ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview", {}, env);
+      expect(res.status).toBe(403);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("returns totals, series and the workspace table for an admin", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        window: { days: number; since: string };
+        totals: {
+          users: number;
+          orgs: number;
+          workspaces: number;
+          storedBytes: number;
+          uploads: number;
+          bytes: number;
+          activeWorkspaces30d: number;
+        };
+        series: { uploads: unknown[]; users: unknown[] };
+        features: Record<string, number>;
+        workspaces: { workspace: string; uploads: number }[];
+      };
+      expect(body.window.days).toBe(30);
+      expect(body.totals.users).toBe(12);
+      expect(body.totals.orgs).toBe(4);
+      expect(body.totals.workspaces).toBe(2);
+      expect(body.totals.storedBytes).toBe(150);
+      expect(body.totals.uploads).toBe(2);
+      expect(body.totals.bytes).toBe(150);
+      expect(body.totals.activeWorkspaces30d).toBe(2);
+      expect(body.features.gallery_created).toBe(1);
+      expect(body.workspaces.map((w) => w.workspace).sort()).toEqual(["acme", "beta"]);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("serves the second request from cache without recomputing", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const kv = fakeKv();
+      const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: kv.binding } as unknown as Env;
+      await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(kv.puts).toBe(1);
+      expect(kv.store.has("metrics:overview:v1:30")).toBe(true);
+      const res = await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      expect(res.status).toBe(200);
+      expect(kv.puts).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("bypasses the cache with ?fresh=1", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const kv = fakeKv();
+      const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: kv.binding } as unknown as Env;
+      await app().request("/admin-ui/metrics/overview?days=30", {}, env);
+      await app().request("/admin-ui/metrics/overview?days=30&fresh=1", {}, env);
+      expect(kv.puts).toBe(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still answers when the cache read throws", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const broken = {
+        get: (async () => {
+          throw new Error("KV down");
+        }) as unknown as KVNamespace["get"],
+        put: (async () => {
+          throw new Error("KV down");
+        }) as unknown as KVNamespace["put"],
+      } as KVNamespace;
+      const env = { AUTH: stubAuth(ADMIN_USER), DB: db, REGISTRY: broken } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview", {}, env);
+      expect(res.status).toBe(200);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("rejects an unsupported window", async () => {
+    const { sqlite, db } = await seededDb();
+    try {
+      const env = {
+        AUTH: stubAuth(ADMIN_USER),
+        DB: db,
+        REGISTRY: fakeKv().binding,
+      } as unknown as Env;
+      const res = await app().request("/admin-ui/metrics/overview?days=365", {}, env);
+      expect(res.status).toBe(400);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/src/routes/admin-ui-metrics.test.ts`
+Expected: FAIL — `Failed to resolve import "../metrics-overview"` once the route file imports it, or 404s on the overview path.
+
+- [ ] **Step 3: Write the overview builder**
+
+Create `apps/api/src/metrics-overview.ts`:
+
+```ts
+/**
+ * Composes the operator metrics overview from the D1 rollups (this worker)
+ * and signup history (the auth worker, over the AUTH service binding — never
+ * a direct cross-database read).
+ *
+ * Cached in KV because D1 bills rows read: the TTL bounds cost by elapsed
+ * time rather than by page loads. Cache keys live under the `metrics:` prefix
+ * and are NOT workspace records, so the `mutateWorkspaceRecord` discipline
+ * that governs `ws:` keys does not apply here.
+ */
+
+import {
+  activeWorkspaceCount,
+  featureTotals,
+  platformSeries,
+  platformStorage,
+  windowStart,
+  workspaceActivity,
+  type DayPoint,
+  type WorkspaceActivity,
+} from "./adoption-queries";
+
+export const OVERVIEW_CACHE_TTL = 600;
+
+/** Windows the UI offers. Anything else is rejected, so the cache stays small. */
+export const ALLOWED_WINDOWS = [7, 30, 90] as const;
+
+export interface SignupPoint {
+  day: string;
+  count: number;
+}
+
+export interface MetricsOverview {
+  window: { days: number; since: string };
+  totals: {
+    /** All-time, from the auth worker. */
+    users: number;
+    /** All-time registered organizations, from the auth worker. */
+    orgs: number;
+    /** Workspaces with at least one recorded upload (not registrations). */
+    workspaces: number;
+    /** Current absolute stored bytes, from `workspace_usage`. */
+    storedBytes: number;
+    activeWorkspaces7d: number;
+    activeWorkspaces30d: number;
+    /** Uploads within the selected window. */
+    uploads: number;
+    /** Bytes uploaded within the selected window — not stored bytes. */
+    bytes: number;
+  };
+  series: {
+    uploads: DayPoint[];
+    users: SignupPoint[];
+    orgs: SignupPoint[];
+  };
+  features: Record<string, number>;
+  workspaces: WorkspaceActivity[];
+}
+
+interface AuthMetrics {
+  users: SignupPoint[];
+  orgs: SignupPoint[];
+  totals: { users: number; orgs: number; admins: number; banned: number };
+}
+
+const EMPTY_AUTH: AuthMetrics = {
+  users: [],
+  orgs: [],
+  totals: { users: 0, orgs: 0, admins: 0, banned: 0 },
+};
+
+export function overviewCacheKey(days: number): string {
+  return `metrics:overview:v1:${days}`;
+}
+
+/**
+ * Signup history from the auth worker. Degrades to zeros rather than failing
+ * the page: the D1-backed half of the overview is still worth showing.
+ */
+async function authMetrics(env: Env, since: string): Promise<AuthMetrics> {
+  try {
+    const res = await env.AUTH.fetch(`https://auth.internal/internal/metrics?since=${since}`);
+    if (!res.ok) return EMPTY_AUTH;
+    return (await res.json()) as AuthMetrics;
+  } catch {
+    return EMPTY_AUTH;
+  }
+}
+
+export async function buildOverview(
+  env: Env,
+  days: number,
+  now = new Date(),
+): Promise<MetricsOverview> {
+  const since = windowStart(days, now);
+  const since7 = windowStart(7, now);
+  const since30 = windowStart(30, now);
+
+  const [uploads, features, table, active7, active30, storage, auth] = await Promise.all([
+    platformSeries(env.DB, "upload", since),
+    featureTotals(env.DB, since),
+    workspaceActivity(env.DB, since),
+    activeWorkspaceCount(env.DB, since7),
+    activeWorkspaceCount(env.DB, since30),
+    platformStorage(env.DB),
+    authMetrics(env, since),
+  ]);
+
+  return {
+    window: { days, since },
+    totals: {
+      users: auth.totals.users,
+      orgs: auth.totals.orgs,
+      workspaces: storage.workspaces,
+      storedBytes: storage.storedBytes,
+      activeWorkspaces7d: active7,
+      activeWorkspaces30d: active30,
+      uploads: uploads.reduce((sum, point) => sum + point.count, 0),
+      bytes: uploads.reduce((sum, point) => sum + point.bytes, 0),
+    },
+    series: { uploads, users: auth.users, orgs: auth.orgs },
+    features,
+    workspaces: table,
+  };
+}
+
+/** Cached read. Cache failures fall through to a live build, never a 500. */
+export async function cachedOverview(
+  env: Env,
+  days: number,
+  fresh: boolean,
+  now = new Date(),
+): Promise<MetricsOverview> {
+  const key = overviewCacheKey(days);
+  if (!fresh) {
+    try {
+      const hit = await env.REGISTRY.get(key);
+      if (hit) return JSON.parse(hit) as MetricsOverview;
+    } catch {
+      // fall through to a live build
+    }
+  }
+  const overview = await buildOverview(env, days, now);
+  try {
+    await env.REGISTRY.put(key, JSON.stringify(overview), { expirationTtl: OVERVIEW_CACHE_TTL });
+  } catch {
+    // caching is an optimization, never a requirement
+  }
+  return overview;
+}
+```
+
+- [ ] **Step 4: Add the route**
+
+In `apps/api/src/routes/admin-ui.ts`, add the import:
+
+```ts
+import { ALLOWED_WINDOWS, cachedOverview } from "../metrics-overview";
+```
+
+Add this handler to the `adminUi` chain, next to the other `GET` routes:
+
+```ts
+  .get("/metrics/overview", async (c) => {
+    const raw = c.req.query("days");
+    const days = raw === undefined ? 30 : Number(raw);
+    if (!ALLOWED_WINDOWS.includes(days as (typeof ALLOWED_WINDOWS)[number])) {
+      throw new ValidationError(`days must be one of ${ALLOWED_WINDOWS.join(", ")}`, {
+        code: "invalid_window",
+      });
+    }
+    return c.json(await cachedOverview(c.env, days, c.req.query("fresh") === "1"));
+  })
+```
+
+`ValidationError` is already imported at the top of the file.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm vitest run apps/api/src/routes/admin-ui-metrics.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Run the full suite and commit**
+
+```bash
+pnpm types && pnpm test
+git add apps/api/src/metrics-overview.ts apps/api/src/routes/admin-ui.ts apps/api/src/routes/admin-ui-metrics.test.ts
+git commit -m "feat(api): add cached /admin-ui/metrics/overview endpoint"
+```
+
+---
+
+### Task 7: The `/admin/metrics` page
+
+**Files:**
+
+- Create: `apps/web/src/pages/admin/metrics.astro`
+- Create: `apps/web/src/styles/admin-metrics.css`
+- Modify: `apps/web/src/layouts/AdminLayout.astro` (add the nav entry and section)
+
+**Interfaces:**
+
+- Consumes: `GET /admin-ui/metrics/overview?days=N` (Task 6).
+- Produces: nothing other tasks depend on.
+
+> **REQUIRED SUB-SKILL:** invoke the `dataviz` skill before writing any chart markup in Step 3. It governs chart form, color, and accessibility, and applies to inline SVG exactly as it does to a charting library.
+
+- [ ] **Step 1: Add the nav entry**
+
+In `apps/web/src/layouts/AdminLayout.astro`:
+
+Change the section type:
+
+```ts
+export type AdminSection = "workspaces" | "metrics" | "users" | "oauth" | "email";
+```
+
+Add to `titles`:
+
+```ts
+  metrics: "Metrics · Admin",
+```
+
+Add to `nav`, immediately after the Workspaces entry:
+
+```ts
+  { href: "/admin/metrics", section: "metrics", label: "Metrics" },
+```
+
+- [ ] **Step 2: Add the stylesheet**
+
+Create `apps/web/src/styles/admin-metrics.css`:
+
+```css
+/* Operator metrics surface. Follows the per-page CSS convention used by
+   admin-workspaces.css / admin-oauth.css — design-system tokens only, no
+   hard-coded colors, so light and dark both work. */
+
+.metrics-tiles {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  margin-block-end: var(--space-5);
+}
+
+.metrics-tile {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+}
+
+.metrics-tile dt {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.metrics-tile dd {
+  font-size: var(--font-size-xl);
+  /* Tabular figures so the numbers don't jitter between refreshes. */
+  font-variant-numeric: tabular-nums;
+  margin: 0;
+}
+
+.metrics-section {
+  margin-block-end: var(--space-5);
+}
+
+.metrics-chart {
+  display: block;
+  inline-size: 100%;
+  block-size: auto;
+}
+
+.metrics-range {
+  display: flex;
+  gap: var(--space-2);
+  margin-block-end: var(--space-3);
+}
+
+/* Wide content scrolls inside its own container; the page body never scrolls
+   horizontally. */
+.metrics-table-wrap {
+  overflow-x: auto;
+}
+
+.metrics-num {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+```
+
+Verify the token names above against `apps/web/src/styles/admin.css` and the design-system stylesheet before committing; substitute the repo's actual token names where they differ. Do not introduce literal color values.
+
+- [ ] **Step 3: Create the page**
+
+Create `apps/web/src/pages/admin/metrics.astro` following the structure of `apps/web/src/pages/admin/index.astro`:
+
+- Frontmatter: `import AdminLayout from "../../layouts/AdminLayout.astro";`, `import "../../styles/admin-metrics.css";`, `export const prerender = false;`
+- `<AdminLayout section="metrics">` wrapping a `<section class="admin-page">` with an `<h2>Adoption</h2>` header and a one-line description.
+- A range toggle (7 / 30 / 90) as buttons with `data-days`.
+- A `<dl class="metrics-tiles">` with one `<div class="metrics-tile"><dt>…</dt><dd id="…"></dd></div>` per figure. The `dd` ids are fixed by `render` below: `tile-users` (Users), `tile-orgs` (Organizations), `tile-workspaces` (Workspaces with uploads), `tile-stored` (Stored bytes), `tile-active-7` (Active, 7d), `tile-active-30` (Active, 30d), `tile-uploads` (Uploads in window). Give the container `id="metrics-tiles"` — the script's early-return guard keys off it.
+- Label the tiles exactly as above. "Workspaces with uploads" is not the registration count (idle workspaces have no `workspace_usage` row); "Organizations" is the registration figure. Mislabelling these two makes the page quietly wrong.
+- Two chart slots (uploads per day, signups per day) rendered as inline SVG bar charts built from the JSON — **write these only after invoking the `dataviz` skill**. Each chart needs an accessible text alternative (a visually-hidden table or `role="img"` with a descriptive `aria-label`), because an SVG bar chart is not readable on its own.
+- A workspace table `<table class="admin-table" id="workspace-activity">` inside a `.metrics-table-wrap`; `render` fills its head and body.
+- A `<div id="metrics-status" class="admin-status">Loading…</div>` following the existing loading-state convention.
+
+Client script, mirroring the `onAstroPageLoad` / `requireElement` / `apiGet` pattern from `apps/web/src/pages/admin/index.astro`:
+
+```ts
+import { onAstroPageLoad, requireElement } from "../../lib/account-shell";
+import { escapeHtml } from "../../lib/admin-ui";
+
+onAstroPageLoad(() => {
+  if (!document.getElementById("metrics-tiles")) return;
+
+  const w = window as unknown as { __UPLOADS_API_ORIGIN__: string };
+  const apiOrigin = w.__UPLOADS_API_ORIGIN__.replace(/\/$/, "");
+  const status = requireElement<HTMLElement>("#metrics-status", "admin");
+
+  interface DayPoint {
+    day: string;
+    count: number;
+    bytes: number;
+  }
+  interface SignupPoint {
+    day: string;
+    count: number;
+  }
+  interface WorkspaceRow {
+    workspace: string;
+    uploads: number;
+    bytes: number;
+    lastActive: string;
+  }
+  interface Overview {
+    window: { days: number; since: string };
+    totals: {
+      users: number;
+      orgs: number;
+      activeWorkspaces7d: number;
+      activeWorkspaces30d: number;
+      uploads: number;
+      bytes: number;
+    };
+    series: { uploads: DayPoint[]; users: SignupPoint[]; orgs: SignupPoint[] };
+    features: Record<string, number>;
+    workspaces: WorkspaceRow[];
+  }
+
+  let days = 30;
+
+  async function load(): Promise<void> {
+    status.hidden = false;
+    status.textContent = "Loading…";
+    try {
+      const res = await fetch(`${apiOrigin}/admin-ui/metrics/overview?days=${days}`, {
+        credentials: "include",
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`request failed: ${res.status}`);
+      render((await res.json()) as Overview);
+      status.hidden = true;
+    } catch {
+      status.hidden = false;
+      status.textContent = "Could not load metrics. Try again.";
+    }
+  }
+
+  void load();
+});
+```
+
+Then `render`, the tile/table half. Workspace names are user-chosen, so `escapeHtml` is required on every one; numeric fields are coerced rather than trusted:
+
+```ts
+const num = (input: unknown): string => {
+  const parsed = Number(input);
+  return Number.isFinite(parsed) ? parsed.toLocaleString() : "0";
+};
+
+const bytes = (input: unknown): string => {
+  const n = Number(input);
+  if (!Number.isFinite(n) || n <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.min(units.length - 1, Math.floor(Math.log(n) / Math.log(1024)));
+  return `${(n / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+function render(overview: Overview): void {
+  const tile = (id: string, value: string) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  };
+  tile("tile-users", num(overview.totals.users));
+  tile("tile-orgs", num(overview.totals.orgs));
+  tile("tile-workspaces", num(overview.totals.workspaces));
+  tile("tile-stored", bytes(overview.totals.storedBytes));
+  tile("tile-active-7", num(overview.totals.activeWorkspaces7d));
+  tile("tile-active-30", num(overview.totals.activeWorkspaces30d));
+  tile("tile-uploads", num(overview.totals.uploads));
+
+  const table = requireElement<HTMLElement>("#workspace-activity", "admin");
+  table.innerHTML =
+    `<thead><tr><th scope="col">Workspace</th><th scope="col" class="metrics-num">Uploads</th><th scope="col" class="metrics-num">Bytes</th><th scope="col">Last active</th></tr></thead><tbody>` +
+    overview.workspaces
+      .map(
+        (row) =>
+          `<tr><td>${escapeHtml(row.workspace)}</td><td class="metrics-num">${num(row.uploads)}</td><td class="metrics-num">${bytes(row.bytes)}</td><td>${escapeHtml(row.lastActive)}</td></tr>`,
+      )
+      .join("") +
+    `</tbody>`;
+
+  drawChart(
+    "chart-uploads",
+    overview.series.uploads.map((p) => ({ day: p.day, value: p.count })),
+    "Uploads per day",
+  );
+  drawChart(
+    "chart-signups",
+    overview.series.users.map((p) => ({ day: p.day, value: p.count })),
+    "Signups per day",
+  );
+}
+```
+
+`drawChart(elementId, points, label)` is the only piece left — **write it after invoking the `dataviz` skill**, which governs its form, color, and accessible alternative. Its signature is fixed by the two calls above: `(elementId: string, points: { day: string; value: number }[], label: string) => void`.
+
+Finally, wire the range buttons:
+
+```ts
+for (const button of document.querySelectorAll<HTMLButtonElement>("[data-days]")) {
+  button.addEventListener("click", () => {
+    days = Number(button.dataset.days);
+    for (const other of document.querySelectorAll<HTMLButtonElement>("[data-days]")) {
+      other.setAttribute("aria-pressed", other === button ? "true" : "false");
+    }
+    void load();
+  });
+}
+```
+
+Give each range button `aria-pressed` in the markup so the active window is exposed to assistive technology, not just conveyed by styling.
+
+- [ ] **Step 4: Verify in the browser**
+
+Start the dev stack and check the page renders, using the signed-in-session recipe from `docs/` (a signed-in browser session requires the `stack-raw` 127.0.0.1 flow — the portless origin cannot produce one in the in-app browser).
+
+Check with the Browser pane tools:
+
+1. `read_console_messages` — no errors.
+2. `read_page` — tiles, charts and table present.
+3. `read_network_requests` — `/admin-ui/metrics/overview` returns 200.
+4. `resize_window` at mobile and desktop, in both light and dark, confirming the table scrolls inside its wrapper and the page body does not scroll horizontally.
+5. `computer {action: "screenshot"}` for the PR.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/pages/admin/metrics.astro apps/web/src/styles/admin-metrics.css apps/web/src/layouts/AdminLayout.astro
+git commit -m "feat(web): add /admin/metrics adoption surface"
+```
+
+---
+
+### Task 8: Analytics Engine write path
+
+**Files:**
+
+- Modify: `apps/api/wrangler.jsonc` (add the `analytics_engine_datasets` binding)
+- Modify: `apps/api/src/adoption.ts` (write the data point)
+- Test: `apps/api/test/adoption-analytics.test.ts`
+
+**Interfaces:**
+
+- Consumes: `AdoptionEvent`, `AdoptionDimensions` from Task 1.
+- Produces: `function writeAdoptionPoint(env: Env, event: AdoptionEvent): void`
+
+- [ ] **Step 1: Add the binding**
+
+In `apps/api/wrangler.jsonc`, add after the `d1_databases` block:
+
+```jsonc
+  // Analytics Engine dataset for wide per-upload dimensions (surface, content
+  // type, client, plan, repo) that would never justify D1 columns. Purely
+  // additive: src/adoption.ts treats an absent ANALYTICS binding as a no-op,
+  // so deleting this block disables the breakdown panel and nothing else.
+  // Reads need ANALYTICS_API_TOKEN (an account token with Account Analytics:
+  // Read) set via `wrangler secret put` — there is no read binding.
+  "analytics_engine_datasets": [
+    {
+      "binding": "ANALYTICS",
+      "dataset": "uploads_adoption",
+    },
+  ],
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/api/test/adoption-analytics.test.ts`:
+
+```ts
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+import { writeAdoptionPoint } from "../src/adoption";
+
+interface Captured {
+  blobs?: unknown[];
+  doubles?: number[];
+  indexes?: string[];
+}
+
+function fakeAnalytics() {
+  const points: Captured[] = [];
+  return {
+    points,
+    binding: { writeDataPoint: (point: Captured) => points.push(point) },
+  };
+}
+
+describe("writeAdoptionPoint", () => {
+  it("writes one point per upload with the workspace as the index", () => {
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, {
+      metric: "upload",
+      workspace: "acme",
+      bytes: 2048,
+      dimensions: { surface: "api", contentType: "image/png", client: "uploads-cli/0.30.0" },
+    });
+    expect(analytics.points).toHaveLength(1);
+    expect(analytics.points[0]?.indexes).toEqual(["acme"]);
+    expect(analytics.points[0]?.doubles).toEqual([2048]);
+    expect(analytics.points[0]?.blobs).toEqual([
+      "acme",
+      "api",
+      "image/png",
+      "uploads-cli/0.30.0",
+      "",
+      "",
+    ]);
+  });
+
+  it("writes nothing for non-upload metrics", () => {
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, { metric: "gallery_created", workspace: "acme" });
+    expect(analytics.points).toHaveLength(0);
+  });
+
+  it("is a no-op when the binding is absent", () => {
+    expect(() =>
+      writeAdoptionPoint({} as unknown as Env, { metric: "upload", workspace: "acme", bytes: 1 }),
+    ).not.toThrow();
+  });
+
+  it("never throws when the binding itself fails", () => {
+    const env = {
+      ANALYTICS: {
+        writeDataPoint: () => {
+          throw new Error("AE down");
+        },
+      },
+    } as unknown as Env;
+    expect(() =>
+      writeAdoptionPoint(env, { metric: "upload", workspace: "acme", bytes: 1 }),
+    ).not.toThrow();
+  });
+
+  it("substitutes empty strings for absent dimensions so blob positions stay stable", () => {
+    const analytics = fakeAnalytics();
+    const env = { ANALYTICS: analytics.binding } as unknown as Env;
+    writeAdoptionPoint(env, { metric: "upload", workspace: "acme", bytes: 1 });
+    expect(analytics.points[0]?.blobs).toEqual(["acme", "", "", "", "", ""]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/test/adoption-analytics.test.ts`
+Expected: FAIL — `writeAdoptionPoint is not a function`.
+
+- [ ] **Step 4: Implement, and call it from `recordAdoptionSafe`**
+
+Add to `apps/api/src/adoption.ts`:
+
+```ts
+/**
+ * Blob positions are a contract with the SQL read path (analytics-engine.ts)
+ * — Analytics Engine has no column names, only ordinals. Append new
+ * dimensions at the END; never reorder or remove, or historical rows change
+ * meaning retroactively.
+ */
+export const BLOB_ORDER = [
+  "workspace",
+  "surface",
+  "contentType",
+  "client",
+  "plan",
+  "repo",
+] as const;
+
+/**
+ * One wide data point per upload. Upload-only by design: the other metrics are
+ * low-volume and fully served by D1, so sending them here would add a second
+ * place to look without adding an answer.
+ *
+ * Never throws and never awaits — an absent binding (self-hosters, tests,
+ * local dev) is a silent no-op.
+ */
+export function writeAdoptionPoint(env: Env, event: AdoptionEvent): void {
+  if (event.metric !== "upload") return;
+  const analytics = (env as { ANALYTICS?: AnalyticsEngineDataset }).ANALYTICS;
+  if (!analytics) return;
+  const d = event.dimensions ?? {};
+  try {
+    analytics.writeDataPoint({
+      // Sampling key: keeps one workspace's traffic from crowding out another.
+      indexes: [event.workspace],
+      blobs: [
+        event.workspace,
+        d.surface ?? "",
+        d.contentType ?? "",
+        d.client ?? "",
+        d.plan ?? "",
+        d.repo ?? "",
+      ],
+      doubles: [normalizeBytes(event.bytes)],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(JSON.stringify({ message: "adoption analytics write failed", error: message }));
+  }
+}
+```
+
+`BLOB_ORDER` is exported so the read path in Task 9 can be checked against it; nothing imports it at runtime, because Analytics Engine addresses columns by ordinal (`blob1`…`blob6`) rather than by name.
+
+In `recordAdoptionSafe`, call it before the D1 write so an AE write still happens if D1 is down:
+
+```ts
+export async function recordAdoptionSafe(
+  env: Env,
+  event: AdoptionEvent,
+  now = new Date(),
+): Promise<void> {
+  writeAdoptionPoint(env, event);
+  try {
+    await bumpDailyMetric(env.DB, event, now);
+  } catch (err) {
+    // ...unchanged...
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+pnpm vitest run apps/api/test/adoption-analytics.test.ts apps/api/test/adoption-sqlite.test.ts
+```
+
+Expected: PASS, both files.
+
+- [ ] **Step 6: Regenerate types, run the suite, and commit**
+
+```bash
+pnpm types && pnpm test
+git add apps/api/wrangler.jsonc apps/api/src/adoption.ts apps/api/test/adoption-analytics.test.ts apps/api/worker-configuration.d.ts
+git commit -m "feat(api): write upload adoption points to Analytics Engine"
+```
+
+---
+
+### Task 9: Analytics Engine read path and breakdown panel
+
+**Files:**
+
+- Create: `apps/api/src/analytics-engine.ts`
+- Modify: `apps/api/src/routes/admin-ui.ts` (add `GET /metrics/breakdown`)
+- Modify: `apps/web/src/pages/admin/metrics.astro` (add the lazily-loaded panel)
+- Test: `apps/api/src/analytics-engine.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing at runtime. `BLOB_COLUMN` below must stay positionally consistent with `BLOB_ORDER` in `adoption.ts` (Task 8) — AE addresses columns by ordinal, so this is a hand-maintained contract, not an import.
+- Produces:
+  - `type BreakdownDimension = "surface" | "contentType" | "client" | "plan" | "repo"`
+  - `interface BreakdownRow { value: string; events: number; bytes: number }`
+  - `type BreakdownResult = { available: true; rows: BreakdownRow[] } | { available: false; reason: string }`
+  - `function breakdownQuery(dimension: BreakdownDimension, days: number): string`
+  - `function fetchBreakdown(env: Env, dimension: BreakdownDimension, days: number, fetchImpl?: typeof fetch): Promise<BreakdownResult>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/src/analytics-engine.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { breakdownQuery, fetchBreakdown } from "./analytics-engine";
+
+function env(overrides: Record<string, unknown> = {}): Env {
+  return {
+    CLOUDFLARE_ACCOUNT_ID: "acct-123",
+    ANALYTICS_API_TOKEN: "tok-abc",
+    ...overrides,
+  } as unknown as Env;
+}
+
+function jsonFetch(payload: unknown, status = 200): typeof fetch {
+  return (async () => new Response(JSON.stringify(payload), { status })) as unknown as typeof fetch;
+}
+
+describe("breakdownQuery", () => {
+  it("selects the blob matching the requested dimension", () => {
+    expect(breakdownQuery("surface", 30)).toContain("blob2");
+    expect(breakdownQuery("repo", 30)).toContain("blob6");
+  });
+
+  it("multiplies by _sample_interval so sampled counts are scaled back up", () => {
+    expect(breakdownQuery("surface", 30)).toContain("_sample_interval");
+  });
+
+  it("windows by the requested number of days", () => {
+    expect(breakdownQuery("surface", 7)).toContain("INTERVAL '7' DAY");
+  });
+});
+
+describe("fetchBreakdown", () => {
+  it("returns rows on success", async () => {
+    const impl = jsonFetch({
+      data: [
+        { value: "api", events: 120, bytes: 5000 },
+        { value: "mcp", events: 40, bytes: 900 },
+      ],
+    });
+    const result = await fetchBreakdown(env(), "surface", 30, impl);
+    expect(result).toEqual({
+      available: true,
+      rows: [
+        { value: "api", events: 120, bytes: 5000 },
+        { value: "mcp", events: 40, bytes: 900 },
+      ],
+    });
+  });
+
+  it("reports unavailable when the token is missing", async () => {
+    const result = await fetchBreakdown(
+      env({ ANALYTICS_API_TOKEN: undefined }),
+      "surface",
+      30,
+      jsonFetch({}),
+    );
+    expect(result).toEqual({ available: false, reason: "not_configured" });
+  });
+
+  it("reports unavailable when the account id is missing", async () => {
+    const result = await fetchBreakdown(
+      env({ CLOUDFLARE_ACCOUNT_ID: undefined }),
+      "surface",
+      30,
+      jsonFetch({}),
+    );
+    expect(result).toEqual({ available: false, reason: "not_configured" });
+  });
+
+  it("reports unavailable on a non-OK response rather than throwing", async () => {
+    const result = await fetchBreakdown(env(), "surface", 30, jsonFetch({ errors: ["nope"] }, 403));
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("reports unavailable when the request throws", async () => {
+    const impl = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const result = await fetchBreakdown(env(), "surface", 30, impl);
+    expect(result).toEqual({ available: false, reason: "query_failed" });
+  });
+
+  it("rejects an unknown dimension without issuing a request", async () => {
+    let called = false;
+    const impl = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+    const result = await fetchBreakdown(env(), "bogus" as never, 30, impl);
+    expect(result).toEqual({ available: false, reason: "invalid_dimension" });
+    expect(called).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm vitest run apps/api/src/analytics-engine.test.ts`
+Expected: FAIL — `Failed to resolve import "./analytics-engine"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/api/src/analytics-engine.ts`:
+
+```ts
+/**
+ * Analytics Engine read path for the operator metrics breakdown panel.
+ *
+ * AE has no read binding, so this goes over the Cloudflare SQL API with an
+ * account token (ANALYTICS_API_TOKEN, an account token carrying "Account
+ * Analytics: Read", set via `wrangler secret put`). That token is distinct
+ * from the local wrangler token in .env.
+ *
+ * EVERY failure mode returns `{ available: false, reason }` rather than
+ * throwing: this panel is additive, and the D1-backed half of the metrics
+ * page must keep working when AE is unconfigured or unreachable.
+ *
+ * Retention is 90 days — AE is for recent dimensional curiosity, never the
+ * durable record. That lives in `daily_metrics`.
+ */
+
+const SQL_ENDPOINT = "https://api.cloudflare.com/client/v4/accounts";
+const DATASET = "uploads_adoption";
+
+export type BreakdownDimension = "surface" | "contentType" | "client" | "plan" | "repo";
+
+export interface BreakdownRow {
+  value: string;
+  events: number;
+  bytes: number;
+}
+
+export type BreakdownResult =
+  | { available: true; rows: BreakdownRow[] }
+  | { available: false; reason: string };
+
+/**
+ * Blob ordinals, matching BLOB_ORDER in adoption.ts. AE columns are
+ * positional, so this mapping is a contract with the write path — appending
+ * is safe, reordering rewrites the meaning of historical rows.
+ */
+const BLOB_COLUMN: Record<BreakdownDimension, string> = {
+  surface: "blob2",
+  contentType: "blob3",
+  client: "blob4",
+  plan: "blob5",
+  repo: "blob6",
+};
+
+export function breakdownQuery(dimension: BreakdownDimension, days: number): string {
+  const column = BLOB_COLUMN[dimension];
+  const window = Math.max(1, Math.min(90, Math.floor(days)));
+  // _sample_interval scales sampled rows back to a real-world estimate; a raw
+  // COUNT() under-reports whenever AE has sampled.
+  return `SELECT ${column} AS value,
+                 SUM(_sample_interval) AS events,
+                 SUM(double1 * _sample_interval) AS bytes
+          FROM ${DATASET}
+          WHERE timestamp > NOW() - INTERVAL '${window}' DAY
+          GROUP BY value
+          ORDER BY events DESC
+          LIMIT 20`;
+}
+
+export async function fetchBreakdown(
+  env: Env,
+  dimension: BreakdownDimension,
+  days: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<BreakdownResult> {
+  if (!(dimension in BLOB_COLUMN)) return { available: false, reason: "invalid_dimension" };
+
+  const account = (env as { CLOUDFLARE_ACCOUNT_ID?: string }).CLOUDFLARE_ACCOUNT_ID;
+  const token = (env as { ANALYTICS_API_TOKEN?: string }).ANALYTICS_API_TOKEN;
+  if (!account || !token) return { available: false, reason: "not_configured" };
+
+  try {
+    const res = await fetchImpl(`${SQL_ENDPOINT}/${account}/analytics_engine/sql`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: breakdownQuery(dimension, days),
+    });
+    if (!res.ok) return { available: false, reason: "query_failed" };
+    const payload = (await res.json()) as { data?: BreakdownRow[] };
+    return { available: true, rows: payload.data ?? [] };
+  } catch {
+    return { available: false, reason: "query_failed" };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm vitest run apps/api/src/analytics-engine.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Add the route**
+
+In `apps/api/src/routes/admin-ui.ts`, add the import:
+
+```ts
+import { fetchBreakdown, type BreakdownDimension } from "../analytics-engine";
+```
+
+Add the handler to the `adminUi` chain:
+
+```ts
+  .get("/metrics/breakdown", async (c) => {
+    const dimension = (c.req.query("dimension") ?? "surface") as BreakdownDimension;
+    const days = Number(c.req.query("days") ?? 30);
+    // Always 200: an unavailable AE is a normal, expected state that the page
+    // renders as a panel message, not an error the caller must handle.
+    return c.json(await fetchBreakdown(c.env, dimension, Number.isFinite(days) ? days : 30));
+  })
+```
+
+- [ ] **Step 6: Add the panel to the page**
+
+In `apps/web/src/pages/admin/metrics.astro`, add below the workspace table:
+
+```html
+<section class="metrics-section" id="breakdown-panel">
+  <h3>Upload breakdown</h3>
+  <p class="admin-hint">Last 90 days, from Analytics Engine. Sampled and approximate.</p>
+  <label for="breakdown-dimension">Group by</label>
+  <select id="breakdown-dimension" class="ul-select">
+    <option value="surface">Surface</option>
+    <option value="contentType">Content type</option>
+    <option value="client">Client</option>
+    <option value="repo">Repository</option>
+  </select>
+  <div id="breakdown-status" class="admin-status" hidden></div>
+  <div class="metrics-table-wrap">
+    <table class="admin-table" id="breakdown-table" aria-label="Upload breakdown"></table>
+  </div>
+</section>
+```
+
+In the client script, load it **after** the overview resolves so it never blocks first paint:
+
+```ts
+async function loadBreakdown(): Promise<void> {
+  const select = requireElement<HTMLSelectElement>("#breakdown-dimension", "admin");
+  const panelStatus = requireElement<HTMLElement>("#breakdown-status", "admin");
+  const table = requireElement<HTMLElement>("#breakdown-table", "admin");
+  try {
+    const res = await fetch(
+      `${apiOrigin}/admin-ui/metrics/breakdown?dimension=${select.value}&days=90`,
+      { credentials: "include", cache: "no-store" },
+    );
+    const body = (await res.json()) as
+      | { available: true; rows: { value: string; events: number; bytes: number }[] }
+      | { available: false; reason: string };
+    if (!body.available) {
+      table.innerHTML = "";
+      panelStatus.hidden = false;
+      panelStatus.textContent =
+        body.reason === "not_configured"
+          ? "Analytics Engine is not configured. Set ANALYTICS_API_TOKEN to enable this panel."
+          : "Breakdown is temporarily unavailable.";
+      return;
+    }
+    panelStatus.hidden = true;
+    // Every interpolated field is either escaped or coerced to a number.
+    // `value` carries client-supplied data (content type, client string, repo
+    // name) that reached AE straight from upload requests, so escapeHtml is
+    // load-bearing here, not decorative. The numeric columns are typed
+    // `number` but arrive as untyped JSON from an external API, so they are
+    // coerced rather than trusted.
+    const num = (input: unknown): string => {
+      const parsed = Number(input);
+      return Number.isFinite(parsed) ? String(parsed) : "0";
+    };
+    table.innerHTML =
+      `<thead><tr><th scope="col">Value</th><th scope="col" class="metrics-num">Uploads</th><th scope="col" class="metrics-num">Bytes</th></tr></thead><tbody>` +
+      body.rows
+        .map(
+          (row) =>
+            `<tr><td>${escapeHtml(row.value || "(none)")}</td><td class="metrics-num">${num(row.events)}</td><td class="metrics-num">${num(row.bytes)}</td></tr>`,
+        )
+        .join("") +
+      `</tbody>`;
+  } catch {
+    panelStatus.hidden = false;
+    panelStatus.textContent = "Breakdown is temporarily unavailable.";
+  }
+}
+```
+
+Call `void loadBreakdown();` at the end of `load()`'s success path, and bind it to the select's `change` event.
+
+- [ ] **Step 7: Verify the unconfigured path in the browser**
+
+With no `ANALYTICS_API_TOKEN` set locally, confirm with the Browser pane tools that the page renders fully, the overview tiles and charts populate, and the breakdown panel shows the "not configured" message with no console errors. This is the state production will be in until the secret is set, so it must look deliberate rather than broken.
+
+- [ ] **Step 8: Run the full suite and commit**
+
+```bash
+pnpm types && pnpm lint && pnpm test
+git add apps/api/src/analytics-engine.ts apps/api/src/analytics-engine.test.ts apps/api/src/routes/admin-ui.ts apps/web/src/pages/admin/metrics.astro
+git commit -m "feat: add Analytics Engine upload breakdown panel"
+```
+
+---
+
+## Post-merge operator checklist
+
+Not code — the manual steps that make the feature fully live.
+
+- [ ] The D1 migrations auto-apply on merge to main via CI. No manual `wrangler d1 migrations apply` is owed for either database.
+- [ ] Confirm the account API token carries **Account Analytics: Read**. If it does not, mint one that does.
+- [ ] Set the worker secret:
+
+```bash
+pnpm --filter @uploads/api exec wrangler secret put ANALYTICS_API_TOKEN
+```
+
+- [ ] Add `CLOUDFLARE_ACCOUNT_ID` to `apps/api/wrangler.jsonc`'s `vars` (the account id is not a secret) if it is not already present.
+- [ ] Load `/admin/metrics` in production and confirm the breakdown panel reports available.
+- [ ] Screenshot the page and attach it to the PR with the `github-screenshots` skill.

--- a/docs/superpowers/plans/2026-07-28-operator-adoption-metrics.md
+++ b/docs/superpowers/plans/2026-07-28-operator-adoption-metrics.md
@@ -439,110 +439,121 @@ git commit -m "feat(api): add daily_metrics table and adoption recording helper"
 - Modify: `apps/api/src/routes/files.ts:220` (pass `surface`)
 - Modify: `apps/api/src/github-promote.ts:154` (pass `surface`)
 - Modify: `apps/mcp/src/tools.ts:691` and `apps/mcp/src/tools.ts:753` (pass `surface`)
-- Test: `apps/api/test/adoption-hooks.test.ts`
+- Test: `apps/api/test/routes-files.test.ts` (extend the existing route-level harness — no new test file)
 
 **Interfaces:**
 
 - Consumes: `recordAdoptionSafe`, `AdoptionEvent`, `UploadSurface` from Task 1.
 - Produces: `putObject`'s `opts` gains `surface?: UploadSurface`.
 
-- [ ] **Step 1: Write the failing test**
+> **These tests must exercise the real wiring, not re-test Task 1's helper.** A test that calls `bumpDailyMetric` directly proves nothing about whether `putObject` invokes it. Assert through the existing route-level harness in `apps/api/test/routes-files.test.ts`, so a hook that is never called fails the test.
 
-Create `apps/api/test/adoption-hooks.test.ts`:
+- [ ] **Step 1: Give the route-level fake D1 a statement recorder**
+
+`makeFakeDB` in `apps/api/test/routes-files.test.ts` hand-matches SQL and no-ops the usage ledger. Extend it to record prepared statements so adoption writes become assertable. Inside `makeFakeDB`, before its `return`:
 
 ```ts
-/// <reference types="node" />
+const statements: { sql: string; args: unknown[] }[] = [];
+```
 
-import { describe, expect, it, vi } from "vitest";
-import { bumpDailyMetric } from "../src/adoption";
-import { SqliteD1, database } from "./helpers/sqlite-d1";
+Expose it on the returned object alongside `metadata`:
 
-const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
+```ts
+    statements,
+```
 
-/**
- * These assert the CONTRACT the hooks must satisfy, independent of the large
- * putObject integration surface: an upload records one `upload` event with the
- * stored byte size, and a delete records one `delete` event with a positive
- * byte figure.
- */
-describe("upload and delete recording contract", () => {
-  it("an upload of N bytes records count 1 and bytes N", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
-    try {
-      const db = database(sqlite);
-      await bumpDailyMetric(
-        db,
-        { metric: "upload", workspace: "acme", bytes: 2048, dimensions: { surface: "api" } },
-        new Date("2026-07-28T10:00:00Z"),
-      );
-      const row = await db
-        .prepare(
-          `SELECT count, bytes FROM daily_metrics WHERE metric = 'upload' AND workspace = 'acme'`,
-        )
-        .first<{ count: number; bytes: number }>();
-      expect(row).toEqual({ count: 1, bytes: 2048 });
-    } finally {
-      sqlite.close();
-    }
+And record each bind — in the object returned by `prepare(sql)`, inside `bind`, before `return this`:
+
+```ts
+statements.push({ sql: normalized, args: values });
+```
+
+Purely additive: no existing assertion in the file changes.
+
+- [ ] **Step 2: Write the failing wiring tests**
+
+Add to `apps/api/test/routes-files.test.ts`. Build the env exactly as the neighbouring put/delete tests in this file already do (same `FakeR2Bucket` and workspace-record setup, same `TOKEN`/`PNG` constants) — if they share a helper, reuse it under its real name rather than inventing one:
+
+```ts
+describe("adoption metrics wiring", () => {
+  /** Identify adoption writes by table, not by statement position. */
+  function adoptionWrites(db: { statements: { sql: string; args: unknown[] }[] }) {
+    return db.statements.filter((s) => s.sql.includes("INSERT INTO daily_metrics"));
+  }
+
+  it("records an upload event when a put succeeds", async () => {
+    const db = makeFakeDB();
+    const env = /* same env construction as the neighbouring put tests */;
+    const res = await app.request(
+      "/v1/files/shot.png",
+      { method: "PUT", headers: { authorization: `Bearer ${TOKEN}` }, body: PNG },
+      env,
+    );
+    expect(res.status).toBe(201);
+
+    const writes = adoptionWrites(db);
+    // One per-workspace row + one platform row.
+    expect(writes).toHaveLength(2);
+    expect(writes.map((w) => w.args[0])).toEqual(["upload", "upload"]);
+    expect(writes.map((w) => w.args[2]).sort()).toEqual(["", "default"]);
+    expect(writes[0]?.args[3]).toBe(PNG.byteLength);
   });
 
-  it("a delete of N bytes records the delete metric with positive bytes", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
-    try {
-      const db = database(sqlite);
-      await bumpDailyMetric(
-        db,
-        { metric: "delete", workspace: "acme", bytes: 2048 },
-        new Date("2026-07-28T10:00:00Z"),
-      );
-      const row = await db
-        .prepare(
-          `SELECT count, bytes FROM daily_metrics WHERE metric = 'delete' AND workspace = 'acme'`,
-        )
-        .first<{ count: number; bytes: number }>();
-      expect(row).toEqual({ count: 1, bytes: 2048 });
-    } finally {
-      sqlite.close();
-    }
+  it("records nothing when the put is rejected", async () => {
+    const db = makeFakeDB();
+    const env = /* same env construction */;
+    const res = await app.request(
+      "/v1/files/shot.png",
+      { method: "PUT", headers: { authorization: "Bearer wrong-token" }, body: PNG },
+      env,
+    );
+    expect(res.status).toBe(401);
+    expect(adoptionWrites(db)).toHaveLength(0);
   });
 
-  it("net stored change for a day is upload.bytes minus delete.bytes", async () => {
-    const sqlite = new SqliteD1(MIGRATION);
-    try {
-      const db = database(sqlite);
-      const at = new Date("2026-07-28T10:00:00Z");
-      await bumpDailyMetric(db, { metric: "upload", workspace: "acme", bytes: 5000 }, at);
-      await bumpDailyMetric(db, { metric: "delete", workspace: "acme", bytes: 2000 }, at);
-      const row = await db
-        .prepare(
-          `SELECT
-             SUM(CASE WHEN metric = 'upload' THEN bytes ELSE 0 END)
-           - SUM(CASE WHEN metric = 'delete' THEN bytes ELSE 0 END) AS net
-           FROM daily_metrics WHERE workspace = 'acme' AND day = '2026-07-28'`,
-        )
-        .first<{ net: number }>();
-      expect(row?.net).toBe(3000);
-    } finally {
-      sqlite.close();
-    }
-  });
-});
+  it("records a delete event with positive bytes when a delete removes an object", async () => {
+    const db = makeFakeDB();
+    const env = /* same env construction */;
+    await app.request(
+      "/v1/files/shot.png",
+      { method: "PUT", headers: { authorization: `Bearer ${TOKEN}` }, body: PNG },
+      env,
+    );
+    const before = adoptionWrites(db).length;
 
-describe("putObject surface plumbing", () => {
-  it("accepts a surface option without altering the result contract", async () => {
-    // Guard against the opts type regressing: this must typecheck.
-    const opts: { surface?: "api" | "mcp" | "promote" } = { surface: "mcp" };
-    expect(opts.surface).toBe("mcp");
+    const res = await app.request(
+      "/v1/files/shot.png",
+      { method: "DELETE", headers: { authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+
+    const deletes = adoptionWrites(db).slice(before);
+    expect(deletes).toHaveLength(2);
+    expect(deletes.map((w) => w.args[0])).toEqual(["delete", "delete"]);
+    // Positive magnitude — direction is carried by the metric, never the sign.
+    for (const write of deletes) expect(write.args[3] as number).toBeGreaterThan(0);
+  });
+
+  it("records no delete event when the key does not exist", async () => {
+    const db = makeFakeDB();
+    const env = /* same env construction */;
+    await app.request(
+      "/v1/files/absent.png",
+      { method: "DELETE", headers: { authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(adoptionWrites(db).filter((w) => w.args[0] === "delete")).toHaveLength(0);
   });
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 3: Run the tests to verify they fail**
 
-Run: `pnpm vitest run apps/api/test/adoption-hooks.test.ts`
-Expected: PASS for the contract tests only if Task 1 landed — they exercise `bumpDailyMetric` directly. If Task 1 is present these already pass; the real verification for this task is Step 5's typecheck plus the full suite. Proceed to Step 3.
+Run: `pnpm vitest run apps/api/test/routes-files.test.ts -t "adoption metrics wiring"`
+Expected: FAIL — `expect(writes).toHaveLength(2)` receives `0`, because no hook exists yet. That red state is the point: it proves these tests actually detect a missing hook.
 
-- [ ] **Step 3: Add `surface` to the `putObject` options type**
+- [ ] **Step 4: Add `surface` to the `putObject` options type**
 
 In `apps/api/src/files-core.ts`, inside the `opts?:` object literal of `putObject`'s signature, after the `metadata?: Record<string, string>;` member, add:
 
@@ -561,7 +572,7 @@ Add to the imports at the top of `files-core.ts`:
 import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 ```
 
-- [ ] **Step 4: Hook the upload event**
+- [ ] **Step 5: Hook the upload event**
 
 In `apps/api/src/files-core.ts`, immediately after the `await recordUsageSafe(env.DB, workspaceName, { bytes: reservedBytes > 0 ? 0 : deltaBytes, objects: replaced ? 0 : 1, uploads: 0 });` call inside `putObject`, add:
 
@@ -583,7 +594,7 @@ await recordAdoptionSafe(env, {
 });
 ```
 
-- [ ] **Step 5: Hook the delete event**
+- [ ] **Step 6: Hook the delete event**
 
 In `apps/api/src/files-core.ts`, in the delete path, immediately after the existing
 
@@ -607,7 +618,7 @@ await recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, byte
 
 Do **not** add a hook to the poster-cleanup delete below it: derived posters are an implementation detail, and counting them would inflate the delete series with events no operator initiated.
 
-- [ ] **Step 6: Pass `surface` from each caller**
+- [ ] **Step 7: Pass `surface` from each caller**
 
 In `apps/api/src/routes/files.ts`, change the `putObject` options argument from
 
@@ -625,7 +636,7 @@ In `apps/api/src/github-promote.ts`, add `surface: "promote"` to the options obj
 
 In `apps/mcp/src/tools.ts`, add `surface: "mcp"` to the options object at the first `putObject` call, and add `surface: "mcp"` to the `putOpts` object used by the second.
 
-- [ ] **Step 7: Typecheck and run the suite**
+- [ ] **Step 8: Typecheck and run the suite**
 
 ```bash
 pnpm types && pnpm test
@@ -633,10 +644,10 @@ pnpm types && pnpm test
 
 Expected: types clean; full suite PASS. Existing `files-core` tests continue to pass because `recordAdoptionSafe` never throws even when the test env has no real `daily_metrics` table.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
-git add apps/api/src/files-core.ts apps/api/src/routes/files.ts apps/api/src/github-promote.ts apps/mcp/src/tools.ts apps/api/test/adoption-hooks.test.ts
+git add apps/api/src/files-core.ts apps/api/src/routes/files.ts apps/api/src/github-promote.ts apps/mcp/src/tools.ts apps/api/test/routes-files.test.ts
 git commit -m "feat(api): record upload and delete adoption events"
 ```
 
@@ -650,16 +661,96 @@ git commit -m "feat(api): record upload and delete adoption events"
 - Modify: `apps/api/src/routes/galleries.ts` (gallery create handler)
 - Modify: `apps/api/src/github-comment-service.ts` (after a managed comment is successfully posted)
 - Modify: `apps/api/src/github-repo-links.ts` (after `recordRepoLink` actually creates a link)
-- Test: `apps/api/test/adoption-feature-events.test.ts`
+- Test: `apps/api/test/adoption-feature-events.test.ts` (vocabulary), plus wiring assertions added to `apps/api/test/github-repo-links-sqlite.test.ts` and `apps/api/test/routes-galleries.test.ts`
 
 **Interfaces:**
 
 - Consumes: `recordAdoptionSafe` from Task 1.
 - Produces: no new exported symbols.
 
-- [ ] **Step 1: Write the failing test**
+> **Assert the real wiring wherever a harness already exists.** Two of these four call sites have cheap existing harnesses — use them. The other two are covered by the vocabulary regression test plus typecheck, which is stated honestly rather than dressed up as end-to-end coverage.
 
-Create `apps/api/test/adoption-feature-events.test.ts`:
+- [ ] **Step 1: Write the failing wiring test for repo links**
+
+`apps/api/test/github-repo-links-sqlite.test.ts` already runs against a real `node:sqlite` D1, so `daily_metrics` can be asserted directly. Change its migration constant to apply both migrations:
+
+```ts
+const MIGRATIONS = [
+  "migrations/20260720120000_github_repo_links.sql",
+  "migrations/20260728120000_daily_metrics.sql",
+];
+```
+
+Update the existing `new SqliteD1(MIGRATION)` calls in the file to `new SqliteD1(MIGRATIONS)`, then add:
+
+```ts
+describe("repo link adoption metrics", () => {
+  async function repoLinkedCount(db: D1Database): Promise<number> {
+    const row = await db
+      .prepare(
+        `SELECT COALESCE(SUM(count), 0) AS n FROM daily_metrics
+         WHERE metric = 'repo_linked' AND workspace = 'acme'`,
+      )
+      .first<{ n: number }>();
+    return row?.n ?? 0;
+  }
+
+  it("records repo_linked on a first claim", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordRepoLink(db, "Acme/Web", "acme", "comment", 42);
+      expect(await repoLinkedCount(db)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not record when a second claim is ignored (first claim wins)", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const db = database(sqlite);
+      await recordRepoLink(db, "Acme/Web", "acme", "comment", 42);
+      await recordRepoLink(db, "Acme/Web", "beta", "comment", 43);
+      // Still exactly one event: the ignored INSERT must not count.
+      const row = await db
+        .prepare(
+          `SELECT COALESCE(SUM(count), 0) AS n FROM daily_metrics WHERE metric = 'repo_linked' AND workspace <> ''`,
+        )
+        .first<{ n: number }>();
+      expect(row?.n).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Write the failing wiring test for gallery creation**
+
+In `apps/api/test/routes-galleries.test.ts`, apply the same statement-recorder approach Task 2 added to `routes-files.test.ts` (record `{ sql, args }` on the fake D1's `bind`, expose a `statements` array), then add:
+
+```ts
+describe("gallery adoption metrics", () => {
+  it("records gallery_created when a gallery is created", async () => {
+    // Build the request exactly as the neighbouring create tests in this file do.
+    const writes = db.statements.filter((s: { sql: string }) =>
+      s.sql.includes("INSERT INTO daily_metrics"),
+    );
+    expect(writes).toHaveLength(2); // per-workspace + platform row
+    expect(writes.map((w: { args: unknown[] }) => w.args[0])).toEqual([
+      "gallery_created",
+      "gallery_created",
+    ]);
+  });
+});
+```
+
+If that suite's fake D1 already records statements, reuse what exists rather than adding a second mechanism.
+
+- [ ] **Step 3: Write the metric-vocabulary regression test**
+
+Create `apps/api/test/adoption-feature-events.test.ts`. This guards the metric names and their zero-byte shape; it does **not** claim to test wiring:
 
 ```ts
 /// <reference types="node" />
@@ -670,7 +761,7 @@ import { SqliteD1, database } from "./helpers/sqlite-d1";
 
 const MIGRATION = "migrations/20260728120000_daily_metrics.sql";
 
-describe("feature adoption metrics", () => {
+describe("feature adoption metric vocabulary", () => {
   it("records each feature metric under its own key with zero bytes", async () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
@@ -705,8 +796,11 @@ describe("feature adoption metrics", () => {
     const sqlite = new SqliteD1(MIGRATION);
     try {
       const db = database(sqlite);
-      const at = new Date("2026-07-28T10:00:00Z");
-      await bumpDailyMetric(db, { metric: "gallery_created", workspace: "acme" }, at);
+      await bumpDailyMetric(
+        db,
+        { metric: "gallery_created", workspace: "acme" },
+        new Date("2026-07-28T10:00:00Z"),
+      );
       const row = await db
         .prepare(`SELECT COUNT(*) AS n FROM daily_metrics WHERE metric = 'upload'`)
         .first<{ n: number }>();
@@ -718,12 +812,15 @@ describe("feature adoption metrics", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] **Step 4: Run the tests to verify they fail**
 
-Run: `pnpm vitest run apps/api/test/adoption-feature-events.test.ts`
-Expected: PASS (it exercises Task 1's helper directly). This file is the regression guard for the metric vocabulary; the wiring below is verified by the full suite in Step 4.
+```bash
+pnpm vitest run apps/api/test/github-repo-links-sqlite.test.ts apps/api/test/routes-galleries.test.ts -t "adoption metrics"
+```
 
-- [ ] **Step 3: Add the four call sites**
+Expected: FAIL — the repo-link and gallery wiring assertions find zero `daily_metrics` writes, because no hook exists yet.
+
+- [ ] **Step 5: Add the four call sites**
 
 In each file, import the helper:
 
@@ -778,7 +875,7 @@ if ((result.meta?.changes ?? 0) > 0) {
 
 Bind `result` to the existing `INSERT OR IGNORE` statement's `.run()` return value if it is not already captured.
 
-- [ ] **Step 4: Typecheck and run the suite**
+- [ ] **Step 6: Typecheck and run the suite**
 
 ```bash
 pnpm types && pnpm test
@@ -786,10 +883,10 @@ pnpm types && pnpm test
 
 Expected: types clean; full suite PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add apps/api/src/routes/workspaces.ts apps/api/src/routes/galleries.ts apps/api/src/github-comment-service.ts apps/api/src/github-repo-links.ts apps/api/test/adoption-feature-events.test.ts
+git add apps/api/src/routes/workspaces.ts apps/api/src/routes/galleries.ts apps/api/src/github-comment-service.ts apps/api/src/github-repo-links.ts apps/api/test/adoption-feature-events.test.ts apps/api/test/github-repo-links-sqlite.test.ts apps/api/test/routes-galleries.test.ts
 git commit -m "feat(api): record workspace, gallery, comment and repo-link adoption events"
 ```
 

--- a/docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md
+++ b/docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md
@@ -224,6 +224,19 @@ All on the existing in-process fake-D1. No new test infrastructure.
   R2's public host and never reach the worker, so views cannot be counted
   without redesigning how files are served. Shipping a "views" number that
   silently counts a fraction of traffic would be worse than omitting it.
+- **Presigned-upload undercounting.** `POST /sign` (`routes/files.ts`) mints a
+  presigned URL for a direct-to-bucket PUT that happens later, entirely
+  outside the Worker. Those uploads never invoke `putObject`, so they are
+  absent from `daily_metrics` and the dashboard's upload counts undercount
+  for any workspace using presigned uploads. The two metrics this affects
+  are NOT equally repairable: `workspace_usage` (current absolute state) can
+  be fixed after the fact by the existing reconcile sweep, which walks the
+  bucket directly. `daily_metrics` (change over time) cannot — once
+  discovered by reconcile, a past upload has no timestamp to attribute it to
+  a particular day. Counting at signing time would also be wrong, since a
+  client can request a signed URL and never use it. Closing this properly
+  needs a post-upload completion callback or storage-event ingestion, both
+  out of scope for this change.
 - **The digest email itself.** This design leaves the query seam; it does not
   build the email.
 - **Per-user tracking** beyond signup counts.

--- a/docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md
+++ b/docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md
@@ -1,0 +1,247 @@
+# Operator adoption metrics — design
+
+Date: 2026-07-28
+Status: approved, ready for planning
+
+## Goal
+
+Give operators one page that answers "is anyone actually using this, and is it
+growing?" — registrations, uploads per day, active workspaces, and which
+features get touched. Internal-only, so the bar is "accurate and cheap", not
+"polished". The aggregate queries are built so a future digest email can call
+them directly.
+
+## What exists today
+
+- **Admin shell** — `/admin` (workspaces), `/admin/users`, `/admin/oauth`,
+  `/admin/email`, sharing `apps/web/src/layouts/AdminLayout.astro`. Data comes
+  from `/admin-ui/*` on apps/api, gated by `requireAdminUser`.
+- **Two D1 databases** — `uploads-production` (workspace usage, CLI telemetry,
+  file metadata, PR activity) and `uploads-auth` (users, orgs, subscriptions).
+  apps/api has no binding into the auth database by design; it reaches auth
+  only over the `AUTH` service binding (see the ownership note at the top of
+  `apps/api/src/org-workspaces.ts`).
+- **No Analytics Engine binding anywhere.**
+- **Almost nothing is a time series.** `workspace_usage` is a running counter
+  with no date dimension. Workspaces live in KV with an optional `createdAt`
+  set only by the self-serve path. `uploads_telemetry_events` has real
+  timestamps but is anonymous, CLI-side, and opt-out, so it cannot be the
+  authoritative upload count.
+
+One exception, and it is a useful one: `user.created_at` and
+`organization.created_at` in the auth D1 are populated epoch-ms columns.
+**Registration history is therefore fully retroactive with no instrumentation
+at all.** Only uploads and feature counters start from deploy day.
+
+## Decisions
+
+| Decision   | Choice                                      | Why                                                                                                                                                                                 |
+| ---------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Storage    | Hybrid: D1 daily rollups + Analytics Engine | D1 owns the exact, durable, low-cardinality numbers that digest emails will quote; AE owns wide dimensional detail we would never add D1 columns for. Neither duplicates the other. |
+| Backfill   | None for uploads                            | No per-upload record exists to reconstruct from. Registrations come back complete anyway via `created_at`.                                                                          |
+| Page shape | Overview + per-workspace table              | Aggregates answer "growing?", the table answers "who?". AE breakdowns load lazily so their latency never blocks first paint.                                                        |
+| Charts     | Inline SVG, no library                      | Matches the zero-dependency style of the existing admin pages.                                                                                                                      |
+
+## Architecture
+
+### 1. Recording — `apps/api/src/adoption.ts`
+
+One exported entry point:
+
+```ts
+recordAdoption(env, event, ctx?): void   // never throws, never awaited on the hot path
+```
+
+It fans out to both sinks — a D1 upsert into `daily_metrics` and
+`env.ANALYTICS?.writeDataPoint(...)`. Both are wrapped and logged as structured
+JSON, following `recordUsageSafe` in `apps/api/src/usage.ts`: **a metrics
+failure must never fail an upload.** The AE binding is optional everywhere, so
+an absent binding (self-hosters, tests, local dev) is a silent no-op.
+
+Event kinds: `upload`, `delete`, `workspace_created`, `gallery_created`,
+`comment_posted`, `repo_linked`.
+
+`count` and `bytes` are always non-negative — a `delete` event records a
+positive byte figure under the `delete` metric rather than a negative one under
+`upload`. Net stored change for a day is `upload.bytes - delete.bytes`,
+computed at read time. Absolute stored totals continue to come from
+`workspace_usage`, which stays the source of truth for current state; this
+table only ever describes _change over time_.
+
+**Only `upload` events are written to Analytics Engine.** The other kinds are
+low-volume and fully served by D1, so sending them to AE would add a second
+place to look without adding an answer.
+
+The upload hook sits in `putObject` (`apps/api/src/files-core.ts`, immediately
+after the existing `recordUsageSafe` call) — the object is durably stored by
+then, and all four callers (the REST files route, `github-promote`, and two
+hosted-MCP tools) funnel through it. `putObject`'s `opts` gains an optional
+`surface: "api" | "mcp" | "promote"` that each caller passes as a literal;
+there is no server-side way to tell a CLI request from any other API request,
+so the finer-grained client identity comes from the existing provenance bag.
+
+### 2. D1 schema
+
+```sql
+CREATE TABLE daily_metrics (
+  metric    TEXT NOT NULL,
+  day       TEXT NOT NULL,               -- 'YYYY-MM-DD', UTC
+  workspace TEXT NOT NULL DEFAULT '',    -- '' = the platform-total row
+  count     INTEGER NOT NULL DEFAULT 0,
+  bytes     INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (metric, day, workspace)
+);
+
+-- Grouped per-workspace scans, served entirely from the index.
+CREATE INDEX daily_metrics_window_idx
+  ON daily_metrics (metric, day, workspace, count, bytes);
+
+-- Headline trend series: exactly one entry per day in the window.
+CREATE INDEX daily_metrics_platform_idx
+  ON daily_metrics (metric, day, count, bytes)
+  WHERE workspace = '';
+```
+
+Writes are blind upserts — `INSERT ... ON CONFLICT(metric, day, workspace) DO
+UPDATE SET count = count + excluded.count, bytes = bytes + excluded.bytes` —
+with no preceding `SELECT`.
+
+Each recorded event writes two rows: the per-workspace row and the platform
+row (`workspace = ''`). D1 has a single writer per database, so the "hot global
+row" concern that would apply to a multi-master store does not apply here.
+
+Key order is `(metric, day, workspace)` so a single metric's day range is
+contiguous. Retention is unbounded: every query is windowed by `day >= ?`, so
+old rows are never scanned and there is nothing to gain from rolling them up.
+
+### 3. Query efficiency
+
+D1 bills rows read, so the read path is the design constraint. Four measures,
+following the precedent set by `20260722180000_file_metadata_value_covering_idx.sql`
+(widened to covering because a sort-before-`LIMIT` billed rows proportional to
+the entire match set) and the partial `auth_tokens_minting_user_idx`:
+
+1. **Covering indexes.** Both indexes above carry `count` and `bytes`, so
+   aggregate queries are served from the index with no table lookup per row.
+2. **Pre-aggregated platform rows.** The headline trend charts read from
+   `daily_metrics_platform_idx` and cost exactly _days_ entries — independent
+   of how many workspaces exist. Without this they would cost
+   _days × active workspaces_ on every page load.
+3. **Sparsity.** A row exists only for a (metric, day, workspace) that actually
+   had activity. The leaderboard scan is therefore proportional to real
+   activity, not to workspaces × window length.
+4. **Cached overview.** The composed overview payload is cached in KV under a
+   `metrics:` prefix (10-minute TTL, `?fresh=1` bypasses). This bounds cost by
+   elapsed time rather than by page loads or refresh-mashing, and the future
+   digest cron reuses the same payload. These keys are not workspace records,
+   so the `mutateWorkspaceRecord` discipline that governs `ws:` keys does not
+   apply — but they must stay under the `metrics:` prefix so the two never mix.
+
+Write-path cost is constant per event (two upserts, ~2 rows read to locate the
+conflict targets) and does not grow with history.
+
+**Active workspaces needs no instrumentation of its own.** It is
+`COUNT(DISTINCT workspace) WHERE metric = 'upload' AND day >= ? AND workspace != ''`,
+served from `daily_metrics_window_idx`. "Active" means _uploaded at least once
+in the window_ — a deliberate choice over "signed in", because uploading is the
+product's actual job and sign-ins are not recorded here.
+
+Auth-side queries need the same care: the all-time `COUNT(*)` over `user` reads
+every row, and the signup grouping needs an index on `user.created_at` to stay
+windowed. Both sit behind the same overview cache.
+
+### 4. Analytics Engine
+
+Binding `ANALYTICS` over a new `uploads_adoption` dataset. One wide data point
+per upload — blobs: workspace, surface, content type, client (from the existing
+provenance bag, e.g. `uploads-cli/0.30.0`), plan, repo; doubles: bytes.
+
+Reads go through a new `apps/api/src/analytics-engine.ts`, which POSTs to
+`/accounts/{id}/analytics_engine/sql` with an injectable fetch for tests and
+applies `_sample_interval` multiplication to counts. It requires
+`ANALYTICS_API_TOKEN` as a **worker secret** (`wrangler secret put`), distinct
+from the local wrangler token in `.env`, and an account token carrying
+**Account Analytics: Read**.
+
+**The entire AE read path fails soft.** An unset token, a missing account id, or
+an API error returns `{ available: false, reason }` and the panel renders an
+unavailable state. The page is fully functional on D1 alone — AE is additive,
+never load-bearing.
+
+### 5. Read endpoints
+
+- `GET /admin-ui/metrics/overview?days=30` — D1 queries and the AUTH call
+  issued in parallel, whole response cached per window size.
+- `GET /admin-ui/metrics/breakdown?dimension=surface&days=30` — AE-backed,
+  fetched lazily by the page.
+- `GET /internal/metrics` on apps/auth — signup-by-day plus totals from its own
+  D1, reached over the `AUTH` service binding. Never a direct cross-database
+  read.
+
+Query functions live in `apps/api/src/adoption-queries.ts` as pure
+`(db, range) => data` with no Hono or Request dependency. That is the seam a
+future digest-email cron calls directly, with no HTTP hop.
+
+### 6. Page — `/admin/metrics`
+
+New nav entry in `AdminLayout.astro`; `AdminSection` gains `"metrics"`.
+Top to bottom: stat tiles (users, workspaces, active 7d/30d, uploads, stored
+bytes) → 7/30/90-day trend charts → sortable workspace table (uploads in
+window, stored bytes, last active, plan, members) → lazily-loaded AE breakdown
+panel with its unavailable state. New `apps/web/src/styles/admin-metrics.css`,
+per the existing per-page CSS convention.
+
+### 7. Error handling
+
+- Recording never throws and never blocks a request; failures log structured
+  JSON and continue.
+- Missing `ANALYTICS` binding → writes no-op. Missing or unscoped read token →
+  panel unavailable, rest of page unaffected.
+- Cache read/write failures fall through to a live query.
+- `/admin-ui/*` enforces `requireAdminUser` server-side; the client-side gate in
+  `AdminLayout` remains a UX affordance only.
+
+### 8. Testing
+
+- `adoption.test.ts` — accumulation, UTC day rollover, delete deltas, D1
+  failure swallowed, absent AE binding is a no-op, platform row written
+  alongside the workspace row.
+- `admin-ui.test.ts` additions — overview shape, admin gating, cache hit/bypass,
+  AE-unavailable path.
+- auth `internal-routes.test.ts` addition — signup aggregation and windowing.
+- AE SQL builder unit test with a stub fetch, covering `_sample_interval`
+  multiplication.
+
+All on the existing in-process fake-D1. No new test infrastructure.
+
+## Out of scope
+
+- **Page views / read traffic.** Public file bytes are served straight from
+  R2's public host and never reach the worker, so views cannot be counted
+  without redesigning how files are served. Shipping a "views" number that
+  silently counts a fraction of traffic would be worse than omitting it.
+- **The digest email itself.** This design leaves the query seam; it does not
+  build the email.
+- **Per-user tracking** beyond signup counts.
+- **Backfill.** See the decision table.
+
+## Suggested build order
+
+Each step leaves the tree shippable:
+
+1. Migration + `adoption.ts` + the `putObject` hook — recording starts
+   accumulating immediately, nothing reads it yet. Landing this first means the
+   charts have real data by the time the page exists.
+2. `adoption-queries.ts` + `/internal/metrics` on apps/auth + the overview
+   endpoint and its cache.
+3. The `/admin/metrics` page and nav entry — D1-backed only.
+4. The AE binding, write path, read module, and breakdown panel.
+
+## Deployment notes
+
+- The D1 migration auto-applies on merge to main via CI; no manual wrangler
+  step is owed.
+- The AE dataset is created implicitly by the first `writeDataPoint`.
+- `ANALYTICS_API_TOKEN` must be set with `wrangler secret put` before the
+  breakdown panel reports as available. Until then the page works, minus that
+  panel.

--- a/docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md
+++ b/docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md
@@ -29,7 +29,11 @@ them directly.
   authoritative upload count.
 
 One exception, and it is a useful one: `user.created_at` and
-`organization.created_at` in the auth D1 are populated epoch-ms columns.
+`organization.created_at` in the auth D1 are populated epoch-**second**
+columns (drizzle `integer(..., { mode: "timestamp" })` divides by 1000 on
+write — `timestamp_ms` would be milliseconds, and this is not that). Grouping
+SQL must therefore read `strftime('%Y-%m-%d', created_at, 'unixepoch')` with no
+`/1000`.
 **Registration history is therefore fully retroactive with no instrumentation
 at all.** Only uploads and feature counters start from deploy day.
 


### PR DESCRIPTION
Adds an operator-only `/admin/metrics` page showing user and workspace registrations, uploads per day, active workspaces, and feature adoption.

Spec: `docs/superpowers/specs/2026-07-28-operator-adoption-metrics-design.md`
Plan: `docs/superpowers/plans/2026-07-28-operator-adoption-metrics.md`

## How it works

**D1 daily rollups** — a new `daily_metrics` table accumulates per-day counters, written from a never-throwing helper hooked into the accounting choke points that already write D1. Metrics failures log and continue; they can never fail an upload.

**Analytics Engine** — one wide data point per upload carries the dimensions that would never justify D1 columns (surface, content type, client, repo). Additive only: an absent binding is a silent no-op, and the whole read path fails soft.

The split is deliberate — D1 answers "how are we growing" and keeps the exact numbers forever; AE answers "who/what/how" within its 90-day retention. Neither is a copy of the other.

**Registration history is retroactive.** `user.created_at` and `organization.created_at` already exist in the auth D1, so signup charts are complete from day one with zero instrumentation. Only uploads and feature counters start accumulating at deploy.

## Query efficiency

D1 bills rows read, so the read path drove the design:

- Both indexes are **covering** (carry `count`/`bytes`), so aggregates never touch the table.
- A **pre-aggregated platform row** (`workspace = ''`) makes the headline trend charts cost exactly *days* index entries instead of *days × workspaces* — independent of how many workspaces exist.
- The table is **sparse** — a row exists only for a (metric, day, workspace) with real activity — so even the leaderboard scan is proportional to actual usage.
- The composed overview is **KV-cached** (10 min, `?fresh=1` bypasses), bounding cost by elapsed time rather than by page loads.

Review caught one query that defeated this: `featureTotals` left the index's leading column unconstrained and produced a full `SCAN`, walking every platform row ever written. It now issues one bound-metric seeking query per metric in a single batch — `SEARCH ... (metric=? AND day>?)`.

## Notable defects caught in review

Every task passed an independent review before the next began. Six defects that lint, typecheck and the test suite all missed:

- **Critical** — the auth call omitted `x-uploads-internal: 1`, so the auth worker would have 404'd every request in production and **every signup number would have silently rendered zero**. Tests missed it because the stub matched on pathname only.
- **Important** — `featureTotals` full-index scan (above).
- **Important** — `dimension in BLOB_COLUMN` walked the prototype chain, so `?dimension=toString` bypassed the SQL allowlist. Now `Object.hasOwn`.
- **Important** — `?since=2026-13-45` passed a shape-only regex, became `Invalid Date`, and returned **200 with zeros** instead of 400.
- **Important** — an event with an empty workspace collided with the platform sentinel and double-counted.
- **Important ×2** — chart axis labels misrepresented their own gridlines (duplicate ticks at low maxima; a gridline drawn at 2.5 but labelled 3).

The last one was only visible by looking at a rendered chart, which is also how two layout bugs surfaced.

## Deliberately out of scope

**Page views / read traffic.** Public file bytes are served straight from R2's public host and never reach the worker, so views aren't countable without redesigning how files are served. A "views" number that silently counted a fraction of traffic would be worse than omitting it.

Also out: the digest email itself (the query functions are pure `(db, range) => data` with no HTTP dependency, which is the seam a future cron calls), and any per-user tracking beyond signup counts.

## Owed after merge

The D1 migrations auto-apply via CI — nothing manual there. The breakdown panel stays in its "not configured" state until:

```bash
pnpm --filter @uploads/api exec wrangler secret put ANALYTICS_API_TOKEN
```

plus `CLOUDFLARE_ACCOUNT_ID` in `apps/api/wrangler.jsonc` vars. The token needs **Account Analytics: Read** — I couldn't verify the existing operator token carries that scope. The page is fully functional without it, and no live AE response has been exercised yet, so a dry run is worth doing once the secret is set.

## Follow-ups (non-blocking)

- The `plan` dimension is wired end to end (blob5) but no caller sets it — either source it from `subscriptionForOrg` or remove the plumbing.
- The internal-header regression guard is indirect: the assertion inside the stub is swallowed by the code's own `try/catch`, and what actually fails is a distant literal. Correct today, fragile to refactors.
- `workspace-teardown.ts` bulk-deletes via `store.delete(batch)`, bypassing the delete hook. That's intentional — a purge is an admin action, and counting 10k objects would make net-bytes/day meaningless — but it deserves a comment saying so.

Unrelated to this branch: CI has no `pnpm typecheck` job at all (only `pnpm types` codegen before oxlint), so `tsc` cleanliness is verified locally but not enforced.

## Verification

3491 tests passing (257 files), `pnpm typecheck` clean, `pnpm lint` clean. The page was browser-verified against a live local stack at each step, including the unconfigured-AE state that production will show until the secret is set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin Metrics dashboard with adoption summaries, charts, workspace activity, feature totals, and configurable time windows.
  * Added upload breakdowns by surface, content type, client, or repository when analytics is configured.
  * Added tracking for uploads, deletes, workspace and gallery creation, comments, and repository links.
  * Added signup metrics and cached metrics overview responses.
* **Bug Fixes**
  * Metrics collection failures no longer interrupt normal file and workspace operations.
* **Tests**
  * Added comprehensive coverage for metrics recording, aggregation, caching, authorization, and graceful failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->