### PR TITLE
refactor(api): dual-auth galleries + usage verticals (#613 phase 2)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,8 @@ import { auth } from "./routes/auth";
 import { tokens } from "./routes/tokens";
 import { workspaces } from "./routes/workspaces";
 import { workspaceFiles } from "./routes/workspace-files";
+import { workspaceGalleries } from "./routes/workspace-galleries";
+import { workspaceUsage } from "./routes/workspace-usage";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
@@ -141,6 +143,12 @@ export const app = new Hono<WorkspaceVars>()
   // (`dualWorkspaceAuth`, applied per-route inside workspace-files.ts), so
   // it does not sit behind the `workspaceAuth` guard further down.
   .route("/v1/workspaces", workspaceFiles)
+  // Canonical dual-auth galleries + usage verticals (issue #613 phase 2):
+  // `/v1/workspaces/:workspace/galleries*` and `/v1/workspaces/:workspace/usage*`.
+  // Same "self-contained sub-router, own auth + error boundary" shape as
+  // `workspaceFiles` above.
+  .route("/v1/workspaces", workspaceGalleries)
+  .route("/v1/workspaces", workspaceUsage)
   // Anonymous CLI/MCP usage pings — no auth, before workspace guard.
   .route("/v1/telemetry", telemetry)
   // Explicit opt-in diagnostic reports (message + optional log) — no auth.

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -45,222 +45,260 @@ async function ownerGallery(c: Context<WorkspaceVars>, id: string) {
   return hydrateOwnerGallery(c.env, c.get("workspace"), record, items);
 }
 
-export const galleries = new Hono<WorkspaceVars>()
-  .post("/", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    const result = unwrapMutation(
-      await createGallery(c.env.DB, {
-        workspace: c.get("workspaceName"),
-        title: typeof body.title === "string" ? body.title : "",
-        description:
-          body.description === null || typeof body.description === "string"
-            ? body.description
-            : undefined,
-      }),
-    );
-    await recordAdoptionSafe(c.env, {
-      metric: "gallery_created",
+/**
+ * Handler bodies (issue #613 phase 2): extracted to named functions so the
+ * canonical dual-auth vertical (`routes/workspace-galleries.ts`) can reuse
+ * them verbatim instead of copy-pasting — same "response shape can't drift"
+ * guarantee `routes/workspace-files.ts` established for phase 1, just via a
+ * shared handler reference rather than a `.fetch()` re-dispatch (galleries
+ * has no cheap self-contained-router alias target the way files did, since
+ * the bearer router here is mounted at a workspace-relative base path, not
+ * `/:workspace/galleries*`).
+ */
+export async function createGalleryHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const result = unwrapMutation(
+    await createGallery(c.env.DB, {
       workspace: c.get("workspaceName"),
+      title: typeof body.title === "string" ? body.title : "",
+      description:
+        body.description === null || typeof body.description === "string"
+          ? body.description
+          : undefined,
+    }),
+  );
+  await recordAdoptionSafe(c.env, {
+    metric: "gallery_created",
+    workspace: c.get("workspaceName"),
+  });
+  return c.json(await ownerGallery(c, result.value.id), 201);
+}
+
+export async function listGalleriesHandler(c: Context<WorkspaceVars>) {
+  const rawLimit = c.req.query("limit");
+  const limit = rawLimit === undefined ? 50 : Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100)
+    throw new ValidationError("limit must be an integer from 1 to 100.");
+  const page = await listGalleries(c.env.DB, c.get("workspaceName"), {
+    limit,
+    cursor: decodeGalleryCursor(c.req.query("cursor")),
+  });
+  const result = page.galleries.map((gallery) => gallerySummary(c.env, gallery));
+  return c.json({
+    galleries: result,
+    nextCursor: page.nextCursor ? encodeGalleryCursor(page.nextCursor) : null,
+  });
+}
+
+export async function galleriesByReferenceHandler(c: Context<WorkspaceVars>) {
+  const parsed = parseExternalReference(c.req.query("provider"), c.req.query("coordinate"));
+  if (!parsed.ok) throw new ValidationError(parsed.message, { code: "gallery_invalid_reference" });
+  const rawLimit = c.req.query("limit");
+  const limit = rawLimit === undefined ? 50 : Number(rawLimit);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
+    throw new ValidationError("limit must be an integer from 1 to 100.");
+  const page = await findGalleriesByReference(
+    c.env.DB,
+    c.get("workspaceName"),
+    parsed.value.normalizedKey,
+    { limit, cursor: decodeGalleryCursor(c.req.query("cursor")) },
+  );
+  return c.json({
+    galleries: page.galleries.map((gallery) => gallerySummary(c.env, gallery)),
+    nextCursor: page.nextCursor ? encodeGalleryCursor(page.nextCursor) : null,
+  });
+}
+
+export async function getGalleryHandler(c: Context<WorkspaceVars>) {
+  return c.json(await ownerGallery(c, c.req.param("id") as string));
+}
+
+export async function updateGalleryHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const { value } = unwrapMutation(
+    await updateGallery(c.env.DB, c.get("workspaceName"), c.req.param("id") as string, {
+      expectedVersion: requireExpectedVersion(body.expectedVersion),
+      title: typeof body.title === "string" ? body.title : undefined,
+      description:
+        body.description === null || typeof body.description === "string"
+          ? body.description
+          : undefined,
+      coverItemId:
+        body.coverItemId === null || typeof body.coverItemId === "string"
+          ? body.coverItemId
+          : undefined,
+    }),
+  );
+  return c.json(await ownerGallery(c, value.id));
+}
+
+export async function deleteGalleryHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const result = await softDeleteGallery(
+    c.env.DB,
+    c.get("workspaceName"),
+    c.req.param("id") as string,
+    requireExpectedVersion(body.expectedVersion),
+  );
+  if (result.status !== "ok" && result.status !== "unchanged") mutationError(result);
+  return c.json({ deleted: true, id: c.req.param("id") as string });
+}
+
+export async function addGalleryItemHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const key = typeof body.objectKey === "string" ? body.objectKey : "";
+  if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
+  const galleryId = c.req.param("id") as string;
+  const gallery = await getGallery(c.env.DB, c.get("workspaceName"), galleryId);
+  if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+  const expectedVersion = requireExpectedVersion(body.expectedVersion);
+  const existing = (await listGalleryItems(c.env.DB, c.get("workspaceName"), galleryId)).find(
+    (item) => item.object_key === key,
+  );
+  if (existing) {
+    const item = (await ownerGallery(c, galleryId)).items.find((entry) => entry.id === existing.id);
+    if (!item)
+      throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
+    return c.json(item, 200);
+  }
+  if (gallery.version !== expectedVersion)
+    throw new ConflictError("Gallery was changed by another request.", {
+      code: "gallery_version_conflict",
+      details: { currentVersion: gallery.version },
     });
