### PR TITLE
chore: serve robots.txt on API, MCP, and auth hosts

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -7,6 +7,7 @@ Hono worker — workspace-scoped REST API for file I/O. Deploys to **api.uploads
 | Path                     | Auth             | Purpose                                       |
 | ------------------------ | ---------------- | --------------------------------------------- |
 | `GET /health`            | —                | Liveness                                      |
+| `GET /robots.txt`        | —                | Crawl policy (`Disallow: /` — service host)   |
 | `/admin/*`               | admin token      | Mint/list/revoke tokens; credential reencrypt |
 | `/v1/:workspace/files/*` | workspace bearer | Put, sign, get, list, delete                  |
 | `/v1/:workspace/usage/*` | workspace bearer | Usage, reconcile, purge-expired               |

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -69,9 +69,27 @@ const adminUiCors = cors({
   maxAge: 86400,
 });
 
+/**
+ * Service-host crawl policy. api.uploads.sh is a REST API — not a content
+ * surface — so every bot is told to stay out. Marketing + docs live on
+ * https://uploads.sh (which has its own, more open robots.txt).
+ */
+export const ROBOTS_TXT = `# https://api.uploads.sh — REST API only; do not crawl.
+# Public docs and marketing: https://uploads.sh
+
+User-agent: *
+Disallow: /
+`;
+
 /** Hono app — also re-exported for vitest (`app.request`). */
 export const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
+  .get("/robots.txt", (c) =>
+    c.text(ROBOTS_TXT, 200, {
+      "Cache-Control": "public, max-age=86400",
+      "Content-Type": "text/plain; charset=utf-8",
+    }),
+  )
   // RFC 9728 discovery: this API is an OAuth resource server (workspace bearer
   // tokens with `files:*` scopes). Public, uncached-cross-origin so browser
   // agents can read it. See src/well-known.ts.

--- a/apps/api/src/well-known.test.ts
+++ b/apps/api/src/well-known.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { app } from "./index";
+import { app, ROBOTS_TXT } from "./index";
 
 // The route reads only c.env.WEB_ORIGIN (with a fallback), no bindings.
 const env = {} as unknown as Env;
