### PR TITLE
fix(web): width-normalize the compare before layer

### DIFF
--- a/apps/web/src/components/ImagePreview.astro
+++ b/apps/web/src/components/ImagePreview.astro
@@ -138,6 +138,29 @@ const counterpartUrl = compare?.src ?? null;
       });
     }
 
+    /**
+     * Full width sizes the compare box to the taller of the two layers, so a
+     * before layer longer than the after image isn't clipped in the one mode
+     * whose whole job is showing the image whole (#552). Only the ratio needs
+     * measuring — the box's width there is already the stage's — so this is a
+     * single custom property, and `aspect-ratio`'s `auto` fallback means an
+     * image that never loads leaves the box exactly as it is today.
+     *
+     * Deliberately not applied in fit mode: that box is capped at
+     * `--preview-max-h`, so sizing it to the taller layer would let one long
+     * screenshot shrink the whole stage — an 800×3000 before against an
+     * 800×600 after would squeeze the after down to a ~187px-wide stamp.
+     * Fit clips instead, and full width is one click away.
+     */
+    const sizePairBox = () => {
+      const layers = [...wrap.querySelectorAll<HTMLImageElement>("img[slot]")];
+      if (layers.length !== 2) return;
+      if (!layers.every((el) => el.complete && el.naturalWidth > 0)) return;
+      const ratio = Math.max(...layers.map((el) => el.naturalHeight / el.naturalWidth));
+      if (!Number.isFinite(ratio) || ratio <= 0) return;
+      wrap.style.setProperty("--pair-ratio", `1 / ${ratio}`);
+    };
+
     // `loading="lazy"` keeps the counterpart out of the initial page fetch,
     // but in fit mode the second slot is `width: auto` — its box derives from
     // its own intrinsic size, which is 0×0 until it loads, and the host
@@ -150,8 +173,10 @@ const counterpartUrl = compare?.src ?? null;
     const activateImages = () => {
       if (imagesActivated) return;
       imagesActivated = true;
-      for (const el of wrap.querySelectorAll<HTMLImageElement>("img[loading='lazy']")) {
-        el.loading = "eager";
+      for (const el of wrap.querySelectorAll<HTMLImageElement>("img[slot]")) {
+        if (el.loading === "lazy") el.loading = "eager";
+        if (el.complete) sizePairBox();
+        else el.addEventListener("load", sizePairBox, { once: true });
       }
     };
 
@@ -341,10 +366,19 @@ const counterpartUrl = compare?.src ?? null;
   /* Full width: host fills the stage, same contract as the single image's
      full-width mode. Fit mode intentionally leaves the host at its shadow
      default (`inline-block`) so it shrink-wraps the sized image below rather
-     than forcing a width the image itself doesn't fill. */
+     than forcing a width the image itself doesn't fill.
+
+     The ratio is the taller of the two layers' (set by `sizePairBox` once both
+     have loaded), which grows the box to whichever layer needs the room
+     instead of clipping the before layer against the after image's height.
+     Safe here and only here: the width is the stage's either way, so a long
+     layer can only add height — it can never shrink the other one, which is
+     what sizing the fit-mode box this way would do. Unset until both images
+     load, and `auto` is plain shrink-to-content — the box today. */
   .image-preview[data-mode="full"] img-comparison-slider {
     display: block;
     width: 100%;
+    aspect-ratio: var(--pair-ratio, auto);
   }
 
   .image-preview img-comparison-slider img {
@@ -362,21 +396,6 @@ const counterpartUrl = compare?.src ?? null;
     max-height: var(--preview-max-h);
   }
 
-  /* Fit, first slot ("before"): the component absolutely positions this
-     layer's shadow container at 100%/100% of the box the second slot just
-     established, so it is excluded from the shrink-to-fit computation above.
-     Real before/after pairs routinely differ by a few pixels (content length
-     changed), so nothing guarantees the two share intrinsic dimensions. Fill
-     the box the after image set and letterbox to it — `contain` never crops,
-     and top-left (not centered) is the shared origin of two screenshots of
-     the same page, since any mismatch is extra content below the fold. */
-  .image-preview[data-mode="fit"] img-comparison-slider img[slot="first"] {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    object-position: left top;
-  }
-
   /* Full, second slot ("after"): same fill-the-stage sizing as the single
      image in full mode. Still the layer that drives the host's width. */
   .image-preview[data-mode="full"] img-comparison-slider img[slot="second"] {
@@ -384,15 +403,33 @@ const counterpartUrl = compare?.src ?? null;
     max-height: none;
   }
 
