### PR TITLE
feat(web): inline before/after comparison on the file page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@uploads/ui": "workspace:*",
     "astro": "^7.0.6",
     "files-sdk": "^2.1.0",
+    "img-comparison-slider": "^8.0.7",
     "markdown-for-agents": "^1.3.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -5,21 +5,71 @@
  * Fit: compact, viewport-capped (photos / wide UI).
  * Full width: stage grows with the image; page scroll (tall screenshots).
  * Tall images auto-open full width. Mode resolution: `lib/image-preview-mode.ts`.
+ *
+ * When `compare` is supplied the stage gains a second, independent axis: the
+ * view switch between this image alone and a draggable before/after slider
+ * (`img-comparison-slider`, a custom element — the public file page ships no
+ * framework runtime and must keep it that way).
  */
+import { compareImages, type BeforeAfterState } from "../lib/before-after-view";
+
 interface Props {
   src: string;
   alt: string;
+  /** The counterpart image and this file's own role; omit for unpaired files. */
+  compare?: { src: string; ownState: BeforeAfterState } | null;
 }
 
-const { src, alt } = Astro.props;
+const { src, alt, compare = null } = Astro.props;
+const pair = compare ? compareImages(compare.ownState, src, compare.src) : null;
+/** The counterpart's URL — the one layer that can 404 out from under us. */
+const counterpartUrl = compare?.src ?? null;
 ---
 
-<div class="media image-preview" data-mode="fit" data-image-preview>
+<div class="media image-preview" data-mode="fit" data-view="single" data-image-preview>
+  {pair && (
+    <div class="view-toggle" role="group" aria-label="Comparison view">
+      <button type="button" data-view-btn="single" aria-pressed="true">This image</button>
+      <button type="button" data-view-btn="compare" aria-pressed="false">Compare</button>
+    </div>
+  )}
   <div class="size-toggle" role="group" aria-label="Preview size">
     <button type="button" data-size="fit" aria-pressed="true">Fit</button>
     <button type="button" data-size="full" aria-pressed="false">Full width</button>
   </div>
-  <img src={src} alt={alt} decoding="async" />
+  <img class="single-image" src={src} alt={alt} decoding="async" />
+  {pair && (
+    <div class="compare-wrap">
+      <img-comparison-slider
+        value="50"
+        role="slider"
+        aria-label="Before and after comparison"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="50"
+        aria-valuetext="50% after"
+      >
+        <img
+          slot="first"
+          src={pair.beforeUrl}
+          alt={`Before: ${alt}`}
+          decoding="async"
+          loading="lazy"
+          data-counterpart={pair.beforeUrl === counterpartUrl ? "true" : null}
+        />
+        <img
+          slot="second"
+          src={pair.afterUrl}
+          alt={`After: ${alt}`}
+          decoding="async"
+          loading="lazy"
+          data-counterpart={pair.afterUrl === counterpartUrl ? "true" : null}
+        />
+      </img-comparison-slider>
+      <span class="compare-label compare-label--before" aria-hidden="true">before</span>
+      <span class="compare-label compare-label--after" aria-hidden="true">after</span>
+    </div>
+  )}
 </div>
 
 <script>
@@ -27,6 +77,54 @@ const { src, alt } = Astro.props;
     resolvePreviewMode,
     type ImagePreviewMode,
   } from "../lib/image-preview-mode";
