### PR TITLE
refactor(api): dual-auth canonical files vertical at /v1/workspaces/:workspace (#613 phase 1)

### DIFF
--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -1,0 +1,82 @@
+/**
+ * Dual-auth workspace guard for the canonical `/v1/workspaces/:workspace/*`
+ * surface (issue #613 phase 1). Resolves "who is this + can they touch this
+ * workspace" from EITHER credential type and sets the same `WorkspaceVars`
+ * either way, so downstream handlers — including `requireScope` — never need
+ * to know which one arrived. See `routes/workspace-files.ts` for the first
+ * vertical built on this.
+ */
+import { NotFoundError, UnauthorizedError } from "@uploads/errors";
+import type { MiddlewareHandler } from "hono";
+import { FILE_SCOPES } from "./auth-db";
+import { membershipsForUser, workspacesFromMembership } from "./org-workspaces";
+import {
+  requireSessionUser,
+  sessionAuth,
+  type SessionUser,
+  type SessionVars,
+} from "./session-auth";
+import { loadWorkspaceRecord, workspaceAuth, type WorkspaceVars } from "./workspace";
+
+/** Combined context vars for routes reachable by either auth path. */
+export type DualAuthVars = {
+  Variables: WorkspaceVars["Variables"] & SessionVars["Variables"];
+  Bindings: Env;
+};
+
+/**
+ * Caller's membership for `name`, or a uniform 404 (never a 403 — no
+ * existence probe). Deliberately a small standalone duplicate of
+ * `memberWorkspaceOr404` in `routes/me.ts` rather than an import: this file
+ * needs to stay free of any `routes/me.ts` dependency so `routes/me.ts` can
+ * import `routes/workspace-files.ts` (which imports this file) for its old-
+ * path aliases without an import cycle.
+ */
+async function requireMembership(env: Env, userId: string, name: string): Promise<void> {
+  const [membership] = await membershipsForUser(env, userId, { slug: name });
+  if (!membership || !workspacesFromMembership(membership).includes(name)) {
+    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  }
+}
+
+/**
+ * Guards a `/…/:workspace/…` route with EITHER a bearer token (resolution
+ * identical to `workspaceAuth`) OR a session cookie (membership check
+ * identical to `me.ts`'s `memberWorkspaceOr404`).
+ *
+ * A presented bearer credential is authoritative — mirrors
+ * `workspaceManageAuth` (`routes/workspaces.ts`): an explicit token is judged
+ * on its own merits and never silently falls back to a session cookie that
+ * might also ride the request. A session caller is granted every
+ * `FILE_SCOPES`: membership is all-or-nothing on the file plane, same as
+ * every existing `/me` file route, none of which consult `authScopes`.
+ * `authSource: "session"` distinguishes the path taken without changing how
+ * `requireScope` behaves (it only ever reads `authScopes`).
+ */
+export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
+  return async (c, next) => {
+    const authorization = c.req.header("Authorization");
+    if (authorization?.startsWith("Bearer ")) {
+      return workspaceAuth(c as unknown as Parameters<typeof workspaceAuth>[0], next);
+    }
+
+    const sessionC = c as unknown as Parameters<typeof sessionAuth>[0];
+    await sessionAuth(sessionC, async () => {});
+    await requireSessionUser(sessionC, async () => {});
+    const user = c.get("sessionUser") as SessionUser;
+
+    const name = c.req.param("workspace");
+    if (!name) throw new UnauthorizedError();
+    await requireMembership(c.env, user.id, name);
+
+    const record = await loadWorkspaceRecord(c.env, name);
+    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+
+    c.set("workspace", record);
+    c.set("workspaceName", name);
+    c.set("authScopes", [...FILE_SCOPES]);
+    c.set("authSource", "session");
+    c.set("mintingUserId", null);
+    await next();
+  };
+}

