### PR TITLE
feat(web): file page rail hierarchy, snippet copy, share pill, click-to-zoom

### DIFF
--- a/apps/api/src/github-avatars.test.ts
+++ b/apps/api/src/github-avatars.test.ts
@@ -44,6 +44,24 @@ describe("githubAvatarProxyUrl", () => {
       "https://api.uploads.sh/public/github/avatars/acme",
     );
   });
+
+  it("coerces non-loopback http to https (local wrangler dev reports the route host as http)", () => {
+    expect(githubAvatarProxyUrl("http://api.uploads.sh", "acme")).toBe(
+      "https://api.uploads.sh/public/github/avatars/acme",
+    );
+  });
+
+  it("keeps loopback origins http so local avatars stay reachable", () => {
+    expect(githubAvatarProxyUrl("http://127.0.0.1:8787", "acme")).toBe(
+      "http://127.0.0.1:8787/public/github/avatars/acme",
+    );
+    expect(githubAvatarProxyUrl("http://localhost:8787", "acme")).toBe(
+      "http://localhost:8787/public/github/avatars/acme",
+    );
+    expect(githubAvatarProxyUrl("http://[::1]:8787", "acme")).toBe(
+      "http://[::1]:8787/public/github/avatars/acme",
+    );
+  });
 });
 
 function memoryCache(): AvatarCache & { store: Map<string, Response> } {

--- a/apps/api/src/github-avatars.ts
+++ b/apps/api/src/github-avatars.ts
@@ -35,9 +35,23 @@ export function ownerFromRepo(repo: string): string | null {
   return normalizeGithubOwner(repo.slice(0, slash));
 }
 
-/** Absolute proxy URL (`{apiOrigin}/public/github/avatars/{owner}`). */
+/**
+ * Absolute proxy URL (`{apiOrigin}/public/github/avatars/{owner}`).
+ *
+ * Non-loopback origins are coerced to `https:` — local wrangler dev reports
+ * the prod route host with an `http:` scheme, and the web page's validator
+ * (public-file.ts `isAvatarUrl`) only accepts https or loopback http, so an
+ * uncoerced dev origin would 503 the whole /f/ page. Loopback stays http so
+ * the avatar remains reachable when the API really is served from 127.0.0.1.
+ */
 export function githubAvatarProxyUrl(apiOrigin: string, owner: string): string {
-  return `${apiOrigin.replace(/\/$/, "")}/public/github/avatars/${encodeURIComponent(owner)}`;
+  const origin = new URL(apiOrigin);
+  const loopback =
+    origin.hostname === "localhost" ||
+    origin.hostname === "127.0.0.1" ||
+    origin.hostname === "[::1]";
+  if (origin.protocol === "http:" && !loopback) origin.protocol = "https:";
+  return `${origin.origin}/public/github/avatars/${encodeURIComponent(owner)}`;
 }
 
 function avatarResponse(

--- a/apps/web/src/components/CopyAsControls.astro
+++ b/apps/web/src/components/CopyAsControls.astro
@@ -14,7 +14,9 @@ interface Props {
 }
 
 const { formats, downloadUrl = null } = Astro.props;
-const defaultCopyValue = formats[0]?.value ?? "";
+const defaultFormat = formats[0];
+const defaultCopyValue = defaultFormat?.value ?? "";
+const defaultCopyLabel = defaultFormat?.label ?? "";
 const show = Boolean(downloadUrl) || formats.length > 0;
 ---
 
@@ -29,26 +31,47 @@ const show = Boolean(downloadUrl) || formats.length > 0;
         <span class="linkfield">
           <label for="copy-format">Copy as</label>
           <div class="copyrow">
-            <select id="copy-format" aria-label="Copy as format">
+            <select id="copy-format" class="ul-select" aria-label="Copy as format">
               {formats.map((format) => <option value={format.id}>{format.label}</option>)}
             </select>
-            <div class="copyout">
-              <input
-                id="copy-value"
-                type="text"
-                readonly
-                value={defaultCopyValue}
-                aria-label="Value to copy"
-              />
+            {/* The whole row is the copy control (Snippet pattern) — a real
+               button inside carries the click/keyboard affordance, so the
+               wrapper only needs a click-through convenience handler. */}
+            <div
+              class="snippet"
+              id="copy-snippet"
+              data-copy-value={defaultCopyValue}
+              tabindex="-1"
+            >
+              <code id="copy-snippet-value">{defaultCopyValue}</code>
               <button
                 type="button"
                 id="copy-format-btn"
+                class="snippet-copy"
                 data-copy={defaultCopyValue}
-                aria-live="polite"
+                data-copy-icon
+                aria-label={`Copy ${defaultCopyLabel}`}
               >
-                Copy
+                <svg class="icon-copy" viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.3"
+                    d="M6 6h7v8H6zM3 2h7v2M3 2v8h3M3 2h0"
+                  />
+                </svg>
+                <svg
+                  class="icon-check is-hidden"
+                  viewBox="0 0 16 16"
+                  width="15"
+                  height="15"
+                  aria-hidden="true"
+                >
+                  <path fill="none" stroke="currentColor" stroke-width="1.6" d="M3 8.5l3.2 3.2L13 4.5" />
+                </svg>
               </button>
             </div>
+            <span id="copy-status" class="sr-only" aria-live="polite" />
           </div>
         </span>
       )}
