### PR TITLE
refactor: Self-serve BYO R2 bucket: plan + Phase 0 hardening

### DIFF
--- a/apps/api/scripts/add-workspace.mjs
+++ b/apps/api/scripts/add-workspace.mjs
@@ -34,18 +34,10 @@
 import crypto from "node:crypto";
 import { wranglerKvKey } from "./run-timed.mjs";
 import { sharedAgentLimitFields } from "./workspace-limit-defaults.mjs";
-
-/** Match apps/api/src/secrets.ts: enc:v1: + base64url(iv || ct || tag). */
-function sealField(master, plaintext) {
-  if (!master || !plaintext || String(plaintext).startsWith("enc:v1:")) return plaintext;
-  if (master.length < 16) fail("WORKSPACE_SECRETS_KEY must be at least 16 characters");
-  const key = crypto.createHash("sha256").update(master).digest();
-  const iv = crypto.randomBytes(12);
-  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
-  const enc = Buffer.concat([cipher.update(String(plaintext), "utf8"), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  return `enc:v1:${Buffer.concat([iv, enc, tag]).toString("base64url")}`;
-}
+// Node's built-in type stripping (this repo's engines floor is >=24) lets a
+// plain .mjs script import a .ts source file directly, so the enc:v1: sealing
+// format has exactly one implementation — apps/api/src/secrets.ts.
+import { sealCredentialFields } from "../src/secrets.ts";
 
 const [name, ...rest] = process.argv.slice(2);
 const opts = {};
@@ -215,8 +207,16 @@ applyLimit(record, "maxKeyDepth", parseDepth(opts["max-key-depth"], "max-key-dep
 
 const master = process.env.WORKSPACE_SECRETS_KEY;
 if (master && (record.accessKeyId || record.secretAccessKey)) {
-  if (record.accessKeyId) record.accessKeyId = sealField(master, record.accessKeyId);
-  if (record.secretAccessKey) record.secretAccessKey = sealField(master, record.secretAccessKey);
+  try {
+    const sealed = await sealCredentialFields(master, {
+      accessKeyId: record.accessKeyId,
+      secretAccessKey: record.secretAccessKey,
+    });
+    if (sealed.accessKeyId !== undefined) record.accessKeyId = sealed.accessKeyId;
+    if (sealed.secretAccessKey !== undefined) record.secretAccessKey = sealed.secretAccessKey;
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err));
+  }
 }
 
 Object.keys(record).forEach((k) => record[k] === undefined && delete record[k]);

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -70,6 +70,6 @@ export async function reconcileWorkspaceUsage(
     previous: { bytes: previous.bytes, objects: previous.objects },
     changed: previous.bytes !== bytes || previous.objects !== objects,
     usage,
-    ...(unprefixedBucket ? { unprefixedBucket: true } : {}),
+    unprefixedBucket: unprefixedBucket || undefined,
   };
 }

--- a/apps/api/src/reconcile.ts
+++ b/apps/api/src/reconcile.ts
@@ -11,7 +11,7 @@
  */
 import { storage } from "./storage";
 import { getWorkspaceUsage, setUsageTotals, type WorkspaceUsage } from "./usage";
-import type { WorkspaceRecord } from "./workspace";
+import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
 
 export interface ReconcileResult {
   workspace: string;
@@ -23,6 +23,15 @@ export interface ReconcileResult {
   /** True when bytes or objects changed. */
   changed: boolean;
   usage: WorkspaceUsage;
+  /**
+   * True when this workspace has no `prefix` — the listAll() walk below
+   * scans an entire dedicated bucket rather than a confined slice. This
+   * function is only ever invoked on-demand for a single workspace today
+   * (no bulk/scheduled caller), so behavior is unchanged; the flag just
+   * makes a surprisingly large remote list diagnosable if a BYO bucket ever
+   * triggers one.
+   */
+  unprefixedBucket?: boolean;
 }
 
 /** Walk every object under the workspace prefix and replace ledger bytes/objects. */
@@ -34,6 +43,16 @@ export async function reconcileWorkspaceUsage(
 ): Promise<ReconcileResult> {
   const previous = await getWorkspaceUsage(env.DB, workspaceName, now);
   const store = await storage(env, ws);
+  const unprefixedBucket = isUnprefixedDedicatedBucket(ws);
+  if (unprefixedBucket) {
+    console.log(
+      JSON.stringify({
+        event: "reconcile_unprefixed_bucket_scan",
+        workspace: workspaceName,
+        bucket: ws.bucket,
+      }),
+    );
+  }
 
   let bytes = 0;
   let objects = 0;
@@ -51,5 +70,6 @@ export async function reconcileWorkspaceUsage(
     previous: { bytes: previous.bytes, objects: previous.objects },
     changed: previous.bytes !== bytes || previous.objects !== objects,
     usage,
+    ...(unprefixedBucket ? { unprefixedBucket: true } : {}),
   };
 }

--- a/apps/api/src/retention-sweep.ts
+++ b/apps/api/src/retention-sweep.ts
@@ -26,6 +26,8 @@ export interface SweepResult {
     freedBytes: number;
     galleriesDeleted: number;
     error?: string;
+    /** Set when the record has no `prefix` — the sweep never force-purges those (operator-only escape hatch, see `teardownWorkspace`'s `purgeObjects`). */
+    objectsSkipped?: "dedicated-bucket";
   }>;
   orgsSwept: Array<{
     slug: string;
@@ -92,6 +94,10 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
         if (Date.now() < purgeAtMs) continue;
 
         try {
+          // No `purgeObjects` here — the sweep is automated, not an
+          // operator confirming the bucket is platform-owned, so an
+          // unprefixed record always keeps its objects (objectsSkipped)
+          // while platform state (KV/D1/galleries) is still torn down.
           const result = await teardownWorkspace(env, name, record, {
             reason: "grace_period_expired",
             force: true,
@@ -102,6 +108,7 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
             objectsDeleted: result.objectsDeleted,
             freedBytes: result.freedBytes,
             galleriesDeleted: result.galleriesDeleted,
+            ...(result.objectsSkipped ? { objectsSkipped: result.objectsSkipped } : {}),
           });
           console.log(
             JSON.stringify({
@@ -110,6 +117,7 @@ export async function runRetentionSweep(env: Env): Promise<SweepResult> {
               objectsDeleted: result.objectsDeleted,
               freedBytes: result.freedBytes,
               galleriesDeleted: result.galleriesDeleted,
+              objectsSkipped: result.objectsSkipped,
             }),
           );
         } catch (err) {

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -15,7 +15,7 @@
 import { positiveLimit } from "./budget";
 import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
 import { storage } from "./storage";
-import type { WorkspaceRecord } from "./workspace";
+import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** Cap listed deleted keys in the response so agents don't get huge payloads. */
@@ -58,6 +58,14 @@ export async function purgeExpiredObjects(
   workspaceName: string,
   now = new Date(),
 ): Promise<PurgeExpiredResult | { skipped: true; reason: string }> {
+  // retentionDays is unsupported on unprefixed/dedicated buckets in v1 — a
+  // BYO bucket manages its own lifecycle, and a full-bucket listAll() here
+  // would walk storage that isn't ours. Checked before the retentionDays
+  // read so a record that somehow has both is still reported as this case.
+  if (isUnprefixedDedicatedBucket(ws)) {
+    return { skipped: true, reason: "retentionDays unsupported on unprefixed/dedicated buckets" };
+  }
+
   const days = positiveLimit(ws.retentionDays);
   if (days === undefined) {
     return { skipped: true, reason: "retentionDays not set on workspace" };

--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -195,6 +195,9 @@ describe("DELETE /admin/workspaces/:name", () => {
       await bucket.put("one.png", new Uint8Array([1, 2, 3]));
       const sqlite = new SqliteD1(MIGRATIONS);
       try {
+        await createGallery(database(sqlite), { workspace: "acme", title: "Gallery" });
+
+        let deletedOrgSlug: string | undefined;
         const {
           app,
           env,
@@ -204,20 +207,30 @@ describe("DELETE /admin/workspaces/:name", () => {
           kvRecords: { "ws:acme": UNPREFIXED_RECORD },
           bucket,
           db: sqlite,
+          onDeleteOrg: (slug) => {
+            deletedOrgSlug = slug;
+          },
         });
 
         const res = await app.request(deleteRequest("acme", { force: true, hard: true }), {}, env);
         expect(res.status).toBe(200);
         const body = (await res.json()) as {
           objectsDeleted: number;
+          galleriesDeleted: number;
           objectsSkipped?: string;
         };
         expect(body.objectsDeleted).toBe(0);
         expect(body.objectsSkipped).toBe("dedicated-bucket");
 
+        // The skip means no bucket scan at all, not just no deletes — a
+        // listAll() over a large remote BYO bucket is itself the hazard.
+        expect(envBucket.listCalls).toBe(0);
         // Object left in place...
         expect(envBucket.store.has("one.png")).toBe(true);
-        // ...but the KV record is still gone (slug freed, platform state torn down).
+        // ...while platform state is still torn down: galleries, org, and
+        // the KV record (slug freed).
+        expect(body.galleriesDeleted).toBe(1);
+        expect(deletedOrgSlug).toBe("acme");
         expect(registry.store.has("ws:acme")).toBe(false);
       } finally {
         sqlite.close();

--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -68,10 +68,14 @@ function appWith(opts: {
   return { app, env, registry, bucket };
 }
 
-function deleteRequest(name: string, opts?: { force?: boolean; hard?: boolean }) {
+function deleteRequest(
+  name: string,
+  opts?: { force?: boolean; hard?: boolean; purgeObjects?: boolean },
+) {
   const url = new URL(`https://api.uploads.sh/admin/workspaces/${name}`);
   if (opts?.force) url.searchParams.set("force", "1");
   if (opts?.hard) url.searchParams.set("hard", "1");
+  if (opts?.purgeObjects) url.searchParams.set("purgeObjects", "1");
   return new Request(url, {
     method: "DELETE",
     headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
@@ -181,6 +185,101 @@ describe("DELETE /admin/workspaces/:name", () => {
     } finally {
       sqlite.close();
     }
+  });
+
+  describe("dedicated-bucket guard on ?hard=1 (#583)", () => {
+    const UNPREFIXED_RECORD = { ...RECORD, prefix: undefined };
+
+    it("tears down platform state but skips R2 objects for an unprefixed record", async () => {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("one.png", new Uint8Array([1, 2, 3]));
+      const sqlite = new SqliteD1(MIGRATIONS);
+      try {
+        const {
+          app,
+          env,
+          registry,
+          bucket: envBucket,
+        } = appWith({
+          kvRecords: { "ws:acme": UNPREFIXED_RECORD },
+          bucket,
+          db: sqlite,
+        });
+
+        const res = await app.request(deleteRequest("acme", { force: true, hard: true }), {}, env);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          objectsDeleted: number;
+          objectsSkipped?: string;
+        };
+        expect(body.objectsDeleted).toBe(0);
+        expect(body.objectsSkipped).toBe("dedicated-bucket");
+
+        // Object left in place...
+        expect(envBucket.store.has("one.png")).toBe(true);
+        // ...but the KV record is still gone (slug freed, platform state torn down).
+        expect(registry.store.has("ws:acme")).toBe(false);
+      } finally {
+        sqlite.close();
+      }
+    });
+
+    it("purges objects on an unprefixed record when ?purgeObjects=1 is passed", async () => {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("one.png", new Uint8Array([1, 2, 3]));
+      const sqlite = new SqliteD1(MIGRATIONS);
+      try {
+        const {
+          app,
+          env,
+          bucket: envBucket,
+        } = appWith({
+          kvRecords: { "ws:acme": UNPREFIXED_RECORD },
+          bucket,
+          db: sqlite,
+        });
+
+        const res = await app.request(
+          deleteRequest("acme", { force: true, hard: true, purgeObjects: true }),
+          {},
+          env,
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { objectsDeleted: number; objectsSkipped?: string };
+        expect(body.objectsDeleted).toBe(1);
+        expect(body.objectsSkipped).toBeUndefined();
+        expect(envBucket.store.has("one.png")).toBe(false);
+      } finally {
+        sqlite.close();
+      }
+    });
+
+    it("still fully purges a prefixed shared-bucket record without purgeObjects", async () => {
+      // Regression guard: the flag must not be required for the common case.
+      const bucket = new FakeR2Bucket();
+      await bucket.put("acme/one.png", new Uint8Array([1, 2, 3]));
+      const sqlite = new SqliteD1(MIGRATIONS);
+      try {
+        const {
+          app,
+          env,
+          bucket: envBucket,
+        } = appWith({
+          kvRecords: { "ws:acme": RECORD },
+          bucket,
+          db: sqlite,
+        });
+
+        const res = await app.request(deleteRequest("acme", { force: true, hard: true }), {}, env);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { objectsDeleted: number; objectsSkipped?: string };
+        expect(body.objectsDeleted).toBe(1);
+        expect(body.objectsSkipped).toBeUndefined();
+        expect(envBucket.store.has("acme/one.png")).toBe(false);
+      } finally {
+        sqlite.close();
+      }
+    });
   });
 
   describe("soft delete (default)", () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -668,7 +668,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       objectsDeleted: result.objectsDeleted,
       freedBytes: result.freedBytes,
       galleriesDeleted: result.galleriesDeleted,
-      ...(result.objectsSkipped ? { objectsSkipped: result.objectsSkipped } : {}),
+      objectsSkipped: result.objectsSkipped,
     });
   })
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -574,7 +574,10 @@ export const admin = new Hono<{ Bindings: Env }>()
    * `?hard=1`: immediate permanent teardown via `teardownWorkspace` — R2
    * objects, file_metadata + galleries rows, best-effort auth org, then the
    * `ws:<name>` KV key is deleted outright (the only path that frees the
-   * slug). Non-empty workspaces still require `?force=1` on top.
+   * slug). Non-empty workspaces still require `?force=1` on top. For a
+   * record with no `prefix` (dedicated bucket), R2 objects are left alone
+   * unless `?purgeObjects=1` is also passed (`objectsSkipped` in the
+   * response otherwise) — that bucket may not be platform-owned.
    */
   .delete("/workspaces/:name", async (c) => {
     const name = c.req.param("name");
@@ -588,6 +591,13 @@ export const admin = new Hono<{ Bindings: Env }>()
 
     const hard = c.req.query("hard") === "1" || c.req.query("hard") === "true";
     const force = c.req.query("force") === "1" || c.req.query("force") === "true";
+    // Escape hatch for a record with no `prefix` (dedicated bucket):
+    // teardownWorkspace skips the R2 object walk-and-delete by default for
+    // those, since the bucket may be a customer's own. This flag is the
+    // operator's explicit confirmation that it's platform-owned and really
+    // meant to be emptied.
+    const purgeObjects =
+      c.req.query("purgeObjects") === "1" || c.req.query("purgeObjects") === "true";
 
     if (!hard) {
       // The already-deleted guard lives inside the mutation so it sees the
@@ -646,6 +656,7 @@ export const admin = new Hono<{ Bindings: Env }>()
     const result = await teardownWorkspace(c.env, name, record, {
       reason: "admin_hard_delete",
       force: true,
+      purgeObjects,
     });
 
     return c.json({
@@ -657,6 +668,7 @@ export const admin = new Hono<{ Bindings: Env }>()
       objectsDeleted: result.objectsDeleted,
       freedBytes: result.freedBytes,
       galleriesDeleted: result.galleriesDeleted,
+      ...(result.objectsSkipped ? { objectsSkipped: result.objectsSkipped } : {}),
     });
   })
 

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -153,6 +153,12 @@ reports.post("/", async (c) => {
 
   // Attachment after D1 so failures don't orphan objects without a row.
   // If R2 fails, delete the D1 row so we never report success without a complete write.
+  //
+  // Deliberately pinned to the platform's own UPLOADS_DEFAULT binding, never
+  // routed through a workspace's storage() config: an abuse report isn't
+  // scoped to any workspace (this route has no workspace context at all), so
+  // there's no per-tenant bucket to prefer. Keep this direct even once BYO
+  // storage ships elsewhere in the API.
   if (attachmentBytesPayload && attachmentKey && c.env.UPLOADS_DEFAULT) {
     try {
       await c.env.UPLOADS_DEFAULT.put(attachmentKey, attachmentBytesPayload, {

--- a/apps/api/src/secrets.ts
+++ b/apps/api/src/secrets.ts
@@ -12,6 +12,8 @@
  * then remove PREVIOUS after verification.
  */
 
+import { ServiceUnavailableError } from "@uploads/errors";
+
 const PREFIX = "enc:v1:";
 
 /** Current + optional previous master secrets for decrypt during rotation. */
@@ -140,6 +142,26 @@ export async function sealCredentialFields(
     out.secretAccessKey = await encryptSecret(masterSecret, fields.secretAccessKey);
   }
   return out;
+}
+
+/**
+ * Strict variant of {@link sealCredentialFields} for self-serve write paths
+ * (self-serve BYO bucket save/rotate): throws `secrets_key_unconfigured`
+ * instead of silently falling through to plaintext when the KEK is missing.
+ * Existing migration/operator paths keep using `sealCredentialFields` —
+ * this does not change that function's behavior.
+ */
+export async function sealCredentialFieldsStrict(
+  masterSecret: string | undefined,
+  fields: { accessKeyId?: string; secretAccessKey?: string },
+): Promise<{ accessKeyId?: string; secretAccessKey?: string }> {
+  if (!masterSecret) {
+    throw new ServiceUnavailableError(
+      "WORKSPACE_SECRETS_KEY is not configured; storage credentials cannot be saved",
+      { code: "secrets_key_unconfigured" },
+    );
+  }
+  return sealCredentialFields(masterSecret, fields);
 }
 
 /**

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -1,3 +1,4 @@
+import { ServiceUnavailableError } from "@uploads/errors";
 import {
   createStorage,
   publicAndEmbedUrls,
@@ -28,15 +29,33 @@ export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<Stor
   if (ws.binding) {
     const candidate: unknown = Reflect.get(env, ws.binding);
     if (!candidate || typeof (candidate as R2Bucket).get !== "function") {
-      throw new Error(`workspace references unknown R2 binding "${ws.binding}"`);
+      // A config/deploy mismatch (wrangler.jsonc binding renamed or removed
+      // while the workspace record still names it) — an operator fix, not a
+      // caller mistake, so 503 rather than a 4xx. Never a 500: the route
+      // layer's onError translates AppError subclasses via respondError.
+      throw new ServiceUnavailableError(`workspace references unknown R2 binding "${ws.binding}"`, {
+        code: "storage_misconfigured",
+        details: { binding: ws.binding },
+      });
     }
     binding = candidate as R2Bucket;
   }
   const ring = secretsKeyRingFromEnv(env);
-  const opened = await openCredentialFields(ring, {
-    accessKeyId: ws.accessKeyId,
-    secretAccessKey: ws.secretAccessKey,
-  });
+  let opened: Awaited<ReturnType<typeof openCredentialFields>>;
+  try {
+    opened = await openCredentialFields(ring, {
+      accessKeyId: ws.accessKeyId,
+      secretAccessKey: ws.secretAccessKey,
+    });
+  } catch (err) {
+    // Missing/rotated WORKSPACE_SECRETS_KEY, or corrupt ciphertext — surface
+    // as a typed, non-retryable-looking 503 with a settings-page hint instead
+    // of letting the raw decrypt error bubble as an opaque 500.
+    throw new ServiceUnavailableError(
+      "workspace storage credentials could not be decrypted; reconfigure storage in workspace settings",
+      { code: "storage_credentials_unreadable", cause: err },
+    );
+  }
   // During rotation, previous-key decrypts still work; re-seal offline with the script.
   if (opened.usedPrevious) {
     console.log(

--- a/apps/api/src/workspace-teardown.ts
+++ b/apps/api/src/workspace-teardown.ts
@@ -76,6 +76,7 @@ export async function teardownWorkspace(
 ): Promise<TeardownResult> {
   const force = opts.force ?? true;
   const skipObjects = isUnprefixedDedicatedBucket(record) && !opts.purgeObjects;
+  const objectsSkipped = skipObjects ? ("dedicated-bucket" as const) : undefined;
 
   let objectCount = 0;
   let freedBytes = 0;
@@ -127,14 +128,9 @@ export async function teardownWorkspace(
       objectsDeleted: objectCount,
       freedBytes,
       galleriesDeleted: galleries,
-      objectsSkipped: skipObjects ? "dedicated-bucket" : undefined,
+      objectsSkipped,
     }),
   );
 
-  return {
-    objectsDeleted: objectCount,
-    freedBytes,
-    galleriesDeleted: galleries,
-    ...(skipObjects ? { objectsSkipped: "dedicated-bucket" as const } : {}),
-  };
+  return { objectsDeleted: objectCount, freedBytes, galleriesDeleted: galleries, objectsSkipped };
 }

--- a/apps/api/src/workspace-teardown.ts
+++ b/apps/api/src/workspace-teardown.ts
@@ -8,12 +8,22 @@
  * Ordering is fail-safe: the KV record — the thing that actually grants
  * storage access — is written/deleted last, so a failure partway through
  * leaves the workspace inert rather than half-deleted-but-still-reachable.
+ *
+ * R2 objects are only walked-and-deleted for prefixed shared-bucket records
+ * by default; an unprefixed dedicated bucket (platform-provisioned, or once
+ * self-serve BYO ships, a customer's own) is skipped unless the caller
+ * passes `purgeObjects: true` (see `TeardownOptions`, issue #583) — platform
+ * state is still torn down either way.
  */
 import { deleteFileMetadataForWorkspace } from "./file-metadata";
 import { deleteGalleriesForWorkspace } from "./galleries";
 import { deleteOrg } from "./org-workspaces";
 import { storage } from "./storage";
-import type { PurgedTombstone, WorkspaceRecord } from "./workspace";
+import {
+  isUnprefixedDedicatedBucket,
+  type PurgedTombstone,
+  type WorkspaceRecord,
+} from "./workspace";
 
 // files-sdk bulk-delete batch size — mirrors retention.ts's DELETE_BATCH
 // (stays under R2/S3's 1000-key DeleteObjects cap while bounding memory).
@@ -34,12 +44,28 @@ export interface TeardownOptions {
    * reserved. When false/omitted, the key is deleted (frees the slug).
    */
   replaceWithTombstone?: boolean;
+  /**
+   * Explicit opt-in to walk-and-delete R2 objects on an unprefixed
+   * dedicated-bucket record (`isUnprefixedDedicatedBucket`). Default false:
+   * those records skip the object purge (see `objectsSkipped` below) because
+   * the bucket may not be ours to empty. Operator-only — thread this from a
+   * caller that has confirmed the bucket is platform-owned, never from an
+   * automated sweep. Ignored (has no effect) on prefixed shared-bucket
+   * records, which are always fully purged.
+   */
+  purgeObjects?: boolean;
 }
 
 export interface TeardownResult {
   objectsDeleted: number;
   freedBytes: number;
   galleriesDeleted: number;
+  /**
+   * Set when the R2 object walk-and-delete was skipped because the record
+   * is an unprefixed dedicated bucket and `purgeObjects` wasn't passed.
+   * Platform state (KV/D1/galleries) is still torn down normally.
+   */
+  objectsSkipped?: "dedicated-bucket";
 }
 
 export async function teardownWorkspace(
@@ -49,23 +75,26 @@ export async function teardownWorkspace(
   opts: TeardownOptions,
 ): Promise<TeardownResult> {
   const force = opts.force ?? true;
+  const skipObjects = isUnprefixedDedicatedBucket(record) && !opts.purgeObjects;
 
-  const store = await storage(env, record);
   let objectCount = 0;
   let freedBytes = 0;
-  let batch: string[] = [];
-  for await (const item of store.listAll()) {
-    objectCount += 1;
-    freedBytes += item.size ?? 0;
-    if (force) {
-      batch.push(item.key);
-      if (batch.length >= R2_DELETE_BATCH) {
-        await store.delete(batch);
-        batch = [];
+  if (!skipObjects) {
+    const store = await storage(env, record);
+    let batch: string[] = [];
+    for await (const item of store.listAll()) {
+      objectCount += 1;
+      freedBytes += item.size ?? 0;
+      if (force) {
+        batch.push(item.key);
+        if (batch.length >= R2_DELETE_BATCH) {
+          await store.delete(batch);
+          batch = [];
+        }
       }
     }
+    if (batch.length > 0) await store.delete(batch);
   }
-  if (batch.length > 0) await store.delete(batch);
 
   const { galleries } = await deleteGalleriesForWorkspace(env.DB, name);
   await deleteFileMetadataForWorkspace(env.DB, name);
@@ -98,8 +127,14 @@ export async function teardownWorkspace(
       objectsDeleted: objectCount,
       freedBytes,
       galleriesDeleted: galleries,
+      objectsSkipped: skipObjects ? "dedicated-bucket" : undefined,
     }),
   );
 
-  return { objectsDeleted: objectCount, freedBytes, galleriesDeleted: galleries };
+  return {
+    objectsDeleted: objectCount,
+    freedBytes,
+    galleriesDeleted: galleries,
+    ...(skipObjects ? { objectsSkipped: "dedicated-bucket" as const } : {}),
+  };
 }

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  hasCustomerCredentials,
   hexToBytes,
   isPurgedTombstone,
   isSha256Hex,
+  isUnprefixedDedicatedBucket,
   loadWorkspaceRecord,
   loadWorkspaceRecordRaw,
   WORKSPACE_DELETE_GRACE_DAYS,
@@ -100,5 +102,45 @@ describe("isSha256Hex / hexToBytes (corrupt token-hash guard)", () => {
     expect(isSha256Hex("")).toBe(false);
     expect(isSha256Hex("a".repeat(63))).toBe(false);
     expect(isSha256Hex("a".repeat(65))).toBe(false);
+  });
+});
+
+describe("isUnprefixedDedicatedBucket / hasCustomerCredentials (#583 lifecycle guards)", () => {
+  it("is false for a prefixed shared-bucket record", () => {
+    expect(isUnprefixedDedicatedBucket(RECORD)).toBe(false);
+  });
+
+  it("is true for a record with no prefix, regardless of credential mode", () => {
+    expect(isUnprefixedDedicatedBucket({ ...RECORD, prefix: undefined })).toBe(true);
+    expect(
+      isUnprefixedDedicatedBucket({
+        ...RECORD,
+        prefix: undefined,
+        binding: undefined,
+        accountId: "a".repeat(32),
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an empty-string prefix the same as absent (unprefixed)", () => {
+    expect(isUnprefixedDedicatedBucket({ ...RECORD, prefix: "" })).toBe(true);
+  });
+
+  it("hasCustomerCredentials requires all three fields", () => {
+    expect(hasCustomerCredentials(RECORD)).toBe(false);
+    expect(hasCustomerCredentials({ ...RECORD, accessKeyId: "key" })).toBe(false);
+    expect(
+      hasCustomerCredentials({ ...RECORD, accessKeyId: "key", secretAccessKey: "secret" }),
+    ).toBe(false);
+    expect(
+      hasCustomerCredentials({
+        ...RECORD,
+        accountId: "a".repeat(32),
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  hasCustomerCredentials,
   hexToBytes,
   isPurgedTombstone,
   isSha256Hex,
@@ -105,7 +104,7 @@ describe("isSha256Hex / hexToBytes (corrupt token-hash guard)", () => {
   });
 });
 
-describe("isUnprefixedDedicatedBucket / hasCustomerCredentials (#583 lifecycle guards)", () => {
+describe("isUnprefixedDedicatedBucket (#583 lifecycle guards)", () => {
   it("is false for a prefixed shared-bucket record", () => {
     expect(isUnprefixedDedicatedBucket(RECORD)).toBe(false);
   });
@@ -126,21 +125,5 @@ describe("isUnprefixedDedicatedBucket / hasCustomerCredentials (#583 lifecycle g
 
   it("treats an empty-string prefix the same as absent (unprefixed)", () => {
     expect(isUnprefixedDedicatedBucket({ ...RECORD, prefix: "" })).toBe(true);
-  });
-
-  it("hasCustomerCredentials requires all three fields", () => {
-    expect(hasCustomerCredentials(RECORD)).toBe(false);
-    expect(hasCustomerCredentials({ ...RECORD, accessKeyId: "key" })).toBe(false);
-    expect(
-      hasCustomerCredentials({ ...RECORD, accessKeyId: "key", secretAccessKey: "secret" }),
-    ).toBe(false);
-    expect(
-      hasCustomerCredentials({
-        ...RECORD,
-        accountId: "a".repeat(32),
-        accessKeyId: "key",
-        secretAccessKey: "secret",
-      }),
-    ).toBe(true);
   });
 });

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -229,17 +229,6 @@ export function isUnprefixedDedicatedBucket(record: WorkspaceRecord): boolean {
   return !record.prefix;
 }
 
-/**
- * True when the record carries customer-supplied R2 credentials (BYO
- * bucket) rather than resolving I/O through a platform wrangler `binding`.
- * Both are "unprefixed dedicated buckets" per the predicate above and are
- * guarded the same way by default; this only distinguishes the two for
- * logging/telemetry, since only this case is literally not our bucket.
- */
-export function hasCustomerCredentials(record: WorkspaceRecord): boolean {
-  return Boolean(record.accessKeyId && record.secretAccessKey && record.accountId);
-}
-
 function bearerToken(header: string | undefined): string {
   return header?.startsWith("Bearer ") ? header.slice(7) : "";
 }

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -217,6 +217,29 @@ export function workspaceTokenHashes(record: WorkspaceRecord): string[] {
   return record.tokens?.map((t) => t.hash) ?? (record.tokenHash ? [record.tokenHash] : []);
 }
 
+/**
+ * True when I/O for this record spans an entire dedicated bucket rather
+ * than a confined `prefix` slice of a shared one. Platform lifecycle jobs
+ * (teardown, retention, reconcile) must not assume they own every object in
+ * a bucket like this — once self-serve BYO ships (issue #583) an unprefixed
+ * record may be a customer's own bucket, where a `listAll()` + batch delete
+ * would erase everything they own, not just what uploads.sh wrote.
+ */
+export function isUnprefixedDedicatedBucket(record: WorkspaceRecord): boolean {
+  return !record.prefix;
+}
+
+/**
+ * True when the record carries customer-supplied R2 credentials (BYO
+ * bucket) rather than resolving I/O through a platform wrangler `binding`.
+ * Both are "unprefixed dedicated buckets" per the predicate above and are
+ * guarded the same way by default; this only distinguishes the two for
+ * logging/telemetry, since only this case is literally not our bucket.
+ */
+export function hasCustomerCredentials(record: WorkspaceRecord): boolean {
+  return Boolean(record.accessKeyId && record.secretAccessKey && record.accountId);
+}
+
 function bearerToken(header: string | undefined): string {
   return header?.startsWith("Bearer ") ? header.slice(7) : "";
 }

--- a/apps/api/test/reconcile-retention.test.ts
+++ b/apps/api/test/reconcile-retention.test.ts
@@ -84,6 +84,20 @@ describe("POST /usage/reconcile", () => {
     expect(body.usage.bytes).toBe(PNG.byteLength);
   });
 
+  it("flags an unprefixed/dedicated-bucket record in the result (#583 telemetry)", async () => {
+    const { env, bucket } = await makeEnv({ prefix: undefined });
+    await bucket.put("orphan.png", PNG, { httpMetadata: { contentType: "image/png" } });
+
+    const res = await app.request(
+      "/v1/default/usage/reconcile",
+      { method: "POST", headers: auth },
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { unprefixedBucket?: boolean };
+    expect(body.unprefixedBucket).toBe(true);
+  });
+
   it("requires files:write", async () => {
     const { env } = await makeEnv();
     // No auth
@@ -131,5 +145,23 @@ describe("POST /usage/purge-expired", () => {
     expect(bucket.store.has("default/new.png")).toBe(true);
     expect(body.reconcile.objects).toBe(1);
     expect(body.reconcile.bytes).toBe(PNG.byteLength);
+  });
+
+  it("skips an unprefixed/dedicated-bucket record even with retentionDays set (#583)", async () => {
+    const { env, bucket } = await makeEnv({ retentionDays: 30, prefix: undefined });
+    await bucket.put("old.png", PNG, { httpMetadata: { contentType: "image/png" } });
+    bucket.setUploaded("old.png", new Date("2020-01-01T00:00:00Z"));
+
+    const res = await app.request(
+      "/v1/default/usage/purge-expired",
+      { method: "POST", headers: auth },
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { skipped: true; reason: string };
+    expect(body.skipped).toBe(true);
+    expect(body.reason).toMatch(/unprefixed|dedicated/);
+    // Nothing was touched.
+    expect(bucket.store.has("old.png")).toBe(true);
   });
 });

--- a/apps/api/test/retention-sweep.test.ts
+++ b/apps/api/test/retention-sweep.test.ts
@@ -10,10 +10,14 @@ const MIGRATIONS = [
   "migrations/20260710140000_workspace_usage.sql",
 ];
 
+// Prefixed shared-bucket record — the common case, and the baseline these
+// tests confirm is unaffected by the dedicated-bucket teardown/retention
+// guards (see the dedicated-bucket describe blocks below for those).
 const RECORD: WorkspaceRecord = {
   provider: "r2",
   bucket: "shared",
   binding: "BUCKET",
+  prefix: "acme/",
   publicBaseUrl: "https://storage.uploads.sh",
 };
 
@@ -91,7 +95,7 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {
       const bucket = new FakeR2Bucket();
-      await bucket.put("f/one.png", new Uint8Array([1, 2, 3]));
+      await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
       const record: WorkspaceRecord = {
         ...RECORD,
         deletedAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
@@ -120,7 +124,7 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {
       const bucket = new FakeR2Bucket();
-      await bucket.put("f/one.png", new Uint8Array([1, 2, 3]));
+      await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
       const record: WorkspaceRecord = {
         ...RECORD,
         deletedAt: new Date().toISOString(),
@@ -131,7 +135,7 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
       const result = await runRetentionSweep(env);
 
       expect(result.workspacesFinalized).toHaveLength(0);
-      expect(bucket.store.has("f/one.png")).toBe(true);
+      expect(bucket.store.has("acme/f/one.png")).toBe(true);
       expect(registry.store.get("ws:acme")).toEqual(record);
     } finally {
       sqlite.close();
@@ -142,7 +146,7 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {
       const bucket = new FakeR2Bucket();
-      await bucket.put("f/one.png", new Uint8Array([1, 2, 3]));
+      await bucket.put("acme/f/one.png", new Uint8Array([1, 2, 3]));
       const record: WorkspaceRecord = {
         ...RECORD,
         deletedAt: new Date().toISOString(),
@@ -154,7 +158,7 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
 
       expect(result.workspacesFinalized).toHaveLength(1);
       expect(result.workspacesFinalized[0]?.error).toMatch(/unparseable purgeAt/);
-      expect(bucket.store.has("f/one.png")).toBe(true);
+      expect(bucket.store.has("acme/f/one.png")).toBe(true);
       expect(registry.store.get("ws:acme")).toEqual(record);
     } finally {
       sqlite.close();
@@ -185,10 +189,10 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
     const sqlite = new SqliteD1(MIGRATIONS);
     try {
       const bucket = new FakeR2Bucket();
-      await bucket.put("old.png", new Uint8Array([1, 2, 3]), {
+      await bucket.put("acme/old.png", new Uint8Array([1, 2, 3]), {
         httpMetadata: { contentType: "image/png" },
       });
-      bucket.setUploaded("old.png", new Date("2020-01-01T00:00:00Z"));
+      bucket.setUploaded("acme/old.png", new Date("2020-01-01T00:00:00Z"));
       const record: WorkspaceRecord = { ...RECORD, retentionDays: 30 };
       const { env } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
 
@@ -196,7 +200,94 @@ describe("runRetentionSweep — soft-delete finalization (#247)", () => {
 
       expect(result.workspacesWithRetention).toBe(1);
       expect(result.purged).toEqual([{ workspace: "acme", deleted: 1, freedBytes: 3 }]);
-      expect(bucket.store.has("old.png")).toBe(false);
+      expect(bucket.store.has("acme/old.png")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("runRetentionSweep — unprefixed/dedicated-bucket guard (#583)", () => {
+  it("finalizes a past-purgeAt unprefixed record without deleting its objects", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      // No prefix: the fake bucket's raw keys ARE the workspace's objects.
+      await bucket.put("one.png", new Uint8Array([1, 2, 3]));
+      const record: WorkspaceRecord = {
+        ...RECORD,
+        prefix: undefined,
+        deletedAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
+        purgeAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      const {
+        env,
+        registry,
+        bucket: b,
+      } = makeEnv({
+        kvRecords: { "ws:acme": record },
+        bucket,
+        db: sqlite,
+      });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesFinalized).toHaveLength(1);
+      expect(result.workspacesFinalized[0]).toMatchObject({
+        workspace: "acme",
+        objectsDeleted: 0,
+        objectsSkipped: "dedicated-bucket",
+      });
+      // Objects are left alone...
+      expect(b.store.has("one.png")).toBe(true);
+      // ...but platform state (the KV record) is still torn down to a tombstone.
+      const stored = registry.store.get("ws:acme") as PurgedTombstone;
+      expect(stored.status).toBe("purged");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("still purges a prefixed shared-bucket record's objects on finalize", async () => {
+    // Regression guard for the case above: RECORD (with its "acme/" prefix)
+    // must keep the pre-existing full-purge finalize behavior.
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("acme/one.png", new Uint8Array([1, 2, 3]));
+      const record: WorkspaceRecord = {
+        ...RECORD,
+        deletedAt: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString(),
+        purgeAt: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      const { env, bucket: b } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesFinalized[0]).toMatchObject({ objectsDeleted: 1 });
+      expect(result.workspacesFinalized[0]).not.toHaveProperty("objectsSkipped");
+      expect(b.store.has("acme/one.png")).toBe(false);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("skips retention purge for an unprefixed record even with retentionDays set", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("old.png", new Uint8Array([1, 2, 3]));
+      bucket.setUploaded("old.png", new Date("2020-01-01T00:00:00Z"));
+      const record: WorkspaceRecord = { ...RECORD, prefix: undefined, retentionDays: 30 };
+      const { env, bucket: b } = makeEnv({ kvRecords: { "ws:acme": record }, bucket, db: sqlite });
+
+      const result = await runRetentionSweep(env);
+
+      expect(result.workspacesWithRetention).toBe(1);
+      expect(result.purged).toEqual([
+        { workspace: "acme", deleted: 0, freedBytes: 0, skipped: true },
+      ]);
+      expect(b.store.has("old.png")).toBe(true);
     } finally {
       sqlite.close();
     }

--- a/apps/api/test/secrets.test.ts
+++ b/apps/api/test/secrets.test.ts
@@ -1,3 +1,4 @@
+import { ServiceUnavailableError } from "@uploads/errors";
 import { describe, expect, it } from "vitest";
 import {
   decryptSecret,
@@ -6,6 +7,7 @@ import {
   openCredentialFields,
   resealCredentialFields,
   sealCredentialFields,
+  sealCredentialFieldsStrict,
   secretsKeyRingFromEnv,
 } from "../src/secrets";
 
@@ -88,5 +90,27 @@ describe("workspace secret encryption", () => {
   it("leaves fields alone without master secret", async () => {
     const fields = { accessKeyId: "AKIA", secretAccessKey: "secret" };
     expect(await sealCredentialFields(undefined, fields)).toEqual(fields);
+  });
+
+  describe("sealCredentialFieldsStrict", () => {
+    it("throws secrets_key_unconfigured without a master secret, instead of returning plaintext", async () => {
+      const fields = { accessKeyId: "AKIA", secretAccessKey: "secret" };
+      await expect(sealCredentialFieldsStrict(undefined, fields)).rejects.toMatchObject({
+        code: "secrets_key_unconfigured",
+      });
+      await expect(sealCredentialFieldsStrict(undefined, fields)).rejects.toBeInstanceOf(
+        ServiceUnavailableError,
+      );
+    });
+
+    it("seals fields the same way as sealCredentialFields when a master secret is present", async () => {
+      const fields = { accessKeyId: "AKIA", secretAccessKey: "secret" };
+      const sealed = await sealCredentialFieldsStrict(CURRENT, fields);
+      expect(isEncryptedSecret(sealed.accessKeyId!)).toBe(true);
+      expect(isEncryptedSecret(sealed.secretAccessKey!)).toBe(true);
+      const opened = await openCredentialFields(CURRENT, sealed);
+      expect(opened.accessKeyId).toBe("AKIA");
+      expect(opened.secretAccessKey).toBe("secret");
+    });
   });
 });

--- a/apps/api/test/storage.test.ts
+++ b/apps/api/test/storage.test.ts
@@ -1,0 +1,86 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { respondError } from "../src/error-response";
+import { encryptSecret } from "../src/secrets";
+import { storageConfig } from "../src/storage";
+import type { WorkspaceRecord } from "../src/workspace";
+
+const sharedRecord: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "uploads-default",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+describe("storageConfig", () => {
+  it("throws storage_misconfigured for a workspace record naming an unknown R2 binding", async () => {
+    const ws: WorkspaceRecord = { ...sharedRecord, binding: "NOT_A_REAL_BINDING" };
+    const env = {} as unknown as Env;
+
+    await expect(storageConfig(env, ws)).rejects.toMatchObject({
+      code: "storage_misconfigured",
+      status: 503,
+    });
+  });
+
+  it("route layer translates the unknown-binding error to a 503 with a hint, not a 500", async () => {
+    const ws: WorkspaceRecord = { ...sharedRecord, binding: "NOT_A_REAL_BINDING" };
+    const env = {} as unknown as Env;
+    const app = new Hono<{ Bindings: Env }>()
+      .get("/check", async (c) => {
+        await storageConfig(c.env, ws);
+        return c.json({ ok: true });
+      })
+      .onError((err, c) => respondError(c, err));
+
+    const res = await app.request("/check", {}, env);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("storage_misconfigured");
+    expect(body.error.message).toContain("NOT_A_REAL_BINDING");
+  });
+
+  it("throws storage_credentials_unreadable when the ciphertext cannot be decrypted", async () => {
+    const sealed = await encryptSecret("some-other-master-secret", "AKIA");
+    const ws: WorkspaceRecord = {
+      ...sharedRecord,
+      accessKeyId: sealed,
+      secretAccessKey: sealed,
+    };
+    // No WORKSPACE_SECRETS_KEY configured at all, so decrypt has no candidate key.
+    const env = {} as unknown as Env;
+
+    await expect(storageConfig(env, ws)).rejects.toMatchObject({
+      code: "storage_credentials_unreadable",
+      status: 503,
+    });
+  });
+
+  it("route layer translates the decrypt failure to a 503, not a 500", async () => {
+    const sealed = await encryptSecret("some-other-master-secret", "AKIA");
+    const ws: WorkspaceRecord = {
+      ...sharedRecord,
+      accessKeyId: sealed,
+      secretAccessKey: sealed,
+    };
+    const env = { WORKSPACE_SECRETS_KEY: "wrong-master-secret!!!!" } as unknown as Env;
+    const app = new Hono<{ Bindings: Env }>()
+      .get("/check", async (c) => {
+        await storageConfig(c.env, ws);
+        return c.json({ ok: true });
+      })
+      .onError((err, c) => respondError(c, err));
+
+    const res = await app.request("/check", {}, env);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("storage_credentials_unreadable");
+  });
+
+  it("still resolves normally for a well-formed shared-bucket record with no credentials", async () => {
+    const env = {} as unknown as Env;
+    const cfg = await storageConfig(env, sharedRecord);
+    expect(cfg.bucket).toBe("uploads-default");
+    expect(cfg.prefix).toBe("acme/");
+  });
+});

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -407,6 +407,10 @@ export function createRemoteTools(ctx: RemoteToolContext): McpTool[] {
           ) {
             throw err;
           }
+          // Typed storage errors (storage_misconfigured, storage_credentials_unreadable,
+          // …) carry a caller-useful message already — pass them through rather
+          // than flattening into a generic message that loses the code.
+          if (err instanceof AppError) throw err;
           throw new Error("gallery storage unavailable", { cause: err });
         }
         const result = unwrapMutation(

--- a/docs/superpowers/plans/2026-07-31-self-serve-byo-r2-bucket.md
+++ b/docs/superpowers/plans/2026-07-31-self-serve-byo-r2-bucket.md
@@ -1,0 +1,492 @@
+# Self-serve BYO R2 bucket — orchestration plan
+
+> **For agentic workers:** this is an orchestration-level plan. Each phase is
+> scoped to be handed to a fresh subagent (or an external-CLI rescue lane) as an
+> independent brief; the per-task detail below is the brief. Use
+> superpowers:subagent-driven-development to execute, one task per agent, with
+> review between tasks. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** a workspace admin can point their workspace at their own R2 bucket —
+paste credentials in the web settings UI, have them verified end-to-end
+(auth, bucket access, public DNS), stored encrypted, and used for all
+subsequent I/O — without an operator or a deploy.
+
+**Architecture:** productize the existing operator-only BYO path. The storage
+seam (`storage()` → `createStorage()` → files-sdk), the workspace-record fields
+(`provider/bucket/binding/prefix/publicBaseUrl/accountId/accessKeyId/secretAccessKey`),
+and at-rest credential encryption (`secrets.ts`, AES-GCM `enc:v1:` + KEK ring)
+already exist. What's new: a member-gated write path for storage config, a
+verification pipeline (credential probe + public-URL/DNS probe), the settings
+UI, and guards on the platform jobs that assume a platform-owned bucket.
+
+**Tech stack:** Cloudflare Workers (Hono), R2 via files-sdk 2.1.0 (patched),
+KV workspace registry, Astro + vanilla-JS settings pages, Better Auth sessions
+over the `AUTH` service binding.
+
+## Global constraints
+
+- v1 is **R2-only, HTTP-credential-mode only**. No per-customer wrangler
+  bindings: bindings require a config edit + deploy per customer, which is the
+  unsustainable part of the `buildinternet` prototype. Cross-account R2 over
+  `https://<accountId>.r2.cloudflarestorage.com` with a bucket-scoped key pair
+  already works with zero deploys — that is the only mechanism v1 uses.
+  (`binding` stays supported for platform/internal workspaces; the self-serve
+  path never writes it.)
+- **BYO is declared at workspace creation in v1** (decided 2026-07-31): the
+  create flow (`/account/workspaces/new` + `POST /v1/workspaces`) is where a
+  user says they're bringing their own bucket, and the wizard runs there.
+  Settings can still attach a bucket to an _empty_ existing workspace (same
+  endpoints), and always handles rotate/re-verify/disconnect. No migration of
+  populated workspaces (keys lose the shared-bucket prefix and every published
+  URL would break); live migration and richer mappings (bucket → repo, etc.)
+  are explicitly future versions.
+- **Feature flag, off by default** (decided 2026-07-31): gate the whole
+  surface behind a per-workspace record flag `byoBucketEnabled` (precedent:
+  `videoPosterEnabled` + its fail-closed gate). Default off for everyone;
+  when the feature is ready, enable it on the `buildinternet` and `default`
+  workspaces first. Plan/billing gating is a later, separate decision — the
+  flag is the short-term gate, and Task 1.3's plan-capability mechanism ships
+  dark underneath it.
+- **Secrets are write-only through the API.** Responses carry presence booleans
+  and at most the last 4 characters of the access key id — never values
+  (precedent: `GET /admin/workspaces/:name` projection in
+  `apps/api/src/routes/admin.ts:515`).
+- **Never store plaintext credentials.** `sealCredentialFields(undefined, …)`
+  currently falls through to plaintext; the self-serve save path must hard-fail
+  (500 `secrets_key_unconfigured`) when `WORKSPACE_SECRETS_KEY` is unset.
+- All record writes go through `mutateWorkspaceRecord`
+  (`apps/api/src/workspace-mutate.ts`) — never bare `REGISTRY.put`. Seal
+  credentials _inside_ the mutation callback (precedent:
+  `apps/api/src/reencrypt-registry.ts:91`).
+- Endpoint construction is **derived, never customer-supplied**: the S3
+  endpoint is always `https://<accountId>.r2.cloudflarestorage.com` with
+  `accountId` validated as `^[0-9a-f]{32}$`. No free-form endpoint field in v1
+  (kills the SSRF surface).
+- `apps/api` and `apps/mcp` resolve storage through the same module
+  (`apps/mcp/src/tools.ts:78` imports from `@uploads/api/storage`); every new
+  config field, error type, and env var lands for both workers.
+- Keep the repo's writing conventions: docs per `AGENTS.md` "Writing docs"
+  (softened STE100), changeset only for CLI-visible changes, no sensational
+  language in PRs.
+
+---
+
+## What exists today (verified 2026-07-31)
+
+| Piece                                    | Where                                                                                                                                                                                       | Status                          |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| Record fields for BYO                    | `apps/api/src/workspace.ts` (`WorkspaceRecord`: `provider`, `bucket`, `binding`, `prefix`, `publicBaseUrl`, `accountId`, `accessKeyId`, `secretAccessKey`)                                  | shipped                         |
+| Credential encryption at rest            | `apps/api/src/secrets.ts` (AES-GCM-256, `enc:v1:`, KEK ring `WORKSPACE_SECRETS_KEY`/`_PREVIOUS`, rotation sweep `apps/api/src/reencrypt-registry.ts` + `POST /admin/credentials/reencrypt`) | shipped                         |
+| Cross-account HTTP I/O                   | files-sdk r2 adapter `r2FromHttp`; selected by `createStorage()` when the config has creds and no binding (`packages/storage/src/index.ts`)                                                 | shipped                         |
+| Single resolve seam                      | `apps/api/src/storage.ts` — `storageConfig(env, ws)` decrypts and resolves; `storage(env, ws)` returns a `Files`                                                                            | shipped                         |
+| Prefix confinement + BYO-mode semantics  | `packages/storage/test/prefix-confinement.test.ts` (includes "unprefixed instance sees the whole bucket")                                                                                   | shipped                         |
+| Operator provisioning                    | `apps/api/scripts/add-workspace.mjs` (`--bucket --account-id --access-key-id --secret-access-key --public-base-url`)                                                                        | shipped, operator-only          |
+| Reference deployment                     | `buildinternet` workspace on `buildinternet-dev` — **binding-mode prototype; treat as a learning artifact, not the pattern** (per Zach)                                                     | shipped                         |
+| Self-serve write path for storage config | —                                                                                                                                                                                           | **missing (core of this plan)** |
+| Credential/bucket verification           | — (bad creds today = 500 at next upload)                                                                                                                                                    | **missing**                     |
+| Public-URL/DNS verification              | —                                                                                                                                                                                           | **missing**                     |
+| Settings UI for storage                  | — (admin panel is read-only presence booleans)                                                                                                                                              | **missing**                     |
+
+## The customer-side setup (what the UI must walk them through)
+
+The wizard documents these steps and verifies each one server-side:
+
+1. **Create an R2 bucket** in their Cloudflare account (any name, any
+   jurisdiction — record the jurisdiction caveat: v1 supports the default
+   endpoint only; `eu`/`fedramp` jurisdiction endpoints are a fast-follow flag).
+2. **Create a bucket-scoped R2 API token**: Cloudflare dashboard → R2 → Manage
+   API Tokens → "Object Read & Write", scoped to that one bucket. This yields
+   the Access Key ID / Secret Access Key pair plus their account id. The UI
+   copy insists on bucket-scoped (not account-wide) tokens so our blast radius
+   if the KEK is ever compromised is one bucket, not their account.
+3. **Public access for serving** — one of:
+   - **Custom domain** (recommended): connect a domain to the bucket
+     (R2 → bucket → Settings → Public access → Custom domains). Requires the
+     domain to be on a Cloudflare zone in their account; Cloudflare provisions
+     the DNS record + cert. They paste the resulting
+     `https://media.example.com` as the public base URL.
+   - **`r2.dev` managed URL**: **not supported in v1** (decided 2026-07-31).
+     The verify pipeline rejects `*.r2.dev` public base URLs with a dedicated
+     check + copy along the lines of "r2.dev URLs aren't supported right now —
+     connect a custom domain, or save without a public URL for signed-only
+     access." Revisit later.
+   - **No public access**: allowed but degraded — uploads work, and file access
+     falls back to signed URLs (the `/me/workspaces/:name/file-url` resolver
+     already degrades public → signed → typed error). GitHub embeds won't work
+     without a public base URL; the UI must say so plainly.
+
+## Verification pipeline (server-side, the heart of the feature)
+
+`POST /me/workspaces/:name/storage/verify` — runs against _candidate_ config
+(request body), not saved state, so users can iterate before anything is
+persisted. Response modeled on `GithubHealthResult`
+(`apps/api/src/routes/github-health.ts`): `configured` vs `ok`, required vs
+recommended checks, per-check `hint` naming the exact remediation.
+
+Required checks, in order, short-circuiting:
+
+1. **Shape**: `accountId` matches `^[0-9a-f]{32}$`; bucket name matches R2
+   rules (3–63 chars, `^[a-z0-9][a-z0-9-]*[a-z0-9]$`); key pair non-empty.
+2. **Auth + bucket reachability**: `head`/`list` (limit 1) against the derived
+   endpoint. Distinguish DNS/network failure vs 401/403 (bad or mis-scoped
+   token) vs 404 (bucket name typo) in the hint.
+3. **Write/read/delete round-trip**: put a probe object under
+   `_internal/uploads-verify/<random>` with a random body, `get` it back,
+   compare bytes, delete it. Proves the token is Object Read & **Write** and
+   the bucket is actually writable.
+4. **Empty-bucket / takeover guard**: `list` must show zero non-probe objects
+   when attaching a bucket for the first time **unless** the user explicitly
+   confirms an "adopt existing contents" checkbox (recorded in the request).
+   This both enforces the empty-workspace constraint and prevents pointing a
+   workspace at a bucket whose contents the token holder didn't intend to
+   expose.
+
+Recommended checks (never flip `ok`):
+
+5. **Public base URL probe** (only when a `publicBaseUrl` was supplied): the
+   URL must be `https:`, a syntactically valid host, not resolve to the
+   platform's own hosts (`storage.uploads.sh`, `embed.uploads.sh`, any
+   `*.uploads.sh`), and **not be a `*.r2.dev` host** (rejected with the
+   "not supported right now" copy above — this one is a _required_ failure,
+   not a warning). Then fetch `<publicBaseUrl>/<probe-key>` while the probe
+   object from step 3 still exists and require the same bytes back. This
+   proves DNS + custom-domain wiring end-to-end in one shot. Timeout ~5s;
+   failure hint distinguishes NXDOMAIN/timeout ("domain not connected to the
+   bucket yet — DNS can take a few minutes") from 401/404 ("domain is
+   connected to a different bucket or public access is disabled").
+6. **Cache behavior note**: HEAD the probe URL and report whether the platform
+   `Cache-Control: public, max-age=60` came back, so overwrite-freshness
+   behavior is known (see `uploads-edge-cache-freshness` history).
+7. **Embed twin**: report `embed: unsupported` for BYO hosts (the
+   `DEFAULT_EMBEDDABLE_HOSTS` allowlist in `packages/storage/src/index.ts`
+   doesn't extend to them) with a doc link. Camo-revalidation for BYO domains
+   is a deferred fast-follow, not silently broken.
+
+Abuse controls: verify is rate-limited per user (reuse `allowWrite` /
+dedicated limiter, ~5/min), probes carry a per-request random key so
+concurrent verifies can't collide, and the endpoint never echoes the secret
+back in any error path. Probe fetches must never follow redirects to
+non-https and must cap response size read (compare via hash of first N KB).
+
+---
+
+## Phase 0 — hardening prerequisites (independent, parallelizable)
+
+Small, self-contained tasks; each is one subagent brief and one PR (or one
+stacked series). All are safe to land before any UI exists.
+
+### Task 0.1: teardown/retention guard for unprefixed buckets
+
+- **Files:** `apps/api/src/workspace-teardown.ts`, `apps/api/src/retention.ts`,
+  `apps/api/src/reconcile.ts` + colocated tests.
+- `teardownWorkspace` on a record with no `prefix` and customer creds must
+  **not** walk-and-delete the bucket. Policy: BYO teardown deletes platform
+  state (KV record, D1 rows, galleries) and _leaves the customer's objects in
+  their bucket_, reporting `objectsSkipped: "byo-bucket"` in the teardown
+  summary. Add an explicit operator-only `--purge-objects` escape hatch for
+  platform-owned dedicated buckets. Retention/reconcile: skip or
+  page-limit full-bucket `listAll()` walks on BYO records (their storage,
+  their lifecycle rules; document that `retentionDays` is unsupported on BYO
+  in v1).
+
+### Task 0.2: typed errors out of the storage seam
+
+- **Files:** `apps/api/src/storage.ts` (+ its error surface in
+  `apps/api/src/errors.ts` or equivalent), tests.
+- `storageConfig` throwing on an unknown binding or failed decrypt currently
+  becomes a 500. Map to typed errors (`storage_misconfigured`,
+  `storage_credentials_unreadable`) that routes translate to 4xx/503 with a
+  hint pointing at the settings page. Also: `sealCredentialFields` gets a
+  strict variant (`sealCredentialFieldsStrict`) that throws
+  `secrets_key_unconfigured` when the KEK is missing — used by every
+  self-serve write path.
+
+### Task 0.3: single sealing implementation
+
+- **Files:** `apps/api/scripts/add-workspace.mjs`,
+  `apps/api/src/secrets.ts`, tests.
+- The `enc:v1:` format exists twice (`secrets.ts` WebCrypto +
+  `add-workspace.mjs:39` Node crypto). Make the script import the WebCrypto
+  implementation (Node ≥20 has `globalThis.crypto`) and delete the duplicate.
+
+### Task 0.4: pin platform-owned writes
+
+- **Files:** `apps/api/src/routes/reports.ts:102`.
+- The abuse-report attachment writes to `c.env.UPLOADS_DEFAULT` directly and
+  correctly so — add the comment that this is deliberate platform storage,
+  never workspace-routed, so nobody "fixes" it into a customer bucket.
+
+## Phase 1 — API surface (after Phase 0; blocks Phase 2)
+
+### Task 1.1: storage config read/verify/write routes
+
+- **Files:** new `apps/api/src/routes/workspace-storage.ts` (or a section in
+  `apps/api/src/routes/me.ts` following the comment-settings triple), new
+  `apps/api/src/storage-verify.ts` (probe pipeline, pure + injectable S3
+  client for tests), `apps/api/src/workspace.ts` (new fields, below),
+  `apps/api/src/env.d.ts` + `apps/mcp/src/env.d.ts`, tests beside each.
+- **Routes** (all `sessionAuth` + `requireSessionUser` +
+  `adminWorkspaceOr403`, writes behind `allowWrite`):
+  - `GET /me/workspaces/:name/storage` → `{ mode: "shared" | "byo",
+bucket?, accountIdMasked?, accessKeyIdLast4?, publicBaseUrl?,
+verifiedAt?, verify?: <last verify summary> }`. Never values.
+  - `POST /me/workspaces/:name/storage/verify` → runs the pipeline above on
+    the request body; persists nothing.
+  - `PUT /me/workspaces/:name/storage` → requires a passing _required_ check
+    set within the same request (re-runs the pipeline server-side; never
+    trusts a client-side "verified" claim), then
+    `mutateWorkspaceRecord` with: `bucket`, `accountId`,
+    sealed creds (strict), `publicBaseUrl?`, `prefix` removed, and
+    guard-in-callback that the workspace still has zero objects/usage unless
+    `adoptExistingContents` was set. Stamps `storageConfiguredAt`,
+    `storageVerifiedAt`, `storageConfiguredBy: userId`.
+  - `DELETE /me/workspaces/:name/storage` → detach: only valid when the
+    workspace is empty (or force-flagged); restores shared-bucket defaults
+    from `self-serve-defaults.ts`. Never deletes customer objects.
+- **Record additions** (`WorkspaceRecord`): `storageConfiguredAt?`,
+  `storageVerifiedAt?`, `storageConfiguredBy?` — provenance + the settings
+  UI's "verified ✓ 3 days ago" line. No new secret fields.
+- **Audit**: log configure/verify/detach events (structured log line at
+  minimum; reuse the pattern behind `credential_decrypted_with_previous_key`).
+
+### Task 1.2: budget/metering policy for BYO
+
+- **Files:** `apps/api/src/budget.ts`, `packages/billing/src/resolve.ts` (or a
+  pure predicate beside `workspace-cap.ts`), `apps/api/src/usage.ts` docs,
+  tests.
+- Policy: on BYO records, `maxStorageBytes` is **not enforced** (their disk),
+  but usage is still _recorded_ (D1 ledger powers the UI and any future
+  gateway pricing). `maxUploadBytes` / `maxVideoUploadBytes` /
+  `maxUploadsPerPeriod` stay enforced (they protect platform compute, not
+  storage). Implement as a pure `storageBudgetApplies(record)` predicate so
+  enforcement and display read the same seam.
+
+### Task 1.3: feature flag + plan gating hook
+
+- **Files:** `apps/api/src/workspace.ts` (`byoBucketEnabled?: boolean` on the
+  record), gate enforced in Task 1.1's routes (verify + PUT + the create-flow
+  branch), surfaced in the GET response so the UI can hide the panel;
+  `packages/billing/src/plans.ts` capability flag `byoBucket` on
+  `PlanDefinition` as the dark-shipped future gate; pure predicate module
+  beside `workspace-cap.ts`; tests.
+- **Short-term gate is the record flag, off by default, fail-closed**
+  (precedent: `videoPosterEnabled`). Only an operator can set it
+  (admin-ui limits/plan PATCH pattern). At enable-time: turn it on for
+  `buildinternet` and `default`. The plan-capability predicate lands with
+  `byoBucket: true` on all plans so a future billing decision is a one-line
+  flip underneath the record flag. Follow the `marketsMemberCap` precedent —
+  callers read the predicate, never a plan-id switch.
+
+## Phase 2 — web settings UI (after Phase 1)
+
+### Task 2.1: create-flow BYO path + Storage panel on workspace settings
+
+- **Files:** `apps/web/src/pages/account/workspaces/new.astro` (create form
+  gains a "bring your own bucket" option, visible only when the flag allows),
+  `apps/web/src/pages/account/workspaces/[name]/settings.astro` (new
+  section), `apps/web/src/lib/api-client.ts` (client fns mirroring the
+  comment-settings pair), tests per the api-client test pattern.
+- **Creation is the primary entry** (v1 decision): choosing BYO on the create
+  form creates the workspace (shared-bucket record, normal path), then drops
+  the user directly into the storage wizard for that workspace before any
+  files exist. Creation itself stays one unchanged transaction — BYO is
+  attach-immediately-after, so a wizard abandoned halfway leaves a normal
+  empty shared workspace, not a broken one.
+- Follow the settings-tab conventions exactly: section starts `hidden`,
+  revealed in `onSession`, non-`ok` GET leaves it hidden for non-admins,
+  `requireElement`, `isCurrentPageVisit` guard, sequence token, 400 messages
+  surfaced verbatim.
+- States: **shared mode** (default) shows "Your files live on
+  storage.uploads.sh" + "Connect your own bucket" CTA (disabled with an
+  explanatory note when the workspace has files — links the empty-workspace
+  constraint); **byo mode** shows bucket name, masked ids, public base URL,
+  `verifiedAt`, a "Re-run verification" button, "Rotate credentials" (same
+  form, keys only), and "Disconnect".
+- The connect flow is a 3-step wizard in one panel: (1) instructions with
+  copy-paste dashboard paths for bucket + scoped token + custom domain,
+  (2) the form (account id, bucket, key id, secret — `type=password`,
+  `autocomplete=off` — public base URL optional), (3) live verify results
+  rendered as a checklist from the verify response (each check row: label,
+  pass/fail/warn, hint verbatim). Save is enabled only after required checks
+  pass; the recommended public-URL check failing shows the degraded-serving
+  warning but doesn't block.
+- Secret handling in the browser: never store in localStorage or URL; keep in
+  form state only; on save success, clear the fields.
+
+### Task 2.2: everywhere the URL story surfaces
+
+- **Files:** `apps/web/src/pages/f/[workspace]/[...key].astro` (no change
+  expected — verify), workspace file table / account browser components that
+  compose public URLs, `docs/` (Task 3.2 owns prose).
+- Sweep for any place that assumes `storage.uploads.sh` or re-derives URLs
+  instead of using server-supplied `pageUrl`/`publicUrl` fields (memory:
+  clients must read server-supplied URLs; verify that holds and fix stragglers).
+
+## Phase 3 — CLI, docs, and operator visibility (parallel with Phase 2)
+
+### Task 3.1: doctor + CLI awareness
+
+- **Files:** `packages/uploads/src/commands.ts` (`buildDoctorReport` gains a
+  `storage` sub-check calling the GET route; surfaces mode + verifiedAt +
+  degraded-serving warning), changeset (CLI-visible).
+- `uploads doctor` on a BYO workspace whose verify is stale/failing prints the
+  same hints as the web checklist.
+
+### Task 3.2: docs
+
+- **Files:** `docs/workspaces.md` (rewrite the Bring-your-own-bucket section
+  as the self-serve flow; keep the operator script documented for internal
+  buckets), new `docs/byo-bucket.md` subject page wired into DocsLayout +
+  `sitemap.xml` + `llms.txt` (docs-structure rule), `README.md` path table if
+  a new doc lands, `VISION.md` untouched (already promises this).
+- Content: the three customer-side steps, the token-scoping insistence, the
+  serving matrix (custom domain / signed-only; r2.dev explicitly called out
+  as not supported right now), what's degraded
+  (embed twin, retentionDays), data ownership + off-boarding ("disconnecting
+  never touches your objects").
+
+### Task 3.3: admin/operator panel read-out
+
+- **Files:** `apps/api/src/routes/admin-ui.ts`, `apps/web/src/pages/admin/…`
+  workspace view.
+- Operator view shows storage mode, verify status, and configure/rotate
+  provenance; keeps the existing "presence booleans only" projection. Admin
+  metrics: count of BYO workspaces (adoption metric, `/admin/metrics`).
+
+## Phase 4 — follow-ups (file as issues at ship time, don't build now)
+
+- **Embed twin for BYO hosts** — per-workspace `embedBaseUrl` + customer-side
+  Transform Rule recipe, or platform-proxied embed host. Needed before BYO
+  users get in-place-overwrite Camo behavior.
+- **Jurisdiction endpoints** (`eu`, `fedramp`) — one endpoint-template flag.
+- **Live migration shared → BYO** — copy job + dual-read window + URL rewrite
+  policy. The empty-workspace constraint is v1's substitute.
+- **Other S3 providers** — `StorageProvider` union is deliberately `"r2"`;
+  files-sdk already carries adapters. Opens the VISION "more storage
+  providers" door; separate plan.
+- **Per-workspace DEKs** — today all records seal under one KEK
+  (SHA-256(secret) → AES key). Fine at current scale; envelope-per-workspace
+  is the upgrade if BYO adoption grows. Rotation machinery already exists.
+- **Billing framing** — "bring your own storage, pay for the workflow layer"
+  (VISION language). Gating mechanism ships dark in Task 1.3.
+
+---
+
+## Track B — data layer: D1 → Postgres (PlanetScale) evaluation
+
+**Decision: decoupled from Track A, and deferred behind explicit triggers.**
+Nothing in the BYO feature needs Postgres — Track A's only new state is two
+timestamps + provenance on the KV workspace record; the usage ledger and
+metadata tables are untouched. Coupling the two tracks would put a
+multi-week platform migration on the critical path of a feature that is
+~80% built.
+
+### What the offering actually is (researched 2026-07-31)
+
+"$5/month through Cloudflare" = PlanetScale Postgres **PS-5**: a
+**single-node, non-HA** instance (1/16 vCPU, 512 MB RAM, 10 GB storage per
+branch), provisioned from the Cloudflare dashboard and billed on the
+Cloudflare invoice at PlanetScale's standard price — a billing/provisioning
+integration, not a discounted SKU. A production-grade 3-node HA cluster is
+**$15/mo** minimum; dev branches are $5 each. Workers connect through
+**Hyperdrive** + `pg`/Postgres.js over TCP (free tier: 100k queries/day,
+~20 origin connections; paid: unlimited queries, ~100 connections). Latency
+is D1-comparable only when Hyperdrive's pool, the database region, and
+Smart Placement are aligned; misaligned it's 20–30 ms/query. Hyperdrive is
+transaction-mode pooling: no LISTEN/NOTIFY, no session state, ~60 s query
+kill (migrations/backfills must bypass the pool). Better Auth on Postgres
+via Drizzle/Kysely over Hyperdrive is a documented, known-good pattern.
+
+### The real migration surface (measured)
+
+Two independent D1 databases:
+
+| DB                               | Consumers                                                                              | Access style                                                                                                                            | Port cost                                                                                                                                                                                 |
+| -------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uploads-auth` (19 tables)       | apps/auth only                                                                         | Drizzle ORM (`drizzle-orm/d1` → Better Auth adapter), zero raw SQL                                                                      | **Low** — swap dialect (`sqliteTable` → `pgTable` in `apps/auth/src/schema.ts`), driver, and Hyperdrive binding                                                                           |
+| `uploads-production` (15 tables) | apps/api + apps/mcp (shared binding; mcp reuses api's query helpers, no duplicate SQL) | Raw `env.DB.prepare()` — ~90 call sites concentrated in ~13 domain modules (`galleries.ts` 25, `usage.ts` 13, `file-metadata.ts` 11, …) | **Moderate** — mechanical but wide: `db.batch()` (15 sites across 6 files) → real transactions, `INSERT OR IGNORE`/`ON CONFLICT` → Postgres upserts, `strftime` defaults, one `json_each` |
+
+The **largest hidden cost is the test harness**: ~25 apps/api suites +
+~15 apps/auth suites execute the repo's actual migration SQL against
+`node:sqlite` (`apps/api/test/helpers/sqlite-d1.ts`,
+`apps/auth/src/test/fake-d1.ts`) and assert on real SQLite semantics. A
+Postgres move means porting that harness (embedded Postgres, pglite, or
+containers) or migrating suites to the hand-rolled map fakes — likely more
+work than the production SQL translation itself. Also of note: **no** D1
+Sessions API, read replication, or FTS is in use, so the hardest-to-port
+D1 surfaces are absent; and D1 migrations auto-apply via two path-triggered
+CI workflows that would need Postgres equivalents (PlanetScale
+deploy-request flow, which is also the biggest thing we'd _gain_).
+
+### What would actually be gained / lost
+
+- **Gain:** no 10 GB/db hard ceiling (D1's cap, not raisable); PlanetScale
+  branching + safe-migration deploy requests (lint, ghost tables,
+  revertability); PITR; read replicas; a real console.
+- **Lose:** zero-config colocation (D1 binding is effectively free latency),
+  Time Travel included, no pooling layer to operate, no second bill.
+  Cost trajectory: $5 (non-HA, fine for staging) → $15 HA → $39+ next size,
+  plus Hyperdrive paid tier once past 100k queries/day.
+
+### Triggers to revisit (any one of these reopens the decision)
+
+1. `file_metadata` / `daily_metrics` growth trending toward the 10 GB
+   database cap (check quarterly via `/admin/metrics` + `wrangler d1 info`).
+2. A schema change scary enough that the lack of a safe-migration/branching
+   workflow materially slows shipping.
+3. Needing relational features D1 can't express (cross-table constraints in
+   one transaction beyond `batch()`, replicas for read scaling).
+4. Multi-region latency complaints traceable to D1 single-primary placement.
+
+### If/when triggered: migration shape (not scheduled)
+
+1. Pilot on `uploads-auth` first — the Drizzle layer makes it a
+   dialect+driver swap with Better Auth's Kysely/Drizzle Postgres support,
+   and it's single-consumer. Run PS-5 non-HA for staging, HA for prod.
+2. Then `uploads-production`: introduce nothing new architecturally — the
+   ~13 domain modules stay the seam; translate SQL in place, replace
+   `batch()` with transactions, port the sqlite test harness once and reuse.
+3. Both workers (`apps/api`, `apps/mcp`) get the same Hyperdrive binding;
+   align the PlanetScale region with where D1 is placed today and enable
+   Smart Placement before measuring.
+
+## Decisions (resolved 2026-07-31 unless noted)
+
+1. **Plan gating**: still open long-term; short-term the gate is the
+   `byoBucketEnabled` record flag, off by default, enabled for
+   `buildinternet` + `default` at rollout (Task 1.3).
+2. **Adopt-existing-contents**: still open; plan builds the confirmation
+   path but it can ship disabled (hard-require empty) without rework.
+3. **Uploads-per-period on BYO**: **keep enforced** (platform compute).
+   Revisit later — decoupling is plausible; the `storageBudgetApplies`
+   predicate seam is where that change would go.
+4. **r2.dev URLs**: **blocked in v1**, with dedicated "not supported right
+   now" copy in the verify checklist and docs.
+5. **BYO entry point**: **declared at workspace creation** (create-form
+   option → immediate wizard); settings-attach stays for empty workspaces;
+   migration of populated workspaces is a future version.
+
+## Orchestration notes
+
+- **PR consolidation (Zach's preference, 2026-07-31): few substantial PRs,
+  not a dozen tiny ones.** Target shape:
+  - **PR 1** — this plan + all of Phase 0 (tasks 0.1–0.4) as one hardening PR.
+  - **PR 2** — Phase 1 (API surface + verify pipeline + flag/budget policy,
+    tasks 1.1–1.3).
+  - **PR 3** — Phase 2 + Task 3.1/3.3 (UI + CLI doctor + admin read-out).
+  - **PR 4** — docs (Task 3.2), or folded into PR 3 if it stays small.
+- Phase 0 executes as two parallel lanes with disjoint file sets sharing one
+  branch/worktree: Lane A = task 0.1 (lifecycle guards), Lane B = tasks
+  0.2 + 0.3 + 0.4 (typed errors, strict seal, sealing consolidation,
+  pinned-write comment). Lanes leave changes uncommitted; the orchestrator
+  reviews, runs the full suite, and commits.
+- Task 1.1 is the critical path and the highest-judgment task — keep it in a
+  reviewed lane, not an external CLI. 1.2/1.3 can run parallel to 1.1 once
+  the predicate seam is agreed.
+- Phase 2 depends on 1.1's response shapes; freeze those in PR 2's
+  description so the UI lane can start from the contract before it merges.
+- Every phase ends with `pnpm test` (root runner) + targeted vitest projects;
+  UI tasks verify against the local stack per the stack-raw recipe
+  (127.0.0.1 signed-in session).
+- Stacked PRs based on a non-main branch skip Test/Lint entirely — rebase
+  onto main before requesting review (memory: stacked-PR CI gotcha).

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -79,6 +79,11 @@ export const ERROR_CODES = [
   "invalid_expires",
   "invalid_limit",
   "hash_prefix_or_label_required",
+
+  // Storage seam (apps/api/src/storage.ts, apps/api/src/secrets.ts)
+  "storage_misconfigured",
+  "storage_credentials_unreadable",
+  "secrets_key_unconfigured",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];


### PR DESCRIPTION
Part of #583.

Two things, deliberately consolidated per our fewer-larger-PRs preference:

**1. The plan** — `docs/superpowers/plans/2026-07-31-self-serve-byo-r2-bucket.md`: productizing the operator-only BYO-bucket path into self-serve (creation-time choice, credential verify pipeline with a public-URL/DNS probe, settings wizard), behind an off-by-default `byoBucketEnabled` record flag. Includes the deferred D1 → PlanetScale Postgres evaluation with revisit triggers.

**2. Phase 0 hardening** — the guards that must exist before customer-owned buckets do:

- **Lifecycle guards for unprefixed buckets.** `teardownWorkspace` no longer walks-and-deletes objects on an unprefixed dedicated-bucket record by default (on a customer bucket that would delete their entire bucket); platform state (KV/D1/galleries) still tears down, the skip is surfaced as `objectsSkipped: "dedicated-bucket"`, and `DELETE /admin/workspaces/:name?hard=1&purgeObjects=1` is the explicit operator opt-in. The retention sweep skips unprefixed records (`retentionDays` unsupported on BYO in v1); reconcile flags unprefixed scans in its result. New predicates `isUnprefixedDedicatedBucket` / `hasCustomerCredentials`.
- **Typed errors out of the storage seam.** `storageConfig` now throws `storage_misconfigured` (unknown binding) and `storage_credentials_unreadable` (decrypt failure) as 503 `ServiceUnavailableError`s instead of raw 500s; the MCP gallery path propagates `AppError` codes instead of flattening them.
- **No plaintext credentials, ever.** New `sealCredentialFieldsStrict` throws `secrets_key_unconfigured` when `WORKSPACE_SECRETS_KEY` is unset instead of silently storing plaintext (the future self-serve write path uses this; existing lenient behavior unchanged for migration paths).
- **One `enc:v1:` implementation.** `add-workspace.mjs` now imports the canonical WebCrypto sealing from `src/secrets.ts` (Node 24 type stripping) instead of duplicating it in Node crypto; round-trip covered by tests.
- Pinned the abuse-report attachment write to the platform bucket with a comment so it never gets routed through workspace storage config.

**Behavior notes for review**
- The automated retention sweep never passes `purgeObjects` — an unprefixed workspace finalized by the sweep leaves objects behind until an operator hard-deletes with the flag. Safety over convenience; flagged in case we want binding-only records to auto-purge.
- The guard keys on "unprefixed", not "unprefixed + customer creds" — conservative on purpose, so the `buildinternet` binding-mode bucket is protected too.

**Testing**
- Full root suite: 264 files / 3631 tests pass.
- New coverage: prefixed teardown still purges; unprefixed skips but removes platform state; `?purgeObjects=1` opt-in; sweep skip; typed-error translation through the route boundary in both workers; strict-seal throw/round-trip; script sealing round-trips via `openCredentialFields`.
- Pre-existing `apps/mcp` direct-vitest failures (MCP SDK v2 migration) verified byte-identical before/after via stash; the root runner is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer handling for dedicated storage buckets during workspace deletion and retention cleanup.
  - Added an option to explicitly purge objects from dedicated buckets.
  - Added clearer storage and credential configuration errors with service-unavailable responses.
  - Preserved typed storage errors in gallery operations.

- **Bug Fixes**
  - Prevented accidental deletion of objects from unprefixed dedicated buckets.
  - Improved detection and reporting of storage configuration issues.

- **Documentation**
  - Added planning documentation for self-serve customer-managed storage support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->