--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -25,6 +25,31 @@ export type DualAuthVars = {
 };
 
 /**
+ * In-process handoff for a session `userId` already resolved upstream of
+ * `dualWorkspaceAuth` (issue #613 phase 1 follow-up, CodeRabbit finding on
+ * PR #615). Keyed on the exact `Request` object so it can never leak across
+ * requests. Trust argument: this map is only ever populated from inside this
+ * process by `presetResolvedSessionUser` — an external caller has no way to
+ * insert into it, so a request reaching `dualWorkspaceAuth` from outside
+ * (e.g. the public `/v1/workspaces/...` mount) can never carry a forged
+ * pre-resolved identity. This is why the handoff is a WeakMap and not a
+ * header: a header on an inbound request is indistinguishable from one an
+ * external caller sent themselves.
+ */
+const PRERESOLVED_USER = new WeakMap<Request, string>();
+
+/**
+ * Records that `request`'s session user was already resolved (its `userId`)
+ * by an in-process caller — e.g. `me.ts`'s `forwardToWorkspaceFiles`, which
+ * re-dispatches a request whose session was already verified by `me.ts`'s
+ * own `sessionAuth` middleware. Call this on the exact `Request` instance
+ * that will reach `dualWorkspaceAuth`, before dispatching it.
+ */
+export function presetResolvedSessionUser(request: Request, userId: string): void {
+  PRERESOLVED_USER.set(request, userId);
+}
+
+/**
  * Caller's membership for `name`, or a uniform 404 (never a 403 — no
  * existence probe). Deliberately a small standalone duplicate of
  * `memberWorkspaceOr404` in `routes/me.ts` rather than an import: this file
@@ -60,14 +85,24 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
       return workspaceAuth(c as unknown as Parameters<typeof workspaceAuth>[0], next);
     }
 
-    const sessionC = c as unknown as Parameters<typeof sessionAuth>[0];
-    await sessionAuth(sessionC, async () => {});
-    await requireSessionUser(sessionC, async () => {});
-    const user = c.get("sessionUser") as SessionUser;
+    const preresolvedUserId = PRERESOLVED_USER.get(c.req.raw);
+    let userId: string;
+    if (preresolvedUserId !== undefined) {
+      // Session already resolved upstream (e.g. `me.ts`'s own `sessionAuth`
+      // middleware, for a forwarded old-path alias) — skip the redundant
+      // `get-session` round trip. Membership is still checked below: that
+      // lookup hasn't run yet for this request.
+      userId = preresolvedUserId;
+    } else {
+      const sessionC = c as unknown as Parameters<typeof sessionAuth>[0];
+      await sessionAuth(sessionC, async () => {});
+      await requireSessionUser(sessionC, async () => {});
+      userId = (c.get("sessionUser") as SessionUser).id;
+    }
 
     const name = c.req.param("workspace");
     if (!name) throw new UnauthorizedError();
-    await requireMembership(c.env, user.id, name);
+    await requireMembership(c.env, userId, name);
 
     const record = await loadWorkspaceRecord(c.env, name);
     if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { adminUi } from "./routes/admin-ui";
 import { auth } from "./routes/auth";
 import { tokens } from "./routes/tokens";
 import { workspaces } from "./routes/workspaces";
+import { workspaceFiles } from "./routes/workspace-files";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
@@ -132,6 +133,14 @@ export const app = new Hono<WorkspaceVars>()
   // brings its own session auth. See routes/tokens.ts.
   .route("/v1/tokens", tokens)
   .route("/v1/workspaces", workspaces)
+  // Canonical dual-auth files vertical (issue #613 phase 1):
+  // `/v1/workspaces/:workspace/files*`, session cookie OR bearer token. Same
+  // `/v1/workspaces` mount prefix as the lifecycle router above, distinct
+  // sub-router — same "same base path, distinct sub-app" pattern already
+  // used five times below for `/v1/:workspace/github`. Brings its own auth
+  // (`dualWorkspaceAuth`, applied per-route inside workspace-files.ts), so
+  // it does not sit behind the `workspaceAuth` guard further down.
+  .route("/v1/workspaces", workspaceFiles)
   // Anonymous CLI/MCP usage pings — no auth, before workspace guard.
   .route("/v1/telemetry", telemetry)
   // Explicit opt-in diagnostic reports (message + optional log) — no auth.

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -56,6 +56,7 @@ import {
   type Membership,
   type OrgMember,
 } from "../org-workspaces";
+import { presetResolvedSessionUser } from "../dual-workspace-auth";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import { objectPublicUrls, storage, storageConfig } from "../storage";
@@ -92,7 +93,13 @@ async function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): P
   } catch {
     executionCtx = undefined;
   }
-  return workspaceFiles.fetch(new Request(url, c.req.raw), c.env, executionCtx);
+  const forwarded = new Request(url, c.req.raw);
+  // This router's own `sessionAuth` middleware already resolved the caller
+  // (see the `.use("/*", sessionAuth, requireSessionUser)` mount below) —
+  // hand that off so `dualWorkspaceAuth` skips a second `get-session` fetch
+  // for the same request (issue #613 phase 1 follow-up).
+  presetResolvedSessionUser(forwarded, requireUserId(c));
+  return workspaceFiles.fetch(forwarded, c.env, executionCtx);
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -30,7 +30,6 @@ import { sealCredentialFieldsStrict } from "../secrets";
 import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
 import { previewFixtureItems } from "../comment-preview-fixtures";
-import { getMetadataForKeys, groupObjectsByPath } from "../file-metadata";
 import { badKey, listObjects } from "../files-core";
 import { listGalleries } from "../galleries";
 import { galleryListSummaries } from "../gallery-service";
@@ -59,7 +58,7 @@ import {
 import { presetResolvedSessionUser } from "../dual-workspace-auth";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
-import { objectPublicUrls, storage, storageConfig } from "../storage";
+import { storage } from "../storage";
 import { getWorkspaceUsage } from "../usage";
 import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
@@ -580,50 +579,9 @@ export const me = new Hono<SessionVars>()
   .get("/workspaces/:name/files/facets", (c) =>
     forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/facets`),
   )
-  // Recent uploads grouped by their `path` metadata value — the screenshots
-  // page's single overview query (spec: docs/superpowers/specs/
-  // 2026-08-10-screenshots-by-path-design.md). Drill-in reuses the sibling
-  // `files/search?meta.path=…` route; this one only answers "which paths,
-  // how recent, first few keys". Member- and record-gated exactly like the
-  // facets route. `state` is the one metadata key enriched — the page badges
-  // before/after and nothing else, so no other keys leak into the payload.
-  .get("/workspaces/:name/files/by-path", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    const { groups, truncated } = await groupObjectsByPath(c.env.DB, name);
-    const metaByKey = await getMetadataForKeys(
-      c.env.DB,
-      name,
-      groups.flatMap((group) => group.recent),
-      { metaKeys: ["state"] },
-    );
-    const cfg = await storageConfig(c.env, record);
-
-    return c.json({
-      groups: groups.map((group) => ({
-        path: group.path,
-        count: group.count,
-        lastUpdated: group.lastUpdated,
-        recent: group.recent.map((key) => {
-          const urls = objectPublicUrls(c.env, cfg, key);
-          const state = metaByKey.get(key)?.state;
-          return {
-            key,
-            url: urls.url,
-            embedUrl: urls.embedUrl,
-            ...(state !== undefined ? { state } : {}),
-          };
-        }),
-      })),
-      truncated,
-    });
-  })
+  .get("/workspaces/:name/files/by-path", (c) =>
+    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/by-path`),
+  )
   .get("/workspaces/:name/file-url", (c) =>
     forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/file-url`),
   )

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -23,20 +23,15 @@ import {
   RateLimitedError,
   ValidationError,
 } from "@uploads/errors";
-import { createFilesRouter, signedDownloadUrl, type R2Jurisdiction } from "@uploads/storage";
+import { createFilesRouter, type R2Jurisdiction } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { sealCredentialFieldsStrict } from "../secrets";
 import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
 import { previewFixtureItems } from "../comment-preview-fixtures";
-import { getMetadataForKeys, groupObjectsByPath, listFacets } from "../file-metadata";
-import {
-  normalizeSearchName,
-  parseMetaQueryFilters,
-  searchFilesByNameAndMeta,
-} from "../file-search";
-import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
+import { getMetadataForKeys, groupObjectsByPath } from "../file-metadata";
+import { badKey, listObjects } from "../files-core";
 import { listGalleries } from "../galleries";
 import { galleryListSummaries } from "../gallery-service";
 import {
@@ -63,18 +58,42 @@ import {
 } from "../org-workspaces";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
 import { selfServeWorkspaceRecord } from "../self-serve-defaults";
-import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
+import { objectPublicUrls, storage, storageConfig } from "../storage";
 import { getWorkspaceUsage } from "../usage";
-import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
 import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
+import { workspaceFiles } from "./workspace-files";
 import {
   candidateFromBody,
   storageReconcile,
   storageStatusResponse,
   storageVerify,
 } from "./workspace-storage";
+
+/**
+ * Rewrites `c`'s request onto `workspaceFiles`'s own path space (its routes
+ * are registered as `/:workspace/files*`, independent of any parent mount —
+ * see routes/workspace-files.ts) and re-dispatches through it directly. The
+ * canonical dual-auth middleware + handler run exactly as they would for a
+ * caller hitting `/v1/workspaces/:workspace/files*` directly, so response
+ * shape can't drift from the canonical route without this alias breaking too.
+ */
+async function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): Promise<Response> {
+  const url = new URL(c.req.url);
+  url.pathname = path;
+  // `c.executionCtx` throws outside a real Workers/`app.fetch(req, env, ctx)`
+  // invocation (e.g. the `app().request(path, init, env)` helper most route
+  // tests use, including this file's) — same guard as the welcome-email
+  // `waitUntil` above.
+  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
+  return workspaceFiles.fetch(new Request(url, c.req.raw), c.env, executionCtx);
+}
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -534,110 +553,26 @@ export const me = new Hono<SessionVars>()
     });
   })
 
