### PR TITLE
docs: bring-your-own-bucket subject page and self-serve flow docs

### DIFF
--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -252,6 +252,7 @@ staged files are promoted into the PR's attachments comment automatically.
 - Agents: https://uploads.sh/docs/agents
 - Reference: https://uploads.sh/docs/reference
 - Plans & limits: https://uploads.sh/docs/limits
+- Bring your own bucket: https://uploads.sh/docs/byo-bucket
 - Agent walkthrough: https://uploads.sh/github-screenshots
 - Source: https://github.com/buildinternet/uploads
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -19,7 +19,7 @@ Landed on the GitHub monorepo instead? Start at [repo llms.txt](https://github.c
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skills and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Docs: plans & limits](https://uploads.sh/docs/limits): storage/file-size/member caps per plan, behavior at each cap, and the GitHub attachment-cap comparison
-- [Docs: bring your own bucket](https://uploads.sh/docs/byo-bucket): point a workspace at your own Cloudflare R2 bucket instead of the shared one — setup steps, the serving matrix, what's degraded, disconnecting (feature-flagged, not GA)
+- [Docs: bring your own bucket](https://uploads.sh/docs/byo-bucket): point a workspace at your own Cloudflare R2 bucket instead of the shared one — setup steps, the serving matrix, what's degraded, disconnecting (in preview)
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
 - [Auth for agents](https://uploads.sh/auth.md): self-serve and invitation enrollment, bearer tokens, and the hosted-MCP OAuth authorization server
 - [Source & docs](https://github.com/buildinternet/uploads): repository, roadmap, and operator docs

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -19,6 +19,7 @@ Landed on the GitHub monorepo instead? Start at [repo llms.txt](https://github.c
 - [Docs: agents](https://uploads.sh/docs/agents): install the agent skills and MCP server, or the all-in-one Claude Code plugin
 - [Docs: reference](https://uploads.sh/docs/reference): manage uploads (list/delete/usage) and what to know before relying on it
 - [Docs: plans & limits](https://uploads.sh/docs/limits): storage/file-size/member caps per plan, behavior at each cap, and the GitHub attachment-cap comparison
+- [Docs: bring your own bucket](https://uploads.sh/docs/byo-bucket): point a workspace at your own Cloudflare R2 bucket instead of the shared one — setup steps, the serving matrix, what's degraded, disconnecting (feature-flagged, not GA)
 - [Agent guide](https://uploads.sh/github-screenshots): how to get coding agents to upload screenshots & video to GitHub PRs and issues
 - [Auth for agents](https://uploads.sh/auth.md): self-serve and invitation enrollment, bearer tokens, and the hosted-MCP OAuth authorization server
 - [Source & docs](https://github.com/buildinternet/uploads): repository, roadmap, and operator docs

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -41,6 +41,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://uploads.sh/docs/byo-bucket</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://uploads.sh/github-screenshots</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -47,6 +47,7 @@ const DOCS_NAV = [
       { slug: "agents", href: "/docs/agents", label: "Set up your agent" },
       { slug: "reference", href: "/docs/reference", label: "Reference" },
       { slug: "limits", href: "/docs/limits", label: "Plans & limits" },
+      { slug: "byo-bucket", href: "/docs/byo-bucket", label: "Bring your own bucket" },
     ],
   },
   {

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -150,7 +150,7 @@ it opens (or run: uploads attach --promote once it exists)</pre>
       <a class="card" href="/docs/byo-bucket">
         <h3>Bring your own bucket <span class="go">→</span></h3>
         <p>
-          Point a workspace at your own Cloudflare R2 bucket instead of the shared one. Flag-gated.
+          Point a workspace at your own Cloudflare R2 bucket instead of the shared one. In preview.
         </p>
       </a>
       <a class="card" href="/github-screenshots">

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -147,6 +147,12 @@ it opens (or run: uploads attach --promote once it exists)</pre>
         <h3>Plans &amp; limits <span class="go">→</span></h3>
         <p>Storage and file-size caps per plan, and how they compare with GitHub's.</p>
       </a>
+      <a class="card" href="/docs/byo-bucket">
+        <h3>Bring your own bucket <span class="go">→</span></h3>
+        <p>
+          Point a workspace at your own Cloudflare R2 bucket instead of the shared one. Flag-gated.
+        </p>
+      </a>
       <a class="card" href="/github-screenshots">
         <h3>Agent walkthrough <span class="go">→</span></h3>
         <p>A guided setup for getting a coding agent to upload screenshots and video to GitHub.</p>

--- a/apps/web/src/pages/docs/byo-bucket.astro
+++ b/apps/web/src/pages/docs/byo-bucket.astro
@@ -26,9 +26,9 @@ const TOC = [
   toc={TOC}
 >
   <div class="callout" id="status">
-    <strong>Feature-flagged, not generally available yet.</strong> Self-serve BYO storage is gated behind
-    a per-workspace flag that an operator turns on. If your workspace doesn't show a "Connect your own
-    bucket" option on its settings page, the flag isn't on for you yet.
+    <strong>In preview.</strong> Bring-your-own-bucket is available to a small set of workspaces while
+    we finish testing, and we'll be rolling it out generally soon. If your workspace doesn't show a "Connect
+    your own bucket" option on its settings page yet, it isn't part of the preview.
   </div>
 
   <section class="lead" id="setup">

--- a/apps/web/src/pages/docs/byo-bucket.astro
+++ b/apps/web/src/pages/docs/byo-bucket.astro
@@ -1,0 +1,175 @@
+---
+// uploads.sh — docs / bring your own bucket. How the self-serve BYO R2
+// flow works: the three customer-side setup steps, the serving matrix, what
+// degrades on a customer bucket, and how disconnect works. The wizard copy
+// on `/account/workspaces/[name]/settings.astro` (storage-step-1) is the
+// source of truth for the exact dashboard paths — keep this page's wording
+// in sync with it rather than re-deriving it.
+import DocsLayout from "../../layouts/DocsLayout.astro";
+
+const TOC = [
+  { id: "status", label: "Current status" },
+  { id: "setup", label: "Set up your bucket" },
+  { id: "serving", label: "Serving: custom domain vs signed-only" },
+  { id: "degraded", label: "What's degraded" },
+  { id: "ownership", label: "Data ownership & disconnecting" },
+];
+---
+
+<DocsLayout
+  title="Bring your own bucket"
+  description="Point a workspace at your own Cloudflare R2 bucket instead of the shared storage.uploads.sh bucket: setup steps, the serving matrix, what's degraded, and how disconnecting works."
+  path="/docs/byo-bucket"
+  heading="Bring your own bucket"
+  tagline="Point a workspace at storage you already pay for, instead of the shared bucket."
+  active="byo-bucket"
+  toc={TOC}
+>
+  <div class="callout" id="status">
+    <strong>Feature-flagged, not generally available yet.</strong> Self-serve BYO storage is gated behind
+    a per-workspace flag that an operator turns on. If your workspace doesn't show a "Connect your own
+    bucket" option on its settings page, the flag isn't on for you yet.
+  </div>
+
+  <section class="lead" id="setup">
+    <h2>
+      Set up your bucket <a class="anchor" href="#setup" aria-label="Link to this section">#</a>
+    </h2>
+    <p>
+      A workspace admin runs the connect wizard from the workspace's settings page. It walks through
+      three steps on the Cloudflare dashboard, then verifies each one before saving anything.
+    </p>
+    <h3>1. Create an R2 bucket</h3>
+    <p>
+      Dashboard → <strong>R2</strong> → <strong>Create bucket</strong>. Any name, any jurisdiction —
+      the wizard's checks target the default endpoint, so a jurisdiction-restricted bucket (<code
+        >eu</code
+      >, <code>fedramp</code>) isn't supported yet.
+    </p>
+    <h3>2. Create a bucket-scoped API token</h3>
+    <p>
+      <strong>R2</strong> → <strong>Manage API Tokens</strong> → <strong>Create API Token</strong>,
+      permission <strong>Object Read &amp; Write</strong>, scoped to that one bucket only. This
+      yields an Access Key ID, a Secret Access Key, and your account ID.
+    </p>
+    <p class="note">
+      Scope the token to the one bucket, not your whole account. uploads.sh stores the key pair
+      encrypted, but a bucket-scoped token keeps the blast radius to that bucket if anything ever
+      goes wrong on either side.
+    </p>
+    <h3>3. Optional: connect a custom domain for public reads</h3>
+    <p>
+      Bucket → <strong>Settings</strong> → <strong>Public access</strong> → <strong
+        >Custom Domains</strong
+      >, and connect a domain on a Cloudflare zone in your account. Cloudflare provisions the DNS
+      record and certificate; paste the resulting URL (for example <code
+        >https://media.example.com</code
+      >) into the wizard as the public base URL. See the serving matrix below for what this step
+      buys you.
+    </p>
+    <p>
+      Paste the account ID, bucket name, and key pair into the wizard's form, then run verify. It
+      checks the shape of what you entered, confirms the token can authenticate against the bucket,
+      round-trips a test object to prove the token is read <em>and</em> write, and (for a first-time attach)
+      confirms the bucket is empty unless you explicitly say to adopt its existing contents. Only a passing
+      verify lets you save.
+    </p>
+    <p class="note">
+      Connecting is only available at workspace creation or on an otherwise-empty existing workspace
+      — there's no migration path yet for moving a workspace that already has files onto a different
+      bucket, because every published URL for those files would break. Upload limits (file size,
+      video size) still apply on a BYO bucket even though the storage-quota budget doesn't.
+    </p>
+  </section>
+
+  <section id="serving">
+    <h2>
+      Serving: custom domain vs signed-only <a
+        class="anchor"
+        href="#serving"
+        aria-label="Link to this section">#</a
+      >
+    </h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Public access</th>
+          <th>How files are served</th>
+          <th>Trade-off</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Custom domain</th>
+          <td>Direct public URL under your domain, same as a normal share link.</td>
+          <td>Recommended — needs a domain on a Cloudflare zone in your account.</td>
+        </tr>
+        <tr>
+          <th scope="row">No public URL</th>
+          <td>Signed URLs, generated on demand.</td>
+          <td>Works for viewing files, but GitHub embeds won't render (see below).</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>r2.dev</code> managed URL</th>
+          <td>—</td>
+          <td
+            ><strong>Not supported right now.</strong> The wizard rejects an <code>r2.dev</code> public
+            base URL outright — connect a custom domain instead, or save without a public URL for signed-only
+            access.</td
+          >
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="degraded">
+    <h2>
+      What's degraded <a class="anchor" href="#degraded" aria-label="Link to this section">#</a>
+    </h2>
+    <ul>
+      <li>
+        <strong>GitHub embeds.</strong> Images on the shared bucket get an embed-friendly twin host that
+        GitHub's image proxy (Camo) revalidates cleanly after an overwrite. That twin doesn't extend to
+        a custom domain, so an image on a BYO bucket without a public URL — or served only through signed
+        URLs — won't render inline in a GitHub comment. It still uploads and still gets a share page;
+        only the inline-image rendering is affected.
+      </li>
+      <li>
+        <strong><code>retentionDays</code> auto-cleanup.</strong> The age-based retention sweep walks
+        a prefix on the shared bucket. A BYO bucket has no shared prefix to confine that walk to, so automatic
+        retention isn't available — delete old files yourself if you need that.
+      </li>
+      <li>
+        <strong>Storage quota.</strong> While a workspace is on a BYO bucket, the plan's storage budget
+        doesn't apply (you're paying Cloudflare directly for that bucket) — but file-size and video-size
+        upload limits still do.
+      </li>
+    </ul>
+  </section>
+
+  <section id="ownership">
+    <h2>
+      Data ownership &amp; disconnecting <a
+        class="anchor"
+        href="#ownership"
+        aria-label="Link to this section">#</a
+      >
+    </h2>
+    <p>
+      The bucket and everything in it are yours. uploads.sh stores only the encrypted credentials
+      and a pointer to the bucket in the workspace record — never a copy of your files' bytes
+      anywhere else.
+    </p>
+    <p>
+      Disconnecting from workspace settings never touches your objects. It removes the stored
+      credentials and points the workspace back at the shared bucket; your bucket, and everything in
+      it, is left exactly as it was. Re-running the connect wizard afterward is a fresh attach, same
+      as the first time.
+    </p>
+  </section>
+
+  <nav class="page-nav" aria-label="More docs">
+    <a class="prev" href="/docs/limits"><span class="dir">← Back</span>Plans &amp; limits</a>
+    <a class="next" href="/docs"><span class="dir">Docs →</span>Overview</a>
+  </nav>
+</DocsLayout>

--- a/apps/web/src/pages/docs/limits.astro
+++ b/apps/web/src/pages/docs/limits.astro
@@ -149,6 +149,6 @@ const TOC = [
 
   <nav class="page-nav" aria-label="More docs">
     <a class="prev" href="/docs/reference"><span class="dir">← Back</span>Reference</a>
-    <a class="next" href="/docs"><span class="dir">Docs →</span>Overview</a>
+    <a class="next" href="/docs/byo-bucket"><span class="dir">Next →</span>Bring your own bucket</a>
   </nav>
 </DocsLayout>

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -222,9 +222,39 @@ they're back under. To comp an exception, edit the workspace record: clear
 
 ## Bring-your-own-bucket
 
-Register with `--bucket` and the record points at a dedicated bucket (own
-binding or S3 credentials, own `publicBaseUrl`, no prefix). The `buildinternet`
-workspace on `buildinternet-dev` is the reference example.
+A workspace can point at a dedicated bucket instead of the shared one (own
+`accountId`/S3 credentials, own `publicBaseUrl`, no prefix — an unprefixed
+instance sees the whole bucket, so the record never has both a BYO credential
+set and a `prefix`). Two ways to get there:
+
+**Self-serve (product feature, flag-gated).** A workspace admin runs a
+connect wizard from the workspace's settings page: three Cloudflare
+dashboard steps (create a bucket, mint a bucket-scoped "Object Read & Write"
+API token, optionally connect a custom domain for public reads), then a
+server-side verify pipeline (`apps/api/src/storage-verify.ts`,
+`POST /me/workspaces/:name/storage/verify`) that checks shape, auth, a
+write/read/delete round-trip, and — for a first attach — that the bucket is
+empty. Only a passing verify unlocks save (`PUT /me/workspaces/:name/storage`).
+Full customer-facing detail (setup steps, the serving matrix, what's
+degraded) lives at [uploads.sh/docs/byo-bucket](https://uploads.sh/docs/byo-bucket)
+(source: `apps/web/src/pages/docs/byo-bucket.astro`). This whole surface sits
+behind the per-workspace
+`byoBucketEnabled` flag (`byoBucketAllowed` in `apps/api/src/workspace.ts`,
+same pattern as `videoPosterEnabled`) — off by default, and readable but not
+writable until an operator turns it on for a workspace. R2-only,
+HTTP-credential-mode only in v1: no per-customer Workers bindings, since a
+binding needs a config edit and a deploy per customer. Attach is limited to
+workspace creation or an otherwise-empty existing workspace — there's no
+migration path yet for a populated workspace, since every published URL
+would break.
+
+**Operator script (internal/platform buckets).** Register with `--bucket`
+and the record points at a dedicated bucket the same way, but through
+`pnpm workspace:add` rather than the self-serve wizard — no verify pipeline,
+no flag gate. This is still how `apps/api/scripts/add-workspace.mjs`
+provisions internal buckets; see [Register a workspace](#register-a-workspace)
+below. The `buildinternet` workspace on `buildinternet-dev` is the reference
+example — a Workers-binding prototype, not the self-serve pattern.
 
 ## R2 credential paths
 


### PR DESCRIPTION
Final piece of the self-serve BYO R2 bucket plan (#583; API in #588, UI/admin/doctor in #590): the docs.

- **New `/docs/byo-bucket` subject page** on DocsLayout: the three customer-side setup steps (bucket, bucket-scoped Object Read & Write token, optional custom domain — wording matched to the settings wizard), the serving matrix with r2.dev explicitly called out as not supported right now, what's degraded on BYO (GitHub embed twin, retentionDays, storage quota off while upload limits stay), and data ownership / disconnect behavior ("disconnecting never touches your objects"). Opens with an honest callout that the feature is flag-gated and not generally available yet.
- **Wiring**: DocsLayout nav, docs hub card, prev/next chain, `sitemap.xml`, `llms.txt` + `llms-full.txt` (per the docs-structure rule).
- **`docs/workspaces.md`**: the BYO section now describes the self-serve wizard/verify flow as the primary path; the `pnpm workspace:add` operator script stays documented for internal/platform buckets, with a note that the binding-mode prototype isn't the pattern.

No code changes. Full suite green (3740 tests), `astro check` clean.

With this merged, #583 is done pending rollout: flip `byoBucketEnabled` on `buildinternet` and `default` via the admin panel's Storage toggle, and file the Phase 4 follow-up issues (embed twin for BYO hosts, jurisdiction endpoints, live migration, other S3 providers, per-workspace DEKs, billing framing).

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_
