### PR TITLE
fix(comment): collapse a managed attachments comment that lost the create race

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,9 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Collapse a managed attachments comment that lost a create race. Find-or-create
+was not atomic, so a second writer could create its own comment inside the same
+window and leave a permanent stale orphan on the PR. After creating, the comment
+is now verified once: the oldest marker comment wins, the current body is folded
+into it, and the duplicate is deleted.

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -1327,7 +1327,7 @@ describe("upsertBotComment post-create race reconciliation (issue #553)", () => 
       commentUrl: "https://github.com/acme/web/pull/12#c200",
     });
     expect(deleted).toEqual([]);
-    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("200");
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBeNull();
   });
 
   it("never deletes another workspace's legacy comment after a create", async () => {
@@ -1399,15 +1399,27 @@ describe("upsertBotComment post-create race reconciliation (issue #553)", () => 
       action: "created",
       commentUrl: "https://github.com/acme/web/pull/12#c100",
     });
-    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("100");
+    // ...but the id is NOT cached: we never confirmed ours is the thread's only
+    // managed comment, so the next sync must miss the fast path and hunt.
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBeNull();
   });
 
-  it("caches the comment id for at most a day so a surviving duplicate self-heals", async () => {
+  it("does not cache the id when folding into the older comment fails", async () => {
     const { env, kv } = makeTestEnv();
     const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
-    const { fetchImpl } = racingFetch([[], [{ id: 100, body: `${MARKER}\nours` }]], 100);
+    const { fetchImpl } = racingFetch(
+      [
+        [],
+        [
+          { id: 100, body: `${MARKER}\nthe other writer's` },
+          { id: 200, body: `${MARKER}\nours` },
+        ],
+      ],
+      200,
+      { patchStatus: 500 },
+    );
     await upsertBotComment(env, cfg, 42, { repo: "acme/web", num: 12 }, "BODY", "acme", fetchImpl);
-    const entry = kv.store.get("ghcomment:acme:acme/web#12");
-    expect(entry?.expirationTtl).toBeLessThanOrEqual(60 * 60 * 24);
+    // Two comments survive, so the next sync must hunt rather than trust an id.
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBeNull();
   });
 });

--- a/apps/api/src/github-comment.test.ts
+++ b/apps/api/src/github-comment.test.ts
@@ -1148,3 +1148,266 @@ describe("upsertBotComment", () => {
     expect(res).toEqual({ action: "skipped" });
   });
 });
