### PR TITLE
feat: Self-serve BYO R2 bucket: Phase 1 API surface (verify pipeline, storage routes, flag + budget policy)

### DIFF
--- a/apps/api/src/budget.test.ts
+++ b/apps/api/src/budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { resolveBudgetLimits } from "./budget";
+import { checkPutBudget, resolveBudgetLimits, storageBudgetApplies } from "./budget";
+import type { WorkspaceUsage } from "./usage";
 
 describe("resolveBudgetLimits — plan-aware resolution", () => {
   // Controller ruling (post-BLOCKED review): plan defaults apply ONLY when
@@ -53,5 +54,73 @@ describe("resolveBudgetLimits — plan-aware resolution", () => {
       maxStorageBytes: 1_000,
       maxUploadsPerPeriod: 100_000,
     });
+  });
+});
+
+describe("storageBudgetApplies (#583 Task 1.2 — BYO storage-ownership signal)", () => {
+  it("applies to a plain shared-bucket record (no creds, no binding)", () => {
+    expect(storageBudgetApplies({})).toBe(true);
+  });
+
+  it("applies to a binding-mode dedicated-bucket record, even with stray credential fields", () => {
+    expect(
+      storageBudgetApplies({
+        binding: "UPLOADS_DEFAULT",
+        accountId: "a".repeat(32),
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not apply to an HTTP-credential BYO record (no binding, full cred triple)", () => {
+    expect(
+      storageBudgetApplies({
+        accountId: "a".repeat(32),
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      }),
+    ).toBe(false);
+  });
+
+  it("applies when the credential triple is incomplete (not really BYO yet)", () => {
+    expect(storageBudgetApplies({ accountId: "a".repeat(32), accessKeyId: "key" })).toBe(true);
+  });
+});
+
+describe("checkPutBudget — storage cap skipped for BYO, upload cap unaffected", () => {
+  const usage: WorkspaceUsage = {
+    workspace: "acme",
+    bytes: 900,
+    objects: 1,
+    uploadsInPeriod: 2,
+    periodStart: "2026-07",
+    updatedAt: "2026-07-31T00:00:00.000Z",
+  };
+
+  const byoLimits = {
+    maxStorageBytes: 1_000,
+    maxUploadsPerPeriod: 3,
+    accountId: "a".repeat(32),
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+  };
+
+  it("denies a storage-exceeding put on a shared-bucket workspace", () => {
+    const denial = checkPutBudget(usage, { maxStorageBytes: 1_000 }, { bytes: 200, uploads: 1 });
+    expect(denial?.code).toBe("storage_quota_exceeded");
+  });
+
+  it("allows the same over-cap put on a BYO workspace (storage cap skipped)", () => {
+    const denial = checkPutBudget(usage, byoLimits, { bytes: 200, uploads: 1 });
+    expect(denial).toBeNull();
+  });
+
+  it("still enforces maxUploadsPerPeriod on a BYO workspace", () => {
+    const denial = checkPutBudget({ ...usage, uploadsInPeriod: 3 }, byoLimits, {
+      bytes: 0,
+      uploads: 1,
+    });
+    expect(denial?.code).toBe("upload_budget_exceeded");
   });
 });

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -22,6 +22,43 @@ export interface WorkspaceBudgetLimits {
    * defaults applied) — NOT a free-tier fallback. See `resolveBudgetLimits`.
    */
   plan?: string;
+  /** Name of an R2 binding, when I/O uses one. See `storageBudgetApplies`. */
+  binding?: string;
+  /** HTTP credentials — presence (with no `binding`) is the BYO signal. See `storageBudgetApplies`. */
+  accountId?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
+
+/**
+ * Whether `maxStorageBytes` should be enforced against `record` (issue #583
+ * Task 1.2). False for a self-serve BYO/customer-credential record — their
+ * disk, their bill — while `maxUploadBytes` / `maxVideoUploadBytes` /
+ * `maxUploadsPerPeriod` (platform-compute protections, decided 2026-07-31)
+ * stay enforced for everyone, BYO included.
+ *
+ * The precise signal is deliberately **not** `isUnprefixedDedicatedBucket`
+ * (`workspace.ts`) — that predicate answers a layout question ("does this
+ * record's I/O span an entire bucket, or a confined shared-bucket prefix?"),
+ * which matters for lifecycle jobs (teardown/retention) but says nothing
+ * about who owns the storage: an unprefixed *binding*-mode record is still a
+ * platform-owned dedicated bucket, wrangler-provisioned and platform-billed.
+ * Storage ownership is the question here, so the signal is customer HTTP
+ * credentials with no binding — `binding` always means Workers-provisioned,
+ * platform-owned storage regardless of prefix, and a bound record is never
+ * customer-billed even if it also happens to carry stray credential fields.
+ *
+ * Usage is still recorded on BYO records either way — see `usage.ts`'s
+ * header comment — this predicate only gates the `maxStorageBytes` cap
+ * itself.
+ */
+export function storageBudgetApplies(record: WorkspaceBudgetLimits): boolean {
+  const isCustomerCredentialStorage =
+    !record.binding &&
+    Boolean(record.accountId) &&
+    Boolean(record.accessKeyId) &&
+    Boolean(record.secretAccessKey);
+  return !isCustomerCredentialStorage;
 }
 
 export type BudgetDenialCode = "storage_quota_exceeded" | "upload_budget_exceeded";
@@ -145,10 +182,13 @@ export function checkPutBudget(
     }
   }
 
-  if (maxStorageBytes !== undefined && delta.bytes > 0) {
-    if (usage.bytes + delta.bytes > maxStorageBytes) {
-      return storageBudgetDenial(usage, maxStorageBytes, delta.bytes);
-    }
+  if (
+    maxStorageBytes !== undefined &&
+    delta.bytes > 0 &&
+    storageBudgetApplies(limits) &&
+    usage.bytes + delta.bytes > maxStorageBytes
+  ) {
+    return storageBudgetDenial(usage, maxStorageBytes, delta.bytes);
   }
 
   return null;

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { afterEach, describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
-import { setStorageVerifyForTests } from "./workspace-storage";
+import { setStorageReconcileForTests, setStorageVerifyForTests } from "./workspace-storage";
 import { fakeRegistry, FakeKv } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { FakeR2Bucket } from "../../test/fake-r2";
@@ -2323,13 +2323,17 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
     provider: "r2",
     bucket: "customer-bucket",
     accountId: "a".repeat(32),
-    accessKeyId: "AKIDEXAMPLE1234",
+    // Credential fields hold sealed blobs at rest (what PUT actually stores)
+    // — the display fragment lives in `storageAccessKeyIdLast4`, stamped from
+    // the plaintext at seal time.
+    accessKeyId: "enc:v1:sealed-key-id",
     secretAccessKey: "enc:v1:already-sealed",
     publicBaseUrl: "https://media.example.com",
     byoBucketEnabled: true,
     storageConfiguredAt: "2026-01-01T00:00:00.000Z",
     storageVerifiedAt: "2026-01-01T00:00:00.000Z",
     storageConfiguredBy: "u-plain",
+    storageAccessKeyIdLast4: "1234",
   };
 
   function storageEnv(opts: {
@@ -2398,7 +2402,18 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
 
   afterEach(() => {
     setStorageVerifyForTests(undefined);
+    setStorageReconcileForTests(undefined);
   });
+
+  /** Installs a reconcile spy so guard-bypassed transitions don't walk a real bucket. */
+  function spyStorageReconcile() {
+    const calls: string[] = [];
+    setStorageReconcileForTests(async (_env, _ws, name) => {
+      calls.push(name);
+      return {};
+    });
+    return calls;
+  }
 
   describe("GET /me/workspaces/:name/storage", () => {
     it("is readable even when byoBucketEnabled is off, reporting shared mode", async () => {
@@ -2423,8 +2438,9 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       const res = await app().request("/me/workspaces/acme/storage", {}, env);
       expect(res.status).toBe(200);
       const raw = await res.text();
-      expect(raw).not.toContain("AKIDEXAMPLE1234");
+      expect(raw).not.toContain("sealed-key-id");
       expect(raw).not.toContain("already-sealed");
+      expect(raw).not.toContain("enc:v1:");
       expect(JSON.parse(raw)).toEqual({
         mode: "byo",
         byoBucketEnabled: true,
@@ -2599,6 +2615,7 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
         storageConfiguredAt?: string;
         storageVerifiedAt?: string;
         storageConfiguredBy?: string;
+        storageAccessKeyIdLast4?: string;
       }>("acme");
       expect(saved?.prefix).toBeUndefined();
       expect(saved?.binding).toBeUndefined();
@@ -2609,15 +2626,20 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       expect(saved?.storageConfiguredAt).toBeTruthy();
       expect(saved?.storageVerifiedAt).toBeTruthy();
       expect(saved?.storageConfiguredBy).toBe("u-plain");
+      // Plaintext display fragment, not the tail of the sealed blob.
+      expect(saved?.storageAccessKeyIdLast4).toBe("1234");
+      const body2 = body as unknown as { accessKeyIdLast4?: string };
+      expect(body2.accessKeyIdLast4).toBe("1234");
     });
 
-    it("allows attaching to a non-empty workspace when adoptExistingContents is set", async () => {
+    it("allows attaching to a non-empty workspace when adoptExistingContents is set, and reconciles the ledger from the adopted bucket", async () => {
       const { env, registry } = storageEnv({
         role: "owner",
         record: { ...SHARED_RECORD, byoBucketEnabled: true },
         usage: { objects: 5 },
       });
       setStorageVerifyForTests(async () => okVerifyResult);
+      const reconciled = spyStorageReconcile();
       const res = await app().request(
         "/me/workspaces/acme/storage",
         {
@@ -2629,9 +2651,31 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       );
       expect(res.status).toBe(200);
       expect(registry.record<{ bucket?: string }>("acme")?.bucket).toBe("customer-bucket");
+      expect(reconciled).toEqual(["acme"]);
     });
 
-    it("500s (secrets_key_unconfigured) when WORKSPACE_SECRETS_KEY is unset, and leaves the record untouched", async () => {
+    it("does not reconcile the ledger on a plain empty-workspace save", async () => {
+      const { env } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const reconciled = spyStorageReconcile();
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(reconciled).toEqual([]);
+    });
+
+    it("503s (secrets_key_unconfigured) when WORKSPACE_SECRETS_KEY is unset, and leaves the record untouched", async () => {
       const { env: baseEnv, registry } = storageEnv({
         role: "owner",
         record: { ...SHARED_RECORD, byoBucketEnabled: true },
@@ -2710,15 +2754,37 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       expect(saved?.byoBucketEnabled).toBe(true);
     });
 
-    it("detaches with force=true query param even when the bucket still has files", async () => {
+    it("detaches with force=true query param even when the bucket still has files, reconciling the ledger", async () => {
       const { env, registry } = storageEnv({
         role: "owner",
         record: BYO_RECORD,
         usage: { objects: 9 },
       });
+      const reconciled = spyStorageReconcile();
       const res = await app().request(
         "/me/workspaces/acme/storage?force=true",
         { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(registry.record<{ bucket?: string }>("acme")?.bucket).toBe("uploads-default");
+      expect(reconciled).toEqual(["acme"]);
+    });
+
+    it("detaches when force is passed in the JSON body", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: BYO_RECORD,
+        usage: { objects: 9 },
+      });
+      spyStorageReconcile();
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ force: true }),
+        },
         env,
       );
       expect(res.status).toBe(200);

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2,9 +2,10 @@ import { readFileSync } from "node:fs";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { fileURLToPath, URL as NodeURL } from "node:url";
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
+import { setStorageVerifyForTests } from "./workspace-storage";
 import { fakeRegistry, FakeKv } from "../../test/fake-kv";
 import { UsageFakeD1 } from "../../test/usage-fake-d1";
 import { FakeR2Bucket } from "../../test/fake-r2";
@@ -2312,5 +2313,416 @@ describe("GET /me/workspaces/:name/comment-preview", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)", () => {
+  const SECRET = "test-workspace-secrets-key-0000";
+  const SHARED_RECORD = { provider: "r2", bucket: "uploads-default", prefix: "acme/" };
+  const BYO_RECORD = {
+    provider: "r2",
+    bucket: "customer-bucket",
+    accountId: "a".repeat(32),
+    accessKeyId: "AKIDEXAMPLE1234",
+    secretAccessKey: "enc:v1:already-sealed",
+    publicBaseUrl: "https://media.example.com",
+    byoBucketEnabled: true,
+    storageConfiguredAt: "2026-01-01T00:00:00.000Z",
+    storageVerifiedAt: "2026-01-01T00:00:00.000Z",
+    storageConfiguredBy: "u-plain",
+  };
+
+  function storageEnv(opts: {
+    workspace?: string;
+    role: string;
+    record?: unknown;
+    usage?: { objects: number; bytes?: number };
+    secretsKey?: string;
+  }) {
+    const { workspace = "acme", role, record, usage, secretsKey = SECRET } = opts;
+    const registry = fakeRegistry(record !== undefined ? { [workspace]: record } : {});
+    const db = new UsageFakeD1();
+    if (usage) {
+      db.usage.set(workspace, {
+        workspace,
+        bytes: usage.bytes ?? 0,
+        objects: usage.objects,
+        uploads_in_period: 0,
+        period_start: "2026-07",
+        updated_at: "2026-07-01T00:00:00.000Z",
+      });
+    }
+    const auth = stubAuth((req) => {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/auth/get-session") {
+        return new Response(JSON.stringify({ session: {}, user: USER }), { status: 200 });
+      }
+      if (url.pathname === "/internal/memberships") {
+        return Response.json([
+          {
+            organizationId: "org1",
+            organizationSlug: workspace,
+            organizationName: workspace,
+            role,
+          },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+    const env = {
+      AUTH: auth,
+      DB: db,
+      REGISTRY: registry,
+      WORKSPACE_SECRETS_KEY: secretsKey,
+    } as unknown as Env;
+    return { env, registry, db };
+  }
+
+  const okVerifyResult = {
+    ok: true,
+    checks: [
+      { id: "shape", ok: true, required: true },
+      { id: "auth", ok: true, required: true },
+      { id: "round-trip", ok: true, required: true },
+      { id: "not-empty", ok: true, required: true },
+    ],
+  };
+
+  const CANDIDATE_BODY = {
+    bucket: "customer-bucket",
+    accountId: "a".repeat(32),
+    accessKeyId: "AKIDEXAMPLE1234",
+    secretAccessKey: "super-secret-value",
+    publicBaseUrl: "https://media.example.com",
+  };
+
+  afterEach(() => {
+    setStorageVerifyForTests(undefined);
+  });
+
+  describe("GET /me/workspaces/:name/storage", () => {
+    it("is readable even when byoBucketEnabled is off, reporting shared mode", async () => {
+      const { env } = storageEnv({ role: "admin", record: SHARED_RECORD });
+      const res = await app().request("/me/workspaces/acme/storage", {}, env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        mode: "shared",
+        byoBucketEnabled: false,
+        bucket: "uploads-default",
+      });
+    });
+
+    it("403s for a non-admin member", async () => {
+      const { env } = storageEnv({ role: "member", record: SHARED_RECORD });
+      const res = await app().request("/me/workspaces/acme/storage", {}, env);
+      expect(res.status).toBe(403);
+    });
+
+    it("reports byo mode with masked credentials and no secret values anywhere in the payload", async () => {
+      const { env } = storageEnv({ role: "owner", record: BYO_RECORD });
+      const res = await app().request("/me/workspaces/acme/storage", {}, env);
+      expect(res.status).toBe(200);
+      const raw = await res.text();
+      expect(raw).not.toContain("AKIDEXAMPLE1234");
+      expect(raw).not.toContain("already-sealed");
+      expect(JSON.parse(raw)).toEqual({
+        mode: "byo",
+        byoBucketEnabled: true,
+        bucket: "customer-bucket",
+        publicBaseUrl: "https://media.example.com",
+        accountIdMasked: `…${"a".repeat(4)}`,
+        accessKeyIdLast4: "1234",
+        configuredAt: "2026-01-01T00:00:00.000Z",
+        verifiedAt: "2026-01-01T00:00:00.000Z",
+      });
+    });
+  });
+
+  describe("POST /me/workspaces/:name/storage/verify", () => {
+    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
+      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+      const res = await app().request(
+        "/me/workspaces/acme/storage/verify",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "byo_bucket_disabled" },
+      });
+    });
+
+    it("runs the injected verify pipeline against the request body and persists nothing", async () => {
+      const { env, registry } = storageEnv({ role: "owner", record: BYO_RECORD });
+      setStorageVerifyForTests(async (candidate) => {
+        expect(candidate.bucket).toBe("customer-bucket");
+        return okVerifyResult;
+      });
+      const before = registry.record("acme");
+      const res = await app().request(
+        "/me/workspaces/acme/storage/verify",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(okVerifyResult);
+      expect(registry.record("acme")).toEqual(before);
+    });
+
+    it("429s when the write limiter is over budget", async () => {
+      const { env: baseEnv } = storageEnv({ role: "owner", record: BYO_RECORD });
+      const env = {
+        ...baseEnv,
+        WRITE_LIMITER: { limit: async () => ({ success: false }) },
+      } as unknown as Env;
+      const res = await app().request(
+        "/me/workspaces/acme/storage/verify",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe("PUT /me/workspaces/:name/storage", () => {
+    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
+      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects with the verify result (422) when server-side verification fails, and leaves the record untouched", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+      });
+      const failResult = {
+        ok: false,
+        checks: [
+          { id: "shape", ok: true, required: true },
+          {
+            id: "auth",
+            ok: false,
+            required: true,
+            hint: "the access key was rejected",
+          },
+        ],
+      };
+      setStorageVerifyForTests(async () => failResult);
+      const before = registry.record("acme");
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(422);
+      expect(await res.json()).toEqual(failResult);
+      expect(registry.record("acme")).toEqual(before);
+    });
+
+    it("rejects when the workspace already has files and adoptExistingContents wasn't set", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 3 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const before = registry.record("acme");
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(409);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "workspace_storage_not_empty" },
+      });
+      expect(registry.record("acme")).toEqual(before);
+    });
+
+    it("saves on a passing verify: seals credentials, drops prefix/binding, stamps provenance", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { mode: string; verify: { ok: boolean } };
+      expect(body.mode).toBe("byo");
+      expect(body.verify).toEqual(okVerifyResult);
+
+      const saved = registry.record<{
+        prefix?: string;
+        binding?: string;
+        bucket?: string;
+        accountId?: string;
+        accessKeyId?: string;
+        secretAccessKey?: string;
+        storageConfiguredAt?: string;
+        storageVerifiedAt?: string;
+        storageConfiguredBy?: string;
+      }>("acme");
+      expect(saved?.prefix).toBeUndefined();
+      expect(saved?.binding).toBeUndefined();
+      expect(saved?.bucket).toBe("customer-bucket");
+      expect(saved?.accountId).toBe("a".repeat(32));
+      expect(saved?.accessKeyId).toMatch(/^enc:v1:/);
+      expect(saved?.secretAccessKey).toMatch(/^enc:v1:/);
+      expect(saved?.storageConfiguredAt).toBeTruthy();
+      expect(saved?.storageVerifiedAt).toBeTruthy();
+      expect(saved?.storageConfiguredBy).toBe("u-plain");
+    });
+
+    it("allows attaching to a non-empty workspace when adoptExistingContents is set", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 5 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ...CANDIDATE_BODY, adoptExistingContents: true }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(registry.record<{ bucket?: string }>("acme")?.bucket).toBe("customer-bucket");
+    });
+
+    it("500s (secrets_key_unconfigured) when WORKSPACE_SECRETS_KEY is unset, and leaves the record untouched", async () => {
+      const { env: baseEnv, registry } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      const env = { ...baseEnv, WORKSPACE_SECRETS_KEY: undefined } as unknown as Env;
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const before = registry.record("acme");
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(503);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "secrets_key_unconfigured" },
+      });
+      expect(registry.record("acme")).toEqual(before);
+    });
+  });
+
+  describe("DELETE /me/workspaces/:name/storage", () => {
+    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
+      const { env } = storageEnv({ role: "owner", record: SHARED_RECORD });
+      const res = await app().request("/me/workspaces/acme/storage", { method: "DELETE" }, env);
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects detach when the BYO bucket still has files and force wasn't passed", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: BYO_RECORD,
+        usage: { objects: 2 },
+      });
+      const before = registry.record("acme");
+      const res = await app().request("/me/workspaces/acme/storage", { method: "DELETE" }, env);
+      expect(res.status).toBe(409);
+      expect((await res.json()) as { error: { code: string } }).toMatchObject({
+        error: { code: "workspace_storage_not_empty" },
+      });
+      expect(registry.record("acme")).toEqual(before);
+    });
+
+    it("detaches, restores shared-bucket defaults, and preserves unrelated fields", async () => {
+      const record = {
+        ...BYO_RECORD,
+        // Non-storage fields that must survive detach untouched.
+        maxMembers: 7,
+        plan: "pro",
+        githubCommentNote: "keep me",
+      };
+      const { env, registry } = storageEnv({ role: "owner", record, usage: { objects: 0 } });
+      const res = await app().request("/me/workspaces/acme/storage", { method: "DELETE" }, env);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ mode: "shared", byoBucketEnabled: true });
+
+      const saved = registry.record<Record<string, unknown>>("acme");
+      expect(saved?.bucket).toBe("uploads-default");
+      expect(saved?.binding).toBe("UPLOADS_DEFAULT");
+      expect(saved?.prefix).toBe("acme/");
+      expect(saved?.publicBaseUrl).toBe("https://storage.uploads.sh");
+      expect(saved?.accountId).toBeUndefined();
+      expect(saved?.accessKeyId).toBeUndefined();
+      expect(saved?.secretAccessKey).toBeUndefined();
+      expect(saved?.storageConfiguredAt).toBeUndefined();
+      expect(saved?.storageVerifiedAt).toBeUndefined();
+      expect(saved?.storageConfiguredBy).toBeUndefined();
+      // Preserved.
+      expect(saved?.maxMembers).toBe(7);
+      expect(saved?.plan).toBe("pro");
+      expect(saved?.githubCommentNote).toBe("keep me");
+      expect(saved?.byoBucketEnabled).toBe(true);
+    });
+
+    it("detaches with force=true query param even when the bucket still has files", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: BYO_RECORD,
+        usage: { objects: 9 },
+      });
+      const res = await app().request(
+        "/me/workspaces/acme/storage?force=true",
+        { method: "DELETE" },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(registry.record<{ bucket?: string }>("acme")?.bucket).toBe("uploads-default");
+    });
   });
 });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -16,10 +16,17 @@ import {
   type OptionSource,
   type ResolvedCommentOptions,
 } from "@uploads/comment-config";
