### PR TITLE
fix(web): consistent header chrome and clearer staging copy

### DIFF
--- a/.changeset/staging-note-clarity.md
+++ b/.changeset/staging-note-clarity.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+Clarify the bare-put staging note: "auto-comments to pull request when opened" instead of "auto-attaches to this branch's PR when it opens".

--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -45,6 +45,26 @@ const MENU_ITEMS = [
     readCachedSessionUser,
     writeCachedSessionUser,
   } from "../lib/account-shell";
+  import { readCachedActiveWorkspace } from "../lib/workspaces-nav";
+
+  /** Last-used workspace files, else the workspaces list (same as home CTA). */
+  function filesHref(): string {
+    const ws = readCachedActiveWorkspace();
+    return ws ? `/account/workspaces/${encodeURIComponent(ws)}` : "/account/workspaces";
+  }
+
+  /** SiteHeader's signed-in-only Files link (absent on pages without the header). */
+  function paintHeaderFiles(signedIn: boolean): void {
+    const link = document.querySelector<HTMLAnchorElement>("[data-header-files]");
+    if (!link) return;
+    if (signedIn) {
+      link.href = filesHref();
+      link.hidden = false;
+    } else {
+      link.hidden = true;
+      link.href = "/account/workspaces";
+    }
+  }
 
   function bootAuthIndicator(): void {
     const root = document.querySelector<HTMLElement>("[data-auth-indicator]");
@@ -89,17 +109,20 @@ const MENU_ITEMS = [
     };
 
     const paintSignedOut = () => {
+      paintHeaderFiles(false);
       slot.innerHTML =
         '<a class="ul-btn ul-btn--solid ul-btn--sm auth-indicator__signin" href="/login">Sign in</a>';
     };
 
     const paintUnavailable = () => {
+      paintHeaderFiles(false);
       slot.innerHTML = '<span class="auth-indicator__muted">auth unavailable</span>';
     };
 
     let menuListeners: AbortController | null = null;
 
     const paintUser = (user: SessionUser) => {
+      paintHeaderFiles(true);
       const initials = escapeHtml(initialsFor(user));
       const email = escapeHtml(user.email);
       const label = escapeHtml(user.name || user.email || "Account");
@@ -173,6 +196,7 @@ const MENU_ITEMS = [
         "click",
         () => {
           clearCachedSessionUser();
+          paintHeaderFiles(false);
           void signOut(origin).then(() => {
             location.href = "/login";
           });

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -74,7 +74,7 @@ const COLUMNS: FooterColumn[] = [
             <a class="wordmark" href="/">
               uploads.sh
             </a>
-            <p>Screenshots &amp; recordings for agent PRs.</p>
+            <p>Screenshot host for coding agents.</p>
           </div>
           {COLUMNS.map((column) => (
             <nav aria-label={column.title}>

--- a/apps/web/src/components/SiteHeader.astro
+++ b/apps/web/src/components/SiteHeader.astro
@@ -5,8 +5,9 @@
  * pattern: the chrome spans the viewport edge-to-edge with a bottom border;
  * page content below keeps its own max-width column.
  *
- * Left: <Brand /> + optional badge. Right: optional GitHub star +
- * <AuthIndicator /> (solid Sign in CTA, or avatar menu when signed in).
+ * Left: <Brand /> + optional badge.
+ * Right (consistent on every surface): Files (signed-in only) · Docs ·
+ * Star on GitHub · <AuthIndicator /> (Sign in CTA, or avatar menu).
  *
  * Centered auth cards (login, device, invite, consent) omit this header.
  */
@@ -14,15 +15,13 @@ import AuthIndicator from "./AuthIndicator.astro";
 import Brand from "./Brand.astro";
 
 interface Props {
-  /** Show the "Star on GitHub" CTA with the live star count. */
-  star?: boolean;
   /** Render the sign-in CTA / avatar menu (requires the auth origin). */
   authOrigin?: string;
   /** Small pill next to the brand (e.g. "admin", "console"). */
   badge?: string;
 }
 
-const { star = false, authOrigin, badge } = Astro.props;
+const { authOrigin, badge } = Astro.props;
 const REPO = "https://github.com/buildinternet/uploads";
 ---
 
@@ -34,29 +33,35 @@ const REPO = "https://github.com/buildinternet/uploads";
     </div>
 
     <div class="site-header__end">
-      {
-        star && (
-          <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
-            <svg viewBox="0 0 16 16" aria-hidden="true">
-              <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-            </svg>
-            Star on GitHub
-            <span class="count" id="star-count" />
-          </a>
-        )
-      }
+      <nav class="site-header__nav" aria-label="Site">
+        {
+          /*
+          Files is signed-in only. AuthIndicator toggles [data-header-files]
+          after the session check (optimistic paint from session cache).
+        */
+        }
+        <a class="site-header__link" data-header-files href="/account/workspaces" hidden>Files</a>
+        <a class="site-header__link" href="/docs">Docs</a>
+      </nav>
+      <a class="star-cta" href={REPO} aria-label="Star buildinternet/uploads on GitHub">
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
+          ></path>
+        </svg>
+        Star on GitHub
+        <span class="count" id="star-count"></span>
+      </a>
       {authOrigin ? <AuthIndicator authOrigin={authOrigin} /> : null}
       <slot name="end" />
     </div>
   </div>
 </header>
 
-{
-  /* Import-only shell stays behind star so non-star pages don't ship the
-     module. Logic lives in site-header-stars.ts: prettier-plugin-astro cannot
-     parse function bodies inside a JSX-conditional script tag (issue #551). */
-  star && <script>import "./site-header-stars";</script>
-}
+{/* Live star count — always shipped; one module for every surface. */}
+<script>
+  import "./site-header-stars";
+</script>
 
 <style>
   /* Full-bleed bar: sits outside page max-width columns (releases/either). */
@@ -91,6 +96,22 @@ const REPO = "https://github.com/buildinternet/uploads";
     gap: 12px;
     margin-left: auto;
     overflow: visible;
+  }
+  .site-header__nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .site-header__link {
+    color: var(--muted, #7d7d77);
+    text-decoration: none;
+    font: 12.5px var(--mono, ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace);
+    letter-spacing: 0.02em;
+  }
+  .site-header__link:hover,
+  .site-header__link:focus-visible {
+    color: var(--accent, #c27eff);
+    outline: none;
   }
   .site-header__badge {
     display: inline-block;

--- a/apps/web/src/components/site-header-stars.ts
+++ b/apps/web/src/components/site-header-stars.ts
@@ -1,8 +1,8 @@
 /**
  * Live GitHub star count for SiteHeader (1h localStorage).
- * Lives in a .ts module so SiteHeader.astro can keep the script behind the
- * `star` guard without prettier-plugin-astro choking on function bodies inside
- * a JSX-conditional `<script>` (issue #551).
+ * Lives in a .ts module imported from SiteHeader so the count re-fills after
+ * ClientRouter swaps without embedding function bodies in a JSX-conditional
+ * `<script>` (prettier-plugin-astro issue #551).
  */
 import { onAstroPageLoad } from "../lib/account-shell";
 

--- a/apps/web/src/layouts/DocsLayout.astro
+++ b/apps/web/src/layouts/DocsLayout.astro
@@ -734,7 +734,7 @@ const fullTitle = `${title} · uploads.sh`;
     </style>
   </head>
   <body>
-    <SiteHeader star authOrigin={authOrigin} />
+    <SiteHeader authOrigin={authOrigin} />
 
     <div class="docs-shell">
       <div class="docs-grid">

--- a/apps/web/src/lib/client-router-boot.test.ts
+++ b/apps/web/src/lib/client-router-boot.test.ts
@@ -84,3 +84,36 @@ describe("Error page chrome", () => {
     expect(readSrc("pages/500.astro")).toContain("ErrorLayout");
   });
 });
+
+describe("SiteHeader chrome", () => {
+  it("ships Docs + Star on every surface (no opt-in star prop)", () => {
+    const src = readSrc("components/SiteHeader.astro");
+    expect(src).toContain('href="/docs"');
+    expect(src).toContain("Star on GitHub");
+    expect(src).toContain("data-header-files");
+    expect(src).toContain('import "./site-header-stars"');
+    // Opt-in was the reason account/admin lacked the star CTA.
+    expect(src).not.toMatch(/star\s*\?\s*:/);
+    expect(src).not.toMatch(/star\s*=\s*false/);
+  });
+
+  it("AuthIndicator toggles the signed-in-only Files link", () => {
+    const src = readSrc("components/AuthIndicator.astro");
+    expect(src).toContain("paintHeaderFiles");
+    expect(src).toContain("data-header-files");
+    expect(src).toContain("readCachedActiveWorkspace");
+  });
+
+  it.each([
+    "layouts/AccountLayout.astro",
+    "layouts/AdminLayout.astro",
+    "layouts/DocsLayout.astro",
+    "layouts/LegalLayout.astro",
+    "layouts/ErrorLayout.astro",
+    "pages/index.astro",
+  ] as const)("%s uses SiteHeader without a star prop", (rel) => {
+    const src = readSrc(rel);
+    expect(src).toContain("SiteHeader");
+    expect(src).not.toMatch(/<SiteHeader[^>]*\sstar[\s/>]/);
+  });
+});

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -61,8 +61,8 @@ const REPO = "https://github.com/buildinternet/uploads";
     </div>
     <div class="block" aria-label="Example output">
       <pre>&gt;&gt; uploading ./after.png
-note: staged for branch feat/nav — auto-attaches to this branch's PR when
-it opens (or run: uploads attach --promote once it exists)</pre>
+note: staged for branch feat/nav — auto-comments to pull request when opened
+(or run: uploads attach --promote once it exists)</pre>
     </div>
     <p>
       Keep doing that as you work and the PR opens with screenshots already attached — see&#32;

--- a/apps/web/src/pages/docs/attach-pull-request-images.astro
+++ b/apps/web/src/pages/docs/attach-pull-request-images.astro
@@ -275,9 +275,9 @@ once the PR exists: uploads attach --promote</pre>
 &gt;&gt; optimized 411.5 KB → 94.2 KB (shot.webp)
 URL: <span class="v">https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp</span>
 MARKDOWN: ![shot.png](https://storage.uploads.sh/gh/you/app/branch/feat-shot/shot.webp)
-note: staged for branch feat/shot — auto-attaches to this branch's PR when
-it opens (or run: uploads attach --promote once it exists). Use --ref/
---prefix for a plain dated upload.</pre>
+note: staged for branch feat/shot — auto-comments to pull request when opened
+(or run: uploads attach --promote once it exists). Use --ref/--prefix for a
+plain dated upload.</pre>
     </div>
     <p>
       On a branch, a bare <code>put</code> stages the file for that branch's future PR — same behavior

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -149,17 +149,6 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         border-radius: var(--radius-lg);
         overflow: hidden;
       }
-      .titlebar {
-        display: flex;
-        align-items: center;
-        padding: 8px 14px;
-        border-bottom: 1px solid var(--line);
-        color: var(--muted);
-        font-family: var(--pixel);
-        font-variation-settings: "ELSH" var(--pixel-shape, 1);
-        font-size: 11px;
-        letter-spacing: 0.05em;
-      }
       .screen {
         padding: 20px 20px 24px;
         font-size: 13px;
@@ -459,11 +448,6 @@ Source (and where to look if something breaks): https://github.com/buildinternet
         white-space: nowrap;
         scrollbar-width: none;
       }
-      .cmdrow .cmdtext::before {
-        content: "$";
-        color: var(--accent);
-        margin-right: 0.5ch;
-      }
       .cmdrow .cmdtext .comment {
         color: var(--muted);
         user-select: none;
@@ -631,7 +615,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     </style>
   </head>
   <body>
-    <SiteHeader star authOrigin={authOrigin} />
+    <SiteHeader authOrigin={authOrigin} />
     <main>
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
       <p class="byline">Now Claude and Codex can add screenshots to pull requests</p>
@@ -655,9 +639,6 @@ Source (and where to look if something breaks): https://github.com/buildinternet
       </p>
 
       <section class="terminal" aria-label="uploads.sh terminal">
-        <div class="titlebar" aria-hidden="true">
-          <span>bash</span>
-        </div>
         <div class="screen">
           <p class="line out"># capture as you work — no PR yet</p>
           <p class="line">
@@ -666,7 +647,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
           </p>
           <p class="line out hidden">&gt;&gt; uploading ./after.png</p>
           <p class="line out hidden">
-            note: staged for branch feat/nav — auto-attaches to this branch's PR when it opens…
+            Staged for branch feat/nav - auto-comments to pull request when opened
           </p>
           <div class="gap hidden"></div>
           <p class="line out hidden"># open your pull request like usual</p>

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -1895,7 +1895,7 @@ export function mergeStagingMeta(
  */
 export function putStagingNoteText(branch: string): string {
   return (
-    `note: staged for branch ${branch} — auto-attaches to this branch's PR when it opens ` +
+    `note: staged for branch ${branch} — auto-comments to pull request when opened ` +
     `(or run: uploads attach --promote once it exists). Use --ref/--prefix for a plain dated upload.`
   );
 }

--- a/packages/uploads/test/commands-put.test.ts
+++ b/packages/uploads/test/commands-put.test.ts
@@ -1731,7 +1731,7 @@ describe("runPut branch staging (issue #403)", () => {
         runPut({ ...ctxWith(client), quiet: false }, [tmpFile()], false, stagingRunner(staged)),
       );
       expect(stderr).toContain(
-        "note: staged for branch feature/thing — auto-attaches to this branch's PR when it opens " +
+        "note: staged for branch feature/thing — auto-comments to pull request when opened " +
           "(or run: uploads attach --promote once it exists). Use --ref/--prefix for a plain dated upload.",
       );
     });

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -726,7 +726,7 @@ describe("runScreenshot auto branch staging (issue #469 lever 1)", () => {
         ),
       );
       expect(stderr).toContain(
-        "note: staged for branch feature/thing — auto-attaches to this branch's PR when it opens " +
+        "note: staged for branch feature/thing — auto-comments to pull request when opened " +
           "(or run: uploads attach --promote once it exists). Use --ref/--prefix for a plain dated upload.",
       );
     });

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -341,9 +341,9 @@ writes it to stderr, `--format json` adds it as an additive optional `hint`
 field on the same response:
 
 ```text
-note: staged for branch fix-header — auto-attaches to this branch's PR when
-it opens (or run: uploads attach --promote once it exists). Use --ref/--prefix
-for a plain dated upload.
+note: staged for branch fix-header — auto-comments to pull request when opened
+(or run: uploads attach --promote once it exists). Use --ref/--prefix for a
+plain dated upload.
 ```
 
 If the same call also trips the stage-time binding warning (issue #398/#400


### PR DESCRIPTION
## In plain terms

The site header is the same on every surface now — Docs, Star on GitHub, and a signed-in Files shortcut — instead of dropping the star CTA on account/admin pages. Alongside that, homepage and CLI copy is tightened so the staging note describes what people actually see (a PR comment), and a few marketing polish items land with it.

## What it does

- **Consistent header:** Docs + Star on GitHub on landing, docs, legal, account, admin, and error pages (no more opt-in `star` prop).
- **Files link (signed-in only):** left of Docs; goes to the last-used workspace files view, else the workspaces list. Hidden when signed out.
- **Homepage polish:** drop the `$` decoration on click-to-copy rows, remove the fake terminal "bash" titlebar, clearer staged-note teaser.
- **Footer:** "Screenshot host for coding agents." (parallel to releases.sh).
- **CLI staging note:** `auto-comments to pull request when opened` (docs examples + skill + tests aligned; promote/`--ref` tails kept).

## What it is not

- Not a redesign of the account shell or auth flow.
- Not changing staging behavior — wording only on the bare-put note.
- Not requesting CodeRabbit by default.

## How to try it

```bash
# after merge / on a preview
# signed out: header shows Docs · Star on GitHub · Sign in
# signed in:  Files · Docs · Star on GitHub · avatar

uploads put ./after.png
# note: staged for branch … — auto-comments to pull request when opened …
```

## Technical notes

- `AuthIndicator` toggles `[data-header-files]` from the same session path as the avatar (optimistic cache + `getSession`).
- Star count module always ships with `SiteHeader` so account pages get the live count too.
- Patch changeset for the published CLI wording.

## Test plan

- [x] `vitest` staging-note tests (`commands-put`, `commands-screenshot`)
- [x] `client-router-boot` SiteHeader chrome tests
- [x] pre-commit types + lint-staged
- [ ] Manual: signed-out homepage/docs header
- [ ] Manual: signed-in account files page shows Files + Star
- [ ] Manual: Files link opens last-used workspace