-    return c.json(await ownerGallery(c, result.value.id), 201);
-  })
-  .get("/", requireScope("files:read"), async (c) => {
-    const rawLimit = c.req.query("limit");
-    const limit = rawLimit === undefined ? 50 : Number(rawLimit);
-    if (!Number.isInteger(limit) || limit < 1 || limit > 100)
-      throw new ValidationError("limit must be an integer from 1 to 100.");
-    const page = await listGalleries(c.env.DB, c.get("workspaceName"), {
-      limit,
-      cursor: decodeGalleryCursor(c.req.query("cursor")),
+  const ws = c.get("workspace");
+  let store: Awaited<ReturnType<typeof storage>>;
+  let config: Awaited<ReturnType<typeof storageConfig>>;
+  try {
+    [store, config] = await Promise.all([storage(c.env, ws), storageConfig(c.env, ws)]);
+  } catch (cause) {
+    throw new ServiceUnavailableError("Gallery storage unavailable.", {
+      code: "gallery_storage_unavailable",
+      cause,
     });
-    const result = page.galleries.map((gallery) => gallerySummary(c.env, gallery));
-    return c.json({
-      galleries: result,
-      nextCursor: page.nextCursor ? encodeGalleryCursor(page.nextCursor) : null,
+  }
+  let exists: boolean;
+  try {
+    exists = await store.exists(key);
+  } catch (cause) {
+    throw new ServiceUnavailableError("Gallery storage unavailable.", {
+      code: "gallery_storage_unavailable",
+      cause,
     });
-  })
-  .get("/by-reference", requireScope("files:read"), async (c) => {
-    const parsed = parseExternalReference(c.req.query("provider"), c.req.query("coordinate"));
-    if (!parsed.ok)
-      throw new ValidationError(parsed.message, { code: "gallery_invalid_reference" });
-    const rawLimit = c.req.query("limit");
-    const limit = rawLimit === undefined ? 50 : Number(rawLimit);
-    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
-      throw new ValidationError("limit must be an integer from 1 to 100.");
-    const page = await findGalleriesByReference(
+  }
+  if (!exists) throw new NotFoundError("Object not found.", { code: "gallery_object_not_found" });
+  if (publicUrl(config, key) === null)
+    throw new ValidationError("Object has no public URL.", { code: "gallery_object_not_public" });
+  const result = unwrapMutation(
+    await addGalleryItem(c.env.DB, c.get("workspaceName"), c.req.param("id") as string, {
+      expectedVersion,
+      objectKey: key,
+      caption: body.caption === null || typeof body.caption === "string" ? body.caption : undefined,
+      altText: body.altText === null || typeof body.altText === "string" ? body.altText : undefined,
+    }),
+  );
+  const item = (await ownerGallery(c, c.req.param("id") as string)).items.find(
+    (entry) => entry.id === result.value.id,
+  );
+  if (!item) throw new NotFoundError("Gallery item not found.");
+  return c.json(item, result.unchanged ? 200 : 201);
+}
+
+export async function reorderGalleryItemsHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  if (!Array.isArray(body.itemIds) || !body.itemIds.every((id) => typeof id === "string"))
+    throw new ValidationError("itemIds must be an array of strings.");
+  const result = unwrapMutation(
+    await reorderGalleryItems(
       c.env.DB,
       c.get("workspaceName"),
-      parsed.value.normalizedKey,
-      { limit, cursor: decodeGalleryCursor(c.req.query("cursor")) },
-    );
-    return c.json({
-      galleries: page.galleries.map((gallery) => gallerySummary(c.env, gallery)),
-      nextCursor: page.nextCursor ? encodeGalleryCursor(page.nextCursor) : null,
-    });
-  })
-  .get("/:id", requireScope("files:read"), async (c) =>
-    c.json(await ownerGallery(c, c.req.param("id"))),
+      c.req.param("id") as string,
+      body.itemIds,
+      requireExpectedVersion(body.expectedVersion),
+    ),
+  );
+  return c.json({
+    items: (await ownerGallery(c, c.req.param("id") as string)).items,
+    unchanged: result.unchanged,
+  });
+}
+
+export async function removeGalleryItemHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const result = await removeGalleryItem(
+    c.env.DB,
+    c.get("workspaceName"),
+    c.req.param("id") as string,
+    c.req.param("itemId") as string,
+    requireExpectedVersion(body.expectedVersion),
+  );
+  if (result.status !== "ok" && result.status !== "unchanged") mutationError(result);
+  return c.json({ deleted: true, id: c.req.param("itemId") as string });
+}
+
+export async function listExternalReferencesHandler(c: Context<WorkspaceVars>) {
+  const gallery = await getGallery(c.env.DB, c.get("workspaceName"), c.req.param("id") as string);
+  if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+  return c.json({
+    references: (await listExternalReferences(c.env.DB, c.get("workspaceName"), gallery.id)).map(
+      referenceDto,
+    ),
+  });
+}
+
+export async function addExternalReferenceHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const gallery = await getGallery(c.env.DB, c.get("workspaceName"), c.req.param("id") as string);
+  if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
+  const parsed = parseExternalReference(body.provider, body.coordinate);
+  if (!parsed.ok) throw new ValidationError(parsed.message, { code: "gallery_invalid_reference" });
+  const result = unwrapMutation(
+    await addExternalReference(c.env.DB, c.get("workspaceName"), c.req.param("id") as string, {
+      expectedVersion: requireExpectedVersion(body.expectedVersion),
+      ...parsed.value,
+    }),
+  );
+  return c.json(referenceDto(result.value), result.unchanged ? 200 : 201);
+}
+
+export async function removeExternalReferenceHandler(c: Context<WorkspaceVars>) {
+  const body = await jsonBody(c);
+  const result = await removeExternalReference(
+    c.env.DB,
+    c.get("workspaceName"),
+    c.req.param("id") as string,
+    c.req.param("referenceId") as string,
+    requireExpectedVersion(body.expectedVersion),
+  );
+  if (result.status !== "ok" && result.status !== "unchanged") mutationError(result);
+  return c.json({ deleted: true, id: c.req.param("referenceId") as string });
+}
+
+export const galleries = new Hono<WorkspaceVars>()
+  .post("/", writeRateLimit, requireScope("files:write"), createGalleryHandler)
+  .get("/", requireScope("files:read"), listGalleriesHandler)
+  .get("/by-reference", requireScope("files:read"), galleriesByReferenceHandler)
+  .get("/:id", requireScope("files:read"), getGalleryHandler)
+  .patch("/:id", writeRateLimit, requireScope("files:write"), updateGalleryHandler)
+  .delete("/:id", writeRateLimit, requireScope("files:write"), deleteGalleryHandler)
+  .post("/:id/items", writeRateLimit, requireScope("files:write"), addGalleryItemHandler)
+  .put("/:id/items/order", writeRateLimit, requireScope("files:write"), reorderGalleryItemsHandler)
+  .delete(
+    "/:id/items/:itemId",
+    writeRateLimit,
+    requireScope("files:write"),
+    removeGalleryItemHandler,
   )
-  .patch("/:id", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    const { value } = unwrapMutation(
-      await updateGallery(c.env.DB, c.get("workspaceName"), c.req.param("id"), {
-        expectedVersion: requireExpectedVersion(body.expectedVersion),
-        title: typeof body.title === "string" ? body.title : undefined,
-        description:
-          body.description === null || typeof body.description === "string"
-            ? body.description
-            : undefined,
-        coverItemId:
-          body.coverItemId === null || typeof body.coverItemId === "string"
-            ? body.coverItemId
-            : undefined,
-      }),
-    );
-    return c.json(await ownerGallery(c, value.id));
-  })
-  .delete("/:id", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    const result = await softDeleteGallery(
-      c.env.DB,
-      c.get("workspaceName"),
-      c.req.param("id"),
-      requireExpectedVersion(body.expectedVersion),
-    );
-    if (result.status !== "ok" && result.status !== "unchanged") mutationError(result);
-    return c.json({ deleted: true, id: c.req.param("id") });
-  })
-  .post("/:id/items", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    const key = typeof body.objectKey === "string" ? body.objectKey : "";
-    if (badKey(key)) throw new ValidationError("invalid key", { code: "invalid_key" });
-    const galleryId = c.req.param("id");
-    const gallery = await getGallery(c.env.DB, c.get("workspaceName"), galleryId);
-    if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-    const expectedVersion = requireExpectedVersion(body.expectedVersion);
-    const existing = (await listGalleryItems(c.env.DB, c.get("workspaceName"), galleryId)).find(
-      (item) => item.object_key === key,
-    );
-    if (existing) {
-      const item = (await ownerGallery(c, galleryId)).items.find(
-        (entry) => entry.id === existing.id,
-      );
-      if (!item)
-        throw new NotFoundError("Gallery item not found.", { code: "gallery_item_not_found" });
-      return c.json(item, 200);
-    }
-    if (gallery.version !== expectedVersion)
-      throw new ConflictError("Gallery was changed by another request.", {
-        code: "gallery_version_conflict",
-        details: { currentVersion: gallery.version },
-      });
-    const ws = c.get("workspace");
-    let store: Awaited<ReturnType<typeof storage>>;
-    let config: Awaited<ReturnType<typeof storageConfig>>;
-    try {
-      [store, config] = await Promise.all([storage(c.env, ws), storageConfig(c.env, ws)]);
-    } catch (cause) {
-      throw new ServiceUnavailableError("Gallery storage unavailable.", {
-        code: "gallery_storage_unavailable",
-        cause,
-      });
-    }
-    let exists: boolean;
-    try {
-      exists = await store.exists(key);
-    } catch (cause) {
-      throw new ServiceUnavailableError("Gallery storage unavailable.", {
-        code: "gallery_storage_unavailable",
-        cause,
-      });
-    }
-    if (!exists) throw new NotFoundError("Object not found.", { code: "gallery_object_not_found" });
-    if (publicUrl(config, key) === null)
-      throw new ValidationError("Object has no public URL.", { code: "gallery_object_not_public" });
-    const result = unwrapMutation(
-      await addGalleryItem(c.env.DB, c.get("workspaceName"), c.req.param("id"), {
-        expectedVersion,
-        objectKey: key,
-        caption:
-          body.caption === null || typeof body.caption === "string" ? body.caption : undefined,
-        altText:
-          body.altText === null || typeof body.altText === "string" ? body.altText : undefined,
-      }),
-    );
-    const item = (await ownerGallery(c, c.req.param("id"))).items.find(
-      (entry) => entry.id === result.value.id,
-    );
-    if (!item) throw new NotFoundError("Gallery item not found.");
-    return c.json(item, result.unchanged ? 200 : 201);
-  })
-  .put("/:id/items/order", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    if (!Array.isArray(body.itemIds) || !body.itemIds.every((id) => typeof id === "string"))
-      throw new ValidationError("itemIds must be an array of strings.");
-    const result = unwrapMutation(
-      await reorderGalleryItems(
-        c.env.DB,
-        c.get("workspaceName"),
-        c.req.param("id"),
-        body.itemIds,
-        requireExpectedVersion(body.expectedVersion),
-      ),
-    );
-    return c.json({
-      items: (await ownerGallery(c, c.req.param("id"))).items,
-      unchanged: result.unchanged,
-    });
-  })
-  .delete("/:id/items/:itemId", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    const result = await removeGalleryItem(
-      c.env.DB,
-      c.get("workspaceName"),
-      c.req.param("id"),
-      c.req.param("itemId"),
-      requireExpectedVersion(body.expectedVersion),
-    );
-    if (result.status !== "ok" && result.status !== "unchanged") mutationError(result);
-    return c.json({ deleted: true, id: c.req.param("itemId") });
-  })
-  .get("/:id/external-references", requireScope("files:read"), async (c) => {
-    const gallery = await getGallery(c.env.DB, c.get("workspaceName"), c.req.param("id"));
-    if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-    return c.json({
-      references: (await listExternalReferences(c.env.DB, c.get("workspaceName"), gallery.id)).map(
-        referenceDto,
-      ),
-    });
-  })
-  .post("/:id/external-references", writeRateLimit, requireScope("files:write"), async (c) => {
-    const body = await jsonBody(c);
-    const gallery = await getGallery(c.env.DB, c.get("workspaceName"), c.req.param("id"));
-    if (!gallery) throw new NotFoundError("Gallery not found.", { code: "gallery_not_found" });
-    const parsed = parseExternalReference(body.provider, body.coordinate);
-    if (!parsed.ok)
-      throw new ValidationError(parsed.message, { code: "gallery_invalid_reference" });
-    const result = unwrapMutation(
-      await addExternalReference(c.env.DB, c.get("workspaceName"), c.req.param("id"), {
-        expectedVersion: requireExpectedVersion(body.expectedVersion),
-        ...parsed.value,
-      }),
-    );
-    return c.json(referenceDto(result.value), result.unchanged ? 200 : 201);
-  })
+  .get("/:id/external-references", requireScope("files:read"), listExternalReferencesHandler)
+  .post(
+    "/:id/external-references",
+    writeRateLimit,
+    requireScope("files:write"),
+    addExternalReferenceHandler,
+  )
   .delete(
     "/:id/external-references/:referenceId",
     writeRateLimit,
     requireScope("files:write"),
-    async (c) => {
-      const body = await jsonBody(c);
-      const result = await removeExternalReference(
-        c.env.DB,
-        c.get("workspaceName"),
-        c.req.param("id"),
-        c.req.param("referenceId"),
-        requireExpectedVersion(body.expectedVersion),
-      );
-      if (result.status !== "ok" && result.status !== "unchanged") mutationError(result);
-      return c.json({ deleted: true, id: c.req.param("referenceId") });
-    },
+    removeExternalReferenceHandler,
   );

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -334,6 +334,11 @@ describe("GET /me/workspaces/:name/usage", () => {
 
     const res = await app().request("/me/workspaces/acme/usage", {}, env);
     expect(res.status).toBe(200);
+    // Issue #613 phase 2: this route now forwards to the canonical dual-auth
+    // handler (`routes/workspace-usage.ts`), whose response is a strict
+    // superset of the pre-#613 shape — adds `scopes` (every `FILE_SCOPES`,
+    // granted to session callers) and `plan` (catalog id; "free" here since
+    // the seeded workspace record has no `plan` field).
     expect(await res.json()).toEqual({
       workspace: "acme",
       bytes: 500,
@@ -343,6 +348,8 @@ describe("GET /me/workspaces/:name/usage", () => {
       updatedAt: "2026-07-10T00:00:00.000Z",
       maxStorageBytes: 1000,
       storageRemainingBytes: 500,
+      scopes: ["files:read", "files:write", "files:delete"],
+      plan: "free",
     });
   });
 });

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -64,6 +64,7 @@ import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
 import { workspaceFiles } from "./workspace-files";