@@ -65,6 +88,8 @@ const show = Boolean(downloadUrl) || formats.length > 0;
         const shell = document.querySelector(".shell");
         if (!shell) return;
 
+        const status = document.getElementById("copy-status");
+
         shell.addEventListener("click", (event) => {
           const target = event.target;
           if (!(target instanceof Element)) return;
@@ -73,6 +98,23 @@ const show = Boolean(downloadUrl) || formats.length > 0;
           void navigator.clipboard
             .writeText(button.dataset.copy || "")
             .then(() => {
+              // Icon-only snippet button: swap SVGs + aria-live text instead
+              // of clobbering textContent (that path is reserved for the
+              // page-level text-labeled share button sharing this handler).
+              if (button.hasAttribute("data-copy-icon")) {
+                const copyIcon = button.querySelector(".icon-copy");
+                const checkIcon = button.querySelector(".icon-check");
+                if (copyIcon) copyIcon.classList.add("is-hidden");
+                if (checkIcon) checkIcon.classList.remove("is-hidden");
+                if (status) status.textContent = "Copied";
+                setTimeout(() => {
+                  if (copyIcon) copyIcon.classList.remove("is-hidden");
+                  if (checkIcon) checkIcon.classList.add("is-hidden");
+                  if (status) status.textContent = "";
+                }, 1500);
+                return;
+              }
+
               const original = button.dataset.copyLabel ?? button.textContent ?? "Copy";
               button.dataset.copyLabel = original;
               button.textContent = "copied ✓";
@@ -85,19 +127,32 @@ const show = Boolean(downloadUrl) || formats.length > 0;
             });
         });
 
-        const select = document.getElementById("copy-format");
-        const input = document.getElementById("copy-value");
+        // Clicking anywhere on the snippet row (not just the icon button)
+        // copies — same target the button already handles, so just forward.
+        const snippet = document.getElementById("copy-snippet");
         const copyButton = document.getElementById("copy-format-btn");
+        if (snippet instanceof HTMLElement && copyButton instanceof HTMLButtonElement) {
+          snippet.addEventListener("click", (event) => {
+            if (event.target === copyButton || copyButton.contains(event.target)) return;
+            copyButton.click();
+          });
+        }
+
+        const select = document.getElementById("copy-format");
+        const valueEl = document.getElementById("copy-snippet-value");
         if (
           select instanceof HTMLSelectElement &&
-          input instanceof HTMLInputElement &&
-          copyButton instanceof HTMLButtonElement
+          valueEl instanceof HTMLElement &&
+          copyButton instanceof HTMLButtonElement &&
+          snippet instanceof HTMLElement
         ) {
           select.addEventListener("change", () => {
             const format = formats.find((f) => f.id === select.value) ?? formats[0];
             if (!format) return;
-            input.value = format.value;
+            valueEl.textContent = format.value;
+            snippet.dataset.copyValue = format.value;
             copyButton.dataset.copy = format.value;
+            copyButton.setAttribute("aria-label", `Copy ${format.label}`);
           });
         }
       })();
