### PR TITLE
refactor(api): canonical routes for github, invites/members, settings, storage, billing verticals (#613 phase 3)

### DIFF
--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -150,7 +150,15 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
     c.set("workspaceName", name);
     c.set("authScopes", [...FILE_SCOPES]);
     c.set("authSource", "session");
-    c.set("mintingUserId", null);
+    // A bearer token's `mintingUserId` names the Better Auth user whose
+    // linked GitHub identity `isEntitledToClaimRepo` checks (see
+    // `github-claim-authz.ts`) — for a session caller, that's simply the
+    // authenticated session user, not `null`. Leaving this `null` on the
+    // session path silently forced every session-admin repo claim through
+    // `github/link` to fail with `not_authorized`, since
+    // `isEntitledToClaimRepo` treats a null minting user as "not entitled"
+    // by construction (CodeRabbit PR #617 review finding 3).
+    c.set("mintingUserId", userId);
     c.set("sessionUserId", userId);
     await next();
   };

--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -6,7 +6,7 @@
  * to know which one arrived. See `routes/workspace-files.ts` for the first
  * vertical built on this.
  */
-import { NotFoundError, UnauthorizedError } from "@uploads/errors";
+import { ForbiddenError, NotFoundError, UnauthorizedError } from "@uploads/errors";
 import type { MiddlewareHandler } from "hono";
 import { FILE_SCOPES } from "./auth-db";
 import { membershipsForUser, workspacesFromMembership } from "./org-workspaces";
@@ -112,6 +112,51 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
     c.set("authScopes", [...FILE_SCOPES]);
     c.set("authSource", "session");
     c.set("mintingUserId", null);
+    await next();
+  };
+}
+
+/**
+ * Session-only admin|owner tier gate, layered AFTER `dualWorkspaceAuth()` for
+ * verticals whose bearer analog is scope-gated but whose SESSION analog needs
+ * a stricter tier than plain membership — first built for the github vertical
+ * (issue #613 phase 3: link/health/activity require admin/owner for a session
+ * caller, matching `routes/me.ts`'s `adminWorkspaceOr403` posture for the
+ * pre-existing `/me/workspaces/:name/repo-links` route). Reusable as-is by
+ * any later vertical with the same "bearer keeps its scope, session needs
+ * admin/owner" posture — e.g. invites/members (see
+ * `.context/613-api-consolidation-plan.md`).
+ *
+ * A no-op for a bearer credential (`authSource !== "session"`): bearer's only
+ * gate stays whatever `requireScope` the route already applies — this
+ * middleware never tightens or loosens bearer behavior.
+ *
+ * For a session caller, `dualWorkspaceAuth` has already proven membership
+ * (non-member 404s before this middleware is ever reached), so a member who
+ * isn't admin/owner gets a 403 here, not a 404 — "not allowed", not "doesn't
+ * exist", same reasoning as `workspace-usage.ts`'s `requireToken` guard.
+ * Deliberately re-resolves the membership role via its own `membershipsForUser`
+ * call rather than threading a role through `DualAuthVars` — `dualWorkspaceAuth`
+ * only ever needed to prove membership existed, not carry the role forward,
+ * and adding a role field to `WorkspaceVars` would leak a session-only concept
+ * into the bearer-shared type. Costs one extra round trip on session admin
+ * routes only, same as `me.ts`'s own `memberWorkspaceOr404` -> `adminWorkspaceOr403`
+ * double-lookup shape.
+ */
+export function requireSessionAdmin(): MiddlewareHandler<DualAuthVars> {
+  return async (c, next) => {
+    if (c.get("authSource") === "session") {
+      const user = c.get("sessionUser") as SessionUser | null;
+      const name = c.get("workspaceName");
+      if (!user || !name) throw new UnauthorizedError();
+      const [membership] = await membershipsForUser(c.env, user.id, { slug: name });
+      const role = membership?.role;
+      if (role !== "admin" && role !== "owner") {
+        throw new ForbiddenError("workspace admin or owner role required", {
+          code: "workspace_admin_required",
+        });
+      }
+    }
     await next();
   };
 }

--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -7,7 +7,8 @@
  * vertical built on this.
  */
 import { ForbiddenError, NotFoundError, UnauthorizedError } from "@uploads/errors";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
