### PR TITLE
docs: fix stale metadata key names in cli.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,11 +210,12 @@ is separate from optimize/frame provenance.
 
 Suggested pairs for screenshots:
 
-| Key    | Example                             | Meaning                          |
-| ------ | ----------------------------------- | -------------------------------- |
-| `url`  | `https://app.example/settings`      | Page URL the shot was taken from |
-| `path` | `/settings` or `Settings > Profile` | In-app route or nav path         |
-| `app`  | `web`, `ios`, `android`             | Surface / product shown          |
+| Key     | Example                             | Meaning                                                                                         |
+| ------- | ----------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `url`   | `https://app.example/settings`      | Page URL the shot was taken from                                                                |
+| `path`  | `/settings` or `Settings > Profile` | In-app route or nav path                                                                        |
+| `app`   | `web`, `ios`, `android`             | Surface / product shown                                                                         |
+| `state` | `before`, `after`                   | UI state shown (`before`, `after`, `empty`, `error`, `loading`); `--state <s>` is the shorthand |
 
 ```bash
 uploads put ./settings.png \
@@ -229,8 +230,8 @@ uploads attach ./mobile-checkout.png \
 
 uploads find app=web path=/settings
 uploads meta get screenshots/myapp/42/settings.webp
-uploads meta set screenshots/myapp/42/settings.webp page=onboarding --delete path
-uploads meta set screenshots/myapp/42/settings.webp --meta page=onboarding
+uploads meta set screenshots/myapp/42/settings.webp path=/onboarding --delete url
+uploads meta set screenshots/myapp/42/settings.webp --meta path=/onboarding
 ```
 
 `meta set` and `find` take pairs in either spelling: positional `k=v`, or the

--- a/skills/uploads-cli/SKILL.md
+++ b/skills/uploads-cli/SKILL.md
@@ -785,7 +785,7 @@ uploads list --prefix screenshots/        # list objects (key + url)
 uploads list --pr 123                      # everything attached to a PR
 uploads list --meta app=myapp              # filter by metadata (repeatable, ANDed)
 uploads list --name hero --meta app=web    # filename substring (+ optional meta)
-uploads find app=myapp page=settings       # same filter, human-friendly positional pairs
+uploads find app=myapp path=/settings      # same filter, human-friendly positional pairs
 uploads find hero                          # filename substring alone
 uploads list --all --json                  # paginate fully, machine-readable
 uploads meta get <key>                     # show an object's metadata


### PR DESCRIPTION
docs/cli.md's `meta set` examples used `page=`, which isn't a documented metadata key — the shipped vocabulary is `path=` / `state=` (per `meta set --help` in `packages/uploads/src/commands.ts` and the uploads-cli skill). Spotted during the #618 docs audit; pre-existing drift, unrelated to that change.

- `meta set` examples now use `path=/onboarding` (with `--delete url`), mirroring the skill's own examples.
- The suggested-pairs table gains the missing `state` row (`before`, `after`, `empty`, `error`, `loading`; `--state <s>` shorthand).
- The uploads-cli skill's quick-reference block had the same slip (`find app=myapp page=settings`) — fixed to `path=/settings`. Different section than #620's skill edits, so no conflict.

Docs-only; no behavior change.