+import { workspaceUsage } from "./workspace-usage";
 import {
   candidateFromBody,
   storageReconcile,
@@ -99,6 +100,28 @@ async function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): P
   // for the same request (issue #613 phase 1 follow-up).
   presetResolvedSessionUser(forwarded, requireUserId(c));
   return workspaceFiles.fetch(forwarded, c.env, executionCtx);
+}
+
+/**
+ * Same forwarding pattern as `forwardToWorkspaceFiles`, targeting the
+ * canonical usage vertical (`routes/workspace-usage.ts`, issue #613 phase 2).
+ * Response shape is a strict superset of the pre-#613 session shape (adds
+ * `scopes`/`plan`; every other field — `workspace`/`bytes`/`objects`/
+ * `uploadsInPeriod`/`periodStart`/limits — matches verbatim), so this is a
+ * genuine forward, not a re-implementation.
+ */
+async function forwardToWorkspaceUsage(c: Context<SessionVars>, path: string): Promise<Response> {
+  const url = new URL(c.req.url);
+  url.pathname = path;
+  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
+  const forwarded = new Request(url, c.req.raw);
+  presetResolvedSessionUser(forwarded, requireUserId(c));
+  return workspaceUsage.fetch(forwarded, c.env, executionCtx);
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -417,18 +440,13 @@ export const me = new Hono<SessionVars>()
   })
 
   // Usage + limits for one workspace — 404s unless the caller is a member.
