### PR TITLE
feat: expose filename search and metadata facets to CLI and MCP

### DIFF
--- a/.changeset/528-filename-search-facets.md
+++ b/.changeset/528-filename-search-facets.md
@@ -1,0 +1,7 @@
+---
+"@buildinternet/uploads": minor
+---
+
+Filename search and metadata facet discovery on the token-authed API, CLI, and both MCP tool sets (issue #528).
+
+`uploads find` / `list` accept `--name <term>` (and a bare name on `find`) for case-insensitive substring matching on object keys, alone or with meta filters. `uploads meta keys` and `uploads meta values <key>` expose the workspace's actual metadata vocabulary. The stdio and hosted MCP tools mirror this with optional `name` on `find_files` and a new `list_metadata_keys` tool.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "./storage": "./src/storage.ts",
     "./files": "./src/files-core.ts",
     "./file-metadata": "./src/file-metadata.ts",
+    "./file-search": "./src/file-search.ts",
     "./guards": "./src/guards.ts",
     "./budget": "./src/budget.ts",
     "./usage": "./src/usage.ts",

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -447,6 +447,8 @@ export async function replaceFileMetadata(
 
 const FIND_DEFAULT_LIMIT = 50;
 const FIND_MAX_LIMIT = 500;
+/** Allow one extra row so callers can probe truncation with `limit + 1`. */
+const FIND_PROBE_MAX_LIMIT = FIND_MAX_LIMIT + 1;
 
 /**
  * Escapes SQL LIKE metacharacters (`%`, `_`, and the escape character itself)
@@ -479,7 +481,9 @@ export async function findObjectsByMetadata(
   const entries = Object.entries(filters);
   if (entries.length === 0) return [];
 
-  const limit = Math.max(1, Math.min(opts.limit ?? FIND_DEFAULT_LIMIT, FIND_MAX_LIMIT));
+  // FIND_PROBE_MAX_LIMIT lets callers request `pageSize + 1` for an exact
+  // truncated signal (name search over-fetches the D1 window; see file-search.ts).
+  const limit = Math.max(1, Math.min(opts.limit ?? FIND_DEFAULT_LIMIT, FIND_PROBE_MAX_LIMIT));
   const params: unknown[] = [];
   const legs = entries.map(([key, value]) => {
     params.push(workspace, key, value);
@@ -606,6 +610,38 @@ export async function facetValues(
     values: rows.map((row) => ({ value: row.meta_value, count: row.count })),
     truncated,
   };
+}
+
+export type FacetKeysResult = {
+  keys: Array<{ key: string; count: number; distinctValues: number }>;
+  truncated: boolean;
+};
+
+export type FacetValuesResult = {
+  key: string;
+  values: Array<{ value: string; count: number }>;
+  truncated: boolean;
+};
+
+/**
+ * Facet discovery shared by token `/files/facets`, session `/me/.../files/facets`,
+ * and hosted MCP `list_metadata_keys`. No `key` → workspace key list; with
+ * `key` → that key's values (validated against `META_KEY_RE`).
+ */
+export async function listFacets(
+  db: D1Database,
+  workspace: string,
+  key?: string,
+): Promise<FacetKeysResult | FacetValuesResult> {
+  if (key === undefined) return facetKeys(db, workspace);
+  if (!META_KEY_RE.test(key)) {
+    throw new ValidationError(`invalid metadata key: ${key}`, {
+      code: "file_metadata_invalid_key",
+      details: { key },
+    });
+  }
+  const { values, truncated } = await facetValues(db, workspace, key);
+  return { key, values, truncated };
 }
 
 /** Max object keys bound into a single `object_key IN (...)` statement (SQLite's ~999 host-parameter limit, kept well under it). */

--- a/apps/api/src/file-search.ts
+++ b/apps/api/src/file-search.ts
@@ -1,0 +1,141 @@
+/**
+ * Filename + metadata search shared by the session-authed `/me/.../files/search`
+ * route, the token-authed `GET /v1/:workspace/files` route, and the hosted MCP
+ * `find_files` tool (issue #528).
+ *
+ * Two paths: with metadata filters the D1 index is selective and a name term
+ * narrows those rows in memory; name alone walks storage via files-sdk
+ * `search()` (substring, never glob/regex). `truncated` is derived from the
+ * underlying query's own cap — not the post-name-filter match count — so a
+ * D1 window that has been fully consumed still reports truncated even when
+ * no surviving rows match the name term (see 070f5cf6).
+ */
+import { ValidationError } from "@uploads/errors";
+import {
+  findObjectsByMetadata,
+  getMetadataForKeys,
+  validateMetadataFilters,
+} from "./file-metadata";
+import { storage } from "./storage";
+import type { WorkspaceRecord } from "./workspace";
+
+/** Max characters accepted in a `?name=` / `name` filename search term. */
+export const SEARCH_NAME_MAX = 128;
+
+/** Default page size for token-route / MCP search (matches findObjectsByMetadata). */
+export const FILE_SEARCH_DEFAULT_LIMIT = 50;
+/** Hard cap on search page size. */
+export const FILE_SEARCH_MAX_LIMIT = 500;
+
+/**
+ * Validate and normalize a filename search term. Lowercased here so the
+ * substring comparison against object keys needs no per-row casing work.
+ * Always passed to files-sdk as a `substring` pattern, never `glob` or
+ * `regex`: glob would make `*` and `?` silently meaningful in a box where
+ * people type filenames, and a user-supplied regex would be a
+ * denial-of-service vector.
+ */
+export function normalizeSearchName(raw: string): string {
+  const term = raw.trim();
+  if (term.length === 0 || term.length > SEARCH_NAME_MAX) {
+    throw new ValidationError("name must be 1–128 characters", {
+      code: "file_search_invalid_name",
+    });
+  }
+  return term.toLowerCase();
+}
+
+/** Clamp a caller-supplied limit into the allowed search page-size range. */
+export function clampSearchLimit(limit: number | undefined): number {
+  return Math.max(1, Math.min(limit ?? FILE_SEARCH_DEFAULT_LIMIT, FILE_SEARCH_MAX_LIMIT));
+}
+
+/**
+ * Parse `meta.<key>=value` query params into a filters map. Duplicate-param
+ * detection is query-string-specific (repeated same key), so it lives here
+ * rather than in `validateMetadataFilters`; count cap + key format are
+ * shared with MCP via that helper. Empty when no `meta.*` params.
+ */
+export function parseMetaQueryFilters(
+  query: Record<string, string>,
+  multiValues: (param: string) => string[] | undefined,
+): Record<string, string> {
+  const metaParamKeys = Object.keys(query).filter((k) => k.startsWith("meta."));
+  const filters: Record<string, string> = {};
+  for (const param of metaParamKeys) {
+    const key = param.slice("meta.".length);
+    const values = multiValues(param) ?? [];
+    if (values.length > 1) {
+      throw new ValidationError(`repeated metadata filter for key: ${key}`, {
+        code: "file_metadata_duplicate_filter",
+        details: { key },
+      });
+    }
+    filters[key] = values[0] ?? query[param]!;
+  }
+  if (Object.keys(filters).length > 0) validateMetadataFilters(filters);
+  return filters;
+}
+
+export interface FileSearchMatch {
+  key: string;
+  metadata: Record<string, string>;
+}
+
+/**
+ * Run the two-path name/metadata search. Callers must ensure at least one of
+ * non-empty `filters` or `nameTerm` is set; this function does not re-check
+ * that precondition. Always over-fetches by one so `truncated` is exact on
+ * both the D1 and storage-walk paths (name filtering can drop rows, so the
+ * probe sits on the source query, not the post-filter count).
+ */
+export async function searchFilesByNameAndMeta(
+  env: Env,
+  record: WorkspaceRecord,
+  workspaceName: string,
+  opts: {
+    filters?: Record<string, string>;
+    nameTerm?: string;
+    prefix?: string;
+    pageSize: number;
+  },
+): Promise<{ matches: FileSearchMatch[]; truncated: boolean }> {
+  const { nameTerm, pageSize, prefix } = opts;
+  const filters = opts.filters;
+  const hasMeta = filters !== undefined && Object.keys(filters).length > 0;
+  const fetchLimit = pageSize + 1;
+
+  if (hasMeta) {
+    const found = await findObjectsByMetadata(env.DB, workspaceName, filters, {
+      prefix,
+      limit: fetchLimit,
+    });
+    // Truncation is about the D1 window, not the post-name-filter count —
+    // a name term can drop every row in the window while more matching-meta
+    // keys still sit beyond the ORDER BY object_key LIMIT.
+    const truncated = found.length > pageSize;
+    const narrowed = nameTerm
+      ? found.filter((match) => match.key.toLowerCase().includes(nameTerm))
+      : found;
+    return { matches: narrowed.slice(0, pageSize), truncated };
+  }
+
+  // Name alone — walk storage. `maxResults` stops as soon as the cap is hit.
+  const store = await storage(env, record);
+  const keys: string[] = [];
+  for await (const file of store.search(nameTerm!, {
+    match: "substring",
+    caseInsensitive: true,
+    maxResults: fetchLimit,
+    ...(prefix ? { prefix } : {}),
+  })) {
+    keys.push(file.key);
+  }
+  const truncated = keys.length > pageSize;
+  const pageKeys = keys.slice(0, pageSize);
+  const metaByKey = await getMetadataForKeys(env.DB, workspaceName, pageKeys);
+  return {
+    matches: pageKeys.map((key) => ({ key, metadata: metaByKey.get(key) ?? {} })),
+    truncated,
+  };
+}

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -15,13 +15,18 @@ import {
   putObject,
 } from "../files-core";
 import {
-  findObjectsByMetadata,
   getFileMetadata,
   getMetadataForKeys,
+  listFacets,
   META_MAX_KEYS,
   setFileMetadata,
-  validateMetadataFilters,
 } from "../file-metadata";
+import {
+  clampSearchLimit,
+  normalizeSearchName,
+  parseMetaQueryFilters,
+  searchFilesByNameAndMeta,
+} from "../file-search";
 import { splitUploadMetaHeaders } from "../provenance";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { requireScope, type WorkspaceVars } from "../workspace";
@@ -228,57 +233,46 @@ export const files = new Hono<WorkspaceVars>()
     return c.json({ workspace: c.get("workspaceName"), ...result }, 201);
   })
 
