### PR TITLE
fix: BYO storage cap, private gallery items, prod CORS gating, astro advisory, CI typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -45,6 +45,12 @@ jobs:
       # oxlint needs the package built to resolve those modules.
       - name: Build workspace packages
         run: pnpm --filter @buildinternet/uploads run build
+
+      # tsc --noEmit across every workspace. Type-aware oxlint below is not a
+      # substitute — it doesn't run the compiler. CONTRIBUTING.md documents
+      # this as part of the CI gate.
+      - name: Typecheck
+        run: pnpm typecheck
 
       - name: Oxlint
         run: pnpm lint
@@ -78,7 +84,7 @@ jobs:
       - name: Generate Wrangler types
         run: pnpm types
 
-      # Single-process Vitest across every workspace project (see vitest.config.ts).
+      # Single-process Vitest across every workspace project (see vitest.projects.ts).
       # The root `pretest` builds @buildinternet/uploads first — apps/mcp imports
       # it from dist. Replaces the former serial `pnpm --filter … test` chain and
       # adds apps/web, packages/email, and packages/errors to CI coverage.

--- a/apps/api/src/budget.test.ts
+++ b/apps/api/src/budget.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { checkPutBudget, resolveBudgetLimits, storageBudgetApplies } from "./budget";
+import {
+  checkPutBudget,
+  enforcedMaxStorageBytes,
+  resolveBudgetLimits,
+  storageBudgetApplies,
+  usageWithLimits,
+} from "./budget";
 import type { WorkspaceUsage } from "./usage";
 
 describe("resolveBudgetLimits — plan-aware resolution", () => {
@@ -122,5 +128,50 @@ describe("checkPutBudget — storage cap skipped for BYO, upload cap unaffected"
       uploads: 1,
     });
     expect(denial?.code).toBe("upload_budget_exceeded");
+  });
+});
+
+describe("enforcedMaxStorageBytes (#365 BYO storage-budget fix)", () => {
+  it("returns undefined for a BYO record (HTTP credentials, no binding)", () => {
+    expect(
+      enforcedMaxStorageBytes({
+        maxStorageBytes: 1_000,
+        accountId: "a".repeat(32),
+        accessKeyId: "key",
+        secretAccessKey: "secret",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns the plan cap for a plain shared-bucket record", () => {
+    expect(enforcedMaxStorageBytes({ plan: "free" })).toBe(250_000_000);
+  });
+});
+
+describe("usageWithLimits — storage fields gated by storage ownership", () => {
+  const usage: WorkspaceUsage = {
+    workspace: "acme",
+    bytes: 900,
+    objects: 1,
+    uploadsInPeriod: 2,
+    periodStart: "2026-07",
+    updatedAt: "2026-07-31T00:00:00.000Z",
+  };
+
+  it("omits maxStorageBytes/storageRemainingBytes for a BYO record", () => {
+    const out = usageWithLimits(usage, {
+      maxStorageBytes: 1_000,
+      accountId: "a".repeat(32),
+      accessKeyId: "key",
+      secretAccessKey: "secret",
+    });
+    expect(out.maxStorageBytes).toBeUndefined();
+    expect(out.storageRemainingBytes).toBeUndefined();
+  });
+
+  it("includes maxStorageBytes/storageRemainingBytes for a shared-bucket record", () => {
+    const out = usageWithLimits(usage, { maxStorageBytes: 1_000 });
+    expect(out.maxStorageBytes).toBe(1_000);
+    expect(out.storageRemainingBytes).toBe(100);
   });
 });

--- a/apps/api/src/budget.ts
+++ b/apps/api/src/budget.ts
@@ -61,6 +61,12 @@ export function storageBudgetApplies(record: WorkspaceBudgetLimits): boolean {
   return !isCustomerCredentialStorage;
 }
 
+/** Storage cap to *enforce*: undefined when the workspace owns its storage. */
+export function enforcedMaxStorageBytes(record: WorkspaceBudgetLimits): number | undefined {
+  if (!storageBudgetApplies(record)) return undefined;
+  return resolveBudgetLimits(record).maxStorageBytes;
+}
+
 export type BudgetDenialCode = "storage_quota_exceeded" | "upload_budget_exceeded";
 
 export interface BudgetDenial {
@@ -174,7 +180,8 @@ export function checkPutBudget(
   limits: WorkspaceBudgetLimits,
   delta: { bytes: number; uploads: number },
 ): BudgetDenial | null {
-  const { maxStorageBytes, maxUploadsPerPeriod } = resolveBudgetLimits(limits);
+  const { maxUploadsPerPeriod } = resolveBudgetLimits(limits);
+  const maxStorageBytes = enforcedMaxStorageBytes(limits);
 
   if (maxUploadsPerPeriod !== undefined && delta.uploads > 0) {
     if (usage.uploadsInPeriod + delta.uploads > maxUploadsPerPeriod) {
@@ -185,7 +192,6 @@ export function checkPutBudget(
   if (
     maxStorageBytes !== undefined &&
     delta.bytes > 0 &&
-    storageBudgetApplies(limits) &&
     usage.bytes + delta.bytes > maxStorageBytes
   ) {
     return storageBudgetDenial(usage, maxStorageBytes, delta.bytes);
@@ -197,6 +203,7 @@ export function checkPutBudget(
 /** Fields for GET /usage — limits + remaining when capped. */
 export function usageWithLimits(usage: WorkspaceUsage, limits: WorkspaceBudgetLimits) {
   const resolved = resolveBudgetLimits(limits);
+  const maxStorageBytes = enforcedMaxStorageBytes(limits);
   const out: Record<string, unknown> = {
     workspace: usage.workspace,
     bytes: usage.bytes,
@@ -206,9 +213,9 @@ export function usageWithLimits(usage: WorkspaceUsage, limits: WorkspaceBudgetLi
     updatedAt: usage.updatedAt,
   };
 
-  if (resolved.maxStorageBytes !== undefined) {
-    out.maxStorageBytes = resolved.maxStorageBytes;
-    out.storageRemainingBytes = Math.max(0, resolved.maxStorageBytes - usage.bytes);
+  if (maxStorageBytes !== undefined) {
+    out.maxStorageBytes = maxStorageBytes;
+    out.storageRemainingBytes = Math.max(0, maxStorageBytes - usage.bytes);
   }
   if (resolved.maxUploadsPerPeriod !== undefined) {
     out.maxUploadsPerPeriod = resolved.maxUploadsPerPeriod;

--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -102,7 +102,7 @@ describe("CORS preflights from the web origin", () => {
 
 // Loopback origins (http://localhost[:port], http://127.0.0.1[:port]) are
 // reflected on credentialed CORS for local dev convenience, but that
-// reflection must not survive in production — see plans/003. A local page
+// reflection must not survive in production. A local page
 // loading a victim's uploads.sh session cookie could otherwise make
 // credentialed cross-origin reads against /admin-ui, /me, and the
 // session-cookie-authenticated /v1/workspaces surface.

--- a/apps/api/src/cors.test.ts
+++ b/apps/api/src/cors.test.ts
@@ -99,3 +99,79 @@ describe("CORS preflights from the web origin", () => {
     expect(res.headers.get("Access-Control-Allow-Methods")).toContain("PATCH");
   });
 });
+
+// Loopback origins (http://localhost[:port], http://127.0.0.1[:port]) are
+// reflected on credentialed CORS for local dev convenience, but that
+// reflection must not survive in production — see plans/003. A local page
+// loading a victim's uploads.sh session cookie could otherwise make
+// credentialed cross-origin reads against /admin-ui, /me, and the
+// session-cookie-authenticated /v1/workspaces surface.
+describe("loopback origin reflection is gated by ENVIRONMENT", () => {
+  function loopbackPreflight(path: string, env: Record<string, unknown>) {
+    return app.request(
+      `https://api.uploads.sh${path}`,
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://localhost:5173",
+          "Access-Control-Request-Method": "GET",
+        },
+      },
+      env as unknown as Env,
+    );
+  }
+
+  it("does not reflect localhost on /me in production", async () => {
+    const res = await loopbackPreflight("/me/workspaces", { ENVIRONMENT: "production" });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("still allows the configured WEB_ORIGIN on /me in production", async () => {
+    const res = await app.request(
+      "https://api.uploads.sh/me/workspaces",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://uploads.sh",
+          "Access-Control-Request-Method": "GET",
+        },
+      },
+      { ENVIRONMENT: "production" } as unknown as Env,
+    );
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("reflects localhost on /me when ENVIRONMENT is unset (dev)", async () => {
+    const res = await loopbackPreflight("/me/workspaces", {});
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("does not reflect localhost on /v1/workspaces in production", async () => {
+    const res = await loopbackPreflight("/v1/workspaces", { ENVIRONMENT: "production" });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  it("still allows the configured WEB_ORIGIN on /v1/workspaces in production", async () => {
+    const res = await app.request(
+      "https://api.uploads.sh/v1/workspaces",
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://uploads.sh",
+          "Access-Control-Request-Method": "POST",
+        },
+      },
+      { ENVIRONMENT: "production" } as unknown as Env,
+    );
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://uploads.sh");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("reflects localhost on /v1/workspaces when ENVIRONMENT is unset (dev)", async () => {
+    const res = await loopbackPreflight("/v1/workspaces", {});
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:5173");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+});

--- a/apps/api/src/files-core.ts
+++ b/apps/api/src/files-core.ts
@@ -11,6 +11,7 @@ import { recordAdoptionSafe, type UploadSurface } from "./adoption";
 import {
   budgetDenialError,
   checkPutBudget,
+  enforcedMaxStorageBytes,
   resolveBudgetLimits,
   storageBudgetDenial,
   uploadBudgetDenial,
@@ -440,7 +441,8 @@ export async function putObject(
   // bytes before the R2 write. Reservations ARE the ledger increments for
   // those fields, so post-put recordUsageSafe must not count them again; a
   // failed write releases both.
-  const { maxUploadsPerPeriod, maxStorageBytes } = resolveBudgetLimits(ws);
+  const { maxUploadsPerPeriod } = resolveBudgetLimits(ws);
+  const maxStorageBytes = enforcedMaxStorageBytes(ws);
   const uploadReservation = await reserveUploads(env.DB, workspaceName, 1, maxUploadsPerPeriod);
   if (!uploadReservation.ok) {
     throw budgetDenialError(

--- a/apps/api/src/gallery-service.ts
+++ b/apps/api/src/gallery-service.ts
@@ -21,6 +21,7 @@ import {
 } from "./galleries";
 import { resolveTitles, withPublicTitleBudget, type TitleInfo } from "./github-titles";
 import { objectPublicUrls, storage, storageConfig } from "./storage";
+import { objectVisibility } from "./visibility";
 import { webOrigin } from "./web-url";
 import type { WorkspaceRecord } from "./workspace";
 
@@ -39,7 +40,7 @@ export interface GalleryItemDto {
   caption: string | null;
   altText: string | null;
   createdAt: string;
-  status: "available" | "missing";
+  status: "available" | "missing" | "withheld";
   url: string | null;
   /** Same object on the embed host when dual-host policy applies; for GitHub markdown. */
   embedUrl: string | null;
@@ -61,7 +62,7 @@ export interface PublicGalleryItemDto {
   position: number;
   caption: string | null;
   altText: string | null;
-  status: "available" | "missing";
+  status: "available" | "missing" | "withheld";
   url: string | null;
   embedUrl: string | null;
   contentType: string | null;
@@ -267,6 +268,7 @@ export async function hydrateGalleryItems(
   env: Env,
   workspace: WorkspaceRecord,
   items: GalleryItemRecord[],
+  opts: { audience: "owner" | "public" } = { audience: "owner" },
 ): Promise<Omit<GalleryItemDto, "pageUrl">[]> {
   let store: Awaited<ReturnType<typeof storage>>;
   let config: Awaited<ReturnType<typeof storageConfig>>;
@@ -293,14 +295,17 @@ export async function hydrateGalleryItems(
           cause,
         });
       }
-      const urls = meta
-        ? objectPublicUrls(env, config, item.object_key)
-        : { url: null, embedUrl: null };
-      if (meta && urls.url === null)
+      const isPrivate = meta ? objectVisibility(meta.metadata) === "private" : false;
+      const withheld = opts.audience === "public" && isPrivate;
+      const urls =
+        meta && !withheld
+          ? objectPublicUrls(env, config, item.object_key)
+          : { url: null, embedUrl: null };
+      if (meta && !withheld && urls.url === null)
         throw new ServiceUnavailableError("Gallery object is not publicly served.", {
           code: "gallery_object_not_public",
         });
-      const dates = meta ? publicObjectDateFields(meta) : {};
+      const dates = meta && !withheld ? publicObjectDateFields(meta) : {};
       return {
         id: item.id,
         objectKey: item.object_key,
@@ -308,11 +313,11 @@ export async function hydrateGalleryItems(
         caption: item.caption,
         altText: item.alt_text,
         createdAt: item.created_at,
-        status: meta ? "available" : "missing",
+        status: withheld ? "withheld" : meta ? "available" : "missing",
         url: urls.url,
         embedUrl: urls.embedUrl,
-        contentType: meta?.type ?? null,
-        size: meta?.size ?? null,
+        contentType: withheld ? null : (meta?.type ?? null),
+        size: withheld ? null : (meta?.size ?? null),
         uploaded: dates.uploaded ?? null,
         modified: dates.modified ?? null,
       };
@@ -409,10 +414,12 @@ export async function hydrateOwnerGallery(
     version: record.version,
     createdAt: record.created_at,
     updatedAt: record.updated_at,
-    items: (await hydrateGalleryItems(env, workspace, items)).map((item) => ({
-      ...item,
-      pageUrl: galleryItemUrl(env, record.id, item.id),
-    })),
+    items: (await hydrateGalleryItems(env, workspace, items, { audience: "owner" })).map(
+      (item) => ({
+        ...item,
+        pageUrl: galleryItemUrl(env, record.id, item.id),
+      }),
+    ),
   };
 }
 
@@ -469,7 +476,7 @@ export async function hydratePublicGallery(
   references: GalleryExternalReferenceRecord[] = [],
 ): Promise<PublicGalleryDto> {
   const [hydrated, publicReferences] = await Promise.all([
-    hydrateGalleryItems(env, workspace, items),
+    hydrateGalleryItems(env, workspace, items, { audience: "public" }),
     enrichPublicReferences(env, references),
   ]);
   return {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,13 +32,20 @@ import { internalBilling } from "./routes/internal-billing";
 import { protectedResourceMetadata, requestOrigin } from "./well-known";
 import { ROBOTS_TXT } from "./robots";
 
+/** Loopback origins are trusted only outside production — mirrors
+ *  apps/auth/src/trusted-origins.ts. */
+function devOriginAllowed(origin: string, env: { ENVIRONMENT?: string }): boolean {
+  if (env.ENVIRONMENT === "production") return false;
+  return /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+}
+
 // Lets the browser console on the web origin (and local dev) call the token-
 // authenticated endpoints. CORS is not the security boundary — bearer tokens
 // are — but without these headers the preflight for Authorization fails.
 const consoleCors = cors({
   origin: (origin, c) => {
     if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;
-    if (/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) return origin;
+    if (devOriginAllowed(origin, c.env)) return origin;
     return null;
   },
   // PATCH is used by browser console clients for file metadata + galleries.
@@ -58,7 +65,7 @@ const consoleCors = cors({
 const adminUiCors = cors({
   origin: (origin, c) => {
     if (origin === (c.env.WEB_ORIGIN || "https://uploads.sh")) return origin;
-    if (/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) return origin;
+    if (devOriginAllowed(origin, c.env)) return origin;
     return null;
   },
   credentials: true,

--- a/apps/api/src/routes/public-galleries.ts
+++ b/apps/api/src/routes/public-galleries.ts
@@ -4,6 +4,7 @@ import { downloadResponse } from "../files-core";
 import { listExternalReferences, listGalleryItems, resolvePublicGallery } from "../galleries";
 import { galleryItemFilename, hydratePublicGallery } from "../gallery-service";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { objectVisibility } from "../visibility";
 import { loadWorkspaceRecord, type WorkspaceVars } from "../workspace";
 
 /** Runs `action`, mapping any thrown error to the 503 the gallery storage routes commit to. */
@@ -46,9 +47,15 @@ export const publicGalleries = new Hono<WorkspaceVars>()
 
     // Mirrors hydrateGalleryItems (gallery-service.ts): the object may have
     // been public at item-add time but the workspace's publicBaseUrl is
-    // mutable afterward. Withhold the bytes here exactly when the gallery's
-    // own read path would withhold the URL, so this route can't be used to
-    // bypass that gate.
+    // mutable afterward, or it may since have been marked private. Withhold
+    // the bytes here exactly when the gallery's own read path would withhold
+    // the item (uniform 404, never a distinct code), so this route can't be
+    // used to bypass that gate.
+    const head = await withGalleryStorageErrors(() => store.head(item.object_key));
+    if (objectVisibility((head as { metadata?: Record<string, string> } | null)?.metadata)) {
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    }
+
     const config = await withGalleryStorageErrors(() => storageConfig(c.env, workspace));
     const urls = objectPublicUrls(c.env, config, item.object_key);
     if (!urls.url) {

--- a/apps/api/test/byo-storage-budget.test.ts
+++ b/apps/api/test/byo-storage-budget.test.ts
@@ -25,9 +25,15 @@ import { UsageFakeD1 } from "./usage-fake-d1";
 // reservation skip the cap for a BYO-shaped record" from "how bytes
 // physically move", which is exactly what this fix changes.
 const fakeBucket = new FakeR2Bucket();
+
+// Function declaration (not const) so the hoisted vi.mock factory below can
+// reference it whenever the mocked module is first imported.
+function forceBinding(ws: Record<string, unknown>) {
+  return { ...ws, binding: "UPLOADS_DEFAULT" };
+}
+
 vi.mock("../src/storage", async (importOriginal) => {
   const original = await importOriginal<typeof import("../src/storage")>();
-  const forceBinding = (ws: Record<string, unknown>) => ({ ...ws, binding: "UPLOADS_DEFAULT" });
   return {
     ...original,
     storageConfig: (env: unknown, ws: Record<string, unknown>) =>

--- a/apps/api/test/byo-storage-budget.test.ts
+++ b/apps/api/test/byo-storage-budget.test.ts
@@ -3,8 +3,8 @@ import { FakeR2Bucket } from "./fake-r2";
 import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
 import { UsageFakeD1 } from "./usage-fake-d1";
 
-// Regression coverage for the BYO-bucket storage-budget fix (issue #365,
-// plan 002): a self-serve BYO workspace is stamped `plan: "free"`, so once
+// Regression coverage for the BYO-bucket storage-budget fix: a self-serve
+// BYO workspace is stamped `plan: "free"`, so once
 // its ledger crosses the free-plan byte cap every upload used to fail with
 // 507 `storage_quota_exceeded` — a hard outage for a customer paying their
 // own R2 bill. The atomic reservation in `putObject` (files-core.ts) must
@@ -120,7 +120,7 @@ function put(env: unknown, key = "shot.png") {
   );
 }
 
-describe("BYO-bucket workspaces skip the platform storage cap (issue #365)", () => {
+describe("BYO-bucket workspaces skip the platform storage cap", () => {
   it("accepts an upload on a BYO workspace already over the free-plan byte cap, and still increments the ledger", async () => {
     const { env, db } = await makeByoEnv();
 

--- a/apps/api/test/byo-storage-budget.test.ts
+++ b/apps/api/test/byo-storage-budget.test.ts
@@ -1,0 +1,174 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { FakeR2Bucket } from "./fake-r2";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+// Regression coverage for the BYO-bucket storage-budget fix (issue #365,
+// plan 002): a self-serve BYO workspace is stamped `plan: "free"`, so once
+// its ledger crosses the free-plan byte cap every upload used to fail with
+// 507 `storage_quota_exceeded` — a hard outage for a customer paying their
+// own R2 bill. The atomic reservation in `putObject` (files-core.ts) must
+// skip the platform storage cap for BYO records the same way the read-side
+// `checkPutBudget` pre-check already does, while still incrementing the
+// usage ledger and still enforcing the per-period upload-count cap.
+//
+// A *real* BYO workspace record has no `binding` — I/O goes over an S3-style
+// HTTP client (files-sdk's r2-http adapter), which this in-process test
+// suite has no business making real network calls to. `storageBudgetApplies`
+// / `enforcedMaxStorageBytes` (budget.ts) only ever inspect the
+// WorkspaceRecord's own fields (`binding`/`accountId`/`accessKeyId`/
+// `secretAccessKey`) — never how `./storage` actually opens the client — so
+// this suite keeps the BYO record shape (no `binding`) for the budget logic
+// under test, while mocking `../src/storage` to force every actual byte
+// read/write through the same `FakeR2Bucket` the rest of the route-level
+// suite (routes-budget.test.ts) already uses. That isolates "does the
+// reservation skip the cap for a BYO-shaped record" from "how bytes
+// physically move", which is exactly what this fix changes.
+const fakeBucket = new FakeR2Bucket();
+vi.mock("../src/storage", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/storage")>();
+  const forceBinding = (ws: Record<string, unknown>) => ({ ...ws, binding: "UPLOADS_DEFAULT" });
+  return {
+    ...original,
+    storageConfig: (env: unknown, ws: Record<string, unknown>) =>
+      original.storageConfig(env as never, forceBinding(ws) as never),
+    storage: (env: unknown, ws: Record<string, unknown>) =>
+      original.storage(env as never, forceBinding(ws) as never),
+  };
+});
+
+const { app } = await import("../src/index");
+
+const TOKEN = "secret-token";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+// BYO signal per `storageBudgetApplies` (budget.ts): HTTP credentials with
+// no `binding`. See the module-level comment above for why storage I/O is
+// still routed through a FakeR2Bucket via the `../src/storage` mock.
+async function makeByoEnv(overrides: Partial<WorkspaceRecord> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "customer-bucket",
+    publicBaseUrl: "https://customer-bucket.example.com",
+    tokenHash: await sha256Hex(TOKEN),
+    plan: "free",
+    accountId: "a".repeat(32),
+    accessKeyId: "customer-key",
+    secretAccessKey: "customer-secret",
+    ...overrides,
+  };
+  const db = new UsageFakeD1();
+  return {
+    env: {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: db,
+      UPLOADS_DEFAULT: fakeBucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    },
+    db,
+  };
+}
+
+async function makeSharedEnv(overrides: Partial<WorkspaceRecord> = {}) {
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "default/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+    ...overrides,
+  };
+  const db = new UsageFakeD1();
+  return {
+    env: {
+      REGISTRY: { get: async () => record, put: async () => undefined },
+      DB: db,
+      UPLOADS_DEFAULT: fakeBucket,
+      WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    },
+    db,
+  };
+}
+
+const auth = { Authorization: `Bearer ${TOKEN}` };
+
+function put(env: unknown, key = "shot.png") {
+  return app.request(
+    `/v1/default/files/${key}`,
+    {
+      method: "PUT",
+      headers: { ...auth, "Content-Type": "image/png" },
+      body: PNG,
+    },
+    env as never,
+  );
+}
+
+describe("BYO-bucket workspaces skip the platform storage cap (issue #365)", () => {
+  it("accepts an upload on a BYO workspace already over the free-plan byte cap, and still increments the ledger", async () => {
+    const { env, db } = await makeByoEnv();
+
+    // A first put establishes the workspace_usage row (real period_start,
+    // real clock) so we don't have to hand-roll D1's period bookkeeping.
+    expect((await put(env, "byo-first.png")).status).toBe(201);
+    const row = db.usage.get("default");
+    expect(row).toBeDefined();
+
+    // Free plan's storage cap is 250_000_000 bytes — push usage past it
+    // directly on the ledger, simulating a workspace that's been accruing
+    // BYO-bucket bytes for a while.
+    db.usage.set("default", { ...row!, bytes: 250_000_000 + 1_000 });
+
+    const before = db.usage.get("default")!.bytes;
+    const res = await put(env, "byo-second.png");
+    expect(res.status).toBe(201);
+
+    const after = db.usage.get("default")!.bytes;
+    expect(after).toBe(before + PNG.byteLength);
+  });
+
+  it("still enforces maxUploadsPerPeriod on a BYO workspace", async () => {
+    const { env, db } = await makeByoEnv({ maxUploadsPerPeriod: 1 });
+    expect((await put(env, "byo-a.png")).status).toBe(201);
+    expect(db.usage.get("default")?.uploads_in_period).toBe(1);
+
+    const res = await put(env, "byo-b.png");
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("upload_budget_exceeded");
+  });
+
+  it("omits maxStorageBytes/storageRemainingBytes from GET /usage for a BYO workspace", async () => {
+    const { env } = await makeByoEnv();
+    await put(env, "byo-usage.png");
+    const res = await app.request("/v1/default/usage", { headers: auth }, env as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.maxStorageBytes).toBeUndefined();
+    expect(body.storageRemainingBytes).toBeUndefined();
+  });
+
+  it("still denies a shared-bucket (non-BYO) workspace over its cap with 507 storage_quota_exceeded", async () => {
+    const { env } = await makeSharedEnv({ maxStorageBytes: PNG.byteLength - 1 });
+    const res = await put(env, "shared.png");
+    expect(res.status).toBe(507);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("storage_quota_exceeded");
+  });
+});

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -923,7 +923,7 @@ describe("GET /public/galleries/:id/items/:item/download", () => {
   });
 });
 
-describe("private gallery items are withheld from the public surfaces (issue #365 / plan 004)", () => {
+describe("private gallery items are withheld from the public surfaces", () => {
   it("public gallery JSON withholds a private item but leaves the public item untouched", async () => {
     await bucket.put("alpha/screenshots/secret.png", PNG, {
       customMetadata: { visibility: "private" },

--- a/apps/api/test/routes-galleries.test.ts
+++ b/apps/api/test/routes-galleries.test.ts
@@ -922,3 +922,95 @@ describe("GET /public/galleries/:id/items/:item/download", () => {
     });
   });
 });
+
+describe("private gallery items are withheld from the public surfaces (issue #365 / plan 004)", () => {
+  it("public gallery JSON withholds a private item but leaves the public item untouched", async () => {
+    await bucket.put("alpha/screenshots/secret.png", PNG, {
+      customMetadata: { visibility: "private" },
+    });
+    const gallery = await create();
+    const publicItem = (await (
+      await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+        method: "POST",
+        body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+      })
+    ).json()) as { id: string };
+    const privateItem = (await (
+      await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+        method: "POST",
+        body: JSON.stringify({ expectedVersion: 2, objectKey: "screenshots/secret.png" }),
+      })
+    ).json()) as { id: string };
+
+    const publicGallery = await app.request(`/public/galleries/${gallery.id}`, {}, env);
+    expect(publicGallery.status).toBe(200);
+    const body = (await publicGallery.json()) as {
+      items: { id: string; status: string; url: string | null; embedUrl: string | null }[];
+    };
+    expect(body.items.find((item) => item.id === publicItem.id)).toMatchObject({
+      status: "available",
+    });
+    expect(body.items.find((item) => item.id === privateItem.id)).toMatchObject({
+      status: "withheld",
+      url: null,
+      embedUrl: null,
+      contentType: null,
+      size: null,
+    });
+  });
+
+  it("404s the public download route for a private item but streams the public one", async () => {
+    await bucket.put("alpha/screenshots/secret.png", PNG, {
+      customMetadata: { visibility: "private" },
+    });
+    const gallery = await create();
+    const publicItem = (await (
+      await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+        method: "POST",
+        body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/one.png" }),
+      })
+    ).json()) as { id: string };
+    const privateItem = (await (
+      await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+        method: "POST",
+        body: JSON.stringify({ expectedVersion: 2, objectKey: "screenshots/secret.png" }),
+      })
+    ).json()) as { id: string };
+
+    const privateDownload = await app.request(
+      `/public/galleries/${gallery.id}/items/${privateItem.id}/download`,
+      {},
+      env,
+    );
+    expect(privateDownload.status).toBe(404);
+    expect(await privateDownload.json()).toMatchObject({
+      error: { code: "gallery_item_not_found" },
+    });
+
+    const publicDownload = await app.request(
+      `/public/galleries/${gallery.id}/items/${publicItem.id}/download`,
+      {},
+      env,
+    );
+    expect(publicDownload.status).toBe(200);
+  });
+
+  it("keeps the private item fully visible (url + status available) on the owner surface", async () => {
+    await bucket.put("alpha/screenshots/secret.png", PNG, {
+      customMetadata: { visibility: "private" },
+    });
+    const gallery = await create();
+    const privateItem = (await (
+      await request(`/v1/alpha/galleries/${gallery.id}/items`, {
+        method: "POST",
+        body: JSON.stringify({ expectedVersion: 1, objectKey: "screenshots/secret.png" }),
+      })
+    ).json()) as { id: string };
+
+    const owner = await request(`/v1/alpha/galleries/${gallery.id}`);
+    expect(owner.status).toBe(200);
+    expect(await owner.json()).toMatchObject({
+      items: [{ id: privateItem.id, status: "available", url: expect.any(String) }],
+    });
+  });
+});

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -9,6 +9,10 @@
     // Origin of the invite page that magic links point at. Defaults to the API
     // host without the `api.` prefix; set explicitly for other deployments.
     "WEB_ORIGIN": "https://uploads.sh",
+    // Gates dev-only CORS origin reflection (localhost/127.0.0.1). Mirrors
+    // apps/auth's ENVIRONMENT convention: set to "production" here; unset in
+    // local dev so miniflare keeps reflecting loopback origins.
+    "ENVIRONMENT": "production",
     // GitHub App identity for server-side PR/issue title resolution (#267).
     // Both ids are public (visible in GitHub URLs); the private key is the
     // only true secret (GITHUB_APP_PRIVATE_KEY, via wrangler secret).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,7 @@
     "@astrojs/react": "^6.0.1",
     "@uploads/billing": "workspace:^",
     "@uploads/ui": "workspace:*",
-    "astro": "^7.0.6",
+    "astro": "^7.1.6",
     "files-sdk": "^2.1.0",
     "img-comparison-slider": "^8.0.7",
     "markdown-for-agents": "^1.3.4",

--- a/apps/web/src/lib/public-gallery.test.ts
+++ b/apps/web/src/lib/public-gallery.test.ts
@@ -4,6 +4,7 @@ import {
   fetchPublicGallery,
   galleryItemDownloadUrl,
   isPublicGallery,
+  mediaKind,
   PUBLIC_GALLERY_CSP,
 } from "./public-gallery";
 
@@ -131,6 +132,22 @@ describe("public gallery API", () => {
         ...gallery,
         items: [{ ...video, videoDimensions: { width: 0, height: 1 } }],
       }),
+    ).toBe(false);
+  });
+
+  it("accepts a withheld (private) item — url/contentType/size null, same shape as a tombstone", () => {
+    const withheld = {
+      ...gallery.items[0],
+      status: "withheld",
+      url: null,
+      embedUrl: null,
+      contentType: null,
+      size: null,
+    };
+    expect(isPublicGallery({ ...gallery, items: [withheld] })).toBe(true);
+    // A withheld item still can't carry a non-null url (would defeat the gate).
+    expect(
+      isPublicGallery({ ...gallery, items: [{ ...withheld, url: gallery.items[0].url }] }),
     ).toBe(false);
   });
 
@@ -264,6 +281,15 @@ describe("public gallery API", () => {
     await expect(
       fetchPublicGallery(ID, { origin: "http://[::1]:8787", fetch: fetcher }),
     ).resolves.toMatchObject({ status: "ok" });
+  });
+});
+
+describe("mediaKind", () => {
+  it("renders a withheld (private) item identically to a missing one", () => {
+    expect(mediaKind({ ...gallery.items[0], status: "missing", url: null })).toBe("missing");
+    expect(
+      mediaKind({ ...gallery.items[0], status: "withheld", url: null, contentType: null }),
+    ).toBe("missing");
   });
 });
 

--- a/apps/web/src/lib/public-gallery.ts
+++ b/apps/web/src/lib/public-gallery.ts
@@ -7,7 +7,7 @@ export interface PublicGalleryItem {
   position: number;
   caption: string | null;
   altText: string | null;
-  status: "available" | "missing";
+  status: "available" | "missing" | "withheld";
   url: string | null;
   /** Embed-host URL when the dual-host policy applies; null otherwise. Always present (see gallery-service.ts). */
   embedUrl: string | null;
@@ -57,7 +57,10 @@ export type MediaKind = "image" | "video" | "file" | "unsupported" | "missing";
 
 /** Gallery variant of `fileKind` (public-file.ts): one shared classifier plus tombstones. */
 export function mediaKind(item: PublicGalleryItem): MediaKind {
-  if (item.status === "missing") return "missing";
+  // "withheld" (private object) renders identically to "missing" — the
+  // public surface has no signal to distinguish an unlisted item from a
+  // deleted one, by design (see visibility.ts / plan 004).
+  if (item.status === "missing" || item.status === "withheld") return "missing";
   return fileKind(item.contentType ?? "");
 }
 
@@ -197,14 +200,16 @@ export function isPublicGallery(value: unknown): value is PublicGallery {
       (item.position as number) > 0 &&
       nullableText(item.caption, 500) &&
       nullableText(item.altText, 300) &&
-      (item.status === "available" || item.status === "missing") &&
+      (item.status === "available" || item.status === "missing" || item.status === "withheld") &&
       nullableHttpsUrl(item.url) &&
       nullableHttpsUrl(item.embedUrl) &&
       nullableText(item.contentType, 128) &&
       sizeOk &&
       optionalIsoDate(item.uploaded) &&
       optionalIsoDate(item.modified) &&
-      (item.status === "missing" ? item.url === null : item.url !== null)
+      (item.status === "missing" || item.status === "withheld"
+        ? item.url === null
+        : item.url !== null)
     );
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,7 +169,7 @@ importers:
     dependencies:
       '@astrojs/cloudflare':
         specifier: ^14.1.2
-        version: 14.1.2(@types/node@26.1.0)(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)
+        version: 14.1.2(@types/node@26.1.0)(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@26.1.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.49.0)(yaml@2.9.0)
@@ -180,11 +180,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       astro:
-        specifier: ^7.0.6
-        version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
+        specifier: ^7.1.6
+        version: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       img-comparison-slider:
         specifier: ^8.0.7
         version: 8.0.7
@@ -276,7 +276,7 @@ importers:
         version: 3.1080.0
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^5.20260706.1
@@ -302,7 +302,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -348,7 +348,7 @@ importers:
         version: 6.0.220(zod@4.4.3)
       files-sdk:
         specifier: ^2.1.0
-        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -421,69 +421,69 @@ packages:
       astro: ^7.0.0
       wrangler: ^4.83.0
 
-  '@astrojs/compiler-binding-darwin-arm64@0.3.0':
-    resolution: {integrity: sha512-3n0uu+uJpnCq8b4JFi3uGDsIisAvHctxSmH+cIO9Gbei1H1Y1QXaYboXyiWJugUmprr3OEYP7+LdodzpVFzLMQ==}
+  '@astrojs/compiler-binding-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@astrojs/compiler-binding-darwin-x64@0.3.0':
-    resolution: {integrity: sha512-scxNGKjOBydMo1QR4LtK0FMgh7ubQomJDv953nz2msQFkPKke/0FpPv/cQM0T/kuZdReZQFU8Oz3iOrP/6WHEg==}
+  '@astrojs/compiler-binding-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.0':
-    resolution: {integrity: sha512-NZrWLolVUANmrnl0zrFK/Sx5Sock1gEUT49ALfMTTCA5Ya2ec/BoJXMIg4KgE+wZcrdXJ8e+WyEhM7YLk/FJkA==}
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@astrojs/compiler-binding-linux-arm64-musl@0.3.0':
-    resolution: {integrity: sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==}
+  '@astrojs/compiler-binding-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@astrojs/compiler-binding-linux-x64-gnu@0.3.0':
-    resolution: {integrity: sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A==}
+  '@astrojs/compiler-binding-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@astrojs/compiler-binding-linux-x64-musl@0.3.0':
-    resolution: {integrity: sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==}
+  '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.3.0':
-    resolution: {integrity: sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg==}
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2':
+    resolution: {integrity: sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.0':
-    resolution: {integrity: sha512-CpY1RII2r1XMpOUVD1VR/F2wtuRsiOCkFULS10Khyj8/DFZMtxVuUCAWGw+CW2Ka0h6eP3Xc1CA+glFlvXMPxA==}
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@astrojs/compiler-binding-win32-x64-msvc@0.3.0':
-    resolution: {integrity: sha512-qmFbs769oeeGrRebAnCW7aBk8m71vf85W/dX/jddfx5Z06/w0wf7TZCfJPOX1Fld2t+4N+iXzfGEJG+zJQ+bzg==}
+  '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@astrojs/compiler-binding@0.3.0':
-    resolution: {integrity: sha512-zlsOT5COD9hRwplJCgQhS21unxON5AKirf0vgt1ijXwuseYIaZdm2ZOpF8fsz+DY9EyXx+I/ukxtg7uoBep68A==}
+  '@astrojs/compiler-binding@0.3.2':
+    resolution: {integrity: sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@astrojs/compiler-rs@0.3.0':
-    resolution: {integrity: sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ==}
+  '@astrojs/compiler-rs@0.3.2':
+    resolution: {integrity: sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg==}
     engines: {node: '>=22.12.0'}
 
   '@astrojs/compiler@2.13.1':
@@ -491,6 +491,9 @@ packages:
 
   '@astrojs/internal-helpers@0.10.1':
     resolution: {integrity: sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==}
+
+  '@astrojs/internal-helpers@0.10.2':
+    resolution: {integrity: sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==}
 
   '@astrojs/language-server@2.16.11':
     resolution: {integrity: sha512-sJ/EfnFp0+gurTrkvONtd9qRqmMZLT9bHelfI1SA35CaQVTrRrA74qteOcNT/al1b9Atg3IiH1Jk/qfckyC+fg==}
@@ -504,8 +507,8 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@astrojs/markdown-satteri@0.3.3':
-    resolution: {integrity: sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g==}
+  '@astrojs/markdown-satteri@0.3.5':
+    resolution: {integrity: sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==}
 
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
@@ -520,8 +523,8 @@ packages:
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
-  '@astrojs/telemetry@3.3.2':
-    resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
+  '@astrojs/telemetry@3.3.3':
+    resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
   '@astrojs/underscore-redirects@1.0.3':
@@ -1786,6 +1789,13 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
@@ -3096,12 +3106,12 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
-  astro@7.0.6:
-    resolution: {integrity: sha512-Myw0sFia+zs/Y0yqfZEsUYXfDPh3ELcLf1f0Q/qQzVXBh/af1qO62WNT+P89DCcfGVV51nMoQhEfkBYqJmoUOQ==}
+  astro@7.1.6:
+    resolution: {integrity: sha512-83x9rYbHazMaZkYrAFRVZXSQx2moFkz0F7cjTDUF3GWfS0a3p2vZXG1ZdhV86rStHApQCodBJW+XTD37xISIrQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     peerDependencies:
-      '@astrojs/markdown-remark': 7.2.1
+      '@astrojs/markdown-remark': 7.2.2
     peerDependenciesMeta:
       '@astrojs/markdown-remark':
         optional: true
@@ -3364,6 +3374,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -3621,6 +3635,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -4037,11 +4055,23 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   hono@4.12.28:
     resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
@@ -4122,11 +4152,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
-
   is-docker@4.0.0:
     resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
     engines: {node: '>=20'}
@@ -4147,11 +4172,6 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-
-  is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -4179,10 +4199,6 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
-
-  is-wsl@3.1.1:
-    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
-    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4393,6 +4409,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magic-string@1.1.0:
+    resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
+
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
@@ -4530,8 +4549,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  neotraverse@0.6.18:
-    resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
+  neotraverse@1.0.1:
+    resolution: {integrity: sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==}
     engines: {node: '>= 10'}
 
   nlcst-to-string@4.0.0:
@@ -4686,6 +4705,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -5535,6 +5557,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -5739,6 +5764,9 @@ packages:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -5758,10 +5786,6 @@ packages:
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
-
-  which-pm-runs@1.1.0:
-    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
-    engines: {node: '>=4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5924,12 +5948,12 @@ snapshots:
       - prettier
       - prettier-plugin-astro
 
-  '@astrojs/cloudflare@14.1.2(@types/node@26.1.0)(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)':
+  '@astrojs/cloudflare@14.1.2(@types/node@26.1.0)(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(esbuild@0.28.1)(terser@5.49.0)(workerd@1.20260701.1)(wrangler@4.110.0)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/underscore-redirects': 1.0.3
       '@cloudflare/vite-plugin': 1.44.0(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.110.0)
-      astro: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
+      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       piccolore: 0.1.3
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
       wrangler: 4.110.0
@@ -5950,56 +5974,56 @@ snapshots:
       - workerd
       - yaml
 
-  '@astrojs/compiler-binding-darwin-arm64@0.3.0':
+  '@astrojs/compiler-binding-darwin-arm64@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-darwin-x64@0.3.0':
+  '@astrojs/compiler-binding-darwin-x64@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.0':
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-arm64-musl@0.3.0':
+  '@astrojs/compiler-binding-linux-arm64-musl@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-x64-gnu@0.3.0':
+  '@astrojs/compiler-binding-linux-x64-gnu@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-linux-x64-musl@0.3.0':
+  '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
 
-  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.0':
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-win32-x64-msvc@0.3.0':
+  '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding@0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
+  '@astrojs/compiler-binding@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     optionalDependencies:
-      '@astrojs/compiler-binding-darwin-arm64': 0.3.0
-      '@astrojs/compiler-binding-darwin-x64': 0.3.0
-      '@astrojs/compiler-binding-linux-arm64-gnu': 0.3.0
-      '@astrojs/compiler-binding-linux-arm64-musl': 0.3.0
-      '@astrojs/compiler-binding-linux-x64-gnu': 0.3.0
-      '@astrojs/compiler-binding-linux-x64-musl': 0.3.0
-      '@astrojs/compiler-binding-wasm32-wasi': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
-      '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.0
-      '@astrojs/compiler-binding-win32-x64-msvc': 0.3.0
+      '@astrojs/compiler-binding-darwin-arm64': 0.3.2
+      '@astrojs/compiler-binding-darwin-x64': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-musl': 0.3.2
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.2
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.3.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@astrojs/compiler-rs@0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
+  '@astrojs/compiler-rs@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@astrojs/compiler-binding': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      '@astrojs/compiler-binding': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -6007,6 +6031,17 @@ snapshots:
   '@astrojs/compiler@2.13.1': {}
 
   '@astrojs/internal-helpers@0.10.1':
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.3.0
+      picomatch: 4.0.5
+      retext-smartypants: 6.2.0
+      shiki: 4.3.1
+      smol-toml: 1.7.0
+      unified: 11.0.5
+
+  '@astrojs/internal-helpers@0.10.2':
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -6043,11 +6078,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdown-satteri@0.3.3':
+  '@astrojs/markdown-satteri@0.3.5':
     dependencies:
-      '@astrojs/internal-helpers': 0.10.1
+      '@astrojs/internal-helpers': 0.10.2
       '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
       satteri: 0.9.4
 
   '@astrojs/prism@4.0.2':
@@ -6080,13 +6116,12 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/telemetry@3.3.2':
+  '@astrojs/telemetry@3.3.3':
     dependencies:
       ci-info: 4.4.0
       dset: 3.1.4
       is-docker: 4.0.0
-      is-wsl: 3.1.1
-      which-pm-runs: 1.1.0
+      package-manager-detector: 1.7.0
 
   '@astrojs/underscore-redirects@1.0.3': {}
 
@@ -7280,7 +7315,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.2
@@ -8458,12 +8493,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0):
+  astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0):
     dependencies:
-      '@astrojs/compiler-rs': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
-      '@astrojs/internal-helpers': 0.10.1
-      '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/telemetry': 3.3.2
+      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      '@astrojs/internal-helpers': 0.10.2
+      '@astrojs/markdown-satteri': 0.3.5
+      '@astrojs/telemetry': 3.3.3
       '@capsizecss/unpack': 4.0.1
       '@clack/prompts': 1.7.0
       '@oslojs/encoding': 1.1.0
@@ -8474,7 +8509,7 @@ snapshots:
       ci-info: 4.4.0
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
-      cookie: 1.1.1
+      cookie: 2.0.1
       devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
@@ -8488,10 +8523,10 @@ snapshots:
       http-cache-semantics: 4.2.0
       js-yaml: 4.3.0
       jsonc-parser: 3.3.1
-      magic-string: 0.30.21
+      magic-string: 1.1.0
       magicast: 0.5.3
       mrmime: 2.0.1
-      neotraverse: 0.6.18
+      neotraverse: 1.0.1
       obug: 2.1.3
       p-limit: 7.3.0
       p-queue: 9.3.1
@@ -8742,6 +8777,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cookie@2.0.1: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -8907,6 +8944,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -9123,7 +9162,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  files-sdk@2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  files-sdk@2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       commander: 15.0.0
       picomatch: 4.0.5
@@ -9135,7 +9174,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       ai: 6.0.220(zod@4.4.3)
-      astro: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
+      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0)
       h3: 1.15.11
       hono: 4.12.28
       react: 19.2.7
@@ -9286,6 +9325,30 @@ snapshots:
       function-bind: 1.1.2
     optional: true
 
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -9303,6 +9366,14 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
 
   hono@4.12.28: {}
 
@@ -9368,8 +9439,6 @@ snapshots:
 
   is-docker@2.2.1: {}
 
-  is-docker@3.0.0: {}
-
   is-docker@4.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -9383,10 +9452,6 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-
-  is-inside-container@1.0.0:
-    dependencies:
-      is-docker: 3.0.0
 
   is-number@7.0.0: {}
 
@@ -9406,10 +9471,6 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
-
-  is-wsl@3.1.1:
-    dependencies:
-      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -9577,6 +9638,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.1.0:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
@@ -9727,7 +9792,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  neotraverse@0.6.18: {}
+  neotraverse@1.0.1: {}
 
   nlcst-to-string@4.0.0:
     dependencies:
@@ -9905,6 +9970,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3:
     optional: true
 
@@ -10004,7 +10073,7 @@ snapshots:
   prettier-plugin-astro@0.14.1:
     dependencies:
       '@astrojs/compiler': 2.13.1
-      prettier: 3.9.4
+      prettier: 3.9.6
       sass-formatter: 0.7.9
 
   prettier@2.8.8: {}
@@ -10758,6 +10827,11 @@ snapshots:
   vary@1.1.2:
     optional: true
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -10924,6 +10998,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
+  web-namespaces@2.0.1: {}
+
   webidl-conversions@4.0.2: {}
 
   webpack-sources@3.5.1: {}
@@ -10974,8 +11050,6 @@ snapshots:
       lodash.sortby: 4.7.0
       tr46: 1.0.1
       webidl-conversions: 4.0.2
-
-  which-pm-runs@1.1.0: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## In plain terms

A batch of five small, independent fixes from a code audit. Two close real gaps for users: bring-your-own-bucket workspaces no longer hit the platform storage cap on their own storage, and files marked private no longer leak through public gallery pages. Two harden the deployed workers: production stops reflecting `localhost` origins on cookie-authenticated CORS, and Astro moves past a reflected-XSS advisory. The fifth makes CI run `pnpm typecheck`, which the docs already promised.

## What it does / what it is not

- **BYO storage cap** (`fix(api)`): the upload reservation now uses the same "their disk, their bill" exemption the pre-check already applied, via a single `enforcedMaxStorageBytes()` helper. `GET /usage` stops reporting a storage cap for BYO workspaces so the settings UI and enforcement agree. Upload-count limits still apply.
- **Private gallery items** (`fix(api)`): the public gallery JSON returns `status: "withheld"` (no URL, no metadata) for private items, and the public item-download route answers a uniform 404. Owner surfaces and the managed GitHub comment are unchanged.
- **CORS gating** (`fix(api)`): loopback origins are only reflected when `ENVIRONMENT` is not `"production"`, mirroring the auth worker's existing convention. **Deploy note:** hitting prod `api.uploads.sh` from a local browser app with session cookies stops working by design; use the local stack.
- **Astro advisory** (`chore(web)`): 7.0.6 → 7.1.6, past the View Transitions XSS advisory floor (7.0.10). No source changes needed.
- **CI typecheck** (`ci`): the lint job now runs `pnpm typecheck` (passing today), with a small timeout bump.
- Not included: no CLI or published-package changes, so no changeset.

## Technical notes

- `hydrateGalleryItems` gained an `audience: "owner" | "public"` option; only the public hydrator withholds. Future callers should pass it explicitly.
- The new `ENVIRONMENT` var is set in `apps/api/wrangler.jsonc` and left unset locally, so miniflare dev behavior is unchanged.

## Test plan

- [x] `pnpm typecheck` — exit 0
- [x] `pnpm test` — 268 files / 3,782 tests pass (includes 13 new tests: BYO budget ×6, CORS gating ×6 across `/me` and `/v1/workspaces`, gallery withholding ×3, plus existing missing-status regressions)
- [x] `pnpm check` — lint + format clean
- [x] `pnpm build` and `pnpm audit --prod` verified on the Astro bump (advisory no longer reported)
