### PR TITLE
feat(api,web): surface actor-on-PR revisit triggers on /admin/metrics

### DIFF
--- a/apps/api/src/adoption-queries.ts
+++ b/apps/api/src/adoption-queries.ts
@@ -175,3 +175,37 @@ export async function platformStorage(
     .first<{ workspaces: number; storedBytes: number }>();
   return { workspaces: row?.workspaces ?? 0, storedBytes: row?.storedBytes ?? 0 };
 }
+
+/** One workspace with more than one distinct minting user actively minting tokens. */
+export interface MultiIdentityWorkspace {
+  workspace: string;
+  users: number;
+}
+
+/**
+ * Workspaces whose `auth_tokens` carry two or more distinct non-null
+ * `minting_user_id` values — a revisit trigger for the actor-on-PR gate
+ * (issue #579): once multiple people mint tokens for the same workspace, the
+ * "is the caller the actor" gate starts mattering more than it does for a
+ * single-identity workspace. Read-only; no writes. All tokens count
+ * (revoked/expired included) since the signal is "has this workspace ever
+ * had multiple minters", not "how many active tokens exist right now".
+ */
+export async function multiIdentityWorkspaces(
+  db: D1Database,
+  limit = DEFAULT_LIMIT,
+): Promise<MultiIdentityWorkspace[]> {
+  const result = await db
+    .prepare(
+      `SELECT workspace, COUNT(DISTINCT minting_user_id) AS users
+       FROM auth_tokens
+       WHERE minting_user_id IS NOT NULL
+       GROUP BY workspace
+       HAVING COUNT(DISTINCT minting_user_id) >= 2
+       ORDER BY users DESC, workspace ASC
+       LIMIT ?`,
+    )
+    .bind(limit)
+    .all<MultiIdentityWorkspace>();
+  return result.results;
+}

--- a/apps/api/src/adoption.ts
+++ b/apps/api/src/adoption.ts
@@ -21,6 +21,7 @@ export const ADOPTION_METRICS = [
   "workspace_created",
   "gallery_created",
   "comment_posted",
+  "comment_actor_dryrun_decline",
   "repo_linked",
 ] as const;
 

--- a/apps/api/src/github-comment-service.test.ts
+++ b/apps/api/src/github-comment-service.test.ts
@@ -162,6 +162,16 @@ describe("postManagedComment actor-on-PR gate (issue #297 control 2)", () => {
       postManagedComment(env, ws, workspaceName, "user_1", TARGET),
     );
     expect(r).toMatchObject({ posted: true, action: "updated" });
+
+    // issue #579: the dry-run decline records an adoption event — one
+    // per-workspace row and one platform-total row, same two-row shape as
+    // comment_posted (never zero, never duplicated) — so /admin/metrics can
+    // show would-decline volume as a revisit trigger.
+    const { results: dryrunRows } = await env.DB.prepare(
+      `SELECT workspace FROM daily_metrics WHERE metric = 'comment_actor_dryrun_decline'`,
+    ).all<{ workspace: string }>();
+    expect(dryrunRows).toHaveLength(2);
+    expect(dryrunRows.map((row) => row.workspace).sort()).toEqual(["", "acme"]);
   });
 });
 

--- a/apps/api/src/github-comment-service.ts
+++ b/apps/api/src/github-comment-service.ts
@@ -113,6 +113,10 @@ async function checkActorAuthorization(
         actorId,
       }),
     );