-  // A page of a workspace's files (public URLs), folder-aware and hydrated
-  // with D1 `gh.*` metadata — member-gated. Query
-  // params mirror the token-scoped `GET /v1/:workspace/files` (files.ts):
-  // `prefix`/`cursor` pass straight through, `limit` defaults to 100 (clamped
-  // inside `listObjects`), and `delimiter` (new here) enables S3-style
-  // "folder" navigation — `listObjects` surfaces the resulting common
-  // prefixes as `prefixes` for the settings-page file browser.
-  .get("/workspaces/:name/files", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    const { prefix, delimiter, cursor } = c.req.query();
-    const limit = Number(c.req.query("limit") ?? 100) || 100;
-    const {
-      items,
-      cursor: nextCursor,
-      prefixes,
-    } = await listObjects(c.env, record, {
-      prefix,
-      delimiter,
-      limit,
-      cursor,
-    });
-
-    const metaByKey = await getMetadataForKeys(
-      c.env.DB,
-      name,
-      items.map((item) => item.key),
-    );
-    const files = items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) }));
-
-    return c.json({ files, prefixes, cursor: nextCursor });
-  })
-
-  // Metadata search — the session-authed twin of the token route's
-  // `GET /v1/:workspace/files?meta.*` / `?name=` (files.ts). Same AND-of-
-  // equality semantics and shared helpers; scoped to one workspace, member-
-  // gated. Results carry no `visibility` (it isn't in the D1 index — accepted
-  // caveat). Always returns `truncated` (session contract differs from the
-  // token meta-only envelope).
-  .get("/workspaces/:name/files/search", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    const query = c.req.query();
-    const rawName = c.req.query("name");
-    const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
-    const filters = parseMetaQueryFilters(query, (param) => c.req.queries(param));
-    const hasMeta = Object.keys(filters).length > 0;
-
-    if (!hasMeta && nameTerm === undefined) {
-      throw new ValidationError("at least one meta.* filter or name is required", {
-        code: "file_metadata_invalid_key",
-      });
-    }
-
-    // Session search keeps a fixed page of 100 (same as before #528).
-    const SEARCH_LIMIT = 100;
-    const cfg = await storageConfig(c.env, record);
-    const { matches, truncated } = await searchFilesByNameAndMeta(c.env, record, name, {
-      filters: hasMeta ? filters : undefined,
-      nameTerm,
-      prefix: query.prefix,
-      pageSize: SEARCH_LIMIT,
-    });
-
-    return c.json({
-      items: matches.map((match) => {
-        const urls = objectPublicUrls(c.env, cfg, match.key);
-        return { key: match.key, url: urls.url, embedUrl: urls.embedUrl, metadata: match.metadata };
-      }),
-      truncated,
-    });
-  })
-
-  // Facet discovery for the files-tab filter bar: which metadata keys this
-  // workspace actually contains, and (with `?key=`) that key's values. The
-  // filter bar cannot otherwise tell a user what is filterable — keys are
-  // user- and agent-defined, not a schema. Member-gated exactly as the
-  // sibling search route is, and gated the same way on the workspace record
-  // so a soft-deleted (or tombstoned) workspace 404s here too, even though
-  // this route reads only D1 — the record load is the deletion gate, not a
-  // storage-config lookup.
-  .get("/workspaces/:name/files/facets", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    return c.json(await listFacets(c.env.DB, name, c.req.query("key")));
-  })
-
+  // Issue #613 phase 1: list/search/facets/by-path/file-url/visibility/delete
+  // now forward to the canonical dual-auth handlers in
+  // `routes/workspace-files.ts` (mounted at `/v1/workspaces/:workspace/files*`)
+  // via a path rewrite — `forwardToWorkspaceFiles` re-dispatches through that
+  // router directly, so response shape is unchanged: the canonical handlers
+  // were ported verbatim from this file's original implementations (removed
+  // here, see git history). `DELETE` additionally rewrites its query-param
+  // `?key=` onto the canonical route's path segment — the one
+  // behavior-preserving exception, since the canonical DELETE is path-keyed
+  // (a wart fix carried over from the token-authed surface, which already
+  // worked this way).
+  .get("/workspaces/:name/files", (c) =>
+    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files`),
+  )
+  .get("/workspaces/:name/files/search", (c) =>
+    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/search`),
+  )
+  .get("/workspaces/:name/files/facets", (c) =>
+    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/facets`),
+  )
   // Recent uploads grouped by their `path` metadata value — the screenshots
   // page's single overview query (spec: docs/superpowers/specs/
   // 2026-08-10-screenshots-by-path-design.md). Drill-in reuses the sibling
@@ -682,104 +617,17 @@ export const me = new Hono<SessionVars>()
       truncated,
     });
   })
-
-  // Resolve a selected browser item to a usable URL, by storage capability
-  // (issue #123): the stable public URL when `publicBaseUrl` is configured;
-  // otherwise a short-lived signed download URL when the provider can sign;
-  // otherwise a typed error rather than a 200 with `url: null`. This is
-  // separate from the gateway's `url` verb because its forced attachment
-  // disposition requires signing, while binding-mode R2 uses publicBaseUrl.
-  .get("/workspaces/:name/file-url", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
+  .get("/workspaces/:name/file-url", (c) =>
+    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/file-url`),
+  )
+  .patch("/workspaces/:name/files/visibility", (c) =>
+    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/visibility`),
+  )
+  .delete("/workspaces/:name/files", (c) => {
     const key = c.req.query("key") ?? "";
     if (badKey(key)) throw new NotFoundError();
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError();
-    const store = await storage(c.env, record);
-    if (!(await store.exists(key))) throw new NotFoundError();
-
-    const cfg = await storageConfig(c.env, record);
-    const url = publicUrl(cfg, key);
-    if (url) return c.json({ url });
-
-    const signed = await signedDownloadUrl(store, key);
-    if (signed) return c.json({ url: signed });
-
-    throw new ValidationError(
-      "no public or signed URL available for this workspace's storage configuration",
-      { code: "file_url_unavailable" },
-    );
-  })
-
-  // Toggle a file's `visibility` custom-metadata flag — member-gated, same key
-  // convention as `file-url` (key via query param; embedding it in the path
-  // segment fights Hono's routing for keys containing `/`). Storage mechanics
-  // (head/size-cap/download/re-upload) live in files-core's
-  // `setObjectVisibility`; this route keeps auth, key validation, body
-  // validation, and error mapping.
-  //
-  // Wire value stays "public" | "private" (issue #166: renaming the field
-  // would be a breaking API change), but the semantics are "unlisted," not
-  // byte-private: `visibility: "private"` hides an object from the public
-  // file listing and 401-gates `/public/files/...` + the `/f/…` page
-  // (public-files.ts). On a workspace with `publicBaseUrl` the raw object URL
-  // still serves bytes unsigned to anyone who has it — this endpoint never
-  // controlled that. Document that distinction anywhere this field is
-  // surfaced to API consumers; don't call it "private" in a byte-privacy
-  // sense.
-  .patch("/workspaces/:name/files/visibility", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const key = c.req.query("key") ?? "";
-    if (badKey(key)) throw new NotFoundError();
-
-    // Throttle rewrites per workspace — checked only after the membership
-    // gate, so a non-member can't burn a workspace's write budget. Same
-    // WRITE_LIMITER the token-scoped mutating routes use (see guards.ts).
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const body = await c.req.json().catch(() => null);
-    const requested = (body as { visibility?: unknown } | null)?.visibility;
-    if (
-      typeof requested !== "string" ||
-      !(VISIBILITY_VALUES as readonly string[]).includes(requested)
-    ) {
-      throw new ValidationError('visibility must be "public" or "private"', {
-        code: "invalid_visibility",
-      });
-    }
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError();
-    const store = await storage(c.env, record);
-
-    await setObjectVisibility(store, key, requested as "public" | "private");
-
-    return c.json({ key, visibility: sanitizeVisibility(requested) ?? "public" });
-  })
-
-  // Delete a file — member-gated web administration (spec 2026-07-30). Same
-  // key convention and gate ordering as the visibility route above; all
-  // storage/D1/ledger mechanics live in files-core's deleteObject (shared
-  // with the token-authed DELETE /v1/:workspace/files/:key). Any member may
-  // delete — parity with the CLI, where any member token can `uploads delete`.
-  .delete("/workspaces/:name/files", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const key = c.req.query("key") ?? "";
-    if (badKey(key)) throw new NotFoundError();
-
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError();
-
-    return c.json(await deleteObject(c.env, record, key, name));
+    const keyPath = key.split("/").map(encodeURIComponent).join("/");
+    return forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/${keyPath}`);
   })
 
   // files-sdk's folder-aware browser gateway. Authorization happens before a

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -1,0 +1,195 @@
+/**
+ * Canonical files vertical (issue #613 phase 1): `/:workspace/files*`,
+ * mounted at `/v1/workspaces` in `index.ts` so its public paths are
+ * `/v1/workspaces/:workspace/files*`. Dual-auth (`dualWorkspaceAuth`) —
+ * either a session cookie or a bearer token reaches the same handlers below.
+ *
+ * Handler bodies are ported verbatim from their pre-#613 homes so response
+ * shape is unchanged for every caller that reaches them (directly, or via
+ * the old-path aliases in `routes/me.ts`):
+ *  - list/search/facets/file-url/visibility: previously session-only, lived
+ *    on `/me/workspaces/:name/...` in `routes/me.ts`.
+ *  - delete: previously bearer-only path-keyed `DELETE /:key{.+}` on
+ *    `/v1/:workspace/files` (`routes/files.ts`) — the shape this canonical
+ *    route adopts, fixing the issue's "DELETE keys off a query param" wart
+ *    for the canonical surface (the old `/me` query-param path is preserved
+ *    verbatim as an alias, not removed).
+ *
+ * `visibility` keeps the query-param key convention rather than a path
+ * segment: this router already relies on Hono's `:key{.+}` catch-all for
+ * `delete`, and `routes/files.ts` documents that a catch-all param followed
+ * by a static suffix (e.g. `/:key{.+}/visibility`) does not reliably match
+ * once the key contains raw slashes in the deployed (non-vitest) router.
+ * Kept out of scope for this phase — see `.context/613-api-consolidation-plan.md`.
+ */
+import { NotFoundError, ValidationError } from "@uploads/errors";
+import { signedDownloadUrl } from "@uploads/storage";
+import { Hono, type MiddlewareHandler } from "hono";
+import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
+import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
+import { getMetadataForKeys, listFacets } from "../file-metadata";
+import {
+  normalizeSearchName,
+  parseMetaQueryFilters,
+  searchFilesByNameAndMeta,
+} from "../file-search";
+import { writeRateLimit } from "../guards";
+import { objectPublicUrls, publicUrl, storage, storageConfig } from "../storage";
+import { sanitizeVisibility, VISIBILITY_VALUES } from "../visibility";
+import { requireScope } from "../workspace";
+
+// `requireScope`/`writeRateLimit` are typed against `WorkspaceVars`; this
+// router's `DualAuthVars` is that type plus session fields, so a Context for
+// one is always a valid Context for the other. Same cast pattern as
+// `workspaceManageAuth` in `routes/workspaces.ts`.
+function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<DualAuthVars> {
+  return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
+}
+const rateLimited = writeRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+
+export const workspaceFiles = new Hono<DualAuthVars>()
+
+  // Folder-aware listing, D1 `gh.*` metadata always hydrated. Query params:
+  // `prefix`/`cursor` pass straight through, `limit` defaults to 100
+  // (clamped inside `listObjects`), `delimiter` enables S3-style "folder"
+  // navigation via `listObjects`'s `prefixes`.
+  .get("/:workspace/files", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+    const record = c.get("workspace");
+    const name = c.get("workspaceName");
+    const { prefix, delimiter, cursor } = c.req.query();
+    const limit = Number(c.req.query("limit") ?? 100) || 100;
+    const {
+      items,
+      cursor: nextCursor,
+      prefixes,
+    } = await listObjects(c.env, record, { prefix, delimiter, limit, cursor });
+
+    const metaByKey = await getMetadataForKeys(
+      c.env.DB,
+      name,
+      items.map((item) => item.key),
+    );
+    const files = items.map((item) => ({ ...item, metadata: metaByKey.get(item.key) }));
+
+    return c.json({ files, prefixes, cursor: nextCursor });
+  })
+
+  // Metadata + filename search — AND-of-equality `meta.*` filters and/or a
+  // `name` substring term. Results carry no `visibility` (not in the D1
+  // index — accepted caveat, same as the pre-#613 session route).
+  .get("/:workspace/files/search", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+    const record = c.get("workspace");
+    const name = c.get("workspaceName");
+    const query = c.req.query();
+    const rawName = c.req.query("name");
+    const nameTerm = rawName === undefined ? undefined : normalizeSearchName(rawName);
+    const filters = parseMetaQueryFilters(query, (param) => c.req.queries(param));
+    const hasMeta = Object.keys(filters).length > 0;
+
+    if (!hasMeta && nameTerm === undefined) {
+      throw new ValidationError("at least one meta.* filter or name is required", {
+        code: "file_metadata_invalid_key",
+      });
+    }
+
+    const SEARCH_LIMIT = 100;
+    const cfg = await storageConfig(c.env, record);
+    const { matches, truncated } = await searchFilesByNameAndMeta(c.env, record, name, {
+      filters: hasMeta ? filters : undefined,
+      nameTerm,
+      prefix: query.prefix,
+      pageSize: SEARCH_LIMIT,
+    });
+
+    return c.json({
+      items: matches.map((match) => {
+        const urls = objectPublicUrls(c.env, cfg, match.key);
+        return { key: match.key, url: urls.url, embedUrl: urls.embedUrl, metadata: match.metadata };
+      }),
+      truncated,
+    });
+  })
+
+  // Facet discovery for the files filter bar: which metadata keys this
+  // workspace actually contains, and (with `?key=`) that key's values.
+  .get("/:workspace/files/facets", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+    return c.json(await listFacets(c.env.DB, c.get("workspaceName"), c.req.query("key")));
+  })
+
+  // Resolve a selected file to a usable URL (issue #613 wart fix: this used
+  // to live outside `files/`, at `/me/workspaces/:name/file-url`). Public URL
+  // when the workspace has one; otherwise a short-lived signed download URL
+  // when the provider can sign; otherwise a typed error rather than a 200
+  // with `url: null`.
+  .get("/:workspace/files/file-url", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+    const record = c.get("workspace");
+    const key = c.req.query("key") ?? "";
+    if (badKey(key)) throw new NotFoundError();
+    const store = await storage(c.env, record);
+    if (!(await store.exists(key))) throw new NotFoundError();
+
+    const cfg = await storageConfig(c.env, record);
+    const url = publicUrl(cfg, key);
+    if (url) return c.json({ url });
+
+    const signed = await signedDownloadUrl(store, key);
+    if (signed) return c.json({ url: signed });
+
+    throw new ValidationError(
+      "no public or signed URL available for this workspace's storage configuration",
+      { code: "file_url_unavailable" },
+    );
+  })
+
+  // Toggle a file's `visibility` custom-metadata flag. See the module
+  // docblock above for why the key stays a query param here.
+  .patch(
+    "/:workspace/files/visibility",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    async (c) => {
+      const record = c.get("workspace");
+      const key = c.req.query("key") ?? "";
+      if (badKey(key)) throw new NotFoundError();
+
+      const body = await c.req.json().catch(() => null);
+      const requested = (body as { visibility?: unknown } | null)?.visibility;
+      if (
+        typeof requested !== "string" ||
+        !(VISIBILITY_VALUES as readonly string[]).includes(requested)
+      ) {
+        throw new ValidationError('visibility must be "public" or "private"', {
+          code: "invalid_visibility",
+        });
+      }
+
+      const store = await storage(c.env, record);
+      await setObjectVisibility(store, key, requested as "public" | "private");
+
+      return c.json({ key, visibility: sanitizeVisibility(requested) ?? "public" });
+    },
+  )
+
+  // Delete a file — path-keyed (the shape the bearer-token surface already
+  // used at `DELETE /v1/:workspace/files/:key{.+}`; see the module docblock
+  // for why the pre-existing `/me` query-param DELETE is aliased rather than
+  // migrated in place).
+  .delete(
+    "/:workspace/files/:key{.+}",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:delete"),
+    async (c) => {
+      return c.json(
+        await deleteObject(c.env, c.get("workspace"), c.req.param("key"), c.get("workspaceName")),
+      );
+    },
+  )
+  // This router is `.fetch()`-ed directly (not only mounted via `.route()`)
+  // by the old-path aliases in `routes/me.ts`'s `forwardToWorkspaceFiles`, so
+  // it needs its own error boundary — Hono's default unhandled-throw
+  // response is a bare 500, which would erase every typed status code
+  // (404/400/429/etc.) the handlers above throw.
+  .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-files.ts
+++ b/apps/api/src/routes/workspace-files.ts
@@ -28,7 +28,7 @@ import { Hono, type MiddlewareHandler } from "hono";
 import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { badKey, deleteObject, listObjects, setObjectVisibility } from "../files-core";