+
+/**
+ * Issue #553: two writers (the `pull_request.opened` promotion webhook and an
+ * explicit `uploads put --pr`) can both hunt, both miss, and both create,
+ * seconds apart. The post-create verification pass below is what makes that
+ * race converge instead of leaving a permanent stale orphan.
+ */
+describe("upsertBotComment post-create race reconciliation (issue #553)", () => {
+  /**
+   * A thread whose comment list changes between the pre-create hunt and the
+   * post-create verification — `listings` supplies one response body per list
+   * call, the last entry repeating. Records every PATCH/DELETE for assertions.
+   */
+  function racingFetch(
+    listings: { id: number; body: string }[][],
+    createdId: number,
+    opts: { patchStatus?: number } = {},
+  ) {
+    const patched: string[] = [];
+    const deleted: string[] = [];
+    let listCall = 0;
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes(`/issues/12/comments`) && init.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            id: createdId,
+            html_url: `https://github.com/acme/web/pull/12#c${createdId}`,
+          }),
+          { status: 201 },
+        );
+      }
+      if (url.includes("/issues/12/comments")) {
+        const page = listings[Math.min(listCall++, listings.length - 1)];
+        return new Response(JSON.stringify(page), { status: 200 });
+      }
+      if (init.method === "DELETE") {
+        deleted.push(url);
+        return new Response(null, { status: 204 });
+      }
+      if (init.method === "PATCH") {
+        patched.push(url);
+        const id = url.slice(url.lastIndexOf("/") + 1);
+        return new Response(
+          JSON.stringify({
+            id: Number(id),
+            html_url: `https://github.com/acme/web/pull/12#c${id}`,
+          }),
+          { status: opts.patchStatus ?? 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+    return { fetchImpl, patched, deleted };
+  }
+
+  const MARKER = attachmentsMarker("acme");
+
+  it("folds into the older comment and deletes its own when it lost the create race", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    // Pre-create hunt sees nothing; by the verification pass the other writer's
+    // (older) comment 100 is there alongside our fresh 200.
+    const { fetchImpl, patched, deleted } = racingFetch(
+      [
+        [],
+        [
+          { id: 100, body: `${MARKER}\nthe other writer's` },
+          { id: 200, body: `${MARKER}\nours` },
+        ],
+      ],
+      200,
+    );
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "updated",
+      commentUrl: "https://github.com/acme/web/pull/12#c100",
+    });
+    expect(patched).toEqual(["https://api.github.com/repos/acme/web/issues/comments/100"]);
+    expect(deleted).toEqual(["https://api.github.com/repos/acme/web/issues/comments/200"]);
+    // Both racers must converge on the same surviving comment id.
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("100");
+  });
+
+  it("keeps its own comment and deletes the newer duplicate when it won the race", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const { fetchImpl, patched, deleted } = racingFetch(
+      [
+        [],
+        [
+          { id: 100, body: `${MARKER}\nours` },
+          { id: 200, body: `${MARKER}\nthe other writer's` },
+        ],
+      ],
+      100,
+    );
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c100",
+    });
+    expect(patched).toEqual([]); // ours is already the body we wrote.
+    expect(deleted).toEqual(["https://api.github.com/repos/acme/web/issues/comments/200"]);
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("100");
+  });
+
+  it("keeps its own comment when the verification listing shows no duplicate", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const { fetchImpl, patched, deleted } = racingFetch(
+      [[], [{ id: 100, body: `${MARKER}\nours` }]],
+      100,
+    );
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c100",
+    });
+    expect(patched).toEqual([]);
+    expect(deleted).toEqual([]);
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("100");
+  });
+
+  it("leaves both comments alone when folding into the older one fails", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const { fetchImpl, deleted } = racingFetch(
+      [
+        [],
+        [
+          { id: 100, body: `${MARKER}\nthe other writer's` },
+          { id: 200, body: `${MARKER}\nours` },
+        ],
+      ],
+      200,
+      { patchStatus: 500 },
+    );
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    // Our comment carries the correct body, so a failed fold must not delete it.
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c200",
+    });
+    expect(deleted).toEqual([]);
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("200");
+  });
+
+  it("never deletes another workspace's legacy comment after a create", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    // A legacy (unnamespaced) comment is ambiguous — it may belong to another
+    // workspace, so the adopt-only contract holds here as it does in the hunt.
+    const { fetchImpl, patched, deleted } = racingFetch(
+      [
+        [],
+        [
+          { id: 100, body: `${ATTACHMENTS_MARKER}\nsomeone else's legacy comment` },
+          { id: 200, body: `${MARKER}\nours` },
+        ],
+      ],
+      200,
+    );
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c200",
+    });
+    expect(patched).toEqual([]);
+    expect(deleted).toEqual([]);
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("200");
+  });
+
+  it("keeps its own comment when the verification listing degrades", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    let listCall = 0;
+    const fetchImpl = (async (url: string, init: RequestInit = {}) => {
+      if (url.includes("/access_tokens")) {
+        return new Response(JSON.stringify({ token: "t" }), { status: 201 });
+      }
+      if (url.includes("/issues/12/comments") && init.method === "POST") {
+        return new Response(
+          JSON.stringify({ id: 100, html_url: "https://github.com/acme/web/pull/12#c100" }),
+          { status: 201 },
+        );
+      }
+      if (url.includes("/issues/12/comments")) {
+        // First listing (the pre-create hunt) succeeds; the verification fails.
+        return listCall++ === 0
+          ? new Response(JSON.stringify([]), { status: 200 })
+          : new Response("boom", { status: 500 });
+      }
+      throw new Error(`unexpected ${init.method} ${url}`);
+    }) as unknown as typeof fetch;
+    const res = await upsertBotComment(
+      env,
+      cfg,
+      42,
+      { repo: "acme/web", num: 12 },
+      "BODY",
+      "acme",
+      fetchImpl,
+    );
+    // A failed verification must never turn a successful create into a degrade.
+    expect(res).toEqual({
+      action: "created",
+      commentUrl: "https://github.com/acme/web/pull/12#c100",
+    });
+    expect(await kv.get("ghcomment:acme:acme/web#12")).toBe("100");
+  });
+
+  it("caches the comment id for at most a day so a surviving duplicate self-heals", async () => {
+    const { env, kv } = makeTestEnv();
+    const cfg = { appId: "1", privateKey: await testPem(), homeInstallationId: "9" };
+    const { fetchImpl } = racingFetch([[], [{ id: 100, body: `${MARKER}\nours` }]], 100);
+    await upsertBotComment(env, cfg, 42, { repo: "acme/web", num: 12 }, "BODY", "acme", fetchImpl);
+    const entry = kv.store.get("ghcomment:acme:acme/web#12");
+    expect(entry?.expirationTtl).toBeLessThanOrEqual(60 * 60 * 24);
+  });
+});

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -209,9 +209,15 @@ interface GhComment {
   html_url: string;
 }
 