-  // Repeatable `meta.<key>=<value>` params switch the listing to the D1
-  // metadata index (ANDed equality across all given pairs) instead of the
-  // R2 prefix-list below; see file-metadata.ts's `findObjectsByMetadata`.
-  // No `meta.*` params at all leaves the existing R2 path untouched.
-  // Contract caveat: D1-path items carry no `visibility` annotation (that
-  // lives in R2 custom metadata and would cost a HEAD per result to
-  // hydrate); callers needing the private marker must HEAD the object.
+  // Repeatable `meta.<key>=<value>` params and optional `?name=` switch the
+  // listing to the shared D1/storage search path (issue #528) instead of the
+  // R2 prefix-list below. No `meta.*` and no `name` leaves the existing R2
+  // path untouched. Contract caveat: search-path items carry no `visibility`
+  // annotation (that lives in R2 custom metadata and would cost a HEAD per
+  // result to hydrate); callers needing the private marker must HEAD the
+  // object. Meta-only responses omit `truncated` (pre-#528 shape); name
+  // searches include it.
   .get("/", requireScope("files:read"), async (c) => {
     const query = c.req.query();
-    const metaParamKeys = Object.keys(query).filter((k) => k.startsWith("meta."));
+    const rawName = c.req.query("name");
+    const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
+    const filters = parseMetaQueryFilters(query, (param) => c.req.queries(param));
+    const hasMeta = Object.keys(filters).length > 0;
 
-    if (metaParamKeys.length > 0) {
-      // Duplicate-param detection is query-string-specific (repeated same
-      // key), so it stays here; count cap + key format are shared with the
-      // MCP find_files tool via validateMetadataFilters.
-      const filters: Record<string, string> = {};
-      for (const param of metaParamKeys) {
-        const key = param.slice("meta.".length);
-        const values = c.req.queries(param) ?? [];
-        if (values.length > 1) {
-          throw new ValidationError(`repeated metadata filter for key: ${key}`, {
-            code: "file_metadata_duplicate_filter",
-            details: { key },
-          });
-        }
-        filters[key] = values[0] ?? query[param];
-      }
-      validateMetadataFilters(filters);
-
+    if (hasMeta || nameTerm !== undefined) {
       const ws = c.get("workspace");
       const limitParam = c.req.query("limit");
-      const limit = limitParam ? Number(limitParam) || undefined : undefined;
-      const [cfg, matches] = await Promise.all([
+      const pageSize = clampSearchLimit(limitParam ? Number(limitParam) || undefined : undefined);
+      const [cfg, result] = await Promise.all([
         storageConfig(c.env, ws),
-        findObjectsByMetadata(c.env.DB, c.get("workspaceName"), filters, {
+        searchFilesByNameAndMeta(c.env, ws, c.get("workspaceName"), {
+          filters: hasMeta ? filters : undefined,
+          nameTerm,
           prefix: query.prefix,
-          limit,
+          pageSize,
         }),
       ]);
-      return c.json({
-        items: matches.map((match) => {
-          const urls = objectPublicUrls(c.env, cfg, match.key);
-          return {
-            key: match.key,
-            url: urls.url,
-            embedUrl: urls.embedUrl,
-            metadata: match.metadata,
-          };
-        }),
-        cursor: null,
+      const items = result.matches.map((match) => {
+        const urls = objectPublicUrls(c.env, cfg, match.key);
+        return {
+          key: match.key,
+          url: urls.url,
+          embedUrl: urls.embedUrl,
+          metadata: match.metadata,
+        };
       });
+      // Meta-only keeps the pre-#528 envelope (no `truncated` field).
+      if (nameTerm === undefined) return c.json({ items, cursor: null });
+      return c.json({ items, cursor: null, truncated: result.truncated });
     }
 
     const { prefix, cursor } = query;
@@ -302,6 +296,15 @@ export const files = new Hono<WorkspaceVars>()
       ...page,
       items: page.items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) })),
     });
+  })
+
+  // Facet discovery (issue #528) — token-authed twin of
+  // `GET /me/workspaces/:name/files/facets`. Keys are user/agent-defined, so
+  // agents need this to discover what is filterable before calling find_files.
+  // Static path must register before `/:key{.+}` so "facets" is not treated
+  // as an object key.
+  .get("/facets", requireScope("files:read"), async (c) => {
+    return c.json(await listFacets(c.env.DB, c.get("workspaceName"), c.req.query("key")));
   })
 
   // Metadata now lives on the key-at-tail routes (same shape PUT/GET/DELETE

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -23,14 +23,12 @@ import { usageWithLimits } from "../budget";
 import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
 import { previewFixtureItems } from "../comment-preview-fixtures";
+import { getMetadataForKeys, listFacets } from "../file-metadata";
 import {
-  facetKeys,
-  facetValues,
-  findObjectsByMetadata,
-  getMetadataForKeys,
-  META_KEY_RE,
-  validateMetadataFilters,
-} from "../file-metadata";
+  normalizeSearchName,
+  parseMetaQueryFilters,
+  searchFilesByNameAndMeta,
+} from "../file-search";
 import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
 import { listGalleries } from "../galleries";
 import { galleryListSummaries } from "../gallery-service";
@@ -214,26 +212,6 @@ function commentSettingsResponse(record: WorkspaceRecord) {
 
 /** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
 const REPO_SHAPE_RE = /^[^/\s]+\/[^/\s]+$/;
-
-/** Max characters accepted in a `?name=` filename search term. */
-const SEARCH_NAME_MAX = 128;
-
-/**
- * Validate and normalize a `?name=` term. Lowercased here so the substring
- * comparison against object keys needs no per-row casing work. Always passed
- * to files-sdk as a `substring` pattern, never `glob` or `regex`: glob would
- * make `*` and `?` silently meaningful in a box where people type filenames,
- * and a user-supplied regex would be a denial-of-service vector.
- */
-function normalizeSearchName(raw: string): string {
-  const term = raw.trim();
-  if (term.length === 0 || term.length > SEARCH_NAME_MAX) {
-    throw new ValidationError("name must be 1–128 characters", {
-      code: "file_search_invalid_name",
-    });
-  }
-  return term.toLowerCase();
-}
 
 interface MyWorkspace {
   workspace: string;
@@ -581,9 +559,11 @@ export const me = new Hono<SessionVars>()
   })
 
   // Metadata search — the session-authed twin of the token route's