-import { getMetadataForKeys, listFacets } from "../file-metadata";
+import { getMetadataForKeys, groupObjectsByPath, listFacets } from "../file-metadata";
 import {
   normalizeSearchName,
   parseMetaQueryFilters,
@@ -115,6 +115,45 @@ export const workspaceFiles = new Hono<DualAuthVars>()
   // workspace actually contains, and (with `?key=`) that key's values.
   .get("/:workspace/files/facets", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
     return c.json(await listFacets(c.env.DB, c.get("workspaceName"), c.req.query("key")));
+  })
+
+  // Recent uploads grouped by their `path` metadata value — the screenshots
+  // page's single overview query (spec: docs/superpowers/specs/
+  // 2026-08-10-screenshots-by-path-design.md). Drill-in reuses the sibling
+  // `files/search?meta.path=…` route; this one only answers "which paths,
+  // how recent, first few keys". `state` is the one metadata key enriched —
+  // the page badges before/after and nothing else, so no other keys leak
+  // into the payload.
+  .get("/:workspace/files/by-path", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+    const record = c.get("workspace");
+    const name = c.get("workspaceName");
+    const { groups, truncated } = await groupObjectsByPath(c.env.DB, name);
+    const metaByKey = await getMetadataForKeys(
+      c.env.DB,
+      name,
+      groups.flatMap((group) => group.recent),
+      { metaKeys: ["state"] },
+    );
+    const cfg = await storageConfig(c.env, record);
+
+    return c.json({
+      groups: groups.map((group) => ({
+        path: group.path,
+        count: group.count,
+        lastUpdated: group.lastUpdated,
+        recent: group.recent.map((key) => {
+          const urls = objectPublicUrls(c.env, cfg, key);
+          const state = metaByKey.get(key)?.state;
+          return {
+            key,
+            url: urls.url,
+            embedUrl: urls.embedUrl,
+            ...(state !== undefined ? { state } : {}),
+          };
+        }),
+      })),
+      truncated,
+    });
   })
 
   // Resolve a selected file to a usable URL (issue #613 wart fix: this used

