### PR TITLE
feat: shared MediaStage viewer, gallery video posters, and skip buttons

### DIFF
--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -5,7 +5,9 @@ import {
   ValidationError,
 } from "@uploads/errors";
 import { publicObjectDateFields } from "./files-core";
-import { displayTitle } from "./file-metadata";
+import { displayTitle, getMetadataForKeys } from "./file-metadata";
+import { VIDEO_TYPES } from "./guards";
+import { videoPresentation, type VideoDimensions } from "./poster";
 import {
   type GalleryCursor,
   type GalleryItemRecord,
@@ -48,6 +50,10 @@ export interface GalleryItemDto {
   uploaded: string | null;
   /** Last-modified ISO when it meaningfully differs from uploaded; else null. */
   modified: string | null;
+  /** Public URL of the derived poster frame (issue #299); videos with one only. */
+  posterUrl?: string;
+  /** Real video dimensions for reserving aspect ratio before playback. */
+  videoDimensions?: VideoDimensions;
 }
 export interface PublicGalleryItemDto {
   id: string;
@@ -65,6 +71,10 @@ export interface PublicGalleryItemDto {
   uploaded?: string;
   /** Distinct last-modified when it differs from uploaded. */
   modified?: string;
+  /** Public URL of the derived poster frame (issue #299); videos with one only. */
+  posterUrl?: string;
+  /** Real video dimensions for reserving aspect ratio before playback. */
+  videoDimensions?: VideoDimensions;
 }
 export interface GalleryDto {
   id: string;
@@ -268,42 +278,76 @@ export async function hydrateGalleryItems(
       cause,
     });
   }
-  return mapBounded(items, 8, async (item) => {
-    let meta: GalleryObjectHead | null;
+  const hydrated = await mapBounded(
+    items,
+    8,
+    async (item): Promise<Omit<GalleryItemDto, "pageUrl">> => {
+      let meta: GalleryObjectHead | null;
+      try {
+        meta = (await store.exists(item.object_key))
+          ? ((await store.head(item.object_key)) as GalleryObjectHead)
+          : null;
+      } catch (cause) {
+        throw new ServiceUnavailableError("Gallery storage unavailable.", {
+          code: "gallery_storage_unavailable",
+          cause,
+        });
+      }
+      const urls = meta
+        ? objectPublicUrls(env, config, item.object_key)
+        : { url: null, embedUrl: null };
+      if (meta && urls.url === null)
+        throw new ServiceUnavailableError("Gallery object is not publicly served.", {
+          code: "gallery_object_not_public",
+        });
+      const dates = meta ? publicObjectDateFields(meta) : {};
+      return {
+        id: item.id,
+        objectKey: item.object_key,
+        position: item.position,
+        caption: item.caption,
+        altText: item.alt_text,
+        createdAt: item.created_at,
+        status: meta ? "available" : "missing",
+        url: urls.url,
+        embedUrl: urls.embedUrl,
+        contentType: meta?.type ?? null,
+        size: meta?.size ?? null,
+        uploaded: dates.uploaded ?? null,
+        modified: dates.modified ?? null,
+      };
+    },
+  );
+
+  // Poster + real dimensions for videos (issue #299): the `video.*` sentinel
+  // rows live in D1 (server-owned, stamped at poster generation), so the
+  // object heads above can't tell us. One batched D1 read for all video items;
+  // failures degrade to bare <video> elements rather than failing the gallery.
+  const videoKeys = hydrated
+    .filter((item) => item.url !== null && VIDEO_TYPES.has(item.contentType ?? ""))
+    .map((item) => item.objectKey);
+  if (videoKeys.length > 0 && workspace.name) {
     try {
-      meta = (await store.exists(item.object_key))
-        ? ((await store.head(item.object_key)) as GalleryObjectHead)
-        : null;
-    } catch (cause) {
-      throw new ServiceUnavailableError("Gallery storage unavailable.", {
-        code: "gallery_storage_unavailable",
-        cause,
+      const metadataByKey = await getMetadataForKeys(env.DB, workspace.name, videoKeys, {
+        metaKeys: ["video.poster", "video.width", "video.height"],
       });
+      for (const item of hydrated) {
+        const metadata = metadataByKey.get(item.objectKey);
+        if (!metadata) continue;
+        const { posterUrl, videoDimensions } = videoPresentation(
+          env,
+          config,
+          item.objectKey,
+          metadata,
+        );
+        if (posterUrl) item.posterUrl = posterUrl;
+        if (videoDimensions) item.videoDimensions = videoDimensions;
+      }
+    } catch {
+      // D1 blip — render the videos without posters.
     }
-    const urls = meta
-      ? objectPublicUrls(env, config, item.object_key)
-      : { url: null, embedUrl: null };
-    if (meta && urls.url === null)
-      throw new ServiceUnavailableError("Gallery object is not publicly served.", {
-        code: "gallery_object_not_public",
-      });
-    const dates = meta ? publicObjectDateFields(meta) : {};
-    return {
-      id: item.id,
-      objectKey: item.object_key,
-      position: item.position,
-      caption: item.caption,
-      altText: item.alt_text,
-      createdAt: item.created_at,
-      status: meta ? "available" : "missing",
-      url: urls.url,
-      embedUrl: urls.embedUrl,
-      contentType: meta?.type ?? null,
-      size: meta?.size ?? null,
-      uploaded: dates.uploaded ?? null,
-      modified: dates.modified ?? null,
-    };
-  });
+  }
+  return hydrated;
 }
 
 export function galleryUrl(env: Env, id: string): string {
@@ -443,6 +487,8 @@ export async function hydratePublicGallery(
       size: item.size,
       ...(item.uploaded ? { uploaded: item.uploaded } : {}),
       ...(item.modified ? { modified: item.modified } : {}),
+      ...(item.posterUrl ? { posterUrl: item.posterUrl } : {}),
+      ...(item.videoDimensions ? { videoDimensions: item.videoDimensions } : {}),
     })),
     references: publicReferences,
   };

--- a/apps/api/src/poster.ts
+++ b/apps/api/src/poster.ts
@@ -20,7 +20,9 @@ import {
   ATTACHMENT_IMAGE_WIDTH_WIDE,
   attachmentImageWidth,
 } from "./github-comment-render";
+import type { StorageConfig } from "@uploads/storage";
 import { allowPoster, VIDEO_TYPES } from "./guards";
+import { objectPublicUrls } from "./storage";
 
 /** Server-owned namespace for derived artifacts — never listed to users. */
 export const POSTER_KEY_PREFIX = "_internal/posters/";
