### PR TITLE
fix(smoke): send the full legacy initialize handshake

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -51,6 +51,23 @@ conformant clients already send them, but the worker did not enforce them
 before it moved to the MCP SDK. A hand-rolled caller that omitted either used
 to work and now does not.
 
+### Legacy `initialize` params are validated
+
+On the legacy leg, `initialize` params are checked against the spec schema, so
+`capabilities` and `clientInfo` are both required:
+
+```json
+{
+  "protocolVersion": "2025-06-18",
+  "capabilities": {},
+  "clientInfo": { "name": "x", "version": "1" }
+}
+```
+
+Omitting either returns `-32603` with a validation dump. The spec has always
+required them, but the pre-SDK server read only `protocolVersion` and ignored
+the rest, so a partial handshake used to succeed.
+
 The REST API's upload guardrails apply: content type is sniffed server-side,
 size-capped, budget-checked, and subject to optional key policy
 (`allowedKeyPrefixes` / `maxKeyDepth`). Writes are rate limited per workspace.

--- a/docs/superpowers/specs/2026-07-29-mcp-2026-07-28-sdk-v2-design.md
+++ b/docs/superpowers/specs/2026-07-29-mcp-2026-07-28-sdk-v2-design.md
@@ -131,11 +131,19 @@ enableJsonResponse: true })`, preserving today's plain-JSON reply body.
 transport enforces the Streamable HTTP header requirements that our hand-rolled
 core never checked — it read the body and answered. Measured against v2.0.0:
 
-| Legacy request                                   | Before | After |
-| ------------------------------------------------ | ------ | ----- |
-| no `Accept: application/json, text/event-stream` | 200    | 406   |
-| `Accept: application/json` only                  | 200    | 406   |
-| no `Content-Type: application/json`              | 200    | 415   |
+| Legacy request                                   | Before | After  |
+| ------------------------------------------------ | ------ | ------ |
+| no `Accept: application/json, text/event-stream` | 200    | 406    |
+| `Accept: application/json` only                  | 200    | 406    |
+| no `Content-Type: application/json`              | 200    | 415    |
+| `initialize` without `capabilities`/`clientInfo` | 200    | -32603 |
+
+The last row was found by the post-deploy smoke run, not by the test suite: the
+transport validates `initialize` params against the spec schema, while the old
+core read only `protocolVersion`. `scripts/smoke-remote-mcp.mjs` sent a partial
+handshake and had to be fixed. Both fields have always been spec-required, so
+this is the same shape of break as the headers — we were previously more
+lenient than the spec.
 
 Both headers have been mandatory since protocol revision `2025-03-26`, so
 conformant MCP clients already send them, but anything hand-rolled against

--- a/scripts/smoke-remote-mcp.mjs
+++ b/scripts/smoke-remote-mcp.mjs
@@ -184,7 +184,14 @@ try {
   mask(scopedToken);
   ok("exchange");
 
-  const initialized = await mcp("initialize", { protocolVersion: "2025-06-18" });
+  // `capabilities` and `clientInfo` are required by the spec and are now
+  // schema-validated by the SDK transport: omitting either gets -32603, where
+  // the pre-SDK server ignored both and echoed the version back.
+  const initialized = await mcp("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "uploads-smoke", version: "1" },
+  });
   if (initialized.body.result?.protocolVersion !== "2025-06-18") {
     throw new Error("MCP initialize returned unexpected protocol version");
   }


### PR DESCRIPTION
The `Remote MCP smoke` workflow fails against the migrated server ([run 30497286749](https://github.com/buildinternet/uploads/actions/runs/30497286749)):

```
ok enrollment
ok exchange
ok revoke
Error: MCP initialize returned unexpected protocol version
```

The enrollment lifecycle is fine — this is the `initialize` call. The script sent `{ protocolVersion: "2025-06-18" }` and nothing else. The v2 SDK transport validates `initialize` params against the spec schema, which requires `capabilities` and `clientInfo`, so it now answers `-32603` and `result` is absent:

| `initialize` params | Result |
| --- | --- |
| `protocolVersion` only | `-32603`, path `["params","capabilities"]` |
| `+ capabilities` | `-32603`, path `["params","clientInfo"]` |
| full params | 200, `protocolVersion: "2025-06-18"` |

Both fields have always been spec-required; the pre-SDK server read only `protocolVersion` and ignored the rest, so a partial handshake used to succeed. Same shape as the `Accept`/`Content-Type` enforcement noted in #557 — the old server was more lenient than the spec, and the SDK is not.

Sends the full handshake, and documents the behaviour in `apps/mcp/README.md` next to the header requirements plus the design doc's compat table.

Worth noting this is the class of regression the smoke workflow exists to catch, and it found one on its first real run after the migration — the local suite missed it because its own fixtures were already sending complete params. Follow-up to #557; unblocks #560.