### PR TITLE
chore: upgrade TypeScript to 7.0.2 across the workspace

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10",
     "wrangler": "^4.110.0"
   }

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10",
     "wrangler": "^4.110.0"
   }

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10",
     "wrangler": "^4.107.0"
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "portless": "^0.15.4",
     "prettier": "^3.9.6",
     "prettier-plugin-astro": "^0.14.1",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },
   "engines": {

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/comment-config/package.json
+++ b/packages/comment-config/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260706.1",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,7 @@
     "src/styles.css"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly --outDir dist",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
@@ -40,12 +40,13 @@
     "lucide-react": "^1.24.0"
   },
   "devDependencies": {
+    "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "files-sdk": "^2.1.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tsup": "^8.3.5",
-    "typescript": "^5.6.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -12,7 +12,8 @@
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "tsup.config.ts"]
 }

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -10,7 +10,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: { index: "src/index.ts" },
   format: ["esm"],
-  dts: true,
+  dts: false,
   clean: true,
   sourcemap: false,
   external: ["react", "react-dom", "react/jsx-runtime"],

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -56,7 +56,7 @@
     "@types/node": "^26.1.0",
     "ai": "^6.0.0",
     "files-sdk": "^2.1.0",
-    "typescript": "^6.0.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -76,8 +76,8 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -119,8 +119,8 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -156,8 +156,8 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -223,8 +223,8 @@ importers:
   packages/billing:
     devDependencies:
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -239,8 +239,8 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -248,8 +248,8 @@ importers:
   packages/email:
     devDependencies:
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -257,8 +257,8 @@ importers:
   packages/errors:
     devDependencies:
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -282,8 +282,8 @@ importers:
         specifier: ^5.20260706.1
         version: 5.20260706.1
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -294,6 +294,9 @@ importers:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
     devDependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -311,10 +314,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.16)(typescript@7.0.2)(yaml@2.9.0)
       typescript:
-        specifier: ^5.6.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   packages/uploads:
     dependencies:
@@ -350,8 +353,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(patch_hash=57a4c6844f6cf84f59a13a9b4fa985a581268201df8fb080f83425a21c894831)(@aws-sdk/client-s3@3.1080.0)(@aws-sdk/s3-presigned-post@3.1080.0)(@aws-sdk/s3-request-presigner@3.1080.0)(@opentelemetry/api@1.9.1)(ai@6.0.220(zod@4.4.3))(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.0)(rollup@4.62.2)(terser@5.49.0)(yaml@2.9.0))(h3@1.15.11)(hono@4.12.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0))
@@ -5419,11 +5422,6 @@ packages:
   typescript-auto-import-cache@0.3.6:
     resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -7315,6 +7313,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -7765,7 +7770,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.4':
@@ -10679,7 +10684,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(postcss@8.5.16)(typescript@7.0.2)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -10700,7 +10705,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.16
-      typescript: 5.9.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -10719,8 +10724,6 @@ snapshots:
   typescript-auto-import-cache@0.3.6:
     dependencies:
       semver: 7.8.5
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
## What

Moves 11 of 12 workspace packages to **TypeScript 7.0.2**, the native Go compiler. `apps/web` is the sole holdout, for a reason upstream controls.

Typecheck on `apps/api` drops from ~2.2s to ~1.1s. The wins are modest at this repo's size; the real value is being on the supported line before the ecosystem moves.

## The constraint that shapes this PR

TypeScript 7's npm package **no longer ships the JS compiler API**. Its main export is just `lib/version.cjs`:

```js
exports.version = version;
exports.versionMajorMinor = "7.0";
```

`ts.createProgram`, `ts.sys`, and the language service now live behind `typescript/unstable/*`. Any tool that does `import ts from "typescript"` and calls compiler APIs breaks at runtime. Using `tsc` as a CLI is fully supported — only the JS-API import path is affected.

Two packages used such tools. Each was handled on its merits rather than pinned by default.

### `packages/ui` — upgraded (build tool changed)

Nothing about this package required an old TypeScript; only tsup's `dts: true` did, since it generates declarations through `rollup-plugin-dts`. `tsc` emits declarations directly, so tsup now builds only the JS bundle:

```
build: "tsup" → "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly --outDir dist"
dts:   true   → false
```

This also lifts the package off a stale `5.6.3` pin, two majors behind the rest of the repo.

Declaration output changes from one bundled `index.d.ts` to per-file `.d.ts` (12 files). `astro check` resolves them cleanly — 150 files, 0 errors.

### `apps/web` — stays on `^6.0.3`

`@astrojs/check@0.9.10` (latest) declares a peer of `typescript: "^5.0.0 || ^6.0.0"`. TS7 is excluded upstream, so this is not a version lag a bump can fix.

Workarounds were tested, not assumed:

- **`astro build` works on TS7** (exit 0) — it runs through esbuild/vite and never touches the TS API. Only `astro check` breaks.
- **Aliasing a second TypeScript** fails: pnpm resolves a peer dep from the host package, so `@astrojs/check` would still receive 7. It would require a real `typescript@6` plus an alias whose `tsc` bin collides in `.bin`, invoked by absolute path.

The payoff wouldn't justify that complexity anyway. `tsconfig.worker.json` — web's only direct `tsc` use — covers **4 files**; `astro check` covers **149**. Upgrading would speed up 4 files and break type coverage on 149.

Tracked in #610 — revisit when Astro ships TS7 support; it becomes a one-line change.

## Behavior changes encountered

TypeScript 7 rejects an inferred `rootDir` (`TS5011`), so the declaration emit needs it explicitly. This is the only TS7-specific code change in the PR.

## Incidental fix

`packages/ui/tsup.config.ts` imports `node:fs` but sat outside every tsconfig `include`, so it had no program and type-aware lint on it failed. This predates this PR — the original file fails identically — and surfaced only because the file is touched here.

Fixed by splitting the config: `tsconfig.json` now covers `src` plus `tsup.config.ts` (typecheck + lint), and a new `tsconfig.build.json` carries `rootDir` for the emit. `@types/node` added at `^26.1.0`, matching the six other packages. Net effect: `tsup.config.ts` is now typechecked, where before it wasn't.

## Verification

| Check | Result |
|---|---|
| `pnpm typecheck` (13 projects) | exit 0 |
| `astro check` | 150 files, 0 errors |
| `pnpm test` | 270 files, 3798 tests passed |
| `pnpm build` (web) | exit 0 |
| `pnpm check` (lint + format) | exit 0 |
| CLI build (`@buildinternet/uploads`) | exit 0, valid `.d.ts` |

A sweep for other fallout found none: no first-party `typescript` imports anywhere, all tsconfigs already on `module: ESNext` + `moduleResolution: bundler` with none of the options TS7 removed, no version pinned in CI, and no docs stating a version.

## No changeset

`typescript` is a devDependency and doesn't affect the published CLI's runtime tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript tooling across the project for improved compatibility and development support.
  * Refined UI package build configuration to produce type declarations more consistently.
  * Improved type-checking coverage for UI build-related files.
  * Updated Node.js type definitions used during UI development.

* **Developer Experience**
  * Enhanced reliability and consistency of development and package build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