+    await recordAdoptionSafe(env, {
+      metric: "comment_actor_dryrun_decline",
+      workspace: workspaceName,
+    });
     return null;
   }
   return {

--- a/apps/api/src/metrics-overview.ts
+++ b/apps/api/src/metrics-overview.ts
@@ -12,11 +12,13 @@
 import {
   activeWorkspacesSince,
   featureTotals,
+  multiIdentityWorkspaces,
   platformSeries,
   platformStorage,
   windowStart,
   workspaceActivity,
   type DayPoint,
+  type MultiIdentityWorkspace,
   type WorkspaceActivity,
 } from "./adoption-queries";
 
@@ -55,6 +57,13 @@ export interface MetricsOverview {
   };
   features: Record<string, number>;
   workspaces: WorkspaceActivity[];
+  /**
+   * Workspaces with two or more distinct `minting_user_id` values in
+   * `auth_tokens` — a read-only revisit trigger for the actor-on-PR gate
+   * (issue #579). Not window-scoped: `auth_tokens` has no window semantics,
+   * so this is all-time, same as `totals.users`/`totals.orgs`.
+   */
+  multiIdentityWorkspaces: MultiIdentityWorkspace[];
 }
 
 interface AuthMetrics {
@@ -112,7 +121,7 @@ export async function buildOverview(
   const since7 = windowStart(7, now);
   const since30 = windowStart(30, now);
 
-  const [uploads, features, table, active30, storage, auth] = await Promise.all([
+  const [uploads, features, table, active30, storage, auth, multiIdentity] = await Promise.all([
     platformSeries(env.DB, "upload", since),
     featureTotals(env.DB, since),
     workspaceActivity(env.DB, since),
@@ -124,6 +133,7 @@ export async function buildOverview(
     activeWorkspacesSince(env.DB, since30),
     platformStorage(env.DB),
     authMetrics(env, since),
+    multiIdentityWorkspaces(env.DB),
   ]);
 
   return {
@@ -141,6 +151,7 @@ export async function buildOverview(
     series: { uploads, users: auth.users, orgs: auth.orgs },
     features,
     workspaces: table,
+    multiIdentityWorkspaces: multiIdentity,
   };
 }
 

--- a/apps/api/src/routes/admin-ui-metrics.test.ts
+++ b/apps/api/src/routes/admin-ui-metrics.test.ts
@@ -5,9 +5,12 @@ import { SqliteD1, database } from "../../test/helpers/sqlite-d1";
 import { respondError } from "../error-response";
 import { adminUi } from "./admin-ui";
 
-// Both: buildOverview reads daily_metrics AND workspace_usage.
+// buildOverview reads daily_metrics, workspace_usage, AND auth_tokens (for
+// the multi-identity workspaces surface, issue #579).
 const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
   "migrations/20260710140000_workspace_usage.sql",
+  "migrations/20260712230000_token_minting_user.sql",
   "migrations/20260728120000_daily_metrics.sql",
 ];
 const ADMIN_USER = { id: "u-admin", email: "admin@b.com", name: "Admin", role: "admin" };
@@ -87,6 +90,16 @@ async function seededDb() {
               ('beta', 50, 1, 1, '2026-07', '2026-07-28T00:00:00Z')`,
     )
     .run();
+  // Multi-identity fixture (issue #579): 'acme' has two distinct minters —
+  // it should surface; 'beta' has one — it should not.
+  await db
+    .prepare(
+      `INSERT INTO auth_tokens (id, workspace, token_hash, scopes, created_at, minting_user_id)
+       VALUES ('t-1', 'acme', 'hash-1', '[]', '2026-07-27T00:00:00Z', 'user-1'),
+              ('t-2', 'acme', 'hash-2', '[]', '2026-07-28T00:00:00Z', 'user-2'),
+              ('t-3', 'beta', 'hash-3', '[]', '2026-07-28T00:00:00Z', 'user-1')`,
+    )
+    .run();
   return { sqlite, db };
 }
 
@@ -141,6 +154,7 @@ describe("GET /admin-ui/metrics/overview", () => {
         series: { uploads: unknown[]; users: unknown[] };
         features: Record<string, number>;
         workspaces: { workspace: string; uploads: number }[];
+        multiIdentityWorkspaces: { workspace: string; users: number }[];
       };
       expect(body.window.days).toBe(30);
       expect(body.totals.users).toBe(12);
@@ -152,6 +166,9 @@ describe("GET /admin-ui/metrics/overview", () => {
       expect(body.totals.activeWorkspaces30d).toBe(2);
       expect(body.features.gallery_created).toBe(1);
       expect(body.workspaces.map((w) => w.workspace).sort()).toEqual(["acme", "beta"]);
+      // issue #579: only 'acme' has >=2 distinct minters in the auth_tokens
+      // fixture — 'beta' (one minter) must not surface.
+      expect(body.multiIdentityWorkspaces).toEqual([{ workspace: "acme", users: 2 }]);
     } finally {
       sqlite.close();
     }

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -99,6 +99,22 @@ export const prerender = false;
         </dl>
       </section>
 
+      <section class="metrics-section" id="multi-identity-panel">
+        <h3>Multi-identity workspaces</h3>
+        <p class="admin-hint">
+          Workspaces with two or more people minting tokens — a revisit trigger for the actor-on-PR
+          gate (issue #579). All-time, not scoped to the selected window.
+        </p>
+        <div class="metrics-table-wrap">
+          <table
+            class="admin-table"
+            id="multi-identity-table"
+            aria-label="Multi-identity workspaces"
+          >
+          </table>
+        </div>
+      </section>
+
       <section class="metrics-section" id="breakdown-panel">
         <h3>Upload breakdown</h3>
         <p class="admin-hint">Last 90 days, from Analytics Engine. Sampled and approximate.</p>
@@ -145,6 +161,10 @@ export const prerender = false;
         bytes: number;
         lastActive: string;
       }
+      interface MultiIdentityWorkspaceRow {
+        workspace: string;
+        users: number;
+      }
       // Mirrors apps/api/src/metrics-overview.ts's MetricsOverview exactly.
       // `totals.workspaces` is workspaces with >=1 recorded upload — not the
       // registration count (idle workspaces have no workspace_usage row).
@@ -166,6 +186,7 @@ export const prerender = false;
         series: { uploads: DayPoint[]; users: SignupPoint[]; orgs: SignupPoint[] };
         features: Record<string, number>;
         workspaces: WorkspaceRow[];
+        multiIdentityWorkspaces: MultiIdentityWorkspaceRow[];
       }
 
       let days = 30;
@@ -508,6 +529,22 @@ export const prerender = false;
         table.innerHTML =
           `<thead><tr><th class="keep" scope="col">Workspace</th><th class="keep num" scope="col">Uploads</th><th class="keep num" scope="col">Bytes</th><th class="keep" scope="col">Last active</th></tr></thead>` +
           `<tbody>${rows}</tbody>`;
+
+        const multiIdentityTable = requireElement<HTMLElement>(
+          "#multi-identity-table",
+          "admin metrics",
+        );
+        const multiIdentityRows = overview.multiIdentityWorkspaces.length
+          ? overview.multiIdentityWorkspaces
+              .map(
+                (row) =>
+                  `<tr class="admin-row"><td>${escapeHtml(row.workspace)}</td><td class="num">${num(row.users)}</td></tr>`,
+              )
+              .join("")
+          : `<tr class="admin-row"><td colspan="2" class="muted">No multi-identity workspaces yet.</td></tr>`;
+        multiIdentityTable.innerHTML =
+          `<thead><tr><th class="keep" scope="col">Workspace</th><th class="keep num" scope="col">Distinct minters</th></tr></thead>` +
+          `<tbody>${multiIdentityRows}</tbody>`;
 
         drawChart(
           "chart-uploads",


### PR DESCRIPTION
## Summary

The actor-on-PR gate (#297) shipped dark: workspaces that haven't opted in
just get a log-only "would decline" console line, and there was no visibility
into how many people are minting tokens for the same workspace — the other
half of the gate's revisit trigger. Both signals now show up on
`/admin/metrics` instead of requiring ad-hoc digging through logs or D1.

- The dry-run decline branch in `checkActorAuthorization`
  (`apps/api/src/github-comment-service.ts`) now records a
  `comment_actor_dryrun_decline` adoption event alongside its existing log
  line, mirroring the `comment_posted` wiring (per-workspace + platform-total
  rows). The metric is added to `ADOPTION_METRICS`, so it's automatically
  picked up by the existing feature-totals query.
- A new read-only query (`multiIdentityWorkspaces` in
  `apps/api/src/adoption-queries.ts`) finds workspaces with two or more
  distinct `minting_user_id` values in `auth_tokens`, wired into the metrics
  overview and rendered as a small table on `/admin/metrics`
  (`apps/web/src/pages/admin/metrics.astro`).

## Test plan

- [x] `pnpm test` (full root suite)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- Extended the "log-only dry-run" test in `github-comment-service.test.ts` to
  assert the two adoption rows.
- Extended `admin-ui-metrics.test.ts` with an `auth_tokens` fixture (one
  multi-identity workspace, one single-identity workspace) and an assertion
  on the new `multiIdentityWorkspaces` field.

Closes #579