-  // `GET /v1/:workspace/files?meta.*` (files.ts). Same AND-of-equality
-  // semantics and shared validators; scoped to one workspace, member-gated.
-  // Results carry no `visibility` (it isn't in the D1 index — accepted caveat).
+  // `GET /v1/:workspace/files?meta.*` / `?name=` (files.ts). Same AND-of-
+  // equality semantics and shared helpers; scoped to one workspace, member-
+  // gated. Results carry no `visibility` (it isn't in the D1 index — accepted
+  // caveat). Always returns `truncated` (session contract differs from the
+  // token meta-only envelope).
   .get("/workspaces/:name/files/search", async (c) => {
     const name = c.req.param("name");
     await memberWorkspaceOr404(c.env, requireUserId(c), name);
@@ -594,76 +574,29 @@ export const me = new Hono<SessionVars>()
     }
 
     const query = c.req.query();
-    const metaParamKeys = Object.keys(query).filter((k) => k.startsWith("meta."));
     const rawName = c.req.query("name");
     const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
+    const filters = parseMetaQueryFilters(query, (param) => c.req.queries(param));
+    const hasMeta = Object.keys(filters).length > 0;
 
-    if (metaParamKeys.length === 0 && nameTerm === undefined) {
+    if (!hasMeta && nameTerm === undefined) {
       throw new ValidationError("at least one meta.* filter or name is required", {
         code: "file_metadata_invalid_key",
       });
     }
 
-    const filters: Record<string, string> = {};
-    for (const param of metaParamKeys) {
-      const key = param.slice("meta.".length);
-      const values = c.req.queries(param) ?? [];
-      if (values.length > 1) {
-        throw new ValidationError(`repeated metadata filter for key: ${key}`, {
-          code: "file_metadata_duplicate_filter",
-          details: { key },
-        });
-      }
-      filters[key] = values[0] ?? query[param];
-    }
-    if (metaParamKeys.length > 0) validateMetadataFilters(filters);
-
+    // Session search keeps a fixed page of 100 (same as before #528).
     const SEARCH_LIMIT = 100;
     const cfg = await storageConfig(c.env, record);
+    const { matches, truncated } = await searchFilesByNameAndMeta(c.env, record, name, {
+      filters: hasMeta ? filters : undefined,
+      nameTerm,
+      prefix: query.prefix,
+      pageSize: SEARCH_LIMIT,
+    });
 
-    // Two paths. With metadata filters the D1 index is the selective one and
-    // already caps at SEARCH_LIMIT, so a name term narrows those rows in
-    // memory and storage is never walked. Name alone has no index to use, so
-    // it walks via files-sdk `search()` — `maxResults` stops the walk as soon
-    // as the cap is reached rather than traversing the whole workspace.
-    //
-    // `truncated` must reflect whether the *underlying* query hit its cap,
-    // not the post-filter match count: on the metadata path, a `?name=` term
-    // narrows the D1 result set in memory, and a cap hit there can still
-    // leave a name-matching count at or below SEARCH_LIMIT even though rows
-    // beyond the D1 window (in object_key order) were never fetched at all.
-    let matches: Array<{ key: string; metadata: Record<string, string> }>;
-    let truncated: boolean;
-    if (metaParamKeys.length > 0) {
-      const found = await findObjectsByMetadata(c.env.DB, name, filters, {
-        prefix: query.prefix,
-        limit: SEARCH_LIMIT + 1,
-      });
-      // The name-filtered set is a subset of `found`, which is capped at
-      // SEARCH_LIMIT + 1, so this subsumes checking the post-filter count.
-      truncated = found.length > SEARCH_LIMIT;
-      matches = nameTerm
-        ? found.filter((match) => match.key.toLowerCase().includes(nameTerm))
-        : found;
-    } else {
-      const store = await storage(c.env, record);
-      const keys: string[] = [];
-      for await (const file of store.search(nameTerm!, {
-        match: "substring",
-        caseInsensitive: true,
-        maxResults: SEARCH_LIMIT + 1,
-        ...(query.prefix ? { prefix: query.prefix } : {}),
-      })) {
-        keys.push(file.key);
-      }
-      const metaByKey = await getMetadataForKeys(c.env.DB, name, keys);
-      matches = keys.map((key) => ({ key, metadata: metaByKey.get(key) ?? {} }));
-      truncated = matches.length > SEARCH_LIMIT;
-    }
-
-    const page = truncated ? matches.slice(0, SEARCH_LIMIT) : matches;
     return c.json({
-      items: page.map((match) => {
+      items: matches.map((match) => {
         const urls = objectPublicUrls(c.env, cfg, match.key);
         return { key: match.key, url: urls.url, embedUrl: urls.embedUrl, metadata: match.metadata };
       }),
@@ -688,18 +621,7 @@ export const me = new Hono<SessionVars>()
       throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
     }
 
-    const key = c.req.query("key");
-    if (key === undefined) {
-      return c.json(await facetKeys(c.env.DB, name));
-    }
-    if (!META_KEY_RE.test(key)) {
-      throw new ValidationError(`invalid metadata key: ${key}`, {
-        code: "file_metadata_invalid_key",
-        details: { key },
-      });
-    }
-    const { values, truncated } = await facetValues(c.env.DB, name, key);
-    return c.json({ key, values, truncated });
+    return c.json(await listFacets(c.env.DB, name, c.req.query("key")));
   })
 
   // Resolve a selected browser item to a usable URL, by storage capability

--- a/apps/api/test/helpers/fake-file-metadata-table.ts
+++ b/apps/api/test/helpers/fake-file-metadata-table.ts
@@ -143,6 +143,53 @@ export class FileMetadataTable {
       }
       return { success: true, results: results as T[], meta: {} };
     }
+    // facetKeys: distinct meta keys with counts (issue #528).
+    if (
+      normalizedSql.startsWith(
+        "SELECT meta_key, COUNT(*) AS count, COUNT(DISTINCT meta_value) AS distinct_values",
+      )
+    ) {
+      const [workspace, limit] = args as [string, number];
+      const scopePrefix = `${workspace} `;
+      const byKey = new Map<string, { count: number; values: Set<string> }>();
+      for (const [scopedKey, map] of this.metadata) {
+        if (!scopedKey.startsWith(scopePrefix)) continue;
+        for (const [meta_key, meta_value] of map.entries()) {
+          // Mirror EXCLUDE_SERVER_KEYS (video.* today).
+          if (meta_key.startsWith("video.")) continue;
+          const entry = byKey.get(meta_key) ?? { count: 0, values: new Set<string>() };
+          entry.count += 1;
+          entry.values.add(meta_value);
+          byKey.set(meta_key, entry);
+        }
+      }
+      const results = [...byKey.entries()]
+        .map(([meta_key, entry]) => ({
+          meta_key,
+          count: entry.count,
+          distinct_values: entry.values.size,
+        }))
+        .sort((a, b) => b.count - a.count || a.meta_key.localeCompare(b.meta_key))
+        .slice(0, limit);
+      return { success: true, results: results as T[], meta: {} };
+    }
+    // facetValues: distinct values for one meta key (issue #528).
+    if (normalizedSql.startsWith("SELECT meta_value, COUNT(*) AS count FROM file_metadata")) {
+      const [workspace, key, limit] = args as [string, string, number];
+      const scopePrefix = `${workspace} `;
+      const counts = new Map<string, number>();
+      for (const [scopedKey, map] of this.metadata) {
+        if (!scopedKey.startsWith(scopePrefix)) continue;
+        const value = map.get(key);
+        if (value === undefined) continue;
+        counts.set(value, (counts.get(value) ?? 0) + 1);
+      }
+      const results = [...counts.entries()]
+        .map(([meta_value, count]) => ({ meta_value, count }))
+        .sort((a, b) => b.count - a.count || a.meta_value.localeCompare(b.meta_value))
+        .slice(0, limit);
+      return { success: true, results: results as T[], meta: {} };
+    }
     return undefined;
   }
 }

