### PR TITLE
fix: teardown/retention D1 cleanup, CLI null-URL markdown, Stripe handler tests

### DIFF
--- a/.changeset/cli-null-url-markdown.md
+++ b/.changeset/cli-null-url-markdown.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": patch
+---
+
+put/attach/screenshot no longer emit broken `![…](null)` markdown on workspaces without a public URL; the CLI now falls back to a plain-text note naming the uploaded key.

--- a/apps/api/src/file-metadata.ts
+++ b/apps/api/src/file-metadata.ts
@@ -420,6 +420,26 @@ export async function deleteFileMetadataForWorkspace(
 }
 
 /**
+ * Deletes all metadata rows for a set of objects in one pass (e.g. the
+ * retention purge's delete batches). Chunked like `getMetadataForKeys` to
+ * stay under D1's bound-parameter limit. No-op on an empty list.
+ */
+export async function deleteFileMetadataForKeys(
+  db: D1Database,
+  workspace: string,
+  keys: string[],
+): Promise<void> {
+  for (let i = 0; i < keys.length; i += METADATA_LOOKUP_CHUNK) {
+    const chunk = keys.slice(i, i + METADATA_LOOKUP_CHUNK);
+    const placeholders = chunk.map(() => "?").join(", ");
+    await db
+      .prepare(`DELETE FROM file_metadata WHERE workspace = ? AND object_key IN (${placeholders})`)
+      .bind(workspace, ...chunk)
+      .run();
+  }
+}
+
+/**
  * Fully replaces an object's metadata: validates `metadata` once (there's no
  * prior state to merge against, so unlike `setFileMetadata` there's nothing
  * to re-read first), then deletes any existing rows and inserts the new set

--- a/apps/api/src/retention.ts
+++ b/apps/api/src/retention.ts
@@ -1,7 +1,9 @@
 /**
  * App-driven retention: delete objects older than `retentionDays` on the
  * workspace record. Uses object `lastModified` from the store (R2 upload time).
- * After purge, call reconcile so the ledger matches storage.
+ * Each delete batch also removes the matching `file_metadata` rows so
+ * find/search and the facet endpoints stop surfacing purged keys. After
+ * purge, call reconcile so the ledger matches storage.
  *
  * files-sdk notes:
  * - Walk with `listAll()` (same as reconcile) — cursor pagination, prefix-scoped.
@@ -13,6 +15,7 @@
  *   lifecycle policy per prefix.
  */
 import { positiveLimit } from "./budget";
+import { deleteFileMetadataForKeys } from "./file-metadata";
 import { reconcileWorkspaceUsage, type ReconcileResult } from "./reconcile";
 import { storage } from "./storage";
 import { isUnprefixedDedicatedBucket, type WorkspaceRecord } from "./workspace";
@@ -83,6 +86,7 @@ export async function purgeExpiredObjects(
     if (batch.length === 0) return;
     // Bulk form: native multi-delete on R2/S3 when available.
     await store.delete(batch);
+    await deleteFileMetadataForKeys(env.DB, workspaceName, batch);
     batch = [];
   }
 