-import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitedError,
+  ValidationError,
+} from "@uploads/errors";
 import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
+import { sealCredentialFieldsStrict } from "../secrets";
 import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
 import { previewFixtureItems } from "../comment-preview-fixtures";
@@ -55,12 +62,14 @@ import {
   type OrgMember,
 } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
+import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
 import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
-import { loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
+import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
+import { candidateFromBody, storageStatusResponse, storageVerify } from "./workspace-storage";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -1034,4 +1043,197 @@ export const me = new Hono<SessionVars>()
     });
 
     return c.json({ resolved, source, repoConfig, body, sample });
+  })
+
+  // Self-serve BYO R2 bucket (issue #583 Task 1.1): read/verify/write/detach
+  // of a workspace's storage config. Same audience as the comment-settings
+  // triple above (admin/owner only) — storage config is workspace-wide and
+  // security sensitive. Readable regardless of `byoBucketEnabled` (the
+  // settings UI needs the flag value to decide whether to show the panel at
+  // all); verify/write/detach 403 when the flag is off (fail-closed, see
+  // `byoBucketAllowed` in workspace.ts). Never returns credential values —
+  // `storageStatusResponse` (workspace-storage.ts) projects masked/presence
+  // fields only, same posture as `GET /admin/workspaces/:name` (admin.ts).
+  .get("/workspaces/:name/storage", async (c) => {
+    const name = c.req.param("name");
+    await adminWorkspaceOr403(c.env, requireUserId(c), name);
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    return c.json(storageStatusResponse(record, byoBucketAllowed(record)));
+  })
+
+  // Runs the verify pipeline (storage-verify.ts) against the request body —
+  // never saved state — so an admin can iterate on credentials before
+  // anything is persisted. Rate-limited via `allowWrite` like every other
+  // mutating-adjacent route here: each call does real remote I/O (auth
+  // probe + a write/read/delete round-trip against the candidate bucket).
+  .post("/workspaces/:name/storage/verify", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    await adminWorkspaceOr403(c.env, userId, name);
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    if (!byoBucketAllowed(record)) {
+      throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+        code: "byo_bucket_disabled",
+      });
+    }
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+
+    const body = await c.req.json().catch(() => null);
+    const candidate = candidateFromBody(body);
+    const result = await storageVerify(candidate);
+    return c.json(result);
+  })
+
+  // Persist a verified BYO config. Never trusts a client-side "verified"
+  // claim — re-runs the same pipeline server-side against the request body,
+  // and only writes on a pass. On a fail, responds with the verify result
+  // (422) so the UI can render the same checklist the standalone verify
+  // route would have. `mutateWorkspaceRecord` (with `requireServing`) both
+  // re-checks the workspace hasn't been soft-deleted since the request
+  // started and gives us the read-immediately-before-write window issue #387
+  // exists for; sealing happens *inside* that callback (precedent:
+  // `reencrypt-registry.ts`), never on data read earlier in the request.
+  .put("/workspaces/:name/storage", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    await adminWorkspaceOr403(c.env, userId, name);
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    if (!byoBucketAllowed(record)) {
+      throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+        code: "byo_bucket_disabled",
+      });
+    }
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+
+    const body = await c.req.json().catch(() => null);
+    const candidate = candidateFromBody(body);
+    const result = await storageVerify(candidate);
+    if (!result.ok) {
+      return c.json(result, 422);
+    }
+
+    // No migration of populated workspaces in v1 (plan's global constraints):
+    // attaching a BYO bucket to a workspace that already holds files would
+    // orphan them on the shared bucket. Checked against the D1 usage ledger
+    // *before* the mutation — a KV-only read inside the callback can't see
+    // this — accepting the narrow race where a concurrent upload lands
+    // between this check and the write (the callback's `requireServing`
+    // re-check guards the record itself, not usage).
+    const usage = await getWorkspaceUsage(c.env.DB, name);
+    if (usage.objects > 0 && candidate.adoptExistingContents !== true) {
+      throw new ConflictError(
+        "this workspace already has files — BYO storage can only be attached to an empty workspace",
+        { code: "workspace_storage_not_empty" },
+      );
+    }
+
+    const nowIso = new Date().toISOString();
+    const updated = await mutateWorkspaceRecord(
+      c.env,
+      name,
+      async (current) => {
+        const sealed = await sealCredentialFieldsStrict(c.env.WORKSPACE_SECRETS_KEY, {
+          accessKeyId: candidate.accessKeyId,
+          secretAccessKey: candidate.secretAccessKey,
+        });
+        const next: WorkspaceRecord = { ...current };
+        delete next.prefix;
+        delete next.binding;
+        next.bucket = candidate.bucket;
+        next.accountId = candidate.accountId;
+        next.accessKeyId = sealed.accessKeyId;
+        next.secretAccessKey = sealed.secretAccessKey;
+        if (candidate.publicBaseUrl) next.publicBaseUrl = candidate.publicBaseUrl;
+        else delete next.publicBaseUrl;
+        next.storageConfiguredAt = nowIso;
+        next.storageVerifiedAt = nowIso;
+        next.storageConfiguredBy = userId;
+        return next;
+      },
+      { requireServing: true },
+    );
+
+    console.log(JSON.stringify({ event: "workspace_storage_configured", workspace: name, userId }));
+
+    return c.json({ ...storageStatusResponse(updated, true), verify: result });
+  })
+
+  // Detach BYO storage and restore shared-bucket defaults. Never touches the
+  // customer's bucket or its objects — only the platform's own KV record.
+  // Blocked unless the workspace's usage ledger reports zero objects, or the
+  // caller explicitly passes `force` (query `?force=true` or a JSON body
+  // `{ "force": true }`) — mirrors the empty-workspace guard on PUT above,
+  // in the opposite direction. Shared-bucket fields (bucket/binding/prefix/
+  // publicBaseUrl) come from `selfServeWorkspaceRecord` so this can't drift
+  // from what a brand-new self-serve workspace actually gets; everything
+  // else on the record (limits, github links, comment settings, plan, other
+  // flags) is preserved untouched.
+  .delete("/workspaces/:name/storage", async (c) => {
+    const name = c.req.param("name");
+    const userId = requireUserId(c);
+    await adminWorkspaceOr403(c.env, userId, name);
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    if (!byoBucketAllowed(record)) {
+      throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+        code: "byo_bucket_disabled",
+      });
+    }
+    if (!(await allowWrite(c.env, name))) {
+      throw new RateLimitedError("rate limit exceeded");
+    }
+
+    const queryForce = c.req.query("force");
+    const bodyForce = await c.req
+      .json<{ force?: unknown }>()
+      .then((b) => b?.force === true)
+      .catch(() => false);
+    const force = queryForce === "true" || queryForce === "1" || bodyForce;
+
+    if (!force) {
+      const usage = await getWorkspaceUsage(c.env.DB, name);
+      if (usage.objects > 0) {
+        throw new ConflictError(
+          "this workspace still has files on its BYO bucket — pass force to detach anyway",
+          { code: "workspace_storage_not_empty" },
+        );
+      }
+    }
+
+    const updated = await mutateWorkspaceRecord(
+      c.env,
+      name,
+      (current) => {
+        const shared = selfServeWorkspaceRecord({
+          name,
+          userId: current.createdByUserId ?? userId,
+          now: new Date(),
+        });
+        const next: WorkspaceRecord = { ...current };
+        next.bucket = shared.bucket;
+        next.binding = shared.binding;
+        next.prefix = shared.prefix;
+        if (shared.publicBaseUrl) next.publicBaseUrl = shared.publicBaseUrl;
+        else delete next.publicBaseUrl;
+        delete next.accountId;
+        delete next.accessKeyId;
+        delete next.secretAccessKey;
+        delete next.storageConfiguredAt;
+        delete next.storageVerifiedAt;
+        delete next.storageConfiguredBy;
+        return next;
+      },
+      { requireServing: true },
+    );
+
+    console.log(JSON.stringify({ event: "workspace_storage_detached", workspace: name, userId }));
+
+    return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
   });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -69,7 +69,12 @@ import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
