### PR TITLE
feat: support R2 jurisdiction endpoints (eu, fedramp) for BYO buckets

### DIFF
--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2675,6 +2675,32 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       expect(reconciled).toEqual([]);
     });
 
+    it("stamps jurisdiction on save, and GET status echoes it", async () => {
+      const { env, registry } = storageEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const res = await app().request(
+        "/me/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ...CANDIDATE_BODY, jurisdiction: "eu" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(registry.record<{ jurisdiction?: string }>("acme")?.jurisdiction).toBe("eu");
+
+      const statusRes = await app().request("/me/workspaces/acme/storage", {}, env);
+      expect(statusRes.status).toBe(200);
+      expect((await statusRes.json()) as { jurisdiction?: string }).toMatchObject({
+        jurisdiction: "eu",
+      });
+    });
+
     it("503s (secrets_key_unconfigured) when WORKSPACE_SECRETS_KEY is unset, and leaves the record untouched", async () => {
       const { env: baseEnv, registry } = storageEnv({
         role: "owner",
@@ -2789,6 +2815,14 @@ describe("workspace storage routes (self-serve BYO bucket, issue #583 Task 1.1)"
       );
       expect(res.status).toBe(200);
       expect(registry.record<{ bucket?: string }>("acme")?.bucket).toBe("uploads-default");
+    });
+
+    it("clears jurisdiction on detach", async () => {
+      const record = { ...BYO_RECORD, jurisdiction: "eu" };
+      const { env, registry } = storageEnv({ role: "owner", record, usage: { objects: 0 } });
+      const res = await app().request("/me/workspaces/acme/storage", { method: "DELETE" }, env);
+      expect(res.status).toBe(200);
+      expect(registry.record<{ jurisdiction?: string }>("acme")?.jurisdiction).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -23,7 +23,7 @@ import {
   RateLimitedError,
   ValidationError,
 } from "@uploads/errors";
-import { createFilesRouter, signedDownloadUrl } from "@uploads/storage";
+import { createFilesRouter, signedDownloadUrl, type R2Jurisdiction } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { sealCredentialFieldsStrict } from "../secrets";
@@ -1157,6 +1157,10 @@ export const me = new Hono<SessionVars>()
         next.secretAccessKey = sealed.secretAccessKey;
         if (candidate.publicBaseUrl) next.publicBaseUrl = candidate.publicBaseUrl;
         else delete next.publicBaseUrl;
+        // Cast is safe: `storageVerify` above already ran the shape check
+        // (storage-verify.ts) that 422s on anything outside R2_JURISDICTIONS.
+        if (candidate.jurisdiction) next.jurisdiction = candidate.jurisdiction as R2Jurisdiction;
+        else delete next.jurisdiction;
         next.storageConfiguredAt = nowIso;
         next.storageVerifiedAt = nowIso;
         next.storageConfiguredBy = userId;
@@ -1247,6 +1251,7 @@ export const me = new Hono<SessionVars>()
         delete next.accountId;
         delete next.accessKeyId;
         delete next.secretAccessKey;
+        delete next.jurisdiction;
         delete next.storageConfiguredAt;
         delete next.storageVerifiedAt;
         delete next.storageConfiguredBy;

--- a/apps/api/src/routes/workspace-storage.ts
+++ b/apps/api/src/routes/workspace-storage.ts
@@ -43,6 +43,7 @@ export interface StorageStatusResponse {
   publicBaseUrl?: string;
   configuredAt?: string;
   verifiedAt?: string;
+  jurisdiction?: string;
 }
 
 /**
@@ -70,6 +71,7 @@ export function storageStatusResponse(
     accessKeyIdLast4: byo ? record.storageAccessKeyIdLast4 : undefined,
     configuredAt: record.storageConfiguredAt,
     verifiedAt: record.storageVerifiedAt,
+    jurisdiction: byo ? record.jurisdiction : undefined,
   };
 }
 
@@ -135,5 +137,7 @@ export function candidateFromBody(body: unknown): StorageVerifyCandidate {
     secretAccessKey: typeof b.secretAccessKey === "string" ? b.secretAccessKey : "",
     publicBaseUrl: typeof b.publicBaseUrl === "string" ? b.publicBaseUrl : undefined,
     adoptExistingContents: b.adoptExistingContents === true,
+    jurisdiction:
+      typeof b.jurisdiction === "string" && b.jurisdiction !== "" ? b.jurisdiction : undefined,
   };
 }

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  defaultStorageClientFactory,
   type StorageProbeClient,
   type StorageVerifyCandidate,
   verifyStorageConfig,
@@ -140,16 +141,28 @@ describe("verifyStorageConfig — shape", () => {
     }
   });
 
-  it("rejects an invalid jurisdiction", async () => {
-    const result = await run({ ...VALID, jurisdiction: "us" }, new FakeStorageClient());
+  it("rejects an invalid jurisdiction before any client is built", async () => {
+    const candidate = { ...VALID, jurisdiction: "us" };
+    const createClient = vi.fn(() => new FakeStorageClient());
+    const result = await verifyStorageConfig(candidate, { createClient });
     expect(result.ok).toBe(false);
     expect(result.checks[0].hint).toMatch(/jurisdiction must be one of: eu, fedramp/);
+    expect(createClient).not.toHaveBeenCalled();
   });
 
-  it("passes shape with a valid jurisdiction", async () => {
-    const result = await run({ ...VALID, jurisdiction: "eu" }, new FakeStorageClient());
+  it("passes shape with a valid jurisdiction and forwards it to the client factory", async () => {
+    const candidate = { ...VALID, jurisdiction: "eu" };
+    const createClient = vi.fn(() => new FakeStorageClient());
+    const result = await verifyStorageConfig(candidate, { createClient });
     const shape = result.checks.find((c) => c.id === "shape")!;
     expect(shape.ok).toBe(true);
+    expect(createClient).toHaveBeenCalledWith(expect.objectContaining({ jurisdiction: "eu" }));
+  });
+
+  it("defaultStorageClientFactory re-guards jurisdiction for direct callers", () => {
+    expect(() => defaultStorageClientFactory({ ...VALID, jurisdiction: "us" })).toThrow(
+      /invalid jurisdiction/,
+    );
   });
 });
 

--- a/apps/api/src/storage-verify.test.ts
+++ b/apps/api/src/storage-verify.test.ts
@@ -139,6 +139,18 @@ describe("verifyStorageConfig — shape", () => {
       expect(listSpy).not.toHaveBeenCalled();
     }
   });
+
+  it("rejects an invalid jurisdiction", async () => {
+    const result = await run({ ...VALID, jurisdiction: "us" }, new FakeStorageClient());
+    expect(result.ok).toBe(false);
+    expect(result.checks[0].hint).toMatch(/jurisdiction must be one of: eu, fedramp/);
+  });
+
+  it("passes shape with a valid jurisdiction", async () => {
+    const result = await run({ ...VALID, jurisdiction: "eu" }, new FakeStorageClient());
+    const shape = result.checks.find((c) => c.id === "shape")!;
+    expect(shape.ok).toBe(true);
+  });
 });
 
 describe("verifyStorageConfig — auth/reachability", () => {

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -18,8 +18,8 @@
  */
 import {
   createStorage,
+  isR2Jurisdiction,
   R2_JURISDICTIONS,
-  type R2Jurisdiction,
   type StorageConfig,
 } from "@uploads/storage";
 
@@ -70,6 +70,13 @@ export type StorageClientFactory = (candidate: StorageVerifyCandidate) => Storag
 
 /** Default factory: routes through the same `createStorage` seam production I/O uses. */
 export function defaultStorageClientFactory(candidate: StorageVerifyCandidate): StorageProbeClient {
+  // `verifyStorageConfig` shape-checks before calling this, but the factory is
+  // exported — re-guard so a direct caller can never interpolate an arbitrary
+  // string into the S3 endpoint.
+  const { jurisdiction } = candidate;
+  if (jurisdiction !== undefined && !isR2Jurisdiction(jurisdiction)) {
+    throw new Error(`invalid jurisdiction: ${JSON.stringify(jurisdiction)}`);
+  }
   const config: StorageConfig = {
     provider: "r2",
     bucket: candidate.bucket,
@@ -77,10 +84,7 @@ export function defaultStorageClientFactory(candidate: StorageVerifyCandidate): 
     accessKeyId: candidate.accessKeyId,
     secretAccessKey: candidate.secretAccessKey,
     publicBaseUrl: candidate.publicBaseUrl,
-    // Safe: this factory only ever runs after `checkShape` has validated
-    // `jurisdiction` against R2_JURISDICTIONS (verifyStorageConfig short-
-    // circuits on shape failure before calling the factory).
-    jurisdiction: candidate.jurisdiction as R2Jurisdiction | undefined,
+    jurisdiction,
   };
   return createStorage(config);
 }
@@ -123,10 +127,7 @@ function checkShape(candidate: StorageVerifyCandidate): StorageVerifyCheck {
     const urlProblem = checkPublicBaseUrlShape(candidate.publicBaseUrl);
     if (urlProblem) problems.push(urlProblem);
   }
-  if (
-    candidate.jurisdiction !== undefined &&
-    !(R2_JURISDICTIONS as readonly string[]).includes(candidate.jurisdiction)
-  ) {
+  if (candidate.jurisdiction !== undefined && !isR2Jurisdiction(candidate.jurisdiction)) {
     problems.push(
       `jurisdiction must be one of: ${R2_JURISDICTIONS.join(", ")} (or omitted for the default endpoint)`,
     );

--- a/apps/api/src/storage-verify.ts
+++ b/apps/api/src/storage-verify.ts
@@ -16,7 +16,12 @@
  *
  * Never include credential values in any check result, hint, or log line.
  */
-import { createStorage, type StorageConfig } from "@uploads/storage";
+import {
+  createStorage,
+  R2_JURISDICTIONS,
+  type R2Jurisdiction,
+  type StorageConfig,
+} from "@uploads/storage";
 
 /** Candidate config a workspace admin is trying to attach — not yet saved. */
 export interface StorageVerifyCandidate {
@@ -32,6 +37,8 @@ export interface StorageVerifyCandidate {
    * empty-bucket guard (required check `not-empty`).
    */
   adoptExistingContents?: boolean;
+  /** R2 jurisdiction of the bucket; validated by the shape check. */
+  jurisdiction?: string;
 }
 
 export interface StorageVerifyCheck {
@@ -70,6 +77,10 @@ export function defaultStorageClientFactory(candidate: StorageVerifyCandidate): 
     accessKeyId: candidate.accessKeyId,
     secretAccessKey: candidate.secretAccessKey,
     publicBaseUrl: candidate.publicBaseUrl,
+    // Safe: this factory only ever runs after `checkShape` has validated
+    // `jurisdiction` against R2_JURISDICTIONS (verifyStorageConfig short-
+    // circuits on shape failure before calling the factory).
+    jurisdiction: candidate.jurisdiction as R2Jurisdiction | undefined,
   };
   return createStorage(config);
 }
@@ -111,6 +122,14 @@ function checkShape(candidate: StorageVerifyCandidate): StorageVerifyCheck {
   if (candidate.publicBaseUrl) {
     const urlProblem = checkPublicBaseUrlShape(candidate.publicBaseUrl);
     if (urlProblem) problems.push(urlProblem);
+  }
+  if (
+    candidate.jurisdiction !== undefined &&
+    !(R2_JURISDICTIONS as readonly string[]).includes(candidate.jurisdiction)
+  ) {
+    problems.push(
+      `jurisdiction must be one of: ${R2_JURISDICTIONS.join(", ")} (or omitted for the default endpoint)`,
+    );
   }
   return {
     id: "shape",

--- a/apps/api/src/storage.ts
+++ b/apps/api/src/storage.ts
@@ -74,6 +74,7 @@ export async function storageConfig(env: Env, ws: WorkspaceRecord): Promise<Stor
     accountId: ws.accountId,
     accessKeyId: opened.accessKeyId,
     secretAccessKey: opened.secretAccessKey,
+    jurisdiction: ws.jurisdiction,
   };
 }
 

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError, InsufficientScopeError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
-import type { StorageProvider } from "@uploads/storage";
+import type { R2Jurisdiction, StorageProvider } from "@uploads/storage";
 import {
   FILE_SCOPES,
   findActiveToken,
@@ -48,6 +48,8 @@ export interface WorkspaceRecord {
   accountId?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
+  /** R2 jurisdiction of a BYO bucket (issue #593). Only ever "eu" or "fedramp"; absent = default endpoint. */
+  jurisdiction?: R2Jurisdiction;
   /** Max bytes for a single image upload. Falls back to DEFAULT_MAX_UPLOAD_BYTES. */
   maxUploadBytes?: number;
   /**

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -947,6 +947,7 @@ describe("getWorkspaceStorageStatus", () => {
           publicBaseUrl: "https://media.example.com",
           configuredAt: "2026-07-01T00:00:00.000Z",
           verifiedAt: "2026-07-01T00:00:00.000Z",
+          jurisdiction: "eu",
         }),
       ),
     );
@@ -963,6 +964,7 @@ describe("getWorkspaceStorageStatus", () => {
         publicBaseUrl: "https://media.example.com",
         configuredAt: "2026-07-01T00:00:00.000Z",
         verifiedAt: "2026-07-01T00:00:00.000Z",
+        jurisdiction: "eu",
       },
     });
   });

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1284,6 +1284,7 @@ export interface WorkspaceStorageStatus {
   publicBaseUrl?: string;
   configuredAt?: string;
   verifiedAt?: string;
+  jurisdiction?: string;
 }
 
 function toWorkspaceStorageStatus(body: unknown): WorkspaceStorageStatus | null {
@@ -1299,6 +1300,7 @@ function toWorkspaceStorageStatus(body: unknown): WorkspaceStorageStatus | null 
     publicBaseUrl: typeof b.publicBaseUrl === "string" ? b.publicBaseUrl : undefined,
     configuredAt: typeof b.configuredAt === "string" ? b.configuredAt : undefined,
     verifiedAt: typeof b.verifiedAt === "string" ? b.verifiedAt : undefined,
+    jurisdiction: typeof b.jurisdiction === "string" ? b.jurisdiction : undefined,
   };
 }
 
@@ -1382,6 +1384,7 @@ export interface StorageCandidate {
   secretAccessKey: string;
   publicBaseUrl?: string;
   adoptExistingContents?: boolean;
+  jurisdiction?: string;
 }
 
 export type StorageVerifyApiResult =

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -239,6 +239,18 @@ if (!workspace) return Astro.redirect("/account/workspaces");
               />
             </div>
             <div class="cs-field">
+              <label for="storage-jurisdiction">Jurisdiction</label>
+              <select id="storage-jurisdiction" class="ul-select">
+                <option value="">Default (no jurisdiction)</option>
+                <option value="eu">European Union (eu)</option>
+                <option value="fedramp">FedRAMP (fedramp)</option>
+              </select>
+              <p class="ul-field__hint">
+                Jurisdiction is chosen at bucket creation on Cloudflare and can't be changed later —
+                pick the one the bucket was created with.
+              </p>
+            </div>
+            <div class="cs-field">
               <label for="storage-access-key-id">Access key ID</label>
               <input
                 type="text"
@@ -838,6 +850,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
       const storageForm = requireElement<HTMLFormElement>("#storage-form", page);
       const storageAccountId = requireElement<HTMLInputElement>("#storage-account-id", page);
       const storageBucket = requireElement<HTMLInputElement>("#storage-bucket", page);
+      // Same worker-configuration.d.ts `Element.remove()` workaround as the
+      // tri-state selects above.
+      const storageJurisdiction = requireElement<HTMLElement>(
+        "#storage-jurisdiction",
+        page,
+      ) as unknown as HTMLSelectElement;
       const storageAccessKeyId = requireElement<HTMLInputElement>("#storage-access-key-id", page);
       const storageSecretAccessKey = requireElement<HTMLInputElement>(
         "#storage-secret-access-key",
@@ -888,6 +906,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           ["Public base URL", status.publicBaseUrl ?? "Signed-only (no public URL)"],
           ["Verified", formatTimestamp(status.verifiedAt)],
         ];
+        if (status.jurisdiction) rows.push(["Jurisdiction", status.jurisdiction]);
         storageByoDetails.innerHTML = rows
           .map(([label, value]) => `<dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`)
           .join("");
@@ -921,6 +940,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           // masked tail, never the plaintext — so the field starts blank.
           storageBucket.value = prefill.bucket ?? "";
           storagePublicBaseUrl.value = prefill.publicBaseUrl ?? "";
+          storageJurisdiction.value = prefill.jurisdiction ?? "";
           goToWizardStep(2);
         } else {
           goToWizardStep(1);
@@ -939,6 +959,7 @@ if (!workspace) return Astro.redirect("/account/workspaces");
           accessKeyId: storageAccessKeyId.value.trim(),
           secretAccessKey: storageSecretAccessKey.value,
           publicBaseUrl: storagePublicBaseUrl.value.trim() || undefined,
+          jurisdiction: storageJurisdiction.value || undefined,
           // Rotating credentials targets the bucket this workspace already
           // owns and is actively serving from, so its non-empty contents are
           // expected, not a mistake — same rationale as the PUT route's

--- a/apps/web/src/pages/docs/byo-bucket.astro
+++ b/apps/web/src/pages/docs/byo-bucket.astro
@@ -41,10 +41,10 @@ const TOC = [
     </p>
     <h3>1. Create an R2 bucket</h3>
     <p>
-      Dashboard → <strong>R2</strong> → <strong>Create bucket</strong>. Any name, any jurisdiction —
-      the wizard's checks target the default endpoint, so a jurisdiction-restricted bucket (<code
-        >eu</code
-      >, <code>fedramp</code>) isn't supported yet.
+      Dashboard → <strong>R2</strong> → <strong>Create bucket</strong>. Any name, any jurisdiction
+      works. If the bucket was created in a jurisdiction (<code>eu</code>, <code>fedramp</code>),
+      pick that same jurisdiction in the wizard so verification and serving target the
+      jurisdiction-specific endpoint.
     </p>
     <h3>2. Create a bucket-scoped API token</h3>
     <p>

--- a/apps/web/src/pages/docs/byo-bucket.astro
+++ b/apps/web/src/pages/docs/byo-bucket.astro
@@ -41,10 +41,11 @@ const TOC = [
     </p>
     <h3>1. Create an R2 bucket</h3>
     <p>
-      Dashboard → <strong>R2</strong> → <strong>Create bucket</strong>. Any name, any jurisdiction
-      works. If the bucket was created in a jurisdiction (<code>eu</code>, <code>fedramp</code>),
-      pick that same jurisdiction in the wizard so verification and serving target the
-      jurisdiction-specific endpoint.
+      Dashboard → <strong>R2</strong> → <strong>Create bucket</strong>. Any name that follows
+      Cloudflare's bucket-naming rules works (3–63 characters; lowercase letters, digits, and
+      hyphens). If you created the bucket in a jurisdiction (<code>eu</code>, or <code>fedramp</code
+      > — available to eligible Cloudflare accounts), pick that same jurisdiction in the wizard so verification
+      and serving target the jurisdiction-specific endpoint.
     </p>
     <h3>2. Create a bucket-scoped API token</h3>
     <p>

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -9,6 +9,10 @@ import { r2 } from "files-sdk/r2";
  */
 export type StorageProvider = "r2";
 
+/** R2 jurisdictions with dedicated S3 endpoints (Cloudflare: eu = European Union, fedramp = FedRAMP). */
+export const R2_JURISDICTIONS = ["eu", "fedramp"] as const;
+export type R2Jurisdiction = (typeof R2_JURISDICTIONS)[number];
+
 export interface StorageConfig {
   provider: StorageProvider;
   bucket: string;
@@ -20,6 +24,13 @@ export interface StorageConfig {
   accountId?: string;
   accessKeyId?: string;
   secretAccessKey?: string;
+  /**
+   * R2 jurisdiction the bucket was created in. Jurisdiction buckets are only
+   * reachable at `https://<accountId>.<jurisdiction>.r2.cloudflarestorage.com`,
+   * so this switches the HTTP adapter's endpoint. Ignored in binding mode
+   * (the wrangler binding declaration carries the jurisdiction there).
+   */
+  jurisdiction?: R2Jurisdiction;
   /**
    * Key prefix all operations are confined under (e.g. "myws/"). Must end
    * with "/". Applied via files-sdk's instance prefix; clients never see it.
@@ -43,9 +54,17 @@ export function createStorage(config: StorageConfig): Files {
         publicBaseUrl: config.publicBaseUrl,
       };
       // Binding mode (hybrid when HTTP creds are also set) vs pure HTTP mode.
+      // Jurisdiction only applies to the HTTP endpoint — a binding's jurisdiction
+      // is fixed by the wrangler bucket declaration, not by anything we pass here.
       const adapter = config.r2Binding
         ? r2({ binding: config.r2Binding, bucket: config.bucket, ...shared })
-        : r2({ bucket: config.bucket, ...shared });
+        : r2({
+            bucket: config.bucket,
+            ...shared,
+            ...(config.jurisdiction && {
+              endpoint: `https://${config.accountId}.${config.jurisdiction}.r2.cloudflarestorage.com`,
+            }),
+          });
       return new Files({ adapter, prefix: config.prefix });
     }
     default:

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -13,6 +13,11 @@ export type StorageProvider = "r2";
 export const R2_JURISDICTIONS = ["eu", "fedramp"] as const;
 export type R2Jurisdiction = (typeof R2_JURISDICTIONS)[number];
 
+/** Type guard for {@link R2Jurisdiction} — use on untrusted strings before they reach `StorageConfig`. */
+export function isR2Jurisdiction(value: string): value is R2Jurisdiction {
+  return (R2_JURISDICTIONS as readonly string[]).includes(value);
+}
+
 export interface StorageConfig {
   provider: StorageProvider;
   bucket: string;
@@ -27,8 +32,10 @@ export interface StorageConfig {
   /**
    * R2 jurisdiction the bucket was created in. Jurisdiction buckets are only
    * reachable at `https://<accountId>.<jurisdiction>.r2.cloudflarestorage.com`,
-   * so this switches the HTTP adapter's endpoint. Ignored in binding mode
-   * (the wrangler binding declaration carries the jurisdiction there).
+   * so this switches the S3 endpoint used for HTTP I/O and hybrid-mode
+   * signing. Ignored only in pure binding mode (no HTTP credentials), where
+   * the wrangler binding declaration carries the jurisdiction and nothing
+   * ever touches the S3 endpoint.
    */
   jurisdiction?: R2Jurisdiction;
   /**
@@ -52,19 +59,17 @@ export function createStorage(config: StorageConfig): Files {
         accessKeyId: config.accessKeyId,
         secretAccessKey: config.secretAccessKey,
         publicBaseUrl: config.publicBaseUrl,
+        // Jurisdiction switches the S3 endpoint for HTTP I/O and hybrid-mode
+        // signing alike; pure binding mode (no HTTP creds) never builds an S3
+        // client, so the extra option is inert there.
+        ...(config.jurisdiction && {
+          endpoint: `https://${config.accountId}.${config.jurisdiction}.r2.cloudflarestorage.com`,
+        }),
       };
       // Binding mode (hybrid when HTTP creds are also set) vs pure HTTP mode.
-      // Jurisdiction only applies to the HTTP endpoint — a binding's jurisdiction
-      // is fixed by the wrangler bucket declaration, not by anything we pass here.
       const adapter = config.r2Binding
         ? r2({ binding: config.r2Binding, bucket: config.bucket, ...shared })
-        : r2({
-            bucket: config.bucket,
-            ...shared,
-            ...(config.jurisdiction && {
-              endpoint: `https://${config.accountId}.${config.jurisdiction}.r2.cloudflarestorage.com`,
-            }),
-          });
+        : r2({ bucket: config.bucket, ...shared });
       return new Files({ adapter, prefix: config.prefix });
     }
     default:

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -156,6 +156,12 @@ describe("signedDownloadUrl", () => {
     expect(url).toContain("X-Amz-Expires=60");
   });
 
+  it("targets the jurisdiction-specific endpoint when configured", async () => {
+    const files = createStorage({ ...base, jurisdiction: "eu" });
+    const url = await signedDownloadUrl(files, "a.png");
+    expect(url).toMatch(/^https:\/\/acct\.eu\.r2\.cloudflarestorage\.com\/shared\/a\.png\?/);
+  });
+
   it("returns null for a binding-only R2 workspace with no signing credentials", async () => {
     const files = createStorage({
       provider: "r2",

--- a/packages/storage/test/index.test.ts
+++ b/packages/storage/test/index.test.ts
@@ -181,4 +181,17 @@ describe("signedDownloadUrl", () => {
     const url = await signedDownloadUrl(files, "a.png");
     expect(url).toMatch(/^https:\/\/acct\.r2\.cloudflarestorage\.com\/shared\/acme\/a\.png\?/);
   });
+
+  it("hybrid signing targets the jurisdiction-specific endpoint when configured", async () => {
+    const files = createStorage({
+      ...base,
+      r2Binding: new FakeR2Bucket() as unknown as R2Bucket,
+      prefix: "acme/",
+      jurisdiction: "fedramp",
+    });
+    const url = await signedDownloadUrl(files, "a.png");
+    expect(url).toMatch(
+      /^https:\/\/acct\.fedramp\.r2\.cloudflarestorage\.com\/shared\/acme\/a\.png\?/,
+    );
+  });
 });

--- a/patches/files-sdk@2.1.0.patch
+++ b/patches/files-sdk@2.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/r2/index.d.ts b/dist/r2/index.d.ts
-index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..804cc074efaf5e3696f5254e88f1587238897ec9 100644
+index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..b1c9bf5315f0ef3dc0010839c72f9c89374d5035 100644
 --- a/dist/r2/index.d.ts
 +++ b/dist/r2/index.d.ts
 @@ -31,6 +31,12 @@ export interface R2HttpOptions {
@@ -15,10 +15,32 @@ index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..804cc074efaf5e3696f5254e88f15872
  }
  export interface R2BindingOptions {
      /** Workers `R2Bucket` binding. Reads and writes go through the binding. */
+@@ -62,6 +68,12 @@ export interface R2BindingOptions {
+      * signing (hybrid mode without `publicBaseUrl`). Defaults to 3600.
+      */
+     defaultUrlExpiresIn?: number;
++    /**
++     * Hybrid mode: override the S3 API endpoint used for signing. Defaults to
++     * `https://<accountId>.r2.cloudflarestorage.com`; set for jurisdiction
++     * buckets (e.g. `https://<accountId>.eu.r2.cloudflarestorage.com`).
++     */
++    endpoint?: string;
+ }
+ export type R2AdapterOptions = R2BindingOptions | R2HttpOptions;
+ export type R2Adapter = Adapter<S3Client | R2Bucket>;
 diff --git a/dist/r2/index.js b/dist/r2/index.js
-index 291ca05dee674c7845e5e18868d481a3e4168b10..a6cff0082dae9e0fef44aad0b73d9257a8e3af15 100644
+index 291ca05dee674c7845e5e18868d481a3e4168b10..654e4b2a617aba3d4eff1074d9dbcf8ed5cf4e3a 100644
 --- a/dist/r2/index.js
 +++ b/dist/r2/index.js
+@@ -137,7 +137,7 @@ var r2FromBinding = (opts) => {
+     ...opts.defaultUrlExpiresIn !== undefined && {
+       defaultUrlExpiresIn: opts.defaultUrlExpiresIn
+     },
+-    endpoint: `https://${opts.accountId}.r2.cloudflarestorage.com`,
++    endpoint: opts.endpoint ?? `https://${opts.accountId}.r2.cloudflarestorage.com`,
+     forcePathStyle: true,
+     region: "auto"
+   }) : null;
 @@ -231,7 +231,11 @@ var r2FromBinding = (opts) => {
            ...options?.prefix && { prefix: options.prefix },
            ...options?.limit !== undefined && { limit: options.limit },

--- a/patches/files-sdk@2.1.0.patch
+++ b/patches/files-sdk@2.1.0.patch
@@ -1,5 +1,22 @@
+diff --git a/dist/r2/index.d.ts b/dist/r2/index.d.ts
+index 4359929d2d8a9f7ef0586a482b5e06dcb4013bbc..804cc074efaf5e3696f5254e88f1587238897ec9 100644
+--- a/dist/r2/index.d.ts
++++ b/dist/r2/index.d.ts
+@@ -31,6 +31,12 @@ export interface R2HttpOptions {
+      * Defaults to 3600.
+      */
+     defaultUrlExpiresIn?: number;
++    /**
++     * Override the S3 API endpoint. Defaults to
++     * `https://<accountId>.r2.cloudflarestorage.com`; set for jurisdiction
++     * buckets (e.g. `https://<accountId>.eu.r2.cloudflarestorage.com`).
++     */
++    endpoint?: string;
+ }
+ export interface R2BindingOptions {
+     /** Workers `R2Bucket` binding. Reads and writes go through the binding. */
 diff --git a/dist/r2/index.js b/dist/r2/index.js
-index 291ca05dee674c7845e5e18868d481a3e4168b10..237e9726bd3e49ea5246cdf50acf62f37a54b035 100644
+index 291ca05dee674c7845e5e18868d481a3e4168b10..a6cff0082dae9e0fef44aad0b73d9257a8e3af15 100644
 --- a/dist/r2/index.js
 +++ b/dist/r2/index.js
 @@ -231,7 +231,11 @@ var r2FromBinding = (opts) => {
@@ -15,3 +32,12 @@ index 291ca05dee674c7845e5e18868d481a3e4168b10..237e9726bd3e49ea5246cdf50acf62f3
          });
        } catch (error) {
          throw mapR2Error(error);
+@@ -336,7 +340,7 @@ var r2FromHttp = (opts) => {
+     ...opts.defaultUrlExpiresIn !== undefined && {
+       defaultUrlExpiresIn: opts.defaultUrlExpiresIn
+     },
+-    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
++    endpoint: opts.endpoint ?? `https://${accountId}.r2.cloudflarestorage.com`,
+     forcePathStyle: true,
+     ...opts.publicBaseUrl && { publicBaseUrl: opts.publicBaseUrl },
+     region: "auto"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  files-sdk@2.1.0: af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db
+  files-sdk@2.1.0: 57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831
 
 importers:
 
@@ -184,7 +184,7 @@ importers:
         version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       img-comparison-slider:
         specifier: ^8.0.7
         version: 8.0.7
@@ -276,7 +276,7 @@ importers:
         version: 3.1080.0
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260706.1
@@ -302,7 +302,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -348,7 +348,7 @@ importers:
         version: 6.0.220(zod@4.4.3)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -9123,7 +9123,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  files-sdk@2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  files-sdk@2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       commander: 15.0.0
       picomatch: 4.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  files-sdk@2.1.0: 9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2
+  files-sdk@2.1.0: af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db
 
 importers:
 
@@ -184,7 +184,7 @@ importers:
         version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       img-comparison-slider:
         specifier: ^8.0.7
         version: 8.0.7
@@ -276,7 +276,7 @@ importers:
         version: 3.1080.0
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260706.1
@@ -302,7 +302,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -348,7 +348,7 @@ importers:
         version: 6.0.220(zod@4.4.3)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -9123,7 +9123,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  files-sdk@2.1.0(patch_hash=9e4b79cace0a4f9f8905aa675e78ffc05bfc59498007f2bf4a2ef882dbf5dee2)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  files-sdk@2.1.0(patch_hash=af95a456ae1cfa5227d9f55940745c2a327cc6c3e5019d2803f4181778f6b0db)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       commander: 15.0.0
       picomatch: 4.0.5


### PR DESCRIPTION
Closes #593 (follow-up from the self-serve BYO bucket ship, #583).

Jurisdiction-restricted R2 buckets (`eu`, `fedramp`) are only reachable at `https://<accountId>.<jurisdiction>.r2.cloudflarestorage.com`, so until now they couldn't attach — the verify pipeline and production I/O both targeted the default endpoint. This threads one optional `jurisdiction` field through every layer:

- **files-sdk patch**: the pinned pnpm patch gains a generic `endpoint` override on `R2HttpOptions` (HTTP path only — a binding's jurisdiction is fixed by its wrangler declaration, so that path is untouched). Both hunks (the existing list()-include fix and this one) verified present.
- **`@uploads/storage`**: `R2_JURISDICTIONS`/`R2Jurisdiction` exported; `StorageConfig.jurisdiction` switches the HTTP adapter's endpoint in `createStorage`.
- **API**: `WorkspaceRecord.jurisdiction`, forwarded by `storageConfig`; the verify candidate carries it as an untrusted string and the shape check validates it against `R2_JURISDICTIONS` (invalid values 422 with a hint before any network I/O). PUT stamps it on the record only after server-side verify passes; DELETE (disconnect) clears it; the status projection returns it on BYO records only.
- **Settings wizard**: a Jurisdiction select (Default / `eu` / `fedramp`) next to the bucket name, included in verify/save bodies, prefilled on credential rotate, and shown in the BYO status read-out.
- **Docs**: `/docs/byo-bucket` step 1 drops the "isn't supported yet" caveat and says to pick the bucket's jurisdiction in the wizard.

No credential handling changed; no CLI change, so no changeset. Full suite green (3745 tests), typecheck clean across all four workers.

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EU and FedRAMP jurisdictions when configuring Bring Your Own storage buckets.
  * Jurisdiction-specific endpoints are now used for storage operations and signed download links.
  * Workspace storage details display the selected jurisdiction.
* **Documentation**
  * Updated BYO bucket guidance to document jurisdiction-specific bucket support.
* **Bug Fixes**
  * Detaching storage now removes the saved jurisdiction setting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->