--- a/apps/api/src/routes/admin-workspace-delete.test.ts
+++ b/apps/api/src/routes/admin-workspace-delete.test.ts
@@ -11,6 +11,8 @@ const ADMIN_TOKEN = "test-admin-token";
 const MIGRATIONS = [
   "migrations/20260711180000_galleries.sql",
   "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260710140000_workspace_usage.sql",
+  "migrations/20260730170533_delete_usage_claims.sql",
 ];
 
 beforeAll(() => {

--- a/apps/api/src/usage.ts
+++ b/apps/api/src/usage.ts
@@ -415,6 +415,19 @@ export async function clearDeleteUsageClaimSafe(
 }
 
 /**
+ * Deletes every usage row for a workspace being torn down — the period
+ * ledger and any in-flight delete claims. Plain (throwing), like
+ * `deleteFileMetadataForWorkspace`: teardown's fail-safe ordering wants a
+ * loud failure before the KV record is removed, not a silent leak.
+ */
+export async function deleteUsageForWorkspace(db: D1Database, workspace: string): Promise<void> {
+  await db.batch([
+    db.prepare(`DELETE FROM workspace_usage WHERE workspace = ?`).bind(workspace),
+    db.prepare(`DELETE FROM delete_usage_claims WHERE workspace = ?`).bind(workspace),
+  ]);
+}
+
+/**
  * Replace absolute bytes/objects from a storage scan (reconcile).
  * Preserves uploads_in_period for the current period when the row exists.
  */

--- a/apps/api/src/workspace-teardown.ts
+++ b/apps/api/src/workspace-teardown.ts
@@ -1,6 +1,6 @@
 /**
  * Shared hard-teardown sequence for a workspace: R2 objects, D1 rows (file
- * metadata + galleries), best-effort auth org, then the `ws:<name>` KV
+ * metadata + galleries + usage), best-effort auth org, then the `ws:<name>` KV
  * record. Used by the admin hard-delete path (`DELETE
  * /admin/workspaces/:name?hard=1`) and by the retention sweep's finalization
  * of an expired soft delete (`apps/api/src/retention-sweep.ts`).
@@ -19,6 +19,7 @@ import { deleteFileMetadataForWorkspace } from "./file-metadata";
 import { deleteGalleriesForWorkspace } from "./galleries";
 import { deleteOrg } from "./org-workspaces";
 import { storage } from "./storage";
+import { deleteUsageForWorkspace } from "./usage";
 import {
   isUnprefixedDedicatedBucket,
   type PurgedTombstone,
@@ -99,6 +100,7 @@ export async function teardownWorkspace(
 
   const { galleries } = await deleteGalleriesForWorkspace(env.DB, name);
   await deleteFileMetadataForWorkspace(env.DB, name);
+  await deleteUsageForWorkspace(env.DB, name);
 
   // Best-effort, like the self-serve rollback path in routes/workspaces.ts
   // — an org left behind after this point is orphaned (no KV record means

--- a/apps/api/test/retention-metadata.test.ts
+++ b/apps/api/test/retention-metadata.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { purgeExpiredObjects } from "../src/retention";
+import type { WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260710140000_workspace_usage.sql",
+];
+
+// Prefixed shared-bucket record — the common case (see retention-sweep.test.ts).
+const RECORD: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "BUCKET",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+  retentionDays: 1,
+};
+
+async function insertMetadataRow(
+  db: D1Database,
+  workspace: string,
+  objectKey: string,
+  metaKey = "gh.repo",
+  metaValue = "acme/web",
+) {
+  await db
+    .prepare(
+      `INSERT INTO file_metadata (workspace, object_key, meta_key, meta_value, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .bind(workspace, objectKey, metaKey, metaValue, new Date().toISOString())
+    .run();
+}
+
+async function metadataRowCount(db: D1Database, workspace: string, objectKey: string) {
+  const row = await db
+    .prepare(`SELECT COUNT(*) as count FROM file_metadata WHERE workspace = ? AND object_key = ?`)
+    .bind(workspace, objectKey)
+    .first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+function makeEnv(bucket: FakeR2Bucket, sqlite: SqliteD1) {
+  return {
+    BUCKET: bucket,
+    DB: database(sqlite),
+  } as unknown as Env;
+}
+
+describe("purgeExpiredObjects — file_metadata cleanup (plan 007)", () => {
+  it("deletes file_metadata rows for expired objects it purges", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("acme/old.png", new Uint8Array([1, 2, 3]));
+      bucket.setUploaded("acme/old.png", new Date("2020-01-01T00:00:00Z"));
+      await bucket.put("acme/fresh.png", new Uint8Array([4, 5, 6]));
+
+      const db = database(sqlite);
+      await insertMetadataRow(db, "acme", "old.png");
+      await insertMetadataRow(db, "acme", "fresh.png");
+      await insertMetadataRow(db, "other-ws", "old.png");
+
+      const env = makeEnv(bucket, sqlite);
+      const result = await purgeExpiredObjects(env, RECORD, "acme");
+
+      expect(result).toMatchObject({ deleted: 1, keys: ["old.png"] });
+      expect(bucket.store.has("acme/old.png")).toBe(false);
+
+      // Expired object's row is gone.
+      expect(await metadataRowCount(db, "acme", "old.png")).toBe(0);
+
+      // Fresh object's row and the other workspace's row survive.
+      expect(await metadataRowCount(db, "acme", "fresh.png")).toBe(1);
+      expect(await metadataRowCount(db, "other-ws", "old.png")).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("leaves all file_metadata rows intact when nothing is expired", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      const bucket = new FakeR2Bucket();
+      await bucket.put("acme/fresh.png", new Uint8Array([4, 5, 6]));
+
+      const db = database(sqlite);
+      await insertMetadataRow(db, "acme", "fresh.png");
+      await insertMetadataRow(db, "other-ws", "fresh.png");
+
+      const env = makeEnv(bucket, sqlite);
+      const result = await purgeExpiredObjects(env, RECORD, "acme");
+
+      expect(result).toMatchObject({ deleted: 0, keys: [] });
+      expect(await metadataRowCount(db, "acme", "fresh.png")).toBe(1);
+      expect(await metadataRowCount(db, "other-ws", "fresh.png")).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/api/test/retention-sweep.test.ts
+++ b/apps/api/test/retention-sweep.test.ts
@@ -8,6 +8,7 @@ const MIGRATIONS = [
   "migrations/20260711180000_galleries.sql",
   "migrations/20260713210559_file_metadata.sql",
   "migrations/20260710140000_workspace_usage.sql",
+  "migrations/20260730170533_delete_usage_claims.sql",
 ];
 
 // Prefixed shared-bucket record — the common case, and the baseline these

--- a/apps/api/test/workspace-teardown-usage.test.ts
+++ b/apps/api/test/workspace-teardown-usage.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { teardownWorkspace } from "../src/workspace-teardown";
+import type { WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260711180000_galleries.sql",
+  "migrations/20260713210559_file_metadata.sql",
+  "migrations/20260710140000_workspace_usage.sql",
+  "migrations/20260730170533_delete_usage_claims.sql",
+];
+
+// Prefixed shared-bucket record — mirrors retention-sweep.test.ts's RECORD.
+const RECORD: WorkspaceRecord = {
+  provider: "r2",
+  bucket: "shared",
+  binding: "BUCKET",
+  prefix: "acme/",
+  publicBaseUrl: "https://storage.uploads.sh",
+};
+
+/** Fake REGISTRY: get/put/delete over an in-memory Map. */
+function fakeRegistry(records: Record<string, unknown> = {}) {
+  const store = new Map(Object.entries(records));
+  return {
+    store,
+    get: (async (key: string) => store.get(key) ?? null) as unknown as KVNamespace["get"],
+    put: (async (key: string, value: string) => {
+      store.set(key, JSON.parse(value));
+    }) as unknown as KVNamespace["put"],
+    delete: (async (key: string) => {
+      store.delete(key);
+    }) as unknown as KVNamespace["delete"],
+  };
+}
+
+/** Fake AUTH service binding: org delete is best-effort, so any response works. */
+function fakeAuth() {
+  return {
+    fetch: (async () => new Response(null, { status: 204 })) as Fetcher["fetch"],
+  };
+}
+
+function makeEnv(opts: {
+  kvRecords?: Record<string, unknown>;
+  bucket?: FakeR2Bucket;
+  db: SqliteD1;
+}) {
+  const { kvRecords = {}, bucket = new FakeR2Bucket(), db } = opts;
+  const registry = fakeRegistry(kvRecords);
+  const env = {
+    REGISTRY: registry,
+    BUCKET: bucket,
+    DB: database(db),
+    AUTH: fakeAuth(),
+  } as unknown as Env;
+  return { env, registry, bucket };
+}
+
+async function seedUsage(sqlite: SqliteD1, workspace: string) {
+  const db = database(sqlite);
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      `INSERT INTO workspace_usage (workspace, bytes, objects, uploads_in_period, period_start, updated_at)
+       VALUES (?, 100, 1, 1, ?, ?)`,
+    )
+    .bind(workspace, now, now)
+    .run();
+  await db
+    .prepare(`INSERT INTO delete_usage_claims (workspace, object_key, claimed_at) VALUES (?, ?, ?)`)
+    .bind(workspace, `${workspace}/f/one.png`, now)
+    .run();
+}
+
+async function countRows(sqlite: SqliteD1, table: string, workspace: string): Promise<number> {
+  const db = database(sqlite);
+  const row = await db
+    .prepare(`SELECT COUNT(*) AS c FROM ${table} WHERE workspace = ?`)
+    .bind(workspace)
+    .first<{ c: number }>();
+  return Number(row?.c ?? 0);
+}
+
+describe("teardownWorkspace — usage ledger cleanup (#006)", () => {
+  it("deletes workspace_usage and delete_usage_claims rows for the torn-down workspace", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedUsage(sqlite, "acme");
+      await seedUsage(sqlite, "other");
+      const { env } = makeEnv({ kvRecords: { "ws:acme": RECORD }, db: sqlite });
+
+      await teardownWorkspace(env, "acme", RECORD, { reason: "test" });
+
+      expect(await countRows(sqlite, "workspace_usage", "acme")).toBe(0);
+      expect(await countRows(sqlite, "delete_usage_claims", "acme")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("leaves other workspaces' usage rows untouched", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedUsage(sqlite, "acme");
+      await seedUsage(sqlite, "other");
+      const { env } = makeEnv({ kvRecords: { "ws:acme": RECORD }, db: sqlite });
+
+      await teardownWorkspace(env, "acme", RECORD, { reason: "test" });
+
+      expect(await countRows(sqlite, "workspace_usage", "other")).toBe(1);
+      expect(await countRows(sqlite, "delete_usage_claims", "other")).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("clears usage rows on the tombstone path too", async () => {
+    const sqlite = new SqliteD1(MIGRATIONS);
+    try {
+      await seedUsage(sqlite, "acme");
+      const { env } = makeEnv({ kvRecords: { "ws:acme": RECORD }, db: sqlite });
+
+      await teardownWorkspace(env, "acme", RECORD, {
+        reason: "test",
+        replaceWithTombstone: true,
+      });
+
+      expect(await countRows(sqlite, "workspace_usage", "acme")).toBe(0);
+      expect(await countRows(sqlite, "delete_usage_claims", "acme")).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/auth/src/stripe-plugin.test.ts
+++ b/apps/auth/src/stripe-plugin.test.ts
@@ -4,12 +4,14 @@
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
 import type { AuthEnv } from "./auth";
+import type { syncWorkspacePlan } from "./billing-bridge";
 import * as schema from "./schema";
 import {
   checkoutSessionParamsFor,
   desiredPlanForStatus,
   isOrgBillingAdmin,
   stripePluginOrNone,
+  subscriptionLifecycleHandlers,
 } from "./stripe-plugin";
 import { createFakeD1 } from "./test/fake-d1";
 
@@ -166,5 +168,85 @@ describe("isOrgBillingAdmin", () => {
     const env = dbEnv();
     const { db, orgId } = await seed(env);
     expect(await isOrgBillingAdmin(db, crypto.randomUUID(), orgId)).toBe(false);
+  });
+});
+
+function recordingSync() {
+  const calls: { referenceId: string; plan: "free" | "pro" }[] = [];
+  const sync = (async (_env, _db, referenceId, plan) => {
+    calls.push({ referenceId, plan });
+  }) as typeof syncWorkspacePlan;
+  return { calls, sync };
+}
+
+describe("subscriptionLifecycleHandlers", () => {
+  function buildHandlers() {
+    const env = dbEnv({ ...ALL_BRIDGE_DEPS });
+    const db = drizzle(env.DB, { schema });
+    const { calls, sync } = recordingSync();
+    const handlers = subscriptionLifecycleHandlers(env, db, sync);
+    return { handlers, calls };
+  }
+
+  it("onSubscriptionComplete syncs the workspace to pro", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionComplete({ subscription: { referenceId: "org_1" } });
+    expect(calls).toEqual([{ referenceId: "org_1", plan: "pro" }]);
+  });
+
+  it("onSubscriptionUpdate syncs to pro for active and trialing", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionUpdate({
+      subscription: { referenceId: "org_1", status: "active" },
+    });
+    await handlers.onSubscriptionUpdate({
+      subscription: { referenceId: "org_1", status: "trialing" },
+    });
+    expect(calls).toEqual([
+      { referenceId: "org_1", plan: "pro" },
+      { referenceId: "org_1", plan: "pro" },
+    ]);
+  });
+
+  it("onSubscriptionUpdate syncs to free for past_due and unpaid", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionUpdate({
+      subscription: { referenceId: "org_1", status: "past_due" },
+    });
+    await handlers.onSubscriptionUpdate({
+      subscription: { referenceId: "org_1", status: "unpaid" },
+    });
+    expect(calls).toEqual([
+      { referenceId: "org_1", plan: "free" },
+      { referenceId: "org_1", plan: "free" },
+    ]);
+  });
+
+  it("onSubscriptionCancel does not downgrade immediately for a period-end cancel", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionCancel({
+      subscription: { referenceId: "org_1", status: "active" },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("onSubscriptionCancel downgrades immediately for a terminal status", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionCancel({
+      subscription: { referenceId: "org_1", status: "canceled" },
+    });
+    expect(calls).toEqual([{ referenceId: "org_1", plan: "free" }]);
+  });
+
+  it("onSubscriptionDeleted syncs the workspace to free", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionDeleted({ subscription: { referenceId: "org_1" } });
+    expect(calls).toEqual([{ referenceId: "org_1", plan: "free" }]);
+  });
+
+  it("passes the subscription's referenceId through verbatim", async () => {
+    const { handlers, calls } = buildHandlers();
+    await handlers.onSubscriptionComplete({ subscription: { referenceId: "org_specific_id" } });
+    expect(calls[0]?.referenceId).toBe("org_specific_id");
   });
 });

--- a/apps/auth/src/stripe-plugin.ts
+++ b/apps/auth/src/stripe-plugin.ts
@@ -38,7 +38,7 @@ import { syncWorkspacePlan } from "./billing-bridge";
 import type { AuthEnv } from "./auth";
 
 type Db = ReturnType<typeof drizzle<typeof schema>>;
-type StripePluginEnv = AuthEnv &
+export type StripePluginEnv = AuthEnv &
   Pick<Env, "STRIPE_SECRET_KEY" | "STRIPE_WEBHOOK_SECRET" | "API" | "BILLING_INTERNAL_KEY"> &
   Pick<Env, "STRIPE_CHECKOUT_TOS_CONSENT">;
 
@@ -87,6 +87,49 @@ export async function isOrgBillingAdmin(
 }
 
 /**
+ * The four subscription lifecycle handlers, extracted (like
+ * `checkoutSessionParamsFor`) so the plan-flip wiring is directly
+ * unit-testable — the configured plugin object doesn't expose its
+ * subscription options for inspection. `sync` is injectable for tests;
+ * production callers use the default `syncWorkspacePlan`.
+ */
+export function subscriptionLifecycleHandlers(
+  env: StripePluginEnv,
+  db: Db,
+  sync: typeof syncWorkspacePlan = syncWorkspacePlan,
+) {
+  return {
+    onSubscriptionComplete: async ({ subscription }: { subscription: { referenceId: string } }) => {
+      await sync(env, db, subscription.referenceId, "pro");
+    },
+    onSubscriptionUpdate: async ({
+      subscription,
+    }: {
+      subscription: { referenceId: string; status: string };
+    }) => {
+      await sync(env, db, subscription.referenceId, desiredPlanForStatus(subscription.status));
+    },
+    onSubscriptionCancel: async ({
+      subscription,
+    }: {
+      subscription: { referenceId: string; status: string };
+    }) => {
+      // cancel_at_period_end keeps status "active"/"trialing" until the
+      // period actually ends — the eventual `subscription.deleted` event
+      // (onSubscriptionDeleted below) does that downgrade. Only an
+      // immediate (non-period-end) cancel, which lands here with a
+      // terminal status already, downgrades now.
+      if (desiredPlanForStatus(subscription.status) === "free") {
+        await sync(env, db, subscription.referenceId, "free");
+      }
+    },
+    onSubscriptionDeleted: async ({ subscription }: { subscription: { referenceId: string } }) => {
+      await sync(env, db, subscription.referenceId, "free");
+    },
+  };
+}
+
+/**
  * `[]` unless `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, the `API` service
  * binding, and `BILLING_INTERNAL_KEY` all resolve — otherwise a single
  * configured `stripe()` plugin. Spread into auth.ts's `plugins` array right
@@ -127,30 +170,7 @@ export function stripePluginOrNone(env: StripePluginEnv, db: Db) {
         // set first, or Stripe rejects the session and the upgrade button
         // dies).
         getCheckoutSessionParams: () => checkoutSessionParamsFor(env),
-        onSubscriptionComplete: async ({ subscription }) => {
-          await syncWorkspacePlan(env, db, subscription.referenceId, "pro");
-        },
-        onSubscriptionUpdate: async ({ subscription }) => {
-          await syncWorkspacePlan(
-            env,
-            db,
-            subscription.referenceId,
-            desiredPlanForStatus(subscription.status),
-          );
-        },
-        onSubscriptionCancel: async ({ subscription }) => {
-          // cancel_at_period_end keeps status "active"/"trialing" until the
-          // period actually ends — the eventual `subscription.deleted` event
-          // (onSubscriptionDeleted below) does that downgrade. Only an
-          // immediate (non-period-end) cancel, which lands here with a
-          // terminal status already, downgrades now.
-          if (desiredPlanForStatus(subscription.status) === "free") {
-            await syncWorkspacePlan(env, db, subscription.referenceId, "free");
-          }
-        },
-        onSubscriptionDeleted: async ({ subscription }) => {
-          await syncWorkspacePlan(env, db, subscription.referenceId, "free");
-        },
+        ...subscriptionLifecycleHandlers(env, db),
       },
     }),
   ];

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -25,7 +25,7 @@ import {
   workspaceFromToken,
   type ResolvedConfig,
 } from "./config.js";
-import { buildMarkdown } from "./embed.js";
+import { buildUploadMarkdown } from "./embed.js";
 import { readLocalRepoCommentConfig, resolveCommentOptions } from "./comment-config.js";
 import { urlForGithubEmbed } from "./public-urls.js";
 import { UploadsError } from "./errors.js";
@@ -618,9 +618,10 @@ export async function uploadPreparedImage(
     }),
     metadata,
   });
-  const markdown = buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+  const markdown = buildUploadMarkdown(urlForGithubEmbed(result.url, result.embedUrl), {
     alt: opts.alt(prepared),
     width: opts.width,
+    key: result.key,
   });
   return { result, prepared, markdown, sentMetadata: metadata };
 }
@@ -1066,8 +1067,9 @@ async function uploadAttachmentBatch(
           upload: {
             ...result,
             file,
-            markdown: buildMarkdown(urlForGithubEmbed(result.url, result.embedUrl)!, {
+            markdown: buildUploadMarkdown(urlForGithubEmbed(result.url, result.embedUrl), {
               alt: sourceName,
+              key: result.key,
             }),
             optimize: {
               optimized: prepared.optimized,

--- a/packages/uploads/src/embed.ts
+++ b/packages/uploads/src/embed.ts
@@ -30,3 +30,18 @@ export function buildMarkdown(url: string, opts: { alt: string; width?: number }
   }
   return `![${opts.alt}](${url})`;
 }
+
+/**
+ * Null-safe wrapper for upload flows: workspaces with no public base URL
+ * (BYO signed-URLs-only) upload fine but have no embeddable URL, and the
+ * markdown must degrade to honest plain text instead of `![alt](null)`.
+ */
+export function buildUploadMarkdown(
+  url: string | null | undefined,
+  opts: { alt: string; width?: number; key: string },
+): string {
+  if (!url) {
+    return `\`${opts.key}\` uploaded (no public URL — this workspace serves signed URLs only)`;
+  }
+  return buildMarkdown(url, opts);
+}

--- a/packages/uploads/src/index.ts
+++ b/packages/uploads/src/index.ts
@@ -1,4 +1,4 @@
-export { inferContentType, buildMarkdown } from "./embed.js";
+export { inferContentType, buildMarkdown, buildUploadMarkdown } from "./embed.js";
 export {
   DEFAULT_EMBED_PUBLIC_BASE_URL,
   embedBaseUrlFromEnv,

--- a/packages/uploads/test/embed.test.ts
+++ b/packages/uploads/test/embed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildMarkdown } from "../src/embed.js";
+import { buildMarkdown, buildUploadMarkdown } from "../src/embed.js";
 
 describe("buildMarkdown", () => {
   it("emits image markdown without width", () => {
@@ -12,5 +12,31 @@ describe("buildMarkdown", () => {
     expect(buildMarkdown("https://x.test/a.png", { alt: "shot", width: 700 })).toBe(
       '<img width="700" alt="shot" src="https://x.test/a.png">',
     );
+  });
+});
+
+describe("buildUploadMarkdown", () => {
+  it("falls through to image markdown when a URL is present", () => {
+    expect(buildUploadMarkdown("https://x.test/a.png", { alt: "shot", key: "gh/a.png" })).toBe(
+      "![shot](https://x.test/a.png)",
+    );
+  });
+
+  it("falls through to the img-width form when width is set", () => {
+    expect(
+      buildUploadMarkdown("https://x.test/a.png", { alt: "shot", width: 700, key: "gh/a.png" }),
+    ).toBe('<img width="700" alt="shot" src="https://x.test/a.png">');
+  });
+
+  it("returns a plain-text fallback naming the key when url is null", () => {
+    const markdown = buildUploadMarkdown(null, { alt: "shot", key: "gh/a.png" });
+    expect(markdown).toContain("`gh/a.png`");
+    expect(markdown).toContain("no public URL");
+  });
+
+  it("returns a plain-text fallback naming the key when url is undefined", () => {
+    const markdown = buildUploadMarkdown(undefined, { alt: "shot", key: "gh/a.png" });
+    expect(markdown).toContain("`gh/a.png`");
+    expect(markdown).toContain("no public URL");
   });
 });


### PR DESCRIPTION
## What

Four independent fixes from a code audit, bundled as one reviewable batch:

- **Teardown clears the usage ledger** — `teardownWorkspace` now deletes a workspace's `workspace_usage` and `delete_usage_claims` rows alongside file metadata and galleries. Previously a re-registered slug inherited the prior tenant's byte/upload counters, and `/admin/metrics` kept summing deleted tenants.
- **Retention purge clears file metadata** — `purgeExpiredObjects` deletes the `file_metadata` rows for each batch of expired objects it removes, so `find`/search and facets stop surfacing keys whose objects are gone.
- **CLI: no more `![…](null)`** — on workspaces without a public base URL (signed-URLs-only), put/attach/screenshot markdown now degrades to a plain-text note naming the uploaded key instead of a broken image embed. Ships with a patch changeset.
- **Stripe lifecycle handler tests** — the four subscription callbacks (complete/update/cancel/deleted → `syncWorkspacePlan`) are extracted into an exported factory (pure refactor, bodies unchanged) and unit-tested, including the period-end-cancel guard that must NOT downgrade immediately.

## Why

The two D1 leaks compound quietly on any workspace that gets deleted or has retention enabled; the CLI bug pastes visibly broken markdown into customer PRs; and the Stripe callbacks were the last untested link in the paid plan-flip path.

## How

- `deleteUsageForWorkspace` (usage.ts) — batched parameterized deletes, called in teardown's fail-safe ordering before the KV record is removed; soft delete still preserves the ledger by design.
- `deleteFileMetadataForKeys` (file-metadata.ts) — chunked placeholder-list delete (same convention as `getMetadataForKeys`), invoked per delete batch inside the purge's `flush()`.
- `buildUploadMarkdown` (embed.ts) — null-safe wrapper over `buildMarkdown`; both CLI call sites drop their `!` assertions.
- `subscriptionLifecycleHandlers` (stripe-plugin.ts) — injectable `sync` parameter so tests record calls without module mocking; spread back into `stripePluginOrNone`.

## Tests

- New: teardown usage cleanup (3 cases, real-SQLite D1 incl. tombstone path), retention metadata purge (cross-workspace and no-op cases), `buildUploadMarkdown` (4 cases), Stripe lifecycle handlers (7 cases).
- Two pre-existing suites (`retention-sweep`, `admin-workspace-delete`) gained the usage-table migrations in their fixture lists — teardown now touches those tables.
- Full run: 270 files / 3,798 tests pass; typecheck and lint/format clean.

## Notes for reviewers

- The teardown/purge changes only stop new leaks; no backfill of already-orphaned rows is included (operator decision).
- `PutResult.url` is still typed `string` though it's `null` at runtime on signed-only workspaces — widening it is deferred as a separate cleanup.
