### PR TITLE
fix(api): single-winner claim for delete usage accounting

### DIFF
--- a/apps/api/migrations/20260730170533_delete_usage_claims.sql
+++ b/apps/api/migrations/20260730170533_delete_usage_claims.sql
@@ -1,0 +1,11 @@
+-- Single-winner claim for delete usage accounting (issue #570).
+-- Two concurrent DELETEs can both head an object and both record a negative
+-- usage delta; INSERT OR IGNORE on (workspace, object_key) makes only the first
+-- claimer debit the ledger. Cleared on a successful re-put of the same key so a
+-- later delete can claim again.
+CREATE TABLE delete_usage_claims (
+  workspace  TEXT NOT NULL,
+  object_key TEXT NOT NULL,
+  claimed_at TEXT NOT NULL,
+  PRIMARY KEY (workspace, object_key)
+);

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -46,6 +46,8 @@ import {
 } from "./provenance";
 import { objectPublicUrls, storage, storageConfig } from "./storage";
 import {
+  claimDeleteUsageSafe,
+  clearDeleteUsageClaimSafe,
   getWorkspaceUsage,
   recordUsageSafe,
   releaseStorageBytesSafe,
@@ -215,7 +217,14 @@ export async function generateAndStorePoster(
       if (stale !== null) {
         await store.delete(posterKey);
         await deleteServerFileMetadataKeys(env.DB, workspaceName, key, POSTER_META_KEYS);
-        await recordUsageSafe(env.DB, workspaceName, { bytes: -stale, objects: -1, uploads: 0 });
+        // Single-winner claim (issue #570) — same gate as deleteObject.
+        if (await claimDeleteUsageSafe(env.DB, workspaceName, posterKey)) {
+          await recordUsageSafe(env.DB, workspaceName, {
+            bytes: -stale,
+            objects: -1,
+            uploads: 0,
+          });
+        }
       }
       return;
     }
@@ -229,6 +238,8 @@ export async function generateAndStorePoster(
       // publicly-fetchable poster at its deterministic _internal/ path.
       ...(visibility === "private" ? { metadata: { [VISIBILITY_META_KEY]: "private" } } : {}),
     });
+    // A re-created poster must be able to debit the ledger on a later delete.
+    await clearDeleteUsageClaimSafe(env.DB, workspaceName, posterKey);
     // Counted because reconcileWorkspaceUsage walks every object under the
     // prefix and would otherwise disagree with the ledger permanently.
     await recordUsageSafe(env.DB, workspaceName, {
@@ -501,14 +512,17 @@ export async function putObject(
   // and any reserved positive byte delta were already applied at reservation
   // time; only remaining deltas (objects; shrink/unlimited bytes) land here.
   //
+  // Clear any prior delete-usage claim for this key (issue #570) so a
+  // re-uploaded object can debit the ledger on its next delete. Runs with
+  // the other post-write bookkeeping below.
+  //
   // Adoption metrics, best-effort and never fatal (see src/adoption.ts).
   // Recorded here rather than at the route so all four putObject callers are
   // covered by construction. `newSize` (not deltaBytes) is the right figure:
   // this counts bytes written by this upload, not net storage change.
   //
-  // These two writes land in different tables (workspace_usage vs
-  // daily_metrics), neither depends on the other's result, and both are
-  // never-throwing — so they run concurrently rather than as two serial D1
+  // These writes land in different tables / are independent, and all are
+  // never-throwing — so they run concurrently rather than as serial D1
   // round trips on every upload.
   await Promise.all([
     recordUsageSafe(env.DB, workspaceName, {
@@ -516,6 +530,7 @@ export async function putObject(
       objects: replaced ? 0 : 1,
       uploads: 0,
     }),
+    clearDeleteUsageClaimSafe(env.DB, workspaceName, finalKey),
     recordAdoptionSafe(env, {
       metric: "upload",
       workspace: workspaceName,
@@ -843,19 +858,26 @@ export async function deleteObject(
   await deleteFileMetadata(env.DB, workspaceName, key);
 
   if (prev !== null) {
-    // Positive magnitude under the `delete` metric — never negative bytes
-    // under `upload`. Net change is computed at read time. These two writes
-    // land in different tables (workspace_usage vs daily_metrics), neither
-    // depends on the other's result, and both are never-throwing — so they
-    // run concurrently rather than as two serial D1 round trips per delete.
-    await Promise.all([
-      recordUsageSafe(env.DB, workspaceName, {
-        bytes: -prev,
-        objects: -1,
-        uploads: 0,
-      }),
-      recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, bytes: prev }),
-    ]);
+    // Single-winner claim (issue #570): concurrent DELETEs can both observe
+    // the object and both reach this branch; only the first claimer debits
+    // the ledger (and records the adoption delete metric). Claim after the
+    // storage delete so a failed delete never burns the slot.
+    const wonClaim = await claimDeleteUsageSafe(env.DB, workspaceName, key);
+    if (wonClaim) {
+      // Positive magnitude under the `delete` metric — never negative bytes
+      // under `upload`. Net change is computed at read time. These two writes
+      // land in different tables (workspace_usage vs daily_metrics), neither
+      // depends on the other's result, and both are never-throwing — so they
+      // run concurrently rather than as two serial D1 round trips per delete.
+      await Promise.all([
+        recordUsageSafe(env.DB, workspaceName, {
+          bytes: -prev,
+          objects: -1,
+          uploads: 0,
+        }),
+        recordAdoptionSafe(env, { metric: "delete", workspace: workspaceName, bytes: prev }),
+      ]);
+    }
   }
 
   // Derived poster (issue #299), best-effort: a missing one is the norm for
@@ -866,11 +888,13 @@ export async function deleteObject(
     const posterSize = await existingSize(store, posterKey);
     if (posterSize !== null) {
       await store.delete(posterKey);
-      await recordUsageSafe(env.DB, workspaceName, {
-        bytes: -posterSize,
-        objects: -1,
-        uploads: 0,
-      });
+      if (await claimDeleteUsageSafe(env.DB, workspaceName, posterKey)) {
+        await recordUsageSafe(env.DB, workspaceName, {
+          bytes: -posterSize,
+          objects: -1,
+          uploads: 0,
+        });
+      }
     }
   } catch (err) {
     console.error({ event: "poster_delete_failed", workspace: workspaceName, key, err });

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -340,6 +340,75 @@ export async function recordUsageSafe(
 }
 
 /**
+ * Single-winner gate for delete usage accounting (issue #570).
+ *
+ * Two concurrent DELETEs can both observe an object via head and both attempt
+ * a negative ledger delta. `INSERT OR IGNORE` on `(workspace, object_key)`
+ * admits only the first claimer; the loser skips metering. Call after the
+ * storage delete succeeds so a failed delete never burns the claim.
+ *
+ * On D1 failure returns `true` so metering falls back to pre-claim behavior
+ * (prefer a possible double-debit under infrastructure failure over silently
+ * dropping a successful single delete's accounting).
+ */
+export async function claimDeleteUsageSafe(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  now = new Date(),
+): Promise<boolean> {
+  try {
+    const result = await db
+      .prepare(
+        `INSERT OR IGNORE INTO delete_usage_claims (workspace, object_key, claimed_at)
+         VALUES (?, ?, ?)`,
+      )
+      .bind(workspace, objectKey, now.toISOString())
+      .run();
+    return (result.meta?.changes ?? 0) > 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "delete usage claim failed",
+        workspace,
+        objectKey,
+        error: message,
+      }),
+    );
+    return true;
+  }
+}
+
+/**
+ * Drop a prior delete-usage claim so a re-uploaded key can be metered on its
+ * next delete. Best-effort: a leftover claim only under-counts a future delete
+ * (reconcile repairs absolute totals).
+ */
+export async function clearDeleteUsageClaimSafe(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+): Promise<void> {
+  try {
+    await db
+      .prepare(`DELETE FROM delete_usage_claims WHERE workspace = ? AND object_key = ?`)
+      .bind(workspace, objectKey)
+      .run();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        message: "delete usage claim clear failed",
+        workspace,
+        objectKey,
+        error: message,
+      }),
+    );
+  }
+}
+
+/**
  * Replace absolute bytes/objects from a storage scan (reconcile).
  * Preserves uploads_in_period for the current period when the row exists.
  */

--- a/apps/api/test/files-core-delete-usage.test.ts
+++ b/apps/api/test/files-core-delete-usage.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Delete usage accounting — single-winner claim (issue #570).
+ *
+ * Unit coverage of claim/clear lives in usage.test.ts; these exercises wire
+ * the claim through putObject/deleteObject end-to-end on the real helpers.
+ */
+import { describe, expect, it } from "vitest";
+import { deleteObject, putObject } from "../src/files-core";
+import { claimDeleteUsageSafe } from "../src/usage";
+import { makePosterEnv, PNG, WORKSPACE } from "./poster-fixtures";
+
+describe("deleteObject usage accounting (issue #570)", () => {
+  it("debits the ledger once on a normal delete", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({
+      bytes: PNG.byteLength,
+      objects: 1,
+    });
+
+    await deleteObject(env, ws, put.key, WORKSPACE);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({ bytes: 0, objects: 0 });
+  });
+
+  it("skips metering when another concurrent delete already claimed the key", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const put = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    const afterPut = db.usage.get(WORKSPACE);
+    expect(afterPut?.bytes).toBe(PNG.byteLength);
+
+    // Sibling request already won the claim (and, in production, already
+    // applied the negative delta). This request still removes the object but
+    // must not debit again.
+    expect(await claimDeleteUsageSafe(env.DB, WORKSPACE, put.key)).toBe(true);
+
+    await deleteObject(env, ws, put.key, WORKSPACE);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({
+      bytes: afterPut?.bytes,
+      objects: afterPut?.objects,
+    });
+  });
+
+  it("allows a re-uploaded key to debit again on a later delete", async () => {
+    const { env, db, ws } = makePosterEnv();
+    const first = await putObject(env, ws, "screenshots/shot.png", PNG, WORKSPACE);
+    await deleteObject(env, ws, first.key, WORKSPACE);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({ bytes: 0, objects: 0 });
+
+    // Same key again (overwrite path with replace) — clearDeleteUsageClaimSafe
+    // must have dropped the prior claim so this lifecycle can meter.
+    const second = await putObject(env, ws, first.key, PNG, WORKSPACE, { replace: true });
+    expect(second.key).toBe(first.key);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({
+      bytes: PNG.byteLength,
+      objects: 1,
+    });
+
+    await deleteObject(env, ws, second.key, WORKSPACE);
+    expect(db.usage.get(WORKSPACE)).toMatchObject({ bytes: 0, objects: 0 });
+  });
+});

--- a/apps/api/test/helpers/fake-delete-usage-claims-table.ts
+++ b/apps/api/test/helpers/fake-delete-usage-claims-table.ts
@@ -1,0 +1,34 @@
+/**
+ * In-memory `delete_usage_claims` (issue #570) for route/files-core fakes.
+ * Mirrors D1 `INSERT OR IGNORE` first-wins and clear-on-re-put semantics.
+ */
+
+export interface FakeRunResult {
+  success: true;
+  meta: { changes: number };
+  results: [];
+}
+
+export class DeleteUsageClaimsTable {
+  /** Key is `workspace\\0object_key` → claimed_at. */
+  readonly claims = new Map<string, string>();
+
+  tryRun(normalizedSql: string, args: unknown[]): FakeRunResult | undefined {
+    if (normalizedSql.startsWith("INSERT OR IGNORE INTO delete_usage_claims")) {
+      const [workspace, objectKey, claimedAt] = args as [string, string, string];
+      const claimKey = `${workspace}\0${objectKey}`;
+      if (this.claims.has(claimKey)) {
+        return { success: true, meta: { changes: 0 }, results: [] };
+      }
+      this.claims.set(claimKey, claimedAt);
+      return { success: true, meta: { changes: 1 }, results: [] };
+    }
+    if (normalizedSql.startsWith("DELETE FROM delete_usage_claims")) {
+      const [workspace, objectKey] = args as [string, string];
+      const claimKey = `${workspace}\0${objectKey}`;
+      const existed = this.claims.delete(claimKey);
+      return { success: true, meta: { changes: existed ? 1 : 0 }, results: [] };
+    }
+    return undefined;
+  }
+}

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
+import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { app } from "../src/index";
 import { getFileMetadata } from "../src/file-metadata";
@@ -40,6 +41,7 @@ interface FakeAuthToken {
 
 function makeFakeDB(authToken?: FakeAuthToken) {
   const table = new FileMetadataTable();
+  const deleteClaims = new DeleteUsageClaimsTable();
   const statements: { sql: string; args: unknown[] }[] = [];
 
   return {
@@ -75,7 +77,11 @@ function makeFakeDB(authToken?: FakeAuthToken) {
         },
         async run() {
           return (
-            table.tryRun(normalized, args) ?? { success: true, meta: { changes: 0 }, results: [] }
+            table.tryRun(normalized, args) ??
+            deleteClaims.tryRun(normalized, args) ??
+              // Default changes:0 is fine for no-op ledger SQL; delete-usage
+              // claims must not fall through here (they gate metering on changes).
+              { success: true, meta: { changes: 0 }, results: [] }
           );
         },
         async all<T>() {

--- a/apps/api/test/routes-me-file-delete.test.ts
+++ b/apps/api/test/routes-me-file-delete.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
+import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { app } from "../src/index";
 
@@ -7,6 +8,7 @@ const USER = { id: "user-1", email: "z@example.com", name: "Z" };
 
 function makeFakeDB() {
   const table = new FileMetadataTable();
+  const deleteClaims = new DeleteUsageClaimsTable();
   return {
     metadata: table.metadata,
     prepare(sql: string) {
@@ -22,7 +24,12 @@ function makeFakeDB() {
         },
         async run() {
           return (
-            table.tryRun(normalized, args) ?? { success: true, meta: { changes: 0 }, results: [] }
+            table.tryRun(normalized, args) ??
+            deleteClaims.tryRun(normalized, args) ?? {
+              success: true,
+              meta: { changes: 0 },
+              results: [],
+            }
           );
         },
         async all<T>() {

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -3,6 +3,7 @@
  * and optional no-op auth_tokens lookups for route tests.
  */
 
+import { DeleteUsageClaimsTable } from "./helpers/fake-delete-usage-claims-table";
 import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
 import { PrActivityTable } from "./helpers/fake-pr-activity-table";
 import { RepoLinksTable } from "./helpers/fake-repo-links-table";
@@ -18,14 +19,17 @@ export type UsageRow = {
 
 export class UsageFakeD1 {
   usage = new Map<string, UsageRow>();
-  /** Backs `delete_usage_claims` (issue #570) — key is `workspace\\0object_key`. */
-  deleteUsageClaims = new Map<string, string>();
   // Backs `file_metadata` so putObject/deleteObject's D1 metadata
   // cascade (Task 2) doesn't blow up in suites that only care about the
   // usage ledger.
   private fileMetadataTable = new FileMetadataTable();
   get fileMetadata() {
     return this.fileMetadataTable.metadata;
+  }
+  // Single-winner delete metering claims (issue #570).
+  private deleteUsageClaimsTable = new DeleteUsageClaimsTable();
+  get deleteUsageClaims() {
+    return this.deleteUsageClaimsTable.claims;
   }
   // Backs `github_repo_links` for implicit-claim (comment/promote routes)
   // and webhook auto-promotion tests.
@@ -81,26 +85,8 @@ export class UsageFakeD1 {
         if (linkResult) return linkResult;
         const activityResult = this.prActivityTable.tryRun(normalized, values);
         if (activityResult) return activityResult;
-        // Single-winner delete metering claims (issue #570).
-        if (normalized.startsWith("INSERT OR IGNORE INTO delete_usage_claims")) {
-          const [workspace, objectKey, claimedAt] = values as [string, string, string];
-          const claimKey = `${workspace}\0${objectKey}`;
-          if (this.deleteUsageClaims.has(claimKey)) {
-            return { success: true as const, meta: { changes: 0 }, results: [] };
-          }
-          this.deleteUsageClaims.set(claimKey, claimedAt);
-          return { success: true as const, meta: { changes: 1 }, results: [] };
-        }
-        if (normalized.startsWith("DELETE FROM delete_usage_claims")) {
-          const [workspace, objectKey] = values as [string, string];
-          const claimKey = `${workspace}\0${objectKey}`;
-          const existed = this.deleteUsageClaims.delete(claimKey);
-          return {
-            success: true as const,
-            meta: { changes: existed ? 1 : 0 },
-            results: [],
-          };
-        }
+        const claimResult = this.deleteUsageClaimsTable.tryRun(normalized, values);
+        if (claimResult) return claimResult;
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
           // applyUsageDelta: (ws, period, updatedAt) with zeros
           // setUsageTotals: (ws, bytes, objects, period, updatedAt)

--- a/apps/api/test/usage-fake-d1.ts
+++ b/apps/api/test/usage-fake-d1.ts
@@ -18,6 +18,8 @@ export type UsageRow = {
 
 export class UsageFakeD1 {
   usage = new Map<string, UsageRow>();
+  /** Backs `delete_usage_claims` (issue #570) — key is `workspace\\0object_key`. */
+  deleteUsageClaims = new Map<string, string>();
   // Backs `file_metadata` so putObject/deleteObject's D1 metadata
   // cascade (Task 2) doesn't blow up in suites that only care about the
   // usage ledger.
@@ -79,6 +81,26 @@ export class UsageFakeD1 {
         if (linkResult) return linkResult;
         const activityResult = this.prActivityTable.tryRun(normalized, values);
         if (activityResult) return activityResult;
+        // Single-winner delete metering claims (issue #570).
+        if (normalized.startsWith("INSERT OR IGNORE INTO delete_usage_claims")) {
+          const [workspace, objectKey, claimedAt] = values as [string, string, string];
+          const claimKey = `${workspace}\0${objectKey}`;
+          if (this.deleteUsageClaims.has(claimKey)) {
+            return { success: true as const, meta: { changes: 0 }, results: [] };
+          }
+          this.deleteUsageClaims.set(claimKey, claimedAt);
+          return { success: true as const, meta: { changes: 1 }, results: [] };
+        }
+        if (normalized.startsWith("DELETE FROM delete_usage_claims")) {
+          const [workspace, objectKey] = values as [string, string];
+          const claimKey = `${workspace}\0${objectKey}`;
+          const existed = this.deleteUsageClaims.delete(claimKey);
+          return {
+            success: true as const,
+            meta: { changes: existed ? 1 : 0 },
+            results: [],
+          };
+        }
         if (normalized.startsWith("INSERT OR IGNORE INTO workspace_usage")) {
           // applyUsageDelta: (ws, period, updatedAt) with zeros
           // setUsageTotals: (ws, bytes, objects, period, updatedAt)

--- a/apps/api/test/usage.test.ts
+++ b/apps/api/test/usage.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   applyUsageDelta,
+  claimDeleteUsageSafe,
+  clearDeleteUsageClaimSafe,
   emptyUsage,
   getWorkspaceUsage,
+  recordUsageSafe,
   releaseStorageBytesSafe,
   releaseUploadsSafe,
   reserveStorageBytes,
@@ -209,5 +212,57 @@ describe("storage byte reservations", () => {
     );
     expect(results.filter((r) => r.ok)).toHaveLength(2);
     expect((await getWorkspaceUsage(db, "acme", now)).bytes).toBe(800);
+  });
+});
+
+describe("delete usage claims (issue #570)", () => {
+  const now = new Date("2026-07-10T00:00:00Z");
+
+  it("admits only the first concurrent claim for a key", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => claimDeleteUsageSafe(db, "acme", "f/x/a.png", now)),
+    );
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect(results.filter((won) => !won)).toHaveLength(4);
+  });
+
+  it("scopes claims per workspace and per key", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    expect(await claimDeleteUsageSafe(db, "acme", "a.png", now)).toBe(true);
+    expect(await claimDeleteUsageSafe(db, "acme", "b.png", now)).toBe(true);
+    expect(await claimDeleteUsageSafe(db, "globex", "a.png", now)).toBe(true);
+    expect(await claimDeleteUsageSafe(db, "acme", "a.png", now)).toBe(false);
+  });
+
+  it("clear allows a re-uploaded key to claim again", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    expect(await claimDeleteUsageSafe(db, "acme", "shot.png", now)).toBe(true);
+    expect(await claimDeleteUsageSafe(db, "acme", "shot.png", now)).toBe(false);
+
+    await clearDeleteUsageClaimSafe(db, "acme", "shot.png");
+    expect(await claimDeleteUsageSafe(db, "acme", "shot.png", now)).toBe(true);
+  });
+
+  it("only one concurrent delete path debits the ledger", async () => {
+    const db = new UsageFakeD1() as unknown as D1Database;
+    await applyUsageDelta(db, "acme", { bytes: 1000, objects: 2, uploads: 2 }, now);
+
+    // Simulate two delete handlers that both observed size 500 for the same key.
+    const size = 500;
+    await Promise.all(
+      Array.from({ length: 2 }, async () => {
+        if (await claimDeleteUsageSafe(db, "acme", "shared.png", now)) {
+          await recordUsageSafe(db, "acme", { bytes: -size, objects: -1, uploads: 0 }, now);
+        }
+      }),
+    );
+
+    // One debit only — the sibling object (500 bytes / 1 object) remains.
+    expect(await getWorkspaceUsage(db, "acme", now)).toMatchObject({
+      bytes: 500,
+      objects: 1,
+      uploadsInPeriod: 2,
+    });
   });
 });


### PR DESCRIPTION
## In plain terms

Two clients deleting the same file at once could each see the object still present and each subtract its size from the workspace usage ledger. That double-debits storage accounting (wrong bytes/objects while other files remain). Deletes still remove the object; only metering is gated so one winner records the delta.

## What it does / what it is not

- Adds a D1 `delete_usage_claims` table and `INSERT OR IGNORE` claim on `(workspace, object_key)` after a successful storage delete.
- Only the claim winner runs usage (and adoption delete) metering for that key.
- Clears the claim on a successful put/poster write so a re-uploaded key can debit again on a later delete.
- Same gate for primary objects and derived posters.
- If the claim table is unavailable, metering falls back to the previous always-record behavior.
- Not a full object inventory or reconcile rewrite; drifted totals still repair via reconcile.

Closes #570.

## Technical notes

- Claim is taken **after** `store.delete` so a failed delete never burns the slot.
- Migration applies on deploy via the usual D1 path (`deploy:api` / `d1-migrations.yml` when `apps/api/migrations/**` changes).

## Test plan

- [x] `vitest` usage claim unit tests (first-wins, isolation, clear, concurrent debit)
- [x] `vitest` put/delete/re-put integration (`files-core-delete-usage.test.ts`)
- [x] poster-lifecycle + me file-delete + usage-resilience regression tests
- [x] API package `tsc --noEmit`
- [ ] CI green on this PR