--- a/apps/api/test/routes-files.test.ts
+++ b/apps/api/test/routes-files.test.ts
@@ -151,11 +151,15 @@ async function makeEnv(
 /** PUT the standard test key with auth, letting each test vary body/headers/env. */
 function putShot(
   env: Parameters<typeof app.request>[2],
-  { body = PNG as BodyInit, headers = {} as Record<string, string> } = {},
+  {
+    body = PNG as BodyInit,
+    headers = {} as Record<string, string>,
+    key = "screenshots/shot.png",
+  } = {},
 ) {
   // Nested key so auto-prefix of bare basenames does not rewrite the path.
   return app.request(
-    "/v1/default/files/screenshots/shot.png",
+    `/v1/default/files/${key}`,
     {
       method: "PUT",
       headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "image/png", ...headers },
@@ -1313,6 +1317,114 @@ describe("GET /v1/:workspace/files list + meta.* filter", () => {
 
     const json = (await res.json()) as { items: { metadata?: object }[] };
     expect(json.items[0].metadata).toBeUndefined();
+  });
+
+  it("matches filenames case-insensitively by substring with ?name=", async () => {
+    const { env } = await makeEnv();
+    await putShot(env, { key: "screenshots/Hero-Shot.png" });
+    await putShot(env, { key: "screenshots/footer.png" });
+
+    const res = await listFiles(env, "?name=hero");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { items: ListedFile[]; truncated: boolean };
+    expect(json.items.map((i) => i.key)).toEqual(["screenshots/Hero-Shot.png"]);
+    expect(json.truncated).toBe(false);
+  });
+
+  it("narrows metadata results by name without walking storage", async () => {
+    const { env, bucket } = await makeEnv();
+    await putShot(env, {
+      key: "f/hero.png",
+      headers: { "X-Uploads-Meta-App": "web" },
+    });
+    await putShot(env, {
+      key: "f/footer.png",
+      headers: { "X-Uploads-Meta-App": "web" },
+    });
+    // Clear the bucket after the puts so only D1 retains the keys — if the
+    // name+meta path walked storage it would return nothing.
+    bucket.store.clear();
+    const listCallsBefore = bucket.listCalls;
+
+    const res = await listFiles(env, "?meta.app=web&name=hero");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { items: ListedFile[]; truncated: boolean };
+    expect(json.items.map((i) => i.key)).toEqual(["f/hero.png"]);
+    expect(bucket.listCalls).toBe(listCallsBefore);
+  });
+
+  it("rejects a blank name with file_search_invalid_name", async () => {
+    const { env } = await makeEnv();
+    const res = await listFiles(env, "?name=%20%20");
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "file_search_invalid_name" },
+    });
+  });
+
+  it("treats the name term as a literal substring, not a glob", async () => {
+    const { env } = await makeEnv();
+    await putShot(env, { key: "report.png" });
+    const res = await listFiles(env, "?name=re*ort");
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { items: unknown[] }).items).toEqual([]);
+  });
+});
+
+describe("GET /v1/:workspace/files/facets", () => {
+  it("lists the workspace's metadata keys with counts", async () => {
+    const { env } = await makeEnv();
+    await putShot(env, {
+      key: "a.png",
+      headers: { "X-Uploads-Meta-App": "web", "X-Uploads-Meta-Gh.Repo": "o/r" },
+    });
+    await putShot(env, {
+      key: "b.png",
+      headers: { "X-Uploads-Meta-Gh.Repo": "o/r" },
+    });
+
+    const res = await listFiles(env, "/facets");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      keys: [
+        { key: "gh.repo", count: 2, distinctValues: 1 },
+        { key: "app", count: 1, distinctValues: 1 },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("lists one key's values when ?key= is given", async () => {
+    const { env } = await makeEnv();
+    await putShot(env, { key: "a.png", headers: { "X-Uploads-Meta-App": "web" } });
+    await putShot(env, { key: "b.png", headers: { "X-Uploads-Meta-App": "web" } });
+    await putShot(env, { key: "c.png", headers: { "X-Uploads-Meta-App": "api" } });
+
+    const res = await listFiles(env, "/facets?key=app");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      key: "app",
+      values: [
+        { value: "web", count: 2 },
+        { value: "api", count: 1 },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("rejects a malformed key with file_metadata_invalid_key", async () => {
+    const { env } = await makeEnv();
+    const res = await listFiles(env, "/facets?key=BadKey");
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: { code: string } }).toMatchObject({
+      error: { code: "file_metadata_invalid_key" },
+    });
+  });
+
+  it("requires authentication", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(`/v1/default/files/facets`, {}, env);
+    expect(res.status).toBe(401);
   });
 });
 

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -45,13 +45,18 @@ import {
   type PromoteResult,
 } from "@uploads/api/github-promote-service";
 import {
-  findObjectsByMetadata,
   getFileMetadata,
+  listFacets,
   META_MAX_KEYS,
   setFileMetadata,
   validateMetadataEntries,
   validateMetadataFilters,
 } from "@uploads/api/file-metadata";
+import {
+  clampSearchLimit,
+  normalizeSearchName,
+  searchFilesByNameAndMeta,
+} from "@uploads/api/file-search";
 import { hasGithubTags, uploaderTags } from "@uploads/api/uploader-identity";
 import { deriveRepoBinding, findRepoLink } from "@uploads/api/github-repo-binding";
 import {
@@ -1018,49 +1023,80 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
     {
       name: "find_files",
       description:
-        "Find objects in the workspace whose queryable custom metadata matches ALL of `filters` (ANDed equality). Returns each match's key, public URL, and full metadata map. Same as the CLI/local MCP's `find_files` tool.",
+        "Find objects whose queryable custom metadata matches ALL of `filters` (ANDed equality) and/or whose key contains `name` (case-insensitive substring). At least one of `filters` or `name` is required. Returns each match's key, public URL, full metadata map, and optional `truncated`. Same as the CLI/local MCP's `find_files` tool.",
       inputSchema: {
         type: "object",
         properties: {
           filters: {
             ...metadataProp,
-            description: "Metadata equality filters (at least one pair). " + METADATA_DESCRIPTION,
+            description:
+              "Metadata equality filters (optional when `name` is set). " + METADATA_DESCRIPTION,
+          },
+          name: {
+            type: "string",
+            description:
+              "Case-insensitive substring match on object keys (1–128 chars). Optional when `filters` is non-empty.",
           },
           prefix: {
             type: "string",
-            description: "Key prefix filter, combinable with filters.",
+            description: "Key prefix filter, combinable with filters/name.",
           },
           limit: {
             type: "number",
             description: "Page size (default 50, max 500).",
           },
         },
-        required: ["filters"],
         additionalProperties: false,
       },
       async handler(args) {
         requireScope("files:read");
-        const filters = optStringRecord(args, "filters");
-        if (!filters || Object.keys(filters).length === 0) {
-          usage("filters must have at least one key");
+        const filters = optStringRecord(args, "filters") ?? {};
+        const rawName = optString(args, "name");
+        const hasMeta = Object.keys(filters).length > 0;
+        if (!hasMeta && !rawName) {
+          usage("find_files requires filters and/or name");
         }
         // Shares the count cap + key-format checks with the REST list endpoint's meta.* filters.
-        validateMetadataFilters(filters);
-        const [cfg, matches] = await Promise.all([
+        if (hasMeta) validateMetadataFilters(filters);
+        const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
+        const pageSize = clampSearchLimit(optPosInt(args, "limit"));
+        const [cfg, result] = await Promise.all([
           storageConfig(env, workspace),
-          findObjectsByMetadata(env.DB, workspaceName, filters, {
+          searchFilesByNameAndMeta(env, workspace, workspaceName, {
+            filters: hasMeta ? filters : undefined,
+            nameTerm,
             prefix: optString(args, "prefix"),
-            limit: optPosInt(args, "limit"),
+            pageSize,
           }),
         ]);
-        return {
-          items: matches.map((match) => ({
-            key: match.key,
-            url: publicUrl(cfg, match.key),
-            metadata: match.metadata,
-          })),
-          cursor: null,
-        };
+        const items = result.matches.map((match) => ({
+          key: match.key,
+          url: publicUrl(cfg, match.key),
+          metadata: match.metadata,
+        }));
+        // Meta-only keeps the pre-#528 shape (no truncated).
+        if (nameTerm === undefined) return { items, cursor: null };
+        return { items, cursor: null, truncated: result.truncated };
+      },
+    },
+    {
+      name: "list_metadata_keys",
+      description:
+        "List the distinct queryable metadata keys present in the workspace, with file counts and distinct-value counts. Use this to discover what is filterable before calling find_files — keys are user/agent-defined, not a fixed schema. Same as the CLI's `uploads meta keys`. Pass optional `key` to list that key's values instead (`uploads meta values <key>`).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          key: {
+            type: "string",
+            description:
+              "When set, return distinct values for this metadata key (with counts) instead of the key list.",
+          },
+        },
+        additionalProperties: false,
+      },
+      async handler(args) {
+        requireScope("files:read");
+        return listFacets(env.DB, workspaceName, optString(args, "key"));
       },
     },
     {

--- a/apps/mcp/test/mcp.test.ts
+++ b/apps/mcp/test/mcp.test.ts
@@ -245,6 +245,52 @@ async function makeEnv(
               }
               return { success: true, results: results as T[], meta: {} };
             }
+            // facetKeys (issue #528)
+            if (
+              normalized.startsWith(
+                "SELECT meta_key, COUNT(*) AS count, COUNT(DISTINCT meta_value) AS distinct_values",
+              )
+            ) {
+              const [ws, limit] = values as [string, number];
+              const scopePrefix = `${ws} `;
+              const byKey = new Map<string, { count: number; values: Set<string> }>();
+              for (const [scoped, map] of metadata.entries()) {
+                if (!scoped.startsWith(scopePrefix)) continue;
+                for (const [meta_key, meta_value] of map.entries()) {
+                  if (meta_key.startsWith("video.")) continue;
+                  const entry = byKey.get(meta_key) ?? { count: 0, values: new Set<string>() };
+                  entry.count += 1;
+                  entry.values.add(meta_value);
+                  byKey.set(meta_key, entry);
+                }
+              }
+              const results = [...byKey.entries()]
+                .map(([meta_key, entry]) => ({
+                  meta_key,
+                  count: entry.count,
+                  distinct_values: entry.values.size,
+                }))
+                .sort((a, b) => b.count - a.count || a.meta_key.localeCompare(b.meta_key))
+                .slice(0, limit);
+              return { success: true, results: results as T[], meta: {} };
+            }
+            // facetValues (issue #528)
+            if (normalized.startsWith("SELECT meta_value, COUNT(*) AS count FROM file_metadata")) {
+              const [ws, key, limit] = values as [string, string, number];
+              const scopePrefix = `${ws} `;
+              const counts = new Map<string, number>();
+              for (const [scoped, map] of metadata.entries()) {
+                if (!scoped.startsWith(scopePrefix)) continue;
+                const value = map.get(key);
+                if (value === undefined) continue;
+                counts.set(value, (counts.get(value) ?? 0) + 1);
+              }
+              const results = [...counts.entries()]
+                .map(([meta_value, count]) => ({ meta_value, count }))
+                .sort((a, b) => b.count - a.count || a.meta_value.localeCompare(b.meta_value))
+                .slice(0, limit);
+              return { success: true, results: results as T[], meta: {} };
+            }
             return { success: true, results: [] as T[], meta: {} };
           },
         };
@@ -581,6 +627,7 @@ describe("mcp worker", () => {
       "get_metadata",
       "health",
       "list",
+      "list_metadata_keys",
       "promote",
       "purge_expired",
       "put",
@@ -1096,13 +1143,72 @@ describe("mcp worker", () => {
     });
   });
 
-  it("find_files requires at least one filter", async () => {
+  it("find_files requires filters and/or name", async () => {
     const { env } = await makeEnv();
     const result = await callTool(env, "find_files", { filters: {} });
     expect(result.isError).toBe(true);
-    expect(result.content).toEqual([
-      { type: "text", text: "filters must have at least one key (USAGE)" },
-    ]);
+    expect((result.content[0] as { text: string }).text).toMatch(/filters and\/or name/);
+  });
+
+  it("find_files matches filenames by substring with name", async () => {
+    const { env } = await makeEnv();
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "Hero-Shot.png",
+      key: "shots/Hero-Shot.png",
+    });
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "footer.png",
+      key: "shots/footer.png",
+    });
+
+    const result = await callTool(env, "find_files", { name: "hero" });
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      items: [{ key: "shots/Hero-Shot.png" }],
+      truncated: false,
+    });
+  });
+
+  it("list_metadata_keys returns workspace keys and per-key values", async () => {
+    const { env } = await makeEnv();
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "a.png",
+      key: "shots/a.png",
+      metadata: { app: "web" },
+    });
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "b.png",
+      key: "shots/b.png",
+      metadata: { app: "web" },
+    });
+    await callTool(env, "put", {
+      contentBase64: PNG_B64,
+      filename: "c.png",
+      key: "shots/c.png",
+      metadata: { app: "api" },
+    });
+
+    const keys = await callTool(env, "list_metadata_keys", {});
+    expect(keys.isError).toBe(false);
+    expect(keys.structuredContent).toEqual({
+      keys: [{ key: "app", count: 3, distinctValues: 2 }],
+      truncated: false,
+    });
+
+    const values = await callTool(env, "list_metadata_keys", { key: "app" });
+    expect(values.isError).toBe(false);
+    expect(values.structuredContent).toEqual({
+      key: "app",
+      values: [
+        { value: "web", count: 2 },
+        { value: "api", count: 1 },
+      ],
+      truncated: false,
+    });
   });
 
   it("computes the default screenshot key without git derivation", async () => {

--- a/packages/uploads/src/cli-catalog.ts
+++ b/packages/uploads/src/cli-catalog.ts
@@ -190,15 +190,17 @@ export const ROOT_COMMANDS: readonly CatalogCommand[] = [
   },
   {
     name: "find",
-    usage: "find k=v...",
-    summary: "List objects matching metadata (alias for list --meta)",
+    usage: "find [k=v...] [--name <term>]",
+    summary: "Find objects by metadata and/or filename substring",
   },
   {
     name: "meta",
-    summary: "Get/set an object's queryable metadata",
+    summary: "Get/set object metadata; discover workspace keys/values",
     subcommands: [
       { name: "get", summary: "Show metadata for an object" },
       { name: "set", summary: "Merge-set and/or delete metadata pairs" },
+      { name: "keys", summary: "List distinct metadata keys in the workspace" },
+      { name: "values", summary: "List distinct values for one metadata key" },
     ],
   },
   {

--- a/packages/uploads/src/client.ts
+++ b/packages/uploads/src/client.ts
@@ -65,6 +65,11 @@ export interface ListOptions {
 export interface FindFilesOptions {
   prefix?: string;
   limit?: number;
+  /**
+   * Case-insensitive substring match on object keys (`?name=`).
+   * At least one of non-empty `filters` or `name` is required.
+   */
+  name?: string;
 }
 
 export interface FindFilesItem {
@@ -76,6 +81,19 @@ export interface FindFilesItem {
 export interface FindFilesResult {
   items: FindFilesItem[];
   cursor: string | null;
+  /** Present when a `name` term was used — true if the underlying query hit its cap. */
+  truncated?: boolean;
+}
+
+export interface MetadataKeysResult {
+  keys: Array<{ key: string; count: number; distinctValues: number }>;
+  truncated: boolean;
+}
+
+export interface MetadataValuesResult {
+  key: string;
+  values: Array<{ value: string; count: number }>;
+  truncated: boolean;
 }
 
 export interface GetMetadataResult {
@@ -1000,18 +1018,34 @@ export function createUploadsClient(config: UploadsClientConfig) {
     },
 
     /**
-     * `GET /v1/:workspace/files?meta.<k>=<v>&…` — ANDed equality filter over
-     * queryable metadata. `filters` must be pre-validated (see `metadata.ts`).
+     * `GET /v1/:workspace/files?meta.<k>=<v>&…&name=…` — ANDed equality filter
+     * over queryable metadata and/or a case-insensitive filename substring.
+     * At least one of non-empty `filters` or `opts.name` is required.
+     * `filters` must be pre-validated when present (see `metadata.ts`).
      */
     async findFiles(
-      filters: Record<string, string>,
+      filters: Record<string, string> = {},
       opts: FindFilesOptions = {},
     ): Promise<FindFilesResult> {
       const params = new URLSearchParams();
       for (const [k, v] of Object.entries(filters)) params.append(`meta.${k}`, v);
+      if (opts.name) params.set("name", opts.name);
       if (opts.prefix) params.set("prefix", opts.prefix);
       if (opts.limit != null) params.set("limit", String(opts.limit));
       return request<FindFilesResult>("GET", `${filesBase(config)}?${params.toString()}`);
+    },
+
+    /** `GET /v1/:workspace/files/facets` — workspace metadata key vocabulary. */
+    async listMetadataKeys(): Promise<MetadataKeysResult> {
+      return request<MetadataKeysResult>("GET", `${filesBase(config)}/facets`);
+    },
+
+    /** `GET /v1/:workspace/files/facets?key=` — distinct values for one key. */
+    async listMetadataValues(key: string): Promise<MetadataValuesResult> {
+      return request<MetadataValuesResult>(
+        "GET",
+        `${filesBase(config)}/facets?${new URLSearchParams({ key })}`,
+      );
     },
 
     async head(key: string): Promise<HeadResult> {

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -2715,35 +2715,55 @@ export async function runGallery(ctx: CliContext, args: string[], help = false):
 
 // --- list ---
 
-const LIST_HELP = `uploads list [--prefix <p>] [--pr <num> | --issue <num>] [--repo <owner/name>] [--limit <n>] [--cursor <c>] [--all] [--meta <k=v>]... [--workspace <name>]
+const LIST_HELP = `uploads list [--prefix <p>] [--pr <num> | --issue <num>] [--repo <owner/name>] [--limit <n>] [--cursor <c>] [--all] [--meta <k=v>]... [--name <term>] [--workspace <name>]
 
 Default prefix: UPLOADS_DEFAULT_PREFIX (screenshots if unset).
 
---meta <k=v> (repeatable, ANDed) switches to the metadata filter endpoint —
-returned items include their matched metadata. Combines with --prefix, not
-with --pr/--issue/--all. See also: uploads find (positional-pair alias).
+--meta <k=v> (repeatable, ANDed) and/or --name <term> switch to the search
+endpoint — returned items include their matched metadata. Combines with
+--prefix, not with --pr/--issue/--all. --name is a case-insensitive
+substring match on object keys. See also: uploads find.
 
 Examples:
   uploads list --prefix screenshots/
   uploads list --pr 123
   uploads list --all --json
   uploads list --meta gh.repo=buildinternet/uploads --meta gh.number=123
+  uploads list --name hero --meta app=web
 `;
 
-/** `--meta k=v` (repeatable) filter path, shared by `runList` and `runFind`. */
+/** Human-mode stderr note when a paged API response was capped server-side. */
+function writeTruncatedNotice(
+  truncated: boolean | undefined,
+  quiet: boolean,
+  detail: string,
+): void {
+  if (truncated && !quiet) {
+    process.stderr.write(`truncated: true (${detail})\n`);
+  }
+}
+
+/** `--meta` / `--name` search path, shared by `runList` and `runFind`. */
 async function runFindFiles(
   ctx: CliContext,
   filters: Record<string, string>,
   flags: CommandFlags["flags"],
+  name?: string,
 ): Promise<number> {
   if (flagString(flags, "--cursor") !== undefined) {
-    throw new UsageError("--cursor is not supported with metadata filters");
+    throw new UsageError("--cursor is not supported with metadata or name filters");
   }
   const prefix = flagString(flags, "--prefix");
   const limit = flagInt(flags, "--limit", "--limit");
-  const result = await ctx.client.findFiles(filters, { prefix, limit });
+  const nameTerm = name ?? flagString(flags, "--name");
+  if (Object.keys(filters).length === 0 && !nameTerm) {
+    throw new UsageError("find requires at least one k=v pair, --meta k=v, or --name <term>", {
+      example: "uploads find path=/settings state=after",
+    });
+  }
+  const result = await ctx.client.findFiles(filters, { prefix, limit, name: nameTerm });
   if (ctx.json) await writeJson(result);
-  else
+  else {
     for (const item of result.items) {
       // LIST_HELP promises matched metadata in the output; render it inline
       // (sorted for stable output) so human mode honors that, not just --json.
@@ -2755,6 +2775,8 @@ async function runFindFiles(
         `${item.key}${item.url ? `  ${item.url}` : ""}${meta ? `  ${meta}` : ""}\n`,
       );
     }
+    writeTruncatedNotice(result.truncated, ctx.quiet, "more matches may exist beyond this page");
+  }
   return 0;
 }
 
@@ -2770,14 +2792,20 @@ export async function runList(
     return 0;
   }
   const metaPairs = flagValues(parsed.flags, "--meta");
-  if (metaPairs.length > 0) {
+  const nameFlag = flagString(parsed.flags, "--name");
+  if (metaPairs.length > 0 || nameFlag !== undefined) {
     if (ghTargetFromFlags(parsed.flags, run)) {
-      throw new UsageError("--meta cannot be combined with --pr/--issue");
+      throw new UsageError("--meta/--name cannot be combined with --pr/--issue");
     }
     if (flagBool(parsed.flags, "--all")) {
-      throw new UsageError("--meta cannot be combined with --all");
+      throw new UsageError("--meta/--name cannot be combined with --all");
     }
-    return runFindFiles(ctx, parseMetaFlags(metaPairs), parsed.flags);
+    return runFindFiles(
+      ctx,
+      metaPairs.length > 0 ? parseMetaFlags(metaPairs) : {},
+      parsed.flags,
+      nameFlag,
+    );
   }
   const defaults = resolvePutDefaults({ envFile: ctx.envFile });
   const prefixFlag = flagString(parsed.flags, "--prefix");
@@ -2812,15 +2840,21 @@ export async function runList(
 
 // --- find ---
 
-const FIND_HELP = `uploads find k=v [k=v...] [--prefix <p>] [--limit <n>] [--workspace <name>]
+const FIND_HELP = `uploads find [k=v...] [--meta k=v]... [--name <term>] [--prefix <p>] [--limit <n>] [--workspace <name>]
 
-Human-friendly alias for \`uploads list --meta k=v...\` — same metadata filter
-(ANDed equality), same output; pairs are positional, or spelled --meta k=v.
+Find objects by queryable metadata (ANDed equality) and/or a case-insensitive
+filename substring. Same output as \`uploads list --meta\` / \`--name\`.
+
+Pairs are positional k=v, or spelled --meta k=v. A bare positional without
+\`=\` is treated as --name (e.g. \`uploads find hero\`). At least one of a
+meta pair or a name term is required.
 
 Examples:
   uploads find gh.repo=buildinternet/uploads gh.number=123
   uploads find path=/settings state=after --prefix screenshots/
   uploads find --meta path=/settings
+  uploads find hero
+  uploads find --name hero --meta app=web
 `;
 
 export async function runFind(ctx: CliContext, args: string[], help = false): Promise<number> {
@@ -2831,14 +2865,33 @@ export async function runFind(ctx: CliContext, args: string[], help = false): Pr
   }
   // Same flag/positional symmetry as `meta set` (issue #545): `find` is the
   // alias for `list --meta`, so `find --meta k=v` must not dead-end.
-  const pairs = [...parsed.positionals, ...flagValues(parsed.flags, "--meta")];
-  if (pairs.length === 0) {
-    throw new UsageError("find requires at least one k=v pair (or --meta k=v)", {
-      example: "uploads find path=/settings state=after",
+  // Bare positionals without `=` are the filename term (issue #528) so
+  // `uploads find hero` works without a flag. Empty input is rejected inside
+  // `runFindFiles` (shared with `list --name` / `--meta`).
+  const nameFlag = flagString(parsed.flags, "--name");
+  const kvPositionals: string[] = [];
+  const bareNames: string[] = [];
+  for (const pos of parsed.positionals) {
+    if (pos.includes("=")) kvPositionals.push(pos);
+    else bareNames.push(pos);
+  }
+  if (bareNames.length > 1) {
+    throw new UsageError("find accepts at most one bare name term (or use --name)", {
+      example: "uploads find hero --meta app=web",
     });
   }
-  const filters = parseMetaFlags(pairs);
-  return runFindFiles(ctx, filters, parsed.flags);
+  if (bareNames.length === 1 && nameFlag !== undefined) {
+    throw new UsageError("pass the name term either as a bare positional or --name, not both", {
+      example: "uploads find hero",
+    });
+  }
+  const pairs = [...kvPositionals, ...flagValues(parsed.flags, "--meta")];
+  return runFindFiles(
+    ctx,
+    pairs.length > 0 ? parseMetaFlags(pairs) : {},
+    parsed.flags,
+    nameFlag ?? bareNames[0],
+  );
 }
 
 // --- meta ---
@@ -2846,11 +2899,14 @@ export async function runFind(ctx: CliContext, args: string[], help = false): Pr
 const META_HELP = `uploads meta <command> [args]
 
 Read/write an object's queryable custom metadata (D1-backed key-value pairs;
-distinct from the R2 provenance headers put on upload).
+distinct from the R2 provenance headers put on upload). Discover which keys
+and values exist in the workspace before filtering with find/list.
 
 Commands:
   get <key>                            Show metadata for an object
   set <key> k=v [k=v...] [--delete k]...   Merge-set and/or delete pairs
+  keys                                 List distinct metadata keys (with counts)
+  values <meta-key>                    List distinct values for one key
 
 Pairs take either form: positional k=v, or --meta k=v (same spelling as
 put/screenshot/list). Both can appear in one call.
@@ -2860,6 +2916,8 @@ Examples:
   uploads meta set screenshots/myapp/42/shot.png path=/settings state=after
   uploads meta set screenshots/myapp/42/shot.png --meta path=/settings
   uploads meta set screenshots/myapp/42/shot.png --delete path --delete state
+  uploads meta keys
+  uploads meta values app
 `;
 
 export async function runMeta(ctx: CliContext, args: string[], help = false): Promise<number> {
@@ -2870,7 +2928,7 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
     return 0;
   }
   if (!action) {
-    throw new UsageError("meta requires a subcommand: get or set", {
+    throw new UsageError("meta requires a subcommand: get, set, keys, or values", {
       example: "uploads meta set screenshots/myapp/42/shot.png --meta path=/settings",
     });
   }
@@ -2920,8 +2978,38 @@ export async function runMeta(ctx: CliContext, args: string[], help = false): Pr
       await resyncCommentAfterMetaSet(ctx, key, [...Object.keys(set ?? {}), ...del]);
       return 0;
     }
+    case "keys": {
+      // Workspace vocabulary discovery (issue #528) — which meta keys exist
+      // and how common they are, before agents guess at find filters.
+      const result = await ctx.client.listMetadataKeys();
+      if (ctx.json) await writeJson(result);
+      else {
+        for (const row of result.keys) {
+          await writeStdout(`${row.key}  count=${row.count}  distinct=${row.distinctValues}\n`);
+        }
+        writeTruncatedNotice(result.truncated, ctx.quiet, "more keys may exist beyond this page");
+      }
+      return 0;
+    }
+    case "values": {
+      const key = parsed.positionals[1];
+      if (!key) {
+        throw new UsageError("meta values requires a metadata key", {
+          example: "uploads meta values app",
+        });
+      }
+      const result = await ctx.client.listMetadataValues(key);
+      if (ctx.json) await writeJson(result);
+      else {
+        for (const row of result.values) {
+          await writeStdout(`${row.value}  count=${row.count}\n`);
+        }
+        writeTruncatedNotice(result.truncated, ctx.quiet, "more values may exist beyond this page");
+      }
+      return 0;
+    }
     default:
-      throw new UsageError(`unknown meta command: ${action} (expected get or set)`, {
+      throw new UsageError(`unknown meta command: ${action} (expected get, set, keys, or values)`, {
         example: "uploads meta get screenshots/myapp/42/shot.png",
       });
   }

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -72,6 +72,8 @@ export {
   type FindFilesOptions,
   type FindFilesItem,
   type FindFilesResult,
+  type MetadataKeysResult,
+  type MetadataValuesResult,
   type GetMetadataResult,
   type PatchMetadataOptions,
 } from "./client.js";

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -1204,32 +1204,65 @@ export function createUploadsMcpTools(opts: {
     {
       name: "find_files",
       description:
-        "Find objects in the workspace whose queryable custom metadata matches ALL of `filters` (ANDed equality). Returns each match's key, public URL, and full metadata map. Same as `uploads find k=v...` / `uploads list --meta k=v`.",
+        "Find objects whose queryable custom metadata matches ALL of `filters` (ANDed equality) and/or whose key contains `name` (case-insensitive substring). At least one of `filters` or `name` is required. Returns each match's key, public URL, full metadata map, and optional `truncated`. Same as `uploads find k=v...` / `uploads find --name <term>`.",
       inputSchema: {
         type: "object",
         properties: {
           filters: {
             ...metadataProp,
-            description: "Metadata equality filters (at least one pair). " + METADATA_DESCRIPTION,
+            description:
+              "Metadata equality filters (optional when `name` is set). " + METADATA_DESCRIPTION,
           },
-          prefix: { type: "string", description: "Key prefix filter, combinable with filters." },
+          name: {
+            type: "string",
+            description:
+              "Case-insensitive substring match on object keys (1–128 chars). Optional when `filters` is non-empty.",
+          },
+          prefix: {
+            type: "string",
+            description: "Key prefix filter, combinable with filters/name.",
+          },
           limit: { type: "number", description: "Page size (default 50, max 500)." },
           workspace: workspaceProp,
         },
-        required: ["filters"],
         additionalProperties: false,
       },
       async handler(args) {
-        const filters = optStringRecord(args, "filters");
-        if (!filters || Object.keys(filters).length === 0) {
-          usage("filters must have at least one key");
+        const filters = optStringRecord(args, "filters") ?? {};
+        const name = optString(args, "name");
+        const hasMeta = Object.keys(filters).length > 0;
+        if (!hasMeta && !name) {
+          usage("find_files requires filters and/or name");
         }
-        validateMetaMap(filters);
+        if (hasMeta) validateMetaMap(filters);
         const { client } = clientFor(args);
         return client.findFiles(filters, {
+          name,
           prefix: optString(args, "prefix"),
           limit: optPosInt(args, "limit"),
         });
+      },
+    },
+    {
+      name: "list_metadata_keys",
+      description:
+        "List the distinct queryable metadata keys present in the workspace, with file counts and distinct-value counts. Use this to discover what is filterable before calling find_files — keys are user/agent-defined, not a fixed schema. Same as `uploads meta keys`. Pass optional `key` to list that key's values instead (`uploads meta values <key>`).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          key: {
+            type: "string",
+            description:
+              "When set, return distinct values for this metadata key (with counts) instead of the key list.",
+          },
+          workspace: workspaceProp,
+        },
+        additionalProperties: false,
+      },
+      async handler(args) {
+        const { client } = clientFor(args);
+        const key = optString(args, "key");
+        return key ? client.listMetadataValues(key) : client.listMetadataKeys();
       },
     },
     {

--- a/packages/uploads/test/client-metadata.test.ts
+++ b/packages/uploads/test/client-metadata.test.ts
@@ -131,6 +131,77 @@ describe("metadata CRUD client methods", () => {
     expect(result.items[0].key).toBe("gh/o/r/pull/123/a.png");
     expect(result.cursor).toBeNull();
   });
+
+  it("findFiles sends ?name= with optional empty filters", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe("/v1/test/files");
+      expect(url.searchParams.get("name")).toBe("hero");
+      expect(url.searchParams.getAll("meta.app")).toEqual(["web"]);
+      return new Response(
+        JSON.stringify({
+          items: [{ key: "f/hero.png", url: "https://x.test/hero.png", metadata: { app: "web" } }],
+          cursor: null,
+          truncated: false,
+        }),
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+    const result = await client.findFiles({ app: "web" }, { name: "hero" });
+    expect(result.items[0].key).toBe("f/hero.png");
+    expect(result.truncated).toBe(false);
+  });
+
+  it("listMetadataKeys GETs /files/facets", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe("https://api.test/v1/test/files/facets");
+      return new Response(
+        JSON.stringify({
+          keys: [{ key: "app", count: 2, distinctValues: 1 }],
+          truncated: false,
+        }),
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+    expect(await client.listMetadataKeys()).toEqual({
+      keys: [{ key: "app", count: 2, distinctValues: 1 }],
+      truncated: false,
+    });
+  });
+
+  it("listMetadataValues GETs /files/facets?key=", async () => {
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe("https://api.test/v1/test/files/facets?key=app");
+      return new Response(
+        JSON.stringify({
+          key: "app",
+          values: [{ value: "web", count: 2 }],
+          truncated: false,
+        }),
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    const client = createUploadsClient({
+      apiUrl: "https://api.test",
+      workspace: "test",
+      token: "up_test_x",
+    });
+    expect(await client.listMetadataValues("app")).toEqual({
+      key: "app",
+      values: [{ value: "web", count: 2 }],
+      truncated: false,
+    });
+  });
 });
 
 describe("list metadata hydration", () => {

--- a/packages/uploads/test/commands-find.test.ts
+++ b/packages/uploads/test/commands-find.test.ts
@@ -4,16 +4,28 @@ import type { UploadsClient } from "../src/client.js";
 import { runFind, type CliContext } from "../src/commands.js";
 
 function fakeClient() {
-  const calls: { filters: Record<string, string>; prefix?: string; limit?: number }[] = [];
+  const calls: {
+    filters: Record<string, string>;
+    prefix?: string;
+    limit?: number;
+    name?: string;
+  }[] = [];
   const client = {
     findFiles: async (
       filters: Record<string, string>,
-      opts: { prefix?: string; limit?: number } = {},
+      opts: { prefix?: string; limit?: number; name?: string } = {},
     ) => {
-      calls.push({ filters, prefix: opts.prefix, limit: opts.limit });
+      calls.push({ filters, prefix: opts.prefix, limit: opts.limit, name: opts.name });
       return {
-        items: [{ key: "gh/o/r/pull/123/a.png", url: "https://x.test/a.png", metadata: filters }],
+        items: [
+          {
+            key: "gh/o/r/pull/123/a.png",
+            url: "https://x.test/a.png",
+            metadata: Object.keys(filters).length > 0 ? filters : { app: "web" },
+          },
+        ],
         cursor: null,
+        truncated: opts.name ? false : undefined,
       };
     },
   } as unknown as UploadsClient;
@@ -59,14 +71,37 @@ describe("runFind", () => {
     expect(calls[0].filters).toEqual({ path: "/settings", state: "after" });
   });
 
-  it("requires at least one pair, and says so instead of dumping help (#545)", async () => {
+  it("requires at least one pair or name, and says so instead of dumping help (#545)", async () => {
     const { client } = fakeClient();
     await expect(runFind(ctxWith(client), [], false)).rejects.toThrow(/find requires at least one/);
   });
 
-  it("rejects a malformed pair", async () => {
+  it("accepts a bare positional as the filename name term (#528)", async () => {
+    const { client, calls } = fakeClient();
+    const code = await runFind(ctxWith(client), ["hero"], false);
+    expect(code).toBe(0);
+    expect(calls[0]).toMatchObject({ filters: {}, name: "hero" });
+  });
+
+  it("accepts --name and combines it with meta filters", async () => {
+    const { client, calls } = fakeClient();
+    const code = await runFind(ctxWith(client), ["app=web", "--name", "hero"], false);
+    expect(code).toBe(0);
+    expect(calls[0]).toMatchObject({ filters: { app: "web" }, name: "hero" });
+  });
+
+  it("rejects both a bare name and --name together", async () => {
     const { client } = fakeClient();
-    await expect(runFind(ctxWith(client), ["nokeyvalue"], false)).rejects.toThrow(UsageError);
+    await expect(runFind(ctxWith(client), ["hero", "--name", "shot"], false)).rejects.toThrow(
+      UsageError,
+    );
+  });
+
+  it("rejects a malformed pair that is not a bare name", async () => {
+    const { client } = fakeClient();
+    // "nokeyvalue" is a bare name term (no `=`), so it is accepted as --name.
+    // A real malformed k=v has `=` but fails parseMetaFlags.
+    await expect(runFind(ctxWith(client), ["=novalue"], false)).rejects.toThrow(UsageError);
   });
 
   it("combines with --prefix and --limit", async () => {

--- a/packages/uploads/test/commands-meta.test.ts
+++ b/packages/uploads/test/commands-meta.test.ts
@@ -6,6 +6,8 @@ import { runMeta, type CliContext } from "../src/commands.js";
 function fakeClient() {
   const getCalls: string[] = [];
   const patchCalls: { key: string; set?: Record<string, string>; delete?: string[] }[] = [];
+  let keysCalled = 0;
+  const valuesCalls: string[] = [];
   const client = {
     getMetadata: async (key: string) => {
       getCalls.push(key);
@@ -18,8 +20,35 @@ function fakeClient() {
       patchCalls.push({ key, ...opts });
       return { metadata: { ...opts.set } };
     },
+    listMetadataKeys: async () => {
+      keysCalled += 1;
+      return {
+        keys: [
+          { key: "gh.repo", count: 2, distinctValues: 1 },
+          { key: "app", count: 1, distinctValues: 1 },
+        ],
+        truncated: false,
+      };
+    },
+    listMetadataValues: async (key: string) => {
+      valuesCalls.push(key);
+      return {
+        key,
+        values: [
+          { value: "web", count: 2 },
+          { value: "api", count: 1 },
+        ],
+        truncated: false,
+      };
+    },
   } as unknown as UploadsClient;
-  return { client, getCalls, patchCalls };
+  return {
+    client,
+    getCalls,
+    patchCalls,
+    keysCalled: () => keysCalled,
+    valuesCalls,
+  };
 }
 
 function ctxWith(client: UploadsClient): CliContext {
@@ -166,6 +195,45 @@ describe("runMeta set", () => {
     await expect(
       runMeta(ctxWith(client), ["set", "screenshots/a.png", "nokeyvalue"], false),
     ).rejects.toThrow(UsageError);
+  });
+});
+
+describe("runMeta keys / values (issue #528)", () => {
+  it("lists workspace metadata keys", async () => {
+    const { client, keysCalled } = fakeClient();
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runMeta(ctxWith(client), ["keys"], false)).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(keysCalled()).toBe(1);
+    expect(stdout.join("")).toBe("gh.repo  count=2  distinct=1\napp  count=1  distinct=1\n");
+  });
+
+  it("lists values for one metadata key", async () => {
+    const { client, valuesCalls } = fakeClient();
+    const stdout: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    try {
+      expect(await runMeta(ctxWith(client), ["values", "app"], false)).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+    }
+    expect(valuesCalls).toEqual(["app"]);
+    expect(stdout.join("")).toBe("web  count=2\napi  count=1\n");
+  });
+
+  it("requires a key for values", async () => {
+    const { client } = fakeClient();
+    await expect(runMeta(ctxWith(client), ["values"], false)).rejects.toThrow(UsageError);
   });
 });
 

--- a/packages/uploads/test/mcp.test.ts
+++ b/packages/uploads/test/mcp.test.ts
@@ -36,6 +36,13 @@ function fakeFactory() {
   }> = [];
   const deletes: string[] = [];
   const configs: UploadsClientConfig[] = [];
+  const findCalls: Array<{
+    filters: Record<string, string>;
+    prefix?: string;
+    limit?: number;
+    name?: string;
+  }> = [];
+  const facetCalls: Array<{ kind: "keys" } | { kind: "values"; key: string }> = [];
   // Keyed by object key, mirroring the server's per-key metadata rows well
   // enough to exercise set_metadata/find_files wiring without a real API.
   const metadataStore = new Map<string, Record<string, string>>();
@@ -100,21 +107,38 @@ function fakeFactory() {
         return { metadata: current };
       },
       findFiles: async (
-        filters: Record<string, string>,
-        opts: { prefix?: string; limit?: number } = {},
+        filters: Record<string, string> = {},
+        opts: { prefix?: string; limit?: number; name?: string } = {},
       ) => {
+        findCalls.push({ filters, ...opts });
         const items = [...metadataStore.entries()]
           .filter(([key, meta]) => {
             if (opts.prefix && !key.startsWith(opts.prefix)) return false;
+            if (opts.name && !key.toLowerCase().includes(opts.name.toLowerCase())) return false;
             return Object.entries(filters).every(([k, v]) => meta[k] === v);
           })
           .slice(0, opts.limit ?? 50)
           .map(([key, meta]) => ({ key, url: `https://x.test/${key}`, metadata: meta }));
-        return { items, cursor: null };
+        return { items, cursor: null, truncated: opts.name ? false : undefined };
+      },
+      listMetadataKeys: async () => {
+        facetCalls.push({ kind: "keys" });
+        return {
+          keys: [{ key: "app", count: 2, distinctValues: 1 }],
+          truncated: false,
+        };
+      },
+      listMetadataValues: async (key: string) => {
+        facetCalls.push({ kind: "values", key });
+        return {
+          key,
+          values: [{ value: "web", count: 2 }],
+          truncated: false,
+        };
       },
     } as unknown as UploadsClient;
   };
-  return { factory, puts, deletes, configs, metadataStore };
+  return { factory, puts, deletes, configs, metadataStore, findCalls, facetCalls };
 }
 
 /** In-memory gallery API contract used to exercise the MCP mutation workflow. */
@@ -247,7 +271,7 @@ function serverWith(overrides?: {
   runner?: CommandRunner;
   factory?: (config: UploadsClientConfig) => UploadsClient;
 }) {
-  const { factory, puts, deletes, configs, metadataStore } = fakeFactory();
+  const { factory, puts, deletes, configs, metadataStore, findCalls, facetCalls } = fakeFactory();
   const server = createMcpServer({
     serverInfo: { name: "uploads", version: "0.0.0-test" },
     validator,
@@ -257,7 +281,7 @@ function serverWith(overrides?: {
       clientFactory: overrides?.factory ?? factory,
     }),
   });
-  return { server, puts, deletes, configs, metadataStore };
+  return { server, puts, deletes, configs, metadataStore, findCalls, facetCalls };
 }
 
 const PNG_B64 = Buffer.from("png-bytes").toString("base64");
@@ -417,6 +441,7 @@ describe("tools/list", () => {
       "get_metadata",
       "set_metadata",
       "find_files",
+      "list_metadata_keys",
       "usage",
       "reconcile",
       "purge_expired",
@@ -1114,11 +1139,47 @@ describe("tools/call get_metadata, set_metadata, find_files", () => {
     });
   });
 
-  it("requires at least one filter", async () => {
+  it("requires filters and/or name", async () => {
     const { server } = serverWith();
     const res = await rpc(server, "tools/call", { name: "find_files", arguments: { filters: {} } });
     expect(res.result.isError).toBe(true);
-    expect(res.result.content[0].text).toContain("filters");
+    expect(res.result.content[0].text).toMatch(/filters|name/);
+  });
+
+  it("finds by name alone", async () => {
+    const { server, findCalls } = serverWith();
+    const res = await rpc(server, "tools/call", {
+      name: "find_files",
+      arguments: { name: "hero" },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(findCalls[0]).toMatchObject({ filters: {}, name: "hero" });
+  });
+
+  it("list_metadata_keys returns keys and values shapes", async () => {
+    const { server, facetCalls } = serverWith();
+    const keys = await rpc(server, "tools/call", {
+      name: "list_metadata_keys",
+      arguments: {},
+    });
+    expect(keys.result.isError).toBe(false);
+    expect(keys.result.structuredContent).toEqual({
+      keys: [{ key: "app", count: 2, distinctValues: 1 }],
+      truncated: false,
+    });
+    expect(facetCalls).toEqual([{ kind: "keys" }]);
+
+    const values = await rpc(server, "tools/call", {
+      name: "list_metadata_keys",
+      arguments: { key: "app" },
+    });
+    expect(values.result.isError).toBe(false);
+    expect(values.result.structuredContent).toEqual({
+      key: "app",
+      values: [{ value: "web", count: 2 }],
+      truncated: false,
+    });
+    expect(facetCalls).toEqual([{ kind: "keys" }, { kind: "values", key: "app" }]);
   });
 });
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -579,11 +579,18 @@ uploads meta set screenshots/myapp/42/settings.webp --meta path=/onboarding  # s
 uploads list --meta app=web --meta path=/settings   # ANDed, repeatable
 uploads find app=web path=/settings                 # same filter, positional pairs
 uploads find --meta app=web                         # --meta works here too
+uploads find hero                                   # bare name = filename substring
+uploads find --name hero --meta app=web             # name + meta, either order
+uploads meta keys                                   # which meta keys exist here
+uploads meta values app                             # values (with counts) for one key
 ```
 
 `meta set` and `find` accept pairs in either spelling: positional `k=v`, or the
 repeatable `--meta k=v` that `put`, `attach`, `screenshot`, and `list` use. Both
-forms can appear in one call.
+forms can appear in one call. `find` also takes a case-insensitive filename
+substring (`--name <term>`, or a bare positional without `=`). When you don't
+know which keys exist, start with `meta keys` / `meta values <key>` (or the MCP
+`list_metadata_keys` tool) — keys are user/agent-defined, not a fixed schema.
 
 On the default `screenshots/…` path, `put` also auto-derives GitHub context and
 stamps `gh.repo`/`gh.kind`/`gh.number`/`gh.ref` from the current branch's PR (or
@@ -777,11 +784,15 @@ comment --body-file` over inline HEREDOCs.
 uploads list --prefix screenshots/        # list objects (key + url)
 uploads list --pr 123                      # everything attached to a PR
 uploads list --meta app=myapp              # filter by metadata (repeatable, ANDed)
+uploads list --name hero --meta app=web    # filename substring (+ optional meta)
 uploads find app=myapp page=settings       # same filter, human-friendly positional pairs
+uploads find hero                          # filename substring alone
 uploads list --all --json                  # paginate fully, machine-readable
 uploads meta get <key>                     # show an object's metadata
 uploads meta set <key> k=v [k=v…] [--delete k]…   # merge-set / delete metadata pairs
 uploads meta set <key> --meta k=v                  # same, in put/list's flag spelling
+uploads meta keys                          # discover workspace metadata keys
+uploads meta values <meta-key>             # distinct values for one key
 uploads delete <key>                       # remove an object
 uploads delete <key> --dry-run             # show what would be deleted
 uploads usage                              # storage / monthly upload counters (+ limits)
@@ -865,8 +876,10 @@ uploads --api-url http://localhost:8787 doctor
 - **MCP:** `uploads mcp` (stdio) mirrors CLI tools; hosted MCP at
   `https://agents.uploads.sh/mcp` — the one to reach for when an agent has no
   local filesystem or git checkout to shell out from (send base64 content
-  directly). Metadata: `get_metadata` / `set_metadata` / `find_files` (same as
-  `meta get` / `meta set` / `find`). Both support multi-file `put` in one call
+  directly). Metadata: `get_metadata` / `set_metadata` / `find_files` /
+  `list_metadata_keys` (same as `meta get` / `meta set` / `find` /
+  `meta keys`|`meta values`). `find_files` accepts optional `name` (filename
+  substring) with or without `filters`. Both support multi-file `put` in one call
   — stdio takes `files` as paths, hosted takes
   `files: [{ filename, contentBase64, alt? }]` (max 20/call; per-item `alt`
   overrides the top-level one) — returning `{ uploads, failures }` with


### PR DESCRIPTION
## In plain terms

PR #527 added filename search and metadata facet discovery for the signed-in web files tab. Agents still could not use either capability: every CLI/MCP find surface required metadata filters, and nothing outside the browser could list which metadata keys exist. This PR closes that gap so agents can search by filename and discover a workspace’s actual metadata vocabulary.

## What it does / what it is not

- Adds `?name=` on the token-authed `GET /v1/:workspace/files` route (substring, case-insensitive; composes with `meta.*`).
- Exposes `GET /v1/:workspace/files/facets` (and `?key=`) behind `files:read`.
- Threads both through the SDK, CLI (`find`/`list --name`, `meta keys`/`meta values`), and both MCP tool sets (`find_files` + `list_metadata_keys`).
- Keeps truncation correct on the name path (derived from the source query cap, not the post-filter match count).
- Still excludes server-owned `video.*` keys from facets.
- Not a web UI change. Meta-only list responses keep their pre-existing shape (no `truncated` field).

## How to try it

Once the API is on this build (local `pnpm dev` or after deploy):

```bash
uploads find hero
uploads find --name hero --meta app=web
uploads list --name hero --json
uploads meta keys
uploads meta values app
```

MCP: call `find_files` with `name` and/or `filters`; call `list_metadata_keys` (optional `key`).

## Technical notes

Shared helpers live in `file-search.ts` (`normalizeSearchName`, `parseMetaQueryFilters`, `searchFilesByNameAndMeta`) and `listFacets` in `file-metadata.ts`, so the session route, token route, and hosted MCP stay on one path. Session search was refactored onto those helpers without changing its contract.

## Test plan

- [x] `pnpm --filter @uploads/api exec vitest run test/routes-files.test.ts -t "list \+ meta|files/facets|name="`
- [x] `pnpm --filter @uploads/api exec vitest run src/routes/me.test.ts -t "files/search|files/facets"`
- [x] `pnpm --filter @uploads/api exec vitest run src/file-metadata-facets.test.ts`
- [x] `pnpm --filter @buildinternet/uploads exec vitest run test/commands-find.test.ts test/commands-meta.test.ts test/client-metadata.test.ts test/mcp.test.ts`
- [x] `pnpm --filter @uploads/mcp exec vitest run test/mcp.test.ts -t "find_files|list_metadata|lists exactly"`
- [x] Built CLI help/usage smoke for `find` and `meta`
- [ ] Live smoke against a running API (`uploads find hero`, `uploads meta keys`)

Closes #528.