-  /* Full, first slot ("before"): same reasoning as the fit-mode override
-     above — fill the box the after image established (here, the full stage
-     width) and letterbox to it rather than resolving its own intrinsic
-     ratio inside an overlay sized to a possibly different-ratio after image. */
-  .image-preview[data-mode="full"] img-comparison-slider img[slot="first"] {
+  /* Both modes, first slot ("before"): the component absolutely positions this
+     layer's shadow container at 100%/100% of the box the second slot
+     established, so it is excluded from the shrink-to-fit computation above
+     and has no box of its own to derive. Give it the box's full width and let
+     its own ratio pick its height — the same rule in either mode, since the
+     mode only changes how wide that box is.
+
+     Width, not "whichever axis fits first", is the shared unit: two shots of
+     the same page differ in length, not in width, so normalizing on width is
+     what puts the same content under the same x in both layers. It is also
+     what every other before/after slider does with mismatched sources.
+     `object-fit: contain` used to size this layer here, which on a several-
+     fold length mismatch made it height-bound instead — it shrank to a
+     fraction of the box's width and left dead space beside it (#552).
+
+     A before layer longer than the box now overflows it and the component's
+     own `.first-overlay` (`overflow: hidden`) clips the tail at the box's
+     bottom edge, trading a slice of below-the-fold content — still readable
+     in "This image" on the before file's own page — for two layers that stay
+     registered. A shorter one letterboxes at the bottom, as it did before. */
+  .image-preview img-comparison-slider img[slot="first"] {
     width: 100%;
-    height: 100%;
-    object-fit: contain;
-    object-position: left top;
+    height: auto;
+    /* Without this, the stage's fit-mode cap further down applies to this
+       layer's height while its width is pinned to the box, squashing its
+       aspect ratio. The box it fills is capped already. */
+    max-height: none;
   }
 
   .compare-label {


### PR DESCRIPTION
Closes #552.

Compare mode fitted the before layer into the after image's box with `object-fit: contain`, which sizes by whichever axis fits first. On a several-fold page-length mismatch that flips the layer to **height**-bound: it renders a fraction of the box's width, left-anchored, with dead stage beside it.

The issue framed this as a rare, low-severity case, and the dramatic version is. But the same rule was quietly costing every mismatched pair: a 20px length difference put the two layers at slightly different scales, so they never quite registered — the thing Compare exists to do.

## What changed

**Normalize on width, in both modes.** Two screenshots of the same page differ in length, not in width, so width is what puts the same content under the same x in both layers. It's also what other before/after sliders do with mismatched sources. The two mode-specific `[slot="first"]` rules collapse into one:

```css
.image-preview img-comparison-slider img[slot="first"] {
  width: 100%;
  height: auto;
  max-height: none;   /* the fit-mode cap would otherwise squash the ratio */
}
```

**Fit clips, Full width grows.** A before layer longer than the box now overflows it, and the two modes want different answers:

- **Fit** is capped at `--preview-max-h`, so the component's own `.first-overlay` clips the tail. Sizing *this* box to the taller layer would let one long screenshot shrink the whole stage — an 800×3000 before against an 800×600 after would squeeze the after down to a ~187px-wide stamp. That's the trade the issue was right to reject.
- **Full width** has no cap and exists to show the image whole, so the box takes the taller layer's ratio via a `--pair-ratio` custom property measured once both images load. Safe *only* here: the width is the stage's either way, so a long layer can only add height — it can never shrink the other one.

That split also makes the clipping recoverable rather than terminal: the tail Fit hides is one click away on a control that's already there.

The `aspect-ratio: var(--pair-ratio, auto)` fallback means an image that never loads leaves the box exactly as it is today. The "after sizes the box" contract is untouched in Fit, where it's load-bearing.

## Verification

CSS-only behavior, so this was measured rather than eyeballed: a harness that inlines the component's `<style>` block verbatim, loads the real `img-comparison-slider@8.0.7` bundle, and uses the real DOM structure — five pairs × both modes.

| pair | old dead strip | new |
| --- | --- | --- |
| 800×3000 / 800×600 (the issue's example) | 488px of a 610px box | 0 |
| 800×620 / 800×600 (ordinary pair) | 20px | 0 |
| 800×300 / 800×600 (before shorter) | 0 | 0 |
| 800×2400 / 800×3000 (both tall, fit cap active) | 0 | 0 |

In all of them the layers now share an origin, share a width, and keep their aspect ratio. `pnpm test:web` 539 passed, `astro check` 0 errors, Prettier and oxlint clean.

<img width="820" alt="Fit and full-width compare stages, before and after the fix" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/566/compare-aspect-mismatch.webp">

**Known, deliberate:** when the Full-width box grows, the corner `after` label sits at the bottom of the grown box — in the letterbox strip rather than on the after image's own bottom edge. It still reads as marking that half of the stage, and chasing it costs more than it's worth.

Per the issue's warning, the `[slot="first"]` / `[slot="second"]` splits were re-verified in both modes, and the slot images' `loading="eager"` flip is untouched — restoring `lazy` there still deadlocks Compare into an empty stage.