@@ -32,6 +34,49 @@ export const POSTER_KEY_PREFIX = "_internal/posters/";
  */
 export function posterKeyFor(key: string): string {
   return `${POSTER_KEY_PREFIX}${key}.jpg`;
+}
+
+/** Real display dimensions of a video, as stamped in `video.width`/`video.height`. */
+export interface VideoDimensions {
+  width: number;
+  height: number;
+}
+
+const POSITIVE_INT_RE_STRICT = /^[1-9][0-9]*$/;
+
+/** Parses a `video.width`/`video.height` D1 string pair into positive integers, or undefined. */
+export function parseVideoDimensions(
+  metadata: Record<string, string>,
+): VideoDimensions | undefined {
+  const widthRaw = metadata["video.width"];
+  const heightRaw = metadata["video.height"];
+  if (!widthRaw || !heightRaw) return undefined;
+  if (!POSITIVE_INT_RE_STRICT.test(widthRaw) || !POSITIVE_INT_RE_STRICT.test(heightRaw)) {
+    return undefined;
+  }
+  const width = Number(widthRaw);
+  const height = Number(heightRaw);
+  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height)) return undefined;
+  return { width, height };
+}
+
+/**
+ * Derived poster URL + real dimensions for a video object, from its D1
+ * `video.*` rows. `video.poster` is a presence flag only — the URL is always
+ * recomputed from the current storage config, never stored. Single home for
+ * that contract (public files route + gallery hydration).
+ */
+export function videoPresentation(
+  env: Env,
+  cfg: StorageConfig,
+  key: string,
+  metadata: Record<string, string>,
+): { posterUrl?: string; videoDimensions?: VideoDimensions } {
+  const posterUrl =
+    metadata["video.poster"] === "1"
+      ? (objectPublicUrls(env, cfg, posterKeyFor(key)).url ?? undefined)
+      : undefined;
+  return { posterUrl, videoDimensions: parseVideoDimensions(metadata) };
 }
 
 /** `m:ss` under an hour, `h:mm:ss` at or above one. */

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { fileURLToPath, URL as NodeURL } from "node:url";
 import { Hono } from "hono";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { respondError } from "../error-response";
 import { me } from "./me";
 import { setStorageReconcileForTests, setStorageVerifyForTests } from "./workspace-storage";