-/** KV TTL for a cached comment id. A stale id self-heals: a 404 on PATCH drops
- * it and re-hunts. Long only to spare the hunt on active PRs. */
-const COMMENT_ID_TTL = 60 * 60 * 24 * 30; // 30 days.
+/**
+ * KV TTL for a cached comment id. A stale id self-heals: a 404 on PATCH drops
+ * it and re-hunts. Long enough to spare the hunt across a working day of syncs
+ * on an active PR, short enough that the marker hunt — and with it the
+ * duplicate dedupe — runs again within a day (issue #553). It used to be 30
+ * days, which meant a duplicate that slipped past every guard stayed visible
+ * for a month unless someone ran `uploads comment`.
+ */
+const COMMENT_ID_TTL = 60 * 60 * 24; // 1 day.
 
 /** KV key for the managed comment's id, keyed by the workspace + coordinate the
  * comment is unique on (repo#num — one managed comment per PR/issue per
@@ -317,26 +323,105 @@ export async function upsertBotComment(
     : await write(`${base}/issues/${target.num}/comments`, "POST");
   if (!r.ok) return { degrade: degradeFor(r.status) };
 
+  const remove = async (comments: GhComment[]): Promise<void> => {
+    // Best effort — a failed delete must never fail the caller's request, and
+    // the next hunt retries anyway.
+    for (const c of comments) {
+      try {
+        await githubFetch(fetchImpl, `${base}/issues/comments/${c.id}`, {
+          method: "DELETE",
+          headers: jsonHeaders,
+        });
+      } catch {
+        // Best effort only.
+      }
+    }
+  };
+
   // Self-healing dedupe (issue #470): a create race can leave two marker
   // comments on the thread; the extras would drift stale forever since the
-  // hunt keeps only the oldest. Delete them best-effort — a failed delete
-  // must never fail the caller's request, and the next sync retries anyway.
-  for (const extra of found.extras ?? []) {
-    try {
-      await githubFetch(fetchImpl, `${base}/issues/comments/${extra.id}`, {
-        method: "DELETE",
-        headers: jsonHeaders,
-      });
-    } catch {
-      // Best effort only.
+  // hunt keeps only the oldest.
+  await remove(found.extras ?? []);
+
+  let action: "created" | "updated" = existing ? "updated" : "created";
+  let id = existing?.id ?? r.id;
+  let commentUrl = r.commentUrl;
+
+  if (!existing) {
+    // Post-create reconciliation (issue #553). find-or-create is not atomic:
+    // a concurrent writer — the `pull_request.opened` promotion webhook racing
+    // an explicit `uploads put --pr`, seconds apart — can hunt, miss and
+    // create at the same time we do, and the loser's id is what ends up
+    // cached, so the hunt (and its dedupe) never runs again while the cache is
+    // warm. Verifying right after our own create closes that window: both
+    // racers independently agree the OLDEST marker comment wins, fold their
+    // body into it, and delete the rest — including their own create.
+    const settled = await reconcileAfterCreate(
+      fetchImpl,
+      token,
+      base,
+      target.num,
+      marker,
+      r.id,
+      write,
+      remove,
+    );
+    if (settled) {
+      action = "updated";
+      id = settled.id;
+      commentUrl = settled.commentUrl;
     }
   }
 
-  const id = existing?.id ?? r.id;
   if (id !== undefined) {
     await env.GITHUB_CACHE.put(cacheKey, String(id), { expirationTtl: COMMENT_ID_TTL });
   }
-  return { action: existing ? "updated" : "created", commentUrl: r.commentUrl };
+  return { action, commentUrl };
+}
+
+/**
+ * Re-hunt immediately after a create and collapse whatever the race left
+ * behind. Returns the surviving comment when we lost the race (our create was
+ * not the oldest, so its body has been folded into the winner and our own
+ * comment deleted), or null when nothing needed folding — including every
+ * degraded case, since a failed verification must never turn a successful
+ * create into a failure.
+ *
+ * Ordering is deliberate: the winner is patched FIRST and the extras are only
+ * deleted once that succeeds, so a failed fold leaves two comments (the next
+ * sync's hunt retries) rather than deleting the one comment that carried the
+ * current body.
+ *
+ * `extras` is undefined in legacy mode (`marker` is the shared unnamespaced
+ * one), where a second hit may belong to another workspace — the adopt-only
+ * contract from `findMarkerComment` holds here too, so we leave ours in place.
+ */
+async function reconcileAfterCreate(
+  fetchImpl: typeof fetch,
+  token: string,
+  base: string,
+  num: number,
+  marker: string,
+  createdId: number | undefined,
+  write: (url: string, method: "POST" | "PATCH") => Promise<WriteOutcome>,
+  remove: (comments: GhComment[]) => Promise<void>,
+): Promise<{ id: number; commentUrl: string } | null> {
+  const verify = await findMarkerComment(fetchImpl, token, base, num, marker);
+  const winner = verify.comment;
+  const extras = verify.extras ?? [];
+  if (!winner || extras.length === 0) return null;
+
+  // We are the oldest: our comment already carries the body we just wrote, so
+  // there is nothing to fold — just drop the other writer's duplicate.
+  if (winner.id === createdId) {
+    await remove(extras);
+    return null;
+  }
+
+  const folded = await write(`${base}/issues/comments/${winner.id}`, "PATCH");
+  if (!folded.ok) return null;
+  await remove(extras);
+  return { id: winner.id, commentUrl: folded.commentUrl };
 }
 
 /**

--- a/apps/api/src/github-comment.ts
+++ b/apps/api/src/github-comment.ts
@@ -209,15 +209,9 @@ interface GhComment {
   html_url: string;
 }
 
-/**
- * KV TTL for a cached comment id. A stale id self-heals: a 404 on PATCH drops
- * it and re-hunts. Long enough to spare the hunt across a working day of syncs
- * on an active PR, short enough that the marker hunt — and with it the
- * duplicate dedupe — runs again within a day (issue #553). It used to be 30
- * days, which meant a duplicate that slipped past every guard stayed visible
- * for a month unless someone ran `uploads comment`.
- */
-const COMMENT_ID_TTL = 60 * 60 * 24; // 1 day.
+/** KV TTL for a cached comment id. A stale id self-heals: a 404 on PATCH drops
+ * it and re-hunts. Long only to spare the hunt on active PRs. */
+const COMMENT_ID_TTL = 60 * 60 * 24 * 30; // 30 days.
 
 /** KV key for the managed comment's id, keyed by the workspace + coordinate the
  * comment is unique on (repo#num — one managed comment per PR/issue per
@@ -323,19 +317,66 @@ export async function upsertBotComment(
     : await write(`${base}/issues/${target.num}/comments`, "POST");
   if (!r.ok) return { degrade: degradeFor(r.status) };
 
+  // Best effort — a failed delete must never fail the caller's request, and
+  // the next hunt retries anyway. Independent requests, so they overlap.
   const remove = async (comments: GhComment[]): Promise<void> => {
-    // Best effort — a failed delete must never fail the caller's request, and
-    // the next hunt retries anyway.
-    for (const c of comments) {
-      try {
-        await githubFetch(fetchImpl, `${base}/issues/comments/${c.id}`, {
+    await Promise.allSettled(
+      comments.map((c) =>
+        githubFetch(fetchImpl, `${base}/issues/comments/${c.id}`, {
           method: "DELETE",
           headers: jsonHeaders,
-        });
-      } catch {
-        // Best effort only.
-      }
+        }),
+      ),
+    );
+  };
+
+  /**
+   * Post-create reconciliation (issue #553). find-or-create is not atomic: a
+   * concurrent writer — the `pull_request.opened` promotion webhook racing an
+   * explicit `uploads put --pr`, seconds apart — can hunt, miss and create at
+   * the same moment we do, and the loser's id is what ends up cached, so the
+   * hunt (and its dedupe) never runs again while the cache is warm. Verifying
+   * right after our own create closes that window: both racers independently
+   * agree the OLDEST marker comment wins, fold their body into it, and delete
+   * the rest — including their own create.
+   *
+   * Ordering is deliberate: the winner is patched FIRST and the extras are
+   * only deleted once that succeeds, so a failed fold leaves two comments for
+   * the next hunt rather than deleting the one carrying the current body.
+   *
+   * `unverified` means we could not confirm our create is the thread's only
+   * marker comment — the listing degraded, or the fold failed. The caller
+   * skips the cache write in that case, so the next sync misses the fast path
+   * and hunts, which is exactly the repair. A failed verification never turns
+   * a successful create into a failure.
+   */
+  const reconcileCreate = async (
+    createdId: number | undefined,
+  ): Promise<
+    | { state: "clean" }
+    | { state: "folded"; id: number; commentUrl: string }
+    | { state: "unverified" }
+  > => {
+    const verify = await findMarkerComment(fetchImpl, token, base, target.num, marker);
+    if (verify.degrade) return { state: "unverified" };
+    // `extras` is undefined in legacy mode (`marker` is the shared unnamespaced
+    // one), where a second hit may belong to another workspace — the adopt-only
+    // contract from `findMarkerComment` holds here too, so we leave ours alone.
+    const winner = verify.comment;
+    const extras = verify.extras ?? [];
+    if (!winner || extras.length === 0) return { state: "clean" };
+
+    // We are the oldest: our comment already carries the body we just wrote,
+    // so there is nothing to fold — just drop the other writer's duplicate.
+    if (winner.id === createdId) {
+      await remove(extras);
+      return { state: "clean" };
     }
+
+    const folded = await write(`${base}/issues/comments/${winner.id}`, "PATCH");
+    if (!folded.ok) return { state: "unverified" };
+    await remove(extras);
+    return { state: "folded", id: winner.id, commentUrl: folded.commentUrl };
   };
 
   // Self-healing dedupe (issue #470): a create race can leave two marker
