### PR TITLE
copy(web): tighten landing pitch for agent screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 A lightweight file-hosting service on Cloudflare Workers. Agents capture
 screenshots as they work — each one staged to the branch automatically — so by
-the time the PR opens it is already furnished with one tidy attachments
-comment. Built on [files-sdk](https://files-sdk.dev) so the storage layer is
+the time the PR opens it has screenshots already attached in one tidy
+attachments comment. Built on [files-sdk](https://files-sdk.dev) so the storage layer is
 provider-agnostic (R2 today; any files-sdk adapter later).
 
 <p>

--- a/VISION.md
+++ b/VISION.md
@@ -2,8 +2,9 @@
 
 An agent restyles a settings page and captures a before and an after with
 `uploads put` — no PR exists yet, so the files stage against the branch. Three
-commits later a PR opens, already furnished: one attachments comment, the pair
-rendered side by side, every capture from the branch in its place. The reviewer
+commits later a PR opens with screenshots already attached: one attachments
+comment, the pair rendered side by side, every capture from the branch in its
+place. The reviewer
 sees the change before reading a line of the diff.
 
 That is the whole vision, played forward: **when agents do the work, the
@@ -154,8 +155,8 @@ Shipped and running in production: the staging loop, GitHub App promotion,
 before/after pairing, managed-comment self-healing, hosted and local MCP,
 OAuth 2.1, self-serve workspaces, plans and billing, galleries, the screenshot
 renderer, screenshot annotations (`uploads annotate` /
-`screenshot --annotate`), and the agent skills. This repo furnishes its own
-PRs with the tool it ships.
+`screenshot --annotate`), and the agent skills. This repo attaches screenshots
+to its own PRs with the tool it ships.
 
 Under active development, in the open. APIs (including auth) can still change.
 Feedback is welcome — open an issue.

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -65,7 +65,7 @@ note: staged for branch feat/nav — auto-attaches to this branch's PR when
 it opens (or run: uploads attach --promote once it exists)</pre>
     </div>
     <p>
-      Keep doing that as you work and the PR opens already furnished — see&#32;
+      Keep doing that as you work and the PR opens with screenshots already attached — see&#32;
       <a href="/docs/attach-pull-request-images#staging">Attach &amp; share</a> for the staged view that
       shows what's queued.
     </p>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -11,7 +11,7 @@ import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../lib/og";
 
 const pageTitle = "uploads.sh — the missing upload command for coding agents";
 const pageDescription =
-  "GitHub has no real way for agents to upload files. By default, pull requests and issues won't include screenshots. Uploads gives Claude, Codex, and other agents a way to host files and show their work on pull requests automatically. They're staged for the branch automatically — and by the time the PR opens, all screenshots appear with one tidy comment.";
+  "GitHub has no API for file uploads, so agents can't include screenshots in pull requests and issues. Uploads gives agents a way to host files and show their work. They're staged for the branch automatically — and when the PR opens, all screenshots appear in one tidy comment without cluttering your repo.";
 
 // Static page (no `prerender = false`) — auth origin is baked at build time,
 // not read from request-time env. See src/lib/auth-client.ts.
@@ -634,12 +634,12 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <SiteHeader star authOrigin={authOrigin} />
     <main>
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
-      <p class="byline">Add screenshots to pull requests.</p>
+      <p class="byline">Now Claude and Codex can add screenshots to pull requests</p>
       <p class="lede">
-        GitHub has no real way for agents to upload files. By default, pull requests and issues
-        won't include screenshots. Uploads gives Claude, Codex, and other agents a way to host files
-        and show their work on pull requests automatically. They're staged for the branch
-        automatically — and by the time the PR opens, all screenshots appear with one tidy comment.
+        GitHub has no API for file uploads, so agents can't include screenshots in pull requests and
+        issues. Uploads gives agents a way to host files and show their work. They're staged for the
+        branch automatically — and when the PR opens, all screenshots appear in one tidy comment
+        without cluttering your repo.
       </p>
 
       <div class="cmdrow hero-install">
@@ -685,7 +685,9 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         </div>
       </section>
 
-      <p class="flow-note"><span class="arrow">└─▶</span> your PR opens already furnished:</p>
+      <p class="flow-note">
+        <span class="arrow">└─▶</span> your PR opens with screenshots already attached:
+      </p>
 
       <section
         class="ghc"


### PR DESCRIPTION
## Summary

Homepage and shared product copy now say the problem more directly: GitHub has no file-upload API for agents, so PRs and issues skip screenshots. Uploads stages captures on the branch and lands them in one tidy comment when the PR opens, without cluttering the repo.

Also swaps the formal “already furnished” line for plain “with screenshots already attached” on the landing flow, docs intro, README, and vision doc. The byline names Claude and Codex.

## How to try it

Open the homepage and docs after deploy (or `pnpm dev:web` locally):

- Byline: “Now Claude and Codex can add screenshots to pull requests”
- Lede: API framing + staging → one tidy comment
- Flow note: “your PR opens with screenshots already attached:”

## Test plan

- [ ] Homepage renders the new byline, lede, and flow note
- [ ] Meta description matches the lede (view source / OG)
- [ ] Docs intro paragraph uses the new “screenshots already attached” phrasing
- [ ] README and VISION openers read cleanly

## Notes for reviewers

Copy-only. No behavior change.

## Follow-ups

None.