+
+describe("GET /robots.txt", () => {
+  it("disallows all crawlers on the API host", async () => {
+    const response = await app.request("https://api.uploads.sh/robots.txt", { method: "GET" }, env);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toMatch(/^text\/plain/);
+    expect(response.headers.get("Cache-Control")).toContain("max-age=86400");
+    const body = await response.text();
+    expect(body).toBe(ROBOTS_TXT);
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /");
+  });
+});
 
 describe("GET /.well-known/oauth-protected-resource", () => {
   it("advertises the API as an OAuth resource server (RFC 9728)", async () => {

--- a/apps/auth/src/index.test.ts
+++ b/apps/auth/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { app } from "./index";
+import { app, ROBOTS_TXT } from "./index";
 import type { AuthEnv } from "./auth";
 import { LOCAL_STACK_AUTH_ORIGIN, LOCAL_STACK_WEB_ORIGIN } from "./local-demo";
 import { createFakeD1 } from "./test/fake-d1";
@@ -30,6 +30,23 @@ describe("GET /health", () => {
     const response = await app.request("/health", {}, envWithoutSecret());
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true });
+  });
+});
+
+describe("GET /robots.txt", () => {
+  it("disallows all crawlers on the auth host", async () => {
+    const response = await app.request(
+      "https://auth.uploads.sh/robots.txt",
+      { method: "GET" },
+      envWithoutSecret(),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toMatch(/^text\/plain/);
+    expect(response.headers.get("Cache-Control")).toContain("max-age=86400");
+    const body = await response.text();
+    expect(body).toBe(ROBOTS_TXT);
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /");
   });
 });
 

--- a/apps/auth/src/index.ts
+++ b/apps/auth/src/index.ts
@@ -57,8 +57,26 @@ const billingPricesCors = cors({
   maxAge: 86400,
 });
 
+/**
+ * Service-host crawl policy. auth.uploads.sh is the sign-in / OAuth AS —
+ * not a content surface — so every bot is told to stay out. Marketing +
+ * docs live on https://uploads.sh.
+ */
+export const ROBOTS_TXT = `# https://auth.uploads.sh — auth / OAuth only; do not crawl.
+# Public docs and marketing: https://uploads.sh
+
+User-agent: *
+Disallow: /
+`;
+
 export const app = new Hono<{ Bindings: AuthEnv }>()
   .get("/health", (c) => c.json({ ok: true }))
+  .get("/robots.txt", (c) =>
+    c.text(ROBOTS_TXT, 200, {
+      "Cache-Control": "public, max-age=86400",
+      "Content-Type": "text/plain; charset=utf-8",
+    }),
+  )
   .use("/billing/prices", billingPricesCors)
   .get("/billing/prices", async (c) => {
     const body = await billingPricesResponseBody(c.env);

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -289,8 +289,26 @@ function respondProtectedResource(c: Context<WorkspaceVars>): Response {
   );
 }
 
+/**
+ * Service-host crawl policy. agents.uploads.sh / mcp.uploads.sh is an MCP
+ * endpoint — not a content surface — so every bot is told to stay out.
+ * Marketing + docs live on https://uploads.sh.
+ */
+export const ROBOTS_TXT = `# https://agents.uploads.sh — MCP server only; do not crawl.
+# Public docs and marketing: https://uploads.sh
+
+User-agent: *
+Disallow: /
+`;
+
 const app = new Hono<WorkspaceVars>()
   .get("/health", (c) => c.json({ ok: true }))
+  .get("/robots.txt", (c) =>
+    c.text(ROBOTS_TXT, 200, {
+      "Cache-Control": "public, max-age=86400",
+      "Content-Type": "text/plain; charset=utf-8",
+    }),
+  )
   // Public discovery — registered before /:workspace/* so ".well-known" is not a tenant.
   .get("/.well-known/mcp/server-card.json", (c) => c.json(mcpServerCard()))
   // OAuth Protected Resource Metadata (RFC 9728). Served at both the origin

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { exportJWK, generateKeyPair, SignJWT, type JWK } from "jose";
-import app from "../src/index";
+import app, { ROBOTS_TXT } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
 import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
 import { resetOAuthJwksCacheForTests } from "../src/oauth";
@@ -457,6 +457,22 @@ describe("hosted gallery tenant isolation", () => {
 });
 
 describe("mcp worker", () => {
+  it("disallows all crawlers on the MCP host", async () => {
+    const { env } = await makeEnv();
+    const response = await app.request(
+      "https://agents.uploads.sh/robots.txt",
+      { method: "GET" },
+      env,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toMatch(/^text\/plain/);
+    expect(response.headers.get("Cache-Control")).toContain("max-age=86400");
+    const body = await response.text();
+    expect(body).toBe(ROBOTS_TXT);
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Disallow: /");
+  });
+
   it("serves an unauthenticated MCP server card for discovery", async () => {
     const { env } = await makeEnv();
     const response = await app.request("/.well-known/mcp/server-card.json", { method: "GET" }, env);


### PR DESCRIPTION
## In plain terms

`uploads.sh` already has a full crawl policy, but the service hosts (`api`, `agents`/`mcp`, and `auth`) returned 404 for `/robots.txt`. Those endpoints are not content surfaces, so crawlers should stay out. Each now serves a basic deny-all `robots.txt` and points bots at the marketing site for public docs.

## What it does / what it is not

- **Does:** add `GET /robots.txt` on the API, MCP, and auth workers with `User-agent: *` / `Disallow: /`, 24h cache, and plain-text content type
- **Does:** cover the route with a unit test in each package
- **Does not:** change the marketing-site robots policy, add sitemaps, or touch storage/embed CDN hosts
- **Does not:** change any authenticated or product behavior

## How to try it

After deploy (or against local wrangler):

```bash
curl -sS https://api.uploads.sh/robots.txt
curl -sS https://agents.uploads.sh/robots.txt
curl -sS https://auth.uploads.sh/robots.txt
```

Locally:

```bash
pnpm --filter @uploads/api test -- src/well-known.test.ts
pnpm --filter @uploads/auth test -- src/index.test.ts
pnpm --filter @uploads/mcp test -- test/mcp.test.ts -t "disallows all crawlers"
```

## Technical notes

- Route sits next to `/health` on each Hono app so it never falls into tenant-path middleware
- Body is a small exported constant (`ROBOTS_TXT`) so tests assert the exact response
- Web (`uploads.sh`) already ships `public/robots.txt`; no change there

## Test plan

- [x] `pnpm --filter @uploads/api test -- src/well-known.test.ts`
- [x] `pnpm --filter @uploads/auth test -- src/index.test.ts`
- [x] `pnpm --filter @uploads/mcp test -- test/mcp.test.ts -t "disallows all crawlers"`
- [x] Pre-commit hook (types + lint-staged) passed on commit
- [ ] CI green on the PR