@@ -50,6 +50,11 @@ function fakeKv(records: Record<string, unknown>): Pick<KVNamespace, "get"> {
 function app() {
   return new Hono<{ Bindings: Env }>().route("/me", me).onError((err, c) => respondError(c, err));
 }
+
+// Some tests below freeze Date (vi.useFakeTimers) to pin a billing period.
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("/me auth gate", () => {
   it("401s with no session cookie", async () => {
@@ -296,6 +301,9 @@ describe("GET /me/workspaces/:name/usage", () => {
   });
 
   it("returns usage + limits for a workspace the caller is a member of", async () => {
+    // Freeze Date inside the seeded period — getWorkspaceUsage zeroes
+    // uploadsInPeriod when period_start differs from the live month.
+    vi.useFakeTimers({ now: new Date("2026-07-15T12:00:00.000Z"), toFake: ["Date"] });
     const db = new UsageFakeD1();
     db.usage.set("acme", {
       workspace: "acme",
@@ -455,6 +463,8 @@ const R2_RECORD = {
 
 describe("GET /me/workspaces/:name/summary", () => {
   it("returns membership + usage + public URL in one payload", async () => {
+    // Freeze Date inside the seeded period — see the usage test above.
+    vi.useFakeTimers({ now: new Date("2026-07-15T12:00:00.000Z"), toFake: ["Date"] });
     const db = new UsageFakeD1();
     db.usage.set("acme", {
       workspace: "acme",

--- a/apps/api/src/routes/public-files.ts
+++ b/apps/api/src/routes/public-files.ts
@@ -10,32 +10,11 @@ import { badKey, downloadResponse, publicObjectDateFields } from "../files-core"
 import { displayTitle, getFileMetadata, isServerMetaKey } from "../file-metadata";
 import { githubAvatarProxyUrl, ownerFromRepo } from "../github-avatars";
 import { resolveTitles, withPublicTitleBudget } from "../github-titles";
-import { posterKeyFor } from "../poster";
+import { videoPresentation } from "../poster";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 import { requestOrigin } from "../well-known";
-
-const POSITIVE_INT_RE_STRICT = /^[1-9][0-9]*$/;
-
-interface VideoDimensions {
-  width: number;
-  height: number;
-}
-
-/** Parses a `video.width`/`video.height` D1 string pair into positive integers, or undefined. */
-function parseVideoDimensions(metadata: Record<string, string>): VideoDimensions | undefined {
-  const widthRaw = metadata["video.width"];
-  const heightRaw = metadata["video.height"];
-  if (!widthRaw || !heightRaw) return undefined;
-  if (!POSITIVE_INT_RE_STRICT.test(widthRaw) || !POSITIVE_INT_RE_STRICT.test(heightRaw)) {
-    return undefined;
-  }
-  const width = Number(widthRaw);
-  const height = Number(heightRaw);
-  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height)) return undefined;
-  return { width, height };
-}
 
 type GithubKind = "pull" | "issue";
 
@@ -225,12 +204,7 @@ export const publicFiles = new Hono<WorkspaceVars>().get("/:workspace/:key{.+}",
     }
   }
 
-  let posterUrl: string | undefined;
-  if (metadata["video.poster"] === "1") {
-    const posterUrls = objectPublicUrls(env, cfg, posterKeyFor(key));
-    posterUrl = posterUrls.url ?? undefined;
-  }
-  const videoDimensions = parseVideoDimensions(metadata);
+  const { posterUrl, videoDimensions } = videoPresentation(env, cfg, key, metadata);
 
   // Live title (KV-cached App ladder) wins over stamped gh.title. Failures and
   // budget timeouts never 500 — keep the stamp or omit title entirely.

--- a/apps/api/test/reconcile-retention.test.ts
+++ b/apps/api/test/reconcile-retention.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FakeR2Bucket } from "./fake-r2";
 import { app } from "../src/index";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
@@ -49,7 +49,15 @@ async function makeEnv(overrides: Partial<WorkspaceRecord> = {}) {
 const auth = { Authorization: `Bearer ${TOKEN}` };
 
 describe("POST /usage/reconcile", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("rebuilds ledger totals from storage when metering drifted", async () => {
+    // Freeze Date inside the seeded billing period — reconcile resets
+    // uploads_in_period whenever period_start differs from the live month,
+    // so an unfrozen clock breaks this test every calendar rollover.
+    vi.useFakeTimers({ now: new Date("2026-07-15T12:00:00.000Z"), toFake: ["Date"] });
     const { env, bucket, db } = await makeEnv();
     // Object in R2 without going through put metering
     await bucket.put("default/orphan.png", PNG, { httpMetadata: { contentType: "image/png" } });

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { fileURLToPath, URL as NodeURL } from "node:url";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { setServerFileMetadata } from "../src/file-metadata";
 import { MAX_GALLERY_ITEMS, MAX_GALLERY_REFERENCES } from "../src/galleries";
 import { app } from "../src/index";
 import { sha256Hex, stampSoftDelete, type WorkspaceRecord } from "../src/workspace";
@@ -283,6 +284,55 @@ describe("gallery routes with SQLite D1", () => {
     ).toBe(201);
     const usage = await request("/v1/alpha/usage");
     expect(await usage.json()).toMatchObject({ bytes: PNG_REPLACEMENT.byteLength, objects: 1 });
+  });
+
+  it("exposes posterUrl + videoDimensions on public gallery video items with the poster sentinel", async () => {
+    const key = "screenshots/clip.mp4";
+    await bucket.put(`alpha/${key}`, PNG, { httpMetadata: { contentType: "video/mp4" } });
+    await setServerFileMetadata(fakeDb as unknown as D1Database, "alpha", key, {
+      "video.poster": "1",
+      "video.width": "1920",
+      "video.height": "1080",
+    });
+    const gallery = await create();
+    const added = await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: key }),
+    });
+    expect(added.status).toBe(201);
+
+    const publicGallery = await app.request(`/public/galleries/${gallery.id}`, {}, env);
+    expect(publicGallery.status).toBe(200);
+    expect(await publicGallery.json()).toMatchObject({
+      items: [
+        {
+          status: "available",
+          contentType: "video/mp4",
+          posterUrl: "https://storage.uploads.sh/alpha/_internal/posters/screenshots/clip.mp4.jpg",
+          videoDimensions: { width: 1920, height: 1080 },
+        },
+      ],
+    });
+
+    // Owner view carries the same derived fields.
+    const owner = await request(`/v1/alpha/galleries/${gallery.id}`);
+    expect(await owner.json()).toMatchObject({
+      items: [{ posterUrl: expect.stringContaining("_internal/posters/") }],
+    });
+  });
+
+  it("omits posterUrl on video items without the sentinel", async () => {
+    const key = "screenshots/bare.mp4";
+    await bucket.put(`alpha/${key}`, PNG, { httpMetadata: { contentType: "video/mp4" } });
+    const gallery = await create();
+    await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ expectedVersion: 1, objectKey: key }),
+    });
+    const publicGallery = await app.request(`/public/galleries/${gallery.id}`, {}, env);
+    const body = (await publicGallery.json()) as { items: Record<string, unknown>[] };
+    expect(body.items[0]).not.toHaveProperty("posterUrl");
+    expect(body.items[0]).not.toHaveProperty("videoDimensions");
   });
 
   it("adds only existing public objects and keeps deleted objects as tombstones", async () => {

--- a/apps/web/src/components/MediaStage.astro
+++ b/apps/web/src/components/MediaStage.astro
@@ -1,0 +1,251 @@
+---
+/**
+ * Shared viewer stage for the public file page (/f/…) and gallery item page
+ * (/g/:id/:item) — one home for the media area (image via ImagePreview, video,
+ * fallbacks) and the stage/rail two-column layout, so the two pages can't
+ * drift apart again. Page-specific rail content (metadata, pager, delete zone,
+ * captions) is slotted in; its styles stay page-scoped.
+ *
+ * Videos use the native player deliberately: these pages ship no framework JS
+ * and the native element already covers controls, poster, PiP, and fullscreen.
+ * Poster + real aspect-ratio come from the derived `video.*` metadata
+ * (issue #299) so the stage doesn't reflow when metadata loads.
+ */
+import ImagePreview from "./ImagePreview.astro";
+import type { BeforeAfterState } from "../lib/before-after-view";
+import type { MediaKind } from "../lib/public-gallery";
+
+interface Props {
+  kind: MediaKind;
+  /** Public object URL; null only for missing (tombstone) items. */
+  url: string | null;
+  /** Basename shown in fallback links. */
+  filename: string;
+  /** Image alt text; falls back to the filename. */
+  alt?: string;
+  /** Derived poster frame URL for videos (issue #299), when one exists. */
+  posterUrl?: string | null;
+  /** Real video dimensions — reserves the aspect ratio before playback. */
+  videoDimensions?: { width: number; height: number } | null;
+  /** Before/after counterpart for images; /f/ only today. */
+  compare?: { src: string; ownState: BeforeAfterState } | null;
+  /** id for the rail figcaption, referenced by the video's aria-describedby. */
+  railId?: string;
+}
+
+const {
+  kind,
+  url,
+  filename,
+  alt = filename,
+  posterUrl = null,
+  videoDimensions = null,
+  compare = null,
+  railId,
+} = Astro.props;
+
+// Non-video, non-image states share one fallback shell.
+const fallback =
+  kind === "file" && url
+    ? { title: "Preview unavailable" }
+    : kind === "unsupported"
+      ? { title: "Unsupported media type", body: "This file cannot be previewed inline." }
+      : kind === "missing"
+        ? {
+            title: "Removed or expired",
+            body: "This item remains in the gallery to preserve its place.",
+          }
+        : null;
+---
+
+<figure class="stage" style="margin:0" data-media-stage>
+  {
+    kind === "image" && url ? (
+      <ImagePreview src={url} alt={alt} compare={compare} />
+    ) : (
+      <div class="media">
+        {kind === "video" && url && (
+          <div class="video-wrap" data-video-stage>
+            <div class="seek-toggle" role="group" aria-label="Skip">
+              <button type="button" data-seek="-10" aria-label="Back 10 seconds">
+                −10s
+              </button>
+              <button type="button" data-seek="10" aria-label="Forward 10 seconds">
+                +10s
+              </button>
+            </div>
+            <video
+              src={url}
+              poster={posterUrl ?? undefined}
+              style={
+                videoDimensions
+                  ? `aspect-ratio:${videoDimensions.width}/${videoDimensions.height}`
+                  : undefined
+              }
+              controls
+              playsinline
+              preload={posterUrl && videoDimensions ? "none" : "metadata"}
+              aria-describedby={railId}
+            >
+              Your browser cannot play this video.
+            </video>
+          </div>
+        )}
+        {fallback && (
+          <div class="fallback">
+            <strong>{fallback.title}</strong>
+            {kind === "file" && url ? (
+              <a href={url} rel="noopener noreferrer">
+                Open {filename}
+              </a>
+            ) : (
+              <span>{fallback.body}</span>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+  <figcaption class="details" id={railId}>
+    <slot />
+  </figcaption>
+</figure>
+
+<style>
+  .stage {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+  }
+  /* Video / non-image fallbacks only — images use ImagePreview. */
+  .media {
+    min-height: 320px;
+    max-height: 78vh;
+    background: var(--bg);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .media video {
+    max-width: 100%;
+    max-height: 78vh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    display: block;
+  }
+  /* Shrink-wraps the video so the overlay pins to its box, not the stage;
+     line-height:0 kills the inline descender gap under the video. */
+  .video-wrap {
+    position: relative;
+    max-width: 100%;
+    line-height: 0;
+  }
+  /* Skip ±10s overlay — visual twin of ImagePreview's size/view pills. */
+  .seek-toggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 2;
+    display: inline-flex;
+    padding: 3px;
+    gap: 2px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    backdrop-filter: blur(8px);
+    line-height: normal;
+  }
+  .seek-toggle button {
+    appearance: none;
+    margin: 0;
+    padding: 5px 11px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font: 11px var(--mono);
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    line-height: 1.2;
+  }
+  .seek-toggle button:hover,
+  .seek-toggle button:focus-visible {
+    color: var(--fg);
+    outline: none;
+  }
+  .seek-toggle button:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 55%, transparent);
+  }
+  .fallback {
+    padding: 60px 30px;
+    text-align: center;
+    color: var(--muted);
+    font: 13px/1.6 var(--mono);
+  }
+  .fallback strong {
+    display: block;
+    color: var(--fg);
+    margin-bottom: 8px;
+  }
+  .fallback a {
+    color: var(--fg);
+    overflow-wrap: anywhere;
+  }
+  /* Right rail: account-shell-like section gap; content is slotted (page-scoped). */
+  .details {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    padding: 18px 20px 22px;
+    border-top: 1px solid var(--line);
+  }
+  .details > :global(*) {
+    min-width: 0;
+  }
+  .details :global(.actions) {
+    margin-top: 0;
+  }
+  @media (min-width: 1080px) {
+    /* aligns with signed-in --bp-rail (1080px); media queries can't read custom props */
+    .stage {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
+    }
+    .details {
+      border-top: none;
+      border-left: 1px solid var(--line);
+      max-height: 78vh;
+      overflow: auto;
+    }
+  }
+  @media (max-width: 760px) {
+    .media {
+      min-height: 220px;
+    }
+  }
+</style>
+
+<script>
+  // Skip ±10s for the native player. Progressive enhancement only — without
+  // JS the buttons are inert and the native controls still work.
+  function bootVideoStages() {
+    for (const wrap of document.querySelectorAll<HTMLElement>("[data-video-stage]")) {
+      if (wrap.dataset.bound) continue;
+      wrap.dataset.bound = "1";
+      const video = wrap.querySelector("video");
+      if (!video) continue;
+      for (const button of wrap.querySelectorAll<HTMLButtonElement>("button[data-seek]")) {
+        button.addEventListener("click", () => {
+          const delta = Number(button.dataset.seek);
+          if (!Number.isFinite(delta)) return;
+          const duration = Number.isFinite(video.duration) ? video.duration : Infinity;
+          video.currentTime = Math.min(Math.max(video.currentTime + delta, 0), duration);
+        });
+      }
+    }
+  }
+  bootVideoStages();
+  document.addEventListener("astro:page-load", bootVideoStages);
+</script>

--- a/apps/web/src/lib/og.ts
+++ b/apps/web/src/lib/og.ts
@@ -7,3 +7,18 @@
  */
 export const OG_SITE_NAME = "uploads.sh";
 export const OG_DEFAULT_IMAGE = "https://uploads.sh/og/home.png";
+
+/**
+ * OG image for a media page: images embed themselves, videos embed their
+ * derived poster frame when one exists (posterUrl is only ever set for
+ * videos), everything else falls back to the brand card. Shared by the /f/
+ * file page and the gallery item page so the rule can't drift.
+ */
+export function ogImageFor(
+  kind: string,
+  url: string | null,
+  posterUrl: string | null | undefined,
+): string {
+  if (kind === "image" && url) return url;
+  return posterUrl ?? OG_DEFAULT_IMAGE;
+}

--- a/apps/web/src/lib/public-file.ts
+++ b/apps/web/src/lib/public-file.ts
@@ -163,7 +163,7 @@ function httpsUrl(value: unknown): value is string {
 }
 
 /** `httpsUrl`, but also accepts `null` — for optional-but-typed URL fields like `embedUrl`. */
-function nullableHttpsUrl(value: unknown): value is string | null {
+export function nullableHttpsUrl(value: unknown): value is string | null {
   return value === null || httpsUrl(value);
 }
 
@@ -220,7 +220,7 @@ function isGithubContext(value: unknown): value is GithubContext {
 }
 
 /** Bounded `videoDimensions` convenience object — both fields positive safe integers. */
-function isVideoDimensions(value: unknown): value is { width: number; height: number } {
+export function isVideoDimensions(value: unknown): value is { width: number; height: number } {
   if (typeof value !== "object" || value === null) return false;
   const dims = value as Record<string, unknown>;
   return (

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -114,6 +114,26 @@ describe("public gallery API", () => {
     expect(isPublicGallery({ ...gallery, items: [noEmbedUrl] })).toBe(false);
   });
 
+  it("accepts poster fields on video items and rejects malformed ones", () => {
+    const video = {
+      ...gallery.items[0],
+      filename: "clip.mp4",
+      contentType: "video/mp4",
+      posterUrl: "https://storage.uploads.sh/_internal/posters/clip.mp4.jpg",
+      videoDimensions: { width: 1920, height: 1080 },
+    };
+    expect(isPublicGallery({ ...gallery, items: [video] })).toBe(true);
+    expect(
+      isPublicGallery({ ...gallery, items: [{ ...video, posterUrl: "javascript:alert(1)" }] }),
+    ).toBe(false);
+    expect(
+      isPublicGallery({
+        ...gallery,
+        items: [{ ...video, videoDimensions: { width: 0, height: 1 } }],
+      }),
+    ).toBe(false);
+  });
+
   it("bounds and sanitizes external references, tolerating their absence", () => {
     const { references: _references, ...withoutReferences } = gallery;
     expect(isPublicGallery(withoutReferences)).toBe(true);

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -1,4 +1,5 @@
 import { CF_RUM_CONNECT_SRC, CF_RUM_SCRIPT_SRC, STYLE_SRC_SELF_AND_INLINE } from "./csp";
+import { fileKind, isVideoDimensions, nullableHttpsUrl } from "./public-file";
 
 export interface PublicGalleryItem {
   id: string;
@@ -17,6 +18,10 @@ export interface PublicGalleryItem {
   uploaded?: string | null;
   /** Distinct last-modified ISO when it differs from uploaded. */
   modified?: string | null;
+  /** Public URL of the derived poster frame (issue #299); present only for videos with one. */
+  posterUrl?: string | null;
+  /** Real video dimensions, for reserving aspect ratio before playback; omitted when unknown. */
+  videoDimensions?: { width: number; height: number };
 }
 
 export interface PublicGalleryReference {
@@ -50,15 +55,10 @@ export type GalleryFetchResult =
 
 export type MediaKind = "image" | "video" | "file" | "unsupported" | "missing";
 
-const imageTypes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]);
-const videoTypes = new Set(["video/mp4", "video/webm"]);
-
+/** Gallery variant of `fileKind` (public-file.ts): one shared classifier plus tombstones. */
 export function mediaKind(item: PublicGalleryItem): MediaKind {
   if (item.status === "missing") return "missing";
-  if (imageTypes.has(item.contentType ?? "")) return "image";
-  if (videoTypes.has(item.contentType ?? "")) return "video";
-  if (item.contentType === "image/svg+xml") return "unsupported";
-  return "file";
+  return fileKind(item.contentType ?? "");
 }
 
 export function galleryPath(galleryId: string): string {
@@ -128,16 +128,6 @@ function nullableText(value: unknown, max: number): value is string | null {
   return value === null || text(value, max);
 }
 
-function safeUrl(value: unknown): value is string | null {
-  if (value === null) return true;
-  if (typeof value !== "string" || value.length > 4096) return false;
-  try {
-    return new URL(value).protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
 /** Optional public date field: omitted, null, or a parseable ISO string. */
 function optionalIsoDate(value: unknown): boolean {
   if (value === undefined || value === null) return true;
@@ -179,7 +169,7 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
         text(reference.provider, 40) &&
         text(reference.resourceType, 40) &&
         text(reference.coordinate, 200) &&
-        safeUrl(reference.canonicalUrl) &&
+        nullableHttpsUrl(reference.canonicalUrl) &&
         titleOk &&
         kindOk
       );
@@ -195,7 +185,12 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
       item.size === undefined ||
       item.size === null ||
       (Number.isSafeInteger(item.size) && (item.size as number) >= 0);
+    const posterUrlOk = item.posterUrl === undefined || nullableHttpsUrl(item.posterUrl);
+    const videoDimensionsOk =
+      item.videoDimensions === undefined || isVideoDimensions(item.videoDimensions);
     return (
+      posterUrlOk &&
+      videoDimensionsOk &&
       text(item.id, 64) &&
       text(item.filename, 1024) &&
       Number.isSafeInteger(item.position) &&
@@ -203,8 +198,8 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
       nullableText(item.caption, 500) &&
       nullableText(item.altText, 300) &&
       (item.status === "available" || item.status === "missing") &&
-      safeUrl(item.url) &&
-      safeUrl(item.embedUrl) &&
+      nullableHttpsUrl(item.url) &&
+      nullableHttpsUrl(item.embedUrl) &&
       nullableText(item.contentType, 128) &&
       sizeOk &&
       optionalIsoDate(item.uploaded) &&

--- a/apps/web/src/pages/f/[workspace]/[...key].astro
+++ b/apps/web/src/pages/f/[workspace]/[...key].astro
@@ -3,7 +3,7 @@ import BaseHead from "../../../components/BaseHead.astro";
 import Brand from "../../../components/Brand.astro";
 import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
-import ImagePreview from "../../../components/ImagePreview.astro";
+import MediaStage from "../../../components/MediaStage.astro";
 import ReportAbuse from "../../../components/ReportAbuse.astro";
 import { GH_KIND_PATH } from "../../../lib/brand-icons";
 import {
@@ -25,7 +25,7 @@ import {
   sameUtcDay,
 } from "../../../lib/public-file";
 import { oembedDiscoveryHref } from "../../../lib/oembed";
-import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../../../lib/og";
+import { OG_DEFAULT_IMAGE, OG_SITE_NAME, ogImageFor } from "../../../lib/og";
 import { env } from "cloudflare:workers";
 
 export const prerender = false;
@@ -118,7 +118,9 @@ const compare =
   counterpart && ownState && kind(file!.contentType) === "image"
     ? { src: counterpart.url, ownState }
     : null;
-const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAULT_IMAGE;
+const ogImage = file
+  ? ogImageFor(kind(file.contentType), file.url, file.posterUrl)
+  : OG_DEFAULT_IMAGE;
 ---
 
 <!doctype html>
@@ -212,44 +214,6 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
         mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71'/%3E%3Cpath d='M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71'/%3E%3C/svg%3E")
           center/contain no-repeat;
       }
-      .stage {
-        background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: var(--radius-lg);
-        overflow: hidden;
-      }
-      /* Video / non-image fallbacks only — images use ImagePreview. */
-      .media {
-        min-height: 320px;
-        max-height: 78vh;
-        background: var(--bg);
-        display: grid;
-        place-items: center;
-        overflow: hidden;
-      }
-      .media video {
-        max-width: 100%;
-        max-height: 78vh;
-        width: auto;
-        height: auto;
-        object-fit: contain;
-        display: block;
-      }
-      .fallback {
-        padding: 60px 30px;
-        text-align: center;
-        color: var(--muted);
-        font: 13px/1.6 var(--mono);
-      }
-      .fallback strong {
-        display: block;
-        color: var(--fg);
-        margin-bottom: 8px;
-      }
-      .fallback a {
-        color: var(--fg);
-        overflow-wrap: anywhere;
-      }
       .filehead {
         margin: 0 0 16px;
         min-width: 0;
@@ -306,17 +270,7 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
       .gh-byline-ref {
         overflow-wrap: anywhere;
       }
-      /* Right rail: account-shell-like section gap; Details uses label + rule. */
-      .details {
-        display: flex;
-        flex-direction: column;
-        gap: 22px;
-        padding: 18px 20px 22px;
-        border-top: 1px solid var(--line);
-      }
-      .details > * {
-        min-width: 0;
-      }
+      /* Right rail content (slotted into MediaStage): Details uses label + rule. */
       .rail-head {
         display: flex;
         align-items: center;
@@ -352,9 +306,6 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
         margin: 0;
         color: var(--body);
         overflow-wrap: anywhere;
-      }
-      .details :global(.actions) {
-        margin-top: 0;
       }
       /* Subordinate to everything above — margin-top:auto sinks it (and ReportAbuse, right
          after it in flow) to the bottom of the rail on tall pages, no-op on short ones. */
@@ -445,24 +396,11 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
         .shell {
           width: min(1200px, calc(100% - 48px));
         }
-        .stage {
-          display: grid;
-          grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
-        }
-        .details {
-          border-top: none;
-          border-left: 1px solid var(--line);
-          max-height: 78vh;
-          overflow: auto;
-        }
       }
       @media (max-width: 760px) {
         .shell {
           width: min(100% - 32px, 1080px);
           padding-top: 24px;
-        }
-        .media {
-          min-height: 220px;
         }
       }
       .danger-zone {
@@ -602,127 +540,96 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
                 </a>
               )}
             </header>
-            <figure class="stage" style="margin:0">
-              {kind(file.contentType) === "image" ? (
-                <ImagePreview src={file.url} alt={filename} compare={compare} />
-              ) : (
-                <div class="media">
-                  {kind(file.contentType) === "video" && (
-                    <video
-                      src={file.url}
-                      poster={file.posterUrl ?? undefined}
-                      style={
-                        file.videoDimensions
-                          ? `aspect-ratio:${file.videoDimensions.width}/${file.videoDimensions.height}`
-                          : undefined
-                      }
-                      controls
-                      playsinline
-                      preload="metadata"
-                    >
-                      Your browser cannot play this video.
-                    </video>
-                  )}
-                  {kind(file.contentType) === "file" && (
-                    <div class="fallback">
-                      <strong>Preview unavailable</strong>
-                      <a href={file.url} rel="noopener noreferrer">
-                        Open {filename}
-                      </a>
-                    </div>
-                  )}
-                  {kind(file.contentType) === "unsupported" && (
-                    <div class="fallback">
-                      <strong>Unsupported media type</strong>
-                      <span>This file cannot be previewed inline.</span>
-                    </div>
-                  )}
+            <MediaStage
+              kind={kind(file.contentType)}
+              url={file.url}
+              filename={filename}
+              posterUrl={file.posterUrl}
+              videoDimensions={file.videoDimensions}
+              compare={compare}
+            >
+              <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
+                {kind(file.contentType) !== "unsupported" && (
+                  <a class="original" href={file.url} rel="noopener noreferrer">
+                    Open original ↗
+                  </a>
+                )}
+              </CopyAsControls>
+              {railRows && (
+                <div>
+                  <div class="rail-head">
+                    <span class="rail-label">Comparison</span>
+                    <span class="rail-rule" aria-hidden="true" />
+                  </div>
+                  <ul class="pairlist">
+                    {railRows.map((row) => (
+                      <li class="pairrow" data-current={row.current ? "true" : "false"}>
+                        {row.href ? (
+                          <a href={row.href} aria-label={`View the ${row.state} image`}>
+                            {row.state} ↗
+                          </a>
+                        ) : (
+                          <>
+                            <span>{row.state}</span>
+                            <span class="pairrow-note">this file</span>
+                          </>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               )}
-              <figcaption class="details">
-                <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
-                  {kind(file.contentType) !== "unsupported" && (
-                    <a class="original" href={file.url} rel="noopener noreferrer">
-                      Open original ↗
-                    </a>
-                  )}
-                </CopyAsControls>
-                {railRows && (
-                  <div>
-                    <div class="rail-head">
-                      <span class="rail-label">Comparison</span>
-                      <span class="rail-rule" aria-hidden="true" />
-                    </div>
-                    <ul class="pairlist">
-                      {railRows.map((row) => (
-                        <li class="pairrow" data-current={row.current ? "true" : "false"}>
-                          {row.href ? (
-                            <a href={row.href} aria-label={`View the ${row.state} image`}>
-                              {row.state} ↗
-                            </a>
-                          ) : (
-                            <>
-                              <span>{row.state}</span>
-                              <span class="pairrow-note">this file</span>
-                            </>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
+              {metadataEntries.length > 0 && (
+                <div>
+                  <div class="rail-head">
+                    <span class="rail-label">Details</span>
+                    <span class="rail-rule" aria-hidden="true" />
                   </div>
-                )}
-                {metadataEntries.length > 0 && (
-                  <div>
-                    <div class="rail-head">
-                      <span class="rail-label">Details</span>
-                      <span class="rail-rule" aria-hidden="true" />
-                    </div>
-                    <dl class="meta">
-                      {metadataEntries.map(([metaKey, metaValue]) => (
-                        <>
-                          <dt>{metaKey}</dt>
-                          <dd>{metaValue}</dd>
-                        </>
-                      ))}
-                    </dl>
-                  </div>
-                )}
-                {footnoteLine && <p class="footnote">{footnoteLine}</p>}
-                <div class="danger-zone" id="delete-zone" hidden>
-                  <button type="button" class="delete-link" id="delete-open">
-                    Delete file…
-                  </button>
-                  <div
-                    class="delete-pop"
-                    id="delete-pop"
-                    role="alertdialog"
-                    aria-label={`Delete ${filename}`}
-                    hidden
-                  >
-                    <p class="delete-pop__text">
-                      Permanently delete <strong>{filename}</strong> for everyone? Links and embeds
-                      will break.
-                    </p>
-                    {gh && (
-                      <p class="delete-pop__text delete-pop__gh">
-                        This file is attached to {ghRef}. The managed comment will keep a broken
-                        link until its next sync.
-                      </p>
-                    )}
-                    <p class="delete-pop__error" id="delete-error" hidden />
-                    <button type="button" class="delete-pop__btn" id="delete-step">
-                      Delete file
-                    </button>
-                  </div>
+                  <dl class="meta">
+                    {metadataEntries.map(([metaKey, metaValue]) => (
+                      <>
+                        <dt>{metaKey}</dt>
+                        <dd>{metaValue}</dd>
+                      </>
+                    ))}
+                  </dl>
                 </div>
-                <ReportAbuse
-                  apiOrigin={origin}
-                  pageUrl={canonical}
-                  workspace={workspace}
-                  objectKey={key}
-                />
-              </figcaption>
-            </figure>
+              )}
+              {footnoteLine && <p class="footnote">{footnoteLine}</p>}
+              <div class="danger-zone" id="delete-zone" hidden>
+                <button type="button" class="delete-link" id="delete-open">
+                  Delete file…
+                </button>
+                <div
+                  class="delete-pop"
+                  id="delete-pop"
+                  role="alertdialog"
+                  aria-label={`Delete ${filename}`}
+                  hidden
+                >
+                  <p class="delete-pop__text">
+                    Permanently delete <strong>{filename}</strong> for everyone? Links and embeds
+                    will break.
+                  </p>
+                  {gh && (
+                    <p class="delete-pop__text delete-pop__gh">
+                      This file is attached to {ghRef}. The managed comment will keep a broken link
+                      until its next sync.
+                    </p>
+                  )}
+                  <p class="delete-pop__error" id="delete-error" hidden />
+                  <button type="button" class="delete-pop__btn" id="delete-step">
+                    Delete file
+                  </button>
+                </div>
+              </div>
+              <ReportAbuse
+                apiOrigin={origin}
+                pageUrl={canonical}
+                workspace={workspace}
+                objectKey={key}
+              />
+            </MediaStage>
             <section class="error" id="deleted-state" hidden>
               <code>file.deleted</code>
               <h1>File deleted</h1>
@@ -898,7 +805,7 @@ const ogImage = file && kind(file.contentType) === "image" ? file.url : OG_DEFAU
             const response = await fetch(target, { method: "DELETE", credentials: "include" });
             if (!response.ok) throw new Error(String(response.status));
             // Swap the page to the deleted state.
-            const figure = document.querySelector(".stage");
+            const figure = document.querySelector("[data-media-stage]");
             const head = document.querySelector(".filehead");
             if (figure) figure.remove();
             if (head) head.remove();

--- a/apps/web/src/pages/g/[id].astro
+++ b/apps/web/src/pages/g/[id].astro
@@ -305,9 +305,10 @@ const oembedHref = gallery ? oembedDiscoveryHref(canonical, Astro.url.origin) : 
                       {kind(item) === "video" && (
                         <video
                           src={item.url!}
+                          poster={item.posterUrl ?? undefined}
                           controls
                           playsinline
-                          preload="metadata"
+                          preload={item.posterUrl ? "none" : "metadata"}
                           aria-describedby={`caption-${item.id}`}
                         >
                           Your browser cannot play this video.

--- a/apps/web/src/pages/g/[id]/[item].astro
+++ b/apps/web/src/pages/g/[id]/[item].astro
@@ -4,7 +4,7 @@ import Brand from "../../../components/Brand.astro";
 import CopyAsControls from "../../../components/CopyAsControls.astro";
 import Footer from "../../../components/Footer.astro";
 import GalleryReferences from "../../../components/GalleryReferences.astro";
-import ImagePreview from "../../../components/ImagePreview.astro";
+import MediaStage from "../../../components/MediaStage.astro";
 import { buildEmbedFormats, type EmbedFormatOption } from "../../../lib/embed-formats";
 import {
   formatBytes,
@@ -22,7 +22,7 @@ import {
   type PublicGalleryItem,
 } from "../../../lib/public-gallery";
 import { oembedDiscoveryHref } from "../../../lib/oembed";
-import { OG_DEFAULT_IMAGE, OG_SITE_NAME } from "../../../lib/og";
+import { OG_DEFAULT_IMAGE, OG_SITE_NAME, ogImageFor } from "../../../lib/og";
 import { env } from "cloudflare:workers";
 
 export const prerender = false;
@@ -78,7 +78,7 @@ const withTime = Boolean(
 const uploadedLabel = uploadedIso ? formatFileDate(uploadedIso, { withTime }) : null;
 const modifiedLabel =
   showModified && modifiedIso ? formatFileDate(modifiedIso, { withTime }) : null;
-const ogImage = item && kind(item) === "image" ? item.url! : OG_DEFAULT_IMAGE;
+const ogImage = item ? ogImageFor(kind(item), item.url, item.posterUrl) : OG_DEFAULT_IMAGE;
 const sizeLabel =
   item && item.size != null && Number.isSafeInteger(item.size) ? formatBytes(item.size) : null;
 // Rail footnote (demoted from a Size/Uploaded/Modified dl — parity with the /f/ file page):
@@ -208,82 +208,13 @@ const footnoteLine = footnoteParts.join(" · ");
         letter-spacing: -0.01em;
         overflow-wrap: anywhere;
       }
-      .stage {
-        background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: var(--radius-lg);
-        overflow: hidden;
-      }
-      /* Video / non-image fallbacks only — images use ImagePreview. */
-      .media {
-        min-height: 320px;
-        max-height: 78vh;
-        background: var(--bg);
-        display: grid;
-        place-items: center;
-        overflow: hidden;
-      }
-      .media video {
-        max-width: 100%;
-        max-height: 78vh;
-        width: auto;
-        height: auto;
-        object-fit: contain;
-        display: block;
-      }
-      .fallback {
-        padding: 60px 30px;
-        text-align: center;
-        color: var(--muted);
-        font: 13px/1.6 var(--mono);
-      }
-      .fallback strong {
-        display: block;
-        color: var(--fg);
-        margin-bottom: 8px;
-      }
-      .fallback a {
-        color: var(--fg);
-        overflow-wrap: anywhere;
-      }
-      /* Right rail: same section gap as the public file page. */
-      .details {
-        display: flex;
-        flex-direction: column;
-        gap: 22px;
-        padding: 18px 20px 22px;
-        border-top: 1px solid var(--line);
-      }
-      .details > * {
-        min-width: 0;
-      }
+      /* Rail content (slotted into MediaStage). */
       .caption {
         margin: 0;
         color: var(--body);
         font-size: 15px;
         line-height: 1.6;
         white-space: pre-wrap;
-      }
-      dl.meta {
-        display: grid;
-        grid-template-columns: auto 1fr;
-        gap: 6px 16px;
-        margin: 0;
-        font: 12px var(--mono);
-      }
-      dl.meta dt {
-        color: var(--muted);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        font-size: 11px;
-      }
-      dl.meta dd {
-        margin: 0;
-        color: var(--body);
-        overflow-wrap: anywhere;
-      }
-      .details :global(.actions) {
-        margin-top: 0;
       }
       /* Subordinate to everything above — margin-top:auto sinks it to the bottom of the
          rail on tall pages, no-op on short ones. */
@@ -341,24 +272,11 @@ const footnoteLine = footnoteParts.join(" · ");
         .shell {
           width: min(1200px, calc(100% - 48px));
         }
-        .stage {
-          display: grid;
-          grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
-        }
-        .details {
-          border-top: none;
-          border-left: 1px solid var(--line);
-          max-height: 78vh;
-          overflow: auto;
-        }
       }
       @media (max-width: 760px) {
         .shell {
           width: min(100% - 32px, 1080px);
           padding-top: 24px;
-        }
-        .media {
-          min-height: 220px;
         }
         .pager a,
         .pager span.disabled {
@@ -403,58 +321,27 @@ const footnoteLine = footnoteParts.join(" · ");
               <h1 class="filetitle">{item.filename}</h1>
               <GalleryReferences references={gallery.references} variant="header" />
             </header>
-            <figure class="stage" style="margin:0">
-              {kind(item) === "image" && item.url ? (
-                <ImagePreview src={item.url} alt={item.altText ?? item.caption ?? item.filename} />
-              ) : (
-                <div class="media">
-                  {kind(item) === "video" && (
-                    <video
-                      src={item.url!}
-                      controls
-                      playsinline
-                      preload="metadata"
-                      aria-describedby="item-caption"
-                    >
-                      Your browser cannot play this video.
-                    </video>
+            <MediaStage
+              kind={kind(item)}
+              url={item.url}
+              filename={item.filename}
+              alt={item.altText ?? item.caption ?? item.filename}
+              posterUrl={item.posterUrl}
+              videoDimensions={item.videoDimensions}
+              railId="item-caption"
+            >
+              {item.caption && <div class="caption">{item.caption}</div>}
+              {item.status === "available" && (
+                <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
+                  {kind(item) !== "unsupported" && item.url && (
+                    <a class="original" href={item.url} rel="noopener noreferrer">
+                      Open original ↗
+                    </a>
                   )}
-                  {kind(item) === "file" && (
-                    <div class="fallback">
-                      <strong>Preview unavailable</strong>
-                      <a href={item.url!} rel="noopener noreferrer">
-                        Open {item.filename}
-                      </a>
-                    </div>
-                  )}
-                  {kind(item) === "unsupported" && (
-                    <div class="fallback">
-                      <strong>Unsupported media type</strong>
-                      <span>This item cannot be opened inline.</span>
-                    </div>
-                  )}
-                  {kind(item) === "missing" && (
-                    <div class="fallback">
-                      <strong>Removed or expired</strong>
-                      <span>This item remains in the gallery to preserve its place.</span>
-                    </div>
-                  )}
-                </div>
+                </CopyAsControls>
               )}
-              <figcaption class="details" id="item-caption">
-                {item.caption && <div class="caption">{item.caption}</div>}
-                {item.status === "available" && (
-                  <CopyAsControls formats={embedFormats} downloadUrl={downloadUrl}>
-                    {kind(item) !== "unsupported" && item.url && (
-                      <a class="original" href={item.url} rel="noopener noreferrer">
-                        Open original ↗
-                      </a>
-                    )}
-                  </CopyAsControls>
-                )}
-                {footnoteLine && <p class="footnote">{footnoteLine}</p>}
-              </figcaption>
-            </figure>
+              {footnoteLine && <p class="footnote">{footnoteLine}</p>}
+            </MediaStage>
             <nav class="pager" aria-label="Gallery items">
               {previous ? (
                 <a href={itemPath(previous)} rel="prev">


### PR DESCRIPTION
## What

Consolidates the two file-viewer layouts and makes the video player first-class on every public surface.

### One shared viewer: `MediaStage.astro`
The `/f/<workspace>/<key>` file page and `/g/<id>/<item>` gallery item page were near-clone layouts with copy-pasted stage markup and ~120 lines of duplicated CSS each — and they had already drifted (the gallery video had no poster, no aspect ratio, and a different rail). Both pages now render through a single `MediaStage` component that owns:

- the stage/rail two-column layout and its breakpoints
- the image path (`ImagePreview`, including Compare mode)
- the video player: poster frame, reserved `aspect-ratio` (no reflow), `controls playsinline`, poster-aware `preload` (`none` when a poster + dimensions can stand in for metadata)
- new **−10s / +10s skip buttons** — a vanilla-JS overlay pill styled after ImagePreview's Fit/Full-width toggles (kept native `<video>` rather than adding Video.js; the skip pill is the only chrome the native player lacked)
- all fallback states (file / unsupported / missing)

Page-specific rail content (metadata list, comparison rows, delete zone, captions, pager) slots in. The delete script targets a stable `data-media-stage` hook instead of a class inside the component.

### Posters reach galleries
The gallery API never exposed the `video.*` poster sentinel, so gallery views could not render posters at all. `hydrateGalleryItems` now does **one batched D1 read** (`getMetadataForKeys`, filtered to `video.poster/width/height`) for all video items and emits `posterUrl` + `videoDimensions` on owner and public gallery DTOs. Fail-soft: a D1 blip degrades to posterless videos.

### Deduplication along the way
- `videoPresentation()` in `poster.ts` is now the single home for the sentinel → poster-URL derivation (was copy-pasted in the public-files route; gallery service would have been a third copy)
- one media-kind classifier (`mediaKind` delegates to `fileKind`), one URL validator (`nullableHttpsUrl`), one `MediaKind` type
- `ogImageFor()` in `lib/og.ts`: images embed themselves, videos embed their poster frame, else the brand card — shared by both pages
- gallery index tiles also get the poster, with `preload="none"` so grids stop fetching per-tile video metadata

### Test de-flake (drive-by)
Three usage tests hardcoded `period_start: "2026-07"` and broke when the calendar rolled to August. They now freeze `Date` only (`vi.useFakeTimers({ toFake: ["Date"] })`) inside the seeded period.

## Verification

- 3763/3763 tests pass; typecheck, lint, format, and `astro build` clean
- New API tests pin `posterUrl`/`videoDimensions` exposure on public + owner gallery responses (sentinel present and absent); web tests cover the new validation fields
- Verified live against the local stack with a real mp4 + seeded sentinel: both public APIs emit posters, all three surfaces render the poster/aspect-ratio player, skip buttons seek correctly (clamped at both ends), and the `/f/` image page kept its layout, copy controls, compare mode, and delete flow

Note: poster *generation* (`video-poster-generation` flag) is still dark in prod, so gallery posters appear once that flips; everything here degrades cleanly without it. Local screenshot capture is blocked by the page's own strict CSP — happy to attach prod screenshots after the flag flip.