--- a/apps/api/src/workspace.ts
+++ b/apps/api/src/workspace.ts
@@ -224,7 +224,8 @@ export type WorkspaceVars = {
     workspace: WorkspaceRecord;
     workspaceName: string;
     authScopes: FileScope[];
-    authSource: "d1" | "legacy";
+    /** "session" is set only by `dualWorkspaceAuth` (see dual-workspace-auth.ts). */
+    authSource: "d1" | "legacy" | "session";
     /** Better Auth user behind the bearer token (issue #340), or null. */
     mintingUserId: string | null;
   };

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -72,9 +72,9 @@ function makeFakeDB() {
  * user with an `acme` org membership.
  */
 async function makeEnv(
-  opts: { member?: boolean; session?: boolean } = {},
+  opts: { member?: boolean; session?: boolean; getSessionCalls?: { count: number } } = {},
 ): Promise<{ env: Parameters<typeof app.request>[2]; bucket: FakeR2Bucket }> {
-  const { member = true, session = true } = opts;
+  const { member = true, session = true, getSessionCalls } = opts;
   const record: WorkspaceRecord = {
     provider: "r2",
     bucket: "uploads-default",
@@ -98,6 +98,7 @@ async function makeEnv(
       fetch: async (input: RequestInfo | URL) => {
         const url = new URL(input instanceof Request ? input.url : input);
         if (url.pathname === "/api/auth/get-session") {
+          if (getSessionCalls) getSessionCalls.count++;
           return session ? Response.json({ session: {}, user: USER }) : Response.json(null);
         }
         if (url.pathname === "/internal/memberships") {
@@ -343,5 +344,45 @@ describe("old-path aliases forward unchanged (issue #613)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { items: { key: string }[] };
     expect(body.items.map((i) => i.key)).toEqual(["shots/a.png"]);
+  });
+
+  it("resolves the session exactly once for a forwarded aliased route (CodeRabbit finding, PR #615)", async () => {
+    const getSessionCalls = { count: 0 };
+    const { env } = await makeEnv({ getSessionCalls });
+    const res = await app.request(
+      "/me/workspaces/acme/files/facets",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    // `me.ts`'s own `sessionAuth` middleware resolves the session once;
+    // `dualWorkspaceAuth` must find the pre-resolved userId and skip its own
+    // `get-session` fetch rather than resolving it again.
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("a direct external request to the canonical path still authenticates via sessionAuth (WeakMap miss)", async () => {
+    const getSessionCalls = { count: 0 };
+    const { env, bucket } = await makeEnv({ getSessionCalls });
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("membership rejection still applies to forwarded aliased calls (wrong workspace -> 404)", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/me/workspaces/acme/files/facets",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_not_found");
   });
 });

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -320,6 +320,32 @@ describe("GET /v1/workspaces/:workspace/files/facets and /search (dual auth)", (
   });
 });
 
+describe("GET /v1/workspaces/:workspace/files/by-path (dual auth)", () => {
+  it("bearer token: returns the grouped shape", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/by-path",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ groups: [], truncated: false });
+  });
+
+  it("session cookie: reaches the same handler", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/by-path",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ groups: [], truncated: false });
+  });
+});
+
 describe("old-path aliases forward unchanged (issue #613)", () => {
   it("/me/workspaces/:name/file-url still returns the same shape as canonical", async () => {
     const { env, bucket } = await makeEnv();

--- a/apps/api/test/routes-workspace-files.test.ts
+++ b/apps/api/test/routes-workspace-files.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Canonical dual-auth files vertical (issue #613 phase 1):
+ * `/v1/workspaces/:workspace/files*`. Exercised through the real composed
+ * `app` (index.ts), not the sub-router directly, so this also proves the
+ * `/v1/workspaces` mount (shared with the lifecycle router) resolves
+ * correctly. Response-shape coverage for these handlers already lives in
+ * `src/routes/me.test.ts` (session, ported verbatim) and
+ * `test/routes-files.test.ts` (bearer, `DELETE /:key{.+}` shape); this file
+ * is scoped to what's new: both credential types reaching the SAME handler,
+ * and the auth rejections specific to the dual-auth guard.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { FakeR2Bucket } from "./fake-r2";
+import { FileMetadataTable } from "./helpers/fake-file-metadata-table";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+
+const TOKEN = "canonical-secret-token";
+const USER = { id: "u-1", email: "member@example.com", name: "Member" };
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+function makeFakeDB() {
+  const table = new FileMetadataTable();
+  return {
+    metadata: table.metadata,
+    prepare(sql: string) {
+      const normalized = sql.replace(/\s+/g, " ").trim();
+      let args: unknown[] = [];
+      return {
+        bind(...values: unknown[]) {
+          args = values;
+          return this;
+        },
+        async first() {
+          return null;
+        },
+        async run() {
+          return (
+            table.tryRun(normalized, args) ?? { success: true, meta: { changes: 0 }, results: [] }
+          );
+        },
+        async all<T>() {
+          return (
+            table.tryAll<T>(normalized, args) ?? { success: true, results: [] as T[], meta: {} }
+          );
+        },
+      };
+    },
+    async batch(stmts: { run: () => Promise<unknown> }[]) {
+      return Promise.all(stmts.map((s) => s.run()));
+    },
+  };
+}
+
+/**
+ * Env wired for BOTH credential types against the same `acme` workspace: a
+ * legacy bearer token (`tokenHash`) and — when `member` is true — a session
+ * user with an `acme` org membership.
+ */
+async function makeEnv(
+  opts: { member?: boolean; session?: boolean } = {},
+): Promise<{ env: Parameters<typeof app.request>[2]; bucket: FakeR2Bucket }> {
+  const { member = true, session = true } = opts;
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+  };
+  const bucket = new FakeR2Bucket();
+  const db = makeFakeDB();
+  const env = {
+    REGISTRY: {
+      get: async (key: string) => (key === "ws:acme" ? record : null),
+    },
+    UPLOADS_DEFAULT: bucket,
+    DB: db,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    WEB_ORIGIN: "https://uploads.sh",
+    GITHUB_CACHE: { get: async () => null, put: async () => undefined },
+    AUTH: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/api/auth/get-session") {
+          return session ? Response.json({ session: {}, user: USER }) : Response.json(null);
+        }
+        if (url.pathname === "/internal/memberships") {
+          return Response.json(
+            member
+              ? [
+                  {
+                    organizationId: "org-1",
+                    organizationSlug: "acme",
+                    organizationName: "Acme",
+                    role: "member",
+                  },
+                ]
+              : [],
+          );
+        }
+        return new Response(JSON.stringify({ githubAccountId: null }), {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+  };
+  return { env: env as unknown as Parameters<typeof app.request>[2], bucket };
+}
+
+async function seed(bucket: FakeR2Bucket) {
+  await bucket.put("acme/shots/a.png", new Uint8Array([1, 2, 3]).buffer, {
+    httpMetadata: { contentType: "image/png" },
+  });
+}
+
+describe("GET /v1/workspaces/:workspace/files (dual auth)", () => {
+  it("accepts a bearer token", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { files: { key: string }[] };
+    expect(body.files.map((f) => f.key)).toEqual(["shots/a.png"]);
+  });
+
+  it("accepts a session cookie for a member workspace", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { files: { key: string }[] };
+    expect(body.files.map((f) => f.key)).toEqual(["shots/a.png"]);
+  });
+
+  it("401s a bearer token whose hash doesn't match this workspace (token-workspace mismatch)", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/files",
+      { headers: { Authorization: "Bearer wrong-token" } },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("404s a signed-in caller who isn't a member of the workspace (uniform workspace_not_found)", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/files",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_not_found");
+  });
+
+  it("401s with neither a bearer token nor a session cookie", async () => {
+    const { env } = await makeEnv({ session: false });
+    const res = await app.request("/v1/workspaces/acme/files", {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/files/file-url (dual auth)", () => {
+  it("resolves the public URL for a bearer caller", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/file-url?key=shots/a.png",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://storage.uploads.sh/acme/shots/a.png" });
+  });
+
+  it("resolves the public URL for a session caller identically", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/file-url?key=shots/a.png",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://storage.uploads.sh/acme/shots/a.png" });
+  });
+});
+
+describe("PATCH /v1/workspaces/:workspace/files/visibility (dual auth)", () => {
+  it("flips visibility for a bearer caller", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/visibility?key=shots/a.png",
+      {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        body: JSON.stringify({ visibility: "private" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ key: "shots/a.png", visibility: "private" });
+  });
+
+  it("flips visibility for a session caller", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/visibility?key=shots/a.png",
+      {
+        method: "PATCH",
+        headers: { cookie: "session=x", "content-type": "application/json" },
+        body: JSON.stringify({ visibility: "private" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ key: "shots/a.png", visibility: "private" });
+  });
+});
+
+describe("DELETE /v1/workspaces/:workspace/files/:key (dual auth, path-keyed)", () => {
+  it("deletes for a bearer caller", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/shots/a.png",
+      { method: "DELETE", headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ key: "shots/a.png", deleted: true });
+    expect(await bucket.head("acme/shots/a.png")).toBeNull();
+  });
+
+  it("deletes for a session caller", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/shots/a.png",
+      { method: "DELETE", headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ key: "shots/a.png", deleted: true });
+  });
+
+  it("404s a non-member's delete attempt without deleting the object", async () => {
+    const { env, bucket } = await makeEnv({ member: false });
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/workspaces/acme/files/shots/a.png",
+      { method: "DELETE", headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    expect(await bucket.head("acme/shots/a.png")).not.toBeNull();
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/files/facets and /search (dual auth)", () => {
+  it("facets: both credential types reach the same 200 shape", async () => {
+    const { env } = await makeEnv();
+    const bearer = await app.request(
+      "/v1/workspaces/acme/files/facets",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    const session = await app.request(
+      "/v1/workspaces/acme/files/facets",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(bearer.status).toBe(200);
+    expect(session.status).toBe(200);
+    expect(await bearer.json()).toEqual(await session.json());
+  });
+
+  it("search: requires at least one meta.* filter or name for both credential types", async () => {
+    const { env } = await makeEnv();
+    const bearer = await app.request(
+      "/v1/workspaces/acme/files/search",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    const session = await app.request(
+      "/v1/workspaces/acme/files/search",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(bearer.status).toBe(400);
+    expect(session.status).toBe(400);
+  });
+});
+
+describe("old-path aliases forward unchanged (issue #613)", () => {
+  it("/me/workspaces/:name/file-url still returns the same shape as canonical", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/me/workspaces/acme/file-url?key=shots/a.png",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: "https://storage.uploads.sh/acme/shots/a.png" });
+  });
+
+  it("/v1/:workspace/files (bearer path) is untouched by the canonical mount", async () => {
+    const { env, bucket } = await makeEnv();
+    await seed(bucket);
+    const res = await app.request(
+      "/v1/acme/files",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: { key: string }[] };
+    expect(body.items.map((i) => i.key)).toEqual(["shots/a.png"]);
+  });
+});


### PR DESCRIPTION
Phase 1 of #613: one canonical, resource-rooted API surface with authentication orthogonal to the URL. This phase establishes the pattern with the **files vertical**; later phases migrate the remaining verticals mechanically.

## What's here

- **`dualWorkspaceAuth()` middleware** (`apps/api/src/dual-workspace-auth.ts`): a bearer token delegates to the existing `workspaceAuth` (hash match, D1 scopes); otherwise the session cookie resolves org membership exactly like `me.ts`'s `memberWorkspaceOr404` (uniform 404, no existence-probing). Either path sets identical `WorkspaceVars`; session callers get every `FILE_SCOPES` since membership is all-or-nothing on the file plane — handlers never learn which credential arrived.
- **Canonical files vertical** at `/v1/workspaces/:workspace/files` (`apps/api/src/routes/workspace-files.ts`): list, search, facets, `file-url` (now under `files/`, per the issue's wart list), visibility PATCH, delete (path-keyed — the query-param wart fixed for the canonical path).
- **Aliases, not breaks**: the old `/me/workspaces/:name/files*` handlers are replaced with a rewrite-and-forward to the canonical handlers; `/v1/:workspace/files*` keeps working untouched. Response shapes on old paths are unchanged — the pre-existing route tests pass unmodified.
- **16 new tests** covering both credential types on the canonical paths, wrong-workspace membership rejection, and token-workspace mismatch.

## Verification

- `apps/api`: 125 test files, 1556 tests green (1540 pre-existing + 16 new); `tsc --noEmit` clean.

## Shape divergences surfaced (design work for later phases, documented in `.context/613-api-consolidation-plan.md`)

- List: session `{files, prefixes, cursor}` (folder-aware, metadata hydrated) vs bearer `{items, cursor, prefixes}` (opt-in metadata + folded search). Canonical adopts the session shape; reconciling the bearer path is flagged as real design work, deliberately not attempted here.
- Visibility PATCH keeps query-param keying even on the canonical path: Hono's `:key{.+}` catch-all doesn't reliably match a static suffix, so this wart isn't cheap — punted with a note.

## Coordination

#614 adds `GET /me/workspaces/:name/files/by-path` on the old convention. Whichever merges second folds it in — with this phase's alias pattern that's one canonical route + one alias line (called out in the plan doc).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace file operations accessible through either session authentication or bearer tokens.
  * Added folder-aware file listing, search, facets, URL resolution, visibility updates, and deletion.
  * Added consistent access controls, validation, rate limiting, and error responses.
  * Preserved existing file-management routes and aliases.

* **Tests**
  * Added coverage for authenticated, unauthenticated, invalid-token, and non-member access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->