### PR TITLE
design: Signed-in shell cleanup: contextual rail, wider content, sidebar hierarchy, loading skeletons

### DIFF
--- a/apps/web/src/components/AuthIndicator.astro
+++ b/apps/web/src/components/AuthIndicator.astro
@@ -277,6 +277,13 @@ const MENU_ITEMS = [
   .auth-indicator :global(.auth-indicator__signin) {
     text-decoration: none;
     white-space: nowrap;
+    /* ul-btn--sm (9px vertical padding, 1.65 line-height) stands ~9px taller
+       than the sibling .star-cta (12.5px font + 6px padding + normal line
+       height, SiteHeader.astro) — match its vertical rhythm so the header
+       controls read as one row. */
+    padding-top: 6px;
+    padding-bottom: 6px;
+    line-height: 1.4;
   }
 
   .auth-indicator :global(.auth-menu) {

--- a/apps/web/src/components/WorkspaceFileTable.tsx
+++ b/apps/web/src/components/WorkspaceFileTable.tsx
@@ -19,7 +19,7 @@
  */
 import { Callout } from "@uploads/ui";
 import "@uploads/ui/styles.css";
-import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
+import { Fragment, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import type { ConnectedWorkSetter } from "../lib/workspace-rail";
 import { applyGhTitles, connectedWork, exactPrMatch, type GhWorkItem } from "../lib/gh-context";
 import {
@@ -427,6 +427,98 @@ function openFile(
   });
 }
 
+// ── Loading skeleton ───────────────────────────────────────────────────
+// Same idea as `workspace-ui.ts`'s HTML-string placeholders (three-tier
+// loading, PR #526): occupy the exact box the real content will occupy so
+// landing data doesn't shift the page. Kept as JSX here (not the HTML-string
+// builders) because this component's loading states render mid-tree, not as
+// a `set:html` swap — but `renderFilesPlaceholderHtml` in workspace-ui.ts
+// mirrors this markup 1:1 for the pre-mount gap in `[name].astro`, so the
+// two hand-offs (static HTML → this component's own loading render → real
+// data) are visually seamless throughout.
+
+/** One masked bar — `--ws-skel-w` drives width, same custom property `.ws-skel` reads. */
+function SkelBar({ width }: { width: string }) {
+  return (
+    <span
+      className="ws-skel"
+      aria-hidden="true"
+      style={{ "--ws-skel-w": width } as CSSProperties}
+    />
+  );
+}
+
+const SKEL_ROW_WIDTHS = ["62%", "48%", "70%", "40%", "55%", "35%"];
+
+/** `wft-row`-shaped skeleton rows — same grid columns as a real row. */
+function FileRowsSkeleton({ rows }: { rows: number }) {
+  return (
+    <>
+      {Array.from({ length: rows }, (_, i) => (
+        <div className="wft-row" key={i}>
+          <span className="wft-name">
+            <SkelBar width={SKEL_ROW_WIDTHS[i % SKEL_ROW_WIDTHS.length]} />
+          </span>
+          <span className="wft-size">
+            <SkelBar width="32px" />
+          </span>
+          <span className="wft-type">
+            <SkelBar width="28px" />
+          </span>
+          <span className="wft-vis">
+            <SkelBar width="52px" />
+          </span>
+          <span />
+        </div>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Full toolbar-and-table skeleton for the initial `info.status === "loading"`
+ * render, when nothing about the workspace (so nothing about the real
+ * filterbar or section head) is known yet. `wft-field-skel` (account-content
+ * .css) gives the filter input/button their real height, since
+ * `.input-group__field`/`__action` normally size themselves from the
+ * `<input>`/`<button>` they wrap. The table head's labels are real text, not
+ * skeleton bars — "name/size/type/visibility" never depend on data.
+ */
+function FilesLoadingSkeleton() {
+  return (
+    <div className="wft" aria-busy="true">
+      <div className="wft-filter">
+        <div className="wft-filterbar input-group">
+          <span className="input-group__field wft-field-skel">
+            <SkelBar width="60%" />
+          </span>
+          <span className="input-group__action wft-field-skel">
+            <SkelBar width="28px" />
+          </span>
+        </div>
+      </div>
+      <div className="wft-sectionhead">
+        <span className="wft-sectionhead__rule wft-sectionhead__rule--lead" />
+        <span className="wft-sectionhead__label">files</span>
+        <span className="wft-sectionhead__rule" />
+        <span className="wft-sectionhead__count">
+          <SkelBar width="44px" />
+        </span>
+      </div>
+      <div className="wft-grid">
+        <div className="wft-head">
+          <span>name</span>
+          <span className="wft-head__size">size</span>
+          <span className="wft-head__type">type</span>
+          <span>visibility</span>
+          <span />
+        </div>
+        <FileRowsSkeleton rows={6} />
+      </div>
+    </div>
+  );
+}
+
 // ── Component ──────────────────────────────────────────────────────────
 
 export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableProps) {
@@ -768,7 +860,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
   };
 
   if (info.status === "loading") {
-    return <p className="wft-status">Loading workspace…</p>;
+    return <FilesLoadingSkeleton />;
   }
 
   if (info.status === "unavailable") {
@@ -1215,7 +1307,7 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
       )}
 
       {view === "list" ? (
-        <div className="wft-grid">
+        <div className="wft-grid" aria-busy={state.status === "loading" || undefined}>
           <div className="wft-head">
             <span>name</span>
             <span className="wft-head__size">size</span>
@@ -1223,6 +1315,12 @@ export function WorkspaceFileTable({ apiOrigin, workspace }: WorkspaceFileTableP
             <span>visibility</span>
             <span />
           </div>
+
+          {/* `folders`/`files` are already `[]` while `state.status ===
+              "loading"` (see above), so this doesn't double up with the
+              real rows below — it's the only content in the grid until the
+              fetch resolves. */}
+          {state.status === "loading" && <FileRowsSkeleton rows={6} />}
 
           {folders.map((folder) => (
             <button

--- a/apps/web/src/layouts/AccountLayout.astro
+++ b/apps/web/src/layouts/AccountLayout.astro
@@ -101,7 +101,18 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
                 aria-haspopup="true"
                 aria-controls="ws-switcher-menu"
               >
-                <span class="ws-switcher__label" id="ws-switcher-label">{switcherHeading}</span>
+                <span class="ws-switcher__body">
+                  <span class="ws-switcher__line1">
+                    {
+                      /* workspaces-nav.ts's paintTriggerBadge inserts the Pro
+                        badge right after this label — keeping the label in
+                        its own line1 wrapper is what keeps the badge on the
+                        name line instead of drifting onto the subtitle. */
+                    }
+                    <span class="ws-switcher__label" id="ws-switcher-label">{switcherHeading}</span>
+                  </span>
+                  <span class="ws-switcher__subtitle">workspace</span>
+                </span>
                 <span class="ws-switcher__chevron" aria-hidden="true" title="Switch workspace"
                   >▾</span
                 >
@@ -122,6 +133,12 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
               </div>
             </div>
 
+            {
+              /* Symmetric eyebrow with "Personal" below — same `.side-label`
+                idiom, shown only once a workspace is active (id lets the
+                optimistic boot script below unhide it alongside the nav). */
+            }
+            <div class="side-label" id="workspace-section-label" hidden={!workspace}>workspace</div>
             <div
               id="workspace-section-nav"
               class="ws-section-nav"
@@ -221,6 +238,8 @@ applyAuthSecurityHeaders(Astro.response.headers, signedInCsp(authOrigin, apiOrig
           }
           section.innerHTML = html;
           section.hidden = false;
+          var sectionLabel = document.getElementById("workspace-section-label");
+          if (sectionLabel) sectionLabel.hidden = false;
         } catch (e) {}
       })();
     </script>

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -2,24 +2,35 @@
 /**
  * Workspace shell: `AccountLayout` + content slot + right-rail summary.
  * Section links live in the sidebar switcher; tab routes only wrap content.
- * Rail data is filled by `initWorkspaceRail` (connected work / usage / details).
- * The usage section only renders with `showUsage` — billing is the only tab
- * that sets it, since meters repeated on every tab were pure noise
- * (issue #365 follow-up). `initWorkspaceRail` tolerates `[data-rail-usage]`
- * being absent from the DOM on every other tab.
+ * Rail data is filled by `initWorkspaceRail` (connected work / usage). The
+ * usage section only renders with `showUsage` — billing is the only tab that
+ * sets it, since meters repeated on every tab were pure noise (issue #365
+ * follow-up). `initWorkspaceRail` tolerates `[data-rail-usage]` being absent
+ * from the DOM on every other tab.
+ *
+ * The details section (slug + base URL) that used to sit here was dropped —
+ * the switcher/URL already carries the slug and the settings tab has its own
+ * slug/public-url summary, so the rail copy was pure duplication. Slug and
+ * base URL still render via `renderDetailsHtml`, just on the settings page
+ * only.
+ *
+ * `tip` is a per-page static hint, server-rendered (no JS, no placeholder):
+ * one short line, optionally linked. Omit it on pages with nothing worth
+ * saying (billing's usage meters already occupy the rail).
  */
 import { GITHUB_APP_INSTALL_URL } from "../lib/github-app";
 import { renderUsagePlaceholderHtml } from "../lib/workspace-ui";
-import { renderDetailsPlaceholderHtml } from "../lib/workspace-rail";
 import AccountLayout from "./AccountLayout.astro";
 
 interface Props {
   workspace: string;
   /** Show the rail's usage section. Billing only — see module doc. */
   showUsage?: boolean;
+  /** Static per-tab hint. `body` may include inline markup (e.g. `<code>`). */
+  tip?: { body: string; href?: string; linkLabel?: string; label?: string };
 }
 
-const { workspace, showUsage = false } = Astro.props;
+const { workspace, showUsage = false, tip } = Astro.props;
 
 const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`;
 ---
@@ -49,26 +60,22 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
         )
       }
 
-      <section class="ws-rail__section">
-        <div class="ws-rail__head">
-          <span class="ws-rail__label">details</span>
-          <span class="ws-rail__rule"></span>
-        </div>
-        {
-          /* `aria-busy` sits on the <dl> itself, not inside the placeholder like
-            the usage section's does: `innerHTML` replaces this element's
-            children but not the element, so the attribute survives the repaint
-            and `paint()` has to clear it explicitly. Without it the skeleton
-            bars are `aria-hidden`, so a screen reader would meet two empty
-            <dd>s with no indication anything is still loading. */
-        }
-        <dl
-          class="ws-rail__kv"
-          data-rail-details
-          aria-busy="true"
-          set:html={renderDetailsPlaceholderHtml()}
-        />
-      </section>
+      {
+        tip && (
+          <section class="ws-rail__section ws-rail__tip">
+            <div class="ws-rail__head">
+              <span class="ws-rail__label">{tip.label ?? "tip"}</span>
+              <span class="ws-rail__rule" />
+            </div>
+            <p class="ws-rail__tip-body" set:html={tip.body} />
+            {tip.href && (
+              <a class="ws-rail__tip-link" href={tip.href}>
+                {tip.linkLabel ?? tip.href}
+              </a>
+            )}
+          </section>
+        )
+      }
 
       <section class="ws-rail__section">
         <div class="ws-rail__head">
@@ -169,29 +176,36 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
     color: var(--muted);
   }
 
-  /* Details — dt/dd pairs are innerHTML-injected by renderDetailsHtml. */
-  .ws-rail__kv {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 6px 18px;
-    margin: 0;
+  /* Tip — server-rendered, static. Filled panel (vs. the plain-list other
+     sections use) so it reads as an aside rather than another data section. */
+  .ws-rail__tip {
+    padding: 12px 14px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 6px;
   }
-  :global(.account-shell) .ws-rail :global(.ws-rail__dt) {
+  .ws-rail__tip .ws-rail__head {
+    margin-bottom: 6px;
+  }
+  .ws-rail__tip-body {
+    margin: 0;
     color: var(--muted);
+    font-size: 12.5px;
+    line-height: 1.55;
+    text-wrap: pretty;
   }
-  :global(.account-shell) .ws-rail :global(.ws-rail__dd) {
-    margin: 0;
-    text-align: right;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .ws-rail__tip-body :global(code) {
+    font-size: 11.5px;
   }
-  :global(.account-shell) .ws-rail :global(.ws-rail__link) {
+  .ws-rail__tip-link {
+    display: inline-block;
+    margin-top: 6px;
     color: var(--fg);
+    font-size: 12px;
     text-decoration: none;
   }
-  :global(.account-shell) .ws-rail :global(.ws-rail__link:hover),
-  :global(.account-shell) .ws-rail :global(.ws-rail__link:focus-visible) {
+  .ws-rail__tip-link:hover,
+  .ws-rail__tip-link:focus-visible {
     color: var(--accent);
     outline: none;
   }

--- a/apps/web/src/layouts/WorkspaceLayout.astro
+++ b/apps/web/src/layouts/WorkspaceLayout.astro
@@ -3,6 +3,10 @@
  * Workspace shell: `AccountLayout` + content slot + right-rail summary.
  * Section links live in the sidebar switcher; tab routes only wrap content.
  * Rail data is filled by `initWorkspaceRail` (connected work / usage / details).
+ * The usage section only renders with `showUsage` — billing is the only tab
+ * that sets it, since meters repeated on every tab were pure noise
+ * (issue #365 follow-up). `initWorkspaceRail` tolerates `[data-rail-usage]`
+ * being absent from the DOM on every other tab.
  */
 import { GITHUB_APP_INSTALL_URL } from "../lib/github-app";
 import { renderUsagePlaceholderHtml } from "../lib/workspace-ui";
@@ -11,9 +15,11 @@ import AccountLayout from "./AccountLayout.astro";
 
 interface Props {
   workspace: string;
+  /** Show the rail's usage section. Billing only — see module doc. */
+  showUsage?: boolean;
 }
 
-const { workspace } = Astro.props;
+const { workspace, showUsage = false } = Astro.props;
 
 const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`;
 ---
@@ -31,13 +37,17 @@ const invitePath = `/account/workspaces/${encodeURIComponent(workspace)}/people`
         <div class="ws-rail__connected-list" data-rail-connected-list></div>
       </section>
 
-      <section class="ws-rail__section">
-        <div class="ws-rail__head">
-          <span class="ws-rail__label">usage</span>
-          <span class="ws-rail__rule"></span>
-        </div>
-        <div class="ws-rail__usage" data-rail-usage set:html={renderUsagePlaceholderHtml()} />
-      </section>
+      {
+        showUsage && (
+          <section class="ws-rail__section">
+            <div class="ws-rail__head">
+              <span class="ws-rail__label">usage</span>
+              <span class="ws-rail__rule" />
+            </div>
+            <div class="ws-rail__usage" data-rail-usage set:html={renderUsagePlaceholderHtml()} />
+          </section>
+        )
+      }
 
       <section class="ws-rail__section">
         <div class="ws-rail__head">

--- a/apps/web/src/lib/workspace-rail.test.ts
+++ b/apps/web/src/lib/workspace-rail.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  planTitleRepaint,
-  renderConnectedWorkHtml,
-  renderDetailsHtml,
-  renderDetailsPlaceholderHtml,
-} from "./workspace-rail";
+import { planTitleRepaint, renderConnectedWorkHtml, renderDetailsHtml } from "./workspace-rail";
 import type { GhWorkItem } from "./gh-context";
 
 function ghItem(overrides: Partial<GhWorkItem> = {}): GhWorkItem {
@@ -149,17 +144,6 @@ describe("renderDetailsHtml", () => {
     });
     expect(html).not.toContain("<img");
     expect(html).toContain("&lt;img");
-  });
-});
-
-describe("renderDetailsPlaceholderHtml", () => {
-  it("keeps the real details labels and only masks the values", () => {
-    const html = renderDetailsPlaceholderHtml();
-    // Labels are Tier 0 — they are known without any request.
-    expect(html).toContain(">slug<");
-    expect(html).toContain(">base url<");
-    expect(html).toContain("ws-rail__dt");
-    expect(html).toContain("ws-skel");
   });
 });
 

--- a/apps/web/src/lib/workspace-rail.ts
+++ b/apps/web/src/lib/workspace-rail.ts
@@ -1,14 +1,16 @@
 /**
  * Live data for `WorkspaceLayout.astro`'s right rail (connected work / usage /
- * details / quick actions — see `.context/2026-07-19-settings-overhaul-3a-reference.html`
- * and design doc §5.5).
+ * quick actions — see `.context/2026-07-19-settings-overhaul-3a-reference.html`
+ * and design doc §5.5). `renderDetailsHtml` also lives here for the settings
+ * tab's own slug/public-url summary — the rail dropped its copy of it as pure
+ * duplication, but the builder stays shared since settings still needs it.
  *
  * `initWorkspaceRail` is mounted once per workspace-tab page load. It:
  *  - defines the documented connected-work hook (`window.__uploadsSetConnectedWork`)
  *    synchronously, before any network round trip, so a files-tab script that
  *    races ahead of this module's session-gated fetches never calls a
  *    not-yet-defined function;
- *  - paints last-known details/usage from the workspace snapshot cache
+ *  - paints the last-known usage value from the workspace snapshot cache
  *    synchronously, then revalidates through the shared `loadWorkspaceSummary`
  *    request once the session gate resolves.
  *
@@ -19,9 +21,9 @@
  * item; an empty array hides it. Non-files tabs never call it, so the section
  * stays hidden by construction.
  */
-import { getGithubInstalled, type GithubTitleMap, type MyWorkspace } from "./api-client";
+import { getGithubInstalled, type GithubTitleMap } from "./api-client";
 import { onSession } from "./account-shell";
-import { escapeHtml, renderUsageHtml, skeletonBarHtml, type UsageSnapshot } from "./workspace-ui";
+import { escapeHtml, renderUsageHtml, type UsageSnapshot } from "./workspace-ui";
 import { readWorkspaceSnapshot } from "./workspace-cache";
 import { loadWorkspaceSummary } from "./workspace-summary-source";
 import { githubKindSvg } from "./brand-icons";
@@ -65,7 +67,7 @@ export interface WorkspaceRailDetails {
 }
 
 /**
- * Pure builder for the rail/settings "details" `<dt>/<dd>` pairs (slug +
+ * Pure builder for the settings tab's "details" `<dt>/<dd>` pairs (slug +
  * base URL only — role lives on People / Account). The base-URL cell is
  * plain text (host of the stable public origin, e.g. `storage.uploads.sh`)
  * — it is a bucket root, not a useful page to open. `hasPublicUrl` without
@@ -80,17 +82,6 @@ export function renderDetailsHtml(ws: WorkspaceRailDetails): string {
   return (
     `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${escapeHtml(ws.organization.slug)}</dd>` +
     `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${baseUrlHtml}</dd>`
-  );
-}
-
-/**
- * Rail details placeholder. The `<dt>` labels are static, so they render for
- * real; only the `<dd>` values are masked.
- */
-export function renderDetailsPlaceholderHtml(): string {
-  return (
-    `<dt class="ws-rail__dt">slug</dt><dd class="ws-rail__dd">${skeletonBarHtml("84px")}</dd>` +
-    `<dt class="ws-rail__dt">base url</dt><dd class="ws-rail__dd">${skeletonBarHtml("132px")}</dd>`
   );
 }
 
@@ -196,50 +187,27 @@ export function initWorkspaceRail(
   const setConnectedWork = bindConnectedWorkSetter(root, apiOrigin);
   setConnectedWork([]);
 
-  const detailsEl = root.querySelector<HTMLElement>("[data-rail-details]");
   const usageEl = root.querySelector<HTMLElement>("[data-rail-usage]");
   const githubCtaEl = root.querySelector<HTMLElement>("[data-rail-github-cta]");
 
   // `data-stale` is a diagnostic marker, not a user-facing affordance: nothing
   // in the app styles or reads it. It exists so warm-paint behavior (this
-  // file's whole point) can be verified in the browser — inspect the rail
-  // elements after a Tier 1 paint and confirm the attribute is set, then
+  // file's whole point) can be verified in the browser — inspect the usage
+  // element after a Tier 1 paint and confirm the attribute is set, then
   // confirm it clears once Tier 2 repaints with fresh data.
-  const paint = (
-    details: WorkspaceRailDetails | null,
-    usage: UsageSnapshot | undefined,
-    stale: boolean,
-  ): void => {
-    if (detailsEl && details) {
-      detailsEl.innerHTML = renderDetailsHtml(details);
-      detailsEl.toggleAttribute("data-stale", stale);
-      // The <dl> carries `aria-busy` itself (see WorkspaceLayout.astro) and
-      // survives the innerHTML swap, so it must be cleared by hand. The usage
-      // section needs no equivalent: its `aria-busy` lives on markup the swap
-      // replaces outright.
-      detailsEl.removeAttribute("aria-busy");
-    }
+  const paint = (usage: UsageSnapshot | undefined, stale: boolean): void => {
     if (usageEl && usage) {
       usageEl.innerHTML = renderUsageHtml(usage);
       usageEl.toggleAttribute("data-stale", stale);
     }
   };
 
-  // Tier 1 — last known values, no network. Runs at module-eval time, before
-  // the session gate resolves. The server-rendered placeholders it overwrites
-  // occupy the same height, so this repaint moves nothing on the page.
+  // Tier 1 — last known value, no network. Runs at module-eval time, before
+  // the session gate resolves. The server-rendered placeholder it overwrites
+  // occupies the same height, so this repaint moves nothing on the page.
+  // `usageEl` (and so this whole tier) only exists on the billing tab.
   const cached = readWorkspaceSnapshot(workspace);
-  if (cached) {
-    paint(
-      {
-        organization: { slug: cached.slug },
-        hasPublicUrl: cached.hasPublicUrl,
-        publicBaseUrl: cached.publicBaseUrl,
-      },
-      cached.usage,
-      true,
-    );
-  }
+  if (cached?.usage) paint(cached.usage, true);
 
   onSession(() => {
     // Suppress the install CTA once this workspace has the App (issue #492).
@@ -251,37 +219,24 @@ export function initWorkspaceRail(
       });
     }
 
+    // Shared per-page-load fetch (workspace-summary-source.ts dedupes with
+    // any other tab consumer), also the source that keeps the cached
+    // snapshot above warm for the *next* visit.
     void loadWorkspaceSummary(apiOrigin, workspace).then((result) => {
       if (result.kind !== "success") {
-        // A warm paint is better than an error string: the values on screen
-        // were true recently, and the failure is already surfaced by whatever
-        // the page body does with the same shared result. But that only holds
-        // per-section — `cached` always carries details when it exists (every
-        // field but `usage` is required), while `cached.usage` can be
-        // undefined on its own (a prior successful response had
-        // `usage: null`). A section with nothing warm to keep must not be
-        // left sitting in Tier 0's skeleton (including its `aria-busy="true"`)
-        // forever — fall back to the error string there instead.
-        if (!cached && detailsEl) {
-          detailsEl.textContent = "Details unavailable.";
-          // `textContent` swaps the <dl>'s children, not the <dl>, so its own
-          // `aria-busy` outlives the write — an error that still announces as
-          // loading. The usage section needs no such clear: its `aria-busy`
-          // lives on a child that `textContent` destroys.
-          detailsEl.removeAttribute("aria-busy");
-        }
+        // A warm paint is better than an error string: the value on screen
+        // was true recently, and the failure is already surfaced by whatever
+        // the page body does with the same shared result. Only fall back to
+        // the error string when there was nothing warm to keep.
         if (!cached?.usage && usageEl) usageEl.textContent = "Usage unavailable.";
         return;
       }
-      const ws: MyWorkspace = result.workspace;
-      paint(ws, result.usage ?? undefined, false);
+      paint(result.usage ?? undefined, false);
       // `result.usage: null` is a genuinely reachable success shape (e.g. a
-      // plan with no usage record yet) — `paint` above already skips the
-      // usage section for it, leaving whatever Tier 1 warm-painted, if
-      // anything, on screen untouched (including its `data-stale`, which
-      // stays honest: the displayed value is still the cached one). Only
-      // fall back to the error string when there was no cached usage to
-      // fall back to, matching the failure branch's same warm-value rule.
+      // plan with no usage record yet) — `paint` above already skips it,
+      // leaving whatever Tier 1 warm-painted, if anything, on screen
+      // untouched (including its `data-stale`, which stays honest: the
+      // displayed value is still the cached one).
       if (usageEl && !result.usage && !cached?.usage) {
         usageEl.textContent = "Usage unavailable.";
       }

--- a/apps/web/src/lib/workspace-ui.test.ts
+++ b/apps/web/src/lib/workspace-ui.test.ts
@@ -5,6 +5,8 @@ import {
   formatGalleryDate,
   formatMarketedBytes,
   orderOrgsOldestFirst,
+  renderDetailListPlaceholderHtml,
+  renderFilesPlaceholderHtml,
   renderGalleriesEmptyHtml,
   renderGalleriesPlaceholderHtml,
   renderGalleriesTableHtml,
@@ -13,6 +15,7 @@ import {
   renderMembersPlaceholderHtml,
   renderUsageHtml,
   renderUsagePlaceholderHtml,
+  renderWorkspacesPlaceholderHtml,
   safeSameOriginPath,
   skeletonBarHtml,
 } from "./workspace-ui";
@@ -364,5 +367,38 @@ describe("renderGalleriesEmptyHtml", () => {
 
   it("escapes a command containing markup", () => {
     expect(renderGalleriesEmptyHtml('a<b>"c"')).not.toContain("<b>");
+  });
+
+  it("skips the restated body sentence — the page note and details block above/below it already cover it", () => {
+    const html = renderGalleriesEmptyHtml(cmd);
+    expect(html).not.toContain("ws-empty-state__body");
+    expect(html).not.toContain("public link");
+  });
+});
+
+describe("placeholder builders reuse the real markup's classes", () => {
+  it("renderWorkspacesPlaceholderHtml mirrors the real dev-links row shape", () => {
+    const html = renderWorkspacesPlaceholderHtml(2);
+    expect(html.match(/<li>/g)).toHaveLength(2);
+    expect(html).toContain('class="slug"');
+  });
+
+  it("renderDetailListPlaceholderHtml mirrors the real detail-list row shape", () => {
+    const html = renderDetailListPlaceholderHtml(2);
+    expect(html.match(/<li>/g)).toHaveLength(2);
+    expect(html).toContain("detail-main");
+    expect(html).toContain("detail-title");
+    expect(html).toContain("detail-meta");
+  });
+
+  it("renderFilesPlaceholderHtml mirrors the real toolbar + table chrome", () => {
+    const html = renderFilesPlaceholderHtml(3);
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("wft-filterbar");
+    expect(html).toContain("wft-sectionhead");
+    // Real column headers — static text, since they never depend on data.
+    expect(html).toContain(">name<");
+    expect(html).toContain(">visibility<");
+    expect(html.match(/class="wft-row"/g)).toHaveLength(3);
   });
 });

--- a/apps/web/src/lib/workspace-ui.ts
+++ b/apps/web/src/lib/workspace-ui.ts
@@ -454,12 +454,16 @@ export function renderUsagePlaceholderHtml(meters = 2): string {
  * Built as the page's primary element rather than a muted footnote: when a
  * workspace has no galleries, "you have none, here is how to make one" *is*
  * the content, and burying it under a command block inverted the hierarchy.
+ *
+ * No body sentence: the page-header note above this block and the "Working
+ * with galleries" details block below it already explain what a gallery is —
+ * a third restatement here was stacking, not informing. This stays down to
+ * the state plus the one action that resolves it.
  */
 export function renderGalleriesEmptyHtml(createCmd: string): string {
   const safe = escapeHtml(createCmd);
   return `<div class="ws-empty-state">
   <p class="ws-empty-state__title">No galleries yet</p>
-  <p class="ws-empty-state__body">A gallery collects screenshots behind one public link you can drop in a pull request.</p>
   <div class="command ws-empty__command">
     <code>${safe}</code>
     <button type="button" data-copy="${safe}" aria-live="polite">copy</button>
@@ -493,5 +497,84 @@ export function renderGalleriesPlaceholderHtml(rows = 3): string {
   </thead>
   <tbody>${body}</tbody>
 </table>
+</div>`;
+}
+
+/**
+ * Workspaces-index placeholder — same `ul.dev-links li` row (link + role
+ * slug) the real list renders, so the swap from placeholder to data doesn't
+ * change row count or height, only content.
+ */
+export function renderWorkspacesPlaceholderHtml(rows = 2): string {
+  const widths = ["132px", "104px"];
+  return Array.from(
+    { length: rows },
+    (_, i) =>
+      `<li>${skeletonBarHtml(widths[i % widths.length])}<span class="slug">${skeletonBarHtml("48px")}</span></li>`,
+  ).join("");
+}
+
+/**
+ * Generic `ul.detail-list` placeholder (profile's sign-in-methods and
+ * sessions lists) — mirrors the real row's title/meta stack so a row's
+ * height doesn't change when data replaces the skeleton.
+ */
+export function renderDetailListPlaceholderHtml(rows = 2): string {
+  const widths = ["120px", "150px"];
+  return Array.from(
+    { length: rows },
+    (_, i) =>
+      `<li><div class="detail-main">` +
+      `<div class="detail-title">${skeletonBarHtml(widths[i % widths.length])}</div>` +
+      `<div class="detail-meta">${skeletonBarHtml("90px")}</div>` +
+      `</div></li>`,
+  ).join("");
+}
+
+/**
+ * Files-tab placeholder for the pre-hydration mount gap in
+ * `[name].astro` — the page dynamic-imports React and `WorkspaceFileTable`,
+ * so the mount point is otherwise empty until that resolves. Mirrors the
+ * component's own `info.status === "loading"` skeleton (same class names:
+ * `wft-filter`/`wft-filterbar`, `wft-sectionhead`, `wft-head`, `wft-row`) so
+ * the static-HTML-to-React handoff is visually seamless, and the real table
+ * head labels (name/size/type/visibility) are static text here too since
+ * they never depend on data.
+ */
+export function renderFilesPlaceholderHtml(rows = 6): string {
+  const widths = ["62%", "48%", "70%", "40%", "55%", "35%"];
+  const rowsHtml = Array.from({ length: rows }, (_, i) => {
+    const w = widths[i % widths.length];
+    return `<div class="wft-row">
+  <span class="wft-name">${skeletonBarHtml(w)}</span>
+  <span class="wft-size">${skeletonBarHtml("32px")}</span>
+  <span class="wft-type">${skeletonBarHtml("28px")}</span>
+  <span class="wft-vis">${skeletonBarHtml("52px")}</span>
+  <span></span>
+</div>`;
+  }).join("");
+  return `<div class="wft" aria-busy="true">
+  <div class="wft-filter">
+    <div class="wft-filterbar input-group">
+      <span class="input-group__field wft-field-skel">${skeletonBarHtml("60%")}</span>
+      <span class="input-group__action wft-field-skel">${skeletonBarHtml("28px")}</span>
+    </div>
+  </div>
+  <div class="wft-sectionhead">
+    <span class="wft-sectionhead__rule wft-sectionhead__rule--lead"></span>
+    <span class="wft-sectionhead__label">files</span>
+    <span class="wft-sectionhead__rule"></span>
+    <span class="wft-sectionhead__count">${skeletonBarHtml("44px")}</span>
+  </div>
+  <div class="wft-grid">
+    <div class="wft-head">
+      <span>name</span>
+      <span class="wft-head__size">size</span>
+      <span class="wft-head__type">type</span>
+      <span>visibility</span>
+      <span></span>
+    </div>
+    ${rowsHtml}
+  </div>
 </div>`;
 }

--- a/apps/web/src/lib/workspaces-nav.test.ts
+++ b/apps/web/src/lib/workspaces-nav.test.ts
@@ -12,6 +12,7 @@ import {
   renderWorkspaceSectionNavHtml,
   resolveDefaultWorkspace,
   resolveSidebarWorkspace,
+  shouldShowTriggerBadge,
   switcherLabel,
   workspaceTabFromPathname,
   writeCachedActiveWorkspace,
@@ -296,6 +297,24 @@ describe("switcherLabel", () => {
     expect(switcherLabel(sample, "buildinternet")).toBe("buildinternet");
     expect(switcherLabel(sample, "unknown")).toBe("unknown");
     expect(switcherLabel(sample, "")).toBe("workspaces");
+  });
+});
+
+describe("shouldShowTriggerBadge", () => {
+  const withPlans: MyWorkspace[] = [
+    { ...sample[0]!, plan: "pro" },
+    { ...sample[1]!, plan: "free" },
+  ];
+
+  it("shows only for the active workspace's own pro plan", () => {
+    expect(shouldShowTriggerBadge(withPlans, "buildinternet")).toBe(true);
+    expect(shouldShowTriggerBadge(withPlans, "side")).toBe(false);
+  });
+
+  it("is false with no active workspace, an unknown one, or a missing plan", () => {
+    expect(shouldShowTriggerBadge(withPlans, "")).toBe(false);
+    expect(shouldShowTriggerBadge(withPlans, "unknown")).toBe(false);
+    expect(shouldShowTriggerBadge(sample, "buildinternet")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -362,12 +362,20 @@ function paint(els: SwitcherEls, workspaces: MyWorkspace[], opts: WorkspacesNavO
   paintTriggerBadge(els, workspaces, active);
   els.menu.innerHTML = renderSwitcherMenuHtml(workspaces, { active, quota: opts.quota });
 
+  // The "workspace" eyebrow above the section nav tracks it 1:1. Toggled
+  // here (not via a `:has(+ …:not([hidden]))` rule in account-shell.css)
+  // because Chromium fails to re-resolve that selector when this function
+  // flips the sibling's `hidden` — the rule matches on paper and still
+  // computes `display: none`.
+  const sectionLabel = document.getElementById("workspace-section-label");
   if (active) {
     els.section.hidden = false;
     els.section.innerHTML = renderWorkspaceSectionNavHtml(active, activeTab);
+    if (sectionLabel) sectionLabel.hidden = false;
   } else {
     els.section.hidden = true;
     els.section.innerHTML = "";
+    if (sectionLabel) sectionLabel.hidden = true;
   }
 }
 

--- a/apps/web/src/lib/workspaces-nav.ts
+++ b/apps/web/src/lib/workspaces-nav.ts
@@ -306,6 +306,15 @@ export function switcherLabel(workspaces: MyWorkspace[], active: string): string
   return match ? displayName(match) : active;
 }
 
+/** Whether the collapsed switcher trigger should show a Pro badge next to
+ * the active workspace name — same rule as the menu row (shouldShowProBadge),
+ * just resolved against whichever workspace is currently active. */
+export function shouldShowTriggerBadge(workspaces: MyWorkspace[], active: string): boolean {
+  if (!active) return false;
+  const match = workspaces.find((ws) => ws.workspace === active);
+  return shouldShowProBadge(match?.plan);
+}
+
 type SwitcherEls = {
   trigger: HTMLButtonElement;
   label: HTMLElement;
@@ -316,6 +325,27 @@ type SwitcherEls = {
 function closeMenu(els: SwitcherEls): void {
   els.trigger.setAttribute("aria-expanded", "false");
   els.menu.hidden = true;
+}
+
+/**
+ * Paint (or remove) the trigger's Pro badge as a sibling element right after
+ * `els.label` — never via innerHTML with the (untrusted) workspace name, so
+ * the label stays a plain textContent write and the badge is its own node.
+ * Re-entrant: repeated calls reuse the existing badge node rather than
+ * creating a new one each paint.
+ */
+function paintTriggerBadge(els: SwitcherEls, workspaces: MyWorkspace[], active: string): void {
+  const existing = els.trigger.querySelector<HTMLElement>("[data-ws-switcher-badge]");
+  if (!shouldShowTriggerBadge(workspaces, active)) {
+    existing?.remove();
+    return;
+  }
+  if (existing) return;
+  const badge = document.createElement("span");
+  badge.dataset.wsSwitcherBadge = "";
+  badge.className = "pro-badge";
+  badge.textContent = "Pro";
+  els.label.insertAdjacentElement("afterend", badge);
 }
 
 function paint(els: SwitcherEls, workspaces: MyWorkspace[], opts: WorkspacesNavOptions): void {
@@ -329,6 +359,7 @@ function paint(els: SwitcherEls, workspaces: MyWorkspace[], opts: WorkspacesNavO
   const activeTab = opts.activeTab || "";
 
   els.label.textContent = switcherLabel(workspaces, active);
+  paintTriggerBadge(els, workspaces, active);
   els.menu.innerHTML = renderSwitcherMenuHtml(workspaces, { active, quota: opts.quota });
 
   if (active) {

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -246,12 +246,12 @@ export const prerender = false;
           .map((row) => {
             const action = row.connectGithub
               ? `<div class="detail-action">
-                <button type="button" class="text-btn" data-connect-github>Connect</button>
+                <button type="button" class="text-btn text-btn--boxed" data-connect-github>Connect</button>
               </div>`
               : "";
-            const badge = row.ok
-              ? `<span class="ul-badge ul-badge--ok">Connected</span>`
-              : `<span class="ul-badge">Not connected</span>`;
+            // Unconnected rows carry no badge: the meta line already says
+            // "Not connected", and the boxed Connect button is the state cue.
+            const badge = row.ok ? `<span class="ul-badge ul-badge--ok">Connected</span>` : "";
             return `<li>
             <div class="detail-main">
               <div class="detail-title">

--- a/apps/web/src/pages/account/profile.astro
+++ b/apps/web/src/pages/account/profile.astro
@@ -1,5 +1,6 @@
 ---
 import AccountLayout from "../../layouts/AccountLayout.astro";
+import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
 ---
@@ -19,8 +20,13 @@ export const prerender = false;
 
     <div class="settings-section">
       <h2>Sign-in methods</h2>
-      <div id="accounts-status" class="muted detail-status">Loading…</div>
-      <ul class="detail-list" id="accounts-list" hidden></ul>
+      <div id="accounts-status" class="muted detail-status" hidden></div>
+      <ul
+        class="detail-list"
+        id="accounts-list"
+        aria-busy="true"
+        set:html={renderDetailListPlaceholderHtml()}
+      />
       <p id="accounts-error" class="detail-error" role="alert" hidden></p>
     </div>
 
@@ -38,8 +44,13 @@ export const prerender = false;
           <button type="button" class="text-btn" id="cli-upgrade-dismiss">Dismiss</button>
         </div>
       </div>
-      <div id="sessions-status" class="muted detail-status">Loading…</div>
-      <ul class="detail-list" id="sessions-list" hidden></ul>
+      <div id="sessions-status" class="muted detail-status" hidden></div>
+      <ul
+        class="detail-list"
+        id="sessions-list"
+        aria-busy="true"
+        set:html={renderDetailListPlaceholderHtml()}
+      />
       <div id="sessions-recover" class="sessions-recover" hidden>
         <p class="muted">Couldn’t load sessions — sign in again to refresh.</p>
         <a class="text-btn" id="sessions-reauth" href="/login">Sign in again</a>
@@ -113,6 +124,7 @@ export const prerender = false;
       resolveUpgradePrompt,
     } from "../../lib/cli-upgrade";
     import { deviceLabel, formatSessionTime, isCliUserAgent } from "../../lib/session-device";
+    import { renderDetailListPlaceholderHtml } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("acct-email")) return;
@@ -176,11 +188,15 @@ export const prerender = false;
       async function loadAccounts(): Promise<void> {
         const status = requireElement<HTMLElement>("#accounts-status", "account profile");
         const list = requireElement<HTMLUListElement>("#accounts-list", "account profile");
-        list.hidden = true;
-        showStatus(status, "Loading…");
+        status.hidden = true;
+        list.hidden = false;
+        list.setAttribute("aria-busy", "true");
+        list.innerHTML = renderDetailListPlaceholderHtml();
 
         const accounts = await listAccounts(authOrigin);
         if (accounts === null) {
+          list.hidden = true;
+          list.removeAttribute("aria-busy");
           showStatus(status, "Couldn’t load sign-in methods.");
           return;
         }
@@ -225,6 +241,7 @@ export const prerender = false;
 
         status.hidden = true;
         list.hidden = false;
+        list.removeAttribute("aria-busy");
         list.innerHTML = rows
           .map((row) => {
             const action = row.connectGithub
@@ -290,10 +307,12 @@ export const prerender = false;
         const error = requireElement<HTMLElement>("#sessions-error", "account profile");
         const upgradeBox = requireElement<HTMLElement>("#cli-upgrade", "account profile");
         error.hidden = true;
-        list.hidden = true;
+        status.hidden = true;
+        list.hidden = false;
+        list.setAttribute("aria-busy", "true");
+        list.innerHTML = renderDetailListPlaceholderHtml();
         recover.hidden = true;
         upgradeBox.hidden = true;
-        showStatus(status, "Loading…");
 
         // Point recovery at this page so re-auth lands back on the sessions list.
         reauth.href = `/login?callbackURL=${encodeURIComponent(`${location.origin}/account/profile`)}`;
@@ -309,11 +328,15 @@ export const prerender = false;
         }
 
         if (sessions === null) {
+          list.hidden = true;
+          list.removeAttribute("aria-busy");
           status.hidden = true;
           recover.hidden = false;
           return;
         }
         if (!sessions.length) {
+          list.hidden = true;
+          list.removeAttribute("aria-busy");
           showStatus(status, "No active sessions.");
           return;
         }
@@ -326,6 +349,7 @@ export const prerender = false;
 
         status.hidden = true;
         list.hidden = false;
+        list.removeAttribute("aria-busy");
         list.innerHTML = ordered
           .map((s) => {
             const current = currentToken != null && s.token === currentToken;

--- a/apps/web/src/pages/account/workspaces.astro
+++ b/apps/web/src/pages/account/workspaces.astro
@@ -7,6 +7,7 @@
  */
 import AccountLayout from "../../layouts/AccountLayout.astro";
 import { isBrowseWorkspace } from "../../lib/workspace-browse-url";
+import { renderWorkspacesPlaceholderHtml } from "../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -31,9 +32,14 @@ if (isBrowseWorkspace(legacyWs)) {
         Choose a workspace, or&#32;<a href="/account/workspaces/new">create one</a>.
       </p>
       <p class="settings-note muted" id="orgs-cap" hidden></p>
-      <div id="orgs-status" class="ws-status muted">Loading…</div>
+      <div id="orgs-status" class="ws-status muted" hidden></div>
       <button id="orgs-retry" type="button" hidden>Try again</button>
-      <ul class="dev-links" id="orgs-list" hidden></ul>
+      <ul
+        class="dev-links"
+        id="orgs-list"
+        aria-busy="true"
+        set:html={renderWorkspacesPlaceholderHtml()}
+      />
     </div>
   </section>
 
@@ -48,7 +54,7 @@ if (isBrowseWorkspace(legacyWs)) {
     } from "../../lib/workspaces-nav";
     import { workspaceCapMessage } from "@uploads/billing";
     import { shouldShowProBadge } from "../../lib/plan-badge";
-    import { escapeHtml } from "../../lib/workspace-ui";
+    import { escapeHtml, renderWorkspacesPlaceholderHtml } from "../../lib/workspace-ui";
 
     onAstroPageLoad(() => {
       if (!document.getElementById("orgs-status")) return;
@@ -67,17 +73,31 @@ if (isBrowseWorkspace(legacyWs)) {
       // renders.
       const managing = isManageRequest(location.search);
 
-      async function loadIndex(): Promise<void> {
-        status.hidden = false;
-        list.hidden = true;
+      function showLoading(): void {
+        status.hidden = true;
         retry.hidden = true;
-        status.textContent = "Loading…";
+        list.hidden = false;
+        list.setAttribute("aria-busy", "true");
+        list.innerHTML = renderWorkspacesPlaceholderHtml();
+      }
+
+      function showListError(message: string, retryable: boolean): void {
+        list.hidden = true;
+        list.removeAttribute("aria-busy");
+        status.hidden = false;
+        status.textContent = message;
+        retry.hidden = !retryable;
+      }
+
+      async function loadIndex(): Promise<void> {
+        showLoading();
 
         const result = await loadWorkspaces(apiOrigin);
         if (result.kind === "unavailable") {
-          status.textContent =
-            "Workspaces are temporarily unavailable. Check the local stack or try again.";
-          retry.hidden = false;
+          showListError(
+            "Workspaces are temporarily unavailable. Check the local stack or try again.",
+            true,
+          );
           return;
         }
 
@@ -94,6 +114,9 @@ if (isBrowseWorkspace(legacyWs)) {
         // No memberships means nothing owned, so the cap can't be reached
         // here — the offer always stands.
         if (!workspaces.length) {
+          list.hidden = true;
+          list.removeAttribute("aria-busy");
+          status.hidden = false;
           status.innerHTML =
             'No workspaces yet — <a href="/account/workspaces/new">create one</a>, or accept an invite.';
           return;
@@ -103,6 +126,9 @@ if (isBrowseWorkspace(legacyWs)) {
           ? null
           : resolveDefaultWorkspace(workspaces, readCachedActiveWorkspace());
         if (open) {
+          list.hidden = true;
+          list.removeAttribute("aria-busy");
+          status.hidden = false;
           status.textContent = "Opening…";
           location.replace(`/account/workspaces/${encodeURIComponent(open)}`);
           return;
@@ -110,6 +136,7 @@ if (isBrowseWorkspace(legacyWs)) {
 
         status.hidden = true;
         list.hidden = false;
+        list.removeAttribute("aria-busy");
         list.innerHTML = workspaces
           .map((ws) => {
             const name = ws.organization.name || ws.workspace;

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -5,6 +5,7 @@
  */
 import WorkspaceLayout from "../../../layouts/WorkspaceLayout.astro";
 import { isBrowseWorkspace } from "../../../lib/workspace-browse-url";
+import { renderFilesPlaceholderHtml } from "../../../lib/workspace-ui";
 
 export const prerender = false;
 
@@ -14,7 +15,12 @@ if (!workspace) return Astro.redirect("/account/workspaces");
 ---
 
 <WorkspaceLayout workspace={workspace}>
-  <div id="ws-files-table"></div>
+  {
+    /* React (dynamic-imported below) replaces this wholesale on mount — it
+      exists only to fill the gap before that import resolves, so it mirrors
+      WorkspaceFileTable's own `info.status === "loading"` render exactly. */
+  }
+  <div id="ws-files-table" set:html={renderFilesPlaceholderHtml()} />
 
   <script>
     import { onAstroPageLoad } from "../../../lib/account-shell";

--- a/apps/web/src/pages/account/workspaces/[name].astro
+++ b/apps/web/src/pages/account/workspaces/[name].astro
@@ -12,9 +12,13 @@ export const prerender = false;
 const nameParam = Astro.params.name ?? "";
 const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
+
+const tip = {
+  body: "attach uploads to a pull request with <code>uploads put ./shot.png --pr 123</code> — they collect into one managed comment.",
+};
 ---
 
-<WorkspaceLayout workspace={workspace}>
+<WorkspaceLayout workspace={workspace} tip={tip}>
   {
     /* React (dynamic-imported below) replaces this wholesale on mount — it
       exists only to fill the gap before that import resolves, so it mirrors

--- a/apps/web/src/pages/account/workspaces/[name]/billing.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/billing.astro
@@ -19,7 +19,7 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 ---
 
-<WorkspaceLayout workspace={workspace}>
+<WorkspaceLayout workspace={workspace} showUsage>
   <div id="ws-status" class="ul-callout status" role="status" hidden></div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 

--- a/apps/web/src/pages/account/workspaces/[name]/galleries.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/galleries.astro
@@ -14,9 +14,13 @@ const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
 
 const createCmd = 'uploads gallery create --title "Release screenshots"';
+
+const tip = {
+  body: "link a gallery to a PR and the public link stays current as you add shots.",
+};
 ---
 
-<WorkspaceLayout workspace={workspace}>
+<WorkspaceLayout workspace={workspace} tip={tip}>
   <div id="ws-status" class="ul-callout status" role="status" hidden></div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 

--- a/apps/web/src/pages/account/workspaces/[name]/people.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/people.astro
@@ -13,9 +13,13 @@ export const prerender = false;
 const nameParam = Astro.params.name ?? "";
 const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
+
+const tip = {
+  body: "invites are workspace-scoped — teammates see every file, not just their own.",
+};
 ---
 
-<WorkspaceLayout workspace={workspace}>
+<WorkspaceLayout workspace={workspace} tip={tip}>
   <div id="ws-status" class="ul-callout status" role="status" hidden></div>
   <button id="ws-retry" type="button" hidden>Try again</button>
 

--- a/apps/web/src/pages/account/workspaces/[name]/settings.astro
+++ b/apps/web/src/pages/account/workspaces/[name]/settings.astro
@@ -16,9 +16,13 @@ export const prerender = false;
 const nameParam = Astro.params.name ?? "";
 const workspace = isBrowseWorkspace(nameParam) ? nameParam : "";
 if (!workspace) return Astro.redirect("/account/workspaces");
+
+const tip = {
+  body: "repo config in <code>.uploads.yml</code> overrides these workspace defaults per repository.",
+};
 ---
 
-<WorkspaceLayout workspace={workspace}>
+<WorkspaceLayout workspace={workspace} tip={tip}>
   <section class="card settings-page">
     <div class="settings-section">
       <details class="ws-settings-summary" open>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -618,7 +618,7 @@ Source (and where to look if something breaks): https://github.com/buildinternet
     <SiteHeader authOrigin={authOrigin} />
     <main>
       <h1>The missing upload command for <span class="nb">coding agents.</span></h1>
-      <p class="byline">Now Claude and Codex can add screenshots to pull requests</p>
+      <p class="byline">Now Claude Code and Codex can add screenshots to pull requests</p>
       <p class="lede">
         GitHub has no API for file uploads, so agents can't include screenshots in pull requests and
         issues. Uploads gives agents a way to host files and show their work. They're staged for the

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -1005,6 +1005,19 @@ section.card .ws-messages .command {
 .wft-filterbar .input-group__field input {
   font-size: 12.5px;
 }
+/* Loading-skeleton stand-in for the filter input/button (workspace-ui.ts's
+   `renderFilesPlaceholderHtml`, mirrored in WorkspaceFileTable's own loading
+   render): `.input-group__field`/`__action` size themselves from the real
+   `<input>`/`<button>` they normally wrap, so a bare `.ws-skel` bar dropped
+   in without them collapses shorter and the swap to the real toolbar shifts
+   the whole page down. This reproduces just enough of that height. */
+.wft-field-skel {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  min-height: 36px;
+  box-sizing: border-box;
+}
 
 .wft-suggest {
   position: absolute;

--- a/apps/web/src/styles/account-content.css
+++ b/apps/web/src/styles/account-content.css
@@ -537,6 +537,21 @@ button.text-btn:disabled {
   opacity: 0.55;
   cursor: default;
 }
+/* Boxed variant — visible border at rest, for actions that must read as a
+   button without hover discovery (e.g. the sign-in-methods Connect, whose
+   row deliberately has no state badge to carry that weight). */
+a.text-btn--boxed,
+button.text-btn--boxed {
+  border-color: var(--line);
+  color: var(--fg);
+}
+a.text-btn--boxed:hover,
+a.text-btn--boxed:focus-visible,
+button.text-btn--boxed:hover,
+button.text-btn--boxed:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
 ul.detail-list .detail-meta {
   color: var(--muted);
   font-size: 11px;

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -234,20 +234,6 @@
   display: none;
 }
 
-/* The "workspace" eyebrow's visibility tracks its next sibling
-   (#workspace-section-nav) rather than its own `hidden` attribute:
-   workspaces-nav.ts (not editable from here) toggles the nav's `hidden` on
-   session resolve for personal routes with a last-used workspace, and never
-   learned about this label — a forward `:has()` check keeps the two in sync
-   through every render path (SSR, the optimistic boot script, and the real
-   nav module) without touching that file. */
-.account-shell nav.side #workspace-section-label {
-  display: none;
-}
-.account-shell nav.side #workspace-section-label:has(+ #workspace-section-nav:not([hidden])) {
-  display: block;
-}
-
 /* Right rail — always a grid track; content from the `rail` slot. */
 .account-shell aside.rail {
   display: grid;

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -36,10 +36,10 @@
 }
 .account-shell nav.side .side-link {
   display: block;
-  padding: 5px var(--side-inset);
+  padding: 7px var(--side-inset);
   margin: 0;
   border: 0;
-  border-radius: 0;
+  border-radius: 6px;
   background: transparent;
   color: var(--muted);
   text-decoration: none;
@@ -50,65 +50,94 @@
   background: transparent;
   outline: none;
 }
+/* Active item — soft rounded pill. Same accent color-mix wash the switcher
+   menu's hover/current rows already use (below), just applied at rest. */
 .account-shell nav.side .side-link[aria-current] {
   color: var(--accent);
   background: color-mix(in srgb, var(--accent) 10%, transparent);
   border: 0;
-  border-radius: 0;
+  border-radius: 6px;
 }
 
-/* Section labels (PERSONAL). Same horizontal inset as side-links. */
+/* Section labels (PERSONAL / workspace). Same horizontal inset as
+   side-links. ~20px above each group (releases' spacing) reads the two
+   groups as distinct rather than one long list. */
 .account-shell nav.side .side-label {
-  margin: 14px 0 4px;
+  margin: 20px 0 6px;
   padding: 0 var(--side-inset);
   color: var(--muted);
   font-size: 10.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
+/* First label in the nav (the workspace-section one, when present) shouldn't
+   add extra air above the switcher card it directly follows. */
+.account-shell nav.side .ws-switcher + .side-label {
+  margin-top: 10px;
+}
 
-/* Workspace switcher — first nav item. */
+/* Workspace switcher — first nav item. Two-line bordered card: name (+ Pro
+   badge, painted by workspaces-nav.ts right after the label element) on line
+   one, a muted "workspace" subtitle on line two, chevron pinned right and
+   vertically centered via the grid. */
 .account-shell nav.side .ws-switcher {
   position: relative;
   margin: 0 0 4px;
 }
 /* Beat signed-in-shell's `nav.side button` (red hover / mono foot). */
 .account-shell nav.side .ws-switcher .ws-switcher__trigger {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   width: 100%;
   max-width: 100%;
-  padding: 0 var(--side-inset);
+  padding: 9px 10px;
   margin: 0;
-  border: 0;
-  border-radius: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
   background: none;
-  color: var(--muted);
+  color: var(--fg);
   font: inherit;
-  font-size: 10.5px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
   text-align: left;
   cursor: pointer;
 }
 .account-shell nav.side .ws-switcher .ws-switcher__trigger:hover,
 .account-shell nav.side .ws-switcher .ws-switcher__trigger:focus-visible,
 .account-shell nav.side .ws-switcher .ws-switcher__trigger[aria-expanded="true"] {
-  color: var(--fg);
+  border-color: var(--accent);
   outline: none;
+}
+.account-shell nav.side .ws-switcher__body {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+.account-shell nav.side .ws-switcher__line1 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 .account-shell nav.side .ws-switcher__label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 600;
 }
-/* Trigger's own Pro badge (workspaces-nav.ts paintTriggerBadge) — same
-   `.pro-badge` idiom as the menu rows (account-content.css), but the
-   uppercase/tracked trigger label needs it pinned so ellipsis on a long
-   workspace name can't push it out of view, and a hair smaller so it doesn't
-   compete with the 10.5px label for the trigger's tight height. */
+.account-shell nav.side .ws-switcher__subtitle {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+/* Trigger's own Pro badge (workspaces-nav.ts paintTriggerBadge, inserted as
+   `label`'s next sibling) — same `.pro-badge` idiom as the menu rows
+   (account-content.css). Lands inside `.ws-switcher__line1` alongside the
+   label, so it stays on the name line rather than pushed to the subtitle. */
 .account-shell nav.side .ws-switcher .ws-switcher__trigger .pro-badge {
   flex: none;
   font-size: 9px;
@@ -122,7 +151,6 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  margin-left: auto;
   border: 1px solid color-mix(in srgb, var(--line) 90%, var(--muted));
   border-radius: 3px;
   color: var(--fg);
@@ -204,6 +232,20 @@
 }
 .account-shell nav.side .ws-section-nav[hidden] {
   display: none;
+}
+
+/* The "workspace" eyebrow's visibility tracks its next sibling
+   (#workspace-section-nav) rather than its own `hidden` attribute:
+   workspaces-nav.ts (not editable from here) toggles the nav's `hidden` on
+   session resolve for personal routes with a last-used workspace, and never
+   learned about this label — a forward `:has()` check keeps the two in sync
+   through every render path (SSR, the optimistic boot script, and the real
+   nav module) without touching that file. */
+.account-shell nav.side #workspace-section-label {
+  display: none;
+}
+.account-shell nav.side #workspace-section-label:has(+ #workspace-section-nav:not([hidden])) {
+  display: block;
 }
 
 /* Right rail — always a grid track; content from the `rail` slot. */

--- a/apps/web/src/styles/account-shell.css
+++ b/apps/web/src/styles/account-shell.css
@@ -10,7 +10,7 @@
    reserves the track. Shell is left-aligned so the nav does not re-center
    as the viewport grows. */
 .account-shell {
-  --width-shell: 1200px;
+  --width-shell: 1440px;
 }
 .account-shell .shell {
   margin-left: 0;
@@ -103,6 +103,16 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/* Trigger's own Pro badge (workspaces-nav.ts paintTriggerBadge) — same
+   `.pro-badge` idiom as the menu rows (account-content.css), but the
+   uppercase/tracked trigger label needs it pinned so ellipsis on a long
+   workspace name can't push it out of view, and a hair smaller so it doesn't
+   compete with the 10.5px label for the trigger's tight height. */
+.account-shell nav.side .ws-switcher .ws-switcher__trigger .pro-badge {
+  flex: none;
+  font-size: 9px;
+  padding: 0 5px;
 }
 /* Visible switcher affordance — boxed chevron, not tiny label-tracking text. */
 .account-shell nav.side .ws-switcher__chevron {

--- a/apps/web/src/styles/signed-in-shell.css
+++ b/apps/web/src/styles/signed-in-shell.css
@@ -9,7 +9,15 @@
 
      --bp-rail       1080px   Below this the fixed 272px right rail has no
                               room beside the content grid, so it restacks
-                              under the main column (account-shell.css).
+                              under the main column (account-shell.css). This
+                              is a viewport-width pinch point (nav + rail +
+                              gutters is a fixed ~530px overhead regardless of
+                              content), not a function of `--width-shell`
+                              (account-shell.css, 1440px): that variable only
+                              caps how wide the shell grows on viewports
+                              already bigger than it, so raising it widens the
+                              content column above ~1080px without moving
+                              where the rail stops fitting below it.
      --bp-stack       680px   At/below this the nav + layout collapse to a
                               single full-width column (this file +
                               account-shell.css). The mid-width rail tier is


### PR DESCRIPTION
Cleans up the signed-in web app shell per feedback: the right rail stopped being a fixed dashboard and became contextual, the content column got the width it was owed, and several load-time/visual rough edges are gone.

## Rail
- **Usage meters render on the billing tab only** — they repeated on every workspace tab and were noise everywhere else (`showUsage` prop on `WorkspaceLayout`).
- **Details section (slug + base url) removed entirely.** The slug already appears in the switcher, heading, and URL; base url is owned by the settings tab via the same `renderDetailsHtml` builder. Pure duplication.
- **Per-tab tip cards** (modeled on the releases settings aside, translated to uploads tokens): one short contextual line on files / galleries / people / settings; billing keeps usage instead.

## Layout
- **Shell width 1200px → 1440px.** With the 180px nav + 272px rail, the content column goes from ~700px to ~908px — tables stop truncating while the screen sits empty. Admin keeps its 960px fallback.

## Sidebar
- **Releases-style hierarchy:** switcher is a two-line bordered card (name + "workspace" subtitle), symmetric eyebrow labels over both nav groups, roomier items with a soft accent pill on the active link. Icons deliberately omitted (mono/terminal brand).
- **Pro badge now paints on the collapsed switcher trigger**, not just the unfurled menu rows.
- The "workspace" eyebrow is toggled in JS alongside the section nav — a `:has(+ …:not([hidden]))` CSS sync matched on paper but Chromium doesn't re-resolve it when the sibling's `hidden` flips, which stripped the eyebrow on personal routes.

## Loading
- **Skeleton placeholders** (following the existing three-tier pattern from #526) for the files table (both the pre-React-mount gap and the component's own loading states, with 1:1 markup so the handoff doesn't shift), the workspaces index, and profile's sign-in-methods/sessions lists.

## Odds and ends
- Galleries empty state trimmed to the title + create command (the page note and help block already explain the concept).
- Sign-in methods: dropped the redundant "Not connected" badge (the meta line already says it) and boxed the Connect button so it reads as one at rest.

Verified against the local stack across fresh loads, ClientRouter soft navigations, and the width tiers. Full suite green (267 files / 3,760 tests).

## Screenshots

**Files tab** — wider content column; rail is now tip + quick actions (usage moved to billing, details removed):

<img width="700" alt="Files tab after: wider content column, tip + quick-actions rail" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/601/127.0.0.1-account-workspaces-dev-demo.webp">

**Loading state** — the same page's skeleton occupies identical geometry, so the swap to data doesn't shift:

<img width="700" alt="Files tab loading skeleton matching the loaded geometry" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/601/files-loading-skeleton.webp">

**Galleries** — trimmed empty state, per-tab tip:

<img width="700" alt="Galleries tab: trimmed empty state, tip rail" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/601/galleries-after.webp">

**Account** — sidebar hierarchy (switcher card, eyebrow groups, active pill) and the boxed Connect with the redundant badge gone:

<img width="700" alt="Account page: releases-style sidebar, tip rail, boxed Connect button" src="https://embed.uploads.sh/default/gh/buildinternet/uploads/pull/601/account-after.webp">
