### PR TITLE
fix(web): improve admin metrics spacing and section hierarchy

### DIFF
--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -14,10 +14,14 @@
 
 .metrics-tiles {
   display: grid;
-  gap: 12px;
+  gap: 14px;
   grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
   margin: 0;
   padding: 0;
+}
+
+#metrics-tiles {
+  margin-bottom: 32px;
 }
 
 .metrics-tile {
@@ -58,8 +62,19 @@
   border-color: var(--accent);
 }
 
+/* Vertical rhythm between sections: a hairline + generous top padding on
+   every section after the first, matching the .admin-subsection separator
+   idiom in admin.css (border-top + padding-top, not just a margin) so
+   headings read as clearly starting a new region rather than trailing off
+   the previous one. */
+.metrics-section + .metrics-section {
+  margin-top: 8px;
+  padding-top: 32px;
+  border-top: 1px solid var(--line);
+}
+
 .metrics-section h3 {
-  margin: 0 0 10px;
+  margin: 0 0 14px;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -141,6 +156,7 @@
 /* Wide content scrolls inside its own container; the page body never
    scrolls horizontally. */
 .metrics-table-wrap {
+  margin-top: 12px;
   overflow-x: auto;
 }
 
@@ -158,7 +174,7 @@
    .admin-page-header p, scoped to this page since no other /admin/* section
    currently needs one. */
 .admin-hint {
-  margin: 0 0 10px;
+  margin: 0 0 12px;
   color: var(--muted);
   font-size: 13px;
   line-height: 1.5;
@@ -166,11 +182,15 @@
 
 #breakdown-panel label {
   display: inline-block;
-  margin: 0 8px 10px 0;
+  margin: 0 8px 12px 0;
   font-size: 13px;
   color: var(--body);
 }
 
 #breakdown-panel #breakdown-status {
   margin: 8px 0;
+}
+
+#breakdown-panel .metrics-table-wrap {
+  margin-top: 16px;
 }


### PR DESCRIPTION
## Summary

Spacing/hierarchy polish pass on `/admin/metrics`, per screenshot feedback that the FEATURE ADOPTION / MULTI-IDENTITY WORKSPACES / UPLOAD BREAKDOWN stretch reads cramped — sections running into each other, headings not standing apart, tiles/tables/hints sitting too close.

CSS-only, scoped entirely to `apps/web/src/styles/admin-metrics.css` (no markup restructuring, no id/class removals, no color changes). `.metrics-section` and `.admin-hint` are metrics-page-specific — not shared with `admin.css` or the other `/admin/*` stylesheets — so nothing here touches workspaces/users/oauth/email.

- `.metrics-section + .metrics-section`: new hairline separator (`border-top` + `padding-top: 32px` + `margin-top: 8px`), mirroring the existing `.admin-subsection + .admin-subsection` idiom already used elsewhere in `admin.css`, so each section (Uploads per day, Signups per day, Workspace activity, Feature adoption, Multi-identity workspaces, Upload breakdown) reads as a clear new region instead of trailing off the previous one.
- `.metrics-section h3`: bottom margin `10px → 14px` for more presence under each heading (type treatment/case unchanged).
- `#metrics-tiles`: added `margin-bottom: 32px` to separate the top stat-tile row from the first chart section.
- `.metrics-tiles`: gap `12px → 14px`.
- `.metrics-table-wrap`: added `margin-top: 12px` so tables get breathing room below their heading/hint.
- `#breakdown-panel .metrics-table-wrap`: `margin-top: 16px` (slightly more, since it follows the dimension `<select>` rather than a heading directly).
- `.admin-hint` / `#breakdown-panel label`: bottom margin `10px → 12px`.

No shared admin stylesheet changed — only `admin-metrics.css`, which is imported solely by `metrics.astro`.

## Test plan

- [x] `pnpm test` — 265 files / 3653 tests pass
- [x] `pnpm lint` — no new warnings/errors introduced (pre-existing warnings unrelated to this file)
- [x] `pnpm typecheck` — passes
- [x] Read `metrics.astro` markup + `admin.css` to confirm `.metrics-section`/`.admin-hint` selectors are metrics-page-only, and checked `admin-workspaces.css`/`admin-oauth.css`/other `/admin/*` pages don't use these classes
- [x] Verified both light/dark theme handling is untouched — only spacing properties changed, no color/token values added or removed
- [ ] No visual screenshot (page is session-auth + admin-gated, can't reach it in a browser here) — changes are conservative spacing-only edits, inspectable directly in the diff