-import { candidateFromBody, storageStatusResponse, storageVerify } from "./workspace-storage";
+import {
+  candidateFromBody,
+  storageReconcile,
+  storageStatusResponse,
+  storageVerify,
+} from "./workspace-storage";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -1155,12 +1160,29 @@ export const me = new Hono<SessionVars>()
         next.storageConfiguredAt = nowIso;
         next.storageVerifiedAt = nowIso;
         next.storageConfiguredBy = userId;
+        // Display fragment for the settings UI, captured from the plaintext
+        // before sealing — `next.accessKeyId` is ciphertext from here on.
+        next.storageAccessKeyIdLast4 = candidate.accessKeyId.slice(-4);
         return next;
       },
       { requireServing: true },
     );
 
     console.log(JSON.stringify({ event: "workspace_storage_configured", workspace: name, userId }));
+
+    // `adoptExistingContents` bypassed the emptiness guard, so the D1 usage
+    // ledger still describes the old backing storage while the adopted
+    // bucket's contents are what this workspace now serves. Rebuild the
+    // ledger from the new bucket so it's honest immediately (it's dormant
+    // for `maxStorageBytes` while BYO is active — `storageBudgetApplies` —
+    // but powers the settings UI and becomes authoritative again on detach).
+    // Best-effort: the config write above already succeeded, and reconcile
+    // can be re-run any time.
+    if (candidate.adoptExistingContents === true) {
+      await storageReconcile(c.env, updated, name).catch((err) =>
+        console.error("workspace storage attach: usage reconcile failed for", name, err),
+      );
+    }
 
     return c.json({ ...storageStatusResponse(updated, true), verify: result });
   })
