### PR TITLE
feat(mcp): branch stage and promote on the hosted server

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ case plus peer deps, no API changes.
 
 How to set up, test, and open a pull request:
 [CONTRIBUTING.md](CONTRIBUTING.md). Agent working conventions live in
-[AGENTS.md](AGENTS.md).
+[AGENTS.md](AGENTS.md). Agents that land on this repo should start at
+[llms.txt](llms.txt) (product use vs monorepo contribute). The product site
+serves https://uploads.sh/llms.txt and https://uploads.sh/llms-full.txt.
 
 ## Local development
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "./uploader-identity": "./src/uploader-identity.ts",
     "./github-comment-service": "./src/github-comment-service.ts",
     "./github-comment-render": "./src/github-comment-render.ts",
+    "./github-promote-service": "./src/github-promote-service.ts",
     "./github-repo-binding": "./src/github-repo-binding.ts"
   },
   "scripts": {

--- a/apps/api/src/github-promote-service.ts
+++ b/apps/api/src/github-promote-service.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared service behind `POST /v1/:workspace/github/promote` and the hosted
+ * MCP `promote` tool (and optional post-`put` promote when a branch is
+ * supplied with pr). Copies this workspace's branch-staged attachments into
+ * the PR prefix, then best-effort records the repo binding the same way the
+ * REST route does (issue #297 claim gate on *new* bindings only).
+ *
+ * Pure workspace-data copy — no GitHub API call for the promote itself.
+ * Claim entitlement may call GitHub; failure to claim never fails the promote.
+ */
+import { isEntitledToClaimRepo } from "./github-claim-authz";
+import { promoteBranchAttachments, type PromoteResult, type PromoteTarget } from "./github-promote";
+import { findRepoLink, recordRepoLink } from "./github-repo-links";
+import type { WorkspaceRecord } from "./workspace";
+
+export type { PromoteResult, PromoteTarget };
+
+/**
+ * Promote branch-staged objects, then attempt the same implicit
+ * repo-link claim the REST route performs after a 2xx promote.
+ */
+export async function postPromoteBranchAttachments(
+  env: Env,
+  ws: WorkspaceRecord,
+  workspaceName: string,
+  mintingUserId: string | null,
+  target: PromoteTarget,
+): Promise<PromoteResult> {
+  const result = await promoteBranchAttachments(env, ws, workspaceName, target);
+
+  // Implicit claim (phase 3): first-claim-wins; never affects the promote
+  // result. Cross-tenant gate on NEW claims only (issue #297) — already-bound
+  // repos re-record via INSERT OR IGNORE (no-op).
+  const existingLink = await findRepoLink(env.DB, target.repo);
+  const canClaim =
+    existingLink !== null || (await isEntitledToClaimRepo(env, target.repo, mintingUserId));
+  if (canClaim) {
+    await recordRepoLink(env.DB, target.repo, workspaceName, "promote");
+  }
+
+  return result;
+}

--- a/apps/api/src/routes/github-promote.ts
+++ b/apps/api/src/routes/github-promote.ts
@@ -9,9 +9,7 @@
  */
 import { ValidationError } from "@uploads/errors";
 import { Hono } from "hono";
-import { promoteBranchAttachments } from "../github-promote";
-import { isEntitledToClaimRepo } from "../github-claim-authz";
-import { findRepoLink, recordRepoLink } from "../github-repo-links";
+import { postPromoteBranchAttachments } from "../github-promote-service";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
 import { jsonBody } from "./json-body";
@@ -60,33 +58,15 @@ export const githubPromote = new Hono<WorkspaceVars>().post(
   async (c) => {
     const target = parseBody(await jsonBody(c));
     const workspaceName = c.get("workspaceName");
-    const result = await promoteBranchAttachments(c.env, c.get("workspace"), workspaceName, target);
-
-    // Implicit claim (phase 3): reaching a 2xx response means this workspace
-    // has proven authenticated write access to this repo's branch-staged
-    // attachments — best-effort record it as the repo's bound workspace.
-    // First-claim-wins (recordRepoLink) and never affects this response.
-    //
-    // Cross-tenant authorization (issue #297): unlike /github/comment, this
-    // route makes no GitHub API call of its own (it only copies the calling
-    // workspace's own R2 objects), so nothing previously stopped workspace A
-    // from being the first to promote against org B's unbound repo and
-    // silently becoming its bound workspace — a defacement/denial vector
-    // against org B's later legitimate `/github/comment` calls, which decline
-    // once a repo is bound elsewhere. Gate the claim itself: an already-bound
-    // repo is always re-recorded (INSERT OR IGNORE no-ops, matching prior
-    // behavior — grandfathered), but a NEW claim only happens when this
-    // workspace's linked GitHub identity is verified as entitled to `repo`.
-    // The promote operation itself (copying the workspace's own data) is
-    // never blocked by this — only the side-effect claim is gated.
-    const existingLink = await findRepoLink(c.env.DB, target.repo);
-    const canClaim =
-      existingLink !== null ||
-      (await isEntitledToClaimRepo(c.env, target.repo, c.get("mintingUserId")));
-    if (canClaim) {
-      await recordRepoLink(c.env.DB, target.repo, workspaceName, "promote");
-    }
-
+    // Promote + gated claim live in github-promote-service so the hosted MCP
+    // promote tool reuses the same path (no drift with this route).
+    const result = await postPromoteBranchAttachments(
+      c.env,
+      c.get("workspace"),
+      workspaceName,
+      c.get("mintingUserId"),
+      target,
+    );
     return c.json(result);
   },
 );

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -7,11 +7,13 @@ the CLI package's transport-agnostic MCP core (`@buildinternet/uploads/mcp`).
 
 Stateless MCP Streamable HTTP: one JSON-RPC message per POST, no sessions or
 SSE (GET/DELETE on the endpoint are 405). Tools cover put/list/delete, metadata
-(`get_metadata` / `set_metadata` / `find_files`), galleries, usage, health, and
-hosted `put`/`comment` that sync the managed attachments comment via the
-GitHub App (bot-only; body honors the repo's `.uploads.yml` when present —
-see https://uploads.sh/docs/comment-config). Local attach/comment/doctor need a
-filesystem or `gh` and live only on the stdio server (`uploads mcp`).
+(`get_metadata` / `set_metadata` / `find_files`), galleries, usage, health,
+branch staging (`put` with `branch` + `repo`), promote (`promote` with
+`repo`/`pr`/`branch`), and managed-comment sync via `put`/`comment`/`promote`
+(bot-only; body honors the repo's `.uploads.yml` when present — see
+https://uploads.sh/docs/comment-config). Local `attach`/`doctor` (filesystem or
+`gh`) and the git-defaulting `staged` tool live only on the stdio server
+(`uploads mcp`).
 
 ### Protocol eras
 

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1,14 +1,22 @@
 /**
- * Remote MCP tool set — the hosted subset of the CLI's stdio tools (put,
- * list, delete, health). Everything is scoped to the workspace resolved by
- * `workspaceAuth`; token scopes are enforced inside handlers, where a throw
- * becomes an isError tool result rather than a JSON-RPC error. Tools needing
- * a filesystem or the gh CLI (attach, comment, doctor) stay stdio-only.
+ * Remote MCP tool set — the hosted subset of the CLI's stdio tools. Everything
+ * is scoped to the workspace resolved by `workspaceAuth`; token scopes are
+ * enforced inside handlers, where a throw becomes an isError tool result
+ * rather than a JSON-RPC error.
+ *
+ * Deliberate hosted divergences (no filesystem / no git / no local `gh`):
+ * - No `attach` tool — use `put` with `pr`/`issue` (+ required `repo`) for the
+ *   same stable key + managed comment, or `put` with `branch` (+ `repo`) to
+ *   stage pre-PR, or `promote` to copy staged files into a PR.
+ * - No `doctor` (local checks). No `staged` tool — no git defaults for branch;
+ *   use `list` / `find_files` + `repo_link_status` (issue #405).
  */
 import {
   buildMarkdown,
   buildScreenshotKey,
   ghAttachmentKey,
+  ghBranchAttachmentKey,
+  ghMetadataForBranch,
   ghMetadataFromTarget,
   type GhTarget,
 } from "@buildinternet/uploads";
@@ -32,6 +40,10 @@ import {
 import { AppError, NotFoundError } from "@uploads/errors";
 import { badKey } from "@uploads/api/files";
 import { postManagedComment, type PostCommentResult } from "@uploads/api/github-comment-service";
+import {
+  postPromoteBranchAttachments,
+  type PromoteResult,
+} from "@uploads/api/github-promote-service";
 import {
   findObjectsByMetadata,
   getFileMetadata,
@@ -167,6 +179,29 @@ function ghTargetFromArgs(args: Record<string, unknown>): GhTarget | undefined {
   return { repo, kind: pr !== undefined ? "pull" : "issues", num: (pr ?? issue) as number };
 }
 
+/**
+ * Branch name for staging / promote. Required non-empty printable string when
+ * present; `ghMetadataForBranch` enforces the metadata value rules and is
+ * the source of truth for "is this branch name stageable?".
+ */
+function branchFromArgs(args: Record<string, unknown>): string | undefined {
+  if (!("branch" in args) || args.branch === undefined || args.branch === null) return undefined;
+  const branch = optString(args, "branch");
+  if (branch === undefined || branch.length === 0) {
+    usage("branch must be a non-empty string");
+  }
+  return branch;
+}
+
+/** Stamp gh.* branch metadata; surface metadata rule failures as usage errors. */
+function branchMetadata(repo: string, branch: string): Record<string, string> {
+  try {
+    return ghMetadataForBranch(repo, branch);
+  } catch (err) {
+    usage(err instanceof Error ? err.message : String(err));
+  }
+}
+
 /** Per-item failure detail, same shape as the CLI/stdio `failures[]` entries. */
 function errorDetail(err: unknown): {
   message: string;
@@ -216,6 +251,30 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
       return { comment };
     } catch (err) {
       return { commentError: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  /**
+   * Best-effort promote (CLI attach --pr parity). Never fails the caller —
+   * promote problems surface as `promoteError` so an upload/comment path
+   * still returns its primary result.
+   */
+  async function attemptPromote(
+    repo: string,
+    num: number,
+    branch: string,
+  ): Promise<{ promotion?: PromoteResult; promoteError?: string }> {
+    try {
+      const promotion = await postPromoteBranchAttachments(
+        env,
+        workspace,
+        workspaceName,
+        ctx.mintingUserId,
+        { repo, num, branch },
+      );
+      return { promotion };
+    } catch (err) {
+      return { promoteError: err instanceof Error ? err.message : String(err) };
     }
   }
 
@@ -439,7 +498,7 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "put",
       description:
-        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). With `pr`/`issue` (+ required `repo`) the key is stable instead (gh/…, always overwrites) and the managed attachments comment is synced by default as uploads-sh[bot] (bot-only on this hosted server, no local gh fallback; body honors the repo's `.uploads.yml` when present) — pass `comment: false` to skip it. Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
+        "Upload base64-encoded content to the workspace and get a public URL plus GitHub-ready embed markdown (the returned `markdown` is ready to paste into a PR or issue). Single file: pass `contentBase64` + `filename` (flat result). Multiple files: pass `files` (uploaded in parallel; returns `uploads` + `failures`, one bad item does not abort the rest). The key defaults to <prefix>/<repo>/<ref>/<name>-<hash>.<ext>; pass `key` for an explicit path instead (single-file only). With `pr`/`issue` (+ required `repo`) the key is stable instead (gh/…, always overwrites) and the managed attachments comment is synced by default as uploads-sh[bot] (bot-only on this hosted server, no local gh fallback; body honors the repo's `.uploads.yml` when present) — pass `comment: false` to skip it. With `branch` (+ required `repo`, no pr/issue) stages under gh/…/branch/… for pre-PR capture (CLI attach --branch parity); no comment yet. With `pr` + `branch`, also best-effort promotes that branch's staged files into the PR before the comment sync (CLI attach --pr auto-promote parity). Uploads are public regardless of GitHub repository visibility; explicit predictable keys must contain only non-sensitive media. The stored content type is sniffed from the bytes and restricted to the workspace's allowlist (images plus mp4/webm by default).",
       inputSchema: {
         type: "object",
         properties: {
@@ -474,12 +533,12 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               required: ["filename", "contentBase64"],
               additionalProperties: false,
             },
-            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/pr/issue/width/metadata apply to every item. Returns { uploads, failures } with per-item results (plus comment/commentError once for the whole batch when the comment sync runs).`,
+            description: `Multiple files to upload in one call (max ${MAX_PUT_FILES} items). Cannot be combined with contentBase64, filename, or key; prefix/repo/ref/pr/issue/branch/width/metadata apply to every item. Returns { uploads, failures } with per-item results (plus comment/commentError / promotion once for the whole batch when those run).`,
           },
           key: {
             type: "string",
             description:
-              "Explicit object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>). Cannot be combined with prefix/repo/ref.",
+              "Explicit object key (default: <prefix>/<repo>/<ref>/<name>-<hash>.<ext>). Cannot be combined with prefix/repo/ref/pr/issue/branch.",
           },
           prefix: {
             type: "string",
@@ -488,27 +547,32 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           repo: {
             type: "string",
             description:
-              "owner/name repo segment for the default key layout (default: misc). REQUIRED (and must be owner/name) with pr/issue — there is no git context on this server to infer it from.",
+              "owner/name repo segment for the default key layout (default: misc). REQUIRED (and must be owner/name) with pr/issue/branch — there is no git context on this server to infer it from.",
           },
           ref: {
             type: "string",
             description:
-              "PR/issue/branch key segment for the default key layout (default: today). Cannot be combined with pr/issue.",
+              "PR/issue/branch key segment for the default key layout (default: today). Cannot be combined with pr/issue/branch.",
           },
           pr: {
             type: "number",
             description:
-              "Attach to this pull request: uses a stable gh/ key (always overwrites) and stamps canonical gh.* metadata. Mutually exclusive with issue and with key/prefix/ref. Requires repo.",
+              "Attach to this pull request: uses a stable gh/ key (always overwrites) and stamps canonical gh.* metadata. Mutually exclusive with issue. Cannot combine with key/prefix/ref, or with branch-only staging (branch alone stages; pr + branch uploads to the PR and promotes that branch). Requires repo.",
           },
           issue: {
             type: "number",
             description:
-              "Attach to this issue: uses a stable gh/ key (always overwrites) and stamps canonical gh.* metadata. Mutually exclusive with pr and with key/prefix/ref. Requires repo.",
+              "Attach to this issue: uses a stable gh/ key (always overwrites) and stamps canonical gh.* metadata. Mutually exclusive with pr and with branch (promotion is PR-only). Cannot combine with key/prefix/ref. Requires repo.",
+          },
+          branch: {
+            type: "string",
+            description:
+              "Git branch name. Without pr/issue: stage under gh/<owner>/<repo>/branch/<branch>/<filename> (pre-PR; no comment). With pr: after upload, best-effort promote this branch's staged files into the PR (never fails the upload; see promotion/promoteError). Requires repo. Cannot combine with issue, key, prefix, or ref.",
           },
           comment: {
             type: "boolean",
             description:
-              "With pr/issue: after a successful upload, create or update the managed attachments comment via the uploads.sh GitHub App (bot-only on this hosted server — no local gh fallback; body honors the repo's `.uploads.yml` when present). Defaults to true when pr/issue is given (requires the files:read scope; a write-only token skips the sync unless comment is explicitly true); pass false to skip. Requires pr or issue. A comment failure never fails the upload; see the response's `comment`/`commentError`.",
+              "With pr/issue: after a successful upload, create or update the managed attachments comment via the uploads.sh GitHub App (bot-only on this hosted server — no local gh fallback; body honors the repo's `.uploads.yml` when present). Defaults to true when pr/issue is given (requires the files:read scope; a write-only token skips the sync unless comment is explicitly true); pass false to skip. Requires pr or issue (not branch-only staging). A comment failure never fails the upload; see the response's `comment`/`commentError`.",
           },
           alt: {
             type: "string",
@@ -558,47 +622,53 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           if (!filename) usage("filename is required");
         }
 
-        // PR/issue targeting (issue #392): mirrors the stdio put contract, but
-        // `repo` is required here (no git context on this server, enforced by
-        // ghTargetFromArgs). Mutually exclusive with key/prefix/ref — a target
-        // always uses the stable gh/ key layout, never the default one.
+        // Destinations (no git on this server — repo is always required when
+        // the key layout needs it):
+        // - pr/issue → stable gh/…/pull|issues/… keys + optional comment (#392)
+        // - branch alone → stage under gh/…/branch/… (CLI attach --branch)
+        // - pr + branch → PR key, then best-effort promote that branch
         const target = ghTargetFromArgs(args);
-        // optBool collapses "absent" to false, but absent vs explicit false
-        // matters here (absent → default-on with pr/issue), so gate on the
-        // raw arg first.
-        const commentArg = args.comment == null ? undefined : optBool(args, "comment");
-        if (commentArg && !target) usage("comment requires pr or issue");
-        // The comment path's gather reads the workspace's own objects,
-        // metadata, and galleries (github-comment-service.ts's
-        // gatherCommentBody) — the same reason the REST route requires
-        // files:read. Checked up front, alongside the other argument
-        // validation, so a files:write-only token is rejected before any
-        // bytes are written — never after a successful upload.
-        if (commentArg === true) requireScope("files:read");
-        // With pr/issue the sync runs by default (parity with CLI put, #537);
-        // comment: false opts out. The default-on case additionally requires
-        // files:read on the token — a write-only token keeps its pre-#537
-        // ability to upload by silently skipping the sync, and only an
-        // explicit comment: true turns that missing scope into an error.
-        const wantComment =
-          commentArg ?? (target !== undefined && ctx.authScopes.includes("files:read"));
-
+        const branch = branchFromArgs(args);
         const explicitKey = optString(args, "key");
         const prefix = optString(args, "prefix");
         const repo = optString(args, "repo");
         const ref = optString(args, "ref");
-        if (target) {
-          if (explicitKey) usage("key cannot be combined with pr/issue");
-          if (prefix) usage("prefix cannot be combined with pr/issue");
-          if (ref) usage("ref cannot be combined with pr/issue");
+
+        if (branch !== undefined && target?.kind === "issues") {
+          usage("branch cannot be combined with issue (promotion only applies to pull requests)");
         }
-        if (explicitKey && (prefix ?? repo ?? ref) !== undefined) {
+        // Branch-only staging vs pr+branch promote-after.
+        const staging = branch !== undefined && !target;
+        const promoteBranch = branch !== undefined && target?.kind === "pull" ? branch : undefined;
+        if (staging) {
+          if (!repo) usage("repo is required with branch (no git context on the hosted server)");
+          if (!validRepoGrammar(repo)) usage("repo must be owner/name");
+        }
+
+        // Stable gh layouts (PR/issue or branch stage) own the key path.
+        const ghLayout = target ? "pr/issue" : staging ? "branch" : null;
+        if (ghLayout) {
+          if (explicitKey) usage(`key cannot be combined with ${ghLayout}`);
+          if (prefix) usage(`prefix cannot be combined with ${ghLayout}`);
+          if (ref) usage(`ref cannot be combined with ${ghLayout}`);
+        } else if (explicitKey && (prefix ?? repo ?? ref) !== undefined) {
           usage("key cannot be combined with prefix/repo/ref");
         }
 
-        // state/app are explicit input and win over a same-named metadata key.
-        // This server cannot derive the EXIF-sourced keys (no image decoding in
-        // the Workers runtime), so these two are the whole canonical surface here.
+        // optBool collapses "absent" to false; absent vs explicit false matters
+        // for default-on comment with pr/issue.
+        const commentArg = args.comment == null ? undefined : optBool(args, "comment");
+        if (commentArg && !target) usage("comment requires pr or issue");
+        // Comment gather needs files:read (same as REST). Check up front so a
+        // write-only token is rejected before any bytes are written when the
+        // caller explicitly asked for comment: true.
+        if (commentArg === true) requireScope("files:read");
+        // Default-on with pr/issue when the token has files:read (#537);
+        // write-only tokens still upload, just skip the sync unless comment:true.
+        const wantComment =
+          commentArg ?? (target !== undefined && ctx.authScopes.includes("files:read"));
+
+        // state/app win over same-named metadata. No EXIF derivation on Workers.
         let metadata = metadataArgWithCanonical(args);
         if (metadata) {
           try {
@@ -607,46 +677,63 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             usage(err instanceof Error ? err.message : String(err));
           }
         }
-        // With a target, stamp the canonical gh.* pairs (parity with the
-        // attach flow, so find/activity-feed/attribution see these uploads).
-        // Canonical keys win over any caller-supplied same-named pair.
+        // Canonical gh.* stamps win over caller pairs (attach parity).
         if (target) metadata = { ...metadata, ...ghMetadataFromTarget(target) };
-        // Uploader attribution (issue #345, parity with the REST PUT hook in
-        // apps/api/src/routes/files.ts): gh.*-tagged uploads get server-derived
-        // `gh.uploader`/`gh.uploader-id` stamped from the OAuth JWT's (or
-        // up_ token's) minting user, spread AFTER the tool-supplied pairs so
-        // a caller can't spoof those keys. Applied once for the whole call —
-        // metadata (like prefix/repo/ref) applies to every item in a batch.
+        else if (staging && repo && branch) {
+          metadata = { ...metadata, ...branchMetadata(repo, branch) };
+        }
+        // Uploader attribution (#345): server tags after caller pairs so they
+        // can't be spoofed; drop if they'd exceed the key cap.
         if (metadata && hasGithubTags(metadata)) {
           const uploader = await uploaderTags(env, ctx.mintingUserId, metadata["gh.repo"]);
           if (uploader) {
-            // Never let attribution break an upload that was valid without
-            // it: drop the server tags if the merge would exceed the cap.
             const merged = { ...metadata, ...uploader };
             if (Object.keys(merged).length <= META_MAX_KEYS) metadata = merged;
           }
         }
 
         const policy = resolveUploadPolicy(workspace);
-        // Pre-decode gate uses the policy ceiling (video caps can exceed
-        // maxBytes); putObject's inspectUpload enforces the content-specific
-        // limit after sniffing, so an over-cap image still fails per item.
+        // Pre-decode uses the policy ceiling (video may exceed maxBytes);
+        // putObject's inspectUpload enforces the content-specific limit.
         const maxBytes = Math.max(policy.maxBytes, policy.maxVideoBytes);
         const alt = optString(args, "alt");
         const width = optPosInt(args, "width");
-        // Strict-overwrite gate (issue #174): defaults false; only matters on
-        // non-gh/ keys (explicit `key`, or the default prefix/repo/ref
-        // layout) — putObject always allows overwrite on gh/-prefixed keys.
+        // Strict overwrite (issue #174) only on non-gh/ keys.
         const replaceArg = optBool(args, "replace") === true;
         const putOpts =
           metadata !== undefined || replaceArg
             ? { metadata, replace: replaceArg, surface: "mcp" as const }
             : { surface: "mcp" as const };
 
+        /** Resolve the object key for one filename (+ bytes for the dated layout). */
+        async function resolveKey(name: string, bytes: Uint8Array): Promise<string> {
+          if (explicitKey) return explicitKey;
+          if (target) return ghAttachmentKey(target, name);
+          if (staging && repo && branch) return ghBranchAttachmentKey(repo, branch, name);
+          // deriveRepoFromGit: false — no git on a worker.
+          return buildScreenshotKey({
+            filename: name,
+            fileBytes: bytes,
+            prefix,
+            repo,
+            ref,
+            deriveRepoFromGit: false,
+          });
+        }
+
+        /** After successful write(s): optional promote, then comment (CLI order). */
+        async function afterUploadExtras(hadSuccess: boolean): Promise<Record<string, unknown>> {
+          if (!hadSuccess || !target) return {};
+          const promoteResult =
+            promoteBranch !== undefined
+              ? await attemptPromote(target.repo, target.num, promoteBranch)
+              : undefined;
+          const commentResult = wantComment ? await attachComment(target) : undefined;
+          return { ...promoteResult, ...commentResult };
+        }
+
         if (multi) {
-          // Decode (and size-gate) every item before any write, so a
-          // structurally invalid batch fails whole with a usage error
-          // instead of leaving partial writes behind.
+          // Decode every item before any write so a bad batch fails whole.
           const decoded = items.map((item, i) => {
             try {
               return decodeBase64(item.contentBase64, maxBytes);
@@ -656,25 +743,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
               );
             }
           });
-          // Keys are deterministic (sanitized name + content hash for the
-          // default layout, or filename alone under a gh/ target), so two
-          // items can collide — e.g. the same file listed twice. Reject
-          // before any write: concurrent same-key puts would double-count
-          // the usage ledger and report more uploads than stored objects.
-          const keys = target
-            ? items.map((item) => ghAttachmentKey(target, item.filename))
-            : await Promise.all(
-                decoded.map((bytes, i) =>
-                  buildScreenshotKey({
-                    filename: items[i]!.filename,
-                    fileBytes: bytes,
-                    prefix,
-                    repo,
-                    ref,
-                    deriveRepoFromGit: false,
-                  }),
-                ),
-              );
+          const keys = await Promise.all(
+            items.map((item, i) => resolveKey(item.filename, decoded[i]!)),
+          );
+          // Deterministic keys can collide (same file twice). Reject first.
           const firstIndexByKey = new Map<string, number>();
           keys.forEach((key, i) => {
             const first = firstIndexByKey.get(key);
@@ -719,40 +791,18 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
             slot.ok ? [] : [{ file: slot.file, error: errorDetail(slot.err) }],
           );
           if (uploads.length === 0 && failures.length > 0) {
-            // Total failure → isError with structuredContent, same as stdio.
             throw new ToolBatchError(batchFailureMessage(failures), {
               workspace: workspaceName,
               uploads,
               failures,
             });
           }
-          // At least one item made it into R2 (issue #392): sync the comment
-          // once for the whole batch, same as the stdio tool syncs once per call.
-          const commentResult =
-            wantComment && target && uploads.length > 0 ? await attachComment(target) : undefined;
-          return { workspace: workspaceName, uploads, failures, ...commentResult };
+          const extras = await afterUploadExtras(uploads.length > 0);
+          return { workspace: workspaceName, uploads, failures, ...extras };
         }
 
         const bytes = decodeBase64(contentBase64!, maxBytes);
-
-        const key =
-          explicitKey ??
-          (target
-            ? ghAttachmentKey(target, filename!)
-            : // deriveRepoFromGit: false — no git (or child_process) on a worker.
-              await buildScreenshotKey({
-                filename: filename!,
-                fileBytes: bytes,
-                prefix,
-                repo,
-                ref,
-                deriveRepoFromGit: false,
-              }));
-
-        // Key/body validation and the size/type guardrails live in putObject,
-        // shared with the REST API — the stored content type is sniffed there.
-        // metadata is undefined when omitted (leave existing D1 rows
-        // untouched); passing opts only when defined preserves that.
+        const key = await resolveKey(filename!, bytes);
         const result = await putObject(env, workspace, key, bytes, workspaceName, putOpts);
         const markdown =
           result.url === null
@@ -761,8 +811,8 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
                 alt: alt ?? filename!,
                 width,
               });
-        const commentResult = wantComment && target ? await attachComment(target) : undefined;
-        return { workspace: workspaceName, ...result, markdown, ...commentResult };
+        const extras = await afterUploadExtras(true);
+        return { workspace: workspaceName, ...result, markdown, ...extras };
       },
     },
     {
@@ -848,6 +898,66 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
         return postManagedComment(env, workspace, workspaceName, ctx.mintingUserId, target, {
           resync: true,
         });
+      },
+    },
+    {
+      name: "promote",
+      description:
+        "Copy this workspace's branch-staged attachments (gh/…/branch/… keys from put with branch, or CLI attach --branch) into a PR's stable gh/…/pull/… prefix, then optionally refresh the managed attachments comment. Hosted stand-in for `uploads attach --promote` — no git context, so repo, pr, and branch are all required. Does not delete staged originals. Promotion is a pure workspace-data copy (no GitHub API for the copy itself); the comment path is bot-only like the comment tool. Returns { promotion: { promoted, skipped }, comment?, commentError? }.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          repo: {
+            type: "string",
+            description:
+              "owner/name repo. REQUIRED — there is no git context on this server to infer it from.",
+          },
+          pr: {
+            type: "number",
+            description: "Pull request number to promote into. Promotion never applies to issues.",
+          },
+          branch: {
+            type: "string",
+            description:
+              "Git branch whose staged prefix (gh/…/branch/<branch>/) should be copied into the PR.",
+          },
+          comment: {
+            type: "boolean",
+            description:
+              "After a successful promote, create or update the managed attachments comment (default true when files:read is on the token; pass false to skip). A comment failure never fails the promote; see commentError.",
+          },
+        },
+        required: ["repo", "pr", "branch"],
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:write");
+        await requireWriteBudget();
+        const repo = requiredString(args, "repo");
+        if (!validRepoGrammar(repo)) usage("repo must be owner/name");
+        const pr = optPosInt(args, "pr");
+        if (pr === undefined) usage("pr is required");
+        const branch = branchFromArgs(args) ?? usage("branch is required");
+        // Validate branch is stageable (metadata rules) before the copy.
+        branchMetadata(repo, branch);
+
+        const commentArg = args.comment == null ? undefined : optBool(args, "comment");
+        if (commentArg === true) requireScope("files:read");
+        const wantComment = commentArg ?? ctx.authScopes.includes("files:read");
+
+        // Primary job — failures throw (isError), unlike put's best-effort promote.
+        const promotion = await postPromoteBranchAttachments(
+          env,
+          workspace,
+          workspaceName,
+          ctx.mintingUserId,
+          { repo, num: pr, branch },
+        );
+
+        const commentResult = wantComment
+          ? await attachComment({ repo, kind: "pull", num: pr })
+          : undefined;
+        return { promotion, ...commentResult };
       },
     },
     {

--- a/apps/mcp/test/mcp-branch-promote.test.ts
+++ b/apps/mcp/test/mcp-branch-promote.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Hosted MCP branch staging (`put` + `branch`) and promote (`promote` tool,
+ * plus `put` with `pr` + `branch` promote-after).
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import app from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "@uploads/api/workspace";
+import { FakeR2Bucket } from "@uploads/storage/test/fake-r2";
+
+const TOKEN = "up_test-ws_legacy-token-value";
+const WS = "test-ws";
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+const GITHUB_APP_CFG_ENV = {
+  GITHUB_APP_ID: "12345",
+  GITHUB_APP_PRIVATE_KEY: "unused",
+  GITHUB_APP_HOME_INSTALLATION_ID: "777",
+  WEB_ORIGIN: "https://uploads.sh",
+};
+
+class FakeKv {
+  store = new Map<string, { value: string; expirationTtl?: number }>();
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key)?.value ?? null;
+  }
+  async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
+    this.store.set(key, { value, expirationTtl: opts?.expirationTtl });
+  }
+}
+
+interface RepoLinkRow {
+  repo_full_name: string;
+  workspace_name: string;
+  installation_id: number | null;
+  source: string;
+  created_at: string;
+}
+
+class RepoLinksTable {
+  readonly rows = new Map<string, RepoLinkRow>();
+
+  tryRun(sql: string, args: unknown[]) {
+    if (sql.startsWith("INSERT OR IGNORE INTO github_repo_links")) {
+      const [repo, workspace, installationId, source, createdAt] = args as [
+        string,
+        string,
+        number | null,
+        string,
+        string,
+      ];
+      if (this.rows.has(repo)) return { success: true, meta: { changes: 0 }, results: [] };
+      this.rows.set(repo, {
+        repo_full_name: repo,
+        workspace_name: workspace,
+        installation_id: installationId,
+        source,
+        created_at: createdAt,
+      });
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    return undefined;
+  }
+
+  tryFirst(sql: string, args: unknown[]) {
+    if (sql.includes("FROM github_repo_links WHERE repo_full_name")) {
+      const [repo] = args as [string];
+      return this.rows.get(repo) ?? null;
+    }
+    return undefined;
+  }
+}
+
+function makeDb(links: RepoLinksTable, metadata: Map<string, Map<string, string>>) {
+  const scopeKey = (ws: string, objectKey: string) => `${ws} ${objectKey}`;
+  return {
+    prepare: (sql: string) => {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      let values: unknown[] = [];
+      const stmt = {
+        bind(...next: unknown[]) {
+          values = next;
+          return stmt;
+        },
+        async first<T>() {
+          if (normalized.includes("github_repo_links")) {
+            return (links.tryFirst(normalized, values) ?? null) as T;
+          }
+          return null as T;
+        },
+        async run() {
+          if (normalized.includes("github_repo_links")) {
+            return (
+              links.tryRun(normalized, values) ?? {
+                success: true,
+                meta: { changes: 0 },
+                results: [],
+              }
+            );
+          }
+          if (normalized.startsWith("INSERT INTO file_metadata")) {
+            const [ws, objectKey, key, value] = values as [string, string, string, string];
+            const map = metadata.get(scopeKey(ws, objectKey)) ?? new Map<string, string>();
+            map.set(key, value);
+            metadata.set(scopeKey(ws, objectKey), map);
+          } else if (normalized.startsWith("DELETE FROM file_metadata")) {
+            const [ws, objectKey] = values as [string, string];
+            // DELETE can be full-key or selective; promote's set path uses full replace.
+            if (values.length === 2) metadata.delete(scopeKey(ws, objectKey));
+          }
+          return { success: true, meta: { changes: 0 }, results: [] };
+        },
+        async all<T>() {
+          // getFileMetadata shape
+          if (normalized.startsWith("SELECT meta_key, meta_value FROM file_metadata")) {
+            const [ws, objectKey] = values as [string, string];
+            const map = metadata.get(scopeKey(ws, objectKey)) ?? new Map<string, string>();
+            return {
+              success: true,
+              results: [...map.entries()].map(([meta_key, meta_value]) => ({
+                meta_key,
+                meta_value,
+              })) as T[],
+              meta: {},
+            };
+          }
+          // getMetadataForKeys: SELECT object_key, meta_key, meta_value …
+          // WHERE workspace = ? AND object_key IN (…optional meta_key filter)
+          if (normalized.includes("SELECT object_key, meta_key, meta_value FROM file_metadata")) {
+            const [ws, ...rest] = values as string[];
+            // Bound object keys always contain '/' (gh/… or screenshots/…).
+            const objectKeys = rest.filter((k) => k.includes("/"));
+            const results: { object_key: string; meta_key: string; meta_value: string }[] = [];
+            for (const objectKey of objectKeys) {
+              const map = metadata.get(scopeKey(ws, objectKey));
+              if (!map) continue;
+              for (const [meta_key, meta_value] of map) {
+                results.push({ object_key: objectKey, meta_key, meta_value });
+              }
+            }
+            return { success: true, results: results as T[], meta: {} };
+          }
+          return { success: true, results: [] as T[], meta: {} };
+        },
+      };
+      return stmt;
+    },
+    async batch(stmts: { run: () => Promise<unknown> }[]) {
+      return Promise.all(stmts.map((s) => s.run()));
+    },
+  };
+}
+
+async function makeEnv(opts: { boundTo?: string } = {}) {
+  const tokenHash = await sha256Hex(TOKEN);
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "test-bucket",
+    binding: "UPLOADS",
+    publicBaseUrl: "https://storage.example.com",
+    tokenHash,
+  };
+  const bucket = new FakeR2Bucket();
+  const links = new RepoLinksTable();
+  if (opts.boundTo) {
+    links.rows.set("acme/widgets", {
+      repo_full_name: "acme/widgets",
+      workspace_name: opts.boundTo,
+      installation_id: 42,
+      source: "comment",
+      created_at: new Date().toISOString(),
+    });
+  }
+  const metadata = new Map<string, Map<string, string>>();
+  const githubCache = new FakeKv();
+  const env = {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    DB: makeDb(links, metadata),
+    UPLOADS: bucket,
+    GITHUB_CACHE: githubCache,
+    ...GITHUB_APP_CFG_ENV,
+  } as unknown as Env;
+  return { env, bucket, links, metadata, githubCache };
+}
+
+async function callTool(env: Env, name: string, args: Record<string, unknown>) {
+  const response = await app.request(
+    "/test-ws/mcp",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+    },
+    env,
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    result: {
+      isError: boolean;
+      structuredContent?: Record<string, unknown>;
+      content: unknown[];
+    };
+  };
+  return body.result;
+}
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+const PNG_B64 = btoa(String.fromCharCode(...PNG_BYTES));
+
+function stubGithubFetch(
+  handler: (url: string, init: RequestInit) => Response | Promise<Response>,
+) {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string, init: RequestInit = {}) =>
+    handler(String(url), init)) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = realFetch;
+  };
+}
+
+describe("hosted put: branch staging", () => {
+  it("stages under gh/…/branch/… with gh.status=staged metadata", async () => {
+    const { env, bucket, metadata } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      branch: "feature/x",
+      repo: "acme/widgets",
+      state: "after",
+    });
+    expect(result.isError).toBe(false);
+    // feature/x sanitizes to feature-x in the key segment.
+    expect(result.structuredContent).toMatchObject({
+      key: "gh/acme/widgets/branch/feature-x/hero.png",
+      url: "https://storage.example.com/gh/acme/widgets/branch/feature-x/hero.png",
+    });
+    expect(bucket.store.has("gh/acme/widgets/branch/feature-x/hero.png")).toBe(true);
+    const meta = metadata.get(`${WS} gh/acme/widgets/branch/feature-x/hero.png`);
+    expect(meta?.get("gh.kind")).toBe("branch");
+    expect(meta?.get("gh.status")).toBe("staged");
+    expect(meta?.get("gh.branch")).toBe("feature/x");
+    expect(meta?.get("gh.repo")).toBe("acme/widgets");
+    expect(meta?.get("state")).toBe("after");
+  });
+
+  it("usage errors: branch without repo", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      branch: "main",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("repo is required with branch") },
+    ]);
+  });
+
+  it("usage errors: branch + issue", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      branch: "main",
+      issue: 7,
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("branch cannot be combined with issue"),
+      },
+    ]);
+  });
+
+  it("usage errors: branch + key", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      branch: "main",
+      repo: "acme/widgets",
+      key: "shots/hero.png",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: expect.stringContaining("key cannot be combined with branch") },
+    ]);
+  });
+
+  it("multi-file stages each under the branch prefix", async () => {
+    const { env, bucket } = await makeEnv();
+    const result = await callTool(env, "put", {
+      files: [
+        { filename: "before.png", contentBase64: PNG_B64 },
+        { filename: "after.png", contentBase64: PNG_B64 },
+      ],
+      branch: "feat",
+      repo: "acme/widgets",
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      uploads: expect.arrayContaining([
+        expect.objectContaining({ key: "gh/acme/widgets/branch/feat/before.png" }),
+        expect.objectContaining({ key: "gh/acme/widgets/branch/feat/after.png" }),
+      ]),
+      failures: [],
+    });
+    expect(bucket.store.has("gh/acme/widgets/branch/feat/before.png")).toBe(true);
+    expect(bucket.store.has("gh/acme/widgets/branch/feat/after.png")).toBe(true);
+  });
+});
+
+describe("hosted promote tool", () => {
+  it("copies staged files into the PR prefix", async () => {
+    const { env, bucket } = await makeEnv({ boundTo: WS });
+    const staged = await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      branch: "feat",
+      repo: "acme/widgets",
+    });
+    expect(staged.isError).toBe(false);
+
+    const result = await callTool(env, "promote", {
+      repo: "acme/widgets",
+      pr: 12,
+      branch: "feat",
+      comment: false,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      promotion: {
+        promoted: ["gh/acme/widgets/pull/12/hero.png"],
+        skipped: [],
+      },
+    });
+    expect(bucket.store.has("gh/acme/widgets/pull/12/hero.png")).toBe(true);
+    // Original staged object is kept.
+    expect(bucket.store.has("gh/acme/widgets/branch/feat/hero.png")).toBe(true);
+  });
+
+  it("returns empty promoted when nothing is staged", async () => {
+    const { env } = await makeEnv({ boundTo: WS });
+    const result = await callTool(env, "promote", {
+      repo: "acme/widgets",
+      pr: 12,
+      branch: "empty-branch",
+      comment: false,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      promotion: { promoted: [], skipped: [] },
+    });
+  });
+
+  it("usage errors: missing branch", async () => {
+    const { env } = await makeEnv();
+    const result = await callTool(env, "promote", {
+      repo: "acme/widgets",
+      pr: 12,
+    });
+    expect(result.isError).toBe(true);
+    // Schema required-property check fires before the handler.
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringMatching(/required property ["']branch["']|branch is required/),
+      },
+    ]);
+  });
+
+  it("refreshes the managed comment after promote by default", async () => {
+    const { env, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "hero.png",
+      branch: "feat",
+      repo: "acme/widgets",
+    });
+
+    const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 5, html_url: "https://github.com/acme/widgets/pull/12#c5" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "promote", {
+        repo: "acme/widgets",
+        pr: 12,
+        branch: "feat",
+      });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent).toMatchObject({
+        promotion: {
+          promoted: ["gh/acme/widgets/pull/12/hero.png"],
+        },
+        comment: expect.objectContaining({ posted: true }),
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("hosted put: pr + branch promote-after", () => {
+  it("uploads to the PR key and promotes staged files from that branch", async () => {
+    const { env, bucket, githubCache } = await makeEnv({ boundTo: WS });
+    githubCache.store.set("ghinst:acme/widgets", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+
+    // Stage first.
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "staged.png",
+      branch: "feat",
+      repo: "acme/widgets",
+    });
+
+    const restore = stubGithubFetch((url, init) => {
+      if (url.includes("/issues/12/comments")) {
+        return init.method === "POST"
+          ? new Response(
+              JSON.stringify({ id: 9, html_url: "https://github.com/acme/widgets/pull/12#c9" }),
+              { status: 201 },
+            )
+          : new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    });
+    try {
+      const result = await callTool(env, "put", {
+        contentBase64: PNG_B64,
+        filename: "new.png",
+        pr: 12,
+        branch: "feat",
+        repo: "acme/widgets",
+      });
+      expect(result.isError).toBe(false);
+      expect(result.structuredContent).toMatchObject({
+        key: "gh/acme/widgets/pull/12/new.png",
+        promotion: {
+          promoted: expect.arrayContaining(["gh/acme/widgets/pull/12/staged.png"]),
+        },
+        comment: expect.objectContaining({ posted: true }),
+      });
+      expect(bucket.store.has("gh/acme/widgets/pull/12/new.png")).toBe(true);
+      expect(bucket.store.has("gh/acme/widgets/pull/12/staged.png")).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -580,6 +580,7 @@ describe("mcp worker", () => {
       "get_metadata",
       "health",
       "list",
+      "promote",
       "purge_expired",
       "put",
       "reconcile",

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,7 +24,8 @@ src/lib/                             Public gallery/file fetch + oEmbed resoluti
 public/_headers                      Per-path response headers (Link, robots, types)
 public/robots.txt                    Crawl policy + Content Signals + AI bot rules
 public/sitemap.xml                   Public URL list (landing only)
-public/llms.txt                      Agent-oriented product summary
+public/llms.txt                      Agent-oriented product index (links to full guide)
+public/llms-full.txt                 Expanded one-file product guide for agents
 public/auth.md                       Agent enrollment / bearer auth + hosted-MCP OAuth
 public/.well-known/api-catalog       RFC 9727 linkset
 public/.well-known/integrations.json integrations.sh v3 surface declaration
@@ -43,15 +44,15 @@ wrangler.jsonc                       Hybrid Worker, static assets, skills index,
 The landing page, `/docs`, and the `/github-screenshots` use-case guide are meant
 for search engines. Agent discovery docs are public but not listed in the sitemap.
 
-| Path                                      | Indexable | Notes                                                      |
-| ----------------------------------------- | --------- | ---------------------------------------------------------- |
-| `/`                                       | yes       | Listed in `sitemap.xml`; Link headers advertise catalogs   |
-| `/docs`                                   | yes       | Plain-language setup guide; in `sitemap.xml`               |
-| `/github-screenshots`                     | yes       | SEO landing: agents uploading media to GitHub; FAQ JSON-LD |
-| `/invite`                                 | **no**    | Magic-link enrollment; robots + meta + `X-Robots-Tag`      |
-| `/console`                                | **no**    | Operator scaffold; same triple coverage                    |
-| `/404`,`/500`                             | **no**    | Status pages                                               |
-| `/auth.md`, `/llms.txt`, `/.well-known/*` | n/a       | Machine-readable; not in sitemap                           |
+| Path                                                        | Indexable | Notes                                                      |
+| ----------------------------------------------------------- | --------- | ---------------------------------------------------------- |
+| `/`                                                         | yes       | Listed in `sitemap.xml`; Link headers advertise catalogs   |
+| `/docs`                                                     | yes       | Plain-language setup guide; in `sitemap.xml`               |
+| `/github-screenshots`                                       | yes       | SEO landing: agents uploading media to GitHub; FAQ JSON-LD |
+| `/invite`                                                   | **no**    | Magic-link enrollment; robots + meta + `X-Robots-Tag`      |
+| `/console`                                                  | **no**    | Operator scaffold; same triple coverage                    |
+| `/404`,`/500`                                               | **no**    | Status pages                                               |
+| `/auth.md`, `/llms.txt`, `/llms-full.txt`, `/.well-known/*` | n/a       | Machine-readable; not in sitemap                           |
 
 `robots.txt` includes explicit `User-agent` blocks for common AI crawlers and
 `Content-Signal` preferences (`search=yes`, `ai-input=yes`, `ai-train=no`).
@@ -134,7 +135,7 @@ curl -sI -H "Accept: text/markdown" https://uploads.sh/
 ```
 
 Browsers (no `text/markdown` in `Accept`) still get HTML. Non-HTML responses
-(JSON discovery docs, `/auth.md`, `/llms.txt`) are left alone. Content-Signal on
+(JSON discovery docs, `/auth.md`, `/llms.txt`, `/llms-full.txt`) are left alone. Content-Signal on
 converted responses matches `robots.txt` (`search=yes`, `ai-input=yes`,
 `ai-train=no`).
 

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -3,8 +3,8 @@
   "supportedVersions": ["2026-07-28", "2025-06-18"],
   "serverInfo": {
     "name": "uploads-mcp",
-    "version": "0.5.0",
-    "description": "Host files on uploads.sh from an agent — put, attach, list, delete, usage, and GitHub attachment comments.",
+    "version": "0.6.0",
+    "description": "Host files on uploads.sh from an agent — put (including branch staging and PR attach), promote, list, delete, usage, galleries, and GitHub attachment comments.",
     "homepage": "https://uploads.sh/"
   },
   "transport": {

--- a/apps/web/public/auth.md
+++ b/apps/web/public/auth.md
@@ -70,6 +70,8 @@ inferred from the `up_<workspace>_…` token form).
 | ---------------------- | ---------------------------------------------------------------- |
 | This file              | https://uploads.sh/auth.md                                       |
 | Agent summary          | https://uploads.sh/llms.txt                                      |
+| Full agent guide       | https://uploads.sh/llms-full.txt                                 |
+| Repo agent entrypoint  | https://github.com/buildinternet/uploads/blob/main/llms.txt      |
 | Integration surfaces   | https://uploads.sh/.well-known/integrations.json                 |
 | API catalog (RFC 9727) | https://uploads.sh/.well-known/api-catalog                       |
 | OpenAPI (summary)      | https://uploads.sh/.well-known/openapi.json (also /openapi.json) |

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -1,0 +1,267 @@
+# uploads.sh — full agent guide
+
+> File hosting for coding agents and humans. Host a file, get a stable public
+> URL, embed it in GitHub pull requests and issues. CLI, installable skills,
+> local stdio MCP, and hosted MCP. Open source for self-hosting.
+
+Shorter index: https://uploads.sh/llms.txt
+Repository agent entrypoint: https://github.com/buildinternet/uploads/blob/main/llms.txt
+
+Access requires a workspace — create your own with a linked GitHub account, or
+be invited. Hosted files are public (including media on private repositories).
+Do not upload secrets or sensitive UI. APIs may change without notice while the
+project is in active development.
+
+## What the product does
+
+GitHub's native image hosting only works through a browser session. Agents
+cannot drag-and-drop. uploads.sh is the missing step: put a local file (or
+base64 on the hosted MCP) and get back durable `url` / `embedUrl` markdown.
+
+The intended loop is **stage as you go**:
+
+1. Capture a visual (your browser tools, or `uploads screenshot`).
+2. On a non-default git branch, bare `uploads put ./shot.png --state after`
+   stages under a branch key automatically — no PR required.
+3. When the PR opens, staged files promote into one managed "📎 Attachments"
+   comment (GitHub App webhook, or the next `uploads attach` / `attach --promote`).
+4. Re-upload the same filename on a stable `gh/…` key; the URL never changes.
+
+Prefer `embedUrl` (https://embed.uploads.sh/…) in GitHub markdown so Camo
+revalidates after overwrite. Prefer the returned `markdown` field rather than
+hand-building storage URLs.
+
+## Install
+
+```bash
+npm install -g @buildinternet/uploads && uploads login
+uploads install
+npx skills add buildinternet/uploads
+```
+
+`uploads login` is one-time and human-in-the-loop (device authorization). It
+writes `UPLOADS_API_URL`, `UPLOADS_WORKSPACE`, and `UPLOADS_TOKEN` to the shared
+config file. Later non-interactive agent runs only need the saved token.
+
+Remote MCP (HTTP):
+
+```bash
+claude mcp add --transport http uploads https://agents.uploads.sh/mcp
+```
+
+Local stdio MCP (full tool parity with the CLI, needs local filesystem):
+
+```bash
+claude mcp add uploads -- uploads mcp
+```
+
+Claude Code plugin (skills + hosted MCP + `/uploads:attach` + pre-PR hook):
+
+```text
+/plugin marketplace add buildinternet/uploads
+/plugin install uploads@uploads
+```
+
+Codex uses the same repo as a plugin (`.codex-plugin/plugin.json`). Keep the
+`uploads` CLI on PATH and run `uploads login` once.
+
+## Auth
+
+Routine path:
+
+1. Get workspace access (self-serve create at /account/workspaces/new with a
+   linked GitHub account, or accept an invitation).
+2. `uploads login` → workspace bearer token `up_<workspace>_…`.
+3. Send `Authorization: Bearer <token>` on API and MCP calls.
+
+Default scopes on login: `files:read`, `files:write`. `files:delete` is not
+default — an admin must grant it. Tokens default to 90 days.
+
+Hosted MCP also accepts OAuth 2.1 from https://auth.uploads.sh (PKCE + dynamic
+client registration). REST API does **not** accept OAuth in v1 — workspace
+bearer only. Full detail: https://uploads.sh/auth.md
+
+Never put `ADMIN_TOKEN` in agent configs. It is break-glass operator access.
+
+## Core CLI workflows
+
+### Stage on a branch (pre-PR)
+
+```bash
+uploads put ./before.png --meta path=/settings --state before
+uploads put ./after.png --meta path=/settings --state after
+uploads staged                    # what's queued + will it auto-attach?
+```
+
+Bare `put` / bare `screenshot` on a non-default branch stage automatically.
+`--state` is a closed set: `before` | `after` | `empty` | `error` | `loading`.
+Pass `--meta path=/route` as a habit; `path` and `state` are the highest-value
+queryable tags.
+
+Staging auto-promotes only when the repo is **bound** to the workspace. Check
+with `uploads github link --status` or `uploads staged` (binding field). If
+unbound, after the PR exists run:
+
+```bash
+uploads attach --promote
+```
+
+### Attach to an existing PR/issue
+
+```bash
+uploads attach ./before.png ./after.png
+uploads attach ./shot.png --issue 45 --repo owner/name
+uploads put ./after.png --pr 123 --alt "Dashboard after" --width 700
+```
+
+`--pr` / `--issue` keys are stable and hash-free:
+`gh/<owner>/<repo>/pull|issues/<num>/<filename>`. They always overwrite in
+place. Other keys are strict (refuse overwrite unless `--replace`).
+
+### Capture
+
+```bash
+uploads screenshot http://localhost:4321/settings --out after.png --state after
+uploads screenshot https://example.com --via remote --pr 123
+```
+
+`--via auto` prefers local Chrome, else remote server render (counts against
+the workspace upload budget). localhost targets are local-only.
+
+### Annotate
+
+```bash
+uploads screenshot http://localhost:3000 --via local --annotate ./callouts.json
+uploads annotate ./shot.png --spec ./callouts.json
+```
+
+See skill `annotate-screenshots` for the JSON spec.
+
+### Manage
+
+```bash
+uploads list --pr 123
+uploads find path=/settings state=after
+uploads delete <key>
+uploads usage
+uploads doctor
+uploads comment --pr 123          # re-sync managed comment without uploading
+```
+
+## Hosted MCP (agents.uploads.sh)
+
+Use when the agent has **no local filesystem or git checkout**. Content is
+base64, not paths. Workspace is inferred from the bearer / OAuth token.
+
+Important tools (not exhaustive):
+
+| Tool | Role |
+| --- | --- |
+| `put` | Upload base64; with `pr`/`issue` + required `repo`, stable gh key + managed comment by default (`comment: false` to skip). With `branch` + `repo` (no pr/issue), stages under `gh/…/branch/…`. With `pr` + `branch`, also promotes that branch after upload |
+| `promote` | Copy branch-staged files into a PR (`repo` + `pr` + `branch` required); optional comment refresh (default on) |
+| `comment` | Refresh managed attachments comment without re-uploading |
+| `list` / `find_files` / `get_metadata` / `set_metadata` | Browse and tag objects |
+| `repo_link_status` | Binding tri-state: `self` \| `other` \| `none` (will staged files auto-attach?) |
+| `delete` / `usage` / galleries… | Lifecycle and collections |
+
+Hosted `put`/`promote` comment paths are **bot-only** (uploads-sh[bot]). No
+local `gh` fallback. Declines surface in the result (`not_installed`,
+`not_authorized`, `forbidden` with `fixUrl`) and never fail the upload itself.
+
+### Why there is no hosted `attach` tool
+
+**Intentional.** Local stdio `attach` takes filesystem paths and can fall back
+to local `gh`. The Worker has neither. Hosted agents use `put` (PR attach or
+branch stage) and `promote` for the same outcomes.
+
+### Why there is no hosted `staged` tool
+
+**Intentional (issue #405).** Local `staged` defaults branch/repo from git.
+Hosted has no git context. Answer the same questions with:
+
+```text
+list  { prefix: "gh/<owner>/<repo>/branch/<branch>/" }
+find_files  { filters: { "gh.branch": "<branch>", "gh.repo": "<owner>/<repo>" } }
+repo_link_status  { repo: "<owner>/<repo>" }
+```
+
+Local stdio MCP exposes a first-class `staged` tool mirroring the CLI.
+
+## Skills
+
+| Skill | When |
+| --- | --- |
+| github-screenshots | Visual needs to land in a PR/issue/share link |
+| annotate-screenshots | Callouts, arrows, redaction on a capture |
+| uploads-cli | Exact flags, keys, MCP contracts, edge cases |
+
+Install: `npx skills add buildinternet/uploads` or `uploads install`.
+
+## Endpoints
+
+- Web: https://uploads.sh
+- API: https://api.uploads.sh
+- Agents / MCP: https://agents.uploads.sh/mcp
+- Public storage: https://storage.uploads.sh
+- Embed (GitHub Camo-friendly): https://embed.uploads.sh
+- oEmbed: https://uploads.sh/oembed?url=<page-url>&format=json
+
+## Machine-readable discovery
+
+- Integration surfaces: https://uploads.sh/.well-known/integrations.json
+- API catalog: https://uploads.sh/.well-known/api-catalog
+- OpenAPI (summary): https://uploads.sh/.well-known/openapi.json (also /openapi.json)
+- MCP server card: https://uploads.sh/.well-known/mcp/server-card.json
+- Agent skills index: https://uploads.sh/.well-known/agent-skills/index.json
+- robots / sitemap: https://uploads.sh/robots.txt · https://uploads.sh/sitemap.xml
+
+Narrative API docs (not full OpenAPI): https://github.com/buildinternet/uploads/blob/main/docs/api.md
+
+## Project instructions snippet
+
+Add to AGENTS.md / CLAUDE.md / Cursor rules in **consumer** repos:
+
+```text
+## Screenshots
+When a change is visually observable (UI, layout, styling), capture it as you
+go — don't wait until the PR is open. After each meaningful visual change:
+
+  uploads put ./shot.png --state before   # or --state after
+
+On a branch, that stages automatically — no --branch flag needed. Stage
+before/after pairs where it makes sense. No need to open the PR first —
+staged files are promoted into the PR's attachments comment automatically.
+```
+
+## Cautions
+
+- Uploads are public until deleted. Private GitHub repos do not make media private.
+- `gh/<owner>/<repo>/pull|issues/<num>/<name>` keys are predictable.
+- Prefer short compressed clips over large raw video on PRs.
+- Exit codes (CLI): `2` usage/token/file, `3` auth/policy, `4` network, `1` other.
+- Telemetry is anonymous command-name pings; opt out with `DO_NOT_TRACK=1` or
+  `UPLOADS_TELEMETRY_DISABLED=1`.
+
+## Docs map
+
+- Home: https://uploads.sh/
+- Docs hub: https://uploads.sh/docs
+- Attach & share: https://uploads.sh/docs/attach-pull-request-images
+- GitHub App: https://uploads.sh/docs/github-app
+- Comment config (`.uploads.yml`): https://uploads.sh/docs/comment-config
+- Agents: https://uploads.sh/docs/agents
+- Reference: https://uploads.sh/docs/reference
+- Plans & limits: https://uploads.sh/docs/limits
+- Agent walkthrough: https://uploads.sh/github-screenshots
+- Source: https://github.com/buildinternet/uploads
+
+## Legal
+
+- Terms: https://uploads.sh/terms
+- Privacy: https://uploads.sh/privacy
+- Operated by Build Internet: https://buildinternet.com
+
+## Do not crawl as public product surface
+
+Enrollment invite pages (`/invite`) and the browser console (`/console`) are
+private operator surfaces. See https://uploads.sh/robots.txt.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -4,9 +4,13 @@
 
 Access requires a workspace — create your own with a linked GitHub account, or be invited to an existing one. Hosted files are public (including media attached to private repositories). Do not upload secrets or sensitive UI. APIs may change without notice while the project is in active development.
 
+Expanded one-file guide: [llms-full.txt](https://uploads.sh/llms-full.txt).
+Landed on the GitHub monorepo instead? Start at [repo llms.txt](https://github.com/buildinternet/uploads/blob/main/llms.txt) (product use vs contribute).
+
 ## Start here
 
 - [Home](https://uploads.sh/): product overview and copyable install commands
+- [Full agent guide (llms-full.txt)](https://uploads.sh/llms-full.txt): install, auth, stage/attach loops, hosted MCP contracts, cautions
 - [Docs](https://uploads.sh/docs): overview, one-time install, and links to the focused guides below
 - [Docs: attach & share](https://uploads.sh/docs/attach-pull-request-images): attach media to PRs/issues, stage screenshots before a PR exists, pair a before/after with --state, get a URL for any file, capture a screenshot, annotate with callouts/redactions
 - [Docs: annotate a screenshot](https://uploads.sh/docs/attach-pull-request-images#annotate): bake boxes, arrows, labels, freeform strokes, and solid redactions into a capture (`uploads screenshot --annotate` or `uploads annotate`)
@@ -18,6 +22,7 @@ Access requires a workspace — create your own with a linked GitHub account, or
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
 - [Auth for agents](https://uploads.sh/auth.md): self-serve and invitation enrollment, bearer tokens, and the hosted-MCP OAuth authorization server
 - [Source & docs](https://github.com/buildinternet/uploads): repository, roadmap, and operator docs
+- [Repo agent entrypoint](https://github.com/buildinternet/uploads/blob/main/llms.txt): monorepo vs product audiences
 - [Enrollment](https://github.com/buildinternet/uploads/blob/main/docs/enrollment.md): how `uploads login` works
 - [API](https://github.com/buildinternet/uploads/blob/main/docs/api.md): REST surface for workspace-scoped files
 - [OpenAPI (summary)](https://uploads.sh/.well-known/openapi.json): machine-readable API surface
@@ -55,9 +60,10 @@ Claude Code plugin (bundles the skills, the hosted MCP server, and the /uploads:
 
 ## Machine-readable discovery
 
+- Full agent guide: https://uploads.sh/llms-full.txt
 - Integration surfaces (API, MCP, CLI + how each authenticates): https://uploads.sh/.well-known/integrations.json
 - API catalog: https://uploads.sh/.well-known/api-catalog
-- OpenAPI (summary): https://uploads.sh/openapi.json
+- OpenAPI (summary): https://uploads.sh/.well-known/openapi.json (also /openapi.json)
 - MCP server card: https://uploads.sh/.well-known/mcp/server-card.json
 - Agent skills index: https://uploads.sh/.well-known/agent-skills/index.json
 - robots / sitemap: https://uploads.sh/robots.txt · https://uploads.sh/sitemap.xml

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -156,7 +156,7 @@ it opens (or run: uploads attach --promote once it exists)</pre>
       Looking for deeper material like the REST API, enrollment internals, self-hosting, or operator
       docs? It all lives in <a href={REPO}>the GitHub repository</a>. Agents can also read <a
         href="/llms.txt">/llms.txt</a
-      > for a machine-friendly index.
+      > (index) or <a href="/llms-full.txt">/llms-full.txt</a> (one-file guide).
     </div>
   </section>
 </DocsLayout>

--- a/apps/web/src/pages/docs/reference.astro
+++ b/apps/web/src/pages/docs/reference.astro
@@ -96,7 +96,7 @@ const REPO = "https://github.com/buildinternet/uploads";
       Looking for deeper material like the REST API, enrollment internals, self-hosting, or operator
       docs? It all lives in <a href={REPO}>the GitHub repository</a>. Agents can also read <a
         href="/llms.txt">/llms.txt</a
-      > for a machine-friendly index.
+      > (index) or <a href="/llms-full.txt">/llms-full.txt</a> (one-file guide).
     </div>
   </section>
 

--- a/apps/web/src/pages/github-screenshots.astro
+++ b/apps/web/src/pages/github-screenshots.astro
@@ -266,7 +266,9 @@ const FAQ_JSON_LD = JSON.stringify({
     </dl>
     <p class="note">
       Every command and flag is in the <a href="/docs">docs</a>. Agents can read&#32;
-      <a href="/llms.txt">/llms.txt</a>. If this saved you a hand-rolled upload script,&#32;
+      <a href="/llms.txt">/llms.txt</a> or the one-file&#32;
+      <a href="/llms-full.txt">/llms-full.txt</a>. If this saved you a hand-rolled upload
+      script,&#32;
       <a href={REPO}>a star on GitHub</a> helps others find it.
     </p>
   </section>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,98 @@
+# uploads (repository)
+
+> Source monorepo for uploads.sh — file hosting for coding agents and humans.
+> Open source (Apache 2.0). Hosted service at https://uploads.sh.
+
+This file is for agents that land on **this GitHub repository**. Pick an
+audience below. Do not treat contributor docs as the product API, and do not
+treat product install docs as monorepo setup.
+
+## Audience A — use the product (CLI / MCP / skills)
+
+You want to host a screenshot, stage PR media, or attach files to GitHub.
+
+- **Canonical product index:** https://uploads.sh/llms.txt
+- **Expanded product guide:** https://uploads.sh/llms-full.txt
+- **Auth for agents:** https://uploads.sh/auth.md
+- **Agent setup walkthrough:** https://uploads.sh/docs/agents
+- **Stage / attach walkthrough:** https://uploads.sh/github-screenshots
+
+Install (product, not monorepo):
+
+```bash
+npm install -g @buildinternet/uploads && uploads login
+uploads install
+npx skills add buildinternet/uploads
+```
+
+Hosted MCP (HTTP):
+
+```bash
+claude mcp add --transport http uploads https://agents.uploads.sh/mcp
+```
+
+In-repo skill sources (installable via `npx skills add buildinternet/uploads`):
+
+- [skills/github-screenshots](skills/github-screenshots) — when/how to put visuals on PRs/issues
+- [skills/annotate-screenshots](skills/annotate-screenshots) — callouts and redaction
+- [skills/uploads-cli](skills/uploads-cli) — CLI and MCP flag reference
+
+Machine-readable product discovery:
+
+- https://uploads.sh/.well-known/integrations.json
+- https://uploads.sh/.well-known/openapi.json (summary OpenAPI)
+- https://uploads.sh/.well-known/mcp/server-card.json
+- https://uploads.sh/.well-known/agent-skills/index.json
+
+## Audience B — work on this monorepo
+
+You are changing the workers, CLI package, web app, or docs in this checkout.
+
+- **Agent working conventions:** [AGENTS.md](AGENTS.md)
+- **Human contrib / PR shape:** [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Local setup:** [docs/local-dev.md](docs/local-dev.md)
+- **Product intent:** [VISION.md](VISION.md), [PRODUCT.md](PRODUCT.md)
+- **Roadmap:** [docs/roadmap.md](docs/roadmap.md)
+
+One-command local setup:
+
+```bash
+pnpm bootstrap
+pnpm dev                 # API on :8787
+pnpm test                # whole suite
+```
+
+Layout summary (full table in [README.md](README.md#whats-in-this-repo)):
+
+| Path | Role |
+| --- | --- |
+| `apps/api/` | REST API worker |
+| `apps/auth/` | Better Auth worker |
+| `apps/mcp/` | Hosted MCP worker (`agents.uploads.sh`) |
+| `apps/web/` | Astro site (uploads.sh) |
+| `packages/uploads/` | `@buildinternet/uploads` CLI + client (npm) |
+| `packages/storage/` | files-sdk adapter factory |
+| `skills/` | Installable agent skills |
+
+`CLAUDE.md` only points at `AGENTS.md` — read that file for conventions.
+
+## Endpoints (hosted product)
+
+- Web: https://uploads.sh
+- API: https://api.uploads.sh
+- Agents / MCP: https://agents.uploads.sh/mcp
+- Public storage: https://storage.uploads.sh
+- Embed (prefer in GitHub markdown): https://embed.uploads.sh
+
+## Cautions
+
+- Hosted files are **public**, including media attached to private repos.
+- Do not upload secrets, tokens, or sensitive UI.
+- APIs may change while the project is in active development.
+- Operator break-glass `ADMIN_TOKEN` is never for routine agent configs.
+
+## Legal
+
+- https://uploads.sh/terms
+- https://uploads.sh/privacy
+- Operated by https://buildinternet.com

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -119,11 +119,14 @@ exists, run `uploads attach --promote` (or any targeted `uploads attach`
 against that PR) to promote and post explicitly.
 
 **No local filesystem?** An agent driving the hosted MCP
-(`agents.uploads.sh/mcp`, no CLI, no git checkout) can still get a visual into
-a PR in one call: the `put` tool takes `pr`/`issue` (+ required `repo`, since
-there's no git context server-side) plus `comment: true` to post straight to
-the managed attachments comment — see the **uploads-cli** skill for the exact
-tool contract and honest decline reasons.
+(`agents.uploads.sh/mcp`, no CLI, no git checkout) can still run the same loop
+with explicit `repo`/`branch`/`pr` (no git defaults on the server):
+
+- Stage as you go: `put` with `branch` + `repo` + base64 content
+- Once the PR exists: `promote` with `repo` + `pr` + `branch`, or `put` with
+  `pr` + `repo` (and optional `branch` to also promote staged files)
+- Managed comment is bot-only on this server — see the **uploads-cli** skill
+  for contracts and honest decline reasons
 
 **Pass `--state before`/`--state after` and `--meta path=/route` as a habit —
 both, every time.** Before/after is the whole point of most PR screenshots, and

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -93,7 +93,9 @@ the two surfaces never drift.
 
 Local stdio MCP mirrors this as the `staged` tool (`branch`/`repo` args,
 same `{ repo, branch, files, binding }` shape). The hosted MCP has no
-dedicated tool for this — see "Hosted MCP: checking what's staged" below.
+dedicated `staged` tool (no git defaults) — list/find_files recipes and
+hosted `put`/`promote` with explicit `repo`/`branch` are under "Hosted MCP"
+below.
 
 Getting those files into the PR's attachments comment needs no extra step
 once a PR exists for that branch:
@@ -906,6 +908,22 @@ uploads --api-url http://localhost:8787 doctor
   tool and `put` with `pr`/`issue` honor the target repo's `.uploads.yml`
   (same as the bot path — no separate MCP config; see
   https://uploads.sh/docs/comment-config).
+
+  **Hosted MCP: branch staging + promote.** There is still no `attach` tool
+  on the hosted server (no filesystem paths) — use `put` instead:
+
+  ```text
+  # Stage pre-PR (CLI attach --branch parity). repo + branch required.
+  put  { contentBase64, filename, repo: "owner/name", branch: "feature/x", state: "after" }
+  # → key gh/owner/name/branch/feature-x/<filename>, gh.status=staged
+
+  # Promote staged files into a PR once it exists (CLI attach --promote).
+  promote  { repo: "owner/name", pr: 123, branch: "feature/x" }
+  # optional comment: false to skip the managed comment refresh (default on)
+
+  # Or attach a new file to the PR and promote that branch in one call:
+  put  { contentBase64, filename, repo: "owner/name", pr: 123, branch: "feature/x" }
+  ```
 
   **Hosted MCP: checking what's staged (issue #405).** There's no dedicated
   `staged` tool on the hosted server — it has no local git context to default


### PR DESCRIPTION
## In plain terms

Hosted MCP agents (no local git checkout) can now stage screenshots against a branch and promote them into a PR the same way the CLI does with `attach --branch` and `attach --promote`. Also adds clearer agent entrypoints (`llms.txt` / `llms-full.txt`) so product use and monorepo work stay distinct.

## What it does / what it is not

- **`put` with `branch` + `repo`** — stages under `gh/…/branch/…` with `gh.status=staged` (pre-PR)
- **`promote` tool** — copies staged files into a PR (`repo` + `pr` + `branch` required); optional comment refresh
- **`put` with `pr` + `branch`** — uploads to the PR key, then best-effort promotes that branch (CLI attach-to-PR parity)
- Shared `postPromoteBranchAttachments` so REST and MCP share promote + claim logic
- Repo-root `llms.txt`, product `llms-full.txt`, and cross-links from docs/skills
- **Not** a hosted `attach` tool (filesystem) or `staged` tool (git defaults) — intentional
- **Not** a CLI package release; no changeset

## How to try it

Against the hosted MCP (after this deploys), with a workspace token:

```text
put   { contentBase64, filename, repo: "owner/name", branch: "feature/x", state: "after" }
promote  { repo: "owner/name", pr: 123, branch: "feature/x" }
```

Or one call once the PR exists:

```text
put  { contentBase64, filename, repo: "owner/name", pr: 123, branch: "feature/x" }
```

## Technical notes

- Promote failures on the optional `put` path never fail the upload (`promoteError`); the standalone `promote` tool throws on promote failure
- Comment path remains bot-only; same declines as existing `put`/`comment`
- OpenAPI summary and remote MCP production smoke are unchanged in this PR

## Test plan

- [x] `pnpm --filter @uploads/mcp test` (109 tests, including 10 new branch/promote cases)
- [x] `pnpm --filter @uploads/api exec vitest run src/routes/github-promote-route.test.ts` (22 tests)
- [x] `pnpm --filter @uploads/mcp typecheck`
- [x] Pre-commit oxlint + oxfmt + prettier
- [ ] Remote MCP smoke (deployed env) — optional follow-up after merge