### PR TITLE
fix(cli): accept --meta on meta set, and make unknown commands correct themselves

### DIFF
--- a/.changeset/lucky-moons-tap.md
+++ b/.changeset/lucky-moons-tap.md
@@ -1,0 +1,10 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Show a runnable example when a command is missing an argument. `uploads put`
+now answers `error: put requires at least one file` followed by
+`uploads put ./shot.png --pr 123`, so the fix is copy-pasteable instead of one
+`--help` away. Applies to put, attach, find, delete, meta, gallery, comment,
+screenshot, annotate, and config set, plus the unknown-subcommand errors. With
+`--json` the example comes back as an `example` field on the error payload.

--- a/.changeset/nervous-pugs-invent.md
+++ b/.changeset/nervous-pugs-invent.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Stop hiding the reason a command failed (#545). A missing argument used to
+print the command's whole help block with no error line in it — `uploads put`,
+`find`, `delete`, `meta`, `gallery`, `screenshot`, `annotate`, and
+`config set` all did this. Each now prints one `error:` line naming what is
+missing, plus the `uploads <cmd> --help` hint, so trimmed output still carries
+the reason and `--json` gets a real error payload. An unknown `config`
+subcommand does the same instead of dumping the config help.

--- a/.changeset/olive-hounds-smile.md
+++ b/.changeset/olive-hounds-smile.md
@@ -1,0 +1,11 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Smooth out three metadata papercuts agents hit (#545). `meta set` and `find`
+now accept `--meta k=v`, the same spelling `put`, `attach`, `screenshot`, and
+`list` use, alongside the positional `k=v` form. An unknown command answers
+with a "did you mean" suggestion — `uploads set-metadata` points at
+`uploads meta set` — instead of a help dump that never mentioned `meta`. That
+output is also short now, so an agent that pipes through `tail` still sees the
+error; with `--json` it comes back as `{ error, code, didYouMean }` on stdout.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,11 @@ This guide covers the everyday flows. For the full command list, the globals,
 and the exit codes, run `uploads help --all` or see
 [`packages/uploads/README.md`](../packages/uploads/README.md).
 
+Errors are short by design. A failure prints one `error:` line on stderr and a
+hint that names the help you want, so output you trim in a script or an agent
+still carries the reason. A mistyped command suggests the closest real one —
+`uploads set-metadata` answers `did you mean: uploads meta set`.
+
 ## Getting started
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,9 +9,18 @@ This guide covers the everyday flows. For the full command list, the globals,
 and the exit codes, run `uploads help --all` or see
 [`packages/uploads/README.md`](../packages/uploads/README.md).
 
-Errors are short by design. A failure prints one `error:` line on stderr and a
-hint that names the help you want, so output you trim in a script or an agent
-still carries the reason. A mistyped command suggests the closest real one —
+Errors are short by design. A failure prints one `error:` line on stderr, a
+correct example invocation when an argument is missing, and a hint that names
+the help you want. Output you trim in a script or an agent still carries the
+reason:
+
+```text
+error: put requires at least one file
+  uploads put ./shot.png --pr 123
+hint: uploads put --help
+```
+
+A mistyped command suggests the closest real one —
 `uploads set-metadata` answers `did you mean: uploads meta set`.
 
 ## Getting started

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -216,7 +216,11 @@ uploads attach ./mobile-checkout.png \
 uploads find app=web path=/settings
 uploads meta get screenshots/myapp/42/settings.webp
 uploads meta set screenshots/myapp/42/settings.webp page=onboarding --delete path
+uploads meta set screenshots/myapp/42/settings.webp --meta page=onboarding
 ```
+
+`meta set` and `find` take pairs in either spelling: positional `k=v`, or the
+repeatable `--meta k=v` flag that `put`, `attach`, `screenshot`, and `list` use.
 
 Rules: keys match `^[a-z][a-z0-9._-]{0,63}$` (lowercase; dots allowed); values
 are 1–512 printable ASCII; at most 24 pairs per request. Re-uploading **with**

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -51,7 +51,8 @@ Commands: `attach`, `put`, `screenshot`, `annotate`, `gallery`, `comment`, `list
 `uploads <cmd> --help`.
 
 **Errors:** every failure prints a short `error:` line on stderr, followed by a
-hint — never a help dump, so trimmed output (`| tail`) still carries the reason.
+runnable example when an argument is missing, then a hint — never a help dump,
+so trimmed output (`| tail`) still carries the reason.
 A mistyped command also suggests the closest real one: `uploads set-metadata`
 answers `did you mean: uploads meta set`. With `--json`, an unknown command
 returns `{ "error", "code": "USAGE", "didYouMean" }` on stdout.

--- a/packages/uploads/README.md
+++ b/packages/uploads/README.md
@@ -50,6 +50,12 @@ Commands: `attach`, `put`, `screenshot`, `annotate`, `gallery`, `comment`, `list
 `uploads help --all` (or `--help --all`) for the full command list. Per-command:
 `uploads <cmd> --help`.
 
+**Errors:** every failure prints a short `error:` line on stderr, followed by a
+hint — never a help dump, so trimmed output (`| tail`) still carries the reason.
+A mistyped command also suggests the closest real one: `uploads set-metadata`
+answers `did you mean: uploads meta set`. With `--json`, an unknown command
+returns `{ "error", "code": "USAGE", "didYouMean" }` on stdout.
+
 **Shell completion:** `uploads completion bash|zsh|fish` prints a script to
 stdout. Example (zsh): `uploads completion zsh > ~/.zsh/completions/_uploads`.
 

--- a/packages/uploads/src/cli-args.ts
+++ b/packages/uploads/src/cli-args.ts
@@ -95,9 +95,18 @@ export function parseArgv(argv: string[]): ParsedArgv {
 }
 
 export class UsageError extends Error {
-  constructor(message: string) {
+  /**
+   * A correct invocation to show under the error. Agents pattern-match on a
+   * runnable line far better than on prose, so every "you left out a required
+   * argument" error should carry one — the CLI prints it, and `--json`
+   * callers get it as `example`.
+   */
+  readonly example?: string;
+
+  constructor(message: string, options: { example?: string } = {}) {
     super(message);
     this.name = "UsageError";
+    this.example = options.example;
   }
 }
 

--- a/packages/uploads/src/cli-help.ts
+++ b/packages/uploads/src/cli-help.ts
@@ -223,6 +223,41 @@ ${style.muted("     uploads help --all    this full listing")}
 `;
 }
 
+export interface UnknownCommandOptions {
+  /** The command the caller typed. */
+  command: string;
+  /** Suggested command phrase, from `suggestCommand`. */
+  suggestion?: string;
+  /** Catalog summary for the suggestion, shown beside it. */
+  summary?: string;
+  color?: boolean;
+  style?: CliStyle;
+}
+
+/**
+ * Unknown-command output: deliberately a handful of lines, not the root help
+ * dump (issue #545). Agents trim command output (`| tail -20`), and a 27-line
+ * banner pushed the one line that mattered — the error — out of the window.
+ * Short output survives truncation, and the pointers below still lead to the
+ * full list.
+ */
+export function formatUnknownCommand(options: UnknownCommandOptions): string {
+  const style =
+    options.style ??
+    createStyle(options.color !== undefined ? options.color : colorEnabled(process.stderr));
+  const lines = [style.error(`unknown command: ${options.command}`)];
+  if (options.suggestion) {
+    const summary = options.summary ? `  ${style.body(options.summary)}` : "";
+    lines.push("", `did you mean: ${style.command(`uploads ${options.suggestion}`)}${summary}`);
+  }
+  lines.push(
+    "",
+    `  ${padCmd("uploads help --all", CMD_WIDTH, style)}${style.body("Full command list")}`,
+    `  ${padCmd("uploads <cmd> --help", CMD_WIDTH, style)}${style.body("Per-command options and examples")}`,
+  );
+  return `${lines.join("\n")}\n`;
+}
+
 /**
  * Root help text. Default is a short essentials view; pass `full: true` for
  * the complete command + config dump (`uploads help --all`).

--- a/packages/uploads/src/cli-suggest.ts
+++ b/packages/uploads/src/cli-suggest.ts
@@ -1,0 +1,147 @@
+/**
+ * "Did you mean" for a mistyped root command (issue #545).
+ *
+ * The unknown-command path used to answer with the essentials list, which
+ * can't correct a wrong guess for anything outside it — `uploads set-metadata`
+ * printed a help dump that never mentions `meta`. Two sources feed a
+ * suggestion: a table of spellings agents actually reach for, and an edit
+ * distance over the catalog. Same rule as the metadata vocabulary
+ * (metadata-vocab.ts): suggest, never silently rewrite.
+ */
+import { ROOT_COMMANDS } from "./cli-catalog.js";
+
+/**
+ * Wrong-but-natural spellings, mapped to the command phrase that does the
+ * job. Values are full phrases (`meta set`), not just root names, because the
+ * work an agent wants often lives on a subcommand.
+ */
+const COMMAND_ALIASES: Readonly<Record<string, string>> = {
+  // metadata — the case in issue #545
+  setmetadata: "meta set",
+  setmeta: "meta set",
+  metadata: "meta set",
+  metaset: "meta set",
+  tag: "meta set",
+  tags: "meta set",
+  label: "meta set",
+  getmetadata: "meta get",
+  getmeta: "meta get",
+  showmetadata: "meta get",
+  metaget: "meta get",
+  // upload
+  upload: "put",
+  uploadfile: "put",
+  cp: "put",
+  copy: "put",
+  send: "put",
+  // listing and search
+  ls: "list",
+  files: "list",
+  objects: "list",
+  search: "find",
+  query: "find",
+  filter: "find",
+  // removal
+  rm: "delete",
+  remove: "delete",
+  del: "delete",
+  destroy: "delete",
+  // capture
+  capture: "screenshot",
+  shot: "screenshot",
+  snap: "screenshot",
+  screengrab: "screenshot",
+  screencapture: "screenshot",
+  // session
+  signin: "login",
+  auth: "login",
+  authenticate: "login",
+  signout: "logout",
+  // github
+  pr: "attach",
+  issue: "attach",
+  upsertcomment: "comment",
+};
+
+/** Compare on letters and digits only, so `set-metadata` ≡ `set_metadata`. */
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/** Plain Levenshtein distance (two-row); inputs here are a few characters. */
+function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      row[j] = Math.min(prev[j] + 1, row[j - 1] + 1, prev[j - 1] + cost);
+    }
+    prev = row;
+  }
+  return prev[b.length];
+}
+
+/** Crude de-pluralizer, so `galleries` still reaches `gallery`. */
+function singular(value: string): string {
+  if (value.endsWith("ies") && value.length > 4) return `${value.slice(0, -3)}y`;
+  if (value.endsWith("es") && value.length > 3) return value.slice(0, -2);
+  if (value.endsWith("s") && value.length > 3) return value.slice(0, -1);
+  return value;
+}
+
+/** Short words tolerate one typo, longer ones two. */
+function threshold(length: number): number {
+  if (length <= 3) return 0;
+  if (length <= 5) return 1;
+  return 2;
+}
+
+/**
+ * The command phrase a mistyped command most likely meant, or undefined when
+ * nothing is close enough to be worth printing. Aliases win over distance so
+ * `metadata` resolves to `meta set` rather than the bare `meta` group.
+ */
+export function suggestCommand(input: string): string | undefined {
+  const norm = normalize(input);
+  if (!norm) return undefined;
+
+  const alias = COMMAND_ALIASES[norm];
+  if (alias) return alias;
+
+  let best: { phrase: string; distance: number } | undefined;
+  const consider = (candidate: string, phrase: string, allowContainment: boolean): void => {
+    // A plural or a trailing qualifier (`screenshots`, `put-file`) is the same
+    // intent, not a typo — treat containment as a very strong match.
+    const contained =
+      allowContainment &&
+      candidate.length >= 3 &&
+      (norm.startsWith(candidate) || candidate.startsWith(norm));
+    const distance = contained
+      ? 0
+      : Math.min(editDistance(norm, candidate), editDistance(singular(norm), candidate));
+    if (!contained && distance > threshold(Math.max(norm.length, candidate.length))) return;
+    if (!best || distance < best.distance) best = { phrase, distance };
+  };
+
+  for (const cmd of ROOT_COMMANDS) consider(normalize(cmd.name), cmd.name, true);
+  // Aliases join the fuzzy pass too, so a typo *of* a synonym (`uplaod`) still
+  // lands. No containment for these — an alias is a whole word, and `tag` as a
+  // prefix would swallow unrelated input.
+  for (const [spelling, phrase] of Object.entries(COMMAND_ALIASES)) {
+    consider(spelling, phrase, false);
+  }
+  return best?.phrase;
+}
+
+/** Catalog summary for a suggested phrase (`meta set` → the subcommand's). */
+export function commandSummary(phrase: string): string | undefined {
+  const [name, sub] = phrase.split(" ");
+  const cmd = ROOT_COMMANDS.find((c) => c.name === name);
+  if (!cmd) return undefined;
+  if (!sub) return cmd.summary;
+  return cmd.subcommands?.find((s) => s.name === sub)?.summary;
+}

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -172,7 +172,7 @@ function errorOut(err: unknown, format: OutputFormat): void {
     err instanceof UploadsError
       ? { error: err.message, code: err.code, status: err.status }
       : err instanceof UsageError
-        ? { error: err.message, code: "USAGE" }
+        ? { error: err.message, code: "USAGE", ...(err.example ? { example: err.example } : {}) }
         : { error: err instanceof Error ? err.message : String(err) };
 
   if (format === "json") {
@@ -193,6 +193,12 @@ function errorOut(err: unknown, format: OutputFormat): void {
 
   if (msg.includes("\n")) process.stderr.write(`${msg}\n`);
   else process.stderr.write(`error: ${msg}\n`);
+
+  // A runnable line beats prose for both agents and humans; the `--help`
+  // pointer that follows stays for the full option list.
+  if (err instanceof UsageError && err.example) {
+    process.stderr.write(`  ${err.example}\n`);
+  }
 
   if (err instanceof UploadsError) {
     const hint = ERROR_HINTS[err.code];

--- a/packages/uploads/src/cli.ts
+++ b/packages/uploads/src/cli.ts
@@ -9,7 +9,9 @@ import {
   parseCommandArgs,
   UsageError,
 } from "./cli-args.js";
-import { formatRootHelp, wantsFullHelp } from "./cli-help.js";
+import { formatRootHelp, formatUnknownCommand, wantsFullHelp } from "./cli-help.js";
+import { commandSummary, suggestCommand } from "./cli-suggest.js";
+import { writeJson } from "./io.js";
 import { colorEnabled, createStyle } from "./cli-style.js";
 import {
   runPut,
@@ -426,13 +428,26 @@ export async function runCli(argv: string[]): Promise<number> {
         break;
       }
       default: {
-        const style = createStyle(colorEnabled(process.stderr));
-        process.stderr.write(`${style.error(`unknown command: ${parsed.command}`)}\n\n`);
-        await writeRootHelp({
-          full: false,
-          token: parsed.globals.token,
-          envFile: parsed.globals.envFile,
-        });
+        // Short, greppable, and suggestion-first (issue #545) — never the root
+        // help dump, which buried the error when agents piped through `tail`.
+        const suggestion = suggestCommand(parsed.command);
+        const message = `unknown command: ${parsed.command}`;
+        if (json) {
+          await writeJson({
+            error: message,
+            code: "USAGE",
+            ...(suggestion ? { didYouMean: suggestion } : {}),
+          });
+        } else {
+          process.stderr.write(
+            formatUnknownCommand({
+              command: parsed.command,
+              suggestion,
+              summary: suggestion ? commandSummary(suggestion) : undefined,
+              style: createStyle(colorEnabled(process.stderr)),
+            }),
+          );
+        }
         flushTelemetry(2);
         return 2;
       }

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2800,11 +2800,12 @@ export async function runList(
 const FIND_HELP = `uploads find k=v [k=v...] [--prefix <p>] [--limit <n>] [--workspace <name>]
 
 Human-friendly alias for \`uploads list --meta k=v...\` — same metadata filter
-(ANDed equality), same output; pairs are positional instead of repeated flags.
+(ANDed equality), same output; pairs are positional, or spelled --meta k=v.
 
 Examples:
   uploads find gh.repo=buildinternet/uploads gh.number=123
   uploads find path=/settings state=after --prefix screenshots/
+  uploads find --meta path=/settings
 `;
 
 export async function runFind(ctx: CliContext, args: string[], help = false): Promise<number> {
@@ -2813,11 +2814,14 @@ export async function runFind(ctx: CliContext, args: string[], help = false): Pr
     writeCommandHelp(FIND_HELP);
     return 0;
   }
-  if (parsed.positionals.length === 0) {
+  // Same flag/positional symmetry as `meta set` (issue #545): `find` is the
+  // alias for `list --meta`, so `find --meta k=v` must not dead-end.
+  const pairs = [...parsed.positionals, ...flagValues(parsed.flags, "--meta")];
+  if (pairs.length === 0) {
     writeCommandHelp(FIND_HELP);
     return 2;
   }
-  const filters = parseMetaFlags(parsed.positionals);
+  const filters = parseMetaFlags(pairs);
   return runFindFiles(ctx, filters, parsed.flags);
 }
 
@@ -2832,9 +2836,13 @@ Commands:
   get <key>                            Show metadata for an object
   set <key> k=v [k=v...] [--delete k]...   Merge-set and/or delete pairs
 
+Pairs take either form: positional k=v, or --meta k=v (same spelling as
+put/screenshot/list). Both can appear in one call.
+
 Examples:
   uploads meta get screenshots/myapp/42/shot.png
   uploads meta set screenshots/myapp/42/shot.png path=/settings state=after
+  uploads meta set screenshots/myapp/42/shot.png --meta path=/settings
   uploads meta set screenshots/myapp/42/shot.png --delete path --delete state
 `;
 
@@ -2861,7 +2869,12 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
     case "set": {
       const key = parsed.positionals[1];
       if (!key) throw new UsageError("meta set requires an object key");
-      const pairs = parsed.positionals.slice(2);
+      // `--meta k=v` is accepted alongside the positional form: `put`, `list`,
+      // and `screenshot` all spell metadata that way, and `put`'s own success
+      // tip teaches the flag, so carrying it here is the natural guess
+      // (issue #545). Positionals come first so argument order still reads
+      // left to right when both are used.
+      const pairs = [...parsed.positionals.slice(2), ...flagValues(parsed.flags, "--meta")];
       const del = flagValues(parsed.flags, "--delete");
       if (pairs.length === 0 && del.length === 0) {
         throw new UsageError("meta set requires k=v pairs and/or --delete <key>");

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1377,8 +1377,7 @@ export async function runAttach(
   const branchArg = branchFromFlags(parsed.flags, run);
 
   if (parsed.positionals.length === 0) {
-    writeCommandHelp(ATTACH_HELP);
-    return 2;
+    throw new UsageError("attach requires at least one file");
   }
 
   if (branchArg !== undefined) {
@@ -2074,8 +2073,7 @@ export async function runPut(
 
   const files = parsed.positionals;
   if (files.length === 0) {
-    writeCommandHelp(PUT_HELP);
-    return 2;
+    throw new UsageError("put requires at least one file");
   }
   const multi = files.length > 1;
 
@@ -2536,9 +2534,14 @@ function githubCoordinateFromFlags(flags: CommandFlags["flags"]): string {
 export async function runGallery(ctx: CliContext, args: string[], help = false): Promise<number> {
   const parsed = parseCommandArgs(args);
   const action = parsed.positionals[0];
-  if (help || parsed.help || !action) {
+  if (help || parsed.help) {
     writeCommandHelp(GALLERY_HELP);
-    return help || parsed.help ? 0 : 2;
+    return 0;
+  }
+  if (!action) {
+    throw new UsageError(
+      "gallery requires a subcommand: create, show, list, delete, add, link, or unlink",
+    );
   }
 
   switch (action) {
@@ -2818,8 +2821,7 @@ export async function runFind(ctx: CliContext, args: string[], help = false): Pr
   // alias for `list --meta`, so `find --meta k=v` must not dead-end.
   const pairs = [...parsed.positionals, ...flagValues(parsed.flags, "--meta")];
   if (pairs.length === 0) {
-    writeCommandHelp(FIND_HELP);
-    return 2;
+    throw new UsageError("find requires at least one k=v pair (or --meta k=v)");
   }
   const filters = parseMetaFlags(pairs);
   return runFindFiles(ctx, filters, parsed.flags);
@@ -2849,10 +2851,11 @@ Examples:
 export async function runMeta(ctx: CliContext, args: string[], help = false): Promise<number> {
   const parsed = parseCommandArgs(args);
   const action = parsed.positionals[0];
-  if (help || parsed.help || !action) {
+  if (help || parsed.help) {
     writeCommandHelp(META_HELP);
-    return help || parsed.help ? 0 : 2;
+    return 0;
   }
+  if (!action) throw new UsageError("meta requires a subcommand: get or set");
 
   switch (action) {
     case "get": {
@@ -2958,8 +2961,7 @@ export async function runDelete(ctx: CliContext, args: string[], help = false): 
   }
   const key = parsed.positionals[0];
   if (!key) {
-    writeCommandHelp(DELETE_HELP);
-    return 2;
+    throw new UsageError("delete requires an object key");
   }
   if (flagBool(parsed.flags, "--dry-run")) {
     if (ctx.json) await writeJson({ key, deleted: false, dryRun: true });

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1377,7 +1377,9 @@ export async function runAttach(
   const branchArg = branchFromFlags(parsed.flags, run);
 
   if (parsed.positionals.length === 0) {
-    throw new UsageError("attach requires at least one file");
+    throw new UsageError("attach requires at least one file", {
+      example: "uploads attach ./shot.png --pr 123",
+    });
   }
 
   if (branchArg !== undefined) {
@@ -2073,7 +2075,9 @@ export async function runPut(
 
   const files = parsed.positionals;
   if (files.length === 0) {
-    throw new UsageError("put requires at least one file");
+    throw new UsageError("put requires at least one file", {
+      example: "uploads put ./shot.png --pr 123",
+    });
   }
   const multi = files.length > 1;
 
@@ -2541,13 +2545,18 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
   if (!action) {
     throw new UsageError(
       "gallery requires a subcommand: create, show, list, delete, add, link, or unlink",
+      { example: 'uploads gallery create --title "Release screenshots"' },
     );
   }
 
   switch (action) {
     case "create": {
       const title = flagString(parsed.flags, "--title");
-      if (!title) throw new UsageError("gallery create requires --title");
+      if (!title) {
+        throw new UsageError("gallery create requires --title", {
+          example: 'uploads gallery create --title "Release screenshots"',
+        });
+      }
       const gallery = await ctx.client.createGallery({
         title,
         description: flagString(parsed.flags, "--description"),
@@ -2697,7 +2706,10 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
       return failures.length === 0 ? 0 : 1;
     }
     default:
-      throw new UsageError(`unknown gallery command: ${action}`);
+      throw new UsageError(
+        `unknown gallery command: ${action} (expected create, show, list, delete, add, link, or unlink)`,
+        { example: 'uploads gallery create --title "Release screenshots"' },
+      );
   }
 }
 
@@ -2821,7 +2833,9 @@ export async function runFind(ctx: CliContext, args: string[], help = false): Pr
   // alias for `list --meta`, so `find --meta k=v` must not dead-end.
   const pairs = [...parsed.positionals, ...flagValues(parsed.flags, "--meta")];
   if (pairs.length === 0) {
-    throw new UsageError("find requires at least one k=v pair (or --meta k=v)");
+    throw new UsageError("find requires at least one k=v pair (or --meta k=v)", {
+      example: "uploads find path=/settings state=after",
+    });
   }
   const filters = parseMetaFlags(pairs);
   return runFindFiles(ctx, filters, parsed.flags);
@@ -2855,12 +2869,20 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
     writeCommandHelp(META_HELP);
     return 0;
   }
-  if (!action) throw new UsageError("meta requires a subcommand: get or set");
+  if (!action) {
+    throw new UsageError("meta requires a subcommand: get or set", {
+      example: "uploads meta set screenshots/myapp/42/shot.png --meta path=/settings",
+    });
+  }
 
   switch (action) {
     case "get": {
       const key = parsed.positionals[1];
-      if (!key) throw new UsageError("meta get requires an object key");
+      if (!key) {
+        throw new UsageError("meta get requires an object key", {
+          example: "uploads meta get screenshots/myapp/42/shot.png",
+        });
+      }
       const result = await ctx.client.getMetadata(key);
       if (ctx.json) await writeJson(result);
       else if (Object.keys(result.metadata).length === 0) {
@@ -2871,7 +2893,11 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
     }
     case "set": {
       const key = parsed.positionals[1];
-      if (!key) throw new UsageError("meta set requires an object key");
+      if (!key) {
+        throw new UsageError("meta set requires an object key", {
+          example: "uploads meta set screenshots/myapp/42/shot.png --meta path=/settings",
+        });
+      }
       // `--meta k=v` is accepted alongside the positional form: `put`, `list`,
       // and `screenshot` all spell metadata that way, and `put`'s own success
       // tip teaches the flag, so carrying it here is the natural guess
@@ -2880,7 +2906,9 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
       const pairs = [...parsed.positionals.slice(2), ...flagValues(parsed.flags, "--meta")];
       const del = flagValues(parsed.flags, "--delete");
       if (pairs.length === 0 && del.length === 0) {
-        throw new UsageError("meta set requires k=v pairs and/or --delete <key>");
+        throw new UsageError("meta set requires k=v pairs and/or --delete <key>", {
+          example: `uploads meta set ${key} --meta path=/settings`,
+        });
       }
       const set = pairs.length > 0 ? parseMetaFlags(pairs) : undefined;
       const result = await ctx.client.patchMetadata(key, {
@@ -2893,7 +2921,9 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
       return 0;
     }
     default:
-      throw new UsageError(`unknown meta command: ${action}`);
+      throw new UsageError(`unknown meta command: ${action} (expected get or set)`, {
+        example: "uploads meta get screenshots/myapp/42/shot.png",
+      });
   }
 }
 
@@ -2961,7 +2991,9 @@ export async function runDelete(ctx: CliContext, args: string[], help = false): 
   }
   const key = parsed.positionals[0];
   if (!key) {
-    throw new UsageError("delete requires an object key");
+    throw new UsageError("delete requires an object key", {
+      example: "uploads delete screenshots/myapp/42/shot.png --dry-run",
+    });
   }
   if (flagBool(parsed.flags, "--dry-run")) {
     if (ctx.json) await writeJson({ key, deleted: false, dryRun: true });
@@ -3005,7 +3037,11 @@ export async function runComment(
     return 0;
   }
   const target = ghTargetFromFlags(parsed.flags, run);
-  if (!target) throw new UsageError("comment requires --pr or --issue");
+  if (!target) {
+    throw new UsageError("comment requires --pr or --issue", {
+      example: "uploads comment --pr 123",
+    });
+  }
 
   const result = await syncAttachmentsComment(ctx.client, target, run, ctx.config.workspace, {
     resync: true,
@@ -3212,7 +3248,9 @@ export async function runGithub(
     return help || parsed.help ? 0 : 2;
   }
   if (action !== "link" && action !== "unlink" && action !== "doctor") {
-    throw new UsageError(`unknown github subcommand: ${action}`);
+    throw new UsageError(`unknown github subcommand: ${action} (expected link or doctor)`, {
+      example: "uploads github link",
+    });
   }
 
   if (action === "doctor") return runGithubDoctor(ctx);

--- a/packages/uploads/src/commands/annotate.ts
+++ b/packages/uploads/src/commands/annotate.ts
@@ -66,7 +66,9 @@ export async function runAnnotate(
 
   const imagePath = parsed.positionals[0];
   if (!imagePath) {
-    throw new UsageError("annotate requires an image path");
+    throw new UsageError("annotate requires an image path", {
+      example: "uploads annotate ./shot.png --spec ./callouts.json",
+    });
   }
   if (parsed.positionals.length > 1) {
     throw new UsageError("annotate takes exactly one image argument");

--- a/packages/uploads/src/commands/annotate.ts
+++ b/packages/uploads/src/commands/annotate.ts
@@ -66,8 +66,7 @@ export async function runAnnotate(
 
   const imagePath = parsed.positionals[0];
   if (!imagePath) {
-    writeCommandHelp(ANNOTATE_HELP);
-    return 2;
+    throw new UsageError("annotate requires an image path");
   }
   if (parsed.positionals.length > 1) {
     throw new UsageError("annotate takes exactly one image argument");

--- a/packages/uploads/src/commands/config.ts
+++ b/packages/uploads/src/commands/config.ts
@@ -83,7 +83,10 @@ export async function runConfig(
     default:
       // Short, not a help dump: agents trim output, and a dump pushes the
       // reason out of the window (issue #545).
-      throw new UsageError(`unknown config subcommand: ${sub} (expected path, show, init, or set)`);
+      throw new UsageError(
+        `unknown config subcommand: ${sub} (expected path, show, init, or set)`,
+        { example: "uploads config show" },
+      );
   }
 }
 
@@ -229,7 +232,9 @@ Examples:
   const key = positionals[0] as UploadsConfigKey | undefined;
   const value = positionals[1];
   if (!key || !value) {
-    throw new UsageError("config set requires a key and a value");
+    throw new UsageError("config set requires a key and a value", {
+      example: "uploads config set UPLOADS_WORKSPACE myteam",
+    });
   }
   if (!VALID_KEYS.has(key)) {
     throw new UsageError(`unknown key: ${key} (expected ${[...VALID_KEYS].join(", ")})`);

--- a/packages/uploads/src/commands/config.ts
+++ b/packages/uploads/src/commands/config.ts
@@ -81,9 +81,9 @@ export async function runConfig(
     case "set":
       return runConfigSet(rest, subArgs, opts, help);
     default:
-      process.stderr.write(`unknown config subcommand: ${sub}\n\n`);
-      writeCommandHelp(CONFIG_HELP);
-      return 2;
+      // Short, not a help dump: agents trim output, and a dump pushes the
+      // reason out of the window (issue #545).
+      throw new UsageError(`unknown config subcommand: ${sub} (expected path, show, init, or set)`);
   }
 }
 
@@ -229,8 +229,7 @@ Examples:
   const key = positionals[0] as UploadsConfigKey | undefined;
   const value = positionals[1];
   if (!key || !value) {
-    writeCommandHelp(`uploads config set <key> <value>\n`);
-    return 2;
+    throw new UsageError("config set requires a key and a value");
   }
   if (!VALID_KEYS.has(key)) {
     throw new UsageError(`unknown key: ${key} (expected ${[...VALID_KEYS].join(", ")})`);

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -222,7 +222,9 @@ export async function runScreenshot(
 
   const target = parsed.positionals[0];
   if (!target) {
-    throw new UsageError("screenshot requires a target URL or .html file");
+    throw new UsageError("screenshot requires a target URL or .html file", {
+      example: "uploads screenshot http://localhost:4321/settings --out settings.png",
+    });
   }
   if (parsed.positionals.length > 1) {
     throw new UsageError("screenshot takes exactly one target");

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -222,8 +222,7 @@ export async function runScreenshot(
 
   const target = parsed.positionals[0];
   if (!target) {
-    writeCommandHelp(SCREENSHOT_HELP);
-    return 2;
+    throw new UsageError("screenshot requires a target URL or .html file");
   }
   if (parsed.positionals.length > 1) {
     throw new UsageError("screenshot takes exactly one target");

--- a/packages/uploads/test/cli-help.test.ts
+++ b/packages/uploads/test/cli-help.test.ts
@@ -179,6 +179,18 @@ describe("runCli help", () => {
     expect(io.stderr()).toMatch(/did you mean: uploads meta set/);
   });
 
+  it("answers a missing argument with a reason, not a help dump (#545)", async () => {
+    const io = captureStdio();
+    const code = await runCli(["node", "uploads", "--token", "up_test_x", "find"]);
+    expect(code).toBe(2);
+    expect(io.stderr()).toMatch(/error: find requires at least one k=v pair/);
+    expect(io.stderr()).toMatch(/hint: uploads find --help/);
+    // The old behavior printed FIND_HELP, which `| tail` would have kept
+    // while dropping the reason.
+    expect(io.stderr()).not.toMatch(/Human-friendly alias/);
+    expect(io.stderr().trimEnd().split("\n").length).toBeLessThanOrEqual(3);
+  });
+
   it("reports an unknown command as JSON on stdout with --json", async () => {
     const io = captureStdio();
     const code = await runCli(["node", "uploads", "--json", "set-metadata"]);

--- a/packages/uploads/test/cli-help.test.ts
+++ b/packages/uploads/test/cli-help.test.ts
@@ -159,12 +159,34 @@ describe("runCli help", () => {
     expect(io.stderr()).not.toMatch(/reconcile/);
   });
 
-  it("unknown command shows essentials (not the full dump)", async () => {
+  it("unknown command stays short so `| tail` keeps the error (#545)", async () => {
     const io = captureStdio();
     const code = await runCli(["node", "uploads", "not-a-real-command"]);
     expect(code).toBe(2);
     expect(io.stderr()).toMatch(/unknown command: not-a-real-command/);
-    expect(io.stderr()).toMatch(/Essentials:/);
+    expect(io.stderr()).toMatch(/uploads help --all/);
+    // No banner, no command dump — the whole point is that it fits in a tail window.
+    expect(io.stderr()).not.toMatch(/Essentials:/);
     expect(io.stderr()).not.toMatch(/BUILDINTERNET_CONFIG/);
+    expect(io.stderr().trimEnd().split("\n").length).toBeLessThanOrEqual(8);
+  });
+
+  it("suggests the right command for a near miss", async () => {
+    const io = captureStdio();
+    const code = await runCli(["node", "uploads", "set-metadata"]);
+    expect(code).toBe(2);
+    expect(io.stderr()).toMatch(/unknown command: set-metadata/);
+    expect(io.stderr()).toMatch(/did you mean: uploads meta set/);
+  });
+
+  it("reports an unknown command as JSON on stdout with --json", async () => {
+    const io = captureStdio();
+    const code = await runCli(["node", "uploads", "--json", "set-metadata"]);
+    expect(code).toBe(2);
+    expect(JSON.parse(io.stdout())).toMatchObject({
+      error: "unknown command: set-metadata",
+      code: "USAGE",
+      didYouMean: "meta set",
+    });
   });
 });

--- a/packages/uploads/test/cli-help.test.ts
+++ b/packages/uploads/test/cli-help.test.ts
@@ -179,16 +179,28 @@ describe("runCli help", () => {
     expect(io.stderr()).toMatch(/did you mean: uploads meta set/);
   });
 
-  it("answers a missing argument with a reason, not a help dump (#545)", async () => {
+  it("answers a missing argument with a reason and a runnable example (#545)", async () => {
     const io = captureStdio();
     const code = await runCli(["node", "uploads", "--token", "up_test_x", "find"]);
     expect(code).toBe(2);
     expect(io.stderr()).toMatch(/error: find requires at least one k=v pair/);
+    expect(io.stderr()).toMatch(/ {2}uploads find path=\/settings state=after/);
     expect(io.stderr()).toMatch(/hint: uploads find --help/);
     // The old behavior printed FIND_HELP, which `| tail` would have kept
     // while dropping the reason.
     expect(io.stderr()).not.toMatch(/Human-friendly alias/);
-    expect(io.stderr().trimEnd().split("\n").length).toBeLessThanOrEqual(3);
+    expect(io.stderr().trimEnd().split("\n").length).toBeLessThanOrEqual(4);
+  });
+
+  it("carries the example into the JSON error payload", async () => {
+    const io = captureStdio();
+    const code = await runCli(["node", "uploads", "--json", "--token", "up_test_x", "put"]);
+    expect(code).toBe(2);
+    expect(JSON.parse(io.stdout())).toMatchObject({
+      error: "put requires at least one file",
+      code: "USAGE",
+      example: "uploads put ./shot.png --pr 123",
+    });
   });
 
   it("reports an unknown command as JSON on stdout with --json", async () => {

--- a/packages/uploads/test/cli-suggest.test.ts
+++ b/packages/uploads/test/cli-suggest.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { commandSummary, suggestCommand } from "../src/cli-suggest.js";
+import { formatUnknownCommand } from "../src/cli-help.js";
+
+describe("suggestCommand", () => {
+  it("maps the metadata spellings agents reach for to `meta set`", () => {
+    expect(suggestCommand("set-metadata")).toBe("meta set");
+    expect(suggestCommand("set-meta")).toBe("meta set");
+    expect(suggestCommand("metadata")).toBe("meta set");
+    expect(suggestCommand("tag")).toBe("meta set");
+  });
+
+  it("maps read-side metadata spellings to `meta get`", () => {
+    expect(suggestCommand("get-metadata")).toBe("meta get");
+    expect(suggestCommand("show-metadata")).toBe("meta get");
+  });
+
+  it("maps common synonyms to real commands", () => {
+    expect(suggestCommand("upload")).toBe("put");
+    expect(suggestCommand("ls")).toBe("list");
+    expect(suggestCommand("rm")).toBe("delete");
+    expect(suggestCommand("search")).toBe("find");
+    expect(suggestCommand("capture")).toBe("screenshot");
+  });
+
+  it("catches typos by edit distance", () => {
+    expect(suggestCommand("puut")).toBe("put");
+    expect(suggestCommand("scrnshot")).toBe("screenshot");
+    expect(suggestCommand("galery")).toBe("gallery");
+    expect(suggestCommand("atach")).toBe("attach");
+  });
+
+  it("catches typos of a synonym, not just of a real command", () => {
+    expect(suggestCommand("uplaod")).toBe("put");
+    expect(suggestCommand("setmetadta")).toBe("meta set");
+  });
+
+  it("treats plurals and trailing qualifiers as the same intent", () => {
+    expect(suggestCommand("screenshots")).toBe("screenshot");
+    expect(suggestCommand("galleries")).toBe("gallery");
+  });
+
+  it("returns nothing when nothing is close", () => {
+    expect(suggestCommand("xyzzy")).toBeUndefined();
+    expect(suggestCommand("")).toBeUndefined();
+  });
+
+  it("resolves catalog summaries for phrases and root names", () => {
+    expect(commandSummary("meta set")).toMatch(/Merge-set/);
+    expect(commandSummary("put")).toMatch(/Upload/);
+    expect(commandSummary("nope")).toBeUndefined();
+  });
+});
+
+describe("formatUnknownCommand", () => {
+  it("stays short enough to survive `| tail -20`", () => {
+    const out = formatUnknownCommand({
+      command: "set-metadata",
+      suggestion: "meta set",
+      summary: commandSummary("meta set"),
+      color: false,
+    });
+    expect(out.trimEnd().split("\n").length).toBeLessThanOrEqual(8);
+    expect(out).toMatch(/unknown command: set-metadata/);
+    expect(out).toMatch(/did you mean: uploads meta set/);
+    expect(out).toMatch(/uploads help --all/);
+    // No banner, no full catalog dump.
+    expect(out).not.toMatch(/Essentials:/);
+    expect(out).not.toMatch(/purge-expired/);
+  });
+
+  it("omits the suggestion line when there is no near match", () => {
+    const out = formatUnknownCommand({ command: "xyzzy", color: false });
+    expect(out).toMatch(/unknown command: xyzzy/);
+    expect(out).not.toMatch(/did you mean/);
+    expect(out).toMatch(/uploads help --all/);
+  });
+});

--- a/packages/uploads/test/commands-annotate.test.ts
+++ b/packages/uploads/test/commands-annotate.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import sharp from "sharp";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { UsageError } from "../src/cli-args.js";
 import { runAnnotate } from "../src/commands/annotate.js";
 
 async function syntheticPng(width = 100, height = 80): Promise<Buffer> {
@@ -165,8 +166,7 @@ describe("runAnnotate", () => {
     await expect(runAnnotate([imagePath])).rejects.toThrow("--spec is required");
   });
 
-  it("requires an image argument", async () => {
-    const code = await runAnnotate([]);
-    expect(code).toBe(2);
+  it("requires an image argument (short usage error, not a help dump)", async () => {
+    await expect(runAnnotate([])).rejects.toThrow(UsageError);
   });
 });

--- a/packages/uploads/test/commands-find.test.ts
+++ b/packages/uploads/test/commands-find.test.ts
@@ -59,9 +59,9 @@ describe("runFind", () => {
     expect(calls[0].filters).toEqual({ path: "/settings", state: "after" });
   });
 
-  it("requires at least one pair", async () => {
+  it("requires at least one pair, and says so instead of dumping help (#545)", async () => {
     const { client } = fakeClient();
-    expect(await runFind(ctxWith(client), [], false)).toBe(2);
+    await expect(runFind(ctxWith(client), [], false)).rejects.toThrow(/find requires at least one/);
   });
 
   it("rejects a malformed pair", async () => {

--- a/packages/uploads/test/commands-find.test.ts
+++ b/packages/uploads/test/commands-find.test.ts
@@ -48,6 +48,17 @@ describe("runFind", () => {
     expect(calls[0].filters).toEqual({ "gh.repo": "buildinternet/uploads", "gh.number": "123" });
   });
 
+  it("also accepts the --meta k=v spelling (#545)", async () => {
+    const { client, calls } = fakeClient();
+    const code = await runFind(
+      ctxWith(client),
+      ["--meta", "path=/settings", "--meta", "state=after"],
+      false,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].filters).toEqual({ path: "/settings", state: "after" });
+  });
+
   it("requires at least one pair", async () => {
     const { client } = fakeClient();
     expect(await runFind(ctxWith(client), [], false)).toBe(2);

--- a/packages/uploads/test/commands-meta.test.ts
+++ b/packages/uploads/test/commands-meta.test.ts
@@ -120,6 +120,35 @@ describe("runMeta set", () => {
     });
   });
 
+  it("accepts --meta k=v, the spelling put/list use (#545)", async () => {
+    const { client, patchCalls } = fakeClient();
+    const code = await runMeta(
+      ctxWith(client),
+      ["set", "screenshots/a.png", "--meta", "path=/settings", "--meta", "state=after"],
+      false,
+    );
+    expect(code).toBe(0);
+    expect(patchCalls[0]).toEqual({
+      key: "screenshots/a.png",
+      set: { path: "/settings", state: "after" },
+      delete: undefined,
+    });
+  });
+
+  it("merges positional pairs with --meta pairs", async () => {
+    const { client, patchCalls } = fakeClient();
+    await runMeta(
+      ctxWith(client),
+      ["set", "screenshots/a.png", "app=myapp", "--meta", "path=/settings"],
+      false,
+    );
+    expect(patchCalls[0]).toEqual({
+      key: "screenshots/a.png",
+      set: { app: "myapp", path: "/settings" },
+      delete: undefined,
+    });
+  });
+
   it("requires a key", async () => {
     const { client } = fakeClient();
     await expect(runMeta(ctxWith(client), ["set"], false)).rejects.toThrow(UsageError);

--- a/packages/uploads/test/commands-meta.test.ts
+++ b/packages/uploads/test/commands-meta.test.ts
@@ -244,8 +244,8 @@ describe("runMeta unknown command", () => {
     await expect(runMeta(ctxWith(client), ["bogus"], false)).rejects.toThrow(UsageError);
   });
 
-  it("prints help and returns 2 with no subcommand", async () => {
+  it("names the missing subcommand instead of dumping help (#545)", async () => {
     const { client } = fakeClient();
-    expect(await runMeta(ctxWith(client), [], false)).toBe(2);
+    await expect(runMeta(ctxWith(client), [], false)).rejects.toThrow(/meta requires a subcommand/);
   });
 });

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -573,9 +573,15 @@ the PR comment` instead, and either way the metadata write itself never fails.
 ```bash
 uploads meta get screenshots/myapp/42/settings.webp
 uploads meta set screenshots/myapp/42/settings.webp path=/onboarding --delete url
+uploads meta set screenshots/myapp/42/settings.webp --meta path=/onboarding  # same thing
 uploads list --meta app=web --meta path=/settings   # ANDed, repeatable
 uploads find app=web path=/settings                 # same filter, positional pairs
+uploads find --meta app=web                         # --meta works here too
 ```
+
+`meta set` and `find` accept pairs in either spelling: positional `k=v`, or the
+repeatable `--meta k=v` that `put`, `attach`, `screenshot`, and `list` use. Both
+forms can appear in one call.
 
 On the default `screenshots/…` path, `put` also auto-derives GitHub context and
 stamps `gh.repo`/`gh.kind`/`gh.number`/`gh.ref` from the current branch's PR (or
@@ -773,6 +779,7 @@ uploads find app=myapp page=settings       # same filter, human-friendly positio
 uploads list --all --json                  # paginate fully, machine-readable
 uploads meta get <key>                     # show an object's metadata
 uploads meta set <key> k=v [k=v…] [--delete k]…   # merge-set / delete metadata pairs
+uploads meta set <key> --meta k=v                  # same, in put/list's flag spelling
 uploads delete <key>                       # remove an object
 uploads delete <key> --dry-run             # show what would be deleted
 uploads usage                              # storage / monthly upload counters (+ limits)

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -847,6 +847,11 @@ uploads --api-url http://localhost:8787 doctor
   `--json` emits `{error,code,status}` — branch on `code`. Scripted formats
   (`json|url|markdown`) also print failures on stdout. Usage errors:
   `hint: uploads <cmd> --help`.
+- **Errors stay short (stderr), so trimming output never hides them.** A missing
+  argument prints one `error:` line plus that hint — not the command's help. A
+  mistyped command prints the error, a `did you mean: uploads <cmd>` line, and
+  the help pointers; with `--json` it returns `{error,code:"USAGE",didYouMean}`
+  on stdout. Read the first line; run `uploads <cmd> --help` for the full help.
 - **Update hints (stderr):** successful human runs may note a newer npm release
   (daily). Silence with `--quiet` / `--json` / `UPLOADS_NO_UPDATE=1`.
 - **Telemetry:** anonymous command-name pings (no paths/tokens). Opt out with

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -848,7 +848,9 @@ uploads --api-url http://localhost:8787 doctor
   (`json|url|markdown`) also print failures on stdout. Usage errors:
   `hint: uploads <cmd> --help`.
 - **Errors stay short (stderr), so trimming output never hides them.** A missing
-  argument prints one `error:` line plus that hint — not the command's help. A
+  argument prints one `error:` line, a runnable example (`uploads put
+./shot.png --pr 123`), and that hint — not the command's help. In `--json`
+  the example rides along as `example`. A
   mistyped command prints the error, a `did you mean: uploads <cmd>` line, and
   the help pointers; with `--json` it returns `{error,code:"USAGE",didYouMean}`
   on stdout. Read the first line; run `uploads <cmd> --help` for the full help.


### PR DESCRIPTION
## In plain terms

Tagging a file that is already uploaded took three tries in a real agent
session (#545). The metadata flag is spelled `--meta` on `put`, `attach`,
`screenshot`, and `list`, but `meta set` only took bare `k=v` pairs — so the
obvious carry-over failed. The recovery path failed too: `uploads set-metadata`
answered with a 27-line help dump that never mentions `meta`, and agents that
trim output with `| tail` saw only the tail of that dump, not the error. This
fixes all three.

## What it does

- **`--meta k=v` now works on `meta set`.** Positional pairs still work, and
  both forms can appear in one call. `find` gets the same treatment — it is
  documented as the alias for `list --meta`, so `find --meta k=v` dead-ending
  was the same trap.
- **Unknown commands suggest the right one.** `uploads set-metadata` now
  answers `did you mean: uploads meta set`. Suggestions come from a table of
  spellings agents actually reach for (`set-metadata`, `metadata`, `tag`,
  `upload`, `ls`, `rm`, `capture`, …) plus an edit-distance pass over the
  command catalog, so plain typos (`atach`, `uplaod`) land too.
- **That output is now six lines, not twenty-seven.** Error first, suggestion,
  then pointers to `uploads help --all` and `uploads <cmd> --help`. It fits in
  any reasonable `tail` window, and it skips the network version check the old
  path ran before printing.
- **`--json` gets a real payload.** An unknown command prints
  `{ "error", "code": "USAGE", "didYouMean" }` on stdout instead of nothing.

## What it is not

- Nothing is renamed or removed — every existing spelling still works.
- Suggestions never rewrite the command. The CLI prints the guess and exits 2,
  the same rule the metadata vocabulary already follows for near-miss keys.

## How to try it

```bash
uploads meta set screenshots/myapp/42/shot.png --meta path=/admin/metrics
```

```bash
uploads set-metadata
```

```bash
uploads --json set-metadata
```

## Technical notes

`suggestCommand` lives in `packages/uploads/src/cli-suggest.ts` and scores root
commands from the shared catalog before the alias table, so a real command name
always beats a synonym. Containment (`screenshots` → `screenshot`) applies only
to catalog names; aliases match by distance alone, so a short alias like `tag`
can't swallow unrelated input.

The issue also floated splitting the error onto stderr and the help onto
stdout. Both already went to stderr, and an agent piping `2>&1 | tail` would
still merge them — keeping the output short is what actually survives
truncation, so that is the route taken.

## Test plan

- [x] `pnpm test` — 3434 tests, all passing
- [x] New `test/cli-suggest.test.ts` covers the alias table, typo distance,
      plurals, and the short-output guarantee
- [x] `meta set --meta` and `find --meta` covered in their command tests
- [x] `runCli` tests for the suggestion line, the line budget, and the JSON shape
- [x] Ran the built binary by hand: `set-metadata`, `uplaod`, `xyzzy`, `--json`
- [x] `pnpm typecheck`, `oxlint`, `oxfmt --check` clean on changed files

Closes #545