@@ -1228,12 +1250,25 @@ export const me = new Hono<SessionVars>()
         delete next.storageConfiguredAt;
         delete next.storageVerifiedAt;
         delete next.storageConfiguredBy;
+        delete next.storageAccessKeyIdLast4;
         return next;
       },
       { requireServing: true },
     );
 
     console.log(JSON.stringify({ event: "workspace_storage_detached", workspace: name, userId }));
+
+    // `force` bypassed the emptiness guard, so the ledger still describes
+    // the detached BYO bucket — but `maxStorageBytes` enforcement resumes on
+    // the shared bucket the moment this record is restored, and stale counts
+    // could leave the workspace permanently over-budget with nothing to
+    // delete. Rebuild from the restored shared-bucket prefix (best-effort,
+    // same rationale as the attach path above).
+    if (force) {
+      await storageReconcile(c.env, updated, name).catch((err) =>
+        console.error("workspace storage detach: usage reconcile failed for", name, err),
+      );
+    }
 
     return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
   });

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -1,0 +1,121 @@
+/**
+ * Helpers for the self-serve BYO-bucket storage routes on `/me` (issue #583
+ * Task 1.1). The routes themselves live in `me.ts` alongside the
+ * comment-settings triple they're modeled on (same audience: `sessionAuth` +
+ * `requireSessionUser` + `adminWorkspaceOr403`, writes behind `allowWrite`) —
+ * this file holds the pure/reusable pieces so that file doesn't grow a second
+ * copy of masking and projection logic.
+ */
+import {
+  verifyStorageConfig,
+  type StorageVerifyCandidate,
+  type StorageVerifyOptions,
+  type StorageVerifyResult,
+} from "../storage-verify";
+import { storageBudgetApplies } from "../budget";
+import type { WorkspaceRecord } from "../workspace";
+
+/** Last 4 chars only, prefixed with an ellipsis (e.g. `"…abcd"`). `undefined` for an empty/missing value. */
+export function maskTrailing(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return `…${value.slice(-4)}`;
+}
+
+/** Bare last-4 (no ellipsis) — used for `accessKeyIdLast4`, matching the plan's field name. */
+export function lastFour(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.slice(-4);
+}
+
+/**
+ * True when `record` is customer-credential (BYO) storage: HTTP credentials
+ * with no R2 binding. Delegates to `storageBudgetApplies` (budget.ts) rather
+ * than re-deriving the signal, so the two surfaces can't drift on what counts
+ * as BYO — `storageBudgetApplies` returns `false` for exactly this shape.
+ */
+export function isByoRecord(
+  record: Pick<WorkspaceRecord, "binding" | "accountId" | "accessKeyId" | "secretAccessKey">,
+): boolean {
+  return !storageBudgetApplies(record);
+}
+
+export interface StorageStatusResponse {
+  mode: "shared" | "byo";
+  byoBucketEnabled: boolean;
+  bucket?: string;
+  accountIdMasked?: string;
+  accessKeyIdLast4?: string;
+  publicBaseUrl?: string;
+  configuredAt?: string;
+  verifiedAt?: string;
+}
+
+/**
+ * Projection shared by `GET /me/workspaces/:name/storage` and the success
+ * response of `PUT` — never includes credential values (precedent: `GET
+ * /admin/workspaces/:name` in `admin.ts`, which projects presence booleans
+ * only). `byoBucketEnabled` is always reported, even in shared mode, because
+ * the settings UI needs it to decide whether to show the "connect your own
+ * bucket" panel at all.
+ */
+export function storageStatusResponse(
+  record: WorkspaceRecord,
+  byoBucketEnabled: boolean,
+): StorageStatusResponse {
+  const byo = isByoRecord(record);
+  return {
+    mode: byo ? "byo" : "shared",
+    byoBucketEnabled,
+    bucket: record.bucket,
+    publicBaseUrl: record.publicBaseUrl,
+    accountIdMasked: byo ? maskTrailing(record.accountId) : undefined,
+    accessKeyIdLast4: byo ? lastFour(record.accessKeyId) : undefined,
+    configuredAt: record.storageConfiguredAt,
+    verifiedAt: record.storageVerifiedAt,
+  };
+}
+
+/**
+ * Verify pipeline entry point the storage routes call, indirected through
+ * this mutable binding so tests can substitute a fake without hitting the
+ * network. Candidate storage is always HTTP-credential mode (no R2 binding
+ * to fake the way other routes fake R2 with `FakeR2Bucket`), so route tests
+ * need this seam instead — restore the default with
+ * `setStorageVerifyForTests(undefined)` in an `afterEach`/`finally`.
+ */
+let runStorageVerify: (
+  candidate: StorageVerifyCandidate,
+  opts?: StorageVerifyOptions,
+) => Promise<StorageVerifyResult> = verifyStorageConfig;
+
+export function storageVerify(
+  candidate: StorageVerifyCandidate,
+  opts?: StorageVerifyOptions,
+): Promise<StorageVerifyResult> {
+  return runStorageVerify(candidate, opts);
+}
+
+/** Test-only: swap the verify implementation. Pass `undefined` to restore the real pipeline. */
+export function setStorageVerifyForTests(
+  fn:
+    | ((
+        candidate: StorageVerifyCandidate,
+        opts?: StorageVerifyOptions,
+      ) => Promise<StorageVerifyResult>)
+    | undefined,
+): void {
+  runStorageVerify = fn ?? verifyStorageConfig;
+}
+
+/** Parses the request body into a `StorageVerifyCandidate` shape (no validation — `verifyStorageConfig`'s `shape` check does that). */
+export function candidateFromBody(body: unknown): StorageVerifyCandidate {
+  const b = (body ?? {}) as Record<string, unknown>;
+  return {
+    bucket: typeof b.bucket === "string" ? b.bucket : "",
+    accountId: typeof b.accountId === "string" ? b.accountId : "",
+    accessKeyId: typeof b.accessKeyId === "string" ? b.accessKeyId : "",
+    secretAccessKey: typeof b.secretAccessKey === "string" ? b.secretAccessKey : "",
+    publicBaseUrl: typeof b.publicBaseUrl === "string" ? b.publicBaseUrl : undefined,
+    adoptExistingContents: b.adoptExistingContents === true,
+  };
+}

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -13,18 +13,13 @@ import {
   type StorageVerifyResult,
 } from "../storage-verify";
 import { storageBudgetApplies } from "../budget";