@@ -144,52 +199,77 @@ const show = Boolean(downloadUrl) || formats.length > 0;
     font: 11px var(--mono);
     margin-bottom: 5px;
   }
-  /* Stacked: format chooser on top, value + Copy beneath — keeps every control
-     legible in the ~300px rail instead of crushing them into one row. */
+  /* Stacked: format chooser on top, snippet row beneath — keeps every
+     control legible in the ~300px rail instead of crushing them into one row. */
   .copyrow {
     display: flex;
     flex-direction: column;
     gap: 6px;
   }
-  .copyout {
+  /* ai-sdk Elements "Snippet" pattern: one bordered row, truncated mono value,
+     icon-only copy affordance — the whole row is clickable. */
+  .snippet {
     display: flex;
-    gap: 6px;
-    align-items: stretch;
-  }
-  .copyrow select,
-  .copyout input,
-  .copyout button {
-    padding: 8px;
+    align-items: flex-start;
+    gap: 8px;
+    min-width: 0;
+    padding: 8px 8px 8px 10px;
     border: 1px solid var(--line);
     border-radius: var(--radius-md);
-    font: 12px var(--mono);
-  }
-  .copyrow select,
-  .copyout input {
-    background: var(--bg);
-    color: var(--body);
-  }
-  .copyrow select {
-    width: 100%;
-  }
-  .copyout input {
-    flex: 1;
-    min-width: 0;
-    padding: 8px 10px;
-  }
-  /* Primary action — solid accent, mirroring the repo's .ul-btn--solid pattern. */
-  .copyout button {
-    padding: 8px 14px;
-    background: var(--accent);
-    border-color: var(--accent);
-    color: var(--bg);
-    font-weight: 600;
+    background: var(--panel);
     cursor: pointer;
   }
-  .copyout button:hover,
-  .copyout button:focus-visible {
-    background: color-mix(in srgb, var(--accent) 88%, #fff);
-    border-color: color-mix(in srgb, var(--accent) 88%, #fff);
+  .snippet:hover {
+    border-color: var(--accent);
+  }
+  /* Wrap the full value — the ~300px rail truncates a single line past
+     usefulness, and format values are bounded (a few lines at worst). */
+  .snippet code {
+    flex: 1;
+    min-width: 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font: 12px/1.5 var(--mono);
+    color: var(--body);
+    padding: 3px 0;
+  }
+  .snippet-copy {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+  }
+  .snippet-copy:hover,
+  .snippet-copy:focus-visible {
+    color: var(--accent);
     outline: none;
+  }
+  .snippet-copy:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 55%, transparent);
+  }
+  .icon-check {
+    color: var(--accent);
+  }
+  .is-hidden {
+    display: none;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 </style>

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -65,6 +65,13 @@ const { src, alt } = Astro.props;
       });
     }
 
+    // Imgur-style click-to-zoom: the image itself is a supplementary toggle:
+    // the pill buttons above remain the visible + accessible affordance.
+    img.addEventListener("click", () => {
+      override = root.dataset.mode === "full" ? "fit" : "full";
+      applyMode(root, override);
+    });
+
     if (img.complete && img.naturalWidth > 0) sync();
     else img.addEventListener("load", sync, { once: true });
   }
@@ -137,6 +144,14 @@ const { src, alt } = Astro.props;
     height: auto;
     max-width: 100%;
     object-fit: contain;
+  }
+
+  .image-preview[data-mode="fit"] img {
+    cursor: zoom-in;
+  }
+
+  .image-preview[data-mode="full"] img {
+    cursor: zoom-out;
   }
 
   .image-preview[data-mode="fit"] {

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -52,6 +52,14 @@ const withTime = Boolean(
 const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime }) : null;
 const modifiedLabel =
   showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime }) : null;
