### PR TITLE
fix(web): progressive-loading skeletons for /admin/metrics

### DIFF
--- a/apps/web/src/lib/admin-ui.ts
+++ b/apps/web/src/lib/admin-ui.ts
@@ -2,6 +2,7 @@
  * Tiny shared helpers for the operator admin tables (/admin/*).
  * Pages still own their data fetches; this only covers markup plumbing.
  */
+import { skeletonBarHtml } from "./workspace-ui";
 
 /** Escape text for insertion into HTML attribute/text nodes. */
 export function escapeHtml(value: string): string {
@@ -9,6 +10,30 @@ export function escapeHtml(value: string): string {
     /[&<>"']/g,
     (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch,
   );
+}
+
+export interface AdminSkeletonColumn {
+  /** CSS length passed to `skeletonBarHtml` (e.g. "88px"). */
+  width: string;
+  /** Adds `class="num"`, matching `.admin-table td.num`'s right alignment. */
+  num?: boolean;
+}
+
+/**
+ * Placeholder `<tr class="admin-row">` rows for an `.admin-table`'s `<tbody>`,
+ * reserving close-to-real height before async data lands. Pairs with a
+ * static `<thead>` already present in the page's server HTML — callers swap
+ * only the `<tbody>` in place once data arrives, same as `workspace-ui.ts`'s
+ * `renderGalleriesPlaceholderHtml` reserves for its table.
+ */
+export function renderAdminTableSkeletonRowsHtml(columns: AdminSkeletonColumn[], rows = 3): string {
+  return Array.from(
+    { length: rows },
+    () =>
+      `<tr class="admin-row">${columns
+        .map((c) => `<td${c.num ? ' class="num"' : ""}>${skeletonBarHtml(c.width)}</td>`)
+        .join("")}</tr>`,
+  ).join("");
 }
 
 /** Remove previously rendered expand-row groups from a table. */

--- a/apps/web/src/pages/admin/metrics.astro
+++ b/apps/web/src/pages/admin/metrics.astro
@@ -7,8 +7,32 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-metrics.css";
+import { renderAdminTableSkeletonRowsHtml } from "../../lib/admin-ui";
 
 export const prerender = false;
+
+// Skeleton rows reserve close-to-real table height before the first
+// `/admin-ui/metrics/overview` response lands (issue #586) — see
+// `renderAdminTableSkeletonRowsHtml`'s doc comment for the swap-in-place
+// contract. Column widths are eyeballed against typical values, not exact:
+// the goal is "close to loaded height", not pixel parity.
+const workspaceActivitySkeleton = renderAdminTableSkeletonRowsHtml(
+  [
+    { width: "92px" },
+    { width: "34px", num: true },
+    { width: "58px", num: true },
+    { width: "76px" },
+  ],
+  5,
+);
+const multiIdentitySkeleton = renderAdminTableSkeletonRowsHtml(
+  [{ width: "108px" }, { width: "26px", num: true }],
+  2,
+);
+const breakdownSkeleton = renderAdminTableSkeletonRowsHtml(
+  [{ width: "96px" }, { width: "34px", num: true }, { width: "58px", num: true }],
+  5,
+);
 ---
 
 <AdminLayout section="metrics">
@@ -60,18 +84,36 @@ export const prerender = false;
 
       <section class="metrics-section">
         <h3>Uploads per day</h3>
-        <div id="chart-uploads"></div>
+        <div id="chart-uploads" aria-busy="true">
+          <div class="metrics-chart-skeleton" aria-hidden="true"></div>
+        </div>
       </section>
 
       <section class="metrics-section">
         <h3>Signups per day</h3>
-        <div id="chart-signups"></div>
+        <div id="chart-signups" aria-busy="true">
+          <div class="metrics-chart-skeleton" aria-hidden="true"></div>
+        </div>
       </section>
 
       <section class="metrics-section">
         <h3>Workspace activity</h3>
         <div class="metrics-table-wrap">
-          <table class="admin-table" id="workspace-activity" aria-label="Workspace activity">
+          <table
+            class="admin-table"
+            id="workspace-activity"
+            aria-label="Workspace activity"
+            aria-busy="true"
+          >
+            <thead>
+              <tr>
+                <th class="keep" scope="col">Workspace</th>
+                <th class="keep num" scope="col">Uploads</th>
+                <th class="keep num" scope="col">Bytes</th>
+                <th class="keep" scope="col">Last active</th>
+              </tr>
+            </thead>
+            <tbody set:html={workspaceActivitySkeleton} />
           </table>
         </div>
       </section>
@@ -110,7 +152,15 @@ export const prerender = false;
             class="admin-table"
             id="multi-identity-table"
             aria-label="Multi-identity workspaces"
+            aria-busy="true"
           >
+            <thead>
+              <tr>
+                <th class="keep" scope="col">Workspace</th>
+                <th class="keep num" scope="col">Distinct minters</th>
+              </tr>
+            </thead>
+            <tbody set:html={multiIdentitySkeleton} />
           </table>
         </div>
       </section>
@@ -127,7 +177,21 @@ export const prerender = false;
         </select>
         <div id="breakdown-status" class="admin-status" role="status" hidden></div>
         <div class="metrics-table-wrap">
-          <table class="admin-table" id="breakdown-table" aria-label="Upload breakdown"></table>
+          <table
+            class="admin-table"
+            id="breakdown-table"
+            aria-label="Upload breakdown"
+            aria-busy="true"
+          >
+            <thead>
+              <tr>
+                <th class="keep" scope="col">Value</th>
+                <th class="keep num" scope="col">Uploads</th>
+                <th class="keep num" scope="col">Bytes</th>
+              </tr>
+            </thead>
+            <tbody set:html={breakdownSkeleton} />
+          </table>
         </div>
       </section>
     </div>
@@ -304,6 +368,11 @@ export const prerender = false;
       ): void {
         const container = document.getElementById(elementId);
         if (!container) return;
+        // The container's own `aspect-ratio: 480 / 200` (admin-metrics.css)
+        // reserves the same box for the skeleton, the "No data yet." message,
+        // and the chart below — clearing aria-busy here (not per-branch)
+        // keeps that in one place.
+        container.removeAttribute("aria-busy");
         if (!points.length) {
           container.innerHTML = `<p class="muted">No data yet.</p>`;
           return;
@@ -508,6 +577,11 @@ export const prerender = false;
           tile(id, num(overview.features[key] ?? 0));
         }
 
+        // The <thead> is now static server HTML (issue #586) — only the
+        // <tbody> is swapped, in place, from its skeleton rows
+        // (`renderAdminTableSkeletonRowsHtml` in the frontmatter) to real
+        // ones, so a window-selector refetch never drops or re-adds the
+        // header.
         const table = requireElement<HTMLElement>("#workspace-activity", "admin metrics");
         // tr.admin-row: .admin-table's cell padding/border rules are scoped
         // to tr.admin-row (see admin.css) — a bare <tr> falls through to
@@ -521,14 +595,9 @@ export const prerender = false;
               )
               .join("")
           : `<tr class="admin-row"><td colspan="4" class="muted">No workspace activity in this window.</td></tr>`;
-        // th.keep: this table is only 4 narrow columns, so all of them stay
-        // visible at the .admin-table mobile breakpoint instead of the
-        // wider workspaces table's "hide the optional ones" collapse — a
-        // bare `th` (no `keep`) is dropped there, which would leave the
-        // data row without column labels.
-        table.innerHTML =
-          `<thead><tr><th class="keep" scope="col">Workspace</th><th class="keep num" scope="col">Uploads</th><th class="keep num" scope="col">Bytes</th><th class="keep" scope="col">Last active</th></tr></thead>` +
-          `<tbody>${rows}</tbody>`;
+        const tableBody = table.querySelector<HTMLElement>("tbody");
+        if (tableBody) tableBody.innerHTML = rows;
+        table.removeAttribute("aria-busy");
 
         const multiIdentityTable = requireElement<HTMLElement>(
           "#multi-identity-table",
@@ -542,9 +611,9 @@ export const prerender = false;
               )
               .join("")
           : `<tr class="admin-row"><td colspan="2" class="muted">No multi-identity workspaces yet.</td></tr>`;
-        multiIdentityTable.innerHTML =
-          `<thead><tr><th class="keep" scope="col">Workspace</th><th class="keep num" scope="col">Distinct minters</th></tr></thead>` +
-          `<tbody>${multiIdentityRows}</tbody>`;
+        const multiIdentityBody = multiIdentityTable.querySelector<HTMLElement>("tbody");
+        if (multiIdentityBody) multiIdentityBody.innerHTML = multiIdentityRows;
+        multiIdentityTable.removeAttribute("aria-busy");
 
         drawChart(
           "chart-uploads",
@@ -590,8 +659,10 @@ export const prerender = false;
             | { available: true; rows: { value: string; events: number; bytes: number }[] }
             | { available: false; reason: string };
           if (seq !== breakdownSeq) return;
+          const tableBody = table.querySelector<HTMLElement>("tbody");
           if (!body.available) {
-            table.innerHTML = "";
+            if (tableBody) tableBody.innerHTML = "";
+            table.removeAttribute("aria-busy");
             panelStatus.hidden = false;
             panelStatus.textContent =
               body.reason === "not_configured"
@@ -606,18 +677,27 @@ export const prerender = false;
           // requests, so escapeHtml is load-bearing here, not decorative.
           // The numeric columns are typed `number` but arrive as untyped
           // JSON from an external API, so they are coerced rather than
-          // trusted.
-          table.innerHTML =
-            `<thead><tr><th class="keep" scope="col">Value</th><th class="keep num" scope="col">Uploads</th><th class="keep num" scope="col">Bytes</th></tr></thead><tbody>` +
-            body.rows
+          // trusted. Only the <tbody> is swapped — the <thead> is static
+          // server HTML (issue #586), same convention as the workspace
+          // activity and multi-identity tables above.
+          if (tableBody) {
+            tableBody.innerHTML = body.rows
               .map(
                 (row) =>
                   `<tr class="admin-row"><td>${escapeHtml(row.value || "(none)")}</td><td class="num">${num(row.events)}</td><td class="num">${bytes(row.bytes)}</td></tr>`,
               )
-              .join("") +
-            `</tbody>`;
+              .join("");
+          }
+          table.removeAttribute("aria-busy");
         } catch {
           if (seq !== breakdownSeq) return;
+          // Leave the table's current content (skeleton on first load, prior
+          // rows on a dimension/window refetch) rather than clearing it —
+          // clearing here would itself introduce the collapse-on-refetch
+          // this change exists to avoid. aria-busy comes off either way: the
+          // skeleton's implicit "still loading" state no longer applies once
+          // the request has failed.
+          table.removeAttribute("aria-busy");
           panelStatus.hidden = false;
           panelStatus.textContent = "Breakdown is temporarily unavailable.";
         }

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -228,3 +228,19 @@
 #breakdown-panel .metrics-table-wrap {
   margin-top: 16px;
 }
+
+/* Loading placeholder emitted by workspace-ui.ts's skeletonBarHtml (reused by
+   admin-ui.ts's skeleton table rows). Duplicated from account-shell.css
+   because this page renders under AdminLayout, which doesn't load that
+   stylesheet — without this rule the bars are invisible unstyled spans and
+   the reserved row heights collapse. Keep in sync with account-shell.css. */
+.ws-skel {
+  display: inline-block;
+  width: var(--ws-skel-w, 100%);
+  min-height: 1em;
+  vertical-align: middle;
+  border-radius: 3px;
+  background: var(--panel);
+  /* Purely decorative and aria-hidden — nothing here should be selectable. */
+  user-select: none;
+}

--- a/apps/web/src/styles/admin-metrics.css
+++ b/apps/web/src/styles/admin-metrics.css
@@ -82,8 +82,42 @@
   color: var(--fg);
 }
 
+/*
+ * Progressive loading (issue #586), following the three-tier pattern PR #526
+ * shipped for /account: static chrome up front (the section heading and, for
+ * tables, the `<thead>`, both now server-rendered), then a skeleton reserving
+ * the real content's footprint until data lands.
+ *
+ * The chart containers (#chart-uploads / #chart-signups) fix `aspect-ratio`
+ * to the SVG's own `viewBox` ratio (480 / 200, see the `drawChart` script)
+ * so the box is the same size whether it holds the skeleton, the rendered
+ * chart, or the "No data yet." empty state — swapping `innerHTML` never
+ * changes the container's own size, so there is nothing to shift.
+ */
 .metrics-chart-wrap {
   position: relative;
+}
+
+#chart-uploads,
+#chart-signups {
+  aspect-ratio: 480 / 200;
+}
+
+/* Centers the "No data yet." message in the same reserved box, rather than
+   letting a lone <p> collapse to its line height. */
+#chart-uploads:has(> p.muted),
+#chart-signups:has(> p.muted) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.metrics-chart-skeleton {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  border-radius: var(--radius-sm);
+  background: var(--panel);
 }
 
 .metrics-chart {


### PR DESCRIPTION
## Summary

`/admin/metrics` fetches `/admin-ui/metrics/overview` client-side. The stat
tiles, per-day charts, workspace activity table, feature adoption tiles,
multi-identity table, and upload breakdown all started life with no reserved
space — the two chart `<div>`s and all three data tables were empty until
JS ran, so the page jumped as each section popped in. This reuses the
tier-0 (static chrome) / tier-2 (skeleton) pattern PR #526 shipped for
`/account`, adapted to this page's plain inline-script Astro shape (no React
here — public/admin pages ship no framework JS).