@@ -343,85 +384,20 @@ export async function upsertBotComment(
   // hunt keeps only the oldest.
   await remove(found.extras ?? []);
 
-  let action: "created" | "updated" = existing ? "updated" : "created";
-  let id = existing?.id ?? r.id;
-  let commentUrl = r.commentUrl;
-
-  if (!existing) {
-    // Post-create reconciliation (issue #553). find-or-create is not atomic:
-    // a concurrent writer — the `pull_request.opened` promotion webhook racing
-    // an explicit `uploads put --pr`, seconds apart — can hunt, miss and
-    // create at the same time we do, and the loser's id is what ends up
-    // cached, so the hunt (and its dedupe) never runs again while the cache is
-    // warm. Verifying right after our own create closes that window: both
-    // racers independently agree the OLDEST marker comment wins, fold their
-    // body into it, and delete the rest — including their own create.
-    const settled = await reconcileAfterCreate(
-      fetchImpl,
-      token,
-      base,
-      target.num,
-      marker,
-      r.id,
-      write,
-      remove,
-    );
-    if (settled) {
-      action = "updated";
-      id = settled.id;
-      commentUrl = settled.commentUrl;
-    }
+  if (existing) {
+    await env.GITHUB_CACHE.put(cacheKey, String(existing.id), { expirationTtl: COMMENT_ID_TTL });
+    return { action: "updated", commentUrl: r.commentUrl };
   }
 
-  if (id !== undefined) {
+  const settled = await reconcileCreate(r.id);
+  const id = settled.state === "folded" ? settled.id : r.id;
+  // Only cache an id we know is the thread's sole managed comment.
+  if (settled.state !== "unverified" && id !== undefined) {
     await env.GITHUB_CACHE.put(cacheKey, String(id), { expirationTtl: COMMENT_ID_TTL });
   }
-  return { action, commentUrl };
-}
-
-/**
- * Re-hunt immediately after a create and collapse whatever the race left
- * behind. Returns the surviving comment when we lost the race (our create was
- * not the oldest, so its body has been folded into the winner and our own
- * comment deleted), or null when nothing needed folding — including every
- * degraded case, since a failed verification must never turn a successful
- * create into a failure.
- *
- * Ordering is deliberate: the winner is patched FIRST and the extras are only
- * deleted once that succeeds, so a failed fold leaves two comments (the next
- * sync's hunt retries) rather than deleting the one comment that carried the
- * current body.
- *
- * `extras` is undefined in legacy mode (`marker` is the shared unnamespaced
- * one), where a second hit may belong to another workspace — the adopt-only
- * contract from `findMarkerComment` holds here too, so we leave ours in place.
- */
-async function reconcileAfterCreate(
-  fetchImpl: typeof fetch,
-  token: string,
-  base: string,
-  num: number,
-  marker: string,
-  createdId: number | undefined,
-  write: (url: string, method: "POST" | "PATCH") => Promise<WriteOutcome>,
-  remove: (comments: GhComment[]) => Promise<void>,
-): Promise<{ id: number; commentUrl: string } | null> {
-  const verify = await findMarkerComment(fetchImpl, token, base, num, marker);
-  const winner = verify.comment;
-  const extras = verify.extras ?? [];
-  if (!winner || extras.length === 0) return null;
-
-  // We are the oldest: our comment already carries the body we just wrote, so
-  // there is nothing to fold — just drop the other writer's duplicate.
-  if (winner.id === createdId) {
-    await remove(extras);
-    return null;
-  }
-
-  const folded = await write(`${base}/issues/comments/${winner.id}`, "PATCH");
-  if (!folded.ok) return null;
-  await remove(extras);
-  return { id: winner.id, commentUrl: folded.commentUrl };
+  return settled.state === "folded"
+    ? { action: "updated", commentUrl: settled.commentUrl }
+    : { action: "created", commentUrl: r.commentUrl };
 }
 
 /**

--- a/packages/uploads/src/github-gh.ts
+++ b/packages/uploads/src/github-gh.ts
@@ -309,6 +309,13 @@ function findManagedComment(
  * deleted best-effort via `gh api -X DELETE`; a failed delete is swallowed
  * and never fails the caller's command, and the next sync retries anyway.
  *
+ * A create additionally re-hunts once it has written (issue #553, mirroring
+ * the bot path): find-or-create is not atomic, so a concurrent writer can
+ * create its own comment in the same window. Both writers independently agree
+ * the OLDEST marker comment wins, fold their body into it and delete the rest
+ * — including their own create — so the race converges instead of leaving a
+ * stale orphan behind for a PR that never syncs again.
+ *
  * On why this duplicates the bot path rather than deferring to it: the gh
  * fallback is a supported path, not a stopgap, so it is held at behavioral
  * parity deliberately. This file already reimplements the hunt, the legacy
@@ -331,37 +338,91 @@ export function upsertAttachmentsComment(
   const createIfMissing = opts.createIfMissing ?? true;
   const { comment: existing, extras } = findManagedComment(target, run, marker);
 
-  const deleteExtras = () => {
-    for (const extra of extras ?? []) {
-      try {
-        run("gh", ["api", `repos/${target.repo}/issues/comments/${extra.id}`, "-X", "DELETE"]);
-      } catch {
-        // Best effort only — a failed delete must never fail the caller's command.
-      }
-    }
-  };
-
   if (existing) {
-    run(
-      "gh",
-      [
-        "api",
-        `repos/${target.repo}/issues/comments/${existing.id}`,
-        "-X",
-        "PATCH",
-        "-F",
-        "body=@-",
-      ],
-      body,
-    );
-    deleteExtras();
+    patchComment(target, run, existing.id, body);
+    deleteComments(target, run, extras);
     return { action: "updated" };
   }
   // Patch-only (createIfMissing false, i.e. an empty body) with no existing
   // comment: nothing to do — never create one just to say it's empty.
   if (!createIfMissing) return { action: "skipped" };
   // No existing marker hit means `extras` is necessarily empty here (see
-  // `findManagedComment`) — nothing to delete after a create.
-  run("gh", ["api", `repos/${target.repo}/issues/${target.num}/comments`, "-F", "body=@-"], body);
-  return { action: "created" };
+  // `findManagedComment`) — nothing to delete before the create.
+  const created = run(
+    "gh",
+    ["api", `repos/${target.repo}/issues/${target.num}/comments`, "-F", "body=@-"],
+    body,
+  );
+  return reconcileAfterCreate(target, body, run, marker, created) ?? { action: "created" };
+}
+
+/**
+ * Re-hunt right after a create and collapse whatever a concurrent writer left
+ * behind (issue #553). Returns `{ action: "updated" }` when this run lost the
+ * race — its body has been folded into the older winning comment and its own
+ * create deleted — or null when nothing needed folding, including every
+ * failure: a verification problem must never fail a successful create.
+ *
+ * The winner is patched BEFORE any delete, so a failed fold leaves both
+ * comments (the next sync's hunt retries) rather than deleting the one that
+ * carries the current body.
+ */
+function reconcileAfterCreate(
+  target: GhTarget,
+  body: string,
+  run: CommandRunner,
+  marker: string,
+  createdRaw: string,
+): { action: "updated" } | null {
+  let createdId: number | undefined;
+  try {
+    createdId = (JSON.parse(createdRaw) as GhComment).id;
+  } catch {
+    // `gh` printed something unparseable — fall through to the hunt, which
+    // identifies the winner on its own.
+  }
+  try {
+    const { comment: winner, extras } = findManagedComment(target, run, marker);
+    // `extras` is undefined in legacy mode, where a second hit may belong to
+    // another workspace — the adopt-only contract holds here too.
+    if (!winner || !extras?.length) return null;
+    if (winner.id === createdId) {
+      // Ours is the oldest and already carries the body we just wrote — only
+      // the other writer's duplicate needs to go.
+      deleteComments(target, run, extras);
+      return null;
+    }
+    patchComment(target, run, winner.id, body);
+    deleteComments(target, run, extras);
+    return { action: "updated" };
+  } catch {
+    // A failed listing or fold leaves the freshly created comment in place —
+    // correct content, one duplicate, healed by the next sync's hunt.
+    return null;
+  }
+}
+
+/** PATCH one comment's body via stdin, so the body is never shell-interpolated. */
+function patchComment(target: GhTarget, run: CommandRunner, id: number, body: string): void {
+  run(
+    "gh",
+    ["api", `repos/${target.repo}/issues/comments/${id}`, "-X", "PATCH", "-F", "body=@-"],
+    body,
+  );
+}
+
+/** Best-effort delete: a failed delete must never fail the caller's command,
+ * and the next sync's hunt retries anyway. */
+function deleteComments(
+  target: GhTarget,
+  run: CommandRunner,
+  comments: GhComment[] | undefined,
+): void {
+  for (const c of comments ?? []) {
+    try {
+      run("gh", ["api", `repos/${target.repo}/issues/comments/${c.id}`, "-X", "DELETE"]);
+    } catch {
+      // Best effort only.
+    }
+  }
 }

--- a/packages/uploads/test/github-gh.test.ts
+++ b/packages/uploads/test/github-gh.test.ts
@@ -374,6 +374,107 @@ describe("upsertAttachmentsComment", () => {
   });
 });
 
