### PR TITLE
chore(release): bump the MCP SDK migration as a minor, not a major

### DIFF
--- a/.changeset/mcp-spec-2026-07-28.md
+++ b/.changeset/mcp-spec-2026-07-28.md
@@ -1,5 +1,5 @@
 ---
-"@buildinternet/uploads": major
+"@buildinternet/uploads": minor
 ---
 
 Adopt MCP spec `2026-07-28` by replacing the hand-rolled protocol core in


### PR DESCRIPTION
Follow-up to #557. Its changeset was marked `major`, which takes `@buildinternet/uploads` from `0.35.1` straight to `1.0.0` (see release PR #558).

The breaking change is real — the `McpServer` interface exported from the `/mcp` subpath lost `handleLine`. But `0.x` already permits breaking changes without a major, and publishing `1.0.0` declares the CLI's API stable. That is a product decision worth making deliberately, not a side effect of a protocol migration.

Downgrades the changeset to `minor` (→ `0.36.0`). The changeset prose is unchanged and still spells out the break, so it lands in the release notes either way.

Release PR #558 will regenerate once this is on main.