-  .get("/workspaces/:name/usage", async (c) => {
-    const name = c.req.param("name");
-    await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    const usage = await getWorkspaceUsage(c.env.DB, name);
-    return c.json(usageWithLimits(usage, record));
-  })
+  // Issue #613 phase 2: forwards to the canonical dual-auth handler in
+  // `routes/workspace-usage.ts` — its response is a strict superset of this
+  // route's old shape (adds `scopes`/`plan`), so this is a genuine forward
+  // (see `forwardToWorkspaceUsage`'s docblock), not a reimplementation.
+  .get("/workspaces/:name/usage", (c) =>
+    forwardToWorkspaceUsage(c, `/${c.req.param("name")}/usage`),
+  )
 
   // Workspace shell for the account rail: membership + public URL + usage.
   .get("/workspaces/:name/summary", async (c) => {
@@ -549,7 +567,17 @@ export const me = new Hono<SessionVars>()
     });
   })
 
-  // Galleries in one workspace — member-gated.
+  // Galleries in one workspace — member-gated. Issue #613 phase 2: NOT
+  // forwarded to the canonical `/v1/workspaces/:workspace/galleries` list —
+  // this session shape carries `itemCount`/`references` per gallery (from
+  // `galleryListSummaries`) that the canonical/bearer list route omits (it
+  // uses the cheaper `gallerySummary` projection instead), so canonical is
+  // not a strict superset. `apps/web/src/lib/api-client.ts`'s `GallerySummary`
+  // does mark both fields optional ("Omitted on older API deployments"), but
+  // per the conservative rule for this migration (keep-and-document over
+  // inventing a new shape), this handler stays as-is rather than either
+  // dropping those fields for everyone or growing the canonical route to add
+  // them just for this alias. See `.context/613-api-consolidation-plan.md`.
   .get("/workspaces/:name/galleries", async (c) => {
     const name = c.req.param("name");
     await memberWorkspaceOr404(c.env, requireUserId(c), name);

--- a/apps/api/src/routes/workspace-galleries.ts
+++ b/apps/api/src/routes/workspace-galleries.ts
@@ -1,0 +1,132 @@
+/**
+ * Canonical galleries vertical (issue #613 phase 2): `/:workspace/galleries*`,
+ * mounted at `/v1/workspaces` in `index.ts` so its public paths are
+ * `/v1/workspaces/:workspace/galleries*`. Dual-auth (`dualWorkspaceAuth`) —
+ * either a session cookie or a bearer token reaches the same handlers below.
+ *
+ * Handler bodies are the exact same functions the pre-#613 bearer router
+ * (`routes/galleries.ts`, still mounted verbatim at `/v1/:workspace/galleries`)
+ * calls — extracted there so this router can reuse them instead of
+ * copy-pasting bodies, same "response shape can't drift" guarantee phase 1
+ * established for files via a `.fetch()` re-dispatch. Galleries doesn't use
+ * that re-dispatch pattern itself (that's for OLD-path aliases forwarding
+ * INTO this canonical router — see `forwardToWorkspaceUsage`/the galleries
+ * divergence note in `.context/613-api-consolidation-plan.md` for why the
+ * old `/me/workspaces/:name/galleries` list is NOT aliased here).
+ */
+import { Hono, type MiddlewareHandler } from "hono";
+import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
+import { writeRateLimit } from "../guards";
+import { requireScope } from "../workspace";
+import {
+  addExternalReferenceHandler,
+  addGalleryItemHandler,
+  createGalleryHandler,
+  deleteGalleryHandler,
+  galleriesByReferenceHandler,
+  getGalleryHandler,
+  listExternalReferencesHandler,
+  listGalleriesHandler,
+  removeExternalReferenceHandler,
+  removeGalleryItemHandler,
+  reorderGalleryItemsHandler,
+  updateGalleryHandler,
+} from "./galleries";
+
+// Same cross-cast pattern as `routes/workspace-files.ts`'s `scoped`: these
+// helpers/handlers are typed against `WorkspaceVars`, a strict subset of this
+// router's `DualAuthVars`, so a Context for one is always a valid Context for
+// the other.
+function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<DualAuthVars> {
+  return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
+}
+const rateLimited = writeRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+
+export const workspaceGalleries = new Hono<DualAuthVars>()
+  .post(
+    "/:workspace/galleries",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    createGalleryHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/galleries",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    listGalleriesHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/galleries/by-reference",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    galleriesByReferenceHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/galleries/:id",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    getGalleryHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .patch(
+    "/:workspace/galleries/:id",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    updateGalleryHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .delete(
+    "/:workspace/galleries/:id",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    deleteGalleryHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .post(
+    "/:workspace/galleries/:id/items",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    addGalleryItemHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .put(
+    "/:workspace/galleries/:id/items/order",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    reorderGalleryItemsHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .delete(
+    "/:workspace/galleries/:id/items/:itemId",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    removeGalleryItemHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/galleries/:id/external-references",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    listExternalReferencesHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .post(
+    "/:workspace/galleries/:id/external-references",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    addExternalReferenceHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .delete(
+    "/:workspace/galleries/:id/external-references/:referenceId",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    removeExternalReferenceHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  // `.fetch()`-ed directly by nothing today (galleries has no old-path
+  // aliases folded through this router — see the module docblock), but this
+  // still needs its own error boundary for consistency with the other
+  // canonical verticals and in case a future alias does re-dispatch through
+  // it directly.
+  .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-usage.ts
+++ b/apps/api/src/routes/workspace-usage.ts
@@ -1,0 +1,92 @@
+/**
+ * Canonical usage vertical (issue #613 phase 2): `/:workspace/usage*`,
+ * mounted at `/v1/workspaces` in `index.ts` so its public paths are
+ * `/v1/workspaces/:workspace/usage*`. Dual-auth (`dualWorkspaceAuth`) for the
+ * read snapshot; the two maintenance ops (`reconcile`, `purge-expired`) are
+ * deliberately bearer-token-only even on this canonical surface — see the
+ * `authSource === "token"` guard below.
+ */
+import { getPlan } from "@uploads/billing";
+import { ForbiddenError } from "@uploads/errors";
+import { Hono, type MiddlewareHandler } from "hono";
+import { usageWithLimits } from "../budget";
+import { dualWorkspaceAuth, type DualAuthVars } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
+import { reconcileWorkspaceUsage } from "../reconcile";
+import { purgeExpiredObjects } from "../retention";
+import { getWorkspaceUsage } from "../usage";
+import { requireScope } from "../workspace";
+
+function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<DualAuthVars> {
+  return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
+}
+
+/**
+ * `reconcile`/`purge-expired` are maintenance ops with deliberately no
+ * session equivalent (see `.context/613-api-consolidation-plan.md`, "usage"
+ * section): a session caller who is a workspace member has already cleared
+ * `dualWorkspaceAuth`'s membership check, so refusing them here is a 403
+ * ("not allowed to do this"), not a 404 ("this doesn't exist") — membership
+ * was already proven, existence was never in question.
+ */
+const requireToken: MiddlewareHandler<DualAuthVars> = async (c, next) => {
+  // `authSource` is `"d1" | "legacy" | "session"` (see `workspace.ts` /
+  // `dual-workspace-auth.ts`) — the two bearer-token varieties vs. a session
+  // cookie. Only a session caller is rejected here.
+  if (c.get("authSource") === "session") {
+    throw new ForbiddenError("requires an API token", { code: "usage_requires_token" });
+  }
+  await next();
+};
+
+export const workspaceUsage = new Hono<DualAuthVars>()
+  .get("/:workspace/usage", dualWorkspaceAuth(), scoped("files:read"), async (c) => {
+    const snapshot = await getWorkspaceUsage(c.env.DB, c.get("workspaceName"));
+    const workspace = c.get("workspace");
+    // `scopes` reflects the presented credential — for a session caller this
+    // is the `FILE_SCOPES` set `dualWorkspaceAuth` grants (matching the
+    // bearer route's own "legacy tokens report the full file-scope set"
+    // note). `plan` is the catalog id (free|pro).
+    return c.json({
+      ...usageWithLimits(snapshot, workspace),
+      scopes: c.get("authScopes"),
+      plan: getPlan(workspace.plan).id,
+    });
+  })
+  .post(
+    "/:workspace/usage/reconcile",
+    dualWorkspaceAuth(),
+    scoped("files:write"),
+    requireToken,
+    async (c) => {
+      const result = await reconcileWorkspaceUsage(
+        c.env,
+        c.get("workspace"),
+        c.get("workspaceName"),
+      );
+      return c.json({
+        ...result,
+        usage: usageWithLimits(result.usage, c.get("workspace")),
+      });
+    },
+  )
+  .post(
+    "/:workspace/usage/purge-expired",
+    dualWorkspaceAuth(),
+    scoped("files:delete"),
+    requireToken,
+    async (c) => {
+      const result = await purgeExpiredObjects(c.env, c.get("workspace"), c.get("workspaceName"));
+      if ("skipped" in result) {
+        return c.json(result, 200);
+      }
+      return c.json({
+        ...result,
+        reconcile: {
+          ...result.reconcile,
+          usage: usageWithLimits(result.reconcile.usage, c.get("workspace")),
+        },
+      });
+    },
+  )
+  .onError((err, c) => respondError(c, err));

--- a/apps/api/test/routes-workspace-galleries.test.ts
+++ b/apps/api/test/routes-workspace-galleries.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Canonical dual-auth galleries vertical (issue #613 phase 2):
+ * `/v1/workspaces/:workspace/galleries*`. Exercised through the real
+ * composed `app` (index.ts), mirroring `routes-workspace-files.test.ts`
+ * (phase 1) and reusing `routes-galleries.test.ts`'s SQLite-backed D1 fake
+ * for real gallery CRUD semantics. Bearer-only coverage for the pre-existing
+ * `/v1/:workspace/galleries*` handlers stays in `test/routes-galleries.test.ts`
+ * (untouched by this phase); this file is scoped to what's new: both
+ * credential types reaching the SAME handlers, scope enforcement, and the
+ * deliberate non-forwarding of the old `/me/workspaces/:name/galleries` list
+ * (see `.context/613-api-consolidation-plan.md`).
+ */
+import { readFileSync } from "node:fs";
+import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+
+const TOKEN = "canonical-gallery-token";
+const READ_TOKEN = "canonical-gallery-read-token";
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const USER = { id: "u-1", email: "member@example.com", name: "Member" };
+
+class SQLiteStatement {
+  values: unknown[] = [];
+  constructor(
+    readonly database: DatabaseSync,
+    readonly sql: string,
+  ) {}
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+  first<T>() {
+    return Promise.resolve(
+      (this.database.prepare(this.sql).get(...(this.values as SQLInputValue[])) as T | undefined) ??
+        null,
+    );
+  }
+  all<T>() {
+    return Promise.resolve({
+      success: true,
+      results: this.database.prepare(this.sql).all(...(this.values as SQLInputValue[])) as T[],
+      meta: {},
+    } as D1Result<T>);
+  }
+  run() {
+    const result = this.database.prepare(this.sql).run(...(this.values as SQLInputValue[]));
+    return Promise.resolve({
+      success: true,
+      results: [],
+      meta: { changes: Number(result.changes) },
+    } as unknown as D1Result);
+  }
+}
+
+class SQLiteD1 {
+  constructor(readonly database: DatabaseSync) {}
+  prepare(sql: string) {
+    return new SQLiteStatement(this.database, sql);
+  }
+  async batch(statements: SQLiteStatement[]) {
+    this.database.exec("BEGIN");
+    try {
+      const results = [];
+      for (const statement of statements) results.push(await statement.run());
+      this.database.exec("COMMIT");
+      return results;
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+let db: DatabaseSync;
+let bucket: FakeR2Bucket;
+let records: Record<string, WorkspaceRecord>;
+
+function migration(name: string) {
+  return readFileSync(fileURLToPath(new NodeURL(`../migrations/${name}`, import.meta.url)), "utf8");
+}
+
+async function makeEnv(
+  opts: { member?: boolean; session?: boolean; getSessionCalls?: { count: number } } = {},
+): Promise<Parameters<typeof app.request>[2]> {
+  const { member = true, session = true, getSessionCalls } = opts;
+  return {
+    DB: new SQLiteD1(db) as unknown as D1Database,
+    WEB_ORIGIN: "https://uploads.test",
+    REGISTRY: { get: async (key: string) => records[key.slice(3)] ?? null },
+    UPLOADS_DEFAULT: bucket,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    AUTH: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/api/auth/get-session") {
+          if (getSessionCalls) getSessionCalls.count++;
+          return session ? Response.json({ session: {}, user: USER }) : Response.json(null);
+        }
+        if (url.pathname === "/internal/memberships") {
+          return Response.json(
+            member
+              ? [
+                  {
+                    organizationId: "org-1",
+                    organizationSlug: "acme",
+                    organizationName: "Acme",
+                    role: "member",
+                  },
+                ]
+              : [],
+          );
+        }
+        return new Response(JSON.stringify({ githubAccountId: null }), {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+  } as unknown as Parameters<typeof app.request>[2];
+}
+
+beforeEach(async () => {
+  db = new DatabaseSync(":memory:");
+  db.exec(migration("20260710120000_auth.sql"));
+  db.exec(migration("20260710140000_workspace_usage.sql"));
+  db.exec(migration("20260711180000_galleries.sql"));
+  db.exec(migration("20260712230000_token_minting_user.sql"));
+  db.exec(migration("20260713210559_file_metadata.sql"));
+  db.exec(migration("20260728120000_daily_metrics.sql"));
+  bucket = new FakeR2Bucket();
+  await bucket.put("acme/screenshots/one.png", PNG);
+  records = {
+    acme: {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "acme/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokenHash: await sha256Hex(TOKEN),
+    },
+    beta: {
+      provider: "r2",
+      bucket: "shared",
+      binding: "UPLOADS_DEFAULT",
+      prefix: "beta/",
+      publicBaseUrl: "https://storage.uploads.sh",
+      tokenHash: await sha256Hex(TOKEN),
+    },
+  };
+});
+
+async function bearer(path: string, init: RequestInit = {}) {
+  return app.request(
+    path,
+    {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-Type": "application/json",
+        ...init.headers,
+      },
+    },
+    await makeEnv(),
+  );
+}
+
+async function createViaCanonical(env: Parameters<typeof app.request>[2]) {
+  const res = await app.request(
+    "/v1/workspaces/acme/galleries",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Launch media" }),
+    },
+    env,
+  );
+  expect(res.status).toBe(201);
+  return res.json() as Promise<{ id: string; version: number }>;
+}
+
+describe("POST/GET/PATCH/DELETE /v1/workspaces/:workspace/galleries (bearer, canonical CRUD)", () => {
+  it("creates, reads, updates, and deletes a gallery", async () => {
+    const env = await makeEnv();
+    const gallery = await createViaCanonical(env);
+    expect(gallery.id).toMatch(/^gal_/);
+
+    const got = await app.request(
+      `/v1/workspaces/acme/galleries/${gallery.id}`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(got.status).toBe(200);
+
+    const patched = await app.request(
+      `/v1/workspaces/acme/galleries/${gallery.id}`,
+      {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ expectedVersion: 1, title: "Updated" }),
+      },
+      env,
+    );
+    expect(patched.status).toBe(200);
+    expect(await patched.json()).toMatchObject({ title: "Updated", version: 2 });
+
+    const deleted = await app.request(
+      `/v1/workspaces/acme/galleries/${gallery.id}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ expectedVersion: 2 }),
+      },
+      env,
+    );
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({ deleted: true, id: gallery.id });
+  });
+
+  it("cross-tenant access 404s (wrong workspace in the path for a bearer token scoped to another)", async () => {
+    const env = await makeEnv();
+    const gallery = await createViaCanonical(env);
+    const res = await app.request(
+      `/v1/workspaces/beta/galleries/${gallery.id}`,
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("gallery_not_found");
+  });
+
+  it("401s a bearer token whose hash doesn't match this workspace", async () => {
+    const env = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { headers: { Authorization: "Bearer wrong-token" } },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("a read-scoped token can list but not create (403 insufficient_scope)", async () => {
+    const env = await makeEnv();
+    const now = new Date().toISOString();
+    await (env as unknown as { DB: D1Database }).DB.prepare(
+      "INSERT INTO auth_tokens (id, workspace, token_hash, label, scopes, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+      .bind(
+        "token-read",
+        "acme",
+        await sha256Hex(READ_TOKEN),
+        null,
+        JSON.stringify(["files:read"]),
+        now,
+      )
+      .run();
+
+    const list = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { headers: { Authorization: `Bearer ${READ_TOKEN}` } },
+      env,
+    );
+    expect(list.status).toBe(200);
+
+    const create = await app.request(
+      "/v1/workspaces/acme/galleries",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${READ_TOKEN}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "nope" }),
+      },
+      env,
+    );
+    expect(create.status).toBe(403);
+    const body = (await create.json()) as { error?: { type?: string } };
+    expect(body.error?.type).toBe("insufficient_scope");
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/galleries (session auth)", () => {
+  it("a member reaches the same handler as a bearer caller (200, identical list shape)", async () => {
+    const env = await makeEnv();
+    await createViaCanonical(env);
+    const bearerRes = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    const sessionRes = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(bearerRes.status).toBe(200);
+    expect(sessionRes.status).toBe(200);
+    expect(await bearerRes.json()).toEqual(await sessionRes.json());
+  });
+
+  it("404s a signed-in caller who isn't a member of the workspace (uniform workspace_not_found)", async () => {
+    const env = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_not_found");
+  });
+
+  it("a session caller can also create/mutate galleries (member implies files:write, unlike the old session surface)", async () => {
+    const env = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/galleries",
+      {
+        method: "POST",
+        headers: { cookie: "session=x", "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "From session" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("old-path /me/workspaces/:name/galleries is NOT forwarded (issue #613 phase 2 divergence)", () => {
+  it("keeps its own richer shape (itemCount/references) rather than the canonical bearer-shaped list", async () => {
+    const env = await makeEnv();
+    await createViaCanonical(env);
+
+    const oldPath = await app.request(
+      "/me/workspaces/acme/galleries",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(oldPath.status).toBe(200);
+    const oldBody = (await oldPath.json()) as { galleries: Record<string, unknown>[] };
+    expect(oldBody.galleries[0]).toHaveProperty("itemCount");
+    expect(oldBody.galleries[0]).toHaveProperty("references");
+    // No `nextCursor` on the old shape — confirms this is still the
+    // pre-#613 handler, not a forward through the canonical route.
+    expect(oldBody).not.toHaveProperty("nextCursor");
+
+    const canonical = await app.request(
+      "/v1/workspaces/acme/galleries",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    const canonicalBody = (await canonical.json()) as { galleries: Record<string, unknown>[] };
+    expect(canonicalBody.galleries[0]).not.toHaveProperty("itemCount");
+    expect(canonicalBody).toHaveProperty("nextCursor");
+  });
+});

--- a/apps/api/test/routes-workspace-galleries.test.ts
+++ b/apps/api/test/routes-workspace-galleries.test.ts
@@ -167,21 +167,6 @@ beforeEach(async () => {
   };
 });
 
-async function bearer(path: string, init: RequestInit = {}) {
-  return app.request(
-    path,
-    {
-      ...init,
-      headers: {
-        Authorization: `Bearer ${TOKEN}`,
-        "Content-Type": "application/json",
-        ...init.headers,
-      },
-    },
-    await makeEnv(),
-  );
-}
-
 async function createViaCanonical(env: Parameters<typeof app.request>[2]) {
   const res = await app.request(
     "/v1/workspaces/acme/galleries",

--- a/apps/api/test/routes-workspace-usage.test.ts
+++ b/apps/api/test/routes-workspace-usage.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Canonical dual-auth usage vertical (issue #613 phase 2):
+ * `/v1/workspaces/:workspace/usage*`. Exercised through the real composed
+ * `app` (index.ts) — same style as `routes-workspace-files.test.ts` (phase
+ * 1). Bearer-only coverage for the pre-existing `/v1/:workspace/usage*`
+ * handlers stays in `test/routes-usage.test.ts`; this file is scoped to the
+ * canonical surface: both credential types reaching the read snapshot, the
+ * session-403 posture on the maintenance ops, and the `/me` alias forward.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeR2Bucket } from "./fake-r2";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const TOKEN = "canonical-usage-token";
+const USER = { id: "u-1", email: "member@example.com", name: "Member" };
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+async function makeEnv(
+  opts: { member?: boolean; session?: boolean; getSessionCalls?: { count: number } } = {},
+): Promise<{ env: Parameters<typeof app.request>[2]; db: UsageFakeD1 }> {
+  const { member = true, session = true, getSessionCalls } = opts;
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "uploads-default",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokenHash: await sha256Hex(TOKEN),
+  };
+  const db = new UsageFakeD1();
+  const env = {
+    REGISTRY: {
+      get: async (key: string) => (key === "ws:acme" ? record : null),
+    },
+    UPLOADS_DEFAULT: new FakeR2Bucket(),
+    DB: db,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    WEB_ORIGIN: "https://uploads.sh",
+    AUTH: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/api/auth/get-session") {
+          if (getSessionCalls) getSessionCalls.count++;
+          return session ? Response.json({ session: {}, user: USER }) : Response.json(null);
+        }
+        if (url.pathname === "/internal/memberships") {
+          return Response.json(
+            member
+              ? [
+                  {
+                    organizationId: "org-1",
+                    organizationSlug: "acme",
+                    organizationName: "Acme",
+                    role: "member",
+                  },
+                ]
+              : [],
+          );
+        }
+        return new Response(JSON.stringify({ githubAccountId: null }), {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+  };
+  return { env: env as unknown as Parameters<typeof app.request>[2], db };
+}
+
+describe("GET /v1/workspaces/:workspace/usage (dual auth)", () => {
+  it("accepts a bearer token and includes scopes + plan", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/usage",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workspace: string; scopes: string[]; plan: string };
+    expect(body.workspace).toBe("acme");
+    expect(body.plan).toBe("free");
+    expect(body.scopes).toEqual(expect.arrayContaining(["files:read", "files:write"]));
+  });
+
+  it("accepts a session cookie for a member workspace, granting every FILE_SCOPES", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/usage",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workspace: string; scopes: string[] };
+    expect(body.workspace).toBe("acme");
+    expect(body.scopes).toEqual(
+      expect.arrayContaining(["files:read", "files:write", "files:delete"]),
+    );
+  });
+
+  it("404s a signed-in caller who isn't a member of the workspace", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/usage",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_not_found");
+  });
+
+  it("401s with neither a bearer token nor a session cookie", async () => {
+    const { env } = await makeEnv({ session: false });
+    const res = await app.request("/v1/workspaces/acme/usage", {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /v1/workspaces/:workspace/usage/reconcile and /purge-expired (token-only)", () => {
+  it("bearer: reconcile succeeds", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/usage/reconcile",
+      { method: "POST", headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { usage: { bytes: number } };
+    expect(body.usage).toBeDefined();
+  });
+
+  it("session: reconcile 403s with a clear error even for a member", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/usage/reconcile",
+      { method: "POST", headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("usage_requires_token");
+  });
+
+  it("session: purge-expired 403s with a clear error even for a member", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/usage/purge-expired",
+      { method: "POST", headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("usage_requires_token");
+  });
+
+  it("non-member session still 404s before reaching the token gate (membership checked first)", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/usage/reconcile",
+      { method: "POST", headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("old-path alias forwards unchanged (issue #613 phase 2)", () => {
+  it("/me/workspaces/:name/usage forwards to the canonical shape (superset: adds scopes + plan)", async () => {
+    const { env } = await makeEnv();
+    const canonical = await app.request(
+      "/v1/workspaces/acme/usage",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/usage",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    // `updatedAt` is stamped fresh per call when no ledger row exists yet
+    // (see `getWorkspaceUsage`'s no-row branch) — not a shape difference, so
+    // it's excluded from the equality check.
+    const { updatedAt: _canonicalUpdatedAt, ...canonicalRest } = (await canonical.json()) as Record<
+      string,
+      unknown
+    >;
+    const { updatedAt: _aliasUpdatedAt, ...aliasRest } = (await alias.json()) as Record<
+      string,
+      unknown
+    >;
+    expect(aliasRest).toEqual(canonicalRest);
+  });
+
+  it("resolves the session exactly once for a forwarded aliased request", async () => {
+    const getSessionCalls = { count: 0 };
+    const { env } = await makeEnv({ getSessionCalls });
+    const res = await app.request(
+      "/me/workspaces/acme/usage",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("membership rejection still applies to the forwarded alias (wrong workspace -> 404)", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/me/workspaces/acme/usage",
+      { headers: { cookie: "session=x" } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_not_found");
+  });
+
+  it("/v1/:workspace/usage (bearer path) is untouched by the canonical mount", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/acme/usage",
+      { headers: { Authorization: `Bearer ${TOKEN}` } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workspace: string };
+    expect(body.workspace).toBe("acme");
+  });
+});


### PR DESCRIPTION
## What moved

Phase 2 of #613 (API surface consolidation), following the pattern PR #615
(phase 1, files vertical) established:

- **`apps/api/src/routes/workspace-galleries.ts`** — canonical
  `/:workspace/galleries*`, mounted at `/v1/workspaces` in `index.ts`
  (public path `/v1/workspaces/:workspace/galleries*`). `dualWorkspaceAuth()`
  + the same per-route `requireScope("files:read"|"files:write")` the bearer
  routes use today, own `.onError()`. Reuses `routes/galleries.ts`'s handler
  bodies verbatim — extracted them into named exported functions
  (`createGalleryHandler`, `listGalleriesHandler`, etc.) rather than
  copy-pasting, cross-cast from `WorkspaceVars` to `DualAuthVars` the same way
  `workspace-files.ts`'s `scoped()` helper does.
- **`apps/api/src/routes/workspace-usage.ts`** — canonical `/:workspace/usage*`.
  `GET` adopts the bearer response shape (`scopes` + `plan`). `POST
  .../reconcile` and `POST .../purge-expired` are dual-authed for membership
  (so a non-member session still 404s) but then require a bearer token — see
  "session-403 posture" below.
- Old bearer paths (`/v1/:workspace/galleries*`, `/v1/:workspace/usage*`) are
  **untouched**, same as phase 1 left `routes/files.ts` alone.

## Alias / shape decisions

- **`GET /me/workspaces/:name/usage` now forwards** to the canonical handler
  (`forwardToWorkspaceUsage` in `routes/me.ts`, same rewrite +
  `presetResolvedSessionUser` pattern as phase 1's
  `forwardToWorkspaceFiles`). The canonical shape is a strict superset of the
  old session shape (only adds `scopes`/`plan`), and
  `apps/web/src/lib/api-client.ts`'s `parseWorkspaceUsage` only requires
  `bytes`/`objects`/`uploadsInPeriod` to be numbers — additive fields are
  safe.
- **`GET /me/workspaces/:name/galleries` is NOT forwarded** — kept on its own
  handler. It uses `galleryListSummaries`, which enriches each gallery with
  `itemCount`/`references` (two extra batch queries); the canonical/bearer
  list route uses the cheaper `gallerySummary` projection and doesn't carry
  those fields. Since canonical is missing fields the session shape has, it's
  not a strict superset, so per the conservative rule for this migration the
  session handler stays as-is rather than forwarding or inventing a new
  canonical shape. (`apps/web/src/lib/api-client.ts`'s `GallerySummary` type
  already marks both fields optional — "Omitted on older API deployments" —
  so the client would in practice tolerate a forward; this is a deliberately
  conservative call, documented in `.context/613-api-consolidation-plan.md`
  for whoever revisits it.)

## Session-403 posture on usage maintenance ops

`reconcile`/`purge-expired` have no session-facing use case (maintenance
ops). On the canonical surface, `dualWorkspaceAuth()` still runs first (so a
signed-in caller who isn't a member gets the uniform 404), then a
`requireToken` guard rejects a session caller who *is* a member with a 403
(`{error: {code: "usage_requires_token"}}`) — membership was already proven,
so refusing them is "not allowed to do this," not "this doesn't exist."

## Test coverage

- `apps/api/test/routes-workspace-galleries.test.ts` — bearer + session CRUD
  through the canonical path, cross-tenant/wrong-workspace 404, a
  read-scoped token 403ing on write (`insufficient_scope`), and a locked-in
  assertion that the old `/me` galleries list is *not* forwarded.
- `apps/api/test/routes-workspace-usage.test.ts` — bearer + session reads,
  the session-403 posture on the maintenance ops, and the `/me` usage alias
  (identical shape modulo `updatedAt`, exactly one `get-session` call per
  forwarded request, membership rejection still applies).
- Updated `apps/api/src/routes/me.test.ts`'s pre-existing usage-shape
  assertion for the new `scopes`/`plan` fields the forward adds.
- Full suite green: `pnpm test` — 274 files / 3857 tests. `pnpm typecheck`
  and `pnpm lint`/`pnpm format:check` also pass.

Ref #613, pattern from #615.