+  import "img-comparison-slider";
+
+  type CompareView = "single" | "compare";
+
+  function applyView(root: HTMLElement, view: CompareView): void {
+    root.dataset.view = view;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>("button[data-view-btn]")) {
+      btn.setAttribute("aria-pressed", btn.dataset.viewBtn === view ? "true" : "false");
+    }
+  }
+
+  /**
+   * Wire the single ⇄ compare switch. No-op for unpaired files. If the
+   * counterpart image fails to load, the switch removes itself rather than
+   * offering a mode that would show a broken half.
+   */
+  function initCompare(root: HTMLElement): void {
+    const wrap = root.querySelector<HTMLElement>(".compare-wrap");
+    const toggle = root.querySelector<HTMLElement>(".view-toggle");
+    if (!wrap || !toggle) return;
+
+    for (const btn of toggle.querySelectorAll<HTMLButtonElement>("button[data-view-btn]")) {
+      btn.addEventListener("click", () => {
+        const view = btn.dataset.viewBtn;
+        if (view !== "single" && view !== "compare") return;
+        applyView(root, view);
+      });
+    }
+
+    const slider = wrap.querySelector("img-comparison-slider");
+    if (slider) {
+      slider.addEventListener("slide", () => {
+        const pct = Math.round(Number((slider as unknown as { value: number }).value) || 0);
+        slider.setAttribute("aria-valuenow", String(pct));
+        slider.setAttribute("aria-valuetext", `${pct}% after`);
+      });
+    }
+
+    const counterpart = wrap.querySelector<HTMLImageElement>("img[data-counterpart]");
+    if (!counterpart) return;
+    const drop = () => {
+      applyView(root, "single");
+      toggle.remove();
+      wrap.remove();
+    };
+    if (counterpart.complete && counterpart.naturalWidth === 0) drop();
+    else counterpart.addEventListener("error", drop, { once: true });
+  }
 
   function applyMode(root: HTMLElement, mode: ImagePreviewMode): void {
     root.dataset.mode = mode;
@@ -38,6 +136,8 @@ const { src, alt } = Astro.props;
   function initPreview(root: HTMLElement): void {
     if (root.dataset.previewReady === "1") return;
     root.dataset.previewReady = "1";
+
+    initCompare(root);
 
     const img = root.querySelector("img");
     if (!(img instanceof HTMLImageElement)) return;
@@ -68,6 +168,7 @@ const { src, alt } = Astro.props;
     // Imgur-style click-to-zoom: the image itself is a supplementary toggle:
     // the pill buttons above remain the visible + accessible affordance.
     img.addEventListener("click", () => {
+      if (root.dataset.view === "compare") return;
       override = root.dataset.mode === "full" ? "fit" : "full";
       applyMode(root, override);
     });
@@ -95,7 +196,8 @@ const { src, alt } = Astro.props;
     overflow: hidden;
   }
 
-  .size-toggle {
+  .size-toggle,
+  .view-toggle {
     position: absolute;
     top: 10px;
     right: 10px;
@@ -109,7 +211,8 @@ const { src, alt } = Astro.props;
     backdrop-filter: blur(8px);
   }
 
-  .size-toggle button {
+  .size-toggle button,
+  .view-toggle button {
     appearance: none;
     margin: 0;
     padding: 5px 11px;
@@ -124,18 +227,103 @@ const { src, alt } = Astro.props;
   }
 
   .size-toggle button:hover,
-  .size-toggle button:focus-visible {
+  .view-toggle button:hover,
+  .size-toggle button:focus-visible,
+  .view-toggle button:focus-visible {
     color: var(--fg);
     outline: none;
   }
 
-  .size-toggle button:focus-visible {
+  .size-toggle button:focus-visible,
+  .view-toggle button:focus-visible {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 55%, transparent);
   }
 
-  .size-toggle button[aria-pressed="true"] {
+  .size-toggle button[aria-pressed="true"],
+  .view-toggle button[aria-pressed="true"] {
     background: color-mix(in srgb, var(--accent) 22%, var(--panel));
     color: var(--fg);
+  }
+
+  .view-toggle {
+    right: auto;
+    left: 10px;
+  }
+
+  .compare-wrap {
+    position: relative;
+    display: none;
+    width: 100%;
+  }
+
+  .image-preview[data-view="compare"] .compare-wrap {
+    display: block;
+  }
+
+  .image-preview[data-view="compare"] > .single-image {
+    display: none;
+  }
+
+  img-comparison-slider {
+    display: block;
+    width: 100%;
+    --divider-width: 2px;
+    --divider-color: var(--accent);
+    --default-handle-width: 44px;
+    --default-handle-color: var(--accent);
+  }
+
+  /* The component's own FOUC guard, replicated from its shipped
+     dist/styles.css (read against v8.0.7 during Task 1). It adds a `rendered`
+     class to itself once laid out; until then both slotted images would
+     render stacked. `:not(:defined)` is NOT sufficient — the gap that matters
+     is between definition and first layout, not before upgrade. */
+  img-comparison-slider {
+    visibility: hidden;
+  }
+
+  img-comparison-slider [slot="second"] {
+    display: none;
+  }
+
+  img-comparison-slider.rendered {
+    visibility: inherit;
+  }
+
+  img-comparison-slider.rendered [slot="second"] {
+    display: unset;
+  }
+
+  img-comparison-slider img {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+
+  .image-preview[data-mode="fit"] img-comparison-slider img {
+    max-height: var(--preview-max-h);
+  }
+
+  .compare-label {
+    position: absolute;
+    bottom: 10px;
+    z-index: 2;
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--panel) 82%, transparent);
+    color: var(--muted);
+    font: 10.5px var(--mono);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    pointer-events: none;
+  }
+
+  .compare-label--before {
+    left: 10px;
+  }
+  .compare-label--after {
+    right: 10px;
   }
 
   .image-preview img {
@@ -170,6 +358,10 @@ const { src, alt } = Astro.props;
   .image-preview[data-mode="full"] img {
     width: 100%;
     max-height: none;
+  }
+
+  .image-preview[data-view="compare"] {
+    place-items: start stretch;
   }
 
   @media (max-width: 760px) {

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -129,10 +129,28 @@ const counterpartUrl = compare?.src ?? null;
       });
     }
 
+    // `loading="lazy"` keeps the counterpart out of the initial page fetch,
+    // but in fit mode the second slot is `width: auto` — its box derives from
+    // its own intrinsic size, which is 0×0 until it loads, and the host
+    // shrink-wraps to that. A 0×0 box never triggers a lazy load, so the
+    // circularity never breaks on its own. Force both layers eager the first
+    // time the user actually opens compare view: that's still deferred past
+    // the initial fetch (the whole reason `lazy` was there), but guarantees
+    // the images load once there's something to load them into.
+    let imagesActivated = false;
+    const activateImages = () => {
+      if (imagesActivated) return;
+      imagesActivated = true;
+      for (const el of wrap.querySelectorAll<HTMLImageElement>("img[loading='lazy']")) {
+        el.loading = "eager";
+      }
+    };
+
     for (const btn of toggle.querySelectorAll<HTMLButtonElement>("button[data-view-btn]")) {
       btn.addEventListener("click", () => {
         const view = btn.dataset.viewBtn;
         if (view !== "single" && view !== "compare") return;
+        if (view === "compare") activateImages();
         applyView(root, view);
       });
     }

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -294,7 +294,7 @@ const counterpartUrl = compare?.src ?? null;
     display: unset;
   }
 
-  img-comparison-slider img {
+  .image-preview img-comparison-slider img {
     display: block;
     width: 100%;
     height: auto;

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -253,6 +253,11 @@ const counterpartUrl = compare?.src ?? null;
   .compare-wrap {
     position: relative;
     display: none;
+    /* Without this, the block-level wrap picks up the inline-level host's
+       baseline descender gap (~4-5px), so the wrap's bottom edge sits below
+       the host's — and the corner labels below, positioned against the wrap,
+       land short of the image's real bottom edge. */
+    line-height: 0;
   }
 
   .image-preview[data-view="compare"] .compare-wrap {
@@ -417,6 +422,25 @@ const counterpartUrl = compare?.src ?? null;
   @media (max-width: 760px) {
     .image-preview {
       min-height: 220px;
+    }
+  }
+
+  /* Below ~480px the two pill groups (view-toggle top-left, size-toggle
+     top-right) together approach or exceed the stage width and form a solid
+     band across the image. Shrink padding/gap/font rather than change the
+     settled button copy ("This image" / "Compare" / "Fit" / "Full width"). */
+  @media (max-width: 480px) {
+    .size-toggle,
+    .view-toggle {
+      padding: 2px;
+      gap: 1px;
+    }
+
+    .size-toggle button,
+    .view-toggle button {
+      padding: 4px 6px;
+      font-size: 9.5px;
+      letter-spacing: 0.01em;
     }
   }
 </style>

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -253,7 +253,6 @@ const counterpartUrl = compare?.src ?? null;
   .compare-wrap {
     position: relative;
     display: none;
-    width: 100%;
   }
 
   .image-preview[data-view="compare"] .compare-wrap {
@@ -264,13 +263,39 @@ const counterpartUrl = compare?.src ?? null;
     display: none;
   }
 
-  img-comparison-slider {
-    display: block;
+  /* Fit: shrink-wrap the wrap to the host's sized box (see the
+     img-comparison-slider rules below) and center it, matching how a lone
+     fit-mode image is centered by the stage's `place-items: center`. This is
+     what keeps the corner labels — positioned against this element — sitting
+     on the image's real edges instead of a full-width box the image doesn't
+     fill. `justify-self` overrides the `justify-items: stretch` set by the
+     compare-view rule further down, for this one grid item only. */
+  .image-preview[data-mode="fit"] .compare-wrap {
+    width: auto;
+    max-width: 100%;
+    justify-self: center;
+  }
+
+  /* Full: wrap fills the stage, same as before. */
+  .image-preview[data-mode="full"] .compare-wrap {
     width: 100%;
+  }
+
+  img-comparison-slider {
+    max-width: 100%;
     --divider-width: 2px;
     --divider-color: var(--accent);
     --default-handle-width: 44px;
     --default-handle-color: var(--accent);
+  }
+
+  /* Full width: host fills the stage, same contract as the single image's
+     full-width mode. Fit mode intentionally leaves the host at its shadow
+     default (`inline-block`) so it shrink-wraps the sized image below rather
+     than forcing a width the image itself doesn't fill. */
+  .image-preview[data-mode="full"] img-comparison-slider {
+    display: block;
+    width: 100%;
   }
 
   /* The component's own FOUC guard, replicated from its shipped
@@ -296,13 +321,24 @@ const counterpartUrl = compare?.src ?? null;
 
   .image-preview img-comparison-slider img {
     display: block;
-    width: 100%;
     height: auto;
     object-fit: contain;
   }
 
+  /* Fit: same intrinsic-ratio sizing as the single image in fit mode — width
+     resolves from the image's own aspect ratio once height is capped, so the
+     host (shrink-wrapped above) matches the visible content and the divider
+     lands on the image's real edges. */
   .image-preview[data-mode="fit"] img-comparison-slider img {
+    width: auto;
+    max-width: 100%;
     max-height: var(--preview-max-h);
+  }
+
+  /* Full: same fill-the-stage sizing as the single image in full mode. */
+  .image-preview[data-mode="full"] img-comparison-slider img {
+    width: 100%;
+    max-height: none;
   }
 
   .compare-label {

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -325,14 +325,28 @@ const counterpartUrl = compare?.src ?? null;
     object-fit: contain;
   }
 
-  /* Fit: same intrinsic-ratio sizing as the single image in fit mode — width
-     resolves from the image's own aspect ratio once height is capped, so the
-     host (shrink-wrapped above) matches the visible content and the divider
-     lands on the image's real edges. */
-  .image-preview[data-mode="fit"] img-comparison-slider img {
+  /* Fit, second slot ("after"): the component keeps this layer in flow inside
+     its shadow tree, so it — and only it — drives the host's shrink-to-fit
+     box. Same intrinsic-ratio sizing as the single image in fit mode. */
+  .image-preview[data-mode="fit"] img-comparison-slider img[slot="second"] {
     width: auto;
     max-width: 100%;
     max-height: var(--preview-max-h);
+  }
+
+  /* Fit, first slot ("before"): the component absolutely positions this
+     layer's shadow container at 100%/100% of the box the second slot just
+     established, so it is excluded from the shrink-to-fit computation above.
+     Real before/after pairs routinely differ by a few pixels (content length
+     changed), so nothing guarantees the two share intrinsic dimensions. Fill
+     the box the after image set and letterbox to it — `contain` never crops,
+     and top-left (not centered) is the shared origin of two screenshots of
+     the same page, since any mismatch is extra content below the fold. */
+  .image-preview[data-mode="fit"] img-comparison-slider img[slot="first"] {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: left top;
   }
 
   /* Full: same fill-the-stage sizing as the single image in full mode. */

--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -12,6 +12,10 @@
  * framework runtime and must keep it that way).
  */
 import { compareImages, type BeforeAfterState } from "../lib/before-after-view";
+/** Vendor FOUC guard (the `rendered` class + slot-hiding rules) — imported
+ * rather than hand-copied so a future minor version can't silently drift out
+ * from under a stale local copy (see Task 1's read of v8.0.7's dist/styles.css). */
+import "img-comparison-slider/dist/styles.css";
 
 interface Props {
   src: string;
@@ -77,7 +81,6 @@ const counterpartUrl = compare?.src ?? null;
     resolvePreviewMode,
     type ImagePreviewMode,
   } from "../lib/image-preview-mode";
-  import "img-comparison-slider";
 
   type CompareView = "single" | "compare";
 
@@ -89,14 +92,42 @@ const counterpartUrl = compare?.src ?? null;
   }
 
   /**
-   * Wire the single ⇄ compare switch. No-op for unpaired files. If the
-   * counterpart image fails to load, the switch removes itself rather than
-   * offering a mode that would show a broken half.
+   * Wire the single ⇄ compare switch. No-op for unpaired files (nothing is
+   * imported: the overwhelming majority of pages using this component have
+   * no pair, and the public file page ships no framework runtime, so the
+   * slider's JS is loaded only on the pages that actually render one). If the
+   * counterpart image fails to load — or the slider module itself fails to
+   * load — the switch removes itself rather than offering a mode that would
+   * show a broken or inert half.
    */
-  function initCompare(root: HTMLElement): void {
+  async function initCompare(root: HTMLElement): Promise<void> {
     const wrap = root.querySelector<HTMLElement>(".compare-wrap");
     const toggle = root.querySelector<HTMLElement>(".view-toggle");
     if (!wrap || !toggle) return;
+
+    const drop = () => {
+      applyView(root, "single");
+      toggle.remove();
+      wrap.remove();
+    };
+
+    const slider = wrap.querySelector("img-comparison-slider");
+    if (slider) {
+      try {
+        await import("img-comparison-slider");
+      } catch {
+        // A failed dynamic import must not leave a live toggle over a dead
+        // element — drop straight back to single and bail before wiring
+        // anything else up.
+        drop();
+        return;
+      }
+      slider.addEventListener("slide", () => {
+        const pct = Math.round(Number((slider as unknown as { value: number }).value) || 0);
+        slider.setAttribute("aria-valuenow", String(pct));
+        slider.setAttribute("aria-valuetext", `${pct}% after`);
+      });
+    }
 
     for (const btn of toggle.querySelectorAll<HTMLButtonElement>("button[data-view-btn]")) {
       btn.addEventListener("click", () => {
@@ -106,22 +137,8 @@ const counterpartUrl = compare?.src ?? null;
       });
     }
 
-    const slider = wrap.querySelector("img-comparison-slider");
-    if (slider) {
-      slider.addEventListener("slide", () => {
-        const pct = Math.round(Number((slider as unknown as { value: number }).value) || 0);
-        slider.setAttribute("aria-valuenow", String(pct));
-        slider.setAttribute("aria-valuetext", `${pct}% after`);
-      });
-    }
-
     const counterpart = wrap.querySelector<HTMLImageElement>("img[data-counterpart]");
     if (!counterpart) return;
-    const drop = () => {
-      applyView(root, "single");
-      toggle.remove();
-      wrap.remove();
-    };
     if (counterpart.complete && counterpart.naturalWidth === 0) drop();
     else counterpart.addEventListener("error", drop, { once: true });
   }
@@ -137,7 +154,7 @@ const counterpartUrl = compare?.src ?? null;
     if (root.dataset.previewReady === "1") return;
     root.dataset.previewReady = "1";
 
-    initCompare(root);
+    void initCompare(root);
 
     const img = root.querySelector("img");
     if (!(img instanceof HTMLImageElement)) return;
@@ -303,27 +320,6 @@ const counterpartUrl = compare?.src ?? null;
     width: 100%;
   }
 
-  /* The component's own FOUC guard, replicated from its shipped
-     dist/styles.css (read against v8.0.7 during Task 1). It adds a `rendered`
-     class to itself once laid out; until then both slotted images would
-     render stacked. `:not(:defined)` is NOT sufficient — the gap that matters
-     is between definition and first layout, not before upgrade. */
-  img-comparison-slider {
-    visibility: hidden;
-  }
-
-  img-comparison-slider [slot="second"] {
-    display: none;
-  }
-
-  img-comparison-slider.rendered {
-    visibility: inherit;
-  }
-
-  img-comparison-slider.rendered [slot="second"] {
-    display: unset;
-  }
-
   .image-preview img-comparison-slider img {
     display: block;
     height: auto;
@@ -354,10 +350,22 @@ const counterpartUrl = compare?.src ?? null;
     object-position: left top;
   }
 
-  /* Full: same fill-the-stage sizing as the single image in full mode. */
-  .image-preview[data-mode="full"] img-comparison-slider img {
+  /* Full, second slot ("after"): same fill-the-stage sizing as the single
+     image in full mode. Still the layer that drives the host's width. */
+  .image-preview[data-mode="full"] img-comparison-slider img[slot="second"] {
     width: 100%;
     max-height: none;
+  }
+
+  /* Full, first slot ("before"): same reasoning as the fit-mode override
+     above — fill the box the after image established (here, the full stage
+     width) and letterbox to it rather than resolving its own intrinsic
+     ratio inside an overlay sized to a possibly different-ratio after image. */
+  .image-preview[data-mode="full"] img-comparison-slider img[slot="first"] {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: left top;
   }
 
   .compare-label {
@@ -389,11 +397,11 @@ const counterpartUrl = compare?.src ?? null;
     object-fit: contain;
   }
 
-  .image-preview[data-mode="fit"] img {
+  .image-preview[data-mode="fit"] .single-image {
     cursor: zoom-in;
   }
 
-  .image-preview[data-mode="full"] img {
+  .image-preview[data-mode="full"] .single-image {
     cursor: zoom-out;
   }
 
@@ -415,8 +423,14 @@ const counterpartUrl = compare?.src ?? null;
     max-height: none;
   }
 
-  .image-preview[data-view="compare"] {
-    place-items: start stretch;
+  /* Fit + compare: match single view's centering (the base rule's
+     `place-items: center`) instead of top-aligning, so toggling between
+     single and compare in fit mode doesn't jump a shorter-than-min-height
+     image vertically. Full mode already sets its own top-aligned
+     `place-items: start stretch` unconditionally above and is unaffected —
+     this selector only matches when both attributes are present. */
+  .image-preview[data-mode="fit"][data-view="compare"] {
+    place-items: center stretch;
   }
 
   @media (max-width: 760px) {

--- a/apps/web/src/lib/before-after-view.test.ts
+++ b/apps/web/src/lib/before-after-view.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { comparisonRows, compareImages, ownBeforeAfterState } from "./before-after-view";
+
+describe("ownBeforeAfterState", () => {
+  it("trusts this file's own state metadata when it is valid", () => {
+    expect(ownBeforeAfterState("before", "after")).toBe("before");
+    expect(ownBeforeAfterState("after", "before")).toBe("after");
+  });
+
+  it("falls back to the counterpart's opposite when metadata is missing", () => {
+    expect(ownBeforeAfterState(undefined, "after")).toBe("before");
+    expect(ownBeforeAfterState(undefined, "before")).toBe("after");
+  });
+
+  it("ignores junk metadata rather than trusting it", () => {
+    expect(ownBeforeAfterState("sideways", "before")).toBe("after");
+    expect(ownBeforeAfterState("", "after")).toBe("before");
+  });
+
+  // The API pairs on `state` metadata, so both sides claiming the same role is
+  // not supposed to happen — but the page must still render a stable order.
+  it("keeps its own claim even when both sides claim the same role", () => {
+    expect(ownBeforeAfterState("after", "after")).toBe("after");
+  });
+});
+
+describe("compareImages", () => {
+  it("puts the before image first when this file is the after", () => {
+    expect(compareImages("after", "own.png", "other.png")).toEqual({
+      beforeUrl: "other.png",
+      afterUrl: "own.png",
+    });
+  });
+
+  it("puts this file first when it is the before", () => {
+    expect(compareImages("before", "own.png", "other.png")).toEqual({
+      beforeUrl: "own.png",
+      afterUrl: "other.png",
+    });
+  });
+});
+
+describe("comparisonRows", () => {
+  it("always orders before then after, regardless of which one this is", () => {
+    expect(comparisonRows("after", "/f/ws/before.png").map((r) => r.state)).toEqual([
+      "before",
+      "after",
+    ]);
+    expect(comparisonRows("before", "/f/ws/after.png").map((r) => r.state)).toEqual([
+      "before",
+      "after",
+    ]);
+  });
+
+  it("links only the counterpart row and marks the current one", () => {
+    const rows = comparisonRows("after", "/f/ws/before.png");
+    expect(rows).toEqual([
+      { state: "before", current: false, href: "/f/ws/before.png" },
+      { state: "after", current: true, href: null },
+    ]);
+  });
+});

--- a/apps/web/src/lib/before-after-view.ts
+++ b/apps/web/src/lib/before-after-view.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure derivations for the file page's before/after paired view (issue #420).
+ *
+ * The API has already done the visibility- and content-type-safe counterpart
+ * lookup (apps/api/src/routes/public-files.ts); everything here is layout
+ * bookkeeping, kept out of the page's frontmatter so it can be tested.
+ */
+
+export type BeforeAfterState = "before" | "after";
+
+/** One row of the rail's Comparison section; `href` is null for this file. */
+export interface ComparisonRow {
+  state: BeforeAfterState;
+  current: boolean;
+  href: string | null;
+}
+
+/**
+ * This file's own role, given the counterpart it was paired with. Uses its own
+ * `state` metadata when that is one of the two valid values, else it is simply
+ * the counterpart's opposite.
+ */
+export function ownBeforeAfterState(
+  metadataState: string | undefined,
+  counterpartState: BeforeAfterState,
+): BeforeAfterState {
+  if (metadataState === "before" || metadataState === "after") return metadataState;
+  return counterpartState === "before" ? "after" : "before";
+}
+
+/** Which URL goes on each side of the slider, whichever half this page is. */
+export function compareImages(
+  ownState: BeforeAfterState,
+  ownUrl: string,
+  counterpartUrl: string,
+): { beforeUrl: string; afterUrl: string } {
+  return ownState === "before"
+    ? { beforeUrl: ownUrl, afterUrl: counterpartUrl }
+    : { beforeUrl: counterpartUrl, afterUrl: ownUrl };
+}
+
+/** Both roles, always before-then-after, with only the counterpart linked. */
+export function comparisonRows(
+  ownState: BeforeAfterState,
+  counterpartHref: string,
+): ComparisonRow[] {
+  return (["before", "after"] as const).map((state) => ({
+    state,
+    current: state === ownState,
+    href: state === ownState ? null : counterpartHref,
+  }));
+}

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -6,6 +6,11 @@ import Footer from "../../../components/Footer.astro";
 import ImagePreview from "../../../components/ImagePreview.astro";
 import ReportAbuse from "../../../components/ReportAbuse.astro";
 import { GH_KIND_PATH } from "../../../lib/brand-icons";
+import {
+  comparisonRows,
+  ownBeforeAfterState,
+  type BeforeAfterState,
+} from "../../../lib/before-after-view";
 import { buildEmbedFormats } from "../../../lib/embed-formats";
 import {
   applyPublicFileHeaders,
@@ -104,33 +109,16 @@ const oembedHref = file ? oembedDiscoveryHref(canonical, Astro.url.origin) : nul
 // rendered when the API actually returned a counterpart.
 const counterpart = file?.counterpart ?? null;
 
-/** This file's own before/after role, given the counterpart it's paired with. */
-function ownBeforeAfterState(
-  metadataState: string | undefined,
-  counterpartState: "before" | "after",
-): "before" | "after" {
-  if (metadataState === "before" || metadataState === "after") return metadataState;
-  return counterpartState === "before" ? "after" : "before";
-}
-
-const ownState: "before" | "after" | null = counterpart
+const ownState: BeforeAfterState | null = counterpart
   ? ownBeforeAfterState(file?.metadata?.state, counterpart.state)
   : null;
-const counterpartFilename = counterpart ? counterpart.key.split("/").filter(Boolean).pop() ?? counterpart.key : null;
 const counterpartHref = counterpart ? filePath(workspace, counterpart.key) : null;
-interface PairPanel {
-  state: "before" | "after";
-  src: string;
-  current: boolean;
-  href: string | null;
-}
-const pairPanels: PairPanel[] | null =
-  counterpart && ownState
-    ? (["before", "after"] as const).map((state) =>
-        state === ownState
-          ? { state, src: file!.url, current: true, href: null }
-          : { state, src: counterpart.url, current: false, href: counterpartHref },
-      )
+const railRows = ownState && counterpartHref ? comparisonRows(ownState, counterpartHref) : null;
+// Belt and braces: the API only pairs images (isPairableImageContentType on both
+// sides, apps/api/src/routes/public-files.ts), so this never actually filters.
+const compare =
+  counterpart && ownState && kind(file!.contentType) === "image"
+    ? { src: counterpart.url, ownState }
     : null;
 const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAULT_IMAGE;
 ---
@@ -208,16 +196,14 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
       /* Subordinate to everything above — margin-top:auto sinks it (and ReportAbuse, right
          after it in flow) to the bottom of the rail on tall pages, no-op on short ones. */
       .footnote { margin:auto 0 0; color:var(--muted); font:11.5px/1.5 var(--mono); }
-      /* Before/after paired view (issue #420) — static side-by-side, no slider. */
-      .pair { display:grid; grid-template-columns:1fr 1fr; gap:1px; background:var(--line); border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; margin:0 0 20px; }
-      .pair-panel { position:relative; background:var(--panel); display:flex; flex-direction:column; }
-      .pair-panel img { width:100%; height:220px; object-fit:contain; background:var(--bg); display:block; }
-      .pair-label { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:8px 12px; font:11px var(--mono); letter-spacing:.08em; text-transform:uppercase; color:var(--muted); }
-      .pair-label strong { color:var(--fg); font-weight:600; }
-      .pair-panel[data-current="true"] .pair-label strong { color:var(--accent); }
-      .pair-link { color:var(--muted); text-decoration:none; font:12px var(--mono); text-transform:none; letter-spacing:normal; }
-      .pair-link:hover, .pair-link:focus-visible { color:var(--accent); outline:none; }
-      @media (max-width: 620px) { .pair { grid-template-columns:1fr; } }
+      /* Before/after counterpart (issue #420) — rail rows; the stage itself
+         carries the comparison via ImagePreview's Compare mode. */
+      .pairlist { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; font:12px var(--mono); }
+      .pairrow { display:flex; align-items:baseline; gap:8px; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); }
+      .pairrow a { color:var(--body); text-decoration:none; }
+      .pairrow a:hover, .pairrow a:focus-visible { color:var(--accent); outline:none; }
+      .pairrow[data-current="true"] { color:var(--accent); }
+      .pairrow-note { color:var(--muted); text-transform:none; letter-spacing:normal; font-size:11.5px; }
       .error { padding:70px 24px; border:1px solid var(--line); border-radius:var(--radius-lg); text-align:center; background:var(--panel); color:var(--body); }
       .error code { color:var(--accent); font-family:var(--mono); }
       .error .signin { display:inline-block; margin-top:18px; padding:9px 16px; border:1px solid var(--line); border-radius:var(--radius-md); background:var(--bg); color:var(--fg); font:12px var(--mono); text-decoration:none; }
@@ -306,24 +292,9 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
               </a>
             )}
           </header>
-          {pairPanels && (
-            <div class="pair" role="group" aria-label={`Before/after comparison, viewing the ${ownState}`}>
-              {pairPanels.map((panel) => (
-                <div class="pair-panel" data-current={panel.current ? "true" : "false"}>
-                  <img src={panel.src} alt={`${panel.state} of ${filename}`} loading={panel.current ? "eager" : "lazy"} />
-                  <div class="pair-label">
-                    <strong>{panel.state}</strong>
-                    {!panel.current && panel.href && (
-                      <a class="pair-link" href={panel.href}>{counterpartFilename} ↗</a>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
           <figure class="stage" style="margin:0">
             {kind(file.contentType) === "image" ? (
-              <ImagePreview src={file.url} alt={filename} />
+              <ImagePreview src={file.url} alt={filename} compare={compare} />
             ) : (
               <div class="media">
                 {kind(file.contentType) === "video" && (
@@ -348,6 +319,30 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
                   <a class="original" href={file.url} rel="noopener noreferrer">Open original ↗</a>
                 )}
               </CopyAsControls>
+              {railRows && (
+                <div>
+                  <div class="rail-head">
+                    <span class="rail-label">Comparison</span>
+                    <span class="rail-rule" aria-hidden="true"></span>
+                  </div>
+                  <ul class="pairlist">
+                    {railRows.map((row) => (
+                      <li class="pairrow" data-current={row.current ? "true" : "false"}>
+                        {row.href ? (
+                          <a href={row.href} aria-label={`View the ${row.state} image`}>
+                            {row.state} ↗
+                          </a>
+                        ) : (
+                          <>
+                            <span>{row.state}</span>
+                            <span class="pairrow-note">this file</span>
+                          </>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
               {metadataEntries.length > 0 && (
                 <div>
                   <div class="rail-head">

--- a/docs/superpowers/plans/2026-07-28-file-page-before-after-compare.md
+++ b/docs/superpowers/plans/2026-07-28-file-page-before-after-compare.md
@@ -136,6 +136,42 @@ screenshot), then:
   math in a pure, unit-tested `apps/web/src/lib/image-compare.ts`. That is a
   decision point for the user, not a silent substitution.
 
+**Verdict (2026-07-28): PASS.** Measured on a deliberately mismatched pair
+(800×600 before, 780×590 after) rendered in a 700px stage:
+
+|                  | x   | y   | width | height |
+| ---------------- | --- | --- | ----- | ------ |
+| first (`before`) | 290 | 65  | 700   | 525    |
+| second (`after`) | 290 | 65  | 700   | 529.5  |
+| host             | 290 | 65  | 700   | 529.5  |
+
+Both layers share an exact origin (Δx 0, Δy 0). Each is width-matched and keeps
+its own aspect ratio; the host grows to the taller of the two. Nothing is
+stretched independently and nothing is clipped. This is the _right_ behavior for
+screenshot pairs — content registers from the top-left, which is how two shots of
+the same page actually differ. The only artifact is a thin band at the bottom
+(here 4.5px) where only the taller image has pixels.
+
+Dragging was verified live (value 50 → 15.7).
+
+Three findings that changed this plan, all folded into Task 3 above:
+
+1. **FOUC guard.** The package ships `dist/styles.css` guarding on a `rendered`
+   class it adds to itself, not on `:defined`. Step 4 now replicates those four
+   rules instead of the `:not(:defined)` rule originally specced.
+2. **No ARIA whatsoever.** It sets `tabindex="0"` and handles arrow keys but
+   publishes no role, name, or value. New Step 3b closes that.
+3. **Keyboard is hold-to-animate**, driven by `requestAnimationFrame`, with only
+   ArrowLeft / ArrowRight — no discrete steps, no Home / End. Weaker than the
+   range-input fallback would have been, but functional.
+
+**Verification limit discovered:** the in-app browser panel reports
+`document.hidden === true`, so `requestAnimationFrame` never ticks there and
+rAF-driven keyboard sliding cannot be observed in it at all — real key presses
+look like no-ops. This is a harness artifact, not a component defect (drag is
+pointer-driven and works fine). Task 5's keyboard check must therefore be done
+outside that panel, or skipped with this noted.
+
 - [ ] **Step 6: Delete the scratch page and commit the dependency**
 
 ```bash
@@ -487,6 +523,41 @@ img.addEventListener("click", () => {
 });
 ```
 
+- [ ] **Step 3b: Give the slider ARIA semantics**
+
+Task 1 read the component's source: it sets `tabindex="0"` on itself and
+handles `ArrowLeft` / `ArrowRight`, but publishes **no** `role`, `aria-label`,
+or value attributes at all. A focusable, keyboard-operable control with no
+accessible name or role is a real gap, and it is ours to close from the light
+DOM. Note its keyboard model is hold-to-animate (the divider glides while the
+key is held) rather than discrete per-press steps, and only those two keys are
+handled — no Home / End.
+
+Add these attributes to the `<img-comparison-slider>` element in the markup
+from Step 2:
+
+```astro
+        role="slider"
+        aria-label="Before and after comparison"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="50"
+        aria-valuetext="50% after"
+```
+
+Then keep them in sync inside `initCompare`, after the button wiring:
+
+```ts
+const slider = wrap.querySelector("img-comparison-slider");
+if (slider) {
+  slider.addEventListener("slide", () => {
+    const pct = Math.round(Number((slider as unknown as { value: number }).value) || 0);
+    slider.setAttribute("aria-valuenow", String(pct));
+    slider.setAttribute("aria-valuetext", `${pct}% after`);
+  });
+}
+```
+
 - [ ] **Step 4: Extend the styles**
 
 The `.size-toggle` rules already describe the pill-group look. Make the view
@@ -525,10 +596,25 @@ img-comparison-slider {
   --default-handle-color: var(--accent);
 }
 
-/* Custom elements upgrade client-side only; without this the two slotted
-     images render stacked for a frame before the component takes over. */
-img-comparison-slider:not(:defined) {
+/* The component's own FOUC guard, replicated from its shipped
+     dist/styles.css (read against v8.0.7 during Task 1). It adds a `rendered`
+     class to itself once laid out; until then both slotted images would
+     render stacked. `:not(:defined)` is NOT sufficient — the gap that matters
+     is between definition and first layout, not before upgrade. */
+img-comparison-slider {
   visibility: hidden;
+}
+
+img-comparison-slider [slot="second"] {
+  display: none;
+}
+
+img-comparison-slider.rendered {
+  visibility: inherit;
+}
+
+img-comparison-slider.rendered [slot="second"] {
+  display: unset;
 }
 
 img-comparison-slider img {

--- a/docs/superpowers/plans/2026-07-28-file-page-before-after-compare.md
+++ b/docs/superpowers/plans/2026-07-28-file-page-before-after-compare.md
@@ -1,0 +1,886 @@
+# File page before/after comparison — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the two-up thumbnail strip on the public file page with a Compare mode on the main image stage, driven by a draggable before/after slider, plus a Comparison row in the right rail.
+
+**Architecture:** `ImagePreview.astro` — the component that already owns the stage's Fit / Full width modes — gains an optional `compare` prop and a second pill group that switches the stage between a single image and an `img-comparison-slider` web component. The page (`f/[workspace]/[...key].astro`) stops rendering `.pair` and instead passes `compare` down and renders a rail section. All pure derivations (own before/after role, image ordering, rail rows) move out of the `.astro` frontmatter into a unit-tested lib module.
+
+**Tech Stack:** Astro 7, Cloudflare Workers SSR, vanilla `<script>` (no framework JS on public pages), `img-comparison-slider` (MIT web component), vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md`
+
+## Global Constraints
+
+- **No framework JS on public pages.** The `/f/` page ships zero React today. Do not add a `client:*` directive or import React here. The slider is a custom element precisely for this reason.
+- **No changeset.** `apps/web` is an ignored package for changesets; adding one silently blocks every npm publish. Do not create one.
+- **Formatting is `oxfmt`, not prettier.** It runs automatically via lint-staged on commit. Do not run prettier.
+- **Commit style:** `feat(web): …` / `test(web): …` / `chore(web): …`. No "comprehensive"/"world-class" wording.
+- **The API guarantees both sides are images.** `counterpart` is only populated when this file _and_ the candidate pass `isPairableImageContentType` (`apps/api/src/routes/public-files.ts:198-224`). Do not add content-type plumbing.
+- **Dependency target:** `img-comparison-slider@^8.0.7`, added to `apps/web` only.
+- Run `pnpm --filter @uploads/web test` for unit tests and `pnpm typecheck` before the final commit.
+
+---
+
+## File Structure
+
+| File                                              | Responsibility                                                                                                                                     |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/web/src/lib/before-after-view.ts`           | **New.** All pure derivations for the paired view: own role, before/after image ordering, rail rows. No DOM.                                       |
+| `apps/web/src/lib/before-after-view.test.ts`      | **New.** Unit tests for the above.                                                                                                                 |
+| `apps/web/src/components/ImagePreview.astro`      | Owns the stage: Fit / Full width, click-to-zoom, and now the single ⇄ compare view switch and the slider markup/styles/script.                     |
+| `apps/web/src/pages/f/[workspace]/[...key].astro` | Page composition only: resolves the counterpart, passes `compare` to `ImagePreview`, renders the Comparison rail section. Loses the `.pair` block. |
+| `apps/web/package.json`                           | Adds the `img-comparison-slider` dependency.                                                                                                       |
+
+---
+
+### Task 1: Spike — prove the component registers mismatched images
+
+The spec requires this before any other work. The component's README does not
+document how it lays out images of differing dimensions, and real before/after
+screenshot pairs are routinely a few pixels apart. If the two layers do not stay
+registered, the whole approach changes.
+
+**Files:**
+
+- Modify: `apps/web/package.json`
+- Temporary (deleted at the end of this task): a scratch HTML page
+
+- [ ] **Step 1: Add the dependency**
+
+```bash
+pnpm --filter @uploads/web add img-comparison-slider@^8.0.7
+```
+
+- [ ] **Step 2: Confirm it is dependency-free and small**
+
+```bash
+pnpm --filter @uploads/web why img-comparison-slider
+```
+
+Expected: `img-comparison-slider 8.x` with no transitive runtime dependencies of
+its own. If it pulls in a framework, stop and report — that contradicts the
+premise of the choice.
+
+- [ ] **Step 3: Write the scratch page**
+
+Create `apps/web/public/__spike.html` (deleted in Step 6). Two deliberately
+mismatched images: 800×600 and 780×590, each with a marker in the same corner so
+mis-registration is visible.
+
+```html
+<!doctype html>
+<meta charset="utf-8" />
+<style>
+  body {
+    background: #111;
+    margin: 0;
+    padding: 40px;
+  }
+  .stage {
+    width: 700px;
+    margin: 0 auto;
+  }
+  img-comparison-slider {
+    display: block;
+    width: 100%;
+  }
+  img-comparison-slider img {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+</style>
+<div class="stage">
+  <img-comparison-slider value="50">
+    <img slot="first" src="https://placehold.co/800x600/222/fff?text=BEFORE+%E2%97%8F" />
+    <img slot="second" src="https://placehold.co/780x590/333/fff?text=AFTER+%E2%97%8F" />
+  </img-comparison-slider>
+</div>
+<script type="module">
+  import "img-comparison-slider";
+</script>
+```
+
+If the machine has no network access for `placehold.co`, generate two local PNGs
+of those exact dimensions instead and reference them by relative path — the
+point of the spike is the dimension mismatch, not the image source.
+
+- [ ] **Step 4: Run the web dev server and look at it**
+
+```bash
+pnpm dev:web
+```
+
+Open `http://localhost:4321/__spike.html` in the browser panel. Drag the divider
+across the full width.
+
+- [ ] **Step 5: Judge the result and record it**
+
+PASS means: both images fill the same box, their corner markers sit at the same
+place, and dragging reveals the second image without it jumping, offsetting, or
+scaling differently from the first.
+
+FAIL means: the layers are offset, one is stretched independently, or the
+component sizes itself to zero height.
+
+Record the verdict in the plan file under this task (one or two sentences plus a
+screenshot), then:
+
+- **On PASS** — continue to Task 2 as written.
+- **On FAIL** — **stop and surface it to the user before writing any more code.**
+  The spec's documented fallback is to hand-roll the divider: a visually-hidden
+  `<input type="range" min="0" max="100">` as the source of truth, driven by
+  `pointerdown`/`pointermove` with `setPointerCapture`, with the pointer-x → percent
+  math in a pure, unit-tested `apps/web/src/lib/image-compare.ts`. That is a
+  decision point for the user, not a silent substitution.
+
+- [ ] **Step 6: Delete the scratch page and commit the dependency**
+
+```bash
+rm apps/web/public/__spike.html
+git add apps/web/package.json pnpm-lock.yaml
+git commit -m "chore(web): add img-comparison-slider for the paired file view"
+```
+
+---
+
+### Task 2: Pure derivations for the paired view
+
+**Files:**
+
+- Create: `apps/web/src/lib/before-after-view.ts`
+- Test: `apps/web/src/lib/before-after-view.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `type BeforeAfterState = "before" | "after"`
+  - `ownBeforeAfterState(metadataState: string | undefined, counterpartState: BeforeAfterState): BeforeAfterState`
+  - `compareImages(ownState: BeforeAfterState, ownUrl: string, counterpartUrl: string): { beforeUrl: string; afterUrl: string }`
+  - `comparisonRows(ownState: BeforeAfterState, counterpartHref: string): ComparisonRow[]`
+  - `interface ComparisonRow { state: BeforeAfterState; current: boolean; href: string | null }`
+
+`ownBeforeAfterState` moves verbatim out of the page's frontmatter
+(`f/[workspace]/[...key].astro:108-114`), where it is currently untestable.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web/src/lib/before-after-view.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { comparisonRows, compareImages, ownBeforeAfterState } from "./before-after-view";
+
+describe("ownBeforeAfterState", () => {
+  it("trusts this file's own state metadata when it is valid", () => {
+    expect(ownBeforeAfterState("before", "after")).toBe("before");
+    expect(ownBeforeAfterState("after", "before")).toBe("after");
+  });
+
+  it("falls back to the counterpart's opposite when metadata is missing", () => {
+    expect(ownBeforeAfterState(undefined, "after")).toBe("before");
+    expect(ownBeforeAfterState(undefined, "before")).toBe("after");
+  });
+
+  it("ignores junk metadata rather than trusting it", () => {
+    expect(ownBeforeAfterState("sideways", "before")).toBe("after");
+    expect(ownBeforeAfterState("", "after")).toBe("before");
+  });
+
+  // The API pairs on `state` metadata, so both sides claiming the same role is
+  // not supposed to happen — but the page must still render a stable order.
+  it("keeps its own claim even when both sides claim the same role", () => {
+    expect(ownBeforeAfterState("after", "after")).toBe("after");
+  });
+});
+
+describe("compareImages", () => {
+  it("puts the before image first when this file is the after", () => {
+    expect(compareImages("after", "own.png", "other.png")).toEqual({
+      beforeUrl: "other.png",
+      afterUrl: "own.png",
+    });
+  });
+
+  it("puts this file first when it is the before", () => {
+    expect(compareImages("before", "own.png", "other.png")).toEqual({
+      beforeUrl: "own.png",
+      afterUrl: "other.png",
+    });
+  });
+});
+
+describe("comparisonRows", () => {
+  it("always orders before then after, regardless of which one this is", () => {
+    expect(comparisonRows("after", "/f/ws/before.png").map((r) => r.state)).toEqual([
+      "before",
+      "after",
+    ]);
+    expect(comparisonRows("before", "/f/ws/after.png").map((r) => r.state)).toEqual([
+      "before",
+      "after",
+    ]);
+  });
+
+  it("links only the counterpart row and marks the current one", () => {
+    const rows = comparisonRows("after", "/f/ws/before.png");
+    expect(rows).toEqual([
+      { state: "before", current: false, href: "/f/ws/before.png" },
+      { state: "after", current: true, href: null },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @uploads/web test before-after-view
+```
+
+Expected: FAIL — `Failed to resolve import "./before-after-view"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/web/src/lib/before-after-view.ts`:
+
+```ts
+/**
+ * Pure derivations for the file page's before/after paired view (issue #420).
+ *
+ * The API has already done the visibility- and content-type-safe counterpart
+ * lookup (apps/api/src/routes/public-files.ts); everything here is layout
+ * bookkeeping, kept out of the page's frontmatter so it can be tested.
+ */
+
+export type BeforeAfterState = "before" | "after";
+
+/** One row of the rail's Comparison section; `href` is null for this file. */
+export interface ComparisonRow {
+  state: BeforeAfterState;
+  current: boolean;
+  href: string | null;
+}
+
+/**
+ * This file's own role, given the counterpart it was paired with. Uses its own
+ * `state` metadata when that is one of the two valid values, else it is simply
+ * the counterpart's opposite.
+ */
+export function ownBeforeAfterState(
+  metadataState: string | undefined,
+  counterpartState: BeforeAfterState,
+): BeforeAfterState {
+  if (metadataState === "before" || metadataState === "after") return metadataState;
+  return counterpartState === "before" ? "after" : "before";
+}
+
+/** Which URL goes on each side of the slider, whichever half this page is. */
+export function compareImages(
+  ownState: BeforeAfterState,
+  ownUrl: string,
+  counterpartUrl: string,
+): { beforeUrl: string; afterUrl: string } {
+  return ownState === "before"
+    ? { beforeUrl: ownUrl, afterUrl: counterpartUrl }
+    : { beforeUrl: counterpartUrl, afterUrl: ownUrl };
+}
+
+/** Both roles, always before-then-after, with only the counterpart linked. */
+export function comparisonRows(
+  ownState: BeforeAfterState,
+  counterpartHref: string,
+): ComparisonRow[] {
+  return (["before", "after"] as const).map((state) => ({
+    state,
+    current: state === ownState,
+    href: state === ownState ? null : counterpartHref,
+  }));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @uploads/web test before-after-view
+```
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/before-after-view.ts apps/web/src/lib/before-after-view.test.ts
+git commit -m "feat(web): pure derivations for the before/after paired view"
+```
+
+---
+
+### Task 3: Compare mode in the image stage
+
+**Files:**
+
+- Modify: `apps/web/src/components/ImagePreview.astro` (whole file — frontmatter, markup, script, styles)
+
+**Interfaces:**
+
+- Consumes: `compareImages`, `BeforeAfterState` from Task 2.
+- Produces: `ImagePreview` accepts a new optional prop
+  `compare?: { src: string; ownState: BeforeAfterState } | null` (default `null`).
+  When omitted, rendering and behavior are byte-for-byte what they are today.
+
+This component has no unit tests today (it is markup plus a DOM script) and this
+task does not add a test harness for it — its verification is the browser pass in
+Task 5. The testable logic it uses lives in Task 2.
+
+- [ ] **Step 1: Extend the frontmatter**
+
+Replace the frontmatter block (lines 1-15) with:
+
+```astro
+---
+/**
+ * Public image stage with Fit / Full width controls.
+ *
+ * Fit: compact, viewport-capped (photos / wide UI).
+ * Full width: stage grows with the image; page scroll (tall screenshots).
+ * Tall images auto-open full width. Mode resolution: `lib/image-preview-mode.ts`.
+ *
+ * When `compare` is supplied the stage gains a second, independent axis: the
+ * view switch between this image alone and a draggable before/after slider
+ * (`img-comparison-slider`, a custom element — the public file page ships no
+ * framework runtime and must keep it that way).
+ */
+import { compareImages, type BeforeAfterState } from "../lib/before-after-view";
+
+interface Props {
+  src: string;
+  alt: string;
+  /** The counterpart image and this file's own role; omit for unpaired files. */
+  compare?: { src: string; ownState: BeforeAfterState } | null;
+}
+
+const { src, alt, compare = null } = Astro.props;
+const pair = compare ? compareImages(compare.ownState, src, compare.src) : null;
+/** The counterpart's URL — the one layer that can 404 out from under us. */
+const counterpartUrl = compare?.src ?? null;
+---
+```
+
+- [ ] **Step 2: Extend the markup**
+
+Replace the markup block (the `<div class="media image-preview">` element) with:
+
+```astro
+<div class="media image-preview" data-mode="fit" data-view="single" data-image-preview>
+  {pair && (
+    <div class="view-toggle" role="group" aria-label="Comparison view">
+      <button type="button" data-view-btn="single" aria-pressed="true">This image</button>
+      <button type="button" data-view-btn="compare" aria-pressed="false">Compare</button>
+    </div>
+  )}
+  <div class="size-toggle" role="group" aria-label="Preview size">
+    <button type="button" data-size="fit" aria-pressed="true">Fit</button>
+    <button type="button" data-size="full" aria-pressed="false">Full width</button>
+  </div>
+  <img class="single-image" src={src} alt={alt} decoding="async" />
+  {pair && (
+    <div class="compare-wrap">
+      <img-comparison-slider value="50">
+        <img
+          slot="first"
+          src={pair.beforeUrl}
+          alt={`Before: ${alt}`}
+          decoding="async"
+          loading="lazy"
+          data-counterpart={pair.beforeUrl === counterpartUrl ? "true" : null}
+        />
+        <img
+          slot="second"
+          src={pair.afterUrl}
+          alt={`After: ${alt}`}
+          decoding="async"
+          loading="lazy"
+          data-counterpart={pair.afterUrl === counterpartUrl ? "true" : null}
+        />
+      </img-comparison-slider>
+      <span class="compare-label compare-label--before" aria-hidden="true">before</span>
+      <span class="compare-label compare-label--after" aria-hidden="true">after</span>
+    </div>
+  )}
+</div>
+```
+
+The `aria-hidden` labels are decoration — the slotted images already carry
+"Before: …" / "After: …" alt text, so a screen reader gets the roles without the
+duplication.
+
+- [ ] **Step 3: Extend the script**
+
+In the `<script>` block, add the import at the top (alongside the existing
+`image-preview-mode` import):
+
+```ts
+import "img-comparison-slider";
+```
+
+Then add this function above `initPreview`:
+
+```ts
+type CompareView = "single" | "compare";
+
+function applyView(root: HTMLElement, view: CompareView): void {
+  root.dataset.view = view;
+  for (const btn of root.querySelectorAll<HTMLButtonElement>("button[data-view-btn]")) {
+    btn.setAttribute("aria-pressed", btn.dataset.viewBtn === view ? "true" : "false");
+  }
+}
+
+/**
+ * Wire the single ⇄ compare switch. No-op for unpaired files. If the
+ * counterpart image fails to load, the switch removes itself rather than
+ * offering a mode that would show a broken half.
+ */
+function initCompare(root: HTMLElement): void {
+  const wrap = root.querySelector<HTMLElement>(".compare-wrap");
+  const toggle = root.querySelector<HTMLElement>(".view-toggle");
+  if (!wrap || !toggle) return;
+
+  for (const btn of toggle.querySelectorAll<HTMLButtonElement>("button[data-view-btn]")) {
+    btn.addEventListener("click", () => {
+      const view = btn.dataset.viewBtn;
+      if (view !== "single" && view !== "compare") return;
+      applyView(root, view);
+    });
+  }
+
+  const counterpart = wrap.querySelector<HTMLImageElement>("img[data-counterpart]");
+  if (!counterpart) return;
+  const drop = () => {
+    applyView(root, "single");
+    toggle.remove();
+    wrap.remove();
+  };
+  if (counterpart.complete && counterpart.naturalWidth === 0) drop();
+  else counterpart.addEventListener("error", drop, { once: true });
+}
+```
+
+Call it from `initPreview`, immediately after the `previewReady` guard:
+
+```ts
+initCompare(root);
+```
+
+Finally, make click-to-zoom yield in compare mode — in compare mode a click on
+the stage is the slider's own "jump the divider here" gesture. Replace the
+existing image click handler with:
+
+```ts
+img.addEventListener("click", () => {
+  if (root.dataset.view === "compare") return;
+  override = root.dataset.mode === "full" ? "fit" : "full";
+  applyMode(root, override);
+});
+```
+
+- [ ] **Step 4: Extend the styles**
+
+The `.size-toggle` rules already describe the pill-group look. Make the view
+toggle share them by widening the existing selectors: replace every
+`.size-toggle` selector in the `<style>` block with `.size-toggle, .view-toggle`
+(and `.size-toggle button` with `.size-toggle button, .view-toggle button`, and
+so on for `:hover`, `:focus-visible`, and `[aria-pressed="true"]`). Then add the
+positional and compare-specific rules:
+
+```css
+.view-toggle {
+  right: auto;
+  left: 10px;
+}
+
+.compare-wrap {
+  position: relative;
+  display: none;
+  width: 100%;
+}
+
+.image-preview[data-view="compare"] .compare-wrap {
+  display: block;
+}
+
+.image-preview[data-view="compare"] > .single-image {
+  display: none;
+}
+
+img-comparison-slider {
+  display: block;
+  width: 100%;
+  --divider-width: 2px;
+  --divider-color: var(--accent);
+  --default-handle-width: 44px;
+  --default-handle-color: var(--accent);
+}
+
+/* Custom elements upgrade client-side only; without this the two slotted
+     images render stacked for a frame before the component takes over. */
+img-comparison-slider:not(:defined) {
+  visibility: hidden;
+}
+
+img-comparison-slider img {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.image-preview[data-mode="fit"] img-comparison-slider img {
+  max-height: var(--preview-max-h);
+}
+
+.compare-label {
+  position: absolute;
+  bottom: 10px;
+  z-index: 2;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 82%, transparent);
+  color: var(--muted);
+  font: 10.5px var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.compare-label--before {
+  left: 10px;
+}
+.compare-label--after {
+  right: 10px;
+}
+```
+
+Compare mode also needs the stage to stop centering a single child. Add to the
+existing `[data-mode="full"]` group:
+
+```css
+.image-preview[data-view="compare"] {
+  place-items: start stretch;
+}
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm --filter @uploads/web typecheck
+```
+
+Expected: no errors. If TypeScript objects to the unknown `img-comparison-slider`
+element in the Astro template, that is a real finding — report it rather than
+casting it away; the package ships its own element typings and importing them may
+be required.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/ImagePreview.astro
+git commit -m "feat(web): compare mode on the public image stage"
+```
+
+---
+
+### Task 4: Page wiring — drop the thumbnail strip, add the rail row
+
+**Files:**
+
+- Modify: `apps/web/src/pages/f/[workspace]/[...key].astro`
+
+**Interfaces:**
+
+- Consumes: `ownBeforeAfterState`, `comparisonRows` from Task 2; the `compare`
+  prop from Task 3.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Replace the frontmatter's pairing block**
+
+Delete lines 107-134 — the local `ownBeforeAfterState` function, the `PairPanel`
+interface, and the `pairPanels` array — and replace them with:
+
+```ts
+const ownState: BeforeAfterState | null = counterpart
+  ? ownBeforeAfterState(file?.metadata?.state, counterpart.state)
+  : null;
+const counterpartHref = counterpart ? filePath(workspace, counterpart.key) : null;
+const railRows = ownState && counterpartHref ? comparisonRows(ownState, counterpartHref) : null;
+// Belt and braces: the API only pairs images (isPairableImageContentType on both
+// sides, apps/api/src/routes/public-files.ts), so this never actually filters.
+const compare =
+  counterpart && ownState && kind(file!.contentType) === "image"
+    ? { src: counterpart.url, ownState }
+    : null;
+```
+
+Delete the now-unused `counterpartFilename` const (line 119).
+
+Add to the imports at the top of the frontmatter:
+
+```ts
+import {
+  comparisonRows,
+  ownBeforeAfterState,
+  type BeforeAfterState,
+} from "../../../lib/before-after-view";
+```
+
+- [ ] **Step 2: Delete the `.pair` markup**
+
+Delete the whole `{pairPanels && ( … )}` block (lines 309-323). Nothing replaces
+it in that position — the stage below is the only image region now.
+
+- [ ] **Step 3: Pass `compare` to the stage**
+
+Change the image branch inside `<figure class="stage">`:
+
+```astro
+            {kind(file.contentType) === "image" ? (
+              <ImagePreview src={file.url} alt={filename} compare={compare} />
+            ) : (
+```
+
+- [ ] **Step 4: Add the rail section**
+
+Insert immediately **before** the `{metadataEntries.length > 0 && …}` block
+inside `<figcaption class="details">`, so Comparison sits above Details:
+
+```astro
+              {railRows && (
+                <div>
+                  <div class="rail-head">
+                    <span class="rail-label">Comparison</span>
+                    <span class="rail-rule" aria-hidden="true"></span>
+                  </div>
+                  <ul class="pairlist">
+                    {railRows.map((row) => (
+                      <li class="pairrow" data-current={row.current ? "true" : "false"}>
+                        {row.href ? (
+                          <a href={row.href} aria-label={`View the ${row.state} image`}>
+                            {row.state} ↗
+                          </a>
+                        ) : (
+                          <>
+                            <span>{row.state}</span>
+                            <span class="pairrow-note">this file</span>
+                          </>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+```
+
+- [ ] **Step 5: Swap the `.pair` styles for `.pairlist` styles**
+
+Delete the five `.pair*` rules and their `@media (max-width: 620px)` companion
+(lines 211-220), and add in their place:
+
+```css
+/* Before/after counterpart (issue #420) — rail rows; the stage itself
+         carries the comparison via ImagePreview's Compare mode. */
+.pairlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font: 12px var(--mono);
+}
+.pairrow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+.pairrow a {
+  color: var(--body);
+  text-decoration: none;
+}
+.pairrow a:hover,
+.pairrow a:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+.pairrow[data-current="true"] {
+  color: var(--accent);
+}
+.pairrow-note {
+  color: var(--muted);
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 11.5px;
+}
+```
+
+- [ ] **Step 6: Typecheck and run the whole web suite**
+
+```bash
+pnpm --filter @uploads/web typecheck && pnpm --filter @uploads/web test
+```
+
+Expected: no type errors; all tests pass, including the untouched
+`public-file.test.ts` counterpart coverage.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/pages/f/[workspace]/[...key].astro
+git commit -m "feat(web): inline before/after comparison on the file page"
+```
+
+---
+
+### Task 5: Browser verification and staged screenshots
+
+**Files:** none modified unless a defect is found.
+
+The `/f/` page is public, but it fetches the file DTO from the API, so the web
+server alone is not enough — the API must be running and hold a real paired
+fixture.
+
+- [ ] **Step 1: Start the raw local stack**
+
+Use the browser panel: `preview_start {name: "stack-raw"}` → web `:4321`, api
+`:8787`, auth `:8788`. Everything lands on `127.0.0.1`.
+
+- [ ] **Step 2: Mint a local token**
+
+```bash
+pnpm workspace:add dev-demo --local
+```
+
+Copy the bearer token it prints. The token echoed in the stack log is stale after
+a restart; this one is not.
+
+- [ ] **Step 3: Seed a paired fixture with mismatched dimensions**
+
+Pairing rule (`apps/api/src/before-after.ts`): same `path` metadata with opposite
+`state` values, scoped to the same key prefix. Deliberately size the two images
+differently — this is the case the spike was about.
+
+```bash
+TOKEN=<token from step 2>
+curl -sf -X PUT "http://127.0.0.1:8787/v1/dev-demo/files/pairtest/shot-before.png" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: image/png" \
+  -H "X-Uploads-Meta-state: before" \
+  -H "X-Uploads-Meta-path: /pairtest" \
+  --data-binary @before.png
+curl -sf -X PUT "http://127.0.0.1:8787/v1/dev-demo/files/pairtest/shot-after.png" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: image/png" \
+  -H "X-Uploads-Meta-state: after" \
+  -H "X-Uploads-Meta-path: /pairtest" \
+  --data-binary @after.png
+```
+
+Any two PNGs of different sizes work; screenshots of two different pages of the
+local site are the most realistic.
+
+- [ ] **Step 4: Verify each behavior**
+
+Open `http://127.0.0.1:4321/f/dev-demo/pairtest/shot-after.png` and confirm:
+
+1. The page opens on the single image — the `after` file, as its URL says.
+2. No thumbnail strip anywhere on the page.
+3. Top-left pill group reads `This image | Compare`; top-right still reads `Fit | Full width`.
+4. Clicking Compare shows the slider; the two layers are registered (Task 1's criterion) despite differing dimensions.
+5. Dragging the handle works; clicking elsewhere in the stage jumps the divider; the divider does **not** toggle zoom.
+6. Tab to the slider, then arrow keys move the divider.
+7. Switching back to This image restores click-to-zoom.
+8. Fit and Full width both behave in **both** views.
+9. The rail shows `COMPARISON` above `DETAILS`, with `before ↗` linking to the counterpart and `after` marked "this file" in the accent color.
+10. Following that link lands on the before page, where the roles are reversed and Compare shows the _same_ left/right arrangement (before on the left) — not a mirrored one.
+11. At a 375px viewport the rail stacks under the stage and the slider is still draggable by touch.
+
+Note `read_page` returns "(empty page)" on this stack — use screenshots and
+`javascript_tool` instead.
+
+- [ ] **Step 5: Verify the counterpart-failure fallback**
+
+In the page console, simulate the counterpart 404ing:
+
+```js
+const img = document.querySelector(".compare-wrap img[data-counterpart]");
+img.dispatchEvent(new Event("error"));
+```
+
+Expected: the Compare pill and the slider both disappear, the single image
+remains, and the page does not shift or error. The rail's Comparison rows stay —
+the counterpart page may still be reachable even if this fetch failed.
+
+- [ ] **Step 6: Confirm no framework JS reached the page**
+
+```js
+Array.from(document.scripts)
+  .map((s) => s.src)
+  .filter(Boolean);
+```
+
+Expected: no `react` / `react-dom` bundle in the list.
+
+- [ ] **Step 7: Stage before/after screenshots for the PR**
+
+Per AGENTS.md, stage as you go rather than waiting for a PR. The "before" here is
+the old thumbnail strip — capture it from `git stash` or from the production page
+at `https://uploads.sh/f/default/gh/buildinternet/uploads/pull/549/file-page-after.webp`,
+which still shows the old layout.
+
+```bash
+uploads put ./file-page-compare-before.webp --meta path=/f --state before
+uploads put ./file-page-compare-after.webp --meta path=/f --state after
+```
+
+- [ ] **Step 8: Full typecheck and test sweep, then commit any fixes**
+
+```bash
+pnpm typecheck && pnpm test
+```
+
+Expected: both green. Commit any defect fixes found during verification with
+`fix(web): …`, each with a one-line note on what the browser pass caught.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section                                                             | Task                                                     |
+| ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| Delete the thumbnail strip                                               | Task 4, steps 2 and 5                                    |
+| Stage: `compare` prop, two-mode toggle, single default                   | Task 3, steps 1-2                                        |
+| Click-to-zoom suppressed in Compare; Fit / Full width in both            | Task 3, steps 3-4; verified Task 5 step 4 items 5, 7, 8  |
+| Adopt `img-comparison-slider`, CSS-var restyling, `:not(:defined)` guard | Task 1; Task 3, steps 3-4                                |
+| Spike mismatched dimensions before other work, with hand-roll fallback   | Task 1 (blocking, with an explicit stop-and-ask on FAIL) |
+| Counterpart-error degrade                                                | Task 3, step 3; verified Task 5 step 5                   |
+| Rail Comparison section, roles only, no filenames                        | Task 4, steps 4-5                                        |
+| Browser verification incl. mismatched pair and mobile                    | Task 5                                                   |
+| No framework JS on public pages                                          | Global constraint; verified Task 5 step 6                |
+
+**Placeholders:** none — every code step carries the actual code, and the one
+open question (spike PASS/FAIL) is an explicit decision point with both branches
+specified rather than a "TBD".
+
+**Type consistency:** `BeforeAfterState`, `ComparisonRow`, `ownBeforeAfterState`,
+`compareImages`, and `comparisonRows` are defined in Task 2 and used with those
+exact names and signatures in Tasks 3 and 4. The `compare` prop shape
+`{ src, ownState }` is identical in Task 3's `Props` and Task 4's construction.
+The `data-view` / `data-mode` / `data-counterpart` attribute names match between
+Task 3's markup, script, and styles.

--- a/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
+++ b/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
@@ -78,31 +78,59 @@ be proven to be an image server-side. Two guards, no API change:
   single mode. Today the same situation renders a broken thumbnail, so this is strictly
   better.
 
-### Slider mechanics
+### Slider mechanics: adopt `img-comparison-slider`
 
-A visually-hidden `<input type="range" min="0" max="100">` is the source of truth for the
-split position. This buys keyboard support (arrows, Home, End), focus handling, and
-screen-reader semantics from the platform instead of hand-rolled ARIA.
+The divider itself is not hand-rolled. `img-comparison-slider`
+(https://github.com/sneas/img-comparison-slider, MIT, v8.0.7) is a dependency-free web
+component under 4 kB gzipped that already provides drag, click-to-jump, touch, and
+keyboard control, plus a `value` attribute (0–100), a `slide` event, and CSS-variable
+styling. Being a plain custom element, it costs the public file page no framework
+runtime — the page ships no React today and must keep it that way.
 
-Pointer interaction writes into that input:
+Markup inside the stage, with `before` always first:
 
-- `pointerdown` on the stage sets the split to the pointer's x and calls
-  `setPointerCapture`, so a drag survives leaving the stage box.
-- `pointermove` while captured updates the split.
-- `pointerup` / `pointercancel` release capture.
-
-Touch works through the same pointer events. There is no autoplay and no hover-scrub.
-
-The pointer-x-to-percentage math and its clamping move into a new pure module,
-`apps/web/src/lib/image-compare.ts`, following the precedent set by
-`image-preview-mode.ts`:
-
-```ts
-/** Pointer x within a stage rect → a 0–100 split percentage, clamped. */
-export function splitFromPointer(clientX: number, rect: { left: number; width: number }): number;
+```html
+<img-comparison-slider>
+  <img slot="first" src="{beforeUrl}" alt="before" />
+  <img slot="second" src="{afterUrl}" alt="after" />
+</img-comparison-slider>
 ```
 
-A zero-width rect returns 50 rather than dividing by zero.
+Slotted images stay in the light DOM, so the stage's existing `img` sizing rules keep
+applying to both layers. The handle and divider are restyled to the page's palette
+through the component's own custom properties (`--divider-width`, `--divider-color`,
+`--default-handle-width`, `--default-handle-color`). The BEFORE / AFTER corner labels are
+ours, positioned in the wrapper rather than inside the component's shadow root.
+
+Rejected alternatives: shadcn/ui has no comparison component, and the community versions
+(shadcn.io, BundUI, Aceternity) are React + Tailwind, which this repo's public pages use
+neither of; `react-compare-slider` is a good component but would put react and react-dom
+on a page that currently ships no framework JS.
+
+Two integration details this brings with it:
+
+- **No SSR.** Custom elements only upgrade client-side. The import lives in the
+  component's client `<script>`, and an `img-comparison-slider:not(:defined)` rule hides
+  or neutralizes the element until it upgrades, so there is no flash of stacked images.
+- **Shadow DOM.** Styling reaches the component only through its documented custom
+  properties and the slotted images. Anything the page needs to restyle beyond those has
+  to live in our wrapper.
+
+#### Spike first
+
+The README does not document how the component lays out images of differing dimensions,
+and before/after screenshot pairs are frequently a few pixels apart. **Before any other
+implementation work**, prototype the component in the stage with a deliberately
+mismatched pair and confirm the two layers stay registered (same origin, same scale) —
+not offset or independently stretched.
+
+If they mis-register and no combination of the component's CSS variables and our own
+slotted-image rules fixes it, fall back to hand-rolling the divider: a visually-hidden
+`<input type="range" min="0" max="100">` as the source of truth (platform keyboard and
+screen-reader semantics for free), driven by `pointerdown` / `pointermove` with
+`setPointerCapture`, with the pointer-x-to-percentage math in a pure, unit-tested
+`apps/web/src/lib/image-compare.ts`. That fallback is a decision point for the
+implementer, not a silent substitution — surface it before proceeding.
 
 ### Rail
 
@@ -131,16 +159,23 @@ that get no stage toggle.
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `apps/web/src/pages/f/[workspace]/[...key].astro` | Delete the `.pair` block, the `PairPanel` interface, `pairPanels`, and the `.pair*` CSS. Pass `compare` to `ImagePreview`. Add the Comparison rail section. Keep `ownState` / `counterpartHref`. |
 | `apps/web/src/components/ImagePreview.astro`      | Optional `compare` prop; compare-mode markup, styles, and slider script; mode toggle; counterpart-error fallback.                                                                                |
-| `apps/web/src/lib/image-compare.ts`               | New. Pure split-position helpers.                                                                                                                                                                |
-| `apps/web/src/lib/image-compare.test.ts`          | New. Unit tests for those helpers.                                                                                                                                                               |
+| `apps/web/package.json`                           | Add the `img-comparison-slider` dependency.                                                                                                                                                      |
+
+Only if the spike fails and the divider is hand-rolled: new
+`apps/web/src/lib/image-compare.ts` plus its unit tests.
 
 ## Testing
 
-- Unit tests for `splitFromPointer`: midpoint, both clamps, out-of-range pointer, zero-width rect.
+The comparison behavior is a third-party component driven by pointer events, so it is
+verified in a browser rather than in unit tests.
+
 - Existing `public-file.test.ts` counterpart coverage is unaffected and must stay green.
 - Browser verification against a locally served paired file (stack-raw on `127.0.0.1`,
   per the local verification recipe): mode switch, drag, click-to-jump, keyboard nudge,
-  Fit / Full width in both modes, mobile width, and the counterpart-fails-to-load fallback.
+  Fit / Full width in both modes, mobile width, a mismatched-dimensions pair, and the
+  counterpart-fails-to-load fallback.
+- Confirm the public file page still ships no framework runtime, and that the added
+  bundle is the component only.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
+++ b/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
@@ -1,0 +1,151 @@
+# File page: inline before/after comparison
+
+Date: 2026-07-28
+Status: approved, ready for planning
+
+## Problem
+
+A file with a before/after counterpart (issue #420, shipped in PRs #424/#425) renders a
+two-up thumbnail strip above the main stage on `/f/:workspace/:key`
+(`apps/web/src/pages/f/[workspace]/[...key].astro`, the `.pair` block). The strip has
+three problems:
+
+- The panels are capped at 220px tall, so on a screenshot pair the actual differences are
+  invisible at that size.
+- The images are not links and not interactive; only a small text link on the counterpart
+  panel navigates anywhere, which is not where a viewer aims.
+- It duplicates the stage below it. The page shows the same image twice at two sizes.
+
+The comparison people actually want — a draggable split view — is absent.
+
+## Design
+
+Delete the thumbnail strip. Redistribute its two jobs: comparing becomes a mode of the
+main stage; navigating to the counterpart becomes a rail row.
+
+Nothing else on the page changes — Fit / Full width, click-to-zoom, Copy as, Details,
+the footnote, and Report a problem all stay as they are.
+
+### Stage
+
+`ImagePreview.astro` gains an optional `compare` prop:
+
+```ts
+interface CompareProps {
+  /** Public URL of the counterpart image. */
+  src: string;
+  /** This file's own role, so the labels and image order are correct. */
+  ownState: "before" | "after";
+}
+```
+
+When the prop is present, the component renders a second pill group in the stage's
+top-left, mirroring the existing Fit / Full width group on the right:
+
+```
+┌────────────────────────────────────────────────────┐
+│ [This image | Compare]          [Fit | Full width] │
+│                                                    │
+│                ← image / slider →                  │
+└────────────────────────────────────────────────────┘
+```
+
+- **This image** — the default. Behavior identical to an unpaired file today, including
+  click-to-zoom.
+- **Compare** — both images occupy the same box. `before` is the base layer; `after` is
+  overlaid and clipped by a CSS `inset` driven by a single `--split` custom property. A
+  vertical rule with a grab handle sits at the split. Corner labels read `BEFORE` (left)
+  and `AFTER` (right).
+
+Fit / Full width continues to size the whole stage in both modes. Click-to-zoom is
+suppressed in Compare mode, because a click there moves the divider — this is the one
+interaction the two modes cannot share. The Fit / Full width pills remain the size
+affordance in Compare mode.
+
+Because the two images may differ slightly in dimensions, both layers use
+`object-fit: contain` against a stage box sized by this file's own image. Mismatched
+aspect ratios letterbox rather than mis-register.
+
+### Degrade rules
+
+The API's counterpart DTO carries no content type
+(`PublicFileCounterpart` in `apps/web/src/lib/public-file.ts`), so the counterpart cannot
+be proven to be an image server-side. Two guards, no API change:
+
+- The `compare` prop is only passed when **this** file's `fileKind` is `image`. A video or
+  PDF with a counterpart keeps the rail row and gets no stage toggle.
+- If the counterpart image fires `error`, the script removes the toggle and forces
+  single mode. Today the same situation renders a broken thumbnail, so this is strictly
+  better.
+
+### Slider mechanics
+
+A visually-hidden `<input type="range" min="0" max="100">` is the source of truth for the
+split position. This buys keyboard support (arrows, Home, End), focus handling, and
+screen-reader semantics from the platform instead of hand-rolled ARIA.
+
+Pointer interaction writes into that input:
+
+- `pointerdown` on the stage sets the split to the pointer's x and calls
+  `setPointerCapture`, so a drag survives leaving the stage box.
+- `pointermove` while captured updates the split.
+- `pointerup` / `pointercancel` release capture.
+
+Touch works through the same pointer events. There is no autoplay and no hover-scrub.
+
+The pointer-x-to-percentage math and its clamping move into a new pure module,
+`apps/web/src/lib/image-compare.ts`, following the precedent set by
+`image-preview-mode.ts`:
+
+```ts
+/** Pointer x within a stage rect → a 0–100 split percentage, clamped. */
+export function splitFromPointer(clientX: number, rect: { left: number; width: number }): number;
+```
+
+A zero-width rect returns 50 rather than dividing by zero.
+
+### Rail
+
+A new section above the footnote, using the page's existing `rail-head` / `rail-label`
+pattern:
+
+```
+COMPARISON ─────────────
+BEFORE ↗
+AFTER            (this file)
+```
+
+Both roles are always listed so the page states which one you are looking at; only the
+counterpart row is a link. Filenames are omitted — the role labels plus the page title
+are context enough, and the counterpart's filename is a near-duplicate of this file's.
+The current file's row is marked with the accent color and a muted "this file" note; the
+link carries an accessible name naming the role and destination (for example,
+`View the before image`).
+
+The rail section renders whenever a counterpart exists, including for non-image files
+that get no stage toggle.
+
+## Files
+
+| File                                              | Change                                                                                                                                                                                           |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/web/src/pages/f/[workspace]/[...key].astro` | Delete the `.pair` block, the `PairPanel` interface, `pairPanels`, and the `.pair*` CSS. Pass `compare` to `ImagePreview`. Add the Comparison rail section. Keep `ownState` / `counterpartHref`. |
+| `apps/web/src/components/ImagePreview.astro`      | Optional `compare` prop; compare-mode markup, styles, and slider script; mode toggle; counterpart-error fallback.                                                                                |
+| `apps/web/src/lib/image-compare.ts`               | New. Pure split-position helpers.                                                                                                                                                                |
+| `apps/web/src/lib/image-compare.test.ts`          | New. Unit tests for those helpers.                                                                                                                                                               |
+
+## Testing
+
+- Unit tests for `splitFromPointer`: midpoint, both clamps, out-of-range pointer, zero-width rect.
+- Existing `public-file.test.ts` counterpart coverage is unaffected and must stay green.
+- Browser verification against a locally served paired file (stack-raw on `127.0.0.1`,
+  per the local verification recipe): mode switch, drag, click-to-jump, keyboard nudge,
+  Fit / Full width in both modes, mobile width, and the counterpart-fails-to-load fallback.
+
+## Out of scope
+
+- A side-by-side (non-slider) third mode. Two stage modes plus Fit / Full width is already
+  the ceiling for stage chrome.
+- Adding `contentType` to the counterpart DTO. The two guards above cover the case without
+  an API change; revisit only if non-image pairs become common.
+- Any change to how pairs are detected or to the managed PR comment's pairing output.

--- a/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
+++ b/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
@@ -68,15 +68,22 @@ aspect ratios letterbox rather than mis-register.
 
 ### Degrade rules
 
-The API's counterpart DTO carries no content type
-(`PublicFileCounterpart` in `apps/web/src/lib/public-file.ts`), so the counterpart cannot
-be proven to be an image server-side. Two guards, no API change:
+The counterpart DTO (`PublicFileCounterpart` in `apps/web/src/lib/public-file.ts`) carries
+no content type, but it does not need to: the API only ever populates `counterpart` when
+**both** this file and the candidate pass `isPairableImageContentType`
+(`apps/api/src/routes/public-files.ts`), whose set is identical to the web app's own
+`imageTypes`. A video, PDF, or SVG therefore never receives a counterpart at all, and any
+counterpart that arrives is renderable as an `<img>`.
 
-- The `compare` prop is only passed when **this** file's `fileKind` is `image`. A video or
-  PDF with a counterpart keeps the rail row and gets no stage toggle.
-- If the counterpart image fires `error`, the script removes the toggle and forces
-  single mode. Today the same situation renders a broken thumbnail, so this is strictly
-  better.
+That leaves one guard, for transport rather than type:
+
+- If the counterpart image fires `error` (deleted between the API read and the browser
+  fetch, network failure), the script removes the Compare toggle and forces single mode.
+  Today the same situation renders a broken thumbnail, so this is strictly better.
+
+Passing `compare` only when this file's `fileKind` is `image` remains a cheap assertion of
+the server's contract, but it is a belt-and-braces check, not the thing standing between a
+viewer and a broken layout.
 
 ### Slider mechanics: adopt `img-comparison-slider`
 
@@ -150,8 +157,7 @@ The current file's row is marked with the accent color and a muted "this file" n
 link carries an accessible name naming the role and destination (for example,
 `View the before image`).
 
-The rail section renders whenever a counterpart exists, including for non-image files
-that get no stage toggle.
+The rail section renders whenever a counterpart exists.
 
 ## Files
 
@@ -181,6 +187,6 @@ verified in a browser rather than in unit tests.
 
 - A side-by-side (non-slider) third mode. Two stage modes plus Fit / Full width is already
   the ceiling for stage chrome.
-- Adding `contentType` to the counterpart DTO. The two guards above cover the case without
-  an API change; revisit only if non-image pairs become common.
+- Adding `contentType` to the counterpart DTO. The API already guarantees both sides are
+  pairable images, so the field would carry no new information.
 - Any change to how pairs are detected or to the managed PR comment's pairing output.

--- a/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
+++ b/docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md
@@ -52,10 +52,10 @@ top-left, mirroring the existing Fit / Full width group on the right:
 
 - **This image** — the default. Behavior identical to an unpaired file today, including
   click-to-zoom.
-- **Compare** — both images occupy the same box. `before` is the base layer; `after` is
-  overlaid and clipped by a CSS `inset` driven by a single `--split` custom property. A
-  vertical rule with a grab handle sits at the split. Corner labels read `BEFORE` (left)
-  and `AFTER` (right).
+- **Compare** — both images occupy the same box, split by a draggable vertical divider
+  with a grab handle, `before` on the left and `after` on the right. Corner labels read
+  `BEFORE` and `AFTER`. The divider is the `img-comparison-slider` web component; see
+  "Slider mechanics" below.
 
 Fit / Full width continues to size the whole stage in both modes. Click-to-zoom is
 suppressed in Compare mode, because a click there moves the divider — this is the one

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       files-sdk:
         specifier: ^2.1.0
         version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      img-comparison-slider:
+        specifier: ^8.0.7
+        version: 8.0.7
       markdown-for-agents:
         specifier: ^1.3.4
         version: 1.3.4
@@ -4069,6 +4072,9 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  img-comparison-slider@8.0.7:
+    resolution: {integrity: sha512-BALViPtL2FgcCa9K8KkrmhWuyeDkVu6XVwBoRm9pU8Y6P1rjw31zujuEMBWTz2w6W30zzdQZNTccvg7J9Gf/LQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -9291,6 +9297,8 @@ snapshots:
       postcss: 8.5.16
 
   ignore@5.3.2: {}
+
+  img-comparison-slider@8.0.7: {}
 
   import-fresh@3.3.1:
     dependencies:


### PR DESCRIPTION
Replaces the before/after thumbnail strip on the file page with a Compare mode on the main image stage.

The old strip capped each panel at 220px, so on a screenshot pair the actual differences were invisible; the panels weren't links, and they duplicated the stage below them. The comparison people actually want — a draggable split — wasn't there.

## What changed

- **The strip is gone.** Markup, `PairPanel`, `pairPanels`, and all `.pair*` CSS.
- **The stage gains a second axis.** A `This image | Compare` pill group mirrors the existing `Fit | Full width` group. Single is the default, so the page still plainly shows the file its URL names.
- **Compare** overlays both images behind a draggable divider, before on the left. Fit and Full width still size the stage in both views; click-to-zoom is suppressed in Compare, where a click moves the divider instead.
- **The rail gains a Comparison section** above Details, listing both roles and linking only the counterpart. Roles alone, no filenames — the page title already says which file you're on.

## Before / after

| | |
| --- | --- |
| **Before** — two small static thumbnails above a duplicate of the same image | ![before](https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-file-page-ui-simplify-3829bf/compare-before.webp) |
| **After** — the comparison is the stage; counterpart moves to the rail | ![after](https://embed.uploads.sh/default/gh/buildinternet/uploads/branch/claude-file-page-ui-simplify-3829bf/compare-after.webp) |

Both captures use the real image pair from #549.

## The slider is a dependency, not hand-rolled

`img-comparison-slider` (MIT, ~3.6 kB gzipped, zero transitive deps). shadcn/ui has no comparison component, and the community versions are React + Tailwind — neither of which this page uses. `react-compare-slider` is good but would put React on a page that ships **zero** framework runtime today, which is the constraint that drove the whole choice.

It's imported dynamically and only when a slider is actually on the page, so galleries and ordinary file pages — the overwhelming majority — never load it. Verified: `customElements.get("img-comparison-slider")` is `false` on an unpaired page.

Two things the component doesn't provide, added here: it publishes no ARIA at all despite being focusable and keyboard-operable, so the host carries `role="slider"` with `aria-valuenow`/`aria-valuetext` kept in sync; and its FOUC guard keys off a `rendered` class it adds to itself, so we use its own shipped stylesheet rather than a hand-copy that could drift on a version bump.

## Sizing, which took some care

Before/after screenshots of the same page routinely differ by a few pixels when content length changes, so the two layers have to stay registered. In Fit, the after image sizes the box and the before layer is fitted into it with `object-fit: contain` anchored top-left — content registers from the top-left corner, which is how two shots of the same page actually differ, and mismatches letterbox rather than crop. Full width applies the same contract. The geometry is identical whichever half of the pair you're viewing.

## Verification

Live browser pass against a seeded pair with deliberately mismatched dimensions (800×600 / 780×590):

- Both layers share an exact origin in Fit and Full; height delta 0 in Full.
- Drag moves the divider (50 → 80.0) with ARIA syncing.
- Fit/Full width behave in both views; click-to-zoom returns in single view.
- If the counterpart fails to load, the toggle and slider remove themselves and the stage falls back to single — the rail link stays.
- 320px and 375px: no overlap, no horizontal overflow.
- Unpaired file page renders exactly as before.

`pnpm test` 3528 passing (260 files), `pnpm typecheck` clean.

## Known edge case

An extreme aspect-ratio mismatch — a before several times taller than the after — makes the before layer height-bound, so it renders narrower than the box with blank space beside it. It fails safe (no crop, no distortion) and needs a several-fold page-length change to trigger. Fixing it properly means abandoning the "after image sizes the box" contract, so it's left as-is deliberately.

Spec and plan: `docs/superpowers/specs/2026-07-28-file-page-before-after-compare-design.md`, `docs/superpowers/plans/2026-07-28-file-page-before-after-compare.md`.