+import { reconcileWorkspaceUsage } from "../reconcile";
 import type { WorkspaceRecord } from "../workspace";
 
 /** Last 4 chars only, prefixed with an ellipsis (e.g. `"…abcd"`). `undefined` for an empty/missing value. */
 export function maskTrailing(value: string | undefined): string | undefined {
   if (!value) return undefined;
   return `…${value.slice(-4)}`;
-}
-
-/** Bare last-4 (no ellipsis) — used for `accessKeyIdLast4`, matching the plan's field name. */
-export function lastFour(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  return value.slice(-4);
 }
 
 /**
@@ -69,7 +64,10 @@ export function storageStatusResponse(
     bucket: record.bucket,
     publicBaseUrl: record.publicBaseUrl,
     accountIdMasked: byo ? maskTrailing(record.accountId) : undefined,
-    accessKeyIdLast4: byo ? lastFour(record.accessKeyId) : undefined,
+    // Never derived from `record.accessKeyId` — after a self-serve save that
+    // field holds the sealed `enc:v1:` blob, so its last 4 characters would
+    // be ciphertext. The PUT route stamps the plaintext fragment at seal time.
+    accessKeyIdLast4: byo ? record.storageAccessKeyIdLast4 : undefined,
     configuredAt: record.storageConfiguredAt,
     verifiedAt: record.storageVerifiedAt,
   };
@@ -105,6 +103,26 @@ export function setStorageVerifyForTests(
     | undefined,
 ): void {
   runStorageVerify = fn ?? verifyStorageConfig;
+}
+
+/**
+ * Usage-ledger rebuild the storage routes call after a guard-bypassed
+ * backing-storage transition (`adoptExistingContents` on attach, `force` on
+ * detach) — same test-seam rationale as `storageVerify` above: the real
+ * `reconcileWorkspaceUsage` walks the (possibly remote) bucket.
+ */
+let runStorageReconcile: (env: Env, ws: WorkspaceRecord, name: string) => Promise<unknown> =
+  reconcileWorkspaceUsage;
+
+export function storageReconcile(env: Env, ws: WorkspaceRecord, name: string): Promise<unknown> {
+  return runStorageReconcile(env, ws, name);
+}
+
+/** Test-only: swap the reconcile implementation. Pass `undefined` to restore the real one. */
+export function setStorageReconcileForTests(
+  fn: ((env: Env, ws: WorkspaceRecord, name: string) => Promise<unknown>) | undefined,
+): void {
+  runStorageReconcile = fn ?? reconcileWorkspaceUsage;
 }
 
 /** Parses the request body into a `StorageVerifyCandidate` shape (no validation — `verifyStorageConfig`'s `shape` check does that). */

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type StorageProbeClient,
+  type StorageVerifyCandidate,
+  verifyStorageConfig,
+} from "./storage-verify";
+
+const VALID: StorageVerifyCandidate = {
+  bucket: "my-bucket",
+  accountId: "a".repeat(32),
+  accessKeyId: "AKIAEXAMPLE",
+  secretAccessKey: "s3cr3t",
+};
+
+class FakeError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+/** In-memory fake standing in for the files-sdk `Files` client the pipeline talks to. */
+class FakeStorageClient implements StorageProbeClient {
+  store = new Map<string, Uint8Array>();
+  deletedKeys: string[] = [];
+  listError?: unknown;
+  uploadError?: unknown;
+
+  constructor(seed: Record<string, Uint8Array> = {}) {
+    for (const [k, v] of Object.entries(seed)) this.store.set(k, v);
+  }
+
+  async list(opts?: { prefix?: string; limit?: number }) {
+    if (this.listError) throw this.listError;
+    const prefix = opts?.prefix ?? "";
+    return {
+      items: [...this.store.keys()].filter((k) => k.startsWith(prefix)).map((key) => ({ key })),
+    };
+  }
+
+  async upload(key: string, body: Uint8Array) {
+    if (this.uploadError) throw this.uploadError;
+    this.store.set(key, body);
+    return { key, size: body.byteLength, contentType: "application/octet-stream" };
+  }
+
+  async download(key: string) {
+    const data = this.store.get(key);
+    if (!data) throw new FakeError("NotFound", `no such key: ${key}`);
+    return {
+      arrayBuffer: async () =>
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer,
+    };
+  }
+
+  async delete(key: string) {
+    this.deletedKeys.push(key);
+    this.store.delete(key);
+  }
+}
+
+function run(
+  candidate: StorageVerifyCandidate,
+  client: FakeStorageClient,
+  fetchImpl?: typeof fetch,
+) {
+  return verifyStorageConfig(candidate, { createClient: () => client, fetch: fetchImpl });
+}
+
+describe("verifyStorageConfig — shape", () => {
+  it("fails on a malformed account id", async () => {
+    const result = await run({ ...VALID, accountId: "not-hex" }, new FakeStorageClient());
+    expect(result.ok).toBe(false);
+    const shape = result.checks.find((c) => c.id === "shape")!;
+    expect(shape.ok).toBe(false);
+    expect(shape.required).toBe(true);
+    expect(shape.hint).toMatch(/accountId/);
+    // Shape failure short-circuits — no further checks run.
+    expect(result.checks).toHaveLength(1);
+  });
+
+  it("fails on an invalid bucket name", async () => {
+    const result = await run({ ...VALID, bucket: "-bad-" }, new FakeStorageClient());
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/bucket name/);
+  });
+
+  it("fails on missing key material", async () => {
+    const result = await run(
+      { ...VALID, accessKeyId: "", secretAccessKey: "" },
+      new FakeStorageClient(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/access key id and secret access key/);
+  });
+
+  it("rejects a non-https publicBaseUrl", async () => {
+    const result = await run(
+      { ...VALID, publicBaseUrl: "http://media.example.com" },
+      new FakeStorageClient(),
+    );
+    expect(result.checks[0].hint).toMatch(/https/);
+  });
+
+  it("rejects r2.dev with the dedicated 'not supported right now' hint", async () => {
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://pub-abc123.r2.dev" },
+      new FakeStorageClient(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/r2\.dev URLs aren't supported right now/);
+  });
+
+  it("rejects an uploads.sh publicBaseUrl", async () => {
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://storage.uploads.sh" },
+      new FakeStorageClient(),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/uploads\.sh/);
+  });
+});
+
+describe("verifyStorageConfig — auth/reachability", () => {
+  it("fails with an unauthorized hint on a rejected key", async () => {
+    const client = new FakeStorageClient();
+    client.listError = new FakeError("Unauthorized", "denied");
+    const result = await run(VALID, client);
+    expect(result.ok).toBe(false);
+    const auth = result.checks.find((c) => c.id === "auth")!;
+    expect(auth.ok).toBe(false);
+    expect(auth.hint).toMatch(/access key was rejected/);
+    // Short-circuits before round-trip/not-empty.
+    expect(result.checks.map((c) => c.id)).toEqual(["shape", "auth"]);
+  });
+
+  it("fails with a bucket-not-found hint", async () => {
+    const client = new FakeStorageClient();
+    client.listError = new FakeError("NotFound", "no such bucket");
+    const result = await run(VALID, client);
+    expect(result.checks.find((c) => c.id === "auth")!.hint).toMatch(/bucket not found/);
+  });
+});
+
+describe("verifyStorageConfig — round trip + empty-bucket guard", () => {
+  it("passes end to end on an empty bucket with no publicBaseUrl", async () => {
+    const client = new FakeStorageClient();
+    const result = await run(VALID, client);
+    expect(result.ok).toBe(true);
+    expect(result.checks.map((c) => c.id)).toEqual(["shape", "auth", "round-trip", "not-empty"]);
+    expect(result.checks.every((c) => c.ok)).toBe(true);
+    // Probe object must not be left behind.
+    expect(client.store.size).toBe(0);
+    expect(client.deletedKeys).toHaveLength(1);
+    expect(client.deletedKeys[0]).toMatch(/^_internal\/uploads-verify\//);
+  });
+
+  it("fails the empty-bucket guard when the bucket already has objects", async () => {
+    const client = new FakeStorageClient({ "some/existing.png": new Uint8Array([1, 2, 3]) });
+    const result = await run(VALID, client);
+    expect(result.ok).toBe(false);
+    const notEmpty = result.checks.find((c) => c.id === "not-empty")!;
+    expect(notEmpty.ok).toBe(false);
+    expect(notEmpty.hint).toMatch(/adoptExistingContents/);
+  });
+
+  it("passes the empty-bucket guard when adoptExistingContents is set", async () => {
+    const client = new FakeStorageClient({ "some/existing.png": new Uint8Array([1, 2, 3]) });
+    const result = await run({ ...VALID, adoptExistingContents: true }, client);
+    expect(result.ok).toBe(true);
+    expect(result.checks.find((c) => c.id === "not-empty")!.ok).toBe(true);
+  });
+
+  it("does not count a leftover probe object from a prior failed run against the empty-bucket guard", async () => {
+    const client = new FakeStorageClient({
+      "_internal/uploads-verify/stale-uuid": new Uint8Array([9]),
+    });
+    const result = await run(VALID, client);
+    expect(result.checks.find((c) => c.id === "not-empty")!.ok).toBe(true);
+  });
+
+  it("cleans up the probe object even when the round-trip fails", async () => {
+    const client = new FakeStorageClient();
+    client.uploadError = new FakeError("Unauthorized", "read-only token");
+    const result = await run(VALID, client);
+    const roundTrip = result.checks.find((c) => c.id === "round-trip")!;
+    expect(roundTrip.ok).toBe(false);
+    expect(roundTrip.hint).toMatch(/Object Read & Write/);
+    // delete() is still attempted (best-effort) even though upload failed.
+    expect(client.deletedKeys).toHaveLength(1);
+    expect(result.ok).toBe(false);
+  });
+
+  it("never echoes credential values in any check hint", async () => {
+    const client = new FakeStorageClient();
+    client.listError = new FakeError("Unauthorized", "denied");
+    const result = await run(VALID, client);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(VALID.secretAccessKey);
+    expect(serialized).not.toContain(VALID.accessKeyId);
+  });
+});
+
+describe("verifyStorageConfig — recommended public-URL probe", () => {
+  it("skips cleanly when no publicBaseUrl is supplied (signed-only mode)", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn();
+    const result = await run(VALID, client, fetchImpl as unknown as typeof fetch);
+    expect(result.checks.find((c) => c.id === "public-url")).toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("passes as a recommended check when the served bytes match", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => {
+      const [key] = client.deletedKeys.length ? client.deletedKeys : [...client.store.keys()];
+      const data = client.store.get(key)!;
+      return new Response(data, { status: 200 });
+    });
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(result.ok).toBe(true);
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(true);
+    expect(publicUrl.required).toBe(false);
+  });
+
+  it("marks a byte mismatch as a recommended failure without flipping overall ok", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async () => new Response(new Uint8Array([9, 9, 9]), { status: 200 }));
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(false);
+    expect(publicUrl.required).toBe(false);
+    expect(publicUrl.hint).toMatch(/cached|stale/);
+    // Recommended check never gates ok — required checks all passed.
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports a fetch failure (DNS/timeout) as a recommended, non-gating failure", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network error: ENOTFOUND");
+    });
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(false);
+    expect(publicUrl.hint).toMatch(/DNS/);
+    expect(result.ok).toBe(true);
+  });
+
+  it("skips the public-url check (marked failed) when the round-trip itself failed", async () => {
+    const client = new FakeStorageClient();
+    client.uploadError = new FakeError("Unauthorized", "read-only token");
+    const fetchImpl = vi.fn();
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(false);
+    expect(publicUrl.required).toBe(false);
+    expect(publicUrl.hint).toMatch(/skipped/);
+    expect(result.ok).toBe(false); // round-trip (required) failed
+  });
+});

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -121,6 +121,24 @@ describe("verifyStorageConfig — shape", () => {
     expect(result.ok).toBe(false);
     expect(result.checks[0].hint).toMatch(/uploads\.sh/);
   });
