### PR TITLE
feat(admin): read one workspace record with ADMIN_TOKEN

### DIFF
--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -85,6 +85,12 @@ function restoreRequest(name: string) {
   });
 }
 
+function getRequest(name: string) {
+  return new Request(`https://api.uploads.sh/admin/workspaces/${name}`, {
+    headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
 describe("DELETE /admin/workspaces/:name", () => {
   it("401s without a valid admin token", async () => {
     const { app, env } = appWith({});
@@ -259,5 +265,106 @@ describe("DELETE /admin/workspaces/:name", () => {
       const body = (await res.json()) as { error: { code: string } };
       expect(body.error.code).toBe("grace_expired");
     });
+  });
+});
+
+describe("GET /admin/workspaces/:name", () => {
+  it("401s without a valid admin token", async () => {
+    const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD } });
+    const res = await app.request(
+      new Request("https://api.uploads.sh/admin/workspaces/acme"),
+      {},
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("404s workspace_not_found for an unknown workspace", async () => {
+    const { app, env } = appWith({});
+    const res = await app.request(getRequest("acme"), {}, env);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("workspace_not_found");
+  });
+
+  it("400s an invalid slug rather than looking it up", async () => {
+    const { app, env } = appWith({});
+    const res = await app.request(getRequest("Not_A_Slug"), {}, env);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_workspace");
+  });
+
+  it("returns the storage placement and defaults for a live workspace", async () => {
+    const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD } });
+    const res = await app.request(getRequest("acme"), {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      name: "acme",
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      deletedAt: null,
+      purgeAt: null,
+      selfServe: false,
+      plan: null,
+      hasHttpCredentials: false,
+    });
+    // Unset key policy reads as the permissive default, not as absent.
+    expect(body.keyPolicy).toMatchObject({ autoPrefixBareKeys: true, allowedKeyPrefixes: null });
+  });
+
+  it("reports a soft-deleted workspace with its grace window instead of 404ing", async () => {
+    const { app, env } = appWith({ kvRecords: { "ws:acme": RECORD } });
+    await app.request(deleteRequest("acme"), {}, env);
+
+    const res = await app.request(getRequest("acme"), {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deletedAt: string | null; purgeAt: string | null };
+    // The whole point of the route: an operator can see the record is inside
+    // its grace window and therefore still restorable.
+    expect(typeof body.deletedAt).toBe("string");
+    expect(typeof body.purgeAt).toBe("string");
+  });
+
+  it("never exposes credentials or token hashes", async () => {
+    const { app, env } = appWith({
+      kvRecords: {
+        "ws:acme": {
+          ...RECORD,
+          accountId: "acct-1",
+          accessKeyId: "AKIAEXAMPLE",
+          secretAccessKey: "super-secret",
+          tokens: [{ hash: "deadbeefcafe", label: "ci", createdAt: "2026-01-01T00:00:00.000Z" }],
+        },
+      },
+    });
+    const res = await app.request(getRequest("acme"), {}, env);
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    for (const secret of ["super-secret", "AKIAEXAMPLE", "deadbeefcafe"]) {
+      expect(raw).not.toContain(secret);
+    }
+    const body = JSON.parse(raw) as {
+      hasHttpCredentials: boolean;
+      tokens: Array<{ label: string | null; createdAt: string }>;
+    };
+    expect(body.hasHttpCredentials).toBe(true);
+    expect(body.tokens).toEqual([{ label: "ci", createdAt: "2026-01-01T00:00:00.000Z" }]);
+  });
+
+  it("surfaces a legacy tokenHash record as one unnamed token", async () => {
+    const { app, env } = appWith({
+      kvRecords: { "ws:acme": { ...RECORD, tokenHash: "legacyhash" } },
+    });
+    const res = await app.request(getRequest("acme"), {}, env);
+    const raw = await res.text();
+    expect(raw).not.toContain("legacyhash");
+    const body = JSON.parse(raw) as { tokens: Array<{ label: string | null }> };
+    expect(body.tokens).toHaveLength(1);
+    expect(body.tokens[0]?.label).toBeNull();
   });
 });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -486,6 +486,78 @@ export const admin = new Hono<{ Bindings: Env }>()
   })
 
   /**
+   * Read one workspace record — the counterpart to the delete/restore pair
+   * below, which were the only other `ADMIN_TOKEN` routes on this path. Its
+   * absence meant there was no token-authed way to answer "does this
+   * workspace exist, and is it soft-deleted?": `/admin-ui/workspaces` can, but
+   * that surface is session-gated (`requireAdminUser`) and so unreachable from
+   * ops tooling or CI holding only `ADMIN_TOKEN`. Operators were left
+   * inferring existence from a destructive endpoint's error codes.
+   *
+   * Scoped deliberately narrow: one named workspace, no listing or search.
+   * Cross-workspace discovery from client credentials stays closed (#183);
+   * this is the operator surface, where the same token can already delete the
+   * workspace it is naming.
+   *
+   * A **soft-deleted** workspace is returned with `deletedAt`/`purgeAt`
+   * stamped rather than 404'd — knowing a record sits inside its grace window,
+   * and is therefore restorable via `POST /workspaces/:name/restore`, is the
+   * main reason to call this. Only a genuinely absent record or a permanent
+   * purged tombstone 404s, matching the delete route's precondition.
+   *
+   * The stored record holds `secretAccessKey`, `accessKeyId`, and per-token
+   * hashes, so this projects an explicit field list rather than echoing it.
+   * Credentials are reported as presence booleans and tokens as their labels
+   * and creation times — never the hashes. Keep it that way when adding
+   * fields: any holder of `ADMIN_TOKEN` or an `operator:read` token can call
+   * this.
+   */
+  .get("/workspaces/:name", async (c) => {
+    const name = c.req.param("name");
+    requireWorkspaceName(name);
+
+    const raw = await loadWorkspaceRecordRaw(c.env, name);
+    if (!raw || isPurgedTombstone(raw)) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+
+    return c.json({
+      name,
+      version: raw.version ?? 0,
+      provider: raw.provider,
+      bucket: raw.bucket,
+      binding: raw.binding ?? null,
+      prefix: raw.prefix ?? null,
+      publicBaseUrl: raw.publicBaseUrl ?? null,
+      plan: raw.plan ?? null,
+      selfServe: raw.selfServe === true,
+      createdAt: raw.createdAt ?? null,
+      createdByUserId: raw.createdByUserId ?? null,
+      deletedAt: raw.deletedAt ?? null,
+      purgeAt: raw.purgeAt ?? null,
+      limits: {
+        maxUploadBytes: raw.maxUploadBytes ?? null,
+        maxVideoUploadBytes: raw.maxVideoUploadBytes ?? null,
+        maxStorageBytes: raw.maxStorageBytes ?? null,
+        maxUploadsPerPeriod: raw.maxUploadsPerPeriod ?? null,
+        maxMembers: raw.maxMembers ?? null,
+        retentionDays: raw.retentionDays ?? null,
+      },
+      keyPolicy: {
+        autoPrefixBareKeys: raw.autoPrefixBareKeys !== false,
+        allowedKeyPrefixes: raw.allowedKeyPrefixes ?? null,
+        maxKeyDepth: raw.maxKeyDepth ?? null,
+      },
+      // Labels and timestamps only — never the hashes.
+      tokens: legacyTokens(raw).map(({ label, createdAt }) => ({
+        label: label ?? null,
+        createdAt,
+      })),
+      hasHttpCredentials: typeof raw.secretAccessKey === "string",
+    });
+  })
+
+  /**
    * Admin-gated workspace teardown (v1 — see issue #241; soft-by-default —
    * see #247). Session-authed self-serve delete is deliberately out of scope
    * here; this is the ops/CI break-glass path, same as `/tokens` and

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -97,6 +97,31 @@ orphan. The sweep isolates an AUTH outage or a single org's delete failure
 (logged, sweep continues) rather than failing the run. Results roll up into the
 sweep's `orgsSwept` field.
 
+## Inspecting a workspace
+
+`GET /admin/workspaces/:name` reads one workspace record — storage placement,
+plan, limits, key policy, and its soft-delete state:
+
+```bash
+curl https://api.uploads.sh/admin/workspaces/acme \
+  -H "authorization: Bearer $ADMIN_TOKEN"
+```
+
+A soft-deleted workspace comes back with `deletedAt`/`purgeAt` set rather than
+404'ing, so this is how you check whether a record is still inside its grace
+window and restorable. Only a workspace that never existed, or one already
+finalized to a purged tombstone, 404s `workspace_not_found`.
+
+Credentials are never returned: `secretAccessKey`/`accessKeyId` collapse to a
+`hasHttpCredentials` boolean, and tokens list their labels and creation times
+without the hashes.
+
+There is no list or search here by design — cross-workspace discovery from
+client credentials stays closed (#183). This is the operator surface, where the
+same token can already delete the workspace it names. `/admin-ui/workspaces`
+lists every workspace for the admin dashboard, but it is session-gated
+(`requireAdminUser`) and unavailable to `ADMIN_TOKEN` holders.
+
 ## Workspace deletion, restore, and finalization
 
 `DELETE /admin/workspaces/:name` is **soft by default** (#247): it stamps


### PR DESCRIPTION
Adds `GET /admin/workspaces/:name`.

`DELETE /workspaces/:name` and `POST /workspaces/:name/restore` were the only `ADMIN_TOKEN` routes on that path, so there was no token-authed way to ask *does this workspace exist, and is it soft-deleted?* `/admin-ui/workspaces` can answer it, but that surface is gated by `sessionAuth + requireSessionUser + requireAdminUser`, so it is unreachable from ops tooling or CI holding only `ADMIN_TOKEN`. In practice that left operators inferring existence from a destructive endpoint's error codes — which is how I misdiagnosed a missing workspace earlier today, reading a route-not-found 404 as `workspace_not_found`.

## Behaviour

A **soft-deleted** workspace is returned with `deletedAt`/`purgeAt` stamped rather than 404'd. Checking whether a record is still inside its grace window, and therefore restorable, is the main reason to call this. Only a genuinely absent record or a finalized purged tombstone 404s `workspace_not_found` — matching the delete route's precondition. An invalid slug 400s `invalid_workspace` before any lookup.

## Scope, deliberately narrow

**One named workspace. No list, no search.** Cross-workspace discovery from client credentials stays closed (#183). This is the operator surface, where the same token can already delete the workspace it names, so existence was already observable — this just stops people probing a destructive endpoint to find out. `/admin-ui/workspaces` remains the listing surface for the session-authed dashboard.

## Secrets

The stored record holds `secretAccessKey`, `accessKeyId`, and per-token hashes, so the handler projects an explicit field list instead of echoing the record. Credentials collapse to a `hasHttpCredentials` boolean; tokens report labels and creation times only. A test asserts the raw response body contains none of the secret values, so a future field addition that leaks one fails rather than passing quietly.

Returned: name, version, provider/bucket/binding/prefix/publicBaseUrl, plan, selfServe, createdAt/createdByUserId, deletedAt/purgeAt, `limits` (upload/video/storage/uploads-per-period/members/retention), `keyPolicy` (autoPrefixBareKeys/allowedKeyPrefixes/maxKeyDepth), tokens, hasHttpCredentials.

## Verification

- 7 new tests in `admin-workspace-delete.test.ts`: 401 unauthenticated, 404 unknown, 400 invalid slug, live-record projection with defaults, soft-deleted grace window, no-secret-leakage, and legacy `tokenHash` migration.
- `pnpm test` — 3554 passed across 260 files. `pnpm run lint` and `pnpm --filter @uploads/api typecheck` clean.
- `docs/ops.md` documents the route, including why there is no list.

Follow-up to the operator friction hit while verifying #557.