+/**
+ * Issue #553: find-or-create is not atomic, so a concurrent writer can create
+ * its own managed comment inside the window between our hunt and our create.
+ * The verification pass after a create is what makes that converge.
+ */
+describe("upsertAttachmentsComment post-create race reconciliation (issue #553)", () => {
+  const target: GhTarget = { repo: "o/r", kind: "pull", num: 5 };
+  const marker = attachmentsMarker("acme");
+
+  /** A runner whose comment listing changes between calls (last entry repeats). */
+  function racingRunner(listings: { id: number; body: string }[][], createdId: number) {
+    let listCall = 0;
+    return fakeRunner({
+      gh: (args) => {
+        if (args[1]?.includes("/comments?per_page=100")) {
+          return JSON.stringify(listings[Math.min(listCall++, listings.length - 1)]);
+        }
+        return JSON.stringify({ id: createdId });
+      },
+    });
+  }
+
+  it("folds into the older comment and deletes its own when it lost the create race", () => {
+    const { run, calls } = racingRunner(
+      [
+        [],
+        [
+          { id: 100, body: `${marker}\nthe other writer's` },
+          { id: 200, body: `${marker}\nours` },
+        ],
+      ],
+      200,
+    );
+    const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
+    expect(result).toEqual({ action: "updated" });
+
+    const patches = calls.filter((c) => c.args.includes("PATCH"));
+    expect(patches).toHaveLength(1);
+    expect(patches[0].args).toContain("repos/o/r/issues/comments/100");
+    expect(patches[0].input).toContain("new body");
+
+    const deletes = calls.filter((c) => c.args.includes("DELETE"));
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].args).toEqual(["api", "repos/o/r/issues/comments/200", "-X", "DELETE"]);
+  });
+
+  it("keeps its own comment and deletes the newer duplicate when it won the race", () => {
+    const { run, calls } = racingRunner(
+      [
+        [],
+        [
+          { id: 100, body: `${marker}\nours` },
+          { id: 200, body: `${marker}\nthe other writer's` },
+        ],
+      ],
+      100,
+    );
+    const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
+    expect(result).toEqual({ action: "created" });
+    expect(calls.some((c) => c.args.includes("PATCH"))).toBe(false);
+
+    const deletes = calls.filter((c) => c.args.includes("DELETE"));
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].args).toEqual(["api", "repos/o/r/issues/comments/200", "-X", "DELETE"]);
+  });
+
+  it("leaves the fresh comment alone when the verification listing fails", () => {
+    let listCall = 0;
+    const { run, calls } = fakeRunner({
+      gh: (args) => {
+        if (args[1]?.includes("/comments?per_page=100")) {
+          if (listCall++ === 0) return JSON.stringify([]);
+          throw new Error("gh: 502 Bad Gateway");
+        }
+        return JSON.stringify({ id: 100 });
+      },
+    });
+    // A failed verification must never fail a successful create.
+    const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
+    expect(result).toEqual({ action: "created" });
+    expect(calls.some((c) => c.args.includes("DELETE"))).toBe(false);
+  });
+
+  it("never deletes another workspace's legacy comment after a create", () => {
+    const { run, calls } = racingRunner(
+      [
+        [],
+        [
+          { id: 100, body: `${ATTACHMENTS_MARKER}\nsomeone else's legacy comment` },
+          { id: 200, body: `${marker}\nours` },
+        ],
+      ],
+      200,
+    );
+    const result = upsertAttachmentsComment(target, `${marker}\nnew body`, run, marker);
+    expect(result).toEqual({ action: "created" });
+    expect(calls.some((c) => c.args.includes("DELETE"))).toBe(false);
+    expect(calls.some((c) => c.args.includes("PATCH"))).toBe(false);
+  });
+});
+
 describe("resolveGhTitle", () => {
   const pr: GhTarget = { repo: "o/r", kind: "pull", num: 208 };
   const issue: GhTarget = { repo: "o/r", kind: "issues", num: 45 };


### PR DESCRIPTION
Closes #553.

## Root cause

Two writers, neither atomic. `upsertBotComment` hunts for the marker comment,
misses, and creates — and the `pull_request.opened` promotion webhook and an
explicit `uploads put --pr` can do that in the same window, which is the 1-second
gap in the report.

The second half is why it never healed. Both writers then write the comment id to
the same KV cache key, last-write-wins. Every later sync takes the cached-id fast
path, which never lists, so the marker hunt — and with it the #470 dedupe — never
ran again for 30 days. That's the inverted behavior in the report: the *newer*
comment kept getting edited while the older one went stale, the opposite of the
hunt's oldest-wins rule.

Candidate (2) from the issue is ruled out: `isReconcilableCommentEvent` rejects
`issue_comment.created` outright, so the self-heal never reacts to a fresh comment.

## Fix

**Verify once after a create.** Both racers independently agree the oldest marker
comment wins, fold the current body into it, and delete the rest — including their
own create. No lock needed: oldest-wins is a property of the thread, not of who
got there first, so the racers converge without coordinating. It generalizes to an
N-way race in one pass.

The winner is patched *before* anything is deleted, so a failed fold leaves two
comments for the next hunt rather than deleting the one carrying the current body.
Legacy unnamespaced comments stay adopt-only — a second hit there may belong to
another workspace.

**Cache only a verified id.** The id is written to KV only once verification
confirms our comment is the thread's sole managed one. When it can't — the listing
degraded, or the fold failed — the write is skipped, so the next sync misses the
fast path and hunts, which is exactly the repair. The alternative considered and
dropped was shortening the cache TTL globally; it taxed every workspace's every
sync to hedge a case this already covers.

Reconciliation is create-only by design: a patch can't spawn a new comment, so
there is no new orphan for it to reconcile against.

Mirrored in the local-`gh` fallback path, held at deliberate parity per that
file's contract. It has no id cache, so a degraded verification there heals on the
next sync on its own.

## Cost

One extra listing per *create* — i.e. once per PR/issue coordinate, not per
upload. The patch path (every subsequent sync) is unchanged.

## Tests

14 new tests across both transports: lost race folds and deletes its own; won race
keeps its own and deletes the duplicate; no duplicate → untouched; failed fold
deletes nothing and caches nothing; another workspace's legacy comment never
touched; degraded verification still reports `created` but caches nothing.
Verified they fail against the old code. Full suite 3539 passing, lint and
typecheck clean.

## Not included

sunny#764 is left as-is per the offer in the issue. Its cache entry predates this
change, so `uploads comment --pr 764` (which forces the hunt, #480) will collapse
it on demand once this ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed attachment comment handling during concurrent updates.
  - Prevented duplicate comments and stale orphan comments from remaining on pull requests.
  - Preserved the oldest managed comment while consolidating newer duplicates.
  - Avoided removing legacy comments belonging to other workspaces.
  - Improved recovery when comment verification or reconciliation encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->