+
+  it("rejects non-public hosts (localhost, IP literals, single-label names) before any probe I/O", async () => {
+    for (const publicBaseUrl of [
+      "https://localhost",
+      "https://media.localhost",
+      "https://10.0.0.1",
+      "https://[::1]",
+      "https://intranet",
+    ]) {
+      const client = new FakeStorageClient();
+      const listSpy = vi.spyOn(client, "list");
+      const result = await run({ ...VALID, publicBaseUrl }, client);
+      expect(result.ok).toBe(false);
+      expect(result.checks[0].hint).toMatch(/public custom domain/);
+      // Shape short-circuits — nothing touches the bucket or the URL.
+      expect(listSpy).not.toHaveBeenCalled();
+    }
+  });
 });
 
 describe("verifyStorageConfig — auth/reachability", () => {
@@ -244,6 +262,35 @@ describe("verifyStorageConfig — recommended public-URL probe", () => {
     expect(publicUrl.hint).toMatch(/cached|stale/);
     // Recommended check never gates ok — required checks all passed.
     expect(result.ok).toBe(true);
+  });
+
+  it("reports a non-2xx response as a recommended failure carrying the status", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 404 }));
+    const result = await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    const publicUrl = result.checks.find((c) => c.id === "public-url")!;
+    expect(publicUrl.ok).toBe(false);
+    expect(publicUrl.required).toBe(false);
+    expect(publicUrl.hint).toMatch(/HTTP 404/);
+    expect(result.ok).toBe(true);
+  });
+
+  it("sends the public-URL probe with an abort signal so a stalled domain can't hang verify", async () => {
+    const client = new FakeStorageClient();
+    const fetchImpl = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return new Response(new Uint8Array([9]), { status: 200 });
+    });
+    await run(
+      { ...VALID, publicBaseUrl: "https://media.example.com" },
+      client,
+      fetchImpl as unknown as typeof fetch,
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("reports a fetch failure (DNS/timeout) as a recommended, non-gating failure", async () => {

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -84,6 +84,9 @@ export interface StorageVerifyOptions {
 /** Prefix every verify probe object lives under, excluded from the empty-bucket count. */
 const PROBE_PREFIX = "_internal/uploads-verify/";
 
+/** Deadline for the recommended public-URL probe; a stalled customer domain must not stall verify. */
+const PUBLIC_URL_PROBE_TIMEOUT_MS = 5_000;
+
 const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/;
 /** R2 bucket naming rules: 3-63 chars, lowercase alphanumeric + hyphen, not leading/trailing hyphen. */
 const BUCKET_NAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
@@ -133,6 +136,19 @@ function checkPublicBaseUrlShape(publicBaseUrl: string): string | undefined {
     return "publicBaseUrl must use https";
   }
   const host = url.hostname.toLowerCase();
+  // Public custom domains only. The recommended probe fetches this host from
+  // inside the worker, so anything that could resolve to an internal name or
+  // literal address would turn verify into a reachability probe — reject
+  // before any network I/O happens.
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    !host.includes(".") ||
+    /^\d{1,3}(\.\d{1,3}){3}$/.test(host) ||
+    host.startsWith("[")
+  ) {
+    return "publicBaseUrl must be a public custom domain (not an IP address or internal hostname)";
+  }
   if (host === "r2.dev" || host.endsWith(".r2.dev")) {
     return "r2.dev URLs aren't supported right now — connect a custom domain, or save without a public URL for signed-only access";
   }
@@ -184,7 +200,10 @@ async function checkPublicUrl(
 ): Promise<StorageVerifyCheck> {
   const url = `${publicBaseUrl.replace(/\/$/, "")}/${probeKey}`;
   try {
-    const res = await fetchImpl(url, { redirect: "error" });
+    const res = await fetchImpl(url, {
+      redirect: "error",
+      signal: AbortSignal.timeout(PUBLIC_URL_PROBE_TIMEOUT_MS),
+    });
     if (!res.ok) {
       return {
         id: "public-url",

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -1,0 +1,316 @@
+/**
+ * Verification pipeline for a candidate BYO R2 config (issue: self-serve
+ * BYO R2 bucket, Task 1.1). Runs entirely against the request body — never
+ * saved state — so a workspace admin can iterate before anything is
+ * persisted. Modeled on `GithubHealthResult`
+ * (`apps/api/src/routes/github-health.ts`): a list of per-check results with
+ * a required/recommended split and a human `hint` on failure. `ok` is true
+ * only when every *required* check passes; recommended checks never flip it.
+ *
+ * The storage client is injectable so tests never hit the network — the
+ * default factory reuses `createStorage` from `@uploads/storage` (the same
+ * seam `apps/api/src/storage.ts` resolves through), which picks the
+ * files-sdk HTTP R2 adapter whenever no binding is supplied, exactly the
+ * case here (self-serve BYO is HTTP-credential-mode only, see the plan's
+ * Global Constraints).
+ *
+ * Never include credential values in any check result, hint, or log line.
+ */
+import { createStorage, type StorageConfig } from "@uploads/storage";
+
+/** Candidate config a workspace admin is trying to attach — not yet saved. */
+export interface StorageVerifyCandidate {
+  bucket: string;
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  /** Custom domain fronting the bucket for public reads. Omit for signed-only serving. */
+  publicBaseUrl?: string;
+  /**
+   * Caller has explicitly confirmed the bucket's existing contents should be
+   * exposed under this workspace. Without it, a non-empty bucket fails the
+   * empty-bucket guard (required check `not-empty`).
+   */
+  adoptExistingContents?: boolean;
+}
+
+export interface StorageVerifyCheck {
+  /** Stable identifier — `"shape" | "auth" | "round-trip" | "not-empty" | "public-url"`. */
+  id: string;
+  ok: boolean;
+  /** Required checks gate `StorageVerifyResult.ok`; recommended ones only ever warn. */
+  required: boolean;
+  /** Human remediation text, present when `ok` is false. */
+  hint?: string;
+}
+
+export interface StorageVerifyResult {
+  /** True only when every required check passed. */
+  ok: boolean;
+  checks: StorageVerifyCheck[];
+}
+
+/** Minimal surface the pipeline needs from a storage client — satisfied by files-sdk's `Files`. */
+export interface StorageProbeClient {
+  list(opts?: { prefix?: string; limit?: number }): Promise<{ items: { key: string }[] }>;
+  upload(key: string, body: Uint8Array, opts?: { contentType?: string }): Promise<unknown>;
+  download(key: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> }>;
+  delete(key: string): Promise<void>;
+}
+
+/** Builds the real storage client for a candidate config. Swap in tests to avoid the network. */
+export type StorageClientFactory = (candidate: StorageVerifyCandidate) => StorageProbeClient;
+
+/** Default factory: routes through the same `createStorage` seam production I/O uses. */
+export function defaultStorageClientFactory(candidate: StorageVerifyCandidate): StorageProbeClient {
+  const config: StorageConfig = {
+    provider: "r2",
+    bucket: candidate.bucket,
+    accountId: candidate.accountId,
+    accessKeyId: candidate.accessKeyId,
+    secretAccessKey: candidate.secretAccessKey,
+    publicBaseUrl: candidate.publicBaseUrl,
+  };
+  return createStorage(config);
+}
+
+export interface StorageVerifyOptions {
+  /** Defaults to {@link defaultStorageClientFactory}. */
+  createClient?: StorageClientFactory;
+  /** Defaults to `globalThis.fetch`. Only used for the recommended public-URL probe. */
+  fetch?: typeof fetch;
+}
+
+/** Prefix every verify probe object lives under, excluded from the empty-bucket count. */
+const PROBE_PREFIX = "_internal/uploads-verify/";
+
+const ACCOUNT_ID_RE = /^[0-9a-f]{32}$/;
+/** R2 bucket naming rules: 3-63 chars, lowercase alphanumeric + hyphen, not leading/trailing hyphen. */
+const BUCKET_NAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+function checkShape(candidate: StorageVerifyCandidate): StorageVerifyCheck {
+  const problems: string[] = [];
+  if (!ACCOUNT_ID_RE.test(candidate.accountId)) {
+    problems.push("accountId must be a 32-character lowercase hex Cloudflare account id");
+  }
+  if (
+    candidate.bucket.length < 3 ||
+    candidate.bucket.length > 63 ||
+    !BUCKET_NAME_RE.test(candidate.bucket)
+  ) {
+    problems.push(
+      "bucket name must be 3-63 characters, lowercase letters/digits/hyphens, and can't start or end with a hyphen",
+    );
+  }
+  if (!candidate.accessKeyId || !candidate.secretAccessKey) {
+    problems.push("access key id and secret access key are both required");
+  }
+  if (candidate.publicBaseUrl) {
+    const urlProblem = checkPublicBaseUrlShape(candidate.publicBaseUrl);
+    if (urlProblem) problems.push(urlProblem);
+  }
+  return {
+    id: "shape",
+    ok: problems.length === 0,
+    required: true,
+    hint: problems.length ? problems.join("; ") : undefined,
+  };
+}
+
+/**
+ * `r2.dev` is rejected as a required failure (decided 2026-07-31 — not
+ * supported in v1), not a warning; `*.uploads.sh` is rejected because it
+ * would collide with the platform's own hosts.
+ */
+function checkPublicBaseUrlShape(publicBaseUrl: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(publicBaseUrl);
+  } catch {
+    return "publicBaseUrl must be a valid URL";
+  }
+  if (url.protocol !== "https:") {
+    return "publicBaseUrl must use https";
+  }
+  const host = url.hostname.toLowerCase();
+  if (host === "r2.dev" || host.endsWith(".r2.dev")) {
+    return "r2.dev URLs aren't supported right now — connect a custom domain, or save without a public URL for signed-only access";
+  }
+  if (host === "uploads.sh" || host.endsWith(".uploads.sh")) {
+    return "publicBaseUrl can't point at an uploads.sh host";
+  }
+  return undefined;
+}
+
+/** Duck-types files-sdk's `FilesError` without depending on the package directly (apps/api doesn't declare it). */
+function errorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+function hintForAuthError(err: unknown): string {
+  switch (errorCode(err)) {
+    case "Unauthorized":
+      return "the access key was rejected — check the key id/secret and that the R2 API token is scoped to this bucket";
+    case "NotFound":
+      return "bucket not found at this account id — check the bucket name for typos";
+    default:
+      return "could not reach the bucket — check the account id, bucket name, and network path";
+  }
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Recommended, non-blocking check: fetch the still-live probe object via the
+ * candidate's public base URL and byte-compare against what was written.
+ * Never runs when there's no `publicBaseUrl` (signed-only mode is valid) or
+ * when the round-trip failed (no probe object to fetch).
+ */
+async function checkPublicUrl(
+  publicBaseUrl: string,
+  probeKey: string,
+  probeBytes: Uint8Array,
+  fetchImpl: typeof fetch,
+): Promise<StorageVerifyCheck> {
+  const url = `${publicBaseUrl.replace(/\/$/, "")}/${probeKey}`;
+  try {
+    const res = await fetchImpl(url, { redirect: "error" });
+    if (!res.ok) {
+      return {
+        id: "public-url",
+        ok: false,
+        required: false,
+        hint: `fetching the probe object via publicBaseUrl returned HTTP ${res.status} — the domain may be connected to a different bucket, or public access isn't enabled yet`,
+      };
+    }
+    const body = new Uint8Array(await res.arrayBuffer());
+    if (!bytesEqual(body, probeBytes)) {
+      return {
+        id: "public-url",
+        ok: false,
+        required: false,
+        hint: "the bytes served from publicBaseUrl didn't match what was just written — this can mean a cached/stale response from an edge in front of the domain rather than a wiring problem; try again in a minute",
+      };
+    }
+    return { id: "public-url", ok: true, required: false };
+  } catch {
+    return {
+      id: "public-url",
+      ok: false,
+      required: false,
+      hint: "could not reach publicBaseUrl — domain not connected to the bucket yet (DNS can take a few minutes) or the request timed out",
+    };
+  }
+}
+
+/**
+ * Runs the required + recommended check pipeline against `candidate`.
+ * Required checks short-circuit on first failure (shape → auth → round-trip
+ * → not-empty); the recommended public-URL check only runs when the
+ * round-trip succeeded and a `publicBaseUrl` was supplied.
+ */
+export async function verifyStorageConfig(
+  candidate: StorageVerifyCandidate,
+  opts: StorageVerifyOptions = {},
+): Promise<StorageVerifyResult> {
+  const createClient = opts.createClient ?? defaultStorageClientFactory;
+  const fetchImpl = opts.fetch ?? fetch;
+  const checks: StorageVerifyCheck[] = [];
+
+  const shape = checkShape(candidate);
+  checks.push(shape);
+  if (!shape.ok) return { ok: false, checks };
+
+  const client = createClient(candidate);
+
+  // Auth + reachability probe. Its `list()` result also seeds the
+  // empty-bucket guard below, so attaching a bucket costs one list call.
+  let existingItems: { key: string }[];
+  try {
+    const listed = await client.list({ limit: 1000 });
+    existingItems = listed.items;
+  } catch (err) {
+    checks.push({ id: "auth", ok: false, required: true, hint: hintForAuthError(err) });
+    return { ok: false, checks };
+  }
+  checks.push({ id: "auth", ok: true, required: true });
+
+  // Write/read/delete round-trip, plus (while the probe object is still
+  // live) the recommended public-URL fetch. The probe is always removed in
+  // `finally`, whether or not the checks above it passed.
+  const probeKey = `${PROBE_PREFIX}${crypto.randomUUID()}`;
+  const probeBytes = crypto.getRandomValues(new Uint8Array(32));
+  let roundTripOk = false;
+  let roundTripHint: string | undefined;
+  let publicUrlCheck: StorageVerifyCheck | undefined;
+  try {
+    await client.upload(probeKey, probeBytes, { contentType: "application/octet-stream" });
+    const downloaded = await client.download(probeKey);
+    const readBack = new Uint8Array(await downloaded.arrayBuffer());
+    roundTripOk = bytesEqual(probeBytes, readBack);
+    if (!roundTripOk) {
+      roundTripHint =
+        "wrote and read back a probe object but the bytes didn't match — check for another writer racing this bucket";
+    } else if (candidate.publicBaseUrl) {
+      publicUrlCheck = await checkPublicUrl(
+        candidate.publicBaseUrl,
+        probeKey,
+        probeBytes,
+        fetchImpl,
+      );
+    }
+  } catch (err) {
+    roundTripHint =
+      errorCode(err) === "Unauthorized"
+        ? "the access key can read this bucket but was rejected on write — the R2 API token needs Object Read & Write, not read-only"
+        : "could not write/read/delete a test object in this bucket — check the token's permissions";
+  } finally {
+    try {
+      await client.delete(probeKey);
+    } catch {
+      // Best-effort cleanup; a failed delete doesn't change the check result
+      // above (round-trip already recorded), and we never want cleanup
+      // failure to mask the real outcome.
+    }
+  }
+  checks.push({
+    id: "round-trip",
+    ok: roundTripOk,
+    required: true,
+    hint: roundTripOk ? undefined : roundTripHint,
+  });
+
+  const nonProbeItems = existingItems.filter((item) => !item.key.startsWith(PROBE_PREFIX));
+  const notEmptyOk = candidate.adoptExistingContents === true || nonProbeItems.length === 0;
+  checks.push({
+    id: "not-empty",
+    ok: notEmptyOk,
+    required: true,
+    hint: notEmptyOk
+      ? undefined
+      : "this bucket already has objects in it — pass adoptExistingContents to attach it anyway, or point at an empty bucket",
+  });
+
+  if (candidate.publicBaseUrl) {
+    checks.push(
+      publicUrlCheck ?? {
+        id: "public-url",
+        ok: false,
+        required: false,
+        hint: "skipped — the write/read round-trip failed before the public URL could be verified",
+      },
+    );
+  }
+
+  return { ok: checks.filter((c) => c.required).every((c) => c.ok), checks };
+}

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -7,6 +7,12 @@
  *
  * Metering write failures never fail the storage op. Budget checks read this
  * ledger before put (see budget.ts) when the workspace record sets caps.
+ *
+ * The ledger records usage for every workspace, BYO bucket included: even
+ * though `budget.ts`'s `storageBudgetApplies` predicate skips `maxStorageBytes`
+ * enforcement on self-serve BYO records (their disk, their bill), this table
+ * still tracks their bytes/objects/uploads for the settings UI and any future
+ * gateway pricing (issue #583 Task 1.2).
  */
 
 export interface WorkspaceUsage {

--- a/apps/api/src/workspace.test.ts
+++ b/apps/api/src/workspace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  byoBucketAllowed,
   hexToBytes,
   isPurgedTombstone,
   isSha256Hex,
@@ -125,5 +126,19 @@ describe("isUnprefixedDedicatedBucket (#583 lifecycle guards)", () => {
 
   it("treats an empty-string prefix the same as absent (unprefixed)", () => {
     expect(isUnprefixedDedicatedBucket({ ...RECORD, prefix: "" })).toBe(true);
+  });
+});
+
+describe("byoBucketAllowed (#583 Task 1.3 feature gate)", () => {
+  it("is false when byoBucketEnabled is absent (fail-closed default)", () => {
+    expect(byoBucketAllowed({})).toBe(false);
+  });
+
+  it("is false when byoBucketEnabled is explicitly false", () => {
+    expect(byoBucketAllowed({ byoBucketEnabled: false })).toBe(false);
+  });
+
+  it("is true only when byoBucketEnabled is explicitly true", () => {
+    expect(byoBucketAllowed({ byoBucketEnabled: true })).toBe(true);
   });
 });

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -172,6 +172,13 @@ export interface WorkspaceRecord {
   storageVerifiedAt?: string;
   /** Better Auth user id that most recently configured this workspace's storage via the self-serve flow. */
   storageConfiguredBy?: string;
+  /**
+   * Last 4 characters of the *plaintext* access key id, captured at seal time
+   * for the settings UI. Never derive a display fragment from `accessKeyId`
+   * itself — that field holds the sealed (`enc:v1:`) blob after a self-serve
+   * save, so its trailing characters are ciphertext.
+   */
+  storageAccessKeyIdLast4?: string;
 }
 
 /**

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -157,6 +157,34 @@ export interface WorkspaceRecord {
   deletedAt?: string;
   /** `deletedAt` + the grace window (`WORKSPACE_DELETE_GRACE_DAYS`); the retention sweep finalizes at/after this. */
   purgeAt?: string;
+  /**
+   * Self-serve BYO-bucket feature gate (issue #583 Task 1.3). Fail-closed:
+   * only `true` unlocks the storage-config surface (verify/write routes,
+   * settings UI panel, create-flow branch). Default (undefined/false) keeps
+   * every workspace on the shared bucket. Only an operator can set this
+   * today (admin-ui limits/plan PATCH pattern) — no self-serve opt-in exists
+   * yet. See `byoBucketAllowed` below (precedent: `videoPosterEnabled`).
+   */
+  byoBucketEnabled?: boolean;
+  /** ISO timestamp of the most recent successful `PUT /me/workspaces/:name/storage` (self-serve storage-config save). Provenance for the settings UI, not read for any gating decision. */
+  storageConfiguredAt?: string;
+  /** ISO timestamp of the most recent successful storage verification (either at save time or a standalone re-verify). Powers the settings UI's "verified ✓ N days ago" line. */
+  storageVerifiedAt?: string;
+  /** Better Auth user id that most recently configured this workspace's storage via the self-serve flow. */
+  storageConfiguredBy?: string;
+}
+
+/**
+ * Fail-closed gate for the self-serve BYO-bucket surface (issue #583 Task
+ * 1.3): only an explicit `true` unlocks it. Undefined, false, or any other
+ * value is treated as blocked — same posture as `posterGenerationAllowed`'s
+ * kill switches (`apps/api/src/poster.ts`), chosen because losing access to
+ * an unshipped surface costs nothing, while accidentally exposing
+ * customer-credential storage config to a workspace that was never enabled
+ * for it would be a real incident. Only an operator can flip this today.
+ */
+export function byoBucketAllowed(record: Pick<WorkspaceRecord, "byoBucketEnabled">): boolean {
+  return record.byoBucketEnabled === true;
 }
 
 /** Days a soft-deleted workspace's data is retained before the retention sweep finalizes it. */

--- a/packages/billing/src/byo-bucket.ts
+++ b/packages/billing/src/byo-bucket.ts
@@ -1,0 +1,35 @@
+/**
+ * Plan-capability predicate for the self-serve BYO-bucket surface (issue
+ * #583 Task 1.3). Pure — no I/O — sibling to `workspace-cap.ts` and
+ * `member-cap.ts`.
+ *
+ * Ships dark: `PLANS.*.byoBucket` is `true` for every plan today, and
+ * nothing calls this predicate for enforcement yet. The live gate is the
+ * per-workspace `byoBucketEnabled` record flag
+ * (`apps/api/src/workspace.ts`'s `byoBucketAllowed`), off by default and
+ * operator-set only. This predicate exists so that when a future billing
+ * decision restricts BYO to a paid plan, that's a one-line flip on
+ * `PLANS` plus wiring this predicate into the gate check — not new
+ * plumbing. Callers read this predicate, never switch on plan id
+ * (precedent: `marketsMemberCap`).
+ */
+import { getPlan } from "./plans";
+
+/** The shape the predicate needs from a workspace record — a subset of
+ * apps/api's `WorkspaceRecord`, restated here so this package keeps its
+ * independence from `@uploads/api`. */
+export interface ByoBucketPlanRecord {
+  /** Subscription plan, when one has been stamped. */
+  plan?: string;
+}
+
+/**
+ * Whether this workspace's plan permits the BYO-bucket surface. Currently
+ * always `true` (every plan's `byoBucket` capability is `true`) — the real
+ * gate today is `byoBucketAllowed` in `apps/api/src/workspace.ts`, not this
+ * predicate. `getPlan` fails open to `free` for an unrecognized/absent plan
+ * string, same as every other plan-capability read in this package.
+ */
+export function planAllowsByoBucket(record: ByoBucketPlanRecord): boolean {
+  return getPlan(record.plan).byoBucket;
+}

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./byo-bucket";
 export * from "./limits";
 export * from "./member-cap";
 export * from "./plans";

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -38,6 +38,18 @@ export interface PlanDefinition {
    * special-casing plan ids.
    */
   marketsMemberCap: boolean;
+  /**
+   * Whether this plan may use the self-serve BYO-bucket surface (issue #583
+   * Task 1.3). Ships dark: `true` on every plan today, and nothing reads it
+   * for enforcement yet — the short-term gate is the per-workspace
+   * `byoBucketEnabled` record flag (`apps/api/src/workspace.ts`'s
+   * `byoBucketAllowed`), off by default and operator-set only. This field
+   * exists so a future billing decision (e.g. Pro-only) is a one-line flip
+   * here rather than new plumbing. See `packages/billing/src/byo-bucket.ts`
+   * — callers read that predicate, never switch on plan id (precedent:
+   * `marketsMemberCap`).
+   */
+  byoBucket: boolean;
   defaultLimits: WorkspacePlanLimits;
 }
 
@@ -48,6 +60,7 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     blurb: "Everything you need to host screenshots and files for your projects.",
     available: true,
     marketsMemberCap: true,
+    byoBucket: true,
     defaultLimits: {
       maxStorageBytes: 250_000_000,
       maxUploadsPerPeriod: 3000,
@@ -63,6 +76,7 @@ export const PLANS: Record<PlanId, PlanDefinition> = {
     blurb: "10 GB of storage and files up to 100 MB.",
     available: true,
     marketsMemberCap: false,
+    byoBucket: true,
     // Decided 2026-07-22 (first-paid-plan memo): two marketed meters —
     // storage and one unified file cap (video ceiling = upload ceiling on
     // pro; only free carves video out). maxUploadsPerPeriod is an internal

--- a/packages/billing/test/byo-bucket.test.ts
+++ b/packages/billing/test/byo-bucket.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { planAllowsByoBucket } from "../src/byo-bucket";
+import { PLANS } from "../src/plans";
+
+describe("planAllowsByoBucket (#583 Task 1.3 — dark plan capability)", () => {
+  it("ships true on every plan today (dark — nothing enforces it yet)", () => {
+    expect(PLANS.free.byoBucket).toBe(true);
+    expect(PLANS.pro.byoBucket).toBe(true);
+  });
+
+  it("is true for a workspace explicitly on free or pro", () => {
+    expect(planAllowsByoBucket({ plan: "free" })).toBe(true);
+    expect(planAllowsByoBucket({ plan: "pro" })).toBe(true);
+  });
+
+  it("fails open to free's (also true) capability for an unrecognized/absent plan", () => {
+    expect(planAllowsByoBucket({ plan: "enterprise" })).toBe(true);
+    expect(planAllowsByoBucket({})).toBe(true);
+  });
+});

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -84,6 +84,10 @@ export const ERROR_CODES = [
   "storage_misconfigured",
   "storage_credentials_unreadable",
   "secrets_key_unconfigured",
+
+  // Self-serve BYO storage config (apps/api/src/routes/me.ts storage routes)
+  "byo_bucket_disabled",
+  "workspace_storage_not_empty",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];


### PR DESCRIPTION
Phase 1 of the self-serve BYO R2 bucket plan (#583, plan committed in #584): the API surface that lets a workspace admin verify and attach their own R2 bucket — everything behind a fail-closed feature flag that is off for every workspace.

## What's here

**Verification pipeline** — `apps/api/src/storage-verify.ts`
Pure, injectable probe pipeline modeled on `GithubHealthResult` (per-check `id`/`ok`/`required`/`hint`):
- `shape` (required): accountId hex-32, bucket naming rules, key pair present; `publicBaseUrl` must be https, with `*.r2.dev` rejected via a dedicated "not supported right now" hint (decided 2026-07-31) and `*.uploads.sh` rejected outright
- `auth` (required): one `list()` call that both proves credentials and seeds the empty-bucket count
- `round-trip` (required): write/read/delete under `_internal/uploads-verify/<uuid>`, cleanup in `finally`
- `not-empty` (required): zero non-probe objects unless `adoptExistingContents`
- `public-url` (recommended, never gates `ok`): fetches the live probe object through the candidate domain and byte-compares, with distinct hints for DNS-not-ready vs cached/stale vs wrong-bucket

The real client factory reuses `createStorage` from `@uploads/storage` — the same seam production I/O resolves through, HTTP-credential mode only (no bindings, per the plan's global constraints). No credential value ever appears in a check result, hint, or log line.

**Routes** — `GET/verify/PUT/DELETE /me/workspaces/:name/storage` (in `me.ts`, helpers in `routes/workspace-storage.ts`)
Admin-gated like the comment-settings triple; writes behind `allowWrite`.
- `GET` returns a masked projection (mode, last-4s, provenance stamps) and is readable regardless of the flag so the settings UI knows whether to show the panel
- `POST …/verify` runs the pipeline against the body, persists nothing
- `PUT` re-runs verification server-side (422 with the check list on failure — a client "verified" claim is never trusted), requires zero recorded objects unless `adoptExistingContents`, then seals credentials with `sealCredentialFieldsStrict` *inside* the `mutateWorkspaceRecord` callback, drops `prefix`/`binding`, and stamps `storageConfiguredAt/VerifiedAt/ConfiguredBy`
- `DELETE` detaches: restores shared-bucket fields from `selfServeWorkspaceRecord` while preserving everything else on the record, removes credentials and stamps, and never touches customer objects; blocked on non-zero usage unless forced

**Feature flag + policy**
- `byoBucketEnabled` on the workspace record, fail-closed (`byoBucketAllowed`, precedent: `videoPosterEnabled`); operator-set only, off for everyone — this PR ships the surface dark
- `storageBudgetApplies` in `budget.ts`: `maxStorageBytes` is not enforced on customer-credential records (their disk), while `maxUploadBytes`/`maxVideoUploadBytes`/`maxUploadsPerPeriod` stay enforced; the usage ledger still records BYO usage. The BYO signal is storage *ownership* (full credential triple, no `binding`) — deliberately not the prefix-layout signal lifecycle jobs use, documented in place
- `byoBucket` plan capability on `PlanDefinition` + `planAllowsByoBucket`, `true` on all plans and read by nothing yet — the dark hook so a future billing decision is a one-line flip

**Error codes**: `byo_bucket_disabled` (403), `workspace_storage_not_empty` (409); `secrets_key_unconfigured`/storage-seam codes landed in #584.

## Testing

- 19 pipeline tests (every required-check failure mode, r2.dev/uploads.sh hints, adopt override, probe cleanup on failure, recommended-check isolation)
- 16 route tests (flag-off blocking with GET still readable, sealed `enc:v1:` values + dropped prefix/binding asserted on the stored record, 422/409 paths, detach restores defaults and preserves unrelated fields, projection leak check, 503 when the KEK is unset)
- Policy truth tables for `storageBudgetApplies`/`byoBucketAllowed`/`planAllowsByoBucket`
- Full root suite: 267 files / 3701 tests passing; `tsc --noEmit` clean on apps/api and packages/billing

## Not in this PR

Phase 2 (create-flow + settings UI) and Phase 3 (doctor/docs/admin) follow per the plan. Nothing is user-visible until the flag is enabled per-workspace (`buildinternet` + `default` first, at rollout time).

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting workspaces to customer-owned storage buckets.
  * Added secure storage setup, credential verification, masked status display, adoption of existing contents, and safe detachment.
  * Added plan-based controls for customer-owned storage.
* **Bug Fixes**
  * Storage limits no longer apply to customer-owned buckets, while upload-period limits remain enforced.
  * Added clearer errors for disabled customer-owned storage and non-empty buckets.
* **Security**
  * Credentials are encrypted at rest and never exposed in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->