+import { type WorkspaceScope } from "./auth-db";
 import { FILE_SCOPES } from "./auth-db";
 import { membershipsForUser, workspacesFromMembership } from "./org-workspaces";
 import {
@@ -16,7 +17,13 @@ import {
   type SessionUser,
   type SessionVars,
 } from "./session-auth";
-import { loadWorkspaceRecord, workspaceAuth, type WorkspaceVars } from "./workspace";
+import {
+  loadWorkspaceRecord,
+  workspaceAuth,
+  workspaceGovernanceAuth,
+  type GovernanceVars,
+  type WorkspaceVars,
+} from "./workspace";
 
 /** Combined context vars for routes reachable by either auth path. */
 export type DualAuthVars = {
@@ -65,6 +72,24 @@ async function requireMembership(env: Env, userId: string, name: string): Promis
 }
 
 /**
+ * Resolves the calling session's `userId`, honoring the `presetResolvedUser`
+ * WeakMap handoff (see above) before falling back to a real `sessionAuth` +
+ * `requireSessionUser` round trip. Shared by `dualWorkspaceAuth` and
+ * `dualGovernanceAuth` (and any session-only-but-bearer-aware guard a
+ * canonical vertical wants to build) so "resolve the session exactly once
+ * per forwarded request" stays true everywhere, not just on the files
+ * vertical. Throws (via `requireSessionUser`) on no session — same as before
+ * this was extracted.
+ */
+export async function resolveSessionUserId(c: Context<SessionVars>): Promise<string> {
+  const preresolvedUserId = PRERESOLVED_USER.get(c.req.raw);
+  if (preresolvedUserId !== undefined) return preresolvedUserId;
+  await sessionAuth(c, async () => {});
+  await requireSessionUser(c, async () => {});
+  return (c.get("sessionUser") as SessionUser).id;
+}
+
+/**
  * Guards a `/…/:workspace/…` route with EITHER a bearer token (resolution
  * identical to `workspaceAuth`) OR a session cookie (membership check
  * identical to `me.ts`'s `memberWorkspaceOr404`).
@@ -85,20 +110,7 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
       return workspaceAuth(c as unknown as Parameters<typeof workspaceAuth>[0], next);
     }
 
-    const preresolvedUserId = PRERESOLVED_USER.get(c.req.raw);
-    let userId: string;
-    if (preresolvedUserId !== undefined) {
-      // Session already resolved upstream (e.g. `me.ts`'s own `sessionAuth`
-      // middleware, for a forwarded old-path alias) — skip the redundant
-      // `get-session` round trip. Membership is still checked below: that
-      // lookup hasn't run yet for this request.
-      userId = preresolvedUserId;
-    } else {
-      const sessionC = c as unknown as Parameters<typeof sessionAuth>[0];
-      await sessionAuth(sessionC, async () => {});
-      await requireSessionUser(sessionC, async () => {});
-      userId = (c.get("sessionUser") as SessionUser).id;
-    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
 
     const name = c.req.param("workspace");
     if (!name) throw new UnauthorizedError();
@@ -157,6 +169,72 @@ export function requireSessionAdmin(): MiddlewareHandler<DualAuthVars> {
         });
       }
     }
+    await next();
+  };
+}
+
+/** Combined context vars for a `dualGovernanceAuth`-guarded route. */
+export type GovernanceSessionVars = {
+  Variables: GovernanceVars["Variables"] & SessionVars["Variables"];
+  Bindings: Env;
+};
+
+/**
+ * Dual-auth guard for the workspace-*governance* scope namespace (issue #613
+ * phase 3, invites/members vertical) — distinct from `dualWorkspaceAuth`,
+ * which grants a session caller every `FILE_SCOPES`. Governance scopes
+ * (`workspace:invite`/`workspace:manage`/etc., see `auth-db.ts`) are a
+ * separate D1 token shape (`workspaceGovernanceAuth`) with no file-plane
+ * analog, so a session caller here is never "granted a scope" — they're held
+ * to the same admin/owner org-role tier the pre-existing `/me` governance-
+ * adjacent routes (`adminWorkspaceOr403` in `routes/me.ts`) already require.
+ *
+ * A presented bearer credential is authoritative and delegates straight to
+ * `workspaceGovernanceAuth(requiredScope)` — verbatim, so a governance-token
+ * caller's behavior is provably unchanged by introducing this guard (see
+ * `routes/workspace-governance-invite.test.ts`, still green against
+ * `POST /v1/workspaces/:name/invites` after it was upgraded to use this
+ * function in place of a bare `workspaceGovernanceAuth("workspace:invite")`).
+ *
+ * With no bearer: resolves the session (honoring the `presetResolvedUser`
+ * WeakMap handoff via `resolveSessionUserId`), 404s a non-member (uniform,
+ * no existence probe — same `requireMembership` shape as `dualWorkspaceAuth`),
+ * then 403s `workspace_admin_required` for a member who isn't admin/owner —
+ * identical codes/ordering to `me.ts`'s `adminWorkspaceOr403`
+ * (`memberWorkspaceOr404` -> role check), so a session caller's behavior is
+ * also provably unchanged by the swap. Sets `governanceMintingUserId` to the
+ * session `userId` (mirroring what a bearer token's `minting_user_id`
+ * represents — "who does this governance action act as") so a handler
+ * written against `GovernanceVars` (e.g. the invite-creation handler in
+ * `routes/workspaces.ts`) needs zero changes to work from either auth path.
+ */
+export function dualGovernanceAuth(
+  requiredScope: WorkspaceScope,
+): MiddlewareHandler<GovernanceSessionVars> {
+  return async (c, next) => {
+    const authorization = c.req.header("Authorization");
+    if (authorization?.startsWith("Bearer ")) {
+      return workspaceGovernanceAuth(requiredScope)(
+        c as unknown as Parameters<ReturnType<typeof workspaceGovernanceAuth>>[0],
+        next,
+      );
+    }
+
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("name") ?? c.req.param("workspace");
+    if (!name) throw new UnauthorizedError();
+
+    const [membership] = await membershipsForUser(c.env, userId, { slug: name });
+    if (!membership || !workspacesFromMembership(membership).includes(name)) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+    if (membership.role !== "admin" && membership.role !== "owner") {
+      throw new ForbiddenError("workspace admin or owner role required", {
+        code: "workspace_admin_required",
+      });
+    }
+
+    c.set("governanceMintingUserId", userId);
     await next();
   };
 }

--- a/apps/api/src/dual-workspace-auth.ts
+++ b/apps/api/src/dual-workspace-auth.ts
@@ -10,7 +10,7 @@ import { ForbiddenError, NotFoundError, UnauthorizedError } from "@uploads/error
 import type { Context, MiddlewareHandler } from "hono";
 import { type WorkspaceScope } from "./auth-db";
 import { FILE_SCOPES } from "./auth-db";
-import { membershipsForUser, workspacesFromMembership } from "./org-workspaces";
+import { adminWorkspaceOr403, memberWorkspaceOr404, membershipsForUser } from "./org-workspaces";
 import {
   requireSessionUser,
   sessionAuth,
@@ -27,7 +27,21 @@ import {
 
 /** Combined context vars for routes reachable by either auth path. */
 export type DualAuthVars = {
-  Variables: WorkspaceVars["Variables"] & SessionVars["Variables"];
+  Variables: WorkspaceVars["Variables"] &
+    SessionVars["Variables"] & {
+      /**
+       * Session `userId` resolved by `dualWorkspaceAuth`'s session branch —
+       * set only when `authSource === "session"`. Lets `requireSessionAdmin`
+       * read the already-resolved id directly instead of calling
+       * `resolveSessionUserId` a second time, which would otherwise either
+       * harmlessly re-hit the `PRERESOLVED_USER` WeakMap on a forwarded/
+       * preset request, or — on a DIRECT (non-forwarded) request, where
+       * nothing preset the WeakMap — trigger a second, redundant
+       * `sessionAuth`/`get-session` network round trip for the same request
+       * (finding 2, `.context/613-api-consolidation-plan.md`).
+       */
+      sessionUserId?: string;
+    };
   Bindings: Env;
 };
 
@@ -57,18 +71,21 @@ export function presetResolvedSessionUser(request: Request, userId: string): voi
 }
 
 /**
- * Caller's membership for `name`, or a uniform 404 (never a 403 — no
- * existence probe). Deliberately a small standalone duplicate of
- * `memberWorkspaceOr404` in `routes/me.ts` rather than an import: this file
- * needs to stay free of any `routes/me.ts` dependency so `routes/me.ts` can
- * import `routes/workspace-files.ts` (which imports this file) for its old-
- * path aliases without an import cycle.
+ * Whether `request` already carries a pre-resolved session `userId` via the
+ * `PRERESOLVED_USER` handoff above. Exposed so a guard that needs to decide
+ * "session path or bearer/token path" — `dualWorkspaceAuth` here,
+ * `dualGovernanceAuth` below, and `routes/workspace-members.ts`'s
+ * `sessionMemberGate` — can give a preset unconditional priority, BEFORE
+ * ever branching on whatever `Authorization` header happens to still be
+ * riding along on the forwarded `Request` (a forwarded `/me` request keeps
+ * its original headers verbatim — see `me.ts`'s `forwardTo*` helpers). Fixes
+ * issue #613 phase 3 review finding 1: a Better Auth bearer-session caller
+ * (no cookie) whose session `me.ts` already validated was being rejected a
+ * second time by a bearer-branch that ran before the preset was ever
+ * consulted.
  */
-async function requireMembership(env: Env, userId: string, name: string): Promise<void> {
-  const [membership] = await membershipsForUser(env, userId, { slug: name });
-  if (!membership || !workspacesFromMembership(membership).includes(name)) {
-    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-  }
+export function hasPreresolvedSession(request: Request): boolean {
+  return PRERESOLVED_USER.has(request);
 }
 
 /**
@@ -102,11 +119,21 @@ export async function resolveSessionUserId(c: Context<SessionVars>): Promise<str
  * every existing `/me` file route, none of which consult `authScopes`.
  * `authSource: "session"` distinguishes the path taken without changing how
  * `requireScope` behaves (it only ever reads `authScopes`).
+ *
+ * A pre-resolved session (`hasPreresolvedSession`, e.g. a forwarded `/me`
+ * request) always takes the session path unconditionally, BEFORE the bearer
+ * check — a forwarded request's original `Authorization` header (a Better
+ * Auth bearer session, say) must never re-route an already-validated caller
+ * into the token path and 401 them a second time. Absent a preset, a bearer
+ * stays authoritative exactly as before: this guard's token path accepts
+ * both legacy hash tokens and D1 tokens (see `workspaceAuth`), so — unlike
+ * `dualGovernanceAuth`/`workspaceManageAuth` — it cannot narrow the bearer
+ * branch to an `up_`-prefixed shape without breaking legacy-token support.
  */
 export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
   return async (c, next) => {
     const authorization = c.req.header("Authorization");
-    if (authorization?.startsWith("Bearer ")) {
+    if (!hasPreresolvedSession(c.req.raw) && authorization?.startsWith("Bearer ")) {
       return workspaceAuth(c as unknown as Parameters<typeof workspaceAuth>[0], next);
     }
 
@@ -114,7 +141,7 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
 
     const name = c.req.param("workspace");
     if (!name) throw new UnauthorizedError();
-    await requireMembership(c.env, userId, name);
+    await memberWorkspaceOr404(c.env, userId, name);
 
     const record = await loadWorkspaceRecord(c.env, name);
     if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
@@ -124,6 +151,7 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
     c.set("authScopes", [...FILE_SCOPES]);
     c.set("authSource", "session");
     c.set("mintingUserId", null);
+    c.set("sessionUserId", userId);
     await next();
   };
 }
@@ -154,14 +182,26 @@ export function dualWorkspaceAuth(): MiddlewareHandler<DualAuthVars> {
  * into the bearer-shared type. Costs one extra round trip on session admin
  * routes only, same as `me.ts`'s own `memberWorkspaceOr404` -> `adminWorkspaceOr403`
  * double-lookup shape.
+ *
+ * Reads the caller's id off `sessionUserId` — set by `dualWorkspaceAuth`'s
+ * session branch on EVERY session-path request, preset-fast-path or not —
+ * rather than `c.get("sessionUser")`, which is only ever set by a real
+ * `sessionAuth` round trip and stays unset on the preset fast path (issue
+ * #613 phase 3 review finding 2: composing `dualWorkspaceAuth()` +
+ * `requireSessionAdmin()` on a forwarded/preset request used to 401 an
+ * already-authenticated caller because of exactly that gap). This also
+ * avoids a second `resolveSessionUserId` call here, which would otherwise
+ * either be a harmless redundant WeakMap hit (preset path) or a genuinely
+ * redundant `get-session` network round trip (direct path, since
+ * `dualWorkspaceAuth` already paid for one).
  */
 export function requireSessionAdmin(): MiddlewareHandler<DualAuthVars> {
   return async (c, next) => {
     if (c.get("authSource") === "session") {
-      const user = c.get("sessionUser") as SessionUser | null;
+      const userId = c.get("sessionUserId");
       const name = c.get("workspaceName");
-      if (!user || !name) throw new UnauthorizedError();
-      const [membership] = await membershipsForUser(c.env, user.id, { slug: name });
+      if (!userId || !name) throw new UnauthorizedError();
+      const [membership] = await membershipsForUser(c.env, userId, { slug: name });
       const role = membership?.role;
       if (role !== "admin" && role !== "owner") {
         throw new ForbiddenError("workspace admin or owner role required", {
@@ -196,13 +236,25 @@ export type GovernanceSessionVars = {
  * `POST /v1/workspaces/:name/invites` after it was upgraded to use this
  * function in place of a bare `workspaceGovernanceAuth("workspace:invite")`).
  *
- * With no bearer: resolves the session (honoring the `presetResolvedUser`
- * WeakMap handoff via `resolveSessionUserId`), 404s a non-member (uniform,
- * no existence probe — same `requireMembership` shape as `dualWorkspaceAuth`),
- * then 403s `workspace_admin_required` for a member who isn't admin/owner —
- * identical codes/ordering to `me.ts`'s `adminWorkspaceOr403`
+ * Bearer discrimination (issue #613 phase 3 review finding 1): a preset
+ * (`hasPreresolvedSession`, e.g. a forwarded `/me` request whose session
+ * `me.ts` already validated) always wins over any bearer header riding along
+ * on the same forwarded request — never re-branch an already-authenticated
+ * caller into the token path. Absent a preset, only an `up_`-shaped bearer is
+ * treated as a governance token — the same discrimination `workspaceManageAuth`
+ * (`routes/workspaces.ts`) already uses to tell a real workspace token apart
+ * from a Better Auth bearer session (`bearer()` plugin, `apps/auth/src/auth.ts`)
+ * riding the same `Authorization` header. Any other bearer (or none) falls
+ * through to `resolveSessionUserId`, which forwards the `Authorization` header
+ * to `get-session` as-is and validates a Better Auth session bearer exactly
+ * like a cookie (`session-auth.ts`'s `resolveSessionUser`) — this is what
+ * lets a bearer-session caller with no cookie succeed here.
+ *
+ * With no (non-`up_`) bearer: resolves the session, 404s a non-member
+ * (uniform, no existence probe) via `adminWorkspaceOr403` — identical
+ * codes/ordering to `me.ts`'s pre-#613 `adminWorkspaceOr403` call
  * (`memberWorkspaceOr404` -> role check), so a session caller's behavior is
- * also provably unchanged by the swap. Sets `governanceMintingUserId` to the
+ * provably unchanged by the swap. Sets `governanceMintingUserId` to the
  * session `userId` (mirroring what a bearer token's `minting_user_id`
  * represents — "who does this governance action act as") so a handler
  * written against `GovernanceVars` (e.g. the invite-creation handler in
@@ -213,7 +265,8 @@ export function dualGovernanceAuth(
 ): MiddlewareHandler<GovernanceSessionVars> {
   return async (c, next) => {
     const authorization = c.req.header("Authorization");
-    if (authorization?.startsWith("Bearer ")) {
+    const rawToken = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+    if (!hasPreresolvedSession(c.req.raw) && rawToken?.startsWith("up_")) {
       return workspaceGovernanceAuth(requiredScope)(
         c as unknown as Parameters<ReturnType<typeof workspaceGovernanceAuth>>[0],
         next,
@@ -224,15 +277,7 @@ export function dualGovernanceAuth(
     const name = c.req.param("name") ?? c.req.param("workspace");
     if (!name) throw new UnauthorizedError();
 
-    const [membership] = await membershipsForUser(c.env, userId, { slug: name });
-    if (!membership || !workspacesFromMembership(membership).includes(name)) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-    if (membership.role !== "admin" && membership.role !== "owner") {
-      throw new ForbiddenError("workspace admin or owner role required", {
-        code: "workspace_admin_required",
-      });
-    }
+    await adminWorkspaceOr403(c.env, userId, name);
 
     c.set("governanceMintingUserId", userId);
     await next();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { workspaces } from "./routes/workspaces";
 import { workspaceFiles } from "./routes/workspace-files";
 import { workspaceGalleries } from "./routes/workspace-galleries";
 import { workspaceUsage } from "./routes/workspace-usage";
+import { workspaceGithub } from "./routes/workspace-github";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
@@ -149,6 +150,11 @@ export const app = new Hono<WorkspaceVars>()
   // `workspaceFiles` above.
   .route("/v1/workspaces", workspaceGalleries)
   .route("/v1/workspaces", workspaceUsage)
+  // Canonical dual-auth github vertical (issue #613 phase 3):
+  // `/v1/workspaces/:workspace/github/*`, collapsing the five sub-routers
+  // mounted separately below into one router. Same "self-contained
+  // sub-router, own auth + error boundary" shape as `workspaceFiles` above.
+  .route("/v1/workspaces", workspaceGithub)
   // Anonymous CLI/MCP usage pings — no auth, before workspace guard.
   .route("/v1/telemetry", telemetry)
   // Explicit opt-in diagnostic reports (message + optional log) — no auth.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import { workspaceFiles } from "./routes/workspace-files";
 import { workspaceGalleries } from "./routes/workspace-galleries";
 import { workspaceUsage } from "./routes/workspace-usage";
 import { workspaceGithub } from "./routes/workspace-github";
+import { workspaceMembers } from "./routes/workspace-members";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
@@ -155,6 +156,17 @@ export const app = new Hono<WorkspaceVars>()
   // mounted separately below into one router. Same "self-contained
   // sub-router, own auth + error boundary" shape as `workspaceFiles` above.
   .route("/v1/workspaces", workspaceGithub)
+  // Canonical invites/members vertical (issue #613 phase 3):
+  // `/v1/workspaces/:workspace/members`, `/people`, `/invites*`,
+  // `/members/:memberId*` — session-only (a bearer 403s
+  // `members_requires_session`; see `routes/workspace-members.ts`'s
+  // docblock for why this vertical mints no new bearer capability). The one
+  // route in this vertical with a real bearer capability,
+  // `POST /:name/invites`, is NOT here — it was upgraded in place inside
+  // `workspaces` above (now `dualGovernanceAuth`-guarded) rather than
+  // parallel-registered, to avoid a same-path double-registration/shadowing
+  // hazard with the pre-existing governance-token route.
+  .route("/v1/workspaces", workspaceMembers)
   // Anonymous CLI/MCP usage pings — no auth, before workspace guard.
   .route("/v1/telemetry", telemetry)
   // Explicit opt-in diagnostic reports (message + optional log) — no auth.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import { workspaceGalleries } from "./routes/workspace-galleries";
 import { workspaceUsage } from "./routes/workspace-usage";
 import { workspaceGithub } from "./routes/workspace-github";
 import { workspaceMembers } from "./routes/workspace-members";
+import { workspaceSettings } from "./routes/workspace-settings";
 import { me } from "./routes/me";
 import { runRetentionSweep } from "./retention-sweep";
 import { runObservabilityRetention } from "./observability-retention";
@@ -167,6 +168,15 @@ export const app = new Hono<WorkspaceVars>()
   // parallel-registered, to avoid a same-path double-registration/shadowing
   // hazard with the pre-existing governance-token route.
   .route("/v1/workspaces", workspaceMembers)
+  // Canonical comment-settings, storage, and billing/summary verticals
+  // (issue #613 phase 3): `/v1/workspaces/:workspace/comment-settings`,
+  // `/storage`, `/storage/verify`, `/summary`, `/billing` — session-only,
+  // two privilege tiers (member for summary/billing, admin/owner for
+  // comment-settings/storage). A bearer 403s `billing_requires_session` or
+  // `settings_requires_session` depending on the tier; see
+  // `routes/workspace-settings.ts`'s docblock. No new bearer capability
+  // minted for any route here, same posture as `workspaceMembers` above.
+  .route("/v1/workspaces", workspaceSettings)
   // Anonymous CLI/MCP usage pings — no auth, before workspace guard.
   .route("/v1/telemetry", telemetry)
   // Explicit opt-in diagnostic reports (message + optional log) — no auth.

--- a/apps/api/src/org-workspaces.ts
+++ b/apps/api/src/org-workspaces.ts
@@ -111,6 +111,91 @@ export function workspacesFromMembership(membership: Membership): string[] {
   return [membership.organizationSlug];
 }
 
+/**
+ * One workspace's membership info, projected for the account-facing session
+ * surfaces (`routes/me.ts`, `routes/workspace-members.ts`). Lives here (not
+ * in `routes/me.ts`) so `routes/workspaces.ts` (governance/self-serve token
+ * routes) can share this membership-resolution logic without importing
+ * `routes/me.ts` — that direction would cycle back once `routes/me.ts`
+ * forwards its `POST /workspaces/:name/invites` alias into
+ * `routes/workspaces.ts`'s now-dual-authed canonical route (issue #613
+ * phase 3).
+ */
+export interface MyWorkspace {
+  workspace: string;
+  organization: { id: string; slug: string; name: string };
+  role: string;
+}
+
+export function myWorkspaceFromMembership(membership: Membership, workspace: string): MyWorkspace {
+  return {
+    workspace,
+    organization: {
+      id: membership.organizationId,
+      slug: membership.organizationSlug,
+      name: membership.organizationName || membership.organizationSlug,
+    },
+    role: membership.role,
+  };
+}
+
+/**
+ * Caller's membership for `name`, or a uniform 404 (not 403 — no existence
+ * probe). Slug-scoped membership query (one AUTH join), not the full list.
+ */
+export async function memberWorkspaceOr404(
+  env: Env,
+  userId: string,
+  name: string,
+): Promise<MyWorkspace> {
+  // 1:1 today: workspace name === org slug. Multi-workspace orgs would expand
+  // via workspacesFromMembership over the full list instead.
+  const [membership] = await membershipsForUser(env, userId, { slug: name });
+  if (!membership || !workspacesFromMembership(membership).includes(name)) {
+    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  }
+  return myWorkspaceFromMembership(membership, name);
+}
+
+/**
+ * Membership admin|owner for this workspace — 404 if not a member, 403 if
+ * member but not privileged. Shared by `routes/me.ts`'s admin-gated session
+ * routes and `routes/workspaces.ts`'s self-serve token governance dual-auth
+ * guard (issue #262 Task 3).
+ */
+export async function adminWorkspaceOr403(
+  env: Env,
+  userId: string,
+  name: string,
+): Promise<MyWorkspace> {
+  const ws = await memberWorkspaceOr404(env, userId, name);
+  if (ws.role !== "admin" && ws.role !== "owner") {
+    throw new ForbiddenError("workspace admin or owner role required", {
+      code: "workspace_admin_required",
+    });
+  }
+  return ws;
+}
+
+/**
+ * True iff the user holds org role `owner` (not `admin`) for workspace
+ * `name`, resolved via the same org<->workspace mapping as
+ * `adminWorkspaceOr403`/`memberWorkspaceOr404` (issue #265 — extends the
+ * #249 self-serve deletion gate from creator-only to creator OR org owner).
+ * Non-throwing: a non-member or unknown workspace is simply `false`, not a
+ * 404 — callers combine this with other ownership checks and want a uniform
+ * "not authorized" outcome rather than a membership-probing 404.
+ */
+export async function isWorkspaceOwner(env: Env, userId: string, name: string): Promise<boolean> {
+  try {
+    const ws = await memberWorkspaceOr404(env, userId, name);
+    return ws.role === "owner";
+  } catch (err) {
+    if (err instanceof NotFoundError) return false;
+    throw err;
+  }
+}
+
 /** A raw member row from the auth worker's `/internal/orgs/:slug/members`. */
 export interface OrgMember {
   id: string;

--- a/apps/api/src/routes/github-activity.ts
+++ b/apps/api/src/routes/github-activity.ts
@@ -6,7 +6,7 @@
  * failure surfaces as a 5xx rather than an empty-looking feed.
  */
 import { ValidationError } from "@uploads/errors";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { listPrActivityForWorkspace } from "../github-pr-activity";
 import { requireScope, type WorkspaceVars } from "../workspace";
 
@@ -24,13 +24,20 @@ function parseLimit(raw: string | undefined): number {
   return limit;
 }
 
+/**
+ * Handler body (issue #613 phase 3): extracted to a named function so the
+ * canonical dual-auth vertical (`routes/workspace-github.ts`) can reuse it
+ * verbatim — same pattern as the other four GitHub sub-routers.
+ */
+export async function githubActivityHandler(c: Context<WorkspaceVars>) {
+  const limit = parseLimit(c.req.query("limit"));
+  const workspaceName = c.get("workspaceName");
+  const activity = await listPrActivityForWorkspace(c.env.DB, workspaceName, limit);
+  return c.json({ workspace: workspaceName, activity });
+}
+
 export const githubActivity = new Hono<WorkspaceVars>().get(
   "/activity",
   requireScope("files:read"),
-  async (c) => {
-    const limit = parseLimit(c.req.query("limit"));
-    const workspaceName = c.get("workspaceName");
-    const activity = await listPrActivityForWorkspace(c.env.DB, workspaceName, limit);
-    return c.json({ workspace: workspaceName, activity });
-  },
+  githubActivityHandler,
 );

--- a/apps/api/src/routes/github-comment.ts
+++ b/apps/api/src/routes/github-comment.ts
@@ -10,7 +10,7 @@
  * tools (issue #392) — this route is just the HTTP wrapper.
  */
 import { ValidationError } from "@uploads/errors";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { postManagedComment } from "../github-comment-service";
 import type { GhTargetKind } from "../github-comment-render";
 import { writeRateLimit } from "../guards";
@@ -46,20 +46,31 @@ function parseTarget(body: Record<string, unknown>): {
   return { repo, num, kind, resync: body.resync === true };
 }
 
+/**
+ * Handler body (issue #613 phase 3): extracted to a named function so the
+ * canonical dual-auth vertical (`routes/workspace-github.ts`) can reuse it
+ * verbatim instead of copy-pasting — same "response shape can't drift"
+ * guarantee `routes/workspace-galleries.ts` established for phase 2. The old
+ * bearer path below keeps its own `requireScope("files:read")` UNCHANGED
+ * (issue #613 flags this as a wart — a write op scoped as a read — but the
+ * fix only applies to the canonical surface, see workspace-github.ts).
+ */
+export async function githubCommentHandler(c: Context<WorkspaceVars>) {
+  const { resync, ...target } = parseTarget(await jsonBody(c));
+  const result = await postManagedComment(
+    c.env,
+    c.get("workspace"),
+    c.get("workspaceName"),
+    c.get("mintingUserId"),
+    target,
+    { resync },
+  );
+  return c.json(result);
+}
+
 export const githubComment = new Hono<WorkspaceVars>().post(
   "/comment",
   writeRateLimit,
   requireScope("files:read"),
-  async (c) => {
-    const { resync, ...target } = parseTarget(await jsonBody(c));
-    const result = await postManagedComment(
-      c.env,
-      c.get("workspace"),
-      c.get("workspaceName"),
-      c.get("mintingUserId"),
-      target,
-      { resync },
-    );
-    return c.json(result);
-  },
+  githubCommentHandler,
 );

--- a/apps/api/src/routes/github-health.ts
+++ b/apps/api/src/routes/github-health.ts
@@ -12,7 +12,7 @@
  * (issue #333) — missing it never flips `ok` to false, it only surfaces a
  * hint that bot-comment self-healing isn't enabled.
  */
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import {
   appEventSubscriptions,
   githubAppConfig,
@@ -38,52 +38,59 @@ export interface GithubHealthResult {
   hint?: string;
 }
 
+/**
+ * Handler body (issue #613 phase 3): extracted to a named function so the
+ * canonical dual-auth vertical (`routes/workspace-github.ts`) can reuse it
+ * verbatim — same pattern as the other four GitHub sub-routers.
+ */
+export async function githubHealthHandler(c: Context<WorkspaceVars>) {
+  const cfg = githubAppConfig(c.env);
+  if (!cfg) {
+    return c.json<GithubHealthResult>({
+      configured: false,
+      ok: false,
+      events: null,
+      missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
+      requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+      recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
+      missingRecommendedEvents: [...RECOMMENDED_WEBHOOK_EVENTS],
+      hint: "GitHub App is not configured on this worker (GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY/GITHUB_APP_HOME_INSTALLATION_ID)",
+    });
+  }
+
+  const events = await appEventSubscriptions(cfg);
+  if (events === null) {
+    return c.json<GithubHealthResult>({
+      configured: true,
+      ok: false,
+      events: null,
+      missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
+      requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+      recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
+      missingRecommendedEvents: [...RECOMMENDED_WEBHOOK_EVENTS],
+      hint: "could not reach GET /app to read subscribed webhook events — try again shortly",
+    });
+  }
+
+  const missingEvents = REQUIRED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
+  const missingRecommendedEvents = RECOMMENDED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
+  return c.json<GithubHealthResult>({
+    configured: true,
+    ok: missingEvents.length === 0,
+    events,
+    missingEvents,
+    requiredEvents: REQUIRED_WEBHOOK_EVENTS,
+    recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
+    missingRecommendedEvents,
+    hint:
+      missingEvents.length > 0
+        ? `subscribe to ${missingEvents.join(", ")} at github.com/settings/apps/<your-app> → Permissions & events → Subscribe to events`
+        : undefined,
+  });
+}
+
 export const githubHealth = new Hono<WorkspaceVars>().get(
   "/health",
   requireScope("files:read"),
-  async (c) => {
-    const cfg = githubAppConfig(c.env);
-    if (!cfg) {
-      return c.json<GithubHealthResult>({
-        configured: false,
-        ok: false,
-        events: null,
-        missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
-        requiredEvents: REQUIRED_WEBHOOK_EVENTS,
-        recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
-        missingRecommendedEvents: [...RECOMMENDED_WEBHOOK_EVENTS],
-        hint: "GitHub App is not configured on this worker (GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY/GITHUB_APP_HOME_INSTALLATION_ID)",
-      });
-    }
-
-    const events = await appEventSubscriptions(cfg);
-    if (events === null) {
-      return c.json<GithubHealthResult>({
-        configured: true,
-        ok: false,
-        events: null,
-        missingEvents: [...REQUIRED_WEBHOOK_EVENTS],
-        requiredEvents: REQUIRED_WEBHOOK_EVENTS,
-        recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
-        missingRecommendedEvents: [...RECOMMENDED_WEBHOOK_EVENTS],
-        hint: "could not reach GET /app to read subscribed webhook events — try again shortly",
-      });
-    }
-
-    const missingEvents = REQUIRED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
-    const missingRecommendedEvents = RECOMMENDED_WEBHOOK_EVENTS.filter((e) => !events.includes(e));
-    return c.json<GithubHealthResult>({
-      configured: true,
-      ok: missingEvents.length === 0,
-      events,
-      missingEvents,
-      requiredEvents: REQUIRED_WEBHOOK_EVENTS,
-      recommendedEvents: RECOMMENDED_WEBHOOK_EVENTS,
-      missingRecommendedEvents,
-      hint:
-        missingEvents.length > 0
-          ? `subscribe to ${missingEvents.join(", ")} at github.com/settings/apps/<your-app> → Permissions & events → Subscribe to events`
-          : undefined,
-    });
-  },
+  githubHealthHandler,
 );

--- a/apps/api/src/routes/github-link.ts
+++ b/apps/api/src/routes/github-link.ts
@@ -9,7 +9,7 @@
  * (`claimed: false`, `owner`) rather than silently pretending to succeed.
  */
 import { ValidationError, ForbiddenError } from "@uploads/errors";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { isEntitledToClaimRepo } from "../github-claim-authz";
 import {
   deleteRepoLinkForWorkspace,
@@ -50,92 +50,105 @@ function linkResponse(repo: string, link: RepoLink | null) {
   };
 }
 
-export const githubLink = new Hono<WorkspaceVars>()
-  .get("/link", requireScope("files:read"), async (c) => {
-    const repo = parseRepo(c.req.query("repo"));
-    const link = await findRepoLink(c.env.DB, repo);
-    return c.json(linkResponse(repo, link));
-  })
-  // `/repo-link` (issue #398): a deliberately minimal, cross-tenant-safe
-  // counterpart to `/link` above. `/link` names the owning workspace in its
-  // response — fine for an authenticated inspect/claim flow the caller
-  // initiated for their own repo, but wrong for the `attach --branch` stage
-  // warning, which fires for ANY repo the CLI happens to detect from local
-  // git context. That warning must be able to say "this repo belongs to
-  // someone else" without ever saying to whom, so this route collapses the
-  // full link record down to a tri-state relative to the calling workspace:
-  // "self" (bound to me), "other" (bound, not to me), or "none" (unbound).
-  // Uses the lenient `findRepoLink` (never throws — a D1 blip degrades to
-  // "none", not a 5xx) because this is advisory-only; the CLI already
-  // silences anything but a clean 200.
-  .get("/repo-link", requireScope("files:read"), async (c) => {
-    const repo = parseRepo(c.req.query("repo"));
-    const workspaceName = c.get("workspaceName");
-    const link = await findRepoLink(c.env.DB, repo);
-    return c.json({ binding: deriveRepoBinding(link, workspaceName) });
-  })
-  .post("/link", writeRateLimit, requireScope("files:write"), async (c) => {
-    const repo = parseRepo((await jsonBody(c)).repo);
-    const workspaceName = c.get("workspaceName");
+/**
+ * Handler bodies (issue #613 phase 3): extracted to named functions so the
+ * canonical dual-auth vertical (`routes/workspace-github.ts`) can reuse them
+ * verbatim — same pattern as `routes/galleries.ts`'s phase-2 extraction.
+ */
+export async function githubLinkGetHandler(c: Context<WorkspaceVars>) {
+  const repo = parseRepo(c.req.query("repo"));
+  const link = await findRepoLink(c.env.DB, repo);
+  return c.json(linkResponse(repo, link));
+}
 
-    const before = await findRepoLink(c.env.DB, repo);
-    if (before) {
-      // Already bound — honestly report the owner rather than claiming
-      // success. First-claim-wins: this call never overwrites it, whether
-      // the owner is this workspace or another one.
-      return c.json({
-        claimed: before.workspaceName === workspaceName,
-        ...linkResponse(repo, before),
-      });
-    }
+// `/repo-link` (issue #398): a deliberately minimal, cross-tenant-safe
+// counterpart to `/link` above. `/link` names the owning workspace in its
+// response — fine for an authenticated inspect/claim flow the caller
+// initiated for their own repo, but wrong for the `attach --branch` stage
+// warning, which fires for ANY repo the CLI happens to detect from local
+// git context. That warning must be able to say "this repo belongs to
+// someone else" without ever saying to whom, so this route collapses the
+// full link record down to a tri-state relative to the calling workspace:
+// "self" (bound to me), "other" (bound, not to me), or "none" (unbound).
+// Uses the lenient `findRepoLink` (never throws — a D1 blip degrades to
+// "none", not a 5xx) because this is advisory-only; the CLI already
+// silences anything but a clean 200.
+export async function githubRepoLinkGetHandler(c: Context<WorkspaceVars>) {
+  const repo = parseRepo(c.req.query("repo"));
+  const workspaceName = c.get("workspaceName");
+  const link = await findRepoLink(c.env.DB, repo);
+  return c.json({ binding: deriveRepoBinding(link, workspaceName) });
+}
 
-    // Cross-tenant authorization (issue #297): this is the explicit-claim
-    // counterpart to the implicit claims in routes/github-comment.ts and
-    // routes/github-promote.ts — same gate, because this endpoint has even
-    // less friction (no upload, no GitHub API call of its own) than either
-    // of those. An unbound repo can only be claimed when this workspace's
-    // linked GitHub identity is verified (via the App's installation token)
-    // to have push/maintain/admin access to it. Soft-decline, not an error —
-    // `uploads github link` reports this the same way it reports "someone
-    // else owns it".
-    const entitled = await isEntitledToClaimRepo(c.env, repo, c.get("mintingUserId"));
-    if (!entitled) {
-      return c.json({
-        claimed: false,
-        reason: "not_authorized" as const,
-        ...linkResponse(repo, null),
-      });
-    }
+export async function githubLinkPostHandler(c: Context<WorkspaceVars>) {
+  const repo = parseRepo((await jsonBody(c)).repo);
+  const workspaceName = c.get("workspaceName");
 
-    await recordRepoLink(c.env.DB, repo, workspaceName, "cli");
-    const after = await findRepoLink(c.env.DB, repo);
+  const before = await findRepoLink(c.env.DB, repo);
+  if (before) {
+    // Already bound — honestly report the owner rather than claiming
+    // success. First-claim-wins: this call never overwrites it, whether
+    // the owner is this workspace or another one.
     return c.json({
-      claimed: after?.workspaceName === workspaceName,
-      ...linkResponse(repo, after),
+      claimed: before.workspaceName === workspaceName,
+      ...linkResponse(repo, before),
     });
-  })
-  // Self-serve unlink (issue #318): a workspace can only remove a binding it
-  // owns — this never lets one workspace unclaim another's repo. Use the
-  // admin-gated route (routes/admin-ui.ts) to reassign or remove someone
-  // else's stuck/abandoned binding.
-  .delete("/link", writeRateLimit, requireScope("files:write"), async (c) => {
-    const repo = parseRepo(c.req.query("repo"));
-    const workspaceName = c.get("workspaceName");
+  }
 
-    // Strict lookup: unlike the GET/POST handlers above (where a D1 blip
-    // degrading to "unclaimed" is an acceptable inspect-only fallback), a
-    // D1 read failure here must surface as a 5xx, not silently report
-    // `{unlinked: false, reason: "not_linked"}` (CodeRabbit, issue #318).
-    const before = await findRepoLinkStrict(c.env.DB, repo);
-    if (!before) {
-      return c.json({ repo, unlinked: false, reason: "not_linked" as const });
-    }
-    if (before.workspaceName !== workspaceName) {
-      throw new ForbiddenError(
-        `${repo} is bound to a different workspace ("${before.workspaceName}") — ask an operator to reassign it`,
-        { code: "not_link_owner" },
-      );
-    }
-    const removed = await deleteRepoLinkForWorkspace(c.env.DB, repo, workspaceName);
-    return c.json({ repo, unlinked: removed });
+  // Cross-tenant authorization (issue #297): this is the explicit-claim
+  // counterpart to the implicit claims in routes/github-comment.ts and
+  // routes/github-promote.ts — same gate, because this endpoint has even
+  // less friction (no upload, no GitHub API call of its own) than either
+  // of those. An unbound repo can only be claimed when this workspace's
+  // linked GitHub identity is verified (via the App's installation token)
+  // to have push/maintain/admin access to it. Soft-decline, not an error —
+  // `uploads github link` reports this the same way it reports "someone
+  // else owns it".
+  const entitled = await isEntitledToClaimRepo(c.env, repo, c.get("mintingUserId"));
+  if (!entitled) {
+    return c.json({
+      claimed: false,
+      reason: "not_authorized" as const,
+      ...linkResponse(repo, null),
+    });
+  }
+
+  await recordRepoLink(c.env.DB, repo, workspaceName, "cli");
+  const after = await findRepoLink(c.env.DB, repo);
+  return c.json({
+    claimed: after?.workspaceName === workspaceName,
+    ...linkResponse(repo, after),
   });
+}
+
+// Self-serve unlink (issue #318): a workspace can only remove a binding it
+// owns — this never lets one workspace unclaim another's repo. Use the
+// admin-gated route (routes/admin-ui.ts) to reassign or remove someone
+// else's stuck/abandoned binding.
+export async function githubLinkDeleteHandler(c: Context<WorkspaceVars>) {
+  const repo = parseRepo(c.req.query("repo"));
+  const workspaceName = c.get("workspaceName");
+
+  // Strict lookup: unlike the GET/POST handlers above (where a D1 blip
+  // degrading to "unclaimed" is an acceptable inspect-only fallback), a
+  // D1 read failure here must surface as a 5xx, not silently report
+  // `{unlinked: false, reason: "not_linked"}` (CodeRabbit, issue #318).
+  const before = await findRepoLinkStrict(c.env.DB, repo);
+  if (!before) {
+    return c.json({ repo, unlinked: false, reason: "not_linked" as const });
+  }
+  if (before.workspaceName !== workspaceName) {
+    throw new ForbiddenError(
+      `${repo} is bound to a different workspace ("${before.workspaceName}") — ask an operator to reassign it`,
+      { code: "not_link_owner" },
+    );
+  }
+  const removed = await deleteRepoLinkForWorkspace(c.env.DB, repo, workspaceName);
+  return c.json({ repo, unlinked: removed });
+}
+
+export const githubLink = new Hono<WorkspaceVars>()
+  .get("/link", requireScope("files:read"), githubLinkGetHandler)
+  .get("/repo-link", requireScope("files:read"), githubRepoLinkGetHandler)
+  .post("/link", writeRateLimit, requireScope("files:write"), githubLinkPostHandler)
+  .delete("/link", writeRateLimit, requireScope("files:write"), githubLinkDeleteHandler);

--- a/apps/api/src/routes/github-promote.ts
+++ b/apps/api/src/routes/github-promote.ts
@@ -8,7 +8,7 @@
  * installation lookup. See github-promote.ts for the copy logic.
  */
 import { ValidationError } from "@uploads/errors";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { postPromoteBranchAttachments } from "../github-promote-service";
 import { writeRateLimit } from "../guards";
 import { requireScope, type WorkspaceVars } from "../workspace";
@@ -51,22 +51,29 @@ function parseBody(body: Record<string, unknown>): PromoteBody {
   return { repo, num, branch };
 }
 
+/**
+ * Handler body (issue #613 phase 3): extracted to a named function so the
+ * canonical dual-auth vertical (`routes/workspace-github.ts`) can reuse it
+ * verbatim — same pattern as `githubCommentHandler` above.
+ */
+export async function githubPromoteHandler(c: Context<WorkspaceVars>) {
+  const target = parseBody(await jsonBody(c));
+  const workspaceName = c.get("workspaceName");
+  // Promote + gated claim live in github-promote-service so the hosted MCP
+  // promote tool reuses the same path (no drift with this route).
+  const result = await postPromoteBranchAttachments(
+    c.env,
+    c.get("workspace"),
+    workspaceName,
+    c.get("mintingUserId"),
+    target,
+  );
+  return c.json(result);
+}
+
 export const githubPromote = new Hono<WorkspaceVars>().post(
   "/promote",
   writeRateLimit,
   requireScope("files:write"),
-  async (c) => {
-    const target = parseBody(await jsonBody(c));
-    const workspaceName = c.get("workspaceName");
-    // Promote + gated claim live in github-promote-service so the hosted MCP
-    // promote tool reuses the same path (no drift with this route).
-    const result = await postPromoteBranchAttachments(
-      c.env,
-      c.get("workspace"),
-      workspaceName,
-      c.get("mintingUserId"),
-      target,
-    );
-    return c.json(result);
-  },
+  githubPromoteHandler,
 );

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -11,22 +11,13 @@
  */
 import { resolveWorkspaceCreateQuota } from "@uploads/billing";
 import {
-  NOTE_MAX_CHARS,
   resolveCommentOptions,
   type OptionSource,
   type ResolvedCommentOptions,
 } from "@uploads/comment-config";
-import {
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-  RateLimitedError,
-  ValidationError,
-} from "@uploads/errors";
-import { createFilesRouter, type R2Jurisdiction } from "@uploads/storage";
+import { NotFoundError, ValidationError } from "@uploads/errors";
+import { createFilesRouter } from "@uploads/storage";
 import { Hono, type Context } from "hono";
-import { usageWithLimits } from "../budget";
-import { sealCredentialFieldsStrict } from "../secrets";
 import { parseExternalReference } from "../external-references";
 import { previewFixtureItems } from "../comment-preview-fixtures";
 import { badKey, listObjects } from "../files-core";
@@ -41,35 +32,24 @@ import { githubInstallStatus, type GithubInstallStatus } from "../github-install
 import { findRepoLink, listRepoLinksForWorkspace } from "../github-repo-links";
 import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-comment-config";
 import { resolveTitles } from "../github-titles";
-import { allowWrite } from "../guards";
 import {
   adminWorkspaceOr403,
   memberWorkspaceOr404,
   membershipsForUser,
   myWorkspaceFromMembership,
-  subscriptionForOrg,
   workspacesFromMembership,
-  type Membership,
   type MyWorkspace,
 } from "../org-workspaces";
 import { presetResolvedSessionUser } from "../dual-workspace-auth";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
-import { selfServeWorkspaceRecord } from "../self-serve-defaults";
 import { storage } from "../storage";
-import { getWorkspaceUsage } from "../usage";
-import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
-import { mutateWorkspaceRecord } from "../workspace-mutate";
-import { planResponse, planSourceFor } from "../workspace-plan";
+import { loadWorkspaceRecord } from "../workspace";
+import { planResponse } from "../workspace-plan";
 import { workspaceFiles } from "./workspace-files";
 import { workspaceMembers } from "./workspace-members";
+import { workspaceSettings } from "./workspace-settings";
 import { workspaceUsage } from "./workspace-usage";
 import { workspaces } from "./workspaces";
-import {
-  candidateFromBody,
-  storageReconcile,
-  storageStatusResponse,
-  storageVerify,
-} from "./workspace-storage";
 
 /**
  * Rewrites `c`'s request onto `workspaceFiles`'s own path space (its routes
@@ -167,150 +147,28 @@ async function forwardToWorkspaceInvite(c: Context<SessionVars>, name: string): 
   return workspaces.fetch(forwarded, c.env, executionCtx);
 }
 
-/** `imageWidth` bounds (issue #307): "full" or an integer clamp width in px. */
-const COMMENT_IMAGE_WIDTH_MIN = 160;
-const COMMENT_IMAGE_WIDTH_MAX = 1000;
-/** `maxInlineImages` bounds (issue #307). */
-const COMMENT_MAX_INLINE_IMAGES_MIN = 1;
-const COMMENT_MAX_INLINE_IMAGES_MAX = 48;
-
-/** The five workspace-level comment-defaults fields (issue #307). */
-const COMMENT_SETTINGS_KEYS = [
-  "imageWidth",
-  "maxInlineImages",
-  "showMetadata",
-  "linkToFilePage",
-  "note",
-] as const;
-type CommentSettingsKey = (typeof COMMENT_SETTINGS_KEYS)[number];
-
-/** Record field each API key writes to. */
-const COMMENT_SETTINGS_RECORD_FIELD: Record<CommentSettingsKey, keyof WorkspaceRecord> = {
-  imageWidth: "githubCommentImageWidth",
-  maxInlineImages: "githubCommentMaxInlineImages",
-  showMetadata: "githubCommentShowMetadata",
-  linkToFilePage: "githubCommentLinkToFilePage",
-  note: "githubCommentNote",
-};
-
-type CommentSettingsValue = string | number | boolean;
-type CommentSettingsPatch = Partial<Record<CommentSettingsKey, CommentSettingsValue | null>>;
-
 /**
- * Validates a PATCH body for the workspace-level managed-comment defaults
- * (issue #307). This is the single enforcement point for the bounds the
- * resolver itself does not clamp (a review finding on the Task 1 parser):
- * imageWidth "full" or an integer 160–1000, maxInlineImages an integer
- * 1–48, and note trimmed, non-empty, and at most `NOTE_MAX_CHARS`. Reject-
- * all-or-apply-all — the whole body is checked before any record mutation,
- * so an invalid field never partially applies. An omitted key means "leave
- * unchanged"; an explicit `null` clears the field. Unknown keys are
- * ignored, mirroring `validateGithubCommentSettingsPatch` (admin-ui.ts) and
- * `validateLimitsPatch` (workspace-limits.ts), the two sibling workspace-
- * record PATCH validators in this codebase.
+ * Same forwarding pattern, targeting the canonical comment-settings/storage/
+ * billing/summary verticals (`routes/workspace-settings.ts`, issue #613
+ * phase 3). The canonical handlers are the exact bodies these four routes
+ * used to run in this file (extracted verbatim, see git history), so this
+ * is a genuine forward, not a reimplementation.
  */
-function validateCommentSettingsPatch(body: unknown): CommentSettingsPatch {
-  if (typeof body !== "object" || body === null || Array.isArray(body)) {
-    throw new ValidationError("request body must be a JSON object", { code: "invalid_settings" });
+async function forwardToWorkspaceSettings(
+  c: Context<SessionVars>,
+  path: string,
+): Promise<Response> {
+  const url = new URL(c.req.url);
+  url.pathname = path;
+  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
   }
-  const record = body as Record<string, unknown>;
-  const patch: CommentSettingsPatch = {};
-
-  if ("imageWidth" in record) {
-    const value = record.imageWidth;
-    if (value === null) {
-      patch.imageWidth = null;
-    } else if (value === "full") {
-      patch.imageWidth = "full";
-    } else if (
-      typeof value === "number" &&
-      Number.isInteger(value) &&
-      value >= COMMENT_IMAGE_WIDTH_MIN &&
-      value <= COMMENT_IMAGE_WIDTH_MAX
-    ) {
-      patch.imageWidth = value;
-    } else {
-      throw new ValidationError(
-        `imageWidth must be "full", an integer ${COMMENT_IMAGE_WIDTH_MIN}–${COMMENT_IMAGE_WIDTH_MAX}, or null`,
-        { code: "invalid_settings", details: { field: "imageWidth" } },
-      );
-    }
-  }
-
-  if ("maxInlineImages" in record) {
-    const value = record.maxInlineImages;
-    if (value === null) {
-      patch.maxInlineImages = null;
-    } else if (
-      typeof value === "number" &&
-      Number.isInteger(value) &&
-      value >= COMMENT_MAX_INLINE_IMAGES_MIN &&
-      value <= COMMENT_MAX_INLINE_IMAGES_MAX
-    ) {
-      patch.maxInlineImages = value;
-    } else {
-      throw new ValidationError(
-        `maxInlineImages must be an integer ${COMMENT_MAX_INLINE_IMAGES_MIN}–${COMMENT_MAX_INLINE_IMAGES_MAX} or null`,
-        { code: "invalid_settings", details: { field: "maxInlineImages" } },
-      );
-    }
-  }
-
-  if ("showMetadata" in record) {
-    const value = record.showMetadata;
-    if (value !== null && typeof value !== "boolean") {
-      throw new ValidationError("showMetadata must be a boolean or null", {
-        code: "invalid_settings",
-        details: { field: "showMetadata" },
-      });
-    }
-    patch.showMetadata = value;
-  }
-
-  if ("linkToFilePage" in record) {
-    const value = record.linkToFilePage;
-    if (value !== null && typeof value !== "boolean") {
-      throw new ValidationError("linkToFilePage must be a boolean or null", {
-        code: "invalid_settings",
-        details: { field: "linkToFilePage" },
-      });
-    }
-    patch.linkToFilePage = value;
-  }
-
-  if ("note" in record) {
-    const value = record.note;
-    if (value === null) {
-      patch.note = null;
-    } else if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (trimmed.length === 0 || trimmed.length > NOTE_MAX_CHARS) {
-        throw new ValidationError(`note must be 1–${NOTE_MAX_CHARS} characters after trimming`, {
-          code: "invalid_settings",
-          details: { field: "note" },
-        });
-      }
-      patch.note = trimmed;
-    } else {
-      throw new ValidationError("note must be a string or null", {
-        code: "invalid_settings",
-        details: { field: "note" },
-      });
-    }
-  }
-
-  return patch;
-}
-
-/** Response body shared by GET and PATCH: the workspace-level comment defaults. */
-function commentSettingsResponse(record: WorkspaceRecord) {
-  return {
-    imageWidth: record.githubCommentImageWidth ?? null,
-    maxInlineImages: record.githubCommentMaxInlineImages ?? null,
-    showMetadata: record.githubCommentShowMetadata ?? null,
-    linkToFilePage: record.githubCommentLinkToFilePage ?? null,
-    note: record.githubCommentNote ?? null,
-  };
+  const forwarded = new Request(url, c.req.raw);
+  presetResolvedSessionUser(forwarded, requireUserId(c));
+  return workspaceSettings.fetch(forwarded, c.env, executionCtx);
 }
 
 /** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
@@ -396,93 +254,20 @@ export const me = new Hono<SessionVars>()
   )
 
   // Workspace shell for the account rail: membership + public URL + usage.
-  .get("/workspaces/:name/summary", async (c) => {
-    const name = c.req.param("name");
-    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    const publicBaseUrl = record.publicBaseUrl;
-    let usage: ReturnType<typeof usageWithLimits> | null = null;
-    if (record) {
-      try {
-        usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
-      } catch {
-        usage = null;
-      }
-    }
-
-    return c.json({
-      workspace: ws.workspace,
-      organization: ws.organization,
-      role: ws.role,
-      hasPublicUrl: Boolean(publicBaseUrl),
-      publicBaseUrl,
-      usage,
-    });
-  })
+  // Issue #613 phase 3: forwards to the canonical dual-auth-free (session-
+  // only) handler in `routes/workspace-settings.ts` — the extracted handler
+  // is byte-for-byte the body this route used to run, so response shape
+  // can't drift. See `forwardToWorkspaceSettings`'s docblock.
+  .get("/workspaces/:name/summary", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/summary`),
+  )
 
   // Plan metadata, resolved effective limits, usage, and subscription state
-  // for the account billing tab — 404s unless the caller is a member.
-  // `plan`/`available`/`planApplied`/`limits` reuse workspace-plan.ts's
-  // `planResponse` — the same attribution contract the admin plan surface
-  // uses (Task 5's Critical fix): a record with no `plan` field must never
-  // display free-plan default caps it isn't actually enforcing, so
-  // `planApplied` is `false` and `limits` mirrors enforcement
-  // (explicit-or-unlimited) rather than the plan defaults.
-  //
-  // `planSource`/`subscription` (issue #445, purely additive to the shape
-  // above — a billing-tab lane builds its UI against this) are sourced from
-  // the auth D1 `subscription` table over the AUTH service binding
-  // (org-workspaces.ts's `subscriptionForOrg`), the same internal-bridge
-  // pattern as every other org lookup here. `subscriptionForOrg` never
-  // throws — an AUTH outage degrades to `subscription: null` +
-  // `planSource: "none"`-or-"admin" (whichever `planSourceFor` derives with a
-  // null subscription) rather than a 500. `stripeCustomerId` is deliberately
-  // dropped here — it's an admin-ui-only field (see routes/admin-ui.ts's
-  // plan surface), never exposed to the member-facing /me API.
-  .get("/workspaces/:name/billing", async (c) => {
-    const name = c.req.param("name");
-    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
-
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) {
-      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    }
-
-    const { plan, available, planApplied, limits } = planResponse(name, record);
-
-    const [usage, authSubscription] = await Promise.all([
-      getWorkspaceUsage(c.env.DB, name)
-        .then((raw) => usageWithLimits(raw, record))
-        .catch(() => null),
-      subscriptionForOrg(c.env, ws.organization.slug),
-    ]);
-
-    const planSource = planSourceFor(record, authSubscription);
-    const subscription = authSubscription
-      ? {
-          status: authSubscription.status,
-          periodEnd: authSubscription.periodEnd,
-          cancelAtPeriodEnd: authSubscription.cancelAtPeriodEnd,
-        }
-      : null;
-
-    return c.json({
-      workspace: ws.workspace,
-      organization: ws.organization,
-      plan,
-      available,
-      planApplied,
-      limits,
-      usage,
-      planSource,
-      subscription,
-    });
-  })
+  // for the account billing tab. Same forward as above. `stripeCustomerId`
+  // redaction preserved exactly in the canonical handler — see its docblock.
+  .get("/workspaces/:name/billing", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/billing`),
+  )
 
   // People in one workspace — member-gated (teammate fields only, not admin
   // raw rows). Issue #613 phase 3: forwards to the canonical dual-auth-free
@@ -674,50 +459,17 @@ export const me = new Hono<SessionVars>()
   // Workspace-level managed-comment defaults (issue #307): image width,
   // inline-image cap, the two legacy booleans, and a short note. Admin/owner
   // only — these are workspace-wide defaults every repo comment inherits
-  // unless a repo's `.uploads.yml` overrides them.
-  .get("/workspaces/:name/comment-settings", async (c) => {
-    const name = c.req.param("name");
-    await adminWorkspaceOr403(c.env, requireUserId(c), name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    return c.json(commentSettingsResponse(record));
-  })
+  // unless a repo's `.uploads.yml` overrides them. Issue #613 phase 3:
+  // forwards to the canonical handler in `routes/workspace-settings.ts` —
+  // the extracted handler is byte-for-byte the body this route used to run.
+  .get("/workspaces/:name/comment-settings", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/comment-settings`),
+  )
 
-  // Patch the defaults above. Validated in full before any write (reject-
-  // all-or-apply-all — see `validateCommentSettingsPatch`); an omitted key
-  // leaves the field unchanged, an explicit `null` clears it.
-  .patch("/workspaces/:name/comment-settings", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    await adminWorkspaceOr403(c.env, userId, name);
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      throw new ValidationError("request body must be valid JSON", { code: "invalid_settings" });
-    }
-    const patch = validateCommentSettingsPatch(body);
-    const record = await mutateWorkspaceRecord(
-      c.env,
-      name,
-      (current) => {
-        const next = { ...current };
-        for (const key of COMMENT_SETTINGS_KEYS) {
-          if (!(key in patch)) continue;
-          const field = COMMENT_SETTINGS_RECORD_FIELD[key];
-          const value = patch[key];
-          if (value === null || value === undefined) delete next[field];
-          else (next as Record<string, unknown>)[field] = value;
-        }
-        return next;
-      },
-      { requireServing: true },
-    );
-    return c.json(commentSettingsResponse(record));
-  })
+  // Patch the defaults above. Same forward as above.
+  .patch("/workspaces/:name/comment-settings", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/comment-settings`),
+  )
 
   // Preview the production managed-comment body against resolved comment
   // settings (issue #307). Admin/owner-gated like the settings routes above:
@@ -797,228 +549,20 @@ export const me = new Hono<SessionVars>()
 
   // Self-serve BYO R2 bucket (issue #583 Task 1.1): read/verify/write/detach
   // of a workspace's storage config. Same audience as the comment-settings
-  // triple above (admin/owner only) — storage config is workspace-wide and
-  // security sensitive. Readable regardless of `byoBucketEnabled` (the
-  // settings UI needs the flag value to decide whether to show the panel at
-  // all); verify/write/detach 403 when the flag is off (fail-closed, see
-  // `byoBucketAllowed` in workspace.ts). Never returns credential values —
-  // `storageStatusResponse` (workspace-storage.ts) projects masked/presence
-  // fields only, same posture as `GET /admin/workspaces/:name` (admin.ts).
-  .get("/workspaces/:name/storage", async (c) => {
-    const name = c.req.param("name");
-    await adminWorkspaceOr403(c.env, requireUserId(c), name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    return c.json(storageStatusResponse(record, byoBucketAllowed(record)));
-  })
-
-  // Runs the verify pipeline (storage-verify.ts) against the request body —
-  // never saved state — so an admin can iterate on credentials before
-  // anything is persisted. Rate-limited via `allowWrite` like every other
-  // mutating-adjacent route here: each call does real remote I/O (auth
-  // probe + a write/read/delete round-trip against the candidate bucket).
-  .post("/workspaces/:name/storage/verify", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    await adminWorkspaceOr403(c.env, userId, name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    if (!byoBucketAllowed(record)) {
-      throw new ForbiddenError("BYO storage is not enabled for this workspace", {
-        code: "byo_bucket_disabled",
-      });
-    }
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const body = await c.req.json().catch(() => null);
-    const candidate = candidateFromBody(body);
-    const result = await storageVerify(candidate);
-    return c.json(result);
-  })
-
-  // Persist a verified BYO config. Never trusts a client-side "verified"
-  // claim — re-runs the same pipeline server-side against the request body,
-  // and only writes on a pass. On a fail, responds with the verify result
-  // (422) so the UI can render the same checklist the standalone verify
-  // route would have. `mutateWorkspaceRecord` (with `requireServing`) both
-  // re-checks the workspace hasn't been soft-deleted since the request
-  // started and gives us the read-immediately-before-write window issue #387
-  // exists for; sealing happens *inside* that callback (precedent:
-  // `reencrypt-registry.ts`), never on data read earlier in the request.
-  .put("/workspaces/:name/storage", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    await adminWorkspaceOr403(c.env, userId, name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    if (!byoBucketAllowed(record)) {
-      throw new ForbiddenError("BYO storage is not enabled for this workspace", {
-        code: "byo_bucket_disabled",
-      });
-    }
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const body = await c.req.json().catch(() => null);
-    const candidate = candidateFromBody(body);
-    const result = await storageVerify(candidate);
-    if (!result.ok) {
-      return c.json(result, 422);
-    }
-
-    // No migration of populated workspaces in v1 (plan's global constraints):
-    // attaching a BYO bucket to a workspace that already holds files would
-    // orphan them on the shared bucket. Checked against the D1 usage ledger
-    // *before* the mutation — a KV-only read inside the callback can't see
-    // this — accepting the narrow race where a concurrent upload lands
-    // between this check and the write (the callback's `requireServing`
-    // re-check guards the record itself, not usage).
-    const usage = await getWorkspaceUsage(c.env.DB, name);
-    if (usage.objects > 0 && candidate.adoptExistingContents !== true) {
-      throw new ConflictError(
-        "this workspace already has files — BYO storage can only be attached to an empty workspace",
-        { code: "workspace_storage_not_empty" },
-      );
-    }
-
-    const nowIso = new Date().toISOString();
-    const updated = await mutateWorkspaceRecord(
-      c.env,
-      name,
-      async (current) => {
-        const sealed = await sealCredentialFieldsStrict(c.env.WORKSPACE_SECRETS_KEY, {
-          accessKeyId: candidate.accessKeyId,
-          secretAccessKey: candidate.secretAccessKey,
-        });
-        const next: WorkspaceRecord = { ...current };
-        delete next.prefix;
-        delete next.binding;
-        next.bucket = candidate.bucket;
-        next.accountId = candidate.accountId;
-        next.accessKeyId = sealed.accessKeyId;
-        next.secretAccessKey = sealed.secretAccessKey;
-        if (candidate.publicBaseUrl) next.publicBaseUrl = candidate.publicBaseUrl;
-        else delete next.publicBaseUrl;
-        // Cast is safe: `storageVerify` above already ran the shape check
-        // (storage-verify.ts) that 422s on anything outside R2_JURISDICTIONS.
-        if (candidate.jurisdiction) next.jurisdiction = candidate.jurisdiction as R2Jurisdiction;
-        else delete next.jurisdiction;
-        next.storageConfiguredAt = nowIso;
-        next.storageVerifiedAt = nowIso;
-        next.storageConfiguredBy = userId;
-        // Display fragment for the settings UI, captured from the plaintext
-        // before sealing — `next.accessKeyId` is ciphertext from here on.
-        next.storageAccessKeyIdLast4 = candidate.accessKeyId.slice(-4);
-        return next;
-      },
-      { requireServing: true },
-    );
-
-    console.log(JSON.stringify({ event: "workspace_storage_configured", workspace: name, userId }));
-
-    // `adoptExistingContents` bypassed the emptiness guard, so the D1 usage
-    // ledger still describes the old backing storage while the adopted
-    // bucket's contents are what this workspace now serves. Rebuild the
-    // ledger from the new bucket so it's honest immediately (it's dormant
-    // for `maxStorageBytes` while BYO is active — `storageBudgetApplies` —
-    // but powers the settings UI and becomes authoritative again on detach).
-    // Best-effort: the config write above already succeeded, and reconcile
-    // can be re-run any time.
-    if (candidate.adoptExistingContents === true) {
-      await storageReconcile(c.env, updated, name).catch((err) =>
-        console.error("workspace storage attach: usage reconcile failed for", name, err),
-      );
-    }
-
-    return c.json({ ...storageStatusResponse(updated, true), verify: result });
-  })
-
-  // Detach BYO storage and restore shared-bucket defaults. Never touches the
-  // customer's bucket or its objects — only the platform's own KV record.
-  // Blocked unless the workspace's usage ledger reports zero objects, or the
-  // caller explicitly passes `force` (query `?force=true` or a JSON body
-  // `{ "force": true }`) — mirrors the empty-workspace guard on PUT above,
-  // in the opposite direction. Shared-bucket fields (bucket/binding/prefix/
-  // publicBaseUrl) come from `selfServeWorkspaceRecord` so this can't drift
-  // from what a brand-new self-serve workspace actually gets; everything
-  // else on the record (limits, github links, comment settings, plan, other
-  // flags) is preserved untouched.
-  .delete("/workspaces/:name/storage", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    await adminWorkspaceOr403(c.env, userId, name);
-    const record = await loadWorkspaceRecord(c.env, name);
-    if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-    if (!byoBucketAllowed(record)) {
-      throw new ForbiddenError("BYO storage is not enabled for this workspace", {
-        code: "byo_bucket_disabled",
-      });
-    }
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const queryForce = c.req.query("force");
-    const bodyForce = await c.req
-      .json<{ force?: unknown }>()
-      .then((b) => b?.force === true)
-      .catch(() => false);
-    const force = queryForce === "true" || queryForce === "1" || bodyForce;
-
-    if (!force) {
-      const usage = await getWorkspaceUsage(c.env.DB, name);
-      if (usage.objects > 0) {
-        throw new ConflictError(
-          "this workspace still has files on its BYO bucket — pass force to detach anyway",
-          { code: "workspace_storage_not_empty" },
-        );
-      }
-    }
-
-    const updated = await mutateWorkspaceRecord(
-      c.env,
-      name,
-      (current) => {
-        const shared = selfServeWorkspaceRecord({
-          name,
-          userId: current.createdByUserId ?? userId,
-          now: new Date(),
-        });
-        const next: WorkspaceRecord = { ...current };
-        next.bucket = shared.bucket;
-        next.binding = shared.binding;
-        next.prefix = shared.prefix;
-        if (shared.publicBaseUrl) next.publicBaseUrl = shared.publicBaseUrl;
-        else delete next.publicBaseUrl;
-        delete next.accountId;
-        delete next.accessKeyId;
-        delete next.secretAccessKey;
-        delete next.jurisdiction;
-        delete next.storageConfiguredAt;
-        delete next.storageVerifiedAt;
-        delete next.storageConfiguredBy;
-        delete next.storageAccessKeyIdLast4;
-        return next;
-      },
-      { requireServing: true },
-    );
-
-    console.log(JSON.stringify({ event: "workspace_storage_detached", workspace: name, userId }));
-
-    // `force` bypassed the emptiness guard, so the ledger still describes
-    // the detached BYO bucket — but `maxStorageBytes` enforcement resumes on
-    // the shared bucket the moment this record is restored, and stale counts
-    // could leave the workspace permanently over-budget with nothing to
-    // delete. Rebuild from the restored shared-bucket prefix (best-effort,
-    // same rationale as the attach path above).
-    if (force) {
-      await storageReconcile(c.env, updated, name).catch((err) =>
-        console.error("workspace storage detach: usage reconcile failed for", name, err),
-      );
-    }
-
-    return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
-  });
+  // triple above (admin/owner only). Issue #613 phase 3: forwards to the
+  // canonical handlers in `routes/workspace-settings.ts` — extracted
+  // byte-for-byte from the bodies these four routes used to run, so
+  // response shape (masked `storageStatusResponse` projection, never
+  // credential values) can't drift.
+  .get("/workspaces/:name/storage", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage`),
+  )
+  .post("/workspaces/:name/storage/verify", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage/verify`),
+  )
+  .put("/workspaces/:name/storage", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage`),
+  )
+  .delete("/workspaces/:name/storage", (c) =>
+    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage`),
+  );

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -52,14 +52,24 @@ import { workspaceUsage } from "./workspace-usage";
 import { workspaces } from "./workspaces";
 
 /**
- * Rewrites `c`'s request onto `workspaceFiles`'s own path space (its routes
- * are registered as `/:workspace/files*`, independent of any parent mount —
- * see routes/workspace-files.ts) and re-dispatches through it directly. The
- * canonical dual-auth middleware + handler run exactly as they would for a
- * caller hitting `/v1/workspaces/:workspace/files*` directly, so response
- * shape can't drift from the canonical route without this alias breaking too.
+ * Rewrites `c`'s request onto `router`'s own path space and re-dispatches
+ * through it directly, so the canonical dual-auth middleware + handler run
+ * exactly as they would for a caller hitting the canonical route directly —
+ * response shape can't drift from the canonical route without the alias
+ * breaking too. `path` must already have every interpolated segment
+ * `encodeURIComponent`-encoded by the caller (see the `forwardToWorkspace*`
+ * wrappers below): an unencoded `/` or `..` in a param would let `URL`
+ * normalize dot segments and reshape which route this actually dispatches
+ * to (CodeRabbit PR #617 review finding 2).
+ *
+ * Shared by every `forwardToWorkspace*` wrapper below — they differ only in
+ * which canonical router they re-dispatch through.
  */
-async function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): Promise<Response> {
+async function forwardTo(
+  router: { fetch: typeof workspaceFiles.fetch },
+  c: Context<SessionVars>,
+  path: string,
+): Promise<Response> {
   const url = new URL(c.req.url);
   url.pathname = path;
   // `c.executionCtx` throws outside a real Workers/`app.fetch(req, env, ctx)`
@@ -78,50 +88,37 @@ async function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): P
   // hand that off so `dualWorkspaceAuth` skips a second `get-session` fetch
   // for the same request (issue #613 phase 1 follow-up).
   presetResolvedSessionUser(forwarded, requireUserId(c));
-  return workspaceFiles.fetch(forwarded, c.env, executionCtx);
+  return router.fetch(forwarded, c.env, executionCtx);
 }
 
 /**
- * Same forwarding pattern as `forwardToWorkspaceFiles`, targeting the
- * canonical usage vertical (`routes/workspace-usage.ts`, issue #613 phase 2).
- * Response shape is a strict superset of the pre-#613 session shape (adds
- * `scopes`/`plan`; every other field — `workspace`/`bytes`/`objects`/
- * `uploadsInPeriod`/`periodStart`/limits — matches verbatim), so this is a
- * genuine forward, not a re-implementation.
+ * Forwards to the canonical files vertical (`routes/workspace-files.ts`,
+ * issue #613 phase 1) — routes registered as `/:workspace/files*`.
  */
-async function forwardToWorkspaceUsage(c: Context<SessionVars>, path: string): Promise<Response> {
-  const url = new URL(c.req.url);
-  url.pathname = path;
-  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
-  try {
-    executionCtx = c.executionCtx;
-  } catch {
-    executionCtx = undefined;
-  }
-  const forwarded = new Request(url, c.req.raw);
-  presetResolvedSessionUser(forwarded, requireUserId(c));
-  return workspaceUsage.fetch(forwarded, c.env, executionCtx);
+function forwardToWorkspaceFiles(c: Context<SessionVars>, path: string): Promise<Response> {
+  return forwardTo(workspaceFiles, c, path);
 }
 
 /**
- * Same forwarding pattern, targeting the canonical invites/members vertical
+ * Forwards to the canonical usage vertical (`routes/workspace-usage.ts`,
+ * issue #613 phase 2). Response shape is a strict superset of the pre-#613
+ * session shape (adds `scopes`/`plan`; every other field —
+ * `workspace`/`bytes`/`objects`/`uploadsInPeriod`/`periodStart`/limits —
+ * matches verbatim), so this is a genuine forward, not a re-implementation.
+ */
+function forwardToWorkspaceUsage(c: Context<SessionVars>, path: string): Promise<Response> {
+  return forwardTo(workspaceUsage, c, path);
+}
+
+/**
+ * Forwards to the canonical invites/members vertical
  * (`routes/workspace-members.ts`, issue #613 phase 3) for the session-only
  * routes (`members`/`people`/`invites` GET/DELETE/`members/:id` PATCH). The
  * canonical handlers are the exact bodies this file's routes used to run
  * (extracted verbatim, see git history), so this is a genuine forward.
  */
-async function forwardToWorkspaceMembers(c: Context<SessionVars>, path: string): Promise<Response> {
-  const url = new URL(c.req.url);
-  url.pathname = path;
-  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
-  try {
-    executionCtx = c.executionCtx;
-  } catch {
-    executionCtx = undefined;
-  }
-  const forwarded = new Request(url, c.req.raw);
-  presetResolvedSessionUser(forwarded, requireUserId(c));
-  return workspaceMembers.fetch(forwarded, c.env, executionCtx);
+function forwardToWorkspaceMembers(c: Context<SessionVars>, path: string): Promise<Response> {
+  return forwardTo(workspaceMembers, c, path);
 }
 
 /**
@@ -133,42 +130,19 @@ async function forwardToWorkspaceMembers(c: Context<SessionVars>, path: string):
  * acceptUrl }` from the same AUTH `/internal/invite` call), so this is a
  * genuine forward, not a reimplementation.
  */
-async function forwardToWorkspaceInvite(c: Context<SessionVars>, name: string): Promise<Response> {
-  const url = new URL(c.req.url);
-  url.pathname = `/${name}/invites`;
-  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
-  try {
-    executionCtx = c.executionCtx;
-  } catch {
-    executionCtx = undefined;
-  }
-  const forwarded = new Request(url, c.req.raw);
-  presetResolvedSessionUser(forwarded, requireUserId(c));
-  return workspaces.fetch(forwarded, c.env, executionCtx);
+function forwardToWorkspaceInvite(c: Context<SessionVars>, name: string): Promise<Response> {
+  return forwardTo(workspaces, c, `/${encodeURIComponent(name)}/invites`);
 }
 
 /**
- * Same forwarding pattern, targeting the canonical comment-settings/storage/
- * billing/summary verticals (`routes/workspace-settings.ts`, issue #613
- * phase 3). The canonical handlers are the exact bodies these four routes
- * used to run in this file (extracted verbatim, see git history), so this
- * is a genuine forward, not a reimplementation.
+ * Forwards to the canonical comment-settings/storage/billing/summary
+ * verticals (`routes/workspace-settings.ts`, issue #613 phase 3). The
+ * canonical handlers are the exact bodies these four routes used to run in
+ * this file (extracted verbatim, see git history), so this is a genuine
+ * forward, not a reimplementation.
  */
-async function forwardToWorkspaceSettings(
-  c: Context<SessionVars>,
-  path: string,
-): Promise<Response> {
-  const url = new URL(c.req.url);
-  url.pathname = path;
-  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
-  try {
-    executionCtx = c.executionCtx;
-  } catch {
-    executionCtx = undefined;
-  }
-  const forwarded = new Request(url, c.req.raw);
-  presetResolvedSessionUser(forwarded, requireUserId(c));
-  return workspaceSettings.fetch(forwarded, c.env, executionCtx);
+function forwardToWorkspaceSettings(c: Context<SessionVars>, path: string): Promise<Response> {
+  return forwardTo(workspaceSettings, c, path);
 }
 
 /** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
@@ -250,7 +224,7 @@ export const me = new Hono<SessionVars>()
   // route's old shape (adds `scopes`/`plan`), so this is a genuine forward
   // (see `forwardToWorkspaceUsage`'s docblock), not a reimplementation.
   .get("/workspaces/:name/usage", (c) =>
-    forwardToWorkspaceUsage(c, `/${c.req.param("name")}/usage`),
+    forwardToWorkspaceUsage(c, `/${encodeURIComponent(c.req.param("name"))}/usage`),
   )
 
   // Workspace shell for the account rail: membership + public URL + usage.
@@ -259,14 +233,14 @@ export const me = new Hono<SessionVars>()
   // is byte-for-byte the body this route used to run, so response shape
   // can't drift. See `forwardToWorkspaceSettings`'s docblock.
   .get("/workspaces/:name/summary", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/summary`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/summary`),
   )
 
   // Plan metadata, resolved effective limits, usage, and subscription state
   // for the account billing tab. Same forward as above. `stripeCustomerId`
   // redaction preserved exactly in the canonical handler — see its docblock.
   .get("/workspaces/:name/billing", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/billing`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/billing`),
   )
 
   // People in one workspace — member-gated (teammate fields only, not admin
@@ -275,13 +249,13 @@ export const me = new Hono<SessionVars>()
   // handler is byte-for-byte the body this route used to run, so response
   // shape can't drift. See `forwardToWorkspaceMembers`'s docblock.
   .get("/workspaces/:name/members", (c) =>
-    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/members`),
+    forwardToWorkspaceMembers(c, `/${encodeURIComponent(c.req.param("name"))}/members`),
   )
 
   // People tab: members + (for admins) pending invites + role in one authz
   // pass. Same forward as above.
   .get("/workspaces/:name/people", (c) =>
-    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/people`),
+    forwardToWorkspaceMembers(c, `/${encodeURIComponent(c.req.param("name"))}/people`),
   )
 
   // Galleries in one workspace — member-gated. Issue #613 phase 2: NOT
@@ -316,28 +290,31 @@ export const me = new Hono<SessionVars>()
   // (a wart fix carried over from the token-authed surface, which already
   // worked this way).
   .get("/workspaces/:name/files", (c) =>
-    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files`),
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/files`),
   )
   .get("/workspaces/:name/files/search", (c) =>
-    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/search`),
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/files/search`),
   )
   .get("/workspaces/:name/files/facets", (c) =>
-    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/facets`),
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/files/facets`),
   )
   .get("/workspaces/:name/files/by-path", (c) =>
-    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/by-path`),
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/files/by-path`),
   )
   .get("/workspaces/:name/file-url", (c) =>
-    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/file-url`),
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/files/file-url`),
   )
   .patch("/workspaces/:name/files/visibility", (c) =>
-    forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/visibility`),
+    forwardToWorkspaceFiles(c, `/${encodeURIComponent(c.req.param("name"))}/files/visibility`),
   )
   .delete("/workspaces/:name/files", (c) => {
     const key = c.req.query("key") ?? "";
     if (badKey(key)) throw new NotFoundError();
     const keyPath = key.split("/").map(encodeURIComponent).join("/");
-    return forwardToWorkspaceFiles(c, `/${c.req.param("name")}/files/${keyPath}`);
+    return forwardToWorkspaceFiles(
+      c,
+      `/${encodeURIComponent(c.req.param("name"))}/files/${keyPath}`,
+    );
   })
 
   // files-sdk's folder-aware browser gateway. Authorization happens before a
@@ -376,24 +353,40 @@ export const me = new Hono<SessionVars>()
   // Issue #613 phase 3: forwards to the canonical session-only handler in
   // `routes/workspace-members.ts`.
   .get("/workspaces/:name/invites", (c) =>
-    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/invites`),
+    forwardToWorkspaceMembers(c, `/${encodeURIComponent(c.req.param("name"))}/invites`),
   )
 
-  // Revoke a pending invite — admin/owner only. Same forward as above.
+  // Revoke a pending invite — admin/owner only. Same forward as above. Each
+  // param is `encodeURIComponent`-ed before interpolation: `c.req.param`
+  // returns the URL-decoded segment, so a raw `/` or `..` here could
+  // otherwise reshape the forwarded pathname and dispatch against a
+  // different route than the one this URL named (CodeRabbit PR #617 review
+  // finding 2 — hygiene/correctness, not an auth bypass, since
+  // `sessionAdminGate` re-resolves membership on whatever workspace the
+  // rewritten request actually names).
   .delete("/workspaces/:name/invites/:id", (c) =>
-    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/invites/${c.req.param("id")}`),
+    forwardToWorkspaceMembers(
+      c,
+      `/${encodeURIComponent(c.req.param("name"))}/invites/${encodeURIComponent(c.req.param("id"))}`,
+    ),
   )
 
   // Remove a member (by opaque member id) — admin/owner only; matrix
-  // enforced in auth worker. Same forward pattern.
+  // enforced in auth worker. Same forward pattern, same per-segment encoding.
   .delete("/workspaces/:name/members/:memberId", (c) =>
-    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/members/${c.req.param("memberId")}`),
+    forwardToWorkspaceMembers(
+      c,
+      `/${encodeURIComponent(c.req.param("name"))}/members/${encodeURIComponent(c.req.param("memberId"))}`,
+    ),
   )
 
   // Change a member's role (admin↔member); auth worker enforces the matrix.
-  // Same forward pattern.
+  // Same forward pattern, same per-segment encoding.
   .patch("/workspaces/:name/members/:memberId", (c) =>
-    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/members/${c.req.param("memberId")}`),
+    forwardToWorkspaceMembers(
+      c,
+      `/${encodeURIComponent(c.req.param("name"))}/members/${encodeURIComponent(c.req.param("memberId"))}`,
+    ),
   )
 
   // Batch PR/issue titles for the connected-work rail (issue #267). Member-
@@ -463,12 +456,12 @@ export const me = new Hono<SessionVars>()
   // forwards to the canonical handler in `routes/workspace-settings.ts` —
   // the extracted handler is byte-for-byte the body this route used to run.
   .get("/workspaces/:name/comment-settings", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/comment-settings`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/comment-settings`),
   )
 
   // Patch the defaults above. Same forward as above.
   .patch("/workspaces/:name/comment-settings", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/comment-settings`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/comment-settings`),
   )
 
   // Preview the production managed-comment body against resolved comment
@@ -555,14 +548,14 @@ export const me = new Hono<SessionVars>()
   // response shape (masked `storageStatusResponse` projection, never
   // credential values) can't drift.
   .get("/workspaces/:name/storage", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage`),
   )
   .post("/workspaces/:name/storage/verify", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage/verify`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage/verify`),
   )
   .put("/workspaces/:name/storage", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage`),
   )
   .delete("/workspaces/:name/storage", (c) =>
-    forwardToWorkspaceSettings(c, `/${c.req.param("name")}/storage`),
+    forwardToWorkspaceSettings(c, `/${encodeURIComponent(c.req.param("name"))}/storage`),
   );

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -27,7 +27,6 @@ import { createFilesRouter, type R2Jurisdiction } from "@uploads/storage";
 import { Hono, type Context } from "hono";
 import { usageWithLimits } from "../budget";
 import { sealCredentialFieldsStrict } from "../secrets";
-import { throwForInviteError } from "../invite-error";
 import { parseExternalReference } from "../external-references";
 import { previewFixtureItems } from "../comment-preview-fixtures";
 import { badKey, listObjects } from "../files-core";
@@ -44,16 +43,14 @@ import { resolveRepoCommentOptions, workspaceCommentDefaults } from "../repo-com
 import { resolveTitles } from "../github-titles";
 import { allowWrite } from "../guards";
 import {
-  invitesForOrg,
-  membersForOrg,
+  adminWorkspaceOr403,
+  memberWorkspaceOr404,
   membershipsForUser,
-  removeMember,
-  revokeInvite,
+  myWorkspaceFromMembership,
   subscriptionForOrg,
-  updateMemberRole,
   workspacesFromMembership,
   type Membership,
-  type OrgMember,
+  type MyWorkspace,
 } from "../org-workspaces";
 import { presetResolvedSessionUser } from "../dual-workspace-auth";
 import { requireSessionUser, sessionAuth, type SessionVars } from "../session-auth";
@@ -64,7 +61,9 @@ import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../
 import { mutateWorkspaceRecord } from "../workspace-mutate";
 import { planResponse, planSourceFor } from "../workspace-plan";
 import { workspaceFiles } from "./workspace-files";
+import { workspaceMembers } from "./workspace-members";
 import { workspaceUsage } from "./workspace-usage";
+import { workspaces } from "./workspaces";
 import {
   candidateFromBody,
   storageReconcile,
@@ -124,7 +123,49 @@ async function forwardToWorkspaceUsage(c: Context<SessionVars>, path: string): P
   return workspaceUsage.fetch(forwarded, c.env, executionCtx);
 }
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/**
+ * Same forwarding pattern, targeting the canonical invites/members vertical
+ * (`routes/workspace-members.ts`, issue #613 phase 3) for the session-only
+ * routes (`members`/`people`/`invites` GET/DELETE/`members/:id` PATCH). The
+ * canonical handlers are the exact bodies this file's routes used to run
+ * (extracted verbatim, see git history), so this is a genuine forward.
+ */
+async function forwardToWorkspaceMembers(c: Context<SessionVars>, path: string): Promise<Response> {
+  const url = new URL(c.req.url);
+  url.pathname = path;
+  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
+  const forwarded = new Request(url, c.req.raw);
+  presetResolvedSessionUser(forwarded, requireUserId(c));
+  return workspaceMembers.fetch(forwarded, c.env, executionCtx);
+}
+
+/**
+ * Forwards `POST /workspaces/:name/invites` to `routes/workspaces.ts`'s
+ * `POST /:name/invites` — the ONE invites/members route with a genuine
+ * bearer capability, upgraded in place to `dualGovernanceAuth` rather than
+ * duplicated into `workspace-members.ts` (see that route's docblock). Same
+ * response shape as this file's pre-#613 handler (both built `{ ...payload,
+ * acceptUrl }` from the same AUTH `/internal/invite` call), so this is a
+ * genuine forward, not a reimplementation.
+ */
+async function forwardToWorkspaceInvite(c: Context<SessionVars>, name: string): Promise<Response> {
+  const url = new URL(c.req.url);
+  url.pathname = `/${name}/invites`;
+  let executionCtx: Context<SessionVars>["executionCtx"] | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
+  const forwarded = new Request(url, c.req.raw);
+  presetResolvedSessionUser(forwarded, requireUserId(c));
+  return workspaces.fetch(forwarded, c.env, executionCtx);
+}
 
 /** `imageWidth` bounds (issue #307): "full" or an integer clamp width in px. */
 const COMMENT_IMAGE_WIDTH_MIN = 160;
@@ -275,48 +316,6 @@ function commentSettingsResponse(record: WorkspaceRecord) {
 /** `?repo=` shape for the comment preview endpoint: exactly one `/`, no empty segments. */
 const REPO_SHAPE_RE = /^[^/\s]+\/[^/\s]+$/;
 
-interface MyWorkspace {
-  workspace: string;
-  organization: { id: string; slug: string; name: string };
-  role: string;
-}
-
-function myWorkspaceFromMembership(membership: Membership, workspace: string): MyWorkspace {
-  return {
-    workspace,
-    organization: {
-      id: membership.organizationId,
-      slug: membership.organizationSlug,
-      name: membership.organizationName || membership.organizationSlug,
-    },
-    role: membership.role,
-  };
-}
-
-function canManageRole(role: string): boolean {
-  return role === "admin" || role === "owner";
-}
-
-/** Sanitize org members for the account people UI (opaque `id` only for managers). */
-function projectMembers(members: OrgMember[], canManage: boolean) {
-  return members.map((m) => {
-    const row: {
-      id?: string;
-      email: string;
-      name: string;
-      role: string;
-      createdAt?: string;
-    } = {
-      email: m.email ?? "",
-      name: m.name ?? "",
-      role: m.role ?? "member",
-      createdAt: m.createdAt,
-    };
-    if (canManage) row.id = m.id;
-    return row;
-  });
-}
-
 /**
  * Every workspace the user's memberships map to. Memberships already include
  * org id/slug/name from AUTH, so this is one service call — not N org
@@ -333,64 +332,12 @@ async function myWorkspaces(env: Env, userId: string): Promise<MyWorkspace[]> {
   return out;
 }
 
-/**
- * Caller's membership for `name`, or a uniform 404 (not 403 — no existence
- * probe). Slug-scoped membership query (one AUTH join), not the full list.
- */
-async function memberWorkspaceOr404(env: Env, userId: string, name: string): Promise<MyWorkspace> {
-  // 1:1 today: workspace name === org slug. Multi-workspace orgs would expand
-  // via workspacesFromMembership over the full list instead.
-  const [membership] = await membershipsForUser(env, userId, { slug: name });
-  if (!membership || !workspacesFromMembership(membership).includes(name)) {
-    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
-  }
-  return myWorkspaceFromMembership(membership, name);
-}
-
 function requireUserId(c: Context<SessionVars>): string {
   // requireSessionUser guarantees a session user; the guard is belt-and-braces
   // and keeps the 404 (not 401) shape uniform with the not-a-member case.
   const userId = c.get("sessionUser")?.id;
   if (!userId) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
   return userId;
-}
-
-/**
- * Membership admin|owner for this workspace — 404 if not a member, 403 if
- * member but not privileged. Exported for reuse by the self-serve token
- * governance dual-auth guard (`workspaces.ts`, issue #262 Task 3).
- */
-export async function adminWorkspaceOr403(
-  env: Env,
-  userId: string,
-  name: string,
-): Promise<MyWorkspace> {
-  const ws = await memberWorkspaceOr404(env, userId, name);
-  if (ws.role !== "admin" && ws.role !== "owner") {
-    throw new ForbiddenError("workspace admin or owner role required", {
-      code: "workspace_admin_required",
-    });
-  }
-  return ws;
-}
-
-/**
- * True iff the user holds org role `owner` (not `admin`) for workspace
- * `name`, resolved via the same org<->workspace mapping as
- * `adminWorkspaceOr403`/`memberWorkspaceOr404` (issue #265 — extends the
- * #249 self-serve deletion gate from creator-only to creator OR org owner).
- * Non-throwing: a non-member or unknown workspace is simply `false`, not a
- * 404 — callers combine this with other ownership checks and want a uniform
- * "not authorized" outcome rather than a membership-probing 404.
- */
-export async function isWorkspaceOwner(env: Env, userId: string, name: string): Promise<boolean> {
-  try {
-    const ws = await memberWorkspaceOr404(env, userId, name);
-    return ws.role === "owner";
-  } catch (err) {
-    if (err instanceof NotFoundError) return false;
-    throw err;
-  }
 }
 
 export const me = new Hono<SessionVars>()
@@ -537,35 +484,20 @@ export const me = new Hono<SessionVars>()
     });
   })
 
-  // People in one workspace — member-gated (teammate fields only, not admin raw rows).
-  .get("/workspaces/:name/members", async (c) => {
-    const name = c.req.param("name");
-    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const canManage = canManageRole(ws.role);
-    const members = await membersForOrg(c.env, ws.organization.slug);
-    return c.json({
-      members: projectMembers(members, canManage),
-    });
-  })
+  // People in one workspace — member-gated (teammate fields only, not admin
+  // raw rows). Issue #613 phase 3: forwards to the canonical dual-auth-free
+  // (session-only) handler in `routes/workspace-members.ts` — the extracted
+  // handler is byte-for-byte the body this route used to run, so response
+  // shape can't drift. See `forwardToWorkspaceMembers`'s docblock.
+  .get("/workspaces/:name/members", (c) =>
+    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/members`),
+  )
 
-  // People tab: members + (for admins) pending invites + role in one authz pass.
-  .get("/workspaces/:name/people", async (c) => {
-    const name = c.req.param("name");
-    const ws = await memberWorkspaceOr404(c.env, requireUserId(c), name);
-    const canManage = canManageRole(ws.role);
-    const [members, invites] = await Promise.all([
-      membersForOrg(c.env, ws.organization.slug),
-      canManage ? invitesForOrg(c.env, ws.organization.slug) : Promise.resolve([]),
-    ]);
-
-    return c.json({
-      role: ws.role,
-      canManage,
-      organization: ws.organization,
-      members: projectMembers(members, canManage),
-      invites: canManage ? invites : [],
-    });
-  })
+  // People tab: members + (for admins) pending invites + role in one authz
+  // pass. Same forward as above.
+  .get("/workspaces/:name/people", (c) =>
+    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/people`),
+  )
 
   // Galleries in one workspace — member-gated. Issue #613 phase 2: NOT
   // forwarded to the canonical `/v1/workspaces/:workspace/galleries` list —
@@ -647,110 +579,37 @@ export const me = new Hono<SessionVars>()
 
   // Invite an email to the org backing this workspace (Better Auth invitation).
   // Workspace org admin|owner only. Returns acceptUrl so self-hosted installs
-  // without Email Sending can still hand the invitee a link.
-  .post("/workspaces/:name/invites", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    // Membership already carries org slug (1:1 mapping) — no second org fetch.
-    const ws = await adminWorkspaceOr403(c.env, userId, name);
-
-    if (!(await allowWrite(c.env, name))) {
-      throw new RateLimitedError("rate limit exceeded");
-    }
-
-    const body = await c.req
-      .json<{ email?: unknown; role?: unknown }>()
-      .catch(() => ({}) as { email?: unknown; role?: unknown });
-    // Account UI always invites as member; API still accepts role for CLI.
-    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
-    const role = typeof body.role === "string" ? body.role.trim() : "member";
-    if (!email || !EMAIL_RE.test(email)) {
-      throw new ValidationError("invalid email address", { code: "invalid_email" });
-    }
-    if (role !== "member" && role !== "admin") {
-      throw new ValidationError("role must be member or admin", { code: "invalid_role" });
-    }
-
-    // Per-recipient rate limit when the binding is configured (hosted always;
-    // self-hosted opt-in via wrangler). Absent binding = no RL (same as other
-    // optional limiters).
-    const limiter = c.env.INVITE_LIMITER;
-    if (limiter) {
-      const { success } = await limiter.limit({ key: `invite:email:${email}` });
-      if (!success) throw new RateLimitedError("invite rate limit exceeded");
-    }
-
-    const response = await c.env.AUTH.fetch("https://auth.internal/internal/invite", {
-      method: "POST",
-      headers: { "content-type": "application/json", "x-uploads-internal": "1" },
-      body: JSON.stringify({
-        organizationSlug: ws.organization.slug,
-        email,
-        role,
-        inviterUserId: userId,
-      }),
-    });
-    const payload = (await response.json().catch(() => null)) as {
-      invitation?: { id?: string };
-      acceptUrl?: string;
-    } | null;
-    if (!response.ok) throwForInviteError(response.status, payload);
-    // Ensure acceptUrl even if an older auth worker omits it.
-    const webOrigin = (c.env.WEB_ORIGIN || "https://uploads.sh").replace(/\/$/, "");
-    const id = payload?.invitation?.id;
-    const acceptUrl =
-      payload?.acceptUrl ?? (id ? `${webOrigin}/accept-invitation/${id}` : undefined);
-    return c.json({ ...payload, acceptUrl }, response.status === 200 ? 200 : 201);
-  })
+  // without Email Sending can still hand the invitee a link. Issue #613
+  // phase 3: forwards to `routes/workspaces.ts`'s canonical
+  // `POST /:name/invites` (now `dualGovernanceAuth`-guarded) — see
+  // `forwardToWorkspaceInvite`'s docblock for why this route, uniquely among
+  // this vertical's session routes, forwards to `workspaces.ts` rather than
+  // `workspace-members.ts`.
+  .post("/workspaces/:name/invites", (c) => forwardToWorkspaceInvite(c, c.req.param("name")))
 
   // Pending invites for this workspace — admin/owner only (they can revoke).
-  .get("/workspaces/:name/invites", async (c) => {
-    const name = c.req.param("name");
-    const ws = await adminWorkspaceOr403(c.env, requireUserId(c), name);
-    const invites = await invitesForOrg(c.env, ws.organization.slug);
-    return c.json({ invites });
-  })
+  // Issue #613 phase 3: forwards to the canonical session-only handler in
+  // `routes/workspace-members.ts`.
+  .get("/workspaces/:name/invites", (c) =>
+    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/invites`),
+  )
 
-  // Revoke a pending invite — admin/owner only.
-  .delete("/workspaces/:name/invites/:id", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    const ws = await adminWorkspaceOr403(c.env, userId, name);
-    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
-    await revokeInvite(c.env, ws.organization.slug, c.req.param("id"), userId);
-    return c.json({ ok: true });
-  })
+  // Revoke a pending invite — admin/owner only. Same forward as above.
+  .delete("/workspaces/:name/invites/:id", (c) =>
+    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/invites/${c.req.param("id")}`),
+  )
 
-  // Remove a member (by opaque member id) — admin/owner only; matrix enforced in auth worker.
-  .delete("/workspaces/:name/members/:memberId", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    const ws = await adminWorkspaceOr403(c.env, userId, name);
-    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
-    await removeMember(c.env, ws.organization.slug, c.req.param("memberId"), userId);
-    return c.json({ ok: true });
-  })
+  // Remove a member (by opaque member id) — admin/owner only; matrix
+  // enforced in auth worker. Same forward pattern.
+  .delete("/workspaces/:name/members/:memberId", (c) =>
+    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/members/${c.req.param("memberId")}`),
+  )
 
   // Change a member's role (admin↔member); auth worker enforces the matrix.
-  .patch("/workspaces/:name/members/:memberId", async (c) => {
-    const name = c.req.param("name");
-    const userId = requireUserId(c);
-    const ws = await adminWorkspaceOr403(c.env, userId, name);
-    if (!(await allowWrite(c.env, name))) throw new RateLimitedError("rate limit exceeded");
-    const body = await c.req.json<{ role?: unknown }>().catch(() => ({}) as { role?: unknown });
-    const role = typeof body.role === "string" ? body.role.trim() : "";
-    if (role !== "admin" && role !== "member") {
-      throw new ValidationError("role must be admin or member", { code: "invalid_role" });
-    }
-    const member = await updateMemberRole(
-      c.env,
-      ws.organization.slug,
-      c.req.param("memberId"),
-      role,
-      userId,
-    );
-    return c.json({ member });
-  })
+  // Same forward pattern.
+  .patch("/workspaces/:name/members/:memberId", (c) =>
+    forwardToWorkspaceMembers(c, `/${c.req.param("name")}/members/${c.req.param("memberId")}`),
+  )
 
   // Batch PR/issue titles for the connected-work rail (issue #267). Member-
   // gated: title text for private repos is sensitive, and membership scoping

--- a/apps/api/src/routes/workspace-github.ts
+++ b/apps/api/src/routes/workspace-github.ts
@@ -1,0 +1,153 @@
+/**
+ * Canonical GitHub vertical (issue #613 phase 3): `/:workspace/github/*`,
+ * mounted at `/v1/workspaces` in `index.ts` so its public paths are
+ * `/v1/workspaces/:workspace/github/*`. Dual-auth (`dualWorkspaceAuth`) —
+ * either a session cookie or a bearer token reaches the same handlers below.
+ *
+ * Collapses the five sub-routers previously mounted separately at
+ * `/v1/:workspace/github` (`github-comment.ts`, `github-promote.ts`,
+ * `github-link.ts`, `github-health.ts`, `github-activity.ts`) into one
+ * router — issue #613 names "five separate sub-routers sharing one mount
+ * prefix" as its own wart, on top of the missing dual-auth surface. Handler
+ * bodies are the exact same functions those old routers call (extracted to
+ * named exports there), same "response shape can't drift" guarantee phase 2
+ * established for galleries. The old bearer paths at
+ * `/v1/:workspace/github/*` are UNCHANGED — still five separate `.route()`
+ * mounts in `index.ts`, still calling the same handler functions with their
+ * own pre-existing scope requirements.
+ *
+ * Authorization posture per route (issue #613 phase 3 plan,
+ * `.context/613-api-consolidation-plan.md`, "github" section):
+ *  - `comment`/`promote` (POST, mutating + GitHub-API-calling/bot-posting):
+ *    token-only on this canonical surface. A session caller who is a member
+ *    gets a 403 `github_requires_token` — mirrors `workspace-usage.ts`'s
+ *    `requireToken`/`usage_requires_token` guard exactly (membership already
+ *    proven by `dualWorkspaceAuth`, so refusal here is "not allowed", not
+ *    "doesn't exist"). Canonical `comment` requires `files:write` (NOT the
+ *    old path's `files:read` — issue #613 flags a write op scoped as a read
+ *    as a wart; fixed here, left untouched on the old bearer path).
+ *  - `link` (GET/POST/DELETE)/`repo-link` (GET)/`health` (GET)/`activity`
+ *    (GET): dual-auth with a session-admin-tier gate layered on top
+ *    (`requireSessionAdmin`, `../dual-workspace-auth.ts`) — bearer keeps
+ *    whatever scope the old path already required; a session caller must be
+ *    workspace admin/owner (matching `routes/me.ts`'s `adminWorkspaceOr403`
+ *    posture for the pre-existing admin-gated `GET
+ *    /me/workspaces/:name/repo-links`). Non-member session -> 404 (from
+ *    `dualWorkspaceAuth`); member-but-not-admin -> 403
+ *    `workspace_admin_required`.
+ *
+ * `GET /me/workspaces/:name/repo-links` is deliberately NOT forwarded/aliased
+ * here — its stripped `{repos: string[]}` projection diverges from the
+ * bearer/canonical `linkResponse` shape (`{repo, linked, workspace, source,
+ * createdAt}`), same "don't forward a shape that isn't a strict superset"
+ * rule phase 2 applied to the galleries list alias.
+ */
+import { ForbiddenError } from "@uploads/errors";
+import { Hono, type MiddlewareHandler } from "hono";
+import { dualWorkspaceAuth, requireSessionAdmin, type DualAuthVars } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
+import { writeRateLimit } from "../guards";
+import { requireScope } from "../workspace";
+import { githubActivityHandler } from "./github-activity";
+import { githubCommentHandler } from "./github-comment";
+import {
+  githubLinkDeleteHandler,
+  githubLinkGetHandler,
+  githubLinkPostHandler,
+  githubRepoLinkGetHandler,
+} from "./github-link";
+import { githubHealthHandler } from "./github-health";
+import { githubPromoteHandler } from "./github-promote";
+
+// Same cross-cast pattern as `routes/workspace-galleries.ts`'s `scoped`:
+// these helpers/handlers are typed against `WorkspaceVars`, a strict subset
+// of this router's `DualAuthVars`, so a Context for one is always a valid
+// Context for the other.
+function scoped(scope: Parameters<typeof requireScope>[0]): MiddlewareHandler<DualAuthVars> {
+  return requireScope(scope) as unknown as MiddlewareHandler<DualAuthVars>;
+}
+const rateLimited = writeRateLimit as unknown as MiddlewareHandler<DualAuthVars>;
+const adminForSession = requireSessionAdmin();
+
+/**
+ * `comment`/`promote` are token-only on the canonical surface — see the
+ * module docblock. Mirrors `workspace-usage.ts`'s `requireToken` exactly,
+ * down to the error code convention (`<vertical>_requires_token`).
+ */
+const requireToken: MiddlewareHandler<DualAuthVars> = async (c, next) => {
+  if (c.get("authSource") === "session") {
+    throw new ForbiddenError("requires an API token", { code: "github_requires_token" });
+  }
+  await next();
+};
+
+export const workspaceGithub = new Hono<DualAuthVars>()
+  .post(
+    "/:workspace/github/comment",
+    dualWorkspaceAuth(),
+    rateLimited,
+    // Canonical wart fix (issue #613): this is a write op, scoped as such
+    // here. The old bearer path keeps `files:read` untouched — see
+    // `routes/github-comment.ts`.
+    scoped("files:write"),
+    requireToken,
+    githubCommentHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .post(
+    "/:workspace/github/promote",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    requireToken,
+    githubPromoteHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/github/link",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    adminForSession,
+    githubLinkGetHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/github/repo-link",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    adminForSession,
+    githubRepoLinkGetHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .post(
+    "/:workspace/github/link",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    adminForSession,
+    githubLinkPostHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .delete(
+    "/:workspace/github/link",
+    dualWorkspaceAuth(),
+    rateLimited,
+    scoped("files:write"),
+    adminForSession,
+    githubLinkDeleteHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/github/health",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    adminForSession,
+    githubHealthHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  .get(
+    "/:workspace/github/activity",
+    dualWorkspaceAuth(),
+    scoped("files:read"),
+    adminForSession,
+    githubActivityHandler as unknown as MiddlewareHandler<DualAuthVars>,
+  )
+  // `.fetch()`-ed directly by nothing today (no old-path alias forwards
+  // through this router — see the module docblock's repo-links note), but
+  // this still needs its own error boundary for consistency with the other
+  // canonical verticals and in case a future alias does re-dispatch through
+  // it directly.
+  .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-governance-invite.test.ts
+++ b/apps/api/src/routes/workspace-governance-invite.test.ts
@@ -38,6 +38,15 @@ function appWith(opts: {
     .onError((err, c) => respondError(c, err));
   const auth = stubAuth(async (req) => {
     const url = new URL(req.url);
+    // Issue #613 phase 3: `POST /:name/invites` is now dual-authed
+    // (`dualGovernanceAuth`) — a request with no bearer token falls through
+    // to a real session resolution instead of an immediate 401, so this
+    // stub needs to answer `get-session` like a real (signed-out) auth
+    // worker would: 401, not the catch-all 404 below (which `sessionAuth`
+    // treats as a service outage, 503 — not this test's intent).
+    if (url.pathname === "/api/auth/get-session") {
+      return new Response(null, { status: 401 });
+    }
     if (url.pathname === "/internal/orgs/acme") {
       if (!orgFound) return new Response(null, { status: 404 });
       return Response.json({ organization: { id: "org1", slug: "acme", name: "Acme" } });

--- a/apps/api/src/routes/workspace-members.ts
+++ b/apps/api/src/routes/workspace-members.ts
@@ -9,16 +9,20 @@
  *
  * Posture (`.context/613-api-consolidation-plan.md`, "invites / members"):
  *
- *  - `GET /members`, `GET /people` — **session-only**: any member. A bearer
- *    credential 403s `members_requires_session` — there is no bearer scope
- *    that grants "read the roster" today and this PR mints no new one. The
- *    `people` response hides `invites` from non-managers, preserved verbatim
- *    from the pre-#613 `/me` handler this was extracted from.
+ *  - `GET /members`, `GET /people` — **session-only**: any member. An
+ *    `up_`-shaped bearer credential 403s `members_requires_session` — there
+ *    is no bearer scope that grants "read the roster" today and this PR
+ *    mints no new one. A non-`up_` bearer (a Better Auth session token, no
+ *    cookie) is not a workspace-token shape and is instead handed to session
+ *    resolution, same as a cookie — see `sessionMemberGate`'s docblock
+ *    (issue #613 phase 3 review finding 1). The `people` response hides
+ *    `invites` from non-managers, preserved verbatim from the pre-#613 `/me`
+ *    handler this was extracted from.
  *  - `GET /invites`, `DELETE /invites/:id`, `DELETE /members/:memberId`,
  *    `PATCH /members/:memberId` — **session-only**, admin/owner-gated. Same
- *    bearer-403 posture as above (same `members_requires_session` code) —
- *    no bearer capability for list/revoke/remove/role-change existed before
- *    this PR and none is added.
+ *    bearer posture as above (same `members_requires_session` code for an
+ *    `up_`-shaped bearer) — no bearer capability for list/revoke/remove/
+ *    role-change existed before this PR and none is added.
  *  - `POST /invites` is NOT here — it is the one route in this vertical with
  *    a genuine pre-existing bearer capability (`workspace:invite` governance
  *    token), so it stays where it already lived at the canonical path
@@ -39,7 +43,7 @@
  */
 import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
-import { resolveSessionUserId } from "../dual-workspace-auth";
+import { hasPreresolvedSession, resolveSessionUserId } from "../dual-workspace-auth";
 import { respondError } from "../error-response";
 import { allowWrite } from "../guards";
 import {
@@ -88,15 +92,32 @@ function projectMembers(members: OrgMember[], canManage: boolean) {
 }
 
 /**
- * Session-only member gate: a bearer `Authorization` header 403s outright
- * (no governance-token fallback — this vertical mints no read/list/manage
- * bearer capability in this PR), otherwise resolves the session + membership
- * with a uniform 404 for non-members (never a 403 — no existence probe, same
- * posture as `dualWorkspaceAuth`/`dualGovernanceAuth`).
+ * Session-only member gate: an `up_`-shaped bearer `Authorization` header
+ * 403s outright (no governance-token fallback — this vertical mints no
+ * read/list/manage bearer capability in this PR), otherwise resolves the
+ * session + membership with a uniform 404 for non-members (never a 403 — no
+ * existence probe, same posture as `dualWorkspaceAuth`/`dualGovernanceAuth`).
+ *
+ * Bearer discrimination (issue #613 phase 3 review finding 1): a preset
+ * (`hasPreresolvedSession`, e.g. a forwarded `/me` request whose session
+ * `me.ts` already validated via its own `sessionAuth`) always wins,
+ * unconditionally, BEFORE ever looking at the `Authorization` header — a
+ * forwarded request keeps its original headers verbatim, so a caller who
+ * authenticated to `/me` with a Better Auth bearer session (no cookie) must
+ * not be rejected a second time here. Absent a preset, only an `up_`-shaped
+ * bearer is rejected as "wrong credential type" — the same `up_`-prefix
+ * discrimination `workspaceManageAuth` (`routes/workspaces.ts`) and
+ * `dualGovernanceAuth` use to tell a workspace/governance token apart from a
+ * Better Auth bearer session riding the same header. Any other bearer (or
+ * none) falls through to `resolveSessionUserId`, which forwards the
+ * `Authorization` header to `get-session` as-is and validates a Better Auth
+ * session bearer exactly like a cookie.
  */
 function sessionMemberGate(): MiddlewareHandler<MembersVars> {
   return async (c, next) => {
-    if (c.req.header("Authorization")?.startsWith("Bearer ")) {
+    const authorization = c.req.header("Authorization");
+    const rawToken = authorization?.startsWith("Bearer ") ? authorization.slice(7) : undefined;
+    if (!hasPreresolvedSession(c.req.raw) && rawToken?.startsWith("up_")) {
       throw new ForbiddenError("requires a session", { code: "members_requires_session" });
     }
     const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);

--- a/apps/api/src/routes/workspace-members.ts
+++ b/apps/api/src/routes/workspace-members.ts
@@ -1,0 +1,220 @@
+/**
+ * Canonical invites/members vertical (issue #613 phase 3):
+ * `/:workspace/members`, `/:workspace/people`, `/:workspace/invites*`,
+ * `/:workspace/members/:memberId*`, mounted at `/v1/workspaces` in
+ * `index.ts` so its public paths are `/v1/workspaces/:workspace/...`. Same
+ * self-contained-router shape as `workspace-github.ts`/`workspace-usage.ts`:
+ * own auth, own `.onError()`, `.fetch()`-able directly by an alias with no
+ * parent-mount dependency for its `:workspace` param.
+ *
+ * Posture (`.context/613-api-consolidation-plan.md`, "invites / members"):
+ *
+ *  - `GET /members`, `GET /people` — **session-only**: any member. A bearer
+ *    credential 403s `members_requires_session` — there is no bearer scope
+ *    that grants "read the roster" today and this PR mints no new one. The
+ *    `people` response hides `invites` from non-managers, preserved verbatim
+ *    from the pre-#613 `/me` handler this was extracted from.
+ *  - `GET /invites`, `DELETE /invites/:id`, `DELETE /members/:memberId`,
+ *    `PATCH /members/:memberId` — **session-only**, admin/owner-gated. Same
+ *    bearer-403 posture as above (same `members_requires_session` code) —
+ *    no bearer capability for list/revoke/remove/role-change existed before
+ *    this PR and none is added.
+ *  - `POST /invites` is NOT here — it is the one route in this vertical with
+ *    a genuine pre-existing bearer capability (`workspace:invite` governance
+ *    token), so it stays where it already lived at the canonical path
+ *    convention: `routes/workspaces.ts`'s `POST /:name/invites`, upgraded in
+ *    place to `dualGovernanceAuth("workspace:invite")`. Registering a second
+ *    `POST /:workspace/invites` here would double-register/shadow that exact
+ *    path — see that route's docblock for the "upgrade in place, don't
+ *    parallel-register" reasoning.
+ *
+ * Session auth here is session-only-with-admin-tier, NOT
+ * `dualWorkspaceAuth`/`requireSessionAdmin` (those grant a session caller
+ * file-plane `FILE_SCOPES`, meaningless for this vertical) and NOT
+ * `dualGovernanceAuth` (that accepts a bearer governance token, which none of
+ * these routes should — no new bearer capability). Deliberately a small
+ * local guard instead, reusing `resolveSessionUserId` from
+ * `dual-workspace-auth.ts` for the same "one get-session call per forwarded
+ * request" property every other vertical gets from the WeakMap handoff.
+ */
+import { ForbiddenError, NotFoundError, RateLimitedError, ValidationError } from "@uploads/errors";
+import { Hono, type Context, type MiddlewareHandler } from "hono";
+import { resolveSessionUserId } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
+import { allowWrite } from "../guards";
+import {
+  invitesForOrg,
+  membersForOrg,
+  membershipsForUser,
+  removeMember,
+  revokeInvite,
+  updateMemberRole,
+  workspacesFromMembership,
+  type OrgMember,
+} from "../org-workspaces";
+import type { SessionVars } from "../session-auth";
+
+/** Context vars a `sessionMemberGate`/`sessionAdminGate`-guarded route can rely on. */
+export type MembersVars = {
+  Variables: SessionVars["Variables"] & {
+    memberOrg: { id: string; slug: string; name: string };
+    memberRole: string;
+  };
+  Bindings: Env;
+};
+
+function canManageRole(role: string): boolean {
+  return role === "admin" || role === "owner";
+}
+
+/** Sanitize org members for the account people UI (opaque `id` only for managers). */
+function projectMembers(members: OrgMember[], canManage: boolean) {
+  return members.map((m) => {
+    const row: {
+      id?: string;
+      email: string;
+      name: string;
+      role: string;
+      createdAt?: string;
+    } = {
+      email: m.email ?? "",
+      name: m.name ?? "",
+      role: m.role ?? "member",
+      createdAt: m.createdAt,
+    };
+    if (canManage) row.id = m.id;
+    return row;
+  });
+}
+
+/**
+ * Session-only member gate: a bearer `Authorization` header 403s outright
+ * (no governance-token fallback — this vertical mints no read/list/manage
+ * bearer capability in this PR), otherwise resolves the session + membership
+ * with a uniform 404 for non-members (never a 403 — no existence probe, same
+ * posture as `dualWorkspaceAuth`/`dualGovernanceAuth`).
+ */
+function sessionMemberGate(): MiddlewareHandler<MembersVars> {
+  return async (c, next) => {
+    if (c.req.header("Authorization")?.startsWith("Bearer ")) {
+      throw new ForbiddenError("requires a session", { code: "members_requires_session" });
+    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("workspace");
+    if (!name) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    const [membership] = await membershipsForUser(c.env, userId, { slug: name });
+    if (!membership || !workspacesFromMembership(membership).includes(name)) {
+      throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    }
+    c.set("memberOrg", {
+      id: membership.organizationId,
+      slug: membership.organizationSlug,
+      name: membership.organizationName || membership.organizationSlug,
+    });
+    c.set("memberRole", membership.role);
+    await next();
+  };
+}
+
+/** `sessionMemberGate` plus an admin/owner role requirement — 403 for a member who isn't. */
+function sessionAdminGate(): MiddlewareHandler<MembersVars> {
+  const memberGate = sessionMemberGate();
+  return async (c, next) => {
+    await memberGate(c, async () => {
+      if (!canManageRole(c.get("memberRole"))) {
+        throw new ForbiddenError("workspace admin or owner role required", {
+          code: "workspace_admin_required",
+        });
+      }
+      await next();
+    });
+  };
+}
+
+/** `GET /:workspace/members` — member-gated; teammate fields only, not admin raw rows. */
+export async function membersHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const canManage = canManageRole(c.get("memberRole"));
+  const members = await membersForOrg(c.env, org.slug);
+  return c.json({ members: projectMembers(members, canManage) });
+}
+
+/** `GET /:workspace/people` — members + (for admins) pending invites + role, one authz pass. */
+export async function peopleHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const role = c.get("memberRole");
+  const canManage = canManageRole(role);
+  const [members, invites] = await Promise.all([
+    membersForOrg(c.env, org.slug),
+    canManage ? invitesForOrg(c.env, org.slug) : Promise.resolve([]),
+  ]);
+  return c.json({
+    role,
+    canManage,
+    organization: org,
+    members: projectMembers(members, canManage),
+    invites: canManage ? invites : [],
+  });
+}
+
+/** `GET /:workspace/invites` — pending invites; admin/owner only (they can revoke). */
+export async function invitesListHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const invites = await invitesForOrg(c.env, org.slug);
+  return c.json({ invites });
+}
+
+/** `DELETE /:workspace/invites/:id` — revoke a pending invite; admin/owner only. */
+export async function inviteRevokeHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+  // `allowWrite` is keyed on workspace name; `org.slug` IS the workspace name
+  // (the 1:1 mapping `org-workspaces.ts` documents), already resolved by
+  // `sessionAdminGate` — reusing it here avoids re-reading (and re-widening)
+  // the `:workspace` path param.
+  if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
+  // `:id` is a required route segment — Hono guarantees it on a matched
+  // route; the `?? ""` is a typing formality only (`Context<MembersVars>`
+  // doesn't carry the literal path, so `param()` can't be narrowed the way
+  // it would be for a handler declared inline on the route).
+  await revokeInvite(c.env, org.slug, c.req.param("id") ?? "", userId);
+  return c.json({ ok: true });
+}
+
+/** `DELETE /:workspace/members/:memberId` — remove a member; admin/owner only. */
+export async function memberRemoveHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+  if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
+  await removeMember(c.env, org.slug, c.req.param("memberId") ?? "", userId);
+  return c.json({ ok: true });
+}
+
+/** `PATCH /:workspace/members/:memberId` — change a member's role; admin/owner only. */
+export async function memberRoleUpdateHandler(c: Context<MembersVars>) {
+  const org = c.get("memberOrg");
+  const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+  if (!(await allowWrite(c.env, org.slug))) throw new RateLimitedError("rate limit exceeded");
+  const body = await c.req.json<{ role?: unknown }>().catch(() => ({}) as { role?: unknown });
+  const role = typeof body.role === "string" ? body.role.trim() : "";
+  if (role !== "admin" && role !== "member") {
+    throw new ValidationError("role must be admin or member", { code: "invalid_role" });
+  }
+  const member = await updateMemberRole(
+    c.env,
+    org.slug,
+    c.req.param("memberId") ?? "",
+    role,
+    userId,
+  );
+  return c.json({ member });
+}
+
+export const workspaceMembers = new Hono<MembersVars>()
+  .get("/:workspace/members", sessionMemberGate(), membersHandler)
+  .get("/:workspace/people", sessionMemberGate(), peopleHandler)
+  .get("/:workspace/invites", sessionAdminGate(), invitesListHandler)
+  .delete("/:workspace/invites/:id", sessionAdminGate(), inviteRevokeHandler)
+  .delete("/:workspace/members/:memberId", sessionAdminGate(), memberRemoveHandler)
+  .patch("/:workspace/members/:memberId", sessionAdminGate(), memberRoleUpdateHandler)
+  .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspace-settings.ts
+++ b/apps/api/src/routes/workspace-settings.ts
@@ -1,0 +1,654 @@
+/**
+ * Canonical comment-settings, storage, and billing/summary verticals (issue
+ * #613 phase 3): `/:workspace/comment-settings`, `/:workspace/storage`,
+ * `/:workspace/storage/verify`, `/:workspace/summary`, `/:workspace/billing`,
+ * mounted at `/v1/workspaces` in `index.ts` so its public paths are
+ * `/v1/workspaces/:workspace/...`. Same self-contained-router shape as
+ * `workspace-members.ts`/`workspace-github.ts`: own auth, own `.onError()`,
+ * `.fetch()`-able directly by an alias with no parent-mount dependency for
+ * its `:workspace` param.
+ *
+ * Posture (`.context/613-api-consolidation-plan.md`, "comment-settings",
+ * "storage", "billing/summary"):
+ *
+ *  - `GET/PATCH /comment-settings`, `GET/POST-verify/PUT/DELETE /storage` —
+ *    **session-only, admin/owner tier**. A bearer `Authorization` header
+ *    403s `settings_requires_session` on every route in this tier — neither
+ *    vertical has a bearer analog today (comment-settings: no
+ *    `/v1/:workspace/github/comment-settings` exists; storage is
+ *    credential-adjacent and a token was never in scope for it), and this PR
+ *    mints no new bearer capability for either. Flat 5-key comment-settings
+ *    envelope (`imageWidth`/`maxInlineImages`/`showMetadata`/
+ *    `linkToFilePage`/`note`) preserved EXACTLY — the admin-ui operator
+ *    surface's prefixed 6-key naming (`/admin-ui/workspaces/:name/settings`)
+ *    is a different privilege tier entirely and stays untouched. Storage's
+ *    masked `storageStatusResponse` projection (never credential values) is
+ *    likewise preserved exactly — see `workspace-storage.ts`.
+ *  - `GET /summary`, `GET /billing` — **session-only, member tier**. A
+ *    bearer header 403s `billing_requires_session` — same "no bearer analog,
+ *    none minted" posture, distinct code from the admin tier above so the
+ *    two privilege levels in this router don't share one coded error.
+ *    `billing`'s `stripeCustomerId` redaction (admin-ui-only field) is
+ *    preserved exactly — see the handler's docblock.
+ *
+ * Session auth here is session-only-with-tier, the same small local-guard
+ * shape `workspace-members.ts` uses (NOT `dualWorkspaceAuth`/
+ * `requireSessionAdmin`, which grant a session caller file-plane
+ * `FILE_SCOPES`, meaningless for this vertical; NOT `dualGovernanceAuth`,
+ * which accepts a bearer governance token, and none of these routes should).
+ * Reuses `resolveSessionUserId` from `dual-workspace-auth.ts` for the same
+ * "one get-session call per forwarded request" property every other
+ * vertical gets from the `presetResolvedSessionUser` WeakMap handoff.
+ */
+import { NOTE_MAX_CHARS } from "@uploads/comment-config";
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitedError,
+  ValidationError,
+} from "@uploads/errors";
+import { type R2Jurisdiction } from "@uploads/storage";
+import { Hono, type Context, type MiddlewareHandler } from "hono";
+import { usageWithLimits } from "../budget";
+import { resolveSessionUserId } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
+import { allowWrite } from "../guards";
+import {
+  adminWorkspaceOr403,
+  memberWorkspaceOr404,
+  subscriptionForOrg,
+  type MyWorkspace,
+} from "../org-workspaces";
+import { sealCredentialFieldsStrict } from "../secrets";
+import { selfServeWorkspaceRecord } from "../self-serve-defaults";
+import type { SessionVars } from "../session-auth";
+import { getWorkspaceUsage } from "../usage";
+import { byoBucketAllowed, loadWorkspaceRecord, type WorkspaceRecord } from "../workspace";
+import { mutateWorkspaceRecord } from "../workspace-mutate";
+import { planResponse, planSourceFor } from "../workspace-plan";
+import {
+  candidateFromBody,
+  storageReconcile,
+  storageStatusResponse,
+  storageVerify,
+} from "./workspace-storage";
+
+/** Context vars a `sessionMemberGate`/`sessionAdminGate`-guarded route can rely on. */
+export type SettingsVars = {
+  Variables: SessionVars["Variables"] & {
+    settingsWorkspace: MyWorkspace;
+    settingsUserId: string;
+  };
+  Bindings: Env;
+};
+
+/**
+ * Session-only member gate for the billing/summary tier: a bearer
+ * `Authorization` header 403s outright (no bearer capability exists for
+ * either route and none is minted here), otherwise resolves the session +
+ * membership with a uniform 404 for non-members (never a 403 — no existence
+ * probe, same posture as `dualWorkspaceAuth`/`dualGovernanceAuth`/
+ * `workspace-members.ts`'s `sessionMemberGate`).
+ */
+function sessionMemberGate(): MiddlewareHandler<SettingsVars> {
+  return async (c, next) => {
+    if (c.req.header("Authorization")?.startsWith("Bearer ")) {
+      throw new ForbiddenError("requires a session", { code: "billing_requires_session" });
+    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("workspace") ?? "";
+    if (!name) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    const ws = await memberWorkspaceOr404(c.env, userId, name);
+    c.set("settingsWorkspace", ws);
+    c.set("settingsUserId", userId);
+    await next();
+  };
+}
+
+/**
+ * Session-only admin/owner gate for the comment-settings/storage tier: same
+ * bearer-403 posture as `sessionMemberGate` above, but with its own coded
+ * error (`settings_requires_session`, not `billing_requires_session`) since
+ * these are a materially different privilege tier within this one router.
+ * `adminWorkspaceOr403` itself produces the 404-then-403 ordering
+ * (non-member -> `workspace_not_found`, member-not-admin ->
+ * `workspace_admin_required`).
+ */
+function sessionAdminGate(): MiddlewareHandler<SettingsVars> {
+  return async (c, next) => {
+    if (c.req.header("Authorization")?.startsWith("Bearer ")) {
+      throw new ForbiddenError("requires a session", { code: "settings_requires_session" });
+    }
+    const userId = await resolveSessionUserId(c as unknown as Context<SessionVars>);
+    const name = c.req.param("workspace") ?? "";
+    if (!name) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+    const ws = await adminWorkspaceOr403(c.env, userId, name);
+    c.set("settingsWorkspace", ws);
+    c.set("settingsUserId", userId);
+    await next();
+  };
+}
+
+/** `imageWidth` bounds (issue #307): "full" or an integer clamp width in px. */
+const COMMENT_IMAGE_WIDTH_MIN = 160;
+const COMMENT_IMAGE_WIDTH_MAX = 1000;
+/** `maxInlineImages` bounds (issue #307). */
+const COMMENT_MAX_INLINE_IMAGES_MIN = 1;
+const COMMENT_MAX_INLINE_IMAGES_MAX = 48;
+
+/** The five workspace-level comment-defaults fields (issue #307). */
+const COMMENT_SETTINGS_KEYS = [
+  "imageWidth",
+  "maxInlineImages",
+  "showMetadata",
+  "linkToFilePage",
+  "note",
+] as const;
+type CommentSettingsKey = (typeof COMMENT_SETTINGS_KEYS)[number];
+
+/** Record field each API key writes to. */
+const COMMENT_SETTINGS_RECORD_FIELD: Record<CommentSettingsKey, keyof WorkspaceRecord> = {
+  imageWidth: "githubCommentImageWidth",
+  maxInlineImages: "githubCommentMaxInlineImages",
+  showMetadata: "githubCommentShowMetadata",
+  linkToFilePage: "githubCommentLinkToFilePage",
+  note: "githubCommentNote",
+};
+
+type CommentSettingsValue = string | number | boolean;
+type CommentSettingsPatch = Partial<Record<CommentSettingsKey, CommentSettingsValue | null>>;
+
+/**
+ * Validates a PATCH body for the workspace-level managed-comment defaults
+ * (issue #307). Single enforcement point for the bounds the resolver itself
+ * does not clamp: imageWidth "full" or an integer 160–1000, maxInlineImages
+ * an integer 1–48, and note trimmed, non-empty, and at most `NOTE_MAX_CHARS`.
+ * Reject-all-or-apply-all — the whole body is checked before any record
+ * mutation, so an invalid field never partially applies. An omitted key
+ * means "leave unchanged"; an explicit `null` clears the field. Unknown keys
+ * are ignored, mirroring `validateGithubCommentSettingsPatch` (admin-ui.ts)
+ * and `validateLimitsPatch` (workspace-limits.ts). Moved verbatim from
+ * `routes/me.ts` (issue #613 phase 3) — see git history for the original.
+ */
+function validateCommentSettingsPatch(body: unknown): CommentSettingsPatch {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new ValidationError("request body must be a JSON object", { code: "invalid_settings" });
+  }
+  const record = body as Record<string, unknown>;
+  const patch: CommentSettingsPatch = {};
+
+  if ("imageWidth" in record) {
+    const value = record.imageWidth;
+    if (value === null) {
+      patch.imageWidth = null;
+    } else if (value === "full") {
+      patch.imageWidth = "full";
+    } else if (
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= COMMENT_IMAGE_WIDTH_MIN &&
+      value <= COMMENT_IMAGE_WIDTH_MAX
+    ) {
+      patch.imageWidth = value;
+    } else {
+      throw new ValidationError(
+        `imageWidth must be "full", an integer ${COMMENT_IMAGE_WIDTH_MIN}–${COMMENT_IMAGE_WIDTH_MAX}, or null`,
+        { code: "invalid_settings", details: { field: "imageWidth" } },
+      );
+    }
+  }
+
+  if ("maxInlineImages" in record) {
+    const value = record.maxInlineImages;
+    if (value === null) {
+      patch.maxInlineImages = null;
+    } else if (
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= COMMENT_MAX_INLINE_IMAGES_MIN &&
+      value <= COMMENT_MAX_INLINE_IMAGES_MAX
+    ) {
+      patch.maxInlineImages = value;
+    } else {
+      throw new ValidationError(
+        `maxInlineImages must be an integer ${COMMENT_MAX_INLINE_IMAGES_MIN}–${COMMENT_MAX_INLINE_IMAGES_MAX} or null`,
+        { code: "invalid_settings", details: { field: "maxInlineImages" } },
+      );
+    }
+  }
+
+  if ("showMetadata" in record) {
+    const value = record.showMetadata;
+    if (value !== null && typeof value !== "boolean") {
+      throw new ValidationError("showMetadata must be a boolean or null", {
+        code: "invalid_settings",
+        details: { field: "showMetadata" },
+      });
+    }
+    patch.showMetadata = value;
+  }
+
+  if ("linkToFilePage" in record) {
+    const value = record.linkToFilePage;
+    if (value !== null && typeof value !== "boolean") {
+      throw new ValidationError("linkToFilePage must be a boolean or null", {
+        code: "invalid_settings",
+        details: { field: "linkToFilePage" },
+      });
+    }
+    patch.linkToFilePage = value;
+  }
+
+  if ("note" in record) {
+    const value = record.note;
+    if (value === null) {
+      patch.note = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0 || trimmed.length > NOTE_MAX_CHARS) {
+        throw new ValidationError(`note must be 1–${NOTE_MAX_CHARS} characters after trimming`, {
+          code: "invalid_settings",
+          details: { field: "note" },
+        });
+      }
+      patch.note = trimmed;
+    } else {
+      throw new ValidationError("note must be a string or null", {
+        code: "invalid_settings",
+        details: { field: "note" },
+      });
+    }
+  }
+
+  return patch;
+}
+
+/** Response body shared by GET and PATCH: the workspace-level comment defaults. */
+function commentSettingsResponse(record: WorkspaceRecord) {
+  return {
+    imageWidth: record.githubCommentImageWidth ?? null,
+    maxInlineImages: record.githubCommentMaxInlineImages ?? null,
+    showMetadata: record.githubCommentShowMetadata ?? null,
+    linkToFilePage: record.githubCommentLinkToFilePage ?? null,
+    note: record.githubCommentNote ?? null,
+  };
+}
+
+/** `GET /:workspace/comment-settings` — admin/owner only. */
+export async function commentSettingsGetHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  return c.json(commentSettingsResponse(record));
+}
+
+/**
+ * `PATCH /:workspace/comment-settings` — admin/owner only. Validated in full
+ * before any write (reject-all-or-apply-all — see
+ * `validateCommentSettingsPatch`); an omitted key leaves the field
+ * unchanged, an explicit `null` clears it.
+ */
+export async function commentSettingsPatchHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    throw new ValidationError("request body must be valid JSON", { code: "invalid_settings" });
+  }
+  const patch = validateCommentSettingsPatch(body);
+  const record = await mutateWorkspaceRecord(
+    c.env,
+    name,
+    (current) => {
+      const next = { ...current };
+      for (const key of COMMENT_SETTINGS_KEYS) {
+        if (!(key in patch)) continue;
+        const field = COMMENT_SETTINGS_RECORD_FIELD[key];
+        const value = patch[key];
+        if (value === null || value === undefined) delete next[field];
+        else (next as Record<string, unknown>)[field] = value;
+      }
+      return next;
+    },
+    { requireServing: true },
+  );
+  return c.json(commentSettingsResponse(record));
+}
+
+/**
+ * `GET /:workspace/storage` — self-serve BYO R2 bucket (issue #583 Task
+ * 1.1), admin/owner only. Readable regardless of `byoBucketEnabled` (the
+ * settings UI needs the flag value to decide whether to show the panel at
+ * all). Never returns credential values — `storageStatusResponse`
+ * (`workspace-storage.ts`) projects masked/presence fields only, same
+ * posture as `GET /admin/workspaces/:name` (admin.ts).
+ */
+export async function storageGetHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  return c.json(storageStatusResponse(record, byoBucketAllowed(record)));
+}
+
+/**
+ * `POST /:workspace/storage/verify` — runs the verify pipeline
+ * (`storage-verify.ts`) against the request body, never saved state, so an
+ * admin can iterate on credentials before anything is persisted. 403s
+ * `byo_bucket_disabled` when the workspace flag is off. Rate-limited via
+ * `allowWrite` like every other mutating-adjacent route here: each call does
+ * real remote I/O (auth probe + a write/read/delete round-trip against the
+ * candidate bucket).
+ */
+export async function storageVerifyHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  if (!byoBucketAllowed(record)) {
+    throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+      code: "byo_bucket_disabled",
+    });
+  }
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const candidate = candidateFromBody(body);
+  const result = await storageVerify(candidate);
+  return c.json(result);
+}
+
+/**
+ * `PUT /:workspace/storage` — persists a verified BYO config. Never trusts a
+ * client-side "verified" claim — re-runs the same pipeline server-side
+ * against the request body, and only writes on a pass. On a fail, responds
+ * with the verify result (422) so the UI can render the same checklist the
+ * standalone verify route would have. `mutateWorkspaceRecord` (with
+ * `requireServing`) both re-checks the workspace hasn't been soft-deleted
+ * since the request started and gives us the read-immediately-before-write
+ * window issue #387 exists for; sealing happens *inside* that callback
+ * (precedent: `reencrypt-registry.ts`), never on data read earlier in the
+ * request.
+ */
+export async function storagePutHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const userId = c.get("settingsUserId");
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  if (!byoBucketAllowed(record)) {
+    throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+      code: "byo_bucket_disabled",
+    });
+  }
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const candidate = candidateFromBody(body);
+  const result = await storageVerify(candidate);
+  if (!result.ok) {
+    return c.json(result, 422);
+  }
+
+  // No migration of populated workspaces in v1 (plan's global constraints):
+  // attaching a BYO bucket to a workspace that already holds files would
+  // orphan them on the shared bucket. Checked against the D1 usage ledger
+  // *before* the mutation — a KV-only read inside the callback can't see
+  // this — accepting the narrow race where a concurrent upload lands
+  // between this check and the write (the callback's `requireServing`
+  // re-check guards the record itself, not usage).
+  const usage = await getWorkspaceUsage(c.env.DB, name);
+  if (usage.objects > 0 && candidate.adoptExistingContents !== true) {
+    throw new ConflictError(
+      "this workspace already has files — BYO storage can only be attached to an empty workspace",
+      { code: "workspace_storage_not_empty" },
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+  const updated = await mutateWorkspaceRecord(
+    c.env,
+    name,
+    async (current) => {
+      const sealed = await sealCredentialFieldsStrict(c.env.WORKSPACE_SECRETS_KEY, {
+        accessKeyId: candidate.accessKeyId,
+        secretAccessKey: candidate.secretAccessKey,
+      });
+      const next: WorkspaceRecord = { ...current };
+      delete next.prefix;
+      delete next.binding;
+      next.bucket = candidate.bucket;
+      next.accountId = candidate.accountId;
+      next.accessKeyId = sealed.accessKeyId;
+      next.secretAccessKey = sealed.secretAccessKey;
+      if (candidate.publicBaseUrl) next.publicBaseUrl = candidate.publicBaseUrl;
+      else delete next.publicBaseUrl;
+      // Cast is safe: `storageVerify` above already ran the shape check
+      // (storage-verify.ts) that 422s on anything outside R2_JURISDICTIONS.
+      if (candidate.jurisdiction) next.jurisdiction = candidate.jurisdiction as R2Jurisdiction;
+      else delete next.jurisdiction;
+      next.storageConfiguredAt = nowIso;
+      next.storageVerifiedAt = nowIso;
+      next.storageConfiguredBy = userId;
+      // Display fragment for the settings UI, captured from the plaintext
+      // before sealing — `next.accessKeyId` is ciphertext from here on.
+      next.storageAccessKeyIdLast4 = candidate.accessKeyId.slice(-4);
+      return next;
+    },
+    { requireServing: true },
+  );
+
+  console.log(JSON.stringify({ event: "workspace_storage_configured", workspace: name, userId }));
+
+  // `adoptExistingContents` bypassed the emptiness guard, so the D1 usage
+  // ledger still describes the old backing storage while the adopted
+  // bucket's contents are what this workspace now serves. Rebuild the
+  // ledger from the new bucket so it's honest immediately (it's dormant for
+  // `maxStorageBytes` while BYO is active — `storageBudgetApplies` — but
+  // powers the settings UI and becomes authoritative again on detach).
+  // Best-effort: the config write above already succeeded, and reconcile
+  // can be re-run any time.
+  if (candidate.adoptExistingContents === true) {
+    await storageReconcile(c.env, updated, name).catch((err) =>
+      console.error("workspace storage attach: usage reconcile failed for", name, err),
+    );
+  }
+
+  return c.json({ ...storageStatusResponse(updated, true), verify: result });
+}
+
+/**
+ * `DELETE /:workspace/storage` — detach BYO storage and restore
+ * shared-bucket defaults. Never touches the customer's bucket or its
+ * objects — only the platform's own KV record. Blocked unless the
+ * workspace's usage ledger reports zero objects, or the caller explicitly
+ * passes `force` (query `?force=true` or a JSON body `{ "force": true }`) —
+ * mirrors the empty-workspace guard on PUT above, in the opposite
+ * direction. Shared-bucket fields (bucket/binding/prefix/publicBaseUrl)
+ * come from `selfServeWorkspaceRecord` so this can't drift from what a
+ * brand-new self-serve workspace actually gets; everything else on the
+ * record (limits, github links, comment settings, plan, other flags) is
+ * preserved untouched.
+ */
+export async function storageDeleteHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const userId = c.get("settingsUserId");
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  if (!byoBucketAllowed(record)) {
+    throw new ForbiddenError("BYO storage is not enabled for this workspace", {
+      code: "byo_bucket_disabled",
+    });
+  }
+  if (!(await allowWrite(c.env, name))) {
+    throw new RateLimitedError("rate limit exceeded");
+  }
+
+  const queryForce = c.req.query("force");
+  const bodyForce = await c.req
+    .json<{ force?: unknown }>()
+    .then((b) => b?.force === true)
+    .catch(() => false);
+  const force = queryForce === "true" || queryForce === "1" || bodyForce;
+
+  if (!force) {
+    const usage = await getWorkspaceUsage(c.env.DB, name);
+    if (usage.objects > 0) {
+      throw new ConflictError(
+        "this workspace still has files on its BYO bucket — pass force to detach anyway",
+        { code: "workspace_storage_not_empty" },
+      );
+    }
+  }
+
+  const updated = await mutateWorkspaceRecord(
+    c.env,
+    name,
+    (current) => {
+      const shared = selfServeWorkspaceRecord({
+        name,
+        userId: current.createdByUserId ?? userId,
+        now: new Date(),
+      });
+      const next: WorkspaceRecord = { ...current };
+      next.bucket = shared.bucket;
+      next.binding = shared.binding;
+      next.prefix = shared.prefix;
+      if (shared.publicBaseUrl) next.publicBaseUrl = shared.publicBaseUrl;
+      else delete next.publicBaseUrl;
+      delete next.accountId;
+      delete next.accessKeyId;
+      delete next.secretAccessKey;
+      delete next.jurisdiction;
+      delete next.storageConfiguredAt;
+      delete next.storageVerifiedAt;
+      delete next.storageConfiguredBy;
+      delete next.storageAccessKeyIdLast4;
+      return next;
+    },
+    { requireServing: true },
+  );
+
+  console.log(JSON.stringify({ event: "workspace_storage_detached", workspace: name, userId }));
+
+  // `force` bypassed the emptiness guard, so the ledger still describes the
+  // detached BYO bucket — but `maxStorageBytes` enforcement resumes on the
+  // shared bucket the moment this record is restored, and stale counts
+  // could leave the workspace permanently over-budget with nothing to
+  // delete. Rebuild from the restored shared-bucket prefix (best-effort,
+  // same rationale as the attach path above).
+  if (force) {
+    await storageReconcile(c.env, updated, name).catch((err) =>
+      console.error("workspace storage detach: usage reconcile failed for", name, err),
+    );
+  }
+
+  return c.json(storageStatusResponse(updated, byoBucketAllowed(updated)));
+}
+
+/** `GET /:workspace/summary` — member-gated: membership + usage + public URL, one payload. */
+export async function summaryHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const ws = c.get("settingsWorkspace");
+
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) {
+    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  }
+
+  const publicBaseUrl = record.publicBaseUrl;
+  let usage: ReturnType<typeof usageWithLimits> | null = null;
+  try {
+    usage = usageWithLimits(await getWorkspaceUsage(c.env.DB, name), record);
+  } catch {
+    usage = null;
+  }
+
+  return c.json({
+    workspace: ws.workspace,
+    organization: ws.organization,
+    role: ws.role,
+    hasPublicUrl: Boolean(publicBaseUrl),
+    publicBaseUrl,
+    usage,
+  });
+}
+
+/**
+ * `GET /:workspace/billing` — member-gated: plan metadata, resolved
+ * effective limits, usage, and subscription state for the account billing
+ * tab. `plan`/`available`/`planApplied`/`limits` reuse `workspace-plan.ts`'s
+ * `planResponse` — the same attribution contract the admin plan surface
+ * uses: a record with no `plan` field must never display free-plan default
+ * caps it isn't actually enforcing, so `planApplied` is `false` and
+ * `limits` mirrors enforcement (explicit-or-unlimited) rather than the plan
+ * defaults.
+ *
+ * `planSource`/`subscription` are sourced from the auth D1 `subscription`
+ * table over the AUTH service binding (`org-workspaces.ts`'s
+ * `subscriptionForOrg`), the same internal-bridge pattern as every other org
+ * lookup here. `subscriptionForOrg` never throws — an AUTH outage degrades
+ * to `subscription: null` + `planSource: "none"`-or-"admin" (whichever
+ * `planSourceFor` derives with a null subscription) rather than a 500.
+ * `stripeCustomerId` is deliberately dropped here — it's an admin-ui-only
+ * field (see `routes/admin-ui.ts`'s plan surface), never exposed to the
+ * member-facing settings API. Preserving this redaction is a hard
+ * requirement carried over unchanged from `routes/me.ts` (issue #613 phase
+ * 3 brief).
+ */
+export async function billingHandler(c: Context<SettingsVars>) {
+  const name = c.req.param("workspace") ?? "";
+  const ws = c.get("settingsWorkspace");
+
+  const record = await loadWorkspaceRecord(c.env, name);
+  if (!record) {
+    throw new NotFoundError("workspace not found", { code: "workspace_not_found" });
+  }
+
+  const { plan, available, planApplied, limits } = planResponse(name, record);
+
+  const [usage, authSubscription] = await Promise.all([
+    getWorkspaceUsage(c.env.DB, name)
+      .then((raw) => usageWithLimits(raw, record))
+      .catch(() => null),
+    subscriptionForOrg(c.env, ws.organization.slug),
+  ]);
+
+  const planSource = planSourceFor(record, authSubscription);
+  const subscription = authSubscription
+    ? {
+        status: authSubscription.status,
+        periodEnd: authSubscription.periodEnd,
+        cancelAtPeriodEnd: authSubscription.cancelAtPeriodEnd,
+      }
+    : null;
+
+  return c.json({
+    workspace: ws.workspace,
+    organization: ws.organization,
+    plan,
+    available,
+    planApplied,
+    limits,
+    usage,
+    planSource,
+    subscription,
+  });
+}
+
+export const workspaceSettings = new Hono<SettingsVars>()
+  .get("/:workspace/summary", sessionMemberGate(), summaryHandler)
+  .get("/:workspace/billing", sessionMemberGate(), billingHandler)
+  .get("/:workspace/comment-settings", sessionAdminGate(), commentSettingsGetHandler)
+  .patch("/:workspace/comment-settings", sessionAdminGate(), commentSettingsPatchHandler)
+  .get("/:workspace/storage", sessionAdminGate(), storageGetHandler)
+  .post("/:workspace/storage/verify", sessionAdminGate(), storageVerifyHandler)
+  .put("/:workspace/storage", sessionAdminGate(), storagePutHandler)
+  .delete("/:workspace/storage", sessionAdminGate(), storageDeleteHandler)
+  .onError((err, c) => respondError(c, err));

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -15,7 +15,8 @@ import {
 } from "@uploads/errors";
 import { resolveWorkspaceCreateQuota, workspaceCapMessage } from "@uploads/billing";
 import { Hono, type MiddlewareHandler } from "hono";
-import { adminWorkspaceOr403, isWorkspaceOwner } from "./me";
+import { dualGovernanceAuth } from "../dual-workspace-auth";
+import { respondError } from "../error-response";
 import {
   isFileScope,
   isOperatorScope,
@@ -27,8 +28,10 @@ import { recordAdoptionSafe } from "../adoption";
 import { allowWorkspaceCreate, allowWrite } from "../guards";
 import { throwForInviteError } from "../invite-error";
 import {
+  adminWorkspaceOr403,
   deleteOrg,
   isGithubLinked,
+  isWorkspaceOwner,
   membershipsForUser,
   orgForWorkspace,
   provisionOrg,
@@ -365,17 +368,41 @@ workspaces.post("/:name/restore", sessionAuth, requireSessionUser, async (c) => 
 });
 
 /**
- * Token-authed invite (issue #262) — mirrors `POST /me/workspaces/:name/invites`
- * but is bearer-token-authed with a D1 `workspace:invite`-scoped token
- * (`workspaceGovernanceAuth`, see `../workspace.ts`) instead of a session
- * cookie. Per the plan's invite-attribution rule, the invite acts as the
- * token's `minting_user_id` — the auth worker's internal invite route
- * independently re-checks that user's org admin/owner role server-side
- * (`apps/auth/src/internal-routes.ts`), so a minter who lost their org role
- * can no longer invite with an old token even though the token itself is
- * still active.
+ * Canonical invites route (issue #613 phase 3): `POST /v1/workspaces/:name/invites`
+ * is now dual-authed via `dualGovernanceAuth("workspace:invite")` rather than
+ * the bare `workspaceGovernanceAuth` it used pre-#613 — EITHER a D1
+ * `workspace:invite`-scoped bearer token (unchanged behavior, delegated
+ * verbatim — see `workspace-governance-invite.test.ts`) OR a session user
+ * holding org role admin/owner in `:name` (matching `adminWorkspaceOr403`'s
+ * posture, the same tier the pre-existing `POST /me/workspaces/:name/invites`
+ * route already required).
+ *
+ * This is the "upgrade the existing path in place" outcome called out in
+ * `.context/613-api-consolidation-plan.md`'s invites/members section: the old
+ * bearer-only path already lived at the canonical `/v1/workspaces/:name/...`
+ * convention, so making it dual-auth here — rather than standing up a
+ * parallel registration in `routes/workspace-members.ts` — avoids a same-path
+ * double-registration/shadowing hazard. The handler body below is completely
+ * unchanged: `dualGovernanceAuth` sets `governanceMintingUserId` to the
+ * session `userId` on the session path (mirroring what a token's
+ * `minting_user_id` represents), so the "act as this user" logic below works
+ * identically for both auth paths without a single line of branching.
+ *
+ * Per the plan's invite-attribution rule, the invite acts as
+ * `governanceMintingUserId` — for a bearer token, the auth worker's internal
+ * invite route independently re-checks that user's org admin/owner role
+ * server-side (`apps/auth/src/internal-routes.ts`), so a minter who lost
+ * their org role can no longer invite with an old token even though the
+ * token itself is still active; for a session caller, `dualGovernanceAuth`
+ * already re-resolved the role on every request (no stale-role risk to begin
+ * with).
+ *
+ * `routes/me.ts`'s `POST /workspaces/:name/invites` now forwards here (see
+ * `forwardToWorkspaceMembers` in `routes/me.ts`) rather than running its own
+ * copy of this handler — the response shape was already identical between
+ * the two paths before this change.
  */
-workspaces.post("/:name/invites", workspaceGovernanceAuth("workspace:invite"), async (c) => {
+workspaces.post("/:name/invites", dualGovernanceAuth("workspace:invite"), async (c) => {
   const name = c.req.param("name");
   requireWorkspaceName(name);
 
@@ -507,3 +534,13 @@ workspaces.delete("/:name/tokens", workspaceManageAuth(), async (c) => {
     },
   });
 });
+
+// Own error boundary (issue #613 phase 3) — required now that `routes/me.ts`
+// `.fetch()`s this router directly for its `POST /workspaces/:name/invites`
+// alias (same "self-contained sub-router, own auth + error boundary" shape
+// `workspace-files.ts`/`workspace-usage.ts`/`workspace-github.ts` already
+// carry for the same reason). Identical formatting to the parent `app`'s own
+// `.onError()` in `index.ts`, so this changes nothing for requests that
+// still reach `workspaces` via the normal `.route("/v1/workspaces", ...)`
+// mount — only the new direct-`.fetch()` path actually depends on it.
+workspaces.onError((err, c) => respondError(c, err));

--- a/apps/api/test/dual-workspace-auth-preset.test.ts
+++ b/apps/api/test/dual-workspace-auth-preset.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression coverage for issue #613 phase 3 whole-branch review finding 2:
+ * `requireSessionAdmin()` used to read `c.get("sessionUser")`, a var only a
+ * real `sessionAuth` round trip ever sets — never the `presetResolvedSessionUser`
+ * WeakMap fast path `dualWorkspaceAuth()` also supports. Composing
+ * `dualWorkspaceAuth()` + `requireSessionAdmin()` (exactly the pattern
+ * `routes/workspace-github.ts` uses, and the pattern the `requireSessionAdmin`
+ * docblock explicitly invites other verticals to reuse) on a PRESET/forwarded
+ * request used to 401 an already-authenticated caller. Exercised directly
+ * against `workspaceGithub` (rather than through a `/me` forward) so the
+ * preset can be set on the exact `Request` instance that reaches the guard,
+ * same technique `routes/me.ts`'s `forwardTo*` helpers use in production.
+ */
+import { describe, expect, it } from "vitest";
+import { presetResolvedSessionUser } from "../src/dual-workspace-auth";
+import { workspaceGithub } from "../src/routes/workspace-github";
+import { type WorkspaceRecord } from "../src/workspace";
+import { FakeKv } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
+import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const WS = "acme";
+const USER_ID = "u-preset-1";
+
+function makeEnv(
+  opts: { role?: string; member?: boolean; getSessionCalls?: { count: number } } = {},
+) {
+  const { role = "admin", member = true, getSessionCalls } = opts;
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [],
+  };
+  return {
+    REGISTRY: { get: async (key: string) => (key === `ws:${WS}` ? record : null) },
+    UPLOADS_DEFAULT: new FakeR2Bucket(),
+    GITHUB_CACHE: new FakeKv(),
+    DB: new UsageFakeD1(),
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    ...GITHUB_APP_CFG_ENV,
+    AUTH: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/api/auth/get-session") {
+          // A preset session must never fall back to a real get-session
+          // round trip — see the "zero get-session calls" assertion below.
+          if (getSessionCalls) getSessionCalls.count++;
+          return Response.json({
+            session: {},
+            user: { id: USER_ID, email: "preset@example.com", name: "Preset" },
+          });
+        }
+        if (url.pathname === "/internal/memberships") {
+          return Response.json(
+            member
+              ? [{ organizationId: "org-1", organizationSlug: WS, organizationName: "Acme", role }]
+              : [],
+          );
+        }
+        return new Response(JSON.stringify({ githubAccountId: null }), {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+  } as unknown as Env;
+}
+
+describe("preset session + requireSessionAdmin composition (issue #613 phase 3 review finding 2)", () => {
+  it("an admin session preset via presetResolvedSessionUser reaches the handler (no re-resolution)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ role: "admin", getSessionCalls });
+    const request = new Request("https://internal/acme/github/link?repo=acme%2Fweb");
+    presetResolvedSessionUser(request, USER_ID);
+    const res = await workspaceGithub.fetch(request, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: "acme/web", linked: false });
+    // Neither `dualWorkspaceAuth`'s session resolution nor `requireSessionAdmin`'s
+    // role check should trigger a real `get-session` call for a preset request.
+    expect(getSessionCalls.count).toBe(0);
+  });
+
+  it("a non-admin member session preset via presetResolvedSessionUser 403s workspace_admin_required", async () => {
+    const env = makeEnv({ role: "member" });
+    const request = new Request("https://internal/acme/github/link?repo=acme%2Fweb");
+    presetResolvedSessionUser(request, USER_ID);
+    const res = await workspaceGithub.fetch(request, env);
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_admin_required",
+    );
+  });
+
+  it("a non-member session preset via presetResolvedSessionUser 404s (dualWorkspaceAuth's own membership check)", async () => {
+    const env = makeEnv({ member: false });
+    const request = new Request("https://internal/acme/github/link?repo=acme%2Fweb");
+    presetResolvedSessionUser(request, USER_ID);
+    const res = await workspaceGithub.fetch(request, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("a direct (non-preset) admin session still works via the real sessionAuth round trip", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ role: "admin", getSessionCalls });
+    const res = await workspaceGithub.fetch(
+      new Request("https://internal/acme/github/link?repo=acme%2Fweb", {
+        headers: { cookie: "session=x" },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    // Direct path still resolves the session exactly once — requireSessionAdmin
+    // reads `sessionUserId` off the context rather than re-resolving.
+    expect(getSessionCalls.count).toBe(1);
+  });
+});

--- a/apps/api/test/dual-workspace-auth-preset.test.ts
+++ b/apps/api/test/dual-workspace-auth-preset.test.ts
@@ -102,6 +102,26 @@ describe("preset session + requireSessionAdmin composition (issue #613 phase 3 r
     expect(res.status).toBe(404);
   });
 
+  // CodeRabbit PR #617 review finding 5: none of the tests above carry an
+  // `Authorization` header, so they never exercise the branch a forwarded
+  // `/me` request actually hits in production — its original bearer header
+  // (e.g. a Better Auth bearer session) rides along verbatim alongside the
+  // preset. A preset must win unconditionally, BEFORE `dualWorkspaceAuth`
+  // ever branches on that header, so it can't get re-routed into the token
+  // path and 401 an already-authenticated caller a second time.
+  it("a preset session takes priority over a forwarded bearer header (no get-session call)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ role: "admin", getSessionCalls });
+    const request = new Request("https://internal/acme/github/link?repo=acme%2Fweb", {
+      headers: { authorization: "Bearer up_acme_not-a-real-token" },
+    });
+    presetResolvedSessionUser(request, USER_ID);
+    const res = await workspaceGithub.fetch(request, env);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: "acme/web", linked: false });
+    expect(getSessionCalls.count).toBe(0);
+  });
+
   it("a direct (non-preset) admin session still works via the real sessionAuth round trip", async () => {
     const getSessionCalls = { count: 0 };
     const env = makeEnv({ role: "admin", getSessionCalls });

--- a/apps/api/test/routes-workspace-github.test.ts
+++ b/apps/api/test/routes-workspace-github.test.ts
@@ -359,6 +359,41 @@ describe("GET/POST/DELETE /v1/workspaces/:workspace/github/link (dual-auth, sess
     expect(memberRes.status).toBe(403);
   });
 
+  // Regression for CodeRabbit PR #617 review finding 3: `dualWorkspaceAuth`
+  // used to hardcode `mintingUserId` to `null` on the session path, so
+  // `isEntitledToClaimRepo` (which treats a null minting user as
+  // "not entitled" by construction) always declined an admin session
+  // caller's claim of an unbound repo — even one they're verifiably
+  // entitled to. `mintingUserId` must carry the real session `userId`
+  // (`USER.id`) so this entitlement check runs against the actual caller.
+  it("claims an unbound repo for an entitled admin session caller (mintingUserId propagation)", async () => {
+    const { env, githubCache, db } = await makeEnv({ role: "admin" });
+    githubCache.store.set("ghinst:acme/web", { value: "42" });
+    githubCache.store.set("ghtok:42", { value: "cached-token" });
+    githubCache.store.set(`ghlogin:${USER.id}`, { value: "octocat" });
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string) =>
+      String(url).includes("/collaborators/octocat/permission")
+        ? new Response(JSON.stringify({ permission: "write" }), { status: 200 })
+        : new Response("nf", { status: 404 })) as unknown as typeof fetch;
+    try {
+      const res = await app.request(
+        "/v1/workspaces/acme/github/link",
+        {
+          method: "POST",
+          headers: { ...sessionCookie, "content-type": "application/json" },
+          body: JSON.stringify({ repo: "acme/web" }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ claimed: true, workspace: WS, source: "cli" });
+      expect(db.repoLinks.get("acme/web")).toMatchObject({ workspace_name: WS, source: "cli" });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   it("DELETE link: admin session 200s, member session 403s", async () => {
     const admin = await makeEnv({ role: "admin" });
     const adminRes = await app.request(

--- a/apps/api/test/routes-workspace-github.test.ts
+++ b/apps/api/test/routes-workspace-github.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Canonical dual-auth github vertical (issue #613 phase 3):
+ * `/v1/workspaces/:workspace/github/*`. Exercised through the real composed
+ * `app` (index.ts) — same style as `routes-workspace-usage.test.ts` (phase
+ * 2). Bearer-only coverage for the pre-existing `/v1/:workspace/github/*`
+ * sub-routers stays in `src/routes/github-*-route.test.ts`; this file is
+ * scoped to the canonical surface: both credential types reaching the
+ * handlers, the token-only posture on comment/promote, the session-admin-tier
+ * posture on link/repo-link/health/activity, and untouched old-path behavior.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import { sha256Hex, type WorkspaceRecord } from "../src/workspace";
+import { FakeKv } from "./fake-kv";
+import { FakeR2Bucket } from "./fake-r2";
+import { GITHUB_APP_CFG_ENV } from "./github-app-env";
+import { withMintingUserToken } from "./helpers/fake-minting-user-token";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const WS = "acme";
+const TOKEN = "canonical-github-token";
+const USER = { id: "u-1", email: "member@example.com", name: "Member" };
+
+beforeAll(() => {
+  if (!(crypto.subtle as SubtleCrypto & { timingSafeEqual?: unknown }).timingSafeEqual) {
+    Object.defineProperty(crypto.subtle, "timingSafeEqual", {
+      value: (left: ArrayBufferView, right: ArrayBufferView) => {
+        const a = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+        const b = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+        if (a.length !== b.length) return false;
+        let difference = 0;
+        for (let index = 0; index < a.length; index++) difference |= a[index] ^ b[index];
+        return difference === 0;
+      },
+    });
+  }
+});
+
+async function makeEnv(
+  opts: {
+    member?: boolean;
+    session?: boolean;
+    role?: string;
+    /** Layers a D1-scoped token on `TOKEN`'s hash, less than the legacy path's full grant. */
+    scopedTokenScopes?: string[];
+  } = {},
+): Promise<{ env: Parameters<typeof app.request>[2]; db: UsageFakeD1; githubCache: FakeKv }> {
+  const { member = true, session = true, role = "member" } = opts;
+  const record: WorkspaceRecord = {
+    provider: "r2",
+    bucket: "b",
+    binding: "UPLOADS_DEFAULT",
+    prefix: "acme/",
+    publicBaseUrl: "https://storage.uploads.sh",
+    tokens: [{ hash: await sha256Hex(TOKEN), createdAt: new Date().toISOString() }],
+  };
+  const db = new UsageFakeD1();
+  if (opts.scopedTokenScopes) {
+    withMintingUserToken(db, {
+      workspace: WS,
+      tokenHash: await sha256Hex(TOKEN),
+      mintingUserId: "minting-1",
+      scopes: opts.scopedTokenScopes,
+    });
+  }
+  const githubCache = new FakeKv();
+  const env = {
+    REGISTRY: {
+      get: async (key: string) => (key === `ws:${WS}` ? record : null),
+    },
+    UPLOADS_DEFAULT: new FakeR2Bucket(),
+    GITHUB_CACHE: githubCache,
+    DB: db,
+    WRITE_LIMITER: { limit: async () => ({ success: true }) },
+    ...GITHUB_APP_CFG_ENV,
+    AUTH: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url = new URL(input instanceof Request ? input.url : input);
+        if (url.pathname === "/api/auth/get-session") {
+          return session ? Response.json({ session: {}, user: USER }) : Response.json(null);
+        }
+        if (url.pathname === "/internal/memberships") {
+          return Response.json(
+            member
+              ? [
+                  {
+                    organizationId: "org-1",
+                    organizationSlug: WS,
+                    organizationName: "Acme",
+                    role,
+                  },
+                ]
+              : [],
+          );
+        }
+        return new Response(JSON.stringify({ githubAccountId: null }), {
+          headers: { "content-type": "application/json" },
+        });
+      },
+    },
+  };
+  return { env: env as unknown as Parameters<typeof app.request>[2], db, githubCache };
+}
+
+function bearer(token = TOKEN) {
+  return { Authorization: `Bearer ${token}` };
+}
+const sessionCookie = { cookie: "session=x" };
+
+describe("POST /v1/workspaces/:workspace/github/comment (token-only)", () => {
+  it("bearer with files:write reaches the handler", async () => {
+    const { env, githubCache } = await makeEnv();
+    githubCache.store.set("ghinst:acme/web", { value: "none" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/comment",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, kind: "pull" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ posted: false, reason: "not_installed" });
+  });
+
+  it("a files:read-only token 403s (canonical requires files:write, unlike the old path)", async () => {
+    const { env } = await makeEnv({ scopedTokenScopes: ["files:read"] });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/comment",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, kind: "pull" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("session member 403s with github_requires_token", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/comment",
+      {
+        method: "POST",
+        headers: { ...sessionCookie, "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, kind: "pull" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("github_requires_token");
+  });
+
+  it("non-member session 404s before reaching the token gate", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/comment",
+      {
+        method: "POST",
+        headers: { ...sessionCookie, "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, kind: "pull" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_not_found");
+  });
+});
+
+describe("old bearer path /v1/:workspace/github/comment is untouched (issue #613 phase 3)", () => {
+  it("a files:read-only token still works (the old path's pre-existing, deliberately-unfixed scope)", async () => {
+    const { env, githubCache } = await makeEnv({ scopedTokenScopes: ["files:read"] });
+    githubCache.store.set("ghinst:acme/web", { value: "none" });
+    const res = await app.request(
+      "/v1/acme/github/comment",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, kind: "pull" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ posted: false, reason: "not_installed" });
+  });
+});
+
+describe("POST /v1/workspaces/:workspace/github/promote (token-only)", () => {
+  it("bearer with files:write reaches the handler", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/promote",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, branch: "feat-x" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ promoted: [], skipped: [] });
+  });
+
+  it("a files:read-only token 403s (missing files:write)", async () => {
+    const { env } = await makeEnv({ scopedTokenScopes: ["files:read"] });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/promote",
+      {
+        method: "POST",
+        headers: { ...bearer(), "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, branch: "feat-x" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("session member 403s with github_requires_token", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/promote",
+      {
+        method: "POST",
+        headers: { ...sessionCookie, "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, branch: "feat-x" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("github_requires_token");
+  });
+
+  it("non-member session 404s before reaching the token gate", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/promote",
+      {
+        method: "POST",
+        headers: { ...sessionCookie, "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web", num: 1, branch: "feat-x" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET/POST/DELETE /v1/workspaces/:workspace/github/link (dual-auth, session-admin-gated)", () => {
+  it("bearer with files:read reaches GET", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { headers: bearer() },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ repo: "acme/web", linked: false });
+  });
+
+  it("bearer missing files:read scope 403s", async () => {
+    const { env } = await makeEnv({ scopedTokenScopes: ["files:write"] });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { headers: bearer() },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("admin session 200s", async () => {
+    const { env } = await makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("owner session 200s", async () => {
+    const { env } = await makeEnv({ role: "owner" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("member (non-admin) session 403s with workspace_admin_required", async () => {
+    const { env } = await makeEnv({ role: "member" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_admin_required");
+  });
+
+  it("non-member session 404s (never reaches the admin-tier check)", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /repo-link: admin session 200s, member session 403s", async () => {
+    const admin = await makeEnv({ role: "admin" });
+    const adminRes = await app.request(
+      "/v1/workspaces/acme/github/repo-link?repo=acme%2Fweb",
+      { headers: sessionCookie },
+      admin.env,
+    );
+    expect(adminRes.status).toBe(200);
+    expect(await adminRes.json()).toEqual({ binding: "none" });
+
+    const member = await makeEnv({ role: "member" });
+    const memberRes = await app.request(
+      "/v1/workspaces/acme/github/repo-link?repo=acme%2Fweb",
+      { headers: sessionCookie },
+      member.env,
+    );
+    expect(memberRes.status).toBe(403);
+  });
+
+  it("POST link: admin session 200s, member session 403s", async () => {
+    const admin = await makeEnv({ role: "admin" });
+    const adminRes = await app.request(
+      "/v1/workspaces/acme/github/link",
+      {
+        method: "POST",
+        headers: { ...sessionCookie, "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web" }),
+      },
+      admin.env,
+    );
+    expect(adminRes.status).toBe(200);
+
+    const member = await makeEnv({ role: "member" });
+    const memberRes = await app.request(
+      "/v1/workspaces/acme/github/link",
+      {
+        method: "POST",
+        headers: { ...sessionCookie, "content-type": "application/json" },
+        body: JSON.stringify({ repo: "acme/web" }),
+      },
+      member.env,
+    );
+    expect(memberRes.status).toBe(403);
+  });
+
+  it("DELETE link: admin session 200s, member session 403s", async () => {
+    const admin = await makeEnv({ role: "admin" });
+    const adminRes = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { method: "DELETE", headers: sessionCookie },
+      admin.env,
+    );
+    expect(adminRes.status).toBe(200);
+
+    const member = await makeEnv({ role: "member" });
+    const memberRes = await app.request(
+      "/v1/workspaces/acme/github/link?repo=acme%2Fweb",
+      { method: "DELETE", headers: sessionCookie },
+      member.env,
+    );
+    expect(memberRes.status).toBe(403);
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/github/health (dual-auth, session-admin-gated)", () => {
+  it("bearer reaches the handler", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/v1/workspaces/acme/github/health", { headers: bearer() }, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("admin session 200s", async () => {
+    const { env } = await makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/health",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("member (non-admin) session 403s", async () => {
+    const { env } = await makeEnv({ role: "member" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/health",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("workspace_admin_required");
+  });
+
+  it("non-member session 404s", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/health",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/github/activity (dual-auth, session-admin-gated)", () => {
+  it("bearer reaches the handler", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/github/activity",
+      { headers: bearer() },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ workspace: "acme", activity: [] });
+  });
+
+  it("admin session 200s", async () => {
+    const { env } = await makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/activity",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("member (non-admin) session 403s", async () => {
+    const { env } = await makeEnv({ role: "member" });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/activity",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("non-member session 404s", async () => {
+    const { env } = await makeEnv({ member: false });
+    const res = await app.request(
+      "/v1/workspaces/acme/github/activity",
+      { headers: sessionCookie },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("old-path bearer routes are untouched by the canonical mount (issue #613 phase 3)", () => {
+  it("/v1/:workspace/github/link", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request(
+      "/v1/acme/github/link?repo=acme%2Fweb",
+      { headers: bearer() },
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("/v1/:workspace/github/health", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/v1/acme/github/health", { headers: bearer() }, env);
+    expect(res.status).toBe(200);
+  });
+
+  it("/v1/:workspace/github/activity", async () => {
+    const { env } = await makeEnv();
+    const res = await app.request("/v1/acme/github/activity", { headers: bearer() }, env);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -164,6 +164,27 @@ describe("GET /v1/workspaces/:workspace/members", () => {
     const res = await app.request("/v1/workspaces/acme/members", {}, env);
     expect(res.status).toBe(401);
   });
+
+  // Issue #613 phase 3 review finding 1: a Better Auth bearer-session caller
+  // (the `bearer()` plugin, apps/auth/src/auth.ts — a device-flow/CLI session
+  // with no cookie) must succeed here exactly like a cookie session. The stub
+  // AUTH's `get-session` doesn't care whether it was reached via `cookie` or
+  // `authorization` (session-auth.ts's `resolveSessionUser` forwards both
+  // unconditionally), so a non-`up_` bearer is the fixture for a Better Auth
+  // session token.
+  it("succeeds for a Better Auth bearer session with no cookie (direct canonical call)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ getSessionCalls });
+    const res = await app.request(
+      "/v1/workspaces/acme/members",
+      { headers: { Authorization: "Bearer better-auth-session-token" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members[0]).toHaveProperty("id", "m-admin");
+    expect(getSessionCalls.count).toBe(1);
+  });
 });
 
 describe("GET /v1/workspaces/:workspace/people", () => {
@@ -408,6 +429,29 @@ describe("POST /v1/workspaces/:workspace/invites (dual governance auth)", () => 
     );
     expect(res.status).toBe(404);
   });
+
+  // Issue #613 phase 3 review finding 1: a Better Auth bearer session (no
+  // `up_` prefix, no cookie) hitting this canonical route directly must
+  // resolve via session auth, not the D1 governance-token path — same
+  // `up_`-prefix discrimination `workspaceManageAuth` already uses.
+  it("admin session presented as a Better Auth bearer (no cookie) works", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer better-auth-session-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ email: "bearer-session@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invitation: { email: string } };
+    expect(body.invitation.email).toBe("bearer-session@example.com");
+  });
 });
 
 describe("/me alias forwards (issue #613 phase 3)", () => {
@@ -539,5 +583,49 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
     const res = await app.request("/me/workspaces/acme/invites", { headers: sessionHeaders }, env);
     expect(res.status).toBe(200);
     expect(((await res.json()) as { invites: unknown[] }).invites).toHaveLength(1);
+  });
+
+  // Issue #613 phase 3 review finding 1: `/me`'s own `sessionAuth` +
+  // `requireSessionUser` middleware validates a Better Auth bearer session
+  // (no cookie) exactly like a cookie session and presets the resolved
+  // userId. `forwardToWorkspaceMembers` re-dispatches with the ORIGINAL
+  // request headers intact — including that `Authorization: Bearer …`
+  // header — so `sessionMemberGate` must consult the preset before ever
+  // branching on the (irrelevant, already-authenticated) bearer header.
+  it("GET /me/workspaces/:name/members succeeds for a caller who authenticated with a Better Auth bearer session (no cookie)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ getSessionCalls });
+    const res = await app.request(
+      "/me/workspaces/acme/members",
+      { headers: { Authorization: "Bearer better-auth-session-token" } },
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members[0]).toHaveProperty("id", "m-admin");
+    // Exactly one get-session call: /me's own middleware resolves it once,
+    // and the preset means the forwarded canonical request never re-resolves.
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("POST /me/workspaces/:name/invites succeeds for a caller who authenticated with a Better Auth bearer session (no cookie)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ getSessionCalls });
+    const res = await app.request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer better-auth-session-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ email: "forwarded-bearer@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invitation: { email: string } };
+    expect(body.invitation.email).toBe("forwarded-bearer@example.com");
+    expect(getSessionCalls.count).toBe(1);
   });
 });

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Canonical invites/members vertical (issue #613 phase 3):
+ * `/v1/workspaces/:workspace/members`, `/people`, `/invites*`,
+ * `/members/:memberId*`. Exercised through the real composed `app`
+ * (index.ts) — same style as `routes-workspace-usage.test.ts` (phase 2).
+ *
+ * `POST /:workspace/invites` lives at `routes/workspaces.ts` (upgraded in
+ * place to `dualGovernanceAuth`, not re-registered here) — its bearer-path
+ * parity is proven in `src/routes/workspace-governance-invite.test.ts`
+ * (unchanged, still green). This file adds the session-path coverage for
+ * that route plus the fully-new session-only routes in
+ * `routes/workspace-members.ts`.
+ */
+import { describe, expect, it } from "vitest";
+import { createToken } from "../src/auth-db";
+import { app } from "../src/index";
+import { SqliteD1, database } from "./helpers/sqlite-d1";
+
+const MIGRATIONS = [
+  "migrations/20260710120000_auth.sql",
+  "migrations/20260712230000_token_minting_user.sql",
+];
+
+const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin" };
+const MEMBER = { id: "u-member", email: "member@example.com", name: "Member" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+interface OrgMemberRow {
+  id: string;
+  userId: string;
+  email: string;
+  name: string | null;
+  role: string;
+}
+
+interface EnvOpts {
+  /** `undefined` = no session cookie sent at all (see requests below). `null` = signed-out (401). */
+  sessionUser?: typeof ADMIN | typeof MEMBER | null;
+  /** Empty array = not a member (404 posture everywhere in this vertical). */
+  memberships?: { organizationId: string; organizationSlug: string; role: string }[];
+  members?: OrgMemberRow[];
+  invites?: { id: string; email: string; role: string; status: string; expiresAt: string | null }[];
+  getSessionCalls?: { count: number };
+  db?: SqliteD1;
+  onDelete?: (path: string) => Response;
+  onPatch?: (path: string, body: unknown) => Response;
+}
+
+function makeEnv(opts: EnvOpts = {}) {
+  const {
+    sessionUser = ADMIN,
+    memberships = [{ organizationId: "org-1", organizationSlug: "acme", role: "admin" }],
+    members = [
+      { id: "m-admin", userId: ADMIN.id, email: ADMIN.email, name: ADMIN.name, role: "admin" },
+    ],
+    invites = [],
+    getSessionCalls,
+    db = new SqliteD1(MIGRATIONS),
+    onDelete,
+    onPatch,
+  } = opts;
+
+  const auth = stubAuth(async (req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      if (getSessionCalls) getSessionCalls.count++;
+      return sessionUser
+        ? Response.json({ session: {}, user: sessionUser })
+        : new Response(null, { status: 401 });
+    }
+    if (url.pathname === "/internal/memberships") {
+      return Response.json(
+        memberships.map((m) => ({
+          organizationId: m.organizationId,
+          organizationSlug: m.organizationSlug,
+          organizationName: "Acme",
+          role: m.role,
+        })),
+      );
+    }
+    if (url.pathname === "/internal/orgs/acme/members" && req.method === "GET") {
+      return Response.json({ members });
+    }
+    if (url.pathname === "/internal/orgs/acme/invites" && req.method === "GET") {
+      return Response.json({ invites });
+    }
+    if (url.pathname === "/internal/orgs/acme" && req.method === "GET") {
+      return Response.json({ organization: { id: "org-1", slug: "acme", name: "Acme" } });
+    }
+    if (url.pathname === "/internal/invite" && req.method === "POST") {
+      const body = (await req.json()) as { email?: string };
+      return Response.json(
+        { invitation: { id: "inv-1", email: body.email, role: "member", status: "pending" } },
+        { status: 201 },
+      );
+    }
+    if (req.method === "DELETE" && onDelete) return onDelete(url.pathname);
+    if (req.method === "DELETE") return new Response(null, { status: 200 });
+    if (req.method === "PATCH" && onPatch) return onPatch(url.pathname, await req.json());
+    if (req.method === "PATCH") {
+      return Response.json({ member: { id: "m-x", userId: "u-x", role: "admin" } });
+    }
+    return new Response(null, { status: 404 });
+  });
+
+  return { AUTH: auth, DB: database(db) } as unknown as Env;
+}
+
+const sessionHeaders = { cookie: "session=x" };
+
+describe("GET /v1/workspaces/:workspace/members", () => {
+  it("returns members for a session member", async () => {
+    const env = makeEnv({
+      sessionUser: MEMBER,
+      memberships: [{ organizationId: "org-1", organizationSlug: "acme", role: "member" }],
+    });
+    const res = await app.request("/v1/workspaces/acme/members", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members).toHaveLength(1);
+    expect(body.members[0]).not.toHaveProperty("id");
+  });
+
+  it("includes opaque member ids for an admin/owner", async () => {
+    const env = makeEnv();
+    const res = await app.request("/v1/workspaces/acme/members", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { members: Record<string, unknown>[] };
+    expect(body.members[0]).toHaveProperty("id", "m-admin");
+  });
+
+  it("404s a non-member session", async () => {
+    const env = makeEnv({ memberships: [] });
+    const res = await app.request("/v1/workspaces/acme/members", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_not_found",
+    );
+  });
+
+  it("403s a bearer token with a coded error", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/members",
+      { headers: { Authorization: "Bearer up_acme_whatever" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "members_requires_session",
+    );
+  });
+
+  it("401s with neither a bearer token nor a session", async () => {
+    const env = makeEnv({ sessionUser: null });
+    const res = await app.request("/v1/workspaces/acme/members", {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/people", () => {
+  it("hides invites from a non-admin member", async () => {
+    const env = makeEnv({
+      sessionUser: MEMBER,
+      memberships: [{ organizationId: "org-1", organizationSlug: "acme", role: "member" }],
+      invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending", expiresAt: null }],
+    });
+    const res = await app.request("/v1/workspaces/acme/people", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { canManage: boolean; invites: unknown[] };
+    expect(body.canManage).toBe(false);
+    expect(body.invites).toEqual([]);
+  });
+
+  it("includes invites for an admin in one authz pass", async () => {
+    const env = makeEnv({
+      invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending", expiresAt: null }],
+    });
+    const res = await app.request("/v1/workspaces/acme/people", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { canManage: boolean; invites: unknown[]; role: string };
+    expect(body.canManage).toBe(true);
+    expect(body.role).toBe("admin");
+    expect(body.invites).toHaveLength(1);
+  });
+
+  it("403s a bearer token", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/people",
+      { headers: { Authorization: "Bearer up_acme_whatever" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("session-only admin routes (invites list/revoke, member remove/role)", () => {
+  it("GET /invites: admin session works, non-admin member 403s, non-member 404s", async () => {
+    const adminEnv = makeEnv({
+      invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending", expiresAt: null }],
+    });
+    const adminRes = await app.request(
+      "/v1/workspaces/acme/invites",
+      { headers: sessionHeaders },
+      adminEnv,
+    );
+    expect(adminRes.status).toBe(200);
+    expect(((await adminRes.json()) as { invites: unknown[] }).invites).toHaveLength(1);
+
+    const memberEnv = makeEnv({
+      sessionUser: MEMBER,
+      memberships: [{ organizationId: "org-1", organizationSlug: "acme", role: "member" }],
+    });
+    const memberRes = await app.request(
+      "/v1/workspaces/acme/invites",
+      { headers: sessionHeaders },
+      memberEnv,
+    );
+    expect(memberRes.status).toBe(403);
+    expect(((await memberRes.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_admin_required",
+    );
+
+    const nonMemberEnv = makeEnv({ memberships: [] });
+    const nonMemberRes = await app.request(
+      "/v1/workspaces/acme/invites",
+      { headers: sessionHeaders },
+      nonMemberEnv,
+    );
+    expect(nonMemberRes.status).toBe(404);
+  });
+
+  it("GET /invites: bearer token 403s (no bearer capability minted for this route)", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      { headers: { Authorization: "Bearer up_acme_whatever" } },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "members_requires_session",
+    );
+  });
+
+  it("DELETE /invites/:id: admin session revokes", async () => {
+    let deletedPath: string | undefined;
+    const env = makeEnv({
+      onDelete: (path) => {
+        deletedPath = path;
+        return new Response(null, { status: 200 });
+      },
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/invites/inv-1",
+      { method: "DELETE", headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(deletedPath).toBe("/internal/orgs/acme/invites/inv-1");
+  });
+
+  it("DELETE /members/:memberId: admin session removes a member", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/members/m-2",
+      { method: "DELETE", headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("PATCH /members/:memberId: admin session changes role", async () => {
+    const env = makeEnv({
+      onPatch: (_path, body) =>
+        Response.json({
+          member: { id: "m-2", userId: "u-2", role: (body as { role: string }).role },
+        }),
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/members/m-2",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ member: { id: "m-2", userId: "u-2", role: "admin" } });
+  });
+
+  it("PATCH /members/:memberId: invalid role 400s before any AUTH call", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/members/m-2",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ role: "owner" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /v1/workspaces/:workspace/invites (dual governance auth)", () => {
+  it("governance token with workspace:invite works (bearer-path parity)", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:invite"],
+      mintedByUserId: "user-minter",
+    });
+    const env = makeEnv({ db });
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invitation: { email: string } };
+    expect(body.invitation.email).toBe("t@example.com");
+  });
+
+  it("token with the wrong scope (workspace:manage only) 403s", async () => {
+    const db = new SqliteD1(MIGRATIONS);
+    const { token } = await createToken(db as unknown as D1Database, {
+      workspace: "acme",
+      scopes: ["workspace:manage"],
+      mintedByUserId: "user-minter",
+    });
+    const env = makeEnv({ db });
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("admin session works", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invitation: { email: string } };
+    expect(body.invitation.email).toBe("t@example.com");
+  });
+
+  it("member-not-admin session 403s", async () => {
+    const env = makeEnv({
+      sessionUser: MEMBER,
+      memberships: [{ organizationId: "org-1", organizationSlug: "acme", role: "member" }],
+    });
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_admin_required",
+    );
+  });
+
+  it("non-member session 404s", async () => {
+    const env = makeEnv({ memberships: [] });
+    const res = await app.request(
+      "/v1/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ email: "t@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("/me alias forwards (issue #613 phase 3)", () => {
+  it("GET /me/workspaces/:name/members matches the canonical shape", async () => {
+    const env = makeEnv();
+    const canonical = await app.request(
+      "/v1/workspaces/acme/members",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/members",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  it("GET /me/workspaces/:name/people matches the canonical shape", async () => {
+    const env = makeEnv({
+      invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending", expiresAt: null }],
+    });
+    const canonical = await app.request(
+      "/v1/workspaces/acme/people",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request("/me/workspaces/acme/people", { headers: sessionHeaders }, env);
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  it("POST /me/workspaces/:name/invites matches the canonical shape", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ email: "alias@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invitation: { email: string } };
+    expect(body.invitation.email).toBe("alias@example.com");
+  });
+
+  it("resolves the session exactly once per forwarded request (members)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ getSessionCalls });
+    const res = await app.request("/me/workspaces/acme/members", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("resolves the session exactly once per forwarded request (invites POST)", async () => {
+    const getSessionCalls = { count: 0 };
+    const env = makeEnv({ getSessionCalls });
+    const res = await app.request(
+      "/me/workspaces/acme/invites",
+      {
+        method: "POST",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ email: "once@example.com" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("membership rejection still applies to the forwarded alias (non-member -> 404)", async () => {
+    const env = makeEnv({ memberships: [] });
+    const res = await app.request("/me/workspaces/acme/members", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_not_found",
+    );
+  });
+
+  it("DELETE /me/workspaces/:name/members/:memberId still works via the forward", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/me/workspaces/acme/members/m-2",
+      { method: "DELETE", headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("PATCH /me/workspaces/:name/members/:memberId still works via the forward", async () => {
+    const env = makeEnv({
+      onPatch: (_path, body) =>
+        Response.json({
+          member: { id: "m-2", userId: "u-2", role: (body as { role: string }).role },
+        }),
+    });
+    const res = await app.request(
+      "/me/workspaces/acme/members/m-2",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ member: { id: "m-2", userId: "u-2", role: "admin" } });
+  });
+
+  it("DELETE /me/workspaces/:name/invites/:id still works via the forward", async () => {
+    const env = makeEnv();
+    const res = await app.request(
+      "/me/workspaces/acme/invites/inv-1",
+      { method: "DELETE", headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("GET /me/workspaces/:name/invites still works via the forward", async () => {
+    const env = makeEnv({
+      invites: [{ id: "i1", email: "x@y.com", role: "member", status: "pending", expiresAt: null }],
+    });
+    const res = await app.request("/me/workspaces/acme/invites", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { invites: unknown[] }).invites).toHaveLength(1);
+  });
+});

--- a/apps/api/test/routes-workspace-members.test.ts
+++ b/apps/api/test/routes-workspace-members.test.ts
@@ -322,8 +322,20 @@ describe("session-only admin routes (invites list/revoke, member remove/role)", 
     expect(await res.json()).toEqual({ member: { id: "m-2", userId: "u-2", role: "admin" } });
   });
 
-  it("PATCH /members/:memberId: invalid role 400s before any AUTH call", async () => {
-    const env = makeEnv();
+  // Was named "...400s before any AUTH call" — false: `sessionAdminGate`
+  // (get-session + /internal/memberships) runs before `memberRoleUpdateHandler`
+  // ever validates `role`, so AUTH calls do happen ahead of the 400. Renamed
+  // to describe only what's actually guaranteed: the invalid role never
+  // reaches the auth worker's own member-role PATCH (CodeRabbit PR #617
+  // review finding 6).
+  it("PATCH /members/:memberId: invalid role 400s and never reaches the auth worker PATCH", async () => {
+    let patched = false;
+    const env = makeEnv({
+      onPatch: () => {
+        patched = true;
+        return Response.json({ member: {} });
+      },
+    });
     const res = await app.request(
       "/v1/workspaces/acme/members/m-2",
       {
@@ -334,6 +346,7 @@ describe("session-only admin routes (invites list/revoke, member remove/role)", 
       env,
     );
     expect(res.status).toBe(400);
+    expect(patched).toBe(false);
   });
 });
 

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -1,0 +1,660 @@
+/**
+ * Canonical comment-settings, storage, and billing/summary verticals (issue
+ * #613 phase 3): `/v1/workspaces/:workspace/comment-settings`, `/storage`,
+ * `/storage/verify`, `/summary`, `/billing`. Exercised through the real
+ * composed `app` (index.ts) — same style as `routes-workspace-members.test.ts`
+ * (phase 3, invites/members).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { app } from "../src/index";
+import {
+  setStorageReconcileForTests,
+  setStorageVerifyForTests,
+} from "../src/routes/workspace-storage";
+import { fakeRegistry } from "./fake-kv";
+import { UsageFakeD1 } from "./usage-fake-d1";
+
+const ADMIN = { id: "u-admin", email: "admin@example.com", name: "Admin" };
+const MEMBER = { id: "u-member", email: "member@example.com", name: "Member" };
+
+function stubAuth(handler: (req: Request) => Response | Promise<Response>): Pick<Fetcher, "fetch"> {
+  return {
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return handler(req);
+    }) as Fetcher["fetch"],
+  };
+}
+
+interface EnvOpts {
+  /** `undefined` = no session cookie sent at all. `null` = signed-out (401). */
+  sessionUser?: typeof ADMIN | typeof MEMBER | null;
+  role?: string;
+  /** Empty array = not a member (uniform 404 posture everywhere in this vertical). */
+  noMembership?: boolean;
+  record?: unknown;
+  subscription?: unknown;
+  usage?: { objects: number; bytes?: number };
+  getSessionCalls?: { count: number };
+  secretsKey?: string;
+  writeLimiterOk?: boolean;
+}
+
+const SHARED_RECORD = { provider: "r2", bucket: "uploads-default", prefix: "acme/" };
+
+function makeEnv(opts: EnvOpts = {}) {
+  const {
+    sessionUser = ADMIN,
+    role = "admin",
+    noMembership = false,
+    record = SHARED_RECORD,
+    subscription = null,
+    usage,
+    getSessionCalls,
+    secretsKey = "test-workspace-secrets-key-0000",
+    writeLimiterOk = true,
+  } = opts;
+
+  const db = new UsageFakeD1();
+  if (usage) {
+    db.usage.set("acme", {
+      workspace: "acme",
+      bytes: usage.bytes ?? 0,
+      objects: usage.objects,
+      uploads_in_period: 0,
+      period_start: "2026-07",
+      updated_at: "2026-07-01T00:00:00.000Z",
+    });
+  }
+
+  const auth = stubAuth(async (req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/api/auth/get-session") {
+      if (getSessionCalls) getSessionCalls.count++;
+      return sessionUser
+        ? Response.json({ session: {}, user: sessionUser })
+        : new Response(null, { status: 401 });
+    }
+    if (url.pathname === "/internal/memberships") {
+      return Response.json(
+        noMembership
+          ? []
+          : [{ organizationId: "org-1", organizationSlug: "acme", organizationName: "Acme", role }],
+      );
+    }
+    if (url.pathname === "/internal/orgs/acme/subscription") {
+      return Response.json({ subscription });
+    }
+    return new Response(null, { status: 404 });
+  });
+
+  const registry = fakeRegistry(record !== undefined ? { acme: record } : {});
+
+  return {
+    env: {
+      AUTH: auth,
+      DB: db,
+      REGISTRY: registry,
+      WORKSPACE_SECRETS_KEY: secretsKey,
+      WRITE_LIMITER: { limit: async () => ({ success: writeLimiterOk }) },
+    } as unknown as Env,
+    registry,
+    db,
+  };
+}
+
+const sessionHeaders = { cookie: "session=x" };
+const bearerHeaders = { Authorization: "Bearer up_acme_whatever" };
+
+describe("GET /v1/workspaces/:workspace/summary", () => {
+  it("200s for a plain member", async () => {
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member" });
+    const res = await app.request("/v1/workspaces/acme/summary", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workspace: string; role: string };
+    expect(body.workspace).toBe("acme");
+    expect(body.role).toBe("member");
+  });
+
+  it("404s a non-member session", async () => {
+    const { env } = makeEnv({ noMembership: true });
+    const res = await app.request("/v1/workspaces/acme/summary", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_not_found",
+    );
+  });
+
+  it("403s a bearer token with a coded error", async () => {
+    const { env } = makeEnv();
+    const res = await app.request("/v1/workspaces/acme/summary", { headers: bearerHeaders }, env);
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "billing_requires_session",
+    );
+  });
+
+  it("401s with neither a bearer token nor a session", async () => {
+    const { env } = makeEnv({ sessionUser: null });
+    const res = await app.request("/v1/workspaces/acme/summary", {}, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /v1/workspaces/:workspace/billing", () => {
+  it("200s for a plain member and never leaks stripeCustomerId", async () => {
+    const { env } = makeEnv({
+      sessionUser: MEMBER,
+      role: "member",
+      record: { ...SHARED_RECORD, plan: "pro" },
+      subscription: {
+        status: "active",
+        periodEnd: "2026-08-15T00:00:00.000Z",
+        cancelAtPeriodEnd: false,
+        stripeCustomerId: "cus_123",
+        plan: "pro",
+      },
+    });
+    const res = await app.request("/v1/workspaces/acme/billing", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    expect(raw).not.toContain("cus_123");
+    expect(raw).not.toContain("stripeCustomerId");
+    const body = JSON.parse(raw) as { plan: string; subscription: Record<string, unknown> | null };
+    expect(body.plan).toBe("pro");
+    expect(body.subscription).not.toHaveProperty("stripeCustomerId");
+  });
+
+  it("404s a non-member session", async () => {
+    const { env } = makeEnv({ noMembership: true });
+    const res = await app.request("/v1/workspaces/acme/billing", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(404);
+  });
+
+  it("403s a bearer token", async () => {
+    const { env } = makeEnv();
+    const res = await app.request("/v1/workspaces/acme/billing", { headers: bearerHeaders }, env);
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "billing_requires_session",
+    );
+  });
+});
+
+describe("GET/PATCH /v1/workspaces/:workspace/comment-settings", () => {
+  it("GET 200s for an admin session", async () => {
+    const { env } = makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      imageWidth: null,
+      maxInlineImages: null,
+      showMetadata: null,
+      linkToFilePage: null,
+      note: null,
+    });
+  });
+
+  it("GET 403s a non-admin member session", async () => {
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_admin_required",
+    );
+  });
+
+  it("GET 404s a non-member session", async () => {
+    const { env } = makeEnv({ noMembership: true });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("GET 403s a bearer token with a coded error", async () => {
+    const { env } = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      { headers: bearerHeaders },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "settings_requires_session",
+    );
+  });
+
+  it("PATCH sets fields and echoes the new state for an owner session", async () => {
+    const { env, registry } = makeEnv({ role: "owner" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ imageWidth: "full", note: "Hi" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ imageWidth: "full", note: "Hi" });
+    expect(registry.record<{ githubCommentNote?: string }>("acme")?.githubCommentNote).toBe("Hi");
+  });
+
+  it("PATCH 403s a bearer token", async () => {
+    const { env } = makeEnv();
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...bearerHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ note: "Hi" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "settings_requires_session",
+    );
+  });
+
+  it("PATCH rejects an invalid field with 400", async () => {
+    const { env } = makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ imageWidth: 1 }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("storage vertical (self-serve BYO bucket)", () => {
+  const BYO_RECORD = {
+    provider: "r2",
+    bucket: "customer-bucket",
+    accountId: "a".repeat(32),
+    accessKeyId: "enc:v1:sealed-key-id",
+    secretAccessKey: "enc:v1:already-sealed",
+    publicBaseUrl: "https://media.example.com",
+    byoBucketEnabled: true,
+    storageConfiguredAt: "2026-01-01T00:00:00.000Z",
+    storageVerifiedAt: "2026-01-01T00:00:00.000Z",
+    storageConfiguredBy: "u-plain",
+    storageAccessKeyIdLast4: "1234",
+  };
+
+  const okVerifyResult = {
+    ok: true,
+    checks: [
+      { id: "shape", ok: true, required: true },
+      { id: "auth", ok: true, required: true },
+      { id: "round-trip", ok: true, required: true },
+      { id: "not-empty", ok: true, required: true },
+    ],
+  };
+
+  const CANDIDATE_BODY = {
+    bucket: "customer-bucket",
+    accountId: "a".repeat(32),
+    accessKeyId: "AKIDEXAMPLE1234",
+    secretAccessKey: "super-secret-value",
+    publicBaseUrl: "https://media.example.com",
+  };
+
+  afterEach(() => {
+    setStorageVerifyForTests(undefined);
+    setStorageReconcileForTests(undefined);
+  });
+
+  describe("GET /v1/workspaces/:workspace/storage", () => {
+    it("reports byo mode with masked credentials and no secret values anywhere in the payload", async () => {
+      const { env } = makeEnv({ role: "owner", record: BYO_RECORD });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const raw = await res.text();
+      expect(raw).not.toContain("sealed-key-id");
+      expect(raw).not.toContain("already-sealed");
+      expect(raw).not.toContain("enc:v1:");
+      const body = JSON.parse(raw) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("accessKeyId");
+      expect(body).not.toHaveProperty("secretAccessKey");
+      expect(body).toMatchObject({ mode: "byo", accessKeyIdLast4: "1234" });
+    });
+
+    it("403s a non-admin member session", async () => {
+      const { env } = makeEnv({ sessionUser: MEMBER, role: "member" });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("404s a non-member session", async () => {
+      const { env } = makeEnv({ noMembership: true });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("403s a bearer token with a coded error", async () => {
+      const { env } = makeEnv();
+      const res = await app.request("/v1/workspaces/acme/storage", { headers: bearerHeaders }, env);
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+        "settings_requires_session",
+      );
+    });
+  });
+
+  describe("POST /v1/workspaces/:workspace/storage/verify", () => {
+    it("403s (byo_bucket_disabled) when the workspace flag is off", async () => {
+      const { env } = makeEnv({ role: "owner", record: SHARED_RECORD });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage/verify",
+        {
+          method: "POST",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+        "byo_bucket_disabled",
+      );
+    });
+
+    it("runs the injected verify pipeline and persists nothing", async () => {
+      const { env, registry } = makeEnv({ role: "owner", record: BYO_RECORD });
+      setStorageVerifyForTests(async (candidate) => {
+        expect(candidate.bucket).toBe("customer-bucket");
+        return okVerifyResult;
+      });
+      const before = registry.record("acme");
+      const res = await app.request(
+        "/v1/workspaces/acme/storage/verify",
+        {
+          method: "POST",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(okVerifyResult);
+      expect(registry.record("acme")).toEqual(before);
+    });
+
+    it("403s a bearer token", async () => {
+      const { env } = makeEnv({ record: BYO_RECORD });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage/verify",
+        {
+          method: "POST",
+          headers: { ...bearerHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+        "settings_requires_session",
+      );
+    });
+  });
+
+  describe("PUT /v1/workspaces/:workspace/storage", () => {
+    it("saves on a passing verify, masking credentials in the response", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+        usage: { objects: 0 },
+      });
+      setStorageVerifyForTests(async () => okVerifyResult);
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      const raw = await res.text();
+      expect(raw).not.toContain("super-secret-value");
+      const body = JSON.parse(raw) as { mode: string };
+      expect(body.mode).toBe("byo");
+      expect(registry.record<{ accessKeyId?: string }>("acme")?.accessKeyId).not.toBe(
+        "AKIDEXAMPLE1234",
+      );
+    });
+
+    it("rejects with the verify result (422) on a failed verify, leaving the record untouched", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: { ...SHARED_RECORD, byoBucketEnabled: true },
+      });
+      const failResult = {
+        ok: false,
+        checks: [{ id: "auth", ok: false, required: true, hint: "rejected" }],
+      };
+      setStorageVerifyForTests(async () => failResult);
+      const before = registry.record("acme");
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...sessionHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(422);
+      expect(registry.record("acme")).toEqual(before);
+    });
+
+    it("403s a bearer token", async () => {
+      const { env } = makeEnv({ record: { ...SHARED_RECORD, byoBucketEnabled: true } });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        {
+          method: "PUT",
+          headers: { ...bearerHeaders, "content-type": "application/json" },
+          body: JSON.stringify(CANDIDATE_BODY),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /v1/workspaces/:workspace/storage", () => {
+    it("detaches and restores shared-bucket defaults", async () => {
+      const { env, registry } = makeEnv({
+        role: "owner",
+        record: BYO_RECORD,
+        usage: { objects: 0 },
+      });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { method: "DELETE", headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ mode: "shared" });
+      const saved = registry.record<{ accessKeyId?: unknown }>("acme");
+      expect(saved?.accessKeyId).toBeUndefined();
+    });
+
+    it("rejects detach when the bucket still has files and force wasn't passed", async () => {
+      const { env } = makeEnv({ role: "owner", record: BYO_RECORD, usage: { objects: 2 } });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { method: "DELETE", headers: sessionHeaders },
+        env,
+      );
+      expect(res.status).toBe(409);
+    });
+
+    it("403s a bearer token", async () => {
+      const { env } = makeEnv({ record: BYO_RECORD, usage: { objects: 0 } });
+      const res = await app.request(
+        "/v1/workspaces/acme/storage",
+        { method: "DELETE", headers: bearerHeaders },
+        env,
+      );
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+        "settings_requires_session",
+      );
+    });
+  });
+});
+
+describe("/me alias forwards (issue #613 phase 3)", () => {
+  it("GET /me/workspaces/:name/summary matches the canonical shape", async () => {
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member", usage: { objects: 0 } });
+    const canonical = await app.request(
+      "/v1/workspaces/acme/summary",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/summary",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  it("GET /me/workspaces/:name/billing matches the canonical shape", async () => {
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member" });
+    const canonical = await app.request(
+      "/v1/workspaces/acme/billing",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/billing",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  it("GET /me/workspaces/:name/comment-settings matches the canonical shape", async () => {
+    const { env } = makeEnv({ role: "admin" });
+    const canonical = await app.request(
+      "/v1/workspaces/acme/comment-settings",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/comment-settings",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  it("PATCH /me/workspaces/:name/comment-settings still works via the forward", async () => {
+    const { env } = makeEnv({ role: "admin" });
+    const res = await app.request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ note: "via alias" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ note: "via alias" });
+  });
+
+  it("GET /me/workspaces/:name/storage matches the canonical shape", async () => {
+    const BYO_RECORD = {
+      provider: "r2",
+      bucket: "customer-bucket",
+      accountId: "a".repeat(32),
+      accessKeyId: "enc:v1:sealed-key-id",
+      secretAccessKey: "enc:v1:already-sealed",
+      byoBucketEnabled: true,
+      storageAccessKeyIdLast4: "1234",
+    };
+    const { env } = makeEnv({ role: "owner", record: BYO_RECORD });
+    const canonical = await app.request(
+      "/v1/workspaces/acme/storage",
+      { headers: sessionHeaders },
+      env,
+    );
+    const alias = await app.request(
+      "/me/workspaces/acme/storage",
+      { headers: sessionHeaders },
+      env,
+    );
+    expect(alias.status).toBe(200);
+    expect(await alias.json()).toEqual(await canonical.json());
+  });
+
+  it("resolves the session exactly once per forwarded request (summary)", async () => {
+    const getSessionCalls = { count: 0 };
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member", getSessionCalls });
+    const res = await app.request("/me/workspaces/acme/summary", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(200);
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("resolves the session exactly once per forwarded request (comment-settings PATCH)", async () => {
+    const getSessionCalls = { count: 0 };
+    const { env } = makeEnv({ role: "admin", getSessionCalls });
+    const res = await app.request(
+      "/me/workspaces/acme/comment-settings",
+      {
+        method: "PATCH",
+        headers: { ...sessionHeaders, "content-type": "application/json" },
+        body: JSON.stringify({ note: "once" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(getSessionCalls.count).toBe(1);
+  });
+
+  it("membership rejection still applies to the forwarded alias (non-member -> 404)", async () => {
+    const { env } = makeEnv({ noMembership: true });
+    const res = await app.request("/me/workspaces/acme/summary", { headers: sessionHeaders }, env);
+    expect(res.status).toBe(404);
+    expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+      "workspace_not_found",
+    );
+  });
+});

--- a/apps/api/test/routes-workspace-settings.test.ts
+++ b/apps/api/test/routes-workspace-settings.test.ts
@@ -554,7 +554,10 @@ describe("/me alias forwards (issue #613 phase 3)", () => {
   });
 
   it("GET /me/workspaces/:name/billing matches the canonical shape", async () => {
-    const { env } = makeEnv({ sessionUser: MEMBER, role: "member" });
+    // Seed a usage row so both responses carry its fixed updated_at; without
+    // one, getWorkspaceUsage stamps each response with its own request-time
+    // updatedAt and the parity comparison flakes across a millisecond tick.
+    const { env } = makeEnv({ sessionUser: MEMBER, role: "member", usage: { objects: 0 } });
     const canonical = await app.request(
       "/v1/workspaces/acme/billing",
       { headers: sessionHeaders },


### PR DESCRIPTION
Phase 3 of #613: every remaining vertical gets a canonical route under `/v1/workspaces/:workspace/<resource>`, following the patterns established in #615 (files) and #616 (galleries, usage). This completes the canonical surface — the only deliberate exclusions are the workspaces list/create/delete routes (session-only per #265) and the phase-1 files bearer-shape unification punt.

The governing rule throughout: **no new token capabilities**. Canonical routes exist for everything, but each keeps its current authorization posture.

## github (collapses 5 sub-routers — a named wart in #613)

- New `routes/workspace-github.ts` replaces the five separate sub-router mounts on the canonical surface; the old `/v1/:workspace/github/*` routers are untouched in behavior and scopes.
- `comment`/`promote`: token-only. A member session gets 403 `github_requires_token` (mirroring #616's `usage_requires_token`). Canonical `comment` requires `files:write` — the old path's `files:read`-for-a-write is a flagged wart, fixed on the new surface only.
- `link`/`repo-link`/`health`/`activity`: dual-auth; session callers need admin/owner (new `requireSessionAdmin()` guard), matching the tier of the only session precedent (`repo-links`).
- `GET /me/workspaces/:name/repo-links` keeps its stripped `{repos}` projection — not forwarded.

## invites/members (governance dual-auth)

- New `dualGovernanceAuth(scope)`: bearer → existing `workspaceGovernanceAuth`; session → membership (uniform 404) + admin/owner. `POST /v1/workspaces/:name/invites` upgraded **in place** — it already lived at the canonical path; governance-token behavior proven unchanged by tests.
- New session-only `routes/workspace-members.ts`: members/people (member tier), invites list/revoke + member remove/role-change (admin tier); any bearer → 403 `members_requires_session`.
- All seven `/me` members/invites routes forward to the canonical handlers with the `presetResolvedSessionUser` handoff (exactly one get-session call per request, test-asserted).
- `workspaceManageAuth` (tokens routes) deliberately **not** reconciled: it falls back to session auth for non-`up_` bearers, which `dualGovernanceAuth` must not — swapping would be a behavior change, not a mechanical unification.
- Shared membership helpers moved from `routes/me.ts` to `org-workspaces.ts` to break an import cycle.

## comment-settings, storage, billing/summary (session-only)

- New `routes/workspace-settings.ts`: comment-settings + storage at admin/owner tier (403 `settings_requires_session` for bearers), summary + billing at member tier (403 `billing_requires_session`). Storage is credential-adjacent and billing carries Stripe data — keeping tokens out is deliberate.
- Handlers moved verbatim from `me.ts`; `/me` routes forward. Preserved exactly: the flat 5-key comment-settings envelope (admin-ui's prefixed operator surface stays separate), the masked `storageStatusResponse` projection, and the `stripeCustomerId` redaction — the tests assert on raw response text, not parsed fields.

## Review hardening

A whole-branch adversarial review plus scoped re-review ran before this PR. The one Important finding is fixed in `d68e1a83`: the new gates branched on "has a bearer header" before consulting the pre-resolved-session handoff, wrongly rejecting Better Auth bearer-session callers (device-flow tokens); the ordering is now preset → session, then `up_`-prefix discrimination for direct bearers (the `workspaceManageAuth` idiom). The same latent ordering bug in `dualWorkspaceAuth` (shipped in #615) is fixed in passing, with regression tests for both forwarded and direct bearer-session calls.

## Tests

3958 tests across 278 files, all green (`pnpm test`); `tsc --noEmit` clean. New suites: `routes-workspace-github.test.ts`, `routes-workspace-members.test.ts`, `routes-workspace-settings.test.ts`, `dual-workspace-auth-preset.test.ts` — covering the bearer/session/tier quadrants, uniform-404 discipline, untouched-old-path proofs, forward parity with single-session-resolution assertions, and redaction proofs.

Refs #613. Pattern precedents: #615, #616.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canonical workspace endpoints for GitHub integrations, member and invite management, workspace settings, billing, usage, and storage.
  - Added session-based workspace access alongside appropriately scoped bearer-token access.
  - Added role-based controls for members, administrators, and owners.
  - Added self-service storage verification, connection management, and restoration.
  - Added workspace invite management with improved authorization and consistent error responses.

- **Bug Fixes**
  - Standardized workspace membership checks and access-denied responses.
  - Preserved `/me` route behavior while forwarding requests to the canonical workspace endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->