+// Rail footnote (demoted from a Size/Uploaded/Modified dl — issue: right-rail hierarchy pass):
+// one muted line beneath the actions instead of a data table.
+const footnoteParts = [
+  file ? formatBytes(file.size) : null,
+  uploadedLabel ? `Uploaded ${uploadedLabel}` : null,
+  modifiedLabel ? `Modified ${modifiedLabel}` : null,
+].filter((part): part is string => Boolean(part));
+const footnoteLine = footnoteParts.join(" · ");
 const gh = file?.github;
 const ghKindLabel = gh?.kind === "pull" ? "Pull request" : gh ? "Issue" : "";
 const ghRef = gh ? `${gh.repo}#${gh.number}` : "";
@@ -155,6 +163,12 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
       .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:0 auto; padding:36px 0 64px; flex:1 0 auto; box-sizing:border-box; }
       nav.top { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
+      /* Click-to-copy share pill — replaces the static "public file" label whenever there's a link to copy. */
+      button.public { appearance:none; -webkit-appearance:none; cursor:pointer; font-family:inherit; display:inline-flex; align-items:center; gap:6px; }
+      button.public:hover, button.public:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      /* Icon lives in ::before, not a child node — CopyAsControls' handler replaces
+         button.textContent on copy, which would otherwise destroy an inline <svg>. */
+      .sharelink::before { content:""; width:11px; height:11px; flex:none; background:currentColor; -webkit-mask:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71'/%3E%3Cpath d='M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71'/%3E%3C/svg%3E") center/contain no-repeat; mask:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71'/%3E%3Cpath d='M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71'/%3E%3C/svg%3E") center/contain no-repeat; }
       .stage { background:var(--panel); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
       /* Video / non-image fallbacks only — images use ImagePreview. */
       .media { min-height:320px; max-height:78vh; background:var(--bg); display:grid; place-items:center; overflow:hidden; }
@@ -181,7 +195,7 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
       .gh-byline:hover .gh-byline-title, .gh-byline:focus-visible .gh-byline-title { color:inherit; }
       .gh-byline-sep { opacity:.7; }
       .gh-byline-ref { overflow-wrap:anywhere; }
-      /* Right rail: account-shell-like section gap; Metadata uses label + rule. */
+      /* Right rail: account-shell-like section gap; Details uses label + rule. */
       .details { display:flex; flex-direction:column; gap:22px; padding:18px 20px 22px; border-top:1px solid var(--line); }
       .details > * { min-width:0; }
       .rail-head { display:flex; align-items:center; gap:10px; margin:0 0 12px; }
@@ -191,6 +205,9 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
       .details :global(.actions) { margin-top:0; }
+      /* Subordinate to everything above — margin-top:auto sinks it (and ReportAbuse, right
+         after it in flow) to the bottom of the rail on tall pages, no-op on short ones. */
+      .footnote { margin:auto 0 0; color:var(--muted); font:11.5px/1.5 var(--mono); }
       /* Before/after paired view (issue #420) — static side-by-side, no slider. */
       .pair { display:grid; grid-template-columns:1fr 1fr; gap:1px; background:var(--line); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; margin:0 0 20px; }
       .pair-panel { position:relative; background:var(--panel); display:flex; flex-direction:column; }
@@ -229,7 +246,21 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
   </head>
   <body>
     <main class="shell">
-      <nav class="top"><Brand /><span class="public">public file</span></nav>
+      <nav class="top">
+        <Brand />
+        {file ? (
+          <button
+            type="button"
+            class="public sharelink"
+            data-copy={canonical}
+            title="Copy link — anyone with this link can view this page"
+          >
+            Public link
+          </button>
+        ) : (
+          <span class="public">public file</span>
+        )}
+      </nav>
       {file ? (
         <>
           <header class="filehead">
@@ -312,15 +343,15 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
               </div>
             )}
             <figcaption class="details">
-              <dl class="meta">
-                <dt>Size</dt><dd>{formatBytes(file.size)}</dd>
-                {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
-                {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}
-              </dl>
+              <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
+                {kind(file.contentType) !== "unsupported" && (
+                  <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>
+                )}
+              </CopyAsControls>
               {metadataEntries.length > 0 && (
                 <div>
                   <div class="rail-head">
-                    <span class="rail-label">Metadata</span>
+                    <span class="rail-label">Details</span>
                     <span class="rail-rule" aria-hidden="true"></span>
                   </div>
                   <dl class="meta">
@@ -333,11 +364,7 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
                   </dl>
                 </div>
               )}
-              <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
-                {kind(file.contentType) !== "unsupported" && (
-                  <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>
-                )}
-              </CopyAsControls>
+              {footnoteLine && <p class="footnote">{footnoteLine}</p>}
               <ReportAbuse
                 apiOrigin={origin}
                 pageUrl={canonical}

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -79,6 +79,14 @@ const modifiedLabel =
 const ogImage = item && kind(item) === "image" ? item.url! : OG_DEFAULT_IMAGE;
 const sizeLabel =
   item && item.size != null && Number.isSafeInteger(item.size) ? formatBytes(item.size) : null;
+// Rail footnote (demoted from a Size/Uploaded/Modified dl — parity with the /f/ file page):
+// one muted line beneath the actions instead of a data table.
+const footnoteParts = [
+  sizeLabel,
+  uploadedLabel ? `Uploaded ${uploadedLabel}` : null,
+  modifiedLabel ? `Modified ${modifiedLabel}` : null,
+].filter((part): part is string => Boolean(part));
+const footnoteLine = footnoteParts.join(" · ");
 ---
 
 <!doctype html>
@@ -128,6 +136,9 @@ const sizeLabel =
       dl.meta dt { color:var(--muted); text-transform:uppercase; letter-spacing:.08em; font-size:11px; }
       dl.meta dd { margin:0; color:var(--body); overflow-wrap:anywhere; }
       .details :global(.actions) { margin-top:0; }
+      /* Subordinate to everything above — margin-top:auto sinks it to the bottom of the
+         rail on tall pages, no-op on short ones. */
+      .footnote { margin:auto 0 0; color:var(--muted); font:11.5px/1.5 var(--mono); }
       .pager { display:flex; align-items:center; justify-content:space-between; gap:12px; margin:22px 0 0; font:13px var(--mono); }
       .pager a, .pager span.disabled { display:inline-block; padding:10px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--panel); color:var(--fg); text-decoration:none; }
       .pager a:hover, .pager a:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
@@ -179,13 +190,6 @@ const sizeLabel =
             )}
             <figcaption class="details" id="item-caption">
               {item.caption && <div class="caption">{item.caption}</div>}
-              {(sizeLabel || uploadedLabel || modifiedLabel) && (
-                <dl class="meta">
-                  {sizeLabel && (<><dt>Size</dt><dd>{sizeLabel}</dd></>)}
-                  {uploadedLabel && (<><dt>Uploaded</dt><dd>{uploadedLabel}</dd></>)}
-                  {modifiedLabel && (<><dt>Modified</dt><dd>{modifiedLabel}</dd></>)}
-                </dl>
-              )}
               {item.status === "available" && (
                 <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
                   {kind(item) !== "unsupported" && item.url && (
@@ -193,6 +197,7 @@ const sizeLabel =
                   )}
                 </CopyAsControls>
               )}
+              {footnoteLine && <p class="footnote">{footnoteLine}</p>}
             </figcaption>
           </figure>
           <nav class="pager" aria-label="Gallery items">

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -117,6 +117,12 @@ const footnoteLine = footnoteParts.join(" · ");
       .shell { width:min(var(--width-viewer, 1080px),calc(100% - 48px)); margin:0 auto; padding:36px 0 64px; flex:1 0 auto; box-sizing:border-box; }
       nav.top { display:flex; align-items:center; justify-content:space-between; margin-bottom:32px; font:13px var(--mono); letter-spacing:.02em; }
       .public { color:var(--muted); font-size:11px; letter-spacing:.1em; text-transform:uppercase; border:1px solid var(--line); border-radius:999px; padding:6px 11px; background:var(--panel); }
+      /* Click-to-copy share pill — same pattern as the public file page. */
+      button.public { appearance:none; -webkit-appearance:none; cursor:pointer; font-family:inherit; display:inline-flex; align-items:center; gap:6px; }
+      button.public:hover, button.public:focus-visible { border-color:var(--accent); color:var(--accent); outline:none; }
+      /* Icon lives in ::before, not a child node — CopyAsControls' handler replaces
+         button.textContent on copy, which would otherwise destroy an inline <svg>. */
+      .sharelink::before { content:""; width:11px; height:11px; flex:none; background:currentColor; -webkit-mask:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71'/%3E%3Cpath d='M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71'/%3E%3C/svg%3E") center/contain no-repeat; mask:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71'/%3E%3Cpath d='M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71'/%3E%3C/svg%3E") center/contain no-repeat; }
       .crumbs { margin-bottom:12px; color:var(--muted); font:13px var(--mono); overflow-wrap:anywhere; }
       .crumbs .count { color:var(--muted); }
       .filehead { margin:0 0 16px; min-width:0; }
@@ -169,7 +175,23 @@ const footnoteLine = footnoteParts.join(" · ");
   </head>
   <body>
     <main class="shell">
-      <nav class="top"><Brand /><span class="public">public gallery</span></nav>
+      <nav class="top">
+        <Brand />
+        {/* Button only when CopyAsControls renders — its delegated
+           `button[data-copy]` handler is what makes the pill copy. */}
+        {embedFormats.length > 0 ? (
+          <button
+            type="button"
+            class="public sharelink"
+            data-copy={canonical}
+            title="Copy link — anyone with this link can view this page"
+          >
+            Public link
+          </button>
+        ) : (
+          <span class="public">public gallery</span>
+        )}
+      </nav>
       {gallery && item ? (
         <>
           <div class="crumbs"><a href={listPath}>{gallery.title}</a> · <span class="count">{index + 1} of {items.length}</span></div>


### PR DESCRIPTION
Reworks the public file page's right rail and copy affordances so the details that describe the image come first and copying takes one click.

## What changed

**Right rail hierarchy** (`/f/` page, with parity on `/g/` items)
- Actions (Open original / Download / Copy as) moved to the top of the rail.
- The metadata section is renamed **Metadata → Details** — `path` and `state` are what describe the shot, so they sit directly under the actions.
- Size + upload/modified dates are demoted to a single muted footnote line that sinks to the bottom of the rail, above "Report a problem".

**Copy as → snippet block** (`CopyAsControls.astro`, shared with gallery items)
- The format select now uses the `.ul-select` primitive (fixes the missing chevron padding).
- The readonly input + labeled "Copy" button are replaced by a snippet block: the full value wraps across lines (no more useless truncation in the ~300px rail) with an icon-only copy button — clicking anywhere on the block copies, with a check-icon flash and an `aria-live` "Copied" announcement.

**"Public file" badge → share control**
- The static pill is now a click-to-copy **Public link** button for the page URL, with a tooltip noting that anyone with the link can view the page. Error/auth states keep the plain label.

**Click-to-zoom** (`ImagePreview.astro`)
- Clicking the image toggles Fit ↔ Full width (`zoom-in`/`zoom-out` cursors), imgur-style. The pill toggle stays as the visible and accessible affordance.

**Local-dev fix** (`apps/api`)
- `githubAvatarProxyUrl` now coerces non-loopback `http:` origins to `https:`. Local wrangler dev reports the prod route host with an http scheme, so every gh-tagged file 503'd its `/f/` page locally (the web validator rightly rejects non-https, non-loopback avatar URLs). Loopback origins stay http so avatars remain reachable in fully-local setups. Scheme behavior pinned in `github-avatars.test.ts`.

## Before / after

| Before | After |
| ------ | ----- |
| <img width="440" alt="File page before: size/date table on top, Metadata label, select plus labeled Copy button" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-image-details-ux-e5a450/file-page-before.webp"> | <img width="440" alt="File page after: actions first, Details section, wrapped copy snippet, share pill, footnote" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-image-details-ux-e5a450/file-page-after.webp"> |

## Verification

- `apps/web`: typecheck clean, 531 tests pass. `apps/api`: typecheck clean, 1370 tests pass.
- Verified live on the `stack-raw` dev stack: zoom toggling and cursors, select-change updating the snippet, block-click copy with icon feedback, share pill copying the canonical URL, mobile stacking, and the gh-tagged `/f/` page rendering 200 with its byline (previously 503).