- **Charts** (`#chart-uploads`, `#chart-signups`): the container now fixes
  `aspect-ratio: 480 / 200` in `admin-metrics.css`, matching the `<svg
  viewBox="0 0 480 200">` `drawChart` renders. A `.metrics-chart-skeleton`
  block (`var(--panel)` fill) occupies that box until data lands; the same
  box also centers the "No data yet." empty state via `:has(> p.muted)`. The
  swap from skeleton → chart → empty state never changes the container's own
  size, so there's nothing to shift.
- **Tables** (`workspace-activity`, `multi-identity-table`,
  `breakdown-table`): `<thead>` moved out of the client script into static
  server HTML — the columns are known ahead of time, so there's no reason to
  gate them behind a fetch. Each `<tbody>` now ships server-rendered
  skeleton rows (new `renderAdminTableSkeletonRowsHtml` in `admin-ui.ts`,
  built on `workspace-ui.ts`'s existing `skeletonBarHtml` primitive — the
  same masked-bar idiom #526 used for `/account`). The script now swaps only
  the `<tbody>`'s `innerHTML` in place, never rebuilding the header.
- **Stat tiles**: left as-is. They already rendered `<dd>—</dd>` at a fixed
  font-size/line-height, so there was no height delta to fix once the
  bytes/numbers land — no skeleton needed there.
- **Window-selector refetch**: unchanged behavior, now correct by
  construction — `render()` only ever overwrites `<tbody>` contents and tile
  text, never removes a section, so switching the 7/30/90-day window can't
  collapse anything. `#metrics-content[data-loading="true"]` still dims to
  0.6 opacity while a refetch is in flight (pre-existing).
- **Error / empty states kept working**: the page-level "Could not load
  metrics. Try again." status still fires on a failed `/overview` fetch. The
  breakdown panel's "Analytics Engine is not configured" / "Breakdown is
  temporarily unavailable." messages still show, now also clearing the
  table's skeleton rows and `aria-busy` when that happens instead of leaving
  stale skeleton bars under an error message. The multi-identity table's
  built-in "No multi-identity workspaces yet." empty row is untouched.
- **Accessibility**: `aria-busy="true"` sits on each chart container/table
  while its skeleton is showing, removed once real content (or an empty/error
  state) lands.
- **Reduced motion**: no shimmer/pulse was added — skeletons are static
  fills, same "deliberately unanimated" call #526 made for `/account`
  (a placeholder is seen once per load, so a pulse would read as noise, not
  progress). Nothing to gate behind `prefers-reduced-motion`.
- Scoped to `apps/web/src/pages/admin/metrics.astro` +
  `apps/web/src/styles/admin-metrics.css`, plus one small addition to the
  existing shared `apps/web/src/lib/admin-ui.ts` (already imported by this
  page for `escapeHtml`) — `renderAdminTableSkeletonRowsHtml`, generic enough
  for other `/admin/*` tables to reuse later, per the issue's "if the pattern
  lands as something shareable" note. No other page's behavior changes.
- Both themes: skeletons use `var(--panel)` / `var(--radius-sm)` tokens only,
  same as `.ws-skel` and the rest of this page's existing CSS — no hardcoded
  colors.

Admin pages are gated server-side (session + admin role), so this couldn't be
screenshotted signed-in from this environment; verified by reading the
rendered markup/CSS and reasoning through each state transition instead.

Closes #586

## Test plan

- [x] `pnpm test` — 265 files / 3653 tests passed
- [x] `pnpm lint` — no new errors (pre-existing unrelated warnings only)
- [x] `pnpm typecheck` — 0 errors across all packages
- [x] Traced every `innerHTML`/`aria-busy` transition in `metrics.astro`'s
      script for the four states each async region can be in: initial
      skeleton, loaded, empty, and error/refetch-in-flight
