### PR TITLE
fix(cli): fold --state into the derived screenshot name and warn on overwrite

### DIFF
--- a/.changeset/screenshot-state-derived-name.md
+++ b/.changeset/screenshot-state-derived-name.md
@@ -1,0 +1,5 @@
+---
+"@buildinternet/uploads": minor
+---
+
+`screenshot` now folds `--state` into the derived object name (e.g. `app.example-settings-before.png` / `-after.png`), so capturing the same URL with different states no longer silently overwrites the earlier capture (issue #618). Folding is skipped when an explicit `--key` is given. `screenshot` also now prints the same `>> replaced existing object (same URL)` note `put` prints when an upload replaces an existing object, in both human output and as a `hint` in `--format json`.

--- a/packages/uploads/src/commands.ts
+++ b/packages/uploads/src/commands.ts
@@ -426,7 +426,7 @@ function formatOptimizeNote(opt: {
   return undefined;
 }
 
-function writeReplacedNote(
+export function writeReplacedNote(
   replaced: boolean | undefined,
   quiet: boolean,
   dryRun = false,

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -27,6 +27,7 @@ import {
   putStagingNoteText,
   resolveStageBindingWarning,
   mergeStagingMeta,
+  writeReplacedNote,
   type BranchTarget,
 } from "../commands.js";
 import { resolvePutDefaults } from "../config.js";
@@ -87,6 +88,15 @@ they reference via file:// or relative paths only resolves with --via local).
 localhost/private-network URLs are reachable only by the
 local backend — with --via remote (or auto falling back to remote) these
 fail fast with a clear error instead of sending a doomed request.
+
+The object name is derived from the target URL (host + path), not chosen by
+you — e.g. https://app.example/settings becomes app.example-settings.png.
+--state folds into that derived name (a -before/-after/... suffix), so
+capturing the same URL with --state before then --state after produces two
+distinct objects instead of the second silently overwriting the first.
+Re-capturing the same URL + --state replaces that object in place — the
+intended idempotency for repeat captures. --key bypasses all of this and
+sets the whole object key verbatim (no folding).
 
 After capture, screenshots share the put upload pipeline: optional --frame,
 optimize-by-default, --pr/--issue attachment + --comment, --gallery, --meta.
@@ -456,6 +466,9 @@ export async function runScreenshot(
     reducedMotion,
     evalJs,
     initScript,
+    // Skip folding when an explicit --key was given — --key sets the whole
+    // key, so there's no auto-derived name to fold state into.
+    state: keyHint ? undefined : explicitMeta.state,
     measureSelectors: annotateSelectors.length > 0 ? annotateSelectors : undefined,
     apiUrl: ctx.config.apiUrl,
     token: ctx.config.token,
@@ -587,6 +600,7 @@ export async function runScreenshot(
         `>> optimized ${prepared.originalBytes} → ${prepared.outputBytes} bytes\n`,
       );
     }
+    writeReplacedNote(result.replaced, ctx.quiet, dryRun, result.wouldRefuse);
     process.stderr.write(`>> key: ${result.key}${dryRun ? " (dry run — not uploaded)" : ""}\n`);
     if (stagingTarget !== undefined) {
       process.stderr.write(
@@ -606,8 +620,14 @@ export async function runScreenshot(
   }
 
   // One JSON `hint` slot (mirrors bare put): the binding warning is more
-  // actionable than the generic staging note, so it wins when both fire.
-  const jsonHint = bindingWarning ?? stagingNote;
+  // actionable than the generic staging note, so it wins when both fire; a
+  // replaced-object note (issue #618) is the lowest priority of the three —
+  // it only surfaces when nothing else already claimed the slot.
+  const replacedHint =
+    result.replaced && explicitMeta.state
+      ? `this upload replaced the existing object at ${result.key} (same derived key for state=${explicitMeta.state})`
+      : undefined;
+  const jsonHint = bindingWarning ?? stagingNote ?? replacedHint;
 
   switch (format) {
     case "json":

--- a/packages/uploads/src/commands/screenshot.ts
+++ b/packages/uploads/src/commands/screenshot.ts
@@ -622,10 +622,13 @@ export async function runScreenshot(
   // One JSON `hint` slot (mirrors bare put): the binding warning is more
   // actionable than the generic staging note, so it wins when both fire; a
   // replaced-object note (issue #618) is the lowest priority of the three —
-  // it only surfaces when nothing else already claimed the slot.
+  // it only surfaces when nothing else already claimed the slot. Since state
+  // folds into the derived key, replaced + state means a same-side re-capture,
+  // which is the intended replace-in-place flow — word it as informational,
+  // not as a problem.
   const replacedHint =
     result.replaced && explicitMeta.state
-      ? `this upload replaced the existing object at ${result.key} (same derived key for state=${explicitMeta.state})`
+      ? `re-capture replaced the previous state=${explicitMeta.state} object at ${result.key} — expected for repeat captures of the same URL + state`
       : undefined;
   const jsonHint = bindingWarning ?? stagingNote ?? replacedHint;
 

--- a/packages/uploads/src/mcp/tools.ts
+++ b/packages/uploads/src/mcp/tools.ts
@@ -873,6 +873,10 @@ export function createUploadsMcpTools(opts: {
             hide: optStringArray(args, "hide"),
             hideDevTools: optBool(args, "noHideDevTools") ? false : undefined,
             reducedMotion: optBool(args, "reducedMotion"),
+            // Skip folding when an explicit key was given — key sets the
+            // whole object key, so there's no auto-derived name to fold
+            // state into.
+            state: keyArg ? undefined : metadataWithCaptureFacts?.state,
             apiUrl: config.apiUrl,
             token: config.token,
           });

--- a/packages/uploads/src/metadata-vocab.ts
+++ b/packages/uploads/src/metadata-vocab.ts
@@ -32,6 +32,11 @@ export type MetaStateValue = (typeof META_STATE_VALUES)[number];
 
 const STATE_VALUE_SET: ReadonlySet<string> = new Set(META_STATE_VALUES);
 
+/** True when `value` is exactly one of the canonical state values. */
+export function isMetaStateValue(value: string): value is MetaStateValue {
+  return STATE_VALUE_SET.has(value);
+}
+
 /** Common spellings agents reach for, mapped to the canonical `state` value. */
 const STATE_ALIASES: Readonly<Record<string, MetaStateValue>> = {
   pre: "before",

--- a/packages/uploads/src/screenshot.ts
+++ b/packages/uploads/src/screenshot.ts
@@ -198,6 +198,14 @@ export interface CaptureScreenshotOptions {
   fullPage?: boolean;
   colorScheme?: "dark" | "light";
   waitUntil?: WaitUntil;
+  /**
+   * Folded into the auto-derived filename's stem (e.g. `-before`) so a
+   * before/after pair of the same URL yields two distinct object names
+   * instead of silently overwriting each other. Callers must omit this when
+   * the caller also gave an explicit object key/name — folding only applies
+   * to the auto-derived name.
+   */
+  state?: string;
   /** Extra CSS selectors to hide (display:none) before capture. */
   hide?: string[];
   /**
@@ -268,6 +276,29 @@ function deriveFilename(target: ScreenshotTarget): string {
 }
 
 /**
+ * Folds a `--state` value into an auto-derived filename's stem, e.g.
+ * `localhost-docs-mcp.png` + "before" → `localhost-docs-mcp-before.png`. This
+ * is what keeps a before/after pair (same URL, two states) from colliding on
+ * the same object key (issue #618) — without it, the second capture silently
+ * overwrote the first.
+ *
+ * No-op when `state` is undefined, and idempotent: re-folding a filename that
+ * already ends with `-<state>` (e.g. re-deriving from a stored filename)
+ * doesn't double-append.
+ *
+ * Callers must skip this entirely when the caller gave an explicit key/name
+ * (e.g. `--key`) — this only applies to the auto-derived filename.
+ */
+export function foldStateIntoFilename(filename: string, state: string | undefined): string {
+  if (!state) return filename;
+  const match = /^(.*?)(\.[^./]+)?$/.exec(filename);
+  const stem = match?.[1] ?? filename;
+  const ext = match?.[2] ?? "";
+  if (stem.endsWith(`-${state}`)) return filename;
+  return `${stem}-${state}${ext}`;
+}
+
+/**
  * Best-effort local-browser probe used only to decide `auto` routing. Never
  * throws — any failure (e.g. optional playwright-core not installed) means
  * "no local browser available". Returns the full detection result (not just
@@ -295,7 +326,7 @@ export async function captureScreenshot(
   const target = classifyTarget(opts.target);
   const viewport = opts.viewport ?? DEFAULT_SCREENSHOT_VIEWPORT;
   const waitUntil = opts.waitUntil ?? "load";
-  const filename = deriveFilename(target);
+  const filename = foldStateIntoFilename(deriveFilename(target), opts.state);
 
   // Only private-network URLs are truly unreachable remotely; an .html file
   // is sent to the remote backend as an inline `html` body (though anything

--- a/packages/uploads/src/screenshot.ts
+++ b/packages/uploads/src/screenshot.ts
@@ -12,6 +12,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
 import { UploadsError } from "./errors.js";
+import { isMetaStateValue } from "./metadata-vocab.js";
 import { captureRemote, MAX_REMOTE_HTML_BYTES } from "./screenshot-remote.js";
 import type { DetectRoots } from "./screenshot-local.js";
 
@@ -286,11 +287,16 @@ function deriveFilename(target: ScreenshotTarget): string {
  * already ends with `-<state>` (e.g. re-deriving from a stored filename)
  * doesn't double-append.
  *
+ * Only the canonical state values fold. Callers pass the merged metadata bag's
+ * `state`, which a free-form `--meta state=…` can populate with any printable
+ * ASCII (validateMetaMap allows `/` and spaces) — that stays metadata-only
+ * rather than entering the object key.
+ *
  * Callers must skip this entirely when the caller gave an explicit key/name
  * (e.g. `--key`) — this only applies to the auto-derived filename.
  */
 export function foldStateIntoFilename(filename: string, state: string | undefined): string {
-  if (!state) return filename;
+  if (!state || !isMetaStateValue(state)) return filename;
   const match = /^(.*?)(\.[^./]+)?$/.exec(filename);
   const stem = match?.[1] ?? filename;
   const ext = match?.[2] ?? "";

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -6,6 +6,7 @@ import { UsageError } from "../src/cli-args.js";
 import type { UploadsClient } from "../src/client.js";
 import type { CliContext } from "../src/commands.js";
 import { runScreenshot, type AnnotateModule } from "../src/commands/screenshot.js";
+import { foldStateIntoFilename } from "../src/screenshot.js";
 import type { CommandRunner } from "../src/github-gh.js";
 import type { CaptureScreenshotResult } from "../src/screenshot.js";
 import type { AnnotationSpec, SpecError } from "../src/annotate/index.js";
@@ -86,9 +87,10 @@ function fakeCapture(
 }
 
 /**
- * Records the `state` the command passed through to captureImpl and mimics
- * the real captureScreenshot's state-folding (issue #618) so wiring can be
- * asserted end to end without going through the real backend-selection code.
+ * Records the `state` the command passed through to captureImpl and applies
+ * the real `foldStateIntoFilename` (issue #618) so wiring — including the
+ * canonical-values-only guard — can be asserted end to end without going
+ * through the real backend-selection code.
  */
 function fakeCaptureRecordingState(record: {
   state?: string;
@@ -96,8 +98,7 @@ function fakeCaptureRecordingState(record: {
   return async (opts) => {
     const state = (opts as { state?: string }).state;
     record.state = state;
-    const filename = state ? `example-com-${state}.png` : "example-com.png";
-    return { png, filename, backend: "remote" };
+    return { png, filename: foldStateIntoFilename("example-com.png", state), backend: "remote" };
   };
 }
 
@@ -944,6 +945,25 @@ describe("runScreenshot --state folded into the derived name (issue #618)", () =
     expect(puts[0]?.key).toBe("screenshots/explicit.png");
   });
 
+  it("does not fold a free-form --meta state into the derived name", async () => {
+    // `--meta state=x/y` passes validateMetaMap (any printable ASCII) and
+    // reaches captureImpl via the merged metadata bag, but only canonical
+    // state values may enter the object key.
+    const { client, puts } = fakeClient();
+    const record: { state?: string } = {};
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--meta", "state=x/y"],
+      false,
+      noRun,
+      fakeCaptureRecordingState(record),
+    );
+    expect(code).toBe(0);
+    expect(record.state).toBe("x/y");
+    expect(puts[0]?.filename).toBe("example-com.png");
+    expect(puts[0]?.metadata?.state).toBe("x/y");
+  });
+
   it("does not fold state when no --state was given", async () => {
     const { client } = fakeClient();
     const record: { state?: string } = {};
@@ -1015,8 +1035,8 @@ describe("runScreenshot replaced-object note (issue #618)", () => {
     );
     const parsed = JSON.parse(stdout);
     expect(parsed.replaced).toBe(true);
-    expect(parsed.hint).toContain("replaced the existing object");
-    expect(parsed.hint).toContain("state=after");
+    expect(parsed.hint).toContain("re-capture replaced the previous state=after object");
+    expect(parsed.hint).toContain("expected for repeat captures");
   });
 
   it("does not set the json hint when replaced but no --state was given", async () => {

--- a/packages/uploads/test/commands-screenshot.test.ts
+++ b/packages/uploads/test/commands-screenshot.test.ts
@@ -11,7 +11,7 @@ import type { CaptureScreenshotResult } from "../src/screenshot.js";
 import type { AnnotationSpec, SpecError } from "../src/annotate/index.js";
 
 /** Fake client capturing put() calls; other methods throw if reached. */
-function fakeClient() {
+function fakeClient(opts: { replaced?: boolean } = {}) {
   const puts: {
     key?: string;
     filename: string;
@@ -23,7 +23,7 @@ function fakeClient() {
   const client = {
     put: async (
       body: Uint8Array,
-      opts: {
+      putOpts: {
         filename: string;
         key?: string;
         prefix?: string;
@@ -32,20 +32,21 @@ function fakeClient() {
       },
     ) => {
       puts.push({
-        key: opts.key,
-        filename: opts.filename,
-        prefix: opts.prefix,
-        dryRun: opts.dryRun,
+        key: putOpts.key,
+        filename: putOpts.filename,
+        prefix: putOpts.prefix,
+        dryRun: putOpts.dryRun,
         body,
-        metadata: opts.metadata,
+        metadata: putOpts.metadata,
       });
       return {
         workspace: "test",
-        key: opts.key ?? "screenshots/misc/generated.png",
-        url: `https://x.test/${opts.key ?? "screenshots/misc/generated.png"}`,
+        key: putOpts.key ?? "screenshots/misc/generated.png",
+        url: `https://x.test/${putOpts.key ?? "screenshots/misc/generated.png"}`,
         embedUrl: null,
         size: body.byteLength,
         contentType: "image/png",
+        replaced: opts.replaced ?? false,
       };
     },
     list: async () => ({ items: [], cursor: null }),
@@ -82,6 +83,22 @@ function fakeCapture(
   measures?: Record<string, { x: number; y: number; w: number; h: number }>,
 ): (opts: unknown) => Promise<CaptureScreenshotResult> {
   return async () => ({ png, filename: "example-com.png", backend, measures });
+}
+
+/**
+ * Records the `state` the command passed through to captureImpl and mimics
+ * the real captureScreenshot's state-folding (issue #618) so wiring can be
+ * asserted end to end without going through the real backend-selection code.
+ */
+function fakeCaptureRecordingState(record: {
+  state?: string;
+}): (opts: unknown) => Promise<CaptureScreenshotResult> {
+  return async (opts) => {
+    const state = (opts as { state?: string }).state;
+    record.state = state;
+    const filename = state ? `example-com-${state}.png` : "example-com.png";
+    return { png, filename, backend: "remote" };
+  };
 }
 
 class FakeAnnotateSpecError extends Error {
@@ -879,6 +896,143 @@ describe("screenshot canonical metadata", () => {
     ]);
     expect(meta?.ticket).toBe("RAL-1");
     expect(meta?.path).toBeUndefined();
+  });
+});
+
+describe("runScreenshot --state folded into the derived name (issue #618)", () => {
+  it("passes --state through to captureImpl, yielding a distinct key per state", async () => {
+    const { client, puts } = fakeClient();
+    const record: { state?: string } = {};
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--state", "before"],
+      false,
+      noRun,
+      fakeCaptureRecordingState(record),
+    );
+    expect(code).toBe(0);
+    expect(record.state).toBe("before");
+    expect(puts[0]?.filename).toBe("example-com-before.png");
+
+    const { client: client2, puts: puts2 } = fakeClient();
+    const record2: { state?: string } = {};
+    const code2 = await runScreenshot(
+      ctxWith(client2),
+      ["https://example.com", "--state", "after"],
+      false,
+      noRun,
+      fakeCaptureRecordingState(record2),
+    );
+    expect(code2).toBe(0);
+    expect(record2.state).toBe("after");
+    expect(puts2[0]?.filename).toBe("example-com-after.png");
+    expect(puts2[0]?.filename).not.toBe(puts[0]?.filename);
+  });
+
+  it("does not fold state when an explicit --key is given", async () => {
+    const { client, puts } = fakeClient();
+    const record: { state?: string } = {};
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com", "--state", "before", "--key", "screenshots/explicit.png"],
+      false,
+      noRun,
+      fakeCaptureRecordingState(record),
+    );
+    expect(code).toBe(0);
+    expect(record.state).toBeUndefined();
+    expect(puts[0]?.key).toBe("screenshots/explicit.png");
+  });
+
+  it("does not fold state when no --state was given", async () => {
+    const { client } = fakeClient();
+    const record: { state?: string } = {};
+    const code = await runScreenshot(
+      ctxWith(client),
+      ["https://example.com"],
+      false,
+      noRun,
+      fakeCaptureRecordingState(record),
+    );
+    expect(code).toBe(0);
+    expect(record.state).toBeUndefined();
+  });
+});
+
+describe("runScreenshot replaced-object note (issue #618)", () => {
+  it("prints the same replaced note as put in human mode", async () => {
+    const { client } = fakeClient({ replaced: true });
+    const stderr = await captureStderr(() =>
+      runScreenshot(
+        { ...ctxWith(client), quiet: false },
+        ["https://example.com", "--state", "after"],
+        false,
+        noRun,
+        fakeCapture("remote"),
+      ),
+    );
+    expect(stderr).toContain(">> replaced existing object (same URL)\n");
+  });
+
+  it("does not print a replaced note when nothing was replaced", async () => {
+    const { client } = fakeClient({ replaced: false });
+    const stderr = await captureStderr(() =>
+      runScreenshot(
+        { ...ctxWith(client), quiet: false },
+        ["https://example.com", "--state", "after"],
+        false,
+        noRun,
+        fakeCapture("remote"),
+      ),
+    );
+    expect(stderr).not.toContain("replaced existing object");
+  });
+
+  it("is suppressed in quiet mode", async () => {
+    const { client } = fakeClient({ replaced: true });
+    const stderr = await captureStderr(() =>
+      runScreenshot(
+        ctxWith(client), // quiet: true by default
+        ["https://example.com", "--state", "after"],
+        false,
+        noRun,
+        fakeCapture("remote"),
+      ),
+    );
+    expect(stderr).not.toContain("replaced existing object");
+  });
+
+  it("carries a replaced+state hint in the json hint slot", async () => {
+    const { client } = fakeClient({ replaced: true });
+    const stdout = await captureStdout(() =>
+      runScreenshot(
+        { ...ctxWith(client), json: true, quiet: false },
+        ["https://example.com", "--state", "after"],
+        false,
+        noRun,
+        fakeCapture("remote"),
+      ),
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.replaced).toBe(true);
+    expect(parsed.hint).toContain("replaced the existing object");
+    expect(parsed.hint).toContain("state=after");
+  });
+
+  it("does not set the json hint when replaced but no --state was given", async () => {
+    const { client } = fakeClient({ replaced: true });
+    const stdout = await captureStdout(() =>
+      runScreenshot(
+        { ...ctxWith(client), json: true, quiet: false },
+        ["https://example.com"],
+        false,
+        noRun,
+        fakeCapture("remote"),
+      ),
+    );
+    const parsed = JSON.parse(stdout);
+    expect(parsed.replaced).toBe(true);
+    expect(parsed.hint).toBeUndefined();
   });
 });
 

--- a/packages/uploads/test/mcp-screenshot.test.ts
+++ b/packages/uploads/test/mcp-screenshot.test.ts
@@ -10,13 +10,16 @@ import { rpc, validator } from "./mcp-harness.js";
 // handler (by design — keeps mcp/tools.ts free of a static reference to the
 // local-backend chain). Mock captureScreenshot there so this test never
 // launches a browser or hits the network, while keeping the real parsers.
+// State-aware: mimics the real captureScreenshot's state-folding (issue
+// #618) closely enough to assert the tool wires `state` through correctly,
+// without going through the real backend-selection code.
 vi.mock("../src/screenshot.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/screenshot.js")>();
   return {
     ...actual,
-    captureScreenshot: vi.fn(async () => ({
+    captureScreenshot: vi.fn(async (opts: { state?: string }) => ({
       png: new Uint8Array([1, 2, 3]),
-      filename: "example-com.png",
+      filename: opts.state ? `example-com-${opts.state}.png` : "example-com.png",
       backend: "remote" as const,
     })),
   };
@@ -134,6 +137,41 @@ describe("mcp screenshot tool", () => {
       arguments: { target: "https://example.com", via: "carrier-pigeon" },
     });
     expect(res.result.isError).toBe(true);
+  });
+});
+
+describe("mcp screenshot tool --state folded into the derived name (issue #618)", () => {
+  it("folds state into the derived key, so before/after produce distinct objects", async () => {
+    const { server: serverBefore, puts: putsBefore } = serverWith();
+    const beforeRes = await rpc(serverBefore, "tools/call", {
+      name: "screenshot",
+      arguments: { target: "https://example.com", state: "before", pr: 9, repo: "o/r" },
+    });
+    expect(beforeRes.result.isError).toBe(false);
+    expect(putsBefore[0]?.key).toBe("gh/o/r/pull/9/example-com-before.png");
+
+    const { server: serverAfter, puts: putsAfter } = serverWith();
+    const afterRes = await rpc(serverAfter, "tools/call", {
+      name: "screenshot",
+      arguments: { target: "https://example.com", state: "after", pr: 9, repo: "o/r" },
+    });
+    expect(afterRes.result.isError).toBe(false);
+    expect(putsAfter[0]?.key).toBe("gh/o/r/pull/9/example-com-after.png");
+    expect(putsAfter[0]?.key).not.toBe(putsBefore[0]?.key);
+  });
+
+  it("does not fold state when an explicit key is given", async () => {
+    const { server, puts } = serverWith();
+    const res = await rpc(server, "tools/call", {
+      name: "screenshot",
+      arguments: {
+        target: "https://example.com",
+        state: "before",
+        key: "screenshots/explicit.png",
+      },
+    });
+    expect(res.result.isError).toBe(false);
+    expect(puts[0]?.key).toBe("screenshots/explicit.png");
   });
 });
 

--- a/packages/uploads/test/screenshot.test.ts
+++ b/packages/uploads/test/screenshot.test.ts
@@ -167,6 +167,19 @@ describe("foldStateIntoFilename", () => {
   it("handles a filename with no extension", () => {
     expect(foldStateIntoFilename("screenshot", "before")).toBe("screenshot-before");
   });
+
+  it("folds only canonical state values — free-form metadata state stays out of the key", () => {
+    // A free-form `--meta state=…` passes validateMetaMap (any printable
+    // ASCII, including `/` and spaces) and reaches the fold via the merged
+    // metadata bag; it must never enter the derived object name.
+    expect(foldStateIntoFilename("localhost-docs-mcp.png", "x/y")).toBe("localhost-docs-mcp.png");
+    expect(foldStateIntoFilename("localhost-docs-mcp.png", "two words")).toBe(
+      "localhost-docs-mcp.png",
+    );
+    expect(foldStateIntoFilename("localhost-docs-mcp.png", "Before")).toBe(
+      "localhost-docs-mcp.png",
+    );
+  });
 });
 
 describe("captureScreenshot backend selection", () => {

--- a/packages/uploads/test/screenshot.test.ts
+++ b/packages/uploads/test/screenshot.test.ts
@@ -7,6 +7,7 @@ import {
   captureScreenshot,
   classifyTarget,
   DEV_TOOLBAR_SELECTORS,
+  foldStateIntoFilename,
   isPrivateOrLocalHost,
   parseViewport,
   parseWaitUntil,
@@ -141,8 +142,68 @@ describe("classifyTarget", () => {
   });
 });
 
+describe("foldStateIntoFilename", () => {
+  it("inserts -<state> before the extension", () => {
+    expect(foldStateIntoFilename("localhost-docs-mcp.png", "before")).toBe(
+      "localhost-docs-mcp-before.png",
+    );
+    expect(foldStateIntoFilename("localhost-docs-mcp.png", "after")).toBe(
+      "localhost-docs-mcp-after.png",
+    );
+  });
+
+  it("is a no-op when no state is given", () => {
+    expect(foldStateIntoFilename("localhost-docs-mcp.png", undefined)).toBe(
+      "localhost-docs-mcp.png",
+    );
+  });
+
+  it("does not double-append when the stem already ends with -<state>", () => {
+    expect(foldStateIntoFilename("localhost-docs-mcp-before.png", "before")).toBe(
+      "localhost-docs-mcp-before.png",
+    );
+  });
+
+  it("handles a filename with no extension", () => {
+    expect(foldStateIntoFilename("screenshot", "before")).toBe("screenshot-before");
+  });
+});
+
 describe("captureScreenshot backend selection", () => {
   const png = new Uint8Array([9, 9, 9]);
+
+  it("folds --state into the derived filename, so before/after produce distinct keys", async () => {
+    const before = await captureScreenshot({
+      target: "https://example.com/docs/mcp",
+      via: "remote",
+      state: "before",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureRemoteImpl: async () => png,
+    });
+    const after = await captureScreenshot({
+      target: "https://example.com/docs/mcp",
+      via: "remote",
+      state: "after",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureRemoteImpl: async () => png,
+    });
+    expect(before.filename).toBe("example.com-docs-mcp-before.png");
+    expect(after.filename).toBe("example.com-docs-mcp-after.png");
+    expect(before.filename).not.toBe(after.filename);
+  });
+
+  it("leaves the derived filename untouched when no state is given", async () => {
+    const result = await captureScreenshot({
+      target: "https://example.com/docs/mcp",
+      via: "remote",
+      apiUrl: "https://api.uploads.sh",
+      token: "t",
+      captureRemoteImpl: async () => png,
+    });
+    expect(result.filename).toBe("example.com-docs-mcp.png");
+  });
 
   it("uses local when --via local is requested", async () => {
     let usedLocal = false;

--- a/skills/github-screenshots/SKILL.md
+++ b/skills/github-screenshots/SKILL.md
@@ -91,8 +91,11 @@ explicitly when you want its extras (uploading several files at once with
 shared flags, or triggering promotion/comment sync as a side effect):
 
 ```bash
-uploads put ./step1-before.png --meta path=/settings --state before
+uploads screenshot http://localhost:4321/settings --out step1-before.png --state before
 uploads screenshot http://localhost:4321/settings --out step2-after.png --state after
+
+# or, capturing an existing local file instead of a live URL:
+uploads put ./step1-before.png --meta path=/settings --state before
 
 # or, explicitly, e.g. to upload several at once:
 uploads attach ./step1-before.png ./step2-after.png --branch --state after
@@ -136,9 +139,21 @@ highest-value queryable tag, and it's just as easy to forget outside
 `uploads put`/`uploads attach` of an existing file have nothing to derive it
 from). Both cost one flag now and make `uploads find state=after` or
 `uploads find path=/settings` work months later, when the filenames mean
-nothing to anyone:
+nothing to anyone.
+
+**`uploads screenshot` for both sides of a same-URL before/after pair is the
+straightforward path** — its object name derives from the captured URL, and
+`--state` folds into that derived name (`localhost-docs-mcp.webp` becomes
+`localhost-docs-mcp-before.webp`/`-after.webp`), so capturing the same URL
+twice with different states lands two distinct objects instead of one
+overwriting the other. An explicit `--key` is unaffected — pass one when you
+need a specific object name. A `put` of an already-existing file still needs
+its own filenames or `--key` to keep before/after distinct, since there's no
+URL to derive a stem from:
 
 ```bash
+uploads screenshot https://app.example/settings --pr 123 --state before
+uploads screenshot https://app.example/settings --pr 123 --state after
 uploads put ./after.png --pr 123 --meta path=/settings --state after
 ```
 

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -457,6 +457,21 @@ limits) — renders and puts share one monthly counter.
 `uploads doctor` reports which local browser (if any) was detected and which
 backend `--via auto` would currently pick.
 
+**Key derivation and `--state`.** Whenever the object's filename is
+auto-derived from the captured URL (host + path) — the default dated
+layout, or the `--pr`/`--issue` leaf name — passing `--state` folds it into
+that derived filename stem —
+`localhost-docs-mcp.webp` becomes `localhost-docs-mcp-before.webp` /
+`localhost-docs-mcp-after.webp` — so capturing the same URL twice with
+`--state before` then `--state after` produces two distinct objects instead
+of the second silently overwriting the first. Re-capturing the same URL with
+the _same_ state still replaces the existing object in place (idempotent
+re-capture). An explicit `--key` is unaffected by `--state` folding. On
+overwrite, human mode prints `>> replaced existing object (same URL)` to
+stderr (same wording as `put`'s hot-swap note, above) and `--format json`
+adds `"replaced": true`, plus a `hint` field when a `--state` capture
+replaced an existing object.
+
 ### Baking in callouts: `--annotate`
 
 `--annotate <file|->` bakes hand-drawn boxes, arrows, labels, freeform


### PR DESCRIPTION
Closes #618.

`uploads screenshot` derived the object name from the captured URL only, so the canonical before/after flow — same route, twice, with `--state before` then `--state after` — collided on one key and the second capture silently overwrote the first. `--state` was metadata only, which also made #419's pairing rule 1 unreachable through the one command that derives `path` automatically.

## Changes

**State folds into the derived name** (fix 2 from the issue). `captureScreenshot` runs the URL-derived filename through a new `foldStateIntoFilename` helper: `localhost-docs-mcp.png` + `--state before` → `localhost-docs-mcp-before.png`. Folding happens once at capture time, so every key layout (branch-staged default, `--pr`/`--issue`, `--ref`/`--prefix` dated) inherits it. It is idempotent, skipped entirely for an explicit `--key`, and re-capturing the same URL + state still replaces in place. The MCP `screenshot` tool already accepted `state` for metadata; it now folds identically for CLI/MCP parity. `put` is untouched — its name comes from a real user file.

No compat gate: for auto-derived names + `--state`, the old behavior was silent data loss, and same-side re-captures keep their replace-in-place idempotency.

**`screenshot` surfaces replacement** (fix 1). Human mode now prints the same `>> replaced existing object (same URL)` note `put` prints (`writeReplacedNote` is now shared), and `--format json` fills its single `hint` slot when a `--state` capture replaced an existing object — lowest priority behind the binding warning and staging note.

**Docs** (fix 3). `screenshot --help` states the name comes from the URL and how `--state` folds in; the github-screenshots skill's worked examples use `screenshot` for both sides of a same-URL pair (the `put` path stays as the existing-file alternative); the uploads-cli skill gains a "Key derivation and `--state`" section covering folding, idempotent re-capture, the `--key` exemption, and the replaced note / JSON fields.

## Testing

- New coverage: `foldStateIntoFilename` unit tests; state folded into derived keys (before/after produce distinct keys); no folding with `--key`; no double-append; replaced note in human/quiet modes; JSON `hint` on replaced + state — for both the CLI command and the MCP tool.
- Full root suite: 274 files, 3873 tests, all passing. `pnpm --filter @buildinternet/uploads typecheck` clean.
- Changeset: `@buildinternet/uploads` minor (verified against the changeset ignore list).
